### PR TITLE
Tile id bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # TileDB
 
-[![Travis](https://img.shields.io/travis/Intel-HLS/TileDB.svg?maxAge=2592000)]
-(https://travis-ci.org/Intel-HLS/TileDB)
+[![Travis](https://travis-ci.org/TileDB-Inc/TileDB.svg?branch=master)]
+(https://travis-ci.org/TileDB-Inc/TileDB)
 
 The installation guide for TileDB can be found at this [Github
-Wiki](https://github.com/Intel-HLS/TileDB/wiki).
+Wiki](https://github.com/TileDB-Inc/TileDB/wiki).
 
 The TileDB C API documentation and tutorials can be
 found at the [TileDB official website](http://istc-bigdata.org/tiledb).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # TileDB
 
-[![Travis][2]][1]
-  [1]: https://travis-ci.org/TileDB-Inc/TileDB
-  [2]: https://travis-ci.org/TileDB-Inc/TileDB.svg?branch=master
+[![Travis](https://travis-ci.org/TileDB-Inc/TileDB.svg?branch=master)](https://travis-ci.org/TileDB-Inc/TileDB)
 
 The installation guide for TileDB can be found at this [Github
 Wiki](https://github.com/TileDB-Inc/TileDB/wiki).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # TileDB
 
-[![Travis](https://travis-ci.org/TileDB-Inc/TileDB.svg?branch=master)]
-(https://travis-ci.org/TileDB-Inc/TileDB)
+[![Travis][2]][1]
+  [1]: https://travis-ci.org/TileDB-Inc/TileDB
+  [2]: https://travis-ci.org/TileDB-Inc/TileDB.svg?branch=master
 
 The installation guide for TileDB can be found at this [Github
 Wiki](https://github.com/TileDB-Inc/TileDB/wiki).

--- a/core/src/array/array_schema.cc
+++ b/core/src/array/array_schema.cc
@@ -1848,7 +1848,7 @@ int64_t ArraySchema::tile_id(const T* cell_coords) const {
   for(int i=0; i<dim_num_; ++i)
     tile_coords[i] = (cell_coords[i] - domain[2*i]) / tile_extents[i]; 
 
-  int tile_id = get_tile_pos(tile_coords);
+  int64_t tile_id = get_tile_pos(tile_coords);
 
   // Return
   return tile_id;


### PR DESCRIPTION
Somewhere in the code the tile_id variable was defined as int, whereas it should have been int64_t. This created problems for very small tile extents in a large domain, which led to tile id overflows due to the numerous space tiles.