### PR TITLE
Revert "don't use deprecated lz4 api"

### DIFF
--- a/core/src/fragment/write_state.cc
+++ b/core/src/fragment/write_state.cc
@@ -674,7 +674,7 @@ int WriteState::compress_tile_lz4(
 
   // Compress tile
   int lz4_size = 
-      LZ4_compress_default(
+      LZ4_compress(
           (const char*) tile, 
           (char*) tile_compressed_, 
           tile_size,


### PR DESCRIPTION
Reverts TileDB-Inc/TileDB#8