### PR TITLE
Remove global error message buffer, save error status to TileDB_CTX

### DIFF
--- a/core/include/c_api/tiledb_constants.h
+++ b/core/include/c_api/tiledb_constants.h
@@ -44,8 +44,9 @@
 
 /**@{*/
 /** Return code. */
-#define TILEDB_ERR -1
 #define TILEDB_OK 0
+#define TILEDB_ERR -1
+#define TILEDB_OOM -2
 /**@}*/
 
 /**@{*/

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -34,6 +34,7 @@
 #include <cassert>
 #include <cstring>
 #include <iostream>
+#include <stack>
 #include "aio_request.h"
 #include "array_schema.h"
 #include "array_schema_c.h"
@@ -57,7 +58,7 @@
 /*        GLOBAL VARIABLES        */
 /* ****************************** */
 
-char tiledb_errmsg[TILEDB_ERRMSG_MAX_LEN];
+// char tiledb_errmsg[TILEDB_ERRMSG_MAX_LEN];
 
 /* ****************************** */
 /*            TILEDB              */
@@ -73,36 +74,34 @@ void tiledb_version(int* major, int* minor, int* rev) {
 /*            CONTEXT             */
 /* ****************************** */
 
-typedef struct TileDB_CTX {
+struct TileDB_CTX {
   // storage manager instance
   tiledb::StorageManager* storage_manager_;
-} TileDB_CTX;
+  // last error assocated with this context
+  tiledb::Status* last_error_;
+};
 
-bool sanity_check(const TileDB_CTX* tiledb_ctx) {
-  if (tiledb_ctx == nullptr || tiledb_ctx->storage_manager_ == nullptr) {
-    std::string errmsg = "Invalid TileDB context";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+static bool save_error(TileDB_CTX* ctx, const tiledb::Status& st) {
+  if (st.ok()) {
     return false;
-  } else {
-    return true;
   }
+  ctx->last_error_ = new tiledb::Status(st);
+  return true;
 }
 
-int tiledb_ctx_init(
-    TileDB_CTX** tiledb_ctx, const TileDB_Config* tiledb_config) {
-  // Initialize error message to empty
-  strcpy(tiledb_errmsg, "");
+tiledb::Status sanity_check(TileDB_CTX* ctx) {
+  if (ctx == nullptr || ctx->storage_manager_ == nullptr) {
+    return tiledb::Status::Error("Invalid TileDB context");
+  }
+  return tiledb::Status::Ok();
+}
 
+int tiledb_ctx_init(TileDB_CTX** ctx, const TileDB_Config* tiledb_config) {
   // Initialize context
-  *tiledb_ctx = (TileDB_CTX*)malloc(sizeof(struct TileDB_CTX));
-  if (*tiledb_ctx == nullptr) {
-    std::string errmsg =
-        "Cannot initialize TileDB context; Failed to allocate memory "
-        "space for the context";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
-    return TILEDB_ERR;
+  tiledb::Status st;
+  *ctx = (TileDB_CTX*)malloc(sizeof(struct TileDB_CTX));
+  if (*ctx == nullptr) {
+    return TILEDB_OOM;
   }
 
   // Initialize a Config object
@@ -117,67 +116,92 @@ int tiledb_ctx_init(
         tiledb_config->write_method_);
 
   // Create storage manager
-  (*tiledb_ctx)->storage_manager_ = new tiledb::StorageManager();
-  tiledb::Status st = (*tiledb_ctx)->storage_manager_->init(config);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  (*ctx)->storage_manager_ = new tiledb::StorageManager();
+  (*ctx)->last_error_ = nullptr;
+  if (save_error(*ctx, (*ctx)->storage_manager_->init(config)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
-int tiledb_ctx_finalize(TileDB_CTX* tiledb_ctx) {
-  // Trivial case
-  if (tiledb_ctx == nullptr)
+int tiledb_ctx_finalize(TileDB_CTX* ctx) {
+  if (ctx == nullptr)
     return TILEDB_OK;
 
-  // Finalize storage manager
   tiledb::Status st;
-  if (tiledb_ctx->storage_manager_ != nullptr)
-    st = tiledb_ctx->storage_manager_->finalize();
-
-  // Clean up
-  delete tiledb_ctx->storage_manager_;
-  free(tiledb_ctx);
-
-  // Error
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
-    return TILEDB_ERR;
+  if (ctx->storage_manager_ != nullptr) {
+    st = ctx->storage_manager_->finalize();
+    delete ctx->storage_manager_;
   }
 
-  // Success
-  return TILEDB_OK;
+  if (ctx->last_error_ != nullptr)
+    delete ctx->last_error_;
+
+  free(ctx);
+
+  return st.ok() ? TILEDB_OK : TILEDB_ERR;
 }
 
+typedef struct tiledb_error_t {
+  // pointer to a copy of the last TileDB error assciated with a given ctx
+  const tiledb::Status* status_;
+} tiledb_error_t;
+
+tiledb_error_t* tiledb_error_last(TileDB_CTX* ctx) {
+  if (ctx == nullptr || ctx->last_error_ == nullptr)
+    return nullptr;
+  tiledb_error_t* err = (tiledb_error_t*)malloc(sizeof(tiledb_error_t));
+  err->status_ = new tiledb::Status(*ctx->last_error_);
+  return err;
+}
+
+const char* tiledb_error_message(tiledb_error_t* err) {
+  if (err == nullptr || err->status_->ok()) {
+    return "";
+  }
+  return err->status_->to_string().c_str();
+}
+
+int tiledb_error_free(tiledb_error_t* err) {
+  if (err != nullptr) {
+    if (err->status_ != nullptr) {
+      delete err->status_;
+    }
+    free(err);
+  }
+  return TILEDB_OK;
+}
 /* ****************************** */
 /*            WORKSPACE           */
 /* ****************************** */
 
-int tiledb_workspace_create(
-    const TileDB_CTX* tiledb_ctx, const char* workspace) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+tiledb::Status check_name_length(
+    const char* obj_name, const char* path, size_t* length) {
+  if (path == nullptr)
+    return tiledb::Status::Error(
+        std::string("Invalid ") + obj_name + " argument is NULL");
+  size_t len = strlen(path);
+  if (len > TILEDB_NAME_MAX_LEN) {
+    return tiledb::Status::Error(
+        std::string("Invalid ") + obj_name + " name length");
+  }
+  if (length != nullptr)
+    *length = len;
+  return tiledb::Status::Ok();
+}
+
+int tiledb_workspace_create(TileDB_CTX* ctx, const char* workspace) {
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
   // Check workspace name length
-  if (workspace == nullptr || strlen(workspace) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid workspace name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, check_name_length("workspace", workspace, nullptr)))
     return TILEDB_ERR;
-  }
 
   // Create the workspace
-  tiledb::Status st = tiledb_ctx->storage_manager_->workspace_create(workspace);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, ctx->storage_manager_->workspace_create(workspace)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
@@ -185,25 +209,17 @@ int tiledb_workspace_create(
 /*              GROUP             */
 /* ****************************** */
 
-int tiledb_group_create(const TileDB_CTX* tiledb_ctx, const char* group) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+int tiledb_group_create(TileDB_CTX* ctx, const char* group) {
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
   // Check group name length
-  if (group == nullptr || strlen(group) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid group name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, check_name_length("group", group, nullptr)))
     return TILEDB_ERR;
-  }
 
   // Create the group
-  tiledb::Status st = tiledb_ctx->storage_manager_->group_create(group);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, ctx->storage_manager_->group_create(group)))
     return TILEDB_ERR;
-  }
 
   // Success
   return TILEDB_OK;
@@ -215,22 +231,25 @@ int tiledb_group_create(const TileDB_CTX* tiledb_ctx, const char* group) {
 
 typedef struct TileDB_Array {
   tiledb::Array* array_;
-  const TileDB_CTX* tiledb_ctx_;
+  TileDB_CTX* ctx_;
 } TileDB_Array;
 
-bool sanity_check(const TileDB_Array* tiledb_array) {
+tiledb::Status sanity_check(const TileDB_Array* tiledb_array) {
   if (tiledb_array == nullptr || tiledb_array->array_ == nullptr ||
-      tiledb_array->tiledb_ctx_ == nullptr) {
-    std::string errmsg = "Invalid TileDB array";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
-    return false;
-  } else {
-    return true;
+      tiledb_array->ctx_ == nullptr) {
+    return tiledb::Status::Error("Invalid TileDB array");
   }
+  return tiledb::Status::Ok();
+}
+
+tiledb::Status sanity_check(TileDB_ArraySchema* sch) {
+  if (sch == nullptr)
+    return tiledb::Status::Error("Invalid TileDB array schema");
+  return tiledb::Status::Ok();
 }
 
 int tiledb_array_set_schema(
+    TileDB_CTX* ctx,
     TileDB_ArraySchema* tiledb_array_schema,
     const char* array_name,
     const char** attributes,
@@ -248,53 +267,51 @@ int tiledb_array_set_schema(
     size_t tile_extents_len,
     int tile_order,
     const int* types) {
-  // Sanity check
-  if (tiledb_array_schema == nullptr) {
-    std::string errmsg = "Invalid array schema pointer";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
-  }
 
-  // Set array name
-  size_t array_name_len = strlen(array_name);
-  if (array_name == nullptr || array_name_len > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid array name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, sanity_check(tiledb_array_schema)))
     return TILEDB_ERR;
-  }
+
+  size_t array_name_len = 0;
+  if (save_error(ctx, check_name_length("array", array_name, &array_name_len)))
+    return TILEDB_ERR;
+
   tiledb_array_schema->array_name_ = (char*)malloc(array_name_len + 1);
+  if (tiledb_array_schema->array_name_ == nullptr)
+    return TILEDB_OOM;
   strcpy(tiledb_array_schema->array_name_, array_name);
 
   // Set attributes and number of attributes
   tiledb_array_schema->attribute_num_ = attribute_num;
   tiledb_array_schema->attributes_ =
       (char**)malloc(attribute_num * sizeof(char*));
+  if (tiledb_array_schema->attributes_ == nullptr)
+    return TILEDB_OOM;
   for (int i = 0; i < attribute_num; ++i) {
-    size_t attribute_len = strlen(attributes[i]);
-    if (attributes[i] == nullptr || attribute_len > TILEDB_NAME_MAX_LEN) {
-      std::string errmsg = "Invalid attribute name length";
-      PRINT_ERROR(errmsg);
-      strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+    size_t attribute_len = 0;
+    if (save_error(
+            ctx, check_name_length("attribute", attributes[i], &attribute_len)))
       return TILEDB_ERR;
-    }
     tiledb_array_schema->attributes_[i] = (char*)malloc(attribute_len + 1);
+    if (tiledb_array_schema->attributes_[i] == nullptr)
+      return TILEDB_OOM;
     strcpy(tiledb_array_schema->attributes_[i], attributes[i]);
   }
 
   // Set dimensions
   tiledb_array_schema->dim_num_ = dim_num;
   tiledb_array_schema->dimensions_ = (char**)malloc(dim_num * sizeof(char*));
+  if (tiledb_array_schema->dimensions_ == nullptr)
+    return TILEDB_OOM;
   for (int i = 0; i < dim_num; ++i) {
-    size_t dimension_len = strlen(dimensions[i]);
-    if (dimensions[i] == nullptr || dimension_len > TILEDB_NAME_MAX_LEN) {
-      std::string errmsg = "Invalid attribute name length";
-      PRINT_ERROR(errmsg);
-      strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+    size_t dimension_len = 0;
+    if (save_error(
+            ctx, check_name_length("dimension", dimensions[i], &dimension_len)))
       return TILEDB_ERR;
-    }
     tiledb_array_schema->dimensions_[i] = (char*)malloc(dimension_len + 1);
+    if (tiledb_array_schema->dimensions_[i] == nullptr)
+      return TILEDB_OOM;
     strcpy(tiledb_array_schema->dimensions_[i], dimensions[i]);
   }
 
@@ -310,11 +327,15 @@ int tiledb_array_set_schema(
     tiledb_array_schema->tile_extents_ = nullptr;
   } else {
     tiledb_array_schema->tile_extents_ = malloc(tile_extents_len);
+    if (tiledb_array_schema->tile_extents_ == nullptr)
+      return TILEDB_OOM;
     memcpy(tiledb_array_schema->tile_extents_, tile_extents, tile_extents_len);
   }
 
   // Set types
   tiledb_array_schema->types_ = (int*)malloc((attribute_num + 1) * sizeof(int));
+  if (tiledb_array_schema->types_ == nullptr)
+    return TILEDB_OOM;
   for (int i = 0; i < attribute_num + 1; ++i)
     tiledb_array_schema->types_[i] = types[i];
 
@@ -324,6 +345,8 @@ int tiledb_array_set_schema(
   } else {
     tiledb_array_schema->cell_val_num_ =
         (int*)malloc((attribute_num) * sizeof(int));
+    if (tiledb_array_schema->cell_val_num_ == nullptr)
+      return TILEDB_OOM;
     for (int i = 0; i < attribute_num; ++i) {
       tiledb_array_schema->cell_val_num_[i] = cell_val_num[i];
     }
@@ -342,18 +365,18 @@ int tiledb_array_set_schema(
   } else {
     tiledb_array_schema->compression_ =
         (int*)malloc((attribute_num + 1) * sizeof(int));
+    if (tiledb_array_schema->compression_ == nullptr)
+      return TILEDB_OOM;
     for (int i = 0; i < attribute_num + 1; ++i)
       tiledb_array_schema->compression_[i] = compression[i];
   }
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_array_create(
-    const TileDB_CTX* tiledb_ctx, const TileDB_ArraySchema* array_schema) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+    TileDB_CTX* ctx, const TileDB_ArraySchema* array_schema) {
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
   // Copy array schema to a C struct
@@ -374,76 +397,61 @@ int tiledb_array_create(
   array_schema_c.types_ = array_schema->types_;
 
   // Create the array
-  tiledb::Status st =
-      tiledb_ctx->storage_manager_->array_create(&array_schema_c);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, ctx->storage_manager_->array_create(&array_schema_c)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_array_init(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* ctx,
     TileDB_Array** tiledb_array,
     const char* array,
     int mode,
     const void* subarray,
     const char** attributes,
     int attribute_num) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
-  // Check array name length
-  if (array == nullptr || strlen(array) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid array name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, check_name_length("array", array, nullptr)))
     return TILEDB_ERR;
-  }
 
   // Allocate memory for the array struct
   *tiledb_array = (TileDB_Array*)malloc(sizeof(struct TileDB_Array));
+  if (tiledb_array == nullptr)
+    return TILEDB_OOM;
 
   // Set TileDB context
-  (*tiledb_array)->tiledb_ctx_ = tiledb_ctx;
+  (*tiledb_array)->ctx_ = ctx;
 
   // Init the array
-  tiledb::Status st = tiledb_ctx->storage_manager_->array_init(
-      (*tiledb_array)->array_,
-      array,
-      mode,
-      subarray,
-      attributes,
-      attribute_num);
-
-  // Return
-  if (!st.ok()) {
+  if (save_error(
+          ctx,
+          ctx->storage_manager_->array_init(
+              (*tiledb_array)->array_,
+              array,
+              mode,
+              subarray,
+              attributes,
+              attribute_num))) {
     free(*tiledb_array);
-    strcpy(tiledb_errmsg, st.to_string().c_str());
     return TILEDB_ERR;
-  } else {
-    return TILEDB_OK;
-  }
+  };
+
+  return TILEDB_OK;
 }
 
 int tiledb_array_reset_subarray(
     const TileDB_Array* tiledb_array, const void* subarray) {
-  // Sanity check
-  if (!sanity_check(tiledb_array))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
 
-  // Reset subarray
-  tiledb::Status st = tiledb_array->array_->reset_subarray(subarray);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
-    return TILEDB_ERR;
-  }
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
-  // Success
+  if (save_error(ctx, tiledb_array->array_->reset_subarray(subarray)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
@@ -451,27 +459,26 @@ int tiledb_array_reset_attributes(
     const TileDB_Array* tiledb_array,
     const char** attributes,
     int attribute_num) {
-  // Sanity check
-  if (!sanity_check(tiledb_array))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
   // Re-Init the array
-  tiledb::Status st =
-      tiledb_array->array_->reset_attributes(attributes, attribute_num);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(
+          ctx,
+          tiledb_array->array_->reset_attributes(attributes, attribute_num)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_array_get_schema(
     const TileDB_Array* tiledb_array, TileDB_ArraySchema* tiledb_array_schema) {
-  // Sanity check
-  if (!sanity_check(tiledb_array))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
   // Get the array schema
   ArraySchemaC array_schema_c;
@@ -493,34 +500,26 @@ int tiledb_array_get_schema(
   tiledb_array_schema->tile_order_ = array_schema_c.tile_order_;
   tiledb_array_schema->types_ = array_schema_c.types_;
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_array_load_schema(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* ctx,
     const char* array,
     TileDB_ArraySchema* tiledb_array_schema) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
   // Check array name length
-  if (array == nullptr || strlen(array) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid array name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, check_name_length("array", array, nullptr)))
     return TILEDB_ERR;
-  }
 
   // Get the array schema
   tiledb::ArraySchema* array_schema;
-  tiledb::Status st =
-      tiledb_ctx->storage_manager_->array_load_schema(array, array_schema);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(
+          ctx, ctx->storage_manager_->array_load_schema(array, array_schema)))
     return TILEDB_ERR;
-  }
+
   ArraySchemaC array_schema_c;
   array_schema->array_schema_export(&array_schema_c);
 
@@ -540,10 +539,8 @@ int tiledb_array_load_schema(
   tiledb_array_schema->tile_order_ = array_schema_c.tile_order_;
   tiledb_array_schema->types_ = array_schema_c.types_;
 
-  // Clean up
   delete array_schema;
 
-  // Success
   return TILEDB_OK;
 }
 
@@ -592,7 +589,6 @@ int tiledb_array_free_schema(TileDB_ArraySchema* tiledb_array_schema) {
   if (tiledb_array_schema->cell_val_num_ != nullptr)
     free(tiledb_array_schema->cell_val_num_);
 
-  // Success
   return TILEDB_OK;
 }
 
@@ -600,146 +596,135 @@ int tiledb_array_write(
     const TileDB_Array* tiledb_array,
     const void** buffers,
     const size_t* buffer_sizes) {
-  // Sanity check
-  if (!sanity_check(tiledb_array))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
 
-  // Write
-  tiledb::Status st = tiledb_array->array_->write(buffers, buffer_sizes);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
-    return TILEDB_ERR;
-  }
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
-  // Success
+  if (save_error(ctx, sanity_check(tiledb_array)))
+    return TILEDB_ERR;
+
+  if (save_error(ctx, tiledb_array->array_->write(buffers, buffer_sizes)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
 int tiledb_array_read(
     const TileDB_Array* tiledb_array, void** buffers, size_t* buffer_sizes) {
-  // Sanity check
-  if (!sanity_check(tiledb_array))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
 
-  // Read
-  tiledb::Status st = tiledb_array->array_->read(buffers, buffer_sizes);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
-    return TILEDB_ERR;
-  }
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
-  // Success
+  if (save_error(ctx, sanity_check(tiledb_array)))
+    return TILEDB_ERR;
+
+  if (save_error(ctx, tiledb_array->array_->read(buffers, buffer_sizes)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
 int tiledb_array_overflow(const TileDB_Array* tiledb_array, int attribute_id) {
-  // Sanity check
-  if (!sanity_check(tiledb_array))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
 
-  // Check overflow
+  TileDB_CTX* ctx = tiledb_array->ctx_;
+
+  if (save_error(ctx, sanity_check(tiledb_array)))
+    return TILEDB_ERR;
+
   return (int)tiledb_array->array_->overflow(attribute_id);
 }
 
-int tiledb_array_consolidate(const TileDB_CTX* tiledb_ctx, const char* array) {
-  // Check array name length
-  if (array == nullptr || strlen(array) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid array name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+int tiledb_array_consolidate(TileDB_CTX* ctx, const char* array) {
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
-  }
 
-  // Consolidate
-  tiledb::Status st = tiledb_ctx->storage_manager_->array_consolidate(array);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, check_name_length("array", array, nullptr)))
     return TILEDB_ERR;
-  }
+
+  if (save_error(ctx, ctx->storage_manager_->array_consolidate(array)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
 int tiledb_array_finalize(TileDB_Array* tiledb_array) {
-  // Sanity check
-  if (!sanity_check(tiledb_array) || !sanity_check(tiledb_array->tiledb_ctx_))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
 
-  // Finalize array
-  tiledb::Status st =
-      tiledb_array->tiledb_ctx_->storage_manager_->array_finalize(
-          tiledb_array->array_);
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
-  free(tiledb_array);
+  if (save_error(ctx, sanity_check(tiledb_array)))
+    return TILEDB_ERR;
 
-  // Error
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(
+          ctx,
+          tiledb_array->ctx_->storage_manager_->array_finalize(
+              tiledb_array->array_))) {
+    free(tiledb_array);
     return TILEDB_ERR;
   }
 
-  // Success
+  free(tiledb_array);
+
   return TILEDB_OK;
 }
 
 int tiledb_array_sync(TileDB_Array* tiledb_array) {
-  // Sanity check
-  if (!sanity_check(tiledb_array) || !sanity_check(tiledb_array->tiledb_ctx_))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
 
-  // Sync
-  tiledb::Status st = tiledb_array->tiledb_ctx_->storage_manager_->array_sync(
-      tiledb_array->array_);
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
-  // Error
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, sanity_check(tiledb_array)))
     return TILEDB_ERR;
-  }
 
-  // Success
+  if (save_error(
+          ctx,
+          tiledb_array->ctx_->storage_manager_->array_sync(
+              tiledb_array->array_)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
 int tiledb_array_sync_attribute(
     TileDB_Array* tiledb_array, const char* attribute) {
-  // Sanity check
-  if (!sanity_check(tiledb_array) || !sanity_check(tiledb_array->tiledb_ctx_))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
 
-  // Sync attribute
-  tiledb::Status st =
-      tiledb_array->tiledb_ctx_->storage_manager_->array_sync_attribute(
-          tiledb_array->array_, attribute);
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
-  // Error
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, sanity_check(tiledb_array)))
     return TILEDB_ERR;
-  }
 
-  // Success
+  if (save_error(
+          ctx,
+          tiledb_array->ctx_->storage_manager_->array_sync_attribute(
+              tiledb_array->array_, attribute)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
 typedef struct TileDB_ArrayIterator {
   tiledb::ArrayIterator* array_it_;
-  const TileDB_CTX* tiledb_ctx_;
+  TileDB_CTX* ctx_;
 } TileDB_ArrayIterator;
 
-bool sanity_check(const TileDB_ArrayIterator* tiledb_array_it) {
+tiledb::Status sanity_check(const TileDB_ArrayIterator* tiledb_array_it) {
   if (tiledb_array_it == nullptr || tiledb_array_it->array_it_ == nullptr ||
-      tiledb_array_it->tiledb_ctx_ == nullptr) {
-    std::string errmsg = "Invalid TileDB array iterator";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
-    return false;
-  } else {
-    return true;
+      tiledb_array_it->ctx_ == nullptr) {
+    return tiledb::Status::Error("Invalid TileDB array iterator");
   }
+  return tiledb::Status::Ok();
 }
 
 int tiledb_array_iterator_init(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* ctx,
     TileDB_ArrayIterator** tiledb_array_it,
     const char* array,
     int mode,
@@ -748,36 +733,31 @@ int tiledb_array_iterator_init(
     int attribute_num,
     void** buffers,
     size_t* buffer_sizes) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
-  // Allocate memory for the array iterator struct
   *tiledb_array_it =
       (TileDB_ArrayIterator*)malloc(sizeof(struct TileDB_ArrayIterator));
+  if (*tiledb_array_it == nullptr)
+    return TILEDB_OOM;
 
-  // Set TileDB context
-  (*tiledb_array_it)->tiledb_ctx_ = tiledb_ctx;
+  (*tiledb_array_it)->ctx_ = ctx;
 
-  // Initialize the array iterator
-  tiledb::Status st = tiledb_ctx->storage_manager_->array_iterator_init(
-      (*tiledb_array_it)->array_it_,
-      array,
-      mode,
-      subarray,
-      attributes,
-      attribute_num,
-      buffers,
-      buffer_sizes);
-
-  // Error
-  if (!st.ok()) {
+  if (save_error(
+          ctx,
+          ctx->storage_manager_->array_iterator_init(
+              (*tiledb_array_it)->array_it_,
+              array,
+              mode,
+              subarray,
+              attributes,
+              attribute_num,
+              buffers,
+              buffer_sizes))) {
     free(*tiledb_array_it);
-    strcpy(tiledb_errmsg, st.to_string().c_str());
     return TILEDB_ERR;
   }
 
-  // Success
   return TILEDB_OK;
 }
 
@@ -786,64 +766,70 @@ int tiledb_array_iterator_get_value(
     int attribute_id,
     const void** value,
     size_t* value_size) {
-  // Sanity check
-  if (!sanity_check(tiledb_array_it))
+  if (!sanity_check(tiledb_array_it).ok())
+    return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_array_it->ctx_;
+
+  if (save_error(ctx, sanity_check(tiledb_array_it)))
     return TILEDB_ERR;
 
   // Get value
-  tiledb::Status st =
-      tiledb_array_it->array_it_->get_value(attribute_id, value, value_size);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(
+          ctx,
+          tiledb_array_it->array_it_->get_value(
+              attribute_id, value, value_size)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_array_iterator_next(TileDB_ArrayIterator* tiledb_array_it) {
-  // Sanity check
-  if (!sanity_check(tiledb_array_it))
+  if (!sanity_check(tiledb_array_it).ok())
     return TILEDB_ERR;
 
-  // Advance iterator
-  tiledb::Status st = tiledb_array_it->array_it_->next();
-  strcpy(tiledb_errmsg, st.to_string().c_str());
-  return TILEDB_ERR;
+  TileDB_CTX* ctx = tiledb_array_it->ctx_;
 
-  // Success
+  if (save_error(ctx, sanity_check(tiledb_array_it)))
+    return TILEDB_ERR;
+
+  if (save_error(ctx, tiledb_array_it->array_it_->next()))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
 int tiledb_array_iterator_end(TileDB_ArrayIterator* tiledb_array_it) {
-  // Sanity check
-  if (!sanity_check(tiledb_array_it))
+  if (!sanity_check(tiledb_array_it).ok())
     return TILEDB_ERR;
 
-  // Check if the iterator reached the end
+  TileDB_CTX* ctx = tiledb_array_it->ctx_;
+
+  if (save_error(ctx, sanity_check(tiledb_array_it)))
+    return TILEDB_ERR;
+
   return (int)tiledb_array_it->array_it_->end();
 }
 
 int tiledb_array_iterator_finalize(TileDB_ArrayIterator* tiledb_array_it) {
-  // Sanity check
-  if (!sanity_check(tiledb_array_it))
+  if (!sanity_check(tiledb_array_it).ok())
     return TILEDB_ERR;
 
-  // Finalize array
-  tiledb::Status st =
-      tiledb_array_it->tiledb_ctx_->storage_manager_->array_iterator_finalize(
-          tiledb_array_it->array_it_);
+  TileDB_CTX* ctx = tiledb_array_it->ctx_;
+
+  if (save_error(ctx, sanity_check(tiledb_array_it)))
+    return TILEDB_ERR;
+
+  if (save_error(
+          ctx,
+          tiledb_array_it->ctx_->storage_manager_->array_iterator_finalize(
+              tiledb_array_it->array_it_))) {
+    free(tiledb_array_it);
+    return TILEDB_ERR;
+  }
 
   free(tiledb_array_it);
 
-  // Error
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
-    return TILEDB_OK;
-  }
-
-  // Success
   return TILEDB_OK;
 }
 
@@ -853,22 +839,24 @@ int tiledb_array_iterator_finalize(TileDB_ArrayIterator* tiledb_array_it) {
 
 typedef struct TileDB_Metadata {
   tiledb::Metadata* metadata_;
-  const TileDB_CTX* tiledb_ctx_;
+  TileDB_CTX* ctx_;
 } TileDB_Metadata;
 
-bool sanity_check(const TileDB_Metadata* tiledb_metadata) {
+tiledb::Status sanity_check(const TileDB_Metadata* tiledb_metadata) {
   if (tiledb_metadata == nullptr || tiledb_metadata->metadata_ == nullptr ||
-      tiledb_metadata->tiledb_ctx_ == nullptr) {
-    std::string errmsg = "Invalid TileDB metadata";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
-    return false;
-  } else {
-    return true;
-  }
+      tiledb_metadata->ctx_ == nullptr)
+    return tiledb::Status::Error("Invalid TileDB metadata");
+  return tiledb::Status::Ok();
+}
+
+tiledb::Status sanity_check(const TileDB_MetadataSchema* sch) {
+  if (sch == nullptr)
+    return tiledb::Status::Error("Invalid metadata schema");
+  return tiledb::Status::Ok();
 }
 
 int tiledb_metadata_set_schema(
+    TileDB_CTX* ctx,
     TileDB_MetadataSchema* tiledb_metadata_schema,
     const char* metadata_name,
     const char** attributes,
@@ -877,44 +865,45 @@ int tiledb_metadata_set_schema(
     const int* cell_val_num,
     const int* compression,
     const int* types) {
-  // Sanity check
-  if (tiledb_metadata_schema == nullptr) {
-    std::string errmsg = "Invalid metadata schema pointer";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
-  }
 
-  // Set metadata name
-  size_t metadata_name_len = strlen(metadata_name);
-  if (metadata_name == nullptr || metadata_name_len > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid metadata name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, sanity_check(tiledb_metadata_schema)))
     return TILEDB_ERR;
-  }
+
+  size_t metadata_name_len = 0;
+  if (save_error(
+          ctx,
+          check_name_length("metadata", metadata_name, &metadata_name_len)))
+    return TILEDB_ERR;
+
   tiledb_metadata_schema->metadata_name_ = (char*)malloc(metadata_name_len + 1);
+  if (tiledb_metadata_schema->metadata_name_ == nullptr)
+    return TILEDB_OOM;
   strcpy(tiledb_metadata_schema->metadata_name_, metadata_name);
 
   /* Set attributes and number of attributes. */
   tiledb_metadata_schema->attribute_num_ = attribute_num;
   tiledb_metadata_schema->attributes_ =
       (char**)malloc(attribute_num * sizeof(char*));
+  if (tiledb_metadata_schema->attributes_ == nullptr)
+    return TILEDB_OOM;
   for (int i = 0; i < attribute_num; ++i) {
-    size_t attribute_len = strlen(attributes[i]);
-    if (attributes[i] == nullptr || attribute_len > TILEDB_NAME_MAX_LEN) {
-      std::string errmsg = "Invalid attribute name length";
-      PRINT_ERROR(errmsg);
-      strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+    size_t attribute_len = 0;
+    if (save_error(
+            ctx, check_name_length("attribute", attributes[i], &attribute_len)))
       return TILEDB_ERR;
-    }
     tiledb_metadata_schema->attributes_[i] = (char*)malloc(attribute_len + 1);
+    if (tiledb_metadata_schema->attributes_[i] == nullptr)
+      return TILEDB_OOM;
     strcpy(tiledb_metadata_schema->attributes_[i], attributes[i]);
   }
 
   // Set types
   tiledb_metadata_schema->types_ =
       (int*)malloc((attribute_num + 1) * sizeof(int));
+  if (tiledb_metadata_schema->types_ == nullptr)
+    return TILEDB_OOM;
   for (int i = 0; i < attribute_num + 1; ++i)
     tiledb_metadata_schema->types_[i] = types[i];
 
@@ -924,6 +913,8 @@ int tiledb_metadata_set_schema(
   } else {
     tiledb_metadata_schema->cell_val_num_ =
         (int*)malloc((attribute_num) * sizeof(int));
+    if (tiledb_metadata_schema->cell_val_num_ == nullptr)
+      return TILEDB_OOM;
     for (int i = 0; i < attribute_num; ++i) {
       tiledb_metadata_schema->cell_val_num_[i] = cell_val_num[i];
     }
@@ -938,19 +929,20 @@ int tiledb_metadata_set_schema(
   } else {
     tiledb_metadata_schema->compression_ =
         (int*)malloc((attribute_num + 1) * sizeof(int));
+    if (tiledb_metadata_schema->compression_ == nullptr)
+      return TILEDB_OOM;
     for (int i = 0; i < attribute_num + 1; ++i)
       tiledb_metadata_schema->compression_[i] = compression[i];
   }
-
-  // Return
   return TILEDB_OK;
 }
 
 int tiledb_metadata_create(
-    const TileDB_CTX* tiledb_ctx,
-    const TileDB_MetadataSchema* metadata_schema) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+    TileDB_CTX* ctx, const TileDB_MetadataSchema* metadata_schema) {
+  if (!sanity_check(ctx).ok())
+    return TILEDB_ERR;
+
+  if (save_error(ctx, sanity_check(metadata_schema)))
     return TILEDB_ERR;
 
   // Copy metadata schema to the proper struct
@@ -963,45 +955,44 @@ int tiledb_metadata_create(
   metadata_schema_c.compression_ = metadata_schema->compression_;
   metadata_schema_c.types_ = metadata_schema->types_;
 
-  // Create the metadata
-  tiledb::Status st =
-      tiledb_ctx->storage_manager_->metadata_create(&metadata_schema_c);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(
+          ctx, ctx->storage_manager_->metadata_create(&metadata_schema_c)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_metadata_init(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* ctx,
     TileDB_Metadata** tiledb_metadata,
     const char* metadata,
     int mode,
     const char** attributes,
     int attribute_num) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
   // Allocate memory for the array struct
   *tiledb_metadata = (TileDB_Metadata*)malloc(sizeof(struct TileDB_Metadata));
+  if (*tiledb_metadata == nullptr)
+    return TILEDB_OOM;
 
   // Set TileDB context
-  (*tiledb_metadata)->tiledb_ctx_ = tiledb_ctx;
+  (*tiledb_metadata)->ctx_ = ctx;
 
   // Init the metadata
-  tiledb::Status st = tiledb_ctx->storage_manager_->metadata_init(
-      (*tiledb_metadata)->metadata_, metadata, mode, attributes, attribute_num);
-  if (!st.ok()) {
+  if (save_error(
+          ctx,
+          ctx->storage_manager_->metadata_init(
+              (*tiledb_metadata)->metadata_,
+              metadata,
+              mode,
+              attributes,
+              attribute_num))) {
     free(*tiledb_metadata);
-    strcpy(tiledb_errmsg, st.to_string().c_str());
     return TILEDB_ERR;
   }
 
-  // Success
   return TILEDB_OK;
 }
 
@@ -1009,27 +1000,30 @@ int tiledb_metadata_reset_attributes(
     const TileDB_Metadata* tiledb_metadata,
     const char** attributes,
     int attribute_num) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata))
+  if (!sanity_check(tiledb_metadata).ok())
     return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_metadata->ctx_;
 
   // Reset attributes
-  tiledb::Status st =
-      tiledb_metadata->metadata_->reset_attributes(attributes, attribute_num);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(
+          ctx,
+          tiledb_metadata->metadata_->reset_attributes(
+              attributes, attribute_num)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_metadata_get_schema(
     const TileDB_Metadata* tiledb_metadata,
     TileDB_MetadataSchema* tiledb_metadata_schema) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata))
+  if (!sanity_check(tiledb_metadata).ok())
+    return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_metadata->ctx_;
+
+  if (save_error(ctx, sanity_check(tiledb_metadata)))
     return TILEDB_ERR;
 
   // Get the metadata schema
@@ -1046,34 +1040,27 @@ int tiledb_metadata_get_schema(
   tiledb_metadata_schema->compression_ = metadata_schema_c.compression_;
   tiledb_metadata_schema->types_ = metadata_schema_c.types_;
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_metadata_load_schema(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* ctx,
     const char* metadata,
     TileDB_MetadataSchema* tiledb_metadata_schema) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
-  // Check metadata name length
-  if (metadata == nullptr || strlen(metadata) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid metadata name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, check_name_length("metadata", metadata, nullptr)))
     return TILEDB_ERR;
-  }
 
   // Get the array schema
   tiledb::ArraySchema* array_schema;
-  tiledb::Status st = tiledb_ctx->storage_manager_->metadata_load_schema(
-      metadata, array_schema);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+
+  if (save_error(
+          ctx,
+          ctx->storage_manager_->metadata_load_schema(metadata, array_schema)))
     return TILEDB_ERR;
-  }
+
   MetadataSchemaC metadata_schema_c;
   array_schema->array_schema_export(&metadata_schema_c);
 
@@ -1086,15 +1073,12 @@ int tiledb_metadata_load_schema(
   tiledb_metadata_schema->compression_ = metadata_schema_c.compression_;
   tiledb_metadata_schema->types_ = metadata_schema_c.types_;
 
-  // Clean up
   delete array_schema;
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_metadata_free_schema(TileDB_MetadataSchema* tiledb_metadata_schema) {
-  // Trivial case
   if (tiledb_metadata_schema == nullptr)
     return TILEDB_OK;
 
@@ -1122,7 +1106,6 @@ int tiledb_metadata_free_schema(TileDB_MetadataSchema* tiledb_metadata_schema) {
   if (tiledb_metadata_schema->cell_val_num_ != nullptr)
     free(tiledb_metadata_schema->cell_val_num_);
 
-  // Success
   return TILEDB_OK;
 }
 
@@ -1132,19 +1115,17 @@ int tiledb_metadata_write(
     size_t keys_size,
     const void** buffers,
     const size_t* buffer_sizes) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata))
+  if (!sanity_check(tiledb_metadata).ok())
     return TILEDB_ERR;
 
-  // Write
-  tiledb::Status st =
-      tiledb_metadata->metadata_->write(keys, keys_size, buffers, buffer_sizes);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
-    return TILEDB_ERR;
-  }
+  TileDB_CTX* ctx = tiledb_metadata->ctx_;
 
-  // Success
+  if (save_error(
+          ctx,
+          tiledb_metadata->metadata_->write(
+              keys, keys_size, buffers, buffer_sizes)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
@@ -1153,128 +1134,104 @@ int tiledb_metadata_read(
     const char* key,
     void** buffers,
     size_t* buffer_sizes) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata))
+  if (!sanity_check(tiledb_metadata).ok())
     return TILEDB_ERR;
 
-  // Read
-  tiledb::Status st =
-      tiledb_metadata->metadata_->read(key, buffers, buffer_sizes);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
-    return TILEDB_ERR;
-  }
+  TileDB_CTX* ctx = tiledb_metadata->ctx_;
 
-  // Success
+  if (save_error(
+          ctx, tiledb_metadata->metadata_->read(key, buffers, buffer_sizes)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
 int tiledb_metadata_overflow(
     const TileDB_Metadata* tiledb_metadata, int attribute_id) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata))
+  if (!sanity_check(tiledb_metadata).ok())
     return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_metadata->ctx_;
 
   return (int)tiledb_metadata->metadata_->overflow(attribute_id);
 }
 
-int tiledb_metadata_consolidate(
-    const TileDB_CTX* tiledb_ctx, const char* metadata) {
-  // Check metadata name length
-  if (metadata == nullptr || strlen(metadata) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid metadata name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+int tiledb_metadata_consolidate(TileDB_CTX* ctx, const char* metadata) {
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
-  }
 
-  // Consolidate
-  tiledb::Status st =
-      tiledb_ctx->storage_manager_->metadata_consolidate(metadata);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, check_name_length("metadata", metadata, nullptr)))
     return TILEDB_ERR;
-  }
 
-  // Success
+  if (save_error(ctx, ctx->storage_manager_->metadata_consolidate(metadata)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
 int tiledb_metadata_finalize(TileDB_Metadata* tiledb_metadata) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata))
+  if (!sanity_check(tiledb_metadata).ok())
     return TILEDB_ERR;
 
-  // Finalize metadata
-  tiledb::Status st =
-      tiledb_metadata->tiledb_ctx_->storage_manager_->metadata_finalize(
-          tiledb_metadata->metadata_);
+  TileDB_CTX* ctx = tiledb_metadata->ctx_;
 
-  // Clean up
-  free(tiledb_metadata);
-
-  // Error
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(
+          ctx,
+          tiledb_metadata->ctx_->storage_manager_->metadata_finalize(
+              tiledb_metadata->metadata_))) {
+    free(tiledb_metadata);
     return TILEDB_ERR;
   }
-
-  // Success
   return TILEDB_OK;
 }
 
 typedef struct TileDB_MetadataIterator {
   tiledb::MetadataIterator* metadata_it_;
-  const TileDB_CTX* tiledb_ctx_;
+  TileDB_CTX* ctx_;
 } TileDB_MetadataIterator;
 
-bool sanity_check(const TileDB_MetadataIterator* tiledb_metadata_it) {
+tiledb::Status sanity_check(const TileDB_MetadataIterator* tiledb_metadata_it) {
   if (tiledb_metadata_it == nullptr ||
       tiledb_metadata_it->metadata_it_ == nullptr ||
-      tiledb_metadata_it->tiledb_ctx_ == nullptr) {
-    std::string errmsg = "Invalid TileDB metadata iterator";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
-    return false;
-  } else {
-    return true;
+      tiledb_metadata_it->ctx_ == nullptr) {
+    return tiledb::Status::Error("Invalid TileDB metadata iterator");
   }
+  return tiledb::Status::Ok();
 }
 
 int tiledb_metadata_iterator_init(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* ctx,
     TileDB_MetadataIterator** tiledb_metadata_it,
     const char* metadata,
     const char** attributes,
     int attribute_num,
     void** buffers,
     size_t* buffer_sizes) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
   // Allocate memory for the metadata struct
   *tiledb_metadata_it =
       (TileDB_MetadataIterator*)malloc(sizeof(struct TileDB_MetadataIterator));
+  if (*tiledb_metadata_it == nullptr)
+    return TILEDB_ERR;
 
   // Set TileDB context
-  (*tiledb_metadata_it)->tiledb_ctx_ = tiledb_ctx;
+  (*tiledb_metadata_it)->ctx_ = ctx;
 
   // Initialize the metadata iterator
-  tiledb::Status st = tiledb_ctx->storage_manager_->metadata_iterator_init(
-      (*tiledb_metadata_it)->metadata_it_,
-      metadata,
-      attributes,
-      attribute_num,
-      buffers,
-      buffer_sizes);
-  if (!st.ok()) {
+  if (save_error(
+          ctx,
+          ctx->storage_manager_->metadata_iterator_init(
+              (*tiledb_metadata_it)->metadata_it_,
+              metadata,
+              attributes,
+              attribute_num,
+              buffers,
+              buffer_sizes))) {
     free(*tiledb_metadata_it);
-    strcpy(tiledb_errmsg, st.to_string().c_str());
     return TILEDB_ERR;
   }
-
-  // Success
   return TILEDB_OK;
 }
 
@@ -1283,42 +1240,41 @@ int tiledb_metadata_iterator_get_value(
     int attribute_id,
     const void** value,
     size_t* value_size) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata_it))
+  if (!sanity_check(tiledb_metadata_it).ok())
     return TILEDB_ERR;
 
-  // Get value
-  tiledb::Status st = tiledb_metadata_it->metadata_it_->get_value(
-      attribute_id, value, value_size);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
-    return TILEDB_ERR;
-  }
+  TileDB_CTX* ctx = tiledb_metadata_it->ctx_;
 
-  // Success
+  if (save_error(ctx, sanity_check(tiledb_metadata_it)))
+    return TILEDB_ERR;
+
+  if (save_error(
+          ctx,
+          tiledb_metadata_it->metadata_it_->get_value(
+              attribute_id, value, value_size)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 
 int tiledb_metadata_iterator_next(TileDB_MetadataIterator* tiledb_metadata_it) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata_it))
+  if (!sanity_check(tiledb_metadata_it).ok())
     return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_metadata_it->ctx_;
 
   // Advance metadata iterator
-  tiledb::Status st = tiledb_metadata_it->metadata_it_->next();
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, tiledb_metadata_it->metadata_it_->next()))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_metadata_iterator_end(TileDB_MetadataIterator* tiledb_metadata_it) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata_it))
+  if (!sanity_check(tiledb_metadata_it).ok())
     return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_metadata_it->ctx_;
 
   // Check if the metadata iterator reached its end
   return (int)tiledb_metadata_it->metadata_it_->end();
@@ -1326,25 +1282,22 @@ int tiledb_metadata_iterator_end(TileDB_MetadataIterator* tiledb_metadata_it) {
 
 int tiledb_metadata_iterator_finalize(
     TileDB_MetadataIterator* tiledb_metadata_it) {
-  // Sanity check
-  if (!sanity_check(tiledb_metadata_it))
+  if (!sanity_check(tiledb_metadata_it).ok())
     return TILEDB_ERR;
 
+  TileDB_CTX* ctx = tiledb_metadata_it->ctx_;
+
   // Finalize metadata iterator
-  tiledb::Status st =
-      tiledb_metadata_it->tiledb_ctx_->storage_manager_
-          ->metadata_iterator_finalize(tiledb_metadata_it->metadata_it_);
-
-  // Clean up
-  free(tiledb_metadata_it);
-
-  // Error
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(
+          ctx,
+          tiledb_metadata_it->ctx_->storage_manager_
+              ->metadata_iterator_finalize(tiledb_metadata_it->metadata_it_))) {
+    free(tiledb_metadata_it);
     return TILEDB_ERR;
   }
 
-  // Success
+  free(tiledb_metadata_it);
+
   return TILEDB_OK;
 }
 
@@ -1352,144 +1305,86 @@ int tiledb_metadata_iterator_finalize(
 /*       DIRECTORY MANAGEMENT     */
 /* ****************************** */
 
-int tiledb_dir_type(const TileDB_CTX* tiledb_ctx, const char* dir) {
-  // Return the directory type
-  return tiledb_ctx->storage_manager_->dir_type(dir);
+int tiledb_dir_type(TileDB_CTX* ctx, const char* dir) {
+  if (ctx == nullptr)
+    return TILEDB_ERR;
+  return ctx->storage_manager_->dir_type(dir);
 }
 
-int tiledb_clear(const TileDB_CTX* tiledb_ctx, const char* dir) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+int tiledb_clear(TileDB_CTX* ctx, const char* dir) {
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
-  // Check directory name length
-  if (dir == nullptr || strlen(dir) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid directory name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, check_name_length("directory", dir, nullptr)))
     return TILEDB_ERR;
-  }
 
-  // Clear
-  tiledb::Status st = tiledb_ctx->storage_manager_->clear(dir);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, ctx->storage_manager_->clear(dir)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
-int tiledb_delete(const TileDB_CTX* tiledb_ctx, const char* dir) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+int tiledb_delete(TileDB_CTX* ctx, const char* dir) {
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
-  // Check directory name length
-  if (dir == nullptr || strlen(dir) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid directory name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, check_name_length("directory", dir, nullptr)))
     return TILEDB_ERR;
-  }
 
-  // Delete
-  tiledb::Status st = tiledb_ctx->storage_manager_->delete_entire(dir);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, ctx->storage_manager_->delete_entire(dir)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
-int tiledb_move(
-    const TileDB_CTX* tiledb_ctx, const char* old_dir, const char* new_dir) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+int tiledb_move(TileDB_CTX* ctx, const char* old_dir, const char* new_dir) {
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
-  // Check old directory name length
-  if (old_dir == nullptr || strlen(old_dir) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid old directory name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, check_name_length("old directory ", old_dir, nullptr)))
     return TILEDB_ERR;
-  }
 
-  // Check new directory name length
-  if (new_dir == nullptr || strlen(new_dir) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid new directory name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(ctx, check_name_length("new directory", new_dir, nullptr)))
     return TILEDB_ERR;
-  }
 
-  // Move
-  tiledb::Status st = tiledb_ctx->storage_manager_->move(old_dir, new_dir);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, ctx->storage_manager_->move(old_dir, new_dir)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_ls(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* ctx,
     const char* parent_dir,
     char** dirs,
     int* dir_types,
     int* dir_num) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
-  // Check parent directory name length
-  if (parent_dir == nullptr || strlen(parent_dir) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid parent directory name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(
+          ctx, check_name_length("parent directory", parent_dir, nullptr)))
     return TILEDB_ERR;
-  }
 
-  // List TileDB objects
-  tiledb::Status st =
-      tiledb_ctx->storage_manager_->ls(parent_dir, dirs, dir_types, *dir_num);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(
+          ctx,
+          ctx->storage_manager_->ls(parent_dir, dirs, dir_types, *dir_num)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
-int tiledb_ls_c(
-    const TileDB_CTX* tiledb_ctx, const char* parent_dir, int* dir_num) {
-  // Sanity check
-  if (!sanity_check(tiledb_ctx))
+int tiledb_ls_c(TileDB_CTX* ctx, const char* parent_dir, int* dir_num) {
+  if (!sanity_check(ctx).ok())
     return TILEDB_ERR;
 
-  // Check parent directory name length
-  if (parent_dir == nullptr || strlen(parent_dir) > TILEDB_NAME_MAX_LEN) {
-    std::string errmsg = "Invalid parent directory name length";
-    PRINT_ERROR(errmsg);
-    strcpy(tiledb_errmsg, (TILEDB_ERRMSG + errmsg).c_str());
+  if (save_error(
+          ctx, check_name_length("parent directory", parent_dir, nullptr)))
     return TILEDB_ERR;
-  }
 
-  // List TileDB objects
-  tiledb::Status st = tiledb_ctx->storage_manager_->ls_c(parent_dir, *dir_num);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, ctx->storage_manager_->ls_c(parent_dir, *dir_num)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }
 
@@ -1499,9 +1394,10 @@ int tiledb_ls_c(
 
 int tiledb_array_aio_read(
     const TileDB_Array* tiledb_array, TileDB_AIO_Request* tiledb_aio_request) {
-  // Sanity check
-  if (!sanity_check(tiledb_array))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
   // Copy the AIO request
   AIO_Request* aio_request = (AIO_Request*)malloc(sizeof(struct AIO_Request));
@@ -1515,20 +1411,18 @@ int tiledb_array_aio_read(
   aio_request->completion_data_ = tiledb_aio_request->completion_data_;
 
   // Submit the AIO read request
-  tiledb::Status st = tiledb_array->array_->aio_read(aio_request);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
-  }
+  if (save_error(ctx, tiledb_array->array_->aio_read(aio_request)))
+    return TILEDB_ERR;
 
-  // Success
   return TILEDB_OK;
 }
 
 int tiledb_array_aio_write(
     const TileDB_Array* tiledb_array, TileDB_AIO_Request* tiledb_aio_request) {
-  // Sanity check
-  if (!sanity_check(tiledb_array))
+  if (!sanity_check(tiledb_array).ok())
     return TILEDB_ERR;
+
+  TileDB_CTX* ctx = tiledb_array->ctx_;
 
   // Copy the AIO request
   AIO_Request* aio_request = (AIO_Request*)malloc(sizeof(struct AIO_Request));
@@ -1542,12 +1436,8 @@ int tiledb_array_aio_write(
   aio_request->completion_data_ = tiledb_aio_request->completion_data_;
 
   // Submit the AIO write request
-  tiledb::Status st = tiledb_array->array_->aio_write(aio_request);
-  if (!st.ok()) {
-    strcpy(tiledb_errmsg, st.to_string().c_str());
+  if (save_error(ctx, tiledb_array->array_->aio_write(aio_request)))
     return TILEDB_ERR;
-  }
 
-  // Success
   return TILEDB_OK;
 }

--- a/examples/src/tiledb_array_create_dense.cc
+++ b/examples/src/tiledb_array_create_dense.cc
@@ -74,7 +74,8 @@ int main() {
 
   // Set array schema
   TileDB_ArraySchema array_schema;
-  tiledb_array_set_schema( 
+  tiledb_array_set_schema(
+      tiledb_ctx,
       &array_schema,              // Array schema struct 
       array_name,                 // Array name 
       attributes,                 // Attributes 

--- a/examples/src/tiledb_array_create_sparse.cc
+++ b/examples/src/tiledb_array_create_sparse.cc
@@ -74,7 +74,8 @@ int main() {
 
   // Set array schema
   TileDB_ArraySchema array_schema;
-  tiledb_array_set_schema( 
+  tiledb_array_set_schema(
+      tiledb_ctx,
       &array_schema,              // Array schema struct 
       array_name,                 // Array name 
       attributes,                 // Attributes 

--- a/examples/src/tiledb_array_parallel_consolidate_dense.cc
+++ b/examples/src/tiledb_array_parallel_consolidate_dense.cc
@@ -46,7 +46,7 @@ void *parallel_read(void* args);
 
 // The arguments for each invocation of parallel_write
 typedef struct _thread_data_t {
-    const TileDB_CTX* tiledb_ctx;
+    TileDB_CTX* tiledb_ctx;
     const char* array_name;
     const void* subarray;
     void** buffers;

--- a/examples/src/tiledb_array_parallel_consolidate_sparse.cc
+++ b/examples/src/tiledb_array_parallel_consolidate_sparse.cc
@@ -46,7 +46,7 @@ void *parallel_read(void* args);
 
 // The arguments for each invocation of parallel_write
 typedef struct _thread_data_t {
-    const TileDB_CTX* tiledb_ctx;
+    TileDB_CTX* tiledb_ctx;
     const char* array_name;
     const void* subarray;
     void** buffers;

--- a/examples/src/tiledb_array_parallel_read_dense_1.cc
+++ b/examples/src/tiledb_array_parallel_read_dense_1.cc
@@ -42,7 +42,7 @@ void *parallel_read(void* args);
 
 // The arguments for each invocation of parallel_write
 typedef struct _thread_data_t {
-    const TileDB_CTX* tiledb_ctx;
+    TileDB_CTX* tiledb_ctx;
     const char* array_name;
     const void* subarray;
     void** buffers;
@@ -137,7 +137,7 @@ void *parallel_read(void* args) {
   // Initialize array
   TileDB_Array* tiledb_array;
   tiledb_array_init(
-      data->tiledb_ctx,                          // Context 
+      data->tiledb_ctx,                          // Context
       &tiledb_array,                             // Array object
       data->array_name,                          // Array name
       TILEDB_ARRAY_READ,                         // Mode

--- a/examples/src/tiledb_array_parallel_read_dense_2.cc
+++ b/examples/src/tiledb_array_parallel_read_dense_2.cc
@@ -38,7 +38,7 @@
 
 // The function to be computed in parallel
 void parallel_read(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* tiledb_ctx,
     const char* array_name,
     const void* subarray,
     void** buffers,
@@ -126,7 +126,7 @@ int main() {
 }
 
 void parallel_read(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* tiledb_ctx,
     const char* array_name,
     const void* subarray,
     void** buffers,

--- a/examples/src/tiledb_array_parallel_read_sparse_1.cc
+++ b/examples/src/tiledb_array_parallel_read_sparse_1.cc
@@ -42,7 +42,7 @@ void *parallel_read(void* args);
 
 // The arguments for each invocation of parallel_write
 typedef struct _thread_data_t {
-    const TileDB_CTX* tiledb_ctx;
+    TileDB_CTX* tiledb_ctx;
     const char* array_name;
     const void* subarray;
     void** buffers;

--- a/examples/src/tiledb_array_parallel_read_sparse_2.cc
+++ b/examples/src/tiledb_array_parallel_read_sparse_2.cc
@@ -39,7 +39,7 @@
 
 // The function to be computed in parallel
 void parallel_read(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* tiledb_ctx,
     const char* array_name,
     const void* subarray,
     void** buffers,
@@ -109,7 +109,7 @@ int main() {
 }
 
 void parallel_read(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* tiledb_ctx,
     const char* array_name,
     const void* subarray,
     void** buffers,

--- a/examples/src/tiledb_array_parallel_write_dense_1.cc
+++ b/examples/src/tiledb_array_parallel_write_dense_1.cc
@@ -41,7 +41,7 @@ void *parallel_write(void* args);
 
 // The arguments for each invocation of parallel_write
 typedef struct _thread_data_t {
-    const TileDB_CTX* tiledb_ctx;
+    TileDB_CTX* tiledb_ctx;
     const char* array_name;
     const void* subarray;
     const void** buffers;

--- a/examples/src/tiledb_array_parallel_write_dense_2.cc
+++ b/examples/src/tiledb_array_parallel_write_dense_2.cc
@@ -40,7 +40,7 @@
 
 // The function to be computed in parallel
 void parallel_write(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* tiledb_ctx,
     const char* array_name,
     const void* subarray,
     const void** buffers,
@@ -157,7 +157,7 @@ int main() {
 }
 
 void parallel_write(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* tiledb_ctx,
     const char* array_name,
     const void* subarray,
     const void** buffers,

--- a/examples/src/tiledb_array_parallel_write_sparse_1.cc
+++ b/examples/src/tiledb_array_parallel_write_sparse_1.cc
@@ -38,7 +38,7 @@ void *parallel_write(void* args);
 
 // The arguments for each invocation of parallel_write
 typedef struct _thread_data_t {
-    const TileDB_CTX* tiledb_ctx;
+    TileDB_CTX* tiledb_ctx;
     const char* array_name;
     const void** buffers;
     const size_t* buffer_sizes;

--- a/examples/src/tiledb_array_parallel_write_sparse_2.cc
+++ b/examples/src/tiledb_array_parallel_write_sparse_2.cc
@@ -38,7 +38,7 @@
 
 // The function to be computed in parallel
 void parallel_write(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* tiledb_ctx,
     const char* array_name,
     const void** buffers,
     const size_t* buffer_sizes);
@@ -129,7 +129,7 @@ int main() {
 }
 
 void parallel_write(
-    const TileDB_CTX* tiledb_ctx,
+    TileDB_CTX* tiledb_ctx,
     const char* array_name,
     const void** buffers,
     const size_t* buffer_sizes) {

--- a/examples/src/tiledb_metadata_create.cc
+++ b/examples/src/tiledb_metadata_create.cc
@@ -60,6 +60,7 @@ int main() {
   // Set metadata schema
   TileDB_MetadataSchema metadata_schema;
   tiledb_metadata_set_schema(
+      tiledb_ctx,
       &metadata_schema,            // Metadata schema struct
       metadata_name,               // Metadata name
       attributes,                  // Attributes

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,7 +55,7 @@ add_executable(
     "src/unit-capi-densearray.cc"
     "src/unit-compression-rle.cc"
     "src/unit-status.cc"
-)
+        src/unit-capi-error.cc)
 
 set_target_properties(
     ${TILEDB_UNITTEST_TARGET_NAME} PROPERTIES

--- a/test/src/unit-capi-arrayschema.cc
+++ b/test/src/unit-capi-arrayschema.cc
@@ -70,6 +70,14 @@ struct ArraySchemaFx {
     assert(rc == TILEDB_OK);
 
     // Create workspace
+    // Create workspace, delete it if it already exists
+    std::string cmd = "test -d " + WORKSPACE;
+    rc = system(cmd.c_str());
+    if (rc == 0) {
+      cmd = "rm -rf " + WORKSPACE;
+      rc = system(cmd.c_str());
+      assert(rc == 0);
+    }
     rc = tiledb_workspace_create(tiledb_ctx_, WORKSPACE.c_str());
     assert(rc == TILEDB_OK);
 
@@ -86,9 +94,8 @@ struct ArraySchemaFx {
     assert(rc == TILEDB_OK);
 
     // Remove the temporary workspace
-    std::string command = "rm -rf ";
-    command.append(WORKSPACE);
-    rc = system(command.c_str());
+    std::string cmd = "rm -rf ";
+    rc = system(cmd.c_str());
     assert(rc == 0);
 
     // Free array schema

--- a/test/src/unit-capi-arrayschema.cc
+++ b/test/src/unit-capi-arrayschema.cc
@@ -117,6 +117,8 @@ struct ArraySchemaFx {
 
     // Set array schema
     rc = tiledb_array_set_schema(
+        // The TileDB_CTX
+        tiledb_ctx_,
         // The array schema structure
         &array_schema_,
         // Array name

--- a/test/src/unit-capi-densearray.cc
+++ b/test/src/unit-capi-densearray.cc
@@ -195,6 +195,7 @@ struct DenseArrayFx {
 
     // Set the array schema
     rc = tiledb_array_set_schema(
+        tiledb_ctx_,
         &array_schema_,
         array_name_.c_str(),
         attributes,

--- a/test/src/unit-capi-densearray.cc
+++ b/test/src/unit-capi-densearray.cc
@@ -67,7 +67,14 @@ struct DenseArrayFx {
     rc = tiledb_ctx_init(&tiledb_ctx_, nullptr);
     assert(rc == TILEDB_OK);
 
-    // Create workspace
+    // Create workspace, delete it if it already exists
+    std::string cmd = "test -d " + WORKSPACE;
+    rc = system(cmd.c_str());
+    if (rc == 0) {
+      cmd = "rm -rf " + WORKSPACE;
+      rc = system(cmd.c_str());
+      assert(rc == 0);
+    }
     rc = tiledb_workspace_create(tiledb_ctx_, WORKSPACE.c_str());
     assert(rc == TILEDB_OK);
   }
@@ -81,9 +88,8 @@ struct DenseArrayFx {
     assert(rc == TILEDB_OK);
 
     // Remove the temporary workspace
-    std::string command = "rm -rf ";
-    command.append(WORKSPACE);
-    rc = system(command.c_str());
+    std::string cmd = "rm -rf " + WORKSPACE;
+    rc = system(cmd.c_str());
     assert(rc == 0);
   }
 

--- a/test/src/unit-capi-sparsearray.cc
+++ b/test/src/unit-capi-sparsearray.cc
@@ -138,6 +138,7 @@ struct SparseArrayFx {
 
     // Set the array schema
     rc = tiledb_array_set_schema(
+        tiledb_ctx_,
         &array_schema_,
         array_name_.c_str(),
         attributes,

--- a/test/src/unit-capi-sparsearray.cc
+++ b/test/src/unit-capi-sparsearray.cc
@@ -63,7 +63,14 @@ struct SparseArrayFx {
     rc = tiledb_ctx_init(&tiledb_ctx_, nullptr);
     assert(rc == TILEDB_OK);
 
-    // Create workspace
+    // Create workspace, delete it if it already exists
+    std::string cmd = "test -d " + WORKSPACE;
+    rc = system(cmd.c_str());
+    if (rc == 0) {
+      cmd = "rm -rf " + WORKSPACE;
+      rc = system(cmd.c_str());
+      assert(rc == 0);
+    }
     rc = tiledb_workspace_create(tiledb_ctx_, WORKSPACE.c_str());
     assert(rc == TILEDB_OK);
   }
@@ -77,9 +84,8 @@ struct SparseArrayFx {
     assert(rc == TILEDB_OK);
 
     // Remove the temporary workspace
-    std::string command = "rm -rf ";
-    command.append(WORKSPACE);
-    rc = system(command.c_str());
+    std::string cmd = "rm -rf " + WORKSPACE;
+    rc = system(cmd.c_str());
     assert(rc == 0);
   }
 


### PR DESCRIPTION
Needs tests, updating the examples, and a review if this is the right way to go.

We may also need to create a new error codes (`TILEDB_BAD_CTX`, `TILEDB_BAD_ALLOC`) to deal with sanity checking input for when we cannot retrieve the error stack from a given context.

Another step towards #29 