### PR TITLE
switch to a global logger

### DIFF
--- a/core/include/logger/logger.h
+++ b/core/include/logger/logger.h
@@ -144,14 +144,16 @@ class Logger {
   std::shared_ptr<spdlog::logger> logger_;
 };
 
+Logger& global_logger();
+
 // TODO: these should go away eventually
 #ifdef TILEDB_VERBOSE
 inline void LOG_ERROR(const std::string& msg) {
-  spdlog::get("tiledb")->error(msg);
+  global_logger().error(msg.c_str());
 }
 
 inline Status LOG_STATUS(const Status& st) {
-  spdlog::get("tiledb")->error(st.to_string());
+  global_logger().error(st.to_string().c_str());
   return st;
 }
 #else

--- a/core/src/logger/logger.cc
+++ b/core/src/logger/logger.cc
@@ -60,6 +60,11 @@ Logger::~Logger() {
   spdlog::drop("tiledb");
 }
 
+Logger& global_logger() {
+  static Logger l;
+  return l;
+}
+
 // definition for logging status objects
 std::ostream& operator<<(std::ostream& os, const Status& st) {
   return os << st.to_string();

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -39,7 +39,6 @@
 #include "array.h"
 #include "basic_array_schema.h"
 #include "filesystem.h"
-#include "logger.h"
 #include "utils.h"
 
 /* ****************************** */
@@ -67,7 +66,6 @@ namespace tiledb {
 
 StorageManager::StorageManager() {
   config_ = nullptr;
-  logger_ = nullptr;
 }
 
 StorageManager::~StorageManager() {
@@ -75,12 +73,6 @@ StorageManager::~StorageManager() {
     delete config_;
     config_ = nullptr;
   }
-
-  if (logger_ != nullptr) {
-    delete logger_;
-    logger_ = nullptr;
-  }
-
   open_array_mtx_destroy();
 }
 
@@ -89,9 +81,6 @@ StorageManager::~StorageManager() {
 /* ****************************** */
 
 Status StorageManager::init(Configurator* config) {
-  // Attach logger
-  logger_ = new Logger();
-
   // Clear previous configurator
   if (config_ != nullptr)
     delete config_;


### PR DESCRIPTION
remove logger creation from Storage Manager class

enable by setting cmake flag `-DTILEDB_VERBOSE=1`