### PR TITLE
Switch Bookkeeping structure to use Buffers

### DIFF
--- a/core/include/fragment/book_keeping.h
+++ b/core/include/fragment/book_keeping.h
@@ -39,6 +39,7 @@
 #include "array_schema.h"
 #include "query_mode.h"
 #include "status.h"
+#include "buffer.h"
 
 namespace tiledb {
 
@@ -250,114 +251,114 @@ class BookKeeping {
   /**
    * Writes the bounding coordinates in the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status flush_bounding_coords(gzFile fd) const;
+  Status write_bounding_coords(Buffer* buff);
 
   /**
    * Writes the cell number of the last tile in the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status flush_last_tile_cell_num(gzFile fd) const;
+  Status write_last_tile_cell_num(Buffer* buff);
 
   /**
    * Writes the MBRs in the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status flush_mbrs(gzFile fd) const;
+  Status write_mbrs(Buffer* buff);
 
   /**
    * Writes the non-empty domain in the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status flush_non_empty_domain(gzFile fd) const;
+  Status write_non_empty_domain(Buffer* buff);
 
   /**
    * Writes the tile offsets in the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status flush_tile_offsets(gzFile fd) const;
+  Status write_tile_offsets(Buffer* buff);
 
   /**
    * Writes the variable tile offsets in the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status flush_tile_var_offsets(gzFile fd) const;
+  Status write_tile_var_offsets(Buffer* buff);
 
   /**
    * Writes the variable tile sizes in the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status flush_tile_var_sizes(gzFile fd) const;
+  Status write_tile_var_sizes(Buffer* buff);
 
   /**
    * Loads the bounding coordinates from the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status load_bounding_coords(gzFile fd);
+  Status load_bounding_coords(Buffer* buff);
 
   /**
    * Loads the cell number of the last tile from the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status load_last_tile_cell_num(gzFile fd);
+  Status load_last_tile_cell_num(Buffer* buff);
 
   /**
    * Loads the MBRs from the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status load_mbrs(gzFile fd);
+  Status load_mbrs(Buffer* buff);
 
   /**
    * Loads the non-empty domain from the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status load_non_empty_domain(gzFile fd);
+  Status load_non_empty_domain(Buffer* buff);
 
   /**
    * Loads the tile offsets from the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status load_tile_offsets(gzFile fd);
+  Status load_tile_offsets(Buffer* buff);
 
   /**
    * Loads the variable tile offsets from the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status load_tile_var_offsets(gzFile fd);
+  Status load_tile_var_offsets(Buffer* buff);
 
   /**
    * Loads the variable tile sizes from the book-keeping file on disk.
    *
-   * @param fd The descriptor of the book-keeping file.
+   * @param buff Buffer pointer
    * @return TILEDB_BK_OK on success and TILEDB_BK_ERR on error.
    */
-  Status load_tile_var_sizes(gzFile fd);
+  Status load_tile_var_sizes(Buffer* buff);
 };
 
 }  // namespace tiledb

--- a/core/include/vfs/filesystem.h
+++ b/core/include/vfs/filesystem.h
@@ -40,6 +40,7 @@
 #include <string>
 #include <vector>
 
+#include "buffer.h"
 #include "status.h"
 #include "uri.h"
 
@@ -189,12 +190,12 @@ Status read_from_file(
  * Read contents of a file into a (growable) byte buffer.
  *
  * @param path  The name of a file.
- * @param buffer A pointer to the allocated buffer
+ * @param buff A pointer to the allocated buffe
  * @param buffer_size The number of bytes allocated to hold the buffer
  * @return Status
  */
 Status read_from_file(
-    const std::string& path, char* buffer, size_t* buffer_size);
+    const std::string& path, Buffer** buff);
 
 // TODO: this should go away
 /** Returns the names of the fragments inside the input directory. */

--- a/core/src/vfs/filesystem.cc
+++ b/core/src/vfs/filesystem.cc
@@ -30,7 +30,7 @@
  * This file includes definitions of filesystem functions.
  */
 
-#include "../../include/vfs/filesystem.h"
+#include "filesystem.h"
 #include "configurator.h"
 #include "logger.h"
 #include "utils.h"
@@ -391,19 +391,17 @@ Status read_from_file(
 }
 
 Status read_from_file(
-    const std::string& path, char* buffer, size_t* buffer_size) {
-  *buffer_size = 0;
+    const std::string& path, Buffer** buff) {
   std::ifstream file(path, std::ios::in | std::ios::binary | std::ios::ate);
   if (!file.is_open()) {
     return LOG_STATUS(Status::OSError(
         std::string("Cannot read file '") + path + "': file open error"));
   }
   std::streampos nbytes = file.tellg();
-  buffer = new char[nbytes];
+  *buff = new Buffer(nbytes);
   file.seekg(0, std::ios::beg);
-  file.read(buffer, nbytes);
+  file.read(static_cast<char*>((*buff)->data()), nbytes);
   file.close();
-  *buffer_size = nbytes;
   return Status::Ok();
 }
 
@@ -652,7 +650,7 @@ Status read_from_gzipfile(
     unsigned int size,
     int* decompressed_size) {
   // Open file
-  gzFile fd = gzopen(path.c_str(), "r");
+  gzFile fd = gzopen(path.c_str(), "rb");
   if (fd == nullptr) {
     return LOG_STATUS(Status::OSError(
         std::string("Could not read file '") + path + "'; file open error"));


### PR DESCRIPTION
Remove special case IO calls in Bookeeping and refactor all
functionality to use the virtual file system functions.

Bookkeeping no longer uses GZIP compression. All compressed IO should be
standardized around Buffer IO.