### PR TITLE
Removing array name from stored array metadata. 

### DIFF
--- a/core/include/array_metadata/array_metadata.h
+++ b/core/include/array_metadata/array_metadata.h
@@ -296,6 +296,9 @@ class ArrayMetadata {
    */
   Layout tile_order_;
 
+  /** The version under which this object was created. */
+  int version_[3];
+
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */

--- a/core/include/c_api/tiledb.h
+++ b/core/include/c_api/tiledb.h
@@ -63,11 +63,6 @@ extern "C" {
 /*            CONSTANTS           */
 /* ****************************** */
 
-/** Version. */
-#define TILEDB_VERSION_MAJOR 0
-#define TILEDB_VERSION_MINOR 6
-#define TILEDB_VERSION_REVISION 1
-
 /**@{*/
 /** Return code. */
 #define TILEDB_OK 0      // Success

--- a/core/include/misc/constants.h
+++ b/core/include/misc/constants.h
@@ -243,6 +243,9 @@ extern const char* unordered_str;
 /** The string representation of null. */
 extern const char* null_str;
 
+/** The version in format { major, minor, revision }. */
+extern const int version[3];
+
 }  // namespace constants
 
 }  // namespace tiledb

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -53,9 +53,9 @@ unsigned int tiledb_var_num() {
 /* ****************************** */
 
 void tiledb_version(int* major, int* minor, int* rev) {
-  *major = TILEDB_VERSION_MAJOR;
-  *minor = TILEDB_VERSION_MINOR;
-  *rev = TILEDB_VERSION_REVISION;
+  *major = tiledb::constants::version[0];
+  *minor = tiledb::constants::version[1];
+  *rev = tiledb::constants::version[2];
 }
 
 /* ********************************* */
@@ -869,7 +869,8 @@ int tiledb_array_metadata_load(
   }
 
   // Create ArrayMetadata object
-  (*array_metadata)->array_metadata_ = new tiledb::ArrayMetadata();
+  (*array_metadata)->array_metadata_ =
+      new tiledb::ArrayMetadata(tiledb::URI(array_name));
   if ((*array_metadata)->array_metadata_ == nullptr) {
     std::free(*array_metadata);
     *array_metadata = nullptr;

--- a/core/src/misc/constants.cc
+++ b/core/src/misc/constants.cc
@@ -244,6 +244,9 @@ const char* unordered_str = "unordered";
 /** The string representation of null. */
 const char* null_str = "null";
 
+/** The version in format { major, minor, revision }. */
+const int version[3] = {1, 0, 0};
+
 }  // namespace constants
 
 }  // namespace tiledb

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -529,7 +529,7 @@ Status StorageManager::open_array_load_metadata(
   if (open_array->array_metadata() != nullptr)
     return Status::Ok();
 
-  auto array_metadata = new ArrayMetadata();
+  auto array_metadata = new ArrayMetadata(array_uri);
   RETURN_NOT_OK_ELSE(
       load(array_uri.to_string(), array_metadata), delete array_metadata);
   open_array->set_array_metadata(array_metadata);

--- a/test/src/unit-capi-version.cc
+++ b/test/src/unit-capi-version.cc
@@ -42,7 +42,7 @@ TEST_CASE("C API: Test version", "[capi]") {
 
   tiledb_version(&major, &minor, &rev);
 
-  CHECK(major == 0);
-  CHECK(minor == 6);
-  CHECK(rev == 1);
+  CHECK(major == 1);
+  CHECK(minor == 0);
+  CHECK(rev == 0);
 }


### PR DESCRIPTION
This will make copying and moving entire arrays much easier. Closes #176.