### PR TITLE
Adding file sizes to fragment metadata

### DIFF
--- a/core/include/fragment/fragment.h
+++ b/core/include/fragment/fragment.h
@@ -78,6 +78,15 @@ class Fragment {
   /** Returns true if the fragment is dense, and false if it is sparse. */
   bool dense() const;
 
+  /** Returns the size of the coordinates file. */
+  uint64_t file_coords_size() const;
+
+  /** Returns the size of the file of attribute with the input id. */
+  uint64_t file_size(unsigned int attribute_id) const;
+
+  /** Returns the size of the file of variable attribute with the input id. */
+  uint64_t file_var_size(unsigned int attribute_id) const;
+
   /**
    * Finalizes the fragment, properly freeing up memory space.
    *

--- a/core/include/fragment/fragment_metadata.h
+++ b/core/include/fragment/fragment_metadata.h
@@ -138,6 +138,12 @@ class FragmentMetadata {
   /** Returns the (expanded) domain in which the fragment is constrained. */
   const void* domain() const;
 
+  /** Returns the size of the attribute with the input id. */
+  uint64_t file_sizes(unsigned int attribute_id) const;
+
+  /** Returns the size of the variable attribute with the input id. */
+  uint64_t file_var_sizes(unsigned int attribute_id) const;
+
   /** Returns the fragment URI. */
   const URI& fragment_uri() const;
 
@@ -209,6 +215,12 @@ class FragmentMetadata {
    */
   void* domain_;
 
+  /** Stores the size of each attribute file. */
+  std::vector<uint64_t> file_sizes_;
+
+  /** Stores the size of each variable attribute file. */
+  std::vector<uint64_t> file_var_sizes_;
+
   /** The uri of the fragment the metadata belongs to. */
   URI fragment_uri_;
 
@@ -248,6 +260,9 @@ class FragmentMetadata {
    */
   std::vector<std::vector<uint64_t>> tile_var_sizes_;
 
+  /** The version of the library that created this metadata. */
+  int version_[3];
+
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
@@ -259,6 +274,12 @@ class FragmentMetadata {
    * @return Status
    */
   Status load_bounding_coords(ConstBuffer* buff);
+
+  /** Loads the sizes of each attribute file from the buffer. */
+  Status load_file_sizes(ConstBuffer* buff);
+
+  /** Loads the sizes of each variable attribute file from the buffer. */
+  Status load_file_var_sizes(ConstBuffer* buff);
 
   /**
    * Loads the cell number of the last tile from the fragment metadata buffer.
@@ -308,6 +329,9 @@ class FragmentMetadata {
    */
   Status load_tile_var_sizes(ConstBuffer* buff);
 
+  /** Loads the library version from the buffer. */
+  Status load_version(ConstBuffer* buff);
+
   /**
    * Writes the bounding coordinates to the fragment metadata buffer.
    *
@@ -315,6 +339,12 @@ class FragmentMetadata {
    * @return Status
    */
   Status write_bounding_coords(Buffer* buff);
+
+  /** Writes the sizes of each attribute file in the buffer. */
+  Status write_file_sizes(Buffer* buff);
+
+  /** Writes the sizes of each variable attribute file in the buffer. */
+  Status write_file_var_sizes(Buffer* buff);
 
   /**
    * Writes the cell number of the last tile to the fragment metadata buffer.
@@ -363,6 +393,9 @@ class FragmentMetadata {
    * @return Status
    */
   Status write_tile_var_sizes(Buffer* buff);
+
+  /** Writes the library version to the buffer. */
+  Status write_version(Buffer* buff);
 };
 
 }  // namespace tiledb

--- a/core/include/fragment/read_state.h
+++ b/core/include/fragment/read_state.h
@@ -454,14 +454,14 @@ class ReadState {
    *
    * @param tile_i The tile index.
    * @param attribute_id The attribute id.
-   * @param tile_io The tile I/O object.
+   * @param file_size The size of the file the input tile belongs to.
    * @param tile_compressed_size The size to be retrieved.
    * @return Status
    */
   Status compute_tile_compressed_size(
       uint64_t tile_i,
       unsigned int attribute_id,
-      TileIO* tile_io,
+      uint64_t file_size,
       uint64_t* tile_compressed_size) const;
 
   /**
@@ -470,14 +470,14 @@ class ReadState {
    *
    * @param tile_i The tile index.
    * @param attribute_id The attribute id.
-   * @param tile_io The tile I/O object.
+   * @param file_size The size of the file the input tile belongs to.
    * @param tile_compressed_size The size to be retrieved.
    * @return Status
    */
   Status compute_tile_compressed_var_size(
       uint64_t tile_i,
       unsigned int attribute_id,
-      TileIO* tile_io,
+      uint64_t file_size,
       uint64_t* tile_compressed_size) const;
 
   /**

--- a/core/include/storage_manager/storage_manager.h
+++ b/core/include/storage_manager/storage_manager.h
@@ -153,9 +153,6 @@ class StorageManager {
   /** Safely moves a TileDB resource. */
   Status move(const URI& old_uri, const URI& new_uri, bool force = false) const;
 
-  /** Retrieves the size of the input URI file. */
-  Status file_size(const URI& uri, uint64_t* size) const;
-
   /**
    * Creates a TileDB group.
    *

--- a/core/include/tile/tile_io.h
+++ b/core/include/tile/tile_io.h
@@ -59,6 +59,15 @@ class TileIO {
    */
   TileIO(StorageManager* storage_manager, const URI& uri);
 
+  /**
+   * Constructor.
+   *
+   * @param storage_manager The storage manager.
+   * @param uri The name of the file that stores data.
+   * @param file_size The size of the file pointed by `uri`.
+   */
+  TileIO(StorageManager* storage_manager, const URI& uri, uint64_t file_size);
+
   /** Destructor. */
   ~TileIO();
 
@@ -66,8 +75,8 @@ class TileIO {
   /*                API                */
   /* ********************************* */
 
-  /** Retrieves the size of the file. */
-  Status file_size(uint64_t* size) const;
+  /** Returns the size of the file. */
+  uint64_t file_size() const;
 
   /**
    * Reads into a tile from the file.
@@ -153,17 +162,20 @@ class TileIO {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
-  /** The file URI. */
-  URI uri_;
-
   /**
    * An internal buffer used to facilitate compression/decompression (or
    * other future filters).
    */
   Buffer* buffer_;
 
+  /** The size of the file pointed by `uri_`. */
+  uint64_t file_size_;
+
   /** The storage manager object. */
   StorageManager* storage_manager_;
+
+  /** The file URI. */
+  URI uri_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/core/src/fragment/fragment.cc
+++ b/core/src/fragment/fragment.cc
@@ -89,6 +89,22 @@ bool Fragment::dense() const {
   return dense_;
 }
 
+uint64_t Fragment::file_coords_size() const {
+  assert(metadata_ != nullptr);
+  auto attribute_num = query_->array_metadata()->attribute_num();
+  return metadata_->file_sizes(attribute_num);
+}
+
+uint64_t Fragment::file_size(unsigned int attribute_id) const {
+  assert(metadata_ != nullptr);
+  return metadata_->file_sizes(attribute_id);
+}
+
+uint64_t Fragment::file_var_size(unsigned int attribute_id) const {
+  assert(metadata_ != nullptr);
+  return metadata_->file_var_sizes(attribute_id);
+}
+
 Status Fragment::finalize() {
   if (write_state_ != nullptr) {  // WRITE
     assert(metadata_ != NULL);

--- a/core/src/misc/constants.cc
+++ b/core/src/misc/constants.cc
@@ -248,7 +248,7 @@ const char* unordered_str = "unordered";
 const char* null_str = "null";
 
 /** The version in format { major, minor, revision }. */
-const int version[3] = {1, 0, 0};
+const int version[3] = {1, 2, 0};
 
 /** The size of a tile chunk. */
 const uint64_t tile_chunk_size = INT_MAX;

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -217,10 +217,6 @@ Status StorageManager::move(
   return vfs_->move_path(old_uri, new_uri);
 }
 
-Status StorageManager::file_size(const URI& uri, uint64_t* size) const {
-  return vfs_->file_size(uri, size);
-}
-
 Status StorageManager::group_create(const std::string& group) const {
   // Create group URI
   URI uri(group);
@@ -269,8 +265,8 @@ Status StorageManager::load(
       array_uri.join_path(constants::array_metadata_filename);
 
   // Read from file
-  auto tile_io = new TileIO(this, array_metadata_uri);
   auto tile = (Tile*)nullptr;
+  auto tile_io = new TileIO(this, array_metadata_uri);
   RETURN_NOT_OK_ELSE(tile_io->read_generic(&tile, 0), delete tile_io);
 
   // Deserialize

--- a/core/src/tile/tile_io.cc
+++ b/core/src/tile/tile_io.cc
@@ -55,8 +55,17 @@ namespace tiledb {
 /* ****************************** */
 
 TileIO::TileIO(StorageManager* storage_manager, const URI& uri)
-    : uri_(uri)
-    , storage_manager_(storage_manager) {
+    : storage_manager_(storage_manager)
+    , uri_(uri) {
+  file_size_ = 0;
+  buffer_ = new Buffer();
+}
+
+TileIO::TileIO(
+    StorageManager* storage_manager, const URI& uri, uint64_t file_size)
+    : file_size_(file_size)
+    , storage_manager_(storage_manager)
+    , uri_(uri) {
   buffer_ = new Buffer();
 }
 
@@ -68,8 +77,8 @@ TileIO::~TileIO() {
 /*               API              */
 /* ****************************** */
 
-Status TileIO::file_size(uint64_t* size) const {
-  return storage_manager_->file_size(uri_, size);
+uint64_t TileIO::file_size() const {
+  return file_size_;
 }
 
 Status TileIO::read(

--- a/test/src/unit-capi-version.cc
+++ b/test/src/unit-capi-version.cc
@@ -31,18 +31,18 @@
  * Tests for the C API library version
  */
 
+#include "constants.h"
 #include "tiledb.h"
-
 #include "catch.hpp"
 
-TEST_CASE("C API: Test version", "[capi]") {
+TEST_CASE("C API: Test version", "[capi] [version]")  {
   int major = -1;
   int minor = -1;
   int rev = -1;
 
   tiledb_version(&major, &minor, &rev);
 
-  CHECK(major == 1);
-  CHECK(minor == 0);
-  CHECK(rev == 0);
+  CHECK(major == tiledb::constants::version[0]);
+  CHECK(minor == tiledb::constants::version[1]);
+  CHECK(rev == tiledb::constants::version[2]);
 }


### PR DESCRIPTION
Removing unnecessary calls to `file_size` by adding the file size info to fragment metadata. Also adding version to fragment metadata. **This library will not work with previously created arrays.**