### PR TITLE
include tiledb.h BEFORE default include path

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -27,7 +27,7 @@
 
 # Include core header directories
 file(GLOB TILEDB_CORE_INCLUDE_DIRS "include/*")
-include_directories(${TILEDB_CORE_INCLUDE_DIRS})
+include_directories(BEFORE ${TILEDB_CORE_INCLUDE_DIRS})
 
 # Gather the core source files
 file(GLOB_RECURSE TILEDB_CORE_HEADERS "include/*")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,7 +35,7 @@ endfunction()
 file(GLOB TILEDB_EXAMPLE_SOURCES "src/*.cc")
 
 # Include TileDB C API headers
-include_directories("${CMAKE_SOURCE_DIR}/core/include/c_api/")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/core/include/c_api/")
 
 # Initialize name for example binaries
 set(EXAMPLE_BINS)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(
 )
 
 target_include_directories(
-  tiledb_unit PRIVATE
+  tiledb_unit BEFORE PRIVATE
   ${TILEDB_CORE_INCLUDE_DIRS}
   ${CMAKE_SOURCE_DIR}/external/catch
 )


### PR DESCRIPTION
fixes tiledb_unit target where the installed tiledb.h header was getting
picked up instead of the in source tree tiledb.h header