### PR TITLE
Remove renaming fragment, as it was slowing down the S3 performance. 

### DIFF
--- a/core/include/misc/constants.h
+++ b/core/include/misc/constants.h
@@ -114,6 +114,9 @@ extern const uint64_t empty_uint64;
 /** The file suffix used in TileDB. */
 extern const char* file_suffix;
 
+/** The fragment file name. */
+extern const char* fragment_filename;
+
 /** The fragment metadata file name. */
 extern const char* fragment_metadata_filename;
 

--- a/core/include/storage_manager/consolidator.h
+++ b/core/include/storage_manager/consolidator.h
@@ -148,11 +148,11 @@ class Consolidator {
       unsigned int buffer_num, void** buffers, uint64_t* buffer_sizes);
 
   /**
-   * Renames the new fragment URI. Effectively, it makes it visible by removing
-   * the "." from the fragment name, and changes the old thread id to the
-   * current thread id (for debugging), keeping the timestamp intact.
+   * Renames the new fragment URI. If the working thread id is different
+   * from the one that created the input URI, the function does nothing.
+   * Otherwise, it appends an extra `_` after the thread id.
    */
-  Status rename_new_fragment(const URI& uri) const;
+  Status rename_new_fragment_uri(URI* uri) const;
 };
 
 }  // namespace tiledb

--- a/core/include/storage_manager/storage_manager.h
+++ b/core/include/storage_manager/storage_manager.h
@@ -141,6 +141,9 @@ class StorageManager {
   /** Creates a directory with the input URI. */
   Status create_dir(const URI& uri);
 
+  /** Creates a special fragment file name inside the `uri` directory. */
+  Status create_fragment_file(const URI& uri);
+
   /** Creates a file with the input URI. */
   Status create_file(const URI& uri);
 

--- a/core/src/misc/constants.cc
+++ b/core/src/misc/constants.cc
@@ -46,6 +46,9 @@ namespace constants {
 /** The array metadata file name. */
 const char* array_metadata_filename = "__array_metadata.tdb";
 
+/** The fragment file name. */
+const char* fragment_filename = "__fragment.tdb";
+
 /** The fragment metadata file name. */
 const char* fragment_metadata_filename = "__fragment_metadata.tdb";
 

--- a/core/src/query/query.cc
+++ b/core/src/query/query.cc
@@ -700,7 +700,7 @@ Status Query::new_fragment() {
   auto array_name = array_metadata_->array_uri().to_string();
   std::string new_fragment_name =
       consolidation ?
-          (array_name + "/." + consolidation_fragment_uri_.last_path_part()) :
+          (array_name + "/" + consolidation_fragment_uri_.last_path_part()) :
           this->new_fragment_name();
 
   if (new_fragment_name.empty())
@@ -729,7 +729,7 @@ std::string Query::new_fragment_name() const {
   // Generate fragment name
   int n = sprintf(
       fragment_name,
-      "%s/.__%s_%llu",
+      "%s/__%s_%llu",
       array_metadata_->array_uri().to_string().c_str(),
       tid.c_str(),
       ms);


### PR DESCRIPTION
S3 does not support rename, only copy to a different object. Now a fragment is distinguished by an extra special file called __fragment.tdb, which is created inside the fragment directory only upon successful creation of the fragment. Current arrays will need to be rebuilt after sync-ing up.