### PR TITLE
For #250: use the `*_ctx()` functions for BLOSC compressor.

### DIFF
--- a/core/src/compressors/blosc_compressor.cc
+++ b/core/src/compressors/blosc_compressor.cc
@@ -49,23 +49,19 @@ Status Blosc::compress(
     return LOG_STATUS(Status::CompressionError(
         "Failed compressing with Blosc; invalid buffer format"));
 
-  // Initialize Blosc compressor
-  if (blosc_set_compressor(compressor) < 0) {
-    return LOG_STATUS(Status::CompressionError(
-        std::string(
-            "Blosc compression error, failed to set Blosc compressor ") +
-        compressor));
-  }
-
   // Compress
-  int rc = blosc_compress(
+  int rc = blosc_compress_ctx(
       level < 0 ? Blosc::default_level() : level,
       1,  // shuffle
       type_size,
       input_buffer->size(),
       input_buffer->data(),
       output_buffer->cur_data(),
-      output_buffer->free_space());
+      output_buffer->free_space(),
+      compressor,
+      0, // blocksize (0 lets BLOSC choose automatically)
+      1  // disable BLOSC thread pool
+  );
 
   // Handle error
   if (rc < 0)
@@ -85,10 +81,12 @@ Status Blosc::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
         "Failed decompressing with Blosc; invalid buffer format"));
 
   // Decompress
-  int rc = blosc_decompress(
+  int rc = blosc_decompress_ctx(
       input_buffer->data(),
       output_buffer->cur_data(),
-      output_buffer->free_space());
+      output_buffer->free_space(),
+      1 // disable BLOSC thread pool
+  );
 
   // Handle error
   if (rc <= 0)

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -31,7 +31,6 @@
  * This file implements the StorageManager class.
  */
 
-#include <blosc.h>
 #include <algorithm>
 #include <sstream>
 
@@ -52,7 +51,6 @@ StorageManager::StorageManager() {
   consolidator_ = new Consolidator(this);
   tile_cache_ = new LRUCache(constants::tile_cache_size);
   vfs_ = nullptr;
-  blosc_init();
 }
 
 StorageManager::~StorageManager() {
@@ -61,7 +59,6 @@ StorageManager::~StorageManager() {
   delete async_thread_[1];
   delete tile_cache_;
   delete vfs_;
-  blosc_destroy();
 }
 
 /* ****************************** */


### PR DESCRIPTION
Now we use the threadsafe `*_ctx` versions for BLOSC compression and decompression.

This change also removes the calls to `blosc_init` and `blosc_destroy` (which are not required when using the threadsafe API).

closes #250 