### PR TITLE
Added an array/fragment metadata cache

### DIFF
--- a/core/include/buffer/buffer.h
+++ b/core/include/buffer/buffer.h
@@ -90,6 +90,12 @@ class Buffer {
   /** Returns the buffer data pointer at the input offset. */
   void* data(uint64_t offset) const;
 
+  /**
+   * Sets `owns_data_` to `false` and thus will not destroy the data
+   * in the destructor.
+   */
+  void disown_data();
+
   /** Returns the number of byte of free space in the buffer. */
   uint64_t free_space() const;
 

--- a/core/include/cache/lru_cache.h
+++ b/core/include/cache/lru_cache.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_LRU_CACHE_H
 #define TILEDB_LRU_CACHE_H
 
+#include "buffer.h"
 #include "status.h"
 
 #include <list>
@@ -114,6 +115,18 @@ class LRUCache {
    * @return Status
    */
   Status insert(const std::string& key, void* object, uint64_t size);
+
+  /**
+   * Reads an entire cached object labeled by `key`.
+   *
+   * @param key The label of the object to be read.
+   * @param buffer The buffer that will store the data to be read. It will be
+   *     resized appropriately.
+   * @param success `true` if the data were read from the cache and `false`
+   *     otherwise.
+   * @return Status.
+   */
+  Status read(const std::string& key, Buffer* buffer, bool* success);
 
   /**
    * Reads a portion of the object labeled by `key`.

--- a/core/include/cache/lru_cache.h
+++ b/core/include/cache/lru_cache.h
@@ -70,8 +70,15 @@ class LRUCache {
   /** Constructor.
    *
    * @param size The maximum cache size.
+   * @param evict_callback The function to be called upon evicting a cache
+   *     object. It takes as input the cache object to be evicted, and
+   *     `evict_callback_data`.
+   * @param evict_callback_data The data input to `evict_callback`.
    */
-  explicit LRUCache(uint64_t max_size);
+  LRUCache(
+      uint64_t max_size,
+      void* (*evict_callback)(LRUCacheItem*, void*) = nullptr,
+      void* evict_callback_data = nullptr);
 
   /** Destructor. */
   ~LRUCache();
@@ -130,6 +137,15 @@ class LRUCache {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /**
+   * A function that will be called upon evicting a cache object. I takes
+   * as input the cache object to be evicted and `evict_callback_data_`.
+   */
+  void* (*evict_callback_)(LRUCacheItem*, void*);
+
+  /** The data input to the evict callback function. */
+  void* evict_callback_data_;
 
   /**
    * Doubly-connected linked list of cache items. The head of the list is the

--- a/core/include/misc/constants.h
+++ b/core/include/misc/constants.h
@@ -162,6 +162,9 @@ extern const char* no_compression_str;
 /** The array metadata cache size. */
 extern const uint64_t array_metadata_cache_size;
 
+/** The fragment metadata cache size. */
+extern const uint64_t fragment_metadata_cache_size;
+
 /** The tile cache size. */
 extern const uint64_t tile_cache_size;
 

--- a/core/include/misc/constants.h
+++ b/core/include/misc/constants.h
@@ -159,6 +159,9 @@ extern const unsigned int var_num;
 /** String describing no compression. */
 extern const char* no_compression_str;
 
+/** The array metadata cache size. */
+extern const uint64_t array_metadata_cache_size;
+
 /** The tile cache size. */
 extern const uint64_t tile_cache_size;
 

--- a/core/include/storage_manager/open_array.h
+++ b/core/include/storage_manager/open_array.h
@@ -83,12 +83,6 @@ class OpenArray {
    */
   FragmentMetadata* fragment_metadata_get(const URI& fragment_uri);
 
-  /**
-   * Removes the metadata of the input fragment from the fragment metadata
-   * map.
-   */
-  void fragment_metadata_rm(const URI& fragment_uri);
-
   /** Increments the counter indicating the times this array has been opened. */
   void incr_cnt();
 
@@ -114,10 +108,9 @@ class OpenArray {
 
   /**
    * Enables searching for loaded fragment metadata by fragment name.
-   * Format: <fragment_name> --> (fragment_metadata, # queries using it)
+   * Format: <fragment_name> --> (fragment_metadata)
    */
-  std::map<std::string, std::pair<FragmentMetadata*, uint64_t>>
-      fragment_metadata_;
+  std::map<std::string, FragmentMetadata*> fragment_metadata_;
 
   /**
    * A mutex used to lock the array when loading the array metadata and

--- a/core/include/storage_manager/storage_manager.h
+++ b/core/include/storage_manager/storage_manager.h
@@ -63,6 +63,7 @@ class StorageManager {
   /*          TYPE DEFINITIONS         */
   /* ********************************* */
 
+  /** Enables iteration over TileDB objects in a path. */
   class ObjectIter {
    public:
     /**
@@ -449,9 +450,6 @@ class StorageManager {
   /** Used for array shared and exclusive locking. */
   std::mutex locked_array_mtx_;
 
-  /** Used for array shared and exclusive locking. */
-  std::condition_variable locked_array_cv_;
-
   /**
    * Stores locked array entries. The map is indexed by the array URI string
    * and stores the number of **shared** locks.
@@ -480,9 +478,8 @@ class StorageManager {
   /*         PRIVATE METHODS           */
   /* ********************************* */
 
-  /** Closes an array, properly managing the opened fragment metadata. */
-  Status array_close(
-      URI array, const std::vector<FragmentMetadata*>& fragment_metadata);
+  /** Closes an array. */
+  Status array_close(URI array);
 
   /**
    * Opens an array, retrieving its metadata and fragment metadata.
@@ -502,9 +499,7 @@ class StorageManager {
   /**
    * Invokes in case an error occurs in array_open. It is a clean-up function.
    */
-  Status array_open_error(
-      OpenArray* open_array,
-      const std::vector<FragmentMetadata*>& fragment_metadata);
+  Status array_open_error(OpenArray* open_array);
 
   /**
    * Starts listening to async queries.

--- a/core/include/storage_manager/storage_manager.h
+++ b/core/include/storage_manager/storage_manager.h
@@ -451,6 +451,9 @@ class StorageManager {
   /** Object that handles array consolidation. */
   Consolidator* consolidator_;
 
+  /** A fragment metadata cache. */
+  LRUCache* fragment_metadata_cache_;
+
   /** Used for array shared and exclusive locking. */
   std::mutex locked_array_mtx_;
 

--- a/core/include/storage_manager/storage_manager.h
+++ b/core/include/storage_manager/storage_manager.h
@@ -192,11 +192,12 @@ class StorageManager {
   /**
    * Loads the metadata of an array from persistent storage into memory.
    *
-   * @param array_name The name (URI path) of the array.
+   * @param array_uri The URI path of the array.
    * @param array_metadata The array metadata to be retrieved.
    * @return Status
    */
-  Status load(const std::string& array_name, ArrayMetadata* array_metadata);
+  Status load_array_metadata(
+      const URI& array_uri, ArrayMetadata** array_metadata);
 
   /**
    * Loads the fragment metadata of an array from persistent storage into
@@ -205,7 +206,7 @@ class StorageManager {
    * @param metadata The fragment metadata to be loaded.
    * @return Status
    */
-  Status load(FragmentMetadata* metadata);
+  Status load_fragment_metadata(FragmentMetadata* metadata);
 
   /**
    * Creates a new object iterator for the input path.
@@ -417,6 +418,9 @@ class StorageManager {
   /*        PRIVATE ATTRIBUTES         */
   /* ********************************* */
 
+  /** An array metadata cache. */
+  LRUCache* array_metadata_cache_;
+
   /**
    * Async condition variable. The first is for user async queries, the second
    * for internal async queries.
@@ -535,7 +539,8 @@ class StorageManager {
   Status open_array_get_entry(const URI& array_uri, OpenArray** open_array);
 
   /** Loads the array metadata into an open array. */
-  Status open_array_load_metadata(const URI& array_uri, OpenArray* open_array);
+  Status open_array_load_array_metadata(
+      const URI& array_uri, OpenArray* open_array);
 
   /** Retrieves the fragment metadata of an open array for a given subarray. */
   Status open_array_load_fragment_metadata(

--- a/core/include/tile/tile.h
+++ b/core/include/tile/tile.h
@@ -149,6 +149,12 @@ class Tile {
   /** Returns the tile data. */
   void* data() const;
 
+  /**
+   * Sets `owns_buff_` to `false` and thus will not destroy the buffer
+   * in the destructor.
+   */
+  void disown_buff();
+
   /** Returns the number of dimensions (0 if this is an attribute tile). */
   unsigned int dim_num() const;
 

--- a/core/src/buffer/buffer.cc
+++ b/core/src/buffer/buffer.cc
@@ -107,6 +107,10 @@ void* Buffer::data(uint64_t offset) const {
   return (char*)data_ + offset;
 }
 
+void Buffer::disown_data() {
+  owns_data_ = false;
+}
+
 uint64_t Buffer::free_space() const {
   assert(alloced_size_ >= size_);
   return alloced_size_ - size_;

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -952,25 +952,13 @@ int tiledb_array_metadata_load(
     return TILEDB_OOM;
   }
 
-  // Create ArrayMetadata object
-  (*array_metadata)->array_metadata_ =
-      new (std::nothrow) tiledb::ArrayMetadata(tiledb::URI(array_name));
-  if ((*array_metadata)->array_metadata_ == nullptr) {
-    delete *array_metadata;
-    save_error(
-        ctx,
-        tiledb::Status::Error(
-            "Failed to allocate TileDB array_metadata object in struct"));
-    return TILEDB_OOM;
-  }
-
   // Load array metadata
   auto storage_manager = ctx->storage_manager_;
   if (save_error(
           ctx,
-          storage_manager->load(
-              array_name, (*array_metadata)->array_metadata_))) {
-    delete (*array_metadata)->array_metadata_;
+          storage_manager->load_array_metadata(
+              tiledb::URI(array_name),
+              &((*array_metadata)->array_metadata_)))) {
     delete *array_metadata;
     return TILEDB_ERR;
   }

--- a/core/src/cache/lru_cache.cc
+++ b/core/src/cache/lru_cache.cc
@@ -58,7 +58,7 @@ LRUCache::~LRUCache() {
 
 void LRUCache::clear() {
   for (auto &item : item_ll_)
-    std::free(item.object_);
+    std::free(item.object_); // TODO: call evict function on object
   item_ll_.clear();
 }
 
@@ -170,7 +170,7 @@ void LRUCache::evict() {
   assert(!item_ll_.empty());
 
   auto item = item_ll_.front();
-  std::free(item.object_);
+  std::free(item.object_); // TODO: call evict function on object
   item_map_.erase(item.key_);
   size_ -= item.size_;
   item_ll_.pop_front();

--- a/core/src/compressors/blosc_compressor.cc
+++ b/core/src/compressors/blosc_compressor.cc
@@ -59,8 +59,8 @@ Status Blosc::compress(
       output_buffer->cur_data(),
       output_buffer->free_space(),
       compressor,
-      0, // blocksize (0 lets BLOSC choose automatically)
-      1  // disable BLOSC thread pool
+      0,  // blocksize (0 lets BLOSC choose automatically)
+      1   // disable BLOSC thread pool
   );
 
   // Handle error
@@ -85,7 +85,7 @@ Status Blosc::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
       input_buffer->data(),
       output_buffer->cur_data(),
       output_buffer->free_space(),
-      1 // disable BLOSC thread pool
+      1  // disable BLOSC thread pool
   );
 
   // Handle error

--- a/core/src/misc/constants.cc
+++ b/core/src/misc/constants.cc
@@ -157,6 +157,9 @@ const unsigned int var_num = std::numeric_limits<unsigned int>::max();
 /** String describing no compression. */
 const char* no_compression_str = "NO_COMPRESSION";
 
+/** The array metadata cache size. */
+const uint64_t array_metadata_cache_size = 10000000;
+
 /** The tile cache size. */
 const uint64_t tile_cache_size = 100000000;
 

--- a/core/src/misc/constants.cc
+++ b/core/src/misc/constants.cc
@@ -160,6 +160,9 @@ const char* no_compression_str = "NO_COMPRESSION";
 /** The array metadata cache size. */
 const uint64_t array_metadata_cache_size = 10000000;
 
+/** The fragment metadata cache size. */
+const uint64_t fragment_metadata_cache_size = 100000000;
+
 /** The tile cache size. */
 const uint64_t tile_cache_size = 100000000;
 

--- a/core/src/storage_manager/consolidator.cc
+++ b/core/src/storage_manager/consolidator.cc
@@ -63,8 +63,8 @@ Status Consolidator::consolidate(const char* array_name) {
   URI array_uri = URI(array_name);
 
   // Get array metadata
-  auto array_meta = new ArrayMetadata(array_uri);
-  RETURN_NOT_OK(storage_manager_->load(array_name, array_meta));
+  auto array_meta = (ArrayMetadata*)nullptr;
+  RETURN_NOT_OK(storage_manager_->load_array_metadata(array_uri, &array_meta));
 
   // Prepare buffers
   void** buffers;

--- a/core/src/storage_manager/open_array.cc
+++ b/core/src/storage_manager/open_array.cc
@@ -46,6 +46,8 @@ OpenArray::OpenArray() {
 
 OpenArray::~OpenArray() {
   delete array_metadata_;
+  for(auto& fragment : fragment_metadata_)
+    delete fragment.second;
 }
 
 /* ****************************** */
@@ -69,8 +71,7 @@ void OpenArray::decr_cnt() {
 }
 
 void OpenArray::fragment_metadata_add(FragmentMetadata* metadata) {
-  fragment_metadata_[metadata->fragment_uri().to_string()] =
-      std::pair<FragmentMetadata*, uint64_t>(metadata, 1);
+  fragment_metadata_[metadata->fragment_uri().to_string()] = metadata;
 }
 
 FragmentMetadata* OpenArray::fragment_metadata_get(const URI& fragment_uri) {
@@ -78,25 +79,7 @@ FragmentMetadata* OpenArray::fragment_metadata_get(const URI& fragment_uri) {
   if (it == fragment_metadata_.end())
     return nullptr;
 
-  ++(it->second.second);
-  return it->second.first;
-}
-
-void OpenArray::fragment_metadata_rm(const URI& fragment_uri) {
-  // Find metadata
-  auto it = fragment_metadata_.find(fragment_uri.to_string());
-  if (it == fragment_metadata_.end())
-    return;
-
-  // Decrement counter
-  --(it->second.second);
-
-  // Potentially remove metadata from main memory
-  // TODO: The following may be left to a cache manager
-  if (it->second.second == 0) {
-    delete it->second.first;
-    fragment_metadata_.erase(it);
-  }
+  return it->second;
 }
 
 void OpenArray::incr_cnt() {

--- a/core/src/storage_manager/open_array.cc
+++ b/core/src/storage_manager/open_array.cc
@@ -46,7 +46,7 @@ OpenArray::OpenArray() {
 
 OpenArray::~OpenArray() {
   delete array_metadata_;
-  for(auto& fragment : fragment_metadata_)
+  for (auto& fragment : fragment_metadata_)
     delete fragment.second;
 }
 

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -627,8 +627,8 @@ Status StorageManager::write_to_cache(
     const URI& uri, uint64_t offset, Buffer* buffer) const {
   // Do not write metadata to cache
   std::string filename = uri.last_path_part();
-  if(filename == constants::fragment_metadata_filename ||
-     filename == constants::array_metadata_filename) {
+  if (filename == constants::fragment_metadata_filename ||
+      filename == constants::array_metadata_filename) {
     return Status::Ok();
   }
 

--- a/core/src/tile/tile.cc
+++ b/core/src/tile/tile.cc
@@ -140,6 +140,10 @@ unsigned int Tile::dim_num() const {
   return dim_num_;
 }
 
+void Tile::disown_buff() {
+  owns_buff_ = false;
+}
+
 bool Tile::empty() const {
   return buffer_->size() == 0;
 }


### PR DESCRIPTION
This is useful when there are successive queries on the same array. The cache prevents reloading the metadata from the storage backend for every single query.