### PR TITLE
Deprecate dim/attr iterator api

### DIFF
--- a/core/include/array_metadata/array_metadata.h
+++ b/core/include/array_metadata/array_metadata.h
@@ -92,6 +92,9 @@ class ArrayMetadata {
   /** Returns a constant pointer to the selected attribute (NULL if error). */
   const Attribute* attribute(unsigned int id) const;
 
+  /** Returns a constant pointer to the selected attribute (NULL if error). */
+  const Attribute* attribute(std::string name) const;
+
   /** Returns the name of the attribute with the input id. */
   const std::string& attribute_name(unsigned id) const;
 

--- a/core/include/array_metadata/domain.h
+++ b/core/include/array_metadata/domain.h
@@ -121,6 +121,9 @@ class Domain {
   /** Returns the i-th dimensions (nullptr upon error). */
   const Dimension* dimension(unsigned int i) const;
 
+  /** Returns the dimension given a name (nullptr upon error). */
+  const Dimension* dimension(std::string name) const;
+
   /** Dumps the domain in ASCII format in the selected output. */
   void dump(FILE* out) const;
 

--- a/core/src/array_metadata/array_metadata.cc
+++ b/core/src/array_metadata/array_metadata.cc
@@ -116,7 +116,17 @@ const URI& ArrayMetadata::array_uri() const {
 const Attribute* ArrayMetadata::attribute(unsigned int id) const {
   if (id < attributes_.size())
     return attributes_[id];
+  return nullptr;
+}
 
+const Attribute* ArrayMetadata::attribute(std::string name) const {
+  unsigned int nattr = attribute_num();
+  for (unsigned int i = 0; i < nattr; i++) {
+    auto attr = attribute(i);
+    if (attr->name() == name) {
+      return attr;
+    }
+  }
   return nullptr;
 }
 

--- a/core/src/array_metadata/domain.cc
+++ b/core/src/array_metadata/domain.cc
@@ -220,15 +220,23 @@ const void* Domain::domain() const {
 const void* Domain::domain(unsigned int i) const {
   if (i > dim_num_)
     return nullptr;
-
   return dimensions_[i]->domain();
 }
 
 const Dimension* Domain::dimension(unsigned int i) const {
   if (i > dim_num_)
     return nullptr;
-
   return dimensions_[i];
+}
+
+const Dimension* Domain::dimension(std::string name) const {
+  for (unsigned int i = 0; i < dim_num_; i++) {
+    auto dim = dimensions_[i];
+    if (dim->name() == name) {
+      return dim;
+    }
+  }
+  return nullptr;
 }
 
 void Domain::dump(FILE* out) const {

--- a/examples/src/tiledb_array_metadata.cc
+++ b/examples/src/tiledb_array_metadata.cc
@@ -134,18 +134,17 @@ int main() {
 
   // Print the attribute names using iterators
   printf("\nArray metadata attribute names: \n");
-  tiledb_attribute_iter_t* attr_iter;
-  const tiledb_attribute_t* attr;
-  const char* attr_name;
-  tiledb_attribute_iter_create(ctx, array_metadata, &attr_iter);
-  int done;
-  tiledb_attribute_iter_done(ctx, attr_iter, &done);
-  while (done != 1) {
-    tiledb_attribute_iter_here(ctx, attr_iter, &attr);
+
+  unsigned int nattr = 0;
+  tiledb_array_metadata_get_num_attributes(ctx, array_metadata, &nattr);
+
+  tiledb_attribute_t* attr = nullptr;
+  const char* attr_name = nullptr;
+  for (unsigned int i = 0; i < nattr; i++) {
+    tiledb_attribute_from_index(ctx, array_metadata, i, &attr);
     tiledb_attribute_get_name(ctx, attr, &attr_name);
     printf("* %s\n", attr_name);
-    tiledb_attribute_iter_next(ctx, attr_iter);
-    tiledb_attribute_iter_done(ctx, attr_iter, &done);
+    tiledb_attribute_free(ctx, attr);
   }
   printf("\n");
 
@@ -156,17 +155,16 @@ int main() {
 
   // Print the dimension names using iterators
   printf("\nArray metadata dimension names: \n");
-  tiledb_dimension_iter_t* dim_iter;
-  const tiledb_dimension_t* dim;
-  const char* dim_name;
-  tiledb_dimension_iter_create(ctx, got_domain, &dim_iter);
-  tiledb_dimension_iter_done(ctx, dim_iter, &done);
-  while (done != 1) {
-    tiledb_dimension_iter_here(ctx, dim_iter, &dim);
+  unsigned int rank = 0;
+  tiledb_domain_get_rank(ctx, domain, &rank);
+
+  tiledb_dimension_t* dim = nullptr;
+  const char* dim_name = nullptr;
+  for (unsigned int i = 0; i < rank; i++) {
+    tiledb_dimension_from_index(ctx, domain, i, &dim);
     tiledb_dimension_get_name(ctx, dim, &dim_name);
     printf("* %s\n", dim_name);
-    tiledb_dimension_iter_next(ctx, dim_iter);
-    tiledb_dimension_iter_done(ctx, dim_iter, &done);
+    tiledb_dimension_free(ctx, dim);
   }
   printf("\n");
 
@@ -175,12 +173,9 @@ int main() {
   tiledb_attribute_free(ctx, a2);
   tiledb_dimension_free(ctx, d1);
   tiledb_dimension_free(ctx, d2);
-  tiledb_attribute_iter_free(ctx, attr_iter);
-  tiledb_dimension_iter_free(ctx, dim_iter);
   tiledb_domain_free(ctx, domain);
   tiledb_domain_free(ctx, got_domain);
   tiledb_array_metadata_free(ctx, array_metadata);
   tiledb_ctx_free(ctx);
-
   return 0;
 }


### PR DESCRIPTION
Replace iterator api with direct index / key accessor functions
for attribute and dimension objects. Update tests and examples to use
the new api.

Iterator api is marked as deprecated, and should throw a warning when
used.