### PR TITLE
Fix fragment metadata off-by-one issue; make format.

### DIFF
--- a/core/include/filesystem/vfs.h
+++ b/core/include/filesystem/vfs.h
@@ -211,9 +211,9 @@ class VFS {
       const URI& uri, const void* buffer, uint64_t buffer_size) const;
 
  private:
-  /* ********************************* */
-  /*         PRIVATE ATTRIBUTES        */
-  /* ********************************* */
+/* ********************************* */
+/*         PRIVATE ATTRIBUTES        */
+/* ********************************* */
 #ifdef HAVE_HDFS
   hdfsFS hdfs_;
 #endif

--- a/core/src/compressors/lz4_compressor.cc
+++ b/core/src/compressors/lz4_compressor.cc
@@ -47,7 +47,7 @@ Status LZ4::compress(
 
   // TODO: level is ignored using the simple api interface
   (void)level;
-  // Compress
+// Compress
 #if LZ4_VERSION_NUMBER >= 10705
   int ret = LZ4_compress_default(
       (char*)input_buffer->data(),

--- a/core/src/fragment/fragment_metadata.cc
+++ b/core/src/fragment/fragment_metadata.cc
@@ -324,8 +324,7 @@ Status FragmentMetadata::load_file_sizes(ConstBuffer* buff) {
 Status FragmentMetadata::load_file_var_sizes(ConstBuffer* buff) {
   unsigned int attribute_num = array_metadata_->attribute_num();
   file_var_sizes_.resize(attribute_num + 1);
-  Status st =
-      buff->read(&file_var_sizes_[0], (attribute_num + 1) * sizeof(uint64_t));
+  Status st = buff->read(&file_var_sizes_[0], attribute_num * sizeof(uint64_t));
 
   if (!st.ok()) {
     return LOG_STATUS(Status::FragmentMetadataError(
@@ -592,8 +591,8 @@ Status FragmentMetadata::write_file_sizes(Buffer* buff) {
 // file_var_sizes_attr#attribute_num (uint64_t)
 Status FragmentMetadata::write_file_var_sizes(Buffer* buff) {
   unsigned int attribute_num = array_metadata_->attribute_num();
-  Status st = buff->write(
-      &next_tile_var_offsets_[0], (attribute_num + 1) * sizeof(uint64_t));
+  Status st =
+      buff->write(&next_tile_var_offsets_[0], attribute_num * sizeof(uint64_t));
   if (!st.ok()) {
     return LOG_STATUS(Status::FragmentMetadataError(
         "Cannot serialize fragment metadata; Writing file sizes failed"));

--- a/core/src/storage_manager/consolidator.cc
+++ b/core/src/storage_manager/consolidator.cc
@@ -115,7 +115,7 @@ Status Consolidator::consolidate(const char* array_name) {
   // Unlock the array
   st = storage_manager_->array_unlock(array_uri, false);
 
-  // Clean up
+// Clean up
 clean_up:
   delete array_meta;
   free_buffers(buffer_num, buffers, buffer_sizes);

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -51,7 +51,7 @@ struct DenseArrayFx {
   const char* DIM2_NAME = "y";
   const tiledb_datatype_t DIM_TYPE = TILEDB_INT64;
 
-  // Group folder name
+// Group folder name
 #ifdef HAVE_HDFS
   const std::string URI_PREFIX = "hdfs://";
   const std::string TEMP_DIR = "/tiledb_test/";

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -45,7 +45,7 @@ struct DenseVectorFx {
   const char* DIM0_NAME = "dim0";
   const tiledb_datatype_t DIM_TYPE = TILEDB_INT64;
 
-  // Group folder name
+// Group folder name
 #ifdef HAVE_HDFS
   const std::string URI_PREFIX = "hdfs://";
   const std::string TEMP_DIR = "/tiledb_test/";

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -53,7 +53,7 @@ struct SparseArrayFx {
   const tiledb_array_type_t ARRAY_TYPE = TILEDB_SPARSE;
   int COMPRESSION_LEVEL = -1;
 
-  // Workspace folder name
+// Workspace folder name
 #ifdef HAVE_HDFS
   const std::string URI_PREFIX = "hdfs://";
   const std::string TEMP_DIR = "/tiledb_test/";


### PR DESCRIPTION
Coordinates do not have variable-size files, so the count was incorrect for a buffer write.