### PR TITLE
tweak *from_name methods to return the only anonymous dim/attr

### DIFF
--- a/core/include/array_metadata/attribute.h
+++ b/core/include/array_metadata/attribute.h
@@ -103,6 +103,9 @@ class Attribute {
   /** Returns the attribute name. */
   const std::string& name() const;
 
+  /** Returns true if this is an anonymous (unlabeled) attribute **/
+  bool is_anonymous() const;
+
   /**
    * Serializes the object members into a binary buffer.
    *

--- a/core/include/array_metadata/dimension.h
+++ b/core/include/array_metadata/dimension.h
@@ -92,6 +92,9 @@ class Dimension {
   /** Returns the dimension name. */
   const std::string& name() const;
 
+  /** Returns true if this is an anonymous (unlabled) dimension **/
+  bool is_anonymous() const;
+
   /**
    * Serializes the object members into a binary buffer.
    *

--- a/core/src/array_metadata/attribute.cc
+++ b/core/src/array_metadata/attribute.cc
@@ -146,6 +146,11 @@ const std::string& Attribute::name() const {
   return name_;
 }
 
+bool Attribute::is_anonymous() const {
+  return name_.empty() ||
+         utils::starts_with(name_, constants::default_attr_name);
+}
+
 // ===== FORMAT =====
 // attribute_name_size (unsigned int)
 // attribute_name (string)

--- a/core/src/array_metadata/dimension.cc
+++ b/core/src/array_metadata/dimension.cc
@@ -154,6 +154,11 @@ const std::string& Dimension::name() const {
   return name_;
 }
 
+bool Dimension::is_anonymous() const {
+  return (
+      name_.empty() || utils::starts_with(name_, constants::default_dim_name));
+}
+
 // ===== FORMAT =====
 // dimension_name_size (unsigned int)
 // dimension_name (string)

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -711,7 +711,28 @@ int tiledb_dimension_from_name(
     *dim = nullptr;
     return TILEDB_OK;
   }
-  auto found_dim = domain->domain_->dimension(std::string(name));
+  std::string name_string(name);
+  const tiledb::Dimension* found_dim = nullptr;
+  if (name_string.empty()) {  // anonymous dimension
+    bool found_anonymous = false;
+    for (unsigned int i = 0; i < ndim; i++) {
+      auto dim = domain->domain_->dimension(i);
+      if (dim->is_anonymous()) {
+        if (found_anonymous) {
+          save_error(
+              ctx,
+              tiledb::Status::Error("dimension from name is ambiguous when "
+                                    "there are multiple anonymous "
+                                    "dimensions, use index instead"));
+          return TILEDB_ERR;
+        }
+        found_anonymous = true;
+        found_dim = dim;
+      }
+    }
+  } else {
+    found_dim = domain->domain_->dimension(name_string);
+  }
   if (found_dim == nullptr) {
     save_error(
         ctx,
@@ -1296,8 +1317,28 @@ int tiledb_attribute_from_name(
     *attr = nullptr;
     return TILEDB_OK;
   }
-  auto found_attr =
-      array_metadata->array_metadata_->attribute(std::string(name));
+  std::string name_string(name);
+  const tiledb::Attribute* found_attr = nullptr;
+  if (name_string.empty()) {  // anonymous attribute
+    bool found_anonymous = false;
+    for (unsigned int i = 0; i < attribute_num; i++) {
+      auto attr = array_metadata->array_metadata_->attribute(i);
+      if (attr->is_anonymous()) {
+        if (found_anonymous) {
+          save_error(
+              ctx,
+              tiledb::Status::Error("attribute from name is ambiguous when "
+                                    "there are multiple anonymous "
+                                    "attributes, use index instead"));
+          return TILEDB_ERR;
+        }
+        found_anonymous = true;
+        found_attr = attr;
+      }
+    }
+  } else {
+    found_attr = array_metadata->array_metadata_->attribute(name_string);
+  }
   if (found_attr == nullptr) {
     save_error(
         ctx,


### PR DESCRIPTION
If more than one dim / attr is anonymous, throw an error (for
consistency) + add tests