### PR TITLE
Consolidate dependent tests into a single TEST_CASE_METHOD

### DIFF
--- a/test/src/unit-capi-kv.cc
+++ b/test/src/unit-capi-kv.cc
@@ -590,67 +590,44 @@ void KVFx::check_read_all(const std::string& path) {
   CHECK(rc == TILEDB_OK);
 }
 
-TEST_CASE_METHOD(
-    KVFx, "C API: Test key-value; Create and write", "[capi], [kv]") {
+TEST_CASE_METHOD(KVFx, "C API: Test key-value", "[capi], [kv]") {
   // File
   create_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
+
+  // create & write
   std::string array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + KV_NAME;
   create_kv(array_name);
   write_kv(array_name);
 
-#ifdef HAVE_S3
-  // S3
-  create_temp_dir(S3_TEMP_DIR);
-  array_name = S3_TEMP_DIR + KV_NAME;
-  create_kv(array_name);
-  write_kv(array_name);
-#endif
-
-#ifdef HAVE_HDFS
-  // HDFS
-  create_temp_dir(HDFS_TEMP_DIR);
-  array_name = HDFS_TEMP_DIR + KV_NAME;
-  create_kv(array_name);
-  write_kv(array_name);
-#endif
-}
-
-TEST_CASE_METHOD(
-    KVFx, "C API: Test key-value; Single-key read", "[capi], [kv]") {
-  // File
-  std::string array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + KV_NAME;
+  // read
   check_single_key_read(array_name);
 
-#ifdef HAVE_S3
-  // S3
-  array_name = S3_TEMP_DIR + KV_NAME;
-  check_single_key_read(array_name);
-#endif
-
-#ifdef HAVE_HDFS
-  // HDFS
-  array_name = HDFS_TEMP_DIR + KV_NAME;
-  check_single_key_read(array_name);
-#endif
-}
-
-TEST_CASE_METHOD(KVFx, "C API: Test key-value; Read all", "[capi], [kv]") {
-  // File
-  std::string array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + KV_NAME;
+  // read all
   check_read_all(array_name);
+
   remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
 
 #ifdef HAVE_S3
-  // S3
+  create_temp_dir(S3_TEMP_DIR);
+
   array_name = S3_TEMP_DIR + KV_NAME;
+  create_kv(array_name);
+  write_kv(array_name);
+  check_single_key_read(array_name);
   check_read_all(array_name);
+
   remove_temp_dir(S3_TEMP_DIR);
 #endif
 
 #ifdef HAVE_HDFS
-  // HDFS
+  create_temp_dir(HDFS_TEMP_DIR);
+
   array_name = HDFS_TEMP_DIR + KV_NAME;
+  create_kv(array_name);
+  write_kv(array_name);
+  check_single_key_read(array_name);
   check_read_all(array_name);
+
   remove_temp_dir(HDFS_TEMP_DIR);
 #endif
 }

--- a/test/src/unit-capi-resource_management.cc
+++ b/test/src/unit-capi-resource_management.cc
@@ -234,55 +234,31 @@ void ResourceMgmtFx::check_move(const std::string& path) {
 }
 
 TEST_CASE_METHOD(
-    ResourceMgmtFx, "C API: Test TileDB object type", "[capi], [resource]") {
+    ResourceMgmtFx,
+    "C API: Test resource management methods",
+    "[capi], [resource]") {
   // File
   create_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
   check_object_type(FILE_URI_PREFIX + FILE_TEMP_DIR);
-
-  // S3
-#ifdef HAVE_S3
-  create_temp_dir(S3_TEMP_DIR);
-  check_object_type(S3_TEMP_DIR);
-#endif
-
-  // HDFS
-#ifdef HAVE_HDFS
-  create_temp_dir(HDFS_TEMP_DIR);
-  check_object_type(HDFS_TEMP_DIR);
-#endif
-}
-
-TEST_CASE_METHOD(
-    ResourceMgmtFx, "C API: Test TileDB delete", "[capi], [resource]") {
-  // File
   check_delete(FILE_URI_PREFIX + FILE_TEMP_DIR);
-
-  // S3
-#ifdef HAVE_S3
-  check_delete(S3_TEMP_DIR);
-#endif
-
-  // HDFS
-#ifdef HAVE_HDFS
-  check_delete(HDFS_TEMP_DIR);
-#endif
-}
-
-TEST_CASE_METHOD(
-    ResourceMgmtFx, "C API: Test TileDB Move", "[capi], [resource]") {
-  // File
   check_move(FILE_URI_PREFIX + FILE_TEMP_DIR);
   remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
 
   // S3
 #ifdef HAVE_S3
+  create_temp_dir(S3_TEMP_DIR);
+  check_object_type(S3_TEMP_DIR);
+  check_delete(S3_TEMP_DIR);
   check_move(S3_TEMP_DIR);
   remove_temp_dir(S3_TEMP_DIR);
 #endif
 
   // HDFS
 #ifdef HAVE_HDFS
-  check_move(HDFS_TEMP_DIR);
+  create_temp_dir(HDFS_TEMP_DIR);
+  check_object_type(HDFS_TEMP_DIR);
+  check_delete(HDFS_TEMP_DIR);
+  check_move(S3_TEMP_DIR);
   remove_temp_dir(HDFS_TEMP_DIR);
 #endif
 }

--- a/test/src/unit-capi-resource_management.cc
+++ b/test/src/unit-capi-resource_management.cc
@@ -258,7 +258,7 @@ TEST_CASE_METHOD(
   create_temp_dir(HDFS_TEMP_DIR);
   check_object_type(HDFS_TEMP_DIR);
   check_delete(HDFS_TEMP_DIR);
-  check_move(S3_TEMP_DIR);
+  check_move(HDFS_TEMP_DIR);
   remove_temp_dir(HDFS_TEMP_DIR);
 #endif
 }


### PR DESCRIPTION
This causes failures when using a test-runner that executes the tests in non-seq. order (ex. CLion).