### PR TITLE
Add Windows support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+version: '{build}'
+image: Visual Studio 2017
+build_script:
+- ps: >-
+    mkdir build
+
+    cd build
+
+    $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+
+    ..\scripts\install-deps.ps1
+
+    ..\bootstrap.ps1
+test_script:
+- ps: cmake --build . --target check --config Release

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ core/lib/*
 core/include/temp
 core/src/temp
 coverage.info
+deps-install/*
 test/obj/*
 test/bin/*
 test/tiledb_test/*
@@ -19,6 +20,7 @@ doxygen/html/
 doxygen/latex/
 examples/bin/*
 examples/obj/*
+scripts/deps-staging/*
 .idea
 *temp*
 *.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,11 @@ find_package(Bzip2 REQUIRED)
 include_directories(${BZIP2_INCLUDE_DIR})
 set(TILEDB_LIB_DEPENDENCIES ${TILEDB_LIB_DEPENDENCIES} ${BZIP2_LIBRARIES})
 
+# On Windows, set a variable for the dependency install location.
+if (WIN32)
+  set(TILEDB_DEPENDENCY_INSTALL_DIR "${CMAKE_SOURCE_DIR}/deps-install")
+endif()
+
 # Find optional library dependencies
 if(USE_HDFS)
   find_package(LIBJVM REQUIRED)
@@ -117,12 +122,32 @@ endif()
 include(SetCXX2011Flag REQUIRED)
 
 # Set compiler flags
-set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG -O0 -g3 -ggdb3 -gdwarf-3 -fvisibility=hidden -Werror -Wall -Wextra")
-set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3 -fvisibility=hidden -Werror -Wall -Wextra")
-set(CMAKE_CXX_FLAGS_COVERAGE "-DDEBUG -g3 -gdwarf-3 --coverage -Werror -Wall -Wextra")
+if (WIN32)
+  # We disable some warnings that are not present in gcc/clang -Wall:
+  #   C4101: unreferenced local variable
+  #   C4244: conversion warning of floating point to integer type.
+  #   C4456: local variable hiding previous local variable
+  #   C4457: local variable hiding function parameter
+  #   C4702: unreachable code
+  #   C4996: deprecation warning about e.g. sscanf.
+  set(MSVC_DISABLE_WARNINGS "/wd4101 /wd4244 /wd4456 /wd4457 /wd4702 /wd4996")
+  # Note: MSVC has the behavior of -fvisibility=hidden by default (you must
+  # explicitly export all symbols you want exported).
+  set(CMAKE_CXX_FLAGS_DEBUG "/DDEBUG /Od /Zi /W4 /WX ${MSVC_DISABLE_WARNINGS}")
+  set(CMAKE_CXX_FLAGS_RELEASE "/DNDEBUG /Ox /W4 /WX ${MSVC_DISABLE_WARNINGS}")
+  # Disable GDI (which we don't need, and causes some macro
+  # re-definition issues if wingdi.h is included)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DNOGDI")
+  # Add /MPn flag from CMake invocation (if defined).
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MSVC_MP_FLAG}")
+else()
+  set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG -O0 -g3 -ggdb3 -gdwarf-3 -fvisibility=hidden -Werror -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3 -fvisibility=hidden -Werror -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS_COVERAGE "-DDEBUG -g3 -gdwarf-3 --coverage -Werror -Wall -Wextra")
 
-if(NOT APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-literal-suffix")
+  if(NOT APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-literal-suffix")
+  endif()
 endif()
 
 # Enable sanitizers only on clang for now

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,0 +1,147 @@
+# PowerShell script for performing TileDB bootstrapping process on
+# Windows.
+
+<#
+.SYNOPSIS
+This is a Powershell script to bootstrap a TileDB build on Windows.
+
+.DESCRIPTION
+This script will check dependencies, and run the CMake build generator
+to generate a Visual Studio solution file that can be used to build or
+develop TileDB.
+
+.PARAMETER Prefix
+Installs files in tree rooted at PREFIX (defaults to TileDB\dist).
+
+.PARAMETER Dependency
+Semicolon separated list to binary dependencies.
+
+.PARAMETER CMakeGenerator
+Optionally specify the CMake generator string, e.g. "Visual Studio 15
+2017". Check 'cmake --help' for a list of supported generators.
+
+.PARAMETER EnableDebug
+Enable Debug build.
+
+.PARAMETER EnableCoverage
+Enable build with code coverage support.
+
+.PARAMETER EnableVerbose
+Enable verbose status messages.
+
+.PARAMETER Hdfs
+Enables building with the HDFS storage backend.
+
+.PARAMETER S3
+Enables building with the S3 storage backend.
+
+.PARAMETER BuildProcesses
+Number of parallel compile jobs.
+
+.LINK
+https://github.com/TileDB-Inc/TileDB
+
+.EXAMPLE
+..\bootstrap.ps1 -Prefix "\path\to\install" -Dependency "\path\to\dep1;\path\to\dep2"
+
+#>
+
+# Note -Debug and -Verbose are included in the PowerShell
+# CommonParameters list, so we don't duplicate them here.
+# TODO: that means they don't appear in the -? usage message.
+[CmdletBinding()]
+Param(
+    [string]$Prefix,
+    [string]$Dependency,
+    [string]$CMakeGenerator,
+    [switch]$EnableDebug,
+    [switch]$EnableCoverage,
+    [switch]$EnableVerbose,
+    [switch]$Hdfs,
+    [switch]$S3,
+    [Alias('J')]
+    [int]
+    $BuildProcesses = $env:NUMBER_OF_PROCESSORS
+)
+
+# Return the directory containing this script file.
+function Get-ScriptDirectory {
+    Split-Path -Parent $PSCommandPath
+}
+
+# Absolute path of TileDB directories.
+$SourceDirectory = Get-ScriptDirectory
+$BinaryDirectory = (Get-Item -Path ".\" -Verbose).FullName
+
+# Choose the default install prefix.
+$DefaultPrefix = Join-Path $SourceDirectory "dist"
+
+# Choose the default dependency install prefix.
+$DefaultDependency = Join-Path $SourceDirectory "deps-install"
+
+# Set TileDB build type
+$BuildType = "Release"
+if ($EnableDebug.IsPresent) {
+    $BuildType = "Debug"
+}
+if ($EnableCoverage.IsPresent) {
+    $BuildType = "Coverage"
+}
+
+# Set TileDB verbosity
+$Verbosity = "OFF"
+if ($EnableVerbose.IsPresent) {
+    $Verbosity = "ON"
+}
+
+# Set TileDB HDFS flag
+$UseHdfs = "OFF"
+if ($Hdfs.IsPresent) {
+    $UseHdfs = "ON"
+}
+
+# Set TileDB S3 flag
+$UseS3 = "OFF"
+if ($S3.IsPresent) {
+    $UseS3 = "ON"
+}
+
+# Set TileDB prefix
+$InstallPrefix = $DefaultPrefix
+if ($Prefix.IsPresent) {
+    $InstallPrefix = $Prefix
+}
+
+# Set TileDB dependency directory string
+$DependencyDir = $DefaultDependency
+if ($Dependency.IsPresent) {
+    $DependencyDir = $Dependency
+}
+
+# Set CMake generator type.
+$GeneratorFlag = ""
+if ($CMakeGenerator.IsPresent) {
+    $GeneratorFlag = "-G ""$CMakeGenerator"""
+}
+
+# Enforce out-of-source build
+if ($SourceDirectory -eq $BinaryDirectory) {
+    Throw "Cannot build the project in the source directory! Out-of-source build is enforced!"
+}
+
+# Check cmake binary
+if ((Get-Command "cmake.exe" -ErrorAction SilentlyContinue) -eq $null) {
+    Throw "Unable to find cmake.exe in your PATH."
+}
+if ($CMakeGenerator -eq $null) {
+    Throw "Could not identify a generator for CMake. Do you have Visual Studio installed?"
+}
+
+# Run CMake.
+# We use Invoke-Expression so we can echo the command to the user.
+$CommandString = "cmake -A x64 -DCMAKE_BUILD_TYPE=$BuildType -DCMAKE_INSTALL_PREFIX=""$InstallPrefix"" -DCMAKE_PREFIX_PATH=""$DependencyDir"" -DMSVC_MP_FLAG=""/MP$BuildProcesses"" -DTILEDB_VERBOSE=$Verbosity -DUSE_HDFS=$UseHdfs -DUSE_S3=$UseS3 $GeneratorFlag ""$SourceDirectory"""
+Write-Host $CommandString
+Write-Host
+Invoke-Expression "$CommandString"
+
+Write-Host "Bootstrap success. Run 'cmake --build .' to build and 'cmake --build . --target check --config $BuildType' to test."

--- a/cmake/Modules/FindLZ4.cmake
+++ b/cmake/Modules/FindLZ4.cmake
@@ -29,6 +29,13 @@
 #   - LZ4_LIBRARIES, the LZ4 library path
 #   - LZ4_FOUND, whether LZ4 has been found
 
+# Set the name of the lz4 shared object
+if (WIN32)
+  set(LZ4_LIB_NAME liblz4)
+else()
+  set(LZ4_LIB_NAME lz4)
+endif()
+
 # Find header files  
 if(LZ4_SEARCH_HEADER_PATHS)
   find_path( 
@@ -43,12 +50,12 @@ endif()
 # Find library
 if(LZ4_SEARCH_LIB_PATH)
   find_library(
-      LZ4_LIBRARIES NAMES lz4
+      LZ4_LIBRARIES NAMES ${LZ4_LIB_NAME}
       PATHS ${LZ4_SEARCH_LIB_PATH}$
       NO_DEFAULT_PATH
   )
 else()
-  find_library(LZ4_LIBRARIES NAMES lz4)
+  find_library(LZ4_LIBRARIES NAMES ${LZ4_LIB_NAME})
 endif()
 
 if(LZ4_INCLUDE_DIR AND LZ4_LIBRARIES)

--- a/cmake/Modules/FindZSTD.cmake
+++ b/cmake/Modules/FindZSTD.cmake
@@ -29,6 +29,13 @@
 #   - ZSTD_LIBRARIES, the Zstandard library path
 #   - ZSTD_FOUND, whether Zstandard has been found
 
+# Set the name of the zstd shared object
+if (WIN32)
+  set(ZSTD_LIB_NAME libzstd)
+else()
+  set(ZSTD_LIB_NAME zstd)
+endif()
+
 # Find header files  
 if(ZSTD_SEARCH_HEADER_PATHS)
   find_path( 
@@ -43,12 +50,12 @@ endif()
 # Find library
 if(ZSTD_SEARCH_LIB_PATH)
   find_library(
-      ZSTD_LIBRARIES NAMES zstd
+      ZSTD_LIBRARIES NAMES ${ZSTD_LIB_NAME}
       PATHS ${ZSTD_SEARCH_LIB_PATH}$
       NO_DEFAULT_PATH
   )
 else()
-  find_library(ZSTD_LIBRARIES NAMES zstd)
+  find_library(ZSTD_LIBRARIES NAMES ${ZSTD_LIB_NAME})
 endif()
 
 if(ZSTD_INCLUDE_DIR AND ZSTD_LIBRARIES)

--- a/cmake/Modules/SetCXX2011Flag.cmake
+++ b/cmake/Modules/SetCXX2011Flag.cmake
@@ -29,11 +29,14 @@
 
 include(CheckCXXCompilerFlag)
 
-# Set support for C++ 2011
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-if(COMPILER_SUPPORTS_CXX11)
-  message(STATUS "Compiler supports C++ 2011.")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-else()
-  message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+# Set support for C++ 2011. MSVC does not allow you to enforce a
+# standard pre-C++14.
+if (NOT WIN32)
+  CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+  if(COMPILER_SUPPORTS_CXX11)
+    message(STATUS "Compiler supports C++ 2011.")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  else()
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+  endif()
 endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -35,11 +35,10 @@ file(GLOB_RECURSE TILEDB_CORE_SOURCES "src/*.cc")
 
 # Gather the external source files
 file(GLOB_RECURSE TILEDB_CORE_EXT_HEADERS 
-       "${CMAKE_SOURCE_DIR}/external/include/spdlog/*"
+       "${CMAKE_SOURCE_DIR}/external/include/spdlog/*.h"
        "${CMAKE_SOURCE_DIR}/external/include/md5/*"
 )
 file(GLOB_RECURSE TILEDB_CORE_EXT_SOURCES 
-       "${CMAKE_SOURCE_DIR}/external/src/spdlog/*"
        "${CMAKE_SOURCE_DIR}/external/src/md5/*"
 )
 
@@ -64,6 +63,18 @@ set_target_properties(tiledb_static PROPERTIES OUTPUT_NAME "tiledb")
 add_library(tiledb_shared SHARED $<TARGET_OBJECTS:TILEDB_CORE_OBJECTS>)
 set_target_properties(tiledb_shared PROPERTIES OUTPUT_NAME "tiledb")
 target_link_libraries(tiledb_shared ${TILEDB_LIB_DEPENDENCIES})
+
+# Link Windows API libraries
+if (WIN32)
+  set(WIN32_LIBS
+    Shlwapi
+  )
+  foreach (LIB ${WIN32_LIBS})
+    find_library(${LIB} $LIB)
+    target_link_libraries(tiledb_static ${LIB})
+    target_link_libraries(tiledb_shared ${LIB})
+  endforeach()
+endif()
 
 # Install libraries
 install(

--- a/core/include/c_api/tiledb.h
+++ b/core/include/c_api/tiledb.h
@@ -49,6 +49,8 @@ extern "C" {
 /** C Library export. */
 #if (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
 #define TILEDB_EXPORT __attribute__((visibility("default")))
+#elif defined _MSC_VER
+#define TILEDB_EXPORT __declspec(dllexport)
 #else
 #define TILEDB_EXPORT
 #pragma message("TILEDB_EXPORT is not defined for this compiler")
@@ -57,6 +59,8 @@ extern "C" {
 
 #if (defined __GNUC__) || defined __INTEL_COMPILER
 #define TILEDB_DEPRECATED __attribute__((deprecated, visibility("default")))
+#elif defined _MSC_VER
+#define TILEDB_DEPRECATED __declspec(deprecated)
 #else
 #define DEPRECATED
 #pragma message("TILEDB_DEPRECATED is not defined for this compiler")

--- a/core/include/filesystem/filelock.h
+++ b/core/include/filesystem/filelock.h
@@ -1,0 +1,48 @@
+/**
+ * @file   filelock.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares a simple platform-agnostic file lock type.
+ */
+
+#ifndef TILEDB_FILELOCK_H
+#define TILEDB_FILELOCK_H
+
+namespace tiledb {
+
+#ifdef _WIN32
+typedef void* filelock_t;
+const filelock_t INVALID_FILELOCK = nullptr;
+#else
+typedef int filelock_t;
+const filelock_t INVALID_FILELOCK = -1;
+#endif
+
+}  // namespace tiledb
+
+#endif  // TILEDB_FILELOCK_H

--- a/core/include/filesystem/vfs.h
+++ b/core/include/filesystem/vfs.h
@@ -35,6 +35,7 @@
 
 #include "buffer.h"
 #include "config.h"
+#include "filelock.h"
 #include "filesystem.h"
 #include "status.h"
 #include "uri.h"
@@ -134,22 +135,22 @@ class VFS {
    * Locks a filelock.
    *
    * @param uri The URI of the filelock.
-   * @param fd A file descriptor for the filelock (used in unlocking the
+   * @param lock A handle for the filelock (used in unlocking the
    *     filelock).
    * @param shared *True* if it is a shared lock, *false* if it is an
    *     exclusive lock.
    * @return Status
    */
-  Status filelock_lock(const URI& uri, int* fd, bool shared) const;
+  Status filelock_lock(const URI& uri, filelock_t* lock, bool shared) const;
 
   /**
    * Unlocks a filelock.
    *
    * @param uri The URI of the filelock.
-   * @param fd The descriptor of the filelock.
+   * @param lock The handle of the filelock.
    * @return Status
    */
-  Status filelock_unlock(const URI& uri, int fd) const;
+  Status filelock_unlock(const URI& uri, filelock_t fd) const;
 
   /**
    * Retrieves the size of a file.

--- a/core/include/filesystem/win_filesystem.h
+++ b/core/include/filesystem/win_filesystem.h
@@ -1,5 +1,5 @@
 /**
- * @file   posix_filesystem.h
+ * @file   win_filesystem.h
  *
  * @section LICENSE
  *
@@ -27,11 +27,13 @@
  *
  * @section DESCRIPTION
  *
- * This file includes declarations of posix filesystem functions.
+ * This file includes declarations of Windows filesystem functions.
  */
 
-#ifndef TILEDB_POSIX_FILESYSTEM_H
-#define TILEDB_POSIX_FILESYSTEM_H
+#ifndef TILEDB_WIN_FILESYSTEM_H
+#define TILEDB_WIN_FILESYSTEM_H
+
+#ifdef _WIN32
 
 #include <sys/types.h>
 #include <string>
@@ -44,11 +46,11 @@
 
 namespace tiledb {
 
-namespace posix {
+namespace win {
 
 /**
- * Returns the absolute posix (string) path of the input in the
- * form "file://<absolute path>"
+ * Returns the absolute (string) path of the input in the
+ * form of a Windows path.
  */
 std::string abs_path(const std::string& path);
 
@@ -120,7 +122,7 @@ Status filelock_lock(const std::string& filename, filelock_t* fd, bool shared);
  * @param fd the open file descriptor to unlock
  * @return Status
  */
-Status filelock_unlock(int fd);
+Status filelock_unlock(filelock_t fd);
 
 /**
  * Checks if the input is an existing directory.
@@ -158,19 +160,6 @@ Status ls(const std::string& path, std::vector<std::string>* paths);
 Status move_path(const std::string& old_path, const std::string& new_path);
 
 /**
- * It takes as input an **absolute** path, and returns it in its canonicalized
- * form, after appropriately replacing "./" and "../" in the path.
- *
- * @param path The input path passed by reference, which will be modified
- *     by the function to hold the canonicalized absolute path. Note that the
- *     path must be absolute, otherwise the function fails. In case of error
- *     (e.g., if "../" are not properly used in *path*, or if *path* is not
- *     absolute), the function sets the empty string (i.e., "") to *path*.
- * @return void
- */
-void purge_dots_from_path(std::string* path);
-
-/**
  * Reads data from a file into a buffer.
  *
  * @param path The name of the file.
@@ -203,8 +192,34 @@ Status sync(const std::string& path);
  */
 Status write(const std::string& path, const void* buffer, uint64_t buffer_size);
 
-}  // namespace posix
+/**
+ * Converts a Windows path to a "file:///" URI.
+ *
+ * @param path The Windows path to convert.
+ * @status A path file URI.
+ */
+std::string uri_from_path(const std::string& path);
+
+/**
+ * Converts a "file:///" URI to a Windows path.
+ *
+ * @param path The URI to convert.
+ * @status A Windows path.
+ */
+std::string path_from_uri(const std::string& uri);
+
+/**
+ * Returns true if the given string is a Windows path.
+ *
+ * @param path The path to check.
+ * @return True if the path is a Windows path.
+ */
+bool is_win_path(const std::string& path);
+
+}  // namespace win
 
 }  // namespace tiledb
 
-#endif  // TILEDB_POSIX_FILESYSTEM_H
+#endif  // _WIN32
+
+#endif  // TILEDB_WIN_FILESYSTEM_H

--- a/core/include/misc/constants.h
+++ b/core/include/misc/constants.h
@@ -145,7 +145,7 @@ extern const uint64_t consolidation_buffer_size;
 extern const uint64_t max_write_bytes;
 
 /** The maximum name length. */
-extern const unsigned name_max_len;
+extern const unsigned uri_max_len;
 
 /** The size of the buffer that holds the sorted cells. */
 extern const uint64_t sorted_buffer_size;

--- a/core/include/misc/uri.h
+++ b/core/include/misc/uri.h
@@ -71,19 +71,19 @@ class URI {
   bool is_invalid() const;
 
   /**
-   * Checks if the input path is posix.
+   * Checks if the input path is file.
    *
    * @param path The path to be checked.
    * @return The result of the check.
    */
-  static bool is_posix(const std::string& path);
+  static bool is_file(const std::string& path);
 
   /**
-   * Checks if the URI is posix.
+   * Checks if the URI is file.
    *
    * @return The result of the check.
    */
-  bool is_posix() const;
+  bool is_file() const;
 
   /**
    * Checks if the input path is HDFS.

--- a/core/include/misc/utils.h
+++ b/core/include/misc/utils.h
@@ -270,6 +270,11 @@ bool starts_with(const std::string& value, const std::string& prefix);
  */
 std::string tile_extent_str(const void* tile_extent, Datatype type);
 
+/**
+ * Returns the current time in milliseconds.
+ */
+uint64_t timestamp_ms();
+
 }  // namespace utils
 
 }  // namespace tiledb

--- a/core/include/storage_manager/locked_array.h
+++ b/core/include/storage_manager/locked_array.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_LOCKED_ARRAY_H
 #define TILEDB_LOCKED_ARRAY_H
 
+#include "filelock.h"
 #include "status.h"
 #include "vfs.h"
 
@@ -96,7 +97,7 @@ class LockedArray {
   bool exclusive_lock_;
 
   /** Filelock handle. */
-  int filelock_;
+  filelock_t filelock_;
 
   /** The locked array mutex. */
   std::mutex mtx_;

--- a/core/src/compressors/gzip_compressor.cc
+++ b/core/src/compressors/gzip_compressor.cc
@@ -45,7 +45,7 @@ Status GZip::compress(
     return LOG_STATUS(Status::CompressionError(
         "Failed compressing with GZip; invalid buffer format"));
 
-  ssize_t ret;
+  int ret;
   z_stream strm;
 
   // Allocate deflate state

--- a/core/src/filesystem/posix_filesystem.cc
+++ b/core/src/filesystem/posix_filesystem.cc
@@ -30,6 +30,8 @@
  * This file includes definitions of POSIX filesystem functions.
  */
 
+#ifndef _WIN32
+
 #include "posix_filesystem.h"
 #include "constants.h"
 #include "logger.h"
@@ -179,7 +181,7 @@ Status file_size(const std::string& path, uint64_t* size) {
   return Status::Ok();
 }
 
-Status filelock_lock(const std::string& filename, int* fd, bool shared) {
+Status filelock_lock(const std::string& filename, filelock_t* fd, bool shared) {
   // Prepare the flock struct
   struct flock fl;
   memset(&fl, 0, sizeof(struct flock));
@@ -206,7 +208,7 @@ Status filelock_lock(const std::string& filename, int* fd, bool shared) {
   return Status::Ok();
 }
 
-Status filelock_unlock(int fd) {
+Status filelock_unlock(filelock_t fd) {
   if (::close(fd) == -1)
     return LOG_STATUS(Status::IOError(
         "Cannot unlock consolidation filelock: Cannot close filelock"));
@@ -412,3 +414,5 @@ Status write(
 }  // namespace posix
 
 }  // namespace tiledb
+
+#endif  // !_WIN32

--- a/core/src/filesystem/vfs.cc
+++ b/core/src/filesystem/vfs.cc
@@ -35,6 +35,7 @@
 #include "hdfs_filesystem.h"
 #include "logger.h"
 #include "posix_filesystem.h"
+#include "win_filesystem.h"
 
 namespace tiledb {
 
@@ -59,8 +60,8 @@ VFS::~VFS() {
   }
 #endif
 #ifdef HAVE_S3
-    // Do not disconnect - may lead to problems
-    // Status st = s3_.disconnect();
+// Do not disconnect - may lead to problems
+// Status st = s3_.disconnect();
 #endif
 }
 
@@ -69,8 +70,15 @@ VFS::~VFS() {
 /* ********************************* */
 
 std::string VFS::abs_path(const std::string& path) {
-  if (URI::is_posix(path))
+#ifdef _WIN32
+  if (win::is_win_path(path))
+    return win::uri_from_path(win::abs_path(path));
+  else if (URI::is_file(path))
+    return win::uri_from_path(win::abs_path(win::path_from_uri(path)));
+#else
+  if (URI::is_file(path))
     return posix::abs_path(path);
+#endif
   if (URI::is_hdfs(path))
     return path;
   if (URI::is_s3(path))
@@ -80,8 +88,12 @@ std::string VFS::abs_path(const std::string& path) {
 }
 
 Status VFS::create_dir(const URI& uri) const {
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::create_dir(uri.to_path());
+#else
     return posix::create_dir(uri.to_path());
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
@@ -106,8 +118,12 @@ Status VFS::create_file(const URI& uri) const {
   if (is_file(uri))
     return Status::Ok();
 
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::create_file(uri.to_path());
+#else
     return posix::create_file(uri.to_path());
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
@@ -157,8 +173,12 @@ Status VFS::remove_bucket(const URI& uri) const {
 }
 
 Status VFS::remove_path(const URI& uri) const {
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::remove_path(uri.to_path());
+#else
     return posix::remove_path(uri.to_path());
+#endif
   } else if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
     return hdfs::remove_path(hdfs_, uri);
@@ -179,8 +199,12 @@ Status VFS::remove_path(const URI& uri) const {
 }
 
 Status VFS::remove_file(const URI& uri) const {
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::remove_file(uri.to_path());
+#else
     return posix::remove_file(uri.to_path());
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
@@ -201,9 +225,14 @@ Status VFS::remove_file(const URI& uri) const {
       Status::VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
-Status VFS::filelock_lock(const URI& uri, int* fd, bool shared) const {
-  if (uri.is_posix())
+Status VFS::filelock_lock(const URI& uri, filelock_t* fd, bool shared) const {
+  if (uri.is_file())
+#ifdef _WIN32
+    return win::filelock_lock(uri.to_path(), fd, shared);
+#else
     return posix::filelock_lock(uri.to_path(), fd, shared);
+#endif
+
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
     return Status::Ok();
@@ -223,9 +252,13 @@ Status VFS::filelock_lock(const URI& uri, int* fd, bool shared) const {
       Status::VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
-Status VFS::filelock_unlock(const URI& uri, int fd) const {
-  if (uri.is_posix()) {
+Status VFS::filelock_unlock(const URI& uri, filelock_t fd) const {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::filelock_unlock(fd);
+#else
     return posix::filelock_unlock(fd);
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
@@ -247,8 +280,12 @@ Status VFS::filelock_unlock(const URI& uri, int fd) const {
 }
 
 Status VFS::file_size(const URI& uri, uint64_t* size) const {
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::file_size(uri.to_path(), size);
+#else
     return posix::file_size(uri.to_path(), size);
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
@@ -270,8 +307,12 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
 }
 
 bool VFS::is_dir(const URI& uri) const {
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::is_dir(uri.to_path());
+#else
     return posix::is_dir(uri.to_path());
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
@@ -291,8 +332,12 @@ bool VFS::is_dir(const URI& uri) const {
 }
 
 bool VFS::is_file(const URI& uri) const {
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::is_file(uri.to_path());
+#else
     return posix::is_file(uri.to_path());
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
@@ -347,8 +392,12 @@ Status VFS::init(const Config::VFSParams& vfs_params) {
 
 Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
   std::vector<std::string> paths;
-  if (parent.is_posix()) {
+  if (parent.is_file()) {
+#ifdef _WIN32
+    RETURN_NOT_OK(win::ls(parent.to_path(), &paths));
+#else
     RETURN_NOT_OK(posix::ls(parent.to_path(), &paths));
+#endif
   } else if (parent.is_hdfs()) {
 #ifdef HAVE_HDFS
     RETURN_NOT_OK(hdfs::ls(hdfs_, parent, &paths));
@@ -374,10 +423,15 @@ Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
 }
 
 Status VFS::move_path(const URI& old_uri, const URI& new_uri) {
-  // Posix
-  if (old_uri.is_posix()) {
-    if (new_uri.is_posix())
+  // File
+  if (old_uri.is_file()) {
+    if (new_uri.is_file()) {
+#ifdef _WIN32
+      return win::move_path(old_uri.to_path(), new_uri.to_path());
+#else
       return posix::move_path(old_uri.to_path(), new_uri.to_path());
+#endif
+    }
     return LOG_STATUS(Status::VFSError(
         "Moving files across filesystems is not supported yet"));
   }
@@ -420,8 +474,12 @@ Status VFS::read(
     return LOG_STATUS(
         Status::VFSError("Cannot read from file; File does not exist"));
 
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::read(uri.to_path(), offset, buffer, nbytes);
+#else
     return posix::read(uri.to_path(), offset, buffer, nbytes);
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
@@ -447,8 +505,12 @@ bool VFS::supports_fs(Filesystem fs) const {
 }
 
 Status VFS::sync(const URI& uri) {
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::sync(uri.to_path());
+#else
     return posix::sync(uri.to_path());
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS
@@ -470,8 +532,12 @@ Status VFS::sync(const URI& uri) {
 }
 
 Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
-  if (uri.is_posix()) {
+  if (uri.is_file()) {
+#ifdef _WIN32
+    return win::write(uri.to_path(), buffer, buffer_size);
+#else
     return posix::write(uri.to_path(), buffer, buffer_size);
+#endif
   }
   if (uri.is_hdfs()) {
 #ifdef HAVE_HDFS

--- a/core/src/filesystem/win_filesystem.cc
+++ b/core/src/filesystem/win_filesystem.cc
@@ -1,0 +1,533 @@
+/**
+ * @file   win_filesystem.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file includes definitions of Windows filesystem functions.
+ */
+
+#ifdef _WIN32
+
+#include "win_filesystem.h"
+#include "constants.h"
+#include "logger.h"
+#include "utils.h"
+
+#include <Shlwapi.h>
+#include <Windows.h>
+#include <wininet.h>  // For INTERNET_MAX_URL_LENGTH
+#include <fstream>
+#include <iostream>
+
+namespace tiledb {
+
+namespace win {
+
+static std::string get_last_error_msg() {
+  DWORD err = GetLastError();
+  LPVOID lpMsgBuf;
+  if (FormatMessage(
+          FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+              FORMAT_MESSAGE_IGNORE_INSERTS,
+          NULL,
+          err,
+          MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+          (LPTSTR)&lpMsgBuf,
+          0,
+          NULL) == 0) {
+    LocalFree(lpMsgBuf);
+    return "unknown error";
+  }
+  std::string msg(reinterpret_cast<char*>(lpMsgBuf));
+  LocalFree(lpMsgBuf);
+  return msg;
+}
+
+std::string abs_path(const std::string& path) {
+  if (path.length() == 0) {
+    return current_dir();
+  }
+  std::string full_path;
+  if (PathIsRelative(path.c_str())) {
+    full_path = current_dir() + "\\" + path;
+  } else {
+    full_path = path;
+  }
+  char result[MAX_PATH];
+  std::string str_result;
+  if (PathCanonicalize(result, full_path.c_str()) == FALSE) {
+    LOG_STATUS(Status::IOError(std::string("Cannot canonicalize path.")));
+  } else {
+    str_result = result;
+  }
+  return str_result;
+}
+
+Status create_dir(const std::string& path) {
+  if (win::is_dir(path)) {
+    return LOG_STATUS(Status::IOError(
+        std::string("Cannot create directory '") + path +
+        "'; Directory already exists"));
+  }
+  if (CreateDirectory(path.c_str(), nullptr) == 0) {
+    return LOG_STATUS(Status::IOError(
+        std::string("Cannot create directory '") + path +
+        "': " + get_last_error_msg()));
+  }
+  return Status::Ok();
+}
+
+Status create_file(const std::string& filename) {
+  if (win::is_file(filename)) {
+    return Status::Ok();
+  }
+
+  HANDLE file_h = CreateFile(
+      filename.c_str(),
+      GENERIC_WRITE,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+      nullptr,
+      CREATE_NEW,
+      FILE_ATTRIBUTE_NORMAL,
+      nullptr);
+  if (file_h == INVALID_HANDLE_VALUE || CloseHandle(file_h) == 0) {
+    return LOG_STATUS(Status::IOError(
+        std::string("Failed to create file '") + filename + "'"));
+  }
+  return Status::Ok();
+}
+
+std::string current_dir() {
+  std::string dir;
+  unsigned long length = GetCurrentDirectory(0, nullptr);
+  char* path = (char*)std::malloc(length * sizeof(char));
+  if (path == nullptr || GetCurrentDirectory(length, path) == 0) {
+    LOG_STATUS(
+        Status::IOError(std::string("Failed to get current directory.")));
+  }
+  dir = path;
+  std::free(path);
+  return dir;
+}
+
+static Status recursively_remove_directory(const std::string& path) {
+  const std::string glob = path + "\\*";
+  WIN32_FIND_DATA find_data;
+
+  // Get first file in directory.
+  HANDLE find_h = FindFirstFileEx(
+      glob.c_str(),
+      FindExInfoBasic,
+      &find_data,
+      FindExSearchNameMatch,
+      nullptr,
+      0);
+  if (find_h == INVALID_HANDLE_VALUE) {
+    goto err;
+  }
+
+  while (true) {
+    // Skip '.' and '..'
+    if (strcmp(find_data.cFileName, ".") != 0 &&
+        strcmp(find_data.cFileName, "..") != 0) {
+      std::string file_path = path + "\\" + find_data.cFileName;
+      if (PathIsDirectory(file_path.c_str())) {
+        if (!recursively_remove_directory(file_path).ok()) {
+          goto err;
+        }
+      } else {
+        if (!remove_file(file_path).ok()) {
+          goto err;
+        }
+      }
+    }
+
+    // Next find result.
+    if (!FindNextFile(find_h, &find_data)) {
+      break;
+    }
+  }
+
+  if (RemoveDirectory(path.c_str()) == 0) {
+    goto err;
+  }
+
+  FindClose(find_h);
+  return Status::Ok();
+
+err:
+  if (find_h != INVALID_HANDLE_VALUE) {
+    FindClose(find_h);
+  }
+  return LOG_STATUS(Status::IOError(
+      std::string("Failed to remove directory '" + path + "'")));
+}
+
+Status remove_path(const std::string& path) {
+  if (win::is_file(path)) {
+    return remove_file(path);
+  } else if (win::is_dir(path)) {
+    return recursively_remove_directory(path);
+  } else {
+    return LOG_STATUS(Status::IOError(std::string(
+        "Failed to delete path '" + path + "'; not a valid path.")));
+  }
+}
+
+Status delete_dir(const std::string& path) {
+  return recursively_remove_directory(path);
+}
+
+Status remove_file(const std::string& path) {
+  if (!DeleteFile(path.c_str())) {
+    return LOG_STATUS(
+        Status::IOError(std::string("Failed to delete file '" + path + "'")));
+  }
+  return Status::Ok();
+}
+
+Status file_size(const std::string& path, uint64_t* size) {
+  LARGE_INTEGER nbytes;
+  HANDLE file_h = CreateFile(
+      path.c_str(),
+      GENERIC_READ,
+      FILE_SHARE_READ,
+      NULL,
+      OPEN_EXISTING,
+      FILE_ATTRIBUTE_NORMAL,
+      NULL);
+  if (file_h == INVALID_HANDLE_VALUE) {
+    return LOG_STATUS(Status::IOError(
+        std::string("Failed to get file size for '" + path + "'")));
+  }
+  if (!GetFileSizeEx(file_h, &nbytes)) {
+    CloseHandle(file_h);
+    return LOG_STATUS(Status::IOError(
+        std::string("Failed to get file size for '" + path + "'")));
+  }
+  *size = nbytes.QuadPart;
+  CloseHandle(file_h);
+  return Status::Ok();
+}
+
+Status filelock_lock(const std::string& filename, filelock_t* fd, bool shared) {
+  HANDLE file_h = CreateFile(
+      filename.c_str(),
+      GENERIC_READ | GENERIC_WRITE,
+      FILE_SHARE_READ | FILE_SHARE_WRITE,
+      NULL,
+      OPEN_EXISTING,
+      FILE_ATTRIBUTE_NORMAL,
+      NULL);
+  if (file_h == INVALID_HANDLE_VALUE) {
+    return LOG_STATUS(Status::IOError(
+        std::string("Failed to lock '" + filename + "'; CreateFile error")));
+  }
+  OVERLAPPED overlapped = {0};
+  if (LockFileEx(
+          file_h,
+          shared ? 0 : LOCKFILE_EXCLUSIVE_LOCK,
+          0,
+          MAXDWORD,
+          MAXDWORD,
+          &overlapped) == 0) {
+    CloseHandle(file_h);
+    *fd = INVALID_FILELOCK;
+    return LOG_STATUS(Status::IOError(
+        std::string("Failed to lock '" + filename + "'; LockFile error")));
+  }
+
+  *fd = file_h;
+  return Status::Ok();
+}
+
+Status filelock_unlock(filelock_t fd) {
+  OVERLAPPED overlapped = {0};
+  if (UnlockFileEx(fd, 0, MAXDWORD, MAXDWORD, &overlapped) == 0) {
+    CloseHandle(fd);
+    return LOG_STATUS(
+        Status::IOError(std::string("Failed to unlock file lock")));
+  }
+  CloseHandle(fd);
+  return Status::Ok();
+}
+
+bool is_dir(const std::string& path) {
+  return PathIsDirectory(path.c_str());
+}
+
+bool is_file(const std::string& path) {
+  return PathFileExists(path.c_str()) && !PathIsDirectory(path.c_str());
+}
+
+Status ls(const std::string& path, std::vector<std::string>* paths) {
+  bool ends_with_slash = path.length() > 0 && path[path.length() - 1] == '\\';
+  const std::string glob = path + (ends_with_slash ? "*" : "\\*");
+  WIN32_FIND_DATA find_data;
+
+  // Get first file in directory.
+  HANDLE find_h = FindFirstFileEx(
+      glob.c_str(),
+      FindExInfoBasic,
+      &find_data,
+      FindExSearchNameMatch,
+      nullptr,
+      0);
+  if (find_h == INVALID_HANDLE_VALUE) {
+    goto err;
+  }
+
+  while (true) {
+    // Skip '.' and '..'
+    if (strcmp(find_data.cFileName, ".") != 0 &&
+        strcmp(find_data.cFileName, "..") != 0) {
+      std::string file_path =
+          path + (ends_with_slash ? "" : "\\") + find_data.cFileName;
+      paths->push_back(file_path);
+    }
+
+    // Next find result.
+    if (!FindNextFile(find_h, &find_data)) {
+      break;
+    }
+  }
+
+  FindClose(find_h);
+  return Status::Ok();
+
+err:
+  if (find_h != INVALID_HANDLE_VALUE) {
+    FindClose(find_h);
+  }
+  return LOG_STATUS(Status::IOError(std::string("Failed to list directory.")));
+}
+
+Status move_path(const std::string& old_path, const std::string& new_path) {
+  if (MoveFileEx(
+          old_path.c_str(), new_path.c_str(), MOVEFILE_REPLACE_EXISTING) == 0) {
+    return LOG_STATUS(Status::IOError(std::string(
+        "Failed to rename '" + old_path + "' to '" + new_path + "'.")));
+  }
+  return Status::Ok();
+}
+
+Status read(
+    const std::string& path, uint64_t offset, void* buffer, uint64_t nbytes) {
+  // Open the file (OPEN_EXISTING with CreateFile() will only open, not create,
+  // the file).
+  HANDLE file_h = CreateFile(
+      path.c_str(),
+      GENERIC_READ,
+      FILE_SHARE_READ,
+      NULL,
+      OPEN_EXISTING,
+      FILE_ATTRIBUTE_NORMAL,
+      NULL);
+  if (file_h == INVALID_HANDLE_VALUE) {
+    return LOG_STATUS(Status::IOError(
+        "Cannot read from file '" + path + "'; File opening error"));
+  }
+
+  LARGE_INTEGER offset_lg_int;
+  offset_lg_int.QuadPart = offset;
+  if (SetFilePointerEx(file_h, offset_lg_int, NULL, FILE_BEGIN) == 0) {
+    CloseHandle(file_h);
+    return LOG_STATUS(Status::IOError(
+        "Cannot read from file '" + path + "'; File seek error"));
+  }
+
+  unsigned long num_bytes_read = 0;
+  if (ReadFile(file_h, buffer, nbytes, &num_bytes_read, NULL) == 0 ||
+      num_bytes_read != nbytes) {
+    CloseHandle(file_h);
+    return LOG_STATUS(Status::IOError(
+        "Cannot read from file '" + path + "'; File read error"));
+  }
+
+  if (CloseHandle(file_h) == 0) {
+    return LOG_STATUS(Status::IOError(
+        "Cannot read from file '" + path + "'; File closing error"));
+  }
+
+  return Status::Ok();
+}
+
+Status sync(const std::string& path) {
+  if (!is_file(path)) {
+    return Status::Ok();
+  }
+
+  // Open the file (OPEN_EXISTING with CreateFile() will only open, not create,
+  // the file).
+  HANDLE file_h = CreateFile(
+      path.c_str(),
+      GENERIC_WRITE,
+      0,
+      NULL,
+      OPEN_EXISTING,
+      FILE_ATTRIBUTE_NORMAL,
+      NULL);
+  if (file_h == INVALID_HANDLE_VALUE) {
+    return LOG_STATUS(
+        Status::IOError("Cannot sync file '" + path + "'; File opening error"));
+  }
+
+  if (FlushFileBuffers(file_h) == 0) {
+    CloseHandle(file_h);
+    return LOG_STATUS(
+        Status::IOError("Cannot sync file '" + path + "'; Sync error"));
+  }
+
+  if (CloseHandle(file_h) == 0) {
+    return LOG_STATUS(Status::IOError(
+        "Cannot read from file '" + path + "'; File closing error"));
+  }
+
+  return Status::Ok();
+}
+
+Status write(
+    const std::string& path, const void* buffer, uint64_t buffer_size) {
+  // Open the file for appending, creating it if it doesn't exist.
+  HANDLE file_h = CreateFile(
+      path.c_str(),
+      GENERIC_WRITE,
+      0,
+      NULL,
+      OPEN_ALWAYS,
+      FILE_ATTRIBUTE_NORMAL,
+      NULL);
+  if (file_h == INVALID_HANDLE_VALUE) {
+    return LOG_STATUS(Status::IOError(
+        "Cannot write to file '" + path + "'; File opening error"));
+  }
+
+  LARGE_INTEGER offset_lg_int;
+  offset_lg_int.QuadPart = 0;
+  if (SetFilePointerEx(file_h, offset_lg_int, NULL, FILE_END) == 0) {
+    CloseHandle(file_h);
+    return LOG_STATUS(Status::IOError(
+        "Cannot write to file '" + path + "'; File seek error"));
+  }
+
+  // Append data to the file in batches of constants::max_write_bytes
+  // bytes at a time
+  unsigned long bytes_written = 0;
+  uint64_t byte_idx = 0;
+  const char* byte_buffer = reinterpret_cast<const char*>(buffer);
+  while (buffer_size > constants::max_write_bytes) {
+    if (WriteFile(
+            file_h,
+            byte_buffer + byte_idx,
+            constants::max_write_bytes,
+            &bytes_written,
+            NULL) == 0 ||
+        bytes_written != constants::max_write_bytes) {
+      return LOG_STATUS(Status::IOError(
+          std::string("Cannot write to file '") + path +
+          "'; File writing error"));
+    }
+    buffer_size -= constants::max_write_bytes;
+    byte_idx += constants::max_write_bytes;
+  }
+  if (WriteFile(
+          file_h, byte_buffer + byte_idx, buffer_size, &bytes_written, NULL) ==
+          0 ||
+      bytes_written != buffer_size) {
+    return LOG_STATUS(Status::IOError(
+        std::string("Cannot write to file '") + path +
+        "'; File writing error"));
+  }
+
+  if (CloseHandle(file_h) == 0) {
+    return LOG_STATUS(Status::IOError(
+        "Cannot write to file '" + path + "'; File closing error"));
+  }
+
+  return Status::Ok();
+}
+
+std::string uri_from_path(const std::string& path) {
+  if (path.length() == 0) {
+    return "";
+  }
+
+  unsigned long uri_length = INTERNET_MAX_URL_LENGTH;
+  char uri[INTERNET_MAX_URL_LENGTH];
+  std::string str_uri;
+  if (UrlCreateFromPath(path.c_str(), uri, &uri_length, NULL) != S_OK) {
+    LOG_STATUS(Status::IOError(
+        std::string("Failed to convert path '" + path + "' to URI.")));
+  }
+  str_uri = uri;
+  return str_uri;
+}
+
+std::string path_from_uri(const std::string& uri) {
+  if (uri.length() == 0) {
+    return "";
+  }
+
+  std::string uri_with_scheme =
+      utils::starts_with(uri, "file:///") ? uri : "file:///" + uri;
+
+  unsigned long path_length = MAX_PATH;
+  char path[MAX_PATH];
+  std::string str_path;
+  if (PathCreateFromUrl(uri_with_scheme.c_str(), path, &path_length, NULL) !=
+      S_OK) {
+    LOG_STATUS(Status::IOError(std::string(
+        "Failed to convert URI '" + uri_with_scheme + "' to path.")));
+  }
+  str_path = path;
+  return str_path;
+}
+
+bool is_win_path(const std::string& path) {
+  if (path.empty()) {
+    // Special case to match the behavior of posix_filesystem.
+    return true;
+  } else if (PathIsURL(path.c_str())) {
+    return false;
+  } else {
+    bool definitely_windows = PathIsUNC(path.c_str()) ||
+                              PathGetDriveNumber(path.c_str()) != -1 ||
+                              path.find('\\') != std::string::npos;
+    if (definitely_windows) {
+      return true;
+    } else {
+      // Bare relative path e.g. "filename.txt"
+      return path.find('/') == std::string::npos;
+    }
+  }
+}
+
+}  // namespace win
+
+}  // namespace tiledb
+
+#endif  // _WIN32

--- a/core/src/fragment/read_state.cc
+++ b/core/src/fragment/read_state.cc
@@ -32,7 +32,6 @@
  */
 
 #include "logger.h"
-#include "posix_filesystem.h"
 #include "query.h"
 #include "utils.h"
 

--- a/core/src/fragment/write_state.cc
+++ b/core/src/fragment/write_state.cc
@@ -40,7 +40,6 @@
 #include "comparators.h"
 #include "const_buffer.h"
 #include "logger.h"
-#include "posix_filesystem.h"
 #include "query.h"
 #include "tile.h"
 #include "utils.h"

--- a/core/src/misc/constants.cc
+++ b/core/src/misc/constants.cc
@@ -143,7 +143,7 @@ const uint64_t consolidation_buffer_size = 10000000;
 const uint64_t max_write_bytes = std::numeric_limits<int>::max();
 
 /** The maximum name length. */
-const unsigned name_max_len = 256;
+const unsigned uri_max_len = 256;
 
 /** The size of the buffer that holds the sorted cells. */
 const uint64_t sorted_buffer_size = 10000000;

--- a/core/src/misc/utils.cc
+++ b/core/src/misc/utils.cc
@@ -38,6 +38,13 @@
 #include <set>
 #include <sstream>
 
+#ifdef _WIN32
+#include <sys/timeb.h>
+#include <sys/types.h>
+#else
+#include <sys/time.h>
+#endif
+
 namespace tiledb {
 
 namespace utils {
@@ -486,6 +493,20 @@ std::string tile_extent_str(const void* tile_extent, Datatype type) {
   }
 
   return "";
+}
+
+uint64_t timestamp_ms() {
+#ifdef _WIN32
+  struct _timeb tb;
+  memset(&tb, 0, sizeof(struct _timeb));
+  _ftime_s(&tb);
+  return static_cast<uint64_t>(tb.time * 1000L + tb.millitm);
+#else
+  struct timeval tp;
+  memset(&tp, 0, sizeof(struct timeval));
+  gettimeofday(&tp, nullptr);
+  return static_cast<uint64_t>(tp.tv_sec * 1000L + tp.tv_usec / 1000);
+#endif
 }
 
 // Explicit template instantiations

--- a/core/src/query/array_ordered_write_state.cc
+++ b/core/src/query/array_ordered_write_state.cc
@@ -972,7 +972,7 @@ void ArrayOrderedWriteState::copy_tile_slab_var(
   update_current_tile_and_offset(aid);
 
   // Fill the local buffer offsets with zeros
-  bzero(local_buffer, local_buffer_size);
+  memset(local_buffer, 0, local_buffer_size);
 
   // Handle offsets first
   for (;;) {

--- a/core/src/query/query.cc
+++ b/core/src/query/query.cc
@@ -34,7 +34,6 @@
 #include "logger.h"
 #include "utils.h"
 
-#include <sys/time.h>
 #include <set>
 #include <sstream>
 
@@ -578,7 +577,7 @@ Status Query::write(void** buffers, uint64_t* buffer_sizes) {
 /* ****************************** */
 
 void Query::add_coords() {
-  size_t attribute_num = array_schema_->attribute_num();
+  unsigned int attribute_num = array_schema_->attribute_num();
   bool has_coords = false;
 
   for (auto id : attribute_ids_) {
@@ -729,10 +728,7 @@ Status Query::new_fragment() {
 }
 
 std::string Query::new_fragment_name() const {
-  struct timeval tp;
-  memset(&tp, 0, sizeof(struct timeval));
-  gettimeofday(&tp, nullptr);
-  auto ms = static_cast<uint64_t>(tp.tv_sec * 1000L + tp.tv_usec / 1000);
+  uint64_t ms = utils::timestamp_ms();
   std::stringstream ss;
   ss << array_schema_->array_uri().to_string() << "/__"
      << std::this_thread::get_id() << "_" << ms;
@@ -761,10 +757,10 @@ Status Query::set_attributes(
       attributes_vec.emplace_back(constants::coords);
   } else {  // Custom attributes
     // Get attributes
-    unsigned name_max_len = constants::name_max_len;
+    unsigned uri_max_len = constants::uri_max_len;
     for (unsigned int i = 0; i < attribute_num; ++i) {
       // Check attribute name length
-      if (attributes[i] == nullptr || strlen(attributes[i]) > name_max_len)
+      if (attributes[i] == nullptr || strlen(attributes[i]) > uri_max_len)
         return LOG_STATUS(Status::QueryError("Invalid attribute name length"));
       attributes_vec.emplace_back(attributes[i]);
     }

--- a/core/src/storage_manager/consolidator.cc
+++ b/core/src/storage_manager/consolidator.cc
@@ -33,8 +33,8 @@
 #include "consolidator.h"
 #include "logger.h"
 #include "storage_manager.h"
+#include "utils.h"
 
-#include <sys/time.h>
 #include <sstream>
 
 /* ****************************** */
@@ -261,10 +261,7 @@ Status Consolidator::rename_new_fragment_uri(URI* uri) const {
   auto timestamp_str = name.substr(name.find_last_of('_') + 1);
 
   // Get current time
-  struct timeval tp;
-  memset(&tp, 0, sizeof(struct timeval));
-  gettimeofday(&tp, nullptr);
-  auto ms = static_cast<uint64_t>(tp.tv_sec * 1000L + tp.tv_usec / 1000);
+  uint64_t ms = utils::timestamp_ms();
 
   std::stringstream ss;
   ss << uri->parent().to_string() << "/__" << std::this_thread::get_id() << "_"

--- a/core/src/storage_manager/locked_array.cc
+++ b/core/src/storage_manager/locked_array.cc
@@ -43,7 +43,7 @@ namespace tiledb {
 LockedArray::LockedArray() {
   shared_locks_ = 0;
   total_locks_ = 0;
-  filelock_ = -1;
+  filelock_ = INVALID_FILELOCK;
   exclusive_lock_ = false;
 }
 
@@ -79,7 +79,7 @@ Status LockedArray::lock_exclusive(VFS* vfs, const URI& uri) {
   std::unique_lock<std::mutex> lk(mtx_);
   cv_.wait(lk, [this] { return !exclusive_lock_ && (shared_locks_ == 0); });
 
-  if (filelock_ == -1)
+  if (filelock_ == INVALID_FILELOCK)
     RETURN_NOT_OK(vfs->filelock_lock(uri, &filelock_, false));
 
   exclusive_lock_ = true;
@@ -92,7 +92,7 @@ Status LockedArray::lock_shared(VFS* vfs, const URI& uri) {
   std::unique_lock<std::mutex> lk(mtx_);
   cv_.wait(lk, [this] { return !exclusive_lock_; });
 
-  if (filelock_ == -1)
+  if (filelock_ == INVALID_FILELOCK)
     RETURN_NOT_OK(vfs->filelock_lock(uri, &filelock_, true));
 
   ++shared_locks_;
@@ -102,9 +102,9 @@ Status LockedArray::lock_shared(VFS* vfs, const URI& uri) {
 }
 
 Status LockedArray::unlock_exclusive(VFS* vfs, const URI& uri) {
-  if (filelock_ != -1)
+  if (filelock_ != INVALID_FILELOCK)
     RETURN_NOT_OK(vfs->filelock_unlock(uri, filelock_));
-  filelock_ = -1;
+  filelock_ = INVALID_FILELOCK;
 
   exclusive_lock_ = false;
   cv_.notify_all();
@@ -113,9 +113,9 @@ Status LockedArray::unlock_exclusive(VFS* vfs, const URI& uri) {
 }
 
 Status LockedArray::unlock_shared(VFS* vfs, const URI& uri) {
-  if (filelock_ != -1)
+  if (filelock_ != INVALID_FILELOCK)
     RETURN_NOT_OK(vfs->filelock_unlock(uri, filelock_));
-  filelock_ = -1;
+  filelock_ = INVALID_FILELOCK;
 
   --shared_locks_;
   if (shared_locks_ == 0)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,7 +28,11 @@
 # Function that builds an executable per example
 function(build_TileDB_example TARGET)
   add_executable(${TARGET} EXCLUDE_FROM_ALL src/${TARGET}.cc)
-  target_link_libraries(${TARGET} tiledb_static -lpthread ${TILEDB_LIB_DEPENDENCIES} ${S3_LIB_DEPENDENCIES})
+  if (WIN32)
+    target_link_libraries(${TARGET} tiledb_static ${TILEDB_LIB_DEPENDENCIES} ${S3_LIB_DEPENDENCIES})
+  else()
+    target_link_libraries(${TARGET} tiledb_static -lpthread ${TILEDB_LIB_DEPENDENCIES} ${S3_LIB_DEPENDENCIES})
+  endif()
 endfunction()
 
 # Get the example sources

--- a/examples/src/tiledb_dense_write_async.cc
+++ b/examples/src/tiledb_dense_write_async.cc
@@ -54,29 +54,29 @@ int main() {
   // clang-format off
   int buffer_a1[] =
   {
-      0,  1,  2,  3,                                     // Upper left tile
-      4,  5,  6,  7,                                     // Upper right tile
-      8,  9,  10, 11,                                    // Lower left tile
-      12, 13, 14, 15                                     // Lower right tile
+      0,  1,  2,  3,                                             // Upper left tile
+      4,  5,  6,  7,                                             // Upper right tile
+      8,  9,  10, 11,                                            // Lower left tile
+      12, 13, 14, 15                                             // Lower right tile
   };
   uint64_t buffer_a2[] =
   {
-      0,  1,  3,  6,                                     // Upper left tile
-      10, 11, 13, 16,                                    // Upper right tile
-      20, 21, 23, 26,                                    // Lower left tile
-      30, 31, 33, 36                                     // Lower right tile
+      0,  1,  3,  6,                                             // Upper left tile
+      10, 11, 13, 16,                                            // Upper right tile
+      20, 21, 23, 26,                                            // Lower left tile
+      30, 31, 33, 36                                             // Lower right tile
   };
   char buffer_var_a2[] =
-      "abbcccdddd"                                       // Upper left tile
-      "effggghhhh"                                       // Upper right tile
-      "ijjkkkllll"                                       // Lower left tile
-      "mnnooopppp";                                      // Lower right tile
+      "abbcccdddd"                                               // Upper left tile
+      "effggghhhh"                                               // Upper right tile
+      "ijjkkkllll"                                               // Lower left tile
+      "mnnooopppp";                                              // Lower right tile
   float buffer_a3[] =
   {
-      0.1,  0.2,  1.1,  1.2,  2.1,  2.2,  3.1,  3.2,     // Upper left tile
-      4.1,  4.2,  5.1,  5.2,  6.1,  6.2,  7.1,  7.2,     // Upper right tile
-      8.1,  8.2,  9.1,  9.2,  10.1, 10.2, 11.1, 11.2,    // Lower left tile
-      12.1, 12.2, 13.1, 13.2, 14.1, 14.2, 15.1, 15.2,    // Lower right tile
+      0.1f,  0.2f,  1.1f,  1.2f,  2.1f,  2.2f,  3.1f,  3.2f,     // Upper left tile
+      4.1f,  4.2f,  5.1f,  5.2f,  6.1f,  6.2f,  7.1f,  7.2f,     // Upper right tile
+      8.1f,  8.2f,  9.1f,  9.2f,  10.1f, 10.2f, 11.1f, 11.2f,    // Lower left tile
+      12.1f, 12.2f, 13.1f, 13.2f, 14.1f, 14.2f, 15.1f, 15.2f,    // Lower right tile
   };
   void* buffers[] = { buffer_a1, buffer_a2, buffer_var_a2, buffer_a3 };
   uint64_t buffer_sizes[] =

--- a/examples/src/tiledb_dense_write_global_1.cc
+++ b/examples/src/tiledb_dense_write_global_1.cc
@@ -55,10 +55,10 @@ int main() {
       "effggghhhh"
       "ijjkkkllll"
       "mnnooopppp";
-  float buffer_a3[] = {0.1,  0.2,  1.1,  1.2,  2.1,  2.2,  3.1,  3.2,
-                       4.1,  4.2,  5.1,  5.2,  6.1,  6.2,  7.1,  7.2,
-                       8.1,  8.2,  9.1,  9.2,  10.1, 10.2, 11.1, 11.2,
-                       12.1, 12.2, 13.1, 13.2, 14.1, 14.2, 15.1, 15.2};
+  float buffer_a3[] = {0.1f,  0.2f,  1.1f,  1.2f,  2.1f,  2.2f,  3.1f,  3.2f,
+                       4.1f,  4.2f,  5.1f,  5.2f,  6.1f,  6.2f,  7.1f,  7.2f,
+                       8.1f,  8.2f,  9.1f,  9.2f,  10.1f, 10.2f, 11.1f, 11.2f,
+                       12.1f, 12.2f, 13.1f, 13.2f, 14.1f, 14.2f, 15.1f, 15.2f};
   void* buffers[] = {buffer_a1, buffer_a2, buffer_var_a2, buffer_a3};
   uint64_t buffer_sizes[] = {
       sizeof(buffer_a1),

--- a/examples/src/tiledb_dense_write_global_2.cc
+++ b/examples/src/tiledb_dense_write_global_2.cc
@@ -70,14 +70,15 @@ int main() {
   tiledb_query_submit(ctx, query);
 
   // Prepare cell buffers - #2
+  // clang-format off
   int buffer_a1_2[] = {6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
   uint64_t buffer_a2_2[] = {0, 1, 3, 6, 10, 11, 13, 16};
   char buffer_var_a2_2[] = "ijjkkkllllmnnooopppp";
   float buffer_a3_2[] = {
-      0.1,  0.2,  1.1,  1.2,  2.1,  2.2,  3.1,  3.2,   // Upper left tile
-      4.1,  4.2,  5.1,  5.2,  6.1,  6.2,  7.1,  7.2,   // Upper right tile
-      8.1,  8.2,  9.1,  9.2,  10.1, 10.2, 11.1, 11.2,  // Lower left tile
-      12.1, 12.2, 13.1, 13.2, 14.1, 14.2, 15.1, 15.2,  // Lower right tile
+      0.1f,  0.2f,  1.1f,  1.2f,  2.1f,  2.2f,  3.1f,  3.2f,   // Upper left tile
+      4.1f,  4.2f,  5.1f,  5.2f,  6.1f,  6.2f,  7.1f,  7.2f,   // Upper right tile
+      8.1f,  8.2f,  9.1f,  9.2f,  10.1f, 10.2f, 11.1f, 11.2f,  // Lower left tile
+      12.1f, 12.2f, 13.1f, 13.2f, 14.1f, 14.2f, 15.1f, 15.2f,  // Lower right tile
   };
   void* buffers_2[] = {buffer_a1_2, buffer_a2_2, buffer_var_a2_2, buffer_a3_2};
   uint64_t buffer_sizes_2[] = {
@@ -86,6 +87,7 @@ int main() {
       20,                 // 8 cells on a2
       32 * sizeof(float)  // 16 cells on a3 (2 values each)
   };
+  // clang-format on
 
   // Reset buffers
   tiledb_query_reset_buffers(ctx, query, buffers_2, buffer_sizes_2);

--- a/examples/src/tiledb_dense_write_global_subarray.cc
+++ b/examples/src/tiledb_dense_write_global_subarray.cc
@@ -52,7 +52,8 @@ int main() {
   int buffer_a1[] = {112, 113, 114, 115};
   uint64_t buffer_a2[] = {0, 1, 3, 6};
   char buffer_var_a2[] = "MNNOOOPPPP";
-  float buffer_a3[] = {112.1, 112.2, 113.1, 113.2, 114.1, 114.2, 115.1, 115.2};
+  float buffer_a3[] = {
+      112.1f, 112.2f, 113.1f, 113.2f, 114.1f, 114.2f, 115.1f, 115.2f};
   void* buffers[] = {buffer_a1, buffer_a2, buffer_var_a2, buffer_a3};
   uint64_t buffer_sizes[] = {
       sizeof(buffer_a1),

--- a/examples/src/tiledb_dense_write_ordered_subarray.cc
+++ b/examples/src/tiledb_dense_write_ordered_subarray.cc
@@ -56,8 +56,18 @@ int main() {
   int buffer_a1[] = {9, 12, 13, 11, 14, 15};
   uint64_t buffer_a2[] = {0, 2, 3, 5, 9, 12};
   char buffer_var_a2[] = "jjmnnllllooopppp";
-  float buffer_a3[] = {
-      9.1, 9.2, 12.1, 12.2, 13.1, 13.2, 11.1, 11.2, 14.1, 14.2, 15.1, 15.2};
+  float buffer_a3[] = {9.1f,
+                       9.2f,
+                       12.1f,
+                       12.2f,
+                       13.1f,
+                       13.2f,
+                       11.1f,
+                       11.2f,
+                       14.1f,
+                       14.2f,
+                       15.1f,
+                       15.2f};
   void* buffers[] = {buffer_a1, buffer_a2, buffer_var_a2, buffer_a3};
   uint64_t buffer_sizes[] = {
       sizeof(buffer_a1),

--- a/examples/src/tiledb_dense_write_unordered.cc
+++ b/examples/src/tiledb_dense_write_unordered.cc
@@ -53,7 +53,8 @@ int main() {
   int buffer_a1[] = {211, 213, 212, 208};
   uint64_t buffer_a2[] = {0, 4, 6, 7};
   char buffer_var_a2[] = "wwwwyyxu";
-  float buffer_a3[] = {211.1, 211.2, 213.1, 213.2, 212.1, 212.2, 208.1, 208.2};
+  float buffer_a3[] = {
+      211.1f, 211.2f, 213.1f, 213.2f, 212.1f, 212.2f, 208.1f, 208.2f};
   uint64_t buffer_coords[] = {4, 2, 3, 4, 3, 3, 3, 1};
   void* buffers[] = {
       buffer_a1, buffer_a2, buffer_var_a2, buffer_a3, buffer_coords};

--- a/examples/src/tiledb_kv_read.cc
+++ b/examples/src/tiledb_kv_read.cc
@@ -38,6 +38,7 @@
 
 #include <tiledb.h>
 #include <iostream>
+#include <string>
 
 int main() {
   // Create TileDB context

--- a/examples/src/tiledb_kv_read_all.cc
+++ b/examples/src/tiledb_kv_read_all.cc
@@ -38,6 +38,7 @@
 
 #include <tiledb.h>
 #include <iostream>
+#include <string>
 
 void print_results(tiledb_ctx_t* ctx, tiledb_kv_t* kv);
 void print_key(void* key, tiledb_datatype_t key_type, uint64_t key_size);

--- a/examples/src/tiledb_kv_write.cc
+++ b/examples/src/tiledb_kv_write.cc
@@ -52,22 +52,22 @@ int main() {
   int key1 = 100;
   int key1_a1 = 1;
   const char* key1_a2 = "a";
-  float key1_a3[] = {1.1, 1.2};
+  float key1_a3[] = {1.1f, 1.2f};
 
   float key2 = 200.0;
   int key2_a1 = 2;
   const char* key2_a2 = "bb";
-  float key2_a3[] = {2.1, 2.2};
+  float key2_a3[] = {2.1f, 2.2f};
 
   double key3[] = {300.0, 300.1};
   int key3_a1 = 3;
   const char* key3_a2 = "ccc";
-  float key3_a3[] = {3.1, 3.2};
+  float key3_a3[] = {3.1f, 3.2f};
 
   char key4[] = "key_4";
   int key4_a1 = 4;
   const char* key4_a2 = "dddd";
-  float key4_a3[] = {4.1, 4.2};
+  float key4_a3[] = {4.1f, 4.2f};
 
   // Create key-values
   tiledb_kv_t* kv;

--- a/examples/src/tiledb_sparse_write_global_1.cc
+++ b/examples/src/tiledb_sparse_write_global_1.cc
@@ -55,8 +55,8 @@ int main() {
   char buffer_var_a2[] = "abbcccddddeffggghhhh";
   float buffer_a3[] =
   {
-      0.1,  0.2,  1.1,  1.2,  2.1,  2.2,  3.1,  3.2,
-      4.1,  4.2,  5.1,  5.2,  6.1,  6.2,  7.1,  7.2
+      0.1f,  0.2f,  1.1f,  1.2f,  2.1f,  2.2f,  3.1f,  3.2f,
+      4.1f,  4.2f,  5.1f,  5.2f,  6.1f,  6.2f,  7.1f,  7.2f
   };
   uint64_t buffer_coords[] = { 1, 1, 1, 2, 1, 4, 2, 3, 3, 1, 4, 2, 3, 3, 3, 4 };
   void* buffers[] =

--- a/examples/src/tiledb_sparse_write_global_2.cc
+++ b/examples/src/tiledb_sparse_write_global_2.cc
@@ -54,8 +54,8 @@ int main() {
   char buffer_var_a2[] = "abbcccddddeffggghhhh";
   float buffer_a3[] = 
   {
-      0.1,  0.2,  1.1,  1.2,  2.1,  2.2,  3.1,  3.2,
-      4.1,  4.2,  5.1,  5.2,  6.1,  6.2,  7.1,  7.2 
+      0.1f,  0.2f,  1.1f,  1.2f,  2.1f,  2.2f,  3.1f,  3.2f,
+      4.1f,  4.2f,  5.1f,  5.2f,  6.1f,  6.2f,  7.1f,  7.2f
   };
   uint64_t buffer_coords[] = { 1, 1, 1, 2 };
   void* buffers[] =

--- a/examples/src/tiledb_sparse_write_unordered_1.cc
+++ b/examples/src/tiledb_sparse_write_unordered_1.cc
@@ -53,8 +53,8 @@ int main() {
   char buffer_var_a2[] = "hhhhffagggeddddbbccc";
   float buffer_a3[] =
   {
-      7.1,  7.2,  5.1,  5.2,  0.1,  0.2,  6.1,  6.2,
-      4.1,  4.2,  3.1,  3.2,  1.1,  1.2,  2.1,  2.2
+      7.1f,  7.2f,  5.1f,  5.2f,  0.1f,  0.2f,  6.1f,  6.2f,
+      4.1f,  4.2f,  3.1f,  3.2f,  1.1f,  1.2f,  2.1f,  2.2f
   };
   uint64_t buffer_coords[] = { 3, 4, 4, 2, 1, 1, 3, 3, 3, 1, 2, 3, 1, 2, 1, 4 };
   void* buffers[] =

--- a/examples/src/tiledb_sparse_write_unordered_1_again.cc
+++ b/examples/src/tiledb_sparse_write_unordered_1_again.cc
@@ -51,7 +51,8 @@ int main() {
   int buffer_a1[] = {107, 104, 106, 105};
   uint64_t buffer_a2[] = {0, 3, 4, 5};
   char buffer_var_a2[] = "yyyuwvvvv";
-  float buffer_a3[] = {107.1, 107.2, 104.1, 104.2, 106.1, 106.2, 105.1, 105.2};
+  float buffer_a3[] = {
+      107.1f, 107.2f, 104.1f, 104.2f, 106.1f, 106.2f, 105.1f, 105.2f};
   int64_t buffer_coords[] = {3, 4, 3, 2, 3, 3, 4, 1};
   void* buffers[] = {
       buffer_a1, buffer_a2, buffer_var_a2, buffer_a3, buffer_coords};

--- a/examples/src/tiledb_sparse_write_unordered_2.cc
+++ b/examples/src/tiledb_sparse_write_unordered_2.cc
@@ -51,7 +51,7 @@ int main() {
   int buffer_a1[] = {7, 5, 0};
   uint64_t buffer_a2[] = {0, 4, 6};
   char buffer_var_a2[] = "hhhhffa";
-  float buffer_a3[] = {7.1, 7.2, 5.1, 5.2, 0.1, 0.2};
+  float buffer_a3[] = {7.1f, 7.2f, 5.1f, 5.2f, 0.1f, 0.2f};
   uint64_t buffer_coords[] = {3, 4, 4, 2, 1, 1};
   void* buffers[] = {
       buffer_a1, buffer_a2, buffer_var_a2, buffer_a3, buffer_coords};
@@ -75,7 +75,8 @@ int main() {
   int buffer_a1_2[] = {6, 4, 3, 1, 2};
   uint64_t buffer_a2_2[] = {0, 3, 4, 8, 10};
   char buffer_var_a2_2[] = "gggeddddbbccc";
-  float buffer_a3_2[] = {6.1, 6.2, 4.1, 4.2, 3.1, 3.2, 1.1, 1.2, 2.1, 2.2};
+  float buffer_a3_2[] = {
+      6.1f, 6.2f, 4.1f, 4.2f, 3.1f, 3.2f, 1.1f, 1.2f, 2.1f, 2.2f};
   uint64_t buffer_coords_2[] = {3, 3, 3, 1, 2, 3, 1, 2, 1, 4};
   void* buffers_2[] = {
       buffer_a1_2, buffer_a2_2, buffer_var_a2_2, buffer_a3_2, buffer_coords_2};

--- a/scripts/install-deps.ps1
+++ b/scripts/install-deps.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+This is a Powershell script to install TileDB dependencies on Windows.
+
+.DESCRIPTION
+This is a Powershell script to install TileDB dependencies on Windows.
+
+.LINK
+https://github.com/TileDB-Inc/TileDB
+
+#>
+
+[CmdletBinding()]
+Param(
+)
+
+# Return the directory containing this script file.
+function Get-ScriptsDirectory {
+    Split-Path -Parent $PSCommandPath
+}
+
+$TileDBRootDirectory = Split-Path -Parent (Get-ScriptsDirectory)
+$InstallPrefix = Join-Path $TileDBRootDirectory "deps-install"
+$StagingDirectory = Join-Path (Get-ScriptsDirectory) "deps-staging"
+$DownloadZlibDest = Join-Path $StagingDirectory "zlib.zip"
+$DownloadLz4Dest = Join-Path $StagingDirectory "lz4.zip"
+$DownloadBloscDest = Join-Path $StagingDirectory "blosc.zip"
+$DownloadZstdDest = Join-Path $StagingDirectory "zstd.zip"
+$DownloadBzip2Dest = Join-Path $StagingDirectory "bzip2.zip"
+
+function DownloadFile([string] $URL, [string] $Dest) {
+    Write-Host "Downloading $URL to $Dest..."
+    Invoke-WebRequest -Uri $URL -OutFile $Dest
+}
+
+function DownloadIfNotExists([string] $Path, [string] $URL) {
+    if (!(Test-Path $Path)) {
+	DownloadFile $URL $Path
+    }
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip([string] $Zipfile, [string] $Dest) {
+    Write-Host "Extracting $Zipfile to $Dest..."
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($Zipfile, $Dest)
+}
+
+function Install-Zlib {
+    $ZlibRoot = (Join-Path $StagingDirectory "zlib-1.2.11")
+    if (!(Test-Path $ZlibRoot)) {
+	DownloadIfNotExists $DownloadZlibDest "https://zlib.net/zlib1211.zip"
+	Unzip $DownloadZlibDest $StagingDirectory
+    }
+    Push-Location
+    Set-Location $ZlibRoot
+    if (!(Test-Path build)) {
+	New-Item -ItemType Directory -Path build
+    }
+    Set-Location build
+    cmake -A X64 -DCMAKE_INSTALL_PREFIX="$InstallPrefix" ..
+    cmake --build . --config Release --target INSTALL
+    Pop-Location
+}
+
+function Install-LZ4 {
+    $Lz4Root = (Join-Path $StagingDirectory "lz4")
+    if (!(Test-Path $Lz4Root)) {
+	DownloadIfNotExists $DownloadLz4Dest "https://github.com/lz4/lz4/releases/download/v1.8.0/lz4_v1_8_0_win64.zip"
+	New-Item -ItemType Directory -Path $Lz4Root
+	Unzip $DownloadLz4Dest $Lz4Root
+    }
+    $DllDir = Join-Path $Lz4Root "dll"
+    Copy-Item (Join-Path $DllDir "liblz4.lib") (Join-Path (Join-Path $InstallPrefix "lib") "liblz4.lib")
+    Copy-Item (Join-Path $DllDir "liblz4.so.1.8.0.dll") (Join-Path (Join-Path $InstallPrefix "bin") "liblz4.dll")
+    $IncDir = Join-Path $Lz4Root "include"
+    Copy-Item (Join-Path $IncDir "*") (Join-Path $InstallPrefix "include")
+}
+
+function Install-Blosc {
+    $BloscRoot = (Join-Path $StagingDirectory "c-blosc-1.12.1")
+    if (!(Test-Path $BloscRoot)) {
+	DownloadIfNotExists $DownloadBloscDest "https://github.com/Blosc/c-blosc/archive/v1.12.1.zip"
+	Unzip $DownloadBloscDest $StagingDirectory
+    }
+    Push-Location
+    Set-Location $BloscRoot
+    if (!(Test-Path build)) {
+	New-Item -ItemType Directory -Path build
+    }
+    Set-Location build
+    cmake -A X64 -DCMAKE_INSTALL_PREFIX="$InstallPrefix" ..
+    cmake --build . --config Release --target INSTALL
+    Move-Item (Join-Path (Join-Path "$InstallPrefix" "lib") "blosc.dll") (Join-Path (Join-Path "$InstallPrefix" "bin") "blosc.dll")
+    Pop-Location
+}
+
+function Install-Zstd {
+    $ZstdRoot = (Join-Path $StagingDirectory "zstd")
+    if (!(Test-Path $ZstdRoot)) {
+	DownloadIfNotExists $DownloadZstdDest "https://github.com/facebook/zstd/releases/download/v1.3.2/zstd-v1.3.2-win64.zip"
+	New-Item -ItemType Directory -Path $ZstdRoot
+	Unzip $DownloadZstdDest $ZstdRoot
+    }
+    $DllDir = Join-Path $ZstdRoot "dll"
+    Copy-Item (Join-Path $DllDir "libzstd.lib") (Join-Path (Join-Path $InstallPrefix "lib") "libzstd.lib")
+    Copy-Item (Join-Path $DllDir "libzstd.dll") (Join-Path (Join-Path $InstallPrefix "bin") "libzstd.dll")
+    $IncDir = Join-Path $ZstdRoot "include"
+    Copy-Item (Join-Path $IncDir "*") (Join-Path $InstallPrefix "include")
+}
+
+function Install-Bzip2 {
+    $Bzip2Root = (Join-Path $StagingDirectory "bzip2")
+    if (!(Test-Path $Bzip2Root)) {
+	DownloadIfNotExists $DownloadBzip2Dest "https://github.com/TileDB-Inc/bzip2-windows/releases/download/v1.0.6/bzip2-1.0.6.zip"
+	New-Item -ItemType Directory -Path $Bzip2Root
+	Unzip $DownloadBzip2Dest $Bzip2Root
+    }
+    Push-Location
+    Set-Location (Join-Path $Bzip2Root "bzip2-1.0.6")
+    if (!(Test-Path build)) {
+	New-Item -ItemType Directory -Path build
+    }
+    Set-Location build
+    cmake -A X64 -DCMAKE_INSTALL_PREFIX="$InstallPrefix" ..
+    cmake --build . --config Release --target INSTALL
+    Pop-Location
+}
+
+function Install-All-Deps {
+    if (!(Test-Path $StagingDirectory)) {
+	New-Item -ItemType Directory -Path $StagingDirectory
+    }
+    Install-Zlib
+    Install-LZ4
+    Install-Blosc
+    Install-Zstd
+    Install-Bzip2
+}
+
+Install-All-Deps
+
+Write-Host "Finished."

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,10 +61,17 @@ set_target_properties(
   CXX_STANDARD_REQUIRED ON
 )
 
-target_link_libraries(
-  tiledb_unit
-  ${TILEDB_LIB_DEPENDENCIES} -lpthread tiledb_shared ${S3_LIB_DEPENDENCIES}
-)
+if (WIN32)
+  target_link_libraries(
+    tiledb_unit
+    ${TILEDB_LIB_DEPENDENCIES} tiledb_shared ${S3_LIB_DEPENDENCIES}
+  )
+else()
+  target_link_libraries(
+    tiledb_unit
+    ${TILEDB_LIB_DEPENDENCIES} -lpthread tiledb_shared ${S3_LIB_DEPENDENCIES}
+  )
+endif()
 
 target_include_directories(
   tiledb_unit BEFORE PRIVATE
@@ -86,9 +93,18 @@ else()
   )
 endif()
 
+# Set PATH so the dependency .DLLs can be located.
+if (WIN32)
+  # Handle escaped semicolons. See
+  # https://cmake.org/pipermail/cmake/2010-December/041176.html
+  set(PATH_STRING "$ENV{PATH};${TILEDB_DEPENDENCY_INSTALL_DIR}/bin")
+  string(REPLACE "\\;" ";" PATH_STRING "${PATH_STRING}")
+  string(REPLACE ";" "\\;" PATH_STRING "${PATH_STRING}")
+  set_tests_properties("tiledb_unit" PROPERTIES ENVIRONMENT "PATH=${PATH_STRING}")
+endif()
 
 # Add custom target 'check'
 add_custom_target(
-  check COMMAND ${CMAKE_CTEST_COMMAND} -V
+  check COMMAND ${CMAKE_CTEST_COMMAND} -V -C ${CMAKE_BUILD_TYPE}
   DEPENDS tiledb_unit
 )

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -54,14 +54,17 @@ void check_correct_file() {
   tiledb_ctx_t* ctx;
   rc = tiledb_ctx_create(&ctx, config);
   CHECK(rc == TILEDB_OK);
+
+  // Remove file
+  tiledb_vfs_t* vfs;
+  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
+  CHECK(tiledb_vfs_remove_file(ctx, vfs, "test_config.txt") == TILEDB_OK);
+  CHECK(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
+
   rc = tiledb_ctx_free(ctx);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_config_free(config);
   CHECK(rc == TILEDB_OK);
-
-  // Remove file
-  std::string cmd = std::string("rm -f test_config.txt");
-  CHECK(system(cmd.c_str()) == 0);
 }
 
 void check_incorrect_file_cannot_open() {
@@ -104,9 +107,13 @@ void check_incorrect_file_missing_value() {
   rc = tiledb_config_free(config);
   CHECK(rc == TILEDB_OK);
 
-  // Remove file
-  std::string cmd = std::string("rm -f test_config.txt");
-  CHECK(system(cmd.c_str()) == 0);
+  // Remove file (with a new valid context).
+  tiledb_vfs_t* vfs;
+  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
+  CHECK(tiledb_vfs_remove_file(ctx, vfs, "test_config.txt") == TILEDB_OK);
+  CHECK(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
+  CHECK(tiledb_ctx_free(ctx) == TILEDB_OK);
 }
 
 void check_incorrect_file_extra_word() {
@@ -133,9 +140,13 @@ void check_incorrect_file_extra_word() {
   rc = tiledb_config_free(config);
   CHECK(rc == TILEDB_OK);
 
-  // Remove file
-  std::string cmd = std::string("rm -f test_config.txt");
-  CHECK(system(cmd.c_str()) == 0);
+  // Remove file (with a new valid context).
+  tiledb_vfs_t* vfs;
+  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
+  CHECK(tiledb_vfs_remove_file(ctx, vfs, "test_config.txt") == TILEDB_OK);
+  CHECK(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
+  CHECK(tiledb_ctx_free(ctx) == TILEDB_OK);
 }
 
 TEST_CASE("C API: Test config", "[capi], [config]") {

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -32,10 +32,14 @@
  */
 
 #include "catch.hpp"
+#ifdef _WIN32
+#include "win_filesystem.h"
+#else
 #include "posix_filesystem.h"
+#endif
 #include "tiledb.h"
 
-#include <sys/time.h>
+#include <cassert>
 #include <cstring>
 #include <ctime>
 #include <iostream>
@@ -56,9 +60,15 @@ struct DenseArrayFx {
   const tiledb::URI S3_BUCKET = tiledb::URI("s3://tiledb");
   const std::string S3_TEMP_DIR = "s3://tiledb/tiledb_test/";
 #endif
+#ifdef _WIN32
+  const std::string FILE_URI_PREFIX = "";
+  const std::string FILE_TEMP_DIR =
+      tiledb::win::current_dir() + "\\tiledb_test\\";
+#else
   const std::string FILE_URI_PREFIX = "file://";
   const std::string FILE_TEMP_DIR =
       tiledb::posix::current_dir() + "/tiledb_test/";
+#endif
   const int ITER_NUM = 10;
 
   // TileDB context and VFS
@@ -230,7 +240,7 @@ DenseArrayFx::DenseArrayFx() {
   vfs_ = nullptr;
   REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
 
-  // Connect to S3
+// Connect to S3
 #ifdef HAVE_S3
   // Create bucket if it does not exist
   int is_bucket = 0;
@@ -537,7 +547,7 @@ void DenseArrayFx::write_dense_array_by_tiles(
       int64_t tile_cols = ((j + tile_extent_1) < domain_size_1) ?
                               tile_extent_1 :
                               (domain_size_1 - j);
-      int64_t k, l;
+      int64_t k = 0, l = 0;
       for (k = 0; k < tile_rows; ++k) {
         for (l = 0; l < tile_cols; ++l) {
           index = uint64_t(k * tile_cols + l);

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -31,7 +31,11 @@
  */
 
 #include "catch.hpp"
+#ifdef _WIN32
+#include "win_filesystem.h"
+#else
 #include "posix_filesystem.h"
+#endif
 #include "tiledb.h"
 
 struct DenseVectorFx {
@@ -46,9 +50,15 @@ struct DenseVectorFx {
   const tiledb::URI S3_BUCKET = tiledb::URI("s3://tiledb");
   const std::string S3_TEMP_DIR = "s3://tiledb/tiledb_test/";
 #endif
+#ifdef _WIN32
+  const std::string FILE_URI_PREFIX = "";
+  const std::string FILE_TEMP_DIR =
+      tiledb::win::current_dir() + "\\tiledb_test\\";
+#else
   const std::string FILE_URI_PREFIX = "file://";
   const std::string FILE_TEMP_DIR =
       tiledb::posix::current_dir() + "/tiledb_test/";
+#endif
   const std::string VECTOR = "vector";
 
   // TileDB context
@@ -79,7 +89,7 @@ DenseVectorFx::DenseVectorFx() {
   vfs_ = nullptr;
   REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
 
-  // Connect to S3
+// Connect to S3
 #ifdef HAVE_S3
   // Create bucket if it does not exist
   int is_bucket = 0;

--- a/test/src/unit-capi-kv.cc
+++ b/test/src/unit-capi-kv.cc
@@ -31,7 +31,11 @@
  */
 
 #include "catch.hpp"
+#ifdef _WIN32
+#include "win_filesystem.h"
+#else
 #include "posix_filesystem.h"
+#endif
 #include "tiledb.h"
 
 struct KVFx {
@@ -42,19 +46,19 @@ struct KVFx {
   int KEY1 = 100;
   const int KEY1_A1 = 1;
   const char* KEY1_A2 = "a";
-  const float KEY1_A3[2] = {1.1, 1.2};
+  const float KEY1_A3[2] = {1.1f, 1.2f};
   const float KEY2 = 200.0;
   const int KEY2_A1 = 2;
   const char* KEY2_A2 = "bb";
-  const float KEY2_A3[2] = {2.1, 2.2};
+  const float KEY2_A3[2] = {2.1f, 2.2f};
   const double KEY3[2] = {300.0, 300.1};
   const int KEY3_A1 = 3;
   const char* KEY3_A2 = "ccc";
-  const float KEY3_A3[2] = {3.1, 3.2};
+  const float KEY3_A3[2] = {3.1f, 3.2f};
   const char* KEY4 = "key_4";
   const int KEY4_A1 = 4;
   const char* KEY4_A2 = "dddd";
-  const float KEY4_A3[2] = {4.1, 4.2};
+  const float KEY4_A3[2] = {4.1f, 4.2f};
 
 #ifdef HAVE_HDFS
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
@@ -63,9 +67,15 @@ struct KVFx {
   const tiledb::URI S3_BUCKET = tiledb::URI("s3://tiledb");
   const std::string S3_TEMP_DIR = "s3://tiledb/tiledb_test/";
 #endif
+#ifdef _WIN32
+  const std::string FILE_URI_PREFIX = "";
+  const std::string FILE_TEMP_DIR =
+      tiledb::win::current_dir() + "\\tiledb_test\\";
+#else
   const std::string FILE_URI_PREFIX = "file://";
   const std::string FILE_TEMP_DIR =
       tiledb::posix::current_dir() + "/tiledb_test/";
+#endif
 
   // TileDB context
   tiledb_ctx_t* ctx_;
@@ -96,7 +106,7 @@ KVFx::KVFx() {
   vfs_ = nullptr;
   REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
 
-  // Connect to S3
+// Connect to S3
 #ifdef HAVE_S3
   // Create bucket if it does not exist
   int is_bucket = 0;

--- a/test/src/unit-capi-resource_management.cc
+++ b/test/src/unit-capi-resource_management.cc
@@ -31,7 +31,13 @@
  */
 
 #include "catch.hpp"
+
+#ifdef _WIN32
+#include "win_filesystem.h"
+#else
 #include "posix_filesystem.h"
+#endif
+
 #include "tiledb.h"
 
 struct ResourceMgmtFx {
@@ -42,11 +48,19 @@ struct ResourceMgmtFx {
   const tiledb::URI S3_BUCKET = tiledb::URI("s3://tiledb");
   const std::string S3_TEMP_DIR = "s3://tiledb/tiledb_test/";
 #endif
+#ifdef _WIN32
+  const std::string FILE_URI_PREFIX = "";
+  const std::string FILE_TEMP_DIR =
+      tiledb::win::current_dir() + "\\tiledb_test\\";
+  const std::string GROUP = "group\\";
+  const std::string ARRAY = "array\\";
+#else
   const std::string FILE_URI_PREFIX = "file://";
   const std::string FILE_TEMP_DIR =
       tiledb::posix::current_dir() + "/tiledb_test/";
   const std::string GROUP = "group/";
   const std::string ARRAY = "array/";
+#endif
 
   // TileDB context
   tiledb_ctx_t* ctx_;
@@ -77,7 +91,7 @@ ResourceMgmtFx::ResourceMgmtFx() {
   vfs_ = nullptr;
   REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
 
-  // Connect to S3
+// Connect to S3
 #ifdef HAVE_S3
   // Create bucket if it does not exist
   int is_bucket = 0;
@@ -243,7 +257,7 @@ TEST_CASE_METHOD(
   check_move(FILE_URI_PREFIX + FILE_TEMP_DIR);
   remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
 
-  // S3
+// S3
 #ifdef HAVE_S3
   create_temp_dir(S3_TEMP_DIR);
   check_object_type(S3_TEMP_DIR);
@@ -252,7 +266,7 @@ TEST_CASE_METHOD(
   remove_temp_dir(S3_TEMP_DIR);
 #endif
 
-  // HDFS
+// HDFS
 #ifdef HAVE_HDFS
   create_temp_dir(HDFS_TEMP_DIR);
   check_object_type(HDFS_TEMP_DIR);

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -32,10 +32,13 @@
  */
 
 #include "catch.hpp"
+#ifdef _WIN32
+#include "win_filesystem.h"
+#else
 #include "posix_filesystem.h"
+#endif
 #include "tiledb.h"
 
-#include <sys/time.h>
 #include <cassert>
 #include <cstring>
 #include <ctime>
@@ -59,9 +62,15 @@ struct SparseArrayFx {
   const tiledb::URI S3_BUCKET = tiledb::URI("s3://tiledb");
   const std::string S3_TEMP_DIR = "s3://tiledb/tiledb_test/";
 #endif
+#ifdef _WIN32
+  const std::string FILE_URI_PREFIX = "";
+  const std::string FILE_TEMP_DIR =
+      tiledb::win::current_dir() + "\\tiledb_test\\";
+#else
   const std::string FILE_URI_PREFIX = "file://";
   const std::string FILE_TEMP_DIR =
       tiledb::posix::current_dir() + "/tiledb_test/";
+#endif
   int ITER_NUM = 5;
   const std::string ARRAY = "sparse_array";
 
@@ -168,7 +177,7 @@ SparseArrayFx::SparseArrayFx() {
   vfs_ = nullptr;
   REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
 
-  // Connect to S3
+// Connect to S3
 #ifdef HAVE_S3
   // Create bucket if it does not exist
   int is_bucket = 0;

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -31,8 +31,12 @@
  */
 
 #include "catch.hpp"
-#include "posix_filesystem.h"
 #include "tiledb.h"
+#ifdef _WIN32
+#include "win_filesystem.h"
+#else
+#include "posix_filesystem.h"
+#endif
 
 #include <iostream>
 
@@ -44,8 +48,13 @@ struct VFSFx {
   const std::string S3_BUCKET = "s3://tiledb/";
   const std::string S3_TEMP_DIR = "s3://tiledb/tiledb_test/";
 #endif
+#ifdef _WIN32
+  const std::string FILE_TEMP_DIR =
+      tiledb::win::current_dir() + "\\tiledb_test\\";
+#else
   const std::string FILE_TEMP_DIR =
       std::string("file://") + tiledb::posix::current_dir() + "/tiledb_test/";
+#endif
 
   // TileDB context and vfs
   tiledb_ctx_t* ctx_;
@@ -299,7 +308,7 @@ void VFSFx::check_move(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(is_file);
 
-  // Move from one bucket to another (only for S3)
+// Move from one bucket to another (only for S3)
 #ifdef HAVE_S3
   if (path == S3_TEMP_DIR) {
     std::string bucket2 = "s3://tiledb2/";

--- a/test/src/unit-capi-walk.cc
+++ b/test/src/unit-capi-walk.cc
@@ -32,7 +32,11 @@
 
 #include "catch.hpp"
 #include "constants.h"
+#ifdef _WIN32
+#include "win_filesystem.h"
+#else
 #include "posix_filesystem.h"
+#endif
 #include "tiledb.h"
 #include "uri.h"
 
@@ -47,9 +51,16 @@ struct WalkFx {
   const tiledb::URI S3_BUCKET = tiledb::URI("s3://tiledb/");
   const std::string S3_TEMP_DIR = "s3://tiledb/tiledb_test/";
 #endif
+
+#ifdef _WIN32
+  const std::string FILE_TEMP_DIR = "tiledb_test\\";
+  const std::string FILE_FULL_TEMP_DIR =
+      tiledb::win::current_dir() + "\\tiledb_test\\";
+#else
   const std::string FILE_TEMP_DIR = "tiledb_test/";
   const std::string FILE_FULL_TEMP_DIR =
       std::string("file://") + tiledb::posix::current_dir() + "/tiledb_test/";
+#endif
 
   // TileDB context and VFS
   tiledb_ctx_t *ctx_;
@@ -78,7 +89,7 @@ WalkFx::WalkFx() {
   vfs_ = nullptr;
   REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
 
-  // Connect to S3
+// Connect to S3
 #ifdef HAVE_S3
   // Create bucket if it does not exist
   int is_bucket = 0;
@@ -223,7 +234,12 @@ TEST_CASE_METHOD(WalkFx, "C API: Test walk", "[capi], [walk]") {
   // File
   remove_temp_dir(FILE_FULL_TEMP_DIR);
   create_hierarchy(FILE_FULL_TEMP_DIR);
+#ifdef _WIN32
+  // `VFS::ls(...)` returns `file:///` URIs instead of Windows paths.
+  golden = get_golden_output(tiledb::win::uri_from_path(FILE_FULL_TEMP_DIR));
+#else
   golden = get_golden_output(FILE_FULL_TEMP_DIR);
+#endif
   walk_str.clear();
   rc = tiledb_walk(
       ctx_, FILE_FULL_TEMP_DIR.c_str(), TILEDB_PREORDER, write_path, &walk_str);

--- a/test/src/unit-uri.cc
+++ b/test/src/unit-uri.cc
@@ -1,0 +1,101 @@
+#include <uri.h>
+#include <catch.hpp>
+
+#ifdef _WIN32
+#include <win_filesystem.h>
+#else
+#include <posix_filesystem.h>
+#endif
+
+using namespace tiledb;
+
+#ifdef _WIN32
+static const char PATH_SEPARATOR = '\\';
+static std::string current_dir() {
+  return win::current_dir();
+}
+#else
+static const char PATH_SEPARATOR = '/';
+static std::string current_dir() {
+  return posix::current_dir();
+}
+#endif
+
+TEST_CASE("URI: Test file URIs", "[uri]") {
+  URI uri("file:///path");
+  CHECK(!uri.is_invalid());
+  CHECK(URI::is_file(uri.to_string()));
+  CHECK(uri.to_string() == "file:///path");
+  uri = URI("file://path");
+  CHECK(uri.is_invalid());
+  uri =
+      URI("file:///path/is/too/long/long/long/long/long/long/long/long/long/"
+          "long/long/long/long/long/long/long/long/long/long/long/long/long/"
+          "long/long/long/long/long/long/long/long/long/long/long/long/long/"
+          "long/long/long/long/long/long/long/long/long/long/long/long/long");
+  CHECK(uri.is_invalid());
+  uri = URI("");
+  CHECK(uri.is_invalid());
+
+  // TODO: re-enable these checks if appropriate for posix_filesystem.
+  // uri = URI("file:///path/../relative");
+  // CHECK(!uri.is_invalid());
+  // CHECK(URI::is_file(uri.to_string()));
+  // CHECK(uri.to_string() == "file:///relative");
+  // uri = URI("file:///path/.././relative/./path");
+  // CHECK(!uri.is_invalid());
+  // CHECK(URI::is_file(uri.to_string()));
+  // CHECK(uri.to_string() == "file:///relative/path");
+}
+
+TEST_CASE("URI: Test relative paths", "[uri]") {
+  URI uri = URI("path1");
+  CHECK(!uri.is_invalid());
+  CHECK(URI::is_file(uri.to_string()));
+  CHECK(uri.to_string().find("file:///") == 0);
+  CHECK(uri.to_path() == current_dir() + PATH_SEPARATOR + "path1");
+#ifdef _WIN32
+  CHECK(uri.to_string() == win::uri_from_path(win::current_dir()) + "/path1");
+#else
+  CHECK(uri.to_string() == "file://" + posix::current_dir() + "/path1");
+#endif
+
+  uri = URI(".");
+  CHECK(!uri.is_invalid());
+  CHECK(uri.to_path() == current_dir());
+}
+
+#ifdef _WIN32
+
+TEST_CASE("URI: Test Windows paths", "[uri]") {
+  URI uri("C:\\path");
+  CHECK(!uri.is_invalid());
+  CHECK(URI::is_file(uri.to_string()));
+  // Windows file URIs keep the drive letter to remain fully qualified.
+  CHECK(uri.to_string() == "file:///C:/path");
+  uri = URI("g:\\path\\..\\relative\\");
+  CHECK(!uri.is_invalid());
+  CHECK(URI::is_file(uri.to_string()));
+  CHECK(uri.to_string() == "file:///g:/relative/");
+  uri = URI("C:\\mixed/slash\\types");
+  CHECK(!uri.is_invalid());
+  CHECK(URI::is_file(uri.to_string()));
+  CHECK(uri.to_string() == "file:///C:/mixed/slash/types");
+  uri = URI("C:/mixed/slash/types");
+  CHECK(!uri.is_invalid());
+  CHECK(URI::is_file(uri.to_string()));
+  CHECK(uri.to_string() == "file:///C:/mixed/slash/types");
+  uri = URI("C:\\Program Files (x86)\\TileDB\\");
+  CHECK(!uri.is_invalid());
+  CHECK(URI::is_file(uri.to_string()));
+  CHECK(uri.to_string() == "file:///C:/Program%20Files%20(x86)/TileDB/");
+  uri = URI("path1\\path2");
+  CHECK(!uri.is_invalid());
+  CHECK(URI::is_file(uri.to_string()));
+  CHECK(uri.to_string().find("file:///") == 0);
+  CHECK(
+      uri.to_string() ==
+      win::uri_from_path(win::current_dir()) + "/path1/path2");
+}
+
+#endif

--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -1,0 +1,185 @@
+#ifdef _WIN32
+
+#include "catch.hpp"
+
+#include <status.h>
+#include <win_filesystem.h>
+#include <cassert>
+
+using namespace tiledb;
+
+static bool starts_with(const std::string& value, const std::string& prefix) {
+  if (prefix.size() > value.size())
+    return false;
+  return std::equal(prefix.begin(), prefix.end(), value.begin());
+}
+
+static bool ends_with(const std::string& value, const std::string& suffix) {
+  if (suffix.size() > value.size())
+    return false;
+  return std::equal(suffix.rbegin(), suffix.rend(), value.rbegin());
+}
+
+struct WinFx {
+  const std::string TEMP_DIR = win::current_dir() + "/";
+
+  WinFx() {
+    bool success = false;
+    if (path_exists(TEMP_DIR + "tiledb_test_dir")) {
+      success = remove_path(TEMP_DIR + "tiledb_test_dir");
+      assert(success);
+    }
+    if (path_exists(TEMP_DIR + "tiledb_test_file")) {
+      success = remove_path(TEMP_DIR + "tiledb_test_file");
+      assert(success);
+    }
+  }
+
+  ~WinFx() {
+    bool success = false;
+    success = remove_path(TEMP_DIR + "tiledb_test_dir");
+    assert(success);
+  }
+
+  bool path_exists(std::string path) {
+    return win::is_file(path) || win::is_dir(path);
+  }
+
+  bool remove_path(std::string path) {
+    return win::remove_path(path).ok();
+  }
+};
+
+TEST_CASE_METHOD(WinFx, "Test Windows filesystem", "[windows]") {
+  const std::string test_dir_path = win::current_dir() + "/tiledb_test_dir";
+  const std::string test_file_path =
+      win::current_dir() + "/tiledb_test_dir/tiledb_test_file";
+  URI test_dir(test_dir_path);
+  URI test_file(test_file_path);
+  Status st;
+
+  CHECK(win::is_win_path("C:\\path"));
+  CHECK(win::is_win_path("C:path"));
+  CHECK(win::is_win_path("..\\path"));
+  CHECK(win::is_win_path("\\path"));
+  CHECK(win::is_win_path("path\\"));
+  CHECK(win::is_win_path("\\\\path1\\path2"));
+  CHECK(win::is_win_path("path1\\path2"));
+  CHECK(win::is_win_path("path"));
+  CHECK(!win::is_win_path("path1/path2"));
+  CHECK(!win::is_win_path("file:///path1/path2"));
+  CHECK(!win::is_win_path("hdfs:///path1/path2"));
+
+  CHECK(win::abs_path(test_dir_path) == test_dir_path);
+  CHECK(win::abs_path(test_file_path) == test_file_path);
+  CHECK(win::abs_path("") == win::current_dir());
+  CHECK(win::abs_path("C:\\") == "C:\\");
+  CHECK(win::abs_path("C:\\path1\\path2\\") == "C:\\path1\\path2\\");
+  CHECK(win::abs_path("C:\\..") == "C:\\");
+  CHECK(win::abs_path("C:\\..\\path1") == "C:\\path1");
+  CHECK(win::abs_path("C:\\path1\\.\\..\\path2\\") == "C:\\path2\\");
+  CHECK(win::abs_path("C:\\path1\\.\\path2\\..\\path3") == "C:\\path1\\path3");
+  CHECK(
+      win::abs_path("path1\\path2\\..\\path3") ==
+      win::current_dir() + "\\path1\\path3");
+  CHECK(win::abs_path("path1") == win::current_dir() + "\\path1");
+  CHECK(win::abs_path("path1\\path2") == win::current_dir() + "\\path1\\path2");
+  CHECK(
+      win::abs_path("path1\\path2\\..\\path3") ==
+      win::current_dir() + "\\path1\\path3");
+
+  CHECK(!win::is_dir(test_dir.to_path()));
+  st = win::create_dir(test_dir.to_path());
+  CHECK(st.ok());
+  CHECK(!win::is_file(test_dir.to_path()));
+  CHECK(win::is_dir(test_dir.to_path()));
+
+  CHECK(!win::is_file(test_file.to_path()));
+  st = win::create_file(test_file.to_path());
+  CHECK(st.ok());
+  CHECK(win::is_file(test_file.to_path()));
+  st = win::create_file(test_file.to_path());
+  CHECK(st.ok());
+  CHECK(win::is_file(test_file.to_path()));
+
+  st = win::create_file(test_file.to_path());
+  CHECK(st.ok());
+  st = win::remove_path(test_file.to_path());
+  CHECK(st.ok());
+  CHECK(!win::is_file(test_file.to_path()));
+
+  st = win::remove_path(test_dir.to_path());
+  CHECK(st.ok());
+  CHECK(!win::is_dir(test_dir.to_path()));
+
+  st = win::create_dir(test_dir.to_path());
+  CHECK(st.ok());
+  st = win::create_file(test_file.to_path());
+  CHECK(st.ok());
+  st = win::remove_path(test_dir.to_path());
+  CHECK(st.ok());
+  CHECK(!win::is_dir(test_dir.to_path()));
+
+  st = win::create_dir(test_dir.to_path());
+  st = win::create_file(test_file.to_path());
+  CHECK(st.ok());
+
+  const unsigned buffer_size = 100000;
+  auto write_buffer = new char[buffer_size];
+  for (int i = 0; i < buffer_size; i++) {
+    write_buffer[i] = 'a' + (i % 26);
+  }
+  st = win::write(test_file.to_path(), write_buffer, buffer_size);
+  CHECK(st.ok());
+  st = win::sync(test_file.to_path());
+  CHECK(st.ok());
+
+  auto read_buffer = new char[26];
+  st = win::read(test_file.to_path(), 0, read_buffer, 26);
+  CHECK(st.ok());
+
+  bool allok = true;
+  for (int i = 0; i < 26; i++) {
+    if (read_buffer[i] != static_cast<char>('a' + i)) {
+      allok = false;
+      break;
+    }
+  }
+  CHECK(allok == true);
+
+  st = win::read(test_file.to_path(), 11, read_buffer, 26);
+  CHECK(st.ok());
+
+  allok = true;
+  for (int i = 0; i < 26; ++i) {
+    if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {
+      allok = false;
+      break;
+    }
+  }
+  CHECK(allok == true);
+
+  std::vector<std::string> paths;
+  st = win::ls(test_dir.to_path(), &paths);
+  CHECK(st.ok());
+  CHECK(paths.size() == 1);
+  CHECK(!starts_with(paths[0], "file:///"));
+  CHECK(ends_with(paths[0], "tiledb_test_dir\\tiledb_test_file"));
+  CHECK(win::is_file(paths[0]));
+
+  uint64_t nbytes = 0;
+  st = win::file_size(test_file.to_path(), &nbytes);
+  CHECK(st.ok());
+  CHECK(nbytes == buffer_size);
+
+  st =
+      win::remove_path(URI("file:///tiledb_test_dir/i_dont_exist").to_string());
+  CHECK(!st.ok());
+
+  st = win::move_path(test_file.to_path(), URI(test_file_path + "2").to_path());
+  CHECK(st.ok());
+  CHECK(!win::is_file(test_file.to_path()));
+  CHECK(win::is_file(URI(test_file_path + "2").to_path()));
+}
+
+#endif  // _WIN32


### PR DESCRIPTION
This PR (replacing #280 ) encompasses the changes required for TileDB to build and run on Windows systems. So far tested only on Windows 7 64-bit.

Steps to build TileDB on Windows:
1. If you don't have Visual Studio, download and install Visual Studio 2017 Community Edition.
2. Download and install PowerShell.
3. Clone TileDB.
4. Open PowerShell and at the prompt, navigate to the TileDB root directory, and execute the following commands:

```
> $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
> mkdir build
> cd build
> ..\scripts\install-deps.ps1
> ..\bootstrap.ps1 -EnableDebug
> cmake --build . --target check --config Debug
```