### PR TITLE
check input's to VFS::read

### DIFF
--- a/core/src/filesystem/hdfs_filesystem.cc
+++ b/core/src/filesystem/hdfs_filesystem.cc
@@ -188,8 +188,8 @@ Status remove_file(hdfsFS fs, const URI& uri) {
   return Status::Ok();
 }
 
-// Read length bytes from file give by path from byte offset offset into pre
-// allocated buffer buffer.
+// Read length bytes from file give by path from byte offset offset into
+// pre-allocated buffer buffer.
 Status read(
     hdfsFS fs, const URI& uri, off_t offset, void* buffer, uint64_t length) {
   hdfsFile readFile =
@@ -199,7 +199,13 @@ Status read(
         std::string("Cannot read file ") + uri.to_string() +
         ": file open error"));
   }
-  int ret = hdfsSeek(fs, readFile, (tOffset)offset);
+  if (offset > std::numeric_limits<tOffset>::max()) {
+    return LOG_STATUS(Status::HDFSError(
+        std::string("Cannot read from from '") + uri.to_string() +
+        "'; offset > typemax(tOffset)"));
+  }
+  tOffset off = static_cast<tOffset>(offset);
+  int ret = hdfsSeek(fs, readFile, off);
   if (ret < 0) {
     return LOG_STATUS(Status::HDFSError(
         std::string("Cannot seek to offset ") + uri.to_string()));

--- a/core/src/query/pq_fragment_cell_range.cc
+++ b/core/src/query/pq_fragment_cell_range.cc
@@ -45,7 +45,7 @@ template <typename T>
 const uint64_t PQFragmentCellRange<T>::INVALID_UINT64 = UINT64_MAX;
 
 template <typename T>
-const unsigned int PQFragmentCellRange<T>::INVALID_UINT = UINT_MAX;
+const unsigned int PQFragmentCellRange<T>::INVALID_UINT = UINT32_MAX;
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */


### PR DESCRIPTION
use `pread` instead of seeking and then reading, correct behavior when (unchecked) seek fails