### PR TITLE
Add tiledb_uri_to_path C API function and tests

### DIFF
--- a/core/include/c_api/tiledb.h
+++ b/core/include/c_api/tiledb.h
@@ -1763,6 +1763,23 @@ TILEDB_EXPORT int tiledb_vfs_supports_fs(
 TILEDB_EXPORT int tiledb_vfs_touch(
     tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri);
 
+/**
+ * Converts the given file URI to a null-terminated platform-native file path.
+ *
+ * @param ctx The TileDB context.
+ * @param uri The URI to be converted.
+ * @param path_out The buffer where the converted path string is stored.
+ * @param path_length The length of the path buffer. On return, this is set to
+ * the length of the converted path string, or 0 on error.
+ * @return TILEDB_OK for success and TILEDB_ERR for error.
+ *
+ * @note The path_out buffer must be allocated according to the platform's
+ * maximum path length (e.g. PATH_MAX), which includes space for the terminating
+ * null character.
+ */
+TILEDB_EXPORT int tiledb_uri_to_path(
+    tiledb_ctx_t* ctx, const char* uri, char* path_out, unsigned* path_length);
+
 #undef TILEDB_EXPORT
 #ifdef __cplusplus
 }

--- a/core/include/misc/uri.h
+++ b/core/include/misc/uri.h
@@ -129,9 +129,23 @@ class URI {
   /** Returns the parent of the URI. */
   URI parent() const;
 
-  /** Returns the URI path, stripping the resource. For examples,
-   *  "file:///my/path/" is the URI, this function will return
-   *  "/my/path/".
+  /**
+   * Returns the URI path for the current platform, stripping the resource. For
+   * example, if "file:///my/path/" is the URI, this function will return
+   * "/my/path/" on Mac and Linux. If "file:///C:/my/path" is the URI, this
+   * function will return "C:\my\path" on Windows. HDFS and S3 URIs are returned
+   * unmodified.
+   *
+   * @param uri The URI to convert.
+   * @return std::string The converted path, or empty string on error.
+   */
+  static std::string to_path(const std::string& uri);
+
+  /** Returns the URI path for the current platform, stripping the resource. For
+   * example, if "file:///my/path/" is the URI, this function will return
+   * "/my/path/" on Mac and Linux. If "file:///C:/my/path" is the URI, this
+   * function will return "C:\my\path" on Windows. HDFS and S3 URIs are returned
+   * unmodified.
    */
   std::string to_path() const;
 

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -2170,3 +2170,21 @@ int tiledb_vfs_touch(tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
 
   return TILEDB_OK;
 }
+
+int tiledb_uri_to_path(
+    tiledb_ctx_t* ctx, const char* uri, char* path_out, unsigned* path_length) {
+  if (sanity_check(ctx) == TILEDB_ERR || uri == nullptr ||
+      path_out == nullptr || path_length == nullptr)
+    return TILEDB_ERR;
+
+  std::string path = tiledb::URI::to_path(uri);
+  if (path.empty() || path.length() + 1 > *path_length) {
+    *path_length = 0;
+    return TILEDB_ERR;
+  } else {
+    *path_length = static_cast<unsigned>(path.length());
+    path.copy(path_out, path.length());
+    path_out[path.length()] = '\0';
+    return TILEDB_OK;
+  }
+}

--- a/core/src/misc/uri.cc
+++ b/core/src/misc/uri.cc
@@ -136,20 +136,24 @@ URI URI::parent() const {
   return URI(uri_.substr(0, pos));
 }
 
-std::string URI::to_path() const {
-  if (is_file()) {
+std::string URI::to_path(const std::string& uri) {
+  if (is_file(uri)) {
 #ifdef _WIN32
-    return win::path_from_uri(uri_);
+    return win::path_from_uri(uri);
 #else
-    return uri_.substr(std::string("file://").size());
+    return uri.substr(std::string("file://").size());
 #endif
   }
 
-  if (is_hdfs() || is_s3())
-    return uri_;
+  if (is_hdfs(uri) || is_s3(uri))
+    return uri;
 
   // Error
   return "";
+}
+
+std::string URI::to_path() const {
+  return to_path(uri_);
 }
 
 std::string URI::to_string() const {

--- a/test/src/unit-capi-uri.cc
+++ b/test/src/unit-capi-uri.cc
@@ -1,0 +1,115 @@
+/**
+ * @file   unit-capi-uri.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C API for URI.
+ */
+
+#include "catch.hpp"
+#include "tiledb.h"
+
+#include <string.h>
+
+#ifdef _WIN32
+#include <Windows.h>
+static const unsigned PLATFORM_PATH_MAX = MAX_PATH;
+#elif __APPLE__
+#include <sys/syslimits.h>
+static const unsigned PLATFORM_PATH_MAX = PATH_MAX;
+#else
+#include <limits.h>
+static const unsigned PLATFORM_PATH_MAX = PATH_MAX;
+#endif
+
+TEST_CASE("C API: Test URI", "[capi], [uri]") {
+  int rc;
+  tiledb_ctx_t *ctx;
+  rc = tiledb_ctx_create(&ctx, nullptr);
+  REQUIRE(rc == TILEDB_OK);
+
+  char path[PLATFORM_PATH_MAX];
+  unsigned path_length = PLATFORM_PATH_MAX;
+  rc = tiledb_uri_to_path(ctx, "file:///my/path", path, &path_length);
+  CHECK(rc == TILEDB_OK);
+#ifdef _WIN32
+  CHECK(path_length == 8);
+  CHECK(path[path_length] == '\0');
+  CHECK(strlen(path) == path_length);
+  CHECK(strcmp(path, "\\my\\path") == 0);
+#else
+  CHECK(path_length == 8);
+  CHECK(path[path_length] == '\0');
+  CHECK(strlen(path) == path_length);
+  CHECK(strcmp(path, "/my/path") == 0);
+#endif
+
+  path_length = 9;
+  rc = tiledb_uri_to_path(ctx, "file:///my/path", path, &path_length);
+  CHECK(rc == TILEDB_OK);
+  path_length = 8;
+  rc = tiledb_uri_to_path(ctx, "file:///my/path", path, &path_length);
+  CHECK(rc == TILEDB_ERR);
+  path_length = 0;
+  rc = tiledb_uri_to_path(ctx, "file:///my/path", path, &path_length);
+  CHECK(rc == TILEDB_ERR);
+  rc = tiledb_uri_to_path(ctx, "file:///my/path", nullptr, &path_length);
+  CHECK(rc == TILEDB_ERR);
+
+  path_length = PLATFORM_PATH_MAX;
+  rc = tiledb_uri_to_path(ctx, "file:///C:/my/path", path, &path_length);
+  CHECK(rc == TILEDB_OK);
+#ifdef _WIN32
+  CHECK(path_length == 10);
+  CHECK(path[path_length] == '\0');
+  CHECK(strlen(path) == path_length);
+  CHECK(strcmp(path, "C:\\my\\path") == 0);
+#else
+  CHECK(path_length == 11);
+  CHECK(path[path_length] == '\0');
+  CHECK(strlen(path) == path_length);
+  CHECK(strcmp(path, "/C:/my/path") == 0);
+#endif
+
+  path_length = PLATFORM_PATH_MAX;
+  rc = tiledb_uri_to_path(ctx, "s3://my/path", path, &path_length);
+  CHECK(rc == TILEDB_OK);
+  CHECK(path_length == 12);
+  CHECK(path[path_length] == '\0');
+  CHECK(strlen(path) == path_length);
+  CHECK(strcmp(path, "s3://my/path") == 0);
+
+  path_length = PLATFORM_PATH_MAX;
+  rc = tiledb_uri_to_path(ctx, "hdfs://my/path", path, &path_length);
+  CHECK(rc == TILEDB_OK);
+  CHECK(path_length == 14);
+  CHECK(path[path_length] == '\0');
+  CHECK(strlen(path) == path_length);
+  CHECK(strcmp(path, "hdfs://my/path") == 0);
+
+  REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
+}

--- a/test/src/unit-uri.cc
+++ b/test/src/unit-uri.cc
@@ -65,6 +65,51 @@ TEST_CASE("URI: Test relative paths", "[uri]") {
   CHECK(uri.to_path() == current_dir());
 }
 
+TEST_CASE("URI: Test URI to path", "[uri]") {
+  URI uri = URI("file:///my/path");
+#ifdef _WIN32
+  // Absolute paths with no drive letter are relative to the current working
+  // directory's drive.
+  CHECK(uri.to_path() == "\\my\\path");
+#else
+  CHECK(uri.to_path() == "/my/path");
+#endif
+
+  uri = URI("file:///my/path/../relative/path");
+#ifdef _WIN32
+  CHECK(uri.to_path() == "\\my\\relative\\path");
+#else
+  CHECK(uri.to_path() == "/my/path/../relative/path");
+#endif
+
+  uri = URI("s3://path/on/s3");
+  CHECK(uri.to_path() == "s3://path/on/s3");
+  uri = URI("s3://relative/../path/on/s3");
+  CHECK(uri.to_path() == "s3://relative/../path/on/s3");
+  uri = URI("hdfs://path/on/hdfs");
+  CHECK(uri.to_path() == "hdfs://path/on/hdfs");
+  uri = URI("hdfs://relative/../path/on/hdfs");
+  CHECK(uri.to_path() == "hdfs://relative/../path/on/hdfs");
+
+  uri = URI("C:\\my\\path");
+#ifdef _WIN32
+  CHECK(uri.to_string() == "file:///C:/my/path");
+  CHECK(uri.to_path() == "C:\\my\\path");
+#else
+  // Windows paths on non-Windows platforms are nonsensical, but have defined
+  // behavior.
+  CHECK(uri.to_string() == "file://" + current_dir() + "/" + "C:\\my\\path");
+  CHECK(uri.to_path() == current_dir() + "/" + "C:\\my\\path");
+#endif
+
+  uri = URI("file:///C:/my/path");
+#ifdef _WIN32
+  CHECK(uri.to_path() == "C:\\my\\path");
+#else
+  CHECK(uri.to_path() == "/C:/my/path");
+#endif
+}
+
 #ifdef _WIN32
 
 TEST_CASE("URI: Test Windows paths", "[uri]") {


### PR DESCRIPTION
New C API function `tiledb_uri_to_path()` to convert URIs to platform-specific paths. Also adds some tests.

This addresses #296.