### PR TITLE
sanity checking the ctx assumes the storage manager is initialized

### DIFF
--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -139,7 +139,7 @@ inline int sanity_check(tiledb_config_t* config) {
 }
 
 inline int sanity_check(tiledb_ctx_t* ctx) {
-  if (ctx == nullptr)
+  if (ctx == nullptr || ctx->mtx_ == nullptr)
     return TILEDB_ERR;
   if (ctx->storage_manager_ == nullptr) {
     tiledb::Status st = tiledb::Status::Error("Invalid TileDB context");
@@ -349,9 +349,8 @@ int tiledb_ctx_free(tiledb_ctx_t* ctx) {
 /* ********************************* */
 
 int tiledb_error_last(tiledb_ctx_t* ctx, tiledb_error_t** err) {
-
   // sanity check
-  if (ctx == nullptr)
+  if (ctx == nullptr || ctx->mtx_ == nullptr)
     return TILEDB_ERR;
 
   {

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -349,7 +349,9 @@ int tiledb_ctx_free(tiledb_ctx_t* ctx) {
 /* ********************************* */
 
 int tiledb_error_last(tiledb_ctx_t* ctx, tiledb_error_t** err) {
-  if (sanity_check(ctx) == TILEDB_ERR)
+
+  // sanity check
+  if (ctx == nullptr)
     return TILEDB_ERR;
 
   {
@@ -364,10 +366,6 @@ int tiledb_error_last(tiledb_ctx_t* ctx, tiledb_error_t** err) {
     // Create error struct
     *err = new (std::nothrow) tiledb_error_t;
     if (*err == nullptr) {
-      tiledb::Status st =
-          tiledb::Status::Error("Failed to allocate error struct");
-      LOG_STATUS(st);
-      save_error(ctx, st);
       return TILEDB_OOM;
     }
 
@@ -375,10 +373,6 @@ int tiledb_error_last(tiledb_ctx_t* ctx, tiledb_error_t** err) {
     (*err)->status_ = new (std::nothrow) tiledb::Status(*(ctx->last_error_));
     if ((*err)->status_ == nullptr) {
       delete *err;
-      tiledb::Status st = tiledb::Status::Error(
-          "Failed to allocate status object in TileDB error struct");
-      LOG_STATUS(st);
-      save_error(ctx, st);
       return TILEDB_OOM;
     }
 


### PR DESCRIPTION
this assumption is not valid on the  error path when creating a ctx fails (ex from a bad config)