### PR TITLE
Fix path bug with S3, and use random bucket names in tests.

### DIFF
--- a/core/include/filesystem/s3.h
+++ b/core/include/filesystem/s3.h
@@ -372,6 +372,13 @@ class S3 {
   Status initiate_multipart_request(Aws::Http::URI aws_uri);
 
   /**
+   * Return the given authority and path strings joined with a '/'
+   * character.
+   */
+  std::string join_authority_and_path(
+      const std::string& authority, const std::string& path) const;
+
+  /**
    * Replaces in the `str` string the string `from` with string `to`.
    *
    * @param str The target string.

--- a/test/src/unit-capi-kv.cc
+++ b/test/src/unit-capi-kv.cc
@@ -37,6 +37,9 @@
 #include "posix_filesystem.h"
 #endif
 #include "tiledb.h"
+#include "utils.h"
+
+#include <thread>
 
 struct KVFx {
   const char* ATTR_1 = "a1";
@@ -64,8 +67,9 @@ struct KVFx {
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
 #endif
 #ifdef HAVE_S3
-  const tiledb::URI S3_BUCKET = tiledb::URI("s3://tiledb");
-  const std::string S3_TEMP_DIR = "s3://tiledb/tiledb_test/";
+  const std::string S3_PREFIX = "s3://";
+  const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
+  const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
 #endif
 #ifdef _WIN32
   const std::string FILE_URI_PREFIX = "";
@@ -90,6 +94,7 @@ struct KVFx {
   void write_kv(const std::string& path);
   void create_temp_dir(const std::string& path);
   void remove_temp_dir(const std::string& path);
+  static std::string random_bucket_name(const std::string& prefix);
 };
 
 KVFx::KVFx() {
@@ -120,6 +125,15 @@ KVFx::KVFx() {
 }
 
 KVFx::~KVFx() {
+#ifdef HAVE_S3
+  int is_bucket = 0;
+  int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
+  CHECK(rc == TILEDB_OK);
+  if (is_bucket) {
+    CHECK(tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str()) == TILEDB_OK);
+  }
+#endif
+
   CHECK(tiledb_vfs_free(ctx_, vfs_) == TILEDB_OK);
   CHECK(tiledb_ctx_free(ctx_) == TILEDB_OK);
 }
@@ -134,6 +148,13 @@ void KVFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
+}
+
+std::string KVFx::random_bucket_name(const std::string& prefix) {
+  std::stringstream ss;
+  ss << prefix << "-" << std::this_thread::get_id() << "-"
+     << tiledb::utils::timestamp_ms();
+  return ss.str();
 }
 
 void KVFx::create_kv(const std::string& path) {

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -38,6 +38,7 @@
 #include "posix_filesystem.h"
 #endif
 #include "tiledb.h"
+#include "utils.h"
 
 #include <cassert>
 #include <cstring>
@@ -45,6 +46,7 @@
 #include <iostream>
 #include <map>
 #include <sstream>
+#include <thread>
 
 struct SparseArrayFx {
   // Constant parameters
@@ -59,8 +61,9 @@ struct SparseArrayFx {
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
 #endif
 #ifdef HAVE_S3
-  const tiledb::URI S3_BUCKET = tiledb::URI("s3://tiledb");
-  const std::string S3_TEMP_DIR = "s3://tiledb/tiledb_test/";
+  const std::string S3_PREFIX = "s3://";
+  const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
+  const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
 #endif
 #ifdef _WIN32
   const std::string FILE_URI_PREFIX = "";
@@ -83,6 +86,7 @@ struct SparseArrayFx {
   ~SparseArrayFx();
   void create_temp_dir(const std::string& path);
   void remove_temp_dir(const std::string& path);
+  static std::string random_bucket_name(const std::string& prefix);
   void check_sorted_reads(
       const std::string& array_name,
       tiledb_compressor_t compressor,
@@ -204,6 +208,12 @@ SparseArrayFx::~SparseArrayFx() {
   remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
 #ifdef HAVE_S3
   remove_temp_dir(S3_TEMP_DIR);
+  int is_bucket = 0;
+  int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
+  CHECK(rc == TILEDB_OK);
+  if (is_bucket) {
+    CHECK(tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str()) == TILEDB_OK);
+  }
 #endif
 #ifdef HAVE_HDFS
   remove_temp_dir(HDFS_TEMP_DIR);
@@ -223,6 +233,13 @@ void SparseArrayFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
+}
+
+std::string SparseArrayFx::random_bucket_name(const std::string& prefix) {
+  std::stringstream ss;
+  ss << prefix << "-" << std::this_thread::get_id() << "-"
+     << tiledb::utils::timestamp_ms();
+  return ss.str();
 }
 
 void SparseArrayFx::create_sparse_array_2D(


### PR DESCRIPTION
Random bucket names fix intermittent test failures due to the S3 consistency guarantees.