### PR TITLE
Add TILEDB_MAX_PATH to C API (#302)

### DIFF
--- a/core/include/c_api/tiledb.h
+++ b/core/include/c_api/tiledb.h
@@ -83,10 +83,14 @@ TILEDB_EXPORT const char* tiledb_coords();
 /** Returns a special value indicating a variable number of elements. */
 TILEDB_EXPORT unsigned int tiledb_var_num();
 
+/** Returns the maximum path length on the current platform. */
+TILEDB_EXPORT unsigned int tiledb_max_path();
+
 /**@{*/
 /** Constants wrapping special functions. */
 #define TILEDB_COORDS tiledb_coords()
 #define TILEDB_VAR_NUM tiledb_var_num()
+#define TILEDB_MAX_PATH tiledb_max_path()
 /**@}*/
 
 /* ****************************** */

--- a/core/include/misc/constants.h
+++ b/core/include/misc/constants.h
@@ -147,6 +147,9 @@ extern const uint64_t max_write_bytes;
 /** The maximum name length. */
 extern const unsigned uri_max_len;
 
+/** The maximum file path length (depending on platform). */
+extern const unsigned path_max_len;
+
 /** The size of the buffer that holds the sorted cells. */
 extern const uint64_t sorted_buffer_size;
 

--- a/core/include/misc/win_constants.h
+++ b/core/include/misc/win_constants.h
@@ -1,0 +1,47 @@
+/**
+ * @file   win_constants.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the Windows-specific TileDB constants.
+ */
+
+#ifndef TILEDB_WIN_CONSTANTS_H
+#define TILEDB_WIN_CONSTANTS_H
+
+namespace tiledb {
+
+namespace constants {
+
+/** The maximum file path length (depending on platform). */
+extern const unsigned path_max_len;
+
+}  // namespace constants
+
+}  // namespace tiledb
+
+#endif  // TILEDB_WIN_CONSTANTS_H

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -53,6 +53,10 @@ unsigned int tiledb_var_num() {
   return tiledb::constants::var_num;
 }
 
+unsigned int tiledb_max_path() {
+  return tiledb::constants::path_max_len;
+}
+
 /* ****************************** */
 /*            VERSION             */
 /* ****************************** */

--- a/core/src/misc/constants.cc
+++ b/core/src/misc/constants.cc
@@ -33,6 +33,15 @@
 #include <cstdint>
 #include <limits>
 
+// Include files for platform path max definition.
+#ifdef _WIN32
+#include "win_constants.h"
+#elif __APPLE__
+#include <sys/syslimits.h>
+#else
+#include <limits.h>
+#endif
+
 #include "compressor.h"
 #include "datatype.h"
 
@@ -144,6 +153,11 @@ const uint64_t max_write_bytes = std::numeric_limits<int>::max();
 
 /** The maximum name length. */
 const unsigned uri_max_len = 256;
+
+/** The maximum file path length (depending on platform). */
+#ifndef _WIN32
+const unsigned path_max_len = PATH_MAX;
+#endif
 
 /** The size of the buffer that holds the sorted cells. */
 const uint64_t sorted_buffer_size = 10000000;

--- a/core/src/misc/win_constants.cc
+++ b/core/src/misc/win_constants.cc
@@ -1,0 +1,50 @@
+/**
+ * @file   win_constants.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the Windows-specific TileDB constants.
+ */
+
+#ifdef _WIN32
+
+#include "win_constants.h"
+
+#include <Windows.h>
+
+namespace tiledb {
+
+namespace constants {
+
+/** The maximum file path length (depending on platform). */
+const unsigned path_max_len = MAX_PATH;
+
+}  // namespace constants
+
+}  // namespace tiledb
+
+#endif  // _WIN32


### PR DESCRIPTION
Add a `TILEDB_MAX_PATH` variable to the C API. Fixes #302.