### PR TITLE
Make config and config_iter independent of context

### DIFF
--- a/core/include/misc/constants.h
+++ b/core/include/misc/constants.h
@@ -341,6 +341,15 @@ extern const char* s3_region;
 /** S3 endpoint override. */
 extern const char* s3_endpoint_override;
 
+/** HDFS default kerb ticket cache path. */
+extern const char* hdfs_kerb_ticket_cache_path;
+
+/** HDFS default name node uri. */
+extern const char* hdfs_name_node_uri;
+
+/** HDFS default username. */
+extern const char* hdfs_username;
+
 /** Prefix indicating a special name reserved by TileDB. */
 extern const char* special_name_prefix;
 

--- a/core/src/misc/constants.cc
+++ b/core/src/misc/constants.cc
@@ -175,10 +175,10 @@ const char* no_compression_str = "NO_COMPRESSION";
 const uint64_t array_schema_cache_size = 10000000;
 
 /** The fragment metadata cache size. */
-const uint64_t fragment_metadata_cache_size = 100000000;
+const uint64_t fragment_metadata_cache_size = 10000000;
 
 /** The tile cache size. */
-const uint64_t tile_cache_size = 100000000;
+const uint64_t tile_cache_size = 10000000;
 
 /** String describing GZIP. */
 const char* gzip_str = "GZIP";
@@ -349,6 +349,15 @@ const char* s3_region = "";
 
 /** S3 endpoint override. */
 const char* s3_endpoint_override = "localhost:9000";
+
+/** HDFS default kerb ticket cache path. */
+const char* hdfs_kerb_ticket_cache_path = "";
+
+/** HDFS default name node uri. */
+const char* hdfs_name_node_uri = "";
+
+/** HDFS default username. */
+const char* hdfs_username = "";
 
 /** Prefix indicating a special name reserved by TileDB. */
 const char* special_name_prefix = "__";

--- a/core/src/storage_manager/storage_manager.cc
+++ b/core/src/storage_manager/storage_manager.cc
@@ -253,7 +253,6 @@ Status StorageManager::group_create(const std::string& group) const {
 Status StorageManager::init(Config* config) {
   if (config != nullptr)
     config_ = *config;
-  RETURN_NOT_OK(config_.init());
   consolidator_ = new Consolidator(this);
   Config::SMParams sm_params = config_.sm_params();
   array_schema_cache_ = new LRUCache(sm_params.array_schema_cache_size_);

--- a/examples/src/tiledb_error.cc
+++ b/examples/src/tiledb_error.cc
@@ -67,9 +67,9 @@ int main() {
 
 void print_error(tiledb_ctx_t* ctx) {
   tiledb_error_t* err;
-  tiledb_error_last(ctx, &err);
+  tiledb_ctx_get_last_error(ctx, &err);
   const char* msg;
-  tiledb_error_message(ctx, err, &msg);
+  tiledb_error_message(err, &msg);
   printf("%s\n", msg);
-  tiledb_error_free(ctx, err);
+  tiledb_error_free(err);
 }

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -118,17 +118,23 @@ struct ArrayMetadataFx {
 ArrayMetadataFx::ArrayMetadataFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
-  REQUIRE(tiledb_config_create(&config) == TILEDB_OK);
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
 #ifdef HAVE_S3
   REQUIRE(
-      tiledb_config_set(config, "vfs.s3.endpoint_override", "localhost:9999") ==
+      tiledb_config_set(
+          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
       TILEDB_OK);
+  REQUIRE(error == nullptr);
 #endif
   ctx_ = nullptr;
+
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
-  REQUIRE(tiledb_config_free(config) == TILEDB_OK);
+  REQUIRE(error == nullptr);
   vfs_ = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
+  REQUIRE(tiledb_config_free(config, &error) == TILEDB_OK);
 
 // Connect to S3
 #ifdef HAVE_S3

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -234,16 +234,21 @@ struct DenseArrayFx {
 DenseArrayFx::DenseArrayFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
-  REQUIRE(tiledb_config_create(&config) == TILEDB_OK);
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
 #ifdef HAVE_S3
   REQUIRE(
-      tiledb_config_set(config, "vfs.s3.endpoint_override", "localhost:9999") ==
+      tiledb_config_set(
+          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
       TILEDB_OK);
+  REQUIRE(error == nullptr);
 #endif
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
-  REQUIRE(tiledb_config_free(config) == TILEDB_OK);
+  REQUIRE(error == nullptr);
   vfs_ = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
+  REQUIRE(tiledb_config_free(config, &error) == TILEDB_OK);
 
 // Connect to S3
 #ifdef HAVE_S3

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -83,16 +83,21 @@ struct DenseVectorFx {
 DenseVectorFx::DenseVectorFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
-  REQUIRE(tiledb_config_create(&config) == TILEDB_OK);
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
 #ifdef HAVE_S3
   REQUIRE(
-      tiledb_config_set(config, "vfs.s3.endpoint_override", "localhost:9999") ==
+      tiledb_config_set(
+          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
       TILEDB_OK);
+  REQUIRE(error == nullptr);
 #endif
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
-  REQUIRE(tiledb_config_free(config) == TILEDB_OK);
+  REQUIRE(error == nullptr);
   vfs_ = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
+  REQUIRE(tiledb_config_free(config, &error) == TILEDB_OK);
 
 // Connect to S3
 #ifdef HAVE_S3

--- a/test/src/unit-capi-error.cc
+++ b/test/src/unit-capi-error.cc
@@ -46,16 +46,16 @@ TEST_CASE("C API: Test error and error message", "[capi], [error]") {
   CHECK(rc == TILEDB_ERR);
 
   tiledb_error_t* err;
-  rc = tiledb_error_last(ctx, &err);
+  rc = tiledb_ctx_get_last_error(ctx, &err);
   CHECK(rc == TILEDB_OK);
 
   const char* errmsg;
-  rc = tiledb_error_message(ctx, err, &errmsg);
+  rc = tiledb_error_message(err, &errmsg);
   CHECK(rc == TILEDB_OK);
   CHECK_THAT(
       errmsg, Catch::Equals("Error: Invalid group directory argument is NULL"));
 
   // Clean up
-  tiledb_error_free(ctx, err);
+  tiledb_error_free(err);
   tiledb_ctx_free(ctx);
 }

--- a/test/src/unit-capi-kv.cc
+++ b/test/src/unit-capi-kv.cc
@@ -105,16 +105,21 @@ struct KVFx {
 KVFx::KVFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
-  REQUIRE(tiledb_config_create(&config) == TILEDB_OK);
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
 #ifdef HAVE_S3
   REQUIRE(
-      tiledb_config_set(config, "vfs.s3.endpoint_override", "localhost:9999") ==
+      tiledb_config_set(
+          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
       TILEDB_OK);
+  REQUIRE(error == nullptr);
 #endif
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
-  REQUIRE(tiledb_config_free(config) == TILEDB_OK);
+  REQUIRE(error == nullptr);
   vfs_ = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
+  REQUIRE(tiledb_config_free(config, &error) == TILEDB_OK);
 
 // Connect to S3
 #ifdef HAVE_S3

--- a/test/src/unit-capi-object_mgmt.cc
+++ b/test/src/unit-capi-object_mgmt.cc
@@ -92,16 +92,21 @@ struct ObjectMgmtFx {
 ObjectMgmtFx::ObjectMgmtFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
-  REQUIRE(tiledb_config_create(&config) == TILEDB_OK);
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
 #ifdef HAVE_S3
   REQUIRE(
-      tiledb_config_set(config, "vfs.s3.endpoint_override", "localhost:9999") ==
+      tiledb_config_set(
+          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
       TILEDB_OK);
+  REQUIRE(error == nullptr);
 #endif
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
-  REQUIRE(tiledb_config_free(config) == TILEDB_OK);
+  REQUIRE(error == nullptr);
   vfs_ = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
+  REQUIRE(tiledb_config_free(config, &error) == TILEDB_OK);
 
 // Connect to S3
 #ifdef HAVE_S3

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -170,16 +170,21 @@ struct SparseArrayFx {
 SparseArrayFx::SparseArrayFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
-  REQUIRE(tiledb_config_create(&config) == TILEDB_OK);
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
 #ifdef HAVE_S3
   REQUIRE(
-      tiledb_config_set(config, "vfs.s3.endpoint_override", "localhost:9999") ==
+      tiledb_config_set(
+          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
       TILEDB_OK);
+  REQUIRE(error == nullptr);
 #endif
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
-  REQUIRE(tiledb_config_free(config) == TILEDB_OK);
+  REQUIRE(error == nullptr);
   vfs_ = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
+  REQUIRE(tiledb_config_free(config, &error) == TILEDB_OK);
 
 // Connect to S3
 #ifdef HAVE_S3

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -78,16 +78,21 @@ struct VFSFx {
 VFSFx::VFSFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
-  REQUIRE(tiledb_config_create(&config) == TILEDB_OK);
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
 #ifdef HAVE_S3
   REQUIRE(
-      tiledb_config_set(config, "vfs.s3.endpoint_override", "localhost:9999") ==
+      tiledb_config_set(
+          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
       TILEDB_OK);
+  REQUIRE(error == nullptr);
 #endif
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
-  REQUIRE(tiledb_config_free(config) == TILEDB_OK);
-  int rc = tiledb_vfs_create(ctx_, &vfs_, nullptr);
+  REQUIRE(error == nullptr);
+  int rc = tiledb_vfs_create(ctx_, &vfs_, config);
   REQUIRE(rc == TILEDB_OK);
+  REQUIRE(tiledb_config_free(config, &error) == TILEDB_OK);
 }
 
 VFSFx::~VFSFx() {


### PR DESCRIPTION
- Removed context from the `tiledb_error_*`, `tiledb_config_*` and `tiledb_config_iter_*` C API functions. 
- Added `tiledb_error_t*` as an argument to the config/config_iter functions. 
- Implemented a `Config::save_to_file` function.