### PR TITLE
Changes in tests and some C API functions

### DIFF
--- a/core/include/c_api/tiledb.h
+++ b/core/include/c_api/tiledb.h
@@ -459,6 +459,18 @@ TILEDB_EXPORT int tiledb_ctx_get_config(
 TILEDB_EXPORT int tiledb_ctx_get_last_error(
     tiledb_ctx_t* ctx, tiledb_error_t** err);
 
+/**
+ * Checks if a given storage filesystem backend is supported.
+ *
+ * @param ctx The TileDB context.
+ * @param fs The filesystem to be checked.
+ * @param is_supported Sets it to `true` if the filesystem is supported, and
+ * `false` otherwise.
+ * @return TILEDB_OK for success and TILEDB_ERR for error.
+ */
+TILEDB_EXPORT int tiledb_ctx_is_supported_fs(
+    tiledb_ctx_t* ctx, tiledb_filesystem_t fs, int* is_supported);
+
 /* ********************************* */
 /*                GROUP              */
 /* ********************************* */
@@ -2090,24 +2102,8 @@ TILEDB_EXPORT int tiledb_vfs_fh_free(tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh);
  * @param is_closed Set to `true` if the file handle is closed.
  * @return TILEDB_OK for success and TILEDB_ERR for error.
  */
-TILEDB_EXPORT int tiledb_vfs_fh_closed(
+TILEDB_EXPORT int tiledb_vfs_fh_is_closed(
     tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh, int* is_closed);
-
-/**
- * Checks if a given storage filesystem backend is supported.
- *
- * @param ctx The TileDB context.
- * @param vfs The virtual filesystem object.
- * @param fs The filesystem to be checked.
- * @param supports Sets it to `true` if the filesystem is supported, and `false`
- *     otherwise.
- * @return TILEDB_OK for success and TILEDB_ERR for error.
- */
-TILEDB_EXPORT int tiledb_vfs_supports_fs(
-    tiledb_ctx_t* ctx,
-    tiledb_vfs_t* vfs,
-    tiledb_filesystem_t fs,
-    int* supports);
 
 /**
  * Touches a file, i.e., creates a new empty file.

--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -672,6 +672,17 @@ int tiledb_ctx_get_last_error(tiledb_ctx_t* ctx, tiledb_error_t** err) {
   return TILEDB_OK;
 }
 
+int tiledb_ctx_is_supported_fs(
+    tiledb_ctx_t* ctx, tiledb_filesystem_t fs, int* is_supported) {
+  if (sanity_check(ctx) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  *is_supported = (int)ctx->storage_manager_->vfs()->supports_fs(
+      static_cast<tiledb::Filesystem>(fs));
+
+  return TILEDB_OK;
+}
+
 /* ****************************** */
 /*              GROUP             */
 /* ****************************** */
@@ -2874,25 +2885,12 @@ int tiledb_vfs_fh_free(tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) {
   return TILEDB_OK;
 }
 
-int tiledb_vfs_fh_closed(
+int tiledb_vfs_fh_is_closed(
     tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh, int* is_closed) {
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, fh) == TILEDB_ERR)
     return TILEDB_ERR;
 
   *is_closed = fh->is_closed_;
-
-  return TILEDB_OK;
-}
-
-int tiledb_vfs_supports_fs(
-    tiledb_ctx_t* ctx,
-    tiledb_vfs_t* vfs,
-    tiledb_filesystem_t fs,
-    int* supports) {
-  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, vfs) == TILEDB_ERR)
-    return TILEDB_ERR;
-
-  *supports = (int)vfs->vfs_->supports_fs(static_cast<tiledb::Filesystem>(fs));
 
   return TILEDB_OK;
 }

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -173,19 +173,16 @@ ArraySchemaFx::~ArraySchemaFx() {
 void ArraySchemaFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
-  tiledb_vfs_t* vfs;
-  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
 
-  int supports = 0;
-  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  int is_supported = 0;
+  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)supports;
-  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  supports_s3_ = (bool)is_supported;
+  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)supports;
+  supports_hdfs_ = (bool)is_supported;
 
   REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
-  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
 }
 
 void ArraySchemaFx::create_temp_dir(const std::string& path) {

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -286,19 +286,16 @@ DenseArrayFx::~DenseArrayFx() {
 void DenseArrayFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
-  tiledb_vfs_t* vfs;
-  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
 
-  int supports = 0;
-  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  int is_supported = 0;
+  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)supports;
-  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  supports_s3_ = (bool)is_supported;
+  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)supports;
+  supports_hdfs_ = (bool)is_supported;
 
   REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
-  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
 }
 
 void DenseArrayFx::create_temp_dir(const std::string& path) {

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -134,19 +134,16 @@ DenseVectorFx::~DenseVectorFx() {
 void DenseVectorFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
-  tiledb_vfs_t* vfs;
-  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
 
-  int supports = 0;
-  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  int is_supported = 0;
+  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)supports;
-  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  supports_s3_ = (bool)is_supported;
+  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)supports;
+  supports_hdfs_ = (bool)is_supported;
 
   REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
-  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
 }
 
 void DenseVectorFx::create_temp_dir(const std::string& path) {

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -46,14 +46,10 @@ struct DenseVectorFx {
   const tiledb_datatype_t ATTR_TYPE = TILEDB_INT64;
   const char* DIM0_NAME = "dim0";
   const tiledb_datatype_t DIM_TYPE = TILEDB_INT64;
-#ifdef HAVE_HDFS
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
-#endif
-#ifdef HAVE_S3
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#endif
 #ifdef _WIN32
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
@@ -69,6 +65,10 @@ struct DenseVectorFx {
   tiledb_ctx_t* ctx_;
   tiledb_vfs_t* vfs_;
 
+  // Supported filesystems
+  bool supports_s3_;
+  bool supports_hdfs_;
+
   // Functions
   DenseVectorFx();
   ~DenseVectorFx();
@@ -78,52 +78,75 @@ struct DenseVectorFx {
   void create_temp_dir(const std::string& path);
   void remove_temp_dir(const std::string& path);
   static std::string random_bucket_name(const std::string& prefix);
+  void set_supported_fs();
 };
 
 DenseVectorFx::DenseVectorFx() {
+  // Supported filesystems
+  set_supported_fs();
+
   // Create TileDB context
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
   REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
-#ifdef HAVE_S3
-  REQUIRE(
-      tiledb_config_set(
-          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
-      TILEDB_OK);
-  REQUIRE(error == nullptr);
-#endif
+  if (supports_s3_) {
+    REQUIRE(
+        tiledb_config_set(
+            config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
+        TILEDB_OK);
+    REQUIRE(error == nullptr);
+  }
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
   REQUIRE(error == nullptr);
   vfs_ = nullptr;
   REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
   REQUIRE(tiledb_config_free(config) == TILEDB_OK);
 
-// Connect to S3
-#ifdef HAVE_S3
-  // Create bucket if it does not exist
-  int is_bucket = 0;
-  int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
-  REQUIRE(rc == TILEDB_OK);
-  if (!is_bucket) {
-    rc = tiledb_vfs_create_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+  // Connect to S3
+  if (supports_s3_) {
+    // Create bucket if it does not exist
+    int is_bucket = 0;
+    int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
     REQUIRE(rc == TILEDB_OK);
+    if (!is_bucket) {
+      rc = tiledb_vfs_create_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+      REQUIRE(rc == TILEDB_OK);
+    }
   }
-#endif
 }
 
 DenseVectorFx::~DenseVectorFx() {
-#ifdef HAVE_S3
-  int is_bucket = 0;
-  int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
-  CHECK(rc == TILEDB_OK);
-  if (is_bucket) {
-    CHECK(tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str()) == TILEDB_OK);
+  if (supports_s3_) {
+    int is_bucket = 0;
+    int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
+    CHECK(rc == TILEDB_OK);
+    if (is_bucket) {
+      CHECK(
+          tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str()) == TILEDB_OK);
+    }
   }
-#endif
 
   CHECK(tiledb_vfs_free(ctx_, vfs_) == TILEDB_OK);
   CHECK(tiledb_ctx_free(ctx_) == TILEDB_OK);
+}
+
+void DenseVectorFx::set_supported_fs() {
+  tiledb_ctx_t* ctx = nullptr;
+  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  tiledb_vfs_t* vfs;
+  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
+
+  int supports = 0;
+  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  REQUIRE(rc == TILEDB_OK);
+  supports_s3_ = (bool)supports;
+  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  REQUIRE(rc == TILEDB_OK);
+  supports_hdfs_ = (bool)supports;
+
+  REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
 }
 
 void DenseVectorFx::create_temp_dir(const std::string& path) {
@@ -286,32 +309,32 @@ TEST_CASE_METHOD(
     DenseVectorFx, "C API: Test 1d dense vector", "[capi], [dense-vector]") {
   std::string vector_name;
 
-#ifdef HAVE_S3
-  // S3
-  create_temp_dir(S3_TEMP_DIR);
-  vector_name = S3_TEMP_DIR + VECTOR;
-  create_dense_vector(vector_name);
-  check_read(vector_name, TILEDB_ROW_MAJOR);
-  check_read(vector_name, TILEDB_COL_MAJOR);
-  check_update(vector_name);
-  remove_temp_dir(S3_TEMP_DIR);
-#elif HAVE_HDFS
-  // HDFS
-  create_temp_dir(HDFS_TEMP_DIR);
-  vector_name = HDFS_TEMP_DIR + VECTOR;
-  create_dense_vector(vector_name);
-  check_read(vector_name, TILEDB_ROW_MAJOR);
-  check_read(vector_name, TILEDB_COL_MAJOR);
-  check_update(vector_name);
-  remove_temp_dir(HDFS_TEMP_DIR);
-#else
-  // File
-  create_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
-  vector_name = FILE_URI_PREFIX + FILE_TEMP_DIR + VECTOR;
-  create_dense_vector(vector_name);
-  check_read(vector_name, TILEDB_ROW_MAJOR);
-  check_read(vector_name, TILEDB_COL_MAJOR);
-  check_update(vector_name);
-  remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
-#endif
+  if (supports_s3_) {
+    // S3
+    create_temp_dir(S3_TEMP_DIR);
+    vector_name = S3_TEMP_DIR + VECTOR;
+    create_dense_vector(vector_name);
+    check_read(vector_name, TILEDB_ROW_MAJOR);
+    check_read(vector_name, TILEDB_COL_MAJOR);
+    check_update(vector_name);
+    remove_temp_dir(S3_TEMP_DIR);
+  } else if (supports_hdfs_) {
+    // HDFS
+    create_temp_dir(HDFS_TEMP_DIR);
+    vector_name = HDFS_TEMP_DIR + VECTOR;
+    create_dense_vector(vector_name);
+    check_read(vector_name, TILEDB_ROW_MAJOR);
+    check_read(vector_name, TILEDB_COL_MAJOR);
+    check_update(vector_name);
+    remove_temp_dir(HDFS_TEMP_DIR);
+  } else {
+    // File
+    create_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
+    vector_name = FILE_URI_PREFIX + FILE_TEMP_DIR + VECTOR;
+    create_dense_vector(vector_name);
+    check_read(vector_name, TILEDB_ROW_MAJOR);
+    check_read(vector_name, TILEDB_COL_MAJOR);
+    check_update(vector_name);
+    remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
+  }
 }

--- a/test/src/unit-capi-kv.cc
+++ b/test/src/unit-capi-kv.cc
@@ -156,19 +156,16 @@ KVFx::~KVFx() {
 void KVFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
-  tiledb_vfs_t* vfs;
-  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
 
-  int supports = 0;
-  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  int is_supported = 0;
+  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)supports;
-  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  supports_s3_ = (bool)is_supported;
+  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)supports;
+  supports_hdfs_ = (bool)is_supported;
 
   REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
-  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
 }
 
 void KVFx::create_temp_dir(const std::string& path) {

--- a/test/src/unit-capi-kv.cc
+++ b/test/src/unit-capi-kv.cc
@@ -64,14 +64,10 @@ struct KVFx {
   const char* KEY4_A2 = "dddd";
   const float KEY4_A3[2] = {4.1f, 4.2f};
 
-#ifdef HAVE_HDFS
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
-#endif
-#ifdef HAVE_S3
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#endif
 #ifdef _WIN32
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
@@ -85,6 +81,10 @@ struct KVFx {
   // TileDB context
   tiledb_ctx_t* ctx_;
   tiledb_vfs_t* vfs_;
+
+  // Supported filesystems
+  bool supports_s3_;
+  bool supports_hdfs_;
 
   // Functions
   KVFx();
@@ -100,52 +100,75 @@ struct KVFx {
   void create_temp_dir(const std::string& path);
   void remove_temp_dir(const std::string& path);
   static std::string random_bucket_name(const std::string& prefix);
+  void set_supported_fs();
 };
 
 KVFx::KVFx() {
+  // Supported filesystems
+  set_supported_fs();
+
   // Create TileDB context
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
   REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
-#ifdef HAVE_S3
-  REQUIRE(
-      tiledb_config_set(
-          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
-      TILEDB_OK);
-  REQUIRE(error == nullptr);
-#endif
+  if (supports_s3_) {
+    REQUIRE(
+        tiledb_config_set(
+            config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
+        TILEDB_OK);
+    REQUIRE(error == nullptr);
+  }
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
   REQUIRE(error == nullptr);
   vfs_ = nullptr;
   REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
   REQUIRE(tiledb_config_free(config) == TILEDB_OK);
 
-// Connect to S3
-#ifdef HAVE_S3
-  // Create bucket if it does not exist
-  int is_bucket = 0;
-  int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
-  REQUIRE(rc == TILEDB_OK);
-  if (!is_bucket) {
-    rc = tiledb_vfs_create_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+  // Connect to S3
+  if (supports_s3_) {
+    // Create bucket if it does not exist
+    int is_bucket = 0;
+    int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
     REQUIRE(rc == TILEDB_OK);
+    if (!is_bucket) {
+      rc = tiledb_vfs_create_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+      REQUIRE(rc == TILEDB_OK);
+    }
   }
-#endif
 }
 
 KVFx::~KVFx() {
-#ifdef HAVE_S3
-  int is_bucket = 0;
-  int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
-  CHECK(rc == TILEDB_OK);
-  if (is_bucket) {
-    CHECK(tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str()) == TILEDB_OK);
+  if (supports_s3_) {
+    int is_bucket = 0;
+    int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
+    CHECK(rc == TILEDB_OK);
+    if (is_bucket) {
+      CHECK(
+          tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str()) == TILEDB_OK);
+    }
   }
-#endif
 
   CHECK(tiledb_vfs_free(ctx_, vfs_) == TILEDB_OK);
   CHECK(tiledb_ctx_free(ctx_) == TILEDB_OK);
+}
+
+void KVFx::set_supported_fs() {
+  tiledb_ctx_t* ctx = nullptr;
+  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  tiledb_vfs_t* vfs;
+  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
+
+  int supports = 0;
+  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  REQUIRE(rc == TILEDB_OK);
+  supports_s3_ = (bool)supports;
+  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  REQUIRE(rc == TILEDB_OK);
+  supports_hdfs_ = (bool)supports;
+
+  REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
 }
 
 void KVFx::create_temp_dir(const std::string& path) {
@@ -838,37 +861,38 @@ void KVFx::check_iter(const std::string& path) {
 TEST_CASE_METHOD(KVFx, "C API: Test key-value", "[capi], [kv]") {
   std::string array_name;
 
-#ifdef HAVE_S3
-  create_temp_dir(S3_TEMP_DIR);
-  array_name = S3_TEMP_DIR + KV_NAME;
-  create_kv(array_name);
-  check_write(array_name);
-  check_single_read(array_name);
-  check_read_on_attribute_subset(array_name);
-  check_iter(array_name);
-  check_interleaved_read_write(array_name);
-  remove_temp_dir(S3_TEMP_DIR);
-#elif HAVE_HDFS
-  create_temp_dir(HDFS_TEMP_DIR);
-  array_name = HDFS_TEMP_DIR + KV_NAME;
-  create_kv(array_name);
-  check_write(array_name);
-  check_single_read(array_name);
-  check_read_on_attribute_subset(array_name);
-  check_iter(array_name);
-  check_interleaved_read_write(array_name);
-  remove_temp_dir(HDFS_TEMP_DIR);
-#else
-  // File
-  create_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
-  array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + KV_NAME;
-  create_kv(array_name);
-  check_kv_item();
-  check_write(array_name);
-  check_single_read(array_name);
-  check_read_on_attribute_subset(array_name);
-  check_iter(array_name);
-  check_interleaved_read_write(array_name);
-  remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
-#endif
+  if (supports_s3_) {
+    // S3
+    create_temp_dir(S3_TEMP_DIR);
+    array_name = S3_TEMP_DIR + KV_NAME;
+    create_kv(array_name);
+    check_write(array_name);
+    check_single_read(array_name);
+    check_read_on_attribute_subset(array_name);
+    check_iter(array_name);
+    check_interleaved_read_write(array_name);
+    remove_temp_dir(S3_TEMP_DIR);
+  } else if (supports_hdfs_) {
+    create_temp_dir(HDFS_TEMP_DIR);
+    array_name = HDFS_TEMP_DIR + KV_NAME;
+    create_kv(array_name);
+    check_write(array_name);
+    check_single_read(array_name);
+    check_read_on_attribute_subset(array_name);
+    check_iter(array_name);
+    check_interleaved_read_write(array_name);
+    remove_temp_dir(HDFS_TEMP_DIR);
+  } else {
+    // File
+    create_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
+    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + KV_NAME;
+    create_kv(array_name);
+    check_kv_item();
+    check_write(array_name);
+    check_single_read(array_name);
+    check_read_on_attribute_subset(array_name);
+    check_iter(array_name);
+    check_interleaved_read_write(array_name);
+    remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
+  }
 }

--- a/test/src/unit-capi-object_mgmt.cc
+++ b/test/src/unit-capi-object_mgmt.cc
@@ -145,19 +145,16 @@ ObjectMgmtFx::~ObjectMgmtFx() {
 void ObjectMgmtFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
-  tiledb_vfs_t* vfs;
-  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
 
-  int supports = 0;
-  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  int is_supported = 0;
+  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)supports;
-  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  supports_s3_ = (bool)is_supported;
+  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)supports;
+  supports_hdfs_ = (bool)is_supported;
 
   REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
-  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
 }
 
 void ObjectMgmtFx::create_temp_dir(const std::string& path) {

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -234,19 +234,16 @@ SparseArrayFx::~SparseArrayFx() {
 void SparseArrayFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
-  tiledb_vfs_t* vfs;
-  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
 
-  int supports = 0;
-  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  int is_supported = 0;
+  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)supports;
-  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  supports_s3_ = (bool)is_supported;
+  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
   REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)supports;
+  supports_hdfs_ = (bool)is_supported;
 
   REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
-  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
 }
 
 void SparseArrayFx::create_temp_dir(const std::string& path) {

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -57,14 +57,10 @@ struct SparseArrayFx {
   const tiledb_datatype_t DIM_TYPE = TILEDB_INT64;
   const tiledb_array_type_t ARRAY_TYPE = TILEDB_SPARSE;
   int COMPRESSION_LEVEL = -1;
-#ifdef HAVE_HDFS
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
-#endif
-#ifdef HAVE_S3
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#endif
 #ifdef _WIN32
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
@@ -81,9 +77,14 @@ struct SparseArrayFx {
   tiledb_ctx_t* ctx_;
   tiledb_vfs_t* vfs_;
 
+  // Supported filesystems
+  bool supports_s3_;
+  bool supports_hdfs_;
+
   // Functions
   SparseArrayFx();
   ~SparseArrayFx();
+  void set_supported_fs();
   void create_temp_dir(const std::string& path);
   void remove_temp_dir(const std::string& path);
   static std::string random_bucket_name(const std::string& prefix);
@@ -168,64 +169,84 @@ struct SparseArrayFx {
 };
 
 SparseArrayFx::SparseArrayFx() {
+  // Supported filesystems
+  set_supported_fs();
+
   // Create TileDB context
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
   REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
-#ifdef HAVE_S3
-  REQUIRE(
-      tiledb_config_set(
-          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
-      TILEDB_OK);
-  REQUIRE(error == nullptr);
-#endif
+  if (supports_s3_) {
+    REQUIRE(
+        tiledb_config_set(
+            config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
+        TILEDB_OK);
+    REQUIRE(error == nullptr);
+  }
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
   REQUIRE(error == nullptr);
   vfs_ = nullptr;
   REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
   REQUIRE(tiledb_config_free(config) == TILEDB_OK);
 
-// Connect to S3
-#ifdef HAVE_S3
-  // Create bucket if it does not exist
-  int is_bucket = 0;
-  int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
-  REQUIRE(rc == TILEDB_OK);
-  if (!is_bucket) {
-    rc = tiledb_vfs_create_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+  // Connect to S3
+  if (supports_s3_) {
+    // Create bucket if it does not exist
+    int is_bucket = 0;
+    int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
     REQUIRE(rc == TILEDB_OK);
+    if (!is_bucket) {
+      rc = tiledb_vfs_create_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+      REQUIRE(rc == TILEDB_OK);
+    }
   }
-#endif
 
   std::srand(0);
 
   create_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
-#ifdef HAVE_S3
-  create_temp_dir(S3_TEMP_DIR);
-#endif
-#ifdef HAVE_HDFS
-  create_temp_dir(HDFS_TEMP_DIR);
-#endif
+  if (supports_s3_)
+    create_temp_dir(S3_TEMP_DIR);
+  if (supports_hdfs_)
+    create_temp_dir(HDFS_TEMP_DIR);
 }
 
 SparseArrayFx::~SparseArrayFx() {
   remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
-#ifdef HAVE_S3
-  remove_temp_dir(S3_TEMP_DIR);
-  int is_bucket = 0;
-  int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
-  CHECK(rc == TILEDB_OK);
-  if (is_bucket) {
-    CHECK(tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str()) == TILEDB_OK);
+
+  if (supports_s3_) {
+    remove_temp_dir(S3_TEMP_DIR);
+    int is_bucket = 0;
+    int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
+    CHECK(rc == TILEDB_OK);
+    if (is_bucket) {
+      CHECK(
+          tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str()) == TILEDB_OK);
+    }
   }
-#endif
-#ifdef HAVE_HDFS
-  remove_temp_dir(HDFS_TEMP_DIR);
-#endif
+  if (supports_hdfs_)
+    remove_temp_dir(HDFS_TEMP_DIR);
 
   CHECK(tiledb_vfs_free(ctx_, vfs_) == TILEDB_OK);
   CHECK(tiledb_ctx_free(ctx_) == TILEDB_OK);
+}
+
+void SparseArrayFx::set_supported_fs() {
+  tiledb_ctx_t* ctx = nullptr;
+  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  tiledb_vfs_t* vfs;
+  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
+
+  int supports = 0;
+  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  REQUIRE(rc == TILEDB_OK);
+  supports_s3_ = (bool)supports;
+  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  REQUIRE(rc == TILEDB_OK);
+  supports_hdfs_ = (bool)supports;
+
+  REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
 }
 
 void SparseArrayFx::create_temp_dir(const std::string& path) {
@@ -506,230 +527,257 @@ TEST_CASE_METHOD(
   std::string array_name;
 
   SECTION("- no compression, row/row-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_NO_COMPRESSION, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_NO_COMPRESSION, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_NO_COMPRESSION, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name,
+          TILEDB_NO_COMPRESSION,
+          TILEDB_ROW_MAJOR,
+          TILEDB_ROW_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name,
+          TILEDB_NO_COMPRESSION,
+          TILEDB_ROW_MAJOR,
+          TILEDB_ROW_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name,
+          TILEDB_NO_COMPRESSION,
+          TILEDB_ROW_MAJOR,
+          TILEDB_ROW_MAJOR);
+    }
   }
 
   SECTION("- no compression, col/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_NO_COMPRESSION, TILEDB_COL_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_NO_COMPRESSION, TILEDB_COL_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_NO_COMPRESSION, TILEDB_COL_MAJOR, TILEDB_COL_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name,
+          TILEDB_NO_COMPRESSION,
+          TILEDB_COL_MAJOR,
+          TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name,
+          TILEDB_NO_COMPRESSION,
+          TILEDB_COL_MAJOR,
+          TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name,
+          TILEDB_NO_COMPRESSION,
+          TILEDB_COL_MAJOR,
+          TILEDB_COL_MAJOR);
+    }
   }
 
   SECTION("- no compression, row/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_NO_COMPRESSION, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_NO_COMPRESSION, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_NO_COMPRESSION, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name,
+          TILEDB_NO_COMPRESSION,
+          TILEDB_ROW_MAJOR,
+          TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name,
+          TILEDB_NO_COMPRESSION,
+          TILEDB_ROW_MAJOR,
+          TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name,
+          TILEDB_NO_COMPRESSION,
+          TILEDB_ROW_MAJOR,
+          TILEDB_COL_MAJOR);
+    }
   }
 
   SECTION("- gzip compression, row/row-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+    }
   }
 
   SECTION("- gzip compression, col/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_GZIP, TILEDB_COL_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_GZIP, TILEDB_COL_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_GZIP, TILEDB_COL_MAJOR, TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_GZIP, TILEDB_COL_MAJOR, TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+    }
   }
 
   SECTION("- gzip compression, row/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_GZIP, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    }
   }
 
   SECTION("- blosc compression, row/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_BLOSC, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_BLOSC, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_BLOSC, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_BLOSC, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_BLOSC, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_BLOSC, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    }
   }
 
   SECTION("- bzip compression, row/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_BZIP2, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_BZIP2, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_BZIP2, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_BZIP2, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_BZIP2, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_BZIP2, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    }
   }
 
   SECTION("- lz4 compression, row/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_LZ4, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_LZ4, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_LZ4, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_LZ4, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_LZ4, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_LZ4, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    }
   }
 
   SECTION("- rle compression, row/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_RLE, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_RLE, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_RLE, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_RLE, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_RLE, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_RLE, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    }
   }
 
   SECTION("- zstd compression, row/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_ZSTD, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_ZSTD, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_ZSTD, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_ZSTD, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_ZSTD, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_ZSTD, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    }
   }
 
   SECTION("- double-delta compression, row/col-major") {
-#ifdef HAVE_S3
-    // S3
-    array_name = S3_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_DOUBLE_DELTA, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#elif HAVE_HDFS
-    // HDFS
-    array_name = HDFS_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_DOUBLE_DELTA, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#else
-    // File
-    array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
-    check_sorted_reads(
-        array_name, TILEDB_DOUBLE_DELTA, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
-#endif
+    if (supports_s3_) {
+      // S3
+      array_name = S3_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_DOUBLE_DELTA, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else if (supports_hdfs_) {
+      // HDFS
+      array_name = HDFS_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_DOUBLE_DELTA, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    } else {
+      // File
+      array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + ARRAY;
+      check_sorted_reads(
+          array_name, TILEDB_DOUBLE_DELTA, TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+    }
   }
 }

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -43,14 +43,10 @@
 #include <thread>
 
 struct VFSFx {
-#ifdef HAVE_HDFS
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
-#endif
-#ifdef HAVE_S3
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#endif
 #ifdef _WIN32
   const std::string FILE_TEMP_DIR =
       tiledb::win::current_dir() + "\\tiledb_test\\";
@@ -63,6 +59,10 @@ struct VFSFx {
   tiledb_ctx_t* ctx_;
   tiledb_vfs_t* vfs_;
 
+  // Supported filesystems
+  bool supports_s3_;
+  bool supports_hdfs_;
+
   // Functions
   VFSFx();
   ~VFSFx();
@@ -72,21 +72,25 @@ struct VFSFx {
   void check_read(const std::string& path);
   void check_append(const std::string& path);
   static std::string random_bucket_name(const std::string& prefix);
+  void set_supported_fs();
 };
 
 VFSFx::VFSFx() {
+  // Supported filesystems
+  set_supported_fs();
+
   // Create TileDB context
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
   REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
-#ifdef HAVE_S3
-  REQUIRE(
-      tiledb_config_set(
-          config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
-      TILEDB_OK);
-  REQUIRE(error == nullptr);
-#endif
+  if (supports_s3_) {
+    REQUIRE(
+        tiledb_config_set(
+            config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==
+        TILEDB_OK);
+    REQUIRE(error == nullptr);
+  }
   REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
   REQUIRE(error == nullptr);
   int rc = tiledb_vfs_create(ctx_, &vfs_, config);
@@ -99,27 +103,45 @@ VFSFx::~VFSFx() {
   CHECK(tiledb_ctx_free(ctx_) == TILEDB_OK);
 }
 
-void VFSFx::check_vfs(const std::string& path) {
-#ifdef HAVE_S3
-  // Check S3 bucket functionality
-  if (path == S3_TEMP_DIR) {
-    int is_bucket = 0;
-    int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
-    REQUIRE(rc == TILEDB_OK);
-    if (is_bucket) {
-      rc = tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str());
-      REQUIRE(rc == TILEDB_OK);
-    }
-    rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
-    REQUIRE(rc == TILEDB_OK);
-    REQUIRE(!is_bucket);
+void VFSFx::set_supported_fs() {
+  tiledb_ctx_t* ctx = nullptr;
+  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  tiledb_vfs_t* vfs;
+  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
 
-    rc = tiledb_vfs_create_bucket(ctx_, vfs_, S3_BUCKET.c_str());
-    REQUIRE(rc == TILEDB_OK);
-    rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
-    REQUIRE(is_bucket);
+  int supports = 0;
+  int rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_S3, &supports);
+  REQUIRE(rc == TILEDB_OK);
+  supports_s3_ = (bool)supports;
+  rc = tiledb_vfs_supports_fs(ctx, vfs, TILEDB_HDFS, &supports);
+  REQUIRE(rc == TILEDB_OK);
+  supports_hdfs_ = (bool)supports;
+
+  REQUIRE(tiledb_ctx_free(ctx) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_free(ctx, vfs) == TILEDB_OK);
+}
+
+void VFSFx::check_vfs(const std::string& path) {
+  if (supports_s3_) {
+    // Check S3 bucket functionality
+    if (path == S3_TEMP_DIR) {
+      int is_bucket = 0;
+      int rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
+      REQUIRE(rc == TILEDB_OK);
+      if (is_bucket) {
+        rc = tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+        REQUIRE(rc == TILEDB_OK);
+      }
+      rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
+      REQUIRE(rc == TILEDB_OK);
+      REQUIRE(!is_bucket);
+
+      rc = tiledb_vfs_create_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+      REQUIRE(rc == TILEDB_OK);
+      rc = tiledb_vfs_is_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_bucket);
+      REQUIRE(is_bucket);
+    }
   }
-#endif
 
   // Create directory, is directory, remove directory
   int is_dir = 0;
@@ -208,35 +230,30 @@ void VFSFx::check_vfs(const std::string& path) {
   int supports = 0;
   rc = tiledb_vfs_supports_fs(ctx_, vfs_, TILEDB_HDFS, &supports);
   CHECK(rc == TILEDB_OK);
-#ifdef HAVE_HDFS
-  CHECK(supports);
-#else
-  CHECK(!supports);
-#endif
+  if (supports_hdfs_)
+    CHECK(supports);
+  else
+    CHECK(!supports);
   rc = tiledb_vfs_supports_fs(ctx_, vfs_, TILEDB_S3, &supports);
   CHECK(rc == TILEDB_OK);
-#ifdef HAVE_S3
-  CHECK(supports);
-#else
-  CHECK(!supports);
-#endif
+  if (supports_s3_)
+    CHECK(supports);
+  else
+    CHECK(!supports);
 
-#ifdef HAVE_S3
-  if (path == S3_TEMP_DIR) {
+  if (supports_s3_ && path == S3_TEMP_DIR) {
     int is_empty;
     rc = tiledb_vfs_is_empty_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_empty);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(!(bool)is_empty);
   }
-#endif
 
-#ifndef HAVE_S3
-  rc = tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str());
-  REQUIRE(rc == TILEDB_OK);
-#endif
+  if (!supports_s3_) {
+    rc = tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str());
+    REQUIRE(rc == TILEDB_OK);
+  }
 
-#ifdef HAVE_S3
-  if (path == S3_TEMP_DIR) {
+  if (supports_s3_ && path == S3_TEMP_DIR) {
     rc = tiledb_vfs_empty_bucket(ctx_, vfs_, S3_BUCKET.c_str());
     REQUIRE(rc == TILEDB_OK);
 
@@ -248,7 +265,6 @@ void VFSFx::check_vfs(const std::string& path) {
     rc = tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str());
     REQUIRE(rc == TILEDB_OK);
   }
-#endif
 }
 
 void VFSFx::check_move(const std::string& path) {
@@ -334,34 +350,34 @@ void VFSFx::check_move(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(is_file);
 
-// Move from one bucket to another (only for S3)
-#ifdef HAVE_S3
-  if (path == S3_TEMP_DIR) {
-    std::string bucket2 = S3_PREFIX + random_bucket_name("tiledb") + "/";
-    std::string subdir3 = bucket2 + "tiledb_test/subdir3/";
-    std::string file3 = subdir3 + "file2";
-    int is_bucket = 0;
+  // Move from one bucket to another (only for S3)
+  if (supports_s3_) {
+    if (path == S3_TEMP_DIR) {
+      std::string bucket2 = S3_PREFIX + random_bucket_name("tiledb") + "/";
+      std::string subdir3 = bucket2 + "tiledb_test/subdir3/";
+      std::string file3 = subdir3 + "file2";
+      int is_bucket = 0;
 
-    rc = tiledb_vfs_is_bucket(ctx_, vfs_, bucket2.c_str(), &is_bucket);
-    REQUIRE(rc == TILEDB_OK);
-    if (is_bucket) {
+      rc = tiledb_vfs_is_bucket(ctx_, vfs_, bucket2.c_str(), &is_bucket);
+      REQUIRE(rc == TILEDB_OK);
+      if (is_bucket) {
+        rc = tiledb_vfs_remove_bucket(ctx_, vfs_, bucket2.c_str());
+        REQUIRE(rc == TILEDB_OK);
+      }
+
+      rc = tiledb_vfs_create_bucket(ctx_, vfs_, bucket2.c_str());
+      REQUIRE(rc == TILEDB_OK);
+
+      rc = tiledb_vfs_move(ctx_, vfs_, subdir2.c_str(), subdir3.c_str(), true);
+      REQUIRE(rc == TILEDB_OK);
+      rc = tiledb_vfs_is_file(ctx_, vfs_, file3.c_str(), &is_file);
+      REQUIRE(rc == TILEDB_OK);
+      REQUIRE(is_file);
+
       rc = tiledb_vfs_remove_bucket(ctx_, vfs_, bucket2.c_str());
       REQUIRE(rc == TILEDB_OK);
     }
-
-    rc = tiledb_vfs_create_bucket(ctx_, vfs_, bucket2.c_str());
-    REQUIRE(rc == TILEDB_OK);
-
-    rc = tiledb_vfs_move(ctx_, vfs_, subdir2.c_str(), subdir3.c_str(), true);
-    REQUIRE(rc == TILEDB_OK);
-    rc = tiledb_vfs_is_file(ctx_, vfs_, file3.c_str(), &is_file);
-    REQUIRE(rc == TILEDB_OK);
-    REQUIRE(is_file);
-
-    rc = tiledb_vfs_remove_bucket(ctx_, vfs_, bucket2.c_str());
-    REQUIRE(rc == TILEDB_OK);
   }
-#endif
 }
 
 void VFSFx::check_write(const std::string& path) {
@@ -555,28 +571,24 @@ std::string VFSFx::random_bucket_name(const std::string& prefix) {
 TEST_CASE_METHOD(VFSFx, "C API: Test virtual filesystem", "[capi], [vfs]") {
   check_vfs(FILE_TEMP_DIR);
 
-#ifdef HAVE_S3
-  // S3
-  check_vfs(S3_TEMP_DIR);
-#endif
+  if (supports_s3_)
+    check_vfs(S3_TEMP_DIR);
 
-#ifdef HAVE_HDFS
-  // HDFS
-  check_vfs(HDFS_TEMP_DIR);
-#endif
+  if (supports_hdfs_)
+    check_vfs(HDFS_TEMP_DIR);
 }
 
-#ifndef HAVE_S3
 TEST_CASE_METHOD(
     VFSFx,
     "C API: Test virtual filesystem when S3 is not supported",
     "[capi], [vfs]") {
-  tiledb_vfs_t* vfs;
-  int rc = tiledb_vfs_create(ctx_, &vfs, nullptr);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_vfs_create_bucket(ctx_, vfs, "s3://foo");
-  REQUIRE(rc == TILEDB_ERR);
-  rc = tiledb_vfs_free(ctx_, vfs);
-  CHECK(rc == TILEDB_OK);
+  if (!supports_s3_) {
+    tiledb_vfs_t* vfs;
+    int rc = tiledb_vfs_create(ctx_, &vfs, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_vfs_create_bucket(ctx_, vfs, "s3://foo");
+    REQUIRE(rc == TILEDB_ERR);
+    rc = tiledb_vfs_free(ctx_, vfs);
+    CHECK(rc == TILEDB_OK);
+  }
 }
-#endif


### PR DESCRIPTION
* Remove preprocessor commands from tests. Use C API instead
* Changing `tiledb_vfs_fh_closed` to `tiledb_vfs_fh_is_closed` for consistency. 
* Changing `tiledb_vfs_supports_fs` to `tiledb_ctx_is_supported_fs` for naming consistency and for simplicity (no need to create a vfs object to check the supported filesystem).
