### PR TITLE
Fix for VFS writes

### DIFF
--- a/core/src/c_api/tiledb.cc
+++ b/core/src/c_api/tiledb.cc
@@ -2841,9 +2841,15 @@ int tiledb_vfs_close(tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) {
     return TILEDB_ERR;
   }
 
+  // Close file in write or append mode
   if (fh->mode_ != tiledb::VFSMode::VFS_READ) {
     if (save_error(ctx, fh->vfs_->close_file(fh->uri_)))
       return TILEDB_ERR;
+
+    // Create an empty file if the file does not exist
+    if (!fh->vfs_->is_file(fh->uri_))
+      if (save_error(ctx, fh->vfs_->create_file(fh->uri_)))
+        return TILEDB_ERR;
   }
 
   fh->is_closed_ = true;

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -443,7 +443,7 @@ void VFSFx::check_write(const std::string& path) {
   REQUIRE(file_size == to_write.size());  // Not 2*to_write.size()
 
   // Opening and closing the file without writing, first deletes previous
-  // file, but then does not create file as it has no contents
+  // file, and then creates an empty file
   rc = tiledb_vfs_open(ctx_, vfs_, file.c_str(), TILEDB_VFS_WRITE, &fh);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_vfs_close(ctx_, fh);
@@ -452,7 +452,10 @@ void VFSFx::check_write(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_vfs_is_file(ctx_, vfs_, file.c_str(), &is_file);
   REQUIRE(rc == TILEDB_OK);
-  REQUIRE(!is_file);
+  REQUIRE(is_file);
+  rc = tiledb_vfs_file_size(ctx_, vfs_, file.c_str(), &file_size);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(file_size == 0);  // Not 2*to_write.size()
 }
 
 void VFSFx::check_append(const std::string& path) {


### PR DESCRIPTION
Opening a VFS file in write mode and closing it without writing should create an empty file (similar to the case of `ofstream`).