### PR TITLE
All cell/tile layouts should be row-major for 1d vectors

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -638,7 +638,10 @@ void ArraySchema::set_cell_var_offsets_compression_level(
 }
 
 void ArraySchema::set_cell_order(Layout cell_order) {
-  cell_order_ = cell_order;
+  if (domain_ != nullptr && domain_->dim_num() == 1)
+    cell_order_ = Layout::ROW_MAJOR;
+  else
+    cell_order_ = cell_order;
 }
 
 Status ArraySchema::set_domain(Domain* domain) {
@@ -671,11 +674,20 @@ Status ArraySchema::set_domain(Domain* domain) {
       coords_compression_ == Compressor::DOUBLE_DELTA)
     coords_compression_ = constants::real_coords_compression;
 
+  // For 1D vectors, the cell/tile layout should always be row-major
+  if (domain_->dim_num() == 1) {
+    cell_order_ = Layout::ROW_MAJOR;
+    tile_order_ = Layout::ROW_MAJOR;
+  }
+
   return Status::Ok();
 }
 
 void ArraySchema::set_tile_order(Layout tile_order) {
-  tile_order_ = tile_order;
+  if (domain_ != nullptr && domain_->dim_num() == 1)
+    tile_order_ = Layout::ROW_MAJOR;
+  else
+    tile_order_ = tile_order;
 }
 
 /* ****************************** */

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -274,7 +274,12 @@ class ArraySchema {
   /** Sets the tile capacity. */
   void set_capacity(uint64_t capacity);
 
-  /** Sets the cell order. */
+  /**
+   * Sets the cell order.
+   *
+   * @note For 1D arrays (vectors), the cell order will always be **row-major**,
+   *     (col-major is equivalent).
+   */
   void set_cell_order(Layout cell_order);
 
   /**
@@ -283,7 +288,12 @@ class ArraySchema {
    */
   Status set_domain(Domain* domain);
 
-  /** Sets the tile order. */
+  /**
+   * Sets the tile order.
+   *
+   * @note For 1D arrays (vectors), the cell order will always be **row-major**,
+   *     (col-major is equivalent).
+   */
   void set_tile_order(Layout tile_order);
 
  private:

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -60,6 +60,7 @@ Query::Query() {
   fragments_borrowed_ = false;
   consolidation_fragment_uri_ = URI();
   status_ = QueryStatus::INPROGRESS;
+  layout_ = Layout::ROW_MAJOR;
 }
 
 Query::Query(Query* common_query) {
@@ -461,7 +462,7 @@ void Query::set_buffers(void** buffers, uint64_t* buffer_sizes) {
 }
 
 void Query::set_callback(
-    std::function<void(void*)> callback, void* callback_data) {
+    const std::function<void(void*)>& callback, void* callback_data) {
   callback_ = callback;
   callback_data_ = callback_data;
 }
@@ -485,7 +486,11 @@ Status Query::set_layout(Layout layout) {
         "Cannot set layout; Ordered layouts can be used when writing to sparse "
         "arrays - use UNORDERED instead"));
 
-  layout_ = layout;
+  // Layout for 1D vectors is row-major (unless it is set to global order)
+  if (array_schema_->dim_num() == 1 && layout != Layout::GLOBAL_ORDER)
+    layout_ = Layout::ROW_MAJOR;
+  else
+    layout_ = layout;
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -271,7 +271,8 @@ class Query {
    * Sets the callback function and its data input that will be called
    * upon the completion of an asynchronous query.
    */
-  void set_callback(std::function<void(void*)> callback, void* callback_data);
+  void set_callback(
+      const std::function<void(void*)>& callback, void* callback_data);
 
   /** Sets and initializes the fragment metadata. */
   Status set_fragment_metadata(


### PR DESCRIPTION
(except for query layouts in global order)