### PR TITLE
Disable Doxygen for an internal C++ API function

### DIFF
--- a/tiledb/sm/cpp_api/tiledb_cpp_api_core_interface.h
+++ b/tiledb/sm/cpp_api/tiledb_cpp_api_core_interface.h
@@ -41,6 +41,11 @@
 namespace tiledb {
 namespace impl {
 
+/** @cond
+ * Doxygen is disabled for this function, as it conflicts with the C
+ * API function of the same name.
+ */
+
 /**
  * Submits a TileDB query in asynchronous mode.
  *
@@ -55,6 +60,8 @@ int tiledb_query_submit_async(
     tiledb_query_t* query,
     std::function<void(void*)> callback,
     void* callback_data = nullptr);
+
+/** @endcond */
 
 }  // namespace impl
 }  // namespace tiledb


### PR DESCRIPTION
This was causing a warning during API documentation generation.