### PR TITLE
Make cpp functions use cells instead of sizes in all places

### DIFF
--- a/examples/cpp_api/tiledb_dense_read_async.cc
+++ b/examples/cpp_api/tiledb_dense_read_async.cc
@@ -83,11 +83,11 @@ int main() {
       a2_buff, result_el["a2"].first, result_el["a2"].second);
   auto a3 = tiledb::group_by_cell<2>(a3_buff);
 
-  std::cout << "Result num: " << result_el["a1"].first << "\n\n";
+  std::cout << "Result num: " << result_el["a1"].second << "\n\n";
   std::cout << std::setw(5) << "a1" << std::setw(10) << "a2" << std::setw(10)
             << "a3[0]" << std::setw(11) << "a3[1]\n";
   std::cout << "-------------------------------------\n";
-  for (unsigned i = 0; i < result_el["a1"].first; ++i) {
+  for (unsigned i = 0; i < result_el["a1"].second; ++i) {
     std::cout << std::setw(5) << a1_buff[i] << std::setw(10)
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)
               << a3[i][0] << std::setw(10) << a3[i][1] << '\n';

--- a/examples/cpp_api/tiledb_dense_read_global.cc
+++ b/examples/cpp_api/tiledb_dense_read_global.cc
@@ -77,7 +77,10 @@ int main() {
   query.set_buffer("a3", a3_buff);
 
   // Submit query
-  std::cout << "\nQuery submitted: " << query.submit() << "\n\n";
+  std::cout << "\nQuery submitted: " << query.submit();
+  std::cout << "\n\ta1: " << query.attribute_status("a1")
+            << "\n\ta2: " << query.attribute_status("a2")
+            << "\n\ta3: " << query.attribute_status("a3");
 
   // Print cell values (assumes all attributes are read)
   auto result_el = query.result_buffer_elements();
@@ -87,11 +90,11 @@ int main() {
       a2_buff, result_el["a2"].first, result_el["a2"].second);
   auto a3 = tiledb::group_by_cell<2>(a3_buff);
 
-  std::cout << "Result num: " << result_el["a1"].first << "\n\n";
+  std::cout << "\n\nResult num: " << result_el["a1"].second << "\n\n";
   std::cout << std::setw(5) << "a1" << std::setw(10) << "a2" << std::setw(10)
             << "a3[0]" << std::setw(11) << "a3[1]\n";
   std::cout << "-------------------------------------\n";
-  for (unsigned i = 0; i < result_el["a1"].first; ++i) {
+  for (unsigned i = 0; i < result_el["a1"].second; ++i) {
     std::cout << std::setw(5) << a1_buff[i] << std::setw(10)
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)
               << a3[i][0] << std::setw(10) << a3[i][1] << '\n';

--- a/examples/cpp_api/tiledb_dense_read_ordered_subarray.cc
+++ b/examples/cpp_api/tiledb_dense_read_ordered_subarray.cc
@@ -75,11 +75,11 @@ int main() {
       a2_buff, result_el["a2"].first, result_el["a2"].second);
   auto a3 = tiledb::group_by_cell<2>(a3_buff);
 
-  std::cout << "Result num: " << result_el["a1"].first << "\n\n";
+  std::cout << "Result num: " << result_el["a1"].second << "\n\n";
   std::cout << std::setw(5) << "a1" << std::setw(10) << "a2" << std::setw(10)
             << "a3[0]" << std::setw(11) << "a3[1]\n";
   std::cout << "------------------------------------\n";
-  for (unsigned i = 0; i < result_el["a1"].first; ++i) {
+  for (unsigned i = 0; i < result_el["a1"].second; ++i) {
     std::cout << std::setw(5) << a1_buff[i] << std::setw(10)
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)
               << a3[i][0] << std::setw(10) << a3[i][1] << '\n';

--- a/examples/cpp_api/tiledb_dense_read_subset_incomplete.cc
+++ b/examples/cpp_api/tiledb_dense_read_subset_incomplete.cc
@@ -63,7 +63,7 @@ int main() {
     query.submit();
     auto result_el = query.result_buffer_elements();
 
-    for (unsigned i = 0; i < result_el["a1"].first; ++i) {
+    for (unsigned i = 0; i < result_el["a1"].second; ++i) {
       std::cout << a1_data[i] << "\n";
     }
   } while (query.query_status() == tiledb::Query::Status::INCOMPLETE);

--- a/examples/cpp_api/tiledb_dense_write_global_1.cc
+++ b/examples/cpp_api/tiledb_dense_write_global_1.cc
@@ -35,7 +35,7 @@
  * ./tiledb_dense_write_global_1_cpp
  */
 
-#include <tiledb/tiledb>
+#include "tiledb/query.h"
 
 int main() {
   // Create TileDB context

--- a/examples/cpp_api/tiledb_sparse_read_global.cc
+++ b/examples/cpp_api/tiledb_sparse_read_global.cc
@@ -90,12 +90,12 @@ int main() {
   auto coords =
       tiledb::group_by_cell<2>(coords_buff, result_el[TILEDB_COORDS].second);
 
-  std::cout << "Result num: " << result_el["a1"].first << "\n\n";
+  std::cout << "Result num: " << result_el["a1"].second << "\n\n";
   std::cout << std::setw(8) << TILEDB_COORDS << std::setw(9) << "a1"
             << std::setw(9) << "a2" << std::setw(11) << "a3[0]" << std::setw(10)
             << "a3[1]\n";
   std::cout << "------------------------------------------------\n";
-  for (unsigned i = 0; i < result_el["a1"].first; ++i) {
+  for (unsigned i = 0; i < result_el["a1"].second; ++i) {
     std::cout << "(" << coords[i][0] << ", " << coords[i][1] << ")"
               << std::setw(10) << a1_buff[i] << std::setw(10)
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)

--- a/examples/cpp_api/tiledb_sparse_read_ordered_subarray.cc
+++ b/examples/cpp_api/tiledb_sparse_read_ordered_subarray.cc
@@ -78,12 +78,12 @@ int main() {
   auto coords =
       tiledb::group_by_cell<2>(coords_buff, result_el[TILEDB_COORDS].second);
 
-  std::cout << "Result num: " << result_el["a1"].first << "\n\n";
+  std::cout << "Result num: " << result_el["a1"].second << "\n\n";
   std::cout << std::setw(8) << TILEDB_COORDS << std::setw(9) << "a1"
             << std::setw(9) << "a2" << std::setw(11) << "a3[0]" << std::setw(10)
             << "a3[1]\n";
   std::cout << "------------------------------------------------\n";
-  for (unsigned i = 0; i < result_el["a1"].first; ++i) {
+  for (unsigned i = 0; i < result_el["a1"].second; ++i) {
     std::cout << "(" << coords[i][0] << ", " << coords[i][1] << ")"
               << std::setw(10) << a1_buff[i] << std::setw(10)
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)

--- a/examples/cpp_api/tiledb_sparse_read_subset_incomplete.cc
+++ b/examples/cpp_api/tiledb_sparse_read_subset_incomplete.cc
@@ -62,7 +62,7 @@ int main() {
     query.submit();
     auto result_el = query.result_buffer_elements();
 
-    for (unsigned i = 0; i < result_el["a1"].first; ++i) {
+    for (unsigned i = 0; i < result_el["a1"].second; ++i) {
       std::cout << a1_data[i] << "\n";
     }
   } while (query.query_status() == tiledb::Query::Status::INCOMPLETE);

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -164,7 +164,8 @@ class TILEDB_EXPORT Array {
           var ? std::pair<uint64_t, uint64_t>(
                     sizes[sid] / TILEDB_OFFSET_SIZE,
                     sizes[sid + 1] / tiledb_datatype_size(a.second.type())) :
-                std::pair<uint64_t, uint64_t>(0, sizes[sid]);
+                std::pair<uint64_t, uint64_t>(
+                    0, sizes[sid] / tiledb_datatype_size(a.second.type()));
       sid += var ? 2 : 1;
     }
 

--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -77,9 +77,9 @@ namespace tiledb {
  * schema.add_attribute(a1);
  *
  * // Specify tile memory layout
- * schema.set_tile_order(TILEDB_GLOBAL_ORDER);
+ * schema.set_tile_order(TILEDB_ROW_MAJOR);
  * // Specify cell memory layout within each tile
- * schema.set_cell_order(TILEDB_GLOBAL_ORDER);
+ * schema.set_cell_order(TILEDB_ROW_MAJOR);
  * schema.set_capacity(10); // For sparse, set capacity of each tile
  *
  * tiledb::Array::create(schema, "my_array"); // Make array with schema

--- a/tiledb/sm/cpp_api/attribute.h
+++ b/tiledb/sm/cpp_api/attribute.h
@@ -113,6 +113,11 @@ class TILEDB_EXPORT Attribute {
    */
   unsigned cell_val_num() const;
 
+  /** Check if attribute is variable sized. **/
+  bool variable_sized() const {
+    return cell_val_num() == TILEDB_VAR_NUM;
+  }
+
   /** Returns the attribute compressor. */
   Compressor compressor() const;
 
@@ -150,6 +155,27 @@ class TILEDB_EXPORT Attribute {
     using DataT = typename impl::TypeHandler<T>;
     auto a = create(ctx, name, DataT::tiledb_type);
     a.set_cell_val_num(DataT::tiledb_num);
+    return a;
+  }
+
+  /**
+   * Factory function for creating a new attribute with datatype T.
+   *
+   * @tparam T Datatype of the attribute. Can either be arithmetic type,
+   *         C-style array, std::string, std::vector, or any trivially
+   *         copyable classes (defined by std::is_trivially_copyable).
+   * @param ctx The TileDB context.
+   * @param name The attribute name.
+   * @param compressor Compressor to use for attribute
+   * @return A new Attribute object.
+   */
+  template <typename T>
+  static Attribute create(
+      const Context& ctx,
+      const std::string& name,
+      const Compressor& compressor) {
+    auto a = create<T>(ctx, name);
+    a.set_compressor(compressor);
     return a;
   }
 

--- a/tiledb/sm/cpp_api/query.cc
+++ b/tiledb/sm/cpp_api/query.cc
@@ -164,12 +164,12 @@ void Query::prepare_submission() {
     if (var_offsets_.count(a)) {
       std::tie(bufsize, tsize, ptr) = var_offsets_[a];
       all_buff_.push_back(ptr);
-      buff_sizes_.push_back(bufsize * tsize);
+      buff_sizes_.push_back(bufsize);
       sub_tsize_.push_back(tsize);
     }
     std::tie(bufsize, tsize, ptr) = attr_buffs_[a];
     all_buff_.push_back(ptr);
-    buff_sizes_.push_back(bufsize * tsize);
+    buff_sizes_.push_back(bufsize);
     attr_names_.push_back(a.c_str());
     sub_tsize_.push_back(tsize);
   }

--- a/tiledb/sm/cpp_api/tiledb
+++ b/tiledb/sm/cpp_api/tiledb
@@ -35,7 +35,6 @@
 #ifndef TILEDB_CPP_H
 #define TILEDB_CPP_H
 
-#include "tiledb.h"
 #include "array.h"
 #include "array_schema.h"
 #include "attribute.h"
@@ -47,6 +46,7 @@
 #include "dimension.h"
 #include "domain.h"
 #include "exception.h"
+#include "filebuf.h"
 #include "group.h"
 #include "map.h"
 #include "map_item.h"
@@ -57,9 +57,9 @@
 #include "object_iter.h"
 #include "query.h"
 #include "schema_base.h"
+#include "tiledb.h"
 #include "utils.h"
 #include "version.h"
 #include "vfs.h"
-#include "filebuf.h"
 
 #endif  // TILEDB_CPP_H

--- a/tiledb/sm/cpp_api/utils.h
+++ b/tiledb/sm/cpp_api/utils.h
@@ -44,15 +44,18 @@
 namespace tiledb {
 
 /**
- * Covert an (offset, data) vector pair into a single vector of vectors.
+ * Convert an (offset, data) vector pair into a single vector of vectors.
  *
- * @tparam T underlying datatype
- * @tparam E element type. usually std::vector<T> or std::string. Must be
- *     constructable by a buff::iterator pair
- * @param offsets Offsets vector
- * @param data Data vector
- * @param num_offsets Number of offset elements populated by query
- * @param num_data Number of data elements populated by query.
+ * @tparam T underlying attribute datatype
+ * @tparam E Cell type. usually std::vector<T> or std::string. Must be
+ *         constructable by {std::vector<T>::iterator, std::vector<T>::iterator}
+ * @param offsets Offsets vector. This specifies the start offset of each
+ *        cell in the data vector.
+ * @param data Data vector. Flat data buffer will cell contents.
+ * @param num_offsets Number of offset elements populated by query. If the
+ *        entire buffer is to be grouped, use offsets.size().
+ * @param num_data Number of data elements populated by query. If the
+ *        entire buffer is to be grouped, use data.size().
  * @return std::vector<E>
  */
 template <typename T, typename E = typename std::vector<T>>
@@ -76,9 +79,9 @@ std::vector<E> group_by_cell(
  * Covert an (offset, data) vector pair into a single vector of vectors.
  * Uses whole vectors.
  *
- * @tparam T underlying datatype
- * @tparam E element type. usually std::vector<T> or std::string. Must be
- *     constructable by a buff::iterator pair
+ * @tparam T underlying attribute datatype
+ * @tparam E Cell type. usually std::vector<T> or std::string. Must be
+ *         constructable by {std::vector<T>::iterator, std::vector<T>::iterator}
  * @param offsets Offsets vector
  * @param data Data vector
  * @param num_offsets Number of offset elements populated by query
@@ -94,9 +97,9 @@ std::vector<E> group_by_cell(
 /**
  * Covert an (offset, data) vector pair into a single vector of vectors.
  *
- * @tparam T underlying datatype
- * @tparam E element type. usually std::vector<T> or std::string. Must be
- *     constructable by a buff::iterator pair
+ * @tparam T underlying attribute datatype
+ * @tparam E Cell type. usually std::vector<T> or std::string. Must be
+ *         constructable by {std::vector<T>::iterator, std::vector<T>::iterator}
  * @param buff pair<offset_vec, data_vec>
  * @param num_offsets Number of offset elements populated by query
  * @param num_data Number of data elements populated by query.
@@ -113,9 +116,9 @@ std::vector<E> group_by_cell(
 /**
  * Group by cell at runtime.
  *
- * @tparam T Element type
- * @tparam E element type. usually std::vector<T> or std::string. Must be
- * constructable by a buff::iterator pair
+ * @tparam T underlying attribute datatype
+ * @tparam E Cell type. usually std::vector<T> or std::string. Must be
+ *         constructable by {std::vector<T>::iterator, std::vector<T>::iterator}
  * @param buff data buffer
  * @param el_per_cell Number of elements per cell to group together
  * @param num_buff Number of elements populated by query. To group whole buffer,
@@ -140,8 +143,8 @@ std::vector<E> group_by_cell(
  * Group by cell at runtime. Uses whole data buffer.
  *
  * @tparam T Element type
- * @tparam E element type. usually std::vector<T> or std::string. Must be
- * constructable by a buff::iterator pair
+ * @tparam E Cell type. usually std::vector<T> or std::string. Must be
+ *         constructable by {std::vector<T>::iterator, std::vector<T>::iterator}
  * @param buff data buffer
  * @param el_per_cell Number of elements per cell to group together
  * @param num_buff Number of elements populated by query. To group whole buffer,


### PR DESCRIPTION
- Proper handling of cell_num for element counts
- convenience functions
- Fix bug that disallowed ordered queries on dense arrays
- Fix bugs in examples & normalize around {offset, data} buffer order for varsize attrs

fixes #482 