### PR TITLE
add raw pointer setters for set_subarray, set_coords, set_buffer

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -84,7 +84,7 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi]") {
     CHECK_THROWS(query.set_subarray<unsigned>({1, 2}));  // Wrong type
     CHECK_THROWS(query.set_subarray<int>({1, 2}));       // Wrong num
     std::vector<int> subarray = {0, 5, 0, 5};
-    query.set_subarray<int>(subarray);
+    query.set_subarray(subarray);
   }
 
   SECTION("Read/Write") {


### PR DESCRIPTION
This is needed for bindings using the c++ api to pass pointers to tiledb
without incuring the extra copy into / out of an std::vector or
std::array or other container object.

Notes have been added in the header documentation that the safer api is
preferred.