### PR TITLE
C++ API fixes

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -154,6 +154,9 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi]") {
       query.set_layout(TILEDB_ROW_MAJOR);
       query.set_subarray(subarray);
 
+      // Make sure no segfault when called before submit
+      query.result_buffer_elements();
+
       REQUIRE(query.submit() == Query::Status::COMPLETE);
       auto ret = query.result_buffer_elements();
       REQUIRE(ret.size() == 5);

--- a/tiledb/sm/cpp_api/query.cc
+++ b/tiledb/sm/cpp_api/query.cc
@@ -84,13 +84,11 @@ Query::Status Query::attribute_status(const std::string& attr) const {
   return to_status(status);
 }
 
-void Query::submit_async() {
-  submit_async([]() {});
-}
-
 std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
 Query::result_buffer_elements() const {
   std::unordered_map<std::string, std::pair<uint64_t, uint64_t>> elements;
+  if (buff_sizes_.size() == 0)
+    return {};  // Query hasn't been submitted
   unsigned bid = 0;
   for (const auto& attr : attrs_) {
     auto var =

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -110,9 +110,6 @@ class TILEDB_EXPORT Query {
   /** Submits the query. Call will block until query is complete. */
   Status submit();
 
-  /** Submit an async query (non-blocking). */
-  void submit_async();
-
   /**
    * Submit an async query, with callback.
    *
@@ -129,6 +126,11 @@ class TILEDB_EXPORT Query {
         ctx, query_.get(), wrapper, nullptr));
   }
 
+  /** Submit an async query (non-blocking). */
+  void submit_async() {
+    submit_async([]() {});
+  }
+
   /**
    * Returns the number of elements in the result buffers. This is a map
    * from the attribute name to a pair of values.
@@ -136,6 +138,8 @@ class TILEDB_EXPORT Query {
    * The first is number of elements for var size attributes, and the second
    * is number of elements in the data buffer. For fixed sized attributes
    * (and coordinates), the first is always 0.
+   *
+   * If the query has not been submitted, an empty map is returned.
    */
   std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
   result_buffer_elements() const;

--- a/tiledb/sm/cpp_api/vfs.cc
+++ b/tiledb/sm/cpp_api/vfs.cc
@@ -48,9 +48,9 @@ VFS::VFS(const Context& ctx)
 
 VFS::VFS(const Context& ctx, const Config& config)
     : ctx_(ctx)
-    , config_(config.ptr())
+    , config_(config)
     , deleter_(ctx) {
-  create_vfs(config);
+  create_vfs(config.ptr().get());
 }
 
 /* ********************************* */
@@ -150,7 +150,7 @@ std::shared_ptr<tiledb_vfs_t> VFS::ptr() const {
   return vfs_;
 }
 
-std::shared_ptr<tiledb_config_t> VFS::config() const {
+Config VFS::config() const {
   return config_;
 }
 

--- a/tiledb/sm/cpp_api/vfs.h
+++ b/tiledb/sm/cpp_api/vfs.h
@@ -131,7 +131,7 @@ class TILEDB_EXPORT VFS {
   std::shared_ptr<tiledb_vfs_t> ptr() const;
 
   /** Get the config **/
-  std::shared_ptr<tiledb_config_t> config() const;
+  Config config() const;
 
  private:
   /* ********************************* */
@@ -142,7 +142,7 @@ class TILEDB_EXPORT VFS {
   std::reference_wrapper<const Context> ctx_;
 
   /** Config **/
-  std::shared_ptr<tiledb_config_t> config_ = nullptr;
+  Config config_;
 
   /** A deleter wrapper. */
   impl::Deleter deleter_;


### PR DESCRIPTION
- Prevent segfault when calling `Query::result_buffer_elements` before any query has been submitted
- fixes #498