### PR TITLE
Fix #535. Workaround glibc 2.25 name collision.

### DIFF
--- a/examples/cpp_api/tiledb_version.cc
+++ b/examples/cpp_api/tiledb_version.cc
@@ -33,12 +33,10 @@
 #include <tiledb/tiledb>
 
 int main() {
+  // The following should print out a string with the format
+  // "TileDB vMAJOR.MINOR.PATCH".
   auto version = tiledb::Version::version();
-  std::cout << "TileDB v" << version.major() << "." << version.minor() << "."
-            << version.patch() << '\n';
-
-  // The following would print the same as above
-  // std::cout << version << '\n';
+  std::cout << version << '\n';
 
   return 0;
 }

--- a/tiledb/sm/cpp_api/version.h
+++ b/tiledb/sm/cpp_api/version.h
@@ -46,21 +46,6 @@ class TILEDB_EXPORT Version {
   /*                API                */
   /* ********************************* */
 
-  /** Returns the major number. */
-  inline int major() const {
-    return major_;
-  }
-
-  /** Returns the minor number. */
-  inline int minor() const {
-    return minor_;
-  }
-
-  /** Returns the patch number. */
-  inline int patch() const {
-    return patch_;
-  }
-
   /**
    * @return TileDB library version object
    */
@@ -71,6 +56,8 @@ class TILEDB_EXPORT Version {
   }
 
  private:
+  friend std::ostream& operator<<(std::ostream& os, const Version& v);
+
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
@@ -88,7 +75,7 @@ class TILEDB_EXPORT Version {
 /** Prints to an output stream. */
 TILEDB_EXPORT inline std::ostream& operator<<(
     std::ostream& os, const Version& v) {
-  os << "TileDB v" << v.major() << '.' << v.minor() << '.' << v.patch();
+  os << "TileDB v" << v.major_ << '.' << v.minor_ << '.' << v.patch_;
   return os;
 }
 


### PR DESCRIPTION
* Remove `major` and `minor` identifiers from `Version` class.

I'm not sure if this is a perfect solution, but it lets me build on Ubuntu 18.04 rc + clang++-6.0.