### PR TITLE
Implement a task cancellation mechanism. Closes #569.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,7 @@
 * Refactored dense ordered writes, making them simpler and more amenable to parallelization.
 * Refactored unordered writes, making them simpler and more amenable to parallelization.
 * Refactored global writes, making them simpler and more amenable to parallelization.
+* Added ability to cancel pending background/async tasks. SIGINT signals now cancel pending tasks.
 
 ## Bug Fixes
 
@@ -35,6 +36,9 @@
 * Added `tiledb_vfs_get_config` function.
 * Added `vfs.max_parallel_ops` and `vfs.min_parallel_size` config parameters.
 * Added `vfs.s3.multipart_part_size` config parameter.
+* Added `tiledb_ctx_cancel_tasks` function.
+* Added `sm.number_of_threads` config parameter.
+* Added `sm.enable_signal_handlers` config parameter.
 
 ### C++ API
 * Support for trivially copyable objects, such as a custom data struct, was added. They will be backed by an `sizeof(T)` sized `char` attribute.
@@ -43,6 +47,7 @@
 * Added a `Dimension::create` factory function that does not take tile extent,
   which sets the tile extent to `NULL`.
 * Added `Query::finalize()` function.
+* Added `Context::cancel_tasks()` function.
 
 ## Breaking changes
 

--- a/test/src/unit-capi-async.cc
+++ b/test/src/unit-capi-async.cc
@@ -53,6 +53,7 @@ struct AsyncFx {
   void create_sparse_array();
   void write_dense_async();
   void write_sparse_async();
+  void write_sparse_async_cancelled();
   void read_dense_async();
   void read_sparse_async();
   void remove_dense_array();
@@ -284,8 +285,8 @@ void AsyncFx::write_dense_async() {
   CHECK(rc == TILEDB_OK);
 
   // Submit query asynchronously
-  int v = 0;
-  rc = tiledb_query_submit_async(ctx_, query, callback, &v);
+  int callback_made = 0;
+  rc = tiledb_query_submit_async(ctx_, query, callback, &callback_made);
   CHECK(rc == TILEDB_OK);
 
   // Wait for query to complete
@@ -300,7 +301,7 @@ void AsyncFx::write_dense_async() {
   CHECK(rc == TILEDB_OK);
 
   // Check correct execution of callback
-  CHECK(v == 1);
+  CHECK(callback_made == 1);
 
   // Clean up
   tiledb_query_free(ctx_, &query);
@@ -349,8 +350,8 @@ void AsyncFx::write_sparse_async() {
   CHECK(rc == TILEDB_OK);
 
   // Submit query asynchronously
-  int v = 0;
-  rc = tiledb_query_submit_async(ctx_, query, callback, &v);
+  int callback_made = 0;
+  rc = tiledb_query_submit_async(ctx_, query, callback, &callback_made);
   CHECK(rc == TILEDB_OK);
 
   // Wait for query to complete
@@ -365,7 +366,91 @@ void AsyncFx::write_sparse_async() {
   CHECK(rc == TILEDB_OK);
 
   // Check correct execution of callback
-  CHECK(v == 1);
+  CHECK(callback_made == 1);
+
+  // Clean up
+  tiledb_query_free(ctx_, &query);
+}
+
+void AsyncFx::write_sparse_async_cancelled() {
+  // Prepare cell buffers
+  int buffer_a1[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  uint64_t buffer_a2[] = {0, 1, 3, 6, 10, 11, 13, 16};
+  char buffer_var_a2[] = "abbcccddddeffggghhhh";
+  float buffer_a3[] = {0.1f,
+                       0.2f,
+                       1.1f,
+                       1.2f,
+                       2.1f,
+                       2.2f,
+                       3.1f,
+                       3.2f,
+                       4.1f,
+                       4.2f,
+                       5.1f,
+                       5.2f,
+                       6.1f,
+                       6.2f,
+                       7.1f,
+                       7.2f};
+  uint64_t buffer_coords[] = {1, 1, 1, 2, 1, 4, 2, 3, 3, 1, 4, 2, 3, 3, 3, 4};
+  void* buffers[] = {
+      buffer_a1, buffer_a2, buffer_var_a2, buffer_a3, buffer_coords};
+  uint64_t buffer_sizes[] = {
+      sizeof(buffer_a1),
+      sizeof(buffer_a2),
+      sizeof(buffer_var_a2) - 1,  // No need to store the last '\0' character
+      sizeof(buffer_a3),
+      sizeof(buffer_coords)};
+
+  // Create query
+  tiledb_query_t* query;
+  const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
+  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_WRITE);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffers(
+      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query asynchronously
+  int callback_made = 0;
+  rc = tiledb_query_submit_async(ctx_, query, callback, &callback_made);
+  CHECK(rc == TILEDB_OK);
+
+  // Cancel it immediately, which sometimes in this test is fast enough to
+  // cancel it and sometimes not.
+  rc = tiledb_ctx_cancel_tasks(ctx_);
+  CHECK(rc == TILEDB_OK);
+
+  // Check query status
+  tiledb_query_status_t status;
+  do {
+    rc = tiledb_query_get_status(ctx_, query, &status);
+    CHECK(rc == TILEDB_OK);
+  } while (status != TILEDB_COMPLETED && status != TILEDB_FAILED);
+  CHECK((status == TILEDB_COMPLETED || status == TILEDB_FAILED));
+
+  // If the query completed, check the callback was made.
+  CHECK(callback_made == (status == TILEDB_COMPLETED ? 1 : 0));
+
+  // If it failed, run it again.
+  if (status == TILEDB_FAILED) {
+    rc = tiledb_query_submit_async(ctx_, query, callback, &callback_made);
+    CHECK(rc == TILEDB_OK);
+    do {
+      rc = tiledb_query_get_status(ctx_, query, &status);
+      CHECK(rc == TILEDB_OK);
+    } while (status != TILEDB_COMPLETED && status != TILEDB_FAILED);
+  }
+
+  CHECK(status == TILEDB_COMPLETED);
+  CHECK(callback_made == 1);
+
+  // Finalize query
+  rc = tiledb_query_finalize(ctx_, query);
+  CHECK(rc == TILEDB_OK);
 
   // Clean up
   tiledb_query_free(ctx_, &query);
@@ -398,8 +483,8 @@ void AsyncFx::read_dense_async() {
   CHECK(rc == TILEDB_OK);
 
   // Submit query with callback
-  int v = 0;
-  rc = tiledb_query_submit_async(ctx_, query, callback, &v);
+  int callback_made = 0;
+  rc = tiledb_query_submit_async(ctx_, query, callback, &callback_made);
   CHECK(rc == TILEDB_OK);
 
   // Wait for the query to complete
@@ -413,7 +498,7 @@ void AsyncFx::read_dense_async() {
   CHECK(rc == TILEDB_OK);
 
   // Check correct execution of callback
-  CHECK(v == 1);
+  CHECK(callback_made == 1);
 
   // Correct buffers
   int c_buffer_a1[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
@@ -470,8 +555,8 @@ void AsyncFx::read_sparse_async() {
   CHECK(rc == TILEDB_OK);
 
   // Submit query with callback
-  int v = 0;
-  rc = tiledb_query_submit_async(ctx_, query, callback, &v);
+  int callback_made = 0;
+  rc = tiledb_query_submit_async(ctx_, query, callback, &callback_made);
   CHECK(rc == TILEDB_OK);
 
   // Wait for the query to complete
@@ -485,7 +570,7 @@ void AsyncFx::read_sparse_async() {
   CHECK(rc == TILEDB_OK);
 
   // Check correct execution of callback
-  CHECK(v == 1);
+  CHECK(callback_made == 1);
 
   // Correct buffers
   int c_buffer_a1[] = {0, 1, 2, 3, 4, 5, 6, 7};
@@ -555,6 +640,15 @@ TEST_CASE_METHOD(
   remove_sparse_array();
   create_sparse_array();
   write_sparse_async();
+  read_sparse_async();
+  remove_sparse_array();
+}
+
+TEST_CASE_METHOD(
+    AsyncFx, "C API: Test async cancellation", "[capi], [async], [cancel]") {
+  remove_sparse_array();
+  create_sparse_array();
+  write_sparse_async_cancelled();
   read_sparse_async();
   remove_sparse_array();
 }

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -183,7 +183,9 @@ void check_save_to_file() {
 
   std::stringstream ss;
   ss << "sm.array_schema_cache_size 10000000\n";
+  ss << "sm.enable_signal_handlers true\n";
   ss << "sm.fragment_metadata_cache_size 10000000\n";
+  ss << "sm.number_of_threads " << std::thread::hardware_concurrency() << "\n";
   ss << "sm.tile_cache_size 10000000\n";
   ss << "vfs.max_parallel_ops " << std::thread::hardware_concurrency() << "\n";
   ss << "vfs.min_parallel_size 10485760\n";
@@ -352,6 +354,9 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.tile_cache_size"] = "100";
   all_param_values["sm.array_schema_cache_size"] = "1000";
   all_param_values["sm.fragment_metadata_cache_size"] = "10000000";
+  all_param_values["sm.enable_signal_handlers"] = "true";
+  all_param_values["sm.number_of_threads"] =
+      std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.min_parallel_size"] = "10485760";

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -105,6 +105,9 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/vfs.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/win_filesystem.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/fragment/fragment_metadata.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/global_state.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/signal_handlers.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/watchdog.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv_item.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv_iter.cc

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -728,6 +728,16 @@ int tiledb_ctx_is_supported_fs(
   return TILEDB_OK;
 }
 
+int tiledb_ctx_cancel_tasks(tiledb_ctx_t* ctx) {
+  if (sanity_check(ctx) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (save_error(ctx, ctx->storage_manager_->cancel_all_tasks()))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 /* ****************************** */
 /*              GROUP             */
 /* ****************************** */

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -344,7 +344,13 @@ TILEDB_EXPORT int tiledb_config_free(tiledb_config_t** config);
  * - `sm.fragment_metadata_cache_size` <br>
  *    The fragment metadata cache size in bytes. Any `uint64_t` value is
  *    acceptable. <br>
+ * - `sm.enable_signal_handlers` <br>
+ *    Whether or not TileDB will install signal handlers. <br>
+ *    **Default**: true
  *    **Default**: 10,000,000
+ * - `sm.number_of_threads` <br>
+ *    The number of allocated threads per TileDB context. <br>
+ *    **Default**: number of cores
  * - `vfs.max_parallel_ops` <br>
  *    The maximum number of VFS parallel operations. <br>
  *    **Default**: number of cores
@@ -752,6 +758,14 @@ TILEDB_EXPORT int tiledb_ctx_get_last_error(
  */
 TILEDB_EXPORT int tiledb_ctx_is_supported_fs(
     tiledb_ctx_t* ctx, tiledb_filesystem_t fs, int* is_supported);
+
+/**
+ * Cancels all background or async tasks associated with the given context.
+ *
+ * @param ctx The TileDB context.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int tiledb_ctx_cancel_tasks(tiledb_ctx_t* ctx);
 
 /* ********************************* */
 /*                GROUP              */

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -115,6 +115,12 @@ class TILEDB_EXPORT Config {
    *    The fragment metadata cache size in bytes. Any `uint64_t` value is
    *    acceptable. <br>
    *    **Default**: 10,000,000
+   * - `sm.enable_signal_handlers` <br>
+   *    Whether or not TileDB will install signal handlers. <br>
+   *    **Default**: true
+   * - `sm.number_of_threads` <br>
+   *    The number of allocated threads per TileDB context. <br>
+   *    **Default**: number of cores
    * - `vfs.max_parallel_ops` <br>
    *    The maximum number of VFS parallel operations. <br>
    *    **Default**: number of cores

--- a/tiledb/sm/cpp_api/context.h
+++ b/tiledb/sm/cpp_api/context.h
@@ -120,6 +120,13 @@ class TILEDB_EXPORT Context {
     return ret != 0;
   }
 
+  /**
+   * Cancels all background or async tasks associated with this context.
+   */
+  void cancel_tasks() const {
+    handle_error(tiledb_ctx_cancel_tasks(ctx_.get()));
+  }
+
   /* ********************************* */
   /*          STATIC FUNCTIONS         */
   /* ********************************* */

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -175,6 +175,11 @@ Status VFS::touch(const URI& uri) const {
   STATS_FUNC_OUT(vfs_create_file);
 }
 
+Status VFS::cancel_all_tasks() {
+  thread_pool_->cancel_all_tasks();
+  return Status::Ok();
+}
+
 Status VFS::create_bucket(const URI& uri) const {
   STATS_FUNC_IN(vfs_create_bucket);
 
@@ -545,11 +550,11 @@ Status VFS::init(const Config::VFSParams& vfs_params) {
 
   vfs_params_ = vfs_params;
 
-  thread_pool_ = std::unique_ptr<ThreadPool>(
-      new (std::nothrow) ThreadPool(vfs_params_.max_parallel_ops_));
+  thread_pool_ = std::unique_ptr<ThreadPool>(new (std::nothrow) ThreadPool());
   if (thread_pool_.get() == nullptr) {
-    return LOG_STATUS(Status::VFSError("Could not create VFS thread pool"));
+    return LOG_STATUS(Status::VFSError("Could not allocate VFS thread pool."));
   }
+  RETURN_NOT_OK(thread_pool_->init(vfs_params.max_parallel_ops_));
 
 #ifdef HAVE_HDFS
   hdfs_ = std::unique_ptr<hdfs::HDFS>(new (std::nothrow) hdfs::HDFS());

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -113,6 +113,11 @@ class VFS {
   Status touch(const URI& uri) const;
 
   /**
+   * Cancels all background or queued tasks.
+   */
+  Status cancel_all_tasks();
+
+  /**
    * Creates an object-store bucket.
    *
    * @param uri The name of the bucket to be created.
@@ -221,7 +226,12 @@ class VFS {
    */
   Status is_empty_bucket(const URI& uri, bool* is_empty) const;
 
-  /** Initializes the virtual filesystem. */
+  /**
+   * Initializes the virtual filesystem with the given configuration.
+   *
+   * @param vfs_params VFS Configuration
+   * @return Status
+   */
   Status init(const Config::VFSParams& vfs_params);
 
   /**

--- a/tiledb/sm/global_state/global_state.cc
+++ b/tiledb/sm/global_state/global_state.cc
@@ -1,0 +1,82 @@
+/**
+ * @file   global_state.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file defines the GlobalState class.
+ */
+
+#include "tiledb/sm/global_state/global_state.h"
+#include "tiledb/sm/global_state/signal_handlers.h"
+#include "tiledb/sm/global_state/watchdog.h"
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+GlobalState& GlobalState::GetGlobalState() {
+  // This is thread-safe in C++11.
+  static GlobalState globalState;
+  return globalState;
+}
+
+GlobalState::GlobalState() {
+  initialized_ = false;
+}
+
+Status GlobalState::initialize(Config* config) {
+  std::unique_lock<std::mutex> lck(init_mtx_);
+  if (!initialized_) {
+    if (config != nullptr) {
+      config_ = *config;
+    }
+    if (config_.sm_params().enable_signal_handlers_) {
+      RETURN_NOT_OK(SignalHandlers::GetSignalHandlers().initialize());
+    }
+    RETURN_NOT_OK(Watchdog::GetWatchdog().initialize());
+    initialized_ = true;
+  }
+  return Status::Ok();
+}
+
+void GlobalState::register_storage_manager(StorageManager* sm) {
+  std::unique_lock<std::mutex> lck(storage_managers_mtx_);
+  storage_managers_.insert(sm);
+}
+
+void GlobalState::unregister_storage_manager(StorageManager* sm) {
+  std::unique_lock<std::mutex> lck(storage_managers_mtx_);
+  storage_managers_.erase(sm);
+}
+
+std::set<StorageManager*> GlobalState::storage_managers() {
+  std::unique_lock<std::mutex> lck(storage_managers_mtx_);
+  return storage_managers_;
+}
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/global_state/global_state.h
+++ b/tiledb/sm/global_state/global_state.h
@@ -1,0 +1,106 @@
+/**
+ * @file   global_state.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file declares the GlobalState class.
+ */
+
+#ifndef TILEDB_GLOBAL_STATE_H
+#define TILEDB_GLOBAL_STATE_H
+
+#include <set>
+
+#include "tiledb/sm/storage_manager/storage_manager.h"
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+/**
+ * Singleton class containing various global TileDB state.
+ */
+class GlobalState {
+ public:
+  GlobalState(const GlobalState&) = delete;
+  GlobalState(const GlobalState&&) = delete;
+  GlobalState& operator=(const GlobalState&) = delete;
+  GlobalState& operator=(const GlobalState&&) = delete;
+
+  /** Returns a reference to the singleton GlobalState instance. */
+  static GlobalState& GetGlobalState();
+
+  /**
+   * Initializes all TileDB global state in an idempotent and threadsafe way.
+   *
+   * @param config The TileDB configuration parameters (or nullptr).
+   * @return Status
+   */
+  Status initialize(Config* config);
+
+  /**
+   * Register the given StorageManger instance.
+   * @param sm The StorageManager
+   */
+  void register_storage_manager(StorageManager* sm);
+
+  /**
+   * Unregister the given StorageManger instance.
+   * @param sm The StorageManager
+   */
+  void unregister_storage_manager(StorageManager* sm);
+
+  /**
+   * Returns a copy of the set of registered StorageManager instances.
+   */
+  std::set<StorageManager*> storage_managers();
+
+ private:
+  /** The TileDB configuration parameters. */
+  Config config_;
+
+  /** True if global state has been initialized. */
+  bool initialized_;
+
+  /** Protects the initialized flag. */
+  std::mutex init_mtx_;
+
+  /** Set of currently active StorageManager instances. */
+  std::set<StorageManager*> storage_managers_;
+
+  /** Mutex protecting list of StorageManagers. */
+  std::mutex storage_managers_mtx_;
+
+  /** Constructor. */
+  GlobalState();
+};
+
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb
+
+#endif

--- a/tiledb/sm/global_state/signal_handlers.cc
+++ b/tiledb/sm/global_state/signal_handlers.cc
@@ -1,0 +1,173 @@
+/**
+ * @file   signal_handlers.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file defines signal handling functionality.
+ */
+
+#include <atomic>
+#include <mutex>
+#include <string>
+
+#include <signal.h>
+
+#ifdef _WIN32
+#include <Windows.h>
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "tiledb/sm/global_state/signal_handlers.h"
+#include "tiledb/sm/misc/logger.h"
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+/* ********************************* */
+/*          Global variables         */
+/* ********************************* */
+
+/**
+ * Flag set to true from the installed signal handlers. This is a global
+ * variable in the interest of being paranoid about what can be modified safely
+ * from a signal handler.
+ */
+std::atomic_bool signal_received(false);
+
+/** Pointer to signal handler installed before ours, if any. */
+static void (*old_sigint_handler)(int) = nullptr;
+
+/* ********************************* */
+/*     Platform-neutral functions    */
+/* ********************************* */
+
+SignalHandlers& SignalHandlers::GetSignalHandlers() {
+  // This is thread-safe in C++11.
+  static SignalHandlers signalHandlers;
+  return signalHandlers;
+}
+
+bool SignalHandlers::signal_received() {
+  bool test = true;
+  return tiledb::sm::global_state::signal_received.compare_exchange_weak(
+      test, false);
+}
+
+/**
+ * Signal handler function.
+ * @param signum Signal number being handled.
+ */
+extern "C" void tiledb_signal_handler(int signum) {
+  switch (signum) {
+    case SIGINT: {
+      if (old_sigint_handler != nullptr) {
+        old_sigint_handler(signum);
+      }
+      signal_received = true;
+      break;
+    }
+  }
+}
+
+#ifdef _WIN32
+/* ********************************* */
+/*       Win32 implementations       */
+/* ********************************* */
+
+static BOOL win_ctrl_handler(DWORD dwCtrlType) {
+  switch (dwCtrlType) {
+    case CTRL_BREAK_EVENT:
+      tiledb_signal_handler(SIGINT);
+      break;
+  }
+  return false;
+}
+
+Status SignalHandlers::initialize() {
+  if (signal(SIGINT, tiledb_signal_handler) == SIG_ERR) {
+    return Status::Error(
+        std::string("Failed to install Win32 SIGINT handler: ") +
+        strerror(errno));
+  }
+
+  // Win32 applications should also handle Ctrl-Break.
+  if (SetConsoleCtrlHandler(win_ctrl_handler, true) == 0) {
+    return Status::Error(std::string("Failed to install Win32 ctrl handler"));
+  }
+  return Status::Ok();
+}
+
+void SignalHandlers::safe_stderr(const char* msg, size_t msg_len) {
+  auto retval = _write(2, msg, (unsigned int)msg_len);
+  // Ignore return value.
+  (void)retval;
+}
+
+#else
+/* ********************************* */
+/*       POSIX implementations       */
+/* ********************************* */
+
+Status SignalHandlers::initialize() {
+  struct sigaction action, old_action;
+  memset(&action, 0, sizeof(struct sigaction));
+  memset(&old_action, 0, sizeof(struct sigaction));
+
+  // Remember the previous signal handler so we can call it before ours.
+  if (sigaction(SIGINT, NULL, &old_action) != 0) {
+    return Status::Error(
+        std::string("Failed to get old SIGINT handler: ") + strerror(errno));
+  }
+  old_sigint_handler = old_action.sa_handler;
+
+  // Block additional SIGINTs while in the SIGINT handler:
+  sigemptyset(&action.sa_mask);
+  sigaddset(&action.sa_mask, SIGINT);
+  action.sa_flags = 0;
+  action.sa_handler = tiledb_signal_handler;
+  if (sigaction(SIGINT, &action, &old_action) != 0) {
+    return Status::Error(
+        std::string("Failed to install SIGINT handler: ") + strerror(errno));
+  }
+
+  return Status::Ok();
+}
+
+void SignalHandlers::safe_stderr(const char* msg, size_t msg_len) {
+  auto retval = write(2, msg, msg_len);
+  // Ignore return value.
+  (void)retval;
+}
+
+#endif
+
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/global_state/signal_handlers.h
+++ b/tiledb/sm/global_state/signal_handlers.h
@@ -1,0 +1,90 @@
+/**
+ * @file   signal_handlers.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file declares SignalHandlers.
+ */
+
+#ifndef TILEDB_SIGNAL_HANDLERS_H
+#define TILEDB_SIGNAL_HANDLERS_H
+
+#include <atomic>
+
+#include "tiledb/sm/misc/status.h"
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+/**
+ * Singleton class that manages process-level signals and signal handlers.
+ */
+class SignalHandlers {
+ public:
+  SignalHandlers(const SignalHandlers&) = delete;
+  SignalHandlers(const SignalHandlers&&) = delete;
+  SignalHandlers& operator=(const SignalHandlers&) = delete;
+  SignalHandlers& operator=(const SignalHandlers&&) = delete;
+
+  /** Returns a reference to the singleton SignalHandlers instance. */
+  static SignalHandlers& GetSignalHandlers();
+
+  /**
+   * Initialize the signal handlers.
+   *
+   * @return Status
+   */
+  Status initialize();
+
+  /**
+   * Returns true if a signal has been received. This will only return true on
+   * the first call after a signal was received, and then false until another
+   * signal is received. This is a thread-safe operation (only one thread will
+   * get a true return value).
+   */
+  static bool signal_received();
+
+  /**
+   * Safely write the given message to stderr, ignoring errors.
+   * This can be called from a signal handler.
+   *
+   * @param msg Message text
+   * @param msg_len Number of chars in message
+   */
+  static void safe_stderr(const char* msg, size_t msg_len);
+
+ private:
+  /** Constructor. */
+  SignalHandlers(){};
+};
+
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb
+
+#endif

--- a/tiledb/sm/global_state/watchdog.cc
+++ b/tiledb/sm/global_state/watchdog.cc
@@ -1,0 +1,64 @@
+#include "tiledb/sm/global_state/watchdog.h"
+#include "tiledb/sm/global_state/global_state.h"
+#include "tiledb/sm/global_state/signal_handlers.h"
+#include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/logger.h"
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+Watchdog& Watchdog::GetWatchdog() {
+  // This is thread-safe in C++11.
+  static Watchdog watchdog;
+  return watchdog;
+}
+
+Watchdog::Watchdog() {
+  should_exit_ = false;
+}
+
+Watchdog::~Watchdog() {
+  {
+    std::unique_lock<std::mutex> lck(mtx_);
+    should_exit_ = true;
+    cv_.notify_one();
+  }
+  thread_.join();
+}
+
+Status Watchdog::initialize() {
+  try {
+    thread_ = std::thread([this]() { watchdog_thread(this); });
+  } catch (const std::exception& e) {
+    return Status::Error(
+        std::string("Could not initialize watchdog thread; ") + e.what());
+  }
+  return Status::Ok();
+}
+
+void Watchdog::watchdog_thread(Watchdog* watchdog) {
+  if (watchdog == nullptr) {
+    return;
+  }
+
+  while (true) {
+    std::unique_lock<std::mutex> lck(watchdog->mtx_);
+    watchdog->cv_.wait_for(
+        lck, std::chrono::milliseconds(constants::watchdog_thread_sleep_ms));
+
+    if (SignalHandlers::signal_received()) {
+      for (auto* sm : GlobalState::GetGlobalState().storage_managers()) {
+        sm->cancel_all_tasks();
+      }
+    }
+
+    if (watchdog->should_exit_) {
+      break;
+    }
+  }
+}
+
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/global_state/watchdog.h
+++ b/tiledb/sm/global_state/watchdog.h
@@ -1,0 +1,94 @@
+/**
+ * @file   watchdog.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file declares the Watchdog thread class.
+ */
+
+#ifndef TILEDB_WATCHDOG_H
+#define TILEDB_WATCHDOG_H
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include "tiledb/sm/misc/status.h"
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+/**
+ * Singleton class that watches for global events and performs actions based on
+ * them (e.g. actions taken on receiving process signals).
+ */
+class Watchdog {
+ public:
+  Watchdog(const Watchdog&) = delete;
+  Watchdog(const Watchdog&&) = delete;
+  Watchdog& operator=(const Watchdog&) = delete;
+  Watchdog& operator=(const Watchdog&&) = delete;
+
+  /** Returns a reference to the singleton Watchdog instance. */
+  static Watchdog& GetWatchdog();
+
+  /**
+   * Initializes the Watchdog thread.
+   *
+   * @return Status
+   */
+  Status initialize();
+
+ private:
+  /** Condition variable for coordinating with the watchdog thread. */
+  std::condition_variable cv_;
+
+  /** Mutex for coordinating with the watchdog thread. */
+  std::mutex mtx_;
+
+  /** True when the watchdog thread should terminate. */
+  bool should_exit_;
+
+  /** Watchdog thread handle. */
+  std::thread thread_;
+
+  /** Constructor. */
+  Watchdog();
+
+  /** Destructor. */
+  ~Watchdog();
+
+  /** Watchdog thread function. */
+  static void watchdog_thread(Watchdog* watchdog);
+};
+
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb
+
+#endif

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -208,6 +208,12 @@ const uint64_t array_schema_cache_size = 10000000;
 /** The fragment metadata cache size. */
 const uint64_t fragment_metadata_cache_size = 10000000;
 
+/** Whether or not the signal handlers are installed. */
+const bool enable_signal_handlers = true;
+
+/** The number of threads allocated per StorageManager. */
+const uint64_t number_of_threads = std::thread::hardware_concurrency();
+
 /** The tile cache size. */
 const uint64_t tile_cache_size = 10000000;
 
@@ -417,6 +423,9 @@ const char* hdfs_username = "";
 
 /** Prefix indicating a special name reserved by TileDB. */
 const char* special_name_prefix = "__";
+
+/** Number of milliseconds between watchdog thread wakeups. */
+const unsigned watchdog_thread_sleep_ms = 1000;
 
 }  // namespace constants
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -196,6 +196,12 @@ extern const uint64_t array_schema_cache_size;
 /** The fragment metadata cache size. */
 extern const uint64_t fragment_metadata_cache_size;
 
+/** Whether or not the signal handlers are installed. */
+extern const bool enable_signal_handlers;
+
+/** The number of threads allocated per StorageManager. */
+extern const uint64_t number_of_threads;
+
 /** The tile cache size. */
 extern const uint64_t tile_cache_size;
 
@@ -404,6 +410,9 @@ extern const char* hdfs_username;
 
 /** Prefix indicating a special name reserved by TileDB. */
 extern const char* special_name_prefix;
+
+/** Number of milliseconds between watchdog thread wakeups. */
+extern const unsigned watchdog_thread_sleep_ms;
 
 }  // namespace constants
 

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -90,6 +90,8 @@ std::vector<URI> Query::fragment_uris() const {
 }
 
 Status Query::init() {
+  status_ = QueryStatus::INPROGRESS;
+
   if (type_ == QueryType::READ)
     return reader_.init();
   return writer_.init();
@@ -105,6 +107,11 @@ Layout Query::layout() const {
   if (type_ == QueryType::WRITE)
     return writer_.layout();
   return reader_.layout();
+}
+
+Status Query::cancel() {
+  status_ = QueryStatus::FAILED;
+  return Status::Ok();
 }
 
 Status Query::process() {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -69,6 +69,14 @@ class Query {
   const ArraySchema* array_schema() const;
 
   /**
+   * Marks a query that has not yet been started as failed. This should not be
+   * called asynchronously to cancel an in-progress query; for that use the
+   * parent StorageManager's cancellation mechanism.
+   * @return Status
+   */
+  Status cancel();
+
+  /**
    * Computes a vector of `subarrays` into which `subarray` must be partitioned,
    * such that each subarray in `subarrays` can be safely answered by the
    * query without a memory overflow.

--- a/tiledb/sm/query/query_macros.h
+++ b/tiledb/sm/query/query_macros.h
@@ -1,0 +1,107 @@
+/**
+ * @file   query_macros.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines macros shared by the query-related files.
+ */
+
+#ifndef TILEDB_QUERY_MACROS_H
+#define TILEDB_QUERY_MACROS_H
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*             MACROS             */
+/* ****************************** */
+
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef MAX
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
+#ifndef RETURN_CANCEL_OR_ERROR
+/**
+ * Returns an error status if the given Status is not Status::Ok, or
+ * if the StorageManager that owns this Query has requested cancellation.
+ */
+#define RETURN_CANCEL_OR_ERROR(s)                              \
+  do {                                                         \
+    Status _s = (s);                                           \
+    if (!_s.ok()) {                                            \
+      return _s;                                               \
+    } else if (storage_manager_->cancellation_in_progress()) { \
+      return Status::QueryError("Query cancelled.");           \
+    }                                                          \
+  } while (false)
+#endif
+
+#ifndef RETURN_CANCEL_OR_ERROR_ELSE
+/**
+ * Returns an error status if the given Status is not Status::Ok, or
+ * if the StorageManager that owns this Query has requested cancellation.
+ * If an error status is returned, also execute the 'else' code.
+ */
+#define RETURN_CANCEL_OR_ERROR_ELSE(s, _else)                  \
+  do {                                                         \
+    Status _s = (s);                                           \
+    if (!_s.ok()) {                                            \
+      _else;                                                   \
+      return _s;                                               \
+    } else if (storage_manager_->cancellation_in_progress()) { \
+      _else;                                                   \
+      return Status::QueryError("Query cancelled.");           \
+    }                                                          \
+  } while (false)
+#endif
+
+#ifndef BREAK_CANCEL_OR_ERROR
+/**
+ * If the given status 's' is not Status::Ok, sets the Status variable
+ * 'outer_st' to 's' and breaks the containing loop.
+ */
+#define BREAK_CANCEL_OR_ERROR(outer_st, s)                     \
+  do {                                                         \
+    Status _s = (s);                                           \
+    if (!_s.ok()) {                                            \
+      outer_st = _s;                                           \
+      break;                                                   \
+    } else if (storage_manager_->cancellation_in_progress()) { \
+      outer_st = Status::QueryError("Query cancelled.");       \
+      break;                                                   \
+    }                                                          \
+  } while (false)
+#endif
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_QUERY_MACROS_H

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -34,15 +34,9 @@
 #include "tiledb/sm/misc/comparators.h"
 #include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/tile_io.h"
-
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 namespace tiledb {
 namespace sm {
@@ -894,24 +888,24 @@ Status Reader::dense_read() {
 
   // Get overlapping sparse tile indexes
   OverlappingTileVec sparse_tiles;
-  RETURN_NOT_OK(compute_overlapping_tiles<T>(&sparse_tiles));
+  RETURN_CANCEL_OR_ERROR(compute_overlapping_tiles<T>(&sparse_tiles));
 
   // Read sparse tiles
-  RETURN_NOT_OK(read_tiles(constants::coords, &sparse_tiles));
+  RETURN_CANCEL_OR_ERROR(read_tiles(constants::coords, &sparse_tiles));
   for (const auto& attr : attributes_) {
     if (attr != constants::coords)
-      RETURN_NOT_OK(read_tiles(attr, &sparse_tiles));
+      RETURN_CANCEL_OR_ERROR(read_tiles(attr, &sparse_tiles));
   }
 
   // Compute the read coordinates for all sparse fragments
   std::list<std::shared_ptr<OverlappingCoords<T>>> coords;
-  RETURN_NOT_OK(compute_overlapping_coords<T>(sparse_tiles, &coords));
+  RETURN_CANCEL_OR_ERROR(compute_overlapping_coords<T>(sparse_tiles, &coords));
 
   // Sort and dedup the coordinates (not applicable to the global order
   // layout for a single fragment)
   if (!(fragment_metadata_.size() == 1 && layout_ == Layout::GLOBAL_ORDER)) {
-    RETURN_NOT_OK(sort_coords<T>(&coords));
-    RETURN_NOT_OK(dedup_coords<T>(&coords));
+    RETURN_CANCEL_OR_ERROR(sort_coords<T>(&coords));
+    RETURN_CANCEL_OR_ERROR(dedup_coords<T>(&coords));
   }
 
   // For each tile, initialize a dense cell range iterator per
@@ -919,17 +913,17 @@ Status Reader::dense_read() {
   std::vector<std::vector<DenseCellRangeIter<T>>> dense_frag_its;
   std::unordered_map<uint64_t, std::pair<uint64_t, std::vector<T>>>
       overlapping_tile_idx_coords;
-  RETURN_NOT_OK(init_tile_fragment_dense_cell_range_iters(
+  RETURN_CANCEL_OR_ERROR(init_tile_fragment_dense_cell_range_iters(
       &dense_frag_its, &overlapping_tile_idx_coords));
 
   // Get the cell ranges
   std::list<DenseCellRange<T>> dense_cell_ranges;
   DenseCellRangeIter<T> it(domain, subarray, layout_);
-  RETURN_NOT_OK(it.begin());
+  RETURN_CANCEL_OR_ERROR(it.begin());
   while (!it.end()) {
     auto o_it = overlapping_tile_idx_coords.find(it.tile_idx());
     assert(o_it != overlapping_tile_idx_coords.end());
-    RETURN_NOT_OK(compute_dense_cell_ranges<T>(
+    RETURN_CANCEL_OR_ERROR(compute_dense_cell_ranges<T>(
         &(o_it->second.second)[0],
         dense_frag_its[o_it->second.first],
         it.range_start(),
@@ -941,7 +935,7 @@ Status Reader::dense_read() {
   // Compute overlapping dense tile indexes
   OverlappingTileVec dense_tiles;
   OverlappingCellRangeList overlapping_cell_ranges;
-  RETURN_NOT_OK(compute_dense_overlapping_tiles_and_cell_ranges<T>(
+  RETURN_CANCEL_OR_ERROR(compute_dense_overlapping_tiles_and_cell_ranges<T>(
       dense_cell_ranges, coords, &dense_tiles, &overlapping_cell_ranges));
   coords.clear();
   dense_cell_ranges.clear();
@@ -949,11 +943,11 @@ Status Reader::dense_read() {
 
   // Read dense tiles
   for (const auto& attr : attributes_)
-    RETURN_NOT_OK(read_tiles(attr, &dense_tiles));
+    RETURN_CANCEL_OR_ERROR(read_tiles(attr, &dense_tiles));
 
   // Copy cells
   for (const auto& attr : attributes_)
-    RETURN_NOT_OK(copy_cells(attr, overlapping_cell_ranges));
+    RETURN_CANCEL_OR_ERROR(copy_cells(attr, overlapping_cell_ranges));
 
   return Status::Ok();
 }
@@ -1325,34 +1319,34 @@ template <class T>
 Status Reader::sparse_read() {
   // Get overlapping tile indexes
   OverlappingTileVec tiles;
-  RETURN_NOT_OK(compute_overlapping_tiles<T>(&tiles));
+  RETURN_CANCEL_OR_ERROR(compute_overlapping_tiles<T>(&tiles));
 
   // Read tiles
-  RETURN_NOT_OK(read_tiles(constants::coords, &tiles));
+  RETURN_CANCEL_OR_ERROR(read_tiles(constants::coords, &tiles));
   for (const auto& attr : attributes_) {
     if (attr != constants::coords)
-      RETURN_NOT_OK(read_tiles(attr, &tiles));
+      RETURN_CANCEL_OR_ERROR(read_tiles(attr, &tiles));
   }
 
   // Compute the read coordinates for all fragments
   std::list<std::shared_ptr<OverlappingCoords<T>>> coords;
-  RETURN_NOT_OK(compute_overlapping_coords<T>(tiles, &coords));
+  RETURN_CANCEL_OR_ERROR(compute_overlapping_coords<T>(tiles, &coords));
 
   // Sort and dedup the coordinates (not applicable to the global order
   // layout for a single fragment)
   if (!(fragment_metadata_.size() == 1 && layout_ == Layout::GLOBAL_ORDER)) {
-    RETURN_NOT_OK(sort_coords<T>(&coords));
-    RETURN_NOT_OK(dedup_coords<T>(&coords));
+    RETURN_CANCEL_OR_ERROR(sort_coords<T>(&coords));
+    RETURN_CANCEL_OR_ERROR(dedup_coords<T>(&coords));
   }
 
   // Compute the maximal cell ranges
   OverlappingCellRangeList cell_ranges;
-  RETURN_NOT_OK(compute_cell_ranges(coords, &cell_ranges));
+  RETURN_CANCEL_OR_ERROR(compute_cell_ranges(coords, &cell_ranges));
   coords.clear();
 
   // Copy cells
   for (const auto& attr : attributes_)
-    RETURN_NOT_OK(copy_cells(attr, cell_ranges));
+    RETURN_CANCEL_OR_ERROR(copy_cells(attr, cell_ranges));
 
   return Status::Ok();
 }

--- a/tiledb/sm/storage_manager/config.cc
+++ b/tiledb/sm/storage_manager/config.cc
@@ -158,6 +158,10 @@ Status Config::set(const std::string& param, const std::string& value) {
     RETURN_NOT_OK(set_sm_array_schema_cache_size(value));
   } else if (param == "sm.fragment_metadata_cache_size") {
     RETURN_NOT_OK(set_sm_fragment_metadata_cache_size(value));
+  } else if (param == "sm.enable_signal_handlers") {
+    RETURN_NOT_OK(set_sm_enable_signal_handlers(value));
+  } else if (param == "sm.number_of_threads") {
+    RETURN_NOT_OK(set_sm_number_of_threads(value));
   } else if (param == "vfs.max_parallel_ops") {
     RETURN_NOT_OK(set_vfs_max_parallel_ops(value));
   } else if (param == "vfs.min_parallel_size") {
@@ -232,6 +236,16 @@ Status Config::unset(const std::string& param) {
         constants::fragment_metadata_cache_size;
     value << sm_params_.fragment_metadata_cache_size_;
     param_values_["sm.fragment_metadata_cache_size"] = value.str();
+    value.str(std::string());
+  } else if (param == "sm.enable_signal_handlers") {
+    sm_params_.enable_signal_handlers_ = constants::enable_signal_handlers;
+    value << (sm_params_.enable_signal_handlers_ ? "true" : "false");
+    param_values_["sm.enable_signal_handlers"] = value.str();
+    value.str(std::string());
+  } else if (param == "sm.number_of_threads") {
+    sm_params_.number_of_threads_ = constants::number_of_threads;
+    value << sm_params_.number_of_threads_;
+    param_values_["sm.number_of_threads"] = value.str();
     value.str(std::string());
   } else if (param == "vfs.max_parallel_ops") {
     vfs_params_.max_parallel_ops_ = constants::vfs_max_parallel_ops;
@@ -335,6 +349,14 @@ void Config::set_default_param_values() {
   param_values_["sm.fragment_metadata_cache_size"] = value.str();
   value.str(std::string());
 
+  value << (sm_params_.enable_signal_handlers_ ? "true" : "false");
+  param_values_["sm.enable_signal_handlers"] = value.str();
+  value.str(std::string());
+
+  value << sm_params_.number_of_threads_;
+  param_values_["sm.number_of_threads"] = value.str();
+  value.str(std::string());
+
   value << vfs_params_.max_parallel_ops_;
   param_values_["vfs.max_parallel_ops"] = value.str();
   value.str(std::string());
@@ -418,6 +440,22 @@ Status Config::set_sm_fragment_metadata_cache_size(const std::string& value) {
   uint64_t v;
   RETURN_NOT_OK(utils::parse::convert(value, &v));
   sm_params_.fragment_metadata_cache_size_ = v;
+
+  return Status::Ok();
+}
+
+Status Config::set_sm_enable_signal_handlers(const std::string& value) {
+  bool v;
+  RETURN_NOT_OK(parse_bool(value, &v));
+  sm_params_.enable_signal_handlers_ = v;
+
+  return Status::Ok();
+}
+
+Status Config::set_sm_number_of_threads(const std::string& value) {
+  uint64_t v;
+  RETURN_NOT_OK(utils::parse::convert(value, &v));
+  sm_params_.number_of_threads_ = v;
 
   return Status::Ok();
 }

--- a/tiledb/sm/storage_manager/config.h
+++ b/tiledb/sm/storage_manager/config.h
@@ -53,11 +53,15 @@ class Config {
   struct SMParams {
     uint64_t array_schema_cache_size_;
     uint64_t fragment_metadata_cache_size_;
+    bool enable_signal_handlers_;
+    uint64_t number_of_threads_;
     uint64_t tile_cache_size_;
 
     SMParams() {
       array_schema_cache_size_ = constants::array_schema_cache_size;
       fragment_metadata_cache_size_ = constants::fragment_metadata_cache_size;
+      enable_signal_handlers_ = constants::enable_signal_handlers;
+      number_of_threads_ = constants::number_of_threads;
       tile_cache_size_ = constants::tile_cache_size;
     }
   };
@@ -157,6 +161,12 @@ class Config {
    *    The fragment metadata cache size in bytes. Any `uint64_t` value is
    *    acceptable. <br>
    *    **Default**: 10,000,000
+   * - `sm.enable_signal_handlers` <br>
+   *    Whether or not TileDB will install signal handlers. <br>
+   *    **Default**: true
+   * - `sm.number_of_threads` <br>
+   *    The number of allocated threads per TileDB context. <br>
+   *    **Default**: number of cores
    * - `vfs.max_parallel_ops` <br>
    *    The maximum number of VFS parallel operations.<br>
    *    **Default**: number of cores
@@ -262,6 +272,12 @@ class Config {
 
   /** Sets the fragment metadata cache size, properly parsing the input value.*/
   Status set_sm_fragment_metadata_cache_size(const std::string& value);
+
+  /** Sets the enable signal handlers value, properly parsing the input value.*/
+  Status set_sm_enable_signal_handlers(const std::string& value);
+
+  /** Sets the number of threads, properly parsing the input value.*/
+  Status set_sm_number_of_threads(const std::string& value);
 
   /** Sets the tile cache size, properly parsing the input value. */
   Status set_sm_tile_cache_size(const std::string& value);


### PR DESCRIPTION
This PR adds a cancellation mechanism for in-progress VFS and SM tasks. It also adds basic POSIX/Win32 signal handling and a "watchdog" thread that wakes up every second to check if a signal has been received. Combined, this provides better interactivity in a REPL environment.

With this PR, the TileDB library will now create 2n+1 threads when the first context is created, and 2n more threads per subsequent context, where n is the number of cores. Each context creates a threadpool of n threads, and each context's VFS instance creates n threads. The +1 is the watchdog thread. The threads per context are joined when the context is destroyed.

The number of threads for the contexts' threadpools is configured with the `sm.number_of_threads` parameter, and for VFS the `vfs.max_parallel_ops` paraeter.