### PR TITLE
Improve sparse read performance ~25%

### DIFF
--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -64,8 +64,8 @@ class RowCmp {
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
   bool operator()(
-      const std::shared_ptr<Reader::OverlappingCoords<T>>& a,
-      const std::shared_ptr<Reader::OverlappingCoords<T>>& b) {
+      const std::unique_ptr<Reader::OverlappingCoords<T>>& a,
+      const std::unique_ptr<Reader::OverlappingCoords<T>>& b) {
     for (unsigned int i = 0; i < dim_num_; ++i) {
       if (a->coords_[i] < b->coords_[i])
         return true;
@@ -103,8 +103,8 @@ class ColCmp {
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
   bool operator()(
-      const std::shared_ptr<Reader::OverlappingCoords<T>>& a,
-      const std::shared_ptr<Reader::OverlappingCoords<T>>& b) {
+      const std::unique_ptr<Reader::OverlappingCoords<T>>& a,
+      const std::unique_ptr<Reader::OverlappingCoords<T>>& b) {
     for (unsigned int i = dim_num_ - 1;; --i) {
       if (a->coords_[i] < b->coords_[i])
         return true;
@@ -150,8 +150,8 @@ class GlobalCmp {
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
   bool operator()(
-      const std::shared_ptr<Reader::OverlappingCoords<T>>& a,
-      const std::shared_ptr<Reader::OverlappingCoords<T>>& b) {
+      const std::unique_ptr<Reader::OverlappingCoords<T>>& a,
+      const std::unique_ptr<Reader::OverlappingCoords<T>>& b) {
     // Compare tile order first
     auto tile_cmp = domain_->tile_order_cmp<T>(a->coords_, b->coords_);
 


### PR DESCRIPTION
This PR uses `unique_ptr` where possible in the `Reader` class, and sacrifices a bit of safety by keeping bare pointers around (instead of all `shared_ptrs`). This improves sparse read performance by about 25% on a simple 3D LiDAR data query application. It also probably improves dense reads, but I did not benchmark those.