### PR TITLE
Use std::vector instead of std::list for OverlappingCoordsList.

### DIFF
--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -1189,6 +1189,41 @@ int Domain::tile_order_cmp(const T* coords_a, const T* coords_b) const {
   return 0;
 }
 
+template <class T>
+int Domain::tile_order_cmp_tile_coords(
+    const T* tile_coords_a, const T* tile_coords_b) const {
+  if (tile_coords_a == nullptr || tile_coords_b == nullptr)
+    return 0;
+
+  if (tile_order_ == Layout::ROW_MAJOR) {
+    for (unsigned i = 0; i < dim_num_; ++i) {
+      auto ta = tile_coords_a[i];
+      auto tb = tile_coords_b[i];
+
+      if (ta < tb)
+        return -1;
+      if (ta > tb)
+        return 1;
+      // else ta == tb --> continue
+    }
+  } else {  // COL_MAJOR
+    for (unsigned i = dim_num_ - 1;; --i) {
+      auto ta = tile_coords_a[i];
+      auto tb = tile_coords_b[i];
+      if (ta < tb)
+        return -1;
+      if (ta > tb)
+        return 1;
+      // else ta == tb --> continue
+
+      if (i == 0)
+        break;
+    }
+  }
+
+  return 0;
+}
+
 uint64_t Domain::tile_slab_col_cell_num(const void* subarray) const {
   // Invoke the proper templated function
   switch (type_) {
@@ -2237,6 +2272,27 @@ template int Domain::tile_order_cmp<uint64_t>(
 template int Domain::tile_order_cmp<float>(
     const float* coords_a, const float* coords_b) const;
 template int Domain::tile_order_cmp<double>(
+    const double* coords_a, const double* coords_b) const;
+
+template int Domain::tile_order_cmp_tile_coords<int8_t>(
+    const int8_t* coords_a, const int8_t* coords_b) const;
+template int Domain::tile_order_cmp_tile_coords<uint8_t>(
+    const uint8_t* coords_a, const uint8_t* coords_b) const;
+template int Domain::tile_order_cmp_tile_coords<int16_t>(
+    const int16_t* coords_a, const int16_t* coords_b) const;
+template int Domain::tile_order_cmp_tile_coords<uint16_t>(
+    const uint16_t* coords_a, const uint16_t* coords_b) const;
+template int Domain::tile_order_cmp_tile_coords<int>(
+    const int* coords_a, const int* coords_b) const;
+template int Domain::tile_order_cmp_tile_coords<unsigned>(
+    const unsigned* coords_a, const unsigned* coords_b) const;
+template int Domain::tile_order_cmp_tile_coords<int64_t>(
+    const int64_t* coords_a, const int64_t* coords_b) const;
+template int Domain::tile_order_cmp_tile_coords<uint64_t>(
+    const uint64_t* coords_a, const uint64_t* coords_b) const;
+template int Domain::tile_order_cmp_tile_coords<float>(
+    const float* coords_a, const float* coords_b) const;
+template int Domain::tile_order_cmp_tile_coords<double>(
     const double* coords_a, const double* coords_b) const;
 
 template uint64_t Domain::tile_id<int>(

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -659,6 +659,21 @@ class Domain {
   template <class T>
   int tile_order_cmp(const T* coords_a, const T* coords_b) const;
 
+  /**
+   * Checks the tile order of the input tile coordinates.
+   *
+   * @tparam T The coordinates type.
+   * @param coords_a The first tile's coordinates.
+   * @param coords_b The second tile's coordinates.
+   * @return One of the following:
+   *    - -1 if the first coordinates precede the second on the tile order
+   *    -  0 if the two coordinates have the same tile order
+   *    - +1 if the first coordinates succeed the second on the tile order
+   */
+  template <class T>
+  int tile_order_cmp_tile_coords(
+      const T* tile_coords_a, const T* tile_coords_b) const;
+
   /** Return the number of cells in a column tile slab of an input subarray. */
   uint64_t tile_slab_col_cell_num(const void* subarray) const;
 

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -64,14 +64,14 @@ class RowCmp {
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
   bool operator()(
-      const std::unique_ptr<Reader::OverlappingCoords<T>>& a,
-      const std::unique_ptr<Reader::OverlappingCoords<T>>& b) {
+      const Reader::OverlappingCoords<T>& a,
+      const Reader::OverlappingCoords<T>& b) {
     for (unsigned int i = 0; i < dim_num_; ++i) {
-      if (a->coords_[i] < b->coords_[i])
+      if (a.coords_[i] < b.coords_[i])
         return true;
-      if (a->coords_[i] > b->coords_[i])
+      if (a.coords_[i] > b.coords_[i])
         return false;
-      // else a->coords_[i] == b->coords_[i] --> continue
+      // else a.coords_[i] == b.coords_[i] --> continue
     }
 
     return false;
@@ -103,14 +103,14 @@ class ColCmp {
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
   bool operator()(
-      const std::unique_ptr<Reader::OverlappingCoords<T>>& a,
-      const std::unique_ptr<Reader::OverlappingCoords<T>>& b) {
+      const Reader::OverlappingCoords<T>& a,
+      const Reader::OverlappingCoords<T>& b) {
     for (unsigned int i = dim_num_ - 1;; --i) {
-      if (a->coords_[i] < b->coords_[i])
+      if (a.coords_[i] < b.coords_[i])
         return true;
-      if (a->coords_[i] > b->coords_[i])
+      if (a.coords_[i] > b.coords_[i])
         return false;
-      // else a->coords_[i] == b->coords_[i] --> continue
+      // else a.coords_[i] == b.coords_[i] --> continue
 
       if (i == 0)
         break;
@@ -150,10 +150,11 @@ class GlobalCmp {
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
   bool operator()(
-      const std::unique_ptr<Reader::OverlappingCoords<T>>& a,
-      const std::unique_ptr<Reader::OverlappingCoords<T>>& b) {
+      const Reader::OverlappingCoords<T>& a,
+      const Reader::OverlappingCoords<T>& b) {
     // Compare tile order first
-    auto tile_cmp = domain_->tile_order_cmp<T>(a->coords_, b->coords_);
+    auto tile_cmp =
+        domain_->tile_order_cmp_tile_coords<T>(a.tile_coords_, b.tile_coords_);
 
     if (tile_cmp == -1)
       return true;
@@ -162,7 +163,7 @@ class GlobalCmp {
     // else tile_cmp == 0 --> continue
 
     // Compare cell order
-    auto cell_cmp = domain_->cell_order_cmp(a->coords_, b->coords_);
+    auto cell_cmp = domain_->cell_order_cmp(a.coords_, b.coords_);
     return cell_cmp == -1;
   }
 

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -165,15 +165,31 @@ class Reader {
     const OverlappingTile* tile_;
     /** The coordinates. */
     const T* coords_;
+    /** The coordinates of the tile. */
+    const T* tile_coords_;
     /** The position of the coordinates in the tile. */
     uint64_t pos_;
+    /** Whether this instance is "valid". */
+    bool valid_;
 
     /** Constructor. */
     OverlappingCoords(
         const OverlappingTile* tile, const T* coords, uint64_t pos)
         : tile_(tile)
         , coords_(coords)
-        , pos_(pos) {
+        , tile_coords_(nullptr)
+        , pos_(pos)
+        , valid_(true) {
+    }
+
+    /** Invalidate this instance. */
+    void invalidate() {
+      valid_ = false;
+    }
+
+    /** Return true if this instance is valid. */
+    bool valid() const {
+      return valid_;
     }
   };
 
@@ -181,8 +197,7 @@ class Reader {
    * Type alias for a list of OverlappingCoords.
    */
   template <typename T>
-  using OverlappingCoordsList =
-      std::list<std::unique_ptr<OverlappingCoords<T>>>;
+  using OverlappingCoordsList = std::vector<OverlappingCoords<T>>;
 
   /** A cell range produced by the dense read algorithm. */
   template <class T>
@@ -441,6 +456,21 @@ class Reader {
    */
   template <class T>
   Status compute_overlapping_tiles(OverlappingTileVec* tiles) const;
+
+  /**
+   * Computes the tile coordinates for each OverlappingCoords and populates
+   * their `tile_coords_` field. The tile coordinates are placed in a
+   * newly-allocated array.
+   *
+   * @tparam T The coords type.
+   * @param all_tile_coords Pointer to the memory allocated by this function.
+   * @param coords The overlapping coords list
+   * @return Status
+   */
+  template <class T>
+  Status compute_tile_coordinates(
+      std::unique_ptr<T[]>* all_tile_coords,
+      OverlappingCoordsList<T>* coords) const;
 
   /**
    * Copies the cells for the input attribute and cell ranges, into


### PR DESCRIPTION
Also avoid using unique_ptrs, and instead allocate directly in the
vector.  This will allow for better parallelization. This change also
precomputes overlapping tile coords, which improves the performance of
sorting (reduces the amount of arithmetic per comparison).

Note that now deduplication does not actually remove elements from the list of overlapping coords (as that is not O(1) in a vector), but simply marks them as "invalid". So I also added an iterator function to skip those invalid elements.

Overall this improves sparse read performance another 10% on my LiDAR benchmark.