### PR TITLE
Add limits.h header for SSIZE_MAX

### DIFF
--- a/tiledb/sm/filesystem/posix_filesystem.cc
+++ b/tiledb/sm/filesystem/posix_filesystem.cc
@@ -39,6 +39,8 @@
 
 #include <dirent.h>
 
+#include <limits.h>
+
 #include <ftw.h>
 
 #include <fstream>


### PR DESCRIPTION
This adds limits.h header for SSIZE_MAX definition. Fixes #586