### PR TITLE
Parallelize some steps of sparse reads.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ option(TILEDB_HDFS "Enables HDFS support using the official Hadoop JNI bindings"
 option(TILEDB_WERROR "Enables the -Werror flag during compilation." ON)
 option(TILEDB_CPP_API "Enables building of the TileDB C++ API." ON)
 option(TILEDB_CMAKE_IDE "(Used for CLion builds). Disables superbuild and sets the EP install dir." OFF)
+option(TILEDB_TBB "Enables use of TBB for parallelization." ON)
 
 ############################################################
 # Superbuild setup

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@
 * Refactored unordered writes, making them simpler and more amenable to parallelization.
 * Refactored global writes, making them simpler and more amenable to parallelization.
 * Added ability to cancel pending background/async tasks. SIGINT signals now cancel pending tasks.
+* Sparse read performance improvements with parallelism (using TBB as a dependency).
 
 ## Bug Fixes
 

--- a/bootstrap
+++ b/bootstrap
@@ -40,6 +40,7 @@ Configuration:
                                     already installed at system-level
     --disable-werror                disables use of -Werror during build
     --disable-cpp-api               disables building of the TileDB C++ API
+    --disable-tbb                   disables use of TBB for parallelization
     --enable-sanitizer=SAN          enable sanitizer (clang only)
                                     (address|memory|thread|undefined)
     --enable-debug                  enable debug build
@@ -76,6 +77,7 @@ tiledb_s3="OFF"
 tiledb_werror="ON"
 tiledb_cpp_api="ON"
 tiledb_force_all_deps="OFF"
+tiledb_tbb="ON"
 enable_multiple=""
 while test $# != 0; do
     case "$1" in
@@ -86,6 +88,7 @@ while test $# != 0; do
     --force-build-all-deps) tiledb_force_all_deps="ON";;
     --disable-werror) tiledb_werror="OFF";;
     --disable-cpp-api) tiledb_cpp_api="OFF";;
+    --disable-tbb) tiledb_tbb="OFF";;
     --enable-sanitizer=*) san=`arg "$1"`
                 sanitizer="$san";;
     --enable-debug) build_type="Debug";;
@@ -154,6 +157,7 @@ ${cmake} -DCMAKE_BUILD_TYPE=${build_type} \
     -DTILEDB_S3=${tiledb_s3} \
     -DTILEDB_WERROR=${tiledb_werror} \
     -DTILEDB_CPP_API=${tiledb_cpp_api} \
+    -DTILEDB_TBB=${tiledb_tbb} \
     -DTILEDB_FORCE_ALL_DEPS=${tiledb_force_all_deps} \
     -DSANITIZER=${sanitizer} \
     ${source_dir} || die "failed to configure the project"

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -38,6 +38,9 @@ Disable use of warnings-as-errors (/WX) during build.
 .Parameter DisableCppApi
 Disable building the TileDB C++ API.
 
+.Parameter DisableTBB
+Disable use of TBB for parallelization.
+
 .PARAMETER BuildProcesses
 Number of parallel compile jobs.
 
@@ -63,6 +66,7 @@ Param(
     [switch]$EnableS3,
     [switch]$DisableWerror,
     [switch]$DisableCppApi,
+    [switch]$DisableTBB,
     [Alias('J')]
     [int]
     $BuildProcesses = $env:NUMBER_OF_PROCESSORS
@@ -114,6 +118,11 @@ if ($DisableCppApi.IsPresent) {
     $CppApi = "OFF"
 }
 
+$TBB = "ON"
+if ($DisableTBB.IsPresent) {
+    $TBB = "OFF"
+}
+
 # Set TileDB prefix
 $InstallPrefix = $DefaultPrefix
 if ($Prefix.IsPresent) {
@@ -147,7 +156,7 @@ if ($CMakeGenerator -eq $null) {
 
 # Run CMake.
 # We use Invoke-Expression so we can echo the command to the user.
-$CommandString = "cmake -A X64 -DCMAKE_BUILD_TYPE=$BuildType -DCMAKE_INSTALL_PREFIX=""$InstallPrefix"" -DCMAKE_PREFIX_PATH=""$DependencyDir"" -DMSVC_MP_FLAG=""/MP$BuildProcesses"" -DTILEDB_VERBOSE=$Verbosity -DTILEDB_S3=$UseS3 -DTILEDB_WERROR=$Werror -DTILEDB_CPP_API=$CppApi $GeneratorFlag ""$SourceDirectory"""
+$CommandString = "cmake -A X64 -DCMAKE_BUILD_TYPE=$BuildType -DCMAKE_INSTALL_PREFIX=""$InstallPrefix"" -DCMAKE_PREFIX_PATH=""$DependencyDir"" -DMSVC_MP_FLAG=""/MP$BuildProcesses"" -DTILEDB_VERBOSE=$Verbosity -DTILEDB_S3=$UseS3 -DTILEDB_WERROR=$Werror -DTILEDB_CPP_API=$CppApi -DTILEDB_TBB=$TBB $GeneratorFlag ""$SourceDirectory"""
 Write-Host $CommandString
 Write-Host
 Invoke-Expression "$CommandString"

--- a/cmake/Modules/FindTBB_EP.cmake
+++ b/cmake/Modules/FindTBB_EP.cmake
@@ -1,0 +1,184 @@
+#
+# FindTBB_EP.cmake
+#
+#
+# The MIT License
+#
+# Copyright (c) 2018 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Finds the Intel TBB library, installing with an ExternalProject as necessary.
+# This module defines:
+#   - TBB_FOUND, whether TBB has been found
+#   - TBB_LIB_DIR, the directory in the build tree with the TBB libraries
+#   - The TBB::tbb imported target
+
+############################################################
+# Helper functions specific to TBB
+############################################################
+
+#
+# Builds the TBB external project such that a subsequent find_package(TBB)
+# will find it. This is a macro so the variables are set in the parent scope.
+#
+macro(build_tbb_ep)
+  set(TBB_SRC_DIR "${TILEDB_EP_BASE}/src/ep_tbb")
+  set(TBB_BUILD_CMAKE "${TBB_SRC_DIR}/cmake/TBBBuild.cmake")
+  # Check if the superbuild downloaded TBB.
+  if (EXISTS "${TBB_BUILD_CMAKE}")
+    include(${TBB_BUILD_CMAKE})
+    if (WIN32)
+      # On Windows the superbuild downloads the binaries, so just set the
+      # search path appropriately.
+      set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${TBB_SRC_DIR}")
+    else()
+      tbb_build(TBB_ROOT ${TBB_SRC_DIR} CONFIG_DIR TBB_DIR)
+    endif()
+  endif()
+endmacro()
+
+#
+# Adds TBB libraries to the TileDB installation manifest.
+#
+function(install_tbb)
+  get_target_property(TBB_LIBRARIES_RELEASE TBB::tbb IMPORTED_LOCATION_RELEASE)
+  get_target_property(TBB_LIBRARIES_DEBUG TBB::tbb IMPORTED_LOCATION_DEBUG)
+
+  if (WIN32)
+    # Install the DLLs to bin.
+    if (CMAKE_BUILD_TYPE MATCHES "Release")
+      install(FILES ${TBB_LIBRARIES_RELEASE} DESTINATION bin)
+    else()
+      install(FILES ${TBB_LIBRARIES_DEBUG} DESTINATION bin)
+    endif()
+
+    # Install the import libraries (.lib) to lib.
+    get_target_property(TBB_LIBRARIES_IMPLIB_RELEASE TBB::tbb IMPORTED_IMPLIB_RELEASE)
+    get_target_property(TBB_LIBRARIES_IMPLIB_DEBUG TBB::tbb IMPORTED_IMPLIB_DEBUG)
+    if (CMAKE_BUILD_TYPE MATCHES "Release")
+      install(FILES ${TBB_LIBRARIES_IMPLIB_RELEASE} DESTINATION lib)
+    else()
+      install(FILES ${TBB_LIBRARIES_IMPLIB_DEBUG} DESTINATION lib)
+    endif()
+  else()
+    # Just install the libraries to lib.
+    if (CMAKE_BUILD_TYPE MATCHES "Release")
+      install(FILES ${TBB_LIBRARIES_RELEASE} DESTINATION lib)
+    else()
+      install(FILES ${TBB_LIBRARIES_DEBUG} DESTINATION lib)
+    endif()
+  endif()
+endfunction()
+
+#
+# Sets a cache variable TBB_LIB_DIR pointing to the TBB libraries in the build tree
+# (for use by e.g. the tests).
+#
+function(save_tbb_dir)
+  if (TARGET TBB::tbb)
+    set(TBB_LIB_IMPLOC)
+    if (CMAKE_BUILD_TYPE MATCHES "Release")
+      get_target_property(TBB_LIB_IMPLOC TBB::tbb IMPORTED_LOCATION_RELEASE)
+    else()
+      get_target_property(TBB_LIB_IMPLOC TBB::tbb IMPORTED_LOCATION_DEBUG)
+    endif()
+    unset(TBB_LIB_DIR CACHE)
+    get_filename_component(TBB_LIB_DIR "${TBB_LIB_IMPLOC}" DIRECTORY CACHE)
+  endif()
+endfunction()
+
+############################################################
+# Regular superbuild EP setup.
+############################################################
+
+# Check to see if the SDK is installed (which provides the find module).
+# This will either use the system-installed AWSSDK find module (if present),
+# or the superbuild-installed find module.
+if (TILEDB_SUPERBUILD)
+  # Don't use find_package in superbuild if we are forcing all deps.
+  if (NOT TILEDB_FORCE_ALL_DEPS)
+    find_package(TBB CONFIG QUIET)
+  endif()
+else()
+  # Try finding a system TBB first.
+  find_package(TBB CONFIG QUIET)
+
+  if (TBB_FOUND)
+    message(STATUS "Found system TBB: ${TBB_IMPORTED_TARGETS}")
+  else()
+    # Build/setup the EP.
+    build_tbb_ep()
+
+    # Try finding again.
+    find_package(TBB CONFIG QUIET)
+
+    # If we found TBB that was built by the EP, we now add it to the TileDB
+    # installation manifest.
+    if (TBB_FOUND)
+      message(STATUS "Found EP TBB: ${TBB_IMPORTED_TARGETS}")
+      # Add TBB libraries to the TileDB installation manifest.
+      install_tbb()
+    endif()
+  endif()
+
+  # Save the library directory to a cache variable.
+  save_tbb_dir()
+endif()
+
+if (NOT TBB_FOUND)
+  if (TILEDB_SUPERBUILD)
+    message(STATUS "Could NOT find TBB")
+    message(STATUS "Adding TBB as an external project")
+
+    if (WIN32)
+      ExternalProject_Add(ep_tbb
+        PREFIX "externals"
+        URL "https://github.com/01org/tbb/releases/download/2018_U3/tbb2018_20180312oss_win.zip"
+        URL_HASH SHA1=7f0b4b227679637f7a4065b0377d55d12fac983b
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        UPDATE_COMMAND ""
+        INSTALL_COMMAND ""
+        LOG_DOWNLOAD TRUE
+        LOG_CONFIGURE TRUE
+        LOG_BUILD TRUE
+        LOG_INSTALL TRUE
+      )
+    else()
+      ExternalProject_Add(ep_tbb
+        PREFIX "externals"
+        URL "https://github.com/01org/tbb/archive/2018_U3.zip"
+        URL_HASH SHA1=c17ae26f2be1dd7ca9586f795d07a226ceca2dc2
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        UPDATE_COMMAND ""
+        INSTALL_COMMAND ""
+        LOG_DOWNLOAD TRUE
+        LOG_CONFIGURE TRUE
+        LOG_BUILD TRUE
+        LOG_INSTALL TRUE
+      )
+    endif()
+
+    list(APPEND TILEDB_EXTERNAL_PROJECTS ep_tbb)
+  else()
+    message(FATAL_ERROR "Unable to find TBB")
+  endif()
+endif()

--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -31,6 +31,7 @@ set(INHERITED_CMAKE_ARGS
   -DTILEDB_TESTS_AWS_S3_CONFIG=${TILEDB_TESTS_AWS_S3_CONFIG}
   -DSANITIZER=${SANITIZER}
   -DTILEDB_EP_BASE=${TILEDB_EP_BASE}
+  -DTILEDB_TBB=${TILEDB_TBB}
 )
 
 if (WIN32)
@@ -65,6 +66,10 @@ if (TILEDB_S3)
     include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindCurl_EP.cmake)
   endif()
   include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindAWSSDK_EP.cmake)
+endif()
+
+if (TILEDB_TBB)
+  include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindTBB_EP.cmake)
 endif()
 
 ############################################################

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -106,6 +106,11 @@ When building from source, TileDB will locate these dependencies if already inst
 Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
+TBB
+^^^
+
+Some TileDB internals are parallelized using the `Intel Threaded Building Blocks <https://www.threadingbuildingblocks.org/>`__ library. The TileDB build system will install this library if it is not already present on your system. You can disable the TBB dependency when configuring the TileDB build, in which case TileDB will fall back on serial implementations of several algorithms. As a part of the TileDB installation process, the TBB dynamic library will also be installed in the same destination as the TileDB dynamic library. The TBB headers are not installed with TileDB.
+
 S3
 ^^
 
@@ -170,6 +175,7 @@ The flags for the bootstrap script and the CMake equivalents are as follows:
 ``--enable-s3``        Enables building with S3 storage backend support        TILEDB_S3=ON
 ``--disable-werror``   Disables building with the ``-Werror`` flag             TILEDB_WERROR=OFF
 ``--disable-cpp-api``  Disables building the TileDB C++ API                    TILEDB_CPP_API=OFF
+``--disable-tbb``      Disables use of TBB for parallelization                 TILEDB_TBB=OFF
 =====================  ======================================================  ==============================
 
 After configuring, run the generated make script::
@@ -246,6 +252,7 @@ The flags for the bootstrap script and the CMake equivalents are as follows:
 ``-EnableS3``          Enables building with the S3 storage backend.     TILEDB_S3=ON
 ``-DisableWerror``     Disables building with the ``/WX`` flag           TILEDB_WERROR=OFF
 ``-DisableCppApi``     Disables building the TileDB C++ API              TILEDB_CPP_API=OFF
+``-DisableTBB``        Disables use of TBB for parallelization           TILEDB_TBB=OFF
 =====================  ================================================  ==============================
 
 Note that the HDFS storage backend is not yet supported on Windows.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,6 +124,16 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test
 )
 
+# Set the PATH on Windows so that the test executable can find the TBB library.
+if (TILEDB_TBB AND WIN32)
+  set(PATH_STRING "$ENV{PATH};${TBB_LIB_DIR}")
+  # Handle escaped semicolons. See
+  # https://cmake.org/pipermail/cmake/2010-December/041176.html
+  string(REPLACE "\\;" ";" PATH_STRING "${PATH_STRING}")
+  string(REPLACE ";" "\\;" PATH_STRING "${PATH_STRING}")
+  set_tests_properties("tiledb_unit" PROPERTIES ENVIRONMENT "PATH=${PATH_STRING}")
+endif()
+
 if(TILEDB_HDFS)
   # need to force flat namespace for the signal chaining to work on macOS
   if (APPLE)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -230,6 +230,16 @@ if (TILEDB_HDFS)
   endif()
 endif()
 
+# TBB dependency
+if (TILEDB_TBB)
+  find_package(TBB_EP REQUIRED)
+  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
+    INTERFACE
+      TBB::tbb
+  )
+  add_definitions(-DHAVE_TBB)
+endif()
+
 # Sanitizer linker flags
 if (SANITIZER)
   target_link_libraries(TILEDB_CORE_OBJECTS_ILIB

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -65,7 +65,7 @@ class RowCmp {
    */
   bool operator()(
       const Reader::OverlappingCoords<T>& a,
-      const Reader::OverlappingCoords<T>& b) {
+      const Reader::OverlappingCoords<T>& b) const {
     for (unsigned int i = 0; i < dim_num_; ++i) {
       if (a.coords_[i] < b.coords_[i])
         return true;
@@ -104,7 +104,7 @@ class ColCmp {
    */
   bool operator()(
       const Reader::OverlappingCoords<T>& a,
-      const Reader::OverlappingCoords<T>& b) {
+      const Reader::OverlappingCoords<T>& b) const {
     for (unsigned int i = dim_num_ - 1;; --i) {
       if (a.coords_[i] < b.coords_[i])
         return true;
@@ -151,7 +151,7 @@ class GlobalCmp {
    */
   bool operator()(
       const Reader::OverlappingCoords<T>& a,
-      const Reader::OverlappingCoords<T>& b) {
+      const Reader::OverlappingCoords<T>& b) const {
     // Compare tile order first
     auto tile_cmp =
         domain_->tile_order_cmp_tile_coords<T>(a.tile_coords_, b.tile_coords_);

--- a/tiledb/sm/misc/parallel_functions.h
+++ b/tiledb/sm/misc/parallel_functions.h
@@ -1,0 +1,104 @@
+/**
+ * @file   parallel_functions.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines several parallelized utility functions.
+ */
+
+#ifndef TILEDB_PARALLEL_FUNCTIONS_H
+#define TILEDB_PARALLEL_FUNCTIONS_H
+
+#include <algorithm>
+
+#ifdef HAVE_TBB
+#include <tbb/concurrent_vector.h>
+#include <tbb/parallel_for_each.h>
+#include <tbb/parallel_sort.h>
+#endif
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * Sort the given iterator range, possibly in parallel.
+ *
+ * @tparam IterT Iterator type
+ * @tparam CmpT Comparator type
+ * @param begin Beginning of range to sort (inclusive).
+ * @param end End of range to sort (exclusive).
+ * @param cmp Comparator.
+ */
+template <typename IterT, typename CmpT>
+void parallel_sort(IterT begin, IterT end, CmpT cmp) {
+#ifdef HAVE_TBB
+  tbb::parallel_sort(begin, end, cmp);
+#else
+  std::sort(begin, end, cmp);
+#endif
+}
+
+/**
+ * Call the given function on each element in the given iterator range,
+ * possibly in parallel.
+ *
+ * @tparam IterT Iterator type
+ * @tparam FuncT Function type (returning Status).
+ * @param begin Beginning of range to sort (inclusive).
+ * @param end End of range to sort (exclusive).
+ * @param F Function to call on each item
+ * @return Vector of Status objects, one for each function invocation.
+ */
+template <typename IterT, typename FuncT>
+std::vector<Status> parallel_for_each(IterT begin, IterT end, const FuncT& F) {
+  std::vector<Status> result;
+#ifdef HAVE_TBB
+  tbb::concurrent_vector<Status> tbb_result;
+  tbb::parallel_for_each(
+      begin,
+      end,
+      [&tbb_result,
+       &F](const typename std::iterator_traits<IterT>::value_type& elem) {
+        tbb_result.push_back(F(elem));
+      });
+  result.insert(result.end(), tbb_result.begin(), tbb_result.end());
+#else
+  std::for_each(
+      begin,
+      end,
+      [&result,
+       &F](const typename std::iterator_traits<IterT>::value_type& elem) {
+        result.push_back(F(elem));
+      });
+#endif
+  return result;
+}
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_PARALLEL_FUNCTIONS_H

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -130,10 +130,18 @@ class Reader {
 
     /** Constructor. */
     OverlappingTile(
-        unsigned fragment_idx, uint64_t tile_idx, bool full_overlap = false)
+        unsigned fragment_idx,
+        uint64_t tile_idx,
+        const std::vector<std::string>& attributes,
+        bool full_overlap = false)
         : fragment_idx_(fragment_idx)
         , tile_idx_(tile_idx)
         , full_overlap_(full_overlap) {
+      attr_tiles_[constants::coords] = std::make_pair(Tile(), Tile());
+      for (const auto& attr : attributes) {
+        if (attr != constants::coords)
+          attr_tiles_[attr] = std::make_pair(Tile(), Tile());
+      }
     }
   };
 
@@ -686,6 +694,15 @@ class Reader {
   template <class T>
   bool overlap(
       const T* a, const T* b, unsigned dim_num, bool* a_contains_b) const;
+
+  /**
+   * Retrieves the tiles on all attributes from all input fragments based on
+   * the tile info in `tiles`.
+   *
+   * @param tiles The retrieved tiles will be stored in `tiles`.
+   * @return Status
+   */
+  Status read_all_tiles(OverlappingTileVec* tiles) const;
 
   /**
    * Retrieves the tiles on a particular attribute from all input fragments


### PR DESCRIPTION
Third in a series of PRs to improve sparse read performance, this parallelizes two expensive steps of the read algorithm: coordinate sorting, and tile IO/decompression. On an EC2 instance with 8 cores/16 HW threads, this gets about a 2.8x performance improvement over single-threaded (on the same LiDAR benchmark as the previous PRs) with 16 threads.

This PR therefore also adds TBB as a dependency. Because TBB is a rather large dependency, and unfortunately cannot be built as a static library, you can also disable the use of TBB with the `--disable-tbb` bootstrap flag or the `TILEDB_TBB=OFF` cmake flag. This will revert to the original serial implementations for those steps. When TBB is enabled, the TBB dynamic library is installed alongside the TileDB library during installation.

Note that as of now, decompression is by far the largest remaining bottleneck in the sparse reads benchmark.