### PR TITLE
[ci-skip] Two docs fixes. Closes #589.

### DIFF
--- a/doc/source/c++-api.rst
+++ b/doc/source/c++-api.rst
@@ -110,6 +110,5 @@ Utils
 
 Version
 -------
-.. doxygenclass:: tiledb::Version
+.. doxygenfunction:: tiledb::version
     :project: TileDB-C++
-    :members:

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -267,8 +267,6 @@ Query
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_get_status
     :project: TileDB-C
-.. doxygenfunction:: tiledb_query_get_attribute_status
-    :project: TileDB-C
 
 Group
 -----


### PR DESCRIPTION
Note warnings as errors are already enabled in `local-build.sh`, and we can't control that flag on RTD.