### PR TITLE
Add PreallocatedBuffer class and use in all decompressors.

### DIFF
--- a/test/src/unit-compression-dd.cc
+++ b/test/src/unit-compression-dd.cc
@@ -52,8 +52,12 @@ TEST_CASE(
   auto decomp_in_buff =
       new tiledb::sm::ConstBuffer(comp_out_buff->data(), comp_out_buff->size());
   auto decomp_out_buff = new tiledb::sm::Buffer();
+  st = decomp_out_buff->realloc(sizeof(data));
+  REQUIRE(st.ok());
+  tiledb::sm::PreallocatedBuffer prealloc_buf(
+      decomp_out_buff->data(), decomp_out_buff->alloced_size());
   st = tiledb::sm::DoubleDelta::decompress(
-      tiledb::sm::Datatype::INT32, decomp_in_buff, decomp_out_buff);
+      tiledb::sm::Datatype::INT32, decomp_in_buff, &prealloc_buf);
   REQUIRE(st.ok());
 
   // Check data
@@ -82,8 +86,12 @@ TEST_CASE(
   auto decomp_in_buff =
       new tiledb::sm::ConstBuffer(comp_out_buff->data(), comp_out_buff->size());
   auto decomp_out_buff = new tiledb::sm::Buffer();
+  st = decomp_out_buff->realloc(sizeof(data));
+  REQUIRE(st.ok());
+  tiledb::sm::PreallocatedBuffer prealloc_buf(
+      decomp_out_buff->data(), decomp_out_buff->alloced_size());
   st = tiledb::sm::DoubleDelta::decompress(
-      tiledb::sm::Datatype::INT32, decomp_in_buff, decomp_out_buff);
+      tiledb::sm::Datatype::INT32, decomp_in_buff, &prealloc_buf);
   REQUIRE(st.ok());
 
   // Check data
@@ -115,8 +123,10 @@ TEST_CASE(
   auto decomp_out_buff = new tiledb::sm::Buffer();
   st = decomp_out_buff->realloc(sizeof(data));
   REQUIRE(st.ok());
+  tiledb::sm::PreallocatedBuffer prealloc_buf(
+      decomp_out_buff->data(), decomp_out_buff->alloced_size());
   st = tiledb::sm::DoubleDelta::decompress(
-      tiledb::sm::Datatype::INT32, decomp_in_buff, decomp_out_buff);
+      tiledb::sm::Datatype::INT32, decomp_in_buff, &prealloc_buf);
   REQUIRE(st.ok());
 
   // Check data
@@ -149,8 +159,10 @@ TEST_CASE(
   auto decomp_out_buff = new tiledb::sm::Buffer();
   st = decomp_out_buff->realloc(sizeof(data));
   REQUIRE(st.ok());
+  tiledb::sm::PreallocatedBuffer prealloc_buf(
+      decomp_out_buff->data(), decomp_out_buff->alloced_size());
   st = tiledb::sm::DoubleDelta::decompress(
-      tiledb::sm::Datatype::INT32, decomp_in_buff, decomp_out_buff);
+      tiledb::sm::Datatype::INT32, decomp_in_buff, &prealloc_buf);
   REQUIRE(st.ok());
 
   // Check data
@@ -191,8 +203,10 @@ TEST_CASE(
   auto decomp_out_buff = new tiledb::sm::Buffer();
   st = decomp_out_buff->realloc(sizeof(int) * n);
   REQUIRE(st.ok());
+  tiledb::sm::PreallocatedBuffer prealloc_buf(
+      decomp_out_buff->data(), decomp_out_buff->alloced_size());
   st = tiledb::sm::DoubleDelta::decompress(
-      tiledb::sm::Datatype::INT32, decomp_in_buff, decomp_out_buff);
+      tiledb::sm::Datatype::INT32, decomp_in_buff, &prealloc_buf);
   REQUIRE(st.ok());
 
   // Check data

--- a/test/src/unit-compression-rle.cc
+++ b/test/src/unit-compression-rle.cc
@@ -93,8 +93,10 @@ TEST_CASE("Compression-RLE: Test all values unique", "[compression], [rle]") {
   input = new ConstBuffer(compressed->data(), compressed->size());
   auto decompressed = new Buffer();
   st = decompressed->realloc(sizeof(data));
+  PreallocatedBuffer prealloc_buf(
+      decompressed->data(), decompressed->alloced_size());
   REQUIRE(st.ok());
-  st = tiledb::sm::RLE::decompress(sizeof(int), input, decompressed);
+  st = tiledb::sm::RLE::decompress(sizeof(int), input, &prealloc_buf);
   CHECK(st.ok());
   CHECK_FALSE(memcmp(data, decompressed->data(), sizeof(data)));
 
@@ -131,8 +133,10 @@ TEST_CASE("Compression-RLE: Test all values the same", "[compression], [rle]") {
   // Decompress data
   st = decompressed->realloc(sizeof(data));
   REQUIRE(st.ok());
+  PreallocatedBuffer prealloc_buf(
+      decompressed->data(), decompressed->alloced_size());
   input = new ConstBuffer(compressed->data(), compressed->size());
-  st = tiledb::sm::RLE::decompress(sizeof(int), input, decompressed);
+  st = tiledb::sm::RLE::decompress(sizeof(int), input, &prealloc_buf);
   CHECK(st.ok());
   CHECK_FALSE(memcmp(data, decompressed->data(), sizeof(data)));
 
@@ -173,8 +177,10 @@ TEST_CASE(
   auto decompressed = new Buffer();
   st = decompressed->realloc(sizeof(data));
   REQUIRE(st.ok());
+  PreallocatedBuffer prealloc_buf(
+      decompressed->data(), decompressed->alloced_size());
   input = new ConstBuffer(compressed->data(), compressed->size());
-  st = tiledb::sm::RLE::decompress(sizeof(int), input, decompressed);
+  st = tiledb::sm::RLE::decompress(sizeof(int), input, &prealloc_buf);
   CHECK(st.ok());
   CHECK_FALSE(memcmp(data, decompressed->data(), sizeof(int)));
 
@@ -215,8 +221,10 @@ TEST_CASE(
   // Decompress data
   st = decompressed->realloc(sizeof(data));
   REQUIRE(st.ok());
+  PreallocatedBuffer prealloc_buf(
+      decompressed->data(), decompressed->alloced_size());
   input = new ConstBuffer(compressed->data(), compressed->size());
-  st = tiledb::sm::RLE::decompress(sizeof(int), input, decompressed);
+  st = tiledb::sm::RLE::decompress(sizeof(int), input, &prealloc_buf);
   CHECK(st.ok());
   CHECK_FALSE(memcmp(data, decompressed->data(), sizeof(data)));
 
@@ -271,8 +279,10 @@ TEST_CASE(
   auto decompressed = new Buffer();
   st = decompressed->realloc(sizeof(data));
   REQUIRE(st.ok());
+  PreallocatedBuffer prealloc_buf(
+      decompressed->data(), decompressed->alloced_size());
   input = new ConstBuffer(compressed->data(), compressed->size());
-  st = tiledb::sm::RLE::decompress(value_size, input, decompressed);
+  st = tiledb::sm::RLE::decompress(value_size, input, &prealloc_buf);
   CHECK(st.ok());
   CHECK_FALSE(memcmp(data, decompressed->data(), sizeof(data)));
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -85,6 +85,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/domain.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/buffer/buffer.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/buffer/const_buffer.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/buffer/preallocated_buffer.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cache/lru_cache.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/compressors/blosc_compressor.cc

--- a/tiledb/sm/buffer/preallocated_buffer.cc
+++ b/tiledb/sm/buffer/preallocated_buffer.cc
@@ -1,0 +1,105 @@
+/**
+ * @file   preallocated_buffer.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class PreallocatedBuffer.
+ */
+
+#include "tiledb/sm/buffer/preallocated_buffer.h"
+#include "tiledb/sm/misc/logger.h"
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*   CONSTRUCTORS & DESTRUCTORS   */
+/* ****************************** */
+
+PreallocatedBuffer::PreallocatedBuffer(const void* data, uint64_t size)
+    : data_(data)
+    , offset_(0)
+    , size_(size) {
+}
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+void PreallocatedBuffer::advance_offset(uint64_t nbytes) {
+  assert(offset_ + nbytes <= size_);
+  offset_ += nbytes;
+}
+
+void* PreallocatedBuffer::cur_data() const {
+  if (data_ == nullptr)
+    return nullptr;
+  return (char*)data_ + offset_;
+}
+
+const void* PreallocatedBuffer::data() const {
+  return data_;
+}
+
+uint64_t PreallocatedBuffer::free_space() const {
+  return size_ - offset_;
+}
+
+uint64_t PreallocatedBuffer::offset() const {
+  return offset_;
+}
+
+Status PreallocatedBuffer::read(void* buffer, uint64_t nbytes) {
+  if (offset_ + nbytes > size_)
+    return Status::PreallocatedBufferError("Read buffer overflow");
+
+  memcpy(buffer, (char*)data_ + offset_, nbytes);
+  offset_ += nbytes;
+
+  return Status::Ok();
+}
+
+uint64_t PreallocatedBuffer::size() const {
+  return size_;
+}
+
+Status PreallocatedBuffer::write(const void* buffer, uint64_t nbytes) {
+  if (offset_ + nbytes > size_)
+    return Status::PreallocatedBufferError("Write would overflow buffer.");
+
+  std::memcpy((char*)data_ + offset_, buffer, nbytes);
+  offset_ += nbytes;
+
+  return Status::Ok();
+}
+
+/* ****************************** */
+/*          PRIVATE METHODS       */
+/* ****************************** */
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/buffer/preallocated_buffer.h
+++ b/tiledb/sm/buffer/preallocated_buffer.h
@@ -1,0 +1,145 @@
+/**
+ * @file   preallocated_buffer.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class PreallocatedBuffer.
+ */
+
+#ifndef TILEDB_PREALLOCATED_BUFFER_H
+#define TILEDB_PREALLOCATED_BUFFER_H
+
+#include <cinttypes>
+
+#include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/sm/misc/status.h"
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * Convenience class wrapping a pre-allocated memory region in a class that
+ * tracks an offset when reading and writing to the region.
+ */
+class PreallocatedBuffer {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * Constructor.
+   *
+   * @param data The data of the buffer.
+   * @param size The size of the buffer.
+   */
+  PreallocatedBuffer(const void* data, uint64_t size);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Advances the offset by *nbytes*. */
+  void advance_offset(uint64_t nbytes);
+
+  /** Returns the buffer data pointer at the current offset. */
+  void* cur_data() const;
+
+  /** Returns the buffer data. */
+  const void* data() const;
+
+  /** Returns the "free space" in the buffer, which is the size minus the
+   * current offset. */
+  uint64_t free_space() const;
+
+  /** Returns the buffer offset. */
+  uint64_t offset() const;
+
+  /**
+   * Reads from the internal buffer into the input buffer.
+   *
+   * @param buffer The buffer to write to when reading from the local buffer.
+   * @param nbytes The number of bytes to read.
+   * @return Status.
+   */
+  Status read(void* buffer, uint64_t nbytes);
+
+  /** Returns the size of the buffer. */
+  uint64_t size() const;
+
+  /**
+   * Returns a value from the buffer of type T.
+   *
+   * @tparam T The type of the value to be read.
+   * @param offset The offset in the local buffer to read from.
+   * @return The desired value of type T.
+   */
+  template <class T>
+  inline T value(uint64_t offset) {
+    return ((const T*)(((const char*)data_) + offset))[0];
+  }
+
+  /**
+   * Returns the value at the current offset of the buffer of type T.
+   *
+   * @tparam T The type of the value to be returned.
+   * @return The value to be returned of type T.
+   */
+  template <class T>
+  inline T value() {
+    return ((const T*)(((const char*)data_) + offset_))[0];
+  }
+
+  /**
+   * Writes exactly *nbytes* into the local buffer by reading from the
+   * input buffer *buf*.
+   *
+   * @param buffer The buffer to read from.
+   * @param nbytes Number of bytes to write.
+   * @return Status.
+   */
+  Status write(const void* buffer, uint64_t nbytes);
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The (read-only) buffer data. */
+  const void* data_;
+
+  /** The current offset in the buffer to read from. */
+  uint64_t offset_;
+
+  /** The size of the buffer. */
+  uint64_t size_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_PREALLOCATED_BUFFER_H

--- a/tiledb/sm/compressors/blosc_compressor.cc
+++ b/tiledb/sm/compressors/blosc_compressor.cc
@@ -75,7 +75,8 @@ Status Blosc::compress(
   return Status::Ok();
 }
 
-Status Blosc::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
+Status Blosc::decompress(
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
     return LOG_STATUS(Status::CompressionError(
@@ -94,7 +95,6 @@ Status Blosc::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
     return LOG_STATUS(Status::CompressionError("Blosc decompress error"));
 
   // Set size of decompressed data
-  output_buffer->advance_size(uint64_t(rc));
   output_buffer->advance_offset(uint64_t(rc));
 
   return Status::Ok();

--- a/tiledb/sm/compressors/blosc_compressor.h
+++ b/tiledb/sm/compressors/blosc_compressor.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
@@ -77,7 +78,8 @@ class Blosc {
    * @param output_buffer Output buffer to write the decompressed data to.
    * @return Status
    */
-  static Status decompress(ConstBuffer* input_buffer, Buffer* output_buffer);
+  static Status decompress(
+      ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 
   /** Returns the default compression level. */
   static int default_level() {

--- a/tiledb/sm/compressors/bzip_compressor.cc
+++ b/tiledb/sm/compressors/bzip_compressor.cc
@@ -87,7 +87,8 @@ Status BZip::compress(
   return Status::Ok();
 }
 
-Status BZip::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
+Status BZip::decompress(
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
     return LOG_STATUS(Status::CompressionError(
@@ -128,7 +129,6 @@ Status BZip::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
   }
 
   // Set size of compressed data
-  output_buffer->advance_size(out_size);
   output_buffer->advance_offset(out_size);
 
   return Status::Ok();

--- a/tiledb/sm/compressors/bzip_compressor.h
+++ b/tiledb/sm/compressors/bzip_compressor.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
@@ -61,7 +62,8 @@ class BZip {
    * @param output_buffer Output buffer to write the decompressed data to.
    * @return Status
    */
-  static Status decompress(ConstBuffer* input_buffer, Buffer* output_buffer);
+  static Status decompress(
+      ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 
   /** Returns the default compression level. */
   static int default_level() {

--- a/tiledb/sm/compressors/dd_compressor.cc
+++ b/tiledb/sm/compressors/dd_compressor.cc
@@ -92,7 +92,9 @@ Status DoubleDelta::compress(
 }
 
 Status DoubleDelta::decompress(
-    Datatype type, ConstBuffer* input_buffer, Buffer* output_buffer) {
+    Datatype type,
+    ConstBuffer* input_buffer,
+    PreallocatedBuffer* output_buffer) {
   switch (type) {
     case Datatype::INT8:
       return DoubleDelta::decompress<int8_t>(input_buffer, output_buffer);
@@ -231,7 +233,7 @@ Status DoubleDelta::compute_bitsize(
 
 template <class T>
 Status DoubleDelta::decompress(
-    ConstBuffer* input_buffer, Buffer* output_buffer) {
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
   // Read bitsize and number of values
   uint8_t bitsize_c = 0;
   uint64_t num = 0;
@@ -396,23 +398,23 @@ template Status DoubleDelta::compress<uint64_t>(
     ConstBuffer* input_buffer, Buffer* output_buffer);
 
 template Status DoubleDelta::decompress<char>(
-    ConstBuffer* input_buffer, Buffer* output_buffer);
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 template Status DoubleDelta::decompress<int8_t>(
-    ConstBuffer* input_buffer, Buffer* output_buffer);
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 template Status DoubleDelta::decompress<uint8_t>(
-    ConstBuffer* input_buffer, Buffer* output_buffer);
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 template Status DoubleDelta::decompress<int16_t>(
-    ConstBuffer* input_buffer, Buffer* output_buffer);
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 template Status DoubleDelta::decompress<uint16_t>(
-    ConstBuffer* input_buffer, Buffer* output_buffer);
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 template Status DoubleDelta::decompress<int>(
-    ConstBuffer* input_buffer, Buffer* output_buffer);
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 template Status DoubleDelta::decompress<uint32_t>(
-    ConstBuffer* input_buffer, Buffer* output_buffer);
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 template Status DoubleDelta::decompress<int64_t>(
-    ConstBuffer* input_buffer, Buffer* output_buffer);
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 template Status DoubleDelta::decompress<uint64_t>(
-    ConstBuffer* input_buffer, Buffer* output_buffer);
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 
 };  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/compressors/dd_compressor.h
+++ b/tiledb/sm/compressors/dd_compressor.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/status.h"
 
@@ -109,7 +110,9 @@ class DoubleDelta {
    * @return Status
    */
   static Status decompress(
-      Datatype type, ConstBuffer* input_buffer, Buffer* output_buffer);
+      Datatype type,
+      ConstBuffer* input_buffer,
+      PreallocatedBuffer* output_buffer);
 
   /** Returns the compression overhead for the given input. */
   static uint64_t overhead(uint64_t nbytes);
@@ -145,7 +148,8 @@ class DoubleDelta {
    * @return Status
    */
   template <class T>
-  static Status decompress(ConstBuffer* input_buffer, Buffer* output_buffer);
+  static Status decompress(
+      ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 
   /**
    * Reads/reconstructs a double delta value from a compressed buffer.

--- a/tiledb/sm/compressors/gzip_compressor.cc
+++ b/tiledb/sm/compressors/gzip_compressor.cc
@@ -82,7 +82,8 @@ Status GZip::compress(
   return Status::Ok();
 }
 
-Status GZip::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
+Status GZip::decompress(
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
     return LOG_STATUS(Status::CompressionError(
@@ -117,7 +118,6 @@ Status GZip::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
 
   // Set size of decompressed data
   uint64_t compressed_size = output_buffer->free_space() - strm.avail_out;
-  output_buffer->advance_size(compressed_size);
   output_buffer->advance_offset(compressed_size);
 
   // Clean up

--- a/tiledb/sm/compressors/gzip_compressor.h
+++ b/tiledb/sm/compressors/gzip_compressor.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/misc/status.h"
 
 #include <cmath>
@@ -63,7 +64,8 @@ class GZip {
    * @param output_buffer Output buffer to write the decompressed data to.
    * @return Status
    */
-  static Status decompress(ConstBuffer* input_buffer, Buffer* output_buffer);
+  static Status decompress(
+      ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 
   /** Returns the compression overhead for the given input. */
   static uint64_t overhead(uint64_t buffer_size);

--- a/tiledb/sm/compressors/lz4_compressor.cc
+++ b/tiledb/sm/compressors/lz4_compressor.cc
@@ -74,7 +74,8 @@ Status LZ4::compress(
   return Status::Ok();
 }
 
-Status LZ4::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
+Status LZ4::decompress(
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
     return LOG_STATUS(Status::CompressionError(
@@ -92,7 +93,6 @@ Status LZ4::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
     return Status::CompressionError("LZ4 decompression failed");
 
   // Set size of decompressed data
-  output_buffer->advance_size(static_cast<uint64_t>(ret));
   output_buffer->advance_offset(static_cast<uint64_t>(ret));
 
   return Status::Ok();

--- a/tiledb/sm/compressors/lz4_compressor.h
+++ b/tiledb/sm/compressors/lz4_compressor.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
@@ -61,7 +62,8 @@ class LZ4 {
    * @param output_buffer Output buffer to write the decompressed data to.
    * @return Status
    */
-  static Status decompress(ConstBuffer* input_buffer, Buffer* output_buffer);
+  static Status decompress(
+      ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 
   /** Returns the default compression level. */
   static int default_level() {

--- a/tiledb/sm/compressors/rle_compressor.cc
+++ b/tiledb/sm/compressors/rle_compressor.cc
@@ -95,7 +95,9 @@ Status RLE::compress(
 }
 
 Status RLE::decompress(
-    uint64_t value_size, ConstBuffer* input_buffer, Buffer* output_buffer) {
+    uint64_t value_size,
+    ConstBuffer* input_buffer,
+    PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr)
     return LOG_STATUS(Status::CompressionError(

--- a/tiledb/sm/compressors/rle_compressor.h
+++ b/tiledb/sm/compressors/rle_compressor.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
@@ -63,7 +64,9 @@ class RLE {
    * @return Status
    */
   static Status decompress(
-      uint64_t value_size, ConstBuffer* input_buffer, Buffer* output_buffer);
+      uint64_t value_size,
+      ConstBuffer* input_buffer,
+      PreallocatedBuffer* output_buffer);
 
   /** Returns the compression overhead for the given input. */
   static uint64_t overhead(uint64_t nbytes, uint64_t value_size);

--- a/tiledb/sm/compressors/zstd_compressor.cc
+++ b/tiledb/sm/compressors/zstd_compressor.cc
@@ -68,7 +68,8 @@ Status ZStd::compress(
   return Status::Ok();
 }
 
-Status ZStd::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
+Status ZStd::decompress(
+    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
     return LOG_STATUS(Status::CompressionError(
@@ -89,7 +90,6 @@ Status ZStd::decompress(ConstBuffer* input_buffer, Buffer* output_buffer) {
   }
 
   // Set size decompressed data
-  output_buffer->advance_size(zstd_ret);
   output_buffer->advance_offset(zstd_ret);
 
   return Status::Ok();

--- a/tiledb/sm/compressors/zstd_compressor.h
+++ b/tiledb/sm/compressors/zstd_compressor.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
@@ -61,7 +62,8 @@ class ZStd {
    * @param output_buffer Output buffer to write the decompressed data to.
    * @return Status
    */
-  static Status decompress(ConstBuffer* input_buffer, Buffer* output_buffer);
+  static Status decompress(
+      ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
 
   /** Returns the default compression level. */
   static int default_level() {

--- a/tiledb/sm/misc/status.cc
+++ b/tiledb/sm/misc/status.cc
@@ -183,6 +183,9 @@ std::string Status::code_to_string() const {
     case StatusCode::Writer:
       type = "[TileDB::Writer] Error";
       break;
+    case StatusCode::PreallocatedBuffer:
+      type = "[TileDB::PreallocatedBuffer] Error";
+      break;
     default:
       type = "[TileDB::?] Error:";
   }

--- a/tiledb/sm/misc/status.h
+++ b/tiledb/sm/misc/status.h
@@ -106,7 +106,8 @@ enum class StatusCode : char {
   Attribute,
   DenseCellRangeIter,
   Reader,
-  Writer
+  Writer,
+  PreallocatedBuffer
 };
 
 class Status {
@@ -290,6 +291,12 @@ class Status {
   /** Return a WriterError error class Status with a given message **/
   static Status WriterError(const std::string& msg) {
     return Status(StatusCode::Writer, msg, -1);
+  }
+
+  /** Return a PreallocatedBufferError error class Status with a given message
+   * **/
+  static Status PreallocatedBufferError(const std::string& msg) {
+    return Status(StatusCode::PreallocatedBuffer, msg, -1);
   }
 
   /** Returns true iff the status indicates success **/


### PR DESCRIPTION
The new `PreallocatedBuffer` class just wraps an allocated region of memory with a private `offset`. With this PR, `PreallocatedBuffer` is now used as the output buffer for decompression functions, which will eventually allow decompression to write into the same underlying tile `Buffer` in parallel.