### PR TITLE
Parallelize decompression and per-tile I/O.

### DIFF
--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -332,8 +332,8 @@ const char* null_str = "null";
 const int version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
-/** The size of a tile chunk. */
-const uint64_t tile_chunk_size = (uint64_t)std::numeric_limits<int>::max();
+/** The maximum size of a tile chunk (unit of compression) in bytes. */
+const uint64_t tile_chunk_size = 64 * 1024;
 
 /** The default attribute name prefix. */
 const char* default_attr_name = "__attr";

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -319,7 +319,7 @@ extern const char* null_str;
 /** The version in format { major, minor, revision }. */
 extern const int version[3];
 
-/** The size of a tile chunk. */
+/** The maximum size of a tile chunk (unit of compression) in bytes. */
 extern const uint64_t tile_chunk_size;
 
 /** The default attribute name prefix. */

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -700,9 +700,12 @@ class Reader {
    * the tile info in `tiles`.
    *
    * @param tiles The retrieved tiles will be stored in `tiles`.
+   * @param ensure_coords If true (the default), always read the coordinate
+   * tiles.
    * @return Status
    */
-  Status read_all_tiles(OverlappingTileVec* tiles) const;
+  Status read_all_tiles(
+      OverlappingTileVec* tiles, bool ensure_coords = true) const;
 
   /**
    * Retrieves the tiles on a particular attribute from all input fragments

--- a/tiledb/sm/tile/tile_io.h
+++ b/tiledb/sm/tile/tile_io.h
@@ -179,6 +179,38 @@ class TileIO {
   URI uri_;
 
   /* ********************************* */
+  /*      PRIVATE TYPE DEFINITIONS     */
+  /* ********************************* */
+
+  /**
+   * Encapsulated information about tile chunks for decompression.
+   */
+  struct DecompressionChunkInfo {
+    /** Number of chunks to decompress. */
+    uint64_t chunk_num_;
+    /** Pointer to start of compressed chunk data. */
+    const char* compressed_chunks_;
+    /** Pointer to start of destination buffer for decompressed chunks. */
+    char* decompressed_chunks_;
+    /** Vector of (offset, len) pairs for the compressed chunks. */
+    std::vector<std::pair<uint64_t, uint64_t>> compressed_chunk_info_;
+    /**
+     * Vector of (offset, len) pairs for the decompressed chunk destinations.
+     */
+    std::vector<std::pair<uint64_t, uint64_t>> decompressed_chunk_info_;
+    /** Total number of bytes that will be decompressed. */
+    uint64_t total_decompressed_bytes_;
+
+    /** Constructor. */
+    DecompressionChunkInfo()
+        : chunk_num_(0)
+        , compressed_chunks_(nullptr)
+        , decompressed_chunks_(nullptr)
+        , total_decompressed_bytes_(0) {
+    }
+  };
+
+  /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
 
@@ -215,6 +247,16 @@ class TileIO {
       uint64_t* chunk_num,
       uint64_t* max_chunk_size,
       uint64_t* overhead);
+
+  /**
+   * Computes necessary info for decompressing chunks of a tile.
+   *
+   * @param tile The tile whose chunking info is being computed.
+   * @param info The info that will be computed.
+   * @return Status
+   */
+  Status compute_decompression_chunk_info(
+      Tile* tile, DecompressionChunkInfo* info);
 
   /**
    * Decompresses buffer_ into a tile.


### PR DESCRIPTION
Decompression is parallelized on a compressor-independent block size (which is now 64KB by default). This allows us to see good scaling in both extremes of very large tiles (via parallel decompression of the tiles' chunks) as well as very small tiles (via parallel decompression of the tiles, which may be composed of single chunks).

This is accomplished with a nested parallelism strategy, depending on TBB's scheduler to ensure a good distribution of work. The nested parallelism structure is as follows. `read_all_tiles` parallelizes over all attributes, calling `read_tiles` per attribute in parallel. Then each `read_tiles` call parallelizes over all tiles for that attribute, calling `tile_io->read()` in parallel. Then `tile_io->read()` parallelizes over compressed chunks, calling `decompress` in parallel.

**Note** that this PR also modifies `dense_read` to use `read_all_tiles`, which means dense reads are benefiting from some parallelism now as well.

On a dense read benchmark I observed linear scaling up to 18 threads on an 18 core machine in both extremes of large and small tiles.