### PR TITLE
Change install directories to use GNUInstallDirs

### DIFF
--- a/cmake/Modules/FindTBB_EP.cmake
+++ b/cmake/Modules/FindTBB_EP.cmake
@@ -61,28 +61,31 @@ function(install_tbb)
   get_target_property(TBB_LIBRARIES_RELEASE TBB::tbb IMPORTED_LOCATION_RELEASE)
   get_target_property(TBB_LIBRARIES_DEBUG TBB::tbb IMPORTED_LOCATION_DEBUG)
 
+  # Get library directory for multiarch linux distros
+  include(GNUInstallDirs)
+
   if (WIN32)
     # Install the DLLs to bin.
     if (CMAKE_BUILD_TYPE MATCHES "Release")
-      install(FILES ${TBB_LIBRARIES_RELEASE} DESTINATION bin)
+      install(FILES ${TBB_LIBRARIES_RELEASE} DESTINATION ${CMAKE_INSTALL_BINDIR})
     else()
-      install(FILES ${TBB_LIBRARIES_DEBUG} DESTINATION bin)
+      install(FILES ${TBB_LIBRARIES_DEBUG} DESTINATION ${CMAKE_INSTALL_BINDIR})
     endif()
 
     # Install the import libraries (.lib) to lib.
     get_target_property(TBB_LIBRARIES_IMPLIB_RELEASE TBB::tbb IMPORTED_IMPLIB_RELEASE)
     get_target_property(TBB_LIBRARIES_IMPLIB_DEBUG TBB::tbb IMPORTED_IMPLIB_DEBUG)
     if (CMAKE_BUILD_TYPE MATCHES "Release")
-      install(FILES ${TBB_LIBRARIES_IMPLIB_RELEASE} DESTINATION lib)
+      install(FILES ${TBB_LIBRARIES_IMPLIB_RELEASE} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     else()
-      install(FILES ${TBB_LIBRARIES_IMPLIB_DEBUG} DESTINATION lib)
+      install(FILES ${TBB_LIBRARIES_IMPLIB_DEBUG} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
   else()
     # Just install the libraries to lib.
     if (CMAKE_BUILD_TYPE MATCHES "Release")
-      install(FILES ${TBB_LIBRARIES_RELEASE} DESTINATION lib)
+      install(FILES ${TBB_LIBRARIES_RELEASE} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     else()
-      install(FILES ${TBB_LIBRARIES_DEBUG} DESTINATION lib)
+      install(FILES ${TBB_LIBRARIES_DEBUG} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
   endif()
 endfunction()

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -373,13 +373,16 @@ set_target_properties(tiledb_static
 ############################################################
 # Installation
 ############################################################
-
 # Install libraries.
 # Note on Windows, the DLL counts as "runtime" and should go into bin.
+
+# Get library directory for multiarch linux distros
+include(GNUInstallDirs)
+
 install(
     TARGETS tiledb_static tiledb_shared
-    PUBLIC_HEADER DESTINATION include/tiledb
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tiledb
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )


### PR DESCRIPTION
This changes the install directories to use `CMAKE_INSTALL_INCLUDESDIR`, `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_BINDIR` to handle linux multi-arch distros.

Closes #601 