### PR TITLE
Improve cmake external project compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,9 @@
 ############################################################
 
 cmake_minimum_required(VERSION 3.3)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
-set(TILEDB_CMAKE_INPUTS_DIR "${CMAKE_SOURCE_DIR}/cmake/inputs")
+set(TILEDB_CMAKE_INPUTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/inputs")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -87,7 +87,7 @@ endif()
 # it is for better CLion support of this superbuild architecture.
 if (TILEDB_CMAKE_IDE)
   set(TILEDB_SUPERBUILD OFF)
-  set(TILEDB_EP_BASE "${CMAKE_BINARY_DIR}/externals")
+  set(TILEDB_EP_BASE "${CMAKE_CURRENT_BINARY_DIR}/externals")
 endif()
 
 # Perform superbuild config and exit.

--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -5,7 +5,7 @@ include (ExternalProject)
 ############################################################
 
 # Build paths for external projects
-set(TILEDB_EP_BASE "${CMAKE_BINARY_DIR}/externals")
+set(TILEDB_EP_BASE "${CMAKE_CURRENT_BINARY_DIR}/externals")
 set(TILEDB_EP_SOURCE_DIR "${TILEDB_EP_BASE}/src")
 set(TILEDB_EP_INSTALL_PREFIX "${TILEDB_EP_BASE}/install")
 
@@ -51,21 +51,21 @@ endif()
 # These includes modify the TILEDB_EXTERNAL_PROJECTS and FORWARD_EP_CMAKE_ARGS
 # variables.
 
-include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindBlosc_EP.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindBzip2_EP.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindCatch_EP.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindLZ4_EP.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindSpdlog_EP.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindZlib_EP.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindZstd_EP.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindBlosc_EP.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindBzip2_EP.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindCatch_EP.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindLZ4_EP.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindSpdlog_EP.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindZlib_EP.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindZstd_EP.cmake)
 
 if (TILEDB_S3)
   if (NOT WIN32)
     # AWS SDK uses builtin WinHTTP and BCrypt instead of these.
-    include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindOpenSSL_EP.cmake)
-    include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindCurl_EP.cmake)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindOpenSSL_EP.cmake)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindCurl_EP.cmake)
   endif()
-  include(${CMAKE_SOURCE_DIR}/cmake/Modules/FindAWSSDK_EP.cmake)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindAWSSDK_EP.cmake)
 endif()
 
 if (TILEDB_TBB)
@@ -93,7 +93,7 @@ ExternalProject_Add(tiledb
 
 add_custom_target(check
   COMMAND ${CMAKE_COMMAND} --build . --target check --config ${CMAKE_BUILD_TYPE}
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tiledb
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tiledb
 )
 
 ############################################################
@@ -102,14 +102,14 @@ add_custom_target(check
 
 add_custom_target(examples
   COMMAND ${CMAKE_COMMAND} --build . --target examples --config ${CMAKE_BUILD_TYPE}
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tiledb
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tiledb
 )
 
 ############################################################
 # "make format" and "make check-format" targets
 ############################################################
 
-set(SCRIPTS_DIR "${CMAKE_SOURCE_DIR}/scripts")
+set(SCRIPTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 
 find_package(ClangTools)
 if (${CLANG_FORMAT_FOUND})
@@ -134,19 +134,19 @@ endif()
 
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
-  set(TILEDB_C_API_HEADERS "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb.h")
-  file(GLOB TILEDB_CPP_API_HEADERS "${CMAKE_SOURCE_DIR}/tiledb/sm/cpp_api/*.h")
+  set(TILEDB_C_API_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/tiledb/sm/c_api/tiledb.h")
+  file(GLOB TILEDB_CPP_API_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/tiledb/sm/cpp_api/*.h")
   set(TILEDB_API_HEADERS ${TILEDB_C_API_HEADERS} ${TILEDB_CPP_API_HEADERS})
-  add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/doxyfile.in
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doxyfile.in
     COMMAND mkdir -p doxygen
-    COMMAND echo INPUT = ${CMAKE_SOURCE_DIR}/doc/mainpage.dox
-      ${TILEDB_API_HEADERS} > ${CMAKE_BINARY_DIR}/doxyfile.in
+    COMMAND echo INPUT = ${CMAKE_CURRENT_SOURCE_DIR}/doc/mainpage.dox
+      ${TILEDB_API_HEADERS} > ${CMAKE_CURRENT_BINARY_DIR}/doxyfile.in
     COMMENT "Preparing for Doxygen documentation" VERBATIM
   )
   add_custom_target(doc
-    ${DOXYGEN_EXECUTABLE} ${CMAKE_SOURCE_DIR}/doc/Doxyfile.mk >
-      ${CMAKE_BINARY_DIR}/Doxyfile.log 2>&1
+    ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.mk >
+      ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile.log 2>&1
     COMMENT "Generating API documentation with Doxygen" VERBATIM
-    DEPENDS ${CMAKE_BINARY_DIR}/doxyfile.in
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/doxyfile.in
   )
 endif(DOXYGEN_FOUND)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -50,12 +50,12 @@ add_custom_target(tiledb-header-dir
 ############################################################
 
 # Get TileDB C API headers
-file(GLOB TILEDB_C_HEADERS "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/*.h")
+file(GLOB TILEDB_C_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/c_api/*.h")
 
 # Copy the headers to the 'tiledb/' directory
 foreach(HEADER ${TILEDB_C_HEADERS})
   string(REGEX
-    REPLACE "^${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/" ""
+    REPLACE "^${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/c_api/" ""
     HEADER_STRIPPED ${HEADER}
   )
   configure_file(${HEADER} ${CMAKE_CURRENT_BINARY_DIR}/tiledb/${HEADER_STRIPPED} COPYONLY)
@@ -73,13 +73,13 @@ add_subdirectory(c_api)
 
 if (TILEDB_CPP_API)
   file(GLOB TILEDB_CPP_HEADERS
-    "${CMAKE_SOURCE_DIR}/tiledb/sm/cpp_api/*.h"
-    "${CMAKE_SOURCE_DIR}/tiledb/sm/cpp_api/tiledb"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/cpp_api/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/cpp_api/tiledb"
   )
 
   foreach(HEADER ${TILEDB_CPP_HEADERS})
     string(REGEX
-      REPLACE "^${CMAKE_SOURCE_DIR}/tiledb/sm/cpp_api/" ""
+      REPLACE "^${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/cpp_api/" ""
       HEADER_STRIPPED ${HEADER}
     )
     configure_file(${HEADER} ${CMAKE_CURRENT_BINARY_DIR}/tiledb/${HEADER_STRIPPED} COPYONLY)

--- a/examples/c_api/CMakeLists.txt
+++ b/examples/c_api/CMakeLists.txt
@@ -43,7 +43,7 @@ function(build_TileDB_example_capi TARGET)
     target_link_libraries(${TARGET}_c pthread)
   endif()
   target_include_directories(${TARGET}_c PUBLIC
-    "${CMAKE_BINARY_DIR}/examples/"
+    "${CMAKE_CURRENT_BINARY_DIR}/../"
   )
   add_dependencies(examples_c ${TARGET}_c)
 endfunction()
@@ -55,7 +55,7 @@ file(GLOB TILEDB_EXAMPLE_SOURCES_CAPI "*.c")
 foreach(EXAMPLE_SOURCE ${TILEDB_EXAMPLE_SOURCES_CAPI})
   # Get the binary name
   string(REGEX
-    REPLACE "^${CMAKE_SOURCE_DIR}/examples/c_api/" ""
+    REPLACE "^${CMAKE_CURRENT_SOURCE_DIR}/" ""
     EXAMPLE_STRIPPED ${EXAMPLE_SOURCE}
   )
   string(REGEX

--- a/examples/cpp_api/CMakeLists.txt
+++ b/examples/cpp_api/CMakeLists.txt
@@ -33,7 +33,7 @@ function(build_TileDB_example_cppapi TARGET)
   add_executable(${TARGET}_cpp EXCLUDE_FROM_ALL ${TARGET}.cc)
   target_link_libraries(${TARGET}_cpp tiledb_shared)
   target_include_directories(${TARGET}_cpp PUBLIC
-    "${CMAKE_BINARY_DIR}/examples/"
+    "${CMAKE_CURRENT_BINARY_DIR}/../"
   )
   add_dependencies(examples_cpp ${TARGET}_cpp)
 endfunction()
@@ -45,7 +45,7 @@ file(GLOB TILEDB_EXAMPLE_SOURCES_CPPAPI "*.cc")
 foreach(EXAMPLE_SOURCE ${TILEDB_EXAMPLE_SOURCES_CPPAPI})
   # Get the binary name
   string(REGEX
-    REPLACE "^${CMAKE_SOURCE_DIR}/examples/cpp_api/" ""
+    REPLACE "^${CMAKE_CURRENT_SOURCE_DIR}/" ""
     EXAMPLE_STRIPPED ${EXAMPLE_SOURCE}
   )
   string(REGEX

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,10 +32,10 @@ find_package(Catch_EP REQUIRED)
 option(TILEDB_TESTS_AWS_S3_CONFIG "Use an S3 config appropriate for AWS in tests" OFF)
 
 # Include TileDB core header directories
-set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_SOURCE_DIR}")
+set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 # Include the C API directory so that the C++ 'tiledb' file can directly
 # include "tiledb.h".
-list(APPEND TILEDB_CORE_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api")
+list(APPEND TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/c_api")
 
 # Gather the test source files
 set(TILEDB_TEST_SOURCES
@@ -121,7 +121,7 @@ target_compile_definitions(tiledb_unit PRIVATE -DTILEDB_CORE_OBJECTS_EXPORTS)
 add_test(
   NAME "tiledb_unit"
   COMMAND $<TARGET_FILE:tiledb_unit> --durations=yes
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 # Set the PATH on Windows so that the test executable can find the TBB library.

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -38,7 +38,7 @@ cmake_policy(SET CMP0063 NEW)
 ############################################################
 
 # The core header directory.
-set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_SOURCE_DIR}")
+set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 # List of API headers (to be installed)
 set(TILEDB_PUBLIC_HEADERS
@@ -129,9 +129,9 @@ set(TILEDB_CORE_SOURCES
 )
 
 # 'External' source files included in the source tree.
-set(TILEDB_EXTERNALS_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/external/include")
+set(TILEDB_EXTERNALS_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../external/include")
 set(TILEDB_EXTERNALS_SOURCES
-  ${CMAKE_SOURCE_DIR}/external/src/md5/md5.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/../external/src/md5/md5.cc
 )
 
 ############################################################


### PR DESCRIPTION
This converts all `CMAKE_SOURCE_DIR` to `CMAKE_CURRENT_SOURCE_DIR` and  `CMAKE_BINARY_DIR` to `CMAKE_CURRENT_BINARY_DIR`. This ensures the project builds correctly regardless if it is the top level cmake project or not.

If you'd like these two changes squashed into a single commit, as in #602 let me know.

Closes #597 