### PR TITLE
C++: remove reset_buffers, implicit map attributes, has_key, subarray partition

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,8 +40,8 @@
 * Added `tiledb_ctx_cancel_tasks` function.
 * Added `sm.number_of_threads` config parameter.
 * Added `sm.enable_signal_handlers` config parameter.
-* Added `tiledb_array_compute_subarray_partitions` for computing subarray partitions based on memory budget.
 * Added `tiledb_kv_has_key` to check if a key exists in the key-value store.
+* Added `tiledb_array_partition_subarray` for computing subarray partitions based on memory budget.
 
 ### C++ API
 * Support for trivially copyable objects, such as a custom data struct, was added. They will be backed by an `sizeof(T)` sized `char` attribute.
@@ -51,6 +51,10 @@
   which sets the tile extent to `NULL`.
 * Added `Query::finalize()` function.
 * Added `Context::cancel_tasks()` function.
+* `tiledb::Attribute` can now be constructed with an enumerated type (e.x. `TILEDB_CHAR`).
+* A `tiledb::Map` defined with only one attribute will allow implicit usage, e.x. `map[key] = val` instead of `map[key][attr] = val`.
+* Added `Array::partition_subarray` for computing subarray partitions based on memory budget.
+* Add `Map::has_key` to check for key presence.
 
 ## Breaking changes
 
@@ -73,6 +77,7 @@
 * Removed `Query::attribute_status`.
 * The API was made header only to improve cross-platform compatibility. `config_iter.h`, `filebuf.h`, `map_item.h`, `map_iter.h`, and `map_proxy.h` are no longer available, but grouped into the headers of the objects they support.
 * Previously a `tiledb::Map` could be created from a `std::map`, an anonymous attribute name was defined. This must now be explicitly defined: `tiledb::Map::create(tiledb::Context, std::string uri, std::map, std::string attr_name)`
+* Removed `tiledb::Query::reset_buffers`. Any previous usages can safely be removed.
 
 # TileDB v1.2.1 Release Notes
 

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -144,7 +144,7 @@ Array
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_compute_max_read_buffer_sizes
     :project: TileDB-C
-.. doxygenfunction:: tiledb_array_compute_subarray_partitions
+.. doxygenfunction:: tiledb_array_partition_subarray
     :project: TileDB-C
 
 Array Schema

--- a/examples/cpp_api/tiledb_dense_write_global_2.cc
+++ b/examples/cpp_api/tiledb_dense_write_global_2.cc
@@ -73,8 +73,7 @@ int main() {
   };
   // clang-format on
 
-  // Reset buffers
-  query.reset_buffers();
+  // Update buffers. Necessary if data pointer or length changes
   query.set_buffer("a1", a1_data);
   query.set_buffer("a2", a2_offsets, a2str);
   query.set_buffer("a3", a3_data);

--- a/examples/cpp_api/tiledb_sparse_write_global_2.cc
+++ b/examples/cpp_api/tiledb_sparse_write_global_2.cc
@@ -83,8 +83,6 @@ int main() {
   a3_buff.clear();
   coords_buff = {1, 4, 2, 3, 3, 1, 4, 2, 3, 3, 3, 4};
 
-  // Reset buffers
-  query.reset_buffers();
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_buff);
   query.set_buffer("a3", a3_buff);

--- a/examples/cpp_api/tiledb_sparse_write_unordered_2.cc
+++ b/examples/cpp_api/tiledb_sparse_write_unordered_2.cc
@@ -67,8 +67,6 @@ int main() {
   a3_buff = {6.1f, 6.2f, 4.1f, 4.2f, 3.1f, 3.2f, 1.1f, 1.2f, 2.1f, 2.2f};
   coords_buff = {3, 3, 3, 1, 2, 3, 1, 2, 1, 4};
 
-  // Reset buffers
-  query.reset_buffers();
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_buff_2);
   query.set_buffer("a3", a3_buff);

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -1936,7 +1936,7 @@ void DenseArrayFx::check_subarray_partitions_2_row(
   uint64_t subarray[] = {1, 4, 1, 4};
   void** subarray_partitions = nullptr;
   uint64_t npartitions;
-  int rc = tiledb_array_compute_subarray_partitions(
+  int rc = tiledb_array_partition_subarray(
       ctx_,
       array_name.c_str(),
       subarray,
@@ -1976,7 +1976,7 @@ void DenseArrayFx::check_subarray_partitions_2_col(
   uint64_t subarray[] = {1, 4, 1, 4};
   void** subarray_partitions = nullptr;
   uint64_t npartitions;
-  int rc = tiledb_array_compute_subarray_partitions(
+  int rc = tiledb_array_partition_subarray(
       ctx_,
       array_name.c_str(),
       subarray,
@@ -2015,7 +2015,7 @@ void DenseArrayFx::check_subarray_partitions_0(const std::string& array_name) {
   uint64_t subarray[] = {1, 4, 1, 4};
   void** subarray_partitions = nullptr;
   uint64_t npartitions;
-  int rc = tiledb_array_compute_subarray_partitions(
+  int rc = tiledb_array_partition_subarray(
       ctx_,
       array_name.c_str(),
       subarray,

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1853,7 +1853,7 @@ int tiledb_array_compute_max_read_buffer_sizes(
   return TILEDB_OK;
 }
 
-int tiledb_array_compute_subarray_partitions(
+int tiledb_array_partition_subarray(
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const void* subarray,

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -2156,7 +2156,7 @@ TILEDB_EXPORT int tiledb_array_compute_max_read_buffer_sizes(
  * uint64_t subarray[] = {11, 20, 11, 20};
  * uint64_t npartitions;
  * void** subarray_partitions;
- * tiledb_array_compute_subarray_partitions(
+ * tiledb_array_partition_subarray(
  *     ctx,
  *     "my_array",
  *     subarray,
@@ -2200,7 +2200,7 @@ TILEDB_EXPORT int tiledb_array_compute_max_read_buffer_sizes(
  *
  * @note The user is responsible for freeing `subarray_partitions`.
  */
-TILEDB_EXPORT int tiledb_array_compute_subarray_partitions(
+TILEDB_EXPORT int tiledb_array_partition_subarray(
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const void* subarray,


### PR DESCRIPTION
- Deprecate reset_buffers
- implicit single attribute map set/get
- untyped attribute constructors

fixes #614, #617