### PR TITLE
Only zero out reader buffer sizes if set.

### DIFF
--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -1587,8 +1587,10 @@ Status Reader::sparse_read() {
 
 void Reader::zero_out_buffer_sizes() {
   for (auto& attr_buffer : attr_buffers_) {
-    *(attr_buffer.second.buffer_size_) = 0;
-    *(attr_buffer.second.buffer_var_size_) = 0;
+    if (attr_buffer.second.buffer_size_ != nullptr)
+      *(attr_buffer.second.buffer_size_) = 0;
+    if (attr_buffer.second.buffer_var_size_ != nullptr)
+      *(attr_buffer.second.buffer_var_size_) = 0;
   }
 }
 


### PR DESCRIPTION
This fixes a segfault from when buffer_var_size_ is not set but it is dereferenced. A unit test is also added for the sequence to create this segfault.

Fixes #606 