### PR TITLE
Add support for Installing Import Targets for TileDB. #596

### DIFF
--- a/cmake/inputs/Config.cmake.in
+++ b/cmake/inputs/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -6,6 +6,46 @@ TileDB to build and link against, you will need to specify the correct paths for
 the ``tiledb/tiledb.h`` (C API) or ``tiledb/tiledb`` (C++ API) files and linking to the
 ``libtiledb`` shared library.
 
+CMake
+-----
+
+TileDB now includes support for CMake's find_package(). To use find_package(TileDB) TileDB
+must be installed globally or ``CMAKE_MODULE_PATH`` must be set to the installation directory.
+
+For example if TileDB was build with ``./boostrap`` and no prefix is given then the
+``</path/to/TileDB>/dist/lib/cmake`` will contain the ``TileDBConfig.cmake`` file used for
+``find_package(TileDB)``. Set your CMAKE_MODULE_PATH like
+``list(APPEND CMAKE_MODULE_PATH "</path/to/TileDB>/dist/lib/cmake")``
+
+The usage of ``find_package`` can also be used in super-build configurations. That is where
+dependencies are build via CMake's ExternalProject_ADD functionality.
+
+Below is example usage of how to link to TileDB in a cmake project::
+
+    # Find TileDB
+    find_package(TileDB REQUIRED)
+    # Link to shared library, this will set header include directories also
+    target_link_libraries(myExecutable TileDB::tiledb_shared)
+
+TileDB can also be linked against a static library::
+
+    # Find TileDB
+    find_package(TileDB REQUIRED)
+    # Link to shared library, this will set header include directories also
+    target_link_libraries(myExecutable TileDB::tiledb_static)
+
+If linking against the static library all required dependencies must be linked also.
+The ``TileDB::tiledb_static`` will error if the required dependencies do not exists.
+
+For example if you link to the static library and are missing LZ4, you will get the following error::
+
+    Target "myExecutable" links to target "LZ4::LZ4" but the target was not found.
+    Perhaps a find_package() call is missing for an IMPORTED target
+
+This can be solved by calling ``find_package(LZ4)`` or using the shared library
+as it has as dependencies linked in statically.
+
+
 macOS or Linux
 --------------
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,7 +94,7 @@ target_include_directories(
 
 target_link_libraries(tiledb_unit
   PUBLIC
-    tiledb_shared
+    tiledb_static
     Catch::Catch
 )
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -311,7 +311,14 @@ set_target_properties(tiledb_static
 
 # Link the dependencies specified earlier
 target_link_libraries(tiledb_shared
-  PUBLIC
+  PRIVATE
+  $<TARGET_PROPERTY:TILEDB_CORE_OBJECTS_ILIB,INTERFACE_LINK_LIBRARIES>
+)
+
+# Add INTERFACE_LINK_LIBRARIES for tiledb_static
+# this exports the required targets for usage of static library
+target_link_libraries(tiledb_static
+    PUBLIC
     $<TARGET_PROPERTY:TILEDB_CORE_OBJECTS_ILIB,INTERFACE_LINK_LIBRARIES>
 )
 
@@ -379,10 +386,53 @@ set_target_properties(tiledb_static
 # Get library directory for multiarch linux distros
 include(GNUInstallDirs)
 
+# Set name for export target file
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+
 install(
-    TARGETS tiledb_static tiledb_shared
+    TARGETS tiledb_static tiledb_shared TILEDB_CORE_OBJECTS_ILIB
+    EXPORT ${TARGETS_EXPORT_NAME}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tiledb
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+
+# Set directory where TileDBConfig.cmake will be installed
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+# Set the generated dir for target cmake modules during build
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+  "${TILEDB_CMAKE_INPUTS_DIR}/Config.cmake.in"
+  "${project_config}"
+  INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/TileDB/TileDBConfig.cmake
+#   * <prefix>/lib/cmake/TileDB/TileDBConfigVersion.cmake
+install(
+  FILES "${project_config}"# "${version_config}"
+  DESTINATION "${config_install_dir}"
+)
+
+# Targets
+#   * <prefix>/lib/cmake/TileDB/TileDBTargets.cmake
+install(
+  EXPORT "${TARGETS_EXPORT_NAME}"
+  NAMESPACE "${PROJECT_NAME}::"
+  DESTINATION "${config_install_dir}"
 )


### PR DESCRIPTION
This add support for installing cmake's TileDBConfig.cmake file for find_package(TileDB) support.

Changes include:

- tiledb_shared is now privately linked to dependencies to avoid setting the dependencies as required targets when importing tiledb_shared.
- tiledb_static now lists the interface_link_libraries so importing its target requires the dependent targets for linking.
- Unit tests switched to linked against tiledb_static to pull in the `INTERFACE_LINK_LIBRARIES`
- Documentation for usage was also updated with details and examples for find_package() usage.