### PR TITLE
Parallelize tile chunk compression and coordinate sorting.

### DIFF
--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -177,7 +177,7 @@ class GlobalCmp {
    * @return `true` if coordinates at `a` precedes coordinates at `b`,
    *     and `false` otherwise.
    */
-  bool operator()(uint64_t a, uint64_t b) {
+  bool operator()(uint64_t a, uint64_t b) const {
     // Get coordinates
     const T* coords_a = &buff_[a * dim_num_];
     const T* coords_b = &buff_[b * dim_num_];

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -333,7 +333,7 @@ const int version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
-const uint64_t tile_chunk_size = 64 * 1024;
+const uint64_t max_tile_chunk_size = 64 * 1024;
 
 /** The default attribute name prefix. */
 const char* default_attr_name = "__attr";

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -320,7 +320,7 @@ extern const char* null_str;
 extern const int version[3];
 
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
-extern const uint64_t tile_chunk_size;
+extern const uint64_t max_tile_chunk_size;
 
 /** The default attribute name prefix. */
 extern const char* default_attr_name;

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -33,6 +33,7 @@
 #include "tiledb/sm/query/writer.h"
 #include "tiledb/sm/misc/comparators.h"
 #include "tiledb/sm/misc/logger.h"
+#include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
@@ -1309,7 +1310,8 @@ Status Writer::sort_coords(std::vector<uint64_t>* cell_pos) const {
     (*cell_pos)[i] = i;
 
   // Sort the coordinates in global order
-  std::sort(cell_pos->begin(), cell_pos->end(), GlobalCmp<T>(domain, buffer));
+  parallel_sort(
+      cell_pos->begin(), cell_pos->end(), GlobalCmp<T>(domain, buffer));
 
   return Status::Ok();
 }

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -230,7 +230,7 @@ void Tile::split_coordinates() {
   uint64_t ptr = 0, ptr_tmp = 0;
 
   // Create a tile clone
-  auto tile_tmp = (char*)malloc(tile_size);
+  auto tile_tmp = (char*)std::malloc(tile_size);
   std::memcpy(tile_tmp, tile_c, tile_size);
 
   // Split coordinates
@@ -288,7 +288,7 @@ void Tile::zip_coordinates() {
   uint64_t ptr = 0, ptr_tmp = 0;
 
   // Create a tile clone
-  auto tile_tmp = (char*)malloc(tile_size);
+  auto tile_tmp = (char*)std::malloc(tile_size);
   std::memcpy(tile_tmp, tile_c, tile_size);
 
   // Zip coordinates

--- a/tiledb/sm/tile/tile_io.h
+++ b/tiledb/sm/tile/tile_io.h
@@ -215,6 +215,14 @@ class TileIO {
   /* ********************************* */
 
   /**
+   * Checks if the given number of bytes can be compressed in a single block.
+   *
+   * @param nbytes Number of bytes including overhead to check.
+   * @return True if the given number of bytes can be compressed
+   */
+  bool can_compress_nbytes(uint64_t nbytes) const;
+
+  /**
    * Compresses a tile. The compressed data are written in buffer_.
    * Note that a coordinates tile must be split into one tile per
    * dimension. In that case *compress_one_tile* will be invoked
@@ -237,16 +245,18 @@ class TileIO {
    * Computes necessary info for chunking a tile upon compression.
    *
    * @param tile The tile whose chunking info is being computed.
-   * @param chunk_num The number of chunks to compute.
-   * @param max_chunk_size The maximum chunk size to compute.
-   * @param overhead The total compression overhead.
+   * @param chunk_num The computed number of chunks.
+   * @param chunk_size The computed chunk size (a multiple of the cell size).
+   * @param chunk_overhead The compression overhead for `chunk_size` bytes.
+   * @param total_overhead The total compression overhead.
    * @return Status
    */
   Status compute_chunking_info(
       Tile* tile,
       uint64_t* chunk_num,
-      uint64_t* max_chunk_size,
-      uint64_t* overhead);
+      uint64_t* chunk_size,
+      uint64_t* chunk_overhead,
+      uint64_t* total_overhead);
 
   /**
    * Computes necessary info for decompressing chunks of a tile.


### PR DESCRIPTION
Parallelize compression over tile chunks. This adds a separate copy stage that concatenates (in parallel) the separately compressed chunks into a single buffer for writing. A future PR could remove that by adding the ability for VFS to write data from buffers with "gaps" (e.g. use the POSIX `writev` function), but that is not addressed here.

This also parallelizes coordinate sorting in `Writer` and fixes a small malloc bug.

These changes lead to about a 2x speedup on my LAS ingestion benchmark with 8 threads.