### PR TITLE
Clean up parallel SM and VFS config params.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 * Refactored global writes, making them simpler and more amenable to parallelization.
 * Added ability to cancel pending background/async tasks. SIGINT signals now cancel pending tasks.
 * Sparse read performance improvements with parallelism (using TBB as a dependency).
+* Async queries now use a configurable number of background threads (default number of threads is 1).
 
 ## Bug Fixes
 
@@ -35,10 +36,11 @@
 
 * Added `tiledb_query_finalize` function. 
 * Added `tiledb_vfs_get_config` function.
-* Added `vfs.max_parallel_ops` and `vfs.min_parallel_size` config parameters.
+* Added `vfs.num_threads` and `vfs.min_parallel_size` config parameters.
+* Added `vfs.{s3,file}.max_parallel_ops` config parameters.
 * Added `vfs.s3.multipart_part_size` config parameter.
 * Added `tiledb_ctx_cancel_tasks` function.
-* Added `sm.number_of_threads` config parameter.
+* Added `sm.num_async_threads` config parameter.
 * Added `sm.enable_signal_handlers` config parameter.
 * Added `tiledb_kv_has_key` to check if a key exists in the key-value store.
 * Added `tiledb_array_partition_subarray` for computing subarray partitions based on memory budget.

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -177,13 +177,17 @@ void check_save_to_file() {
   ss << "sm.array_schema_cache_size 10000000\n";
   ss << "sm.enable_signal_handlers true\n";
   ss << "sm.fragment_metadata_cache_size 10000000\n";
-  ss << "sm.number_of_threads " << std::thread::hardware_concurrency() << "\n";
+  ss << "sm.num_async_threads 1\n";
   ss << "sm.tile_cache_size 10000000\n";
-  ss << "vfs.max_parallel_ops " << std::thread::hardware_concurrency() << "\n";
+  ss << "vfs.file.max_parallel_ops " << std::thread::hardware_concurrency()
+     << "\n";
   ss << "vfs.min_parallel_size 10485760\n";
+  ss << "vfs.num_threads " << std::thread::hardware_concurrency() << "\n";
   ss << "vfs.s3.connect_max_tries 5\n";
   ss << "vfs.s3.connect_scale_factor 25\n";
   ss << "vfs.s3.connect_timeout_ms 3000\n";
+  ss << "vfs.s3.max_parallel_ops " << std::thread::hardware_concurrency()
+     << "\n";
   ss << "vfs.s3.multipart_part_size 5242880\n";
   ss << "vfs.s3.region us-east-1\n";
   ss << "vfs.s3.request_timeout_ms 3000\n";
@@ -337,15 +341,18 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.array_schema_cache_size"] = "1000";
   all_param_values["sm.fragment_metadata_cache_size"] = "10000000";
   all_param_values["sm.enable_signal_handlers"] = "true";
-  all_param_values["sm.number_of_threads"] =
-      std::to_string(std::thread::hardware_concurrency());
-  all_param_values["vfs.max_parallel_ops"] =
+  all_param_values["sm.num_async_threads"] = "1";
+  all_param_values["vfs.num_threads"] =
       std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.min_parallel_size"] = "10485760";
+  all_param_values["vfs.file.max_parallel_ops"] =
+      std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.s3.scheme"] = "https";
   all_param_values["vfs.s3.region"] = "us-east-1";
   all_param_values["vfs.s3.endpoint_override"] = "";
   all_param_values["vfs.s3.use_virtual_addressing"] = "true";
+  all_param_values["vfs.s3.max_parallel_ops"] =
+      std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.s3.multipart_part_size"] = "5242880";
   all_param_values["vfs.s3.connect_timeout_ms"] = "3000";
   all_param_values["vfs.s3.connect_max_tries"] = "5";
@@ -356,13 +363,17 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.hdfs.name_node_uri"] = "";
 
   std::map<std::string, std::string> vfs_param_values;
-  vfs_param_values["max_parallel_ops"] =
+  vfs_param_values["num_threads"] =
       std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["min_parallel_size"] = "10485760";
+  vfs_param_values["file.max_parallel_ops"] =
+      std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["s3.scheme"] = "https";
   vfs_param_values["s3.region"] = "us-east-1";
   vfs_param_values["s3.endpoint_override"] = "";
   vfs_param_values["s3.use_virtual_addressing"] = "true";
+  vfs_param_values["s3.max_parallel_ops"] =
+      std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["s3.multipart_part_size"] = "5242880";
   vfs_param_values["s3.connect_timeout_ms"] = "3000";
   vfs_param_values["s3.connect_max_tries"] = "5";
@@ -377,6 +388,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["region"] = "us-east-1";
   s3_param_values["endpoint_override"] = "";
   s3_param_values["use_virtual_addressing"] = "true";
+  s3_param_values["max_parallel_ops"] =
+      std::to_string(std::thread::hardware_concurrency());
   s3_param_values["multipart_part_size"] = "5242880";
   s3_param_values["connect_timeout_ms"] = "3000";
   s3_param_values["connect_max_tries"] = "5";

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -346,16 +346,22 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Whether or not TileDB will install signal handlers. <br>
  *    **Default**: true
  *    **Default**: 10,000,000
- * - `sm.number_of_threads` <br>
- *    The number of allocated threads per TileDB context. <br>
- *    **Default**: number of cores
- * - `vfs.max_parallel_ops` <br>
- *    The maximum number of VFS parallel operations. <br>
+ * - `sm.num_async_threads` <br>
+ *    The number of threads allocated for async queries. <br>
+ *    **Default**: 1
+ * - `vfs.num_threads` <br>
+ *    The number of threads allocated for VFS operations (any backend), per VFS
+ *    instance. <br>
  *    **Default**: number of cores
  * - `vfs.min_parallel_size` <br>
- *    The minimum number of bytes in a parallel VFS operation. (Does not
- *    affect parallel S3 writes.) <br>
+ *    The minimum number of bytes in a parallel VFS operation
+ *    (except parallel S3 writes, which are controlled by
+ *    `vfs.s3.multipart_part_size`.) <br>
  *    **Default**: 10MB
+ * - `vfs.file.max_parallel_ops` <br>
+ *    The maximum number of parallel operations on objects with `file:///`
+ *    URIs. <br>
+ *    **Default**: `vfs.num_threads`
  * - `vfs.s3.region` <br>
  *    The S3 region, if S3 is enabled. <br>
  *    **Default**: us-east-1
@@ -369,12 +375,15 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The S3 use of virtual addressing (`true` or `false`), if S3 is
  *    enabled. <br>
  *    **Default**: true
+ * - `vfs.s3.max_parallel_ops` <br>
+ *    The maximum number of S3 backend parallel operations. <br>
+ *    **Default**: `vfs.num_threads`
  * - `vfs.s3.multipart_part_size` <br>
- *    The part size (in bytes) used in S3 multipart writes, if S3 is enabled.
+ *    The part size (in bytes) used in S3 multipart writes.
  *    Any `uint64_t` value is acceptable. Note: `vfs.s3.multipart_part_size *
- *    vfs.max_parallel_ops` bytes will be buffered before issuing multipart
+ *    vfs.s3.max_parallel_ops` bytes will be buffered before issuing multipart
  *    uploads in parallel. <br>
- *    **Default**: 5*1024*1024
+ *    **Default**: 5MB
  * - `vfs.s3.connect_timeout_ms` <br>
  *    The connection timeout in ms. Any `long` value is acceptable. <br>
  *    **Default**: 3000

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -229,16 +229,22 @@ class Config {
    * - `sm.enable_signal_handlers` <br>
    *    Whether or not TileDB will install signal handlers. <br>
    *    **Default**: true
-   * - `sm.number_of_threads` <br>
-   *    The number of allocated threads per TileDB context. <br>
-   *    **Default**: number of cores
-   * - `vfs.max_parallel_ops` <br>
-   *    The maximum number of VFS parallel operations. <br>
+   * - `sm.num_async_threads` <br>
+   *    The number of threads allocated for async queries. <br>
+   *    **Default**: 1
+   * - `vfs.num_threads` <br>
+   *    The number of threads allocated for VFS operations (any backend), per
+   *    VFS instance. <br>
    *    **Default**: number of cores
    * - `vfs.min_parallel_size` <br>
-   *    The minimum number of bytes in a parallel VFS operation. (Does not
-   *    affect parallel S3 writes.) <br>
+   *    The minimum number of bytes in a parallel VFS operation
+   *    (except parallel S3 writes, which are controlled by
+   *    `vfs.s3.multipart_part_size`.) <br>
    *    **Default**: 10MB
+   * - `vfs.file.max_parallel_ops` <br>
+   *    The maximum number of parallel operations on objects with `file:///`
+   *    URIs. <br>
+   *    **Default**: `vfs.num_threads`
    * - `vfs.s3.region` <br>
    *    The S3 region, if S3 is enabled. <br>
    *    **Default**: us-east-1
@@ -252,12 +258,15 @@ class Config {
    *    The S3 use of virtual addressing (`true` or `false`), if S3 is
    *    enabled. <br>
    *    **Default**: true
+   * - `vfs.s3.max_parallel_ops` <br>
+   *    The maximum number of S3 backend parallel operations. <br>
+   *    **Default**: `vfs.num_threads`
    * - `vfs.s3.multipart_part_size` <br>
-   *    The part size (in bytes) used in S3 multipart writes, if S3 is enabled.
+   *    The part size (in bytes) used in S3 multipart writes.
    *    Any `uint64_t` value is acceptable. Note: `vfs.s3.multipart_part_size *
-   *    vfs.max_parallel_ops` bytes will be buffered before issuing multipart
+   *    vfs.s3.max_parallel_ops` bytes will be buffered before issuing multipart
    *    uploads in parallel. <br>
-   *    **Default**: 5*1024*1024
+   *    **Default**: 5MB
    * - `vfs.s3.connect_timeout_ms` <br>
    *    The connection timeout in ms. Any `long` value is acceptable. <br>
    *    **Default**: 3000

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -460,7 +460,7 @@ Status Posix::write(
   // bytes, and cap the number of parallel operations at the thread pool size.
   uint64_t num_ops = std::min(
       std::max(buffer_size / vfs_params_.min_parallel_size_, uint64_t(1)),
-      vfs_thread_pool_->num_threads());
+      vfs_params_.file_params_.max_parallel_ops_);
 
   if (num_ops == 1) {
     if (!write_at(fd, file_offset, buffer, buffer_size).ok()) {

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -92,6 +92,7 @@ class S3 {
       scheme_ = constants::s3_scheme;
       endpoint_override_ = constants::s3_endpoint_override;
       use_virtual_addressing_ = constants::s3_use_virtual_addressing;
+      max_parallel_ops_ = constants::s3_max_parallel_ops;
       multipart_part_size_ = constants::s3_multipart_part_size;
       request_timeout_ms_ = constants::s3_request_timeout_ms;
       connect_timeout_ms_ = constants::s3_connect_timeout_ms;
@@ -103,6 +104,7 @@ class S3 {
     std::string scheme_;
     std::string endpoint_override_;
     bool use_virtual_addressing_;
+    uint64_t max_parallel_ops_;
     uint64_t multipart_part_size_;
     long request_timeout_ms_;
     long connect_timeout_ms_;
@@ -365,6 +367,9 @@ class S3 {
 
   /** Protects multi-part upload data structures. */
   std::mutex multipart_upload_mtx_;
+
+  /** The maximum number of parallel operations issued. */
+  uint64_t max_parallel_ops_;
 
   /** The length of a non-terminal multipart part. */
   uint64_t multipart_part_size_;

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -380,6 +380,14 @@ class VFS {
    * @return Status
    */
   Status decr_lock_count(const URI& uri, bool* is_zero) const;
+
+  /**
+   * Return the backend-specific max number of parallel operations for VFS read.
+   *
+   * @param uri URI (used for determining the backend)
+   * @return Max number of parallel operations
+   */
+  uint64_t max_parallel_ops(const URI& uri) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -453,7 +453,7 @@ Status Win::write(
   // bytes, and cap the number of parallel operations at the thread pool size.
   uint64_t num_ops = std::min(
       std::max(buffer_size / vfs_params_.min_parallel_size_, uint64_t(1)),
-      vfs_thread_pool_->num_threads());
+      vfs_params_.file_params_.max_parallel_ops_);
 
   if (num_ops == 1) {
     if (!write_at(file_h, file_offset, buffer, buffer_size).ok()) {

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -176,11 +176,14 @@ const uint64_t consolidation_buffer_size = 50000000;
 /** The maximum number of bytes written in a single I/O. */
 const uint64_t max_write_bytes = std::numeric_limits<int>::max();
 
-/** The default maximum number of parallel VFS operations. */
-const uint64_t vfs_max_parallel_ops = std::thread::hardware_concurrency();
+/** The default number of allocated VFS threads. */
+const uint64_t vfs_num_threads = std::thread::hardware_concurrency();
 
 /** The default minimum number of bytes in a parallel VFS operation. */
 const uint64_t vfs_min_parallel_size = 10 * 1024 * 1024;
+
+/** The default maximum number of parallel file:/// operations. */
+const uint64_t vfs_file_max_parallel_ops = vfs_num_threads;
 
 /** The maximum name length. */
 const unsigned uri_max_len = 256;
@@ -211,8 +214,8 @@ const uint64_t fragment_metadata_cache_size = 10000000;
 /** Whether or not the signal handlers are installed. */
 const bool enable_signal_handlers = true;
 
-/** The number of threads allocated per StorageManager. */
-const uint64_t number_of_threads = std::thread::hardware_concurrency();
+/** The number of threads allocated per StorageManager for async queries. */
+const uint64_t num_async_threads = 1;
 
 /** The tile cache size. */
 const uint64_t tile_cache_size = 10000000;
@@ -402,6 +405,9 @@ const long s3_request_timeout_ms = 3000;
 
 /** S3 scheme (http for local minio, https for AWS S3). */
 const char* s3_scheme = "https";
+
+/** S3 max parallel operations. */
+const uint64_t s3_max_parallel_ops = vfs_num_threads;
 
 /** Size of parts used in the S3 multi-part uploads. */
 const uint64_t s3_multipart_part_size = 5 * 1024 * 1024;

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -166,11 +166,14 @@ extern const uint64_t consolidation_buffer_size;
 /** The maximum number of bytes written in a single I/O. */
 extern const uint64_t max_write_bytes;
 
-/** The default maximum number of parallel VFS operations. */
-extern const uint64_t vfs_max_parallel_ops;
+/** The default number of allocated VFS threads. */
+extern const uint64_t vfs_num_threads;
 
 /** The default minimum number of bytes in a parallel VFS operation. */
 extern const uint64_t vfs_min_parallel_size;
+
+/** The default maximum number of parallel file:/// operations. */
+extern const uint64_t vfs_file_max_parallel_ops;
 
 /** The maximum name length. */
 extern const unsigned uri_max_len;
@@ -199,8 +202,8 @@ extern const uint64_t fragment_metadata_cache_size;
 /** Whether or not the signal handlers are installed. */
 extern const bool enable_signal_handlers;
 
-/** The number of threads allocated per StorageManager. */
-extern const uint64_t number_of_threads;
+/** The number of threads allocated per StorageManager for async queries. */
+extern const uint64_t num_async_threads;
 
 /** The tile cache size. */
 extern const uint64_t tile_cache_size;
@@ -389,6 +392,9 @@ extern const long s3_request_timeout_ms;
 
 /** S3 scheme (http for local minio, https for AWS S3). */
 extern const char* s3_scheme;
+
+/** The default maximum number of parallel S3 operations. */
+extern const uint64_t s3_max_parallel_ops;
 
 /** Size of parts used in the S3 multi-part uploads. */
 extern const uint64_t s3_multipart_part_size;

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -631,8 +631,8 @@ class StorageManager {
   /** Guards queries_in_progress_ counter. */
   std::condition_variable queries_in_progress_cv_;
 
-  /** The storage manager's thread pool. */
-  std::unique_ptr<ThreadPool> thread_pool_;
+  /** The storage manager's thread pool for async queries. */
+  std::unique_ptr<ThreadPool> async_thread_pool_;
 
   /** A tile cache. */
   LRUCache* tile_cache_;


### PR DESCRIPTION
Changes:
- Rename `sm.number_of_threads` config param to `sm.num_async_threads` and set default to 1.
- Rename `vfs.max_parallel_ops` config param to `vfs.num_threads`.
- Add `vfs.{file,s3}.max_parallel_ops` config params, which all default to `vfs.num_threads`.
- Disable parallel VFS reads for HDFS URIs.

Closes #629.