### PR TITLE
Add S3 proxy params; allow bucket creation outside of us-east-1.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -35,6 +35,7 @@
 * Added `vfs.num_threads` and `vfs.min_parallel_size` config parameters.
 * Added `vfs.{s3,file}.max_parallel_ops` config parameters.
 * Added `vfs.s3.multipart_part_size` config parameter.
+* Added `vfs.s3.proxy_{scheme,host,port,username,password}` config parameters.
 * Added `tiledb_ctx_cancel_tasks` function.
 * Added `sm.num_async_threads`, `sm.num_tbb_threads`, and `sm.enable_signal_handlers` config parameters.
 * Added `tiledb_kv_has_key` to check if a key exists in the key-value store.

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -170,6 +170,11 @@ void check_save_to_file() {
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
 
+  // Check that password is not serialized.
+  rc = tiledb_config_set(config, "vfs.s3.proxy_password", "password", &error);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+
   rc = tiledb_config_save_to_file(config, "test_config.txt", &error);
   REQUIRE(rc == TILEDB_OK);
 
@@ -192,6 +197,8 @@ void check_save_to_file() {
   ss << "vfs.s3.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
   ss << "vfs.s3.multipart_part_size 5242880\n";
+  ss << "vfs.s3.proxy_port 0\n";
+  ss << "vfs.s3.proxy_scheme https\n";
   ss << "vfs.s3.region us-east-1\n";
   ss << "vfs.s3.request_timeout_ms 3000\n";
   ss << "vfs.s3.scheme https\n";
@@ -364,6 +371,11 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.s3.connect_max_tries"] = "5";
   all_param_values["vfs.s3.connect_scale_factor"] = "25";
   all_param_values["vfs.s3.request_timeout_ms"] = "3000";
+  all_param_values["vfs.s3.proxy_host"] = "";
+  all_param_values["vfs.s3.proxy_password"] = "";
+  all_param_values["vfs.s3.proxy_port"] = "0";
+  all_param_values["vfs.s3.proxy_scheme"] = "https";
+  all_param_values["vfs.s3.proxy_username"] = "";
   all_param_values["vfs.hdfs.username"] = "stavros";
   all_param_values["vfs.hdfs.kerb_ticket_cache_path"] = "";
   all_param_values["vfs.hdfs.name_node_uri"] = "";
@@ -385,6 +397,11 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.connect_max_tries"] = "5";
   vfs_param_values["s3.connect_scale_factor"] = "25";
   vfs_param_values["s3.request_timeout_ms"] = "3000";
+  vfs_param_values["s3.proxy_host"] = "";
+  vfs_param_values["s3.proxy_password"] = "";
+  vfs_param_values["s3.proxy_port"] = "0";
+  vfs_param_values["s3.proxy_scheme"] = "https";
+  vfs_param_values["s3.proxy_username"] = "";
   vfs_param_values["hdfs.username"] = "stavros";
   vfs_param_values["hdfs.kerb_ticket_cache_path"] = "";
   vfs_param_values["hdfs.name_node_uri"] = "";
@@ -401,6 +418,11 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["connect_max_tries"] = "5";
   s3_param_values["connect_scale_factor"] = "25";
   s3_param_values["request_timeout_ms"] = "3000";
+  s3_param_values["proxy_host"] = "";
+  s3_param_values["proxy_password"] = "";
+  s3_param_values["proxy_port"] = "0";
+  s3_param_values["proxy_scheme"] = "https";
+  s3_param_values["proxy_username"] = "";
 
   // Create an iterator and iterate over all parameters
   tiledb_config_iter_t* config_iter = nullptr;

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -413,6 +413,23 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.s3.request_timeout_ms` <br>
  *    The request timeout in ms. Any `long` value is acceptable. <br>
  *    **Default**: 3000
+ * - `vfs.s3.proxy_host` <br>
+ *    The proxy host. <br>
+ *    **Default**: ""
+ * - `vfs.s3.proxy_port` <br>
+ *    The proxy port. <br>
+ *    **Default**: 0
+ * - `vfs.s3.proxy_scheme` <br>
+ *    The proxy scheme. <br>
+ *    **Default**: "https"
+ * - `vfs.s3.proxy_username` <br>
+ *    The proxy username. Note: this parameter is not serialized by
+ *    `tiledb_config_save_to_file`. <br>
+ *    **Default**: ""
+ * - `vfs.s3.proxy_password` <br>
+ *    The proxy password. Note: this parameter is not serialized by
+ *    `tiledb_config_save_to_file`. <br>
+ *    **Default**: ""
  * - `vfs.hdfs.name_node"` <br>
  *    Name node for HDFS. <br>
  *    **Default**: ""

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -294,9 +294,27 @@ class Config {
    * - `vfs.s3.connect_scale_factor` <br>
    *    The scale factor for exponential backofff when connecting to S3.
    *    Any `long` value is acceptable. <br>
-   *    **Default**: 25   * - `vfs.s3.request_timeout_ms` <br>
+   *    **Default**: 25
+   * - `vfs.s3.request_timeout_ms` <br>
    *    The request timeout in ms. Any `long` value is acceptable. <br>
    *    **Default**: 3000
+   * - `vfs.s3.proxy_host` <br>
+   *    The proxy host. <br>
+   *    **Default**: ""
+   * - `vfs.s3.proxy_port` <br>
+   *    The proxy port. <br>
+   *    **Default**: 0
+   * - `vfs.s3.proxy_scheme` <br>
+   *    The proxy scheme. <br>
+   *    **Default**: "https"
+   * - `vfs.s3.proxy_username` <br>
+   *    The proxy username. Note: this parameter is not serialized by
+   *    `tiledb_config_save_to_file`. <br>
+   *    **Default**: ""
+   * - `vfs.s3.proxy_password` <br>
+   *    The proxy password. Note: this parameter is not serialized by
+   *    `tiledb_config_save_to_file`. <br>
+   *    **Default**: ""
    * - `vfs.hdfs.name_node"` <br>
    *    Name node for HDFS. <br>
    *    **Default**: ""

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -82,37 +82,6 @@ namespace sm {
 class S3 {
  public:
   /* ********************************* */
-  /*          TYPE DEFINITIONS         */
-  /* ********************************* */
-
-  /** S3 configuration parameters. */
-  struct S3Config {
-    S3Config() {
-      region_ = constants::s3_region;
-      scheme_ = constants::s3_scheme;
-      endpoint_override_ = constants::s3_endpoint_override;
-      use_virtual_addressing_ = constants::s3_use_virtual_addressing;
-      max_parallel_ops_ = constants::s3_max_parallel_ops;
-      multipart_part_size_ = constants::s3_multipart_part_size;
-      request_timeout_ms_ = constants::s3_request_timeout_ms;
-      connect_timeout_ms_ = constants::s3_connect_timeout_ms;
-      connect_max_tries_ = constants::s3_connect_max_tries;
-      connect_scale_factor_ = constants::s3_connect_scale_factor;
-    }
-
-    std::string region_;
-    std::string scheme_;
-    std::string endpoint_override_;
-    bool use_virtual_addressing_;
-    uint64_t max_parallel_ops_;
-    uint64_t multipart_part_size_;
-    long request_timeout_ms_;
-    long connect_timeout_ms_;
-    long connect_max_tries_;
-    long connect_scale_factor_;
-  };
-
-  /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
@@ -133,7 +102,7 @@ class S3 {
    * @param thread_pool The parent VFS thread pool.
    * @return Status
    */
-  Status init(const S3Config& s3_config, ThreadPool* thread_pool);
+  Status init(const Config::S3Params& s3_config, ThreadPool* thread_pool);
 
   /**
    * Creates a bucket.
@@ -376,6 +345,9 @@ class S3 {
 
   /** File buffers used in the multi-part uploads. */
   std::unordered_map<std::string, Buffer*> file_buffers_;
+
+  /** The AWS region this instance was initialized with. */
+  std::string region_;
 
   /** Pointer to thread pool owned by parent VFS instance. */
   ThreadPool* vfs_thread_pool_;

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -576,17 +576,7 @@ Status VFS::init(const Config::VFSParams& vfs_params) {
 #endif
 
 #ifdef HAVE_S3
-  S3::S3Config s3_config;
-  s3_config.region_ = vfs_params.s3_params_.region_;
-  s3_config.scheme_ = vfs_params.s3_params_.scheme_;
-  s3_config.endpoint_override_ = vfs_params.s3_params_.endpoint_override_;
-  s3_config.use_virtual_addressing_ =
-      vfs_params.s3_params_.use_virtual_addressing_;
-  s3_config.max_parallel_ops_ = vfs_params.s3_params_.max_parallel_ops_;
-  s3_config.multipart_part_size_ = vfs_params.s3_params_.multipart_part_size_;
-  s3_config.connect_timeout_ms_ = vfs_params.s3_params_.connect_timeout_ms_;
-  s3_config.request_timeout_ms_ = vfs_params.s3_params_.request_timeout_ms_;
-  RETURN_NOT_OK(s3_.init(s3_config, thread_pool_.get()));
+  RETURN_NOT_OK(s3_.init(vfs_params.s3_params_, thread_pool_.get()));
 #endif
 
 #ifdef WIN32

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -438,6 +438,21 @@ const char* s3_region = "us-east-1";
 /** S3 endpoint override. */
 const char* s3_endpoint_override = "";
 
+/** S3 proxy scheme. */
+const char* s3_proxy_scheme = "https";
+
+/** S3 proxy host. */
+const char* s3_proxy_host = "";
+
+/** S3 proxy port. */
+const unsigned s3_proxy_port = 0;
+
+/** S3 proxy username. */
+const char* s3_proxy_username = "";
+
+/** S3 proxy password. */
+const char* s3_proxy_password = "";
+
 /** HDFS default kerb ticket cache path. */
 const char* hdfs_kerb_ticket_cache_path = "";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -417,6 +417,21 @@ extern const char* s3_region;
 /** S3 endpoint override. */
 extern const char* s3_endpoint_override;
 
+/** S3 proxy scheme. */
+extern const char* s3_proxy_scheme;
+
+/** S3 proxy host. */
+extern const char* s3_proxy_host;
+
+/** S3 proxy port. */
+extern const unsigned s3_proxy_port;
+
+/** S3 proxy username. */
+extern const char* s3_proxy_username;
+
+/** S3 proxy password. */
+extern const char* s3_proxy_password;
+
 /** HDFS default kerb ticket cache path. */
 extern const char* hdfs_kerb_ticket_cache_path;
 

--- a/tiledb/sm/storage_manager/config.cc
+++ b/tiledb/sm/storage_manager/config.cc
@@ -48,6 +48,9 @@ namespace sm {
 
 const char Config::COMMENT_START = '#';
 
+const std::set<std::string> Config::unserialized_params_ = {
+    "vfs.s3.proxy_username", "vfs.s3.proxy_password"};
+
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
@@ -131,6 +134,8 @@ Status Config::save_to_file(const std::string& filename) {
     return LOG_STATUS(Status::ConfigError(msg.str()));
   }
   for (auto& pv : param_values_) {
+    if (unserialized_params_.count(pv.first) != 0)
+      continue;
     if (!pv.second.empty())
       ofs << pv.first << " " << pv.second << "\n";
   }
@@ -194,6 +199,16 @@ Status Config::set(const std::string& param, const std::string& value) {
     RETURN_NOT_OK(set_vfs_s3_connect_scale_factor(value));
   } else if (param == "vfs.s3.request_timeout_ms") {
     RETURN_NOT_OK(set_vfs_s3_request_timeout_ms(value));
+  } else if (param == "vfs.s3.proxy_scheme") {
+    RETURN_NOT_OK(set_vfs_s3_proxy_scheme(value));
+  } else if (param == "vfs.s3.proxy_host") {
+    RETURN_NOT_OK(set_vfs_s3_proxy_host(value));
+  } else if (param == "vfs.s3.proxy_port") {
+    RETURN_NOT_OK(set_vfs_s3_proxy_port(value));
+  } else if (param == "vfs.s3.proxy_username") {
+    RETURN_NOT_OK(set_vfs_s3_proxy_username(value));
+  } else if (param == "vfs.s3.proxy_password") {
+    RETURN_NOT_OK(set_vfs_s3_proxy_password(value));
   } else if (param == "vfs.hdfs.name_node") {
     RETURN_NOT_OK(set_vfs_hdfs_name_node(value));
   } else if (param == "vfs.hdfs.username") {
@@ -345,6 +360,31 @@ Status Config::unset(const std::string& param) {
     value << vfs_params_.s3_params_.request_timeout_ms_;
     param_values_["vfs.s3.request_timeout_ms"] = value.str();
     value.str(std::string());
+  } else if (param == "vfs.s3.proxy_scheme") {
+    vfs_params_.s3_params_.proxy_scheme_ = constants::s3_proxy_scheme;
+    value << vfs_params_.s3_params_.proxy_scheme_;
+    param_values_["vfs.s3.proxy_scheme"] = value.str();
+    value.str(std::string());
+  } else if (param == "vfs.s3.proxy_host") {
+    vfs_params_.s3_params_.proxy_host_ = constants::s3_proxy_host;
+    value << vfs_params_.s3_params_.proxy_host_;
+    param_values_["vfs.s3.proxy_host"] = value.str();
+    value.str(std::string());
+  } else if (param == "vfs.s3.proxy_port") {
+    vfs_params_.s3_params_.proxy_port_ = constants::s3_proxy_port;
+    value << vfs_params_.s3_params_.proxy_port_;
+    param_values_["vfs.s3.proxy_port"] = value.str();
+    value.str(std::string());
+  } else if (param == "vfs.s3.proxy_username") {
+    vfs_params_.s3_params_.proxy_username_ = constants::s3_proxy_username;
+    value << vfs_params_.s3_params_.proxy_username_;
+    param_values_["vfs.s3.proxy_username"] = value.str();
+    value.str(std::string());
+  } else if (param == "vfs.s3.proxy_password") {
+    vfs_params_.s3_params_.proxy_password_ = constants::s3_proxy_password;
+    value << vfs_params_.s3_params_.proxy_password_;
+    param_values_["vfs.s3.proxy_password"] = value.str();
+    value.str(std::string());
   } else if (param == "vfs.hdfs.name_node") {
     vfs_params_.hdfs_params_.name_node_uri_ = constants::hdfs_name_node_uri;
     value << vfs_params_.hdfs_params_.name_node_uri_;
@@ -456,6 +496,26 @@ void Config::set_default_param_values() {
 
   value << vfs_params_.s3_params_.request_timeout_ms_;
   param_values_["vfs.s3.request_timeout_ms"] = value.str();
+  value.str(std::string());
+
+  value << vfs_params_.s3_params_.proxy_scheme_;
+  param_values_["vfs.s3.proxy_scheme"] = value.str();
+  value.str(std::string());
+
+  value << vfs_params_.s3_params_.proxy_host_;
+  param_values_["vfs.s3.proxy_host"] = value.str();
+  value.str(std::string());
+
+  value << vfs_params_.s3_params_.proxy_port_;
+  param_values_["vfs.s3.proxy_port"] = value.str();
+  value.str(std::string());
+
+  value << vfs_params_.s3_params_.proxy_username_;
+  param_values_["vfs.s3.proxy_username"] = value.str();
+  value.str(std::string());
+
+  value << vfs_params_.s3_params_.proxy_password_;
+  param_values_["vfs.s3.proxy_password"] = value.str();
   value.str(std::string());
 
   value << vfs_params_.hdfs_params_.name_node_uri_;
@@ -646,6 +706,33 @@ Status Config::set_vfs_s3_request_timeout_ms(const std::string& value) {
   RETURN_NOT_OK(utils::parse::convert(value, &v));
   vfs_params_.s3_params_.request_timeout_ms_ = v;
 
+  return Status::Ok();
+}
+
+Status Config::set_vfs_s3_proxy_scheme(const std::string& value) {
+  vfs_params_.s3_params_.proxy_scheme_ = value;
+  return Status::Ok();
+}
+
+Status Config::set_vfs_s3_proxy_host(const std::string& value) {
+  vfs_params_.s3_params_.proxy_host_ = value;
+  return Status::Ok();
+}
+
+Status Config::set_vfs_s3_proxy_port(const std::string& value) {
+  uint64_t v;
+  RETURN_NOT_OK(utils::parse::convert(value, &v));
+  vfs_params_.s3_params_.proxy_port_ = static_cast<unsigned>(v);
+  return Status::Ok();
+}
+
+Status Config::set_vfs_s3_proxy_username(const std::string& value) {
+  vfs_params_.s3_params_.proxy_username_ = value;
+  return Status::Ok();
+}
+
+Status Config::set_vfs_s3_proxy_password(const std::string& value) {
+  vfs_params_.s3_params_.proxy_password_ = value;
   return Status::Ok();
 }
 

--- a/tiledb/sm/storage_manager/config.h
+++ b/tiledb/sm/storage_manager/config.h
@@ -37,6 +37,7 @@
 #include "tiledb/sm/misc/status.h"
 
 #include <map>
+#include <set>
 #include <thread>
 
 namespace tiledb {
@@ -83,6 +84,11 @@ class Config {
     long connect_max_tries_;
     long connect_scale_factor_;
     long request_timeout_ms_;
+    std::string proxy_scheme_;
+    std::string proxy_host_;
+    unsigned proxy_port_;
+    std::string proxy_username_;
+    std::string proxy_password_;
 
     S3Params() {
       region_ = constants::s3_region;
@@ -95,6 +101,11 @@ class Config {
       connect_max_tries_ = constants::s3_connect_max_tries;
       connect_scale_factor_ = constants::s3_connect_scale_factor;
       request_timeout_ms_ = constants::s3_request_timeout_ms;
+      proxy_scheme_ = constants::s3_proxy_scheme;
+      proxy_host_ = constants::s3_proxy_host;
+      proxy_port_ = constants::s3_proxy_port;
+      proxy_username_ = constants::s3_proxy_username;
+      proxy_password_ = constants::s3_proxy_password;
     }
   };
 
@@ -250,6 +261,23 @@ class Config {
    * - `vfs.s3.request_timeout_ms` <br>
    *    The request timeout in ms. Any `long` value is acceptable. <br>
    *    **Default**: 3000
+   * - `vfs.s3.proxy_host` <br>
+   *    The proxy host. <br>
+   *    **Default**: ""
+   * - `vfs.s3.proxy_port` <br>
+   *    The proxy port. <br>
+   *    **Default**: 0
+   * - `vfs.s3.proxy_scheme` <br>
+   *    The proxy scheme. <br>
+   *    **Default**: "https"
+   * - `vfs.s3.proxy_username` <br>
+   *    The proxy username. Note: this parameter is not serialized by
+   *    `tiledb_config_save_to_file`. <br>
+   *    **Default**: ""
+   * - `vfs.s3.proxy_password` <br>
+   *    The proxy password. Note: this parameter is not serialized by
+   *    `tiledb_config_save_to_file`. <br>
+   *    **Default**: ""
    * - `vfs.hdfs.name_node"` <br>
    *    Name node for HDFS. <br>
    *    **Default**: ""
@@ -300,6 +328,9 @@ class Config {
 
   /** Character indicating the start of a comment in a config file. */
   static const char COMMENT_START;
+
+  /** Set of parameter names that are not serialized to file. */
+  static const std::set<std::string> unserialized_params_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */
@@ -373,6 +404,21 @@ class Config {
 
   /** Sets the S3 request timeout in milliseconds. */
   Status set_vfs_s3_request_timeout_ms(const std::string& value);
+
+  /** Sets the S3 proxy scheme. */
+  Status set_vfs_s3_proxy_scheme(const std::string& value);
+
+  /** Sets the S3 proxy host. */
+  Status set_vfs_s3_proxy_host(const std::string& value);
+
+  /** Sets the S3 proxy port. */
+  Status set_vfs_s3_proxy_port(const std::string& value);
+
+  /** Sets the S3 proxy username. */
+  Status set_vfs_s3_proxy_username(const std::string& value);
+
+  /** Sets the S3 proxy password. */
+  Status set_vfs_s3_proxy_password(const std::string& value);
 
   /** Sets the HDFS namenode hostname and port (uri) */
   Status set_vfs_hdfs_name_node(const std::string& value);


### PR DESCRIPTION
Note that `vfs.s3.proxy_username` and `vfs.s3.proxy_password` are not serialized to file.

This also removes the redundant `S3::S3Config` struct.

Closes #524; closes #562.