### PR TITLE
Switch to UUIDs for fragment names instead of thread ids.

### DIFF
--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -59,10 +59,14 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindSpdlog_EP.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindZlib_EP.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindZstd_EP.cmake)
 
+if (NOT WIN32)
+  # Note: on Windows, AWS SDK uses builtin BCrypt.
+  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindOpenSSL_EP.cmake)
+endif()
+
 if (TILEDB_S3)
   if (NOT WIN32)
-    # AWS SDK uses builtin WinHTTP and BCrypt instead of these.
-    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindOpenSSL_EP.cmake)
+    # AWS SDK uses builtin WinHTTP instead of this.
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindCurl_EP.cmake)
   endif()
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindAWSSDK_EP.cmake)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-status.cc
   src/unit-threadpool.cc
   src/unit-uri.cc
+  src/unit-uuid.cc
   src/unit-win-filesystem.cc
   src/unit.cc
 )

--- a/test/src/unit-uuid.cc
+++ b/test/src/unit-uuid.cc
@@ -1,0 +1,78 @@
+/**
+ * @file   unit-uuid.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the UUID utility functions.
+ */
+
+#include <catch.hpp>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include "tiledb/sm/global_state/global_state.h"
+#include "tiledb/sm/misc/uuid.h"
+
+using namespace tiledb::sm;
+
+TEST_CASE("UUID: Test generate", "[uuid]") {
+  // Initialize global OpenSSL state if required.
+  REQUIRE(global_state::GlobalState::GetGlobalState().initialize(nullptr).ok());
+
+  SECTION("- Serial") {
+    std::string uuid0, uuid1, uuid2;
+    REQUIRE(uuid::generate_uuid(&uuid0).ok());
+    REQUIRE(uuid0.length() == 36);
+    REQUIRE(uuid::generate_uuid(&uuid1).ok());
+    REQUIRE(uuid1.length() == 36);
+    REQUIRE(uuid0 != uuid1);
+
+    REQUIRE(uuid::generate_uuid(&uuid2, false).ok());
+    REQUIRE(uuid2.length() == 32);
+  }
+
+  SECTION("- Threaded") {
+    const unsigned nthreads = 20;
+    std::vector<std::string> uuids(nthreads);
+    std::vector<std::thread> threads;
+    for (unsigned i = 0; i < nthreads; i++) {
+      threads.emplace_back([&uuids, i]() {
+        std::string& uuid = uuids[i];
+        REQUIRE(uuid::generate_uuid(&uuid).ok());
+        REQUIRE(uuid.length() == 36);
+      });
+    }
+    for (auto& t : threads) {
+      t.join();
+    }
+    // Check uniqueness
+    std::set<std::string> uuid_set;
+    uuid_set.insert(uuids.begin(), uuids.end());
+    REQUIRE(uuid_set.size() == uuids.size());
+  }
+}

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -102,6 +102,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/win.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/fragment/fragment_metadata.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/global_state.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/openssl_state.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/signal_handlers.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/watchdog.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv.cc
@@ -114,6 +115,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/thread_pool.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/uri.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/utils.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/uuid.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/win_constants.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/reader.cc
@@ -198,11 +200,15 @@ endif()
 # so we can use the targets created by the calls to find_package().
 add_library(TILEDB_CORE_OBJECTS_ILIB INTERFACE)
 
+# Find OpenSSL first in case it's needed for S3
+if (NOT WIN32)
+  find_package(OpenSSL_EP REQUIRED)
+endif()
+
 # S3 dependencies
 if (TILEDB_S3)
   message(STATUS "The TileDB library is compiled with S3 support.")
   find_package(Curl_EP REQUIRED)
-  find_package(OpenSSL_EP REQUIRED)
   find_package(AWSSDK_EP REQUIRED)
   target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
     INTERFACE
@@ -210,12 +216,10 @@ if (TILEDB_S3)
       AWSSDK::aws-cpp-sdk-core
   )
   if (NOT WIN32)
-    # No Curl or OpenSSL required on Windows.
+    # No Curl required on Windows.
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
       INTERFACE
         Curl::Curl
-        OpenSSL::SSL
-        OpenSSL::Crypto
     )
   endif()
   add_definitions(-DHAVE_S3)
@@ -281,6 +285,13 @@ target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
     Zlib::Zlib
     Zstd::Zstd
 )
+if (NOT WIN32)
+  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
+    INTERFACE
+      OpenSSL::SSL
+      OpenSSL::Crypto
+  )
+endif()
 
 # Copy over dependency info (e.g. include directories) to the core objects.
 target_compile_definitions(TILEDB_CORE_OBJECTS
@@ -324,7 +335,7 @@ target_link_libraries(tiledb_static
 
 # Windows linker configuration
 if (WIN32)
-  set(WIN32_LIBS shlwapi)
+  set(WIN32_LIBS shlwapi rpcrt4)
 
   if (TILEDB_S3)
     list(APPEND WIN32_LIBS bcrypt winhttp wininet userenv version)

--- a/tiledb/sm/global_state/openssl_state.h
+++ b/tiledb/sm/global_state/openssl_state.h
@@ -1,0 +1,53 @@
+/**
+ * @file   openssl_state.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file declares the OpenSSL state, if OpenSSL is present.
+ */
+
+#ifndef TILEDB_OPENSSL_STATE_H
+#define TILEDB_OPENSSL_STATE_H
+
+#include "tiledb/sm/misc/status.h"
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+/**
+ * Initializes any required state for the OpenSSL library.
+ *
+ * @return Status
+ */
+Status init_openssl();
+
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb
+
+#endif

--- a/tiledb/sm/misc/uuid.cc
+++ b/tiledb/sm/misc/uuid.cc
@@ -1,0 +1,176 @@
+/**
+ * @file   uuid.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a platform-independent UUID generator.
+ */
+
+#include <mutex>
+#include <vector>
+
+#include "tiledb/sm/misc/uuid.h"
+
+#ifdef _WIN32
+#include <Rpc.h>
+#else
+#include <openssl/err.h>
+#include <openssl/rand.h>
+#include <cstdio>
+#endif
+
+namespace tiledb {
+namespace sm {
+namespace uuid {
+
+/** Mutex to guard UUID generation. */
+static std::mutex uuid_mtx;
+
+#ifdef _WIN32
+
+/**
+ * Generate a UUID using Win32 RPC API.
+ */
+Status generate_uuid_win32(std::string* uuid_str) {
+  if (uuid_str == nullptr)
+    return Status::UtilsError("Null UUID string argument");
+
+  UUID uuid;
+  RPC_STATUS rc = UuidCreate(&uuid);
+  if (rc != RPC_S_OK)
+    return Status::UtilsError("Unable to generate Win32 UUID: creation error");
+
+  char* buf = nullptr;
+  rc = UuidToStringA(&uuid, reinterpret_cast<RPC_CSTR*>(&buf));
+  if (rc != RPC_S_OK)
+    return Status::UtilsError(
+        "Unable to generate Win32 UUID: string conversion error");
+
+  *uuid_str = std::string(buf);
+
+  rc = RpcStringFreeA(reinterpret_cast<RPC_CSTR*>(&buf));
+  if (rc != RPC_S_OK)
+    return Status::UtilsError("Unable to generate Win32 UUID: free error");
+
+  return Status::Ok();
+}
+
+#else
+
+/**
+ * Generate a UUID using OpenSSL.
+ *
+ * Initially from: https://gist.github.com/kvelakur/9069c9896577c3040030
+ * "Generating a Version 4 UUID using OpenSSL"
+ */
+Status generate_uuid_openssl(std::string* uuid_str) {
+  if (uuid_str == nullptr)
+    return Status::UtilsError("Null UUID string argument");
+
+  union {
+    struct {
+      uint32_t time_low;
+      uint16_t time_mid;
+      uint16_t time_hi_and_version;
+      uint8_t clk_seq_hi_res;
+      uint8_t clk_seq_low;
+      uint8_t node[6];
+    };
+    uint8_t __rnd[16];
+  } uuid;
+
+  int rc = RAND_bytes(uuid.__rnd, sizeof(uuid));
+  if (rc < 1) {
+    char err_msg[256];
+    ERR_error_string_n(ERR_get_error(), err_msg, sizeof(err_msg));
+    return Status::UtilsError(
+        "Cannot generate random bytes with OpenSSL: " + std::string(err_msg));
+  }
+
+  // Refer Section 4.2 of RFC-4122
+  // https://tools.ietf.org/html/rfc4122#section-4.2
+  uuid.clk_seq_hi_res = (uint8_t)((uuid.clk_seq_hi_res & 0x3F) | 0x80);
+  uuid.time_hi_and_version =
+      (uint16_t)((uuid.time_hi_and_version & 0x0FFF) | 0x4000);
+
+  // Format the UUID as a string.
+  char buf[128];
+  rc = snprintf(
+      buf,
+      sizeof(buf),
+      "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+      uuid.time_low,
+      uuid.time_mid,
+      uuid.time_hi_and_version,
+      uuid.clk_seq_hi_res,
+      uuid.clk_seq_low,
+      uuid.node[0],
+      uuid.node[1],
+      uuid.node[2],
+      uuid.node[3],
+      uuid.node[4],
+      uuid.node[5]);
+
+  if (rc < 0)
+    return Status::UtilsError("Error formatting UUID string");
+
+  *uuid_str = std::string(buf);
+
+  return Status::Ok();
+}
+
+#endif
+
+Status generate_uuid(std::string* uuid, bool hyphenate) {
+  if (uuid == nullptr)
+    return Status::UtilsError("Null UUID string argument");
+
+  std::string uuid_str;
+  {
+    // OpenSSL is not threadsafe, so grab a lock here. We are locking in the
+    // Windows case as well just to be careful.
+    std::unique_lock<std::mutex> lck(uuid_mtx);
+#ifdef _WIN32
+    RETURN_NOT_OK(generate_uuid_win32(&uuid_str));
+#else
+    RETURN_NOT_OK(generate_uuid_openssl(&uuid_str));
+#endif
+  }
+
+  uuid->clear();
+  for (unsigned i = 0; i < uuid_str.length(); i++) {
+    if (uuid_str[i] == '-' && !hyphenate)
+      continue;
+    uuid->push_back(uuid_str[i]);
+  }
+
+  return Status::Ok();
+}
+
+}  // namespace uuid
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/misc/uuid.h
+++ b/tiledb/sm/misc/uuid.h
@@ -1,0 +1,57 @@
+/**
+ * @file   uuid.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares a platform-independent UUID generator.
+ */
+
+#ifndef TILEDB_UUID_H
+#define TILEDB_UUID_H
+
+#include "tiledb/sm/misc/status.h"
+
+namespace tiledb {
+namespace sm {
+namespace uuid {
+
+/**
+ * Generates a 128-bit UUID. The string is formatted with hyphens like:
+ * 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx' where 'x' is a hexadecimal digit.
+ * Note: this function internally acquires a lock.
+ *
+ * @param uuid Output parameter which will store the UUID in string format.
+ * @param hyphenate If false, the UUID string will not be hyphenated.
+ * @return Status
+ */
+Status generate_uuid(std::string* uuid, bool hyphenate = true);
+
+}  // namespace uuid
+}  // namespace sm
+}  // namespace tiledb
+
+#endif

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -445,18 +445,18 @@ class Writer {
       std::vector<Tile>* tiles) const;
 
   /**
-   * Returns a new fragment name, which is in the form: <br>
-   * .__thread-id_timestamp. For instance,
-   *  __6426153_1458759561320
+   * Generates a new fragment name, which is in the form: <br>
+   * .__uuid_timestamp. For instance,
+   *  __6ba7b8129dad11d180b400c04fd430c8_1458759561320
    *
    * Note that this is a temporary name, initiated by a new write process.
    * After the new fragmemt is finalized, the array will change its name
    * by removing the leading '.' character.
    *
-   * @return A new special fragment name on success, or "" (empty string) on
-   *     error.
+   * @param frag_uri Will store the new special fragment name
+   * @return Status
    */
-  std::string new_fragment_name() const;
+  Status new_fragment_name(std::string* frag_uri) const;
 
   /**
    * Writes in an ordered layout (col- or row-major order). Applicable only


### PR DESCRIPTION
This (hopefully) addresses #593 by fixing the fragment name collision across MPI nodes.

OpenSSL is also now required on non-Windows platforms.