### PR TITLE
Convenience build fixes for ExternalProject users.

### DIFF
--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -92,18 +92,22 @@ ExternalProject_Add(tiledb
 )
 
 ############################################################
-# "make check" target
+# Convenience superbuild targets that invoke TileDB targets
 ############################################################
 
+# make install-tiledb
+add_custom_target(install-tiledb
+  COMMAND ${CMAKE_COMMAND} --build . --target install --config ${CMAKE_BUILD_TYPE}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tiledb
+)
+
+# make check
 add_custom_target(check
   COMMAND ${CMAKE_COMMAND} --build . --target check --config ${CMAKE_BUILD_TYPE}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tiledb
 )
 
-############################################################
-# "make examples" target
-############################################################
-
+# make examples
 add_custom_target(examples
   COMMAND ${CMAKE_COMMAND} --build . --target examples --config ${CMAKE_BUILD_TYPE}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tiledb

--- a/cmake/inputs/Config.cmake.in
+++ b/cmake/inputs/Config.cmake.in
@@ -1,4 +1,22 @@
+#
+# This file attempts to locate the TileDB library. If found, the following
+# imported targets are created:
+#   - TileDB::tiledb_shared
+#   - TileDB::tiledb_static
+# And the following variables are defined:
+#   - TILEDB_FOUND
+#   - TileDB_FOUND
+#
+
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")
+
+if (NOT DEFINED TILEDB_FOUND)
+  if (TARGET TileDB::tiledb_shared)
+    set(TILEDB_FOUND TRUE)
+  else()
+    set(TILEDB_FOUND FALSE)
+  endif()
+endif()


### PR DESCRIPTION
This adds a top-level install target so you can do `make install-tiledb` from the topmost build directory, and a more typical `TILEDB_FOUND` variable.