### PR TITLE
Implemented explicit opening/closing of arrays

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,8 +40,11 @@
 * Added `sm.num_async_threads`, `sm.num_tbb_threads`, and `sm.enable_signal_handlers` config parameters.
 * Added `tiledb_kv_has_key` to check if a key exists in the key-value store.
 * Added `tiledb_array_partition_subarray` for computing subarray partitions based on memory budget.
-* Added `tiledb_kv_iter_finalize`, which must be called before freeing the kv iterator.
 * Added `tiledb_kv_free`.
+* Added `tiledb_array_{open, close, free}`.
+* Added `tiledb_array_alloc`
+* Added `tiledb_kv_alloc`
+* Added `tiledb_kv_iter_alloc` which takes as input a kv object
 
 ### C++ API
 * Support for trivially copyable objects, such as a custom data struct, was added. They will be backed by an `sizeof(T)` sized `char` attribute.
@@ -55,8 +58,9 @@
 * A `tiledb::Map` defined with only one attribute will allow implicit usage, e.x. `map[key] = val` instead of `map[key][attr] = val`.
 * Added `Array::partition_subarray` for computing subarray partitions based on memory budget.
 * Added `Map::has_key` to check for key presence.
-* Added `Map::finalize`.
 * `MapIter` can be used to create iterators for a map.
+* Added `Array::{open, close}`
+* Added `Map::{open, close}`
 
 ## Breaking changes
 
@@ -70,6 +74,12 @@
 * All `tiledb_*_free` functions now return `void` and do not take `ctx` as input (except for `tiledb_ctx_free`).
 * Changed signature of `tiledb_kv_close` to take a `tiledb_kv_t*` argument instead of `tiledb_kv_t**`.
 * Renamed `tiledb_domain_get_rank` to `tiledb_domain_get_ndim` to avoid confusion with matrix def of rank.
+* Changed signature of `tiledb_array_get_non_empty_domain`.
+* Changed signature of `tiledb_array_partition_subarray`.
+* Changed signature of `tiledb_array_compute_max_read_buffer_sizes`.
+* Changed signature of `tiledb_{array,kv}_open`.
+* Removed `tiledb_kv_iter_create`
+* Renamed all C API functions that create TileDB objects from `tiledb_*_create` to `tiledb_*_alloc`.
 
 ### C++ API
 * Fixes with `Array::max_buffer_elements` and `Query::result_buffer_elements` to comply with the API docs. `pair.first` is the number of elements of the offsets buffer. If `pair.first` is 0, it is a fixed-sized attribute or coordinates.

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -83,7 +83,7 @@ Enumerations
 
 Context
 -------
-.. doxygenfunction:: tiledb_ctx_create
+.. doxygenfunction:: tiledb_ctx_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_ctx_free
     :project: TileDB-C
@@ -96,7 +96,7 @@ Context
 
 Config
 ------
-.. doxygenfunction:: tiledb_config_create
+.. doxygenfunction:: tiledb_config_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_config_free
     :project: TileDB-C
@@ -113,7 +113,7 @@ Config
 
 Config Iterator
 ---------------
-.. doxygenfunction:: tiledb_config_iter_create
+.. doxygenfunction:: tiledb_config_iter_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_config_iter_free
     :project: TileDB-C
@@ -136,6 +136,14 @@ Error
 
 Array
 -----
+.. doxygenfunction:: tiledb_array_alloc
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_open
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_close
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_free
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_array_create
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_consolidate
@@ -149,7 +157,7 @@ Array
 
 Array Schema
 ------------
-.. doxygenfunction:: tiledb_array_schema_create
+.. doxygenfunction:: tiledb_array_schema_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_schema_free
     :project: TileDB-C
@@ -194,7 +202,7 @@ Array Schema
 
 Attribute
 ---------
-.. doxygenfunction:: tiledb_attribute_create
+.. doxygenfunction:: tiledb_attribute_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_attribute_free
     :project: TileDB-C
@@ -215,7 +223,7 @@ Attribute
 
 Domain
 ------
-.. doxygenfunction:: tiledb_domain_create
+.. doxygenfunction:: tiledb_domain_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_domain_free
     :project: TileDB-C
@@ -234,7 +242,7 @@ Domain
 
 Dimension
 ---------
-.. doxygenfunction:: tiledb_dimension_create
+.. doxygenfunction:: tiledb_dimension_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_dimension_free
     :project: TileDB-C
@@ -251,7 +259,7 @@ Dimension
 
 Query
 -----
-.. doxygenfunction:: tiledb_query_create
+.. doxygenfunction:: tiledb_query_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_set_subarray
     :project: TileDB-C
@@ -277,6 +285,8 @@ Group
 
 Key-value
 ---------
+.. doxygenfunction:: tiledb_kv_alloc
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_create
     :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_consolidate
@@ -301,7 +311,7 @@ Key-value
 
 Key-value Schema
 ----------------
-.. doxygenfunction:: tiledb_kv_schema_create
+.. doxygenfunction:: tiledb_kv_schema_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_schema_free
     :project: TileDB-C
@@ -322,7 +332,7 @@ Key-value Schema
 
 Key-value Item
 --------------
-.. doxygenfunction:: tiledb_kv_item_create
+.. doxygenfunction:: tiledb_kv_item_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_item_free
     :project: TileDB-C
@@ -337,7 +347,7 @@ Key-value Item
 
 Key-value Iterator
 ------------------
-.. doxygenfunction:: tiledb_kv_iter_create
+.. doxygenfunction:: tiledb_kv_iter_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_iter_finalize
     :project: TileDB-C
@@ -365,7 +375,7 @@ Object Management
 
 VFS
 ---
-.. doxygenfunction:: tiledb_vfs_create
+.. doxygenfunction:: tiledb_vfs_alloc
     :project: TileDB-C
 .. doxygenfunction:: tiledb_vfs_free
     :project: TileDB-C

--- a/examples/c_api/tiledb_array_consolidate.c
+++ b/examples/c_api/tiledb_array_consolidate.c
@@ -65,7 +65,7 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Consolidate array
   tiledb_array_consolidate(ctx, "my_dense_array");

--- a/examples/c_api/tiledb_array_schema.c
+++ b/examples/c_api/tiledb_array_schema.c
@@ -121,11 +121,11 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  tiledb_array_schema_create(ctx, &array_schema, TILEDB_SPARSE);
+  tiledb_array_schema_alloc(ctx, &array_schema, TILEDB_SPARSE);
 
   // Print array schema contents
   printf("First dump:\n");
@@ -149,15 +149,15 @@ int main() {
   uint64_t d1_domain[] = {1, 1000};
   uint64_t d1_extent = 10;
   tiledb_dimension_t* d1;
-  tiledb_dimension_create(ctx, &d1, "", TILEDB_UINT64, d1_domain, &d1_extent);
+  tiledb_dimension_alloc(ctx, &d1, "", TILEDB_UINT64, d1_domain, &d1_extent);
   uint64_t d2_domain[] = {101, 10000};
   uint64_t d2_extent = 100;
   tiledb_dimension_t* d2;
-  tiledb_dimension_create(ctx, &d2, "d2", TILEDB_UINT64, d2_domain, &d2_extent);
+  tiledb_dimension_alloc(ctx, &d2, "d2", TILEDB_UINT64, d2_domain, &d2_extent);
 
   // Create and set domain
   tiledb_domain_t* domain;
-  tiledb_domain_create(ctx, &domain);
+  tiledb_domain_alloc(ctx, &domain);
   tiledb_domain_add_dimension(ctx, domain, d1);
   tiledb_domain_add_dimension(ctx, domain, d2);
   tiledb_array_schema_set_domain(ctx, array_schema, domain);
@@ -168,8 +168,8 @@ int main() {
   // compression level (`-1`). We make another printout to see how the
   // array schema contents got updated.
   tiledb_attribute_t *a1, *a2;
-  tiledb_attribute_create(ctx, &a1, "", TILEDB_INT32);
-  tiledb_attribute_create(ctx, &a2, "a2", TILEDB_FLOAT32);
+  tiledb_attribute_alloc(ctx, &a1, "", TILEDB_INT32);
+  tiledb_attribute_alloc(ctx, &a2, "a2", TILEDB_FLOAT32);
   tiledb_attribute_set_cell_val_num(ctx, a1, 3);
   tiledb_attribute_set_compressor(ctx, a2, TILEDB_GZIP, -1);
   tiledb_array_schema_add_attribute(ctx, array_schema, a1);

--- a/examples/c_api/tiledb_config.c
+++ b/examples/c_api/tiledb_config.c
@@ -68,11 +68,11 @@ int main() {
   // Create a TileDB config
   tiledb_config_t* config;
   tiledb_error_t* error = NULL;
-  tiledb_config_create(&config, &error);
+  tiledb_config_alloc(&config, &error);
 
   // Create a TileDB config iterator
   tiledb_config_iter_t* config_iter;
-  tiledb_config_iter_create(config, &config_iter, NULL, &error);
+  tiledb_config_iter_alloc(config, &config_iter, NULL, &error);
 
   // Upon creating a TileDB config (and before setting any values to the
   // config parameters), the config contains the default settings. We can
@@ -113,8 +113,8 @@ int main() {
   // Assign a config object to a context and VFS
   tiledb_ctx_t* ctx;
   tiledb_vfs_t* vfs;
-  tiledb_ctx_create(&ctx, config);
-  tiledb_vfs_create(ctx, &vfs, config);
+  tiledb_ctx_alloc(&ctx, config);
+  tiledb_vfs_alloc(ctx, &vfs, config);
 
   // Clean up
   tiledb_config_free(&config);

--- a/examples/c_api/tiledb_dense_create.c
+++ b/examples/c_api/tiledb_dense_create.c
@@ -45,41 +45,41 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create dimensions
   uint64_t dim_domain[] = {1, 4, 1, 4};
   uint64_t tile_extents[] = {2, 2};
   tiledb_dimension_t* d1;
-  tiledb_dimension_create(
+  tiledb_dimension_alloc(
       ctx, &d1, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0]);
   tiledb_dimension_t* d2;
-  tiledb_dimension_create(
+  tiledb_dimension_alloc(
       ctx, &d2, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1]);
 
   // Create domain
   tiledb_domain_t* domain;
-  tiledb_domain_create(ctx, &domain);
+  tiledb_domain_alloc(ctx, &domain);
   tiledb_domain_add_dimension(ctx, domain, d1);
   tiledb_domain_add_dimension(ctx, domain, d2);
 
   // Create attributes
   tiledb_attribute_t* a1;
-  tiledb_attribute_create(ctx, &a1, "a1", TILEDB_INT32);
+  tiledb_attribute_alloc(ctx, &a1, "a1", TILEDB_INT32);
   tiledb_attribute_set_compressor(ctx, a1, TILEDB_BLOSC_LZ, -1);
   tiledb_attribute_set_cell_val_num(ctx, a1, 1);
   tiledb_attribute_t* a2;
-  tiledb_attribute_create(ctx, &a2, "a2", TILEDB_CHAR);
+  tiledb_attribute_alloc(ctx, &a2, "a2", TILEDB_CHAR);
   tiledb_attribute_set_compressor(ctx, a2, TILEDB_GZIP, -1);
   tiledb_attribute_set_cell_val_num(ctx, a2, TILEDB_VAR_NUM);
   tiledb_attribute_t* a3;
-  tiledb_attribute_create(ctx, &a3, "a3", TILEDB_FLOAT32);
+  tiledb_attribute_alloc(ctx, &a3, "a3", TILEDB_FLOAT32);
   tiledb_attribute_set_compressor(ctx, a3, TILEDB_ZSTD, -1);
   tiledb_attribute_set_cell_val_num(ctx, a3, 2);
 
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  tiledb_array_schema_create(ctx, &array_schema, TILEDB_DENSE);
+  tiledb_array_schema_alloc(ctx, &array_schema, TILEDB_DENSE);
   tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
   tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
   tiledb_array_schema_set_domain(ctx, array_schema, domain);

--- a/examples/c_api/tiledb_dense_read_async.c
+++ b/examples/c_api/tiledb_dense_read_async.c
@@ -81,14 +81,19 @@ void print_upon_completion(void* s) {
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Calculate maximum buffer sizes for each attribute
   const char* attributes[] = {"a1", "a2", "a3"};
   uint64_t buffer_sizes[4];
   uint64_t subarray[] = {1, 4, 1, 4};
   tiledb_array_compute_max_read_buffer_sizes(
-      ctx, "my_dense_array", subarray, attributes, 3, &buffer_sizes[0]);
+      ctx, array, subarray, attributes, 3, &buffer_sizes[0]);
 
   // Prepare cell buffers
   int* buffer_a1 = malloc(buffer_sizes[0]);
@@ -99,7 +104,7 @@ int main() {
 
   // Create query
   tiledb_query_t* query;
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_READ);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
 
@@ -133,7 +138,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
   free(buffer_a1);

--- a/examples/c_api/tiledb_dense_read_global.c
+++ b/examples/c_api/tiledb_dense_read_global.c
@@ -75,12 +75,17 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Print non-empty domain
   int is_empty = 0;
   uint64_t domain[4];
-  tiledb_array_get_non_empty_domain(ctx, "my_dense_array", domain, &is_empty);
+  tiledb_array_get_non_empty_domain(ctx, array, domain, &is_empty);
   printf("Non-empty domain:\n");
   printf(
       "d1: (%llu, %llu)\n",
@@ -96,7 +101,7 @@ int main() {
   uint64_t buffer_sizes[4];
   uint64_t subarray[] = {1, 4, 1, 4};
   tiledb_array_compute_max_read_buffer_sizes(
-      ctx, "my_dense_array", subarray, attributes, 3, &buffer_sizes[0]);
+      ctx, array, subarray, attributes, 3, &buffer_sizes[0]);
   printf("Maximum buffer sizes:\n");
   printf("a1: %llu\n", (unsigned long long)buffer_sizes[0]);
   printf(
@@ -119,7 +124,7 @@ int main() {
   // for the query, which means that we wish to get all the array cells.
 
   tiledb_query_t* query;
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_READ);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
 
@@ -147,7 +152,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
   free(buffer_a1);

--- a/examples/c_api/tiledb_dense_read_ordered_subarray.c
+++ b/examples/c_api/tiledb_dense_read_ordered_subarray.c
@@ -66,14 +66,19 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Compute maximum buffer sizes for each attribute
   const char* attributes[] = {"a1", "a2", "a3"};
   uint64_t buffer_sizes[4];
   uint64_t subarray[] = {3, 4, 2, 4};
   tiledb_array_compute_max_read_buffer_sizes(
-      ctx, "my_dense_array", subarray, attributes, 3, &buffer_sizes[0]);
+      ctx, array, subarray, attributes, 3, &buffer_sizes[0]);
 
   // Prepare cell buffers
   int* buffer_a1 = malloc(buffer_sizes[0]);
@@ -84,7 +89,7 @@ int main() {
 
   // Create query
   tiledb_query_t* query;
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_READ);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
@@ -109,7 +114,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
   free(buffer_a1);

--- a/examples/c_api/tiledb_dense_read_subset_incomplete.c
+++ b/examples/c_api/tiledb_dense_read_subset_incomplete.c
@@ -67,7 +67,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers. Notice that this time we prepare a buffer only for
   // `a1` (as we will not be querying the rest of the attributes) and we assign
@@ -82,7 +87,7 @@ int main() {
   tiledb_query_t* query;
   const char* attributes[] = {"a1"};
   uint64_t subarray[] = {3, 4, 2, 4};
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_READ);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_COL_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_buffers(ctx, query, attributes, 1, buffers, buffer_sizes);
@@ -114,7 +119,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_dense_write_async.c
+++ b/examples/c_api/tiledb_dense_write_async.c
@@ -56,7 +56,7 @@ void print_upon_completion(void* s) {
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Set attributes
   const char* attributes[] = {"a1", "a2", "a3"};
@@ -92,9 +92,14 @@ int main() {
   };
   // clang-format on
 
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
+
   // Create query
   tiledb_query_t* query;
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
 
@@ -120,7 +125,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_dense_write_global_1.c
+++ b/examples/c_api/tiledb_dense_write_global_1.c
@@ -48,7 +48,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers. Recall that the user is responsible for populating
   // and providing her own buffers to TileDB. We need one buffer per
@@ -80,7 +85,7 @@ int main() {
   // domain.
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3"};
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
 
@@ -90,7 +95,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_dense_write_global_2.c
+++ b/examples/c_api/tiledb_dense_write_global_2.c
@@ -52,7 +52,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers - #1
   // This time, we populate the buffers with only some portion of the
@@ -72,7 +77,7 @@ int main() {
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3"};
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
 
@@ -111,7 +116,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_dense_write_global_subarray.c
+++ b/examples/c_api/tiledb_dense_write_global_subarray.c
@@ -49,7 +49,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers
   int buffer_a1[] = {112, 113, 114, 115};
@@ -68,7 +73,7 @@ int main() {
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3"};
   uint64_t subarray[] = {3, 4, 3, 4};
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
@@ -79,7 +84,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_dense_write_ordered_subarray.c
+++ b/examples/c_api/tiledb_dense_write_ordered_subarray.c
@@ -52,7 +52,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers
   int buffer_a1[] = {9, 12, 13, 11, 14, 15};
@@ -84,7 +89,7 @@ int main() {
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3"};
   uint64_t subarray[] = {3, 4, 2, 4};
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
@@ -95,7 +100,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_dense_write_unordered.c
+++ b/examples/c_api/tiledb_dense_write_unordered.c
@@ -49,7 +49,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_dense_array", &array);
+  tiledb_array_open(ctx, array);
 
   // We prepare buffers to write 4 cells on all three attributes. Observe
   // that now we need to prepare an extra buffer to specify the coordinates
@@ -75,7 +80,7 @@ int main() {
   // we are writing random cells.
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  tiledb_query_create(ctx, &query, "my_dense_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
 
@@ -85,7 +90,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_error.c
+++ b/examples/c_api/tiledb_error.c
@@ -52,7 +52,7 @@ void print_error(tiledb_ctx_t* ctx);
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create a group. The code below creates a group `my_group` and prints a
   // message because (normally) it will succeed.

--- a/examples/c_api/tiledb_group_create.c
+++ b/examples/c_api/tiledb_group_create.c
@@ -56,7 +56,7 @@
 int main() {
   // Create context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create a group
   tiledb_group_create(ctx, "my_group");

--- a/examples/c_api/tiledb_kv_create.c
+++ b/examples/c_api/tiledb_kv_create.c
@@ -99,26 +99,26 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create attributes
   tiledb_attribute_t* a1;
-  tiledb_attribute_create(ctx, &a1, "a1", TILEDB_INT32);
+  tiledb_attribute_alloc(ctx, &a1, "a1", TILEDB_INT32);
   tiledb_attribute_set_compressor(ctx, a1, TILEDB_BLOSC_LZ, -1);
   tiledb_attribute_set_cell_val_num(ctx, a1, 1);
   tiledb_attribute_t* a2;
-  tiledb_attribute_create(ctx, &a2, "a2", TILEDB_CHAR);
+  tiledb_attribute_alloc(ctx, &a2, "a2", TILEDB_CHAR);
   tiledb_attribute_set_compressor(ctx, a2, TILEDB_GZIP, -1);
   tiledb_attribute_set_cell_val_num(ctx, a2, TILEDB_VAR_NUM);
   tiledb_attribute_t* a3;
-  tiledb_attribute_create(ctx, &a3, "a3", TILEDB_FLOAT32);
+  tiledb_attribute_alloc(ctx, &a3, "a3", TILEDB_FLOAT32);
   tiledb_attribute_set_compressor(ctx, a3, TILEDB_ZSTD, -1);
   tiledb_attribute_set_cell_val_num(ctx, a3, 2);
 
   // Create kv schema
   const char* kv_uri = "my_kv";
   tiledb_kv_schema_t* kv_schema;
-  tiledb_kv_schema_create(ctx, &kv_schema);
+  tiledb_kv_schema_alloc(ctx, &kv_schema);
   tiledb_kv_schema_add_attribute(ctx, kv_schema, a1);
   tiledb_kv_schema_add_attribute(ctx, kv_schema, a2);
   tiledb_kv_schema_add_attribute(ctx, kv_schema, a3);

--- a/examples/c_api/tiledb_kv_iter.c
+++ b/examples/c_api/tiledb_kv_iter.c
@@ -67,12 +67,19 @@ void print(const void* v, tiledb_datatype_t type, uint64_t size);
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create key-value iterator
   const char* attributes[] = {"a1", "a2", "a3"};
+
+  // Open a kv
+  tiledb_kv_t* kv;
+  tiledb_kv_alloc(ctx, "my_kv", &kv);
+  tiledb_kv_open(ctx, kv, attributes, 3);
+
+  // Create a kv iterator
   tiledb_kv_iter_t* kv_iter;
-  tiledb_kv_iter_create(ctx, &kv_iter, "my_kv", attributes, 3);
+  tiledb_kv_iter_alloc(ctx, kv, &kv_iter);
 
   int done;
   tiledb_kv_iter_done(ctx, kv_iter, &done);
@@ -85,10 +92,11 @@ int main() {
     tiledb_kv_iter_done(ctx, kv_iter, &done);
   }
 
-  // Finalize
-  tiledb_kv_iter_finalize(ctx, kv_iter);
+  // Close the kv
+  tiledb_kv_close(ctx, kv);
 
   // Clean up
+  tiledb_kv_free(&kv);
   tiledb_kv_iter_free(&kv_iter);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_kv_read.c
+++ b/examples/c_api/tiledb_kv_read.c
@@ -49,11 +49,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Open a key-value store
   tiledb_kv_t* kv;
-  tiledb_kv_open(ctx, &kv, "my_kv", NULL, 0);
+  tiledb_kv_alloc(ctx, "my_kv", &kv);
+  tiledb_kv_open(ctx, kv, NULL, 0);
 
   // Get key-value item
   int key = 100;

--- a/examples/c_api/tiledb_kv_write.c
+++ b/examples/c_api/tiledb_kv_write.c
@@ -41,7 +41,7 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // We first create some key-value items. Note that at this point these
   // are independent of the key-value store they will be inserted into.
@@ -54,7 +54,7 @@ int main() {
   const char* key1_a2 = "a";
   float key1_a3[] = {1.1f, 1.2f};
   tiledb_kv_item_t* kv_item1;
-  tiledb_kv_item_create(ctx, &kv_item1);
+  tiledb_kv_item_alloc(ctx, &kv_item1);
   tiledb_kv_item_set_key(ctx, kv_item1, &key1, TILEDB_INT32, sizeof(key1));
   tiledb_kv_item_set_value(
       ctx, kv_item1, "a1", &key1_a1, TILEDB_INT32, sizeof(key1_a1));
@@ -69,7 +69,7 @@ int main() {
   const char* key2_a2 = "bb";
   float key2_a3[] = {2.1f, 2.2f};
   tiledb_kv_item_t* kv_item2;
-  tiledb_kv_item_create(ctx, &kv_item2);
+  tiledb_kv_item_alloc(ctx, &kv_item2);
   tiledb_kv_item_set_key(ctx, kv_item2, &key2, TILEDB_FLOAT32, sizeof(key2));
   tiledb_kv_item_set_value(
       ctx, kv_item2, "a1", &key2_a1, TILEDB_INT32, sizeof(key2_a1));
@@ -84,7 +84,7 @@ int main() {
   const char* key3_a2 = "ccc";
   float key3_a3[] = {3.1f, 3.2f};
   tiledb_kv_item_t* kv_item3;
-  tiledb_kv_item_create(ctx, &kv_item3);
+  tiledb_kv_item_alloc(ctx, &kv_item3);
   tiledb_kv_item_set_key(ctx, kv_item3, &key3, TILEDB_FLOAT64, sizeof(key3));
   tiledb_kv_item_set_value(
       ctx, kv_item3, "a1", &key3_a1, TILEDB_INT32, sizeof(key3_a1));
@@ -99,7 +99,7 @@ int main() {
   const char* key4_a2 = "dddd";
   float key4_a3[] = {4.1f, 4.2f};
   tiledb_kv_item_t* kv_item4;
-  tiledb_kv_item_create(ctx, &kv_item4);
+  tiledb_kv_item_alloc(ctx, &kv_item4);
   tiledb_kv_item_set_key(ctx, kv_item4, &key4, TILEDB_CHAR, strlen(key4));
   tiledb_kv_item_set_value(
       ctx, kv_item4, "a1", &key4_a1, TILEDB_INT32, sizeof(key4_a1));
@@ -110,7 +110,8 @@ int main() {
 
   // Open the key-value store
   tiledb_kv_t* kv;
-  tiledb_kv_open(ctx, &kv, "my_kv", NULL, 0);
+  tiledb_kv_alloc(ctx, "my_kv", &kv);
+  tiledb_kv_open(ctx, kv, NULL, 0);
 
   // We add items to a key-value store in the code snippets below. Note that
   // when an item is added to the key-value store, it is only buffered in

--- a/examples/c_api/tiledb_object_ls_walk.c
+++ b/examples/c_api/tiledb_object_ls_walk.c
@@ -119,7 +119,7 @@ int print_path(const char* path, tiledb_object_t type, void* data);
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // List children
   printf("List children:\n");

--- a/examples/c_api/tiledb_object_move.c
+++ b/examples/c_api/tiledb_object_move.c
@@ -73,7 +73,7 @@
 int main() {
   // Create context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Rename a valid group and array
   tiledb_object_move(ctx, "my_group", "my_group_2");

--- a/examples/c_api/tiledb_object_remove.c
+++ b/examples/c_api/tiledb_object_remove.c
@@ -60,7 +60,7 @@
 int main() {
   // Create context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Delete a valid group and array
   tiledb_object_remove(ctx, "my_group");

--- a/examples/c_api/tiledb_object_type.c
+++ b/examples/c_api/tiledb_object_type.c
@@ -58,7 +58,7 @@ void print_object_type(tiledb_object_t type);
 int main() {
   // Create context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Get object type for group
   tiledb_object_t type;

--- a/examples/c_api/tiledb_sparse_create.c
+++ b/examples/c_api/tiledb_sparse_create.c
@@ -41,22 +41,22 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create two dimensions with names `d1` and `d2`. They both have type
   // `uint64`, domain `[1,4]` and tile extent `2`.
   uint64_t dim_domain[] = {1, 4, 1, 4};
   uint64_t tile_extents[] = {2, 2};
   tiledb_dimension_t* d1;
-  tiledb_dimension_create(
+  tiledb_dimension_alloc(
       ctx, &d1, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0]);
   tiledb_dimension_t* d2;
-  tiledb_dimension_create(
+  tiledb_dimension_alloc(
       ctx, &d2, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1]);
 
   // Create domain
   tiledb_domain_t* domain;
-  tiledb_domain_create(ctx, &domain);
+  tiledb_domain_alloc(ctx, &domain);
   tiledb_domain_add_dimension(ctx, domain, d1);
   tiledb_domain_add_dimension(ctx, domain, d2);
 
@@ -67,15 +67,15 @@ int main() {
   // compression levels are set to `-1`, which implies the default level for
   // each compressor.
   tiledb_attribute_t* a1;
-  tiledb_attribute_create(ctx, &a1, "a1", TILEDB_INT32);
+  tiledb_attribute_alloc(ctx, &a1, "a1", TILEDB_INT32);
   tiledb_attribute_set_compressor(ctx, a1, TILEDB_BLOSC_LZ, -1);
   tiledb_attribute_set_cell_val_num(ctx, a1, 1);
   tiledb_attribute_t* a2;
-  tiledb_attribute_create(ctx, &a2, "a2", TILEDB_CHAR);
+  tiledb_attribute_alloc(ctx, &a2, "a2", TILEDB_CHAR);
   tiledb_attribute_set_compressor(ctx, a2, TILEDB_GZIP, -1);
   tiledb_attribute_set_cell_val_num(ctx, a2, TILEDB_VAR_NUM);
   tiledb_attribute_t* a3;
-  tiledb_attribute_create(ctx, &a3, "a3", TILEDB_FLOAT32);
+  tiledb_attribute_alloc(ctx, &a3, "a3", TILEDB_FLOAT32);
   tiledb_attribute_set_compressor(ctx, a3, TILEDB_ZSTD, -1);
   tiledb_attribute_set_cell_val_num(ctx, a3, 2);
 
@@ -83,7 +83,7 @@ int main() {
   // and the cell and tile order to `row-major`. We set the data tile capacity
   // to `2`. We also assign the array domain and attributes we created above.
   tiledb_array_schema_t* array_schema;
-  tiledb_array_schema_create(ctx, &array_schema, TILEDB_SPARSE);
+  tiledb_array_schema_alloc(ctx, &array_schema, TILEDB_SPARSE);
   tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
   tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
   tiledb_array_schema_set_capacity(ctx, array_schema, 2);

--- a/examples/c_api/tiledb_sparse_read_global.c
+++ b/examples/c_api/tiledb_sparse_read_global.c
@@ -70,12 +70,17 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_sparse_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Print non-empty domain
   int is_empty = 0;
   uint64_t domain[4];
-  tiledb_array_get_non_empty_domain(ctx, "my_sparse_array", domain, &is_empty);
+  tiledb_array_get_non_empty_domain(ctx, array, domain, &is_empty);
   printf("Non-empty domain:\n");
   printf(
       "d1: (%llu, %llu)\n",
@@ -91,7 +96,7 @@ int main() {
   uint64_t buffer_sizes[5];
   uint64_t subarray[] = {1, 4, 1, 4};
   tiledb_array_compute_max_read_buffer_sizes(
-      ctx, "my_sparse_array", subarray, attributes, 4, &buffer_sizes[0]);
+      ctx, array, subarray, attributes, 4, &buffer_sizes[0]);
   printf("Maximum buffer sizes:\n");
   printf("a1: %llu\n", (unsigned long long)buffer_sizes[0]);
   printf(
@@ -115,7 +120,7 @@ int main() {
   // for the query, which means that we wish to get all the array cells.
   tiledb_query_t* query;
 
-  tiledb_query_create(ctx, &query, "my_sparse_array", TILEDB_READ);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
 
@@ -143,7 +148,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
   free(buffer_a1);

--- a/examples/c_api/tiledb_sparse_read_ordered_subarray.c
+++ b/examples/c_api/tiledb_sparse_read_ordered_subarray.c
@@ -64,14 +64,19 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_sparse_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Calculate maximum buffer sizes for each attribute
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   uint64_t buffer_sizes[5];
   uint64_t subarray[] = {3, 4, 2, 4};
   tiledb_array_compute_max_read_buffer_sizes(
-      ctx, "my_sparse_array", subarray, attributes, 4, &buffer_sizes[0]);
+      ctx, array, subarray, attributes, 4, &buffer_sizes[0]);
 
   // Prepare cell buffers
   int* buffer_a1 = malloc(buffer_sizes[0]);
@@ -87,7 +92,7 @@ int main() {
   // of `subarray` is `uint64`, i.e., the same as the dimension domains
   // specified upon creation of the array.
   tiledb_query_t* query;
-  tiledb_query_create(ctx, &query, "my_sparse_array", TILEDB_READ);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
@@ -116,7 +121,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
   free(buffer_a1);

--- a/examples/c_api/tiledb_sparse_read_subset.c
+++ b/examples/c_api/tiledb_sparse_read_subset.c
@@ -59,7 +59,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_sparse_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers. Notice that this time we prepare a buffer only for
   // `a1` (as we will not be querying the rest of the attributes) and we assign
@@ -74,7 +79,7 @@ int main() {
   tiledb_query_t* query;
   const char* attributes[] = {"a1"};
   uint64_t subarray[] = {3, 4, 2, 4};
-  tiledb_query_create(ctx, &query, "my_sparse_array", TILEDB_READ);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_COL_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_buffers(ctx, query, attributes, 1, buffers, buffer_sizes);
@@ -89,7 +94,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_sparse_write_global_1.c
+++ b/examples/c_api/tiledb_sparse_write_global_1.c
@@ -48,7 +48,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_sparse_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers. Recall that the user is responsible for populating
   // and providing her own buffers to TileDB. We need one buffer per
@@ -91,7 +96,7 @@ int main() {
   // query tells TileDB that we are writing in the entire domain.
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  tiledb_query_create(ctx, &query, "my_sparse_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
 
@@ -101,7 +106,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_sparse_write_global_2.c
+++ b/examples/c_api/tiledb_sparse_write_global_2.c
@@ -49,7 +49,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_sparse_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers - #1
   int buffer_a1[] = {0, 1, 2};
@@ -84,7 +89,7 @@ int main() {
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  tiledb_query_create(ctx, &query, "my_sparse_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
 
@@ -111,7 +116,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_sparse_write_unordered_1.c
+++ b/examples/c_api/tiledb_sparse_write_unordered_1.c
@@ -47,7 +47,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_sparse_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers
   int buffer_a1[] = {7, 5, 0, 6, 4, 3, 1, 2};
@@ -83,7 +88,7 @@ int main() {
   // layout to `TILEDB_UNORDERED`.
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  tiledb_query_create(ctx, &query, "my_sparse_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
 
@@ -93,7 +98,11 @@ int main() {
   // Finalize query
   tiledb_query_finalize(ctx, query);
 
+  // Close array
+  tiledb_array_close(ctx, array);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_sparse_write_unordered_2.c
+++ b/examples/c_api/tiledb_sparse_write_unordered_2.c
@@ -49,7 +49,12 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
+
+  // Open array
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, "my_sparse_array", &array);
+  tiledb_array_open(ctx, array);
 
   // Prepare cell buffers - #1
   int buffer_a1[] = {7, 5, 0};
@@ -69,7 +74,7 @@ int main() {
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  tiledb_query_create(ctx, &query, "my_sparse_array", TILEDB_WRITE);
+  tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
 
@@ -102,6 +107,7 @@ int main() {
   tiledb_query_finalize(ctx, query);
 
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
 

--- a/examples/c_api/tiledb_vfs.c
+++ b/examples/c_api/tiledb_vfs.c
@@ -46,11 +46,11 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create TileDB VFS
   tiledb_vfs_t* vfs;
-  tiledb_vfs_create(ctx, &vfs, NULL);
+  tiledb_vfs_alloc(ctx, &vfs, NULL);
 
   // Create directory
   int is_dir = 0;

--- a/examples/c_api/tiledb_vfs_read.c
+++ b/examples/c_api/tiledb_vfs_read.c
@@ -45,11 +45,11 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create TileDB VFS
   tiledb_vfs_t* vfs;
-  tiledb_vfs_create(ctx, &vfs, NULL);
+  tiledb_vfs_alloc(ctx, &vfs, NULL);
 
   // Read binary data
   tiledb_vfs_fh_t* fh;

--- a/examples/c_api/tiledb_vfs_write.c
+++ b/examples/c_api/tiledb_vfs_write.c
@@ -43,11 +43,11 @@
 int main() {
   // Create TileDB context
   tiledb_ctx_t* ctx;
-  tiledb_ctx_create(&ctx, NULL);
+  tiledb_ctx_alloc(&ctx, NULL);
 
   // Create TileDB VFS
   tiledb_vfs_t* vfs;
-  tiledb_vfs_create(ctx, &vfs, NULL);
+  tiledb_vfs_alloc(ctx, &vfs, NULL);
 
   // Write binary data
   tiledb_vfs_fh_t* fh;

--- a/examples/cpp_api/tiledb_dense_read_async.cc
+++ b/examples/cpp_api/tiledb_dense_read_async.cc
@@ -47,10 +47,12 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Calcuate maximum buffer sizes for the query results per attribute
   const std::vector<uint64_t> subarray = {1, 4, 1, 4};
-  auto max_sizes =
-      tiledb::Array::max_buffer_elements(ctx, "my_dense_array", subarray);
+  auto max_sizes = array.max_buffer_elements(subarray);
 
   // Prepare cell buffers
   std::vector<int> a1_buff(max_sizes["a1"].second);
@@ -59,7 +61,7 @@ int main() {
   std::vector<float> a3_buff(max_sizes["a3"].second);
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_READ);
+  tiledb::Query query(ctx, array, TILEDB_READ);
   query.set_layout(TILEDB_GLOBAL_ORDER);
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_offsets, a2_data);
@@ -93,6 +95,9 @@ int main() {
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)
               << a3[i][0] << std::setw(10) << a3[i][1] << '\n';
   }
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_dense_read_global.cc
+++ b/examples/cpp_api/tiledb_dense_read_global.cc
@@ -44,9 +44,11 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Print non-empty domain
-  auto domain =
-      tiledb::Array::non_empty_domain<uint64_t>(ctx, "my_dense_array");
+  auto domain = array.non_empty_domain<uint64_t>();
   std::cout << "Non empty domain:\n";
   for (const auto& d : domain) {
     std::cout << d.first << ": (" << d.second.first << ", " << d.second.second
@@ -55,8 +57,7 @@ int main() {
 
   // Print maximum buffer elements for the query results per attribute
   const std::vector<uint64_t> subarray = {1, 4, 1, 4};
-  auto max_sizes =
-      tiledb::Array::max_buffer_elements(ctx, "my_dense_array", subarray);
+  auto max_sizes = array.max_buffer_elements(subarray);
   std::cout << "\nMaximum buffer elements:\n";
   for (const auto& e : max_sizes) {
     std::cout << e.first << ": (" << e.second.first << ", " << e.second.second
@@ -70,7 +71,7 @@ int main() {
   std::vector<float> a3_buff(max_sizes["a3"].second);
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_READ);
+  tiledb::Query query(ctx, array, TILEDB_READ);
   query.set_layout(TILEDB_GLOBAL_ORDER);
   query.set_subarray(subarray);
   query.set_buffer("a1", a1_buff);
@@ -100,6 +101,9 @@ int main() {
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)
               << a3[i][0] << std::setw(10) << a3[i][1] << '\n';
   }
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_dense_read_ordered_subarray.cc
+++ b/examples/cpp_api/tiledb_dense_read_ordered_subarray.cc
@@ -46,10 +46,12 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Compute maximum buffer elements for the query results per attribute
   const std::vector<uint64_t> subarray = {3, 4, 2, 4};
-  auto max_sizes =
-      tiledb::Array::max_buffer_elements(ctx, "my_dense_array", subarray);
+  auto max_sizes = array.max_buffer_elements(subarray);
 
   // Prepare cell buffers
   std::vector<int> a1_buff(max_sizes["a1"].second);
@@ -58,7 +60,7 @@ int main() {
   std::vector<float> a3_buff(max_sizes["a3"].second);
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_READ);
+  tiledb::Query query(ctx, array, TILEDB_READ);
   query.set_layout(TILEDB_ROW_MAJOR);
   query.set_subarray(subarray);
   query.set_buffer("a1", a1_buff);
@@ -87,6 +89,9 @@ int main() {
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)
               << a3[i][0] << std::setw(10) << a3[i][1] << '\n';
   }
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_dense_read_subset_incomplete.cc
+++ b/examples/cpp_api/tiledb_dense_read_subset_incomplete.cc
@@ -47,11 +47,14 @@ int main() {
   // Create TileDB Context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Prepare cell buffers
   std::vector<int> a1_data(2);
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_READ);
+  tiledb::Query query(ctx, array, TILEDB_READ);
   query.set_layout(TILEDB_COL_MAJOR);
   query.set_subarray<uint64_t>({3, 4, 2, 4});
   query.set_buffer("a1", a1_data);
@@ -70,6 +73,9 @@ int main() {
 
   // Finalize after we're done re-submitting the query.
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_dense_write_async.cc
+++ b/examples/cpp_api/tiledb_dense_write_async.cc
@@ -42,6 +42,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Prepare cell buffers
   // clang-format off
   std::vector<int> a1_data = {
@@ -67,7 +70,7 @@ int main() {
   // clang-format on
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_GLOBAL_ORDER);
   query.set_buffer("a1", a1_data);
   query.set_buffer("a2", a2_offsets, a2_data);
@@ -82,6 +85,9 @@ int main() {
   do {
     status = query.query_status();
   } while (status == tiledb::Query::Status::INPROGRESS);
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_dense_write_global_1.cc
+++ b/examples/cpp_api/tiledb_dense_write_global_1.cc
@@ -41,6 +41,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Prepare cell buffers
   std::vector<int> a1_data = {
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
@@ -59,7 +62,7 @@ int main() {
   };
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_GLOBAL_ORDER);
   query.set_buffer("a1", a1_data);
   query.set_buffer("a2", a2_offsets, a2str);
@@ -67,8 +70,12 @@ int main() {
 
   // Submit query
   query.submit();
+
   // Finalize query
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_dense_write_global_2.cc
+++ b/examples/cpp_api/tiledb_dense_write_global_2.cc
@@ -43,6 +43,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Prepare cell buffers - #1
   std::vector<int> a1_data = {0, 1, 2, 3, 4, 5};
   std::string a2str = "abbcccddddeffggghhhh";
@@ -50,7 +53,7 @@ int main() {
   std::vector<float> a3_data = {};
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_GLOBAL_ORDER);
   query.set_buffer("a1", a1_data);
   query.set_buffer("a2", a2_offsets, a2str);
@@ -83,6 +86,9 @@ int main() {
 
   // Finalize query only after the second write.
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_dense_write_global_subarray.cc
+++ b/examples/cpp_api/tiledb_dense_write_global_subarray.cc
@@ -43,6 +43,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Prepare cell buffers
   std::vector<int> a1_data = {112, 113, 114, 115};
   std::vector<std::string> a2 = {"M", "NN", "OOO", "PPPP"};
@@ -53,7 +56,7 @@ int main() {
   auto a2_buff = tiledb::ungroup_var_buffer(a2);
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_GLOBAL_ORDER);
   query.set_subarray<uint64_t>({3, 4, 3, 4});
   query.set_buffer("a1", a1_data);
@@ -62,8 +65,12 @@ int main() {
 
   // Submit query
   query.submit();
+
   // Finalize query
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_dense_write_ordered_subarray.cc
+++ b/examples/cpp_api/tiledb_dense_write_ordered_subarray.cc
@@ -47,6 +47,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Prepare cell buffers
   // clang-format off
   std::vector<int> a1_data = {9, 12, 13, 11, 14, 15};
@@ -57,7 +60,7 @@ int main() {
   // clang-format on
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_ROW_MAJOR);
   query.set_subarray<uint64_t>({3, 4, 2, 4});
   query.set_buffer("a1", a1_data);
@@ -66,8 +69,12 @@ int main() {
 
   // Submit query
   query.submit();
+
   // Finalize query
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_dense_write_unordered.cc
+++ b/examples/cpp_api/tiledb_dense_write_unordered.cc
@@ -44,6 +44,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_dense_array");
+
   // Prepare cell buffers
   std::vector<int> a1_data = {211, 213, 212, 208};
   std::vector<std::string> a2 = {"wwww", "yy", "x", "u"};
@@ -55,7 +58,7 @@ int main() {
   auto a2_buff = tiledb::ungroup_var_buffer(a2);
 
   // Create query
-  tiledb::Query query(ctx, "my_dense_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_UNORDERED);
   query.set_subarray<uint64_t>({{{3, 4}}, {{3, 4}}});
   query.set_buffer("a1", a1_data);
@@ -65,8 +68,12 @@ int main() {
 
   // Submit query
   query.submit();
+
   // Finalize query
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_map_iter.cc
+++ b/examples/cpp_api/tiledb_map_iter.cc
@@ -42,63 +42,22 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
-  // Create TileDB map
+  // Create TileDB map and map iterator
   tiledb::Map map(ctx, "my_map");
+  tiledb::MapIter iter(map), end(map, true);
 
   using my_cell_t = std::tuple<int, std::string, std::array<float, 2>>;
 
   // Read using iterator
   std::cout << "Iterating over all keys:\n";
-  for (auto& item : map) {
-    my_cell_t vals = item[{"a1", "a2", "a3"}];
+  while (iter != end) {
+    my_cell_t vals = (*iter)[{"a1", "a2", "a3"}];
     std::cout << "a1: " << std::get<0>(vals) << "\n"
               << "a2: " << std::get<1>(vals) << "\n"
               << "a3: " << std::get<2>(vals)[0] << " " << std::get<2>(vals)[1]
               << "\n";
     std::cout << "-----\n";
-  }
-
-  // Read using iterator, only int keys
-  std::cout << "\nOnly iterating over int keys:\n";
-  for (auto item = map.begin<int>(); item != map.end(); ++item) {
-    auto key = item->key<int>();
-    my_cell_t vals = (*item)[{"a1", "a2", "a3"}];
-    std::cout << "key: " << key << "\n"
-              << "a1: " << std::get<0>(vals) << "\n"
-              << "a2: " << std::get<1>(vals) << "\n"
-              << "a3: " << std::get<2>(vals)[0] << " " << std::get<2>(vals)[1]
-              << "\n";
-    std::cout << "-----\n";
-  }
-
-  // Read using iterator, only string keys
-  std::cout << "\nOnly iterating over string keys:\n";
-  for (auto item = map.begin<std::string>(); item != map.end(); ++item) {
-    auto key = item->key<std::string>();
-    my_cell_t vals = (*item)[{"a1", "a2", "a3"}];
-    std::cout << "key: " << key << "\n"
-              << "a1: " << std::get<0>(vals) << "\n"
-              << "a2: " << std::get<1>(vals) << "\n"
-              << "a3: " << std::get<2>(vals)[0] << " " << std::get<2>(vals)[1]
-              << "\n";
-    std::cout << "-----\n";
-  }
-
-  // Read using iterator, only double vector keys
-  std::cout << "\nOnly iterating over double vector keys:\n";
-  for (auto item = map.begin<std::vector<double>>(); item != map.end();
-       ++item) {
-    auto key = item->key<std::vector<double>>();
-    auto key_type = item->key_info();
-    my_cell_t vals = (*item)[{"a1", "a2", "a3"}];
-    std::cout << "key: ";
-    for (uint64_t i = 0; i < key_type.second / sizeof(double); ++i)
-      std::cout << key[i] << " ";
-    std::cout << "\na1: " << std::get<0>(vals) << "\n"
-              << "a2: " << std::get<1>(vals) << "\n"
-              << "a3: " << std::get<2>(vals)[0] << " " << std::get<2>(vals)[1]
-              << "\n";
-    std::cout << "-----\n";
+    ++iter;
   }
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope

--- a/examples/cpp_api/tiledb_map_read.cc
+++ b/examples/cpp_api/tiledb_map_read.cc
@@ -84,7 +84,7 @@ int main() {
   }
 
   // Finalize map
-  map.finalize();
+  map.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_map_write.cc
+++ b/examples/cpp_api/tiledb_map_write.cc
@@ -65,8 +65,10 @@ int main() {
     // Add items to map
     map.add_item(item1).add_item(item2);
 
-    // Force-write the buffered items to the persistent storage
+    // Flush and reopen the map
     map.flush();
+    map.close();
+    map.open();
 
     // Write another item. These will be flushed on map destruction.
     map.add_item(item4);
@@ -91,7 +93,7 @@ int main() {
     }
 
     // Finalize map
-    map.finalize();
+    map.close();
   }
 
   // Consolidate fragments (optional)

--- a/examples/cpp_api/tiledb_sparse_read_global.cc
+++ b/examples/cpp_api/tiledb_sparse_read_global.cc
@@ -44,9 +44,11 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_sparse_array");
+
   // Print non-empty domain
-  auto domain =
-      tiledb::Array::non_empty_domain<uint64_t>(ctx, "my_sparse_array");
+  auto domain = array.non_empty_domain<uint64_t>();
   std::cout << "Non empty domain:\n";
   for (const auto& d : domain) {
     std::cout << d.first << ": (" << d.second.first << ", " << d.second.second
@@ -55,8 +57,7 @@ int main() {
 
   // Print maximum buffer elements for the query results per attribute
   const std::vector<uint64_t> subarray = {1, 4, 1, 4};
-  auto max_sizes =
-      tiledb::Array::max_buffer_elements(ctx, "my_sparse_array", subarray);
+  auto max_sizes = array.max_buffer_elements(subarray);
   std::cout << "\nMaximum buffer elements:\n";
   for (const auto& e : max_sizes) {
     std::cout << e.first << ": (" << e.second.first << ", " << e.second.second
@@ -71,7 +72,7 @@ int main() {
   std::vector<uint64_t> coords_buff(max_sizes[TILEDB_COORDS].second);
 
   // Create query
-  tiledb::Query query(ctx, "my_sparse_array", TILEDB_READ);
+  tiledb::Query query(ctx, array, TILEDB_READ);
   query.set_layout(TILEDB_GLOBAL_ORDER);
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_offsets, a2_data);
@@ -104,6 +105,9 @@ int main() {
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)
               << a3[i][0] << std::setw(10) << a3[i][1] << '\n';
   }
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_sparse_read_ordered_subarray.cc
+++ b/examples/cpp_api/tiledb_sparse_read_ordered_subarray.cc
@@ -46,10 +46,12 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_sparse_array");
+
   // Calculate maximum buffer elements for the query results per attribute
   const std::vector<uint64_t> subarray = {3, 4, 2, 4};
-  auto max_sizes =
-      tiledb::Array::max_buffer_elements(ctx, "my_sparse_array", subarray);
+  auto max_sizes = array.max_buffer_elements(subarray);
 
   // Prepare cell buffers
   std::vector<int> a1_buff(max_sizes["a1"].second);
@@ -59,7 +61,7 @@ int main() {
   std::vector<uint64_t> coords_buff(max_sizes[TILEDB_COORDS].second);
 
   // Create query
-  tiledb::Query query(ctx, "my_sparse_array", TILEDB_READ);
+  tiledb::Query query(ctx, array, TILEDB_READ);
   query.set_layout(TILEDB_ROW_MAJOR).set_subarray(subarray);
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_offsets, a2_data);
@@ -92,6 +94,9 @@ int main() {
               << std::string(a2[i].data(), a2[i].size()) << std::setw(10)
               << a3[i][0] << std::setw(10) << a3[i][1] << '\n';
   }
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_sparse_read_subset.cc
+++ b/examples/cpp_api/tiledb_sparse_read_subset.cc
@@ -49,8 +49,11 @@ int main() {
   // Prepare cell buffers
   std::vector<int> a1_data(3);
 
+  // Open array
+  tiledb::Array array(ctx, "my_sparse_array");
+
   // Create query
-  tiledb::Query query(ctx, "my_sparse_array", TILEDB_READ);
+  tiledb::Query query(ctx, array, TILEDB_READ);
   query.set_layout(TILEDB_COL_MAJOR);
   query.set_subarray<uint64_t>({3, 4, 2, 4});
   query.set_buffer("a1", a1_data);
@@ -62,6 +65,9 @@ int main() {
   auto result_el = query.result_buffer_elements();
   for (unsigned i = 0; i < result_el["a1"].second; ++i)
     std::cout << a1_data[i] << "\n";
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_sparse_write_global_1.cc
+++ b/examples/cpp_api/tiledb_sparse_write_global_1.cc
@@ -43,6 +43,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_sparse_array");
+
   // Prepare cell buffers
   std::vector<int> a1_buff = {0, 1, 2, 3, 4, 5, 6, 7};
   std::vector<std::string> a2_str = {
@@ -68,7 +71,7 @@ int main() {
       1, 1, 1, 2, 1, 4, 2, 3, 3, 1, 4, 2, 3, 3, 3, 4};
 
   // Create query
-  tiledb::Query query(ctx, "my_sparse_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_GLOBAL_ORDER);
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_buff);
@@ -77,8 +80,12 @@ int main() {
 
   // Submit query
   query.submit();
+
   // Finalize query
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_sparse_write_global_2.cc
+++ b/examples/cpp_api/tiledb_sparse_write_global_2.cc
@@ -42,6 +42,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_sparse_array");
+
   // Prepare cell buffers - #1
   std::vector<int> a1_buff = {0, 1, 2};
   auto a2_buff = tiledb::ungroup_var_buffer<std::string>(
@@ -65,7 +68,7 @@ int main() {
   std::vector<uint64_t> coords_buff = {1, 1, 1, 2};
 
   // Create query
-  tiledb::Query query(ctx, "my_sparse_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_GLOBAL_ORDER);
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_buff);
@@ -90,8 +93,12 @@ int main() {
 
   // Submit query - #2
   query.submit();
+
   // Finalize query only after the second write.
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_sparse_write_unordered_1.cc
+++ b/examples/cpp_api/tiledb_sparse_write_unordered_1.cc
@@ -41,6 +41,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_sparse_array");
+
   // Prepare cell buffers
   std::vector<int> a1_buff = {7, 5, 0, 6, 4, 3, 1, 2};
   std::vector<std::string> a2_str = {
@@ -66,7 +69,7 @@ int main() {
       3, 4, 4, 2, 1, 1, 3, 3, 3, 1, 2, 3, 1, 2, 1, 4};
 
   // Create query
-  tiledb::Query query(ctx, "my_sparse_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_UNORDERED);
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_buff);
@@ -75,8 +78,12 @@ int main() {
 
   // Submit query
   query.submit();
+
   // Finalize query
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_sparse_write_unordered_1_again.cc
+++ b/examples/cpp_api/tiledb_sparse_write_unordered_1_again.cc
@@ -42,6 +42,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_sparse_array");
+
   // Prepare cell buffers
   std::vector<int> a1_buff = {107, 104, 106, 105};
   std::vector<std::string> a2_str = {"yyy", "u", "w", "vvvv"};
@@ -51,7 +54,7 @@ int main() {
   std::vector<uint64_t> coords_buff = {3, 4, 3, 2, 3, 3, 4, 1};
 
   // Create query
-  tiledb::Query query(ctx, "my_sparse_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_UNORDERED);
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_buff);
@@ -60,8 +63,12 @@ int main() {
 
   // Submit query
   query.submit();
+
   // Finalize query
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/examples/cpp_api/tiledb_sparse_write_unordered_2.cc
+++ b/examples/cpp_api/tiledb_sparse_write_unordered_2.cc
@@ -42,6 +42,9 @@ int main() {
   // Create TileDB context
   tiledb::Context ctx;
 
+  // Open array
+  tiledb::Array array(ctx, "my_sparse_array");
+
   // Prepare cell buffers - #1
   std::vector<int> a1_buff = {7, 5, 0};
   auto a2_buff = tiledb::ungroup_var_buffer<std::string>({"hhhh", "ff", "a"});
@@ -49,7 +52,7 @@ int main() {
   std::vector<uint64_t> coords_buff = {3, 4, 4, 2, 1, 1};
 
   // Create query
-  tiledb::Query query(ctx, "my_sparse_array", TILEDB_WRITE);
+  tiledb::Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_UNORDERED);
   query.set_buffer("a1", a1_buff);
   query.set_buffer("a2", a2_buff);
@@ -74,8 +77,12 @@ int main() {
 
   // Submit query - #2
   query.submit();
+
   // Finalize query only after the second write.
   query.finalize();
+
+  // Close array
+  array.close();
 
   // Nothing to clean up - all C++ objects are deleted when exiting scope
 

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -124,7 +124,7 @@ ArraySchemaFx::ArraySchemaFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
 
   if (supports_s3_) {
@@ -145,10 +145,10 @@ ArraySchemaFx::ArraySchemaFx() {
   }
 
   ctx_ = nullptr;
-  REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx_, config) == TILEDB_OK);
   REQUIRE(error == nullptr);
   vfs_ = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_alloc(ctx_, &vfs_, config) == TILEDB_OK);
   tiledb_config_free(&config);
 
   // Connect to S3
@@ -181,7 +181,7 @@ ArraySchemaFx::~ArraySchemaFx() {
 
 void ArraySchemaFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
-  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx, nullptr) == TILEDB_OK);
 
   int is_supported = 0;
   int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
@@ -222,7 +222,7 @@ void ArraySchemaFx::delete_array(const std::string& path) {
 void ArraySchemaFx::create_array(const std::string& path) {
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  int rc = tiledb_array_schema_create(ctx_, &array_schema, ARRAY_TYPE);
+  int rc = tiledb_array_schema_alloc(ctx_, &array_schema, ARRAY_TYPE);
   REQUIRE(rc == TILEDB_OK);
 
   // Set schema members
@@ -241,21 +241,21 @@ void ArraySchemaFx::create_array(const std::string& path) {
 
   // Create dimensions
   tiledb_dimension_t* d1;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d1, DIM1_NAME, TILEDB_INT64, &DIM_DOMAIN[0], &TILE_EXTENTS[0]);
   REQUIRE(rc == TILEDB_OK);
   tiledb_dimension_t* d2;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, DIM2_NAME, TILEDB_INT64, &DIM_DOMAIN[2], &TILE_EXTENTS[1]);
   REQUIRE(rc == TILEDB_OK);
   tiledb_dimension_t* d3;  // This will be an invalid dimension
   int dim_domain_int[] = {0, 10};
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d3, DIM2_NAME, TILEDB_INT32, dim_domain_int, &TILE_EXTENTS[1]);
   REQUIRE(rc == TILEDB_OK);
   tiledb_dimension_t* d4;  // This will be an invalid dimension
   int tile_extent = 10000;
-  rc = tiledb_dimension_create(  // This will not even be created
+  rc = tiledb_dimension_alloc(  // This will not even be created
       ctx_,
       &d4,
       DIM2_NAME,
@@ -266,7 +266,7 @@ void ArraySchemaFx::create_array(const std::string& path) {
 
   // Set domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   REQUIRE(rc == TILEDB_OK);
@@ -289,7 +289,7 @@ void ArraySchemaFx::create_array(const std::string& path) {
 
   // Set invalid attribute
   tiledb_attribute_t* inv_attr;
-  rc = tiledb_attribute_create(ctx_, &inv_attr, "__foo", ATTR_TYPE);
+  rc = tiledb_attribute_alloc(ctx_, &inv_attr, "__foo", ATTR_TYPE);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_schema_add_attribute(ctx_, array_schema, inv_attr);
   REQUIRE(rc == TILEDB_ERR);
@@ -297,7 +297,7 @@ void ArraySchemaFx::create_array(const std::string& path) {
 
   // Set attribute
   tiledb_attribute_t* attr;
-  rc = tiledb_attribute_create(ctx_, &attr, ATTR_NAME, ATTR_TYPE);
+  rc = tiledb_attribute_alloc(ctx_, &attr, ATTR_NAME, ATTR_TYPE);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_schema_add_attribute(ctx_, array_schema, attr);
   REQUIRE(rc == TILEDB_OK);
@@ -573,18 +573,18 @@ TEST_CASE_METHOD(
     "[capi], [array-schema]") {
   // Create dimensions
   tiledb_dimension_t* d1;
-  int rc = tiledb_dimension_create(
+  int rc = tiledb_dimension_alloc(
       ctx_, &d1, "", TILEDB_INT64, &DIM_DOMAIN[0], &TILE_EXTENTS[0]);
   REQUIRE(rc == TILEDB_OK);
 
   tiledb_dimension_t* d2;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, "d2", TILEDB_INT64, &DIM_DOMAIN[2], &TILE_EXTENTS[1]);
   REQUIRE(rc == TILEDB_OK);
 
   // Set domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   REQUIRE(rc == TILEDB_OK);
@@ -616,18 +616,18 @@ TEST_CASE_METHOD(
     "[capi], [array-schema]") {
   // Create dimensions
   tiledb_dimension_t* d1;
-  int rc = tiledb_dimension_create(
+  int rc = tiledb_dimension_alloc(
       ctx_, &d1, "", TILEDB_INT64, &DIM_DOMAIN[0], &TILE_EXTENTS[0]);
   REQUIRE(rc == TILEDB_OK);
 
   tiledb_dimension_t* d2;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, "", TILEDB_INT64, &DIM_DOMAIN[2], &TILE_EXTENTS[1]);
   REQUIRE(rc == TILEDB_OK);
 
   // Set domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   REQUIRE(rc == TILEDB_OK);
@@ -656,18 +656,18 @@ TEST_CASE_METHOD(
     "[capi], [array-schema]") {
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  int rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_DENSE);
+  int rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_DENSE);
   REQUIRE(rc == TILEDB_OK);
 
   // Create dimensions
   tiledb_dimension_t* d1;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d1, "", TILEDB_INT64, &DIM_DOMAIN[0], &TILE_EXTENTS[0]);
   REQUIRE(rc == TILEDB_OK);
 
   // Set domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   REQUIRE(rc == TILEDB_OK);
@@ -676,10 +676,10 @@ TEST_CASE_METHOD(
 
   // Set attribute
   tiledb_attribute_t* attr1;
-  rc = tiledb_attribute_create(ctx_, &attr1, "", ATTR_TYPE);
+  rc = tiledb_attribute_alloc(ctx_, &attr1, "", ATTR_TYPE);
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_t* attr2;
-  rc = tiledb_attribute_create(ctx_, &attr2, "foo", ATTR_TYPE);
+  rc = tiledb_attribute_alloc(ctx_, &attr2, "foo", ATTR_TYPE);
   REQUIRE(rc == TILEDB_OK);
 
   rc = tiledb_array_schema_add_attribute(ctx_, array_schema, attr1);
@@ -719,18 +719,18 @@ TEST_CASE_METHOD(
     "[capi], [array-schema]") {
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  int rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_DENSE);
+  int rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_DENSE);
   REQUIRE(rc == TILEDB_OK);
 
   // Create dimensions
   tiledb_dimension_t* d1;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d1, "", TILEDB_INT64, &DIM_DOMAIN[0], &TILE_EXTENTS[0]);
   REQUIRE(rc == TILEDB_OK);
 
   // Set domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   REQUIRE(rc == TILEDB_OK);
@@ -739,10 +739,10 @@ TEST_CASE_METHOD(
 
   // Set attribute
   tiledb_attribute_t* attr1;
-  rc = tiledb_attribute_create(ctx_, &attr1, "", ATTR_TYPE);
+  rc = tiledb_attribute_alloc(ctx_, &attr1, "", ATTR_TYPE);
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_t* attr2;
-  rc = tiledb_attribute_create(ctx_, &attr2, "", ATTR_TYPE);
+  rc = tiledb_attribute_alloc(ctx_, &attr2, "", ATTR_TYPE);
   REQUIRE(rc == TILEDB_OK);
 
   rc = tiledb_array_schema_add_attribute(ctx_, array_schema, attr1);
@@ -775,20 +775,20 @@ TEST_CASE_METHOD(
     "[capi], [array-schema]") {
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  int rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_DENSE);
+  int rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_DENSE);
   REQUIRE(rc == TILEDB_OK);
 
   // Create dimensions
   tiledb_dimension_t* d1;
   double dim_domain[] = {0, 9};
   double tile_extent = 5;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d1, "", TILEDB_FLOAT64, dim_domain, &tile_extent);
   REQUIRE(rc == TILEDB_OK);
 
   // Set domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   REQUIRE(rc == TILEDB_OK);
@@ -808,14 +808,14 @@ TEST_CASE_METHOD(
   // Create dimension with huge range and no tile extent - ok
   tiledb_dimension_t* d1;
   uint64_t dim_domain[] = {0, UINT64_MAX};
-  int rc = tiledb_dimension_create(
+  int rc = tiledb_dimension_alloc(
       ctx_, &d1, "d1", TILEDB_UINT64, dim_domain, nullptr);
   CHECK(rc == TILEDB_OK);
 
   // Create dimension with huge range and tile extent - error
   tiledb_dimension_t* d2;
   uint64_t tile_extent = 7;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, "d2", TILEDB_UINT64, dim_domain, &tile_extent);
   CHECK(rc == TILEDB_ERR);
 
@@ -823,7 +823,7 @@ TEST_CASE_METHOD(
   tiledb_dimension_t* d3;
   dim_domain[1] = 10;
   tile_extent = 20;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d3, "d3", TILEDB_UINT64, dim_domain, &tile_extent);
   CHECK(rc == TILEDB_ERR);
 
@@ -831,7 +831,7 @@ TEST_CASE_METHOD(
   tiledb_dimension_t* d4;
   dim_domain[0] = 10;
   dim_domain[1] = 1;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d4, "d4", TILEDB_UINT64, dim_domain, &tile_extent);
   CHECK(rc == TILEDB_ERR);
 

--- a/test/src/unit-capi-async.cc
+++ b/test/src/unit-capi-async.cc
@@ -64,7 +64,7 @@ struct AsyncFx {
 
 AsyncFx::AsyncFx() {
   ctx_ = nullptr;
-  REQUIRE(tiledb_ctx_create(&ctx_, NULL) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx_, NULL) == TILEDB_OK);
 }
 
 AsyncFx::~AsyncFx() {
@@ -76,17 +76,17 @@ void AsyncFx::create_dense_array() {
   uint64_t dim_domain[] = {1, 4, 1, 4};
   uint64_t tile_extents[] = {2, 2};
   tiledb_dimension_t* d1;
-  int rc = tiledb_dimension_create(
+  int rc = tiledb_dimension_alloc(
       ctx_, &d1, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0]);
   CHECK(rc == TILEDB_OK);
   tiledb_dimension_t* d2;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1]);
   CHECK(rc == TILEDB_OK);
 
   // Create domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   CHECK(rc == TILEDB_OK);
@@ -95,7 +95,7 @@ void AsyncFx::create_dense_array() {
 
   // Create attributes
   tiledb_attribute_t* a1;
-  rc = tiledb_attribute_create(ctx_, &a1, "a1", TILEDB_INT32);
+  rc = tiledb_attribute_alloc(ctx_, &a1, "a1", TILEDB_INT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a1, TILEDB_BLOSC_LZ, -1);
   CHECK(rc == TILEDB_OK);
@@ -103,7 +103,7 @@ void AsyncFx::create_dense_array() {
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a2;
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_attribute_create(ctx_, &a2, "a2", TILEDB_CHAR);
+  rc = tiledb_attribute_alloc(ctx_, &a2, "a2", TILEDB_CHAR);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a2, TILEDB_GZIP, -1);
   CHECK(rc == TILEDB_OK);
@@ -111,7 +111,7 @@ void AsyncFx::create_dense_array() {
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a3;
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_attribute_create(ctx_, &a3, "a3", TILEDB_FLOAT32);
+  rc = tiledb_attribute_alloc(ctx_, &a3, "a3", TILEDB_FLOAT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a3, TILEDB_ZSTD, -1);
   CHECK(rc == TILEDB_OK);
@@ -120,7 +120,7 @@ void AsyncFx::create_dense_array() {
 
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_DENSE);
+  rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_DENSE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -158,17 +158,17 @@ void AsyncFx::create_sparse_array() {
   uint64_t dim_domain[] = {1, 4, 1, 4};
   uint64_t tile_extents[] = {2, 2};
   tiledb_dimension_t* d1;
-  int rc = tiledb_dimension_create(
+  int rc = tiledb_dimension_alloc(
       ctx_, &d1, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0]);
   CHECK(rc == TILEDB_OK);
   tiledb_dimension_t* d2;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1]);
   CHECK(rc == TILEDB_OK);
 
   // Create domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   CHECK(rc == TILEDB_OK);
@@ -177,21 +177,21 @@ void AsyncFx::create_sparse_array() {
 
   // Create attributes
   tiledb_attribute_t* a1;
-  rc = tiledb_attribute_create(ctx_, &a1, "a1", TILEDB_INT32);
+  rc = tiledb_attribute_alloc(ctx_, &a1, "a1", TILEDB_INT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a1, TILEDB_BLOSC_LZ, -1);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_cell_val_num(ctx_, a1, 1);
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a2;
-  rc = tiledb_attribute_create(ctx_, &a2, "a2", TILEDB_CHAR);
+  rc = tiledb_attribute_alloc(ctx_, &a2, "a2", TILEDB_CHAR);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a2, TILEDB_GZIP, -1);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_cell_val_num(ctx_, a2, TILEDB_VAR_NUM);
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a3;
-  rc = tiledb_attribute_create(ctx_, &a3, "a3", TILEDB_FLOAT32);
+  rc = tiledb_attribute_alloc(ctx_, &a3, "a3", TILEDB_FLOAT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a3, TILEDB_ZSTD, -1);
   CHECK(rc == TILEDB_OK);
@@ -200,7 +200,7 @@ void AsyncFx::create_sparse_array() {
 
   // Create array schmea
   tiledb_array_schema_t* array_schema;
-  rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_SPARSE);
+  rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_SPARSE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -274,9 +274,16 @@ void AsyncFx::write_dense_async() {
   };
   // clang-format on
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -303,7 +310,12 @@ void AsyncFx::write_dense_async() {
   // Check correct execution of callback
   CHECK(callback_made == 1);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -338,10 +350,17 @@ void AsyncFx::write_sparse_async() {
       sizeof(buffer_a3),
       sizeof(buffer_coords)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -365,10 +384,15 @@ void AsyncFx::write_sparse_async() {
   rc = tiledb_query_finalize(ctx_, query);
   CHECK(rc == TILEDB_OK);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Check correct execution of callback
   CHECK(callback_made == 1);
 
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -403,10 +427,17 @@ void AsyncFx::write_sparse_async_cancelled() {
       sizeof(buffer_a3),
       sizeof(buffer_coords)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
@@ -452,17 +483,29 @@ void AsyncFx::write_sparse_async_cancelled() {
   rc = tiledb_query_finalize(ctx_, query);
   CHECK(rc == TILEDB_OK);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
 void AsyncFx::read_dense_async() {
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Calculate maximum buffer sizes for each attribute
   const char* attributes[] = {"a1", "a2", "a3"};
   uint64_t buffer_sizes[4];
   uint64_t subarray[] = {1, 4, 1, 4};
-  int rc = tiledb_array_compute_max_read_buffer_sizes(
-      ctx_, DENSE_ARRAY_NAME, subarray, attributes, 3, &buffer_sizes[0]);
+  rc = tiledb_array_compute_max_read_buffer_sizes(
+      ctx_, array, subarray, attributes, 3, &buffer_sizes[0]);
   CHECK(rc == TILEDB_OK);
 
   // Prepare cell buffers
@@ -474,7 +517,7 @@ void AsyncFx::read_dense_async() {
 
   // Create query
   tiledb_query_t* query;
-  rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -522,17 +565,29 @@ void AsyncFx::read_dense_async() {
   CHECK(!memcmp(buffer_var_a2, c_buffer_var_a2, sizeof(c_buffer_var_a2) - 1));
   CHECK(!memcmp(buffer_a3, c_buffer_a3, sizeof(c_buffer_a3)));
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
 void AsyncFx::read_sparse_async() {
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Calculate maximum buffer sizes for each attribute
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   uint64_t buffer_sizes[5];
   uint64_t subarray[] = {1, 4, 1, 4};
-  int rc = tiledb_array_compute_max_read_buffer_sizes(
-      ctx_, SPARSE_ARRAY_NAME, subarray, attributes, 4, &buffer_sizes[0]);
+  rc = tiledb_array_compute_max_read_buffer_sizes(
+      ctx_, array, subarray, attributes, 4, &buffer_sizes[0]);
   CHECK(rc == TILEDB_OK);
 
   // Prepare cell buffers
@@ -546,7 +601,7 @@ void AsyncFx::read_sparse_async() {
 
   // Create query
   tiledb_query_t* query;
-  rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -601,7 +656,12 @@ void AsyncFx::read_sparse_async() {
   CHECK(!memcmp(buffer_a3, c_buffer_a3, sizeof(c_buffer_a3)));
   CHECK(!memcmp(buffer_coords, c_buffer_coords, sizeof(c_buffer_coords)));
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -43,10 +43,10 @@
 void remove_file(const std::string& filename) {
   // Remove file
   tiledb_ctx_t* ctx = nullptr;
-  int rc = tiledb_ctx_create(&ctx, nullptr);
+  int rc = tiledb_ctx_alloc(&ctx, nullptr);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx, &vfs, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_alloc(ctx, &vfs, nullptr) == TILEDB_OK);
   CHECK(tiledb_vfs_remove_file(ctx, vfs, filename.c_str()) == TILEDB_OK);
   tiledb_vfs_free(&vfs);
   tiledb_ctx_free(&ctx);
@@ -65,14 +65,14 @@ void check_load_correct_file() {
   // Set config from file
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  int rc = tiledb_config_create(&config, &error);
+  int rc = tiledb_config_alloc(&config, &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
   rc = tiledb_config_load_from_file(config, "test_config.txt", &error);
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
   tiledb_ctx_t* ctx = nullptr;
-  rc = tiledb_ctx_create(&ctx, config);
+  rc = tiledb_ctx_alloc(&ctx, config);
   CHECK(rc == TILEDB_OK);
   tiledb_ctx_free(&ctx);
   tiledb_config_free(&config);
@@ -91,7 +91,7 @@ void check_load_incorrect_file_cannot_open() {
   // Set config from file
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  int rc = tiledb_config_create(&config, &error);
+  int rc = tiledb_config_alloc(&config, &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
   rc = tiledb_config_load_from_file(config, "non_existent_file", &error);
@@ -118,7 +118,7 @@ void check_load_incorrect_file_missing_value() {
   // Set config from file
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  int rc = tiledb_config_create(&config, &error);
+  int rc = tiledb_config_alloc(&config, &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
   rc = tiledb_config_load_from_file(config, "test_config.txt", &error);
@@ -148,7 +148,7 @@ void check_load_incorrect_file_extra_word() {
   // Set config from file
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  int rc = tiledb_config_create(&config, &error);
+  int rc = tiledb_config_alloc(&config, &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
   rc = tiledb_config_load_from_file(config, "test_config.txt", &error);
@@ -166,7 +166,7 @@ void check_load_incorrect_file_extra_word() {
 void check_save_to_file() {
   tiledb_config_t* config;
   tiledb_error_t* error;
-  int rc = tiledb_config_create(&config, &error);
+  int rc = tiledb_config_alloc(&config, &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
 
@@ -217,7 +217,7 @@ void check_save_to_file() {
 TEST_CASE("C API: Test config", "[capi], [config]") {
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  int rc = tiledb_config_create(&config, &error);
+  int rc = tiledb_config_alloc(&config, &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
 
@@ -226,7 +226,7 @@ TEST_CASE("C API: Test config", "[capi], [config]") {
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
   tiledb_ctx_t* ctx;
-  rc = tiledb_ctx_create(&ctx, config);
+  rc = tiledb_ctx_alloc(&ctx, config);
   CHECK(rc == TILEDB_OK);
   tiledb_ctx_free(&ctx);
   CHECK(ctx == nullptr);
@@ -245,7 +245,7 @@ TEST_CASE("C API: Test config", "[capi], [config]") {
   CHECK(value == nullptr);
 
   // Check get config from context
-  rc = tiledb_ctx_create(&ctx, config);
+  rc = tiledb_ctx_alloc(&ctx, config);
   CHECK(rc == TILEDB_OK);
   tiledb_config_t* get_config = nullptr;
   rc = tiledb_ctx_get_config(ctx, &get_config);
@@ -261,7 +261,7 @@ TEST_CASE("C API: Test config", "[capi], [config]") {
   rc = tiledb_config_set(config, "sm.tile_cache_size", "+100", &error);
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
-  rc = tiledb_ctx_create(&ctx, config);
+  rc = tiledb_ctx_alloc(&ctx, config);
   CHECK(rc == TILEDB_OK);
   tiledb_ctx_free(&ctx);
 
@@ -323,13 +323,13 @@ TEST_CASE("C API: Test config", "[capi], [config]") {
 
 TEST_CASE("C API: Test config iter", "[capi], [config]") {
   tiledb_ctx_t* ctx;
-  int rc = tiledb_ctx_create(&ctx, nullptr);
+  int rc = tiledb_ctx_alloc(&ctx, nullptr);
   REQUIRE(rc == TILEDB_OK);
 
   // Populate a config
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  rc = tiledb_config_create(&config, &error);
+  rc = tiledb_config_alloc(&config, &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
   rc = tiledb_config_set(config, "sm.tile_cache_size", "100", &error);
@@ -426,7 +426,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
 
   // Create an iterator and iterate over all parameters
   tiledb_config_iter_t* config_iter = nullptr;
-  rc = tiledb_config_iter_create(config, &config_iter, nullptr, &error);
+  rc = tiledb_config_iter_alloc(config, &config_iter, nullptr, &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
   int done;
@@ -455,7 +455,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   CHECK(error == nullptr);
 
   // Create an iterator and iterate over vfs parameters
-  rc = tiledb_config_iter_create(config, &config_iter, "vfs.", &error);
+  rc = tiledb_config_iter_alloc(config, &config_iter, "vfs.", &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
   rc = tiledb_config_iter_done(config_iter, &done, &error);
@@ -481,7 +481,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   tiledb_config_iter_free(&config_iter);
 
   // Create an iterator and iterate over s3 parameters
-  rc = tiledb_config_iter_create(config, &config_iter, "vfs.s3.", &error);
+  rc = tiledb_config_iter_alloc(config, &config_iter, "vfs.s3.", &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
   rc = tiledb_config_iter_done(config_iter, &done, &error);
@@ -524,7 +524,7 @@ TEST_CASE(
     "C API: Test boolean config values are normalized", "[capi][config]") {
   tiledb_error_t* err;
   tiledb_config_t* config = nullptr;
-  int rc = tiledb_config_create(&config, &err);
+  int rc = tiledb_config_alloc(&config, &err);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_config_set(config, "vfs.s3.use_virtual_addressing", "TRUE", &err);
   CHECK(rc == TILEDB_OK);

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -71,7 +71,7 @@ struct ConsolidationFx {
 
 ConsolidationFx::ConsolidationFx() {
   ctx_ = nullptr;
-  REQUIRE(tiledb_ctx_create(&ctx_, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx_, nullptr) == TILEDB_OK);
 }
 
 ConsolidationFx::~ConsolidationFx() {
@@ -83,17 +83,17 @@ void ConsolidationFx::create_dense_array() {
   uint64_t dim_domain[] = {1, 4, 1, 4};
   uint64_t tile_extents[] = {2, 2};
   tiledb_dimension_t* d1;
-  int rc = tiledb_dimension_create(
+  int rc = tiledb_dimension_alloc(
       ctx_, &d1, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0]);
   CHECK(rc == TILEDB_OK);
   tiledb_dimension_t* d2;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1]);
   CHECK(rc == TILEDB_OK);
 
   // Create domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   CHECK(rc == TILEDB_OK);
@@ -102,7 +102,7 @@ void ConsolidationFx::create_dense_array() {
 
   // Create attributes
   tiledb_attribute_t* a1;
-  rc = tiledb_attribute_create(ctx_, &a1, "a1", TILEDB_INT32);
+  rc = tiledb_attribute_alloc(ctx_, &a1, "a1", TILEDB_INT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a1, TILEDB_BLOSC_LZ, -1);
   CHECK(rc == TILEDB_OK);
@@ -110,7 +110,7 @@ void ConsolidationFx::create_dense_array() {
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a2;
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_attribute_create(ctx_, &a2, "a2", TILEDB_CHAR);
+  rc = tiledb_attribute_alloc(ctx_, &a2, "a2", TILEDB_CHAR);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a2, TILEDB_GZIP, -1);
   CHECK(rc == TILEDB_OK);
@@ -118,7 +118,7 @@ void ConsolidationFx::create_dense_array() {
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a3;
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_attribute_create(ctx_, &a3, "a3", TILEDB_FLOAT32);
+  rc = tiledb_attribute_alloc(ctx_, &a3, "a3", TILEDB_FLOAT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a3, TILEDB_ZSTD, -1);
   CHECK(rc == TILEDB_OK);
@@ -127,7 +127,7 @@ void ConsolidationFx::create_dense_array() {
 
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_DENSE);
+  rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_DENSE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -165,17 +165,17 @@ void ConsolidationFx::create_sparse_array() {
   uint64_t dim_domain[] = {1, 4, 1, 4};
   uint64_t tile_extents[] = {2, 2};
   tiledb_dimension_t* d1;
-  int rc = tiledb_dimension_create(
+  int rc = tiledb_dimension_alloc(
       ctx_, &d1, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0]);
   CHECK(rc == TILEDB_OK);
   tiledb_dimension_t* d2;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1]);
   CHECK(rc == TILEDB_OK);
 
   // Create domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   CHECK(rc == TILEDB_OK);
@@ -184,21 +184,21 @@ void ConsolidationFx::create_sparse_array() {
 
   // Create attributes
   tiledb_attribute_t* a1;
-  rc = tiledb_attribute_create(ctx_, &a1, "a1", TILEDB_INT32);
+  rc = tiledb_attribute_alloc(ctx_, &a1, "a1", TILEDB_INT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a1, TILEDB_BLOSC_LZ, -1);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_cell_val_num(ctx_, a1, 1);
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a2;
-  rc = tiledb_attribute_create(ctx_, &a2, "a2", TILEDB_CHAR);
+  rc = tiledb_attribute_alloc(ctx_, &a2, "a2", TILEDB_CHAR);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a2, TILEDB_GZIP, -1);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_cell_val_num(ctx_, a2, TILEDB_VAR_NUM);
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a3;
-  rc = tiledb_attribute_create(ctx_, &a3, "a3", TILEDB_FLOAT32);
+  rc = tiledb_attribute_alloc(ctx_, &a3, "a3", TILEDB_FLOAT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a3, TILEDB_ZSTD, -1);
   CHECK(rc == TILEDB_OK);
@@ -207,7 +207,7 @@ void ConsolidationFx::create_sparse_array() {
 
   // Create array schmea
   tiledb_array_schema_t* array_schema;
-  rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_SPARSE);
+  rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_SPARSE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -277,9 +277,16 @@ void ConsolidationFx::write_dense_full() {
   };
   // clang-format on
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -295,7 +302,12 @@ void ConsolidationFx::write_dense_full() {
   rc = tiledb_query_finalize(ctx_, query);
   CHECK(rc == TILEDB_OK);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -313,11 +325,18 @@ void ConsolidationFx::write_dense_subarray() {
       sizeof(buffer_var_a2) - 1,  // No need to store the last '\0' character
       sizeof(buffer_a3)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3"};
   uint64_t subarray[] = {3, 4, 3, 4};
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -335,7 +354,12 @@ void ConsolidationFx::write_dense_subarray() {
   rc = tiledb_query_finalize(ctx_, query);
   CHECK(rc == TILEDB_OK);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -356,10 +380,17 @@ void ConsolidationFx::write_dense_unordered() {
       sizeof(buffer_a3),
       sizeof(buffer_coords)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 4, buffers, buffer_sizes);
@@ -375,7 +406,12 @@ void ConsolidationFx::write_dense_unordered() {
   rc = tiledb_query_finalize(ctx_, query);
   CHECK(rc == TILEDB_OK);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -410,10 +446,17 @@ void ConsolidationFx::write_sparse_full() {
       sizeof(buffer_a3),
       sizeof(buffer_coords)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -429,7 +472,12 @@ void ConsolidationFx::write_sparse_full() {
   rc = tiledb_query_finalize(ctx_, query);
   CHECK(rc == TILEDB_OK);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -450,10 +498,17 @@ void ConsolidationFx::write_sparse_unordered() {
       sizeof(buffer_a3),
       sizeof(buffer_coords)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
@@ -469,7 +524,12 @@ void ConsolidationFx::write_sparse_unordered() {
   rc = tiledb_query_finalize(ctx_, query);
   CHECK(rc == TILEDB_OK);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -491,12 +551,19 @@ void ConsolidationFx::read_dense_full_subarray_unordered() {
       212.1f, 212.2f, 213.1f, 213.2f, 114.1f, 114.2f, 115.1f, 115.2f,
   };
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Compute max buffer sizes
   const char* attributes[] = {"a1", "a2", "a3"};
   uint64_t max_buffer_sizes[4];
   uint64_t subarray[] = {1, 4, 1, 4};
-  int rc = tiledb_array_compute_max_read_buffer_sizes(
-      ctx_, DENSE_ARRAY_NAME, subarray, attributes, 3, &max_buffer_sizes[0]);
+  rc = tiledb_array_compute_max_read_buffer_sizes(
+      ctx_, array, subarray, attributes, 3, &max_buffer_sizes[0]);
   CHECK(rc == TILEDB_OK);
 
   // Prepare cell buffers
@@ -512,7 +579,7 @@ void ConsolidationFx::read_dense_full_subarray_unordered() {
 
   // Create query
   tiledb_query_t* query;
-  rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -542,7 +609,12 @@ void ConsolidationFx::read_dense_full_subarray_unordered() {
   CHECK(!memcmp(buffer_var_a2, c_buffer_var_a2, sizeof(c_buffer_var_a2) - 1));
   CHECK(!memcmp(buffer_a3, c_buffer_a3, sizeof(c_buffer_a3)));
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   free(buffer_a1);
   free(buffer_a2);
@@ -568,12 +640,19 @@ void ConsolidationFx::read_dense_subarray_full_unordered() {
       212.1f, 212.2f, 213.1f, 213.2f, 14.1f, 14.2f, 15.1f,  15.2f,
   };
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Compute max buffer sizes
   const char* attributes[] = {"a1", "a2", "a3"};
   uint64_t max_buffer_sizes[4];
   uint64_t subarray[] = {1, 4, 1, 4};
-  int rc = tiledb_array_compute_max_read_buffer_sizes(
-      ctx_, DENSE_ARRAY_NAME, subarray, attributes, 3, &max_buffer_sizes[0]);
+  rc = tiledb_array_compute_max_read_buffer_sizes(
+      ctx_, array, subarray, attributes, 3, &max_buffer_sizes[0]);
   CHECK(rc == TILEDB_OK);
 
   // Prepare cell buffers
@@ -589,7 +668,7 @@ void ConsolidationFx::read_dense_subarray_full_unordered() {
 
   // Create query
   tiledb_query_t* query;
-  rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -611,7 +690,12 @@ void ConsolidationFx::read_dense_subarray_full_unordered() {
   CHECK(!memcmp(buffer_var_a2, c_buffer_var_a2, sizeof(c_buffer_var_a2) - 1));
   CHECK(!memcmp(buffer_a3, c_buffer_a3, sizeof(c_buffer_a3)));
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   free(buffer_a1);
   free(buffer_a2);
@@ -636,12 +720,19 @@ void ConsolidationFx::read_dense_subarray_unordered_full() {
       12.1f, 12.2f, 13.1f, 13.2f, 14.1f, 14.2f, 15.1f, 15.2f,
   };
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Compute max buffer sizes
   const char* attributes[] = {"a1", "a2", "a3"};
   uint64_t max_buffer_sizes[4];
   uint64_t subarray[] = {1, 4, 1, 4};
-  int rc = tiledb_array_compute_max_read_buffer_sizes(
-      ctx_, DENSE_ARRAY_NAME, subarray, attributes, 3, &max_buffer_sizes[0]);
+  rc = tiledb_array_compute_max_read_buffer_sizes(
+      ctx_, array, subarray, attributes, 3, &max_buffer_sizes[0]);
   CHECK(rc == TILEDB_OK);
 
   // Prepare cell buffers
@@ -657,7 +748,7 @@ void ConsolidationFx::read_dense_subarray_unordered_full() {
 
   // Create query
   tiledb_query_t* query;
-  rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -679,7 +770,12 @@ void ConsolidationFx::read_dense_subarray_unordered_full() {
   CHECK(!memcmp(buffer_var_a2, c_buffer_var_a2, sizeof(c_buffer_var_a2) - 1));
   CHECK(!memcmp(buffer_a3, c_buffer_a3, sizeof(c_buffer_a3)));
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   free(buffer_a1);
   free(buffer_a2);
@@ -698,12 +794,19 @@ void ConsolidationFx::read_sparse_full_unordered() {
   uint64_t c_buffer_coords[] = {1, 1, 1, 2, 1, 4, 2, 3, 3, 1,
                                 3, 2, 4, 1, 4, 2, 3, 3, 3, 4};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Compute max buffer sizes
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   uint64_t max_buffer_sizes[5];
   uint64_t subarray[] = {1, 4, 1, 4};
-  int rc = tiledb_array_compute_max_read_buffer_sizes(
-      ctx_, SPARSE_ARRAY_NAME, subarray, attributes, 4, &max_buffer_sizes[0]);
+  rc = tiledb_array_compute_max_read_buffer_sizes(
+      ctx_, array, subarray, attributes, 4, &max_buffer_sizes[0]);
   CHECK(rc == TILEDB_OK);
 
   // Prepare cell buffers
@@ -722,7 +825,7 @@ void ConsolidationFx::read_sparse_full_unordered() {
 
   // Create query
   tiledb_query_t* query;
-  rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -745,7 +848,12 @@ void ConsolidationFx::read_sparse_full_unordered() {
   CHECK(!memcmp(buffer_a3, c_buffer_a3, sizeof(c_buffer_a3)));
   CHECK(!memcmp(buffer_coords, c_buffer_coords, sizeof(c_buffer_coords)));
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   free(buffer_a1);
   free(buffer_a2);
@@ -764,12 +872,19 @@ void ConsolidationFx::read_sparse_unordered_full() {
   uint64_t c_buffer_coords[] = {1, 1, 1, 2, 1, 4, 2, 3, 3, 1,
                                 3, 2, 4, 1, 4, 2, 3, 3, 3, 4};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Compute max buffer sizes
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   uint64_t max_buffer_sizes[5];
   uint64_t subarray[] = {1, 4, 1, 4};
-  int rc = tiledb_array_compute_max_read_buffer_sizes(
-      ctx_, SPARSE_ARRAY_NAME, subarray, attributes, 4, &max_buffer_sizes[0]);
+  rc = tiledb_array_compute_max_read_buffer_sizes(
+      ctx_, array, subarray, attributes, 4, &max_buffer_sizes[0]);
   CHECK(rc == TILEDB_OK);
 
   // Prepare cell buffers
@@ -788,7 +903,7 @@ void ConsolidationFx::read_sparse_unordered_full() {
 
   // Create query
   tiledb_query_t* query;
-  rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -811,7 +926,12 @@ void ConsolidationFx::read_sparse_unordered_full() {
   CHECK(!memcmp(buffer_a3, c_buffer_a3, sizeof(c_buffer_a3)));
   CHECK(!memcmp(buffer_coords, c_buffer_coords, sizeof(c_buffer_coords)));
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
   free(buffer_a1);
   free(buffer_a2);

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -90,7 +90,7 @@ DenseVectorFx::DenseVectorFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
   if (supports_s3_) {
 #ifndef TILEDB_TESTS_AWS_S3_CONFIG
@@ -108,10 +108,10 @@ DenseVectorFx::DenseVectorFx() {
     REQUIRE(error == nullptr);
 #endif
   }
-  REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx_, config) == TILEDB_OK);
   REQUIRE(error == nullptr);
   vfs_ = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_alloc(ctx_, &vfs_, config) == TILEDB_OK);
   tiledb_config_free(&config);
 
   // Connect to S3
@@ -144,7 +144,7 @@ DenseVectorFx::~DenseVectorFx() {
 
 void DenseVectorFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
-  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx, nullptr) == TILEDB_OK);
 
   int is_supported = 0;
   int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
@@ -183,10 +183,10 @@ void DenseVectorFx::create_dense_vector(const std::string& path) {
 
   // Create domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   REQUIRE(rc == TILEDB_OK);
   tiledb_dimension_t* dim;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &dim, DIM0_NAME, TILEDB_INT64, dim_domain, &tile_extent);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, dim);
@@ -194,12 +194,12 @@ void DenseVectorFx::create_dense_vector(const std::string& path) {
 
   // Create attribute
   tiledb_attribute_t* attr;
-  rc = tiledb_attribute_create(ctx_, &attr, ATTR_NAME, ATTR_TYPE);
+  rc = tiledb_attribute_alloc(ctx_, &attr, ATTR_NAME, ATTR_TYPE);
   REQUIRE(rc == TILEDB_OK);
 
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_DENSE);
+  rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_DENSE);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
   REQUIRE(rc == TILEDB_OK);
@@ -222,12 +222,19 @@ void DenseVectorFx::create_dense_vector(const std::string& path) {
 
   const char* attributes[] = {ATTR_NAME};
 
+  // Open array
+  tiledb_array_t* array;
+  rc = tiledb_array_alloc(ctx_, path.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   int64_t buffer_val[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   // Write array
   void* write_buffers[] = {buffer_val};
   uint64_t write_buffer_sizes[] = {sizeof(buffer_val)};
   tiledb_query_t* write_query;
-  rc = tiledb_query_create(ctx_, &write_query, path.c_str(), TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &write_query, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, write_query, attributes, 1, write_buffers, write_buffer_sizes);
@@ -238,6 +245,13 @@ void DenseVectorFx::create_dense_vector(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_finalize(ctx_, write_query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&write_query);
 }
 
@@ -251,7 +265,14 @@ void DenseVectorFx::check_read(
   tiledb_query_t* read_query = nullptr;
   const char* attributes[] = {ATTR_NAME};
 
-  int rc = tiledb_query_create(ctx_, &read_query, path.c_str(), TILEDB_READ);
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, path.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_query_alloc(ctx_, &read_query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, read_query, attributes, 1, read_buffers, read_buffer_sizes);
@@ -264,11 +285,18 @@ void DenseVectorFx::check_read(
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_finalize(ctx_, read_query);
   REQUIRE(rc == TILEDB_OK);
-  tiledb_query_free(&read_query);
 
   CHECK(buffer[0] == 0);
   CHECK(buffer[1] == 1);
   CHECK(buffer[2] == 2);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_query_free(&read_query);
 }
 
 void DenseVectorFx::check_update(const std::string& path) {
@@ -278,9 +306,16 @@ void DenseVectorFx::check_update(const std::string& path) {
   void* update_buffers[] = {update_buffer};
   uint64_t update_buffer_sizes[] = {sizeof(update_buffer)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, path.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Update
   tiledb_query_t* update_query;
-  int rc = tiledb_query_create(ctx_, &update_query, path.c_str(), TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &update_query, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, update_query, attributes, 1, update_buffers, update_buffer_sizes);
@@ -293,14 +328,24 @@ void DenseVectorFx::check_update(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_finalize(ctx_, update_query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
   tiledb_query_free(&update_query);
+
+  // Open array
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
 
   // Read
   int64_t buffer[] = {0, 0, 0};
   void* read_buffers[] = {buffer};
   uint64_t read_buffer_sizes[] = {sizeof(buffer)};
   tiledb_query_t* read_query = nullptr;
-  rc = tiledb_query_create(ctx_, &read_query, path.c_str(), TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &read_query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, read_query, attributes, 1, read_buffers, read_buffer_sizes);
@@ -313,12 +358,26 @@ void DenseVectorFx::check_update(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_finalize(ctx_, read_query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&read_query);
 
   CHECK((buffer[0] == 9 && buffer[1] == 8 && buffer[2] == 7));
 }
 
 void DenseVectorFx::check_duplicate_coords(const std::string& path) {
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, path.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   const int64_t num_writes = 5;
   for (int64_t write_num = 0; write_num < num_writes; write_num++) {
     const char* attributes[] = {ATTR_NAME, TILEDB_COORDS};
@@ -330,8 +389,7 @@ void DenseVectorFx::check_duplicate_coords(const std::string& path) {
 
     // Update
     tiledb_query_t* update_query;
-    int rc =
-        tiledb_query_create(ctx_, &update_query, path.c_str(), TILEDB_WRITE);
+    rc = tiledb_query_alloc(ctx_, &update_query, array, TILEDB_WRITE);
     REQUIRE(rc == TILEDB_OK);
     rc = tiledb_query_set_buffers(
         ctx_, update_query, attributes, 2, update_buffers, update_buffer_sizes);
@@ -345,6 +403,14 @@ void DenseVectorFx::check_duplicate_coords(const std::string& path) {
     tiledb_query_free(&update_query);
   }
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Open array
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Read
   uint64_t subarray[] = {7, 9};
   const char* attributes[] = {ATTR_NAME};
@@ -352,7 +418,7 @@ void DenseVectorFx::check_duplicate_coords(const std::string& path) {
   void* read_buffers[] = {buffer};
   uint64_t read_buffer_sizes[] = {sizeof(buffer)};
   tiledb_query_t* read_query = nullptr;
-  int rc = tiledb_query_create(ctx_, &read_query, path.c_str(), TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &read_query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, read_query, attributes, 1, read_buffers, read_buffer_sizes);
@@ -365,6 +431,13 @@ void DenseVectorFx::check_duplicate_coords(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_finalize(ctx_, read_query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&read_query);
 
   CHECK(

--- a/test/src/unit-capi-error.cc
+++ b/test/src/unit-capi-error.cc
@@ -38,7 +38,7 @@
 
 TEST_CASE("C API: Test error and error message", "[capi], [error]") {
   tiledb_ctx_t* ctx;
-  int rc = tiledb_ctx_create(&ctx, nullptr);
+  int rc = tiledb_ctx_alloc(&ctx, nullptr);
   CHECK(rc == TILEDB_OK);
 
   const char* bad_path = nullptr;

--- a/test/src/unit-capi-incomplete.cc
+++ b/test/src/unit-capi-incomplete.cc
@@ -74,7 +74,7 @@ struct IncompleteFx {
 
 IncompleteFx::IncompleteFx() {
   ctx_ = nullptr;
-  REQUIRE(tiledb_ctx_create(&ctx_, NULL) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx_, NULL) == TILEDB_OK);
 }
 
 IncompleteFx::~IncompleteFx() {
@@ -86,17 +86,17 @@ void IncompleteFx::create_dense_array() {
   uint64_t dim_domain[] = {1, 4, 1, 4};
   uint64_t tile_extents[] = {2, 2};
   tiledb_dimension_t* d1;
-  int rc = tiledb_dimension_create(
+  int rc = tiledb_dimension_alloc(
       ctx_, &d1, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0]);
   CHECK(rc == TILEDB_OK);
   tiledb_dimension_t* d2;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1]);
   CHECK(rc == TILEDB_OK);
 
   // Create domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   CHECK(rc == TILEDB_OK);
@@ -105,7 +105,7 @@ void IncompleteFx::create_dense_array() {
 
   // Create attributes
   tiledb_attribute_t* a1;
-  rc = tiledb_attribute_create(ctx_, &a1, "a1", TILEDB_INT32);
+  rc = tiledb_attribute_alloc(ctx_, &a1, "a1", TILEDB_INT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a1, TILEDB_BLOSC_LZ, -1);
   CHECK(rc == TILEDB_OK);
@@ -113,7 +113,7 @@ void IncompleteFx::create_dense_array() {
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a2;
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_attribute_create(ctx_, &a2, "a2", TILEDB_CHAR);
+  rc = tiledb_attribute_alloc(ctx_, &a2, "a2", TILEDB_CHAR);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a2, TILEDB_GZIP, -1);
   CHECK(rc == TILEDB_OK);
@@ -121,7 +121,7 @@ void IncompleteFx::create_dense_array() {
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a3;
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_attribute_create(ctx_, &a3, "a3", TILEDB_FLOAT32);
+  rc = tiledb_attribute_alloc(ctx_, &a3, "a3", TILEDB_FLOAT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a3, TILEDB_ZSTD, -1);
   CHECK(rc == TILEDB_OK);
@@ -130,7 +130,7 @@ void IncompleteFx::create_dense_array() {
 
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_DENSE);
+  rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_DENSE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -168,17 +168,17 @@ void IncompleteFx::create_sparse_array() {
   uint64_t dim_domain[] = {1, 4, 1, 4};
   uint64_t tile_extents[] = {2, 2};
   tiledb_dimension_t* d1;
-  int rc = tiledb_dimension_create(
+  int rc = tiledb_dimension_alloc(
       ctx_, &d1, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0]);
   CHECK(rc == TILEDB_OK);
   tiledb_dimension_t* d2;
-  rc = tiledb_dimension_create(
+  rc = tiledb_dimension_alloc(
       ctx_, &d2, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1]);
   CHECK(rc == TILEDB_OK);
 
   // Create domain
   tiledb_domain_t* domain;
-  rc = tiledb_domain_create(ctx_, &domain);
+  rc = tiledb_domain_alloc(ctx_, &domain);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_domain_add_dimension(ctx_, domain, d1);
   CHECK(rc == TILEDB_OK);
@@ -187,21 +187,21 @@ void IncompleteFx::create_sparse_array() {
 
   // Create attributes
   tiledb_attribute_t* a1;
-  rc = tiledb_attribute_create(ctx_, &a1, "a1", TILEDB_INT32);
+  rc = tiledb_attribute_alloc(ctx_, &a1, "a1", TILEDB_INT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a1, TILEDB_BLOSC_LZ, -1);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_cell_val_num(ctx_, a1, 1);
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a2;
-  rc = tiledb_attribute_create(ctx_, &a2, "a2", TILEDB_CHAR);
+  rc = tiledb_attribute_alloc(ctx_, &a2, "a2", TILEDB_CHAR);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a2, TILEDB_GZIP, -1);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_cell_val_num(ctx_, a2, TILEDB_VAR_NUM);
   CHECK(rc == TILEDB_OK);
   tiledb_attribute_t* a3;
-  rc = tiledb_attribute_create(ctx_, &a3, "a3", TILEDB_FLOAT32);
+  rc = tiledb_attribute_alloc(ctx_, &a3, "a3", TILEDB_FLOAT32);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_attribute_set_compressor(ctx_, a3, TILEDB_ZSTD, -1);
   CHECK(rc == TILEDB_OK);
@@ -210,7 +210,7 @@ void IncompleteFx::create_sparse_array() {
 
   // Create array schmea
   tiledb_array_schema_t* array_schema;
-  rc = tiledb_array_schema_create(ctx_, &array_schema, TILEDB_SPARSE);
+  rc = tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_SPARSE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -280,9 +280,16 @@ void IncompleteFx::write_dense_full() {
   };
   // clang-format on
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -298,7 +305,12 @@ void IncompleteFx::write_dense_full() {
   rc = tiledb_query_finalize(ctx_, query);
   CHECK(rc == TILEDB_OK);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -333,10 +345,17 @@ void IncompleteFx::write_sparse_full() {
       sizeof(buffer_a3),
       sizeof(buffer_coords)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
-  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_WRITE);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
@@ -352,7 +371,12 @@ void IncompleteFx::write_sparse_full() {
   rc = tiledb_query_finalize(ctx_, query);
   CHECK(rc == TILEDB_OK);
 
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -389,9 +413,16 @@ void IncompleteFx::check_dense_incomplete() {
   void* buffers[] = {buffer_a1};
   uint64_t buffer_sizes[] = {sizeof(buffer_a1)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 1, buffers, buffer_sizes);
@@ -414,6 +445,13 @@ void IncompleteFx::check_dense_incomplete() {
   // Free/finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 
   // Check buffer
@@ -434,9 +472,16 @@ void IncompleteFx::check_dense_until_complete() {
   void* buffers[] = {buffer_a1};
   uint64_t buffer_sizes[] = {sizeof(buffer_a1)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 1, buffers, buffer_sizes);
@@ -478,6 +523,13 @@ void IncompleteFx::check_dense_until_complete() {
   // Free/finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -494,9 +546,16 @@ void IncompleteFx::check_dense_unsplittable_overflow() {
   void* buffers[] = {buffer_a2, buffer_a2_var};
   uint64_t buffer_sizes[] = {sizeof(buffer_a2), sizeof(buffer_a2_var)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 1, buffers, buffer_sizes);
@@ -510,9 +569,16 @@ void IncompleteFx::check_dense_unsplittable_overflow() {
   rc = tiledb_query_submit(ctx_, query);
   CHECK(rc == TILEDB_ERR);
 
-  // Free/finalize query
+  // Finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -529,9 +595,16 @@ void IncompleteFx::check_dense_unsplittable_complete() {
   void* buffers[] = {buffer_a2, buffer_a2_var};
   uint64_t buffer_sizes[] = {sizeof(buffer_a2), sizeof(buffer_a2_var)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 1, buffers, buffer_sizes);
@@ -549,9 +622,16 @@ void IncompleteFx::check_dense_unsplittable_complete() {
   char c_buffer_a2_var[2] = {'b', 'b'};
   CHECK(!memcmp(buffer_a2_var, c_buffer_a2_var, sizeof(c_buffer_a2_var)));
 
-  // Free/finalize query
+  // Finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -567,9 +647,16 @@ void IncompleteFx::check_dense_reset_buffers() {
   void* buffers[] = {buffer_a1};
   uint64_t buffer_sizes[] = {sizeof(buffer_a1)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, DENSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 1, buffers, buffer_sizes);
@@ -617,9 +704,16 @@ void IncompleteFx::check_dense_reset_buffers() {
   CHECK(!memcmp(buffer_a1, c_buffer_a1_2, sizeof(c_buffer_a1_2)));
   CHECK(buffer_sizes[0] == 2 * sizeof(int));
 
-  // Free/finalize query
+  // Finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -635,9 +729,16 @@ void IncompleteFx::check_sparse_incomplete() {
   void* buffers[] = {buffer_a1};
   uint64_t buffer_sizes[] = {sizeof(buffer_a1)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 1, buffers, buffer_sizes);
@@ -657,9 +758,16 @@ void IncompleteFx::check_sparse_incomplete() {
   CHECK(rc == TILEDB_OK);
   CHECK(status == TILEDB_INCOMPLETE);
 
-  // Free/finalize query
+  // Finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 
   // Check buffer
@@ -680,9 +788,16 @@ void IncompleteFx::check_sparse_until_complete() {
   void* buffers[] = {buffer_a1};
   uint64_t buffer_sizes[] = {sizeof(buffer_a1)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 1, buffers, buffer_sizes);
@@ -721,9 +836,16 @@ void IncompleteFx::check_sparse_until_complete() {
   CHECK(!memcmp(buffer_a1, c_buffer_a1, sizeof(c_buffer_a1)));
   CHECK(buffer_sizes[0] == sizeof(int));
 
-  // Free/finalize query
+  // Finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -740,9 +862,16 @@ void IncompleteFx::check_sparse_unsplittable_overflow() {
   void* buffers[] = {buffer_a2, buffer_a2_var};
   uint64_t buffer_sizes[] = {sizeof(buffer_a2), sizeof(buffer_a2_var)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 1, buffers, buffer_sizes);
@@ -756,9 +885,16 @@ void IncompleteFx::check_sparse_unsplittable_overflow() {
   rc = tiledb_query_submit(ctx_, query);
   CHECK(rc == TILEDB_ERR);
 
-  // Free/finalize query
+  // Finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
@@ -775,9 +911,16 @@ void IncompleteFx::check_sparse_unsplittable_complete() {
   void* buffers[] = {buffer_a2, buffer_a2_var};
   uint64_t buffer_sizes[] = {sizeof(buffer_a2), sizeof(buffer_a2_var)};
 
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query;
-  int rc = tiledb_query_create(ctx_, &query, SPARSE_ARRAY_NAME, TILEDB_READ);
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffers(
       ctx_, query, attributes, 1, buffers, buffer_sizes);
@@ -795,9 +938,16 @@ void IncompleteFx::check_sparse_unsplittable_complete() {
   char c_buffer_a2_var[2] = {'b', 'b'};
   CHECK(!memcmp(buffer_a2_var, c_buffer_a2_var, sizeof(c_buffer_a2_var)));
 
-  // Free/finalize query
+  // Finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 

--- a/test/src/unit-capi-object_mgmt.cc
+++ b/test/src/unit-capi-object_mgmt.cc
@@ -99,7 +99,7 @@ ObjectMgmtFx::ObjectMgmtFx() {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
 
   if (supports_s3_) {
@@ -119,10 +119,10 @@ ObjectMgmtFx::ObjectMgmtFx() {
 #endif
   }
 
-  REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx_, config) == TILEDB_OK);
   REQUIRE(error == nullptr);
   vfs_ = nullptr;
-  REQUIRE(tiledb_vfs_create(ctx_, &vfs_, config) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_alloc(ctx_, &vfs_, config) == TILEDB_OK);
   tiledb_config_free(&config);
 
   // Connect to S3
@@ -155,7 +155,7 @@ ObjectMgmtFx::~ObjectMgmtFx() {
 
 void ObjectMgmtFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
-  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx, nullptr) == TILEDB_OK);
 
   int is_supported = 0;
   int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
@@ -182,7 +182,7 @@ void ObjectMgmtFx::remove_temp_dir(const std::string& path) {
 
 void ObjectMgmtFx::create_array(const std::string& path) {
   tiledb_attribute_t* a1;
-  tiledb_attribute_create(ctx_, &a1, "a1", TILEDB_FLOAT32);
+  tiledb_attribute_alloc(ctx_, &a1, "a1", TILEDB_FLOAT32);
 
   // Domain and tile extents
   int64_t dim_domain[2] = {1, 1};
@@ -190,17 +190,17 @@ void ObjectMgmtFx::create_array(const std::string& path) {
 
   // Create dimension
   tiledb_dimension_t* d1;
-  tiledb_dimension_create(
+  tiledb_dimension_alloc(
       ctx_, &d1, "d1", TILEDB_INT64, &dim_domain[0], &tile_extents[0]);
 
   // Domain
   tiledb_domain_t* domain;
-  tiledb_domain_create(ctx_, &domain);
+  tiledb_domain_alloc(ctx_, &domain);
   tiledb_domain_add_dimension(ctx_, domain, d1);
 
   // Create array schema
   tiledb_array_schema_t* array_schema;
-  tiledb_array_schema_create(ctx_, &array_schema, TILEDB_DENSE);
+  tiledb_array_schema_alloc(ctx_, &array_schema, TILEDB_DENSE);
   tiledb_array_schema_set_domain(ctx_, array_schema, domain);
   tiledb_array_schema_add_attribute(ctx_, array_schema, a1);
 

--- a/test/src/unit-capi-uri.cc
+++ b/test/src/unit-capi-uri.cc
@@ -49,7 +49,7 @@ static const unsigned PLATFORM_PATH_MAX = PATH_MAX;
 TEST_CASE("C API: Test URI", "[capi], [uri]") {
   int rc;
   tiledb_ctx_t* ctx;
-  rc = tiledb_ctx_create(&ctx, nullptr);
+  rc = tiledb_ctx_alloc(&ctx, nullptr);
   REQUIRE(rc == TILEDB_OK);
 
   char path[PLATFORM_PATH_MAX];

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -97,7 +97,7 @@ VFSFx::~VFSFx() {
 
 void VFSFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
-  REQUIRE(tiledb_ctx_create(&ctx, nullptr) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx, nullptr) == TILEDB_OK);
 
   int is_supported = 0;
   int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
@@ -119,7 +119,7 @@ void VFSFx::set_num_vfs_threads(unsigned num_threads) {
   // Create TileDB context
   tiledb_config_t* config = nullptr;
   tiledb_error_t* error = nullptr;
-  REQUIRE(tiledb_config_create(&config, &error) == TILEDB_OK);
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
   if (supports_s3_) {
 #ifndef TILEDB_TESTS_AWS_S3_CONFIG
@@ -165,9 +165,9 @@ void VFSFx::set_num_vfs_threads(unsigned num_threads) {
       TILEDB_OK);
   REQUIRE(error == nullptr);
 
-  REQUIRE(tiledb_ctx_create(&ctx_, config) == TILEDB_OK);
+  REQUIRE(tiledb_ctx_alloc(&ctx_, config) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  int rc = tiledb_vfs_create(ctx_, &vfs_, config);
+  int rc = tiledb_vfs_alloc(ctx_, &vfs_, config);
   REQUIRE(rc == TILEDB_OK);
   tiledb_config_free(&config);
 }
@@ -650,7 +650,7 @@ TEST_CASE_METHOD(
     "[capi], [vfs]") {
   if (!supports_s3_) {
     tiledb_vfs_t* vfs;
-    int rc = tiledb_vfs_create(ctx_, &vfs, nullptr);
+    int rc = tiledb_vfs_alloc(ctx_, &vfs, nullptr);
     REQUIRE(rc == TILEDB_OK);
     rc = tiledb_vfs_create_bucket(ctx_, vfs, "s3://foo");
     REQUIRE(rc == TILEDB_ERR);
@@ -663,7 +663,7 @@ TEST_CASE_METHOD(
   // Prepare a config
   tiledb_error_t* error = nullptr;
   tiledb_config_t* config;
-  int rc = tiledb_config_create(&config, &error);
+  int rc = tiledb_config_alloc(&config, &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
   rc = tiledb_config_set(config, "vfs.s3.scheme", "http", &error);
@@ -672,7 +672,7 @@ TEST_CASE_METHOD(
 
   // Create VFS
   tiledb_vfs_t* vfs;
-  rc = tiledb_vfs_create(ctx_, &vfs, config);
+  rc = tiledb_vfs_alloc(ctx_, &vfs, config);
   REQUIRE(rc == TILEDB_OK);
 
   // Get VFS config and check

--- a/test/src/unit-cppapi-map.cc
+++ b/test/src/unit-cppapi-map.cc
@@ -62,7 +62,7 @@ struct CPPMapFx {
   VFS vfs;
 };
 
-TEST_CASE_METHOD(CPPMapFx, "C++ API: Map", "[cppapi]") {
+TEST_CASE_METHOD(CPPMapFx, "C++ API: Map", "[cppapi], [cppapi-map]") {
   Map map(ctx, "cpp_unit_map");
 
   int simple_key = 10;
@@ -77,7 +77,10 @@ TEST_CASE_METHOD(CPPMapFx, "C++ API: Map", "[cppapi]") {
   CHECK_THROWS(map.add_item(i1));
   i1["a1"] = 1;
   map.add_item(i1);
+
   map.flush();
+  map.close();
+  map.open();
 
   using my_cell_t = std::tuple<int, std::string, std::array<double, 2>>;
 
@@ -92,6 +95,9 @@ TEST_CASE_METHOD(CPPMapFx, "C++ API: Map", "[cppapi]") {
   map[compound_key][{"a1", "a2", "a3"}] = my_cell_t(2, "aaa", {{4.2, 1}});
 
   map.flush();
+  map.close();
+  map.open();
+
   CHECK(map.has_key(simple_key));
   CHECK(map.has_key(compound_key));
   CHECK(!map.has_key(3453463));
@@ -106,7 +112,7 @@ TEST_CASE_METHOD(CPPMapFx, "C++ API: Map", "[cppapi]") {
   CHECK(std::get<2>(ret).size() == 2);
   CHECK(std::get<2>(ret)[0] == 4.2);
 
-  map.finalize();
+  map.close();
 }
 
 /**
@@ -119,7 +125,7 @@ TEST_CASE_METHOD(CPPMapFx, "C++ API: Map", "[cppapi]") {
 TEST_CASE_METHOD(
     CPPMapFx,
     "C++ API: Map Issue 606 segault in Reader::zero_out_buffer_sizes()",
-    "[cppapi]") {
+    "[cppapi], [cppapi-map]") {
   Map map(ctx, "cpp_unit_map");
 
   int simple_key = 1;
@@ -137,7 +143,12 @@ TEST_CASE_METHOD(
 
   // Add the item
   map.add_item(i1);
+
+  // Flush and reopen
   map.flush();
+  map.close();
+  map.open();
+
   CHECK(map.has_key(simple_key));
 
   // Validate item is now on map
@@ -147,7 +158,7 @@ TEST_CASE_METHOD(
   CHECK(test_get_item_by_key.get<std::string>("a2") == "someval");
   CHECK(test_get_item_by_key.get<std::array<double, 2>>("a3")[0] == 3);
 
-  map.finalize();
+  map.close();
 }
 
 struct CPPMapFx1A {
@@ -175,14 +186,19 @@ struct CPPMapFx1A {
   VFS vfs;
 };
 
-TEST_CASE_METHOD(CPPMapFx1A, "C++ API: Map, implicit attribute", "[cppapi]") {
+TEST_CASE_METHOD(
+    CPPMapFx1A, "C++ API: Map, implicit attribute", "[cppapi], [cppapi-map]") {
   Map map(ctx, "cpp_unit_map");
-
   map[10] = 1;
+
+  // Flush and reopen
   map.flush();
+  map.close();
+  map.open();
+
   assert(int(map[10]) == 1);
 
-  map.finalize();
+  map.close();
 }
 
 struct CPPMapFromMapFx {
@@ -210,17 +226,35 @@ struct CPPMapFromMapFx {
   VFS vfs;
 };
 
-TEST_CASE_METHOD(CPPMapFromMapFx, "C++ API: Map from std::map", "[cppapi]") {
+TEST_CASE_METHOD(
+    CPPMapFromMapFx, "C++ API: Map from std::map", "[cppapi], [cppapi-map]") {
   Map map(ctx, "cpp_unit_map");
   CHECK(map[0]["val"].get<std::string>() == "0");
   CHECK(map[1]["val"].get<std::string>() == "12");
   CHECK(map[2].get<std::string>() == "123");  // implicit
+  map.close();
 
-  map.finalize();
+  // Check reopening
+  map.open();
+  CHECK(map[0]["val"].get<std::string>() == "0");
+  CHECK(map[1]["val"].get<std::string>() == "12");
+  CHECK(map[2].get<std::string>() == "123");  // implicit
+
+  // Check opening without closing
+  map.open();
+  CHECK(map[0]["val"].get<std::string>() == "0");
+  CHECK(map[1]["val"].get<std::string>() == "12");
+  CHECK(map[2].get<std::string>() == "123");  // implicit
+  map.close();
 }
 
-TEST_CASE_METHOD(CPPMapFromMapFx, "C++ API: Map iter", "[cppapi]") {
+TEST_CASE_METHOD(
+    CPPMapFromMapFx, "C++ API: Map iter", "[cppapi], [cppapi-map]") {
   Map map(ctx, "cpp_unit_map");
+
+  // Test closing and reopening
+  map.close();
+  map.open();
 
   std::vector<std::string> vals;
   for (auto& item : map) {
@@ -233,11 +267,9 @@ TEST_CASE_METHOD(CPPMapFromMapFx, "C++ API: Map iter", "[cppapi]") {
   CHECK(std::count(vals.begin(), vals.end(), "123") == 1);
 
   MapIter iter(map), end(map, true);
-  iter.init();
-  vals = {};
-  while (iter != end) {
+  vals.clear();
+  for (; iter != end; ++iter) {
     vals.push_back(iter->get<std::string>());
-    ++iter;
   }
 
   REQUIRE(vals.size() == 3);
@@ -245,7 +277,5 @@ TEST_CASE_METHOD(CPPMapFromMapFx, "C++ API: Map iter", "[cppapi]") {
   CHECK(std::count(vals.begin(), vals.end(), "12") == 1);
   CHECK(std::count(vals.begin(), vals.end(), "123") == 1);
 
-  // don't need to finalize end since init() not called
-  iter.finalize();
-  map.finalize();
+  map.close();
 }

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -195,9 +195,7 @@ Status ArraySchema::buffer_num(
 
   *buffer_num = 0;
   for (unsigned int i = 0; i < attribute_num; ++i) {
-    unsigned int id;
-    RETURN_NOT_OK(attribute_id(attributes[i], &id));
-    if (var_size(id))
+    if (var_size(attributes[i]))
       (*buffer_num) += 2;
     else
       ++(*buffer_num);

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -303,7 +303,7 @@ TILEDB_EXPORT void tiledb_error_free(tiledb_error_t** err);
  * @code{.c}
  * tiledb_config_t* config;
  * tiledb_error_t* error = NULL;
- * tiledb_config_create(&config, &error);
+ * tiledb_config_alloc(&config, &error);
  * @endcode
  *
  * @param config The config to be created.
@@ -311,7 +311,7 @@ TILEDB_EXPORT void tiledb_error_free(tiledb_error_t** err);
  *     no error).
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_config_create(
+TILEDB_EXPORT int tiledb_config_alloc(
     tiledb_config_t** config, tiledb_error_t** error);
 
 /**
@@ -322,7 +322,7 @@ TILEDB_EXPORT int tiledb_config_create(
  * @code{.c}
  * tiledb_config_t* config;
  * tiledb_error_t* error = NULL;
- * tiledb_config_create(&config, &error);
+ * tiledb_config_alloc(&config, &error);
  * tiledb_config_free(&config);
  * @endcode
  *
@@ -561,7 +561,7 @@ TILEDB_EXPORT int tiledb_config_save_to_file(
  * @code{.c}
  * tiledb_error_t* error = NULL;
  * tiledb_config_iter_t* config_iter;
- * tiledb_config_iter_create(config, &config_iter, NULL, &error);
+ * tiledb_config_iter_alloc(config, &config_iter, NULL, &error);
  * @endcode
  *
  * The following creates a config iterator with a prefix. This
@@ -573,7 +573,7 @@ TILEDB_EXPORT int tiledb_config_save_to_file(
  * @code{.c}
  * tiledb_error_t* error = NULL;
  * tiledb_config_iter_t* config_iter;
- * tiledb_config_iter_create(config, &config_iter, "vfs.s3.", &error);
+ * tiledb_config_iter_alloc(config, &config_iter, "vfs.s3.", &error);
  * @endcode
  *
  * @param config A config object the iterator will operate on.
@@ -586,7 +586,7 @@ TILEDB_EXPORT int tiledb_config_save_to_file(
  *     no error).
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_config_iter_create(
+TILEDB_EXPORT int tiledb_config_iter_alloc(
     tiledb_config_t* config,
     tiledb_config_iter_t** config_iter,
     const char* prefix,
@@ -713,22 +713,21 @@ TILEDB_EXPORT int tiledb_config_iter_done(
  *
  * @code{.c}
  * tiledb_ctx_t* ctx;
- * tiledb_ctx_create(&ctx, NULL);
+ * tiledb_ctx_alloc(&ctx, NULL);
  * @endcode
  *
  * With some config:
  *
  * @code{.c}
  * tiledb_ctx_t* ctx;
- * tiledb_ctx_create(&ctx, config);
+ * tiledb_ctx_alloc(&ctx, config);
  * @endcode
  *
  * @param ctx The TileDB context to be created.
  * @param config The configuration parameters (`NULL` means default).
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_ctx_create(
-    tiledb_ctx_t** ctx, tiledb_config_t* config);
+TILEDB_EXPORT int tiledb_ctx_alloc(tiledb_ctx_t** ctx, tiledb_config_t* config);
 
 /**
  * Destroys the TileDB context, freeing all associated memory and resources.
@@ -737,7 +736,7 @@ TILEDB_EXPORT int tiledb_ctx_create(
  *
  * @code{.c}
  * tiledb_ctx_t* ctx;
- * tiledb_ctx_create(&ctx, NULL);
+ * tiledb_ctx_alloc(&ctx, NULL);
  * tiledb_ctx_free(&ctx);
  * @endcode
  *
@@ -838,7 +837,7 @@ TILEDB_EXPORT int tiledb_group_create(tiledb_ctx_t* ctx, const char* group_uri);
  *
  * @code{.c}
  * tiledb_attribute_t* attr;
- * tiledb_attribute_create(ctx, &attr, "my_attr", TILEDB_INT32);
+ * tiledb_attribute_alloc(ctx, &attr, "my_attr", TILEDB_INT32);
  * @endcode
  *
  * @param ctx The TileDB context.
@@ -849,7 +848,7 @@ TILEDB_EXPORT int tiledb_group_create(tiledb_ctx_t* ctx, const char* group_uri);
  *
  * @note The default number of values per cell is 1.
  */
-TILEDB_EXPORT int tiledb_attribute_create(
+TILEDB_EXPORT int tiledb_attribute_alloc(
     tiledb_ctx_t* ctx,
     tiledb_attribute_t** attr,
     const char* name,
@@ -862,7 +861,7 @@ TILEDB_EXPORT int tiledb_attribute_create(
  *
  * @code{.c}
  * tiledb_attribute_t* attr;
- * tiledb_attribute_create(ctx, &attr, "my_attr", TILEDB_INT32);
+ * tiledb_attribute_alloc(ctx, &attr, "my_attr", TILEDB_INT32);
  * tiledb_attribute_free(&attr);
  * @endcode
  *
@@ -1045,14 +1044,14 @@ TILEDB_EXPORT int tiledb_attribute_dump(
  *
  * @code{.c}
  * tiledb_domain_t* domain;
- * tiledb_domain_create(ctx, &domain);
+ * tiledb_domain_alloc(ctx, &domain);
  * @endcode
  *
  * @param ctx The TileDB context.
  * @param domain The TileDB domain to be created.
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_domain_create(
+TILEDB_EXPORT int tiledb_domain_alloc(
     tiledb_ctx_t* ctx, tiledb_domain_t** domain);
 
 /**
@@ -1062,7 +1061,7 @@ TILEDB_EXPORT int tiledb_domain_create(
  *
  * @code{.c}
  * tiledb_domain_t* domain;
- * tiledb_domain_create(ctx, &domain);
+ * tiledb_domain_alloc(ctx, &domain);
  * tiledb_domain_free(&domain);
  * @endcode
  *
@@ -1114,7 +1113,7 @@ TILEDB_EXPORT int tiledb_domain_get_ndim(
  * @code{.c}
  * tiledb_dimension_t* dim;
  * uint64_t dim_domain[] = {1, 10};
- * tiledb_dimension_create(ctx, &dim, "dim_0", TILEDB_INT64, dim_domain, 5);
+ * tiledb_dimension_alloc(ctx, &dim, "dim_0", TILEDB_INT64, dim_domain, 5);
  * tiledb_domain_add_dimension(ctx, domain, dim);
  * @endcode
  *
@@ -1204,7 +1203,7 @@ TILEDB_EXPORT int tiledb_domain_dump(
  * @code{.c}
  * tiledb_dimension_t* dim;
  * uint64_t dim_domain[] = {1, 10};
- * tiledb_dimension_create(ctx, &dim, "dim_0", TILEDB_INT64, dim_domain, 5);
+ * tiledb_dimension_alloc(ctx, &dim, "dim_0", TILEDB_INT64, dim_domain, 5);
  * @endcode
  *
  * @param ctx The TileDB context.
@@ -1215,7 +1214,7 @@ TILEDB_EXPORT int tiledb_domain_dump(
  * @param tile_extent The dimension tile extent.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_dimension_create(
+TILEDB_EXPORT int tiledb_dimension_alloc(
     tiledb_ctx_t* ctx,
     tiledb_dimension_t** dim,
     const char* name,
@@ -1343,7 +1342,7 @@ TILEDB_EXPORT int tiledb_dimension_dump(
  *
  * @code{.c}
  * tiledb_array_schema_t* array_schema;
- * tiledb_array_schema_create(ctx, &array_schema, TILEDB_DENSE);
+ * tiledb_array_schema_alloc(ctx, &array_schema, TILEDB_DENSE);
  * @endcode
  *
  * @param ctx The TileDB context.
@@ -1351,7 +1350,7 @@ TILEDB_EXPORT int tiledb_dimension_dump(
  * @param array_type The array type.
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_array_schema_create(
+TILEDB_EXPORT int tiledb_array_schema_alloc(
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t** array_schema,
     tiledb_array_type_t array_type);
@@ -1377,7 +1376,7 @@ TILEDB_EXPORT void tiledb_array_schema_free(
  *
  * @code{.c}
  * tiledb_attribute_t* attr;
- * tiledb_attribute_create(ctx, &attr, "my_attr", TILEDB_INT32);
+ * tiledb_attribute_alloc(ctx, &attr, "my_attr", TILEDB_INT32);
  * tiledb_array_schema_add_attribute(ctx, array_schema, attr);
  * @endcode
  *
@@ -1398,7 +1397,7 @@ TILEDB_EXPORT int tiledb_array_schema_add_attribute(
  *
  * @code{.c}
  * tiledb_domain_t* domain;
- * tiledb_domain_create(ctx, &domain);
+ * tiledb_domain_alloc(ctx, &domain);
  * // -- Add dimensions to the domain here -- //
  * tiledb_array_schema_set_domain(ctx, array_schema, domain);
  * @endcode
@@ -1804,38 +1803,27 @@ TILEDB_EXPORT int tiledb_array_schema_dump(
 /**
  * Creates a TileDB query object.
  *
- * When creating a query, the storage manager "opens" the array in read or write
- * mode based on the query type, incrementing the array's reference count and
- * loading the array metadata (schema and fragment metadata) into its
- * main-memory cache.
- *
- * The storage manager also acquires a **shared lock** on the array. This means
- * multiple read and write queries to the same array can be made concurrently
- * (in TileDB, only consolidation requires an exclusive lock for a short period
- * of time).
- *
- * To "close" an array, the user should call `tiledb_query_finalize` (see the
- * documentation of that function for more details).
- *
  * **Example:**
  *
  * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_open(ctx, "file:///my_array", &array);
  * tiledb_query_t* query;
- * tiledb_query_create(ctx, &query, "file:///my_array", TILEDB_READ);
+ * tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
  * @endcode
  *
  * @param ctx The TileDB context.
  * @param query The query object to be created.
- * @param array_uri The name of the array the query will focus on.
+ * @param array An opened array object.
  * @param type The query type, which must be one of the following:
  *    - `TILEDB_WRITE`
  *    - `TILEDB_READ`
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_query_create(
+TILEDB_EXPORT int tiledb_query_alloc(
     tiledb_ctx_t* ctx,
     tiledb_query_t** query,
-    const char* array_uri,
+    tiledb_array_t* array,
     tiledb_query_type_t type);
 
 /**
@@ -1940,21 +1928,9 @@ TILEDB_EXPORT int tiledb_query_set_layout(
     tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_layout_t layout);
 
 /**
- * Finalizes a TileDB query object, flushing all internal state.
- *
- * This function has two effects.
- *
- * (i) If the query was writing in global order, it flushes the internal state.
- * It is **required** to finalize global-order write query objects in order to
- * ensure correct execution.
- *
- * (ii) For any query, it "closes" the corresponding array. This causes the
- * storage manager to decrement the reference count of the array. When the
- * reference count reaches 0, the storage manager evicts the array metadata
- * (schema and fragment metadata) from its in-memory cache, and releases all
- * related locks. Therefore, it is advantageous to wait to finalize query
- * objects on the same array until you are done issuing queries to that array
- * or consolidation is needed.
+ * Flushes all internal state of a query object and finalizes the query.
+ * This is applicable only to global layout writes. It has no effect for
+ * any other query type.
  *
  * **Example:**
  *
@@ -1965,7 +1941,7 @@ TILEDB_EXPORT int tiledb_query_set_layout(
  * @endcode
  *
  * @param ctx The TileDB context.
- * @param query The query object to be finalized.
+ * @param query The query object to be flushed.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int tiledb_query_finalize(
@@ -2078,6 +2054,101 @@ TILEDB_EXPORT int tiledb_query_get_status(
 /* ********************************* */
 
 /**
+ * Allocates a TileDB array object.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "hdfs:///tiledb_arrays/my_array", &array);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_uri The array URI.
+ * @param array The array object to be created.
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int tiledb_array_alloc(
+    tiledb_ctx_t* ctx, const char* array_uri, tiledb_array_t** array);
+
+/**
+ * Opens a TileDB array.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "hdfs:///tiledb_arrays/my_array", &array);
+ * tiledb_array_open(ctx, array);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array The array object to be opened.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int tiledb_array_open(tiledb_ctx_t* ctx, tiledb_array_t* array);
+
+/**
+ * Closes a TileDB array.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "hdfs:///tiledb_arrays/my_array", &array);
+ * tiledb_array_open(ctx, array);
+ * tiledb_array_close(ctx, array);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array The array object to be closed.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note If the array object has already been closed, the function has
+ *     no effect.
+ */
+TILEDB_EXPORT int tiledb_array_close(tiledb_ctx_t* ctx, tiledb_array_t* array);
+
+/**
+ * Frees a TileDB array object.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "hdfs:///tiledb_arrays/my_array", &array);
+ * tiledb_array_open(ctx, array);
+ * tiledb_array_close(ctx, array);
+ * tiledb_array_free(&array);
+ * @endcode
+ *
+ * @param array The array object to be freed.
+ */
+TILEDB_EXPORT void tiledb_array_free(tiledb_array_t** array);
+
+/**
+ * Retrieves the schema of an array.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_schema_t* array_schema;
+ * tiledb_array_get_schema(ctx, &array_schema);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array The open array.
+ * @param array_schema The array schema to be retrieved.
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ *
+ * @note The user must free the array schema with `tiledb_array_schema_free`.
+ */
+TILEDB_EXPORT int tiledb_array_get_schema(
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    tiledb_array_schema_t** array_schema);
+
+/**
  * Creates a new TileDB array given an input schema.
  *
  * **Example:**
@@ -2124,18 +2195,21 @@ TILEDB_EXPORT int tiledb_array_consolidate(
  * @code{.c}
  * uint64_t domain[4]; // Assuming a 2D array, 2 [low, high] pairs
  * int is_empty;
- * tiledb_array_get_non_empty_domain(ctx, "my_array", domain, &is_empty);
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "my_array", &array);
+ * tiledb_array_open(ctx, array);
+ * tiledb_array_get_non_empty_domain(ctx, array, domain, &is_empty);
  * @endcode
  *
  * @param ctx The TileDB context
- * @param array_uri The array URI.
+ * @param array The array object (must be opened beforehand).
  * @param domain The domain to be retrieved.
  * @param is_empty The function sets it to `1` if the non-empty domain is
  *     empty (i.e., the array does not contain any data yet), and `0` otherwise.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int tiledb_array_get_non_empty_domain(
-    tiledb_ctx_t* ctx, const char* array_uri, void* domain, int* is_empty);
+    tiledb_ctx_t* ctx, tiledb_array_t* array, void* domain, int* is_empty);
 
 /**
  * Computes an upper bound on the buffer sizes required for a read
@@ -2144,15 +2218,18 @@ TILEDB_EXPORT int tiledb_array_get_non_empty_domain(
  * **Example:**
  *
  * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "my_array", &array);
+ * tiledb_array_open(ctx, array);
  * uint64_t buffer_sizes[2];
  * const char* attributes[] = {"attr_1", "attr_2"};
  * uint64_t subarray[] = {10, 20, 10, 100};
  * tiledb_array_compute_max_read_buffer_sizes(
- *     ctx, "my_array", subarray, attributes, 2, buffer_sizes);
+ *     ctx, array, subarray, attributes, 2, buffer_sizes);
  * @endcode
  *
  * @param ctx The TileDB context.
- * @param array_uri The array URI.
+ * @param array The array object (must be opened beforehand).
  * @param subarray The subarray to focus on. Note that it must have the same
  *     underlying type as the array domain.
  * @param attributes The attributes to focus on.
@@ -2166,7 +2243,7 @@ TILEDB_EXPORT int tiledb_array_get_non_empty_domain(
  */
 TILEDB_EXPORT int tiledb_array_compute_max_read_buffer_sizes(
     tiledb_ctx_t* ctx,
-    const char* array_uri,
+    tiledb_array_t* array,
     const void* subarray,
     const char** attributes,
     unsigned attribute_num,
@@ -2179,6 +2256,9 @@ TILEDB_EXPORT int tiledb_array_compute_max_read_buffer_sizes(
  * **Example:**
  *
  * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "my_array", &array);
+ * tiledb_array_open(ctx, array);
  * uint64_t buffer_sizes[] = {200, 200};
  * const char* attributes[] = {"attr_1", "attr_2"};
  * uint64_t subarray[] = {11, 20, 11, 20};
@@ -2186,7 +2266,7 @@ TILEDB_EXPORT int tiledb_array_compute_max_read_buffer_sizes(
  * void** subarray_partitions;
  * tiledb_array_partition_subarray(
  *     ctx,
- *     "my_array",
+ *     array,
  *     subarray,
  *     TILEDB_ROW_MAJOR,
  *     attributes,
@@ -2214,7 +2294,7 @@ TILEDB_EXPORT int tiledb_array_compute_max_read_buffer_sizes(
  * instead of by rows).
  *
  * @param ctx The TileDB context.
- * @param array_uri The array URI.
+ * @param array The array object (must be opened beforehand).
  * @param subarray The subarray.
  * @param layout The layout in which the results are retrieved in the subarray.
  * @param attributes The attributes.
@@ -2230,7 +2310,7 @@ TILEDB_EXPORT int tiledb_array_compute_max_read_buffer_sizes(
  */
 TILEDB_EXPORT int tiledb_array_partition_subarray(
     tiledb_ctx_t* ctx,
-    const char* array_uri,
+    tiledb_array_t* array,
     const void* subarray,
     tiledb_layout_t layout,
     const char** attributes,
@@ -2365,14 +2445,14 @@ TILEDB_EXPORT int tiledb_object_ls(
  *
  * @code{.c}
  * tiledb_kv_schema_t* kv_schema;
- * tiledb_kv_schema_create(ctx, &kv_schema);
+ * tiledb_kv_schema_alloc(ctx, &kv_schema);
  * @endcode
  *
  * @param ctx The TileDB context.
  * @param kv_schema The TileDB key-value schema to be created.
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_kv_schema_create(
+TILEDB_EXPORT int tiledb_kv_schema_alloc(
     tiledb_ctx_t* ctx, tiledb_kv_schema_t** kv_schema);
 
 /**
@@ -2395,7 +2475,7 @@ TILEDB_EXPORT void tiledb_kv_schema_free(tiledb_kv_schema_t** kv_schema);
  *
  * @code{.c}
  * tiledb_attribute_t* attr;
- * tiledb_attribute_create(ctx, &attr, "my_attr", TILEDB_INT32);
+ * tiledb_attribute_alloc(ctx, &attr, "my_attr", TILEDB_INT32);
  * tiledb_kv_schema_add_attribute(ctx, kv_schema, attr);
  * @endcode
  *
@@ -2545,14 +2625,14 @@ TILEDB_EXPORT int tiledb_kv_schema_dump(
  *
  * @code{.c}
  * tiledb_kv_item_t* kv_item;
- * tiledb_kv_item_create(ctx, &kv_item);
+ * tiledb_kv_item_alloc(ctx, &kv_item);
  * @endcode
  *
  * @param ctx The TileDB context.
  * @param kv_item The key-value item to be created.
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_kv_item_create(
+TILEDB_EXPORT int tiledb_kv_item_alloc(
     tiledb_ctx_t* ctx, tiledb_kv_item_t** kv_item);
 
 /**
@@ -2728,30 +2808,48 @@ TILEDB_EXPORT int tiledb_kv_set_max_buffered_items(
     tiledb_ctx_t* ctx, tiledb_kv_t* kv, uint64_t max_items);
 
 /**
+ * Creates a key-value store object.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_kv_t* kv;
+ * tiledb_kv_alloc(ctx, "my_kv", &kv);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param kv_uri The URI of the key-value store.
+ * @param kv The key-value store object to be created.
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int tiledb_kv_alloc(
+    tiledb_ctx_t* ctx, const char* kv_uri, tiledb_kv_t** kv);
+
+/**
  * Prepares a key-value store for reading/writing.
  *
  * **Example:**
  *
  * @code{.c}
  * tiledb_kv_t* kv;
+ * tiledb_kv_alloc(ctx, "my_kv", &kv);
  * const char* attributes[] = {"attr_1", "attr_2"};
- * tiledb_kv_open(ctx, &kv, "my_kv", attributes, 2);
- * // Make sure to close the kv in the end
+ * tiledb_kv_open(ctx, kv, attributes, 2);
  * @endcode
  *
  * @param ctx The TileDB context.
- * @param kv The key-value store.
- * @param kv_uri The URI of the key-value store.
+ * @param kv An opened key-value store object.
  * @param attributes The attributes to focus on. `NULL` indicates all
  *     attributes. If the key-value object is used for writing key-value
  *     items, **all** attributes must be specified.
  * @param attribute_num The number of `attributes`.
- * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note If the kv object is already open, this function has no effect.
  */
 TILEDB_EXPORT int tiledb_kv_open(
     tiledb_ctx_t* ctx,
-    tiledb_kv_t** kv,
-    const char* kv_uri,
+    tiledb_kv_t* kv,
     const char** attributes,
     unsigned int attribute_num);
 
@@ -2768,6 +2866,8 @@ TILEDB_EXPORT int tiledb_kv_open(
  * @param ctx The TileDB context.
  * @param kv The key-value store to be closed.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note If the kv object is already closed, this function has no effect.
  */
 TILEDB_EXPORT int tiledb_kv_close(tiledb_ctx_t* ctx, tiledb_kv_t* kv);
 
@@ -2779,6 +2879,26 @@ TILEDB_EXPORT int tiledb_kv_close(tiledb_ctx_t* ctx, tiledb_kv_t* kv);
 TILEDB_EXPORT void tiledb_kv_free(tiledb_kv_t** kv);
 
 /**
+ * Retrieves the schema of a kv object.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_kv_schema_t* kv_schema;
+ * tiledb_kv_get_schema(ctx, &kv_schema);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param kv The open kv.
+ * @param kv_schema The kv schema to be retrieved.
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ *
+ * @note The user must free the kv schema with `tiledb_kv_schema_free`.
+ */
+TILEDB_EXPORT int tiledb_kv_get_schema(
+    tiledb_ctx_t* ctx, tiledb_kv_t* kv, tiledb_kv_schema_t** kv_schema);
+
+/**
  * Adds a key-value item to a key-value store. The item is buffered
  * internally and periodically flushed to persistent storage.
  * `tiledb_kv_flush` forces flushing the buffered items to storage.
@@ -2787,7 +2907,7 @@ TILEDB_EXPORT void tiledb_kv_free(tiledb_kv_t** kv);
  *
  * @code{.c}
  * tiledb_kv_item_t* kv_item;
- * tiledb_kv_item_create(ctx, &kv_item);
+ * tiledb_kv_item_alloc(ctx, &kv_item);
  * // Add a key and values to the kv item...
  * tiledb_kv_add_item(ctx, kv, kv_item);
  * @endcode
@@ -2873,37 +2993,21 @@ TILEDB_EXPORT int tiledb_kv_has_key(
  * **Example:**
  *
  * @code{.c}
+ * tiledb_kv_t* kv;
+ * tiledb_kv_alloc(ctx, "my_kv", &kv);
+ * const char* attributes[] = {"attr_1", "attr_2"};
+ * tiledb_kv_open(ctx, kv, attributes, 2);
  * tiledb_kv_iter_t* kv_iter;
- * const char* attributes[] = {"attr_0", "attr_1"};
- * tiledb_kv_iter_create(ctx, &kv_iter, "my_kv", attributes, 2);
- * // Make sure to delete the kv iterator in the end
+ * tiledb_kv_iter_alloc(ctx, kv, &kv_iter);
  * @endcode
  *
  * @param ctx The TileDB context.
- * @param kv_iter The key-value store iterator to be created.
- * @param kv_uri The URI of the key-value store.
- * @param attributes The attributes to focus on. `NULL` indicates all
- *     attributes. If the key-value object is used for writing key-value
- *     items, **all** attributes must be specified.
- * @param attribute_num The number of `attributes`.
+ * @param kv The kv the iterator is associated with.
+ * @param kv_iter The kv iterator to be created.
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_kv_iter_create(
-    tiledb_ctx_t* ctx,
-    tiledb_kv_iter_t** kv_iter,
-    const char* kv_uri,
-    const char** attributes,
-    unsigned int attribute_num);
-
-/**
- * Finalizes the key-value iterator.
- *
- * @param ctx The TileDB context.
- * @param kv_iter The key-value iterator to be finalized.
- * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
- */
-TILEDB_EXPORT int tiledb_kv_iter_finalize(
-    tiledb_ctx_t* ctx, tiledb_kv_iter_t* kv_iter);
+TILEDB_EXPORT int tiledb_kv_iter_alloc(
+    tiledb_ctx_t* ctx, tiledb_kv_t* kv, tiledb_kv_iter_t** kv_iter);
 
 /**
  * Frees a key-value store iterator.
@@ -2983,7 +3087,7 @@ TILEDB_EXPORT int tiledb_kv_iter_done(
  *
  * @code{.c}
  * tiledb_vfs_t* vfs;
- * tiledb_vfs_create(ctx, &vfs, config);
+ * tiledb_vfs_alloc(ctx, &vfs, config);
  * @endcode
  *
  * @param ctx The TileDB context.
@@ -2991,7 +3095,7 @@ TILEDB_EXPORT int tiledb_kv_iter_done(
  * @param config Configuration parameters.
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_vfs_create(
+TILEDB_EXPORT int tiledb_vfs_alloc(
     tiledb_ctx_t* ctx, tiledb_vfs_t** vfs, tiledb_config_t* config);
 
 /**

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -51,6 +51,60 @@ namespace tiledb {
 class Array {
  public:
   /**
+   * Constructor.
+   *
+   * @param array_uri The array URI.
+   */
+  Array(const Context& ctx, const std::string& array_uri)
+      : ctx_(ctx)
+      , schema_(ArraySchema(ctx, (tiledb_array_schema_t*)nullptr))
+      , uri_(array_uri) {
+    tiledb_array_t* array;
+    ctx.handle_error(tiledb_array_alloc(ctx, array_uri.c_str(), &array));
+    array_ = std::shared_ptr<tiledb_array_t>(array, deleter_);
+    ctx.handle_error(tiledb_array_open(ctx, array));
+
+    tiledb_array_schema_t* array_schema;
+    ctx.handle_error(tiledb_array_get_schema(ctx, array, &array_schema));
+    schema_ = ArraySchema(ctx, array_schema);
+  }
+
+  Array(const Array&) = default;
+  Array(Array&& array) = default;
+  Array& operator=(const Array&) = default;
+  Array& operator=(Array&& o) = default;
+
+  /** Returns the array URI. */
+  std::string uri() const {
+    return uri_;
+  }
+
+  /** Returns a shared pointer to the C TileDB array object. */
+  std::shared_ptr<tiledb_array_t> ptr() const {
+    return array_;
+  }
+
+  /** Auxiliary operator for getting the underlying C TileDB object. */
+  operator tiledb_array_t*() const {
+    return array_.get();
+  }
+
+  /** Opens the array. */
+  void open() {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_array_open(ctx, array_.get()));
+    tiledb_array_schema_t* array_schema;
+    ctx.handle_error(tiledb_array_get_schema(ctx, array_.get(), &array_schema));
+    schema_ = ArraySchema(ctx, array_schema);
+  }
+
+  /** Closes the array. */
+  void close() {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_array_close(ctx, array_.get()));
+  }
+
+  /**
    * Consolidates the fragments of an array into a single fragment.
    *
    * You must first finalize all queries to the array before consolidation can
@@ -72,28 +126,26 @@ class Array {
   }
 
   /**
-   * Get the non-empty domain of an array. This returns the bounding
+   * Get the non-empty domain of the array. This returns the bounding
    * coordinates for each dimension.
    *
    * @tparam T Domain datatype
-   * @param uri array name
-   * @param schema array schema
    * @return Vector of dim names with a {lower, upper} pair. Inclusive.
    *         Empty vector if the array has no data.
    */
   template <typename T>
-  static std::vector<std::pair<std::string, std::pair<T, T>>> non_empty_domain(
-      const std::string& uri, const ArraySchema& schema) {
-    impl::type_check<T>(schema.domain().type());
-
+  std::vector<std::pair<std::string, std::pair<T, T>>> non_empty_domain() {
+    impl::type_check<T>(schema_.domain().type());
     std::vector<std::pair<std::string, std::pair<T, T>>> ret;
 
-    auto dims = schema.domain().dimensions();
+    auto dims = schema_.domain().dimensions();
     std::vector<T> buf(dims.size() * 2);
-    auto& ctx = schema.context();
     int empty;
+
+    auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_array_get_non_empty_domain(
-        ctx, uri.c_str(), buf.data(), &empty));
+        ctx, array_.get(), buf.data(), &empty));
+
     if (empty)
       return ret;
 
@@ -104,23 +156,6 @@ class Array {
     }
 
     return ret;
-  }
-
-  /**
-   * Get the non-empty domain of an array. This returns the bounding
-   * coordinates for each dimension.
-   *
-   * @tparam T domain datatype
-   * @param ctx The TileDB context.
-   * @param uri Array name.
-   * @return Vector of dim names with a {lower, upper} pair. Inclusive.
-   *         Empty vector if the array has no data.
-   */
-  template <typename T>
-  static std::vector<std::pair<std::string, std::pair<T, T>>> non_empty_domain(
-      const Context& ctx, const std::string& uri) {
-    ArraySchema schema(ctx, uri);
-    return non_empty_domain<T>(uri, schema);
   }
 
   /**
@@ -138,16 +173,13 @@ class Array {
    *     and the second is the maximum number of elements of the value buffer.
    */
   template <typename T>
-  static std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
-  max_buffer_elements(
-      const std::string& uri,
-      const ArraySchema& schema,
-      const std::vector<T>& subarray) {
-    auto ctx = schema.context();
-    impl::type_check<T>(schema.domain().type(), 1);
+  std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
+  max_buffer_elements(const std::vector<T>& subarray) {
+    auto ctx = ctx_.get();
+    impl::type_check<T>(schema_.domain().type(), 1);
 
     std::vector<uint64_t> sizes;
-    auto attrs = schema.attributes();
+    auto attrs = schema_.attributes();
     std::vector<const char*> names;
 
     unsigned nbuffs = 0, attr_num = 0;
@@ -156,7 +188,7 @@ class Array {
       ++attr_num;
       names.push_back(a.first.c_str());
     }
-    if (schema.array_type() == TILEDB_SPARSE) {
+    if (schema_.array_type() == TILEDB_SPARSE) {
       ++nbuffs;
       ++attr_num;
       names.push_back(TILEDB_COORDS);
@@ -165,7 +197,7 @@ class Array {
     sizes.resize(nbuffs);
     ctx.handle_error(tiledb_array_compute_max_read_buffer_sizes(
         ctx,
-        uri.c_str(),
+        array_.get(),
         subarray.data(),
         names.data(),
         attr_num,
@@ -184,35 +216,11 @@ class Array {
       sid += var ? 2 : 1;
     }
 
-    if (schema.array_type() == TILEDB_SPARSE)
+    if (schema_.array_type() == TILEDB_SPARSE)
       ret[TILEDB_COORDS] = std::pair<uint64_t, uint64_t>(
-          0, sizes.back() / tiledb_datatype_size(schema.domain().type()));
+          0, sizes.back() / tiledb_datatype_size(schema_.domain().type()));
 
     return ret;
-  }
-
-  /**
-   * Compute an upper bound on the buffer elements needed to read a subarray.
-   *
-   * @tparam T The domain datatype
-   * @param ctx The TileDB context
-   * @param uri The array URI.
-   * @param subarray Targeted subarray.
-   * @return The maximum number of elements for each array attribute (plus
-   *     coordinates for sparse arrays).
-   *     Note that two numbers are returned per attribute. The first
-   *     is the maximum number of elements in the offset buffer
-   *     (0 for fixed-sized attributes and coordinates),
-   *     and the second is the maximum number of elements of the value buffer.
-   */
-  template <typename T>
-  static std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
-  max_buffer_elements(
-      const Context& ctx,
-      const std::string& uri,
-      const std::vector<T>& subarray) {
-    ArraySchema schema(ctx, uri);
-    return max_buffer_elements<T>(uri, schema, subarray);
   }
 
   /**
@@ -230,16 +238,14 @@ class Array {
    * @return list of subarrays
    */
   template <typename T>
-  static std::vector<std::vector<T>> partition_subarray(
-      const std::string& uri,
-      const ArraySchema& schema,
+  std::vector<std::vector<T>> partition_subarray(
       const std::vector<T>& subarray,
       const std::vector<std::string>& attrs,
-      const std::vector<uint64_t>& buffer_sizes,
+      const std::vector<size_t>& buffer_sizes,
       tiledb_layout_t layout) {
-    impl::type_check<T>(schema.domain().type());
+    impl::type_check<T>(schema_.domain().type());
 
-    const auto& schema_attrs = schema.attributes();
+    const auto& schema_attrs = schema_.attributes();
     std::vector<const char*> attrnames;
     std::vector<uint64_t> buff_sizes_scaled;
     unsigned expected_buff_cnt = 0;
@@ -261,16 +267,16 @@ class Array {
     if (expected_buff_cnt != buffer_sizes.size())
       throw TileDBError(
           "buffer_sizes size does not match number of provided attributes.");
-    if (subarray.size() != schema.domain().ndim() * 2)
-      throw TileDBError("Subarray should have array rank * 2 values.");
+    if (subarray.size() != schema_.domain().ndim() * 2)
+      throw TileDBError("Subarray should have array ndim * 2 values.");
 
-    auto& ctx = schema.context();
+    auto& ctx = ctx_.get();
     T** partition_buf;
     uint64_t npartitions;
 
     ctx.handle_error(tiledb_array_partition_subarray(
         ctx,
-        uri.c_str(),
+        array_.get(),
         subarray.data(),
         layout,
         attrnames.data(),
@@ -292,32 +298,29 @@ class Array {
     return ret;
   }
 
-  /**
-   * Partitions a subarray into multiple subarrays to meet buffer
-   * size constraints. Layout is used to split the subarray by
-   * the optimal axis.
-   *
-   * @tparam T Domain type
-   * @param uri Array URI
-   * @param schema Array Schema
-   * @param subarray Subarray to be decomposed
-   * @param attrs Attributes being queried
-   * @param buffer_sizes Buffer size limits
-   * @param layout Layout of query
-   * @return list of subarrays
-   */
-  template <typename T>
-  static std::vector<std::vector<T>> partition_subarray(
-      const Context& ctx,
-      const std::string& uri,
-      const std::vector<T>& subarray,
-      const std::vector<std::string>& attrs,
-      const std::vector<size_t>& buffer_sizes,
-      tiledb_layout_t layout) {
-    ArraySchema schema(ctx, uri);
-    return partition_subarray(
-        uri, schema, subarray, attrs, buffer_sizes, layout);
-  }
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The TileDB context. */
+  std::reference_wrapper<const Context> ctx_;
+
+  /** Deleter wrapper. */
+  impl::Deleter deleter_;
+
+  /** Pointer to the TileDB C array object. */
+  std::shared_ptr<tiledb_array_t> array_;
+
+  /** The array schema. */
+  ArraySchema schema_;
+
+  /** The array URI. */
+  std::string uri_;
+
+  /* ********************************* */
+  /*          PRIVATE METHODS          */
+  /* ********************************* */
 };
 
 }  // namespace tiledb

--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -97,7 +97,7 @@ class ArraySchema : public Schema {
   explicit ArraySchema(const Context& ctx, tiledb_array_type_t type)
       : Schema(ctx) {
     tiledb_array_schema_t* schema;
-    ctx.handle_error(tiledb_array_schema_create(ctx, &schema, type));
+    ctx.handle_error(tiledb_array_schema_alloc(ctx, &schema, type));
     schema_ = std::shared_ptr<tiledb_array_schema_t>(schema, deleter_);
   };
 
@@ -109,6 +109,16 @@ class ArraySchema : public Schema {
     schema_ = std::shared_ptr<tiledb_array_schema_t>(schema, deleter_);
   };
 
+  /**
+   * Loads the schema of an existing array with the input C array
+   * schema object.
+   */
+  ArraySchema(const Context& ctx, tiledb_array_schema_t* schema)
+      : Schema(ctx) {
+    schema_ = std::shared_ptr<tiledb_array_schema_t>(schema, deleter_);
+  };
+
+  ArraySchema() = default;
   ArraySchema(const ArraySchema&) = default;
   ArraySchema(ArraySchema&& o) = default;
   ArraySchema& operator=(const ArraySchema&) = default;

--- a/tiledb/sm/cpp_api/attribute.h
+++ b/tiledb/sm/cpp_api/attribute.h
@@ -275,7 +275,7 @@ class Attribute {
   void init_from_type(const std::string& name, tiledb_datatype_t type) {
     tiledb_attribute_t* attr;
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_attribute_create(ctx, &attr, name.c_str(), type));
+    ctx.handle_error(tiledb_attribute_alloc(ctx, &attr, name.c_str(), type));
     attr_ = std::shared_ptr<tiledb_attribute_t>(attr, deleter_);
   }
 };

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -401,7 +401,7 @@ class Config {
   void create_config() {
     tiledb_config_t* config;
     tiledb_error_t* err;
-    tiledb_config_create(&config, &err);
+    tiledb_config_alloc(&config, &err);
     impl::check_config_error(err);
 
     config_ = std::shared_ptr<tiledb_config_t>(config, Config::free);
@@ -446,7 +446,7 @@ inline void ConfigIter::init(const Config& config) {
   tiledb_config_iter_t* iter;
   tiledb_error_t* err;
   const char* p = prefix_.size() ? prefix_.c_str() : nullptr;
-  tiledb_config_iter_create(config.ptr().get(), &iter, p, &err);
+  tiledb_config_iter_alloc(config.ptr().get(), &iter, p, &err);
   check_config_error(err);
 
   iter_ = std::shared_ptr<tiledb_config_iter_t>(iter, ConfigIter::free);

--- a/tiledb/sm/cpp_api/context.h
+++ b/tiledb/sm/cpp_api/context.h
@@ -74,7 +74,7 @@ class Context {
   /** Constructor. */
   Context() {
     tiledb_ctx_t* ctx;
-    if (tiledb_ctx_create(&ctx, nullptr) != TILEDB_OK)
+    if (tiledb_ctx_alloc(&ctx, nullptr) != TILEDB_OK)
       throw TileDBError("[TileDB::C++API] Error: Failed to create context");
     ctx_ = std::shared_ptr<tiledb_ctx_t>(ctx, Context::free);
     error_handler_ = default_error_handler;
@@ -83,7 +83,7 @@ class Context {
   /** Constructor with config paramters. */
   explicit Context(const Config& config) {
     tiledb_ctx_t* ctx;
-    if (tiledb_ctx_create(&ctx, config) != TILEDB_OK)
+    if (tiledb_ctx_alloc(&ctx, config) != TILEDB_OK)
       throw TileDBError("[TileDB::C++API] Error: Failed to create context");
     ctx_ = std::shared_ptr<tiledb_ctx_t>(ctx, Context::free);
     error_handler_ = default_error_handler;

--- a/tiledb/sm/cpp_api/deleter.h
+++ b/tiledb/sm/cpp_api/deleter.h
@@ -70,6 +70,10 @@ class Deleter {
     tiledb_vfs_fh_free(&p);
   }
 
+  void operator()(tiledb_array_t* p) const {
+    tiledb_array_free(&p);
+  }
+
   void operator()(tiledb_query_t* p) const {
     tiledb_query_free(&p);
   }

--- a/tiledb/sm/cpp_api/dimension.h
+++ b/tiledb/sm/cpp_api/dimension.h
@@ -360,7 +360,7 @@ class Dimension {
       const void* domain,
       const void* tile_extent) {
     tiledb_dimension_t* d;
-    ctx.handle_error(tiledb_dimension_create(
+    ctx.handle_error(tiledb_dimension_alloc(
         ctx, &d, name.c_str(), type, domain, tile_extent));
     return Dimension(ctx, d);
   }

--- a/tiledb/sm/cpp_api/domain.h
+++ b/tiledb/sm/cpp_api/domain.h
@@ -93,7 +93,7 @@ class Domain {
   explicit Domain(const Context& ctx)
       : ctx_(ctx) {
     tiledb_domain_t* domain;
-    ctx.handle_error(tiledb_domain_create(ctx, &domain));
+    ctx.handle_error(tiledb_domain_alloc(ctx, &domain));
     domain_ = std::shared_ptr<tiledb_domain_t>(domain, deleter_);
   }
 

--- a/tiledb/sm/cpp_api/map_schema.h
+++ b/tiledb/sm/cpp_api/map_schema.h
@@ -60,7 +60,7 @@ class MapSchema : public Schema {
   explicit MapSchema(const Context& ctx)
       : Schema(ctx) {
     tiledb_kv_schema_t* schema;
-    ctx.handle_error(tiledb_kv_schema_create(ctx, &schema));
+    ctx.handle_error(tiledb_kv_schema_alloc(ctx, &schema));
     schema_ = std::shared_ptr<tiledb_kv_schema_t>(schema, deleter_);
   }
 
@@ -69,6 +69,15 @@ class MapSchema : public Schema {
       : Schema(ctx) {
     tiledb_kv_schema_t* schema;
     ctx.handle_error(tiledb_kv_schema_load(ctx, &schema, uri.c_str()));
+    schema_ = std::shared_ptr<tiledb_kv_schema_t>(schema, deleter_);
+  }
+
+  /**
+   * Loads the schema of an existing kv with the input C array
+   * schema object.
+   */
+  MapSchema(const Context& ctx, tiledb_kv_schema_t* schema)
+      : Schema(ctx) {
     schema_ = std::shared_ptr<tiledb_kv_schema_t>(schema, deleter_);
   }
 

--- a/tiledb/sm/cpp_api/vfs.h
+++ b/tiledb/sm/cpp_api/vfs.h
@@ -464,7 +464,7 @@ class VFS {
   /** Creates a TileDB C VFS object, using the input config. */
   void create_vfs(tiledb_config_t* config) {
     tiledb_vfs_t* vfs;
-    int rc = tiledb_vfs_create(ctx_.get(), &vfs, config);
+    int rc = tiledb_vfs_alloc(ctx_.get(), &vfs, config);
     if (rc != TILEDB_OK)
       throw std::runtime_error(
           "[TileDB::C++API] Error: Failed to create VFS object");

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -238,7 +238,7 @@ Status Posix::filelock_lock(
   // Open the file
   *fd = ::open(filename.c_str(), O_RDWR);
   if (*fd == -1) {
-    return LOG_STATUS(Status::StorageManagerError(
+    return LOG_STATUS(Status::IOError(
         "Cannot open filelock '" + filename + "'; " + strerror(errno)));
   }
   // Acquire the lock

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -89,8 +89,12 @@ FragmentMetadata::~FragmentMetadata() {
 }
 
 /* ****************************** */
-/*             ACCESSORS          */
+/*                API             */
 /* ****************************** */
+
+const URI& FragmentMetadata::array_uri() const {
+  return array_schema_->array_uri();
+}
 
 void FragmentMetadata::set_bounding_coords(
     uint64_t tile, const void* bounding_coords) {

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -69,6 +69,9 @@ class FragmentMetadata {
   /*                API                */
   /* ********************************* */
 
+  /** Returns the array URI. */
+  const URI& array_uri() const;
+
   /** Returns the number of cells in the tile at the input position. */
   uint64_t cell_num(uint64_t tile_pos) const;
 

--- a/tiledb/sm/kv/kv.h
+++ b/tiledb/sm/kv/kv.h
@@ -122,18 +122,13 @@ class KV {
    * @param attributes The attributes of the key-value store schema to focus on.
    *     Use `nullptr` to indicate **all** attributes.
    * @param attribute_num The number of attributes.
-   * @param include_keys If `true` the special key attributes will be included.
    * @return Status
    *
    * @note If the key-value store will be used for writes, `attributes` **must**
    *     be set to `nullptr`, indicating that all attributes will participate in
    *     the write.
    */
-  Status init(
-      const std::string& uri,
-      const char** attributes,
-      unsigned attribute_num,
-      bool include_keys = false);
+  Status init(const URI& uri, const char** attributes, unsigned attribute_num);
 
   /** Clears the key-value store. */
   void clear();
@@ -143,6 +138,9 @@ class KV {
    * will be flushed to persistent storage.
    */
   Status finalize();
+
+  /** The open array used for dispatching queries. */
+  OpenArray* open_array() const;
 
   /** Sets the number of maximum written items buffered before being flushed. */
   Status set_max_buffered_items(uint64_t max_items);
@@ -157,6 +155,9 @@ class KV {
    * Note that these exclude the special key attributes and coordinates.
    */
   std::vector<std::string> attributes_;
+
+  /** The array object that will receive the queries. */
+  OpenArray* open_array_;
 
   /**
    * Indicates whether an attribute is variable-sized or not.
@@ -247,7 +248,7 @@ class KV {
   uint64_t max_items_;
 
   /** The key-value store schema. */
-  ArraySchema* schema_;
+  const ArraySchema* schema_;
 
   /** TileDB storage manager. */
   StorageManager* storage_manager_;

--- a/tiledb/sm/kv/kv_item.cc
+++ b/tiledb/sm/kv/kv_item.cc
@@ -91,11 +91,14 @@ bool KVItem::good(
   if (key_.key_ == nullptr)
     return false;
 
-  if (values_.size() != attributes.size())
-    return false;
-
   auto attribute_num = attributes.size();
   for (unsigned i = 0; i < attribute_num; ++i) {
+    // Skip the special attributes
+    if (attributes[i] == constants::coords ||
+        attributes[i] == constants::key_attr_name ||
+        attributes[i] == constants::key_type_attr_name)
+      continue;
+
     auto it = values_.find(attributes[i]);
     if (it == values_.end())
       return false;

--- a/tiledb/sm/kv/kv_iter.h
+++ b/tiledb/sm/kv/kv_iter.h
@@ -70,17 +70,10 @@ class KVIter {
    * Initializes the key-value store iterator. The pointer is placed to the
    * first item in the store.
    *
-   * @param uri The URI of the key-value store.
-   * @param attributes The attributes of the key-value store schema to focus on.
-   *     Use `nullptr` to indicate **all** attributes.
-   * @param attribute_num The number of attributes.
+   * @param kv The kv the iterator is associated with.
    * @return Status
    */
-  Status init(
-      const std::string& uri, const char** attributes, unsigned attribute_num);
-
-  /** Finalizes the key-value store iterator and frees all memory. */
-  Status finalize();
+  Status init(KV* kv);
 
   /** Moves to the next key-value item. */
   Status next();
@@ -89,9 +82,6 @@ class KVIter {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
-
-  /** The key-value URI.*/
-  URI kv_uri_;
 
   /** A key-value store that will help reading items one-by-one using a hash. */
   KV* kv_;
@@ -129,9 +119,6 @@ class KVIter {
 
   /** Initializes a read query. */
   Status init_read_query();
-
-  /** Finalizes a read query. */
-  Status finalize_read_query();
 
   /** Submits a read query, recording its status. */
   Status submit_read_query();

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -56,7 +56,11 @@ class Query {
   /* ********************************* */
 
   /** Constructor. */
-  explicit Query(QueryType type);
+  Query(
+      StorageManager* storage_manager,
+      QueryType type,
+      const ArraySchema* array_schema,
+      const std::vector<FragmentMetadata*>& fragment_metadata);
 
   /** Destructor. */
   ~Query();
@@ -77,8 +81,8 @@ class Query {
   Status cancel();
 
   /**
-   * Finalizes the query, properly finalizing and deleting the involved
-   * fragments.
+   * Finalizes the query, flushing all internal state. Applicable only to global
+   * layout writes. It has no effect for any other query type.
    */
   Status finalize();
 
@@ -99,9 +103,6 @@ class Query {
 
   /** Processes a query. */
   Status process();
-
-  /** Sets the array schema. */
-  void set_array_schema(const ArraySchema* array_schema);
 
   /**
    * Sets the buffers to the query for a set of attributes.
@@ -136,10 +137,6 @@ class Query {
   void set_callback(
       const std::function<void(void*)>& callback, void* callback_data);
 
-  /** Sets the fragment metadata. */
-  void set_fragment_metadata(
-      const std::vector<FragmentMetadata*>& fragment_metadata);
-
   /** Sets the fragment URI. Applicable only to write queries. */
   void set_fragment_uri(const URI& fragment_uri);
 
@@ -149,9 +146,6 @@ class Query {
    * layout for both reads and writes.
    */
   Status set_layout(Layout layout);
-
-  /** Sets the storage manager. */
-  void set_storage_manager(StorageManager* storage_manager);
 
   /**
    * Sets the query subarray. If it is null, then the subarray will be set to
@@ -201,6 +195,16 @@ class Query {
   /** Correctness checks for `subarray`. */
   template <class T>
   Status check_subarray_bounds(const T* subarray) const;
+
+  /** Sets the array schema. */
+  void set_array_schema(const ArraySchema* array_schema);
+
+  /** Sets the fragment metadata. */
+  void set_fragment_metadata(
+      const std::vector<FragmentMetadata*>& fragment_metadata);
+
+  /** Sets the storage manager. */
+  void set_storage_manager(StorageManager* storage_manager);
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -127,11 +127,6 @@ bool Reader::done() const {
   return read_state_.idx_ >= read_state_.subarray_partitions_.size();
 }
 
-Status Reader::finalize() {
-  clear_read_state();
-  return Status::Ok();
-}
-
 unsigned Reader::fragment_num() const {
   return (unsigned int)fragment_metadata_.size();
 }

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -296,9 +296,6 @@ class Reader {
    */
   bool done() const;
 
-  /** Finalizes the reader. */
-  Status finalize();
-
   /** Returns the number of fragments involved in the (read) query. */
   unsigned fragment_num() const;
 
@@ -320,7 +317,10 @@ class Reader {
   /** Performs a read query using its set members. */
   Status read();
 
-  /** Sets the array schema. */
+  /**
+   * Sets the array schema. If the array is a kv store, then this
+   * function also sets global order as the default layout.
+   */
   void set_array_schema(const ArraySchema* array_schema);
 
   /**

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -153,7 +153,10 @@ class Writer {
   /** Returns the cell layout. */
   Layout layout() const;
 
-  /** Sets the array schema. */
+  /*
+   * Sets the array schema. If the array is a kv store, then this
+   * function also sets global order as the default layout.
+   */
   void set_array_schema(const ArraySchema* array_schema);
 
   /**

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -34,6 +34,7 @@
 #define TILEDB_CONSOLIDATOR_H
 
 #include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/storage_manager/open_array.h"
 
 #include <vector>
 
@@ -94,7 +95,6 @@ class Consolidator {
   /** Cleans up the inputs. */
   void clean_up(
       void* subarray,
-      ArraySchema* array_schema,
       unsigned buffer_num,
       void** buffers,
       uint64_t* buffer_sizes,
@@ -113,7 +113,7 @@ class Consolidator {
    * @return Status
    */
   Status create_buffers(
-      ArraySchema* array_schema,
+      const ArraySchema* array_schema,
       void*** buffers,
       uint64_t** buffer_sizes,
       unsigned int* buffer_num);
@@ -125,7 +125,7 @@ class Consolidator {
    * @param query_r This query reads from the fragments to be consolidated.
    * @param query_w This query writes to the new consolidated fragment.
    * @param write_subarray The subarray to write into.
-   * @param array_name The array name.
+   * @param open_array The opened array.
    * @param buffers The buffers to be passed in the queries.
    * @param buffer_sizes The corresponding buffer sizes.
    * @param fragment_num The number of fragments to be retrieved.
@@ -135,16 +135,13 @@ class Consolidator {
       Query** query_r,
       Query** query_w,
       void* write_subarray,
-      const char* array_name,
+      OpenArray* open_array,
       void** buffers,
       uint64_t* buffer_sizes,
       unsigned int* fragment_num);
 
   /** Creates the subarray that should represent the entire array domain. */
-  Status create_subarray(
-      const std::string& array_name,
-      const ArraySchema* array_schema,
-      void** subarray) const;
+  Status create_subarray(OpenArray* open_array, void** subarray) const;
 
   /**
    * Deletes the old fragments that got consolidated.
@@ -152,9 +149,6 @@ class Consolidator {
    * @return Status
    */
   Status delete_old_fragments(const std::vector<URI>& uris);
-
-  /** Finalizes the input queries. */
-  Status finalize_queries(Query* query_r, Query* query_w);
 
   /**
    * Frees the input buffers.

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -59,7 +59,7 @@ OpenArray::~OpenArray() {
 /*               API              */
 /* ****************************** */
 
-const ArraySchema* OpenArray::array_schema() const {
+ArraySchema* OpenArray::array_schema() const {
   return array_schema_;
 }
 
@@ -100,6 +100,15 @@ const std::vector<FragmentMetadata*>& OpenArray::fragment_metadata() const {
   return fragment_metadata_;
 }
 
+FragmentMetadata* OpenArray::fragment_metadata_get(
+    const URI& fragment_uri) const {
+  auto it = fragment_metadata_map_.find(fragment_uri.to_string());
+  if (it == fragment_metadata_map_.end())
+    return nullptr;
+
+  return it->second;
+}
+
 bool OpenArray::fragment_metadata_empty() const {
   return fragment_metadata_.empty();
 }
@@ -112,13 +121,17 @@ void OpenArray::mtx_unlock() {
   mtx_.unlock();
 }
 
-void OpenArray::set_array_schema(const ArraySchema* array_schema) {
+void OpenArray::set_array_schema(ArraySchema* array_schema) {
   array_schema_ = array_schema;
 }
 
 void OpenArray::set_fragment_metadata(
     const std::vector<FragmentMetadata*>& metadata) {
   fragment_metadata_ = metadata;
+
+  fragment_metadata_map_.clear();
+  for (const auto& f : metadata)
+    fragment_metadata_map_[f->fragment_uri().to_string()] = f;
 }
 
 /* ****************************** */

--- a/tiledb/sm/storage_manager/open_array.h
+++ b/tiledb/sm/storage_manager/open_array.h
@@ -36,6 +36,7 @@
 
 #include <map>
 #include <mutex>
+#include <unordered_map>
 #include <vector>
 
 #include "tiledb/sm/array_schema/array_schema.h"
@@ -64,7 +65,7 @@ class OpenArray {
   /* ********************************* */
 
   /** Returns the array schema. */
-  const ArraySchema* array_schema() const;
+  ArraySchema* array_schema() const;
 
   /** Returns the array URI. */
   const URI& array_uri() const;
@@ -87,6 +88,15 @@ class OpenArray {
   /** Returns the fragment metadata. */
   const std::vector<FragmentMetadata*>& fragment_metadata() const;
 
+  /**
+   * Returns the fragment metadata object given a URI, or `nullptr` if
+   * the fragment metadata have not been loaded for that URI yet.
+   *
+   * @param fragment_uri The fragment URI.
+   * @return Status
+   */
+  FragmentMetadata* fragment_metadata_get(const URI& fragment_uri) const;
+
   /** Returns `true` if the fragment metadata is empty. */
   bool fragment_metadata_empty() const;
 
@@ -97,7 +107,7 @@ class OpenArray {
   void mtx_unlock();
 
   /** Sets an array schema. */
-  void set_array_schema(const ArraySchema* array_schema);
+  void set_array_schema(ArraySchema* array_schema);
 
   /** Sets the fragment metadata. */
   void set_fragment_metadata(const std::vector<FragmentMetadata*>& metadata);
@@ -108,7 +118,7 @@ class OpenArray {
   /* ********************************* */
 
   /** The array schema. */
-  const ArraySchema* array_schema_;
+  ArraySchema* array_schema_;
 
   /** The array URI. */
   URI array_uri_;
@@ -121,6 +131,9 @@ class OpenArray {
 
   /** The fragment metadata of the open array. */
   std::vector<FragmentMetadata*> fragment_metadata_;
+
+  /** A map from fragment URI to metadata object. */
+  std::unordered_map<std::string, FragmentMetadata*> fragment_metadata_map_;
 
   /**
    * A mutex used to lock the array when loading the array metadata and

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -75,45 +75,154 @@ StorageManager::~StorageManager() {
   delete tile_cache_;
   delete vfs_;
 
-  // Delete all open arrays, force-releasing any filelocks
-  open_array_mtx_.lock();
+  // Release all filelocks
   for (auto& open_array_it : open_arrays_) {
     open_array_it.second->file_unlock(vfs_);
     delete open_array_it.second;
   }
-  open_array_mtx_.unlock();
+
+  for (auto& fl_it : xfilelocks_) {
+    auto filelock = fl_it.second;
+    auto lock_uri = URI(fl_it.first).join_path(constants::filelock_name);
+    if (filelock != INVALID_FILELOCK)
+      vfs_->filelock_unlock(lock_uri, filelock);
+  }
 }
 
 /* ****************************** */
 /*               API              */
 /* ****************************** */
 
+Status StorageManager::array_close(const URI& array_uri) {
+  // Lock mutex
+  open_array_mtx_.lock();
+
+  // Find the open array entry
+  auto it = open_arrays_.find(array_uri.to_string());
+
+  // Do nothing if array is closed
+  if (it == open_arrays_.end()) {
+    open_array_mtx_.unlock();
+    return Status::Ok();
+  }
+
+  // For easy reference
+  OpenArray* open_array = it->second;
+
+  // Lock the mutex of the array and decrement counter
+  open_array->mtx_lock();
+  open_array->cnt_decr();
+
+  // Close the array if the counter reaches 0
+  if (open_array->cnt() == 0) {
+    // Release file lock
+    auto st = open_array->file_unlock(vfs_);
+    if (!st.ok()) {
+      open_array->mtx_unlock();
+      open_array_mtx_.unlock();
+      return st;
+    }
+
+    // Remove open array entry
+    open_array->mtx_unlock();
+    delete open_array;
+    open_arrays_.erase(it);
+  } else {  // Just unlock the array mutex
+    open_array->mtx_unlock();
+  }
+
+  // Unlock mutex and notify condition on exclusive locks
+  open_array_mtx_.unlock();
+  xlock_cv_.notify_all();
+
+  return Status::Ok();
+}
+
+Status StorageManager::array_open(
+    const URI& array_uri, OpenArray** open_array) {
+  // Check if array exists
+  ObjectType obj_type;
+  RETURN_NOT_OK(this->object_type(array_uri, &obj_type));
+  if (obj_type != ObjectType::ARRAY && obj_type != ObjectType::KEY_VALUE) {
+    return LOG_STATUS(
+        Status::StorageManagerError("Cannot open array; Array does not exist"));
+  }
+
+  // Lock mutex
+  open_array_mtx_.lock();
+
+  // Find the open array entry
+  auto it = open_arrays_.find(array_uri.to_string());
+  if (it != open_arrays_.end()) {
+    *open_array = it->second;
+  } else {  // Create a new entry
+    *open_array = new OpenArray(array_uri);
+    open_arrays_[array_uri.to_string()] = *open_array;
+  }
+
+  // Lock the array and increment counter
+  (*open_array)->mtx_lock();
+  (*open_array)->cnt_incr();
+
+  // Unlock mutex
+  open_array_mtx_.unlock();
+
+  // Acquire a shared filelock
+  auto st = (*open_array)->file_lock(vfs_);
+  if (!st.ok()) {
+    (*open_array)->mtx_unlock();
+    array_close((*open_array)->array_uri());
+    return st;
+  }
+
+  // Load array schema if not fetched already
+  if ((*open_array)->array_schema() == nullptr) {
+    auto st = load_array_schema(array_uri, obj_type, *open_array);
+    if (!st.ok()) {
+      (*open_array)->mtx_unlock();
+      array_close((*open_array)->array_uri());
+      return st;
+    }
+  }
+
+  // Get fragment metadata in the case of reads, if not fetched already
+  st = load_fragment_metadata(*open_array);
+  if (!st.ok()) {
+    (*open_array)->mtx_unlock();
+    array_close((*open_array)->array_uri());
+    return st;
+  }
+
+  // Unlock the array mutex
+  (*open_array)->mtx_unlock();
+
+  // Note that we retain the (shared) lock on the array filelock
+
+  return Status::Ok();
+}
+
 Status StorageManager::array_compute_max_read_buffer_sizes(
-    const char* array_uri,
+    OpenArray* open_array,
     const void* subarray,
     const char** attributes,
     unsigned attribute_num,
     uint64_t* buffer_sizes) {
   // Open the array
-  auto uri = URI(array_uri);
-  std::vector<FragmentMetadata*> metadata;
-  auto array_schema = (const ArraySchema*)nullptr;
-  RETURN_NOT_OK(array_open(uri, QueryType::READ, &array_schema, &metadata));
+  open_array->mtx_lock();
+  auto array_schema = open_array->array_schema();
+  auto metadata = open_array->fragment_metadata();
+  open_array->mtx_unlock();
 
   // Check attributes
-  RETURN_NOT_OK_ELSE(
-      array_schema->check_attributes(attributes, attribute_num),
-      array_close(uri));
+  RETURN_NOT_OK(array_schema->check_attributes(attributes, attribute_num));
 
   // Compute buffer sizes
   std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
       buffer_sizes_tmp;
   for (unsigned i = 0; i < attribute_num; ++i)
     buffer_sizes_tmp[attributes[i]] = std::pair<uint64_t, uint64_t>(0, 0);
-  RETURN_NOT_OK_ELSE(
-      array_compute_max_read_buffer_sizes(
-          array_schema, metadata, subarray, &buffer_sizes_tmp),
-      array_close(uri));
+  RETURN_NOT_OK(array_compute_max_read_buffer_sizes(
+      array_schema, metadata, subarray, &buffer_sizes_tmp));
 
   // Copy to input buffer sizes
   unsigned bid = 0;
@@ -130,7 +239,7 @@ Status StorageManager::array_compute_max_read_buffer_sizes(
   }
 
   // Close array
-  return array_close(uri);
+  return Status::Ok();
 }
 
 Status StorageManager::array_compute_max_read_buffer_sizes(
@@ -214,7 +323,7 @@ Status StorageManager::array_compute_max_read_buffer_sizes(
 }
 
 Status StorageManager::array_compute_subarray_partitions(
-    const char* array_uri,
+    OpenArray* open_array,
     const void* subarray,
     Layout layout,
     const char** attributes,
@@ -227,18 +336,17 @@ Status StorageManager::array_compute_subarray_partitions(
   *subarray_partitions = nullptr;
 
   // Open the array
-  auto uri = URI(array_uri);
-  std::vector<FragmentMetadata*> metadata;
-  auto array_schema = (const ArraySchema*)nullptr;
-  RETURN_NOT_OK(array_open(uri, QueryType::READ, &array_schema, &metadata));
+  open_array->mtx_lock();
+  auto array_schema = open_array->array_schema();
+  auto metadata = open_array->fragment_metadata();
+  open_array->mtx_unlock();
+
   auto subarray_size = 2 * array_schema->coords_size();
 
   // Compute buffer sizes map
   std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
       buffer_sizes_map;
-  RETURN_NOT_OK_ELSE(
-      array_schema->check_attributes(attributes, attribute_num),
-      array_close(uri));
+  RETURN_NOT_OK(array_schema->check_attributes(attributes, attribute_num));
   for (unsigned i = 0, bid = 0; i < attribute_num; ++i) {
     if (array_schema->var_size(attributes[i])) {
       buffer_sizes_map[attributes[i]] = std::pair<uint64_t, uint64_t>(
@@ -253,18 +361,14 @@ Status StorageManager::array_compute_subarray_partitions(
 
   // Get partitions
   std::vector<void*> subarray_partitions_vec;
-  RETURN_NOT_OK_ELSE(
-      Reader::compute_subarray_partitions(
-          this,
-          array_schema,
-          metadata,
-          subarray,
-          layout,
-          buffer_sizes_map,
-          &subarray_partitions_vec),
-      array_close(uri));
-
-  RETURN_NOT_OK(array_close(uri));
+  RETURN_NOT_OK(Reader::compute_subarray_partitions(
+      this,
+      array_schema,
+      metadata,
+      subarray,
+      layout,
+      buffer_sizes_map,
+      &subarray_partitions_vec));
 
   // Handle empty partitions
   if (subarray_partitions_vec.empty())
@@ -368,13 +472,17 @@ Status StorageManager::array_create(
 }
 
 Status StorageManager::array_get_non_empty_domain(
-    const char* array_uri, void* domain, bool* is_empty) {
+    OpenArray* open_array, void* domain, bool* is_empty) {
+  if (open_array == nullptr)
+    return LOG_STATUS(Status::StorageManagerError(
+        "Cannot get non-empty domain; Open array object is null"));
+
   // Open the array
   *is_empty = true;
-  auto uri = URI(array_uri);
-  std::vector<FragmentMetadata*> metadata;
-  auto array_schema = (const ArraySchema*)nullptr;
-  RETURN_NOT_OK(array_open(uri, QueryType::READ, &array_schema, &metadata));
+  open_array->mtx_lock();
+  auto array_schema = open_array->array_schema();
+  auto metadata = open_array->fragment_metadata();
+  open_array->mtx_unlock();
 
   // Return if there are no metadata
   if (metadata.empty())
@@ -431,7 +539,7 @@ Status StorageManager::array_get_non_empty_domain(
   *is_empty = false;
 
   // Close array
-  return array_close(uri);
+  return Status::Ok();
 }
 
 Status StorageManager::array_xlock(const URI& array_uri) {
@@ -739,7 +847,6 @@ Status StorageManager::load_array_schema(
 Status StorageManager::load_fragment_metadata(
     FragmentMetadata* fragment_metadata) {
   const URI& fragment_uri = fragment_metadata->fragment_uri();
-
   bool fragment_exists;
   RETURN_NOT_OK(is_fragment(fragment_uri, &fragment_exists));
   if (!fragment_exists)
@@ -981,31 +1088,16 @@ Status StorageManager::object_iter_next_preorder(
   return Status::Ok();
 }
 
-Status StorageManager::query_finalize(Query* query) {
-  auto array_uri = query->array_schema()->array_uri();
-  auto st_query = query->finalize();
-  auto st_array = array_close(array_uri);
-
-  if (!st_query.ok())
-    return st_query;
-  if (!st_array.ok())
-    return st_array;
-  return Status::Ok();
-}
-
 Status StorageManager::query_create(
-    Query** query, const char* array_name, QueryType type, URI fragment_uri) {
-  // Open the array
-  std::vector<FragmentMetadata*> fragment_metadata;
-  auto array_schema = (const ArraySchema*)nullptr;
-  RETURN_NOT_OK(
-      array_open(URI(array_name), type, &array_schema, &fragment_metadata));
+    Query** query, OpenArray* open_array, QueryType type, URI fragment_uri) {
+  // For easy reference
+  open_array->mtx_lock();
+  auto array_schema = open_array->array_schema();
+  auto metadata = open_array->fragment_metadata();
+  open_array->mtx_unlock();
 
   // Create query
-  *query = new Query(type);
-  (*query)->set_storage_manager(this);
-  (*query)->set_array_schema(array_schema);
-  (*query)->set_fragment_metadata(fragment_metadata);
+  *query = new Query(this, type, array_schema, metadata);
 
   if (type == QueryType::WRITE)
     (*query)->set_fragment_uri(fragment_uri);
@@ -1105,17 +1197,33 @@ Status StorageManager::store_array_schema(ArraySchema* array_schema) {
 }
 
 Status StorageManager::store_fragment_metadata(FragmentMetadata* metadata) {
+  // Find the corresponding open array
+  auto array_uri = metadata->array_uri();
+  auto open_array_it = open_arrays_.find(array_uri.to_string());
+  assert(open_array_it != open_arrays_.end());
+  auto open_array = open_array_it->second;
+
+  // Lock the open array
+  open_array->mtx_lock();
+
   // Do nothing if fragment directory does not exist. The fragment directory
   // is created only when some attribute file is written
   bool is_dir;
   const URI& fragment_uri = metadata->fragment_uri();
-  RETURN_NOT_OK(vfs_->is_dir(fragment_uri, &is_dir));
-  if (!is_dir)
+  RETURN_NOT_OK_ELSE(
+      vfs_->is_dir(fragment_uri, &is_dir), open_array->mtx_unlock());
+  if (!is_dir) {
+    open_array->mtx_unlock();
     return Status::Ok();
+  }
 
   // Serialize
   auto buff = new Buffer();
-  RETURN_NOT_OK_ELSE(metadata->serialize(buff), delete buff);
+  auto st = metadata->serialize(buff);
+  if (!st.ok()) {
+    open_array->mtx_unlock();
+    delete buff;
+  }
 
   // Write to file
   URI fragment_metadata_uri = fragment_uri.join_path(
@@ -1131,13 +1239,16 @@ Status StorageManager::store_fragment_metadata(FragmentMetadata* metadata) {
       false);
 
   auto tile_io = new TileIO(this, fragment_metadata_uri);
-  Status st = tile_io->write_generic(tile);
+  st = tile_io->write_generic(tile);
   if (st.ok())
     st = close_file(fragment_metadata_uri);
 
   delete tile;
   delete tile_io;
   delete buff;
+
+  // Unlock the array
+  open_array->mtx_unlock();
 
   return st;
 }
@@ -1197,52 +1308,6 @@ Status StorageManager::write(const URI& uri, Buffer* buffer) const {
 /* ****************************** */
 /*         PRIVATE METHODS        */
 /* ****************************** */
-
-Status StorageManager::array_close(const URI& array_uri) {
-  // Lock mutex
-  open_array_mtx_.lock();
-
-  // Find the open array entry
-  auto it = open_arrays_.find(array_uri.to_string());
-
-  // Sanity check
-  if (it == open_arrays_.end()) {
-    open_array_mtx_.unlock();
-    return LOG_STATUS(Status::StorageManagerError(
-        "Cannot close array; Open array entry not found"));
-  }
-
-  // For easy reference
-  OpenArray* open_array = it->second;
-
-  // Lock the mutex of the array and decrement counter
-  open_array->mtx_lock();
-  open_array->cnt_decr();
-
-  // Close the array if the counter reaches 0
-  if (open_array->cnt() == 0) {
-    // Release file lock
-    auto st = open_array->file_unlock(vfs_);
-    if (!st.ok()) {
-      open_array->mtx_unlock();
-      open_array_mtx_.unlock();
-      return st;
-    }
-
-    // Remove open array entry
-    open_array->mtx_unlock();
-    delete open_array;
-    open_arrays_.erase(it);
-  } else {  // Just unlock the array mutex
-    open_array->mtx_unlock();
-  }
-
-  // Unlock mutex and notify condition on exclusive locks
-  open_array_mtx_.unlock();
-  xlock_cv_.notify_all();
-
-  return Status::Ok();
-}
 
 template <class T>
 Status StorageManager::array_compute_max_read_buffer_sizes(
@@ -1318,70 +1383,6 @@ void StorageManager::array_get_non_empty_domain(
   delete[] coords;
 }
 
-Status StorageManager::array_open(
-    const URI& array_uri,
-    QueryType type,
-    const ArraySchema** array_schema,
-    std::vector<FragmentMetadata*>* fragment_metadata) {
-  // Check if array exists
-  ObjectType obj_type;
-  RETURN_NOT_OK(this->object_type(array_uri, &obj_type));
-  if (obj_type != ObjectType::ARRAY && obj_type != ObjectType::KEY_VALUE) {
-    return LOG_STATUS(
-        Status::StorageManagerError("Cannot open array; Array does not exist"));
-  }
-
-  // Lock mutex
-  open_array_mtx_.lock();
-
-  // Find the open array entry
-  OpenArray* open_array;
-  auto it = open_arrays_.find(array_uri.to_string());
-  if (it != open_arrays_.end()) {
-    open_array = it->second;
-  } else {  // Create a new entry
-    open_array = new OpenArray(array_uri);
-    open_arrays_[array_uri.to_string()] = open_array;
-  }
-
-  // Lock the mutex of the array and increment counter
-  open_array->mtx_lock();
-  open_array->cnt_incr();
-
-  // Unlock mutex
-  open_array_mtx_.unlock();
-
-  // Get a (shared) filelock
-  RETURN_NOT_OK(open_array->file_lock(vfs_));
-
-  // Load array schema if not fetched already
-  if (open_array->array_schema() == nullptr) {
-    auto st = load_array_schema(array_uri, obj_type, open_array);
-    if (!st.ok()) {
-      open_array->mtx_unlock();
-      array_close(open_array->array_uri());
-      return st;
-    }
-  }
-  *array_schema = open_array->array_schema();
-
-  // Get fragment metadata in the case of reads, if not fetched already
-  if (type == QueryType::READ && open_array->fragment_metadata_empty()) {
-    auto st = load_fragment_metadata(open_array);
-    if (!st.ok()) {
-      open_array->mtx_unlock();
-      array_close(open_array->array_uri());
-      return st;
-    }
-  }
-  *fragment_metadata = open_array->fragment_metadata();
-
-  // Unlock the array mutex
-  open_array->mtx_unlock();
-
-  return Status::Ok();
-}
-
 Status StorageManager::get_fragment_uris(
     const URI& array_uri, std::vector<URI>* fragment_uris) const {
   // Get all uris in the array directory
@@ -1433,17 +1434,19 @@ Status StorageManager::load_fragment_metadata(OpenArray* open_array) {
   if (fragment_uris.empty())
     return Status::Ok();
 
-  // Load the metadata for each fragment
+  // Load the metadata for each fragment, only if they are not already loaded
   std::vector<FragmentMetadata*> fragment_metadata;
   for (auto& uri : fragment_uris) {
-    URI coords_uri = uri.join_path(
-        std::string("/") + constants::coords + constants::file_suffix);
-    bool sparse;
-    RETURN_NOT_OK(vfs_->is_file(coords_uri, &sparse));
-    auto metadata =
-        new FragmentMetadata(open_array->array_schema(), !sparse, uri);
-    RETURN_NOT_OK_ELSE(load_fragment_metadata(metadata), delete metadata);
-    fragment_metadata.push_back(metadata);
+    auto metadata = open_array->fragment_metadata_get(uri);
+    if (metadata == nullptr) {
+      URI coords_uri =
+          uri.join_path(constants::coords + constants::file_suffix);
+      bool sparse;
+      RETURN_NOT_OK(vfs_->is_file(coords_uri, &sparse));
+      metadata = new FragmentMetadata(open_array->array_schema(), !sparse, uri);
+      RETURN_NOT_OK_ELSE(load_fragment_metadata(metadata), delete metadata);
+      fragment_metadata.push_back(metadata);
+    }
   }
   open_array->set_fragment_metadata(fragment_metadata);
 


### PR DESCRIPTION
Closes #639
    
- Implemented `tiledb_array_{open, close, free}` and changed `tiledb_array_get_non_empty_domain` to work with array objects.
- Changed `tiledb_array_partition_subarray` to take an opened array object as input
- Changed the `tiledb_array_compute_max_read_buffer_sizes` to take as input an opened array.
- Changed `tiledb_query_create` to take an open array as argument instead of a URI.
- Added Array object in the C++ API for opening/closing arrays. The Query object now takes an open array as argument.
- Made C++ API functions `non_empty_domain`, `partition_subarray` and `max_buffer_elements` member functions of Array (they used to be static functions).
- Added `Array::open` and `Map::open`
- Lock open array when storing the fragment metadata.
- Close all open arrays when destroying the storage manager.
- Added `tiledb_array_alloc` and `tiledb_kv_alloc`
- Associated a kv iter with a kv object, introducing `tiledb_kv_iter_alloc` that takes as input a kv object.
- Removed `MapIter::init` as the map iterator is now initialized upon construction.
- Now query finalize has effect only on global writes, and no effect for other query types (can be omitted).
- Renamed all `_*_create` C API functions that create TileDB struct objects to `_*_alloc`.