### PR TITLE
Set buffer for an individual attribute to the query

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,6 +45,7 @@
 * Added `tiledb_array_alloc`
 * Added `tiledb_kv_alloc`
 * Added `tiledb_kv_iter_alloc` which takes as input a kv object
+* Added `tiledb_query_set_buffer` which sets a single attribute buffer
 
 ### C++ API
 * Support for trivially copyable objects, such as a custom data struct, was added. They will be backed by an `sizeof(T)` sized `char` attribute.
@@ -80,6 +81,8 @@
 * Changed signature of `tiledb_{array,kv}_open`.
 * Removed `tiledb_kv_iter_create`
 * Renamed all C API functions that create TileDB objects from `tiledb_*_create` to `tiledb_*_alloc`.
+* Removed `tiledb_query_set_buffers`
+* Removed `tiledb_query_reset_buffers`
 
 ### C++ API
 * Fixes with `Array::max_buffer_elements` and `Query::result_buffer_elements` to comply with the API docs. `pair.first` is the number of elements of the offsets buffer. If `pair.first` is 0, it is a fixed-sized attribute or coordinates.

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -263,7 +263,7 @@ Query
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_set_subarray
     :project: TileDB-C
-.. doxygenfunction:: tiledb_query_set_buffers
+.. doxygenfunction:: tiledb_query_set_buffer
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_set_layout
     :project: TileDB-C
@@ -272,8 +272,6 @@ Query
 .. doxygenfunction:: tiledb_query_submit
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_submit_async
-    :project: TileDB-C
-.. doxygenfunction:: tiledb_query_reset_buffers
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_get_status
     :project: TileDB-C

--- a/examples/c_api/tiledb_dense_read_async.c
+++ b/examples/c_api/tiledb_dense_read_async.c
@@ -106,7 +106,18 @@ int main() {
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
-  tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
 
   // Submit query with callback
   char s[100] = "Callback: Query completed";

--- a/examples/c_api/tiledb_dense_read_global.c
+++ b/examples/c_api/tiledb_dense_read_global.c
@@ -125,7 +125,18 @@ int main() {
 
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
-  tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
 
   // Submit query

--- a/examples/c_api/tiledb_dense_read_ordered_subarray.c
+++ b/examples/c_api/tiledb_dense_read_ordered_subarray.c
@@ -92,7 +92,18 @@ int main() {
   tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
-  tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
 
   // Submit query
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_dense_read_subset_incomplete.c
+++ b/examples/c_api/tiledb_dense_read_subset_incomplete.c
@@ -90,7 +90,8 @@ int main() {
   tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_COL_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
-  tiledb_query_set_buffers(ctx, query, attributes, 1, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
 
   // Loop until the query is completed. The buffer we created the query with
   // cannot hold the entire result. Instead of crashing, query submission will

--- a/examples/c_api/tiledb_dense_write_async.c
+++ b/examples/c_api/tiledb_dense_write_async.c
@@ -101,7 +101,18 @@ int main() {
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
-  tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
 
   // We submit a query asynchronously via the appropriate API call. This
   // function will return almost immediately after its invocation, with TileDB

--- a/examples/c_api/tiledb_dense_write_global_1.c
+++ b/examples/c_api/tiledb_dense_write_global_1.c
@@ -87,7 +87,18 @@ int main() {
   const char* attributes[] = {"a1", "a2", "a3"};
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
-  tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
 
   // Submit query
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_dense_write_global_2.c
+++ b/examples/c_api/tiledb_dense_write_global_2.c
@@ -79,7 +79,18 @@ int main() {
   const char* attributes[] = {"a1", "a2", "a3"};
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
-  tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
 
   // Submit query - #1
   // This writes to the array only partially, keeping the **same fragment**
@@ -108,7 +119,18 @@ int main() {
   // Reset buffers. Alternatively, instead of resetting the buffers, we could
   // repopulate the original buffers with the new cells. The result would
   // have been the same.
-  tiledb_query_reset_buffers(ctx, query, buffers_2, buffer_sizes_2);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers_2[0], &buffer_sizes_2[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers_2[1],
+      &buffer_sizes_2[1],
+      buffers_2[2],
+      &buffer_sizes_2[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers_2[3], &buffer_sizes_2[3]);
 
   // Submit query - #2
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_dense_write_global_subarray.c
+++ b/examples/c_api/tiledb_dense_write_global_subarray.c
@@ -76,7 +76,18 @@ int main() {
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   tiledb_query_set_subarray(ctx, query, subarray);
-  tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
 
   // Submit query
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_dense_write_ordered_subarray.c
+++ b/examples/c_api/tiledb_dense_write_ordered_subarray.c
@@ -92,7 +92,18 @@ int main() {
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
-  tiledb_query_set_buffers(ctx, query, attributes, 3, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
 
   // Submit query
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_dense_write_unordered.c
+++ b/examples/c_api/tiledb_dense_write_unordered.c
@@ -81,7 +81,20 @@ int main() {
   tiledb_query_t* query;
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
-  tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
 
   // Submit query

--- a/examples/c_api/tiledb_sparse_read_global.c
+++ b/examples/c_api/tiledb_sparse_read_global.c
@@ -122,7 +122,20 @@ int main() {
 
   tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
-  tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
 
   // Submit query
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_sparse_read_ordered_subarray.c
+++ b/examples/c_api/tiledb_sparse_read_ordered_subarray.c
@@ -95,7 +95,20 @@ int main() {
   tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
-  tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
 
   // Submit query
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_sparse_read_subset.c
+++ b/examples/c_api/tiledb_sparse_read_subset.c
@@ -82,7 +82,8 @@ int main() {
   tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   tiledb_query_set_layout(ctx, query, TILEDB_COL_MAJOR);
   tiledb_query_set_subarray(ctx, query, subarray);
-  tiledb_query_set_buffers(ctx, query, attributes, 1, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
   tiledb_query_submit(ctx, query);
 
   // Print the results

--- a/examples/c_api/tiledb_sparse_write_global_1.c
+++ b/examples/c_api/tiledb_sparse_write_global_1.c
@@ -98,7 +98,20 @@ int main() {
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
-  tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
 
   // Submit query
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_sparse_write_global_2.c
+++ b/examples/c_api/tiledb_sparse_write_global_2.c
@@ -91,7 +91,20 @@ int main() {
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
-  tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
 
   // Submit query - #1
   tiledb_query_submit(ctx, query);
@@ -108,7 +121,20 @@ int main() {
       sizeof(buffer_a1_2), 0, 0, 0, sizeof(buffer_coords_2)};
 
   // Reset buffers
-  tiledb_query_reset_buffers(ctx, query, buffers_2, buffer_sizes_2);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers_2[0], &buffer_sizes_2[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers_2[1],
+      &buffer_sizes_2[1],
+      buffers_2[2],
+      &buffer_sizes_2[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers_2[3], &buffer_sizes_2[3]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers_2[4], &buffer_sizes_2[4]);
 
   // Submit query - #2
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_sparse_write_unordered_1.c
+++ b/examples/c_api/tiledb_sparse_write_unordered_1.c
@@ -90,7 +90,20 @@ int main() {
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
-  tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
 
   // Submit query
   tiledb_query_submit(ctx, query);

--- a/examples/c_api/tiledb_sparse_write_unordered_2.c
+++ b/examples/c_api/tiledb_sparse_write_unordered_2.c
@@ -76,7 +76,20 @@ int main() {
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   tiledb_query_alloc(ctx, &query, array, TILEDB_WRITE);
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
-  tiledb_query_set_buffers(ctx, query, attributes, 4, buffers, buffer_sizes);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
 
   // Submit query - #1
   tiledb_query_submit(ctx, query);
@@ -98,7 +111,20 @@ int main() {
       sizeof(buffer_coords_2)};
 
   // Reset buffers
-  tiledb_query_reset_buffers(ctx, query, buffers_2, buffer_sizes_2);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers_2[0], &buffer_sizes_2[0]);
+  tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      buffers_2[1],
+      &buffer_sizes_2[1],
+      buffers_2[2],
+      &buffer_sizes_2[2]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers_2[3], &buffer_sizes_2[3]);
+  tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers_2[4], &buffer_sizes_2[4]);
 
   // Submit query - #2
   tiledb_query_submit(ctx, query);

--- a/test/src/unit-capi-any.cc
+++ b/test/src/unit-capi-any.cc
@@ -156,8 +156,14 @@ void AnyFx::write_array(const std::string& array_name) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[0],
+      (uint64_t*)buffers[0],
+      &buffer_sizes[0],
+      buffers[1],
+      &buffer_sizes[1]);
   REQUIRE(rc == TILEDB_OK);
 
   // Submit query
@@ -208,8 +214,14 @@ void AnyFx::read_array(const std::string& array_name) {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[0],
+      (uint64_t*)buffers[0],
+      &buffer_sizes[0],
+      buffers[1],
+      &buffer_sizes[1]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);

--- a/test/src/unit-capi-async.cc
+++ b/test/src/unit-capi-async.cc
@@ -287,8 +287,20 @@ void AsyncFx::write_dense_async() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query asynchronously
@@ -364,8 +376,23 @@ void AsyncFx::write_sparse_async() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query asynchronously
@@ -441,8 +468,23 @@ void AsyncFx::write_sparse_async_cancelled() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query asynchronously
@@ -521,8 +563,20 @@ void AsyncFx::read_dense_async() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query with callback
@@ -605,8 +659,23 @@ void AsyncFx::read_sparse_async() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query with callback

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -290,8 +290,20 @@ void ConsolidationFx::write_dense_full() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -342,8 +354,20 @@ void ConsolidationFx::write_dense_subarray() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -392,10 +416,25 @@ void ConsolidationFx::write_dense_unordered() {
   const char* attributes[] = {"a1", "a2", "a3", TILEDB_COORDS};
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
-  CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -460,8 +499,23 @@ void ConsolidationFx::write_sparse_full() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -512,8 +566,23 @@ void ConsolidationFx::write_sparse_unordered() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -583,8 +652,20 @@ void ConsolidationFx::read_dense_full_subarray_unordered() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -672,8 +753,20 @@ void ConsolidationFx::read_dense_subarray_full_unordered() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -752,8 +845,20 @@ void ConsolidationFx::read_dense_subarray_unordered_full() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -829,8 +934,23 @@ void ConsolidationFx::read_sparse_full_unordered() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -907,8 +1027,23 @@ void ConsolidationFx::read_sparse_unordered_full() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -506,8 +506,8 @@ int* DenseArrayFx::read_dense_array_2D(
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, query_type);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -590,8 +590,11 @@ void DenseArrayFx::update_dense_array_2D(
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 2, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[1], buffers[1], &buffer_sizes[1]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   REQUIRE(rc == TILEDB_OK);
@@ -647,8 +650,8 @@ void DenseArrayFx::write_dense_array_by_tiles(
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);
@@ -672,7 +675,6 @@ void DenseArrayFx::write_dense_array_by_tiles(
       buffer_size = k * l * sizeof(int);
       buffer_sizes[0] = {buffer_size};
 
-      //    tiledb_query_reset_buffers(ctx_, query, buffers, buffer_sizes);
       rc = tiledb_query_submit(ctx_, query);
       REQUIRE(rc == TILEDB_OK);
     }
@@ -717,8 +719,8 @@ void DenseArrayFx::write_dense_subarray_2D(
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, query_type);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -763,8 +765,8 @@ void DenseArrayFx::write_dense_subarray_2D_with_cancel(
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, query_type);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -1057,8 +1059,8 @@ void DenseArrayFx::check_invalid_cell_num_in_dense_writes(
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);
@@ -1071,8 +1073,8 @@ void DenseArrayFx::check_invalid_cell_num_in_dense_writes(
   // Ordered layout
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   REQUIRE(rc == TILEDB_OK);
@@ -1475,8 +1477,20 @@ void DenseArrayFx::write_dense_array(const std::string& array_name) {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -1529,8 +1543,20 @@ void DenseArrayFx::write_partial_dense_array(const std::string& array_name) {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
   uint64_t subarray[] = {3, 4, 3, 4};
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
@@ -1608,8 +1634,23 @@ void DenseArrayFx::read_dense_array_with_coords_full_global(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -1705,8 +1746,23 @@ void DenseArrayFx::read_dense_array_with_coords_full_row(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -1801,8 +1857,23 @@ void DenseArrayFx::read_dense_array_with_coords_full_col(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_COL_MAJOR);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -1900,8 +1971,23 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_global(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
@@ -1999,8 +2085,23 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_row(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
@@ -2098,8 +2199,23 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_col(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_COL_MAJOR);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
@@ -2489,5 +2605,83 @@ TEST_CASE_METHOD(
   std::string temp_dir = FILE_URI_PREFIX + FILE_TEMP_DIR;
   create_temp_dir(temp_dir);
   check_non_empty_domain(temp_dir);
+  remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    DenseArrayFx,
+    "C API: Test dense array, invalid set query buffer",
+    "[capi], [dense], [dense-invalid-set-query-buffer]") {
+  std::string temp_dir = FILE_URI_PREFIX + FILE_TEMP_DIR;
+  create_temp_dir(temp_dir);
+
+  // Create and write dense array
+  std::string array_name = temp_dir + "dense_non_empty_domain";
+  create_dense_array(array_name);
+  write_dense_array(array_name);
+
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Allocate query
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Aux variables
+  uint64_t off[1];
+  uint64_t off_size;
+  int a1[1];
+  uint64_t a1_size = sizeof(a1);
+
+  // Check invalid attribute
+  rc = tiledb_query_set_buffer(ctx_, query, "foo", a1, &a1_size);
+  CHECK(rc == TILEDB_ERR);
+
+  // Check invalid attribute
+  rc = tiledb_query_set_buffer_var(
+      ctx_, query, "foo", off, &off_size, a1, &a1_size);
+  CHECK(rc == TILEDB_ERR);
+
+  // Check non-fixed attribute
+  rc = tiledb_query_set_buffer(ctx_, query, "a2", a1, &a1_size);
+  CHECK(rc == TILEDB_ERR);
+
+  // Check non-var attribute
+  rc = tiledb_query_set_buffer_var(
+      ctx_, query, "a1", off, &off_size, a1, &a1_size);
+  CHECK(rc == TILEDB_ERR);
+
+  // Check no buffers set
+  rc = tiledb_query_submit(ctx_, query);
+  CHECK(rc == TILEDB_ERR);
+
+  // Issue an incomplete query
+  rc = tiledb_query_set_buffer(ctx_, query, "a1", a1, &a1_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_submit(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Check that setting a new attribute for an incomplete query fails
+  rc = tiledb_query_set_buffer_var(
+      ctx_, query, "a2", off, &off_size, a1, &a1_size);
+  CHECK(rc == TILEDB_ERR);
+
+  // But resetting an existing attribute buffer succeeds
+  rc = tiledb_query_set_buffer(ctx_, query, "a1", a1, &a1_size);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_query_free(&query);
+  tiledb_array_free(&array);
+
   remove_temp_dir(temp_dir);
 }

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -236,8 +236,12 @@ void DenseVectorFx::create_dense_vector(const std::string& path) {
   tiledb_query_t* write_query;
   rc = tiledb_query_alloc(ctx_, &write_query, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, write_query, attributes, 1, write_buffers, write_buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_,
+      write_query,
+      attributes[0],
+      write_buffers[0],
+      &write_buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, write_query, TILEDB_ROW_MAJOR);
   REQUIRE(rc == TILEDB_OK);
@@ -274,8 +278,8 @@ void DenseVectorFx::check_read(
 
   rc = tiledb_query_alloc(ctx_, &read_query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, read_query, attributes, 1, read_buffers, read_buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, read_query, attributes[0], read_buffers[0], &read_buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, read_query, layout);
   REQUIRE(rc == TILEDB_OK);
@@ -317,8 +321,12 @@ void DenseVectorFx::check_update(const std::string& path) {
   tiledb_query_t* update_query;
   rc = tiledb_query_alloc(ctx_, &update_query, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, update_query, attributes, 1, update_buffers, update_buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_,
+      update_query,
+      attributes[0],
+      update_buffers[0],
+      &update_buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, update_query, TILEDB_ROW_MAJOR);
   REQUIRE(rc == TILEDB_OK);
@@ -347,8 +355,8 @@ void DenseVectorFx::check_update(const std::string& path) {
   tiledb_query_t* read_query = nullptr;
   rc = tiledb_query_alloc(ctx_, &read_query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, read_query, attributes, 1, read_buffers, read_buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, read_query, attributes[0], read_buffers[0], &read_buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, read_query, TILEDB_COL_MAJOR);
   REQUIRE(rc == TILEDB_OK);
@@ -391,8 +399,19 @@ void DenseVectorFx::check_duplicate_coords(const std::string& path) {
     tiledb_query_t* update_query;
     rc = tiledb_query_alloc(ctx_, &update_query, array, TILEDB_WRITE);
     REQUIRE(rc == TILEDB_OK);
-    rc = tiledb_query_set_buffers(
-        ctx_, update_query, attributes, 2, update_buffers, update_buffer_sizes);
+    rc = tiledb_query_set_buffer(
+        ctx_,
+        update_query,
+        attributes[0],
+        update_buffers[0],
+        &update_buffer_sizes[0]);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_query_set_buffer(
+        ctx_,
+        update_query,
+        attributes[1],
+        update_buffers[1],
+        &update_buffer_sizes[1]);
     REQUIRE(rc == TILEDB_OK);
     rc = tiledb_query_set_layout(ctx_, update_query, TILEDB_UNORDERED);
     REQUIRE(rc == TILEDB_OK);
@@ -420,8 +439,8 @@ void DenseVectorFx::check_duplicate_coords(const std::string& path) {
   tiledb_query_t* read_query = nullptr;
   rc = tiledb_query_alloc(ctx_, &read_query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, read_query, attributes, 1, read_buffers, read_buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, read_query, attributes[0], read_buffers[0], &read_buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, read_query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);

--- a/test/src/unit-capi-incomplete.cc
+++ b/test/src/unit-capi-incomplete.cc
@@ -293,8 +293,20 @@ void IncompleteFx::write_dense_full() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -359,8 +371,23 @@ void IncompleteFx::write_sparse_full() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -424,8 +451,8 @@ void IncompleteFx::check_dense_incomplete() {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -483,8 +510,8 @@ void IncompleteFx::check_dense_until_complete() {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -557,8 +584,14 @@ void IncompleteFx::check_dense_unsplittable_overflow() {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[0],
+      (uint64_t*)buffers[0],
+      &buffer_sizes[0],
+      buffers[1],
+      &buffer_sizes[1]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -606,8 +639,14 @@ void IncompleteFx::check_dense_unsplittable_complete() {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[0],
+      (uint64_t*)buffers[0],
+      &buffer_sizes[0],
+      buffers[1],
+      &buffer_sizes[1]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -658,8 +697,8 @@ void IncompleteFx::check_dense_reset_buffers() {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -680,15 +719,6 @@ void IncompleteFx::check_dense_reset_buffers() {
   rc = tiledb_query_get_status(ctx_, query, &status);
   CHECK(rc == TILEDB_OK);
   CHECK(status == TILEDB_INCOMPLETE);
-
-  // Reset buffer sizes to something smaller
-  uint64_t new_buffer_sizes[] = {1};
-  rc = tiledb_query_reset_buffers(ctx_, query, buffers, new_buffer_sizes);
-  CHECK(rc == TILEDB_ERR);
-
-  // Reset buffer sizes to the original
-  rc = tiledb_query_reset_buffers(ctx_, query, buffers, buffer_sizes);
-  CHECK(rc == TILEDB_OK);
 
   // Resubmit query
   rc = tiledb_query_submit(ctx_, query);
@@ -740,8 +770,8 @@ void IncompleteFx::check_sparse_incomplete() {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -799,8 +829,8 @@ void IncompleteFx::check_sparse_until_complete() {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -873,8 +903,14 @@ void IncompleteFx::check_sparse_unsplittable_overflow() {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[0],
+      (uint64_t*)buffers[0],
+      &buffer_sizes[0],
+      buffers[1],
+      &buffer_sizes[1]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -922,8 +958,14 @@ void IncompleteFx::check_sparse_unsplittable_complete() {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[0],
+      (uint64_t*)buffers[0],
+      &buffer_sizes[0],
+      buffers[1],
+      &buffer_sizes[1]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -399,8 +399,9 @@ int* SparseArrayFx::read_sparse_array_2D(
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, query_type);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 1, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  REQUIRE(rc == TILEDB_OK);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
@@ -465,8 +466,11 @@ void SparseArrayFx::write_sparse_array_unsorted_2D(
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, &query, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 2, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[1], buffers[1], &buffer_sizes[1]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   REQUIRE(rc == TILEDB_OK);
@@ -700,8 +704,23 @@ void SparseArrayFx::check_sparse_array_unordered_with_duplicates_error(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -780,8 +799,23 @@ void SparseArrayFx::check_sparse_array_unordered_with_duplicates_no_check(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query - this is unsafe but it should be passing
@@ -859,8 +893,23 @@ void SparseArrayFx::check_sparse_array_unordered_with_duplicates_dedup(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit WRITE query
@@ -899,8 +948,23 @@ void SparseArrayFx::check_sparse_array_unordered_with_duplicates_dedup(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, r_buffers, r_buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], r_buffers[0], &r_buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)r_buffers[1],
+      &r_buffer_sizes[1],
+      r_buffers[2],
+      &r_buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], r_buffers[3], &r_buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], r_buffers[4], &r_buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit READ query
@@ -1003,8 +1067,23 @@ void SparseArrayFx::check_sparse_array_unordered_with_all_duplicates_dedup(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit WRITE query
@@ -1043,8 +1122,23 @@ void SparseArrayFx::check_sparse_array_unordered_with_all_duplicates_dedup(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, r_buffers, r_buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], r_buffers[0], &r_buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)r_buffers[1],
+      &r_buffer_sizes[1],
+      r_buffers[2],
+      &r_buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], r_buffers[3], &r_buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], r_buffers[4], &r_buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit READ query
@@ -1121,8 +1215,23 @@ void SparseArrayFx::check_sparse_array_global_with_duplicates_error(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -1199,8 +1308,23 @@ void SparseArrayFx::check_sparse_array_global_with_duplicates_no_check(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query - this is unsafe but it should be passing
@@ -1280,8 +1404,23 @@ void SparseArrayFx::check_sparse_array_global_with_duplicates_dedup(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit WRITE query
@@ -1320,8 +1459,23 @@ void SparseArrayFx::check_sparse_array_global_with_duplicates_dedup(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, r_buffers, r_buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], r_buffers[0], &r_buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)r_buffers[1],
+      &r_buffer_sizes[1],
+      r_buffers[2],
+      &r_buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], r_buffers[3], &r_buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], r_buffers[4], &r_buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit READ query
@@ -1428,8 +1582,23 @@ void SparseArrayFx::check_sparse_array_global_with_all_duplicates_dedup(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit WRITE query
@@ -1468,8 +1637,23 @@ void SparseArrayFx::check_sparse_array_global_with_all_duplicates_dedup(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 4, r_buffers, r_buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], r_buffers[0], &r_buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)r_buffers[1],
+      &r_buffer_sizes[1],
+      r_buffers[2],
+      &r_buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[2], r_buffers[3], &r_buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[3], r_buffers[4], &r_buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit READ query
@@ -1567,8 +1751,23 @@ void SparseArrayFx::write_partial_sparse_array(const std::string& array_name) {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx_, query, attributes, 4, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(
+      ctx_, query, attributes[3], buffers[4], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
   // Submit query

--- a/test/src/unit-capi-string.cc
+++ b/test/src/unit-capi-string.cc
@@ -183,8 +183,26 @@ void StringFx::write_array(const std::string& array_name) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[2],
+      (uint64_t*)buffers[3],
+      &buffer_sizes[3],
+      buffers[4],
+      &buffer_sizes[4]);
   REQUIRE(rc == TILEDB_OK);
 
   // Submit query
@@ -245,8 +263,26 @@ void StringFx::read_array(const std::string& array_name) {
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx, &query, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_buffers(
-      ctx, query, attributes, 3, buffers, buffer_sizes);
+  rc = tiledb_query_set_buffer(
+      ctx, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[1],
+      (uint64_t*)buffers[1],
+      &buffer_sizes[1],
+      buffers[2],
+      &buffer_sizes[2]);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      attributes[2],
+      (uint64_t*)buffers[3],
+      &buffer_sizes[3],
+      buffers[4],
+      &buffer_sizes[4]);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -87,13 +87,6 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi]") {
     Query query(ctx, array, TILEDB_WRITE);
     CHECK_THROWS(query.set_subarray<unsigned>({1, 2}));  // Wrong type
     CHECK_THROWS(query.set_subarray<int>({1, 2}));       // Wrong num
-    std::vector<int> subarray = {0, 5, 0, 5};
-    query.set_subarray(subarray);
-    // TODO: This is only required because the array is currently locked
-    // on query creation. If we don't finalize, the file won't be unlocked
-    // and we won't be able to delete the array in between tests on Windows
-    // (which has stricter file removal rules).
-    query.finalize();
     array.close();
   }
 

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -316,6 +316,19 @@ Status ArraySchema::check() const {
 }
 
 Status ArraySchema::check_attributes(
+    const std::vector<std::string>& attributes) const {
+  for (const auto& attr : attributes) {
+    if (attr == constants::coords)
+      continue;
+    if (attribute_map_.find(attr) == attribute_map_.end())
+      return LOG_STATUS(Status::ArraySchemaError(
+          "Attribute check failed; cannot find attribute"));
+  }
+
+  return Status::Ok();
+}
+
+Status ArraySchema::check_attributes(
     const char** attributes, unsigned attribute_num) const {
   for (unsigned i = 0; i < attribute_num; ++i) {
     if (attributes[i] == constants::coords)

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -191,6 +191,15 @@ class ArraySchema {
   Status check_attributes(
       const char** attributes, unsigned attribute_num) const;
 
+  /**
+   * Throws an error if there is an attribute in the input that does not
+   * exist in the schema.
+   *
+   * @param attributes The attributes to be checked.
+   * @return Status
+   */
+  Status check_attributes(const std::vector<std::string>& attributes) const;
+
   /** Returns the compression type of the attribute with the input id. */
   Compressor compression(unsigned int attribute_id) const;
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1652,13 +1652,32 @@ int tiledb_query_set_subarray(
   return TILEDB_OK;
 }
 
-int tiledb_query_set_buffers(
+int tiledb_query_set_buffer(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    const char** attributes,
-    unsigned int attribute_num,
-    void** buffers,
-    uint64_t* buffer_sizes) {
+    const char* attribute,
+    void* buffer,
+    uint64_t* buffer_size) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Set attributes and buffers
+  if (save_error(
+          ctx, query->query_->set_buffer(attribute, buffer, buffer_size)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int tiledb_query_set_buffer_var(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* attribute,
+    uint64_t* buffer_off,
+    uint64_t* buffer_off_size,
+    void* buffer_val,
+    uint64_t* buffer_val_size) {
   // Sanity check
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
     return TILEDB_ERR;
@@ -1666,8 +1685,12 @@ int tiledb_query_set_buffers(
   // Set attributes and buffers
   if (save_error(
           ctx,
-          query->query_->set_buffers(
-              attributes, attribute_num, buffers, buffer_sizes)))
+          query->query_->set_buffer(
+              attribute,
+              buffer_off,
+              buffer_off_size,
+              buffer_val,
+              buffer_val_size)))
     return TILEDB_ERR;
 
   return TILEDB_OK;
@@ -1736,23 +1759,6 @@ int tiledb_query_submit_async(
               query->query_, callback, callback_data)))
     return TILEDB_ERR;
 
-  return TILEDB_OK;
-}
-
-int tiledb_query_reset_buffers(
-    tiledb_ctx_t* ctx,
-    tiledb_query_t* query,
-    void** buffers,
-    uint64_t* buffer_sizes) {
-  // Sanity check
-  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
-    return TILEDB_ERR;
-
-  // Reset buffers
-  if (save_error(ctx, query->query_->set_buffers(buffers, buffer_sizes)))
-    return TILEDB_ERR;
-
-  // Success
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1852,48 +1852,80 @@ TILEDB_EXPORT int tiledb_query_set_subarray(
     tiledb_ctx_t* ctx, tiledb_query_t* query, const void* subarray);
 
 /**
- * Sets the buffers to the query, which will either hold the attribute
- * values to be written (if it is a write query), or will hold the
- * results from a read query.
+ * Sets the buffer for a fixed-sized attribute to a query, which will
+ * either hold the values to be written (if it is a write query), or will hold
+ * the results from a read query.
  *
  * **Example:**
  *
  * @code{.c}
- * const char* attributes[] = {"attr_1", "attr_2"};
- * int attr_1[100];
- * float attr_2[100];
- * void* buffers[] = {attr_1, attr_2};
- * uint64_t buffer_sizes[] = {sizeof(attr_1), sizeof(attr_2)};
- * tiledb_query_set_buffers(ctx, query, attributes, 2, buffers, buffer_sizes);
+ * int a1[100];
+ * uint64_t a2_size = sizeof(a1);
+ * tiledb_query_set_buffer(ctx, query, "a1", a1, &a2_size);
  * @endcode
  *
  * @param ctx The TileDB context.
  * @param query The TileDB query.
- * @param attributes A set of the array attributes the read/write will be
- *     constrained on. Note that the coordinates have special attribute name
- *     `TILEDB_COORDS`. If it is set to `NULL`, then this means **all**
- *     attributes, in the way they were defined upon the array creation,
- *     including the special attributes of coordinates and keys.
- * @param attribute_num The number of the input attributes.
- * @param buffers The buffers that either have the input data to be written,
- *     or will hold the data to be read. Note that there is one buffer per
- *     fixed-sized attribute, and two buffers for each variable-sized
- *     attribute (the first holds the offsets, and the second the actual
- *     values).
- * @param buffer_sizes There must be an one-to-one correspondence with
- *     *buffers*. In the case of writes, they contain the sizes of *buffers*.
- *     In the case of reads, they initially contain the allocated sizes of
- *     *buffers*, but after the termination of the function they will contain
- *     the sizes of the useful (read) data in the buffers.
+ * @param attribute The attribute to set the buffer for. Note that the
+ *     coordinates have special attribute name `TILEDB_COORDS`.
+ * @param buffer The buffer that either have the input data to be written,
+ *     or will hold the data to be read.
+ * @param buffer_size In the case of writes, this is the size of `buffer`
+ *     in bytes. In the case of reads, this initially contains the allocated
+ *     size of `buffer`, but after the termination of the function
+ *     it will contain the size of the useful (read) data in `buffer`.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int tiledb_query_set_buffers(
+TILEDB_EXPORT int tiledb_query_set_buffer(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    const char** attributes,
-    unsigned int attribute_num,
-    void** buffers,
-    uint64_t* buffer_sizes);
+    const char* attribute,
+    void* buffer,
+    uint64_t* buffer_size);
+
+/**
+ * Sets the buffer for a var-sized attribute to a query, which will
+ * either hold the values to be written (if it is a write query), or will hold
+ * the results from a read query.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint64_t a2_off[10];
+ * uint64_t a2_off_size = sizeof(a2_off);
+ * char a2_val[100];
+ * uint64_t a2_val_size = sizeof(a2_val);
+ * tiledb_query_set_buffer_var(
+ *     ctx, query, "a2", a2_off, &a2_off_size, a2_val, &a2_val_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param attribute The attribute to set the buffer for.
+ * @param buffer_off The buffer that either have the input data to be written,
+ *     or will hold the data to be read. This buffer holds the starting offsets
+ *     of each cell value in `buffer_val`.
+ * @param buffer_off_size In the case of writes, it is the size of `buffer_off`
+ *     in bytes. In the case of reads, this initially contains the allocated
+ *     size of `buffer_off`, but after the termination of the function
+ *     it will contain the size of the useful (read) data in `buffer_off`.
+ * @param buffer_val The buffer that either have the input data to be written,
+ *     or will hold the data to be read. This buffer holds the actual var-sized
+ *     cell values.
+ * @param buffer_val_size In the case of writes, it is the size of `buffer_val`
+ *     in bytes. In the case of reads, this initially contains the allocated
+ *     size of `buffer_val`, but after the termination of the function
+ *     it will contain the size of the useful (read) data in `buffer_val`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int tiledb_query_set_buffer_var(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* attribute,
+    uint64_t* buffer_off,
+    uint64_t* buffer_off_size,
+    void* buffer_val,
+    uint64_t* buffer_val_size);
 
 /**
  * Sets the layout of the cells to be written or read.
@@ -2009,27 +2041,6 @@ TILEDB_EXPORT int tiledb_query_submit_async(
     tiledb_query_t* query,
     void (*callback)(void*),
     void* callback_data);
-
-/**
- * Resets the query buffers.
- *
- * **Example:**
- *
- * @code{.c}
- * tiledb_query_reset_buffers(ctx, query, buffers, buffer_sizes);
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param query The query whose buffers are to be se.
- * @param buffers The buffers to be set.
- * @param buffer_sizes The corresponding buffer sizes.
- * @return `TILEDB_OK` upon success, and `TILEDB_ERR` upon error.
- */
-TILEDB_EXPORT int tiledb_query_reset_buffers(
-    tiledb_ctx_t* ctx,
-    tiledb_query_t* query,
-    void** buffers,
-    uint64_t* buffer_sizes);
 
 /**
  * Retrieves the status of a query.

--- a/tiledb/sm/kv/kv.h
+++ b/tiledb/sm/kv/kv.h
@@ -174,10 +174,7 @@ class KV {
   std::vector<Datatype> read_attribute_types_;
 
   /** These are the attributes to be passed to a TileDB read query. */
-  char** read_attributes_;
-
-  /** The number of read query attributes. */
-  unsigned read_attribute_num_;
+  std::vector<std::string> read_attributes_;
 
   /** Buffers to be used in read queries. */
   void** read_buffers_;
@@ -208,10 +205,7 @@ class KV {
   std::vector<bool> write_attribute_var_sizes_;
 
   /** These are the attributes to be passed to a TileDB write query. */
-  char** write_attributes_;
-
-  /** The number of write query attributes. */
-  unsigned write_attribute_num_;
+  std::vector<std::string> write_attributes_;
 
   /** Buffers to be used in write queries. */
   void** write_buffers_;
@@ -330,6 +324,13 @@ class KV {
    * read query.
    */
   Status realloc_read_buffers();
+
+  /** Sets the query buffers for the input attributes. */
+  Status set_query_buffers(
+      Query* query,
+      const std::vector<std::string>& attributes,
+      void** buffers,
+      uint64_t* buffer_sizes) const;
 
   /** Submits a read query. */
   Status submit_read_query(const uint64_t* subarray);

--- a/tiledb/sm/kv/kv_iter.h
+++ b/tiledb/sm/kv/kv_iter.h
@@ -90,10 +90,10 @@ class KVIter {
   StorageManager* storage_manager_;
 
   /** Buffer for storing coordinates (i.e., key hashes). */
-  uint64_t* read_buffers_[1];
+  uint64_t* coords_buffer_;
 
   /** The coordinates buffer size. */
-  uint64_t read_buffer_sizes_[1];
+  uint64_t coords_buffer_size_;
 
   /** The current item from the read ones. */
   uint64_t current_item_;
@@ -116,9 +116,6 @@ class KVIter {
 
   /** Clears the iterator. */
   void clear();
-
-  /** Initializes a read query. */
-  Status init_read_query();
 
   /** Submits a read query, recording its status. */
   Status submit_read_query();

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -95,9 +95,9 @@ Status Query::init() {
   // Only if the query has not been initialized before
   if (status_ == QueryStatus::UNINITIALIZED) {
     if (type_ == QueryType::READ) {
-      RETURN_NOT_OK_ELSE(reader_.init(), status_ = QueryStatus::FAILED);
+      RETURN_NOT_OK(reader_.init());
     } else {  // Write
-      RETURN_NOT_OK_ELSE(writer_.init(), status_ = QueryStatus::FAILED);
+      RETURN_NOT_OK(writer_.init());
     }
   }
 
@@ -164,21 +164,24 @@ Status Query::process() {
   return Status::Ok();
 }
 
-Status Query::set_buffers(
-    const char** attributes,
-    unsigned int attribute_num,
-    void** buffers,
-    uint64_t* buffer_sizes) {
+Status Query::set_buffer(
+    const char* attribute, void* buffer, uint64_t* buffer_size) {
   if (type_ == QueryType::WRITE)
-    return writer_.set_buffers(
-        attributes, attribute_num, buffers, buffer_sizes);
-  return reader_.set_buffers(attributes, attribute_num, buffers, buffer_sizes);
+    return writer_.set_buffer(attribute, buffer, buffer_size);
+  return reader_.set_buffer(attribute, buffer, buffer_size);
 }
 
-Status Query::set_buffers(void** buffers, uint64_t* buffer_sizes) {
+Status Query::set_buffer(
+    const char* attribute,
+    uint64_t* buffer_off,
+    uint64_t* buffer_off_size,
+    void* buffer_val,
+    uint64_t* buffer_val_size) {
   if (type_ == QueryType::WRITE)
-    return writer_.set_buffers(buffers, buffer_sizes);
-  return reader_.set_buffers(buffers, buffer_sizes);
+    return writer_.set_buffer(
+        attribute, buffer_off, buffer_off_size, buffer_val, buffer_val_size);
+  return reader_.set_buffer(
+      attribute, buffer_off, buffer_off_size, buffer_val, buffer_val_size);
 }
 
 void Query::set_callback(

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -105,30 +105,47 @@ class Query {
   Status process();
 
   /**
-   * Sets the buffers to the query for a set of attributes.
+   * Sets the buffer for a fixed-sized attribute.
    *
-   * @param attributes The attributes the query will focus on.
-   * @param attribute_num The number of attributes.
-   * @param buffers The buffers that either have the input data to be written,
-   *     or will hold the data to be read. Note that there is one buffer per
-   *     fixed-sized attribute, and two buffers for each variable-sized
-   *     attribute (the first holds the offsets, and the second the actual
-   *     values).
-   * @param buffer_sizes There must be an one-to-one correspondence with
-   *     *buffers*. In the case of writes, they contain the sizes of *buffers*.
-   *     In the case of reads, they initially contain the allocated sizes of
-   *     *buffers*, but after the termination of the function they will contain
-   *     the sizes of the useful (read) data in the buffers.
+   * @param attribute The attribute to set the buffer for.
+   * @param buffer The buffer that either have the input data to be written,
+   *     or will hold the data to be read.
+   * @param buffer_size In the case of writes, this is the size of `buffer`
+   *     in bytes. In the case of reads, this initially contains the allocated
+   *     size of `buffer`, but after the termination of the function
+   *     it will contain the size of the useful (read) data in `buffer`.
    * @return Status
    */
-  Status set_buffers(
-      const char** attributes,
-      unsigned int attribute_num,
-      void** buffers,
-      uint64_t* buffer_sizes);
+  Status set_buffer(const char* attribute, void* buffer, uint64_t* buffer_size);
 
-  /** Sets the query buffers. */
-  Status set_buffers(void** buffers, uint64_t* buffer_sizes);
+  /**
+   * Sets the buffer for a var-sized attribute.
+   *
+   * @param attribute The attribute to set the buffer for.
+   * @param buffer_off The buffer that either have the input data to be written,
+   *     or will hold the data to be read. This buffer holds the starting
+   *     offsets of each cell value in `buffer_val`.
+   * @param buffer_off_size In the case of writes, it is the size of
+   *     `buffer_off` in bytes. In the case of reads, this initially contains
+   *     the allocated size of `buffer_off`, but after the termination of the
+   *     function it will contain the size of the useful (read) data in
+   *     `buffer_off`.
+   * @param buffer_val The buffer that either have the input data to be written,
+   *     or will hold the data to be read. This buffer holds the actual
+   *     var-sized cell values.
+   * @param buffer_val_size In the case of writes, it is the size of
+   *     `buffer_val` in bytes. In the case of reads, this initially contains
+   *     the allocated size of `buffer_val`, but after the termination of the
+   *     function it will contain the size of the useful (read) data in
+   *     `buffer_val`.
+   * @return Status
+   */
+  Status set_buffer(
+      const char* attribute,
+      uint64_t* buffer_off,
+      uint64_t* buffer_off_size,
+      void* buffer_val,
+      uint64_t* buffer_val_size);
 
   /**
    * Sets the callback function and its data input that will be called

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -160,26 +160,34 @@ class Writer {
   void set_array_schema(const ArraySchema* array_schema);
 
   /**
-   * Sets the buffers to the query for a set of attributes.
+   * Sets the buffer for a fixed-sized attribute.
    *
-   * @param attributes The attributes the query will focus on.
-   * @param attribute_num The number of attributes.
-   * @param buffers The buffers that either have the input data to be written.
-   *     Note that there is one buffer per fixed-sized attribute, and two
-   *     buffers for each variable-sized attribute (the first holds the offsets,
-   *     and the second the actual values).
-   * @param buffer_sizes There must be an one-to-one correspondence with
-   *     *buffers*. They contain the sizes of *buffers*.
+   * @param attribute The attribute to set the buffer for.
+   * @param buffer The buffer that has the input data to be written.
+   * @param buffer_size The size of `buffer` in bytes.
    * @return Status
    */
-  Status set_buffers(
-      const char** attributes,
-      unsigned int attribute_num,
-      void** buffers,
-      uint64_t* buffer_sizes);
+  Status set_buffer(const char* attribute, void* buffer, uint64_t* buffer_size);
 
-  /** Sets the query buffers. */
-  Status set_buffers(void** buffers, uint64_t* buffer_sizes);
+  /**
+   * Sets the buffer for a var-sized attribute.
+   *
+   * @param attribute The attribute to set the buffer for.
+   * @param buffer_off The buffer that has the input data to be written,
+   *     This buffer holds the starting offsets of each cell value in
+   *     `buffer_val`.
+   * @param buffer_off_size The size of `buffer_off` in bytes.
+   * @param buffer_val The buffer that has the input data to be written.
+   *     This buffer holds the actual var-sized cell values.
+   * @param buffer_val_size The size of `buffer_val` in bytes.
+   * @return Status
+   */
+  Status set_buffer(
+      const char* attribute,
+      uint64_t* buffer_off,
+      uint64_t* buffer_off_size,
+      void* buffer_val,
+      uint64_t* buffer_val_size);
 
   /** Sets the fragment URI. Applicable only to write queries. */
   void set_fragment_uri(const URI& fragment_uri);
@@ -240,6 +248,9 @@ class Writer {
 
   /** The state associated with global writes. */
   std::unique_ptr<GlobalWriteState> global_write_state_;
+
+  /** True if the writer has been initialized. */
+  bool initialized_;
 
   /** The layout of the cells in the user buffers. */
   Layout layout_;

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -169,6 +169,15 @@ class Consolidator {
    * consolidated fragments.
    */
   Status rename_new_fragment_uri(URI* uri) const;
+
+  /**
+   * Sets the buffers to the query, using all the attributes in the
+   * query schema. There is a 1-1 correspondence between the input `buffers`
+   * and the attributes in the schema, considering also the coordinates
+   * if the array is sparse in the end.
+   */
+  Status set_query_buffers(
+      Query* query, void** buffers, uint64_t* buffer_sizes) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -126,6 +126,27 @@ class StorageManager {
    * @param subarray The subarray to focus on. Note that it must have the same
    *     underlying type as the array domain.
    * @param attributes The attributes to focus on.
+   * @param buffer_sizes The buffer sizes to be retrieved. Note that one
+   *     buffer size corresponds to a fixed-sized attributes, and two
+   *     buffer sizes for a variable-sized attribute (the first is the
+   *     size of the offsets, whereas the second is the size of the
+   *     actual variable-sized cell values.
+   * @return Status
+   */
+  Status array_compute_max_read_buffer_sizes(
+      OpenArray* open_array,
+      const void* subarray,
+      const std::vector<std::string>& attributes,
+      uint64_t* buffer_sizes);
+
+  /**
+   * Computes an upper bound on the buffer sizes required for a read
+   * query, for a given subarray and set of attributes.
+   *
+   * @param open_array The opened array.
+   * @param subarray The subarray to focus on. Note that it must have the same
+   *     underlying type as the array domain.
+   * @param attributes The attributes to focus on.
    * @param attribute_num The number of attributes.
    * @param buffer_sizes The buffer sizes to be retrieved. Note that one
    *     buffer size corresponds to a fixed-sized attributes, and two


### PR DESCRIPTION
Partially addresses #608 

- Added `tiledb_query_set_buffer` which sets a single attribute buffer
- Removed `tiledb_query_set_buffers`
- Removed `tiledb_query_reset_buffers`