### PR TITLE
Make fragment metadata consistent with multiprocess read/writes.

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -743,8 +743,8 @@ Status StorageManager::is_file(const URI& uri, bool* is_file) const {
 }
 
 Status StorageManager::is_fragment(const URI& uri, bool* is_fragment) const {
-  RETURN_NOT_OK(vfs_->is_file(
-      uri.join_path(constants::fragment_metadata_filename), is_fragment));
+  RETURN_NOT_OK(TileIO::is_generic_tile(
+      this, uri.join_path(constants::fragment_metadata_filename), is_fragment));
   return Status::Ok();
 }
 


### PR DESCRIPTION
If one process is in the middle of updating a fragment's metadata, any other processes trying to read the fragment will not include it as a valid fragment to be read due to the inconsistent state of the metadata.

The validity check added just ensures that the file size is exactly equal to the header size plus the compressed tile size.

Closes #664.