### PR TITLE
Addressed various KV/Map issues

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -66,6 +66,7 @@
 * Added `Map::{open, close}`
 * Added `Array::query_type`
 * Added `Query::query_type`
+* Added optional attributes argument in `Map::Map` and `Map::open`
 
 ## Breaking changes
 
@@ -105,6 +106,7 @@
 * `Map::begin` refers to the same iterator object. For multiple concurrent iterators, a `MapIter` should be manually constructed instead of using `Map::begin()` more than once.
 * Renamed `Domain::rank` to `Domain::ndim` to avoid confusion with matrix def of rank.
 * Added query type argument to `Array` constructor
+* Removed iterator functionality from `Map`.
 
 # TileDB v1.2.2 Release Notes
 

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -267,6 +267,8 @@ Query
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_set_buffer
     :project: TileDB-C
+.. doxygenfunction:: tiledb_query_set_buffer_var
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_query_set_layout
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_free

--- a/test/src/unit-cppapi-map.cc
+++ b/test/src/unit-cppapi-map.cc
@@ -249,6 +249,31 @@ TEST_CASE_METHOD(
 }
 
 TEST_CASE_METHOD(
+    CPPMapFromMapFx,
+    "C++ API: Map with explicit attributes",
+    "[cppapi], [cppapi-map]") {
+  std::vector<std::string> attributes = {std::string("val")};
+  Map map(ctx, "cpp_unit_map", attributes);
+  CHECK(map[0]["val"].get<std::string>() == "0");
+  CHECK(map[1]["val"].get<std::string>() == "12");
+  CHECK(map[2].get<std::string>() == "123");  // implicit
+  map.close();
+
+  // Check reopening
+  map.open(attributes);
+  CHECK(map[0]["val"].get<std::string>() == "0");
+  CHECK(map[1]["val"].get<std::string>() == "12");
+  CHECK(map[2].get<std::string>() == "123");  // implicit
+
+  // Check opening without closing
+  map.open();
+  CHECK(map[0]["val"].get<std::string>() == "0");
+  CHECK(map[1]["val"].get<std::string>() == "12");
+  CHECK(map[2].get<std::string>() == "123");  // implicit
+  map.close();
+}
+
+TEST_CASE_METHOD(
     CPPMapFromMapFx, "C++ API: Map iter", "[cppapi], [cppapi-map]") {
   Map map(ctx, "cpp_unit_map");
 
@@ -256,18 +281,9 @@ TEST_CASE_METHOD(
   map.close();
   map.open();
 
-  std::vector<std::string> vals;
-  for (auto& item : map) {
-    vals.push_back(item.get<std::string>());
-  }
-
-  REQUIRE(vals.size() == 3);
-  CHECK(std::count(vals.begin(), vals.end(), "0") == 1);
-  CHECK(std::count(vals.begin(), vals.end(), "12") == 1);
-  CHECK(std::count(vals.begin(), vals.end(), "123") == 1);
-
   MapIter iter(map), end(map, true);
-  vals.clear();
+
+  std::vector<std::string> vals;
   for (; iter != end; ++iter) {
     vals.push_back(iter->get<std::string>());
   }

--- a/tiledb/sm/kv/kv.h
+++ b/tiledb/sm/kv/kv.h
@@ -80,6 +80,12 @@ class KV {
   /** The tile capacity of the KV schema. */
   uint64_t capacity() const;
 
+  /**
+   * Returns `true` if the kv contains written unflushed items buffered
+   * in main memory.
+   */
+  bool dirty() const;
+
   /** Flushes the buffered written items to persistent storage. */
   Status flush();
 

--- a/tiledb/sm/kv/kv_item.cc
+++ b/tiledb/sm/kv/kv_item.cc
@@ -83,13 +83,13 @@ void KVItem::clear() {
   values_.clear();
 }
 
-bool KVItem::good(
+Status KVItem::good(
     const std::vector<std::string>& attributes,
     const std::vector<Datatype>& types) const {
   assert(attributes.size() == types.size());
 
   if (key_.key_ == nullptr)
-    return false;
+    return LOG_STATUS(Status::KVItemError("Invalid item; The key is null"));
 
   auto attribute_num = attributes.size();
   for (unsigned i = 0; i < attribute_num; ++i) {
@@ -101,14 +101,21 @@ bool KVItem::good(
 
     auto it = values_.find(attributes[i]);
     if (it == values_.end())
-      return false;
+      return LOG_STATUS(Status::KVItemError(
+          std::string("Invalid item; ") + "Missing value on attribute " +
+          attributes[i]));
     if (it->second->value_ == nullptr)
-      return false;
+      return LOG_STATUS(Status::KVItemError(
+          std::string("Invalid item; Value on attribute ") + attributes[i] +
+          " is null"));
     if (it->second->value_type_ != types[i])
-      return false;
+      return LOG_STATUS(Status::KVItemError(
+          std::string("Invalid item; Type mismatch on attribute ") +
+          attributes[i] + ", " + datatype_str(it->second->value_type_) +
+          " != " + datatype_str(types[i])));
   }
 
-  return true;
+  return Status::Ok();
 }
 
 const KVItem::Hash& KVItem::hash() const {

--- a/tiledb/sm/kv/kv_item.h
+++ b/tiledb/sm/kv/kv_item.h
@@ -99,8 +99,12 @@ class KVItem {
    * `attributes`, and have the same types as `types` (there is a one-to-one
    * correspondence. Returns `false` when the key is `nullptr`, or a set
    * value is `nullptr`.
+   *
+   * @param attributes The attributes to check.
+   * @param types The types to be checked.
+   * @return Status
    */
-  bool good(
+  Status good(
       const std::vector<std::string>& attributes,
       const std::vector<Datatype>& types) const;
 

--- a/tiledb/sm/kv/kv_iter.cc
+++ b/tiledb/sm/kv/kv_iter.cc
@@ -78,6 +78,12 @@ Status KVIter::here(KVItem** kv_item) const {
 }
 
 Status KVIter::init(KV* kv) {
+  // Error if kv is dirty
+  if (kv->dirty())
+    return LOG_STATUS(
+        Status::KVIterError("Cannot initialize kv iterator; The input kv is "
+                            "dirty - consider flushing the kv"));
+
   kv_ = kv;
 
   coords_buffer_ = new (std::nothrow) uint64_t[2 * max_item_num_];

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -106,7 +106,7 @@ std::vector<FragmentMetadata*> OpenArray::fragment_metadata(
 
   std::vector<FragmentMetadata*> ret;
   for (uint64_t i = 0; i < fragment_metadata_.size(); ++i) {
-    if (snapshot <= i) {
+    if (snapshot >= i) {
       for (auto& f : fragment_metadata_[i])
         ret.push_back(f);
     } else {

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -141,6 +141,19 @@ class StorageManager {
       uint64_t* snapshot);
 
   /**
+   * Reopens an already open array, loading the fragment metadata of any new
+   * fragments and acquiring a new snapshot identifier.
+   * This is applicable only to arrays opened for reads.
+   * When the new snapshot snapshot is used in future queries, the queries
+   * will see the fragments in the array created at or before this snapshot.
+   *
+   * @param open_array The open array to be reopened.
+   * @param snapshot A new snapshot identifier retrieved.
+   * @return Status
+   */
+  Status array_reopen(OpenArray* open_array, uint64_t* snapshot);
+
+  /**
    * Computes an upper bound on the buffer sizes required for a read
    * query, for a given subarray and set of attributes.
    *


### PR DESCRIPTION
- Removed iterator functionality from Map
- Closes #682
- KV/Map now reopen the array immediately after a flush, so that they are always up-to-date with the latest updates.
- The kv iterator cannot be initialized with a dirty kv
- Added optional attributes argument in Map::Map and Map::open