### PR TITLE
C API additions/changes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -48,6 +48,12 @@
 * Added `tiledb_query_set_buffer` which sets a single attribute buffer
 * Added `tiledb_query_get_type`
 * Added `tiledb_array_get_query_type`
+* Added `tiledb_kv_schema_{set,get}_capacity`.
+* Added `tiledb_query_has_results`
+* Added `tiledb_kv_is_dirty`
+* Added `tiledb_kv_iter_reset`
+* Added `tiledb_array_reopen`
+* Added `tiledb_kv_reopen`
 
 ### C++ API
 * Support for trivially copyable objects, such as a custom data struct, was added. They will be backed by an `sizeof(T)` sized `char` attribute.
@@ -67,6 +73,14 @@
 * Added `Array::query_type`
 * Added `Query::query_type`
 * Added optional attributes argument in `Map::Map` and `Map::open`
+* Added `MapSchema::set_capacity` and `MapSchema::capacity`
+* Added `Query::has_results`
+* Added `Map::is_dirty`
+* Added `MapIter::reset`
+* Added an extra `Query` constructor that omits the query type (this is inherited from the input array).
+* Changed the return type of the `Query` setters to return the object reference.
+* Added `Array::reopen`
+* Added `Map::reopen`
 
 ## Breaking changes
 

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -140,6 +140,8 @@ Array
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_open
     :project: TileDB-C
+.. doxygenfunction:: tiledb_array_reopen
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_array_close
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_free
@@ -281,6 +283,8 @@ Query
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_get_type
     :project: TileDB-C
+.. doxygenfunction:: tiledb_query_has_results
+    :project: TileDB-C
 
 Group
 -----
@@ -299,6 +303,8 @@ Key-value
     :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_open
     :project: TileDB-C
+.. doxygenfunction:: tiledb_kv_reopen
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_close
     :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_free
@@ -310,6 +316,8 @@ Key-value
 .. doxygenfunction:: tiledb_kv_get_item
     :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_has_key
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_kv_is_dirty
     :project: TileDB-C
 
 
@@ -332,6 +340,10 @@ Key-value Schema
 .. doxygenfunction:: tiledb_kv_schema_get_attribute_from_name
     :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_schema_dump
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_kv_schema_set_capacity
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_kv_schema_get_capacity
     :project: TileDB-C
 
 Key-value Item
@@ -362,6 +374,8 @@ Key-value Iterator
 .. doxygenfunction:: tiledb_kv_iter_next
     :project: TileDB-C
 .. doxygenfunction:: tiledb_kv_iter_done
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_kv_iter_reset
     :project: TileDB-C
 
 Object Management

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -1844,9 +1844,20 @@ void SparseArrayFx::check_sparse_array_no_results(
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   REQUIRE(rc == TILEDB_OK);
 
+  // Check that it has no results before submission
+  int has_results;
+  rc = tiledb_query_has_results(ctx_, query, &has_results);
+  CHECK(rc == TILEDB_OK);
+  CHECK(!has_results);
+
   // Submit query
   rc = tiledb_query_submit(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
+
+  // Check that it has no results also after submission
+  rc = tiledb_query_has_results(ctx_, query, &has_results);
+  CHECK(rc == TILEDB_OK);
+  CHECK(!has_results);
 
   tiledb_query_status_t status;
   rc = tiledb_query_get_status(ctx_, query, &status);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -148,15 +148,22 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi]") {
 
       REQUIRE(query.submit() == Query::Status::COMPLETE);
 
+      CHECK(!query.has_results());
+
       query.finalize();
-      tiledb::Array::consolidate(ctx, "cpp_unit_array");
       array.close();
+
+      tiledb::Array::consolidate(ctx, "cpp_unit_array");
     } catch (std::exception& e) {
       std::cout << e.what() << std::endl;
     }
 
     {
       Array array(ctx, "cpp_unit_array", TILEDB_READ);
+
+      // Reopen should work
+      array.reopen();
+
       std::vector<std::string> attrs = {"a1"};
       std::vector<size_t> buffer_el = {1};
       auto parts = array.partition_subarray<int>(
@@ -212,7 +219,10 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi]") {
       a4buf.second.resize(buff_el["a4"].second);
       a1.resize(buff_el["a5"].second);
 
-      Query query(ctx, array, TILEDB_READ);
+      Query query(ctx, array);
+
+      CHECK(!query.has_results());
+
       query.set_buffer("a1", a1);
       query.set_buffer("a2", a2buf);
       query.set_buffer("a3", a3);
@@ -225,6 +235,8 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi]") {
       query.result_buffer_elements();
 
       REQUIRE(query.submit() == Query::Status::COMPLETE);
+
+      CHECK(query.has_results());
 
       query.finalize();
       array.close();

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -105,6 +105,15 @@ class Array {
     schema_ = ArraySchema(ctx, array_schema);
   }
 
+  /** Re-opens the array. */
+  void reopen() {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_array_reopen(ctx, array_.get()));
+    tiledb_array_schema_t* array_schema;
+    ctx.handle_error(tiledb_array_get_schema(ctx, array_.get(), &array_schema));
+    schema_ = ArraySchema(ctx, array_schema);
+  }
+
   /** Closes the array. */
   void close() {
     auto& ctx = ctx_.get();

--- a/tiledb/sm/cpp_api/map_schema.h
+++ b/tiledb/sm/cpp_api/map_schema.h
@@ -165,6 +165,23 @@ class MapSchema : public Schema {
     return {ctx, attr};
   }
 
+  /** Sets the tile capacity. */
+  MapSchema& set_capacity(uint64_t capacity) {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(
+        tiledb_kv_schema_set_capacity(ctx, schema_.get(), capacity));
+    return *this;
+  }
+
+  /** Returns the tile capacity. */
+  uint64_t capacity() const {
+    auto& ctx = ctx_.get();
+    uint64_t capacity;
+    ctx.handle_error(
+        tiledb_kv_schema_get_capacity(ctx, schema_.get(), &capacity));
+    return capacity;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/kv/kv.cc
+++ b/tiledb/sm/kv/kv.cc
@@ -146,6 +146,7 @@ void KV::clear() {
 
 Status KV::finalize() {
   RETURN_NOT_OK(flush());
+  std::unique_lock<std::mutex> lck(mtx_);
   RETURN_NOT_OK(storage_manager_->array_close(kv_uri_, QueryType::READ));
   RETURN_NOT_OK(storage_manager_->array_close(kv_uri_, QueryType::WRITE));
   clear();
@@ -373,6 +374,11 @@ Status KV::set_max_buffered_items(uint64_t max_items) {
 
 uint64_t KV::snapshot() const {
   return snapshot_;
+}
+
+Status KV::reopen() {
+  std::unique_lock<std::mutex> lck(mtx_);
+  return storage_manager_->array_reopen(open_array_for_reads_, &snapshot_);
 }
 
 /* ********************************* */

--- a/tiledb/sm/kv/kv.h
+++ b/tiledb/sm/kv/kv.h
@@ -147,6 +147,9 @@ class KV {
    */
   Status finalize();
 
+  /** Re-opens the key-value store for reads. */
+  Status reopen();
+
   /** The open array used for dispatching read queries. */
   OpenArray* open_array_for_reads() const;
 

--- a/tiledb/sm/kv/kv_iter.h
+++ b/tiledb/sm/kv/kv_iter.h
@@ -78,6 +78,9 @@ class KVIter {
   /** Moves to the next key-value item. */
   Status next();
 
+  /** Resets the iterator, so that it can start iterating from the beginning. */
+  Status reset();
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -91,6 +91,12 @@ std::vector<URI> Query::fragment_uris() const {
   return reader_.fragment_uris();
 }
 
+bool Query::has_results() const {
+  if (status_ == QueryStatus::UNINITIALIZED || type_ == QueryType::WRITE)
+    return false;
+  return !reader_.no_results();
+}
+
 Status Query::init() {
   // Only if the query has not been initialized before
   if (status_ == QueryStatus::UNINITIALIZED) {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -105,6 +105,12 @@ class Query {
   /** Returns a vector with the fragment URIs. */
   std::vector<URI> fragment_uris() const;
 
+  /**
+   * Returns `true` if the query has results. Applicable only to read
+   * queries (it returns `false` for write queries).
+   */
+  bool has_results() const;
+
   /** Initializes the query. */
   Status init();
 

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -285,6 +285,14 @@ Status Reader::next_subarray_partition() {
   return Status::Ok();
 }
 
+bool Reader::no_results() const {
+  for (const auto& it : attr_buffers_) {
+    if (*(it.second.buffer_size_) != 0)
+      return false;
+  }
+  return true;
+}
+
 Status Reader::read() {
   // This is needed in case the buffers were reset with smaller sizes
   RETURN_NOT_OK(calibrate_cur_partition());
@@ -1592,14 +1600,6 @@ Status Reader::init_tile_fragment_dense_cell_range_iters(
   }
 
   return Status::Ok();
-}
-
-bool Reader::no_results() const {
-  for (const auto& it : attr_buffers_) {
-    if (*(it.second.buffer_size_) != 0)
-      return false;
-  }
-  return true;
 }
 
 template <class T>

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -354,6 +354,9 @@ class Reader {
    */
   Status next_subarray_partition();
 
+  /** Returns `true` if no results were retrieved after a query. */
+  bool no_results() const;
+
   /** Performs a read query using its set members. */
   Status read();
 
@@ -802,9 +805,6 @@ class Reader {
       std::vector<std::vector<DenseCellRangeIter<T>>>* iters,
       std::unordered_map<uint64_t, std::pair<uint64_t, std::vector<T>>>*
           overlapping_tile_idx_coords);
-
-  /** Returns `true` if no results were retrieved after a query. */
-  bool no_results() const;
 
   /**
    * Checks whether two hyper-rectangles overlap, and determines whether


### PR DESCRIPTION
- Added `tiledb_kv_schema_{set,get}_capacity`, `MapSchema::set_capacity` and `MapSchema::capacity`
- Added `tiledb_query_has_results` and `Query::has_results`
- Added `tiledb_kv_is_dirty` and `Map::is_dirty`
- Added `tiledb_kv_iter_reset` and `MapIter::reset`
- Added an extra `Query` constructor that omits the query type argument (it is inherited from the array input).
- Changed the return type of the `Query` setters to return the object reference.
- Added `tiledb_array_reopen` and `Array::reopen`
- Added `tiledb_kv_reopen` and `Map::reopen`.