### PR TITLE
Reset query state when resetting the subarray. Closes #691

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1852,6 +1852,14 @@ TILEDB_EXPORT int tiledb_query_alloc(
  *     for dense arrays, and specifically dense writes. Note that `subarray`
  *     must have the same type as the domain.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note If you set the subarray of a completed, incomplete or in-progress
+ *     query, this function will clear the internal state and render it
+ *     as uninitialized. However, the potentially set layout and attribute
+ *     buffers will be retained. This is useful when the user wishes to
+ *     fix the attributes and layout, but explore different subarrays with
+ *     the same `tiledb_query_t` object (i.e., without having to created
+ *     a new object).
  */
 TILEDB_EXPORT int tiledb_query_set_subarray(
     tiledb_ctx_t* ctx, tiledb_query_t* query, const void* subarray);

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -74,7 +74,7 @@ Status Query::finalize() {
     return Status::Ok();
 
   RETURN_NOT_OK(writer_.finalize());
-  status_ = QueryStatus::UNINITIALIZED;
+  status_ = QueryStatus::COMPLETED;
   return Status::Ok();
 }
 
@@ -250,6 +250,8 @@ Status Query::set_subarray(const void* subarray) {
   } else {  // READ
     RETURN_NOT_OK(reader_.set_subarray(subarray));
   }
+
+  status_ = QueryStatus::UNINITIALIZED;
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -78,6 +78,13 @@ class Reader {
      * to be split next.
      */
     std::list<void*> subarray_partitions_;
+    /** True if the reader has been initialized. */
+    bool initialized_;
+    /**
+     * `True` if the query produced results that could not fit in
+     * some buffer.
+     */
+    bool overflowed_;
   };
 
   /** Contains the buffer(s) and buffer size(s) for some attribute. */
@@ -431,17 +438,8 @@ class Reader {
   /** The fragment metadata. */
   std::vector<FragmentMetadata*> fragment_metadata_;
 
-  /** True if the reader has been initialized. */
-  bool initialized_;
-
   /** The layout of the cells in the result of the subarray. */
   Layout layout_;
-
-  /**
-   * `True` if the query produced results that could not fit in
-   * some buffer.
-   */
-  bool overflowed_;
 
   /** To handle incomplete read queries. */
   ReadState read_state_;

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -482,6 +482,12 @@ class Writer {
   Status new_fragment_name(std::string* frag_uri) const;
 
   /**
+   * This deletes the global write state and deletes the potentially
+   * partially written fragment.
+   */
+  void nuke_global_write_state();
+
+  /**
    * Writes in an ordered layout (col- or row-major order). Applicable only
    * to dense arrays.
    */
@@ -623,6 +629,9 @@ class Writer {
       const std::vector<uint64_t>& cell_pos,
       const std::set<uint64_t>& coord_dups,
       std::vector<Tile>* tiles) const;
+
+  /** Resets the writer object, rendering it incomplete. */
+  void reset();
 
   /**
    * Sorts the coordinates of the user buffers, creating a vector with


### PR DESCRIPTION
When resetting the subarray to a query object, the internal (read/write) state is nuked and the query is rendered uninitialized. However, the rest of its attributes (e.g., layout and attribute buffers) remain unchanged. 