### PR TITLE
Fixed consistency issue in consolidator and optimized locking

### DIFF
--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -120,7 +120,8 @@ class Consolidator {
 
   /**
    * Creates the queries needed for consolidation. It also retrieves
-   * the number of fragments to be consolidated.
+   * the number of fragments to be consolidated and the URI of the
+   * new fragment to be created.
    *
    * @param query_r This query reads from the fragments to be consolidated.
    * @param query_w This query writes to the new consolidated fragment.
@@ -134,6 +135,7 @@ class Consolidator {
    * @param buffers The buffers to be passed in the queries.
    * @param buffer_sizes The corresponding buffer sizes.
    * @param fragment_num The number of fragments to be retrieved.
+   * @param new_fragment_uri The URI of the new fragment to be created.
    * @return Status
    */
   Status create_queries(
@@ -145,14 +147,25 @@ class Consolidator {
       uint64_t snapshot,
       void** buffers,
       uint64_t* buffer_sizes,
-      unsigned int* fragment_num);
+      unsigned int* fragment_num,
+      URI* new_fragment_uri);
 
   /** Creates the subarray that should represent the entire array domain. */
   Status create_subarray(
       OpenArray* open_array, uint64_t snapshot, void** subarray) const;
 
   /**
+   * Deletes the fragment metadata files of the old fragments that
+   * got consolidated. This renders the old fragments "invisible".
+   *
+   * @param uris The URIs of the old fragments.
+   * @return Status
+   */
+  Status delete_old_fragment_metadata(const std::vector<URI>& uris);
+
+  /**
    * Deletes the old fragments that got consolidated.
+   *
    * @param uris The URIs of the old fragments.
    * @return Status
    */

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -318,9 +318,6 @@ class StorageManager {
   /** Creates an empty file with the input URI. */
   Status touch(const URI& uri);
 
-  /** Deletes a fragment directory. */
-  Status delete_fragment(const URI& uri) const;
-
   /**
    * Creates a TileDB group.
    *
@@ -665,15 +662,11 @@ class StorageManager {
   /** A fragment metadata cache. */
   LRUCache* fragment_metadata_cache_;
 
-  /**
-   * Mutex for managing OpenArray objects. Its purpose is threefold:
-   *
-   * - Protect `open_arrays_` during `array_{open, close} and
-   *   `array_{xlock, xunlock}`.
-   * - Protect `xfilelocks_` during `array_{xlock, xunlock}
-   * - Used by conditional variable `xlock_cv_`.
-   */
-  std::mutex open_array_mtx_;
+  /** Mutex for managing OpenArray objects for reads. */
+  std::mutex open_array_for_reads_mtx_;
+
+  /** Mutex for managing OpenArray objects for writes. */
+  std::mutex open_array_for_writes_mtx_;
 
   /** Stores the currently open arrays for reads. */
   std::map<std::string, OpenArray*> open_arrays_for_reads_;


### PR DESCRIPTION
Array locking is required practically at one place: when the consolidator is about to finalize the new merged fragment and delete the old fragments. This is currently partially addressed; there is a scenario where the consolidator finalizes the new fragment (so it becomes visible) and an array is opened just before the consolidator acquires an exclusive lock and deletes the old fragments, i.e., the opened array will "see" both the old fragments and the merged fragment. This PR fixes this issue.

This PR also optimizes locking in the consolidator. Specifically, instead of locking the array until the entire old fragment metadata directories are deleted, the consolidator locks the array only for deleting the **metadata files** of the fragments (which are typically much smaller than the data files), then unlocks the array and proceeds to delete the rest of the fragment data files without locking.