### PR TITLE
Do not calibrate subarray in next read query submission.

### DIFF
--- a/test/src/unit-capi-incomplete.cc
+++ b/test/src/unit-capi-incomplete.cc
@@ -624,9 +624,7 @@ void IncompleteFx::check_dense_shrink_buffer_size() {
   CHECK(status == TILEDB_INCOMPLETE);
 
   // Check new buffer contents
-  int c_buffer_a1_2[1] = {2};
-  CHECK(!memcmp(buffer_a1, c_buffer_a1_2, sizeof(c_buffer_a1_2)));
-  CHECK(buffer_sizes[0] == sizeof(int));
+  CHECK(buffer_sizes[0] == 0);
 
   // Free/finalize query
   rc = tiledb_query_finalize(ctx_, query);

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -272,9 +272,6 @@ bool Reader::no_results() const {
 }
 
 Status Reader::read() {
-  // This is needed in case the buffers were reset with smaller sizes
-  RETURN_NOT_OK(calibrate_cur_partition());
-
   if (fragment_metadata_.empty() ||
       read_state_.cur_subarray_partition_ == nullptr) {
     zero_out_buffer_sizes();
@@ -456,23 +453,6 @@ Status Reader::set_subarray(const void* subarray) {
 /* ****************************** */
 /*          PRIVATE METHODS       */
 /* ****************************** */
-
-Status Reader::calibrate_cur_partition() {
-  if (read_state_.cur_subarray_partition_ != nullptr) {
-    auto subarray_size = 2 * array_schema_->coords_size();
-    auto partition_to_push = std::malloc(subarray_size);
-    if (partition_to_push == nullptr)
-      return LOG_STATUS(Status::ReaderError(
-          "Cannot calibrate current partition; Memory allocation failed"));
-    std::memcpy(
-        partition_to_push, read_state_.cur_subarray_partition_, subarray_size);
-
-    read_state_.subarray_partitions_.push_front(partition_to_push);
-    next_subarray_partition();
-  }
-
-  return Status::Ok();
-}
 
 void Reader::clear_read_state() {
   for (auto p : read_state_.subarray_partitions_)

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -451,12 +451,6 @@ class Reader {
   /*           PRIVATE METHODS         */
   /* ********************************* */
 
-  /**
-   * Re-checks if the current partition must be split, in case the user
-   * has reset the buffers with smaller sizes in between query submissions.
-   */
-  Status calibrate_cur_partition();
-
   /** Clears the read state. */
   void clear_read_state();
 


### PR DESCRIPTION
Currently, the reader calibrates the next subarray partition to be processed. This was meant to capture the scenario where the user resets the attribute buffers with a smaller size in between two query submission in the case of incomplete queries, so that the next subarray partition is estimated to fit the results in the new buffer (instead of being incomplete without returning any results). 

The problem is that, since the internal partitions are just estimates, the user may reset the attribute buffers with larger sizes, to accommodate the case where the query was incomplete because of insufficient buffer sizes. Calibrating the subarray partition in this case may lead to another estimate that again eventually lead to an incomplete query with no results, and so on. In general, we expect the user to increase the buffer sizes if need be, rather than decrease them. Therefore, we'd better remove calibrating the subarray.