### PR TITLE
Update tiledb_uri_to_path example.

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3769,7 +3769,7 @@ TILEDB_EXPORT int tiledb_vfs_touch(
  * @code{.c}
  * char path[TILEDB_MAX_PATH];
  * unsigned length;
- * tiledb_uri_to_path(ctx, kv, &kv_item, "file:///my_array", path, &length);
+ * tiledb_uri_to_path(ctx, "file:///my_array", path, &length);
  * // This will set "my_array" to `path`
  * @endcode
  *


### PR DESCRIPTION
This update the example for tiledb_uri_to_path.

Fixes #714