### PR TITLE
Cache attribute URIs when FragmentMetadata objects are created.

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -407,15 +407,21 @@ and ``"key_3": 3``.
 
          void write_map() {
            tiledb::Context ctx;
-
+         
            // Open the map
            tiledb::Map map(ctx, map_name);
-
+         
            // Write some values
-           map["key_1"] = 1;
-           map["key_2"] = 2;
-           map["key_3"] = 3;
-
+           auto item1 = tiledb::Map::create_item(ctx, "key_1");
+           auto item2 = tiledb::Map::create_item(ctx, "key_2");
+           auto item3 = tiledb::Map::create_item(ctx, "key_3");
+           item1.set("a", 1);
+           item2.set("a", 2);
+           item3.set("a", 3);
+           map.add_item(item1);
+           map.add_item(item2);
+           map.add_item(item3);
+         
            // Close the map
            map.close();
          }

--- a/examples/cpp_api/quickstart_map.cc
+++ b/examples/cpp_api/quickstart_map.cc
@@ -61,9 +61,15 @@ void write_map() {
   tiledb::Map map(ctx, map_name);
 
   // Write some values
-  map["key_1"] = 1;
-  map["key_2"] = 2;
-  map["key_3"] = 3;
+  auto item1 = tiledb::Map::create_item(ctx, "key_1");
+  auto item2 = tiledb::Map::create_item(ctx, "key_2");
+  auto item3 = tiledb::Map::create_item(ctx, "key_3");
+  item1.set("a", 1);
+  item2.set("a", 2);
+  item3.set("a", 3);
+  map.add_item(item1);
+  map.add_item(item2);
+  map.add_item(item3);
 
   // Close the map
   map.close();

--- a/tiledb/sm/cpp_api/map.h
+++ b/tiledb/sm/cpp_api/map.h
@@ -823,6 +823,11 @@ class Map {
    * auto item = map[key];
    * @endcode
    *
+   * @note For writing to the map, e.g. `map[key] = value`, it is usually much
+   * more efficient to instead use Map::create_item() to create a MapItem,
+   * set attribute values on the MapItem, and then Map::add_item to add
+   * the item to the map.
+   *
    * @tparam T Key type
    * @param key Item key
    * @return The item

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -65,9 +65,19 @@ FragmentMetadata::FragmentMetadata(
   tile_index_base_ = 0;
 
   auto attributes = array_schema_->attributes();
-  for (unsigned i = 0; i < attributes.size(); ++i)
-    attribute_idx_map_[attributes[i]->name()] = i;
+  for (unsigned i = 0; i < attributes.size(); ++i) {
+    auto attr_name = attributes[i]->name();
+    attribute_idx_map_[attr_name] = i;
+    attribute_uri_map_[attr_name] =
+        fragment_uri_.join_path(attr_name + constants::file_suffix);
+    if (attributes[i]->var_size())
+      attribute_var_uri_map_[attr_name] =
+          fragment_uri_.join_path(attr_name + "_var" + constants::file_suffix);
+  }
+
   attribute_idx_map_[constants::coords] = array_schema_->attribute_num();
+  attribute_uri_map_[constants::coords] =
+      fragment_uri_.join_path(constants::coords + constants::file_suffix);
 }
 
 FragmentMetadata::~FragmentMetadata() {
@@ -485,11 +495,11 @@ uint64_t FragmentMetadata::tile_num() const {
 }
 
 URI FragmentMetadata::attr_uri(const std::string& attribute) const {
-  return fragment_uri_.join_path(attribute + constants::file_suffix);
+  return attribute_uri_map_.at(attribute);
 }
 
 URI FragmentMetadata::attr_var_uri(const std::string& attribute) const {
-  return fragment_uri_.join_path(attribute + "_var" + constants::file_suffix);
+  return attribute_var_uri_map_.at(attribute);
 }
 
 uint64_t FragmentMetadata::file_offset(

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -439,6 +439,12 @@ class FragmentMetadata {
   /** Maps an attribute to an index used in the various vector class members. */
   std::unordered_map<std::string, unsigned> attribute_idx_map_;
 
+  /** Maps an attribute to its absolute URI within this fragment. */
+  std::unordered_map<std::string, URI> attribute_uri_map_;
+
+  /** Maps an attribute to its absolute '_var' URI within this fragment. */
+  std::unordered_map<std::string, URI> attribute_var_uri_map_;
+
   /** A vector storing the first and last coordinates of each tile. */
   std::vector<void*> bounding_coords_;
 


### PR DESCRIPTION
Closes #720. Also add a small doc comment for Map writes.