### PR TITLE
Fixes for tiledb array examples in c_api

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -2263,7 +2263,7 @@ TILEDB_EXPORT void tiledb_array_free(tiledb_array_t** array);
  *
  * @code{.c}
  * tiledb_array_schema_t* array_schema;
- * tiledb_array_get_schema(ctx, &array_schema);
+ * tiledb_array_get_schema(ctx, array, &array_schema);
  * @endcode
  *
  * @param ctx The TileDB context.
@@ -2287,7 +2287,7 @@ TILEDB_EXPORT int tiledb_array_get_schema(
  * tiledb_array_t* array;
  * tiledb_array_alloc(ctx, "hdfs:///tiledb_arrays/my_array", &array);
  * tiledb_array_open(ctx, array, TILEDB_READ);
- * tiledb_query_type_t* query_type;
+ * tiledb_query_type_t query_type;
  * tiledb_array_get_type(ctx, array, &query_type);
  * @endcode
  *


### PR DESCRIPTION
Update tiledb_array_get_schema example.
Update tiledb_array_get_query_type example.


Fixes #722