### PR TITLE
Don't use implicit list initialize for unordered_map

### DIFF
--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -357,7 +357,9 @@ class Query {
   result_buffer_elements() const {
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>> elements;
     if (buff_sizes_.size() == 0)
-      return {};  // Query hasn't been submitted
+      return std::unordered_map<
+          std::string,
+          std::pair<uint64_t, uint64_t>>();  // Query hasn't been submitted
     for (const auto& b_it : buff_sizes_) {
       auto attr_name = b_it.first;
       auto size_pair = b_it.second;


### PR DESCRIPTION
This works around a issue with gcc 4.9
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58930

Fixes #764