### PR TITLE
Null tile extents for dimensions of dense arrays get assigned the dimension domain range

### DIFF
--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -837,13 +837,111 @@ TEST_CASE_METHOD(
       ctx_, "d3", TILEDB_UINT64, dim_domain, &tile_extent, &d3);
   CHECK(rc == TILEDB_ERR);
 
-  // Create dimension with invalud domain - error
+  // Create dimension with invalid domain - error
   tiledb_dimension_t* d4;
   dim_domain[0] = 10;
   dim_domain[1] = 1;
   rc = tiledb_dimension_alloc(
       ctx_, "d4", TILEDB_UINT64, dim_domain, &tile_extent, &d4);
   CHECK(rc == TILEDB_ERR);
+
+  // Clean up
+  tiledb_dimension_free(&d1);
+}
+
+TEST_CASE_METHOD(
+    ArraySchemaFx,
+    "C API: Test dense array schema with null tile extent",
+    "[capi], [array-schema]") {
+  // Create dimension with null extent
+  tiledb_dimension_t* d1;
+  uint64_t dim_domain[] = {0, UINT64_MAX - 1};
+  int rc = tiledb_dimension_alloc(
+      ctx_, "d1", TILEDB_UINT64, dim_domain, nullptr, &d1);
+  CHECK(rc == TILEDB_OK);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  rc = tiledb_array_schema_alloc(ctx_, TILEDB_DENSE, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set domain
+  tiledb_domain_t* domain;
+  rc = tiledb_domain_alloc(ctx_, &domain);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, d1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_domain(ctx_, array_schema, domain);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set attribute
+  tiledb_attribute_t* attr1;
+  rc = tiledb_attribute_alloc(ctx_, "", ATTR_TYPE, &attr1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_add_attribute(ctx_, array_schema, attr1);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Check schema
+  rc = tiledb_array_schema_check(ctx_, array_schema);
+  CHECK(rc == TILEDB_OK);
+
+  // Get domain
+  tiledb_domain_t* domain_get;
+  rc = tiledb_array_schema_get_domain(ctx_, array_schema, &domain_get);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Get dimensions
+  tiledb_dimension_t* d1_get;
+  rc = tiledb_domain_get_dimension_from_index(ctx_, domain_get, 0, &d1_get);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Get extent
+  void* tile_extent;
+  rc = tiledb_dimension_get_tile_extent(ctx_, d1_get, &tile_extent);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(*((uint64_t*)tile_extent) == UINT64_MAX);
+
+  // Clean up
+  tiledb_attribute_free(&attr1);
+  tiledb_dimension_free(&d1);
+  tiledb_dimension_free(&d1_get);
+  tiledb_domain_free(&domain);
+  tiledb_domain_free(&domain_get);
+  tiledb_array_schema_free(&array_schema);
+
+  // Clean up
+  tiledb_dimension_free(&d1);
+}
+
+TEST_CASE_METHOD(
+    ArraySchemaFx,
+    "C API: Test dense array schema with null tile extent with domain overflow",
+    "[capi], [array-schema]") {
+  // Create dimension with null extent
+  tiledb_dimension_t* d1;
+  uint64_t dim_domain[] = {0, UINT64_MAX};
+  int rc = tiledb_dimension_alloc(
+      ctx_, "d1", TILEDB_UINT64, dim_domain, nullptr, &d1);
+  CHECK(rc == TILEDB_OK);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  rc = tiledb_array_schema_alloc(ctx_, TILEDB_DENSE, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set domain
+  tiledb_domain_t* domain;
+  rc = tiledb_domain_alloc(ctx_, &domain);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, d1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_domain(ctx_, array_schema, domain);
+  REQUIRE(rc == TILEDB_ERR);
+
+  // Clean up
+  tiledb_dimension_free(&d1);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
 
   // Clean up
   tiledb_dimension_free(&d1);

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -162,4 +162,14 @@ TEST_CASE("C++ API: Schema", "[cppapi]") {
         dom.add_dimension(Dimension::create<uint64_t>(ctx, "d2", {{0, 10}})),
         TileDBError);
   }
+
+  SECTION("Dimensions without tile extent") {
+    Domain dom(ctx);
+    dom.add_dimension(Dimension::create<int>(ctx, "d1", {{0, 10}}));
+    ArraySchema schema(ctx, TILEDB_DENSE);
+    schema.set_domain(dom);
+
+    auto dom_get = schema.domain();
+    CHECK(dom_get.dimensions()[0].tile_extent<int>() == 11);
+  }
 }

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -233,16 +233,11 @@ Status ArraySchema::check() const {
         "Array schema check failed; No dimensions provided"));
 
   if (array_type_ == ArrayType::DENSE) {
-    if (domain_->null_tile_extents()) {
-      return LOG_STATUS(
-          Status::ArraySchemaError("Array schema check failed; Dense arrays "
-                                   "can not have null tile extents"));
-    }
     if (domain_->type() == Datatype::FLOAT32 ||
         domain_->type() == Datatype::FLOAT64) {
       return LOG_STATUS(
           Status::ArraySchemaError("Array schema check failed; Dense arrays "
-                                   "can not have floating point domains"));
+                                   "cannot have floating point domains"));
     }
     if (attribute_num_ == 0) {
       return LOG_STATUS(Status::ArraySchemaError(
@@ -640,11 +635,8 @@ Status ArraySchema::set_domain(Domain* domain) {
         "Cannot set domain; The array is defined as a key-value store");
 
   if (array_type_ == ArrayType::DENSE) {
-    if (domain->null_tile_extents()) {
-      return LOG_STATUS(
-          Status::ArraySchemaError("Cannot set domain; Dense arrays "
-                                   "cannot have null tile extents"));
-    }
+    RETURN_NOT_OK(domain->set_null_tile_extents_to_range());
+
     if (domain->type() == Datatype::FLOAT32 ||
         domain->type() == Datatype::FLOAT64) {
       return LOG_STATUS(

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -110,6 +110,21 @@ class Dimension {
   /** Sets the tile extent. */
   Status set_tile_extent(const void* tile_extent);
 
+  /**
+   * If the tile extent is `null`, this function sets the
+   * the tile extent to the dimension domain range.
+   */
+  Status set_null_tile_extent_to_range();
+
+  /**
+   * If the tile extent is `null`, this function sets the
+   * the tile extent to the dimension domain range.
+   *
+   * @tparam T The dimension type.
+   */
+  template <class T>
+  Status set_null_tile_extent_to_range();
+
   /** Returns the tile extent. */
   void* tile_extent() const;
 

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/status.h"
@@ -535,6 +536,12 @@ class Domain {
   Status serialize(Buffer* buff);
 
   /**
+   * For every dimension that has a null tile extent, it sets
+   * the tile extent to that dimension domain range.
+   */
+  Status set_null_tile_extents_to_range();
+
+  /**
    * Returns the type of overlap of the input subarrays.
    *
    * @tparam T The types of the subarrays.
@@ -568,27 +575,6 @@ class Domain {
       const T* subarray_b,
       T* overlap_subarray,
       bool* overlap) const;
-
-  /**
-   * Checks the order of the input coordinates. First the tile order is checked
-   * (which, in case of non-regular tiles, is always the same), breaking the
-   * tie by checking the cell order.
-   *
-   * @tparam T The coordinates type.
-   * @param coords_a The first input coordinates.
-   * @param coords_b The second input coordinates.
-   * @param tile_coords This is an auxiliary input that helps in calculating the
-   *     tile id. It is strongly advised that the caller initializes this
-   *     parameter once and calls the function many times with the same
-   *     auxiliary input to improve performance.
-   * @return One of the following:
-   *    - -1 if the first coordinates precede the second
-   *    -  0 if the two coordinates are identical
-   *    - +1 if the first coordinates succeed the second
-   */
-  template <class T>
-  int tile_cell_order_cmp(
-      const T* coords_a, const T* coords_b, T* tile_coords) const;
 
   /** Returns the tile extents. */
   const void* tile_extents() const;
@@ -649,25 +635,6 @@ class Domain {
    * @tparam T The coordinates type.
    * @param coords_a The first input coordinates.
    * @param coords_b The second input coordinates.
-   * @param tile_coords This is an auxiliary input that helps in calculating the
-   *     tile id. It is strongly advised that the caller initializes this
-   *     parameter once and calls the function many times with the same
-   *     auxiliary input to improve performance.
-   * @return One of the following:
-   *    - -1 if the first coordinates precede the second on the tile order
-   *    -  0 if the two coordinates have the same tile order
-   *    - +1 if the first coordinates succeed the second on the tile order
-   */
-  template <class T>
-  int tile_order_cmp(
-      const T* coords_a, const T* coords_b, T* tile_coords) const;
-
-  /**
-   * Checks the tile order of the input coordinates.
-   *
-   * @tparam T The coordinates type.
-   * @param coords_a The first input coordinates.
-   * @param coords_b The second input coordinates.
    * @return One of the following:
    *    - -1 if the first coordinates precede the second on the tile order
    *    -  0 if the two coordinates have the same tile order
@@ -690,12 +657,6 @@ class Domain {
   template <class T>
   int tile_order_cmp_tile_coords(
       const T* tile_coords_a, const T* tile_coords_b) const;
-
-  /** Return the number of cells in a column tile slab of an input subarray. */
-  uint64_t tile_slab_col_cell_num(const void* subarray) const;
-
-  /** Return the number of cells in a row tile slab of an input subarray. */
-  uint64_t tile_slab_row_cell_num(const void* subarray) const;
 
   /** Returns the dimensions type. */
   Datatype type() const;

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1301,15 +1301,13 @@ TILEDB_EXPORT int tiledb_dimension_get_domain(
  * **Example:**
  *
  * @code{.c}
- * uint64_t tile_extent;
+ * void* tile_extent;
  * tiledb_dimension_get_tile_extent(ctx, dim, &tile_extent);
  * @endcode
  *
  * @param ctx The TileDB context.
  * @param dim The dimension.
- * @param tile_extent The tile extent to be retrieved. Note that the defined
- * type of input `tile_extent` must be the same as the dimension type, otherwise
- *     the behavior is unpredictable (it will probably segfault).
+ * @param tile_extent The tile extent (pointer) to be retrieved.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int tiledb_dimension_get_tile_extent(


### PR DESCRIPTION
Also minor `Domain` class cleanup. 
Closes #718