### PR TITLE
Add query support for getting subarray

### DIFF
--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -150,6 +150,100 @@ bool is_uint(const std::string& str) {
 /*           FUNCTIONS            */
 /* ****************************** */
 
+template <>
+Status check_template_type_to_datatype<int8_t>(Datatype datatype) {
+  if (datatype == Datatype::INT8)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type int8_t but datatype is not Datatype::INT8");
+}
+template <>
+Status check_template_type_to_datatype<uint8_t>(Datatype datatype) {
+  if (datatype == Datatype::UINT8)
+    return Status::Ok();
+  else if (datatype == Datatype::STRING_ASCII)
+    return Status::Ok();
+  else if (datatype == Datatype::STRING_UTF8)
+    return Status::Ok();
+
+  return Status::Error(
+      "Template of type uint8_t but datatype is not Datatype::UINT8 nor "
+      "Datatype::STRING_ASCII nor atatype::STRING_UTF8");
+}
+template <>
+Status check_template_type_to_datatype<int16_t>(Datatype datatype) {
+  if (datatype == Datatype::INT16)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type int16_t but datatype is not Datatype::INT16");
+}
+template <>
+Status check_template_type_to_datatype<uint16_t>(Datatype datatype) {
+  if (datatype == Datatype::UINT16)
+    return Status::Ok();
+  else if (datatype == Datatype::STRING_UTF16)
+    return Status::Ok();
+  else if (datatype == Datatype::STRING_UCS2)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type uint16_t but datatype is not Datatype::UINT16 nor "
+      "Datatype::STRING_UTF16 nor Datatype::STRING_UCS2");
+}
+template <>
+Status check_template_type_to_datatype<int32_t>(Datatype datatype) {
+  if (datatype == Datatype::INT32)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type int32_t but datatype is not Datatype::INT32");
+}
+template <>
+Status check_template_type_to_datatype<uint32_t>(Datatype datatype) {
+  if (datatype == Datatype::UINT32)
+    return Status::Ok();
+  else if (datatype == Datatype::STRING_UTF32)
+    return Status::Ok();
+  else if (datatype == Datatype::STRING_UCS4)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type uint32_t but datatype is not Datatype::UINT32 nor "
+      "Datatype::STRING_UTF32 nor Datatype::STRING_UCS4");
+}
+template <>
+Status check_template_type_to_datatype<int64_t>(Datatype datatype) {
+  if (datatype == Datatype::INT64)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type int64_t but datatype is not Datatype::INT64");
+}
+template <>
+Status check_template_type_to_datatype<uint64_t>(Datatype datatype) {
+  if (datatype == Datatype::UINT64)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type uint64_t but datatype is not Datatype::UINT64");
+}
+template <>
+Status check_template_type_to_datatype<float>(Datatype datatype) {
+  if (datatype == Datatype::FLOAT32)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type float but datatype is not Datatype::FLOAT32");
+}
+template <>
+Status check_template_type_to_datatype<double>(Datatype datatype) {
+  if (datatype == Datatype::FLOAT64)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type double but datatype is not Datatype::FLOAT64");
+}
+template <>
+Status check_template_type_to_datatype<char>(Datatype datatype) {
+  if (datatype == Datatype::CHAR)
+    return Status::Ok();
+  return Status::Error(
+      "Template of type char but datatype is not Datatype::CHAR");
+}
+
 template <class T>
 inline bool coords_in_rect(
     const T* coords, const T* rect, unsigned int dim_num) {

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -77,6 +77,14 @@ bool is_uint(const std::string& str);
 /* ********************************* */
 
 /**
+ * Check if a given type T is quivalent to the tiledb::sm::DataTtpe
+ * @tparam T
+ * @param datatype to compare T to
+ * @return Status indicating Ok() on equal data types else Status:Error()
+ */
+template <class T>
+Status check_template_type_to_datatype(Datatype datatype);
+/**
  * Checks if `coords` are inside `rect`.
  *
  * @tparam T The type of the cell and subarray.

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -459,6 +459,10 @@ Status Reader::set_subarray(const void* subarray) {
   return Status::Ok();
 }
 
+void* Reader::subarray() const {
+  return read_state_.subarray_;
+}
+
 /* ****************************** */
 /*          PRIVATE METHODS       */
 /* ****************************** */

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -363,6 +363,12 @@ class Reader {
    */
   Status set_subarray(const void* subarray);
 
+  /*
+   * Return the subarray
+   * @return subarray
+   */
+  void* subarray() const;
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -265,6 +265,10 @@ Status Writer::set_subarray(const void* subarray) {
   return Status::Ok();
 }
 
+void* Writer::subarray() const {
+  return subarray_;
+}
+
 Status Writer::write() {
   STATS_FUNC_IN(writer_write);
 

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -183,6 +183,12 @@ class Writer {
    */
   Status set_subarray(const void* subarray);
 
+  /*
+   * Return the subarray
+   * @return subarray
+   */
+  void* subarray() const;
+
   /** Performs a write query using its set members. */
   Status write();
 


### PR DESCRIPTION
This add support for getting the subarray from the query class based on the underlying writer or reader. This is an internal function for now, I've not exposed it via the c or c++ api, although it would be trial too if we wanted. Let me know if we do want to expose it and I'll add it to this merge request

I also used this as an opportunity to start moving away from the void* and returned a vector that is templated based on the datatype. Usage would be
```
std::vector<int64_t> subarray = query.subarray<int64_t>();
```

Closes #834 