### PR TITLE
Add query get attributes list support

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -70,6 +70,12 @@ const ArraySchema* Query::array_schema() const {
   return reader_.array_schema();
 }
 
+std::vector<std::string> Query::attributes() const {
+  if (type_ == QueryType::WRITE)
+    return writer_.attributes();
+  return reader_.attributes();
+}
+
 Status Query::finalize() {
   if (status_ == QueryStatus::UNINITIALIZED)
     return Status::Ok();

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -75,6 +75,12 @@ class Query {
   const ArraySchema* array_schema() const;
 
   /**
+   * Return vector of attributes
+   * @return attributes for query
+   */
+  std::vector<std::string> attributes() const;
+
+  /**
    * Marks a query that has not yet been started as failed. This should not be
    * called asynchronously to cancel an in-progress query; for that use the
    * parent StorageManager's cancellation mechanism.

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -104,6 +104,10 @@ const ArraySchema* Reader::array_schema() const {
   return array_schema_;
 }
 
+std::vector<std::string> Reader::attributes() const {
+  return attributes_;
+}
+
 bool Reader::incomplete() const {
   return read_state_.overflowed_ ||
          read_state_.cur_subarray_partition_ != nullptr;

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -258,6 +258,12 @@ class Reader {
   const ArraySchema* array_schema() const;
 
   /**
+   * Return list of attribtues for query
+   * @return vector of attributes for query
+   */
+  std::vector<std::string> attributes() const;
+
+  /**
    * Returns `true` if the query was incomplete, i.e., if all subarray
    * partitions in the read state have not been processed or there
    * was some buffer overflow.

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -73,6 +73,10 @@ const ArraySchema* Writer::array_schema() const {
   return array_schema_;
 }
 
+std::vector<std::string> Writer::attributes() const {
+  return attributes_;
+}
+
 Status Writer::finalize() {
   if (global_write_state_ != nullptr)
     return finalize_global_write_state();

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -115,6 +115,12 @@ class Writer {
   /** Returns the array schema. */
   const ArraySchema* array_schema() const;
 
+  /**
+   * Return list of attribtues for query
+   * @return vector of attributes for query
+   */
+  std::vector<std::string> attributes() const;
+
   /** Finalizes the reader. */
   Status finalize();
 


### PR DESCRIPTION
This add support for getting the attribute list for a query from the underlying read/write object. This is not exposed via the c/cpp api but is needed internally for serialization work.

Closes #837