### PR TITLE
Add query get buffer support for attribute buffers

### DIFF
--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -108,6 +108,13 @@ std::vector<std::string> Reader::attributes() const {
   return attributes_;
 }
 
+AttributeBuffer Reader::buffer(const std::string& attribute) const {
+  auto attrbuf = attr_buffers_.find(attribute);
+  if (attrbuf == attr_buffers_.end())
+    return AttributeBuffer{};
+  return attrbuf->second;
+}
+
 bool Reader::incomplete() const {
   return read_state_.overflowed_ ||
          read_state_.cur_subarray_partition_ != nullptr;

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -264,6 +264,13 @@ class Reader {
   std::vector<std::string> attributes() const;
 
   /**
+   * Fetch AttributeBuffer for attribute
+   * @param attribute to fetch
+   * @return AttributeBuffer for attribute
+   */
+  AttributeBuffer buffer(const std::string& attribute) const;
+
+  /**
    * Returns `true` if the query was incomplete, i.e., if all subarray
    * partitions in the read state have not been processed or there
    * was some buffer overflow.

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -77,6 +77,13 @@ std::vector<std::string> Writer::attributes() const {
   return attributes_;
 }
 
+AttributeBuffer Writer::buffer(const std::string& attribute) const {
+  auto attrbuf = attr_buffers_.find(attribute);
+  if (attrbuf == attr_buffers_.end())
+    return AttributeBuffer{};
+  return attrbuf->second;
+}
+
 Status Writer::finalize() {
   if (global_write_state_ != nullptr)
     return finalize_global_write_state();

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -121,6 +121,13 @@ class Writer {
    */
   std::vector<std::string> attributes() const;
 
+  /**
+   * Fetch AttributeBuffer for attribute
+   * @param attribute to fetch
+   * @return AttributeBuffer for attribute
+   */
+  AttributeBuffer buffer(const std::string& attribute) const;
+
   /** Finalizes the reader. */
   Status finalize();
 


### PR DESCRIPTION
This add the ability to get a query buffer for a given attribute name from the query class. It is not exposed externally. This requires https://github.com/TileDB-Inc/TileDB/pull/835 to be merged first as I am using the common template function of `check_template_type_to_datatype`. I could include `check_template_type_to_datatype` in this pull request but I am awaiting feedback in #835.

I'd like to get feedback on the design of using a std::pair and template vector type for returning the buffer. @jakebolewski had originally mentioned to use a std::array for copying the contents of the buffer but a std::array must be compile time constant so is not feasible for copying and returning an unknown sized buffer.

Example usage:

```
auto buffer = query.buffer<int64_t>("a1");
```

Closes #839