### PR TITLE
Support TileDB compilation under Cygwin

### DIFF
--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -39,7 +39,7 @@
 #include <thread>
 
 #include "catch.hpp"
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/filesystem/win.h"
 #else
 #include "tiledb/sm/filesystem/posix.h"
@@ -53,7 +53,7 @@ struct ArraySchemaFx {
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#ifdef _WIN32
+#ifdef _MSC_VER
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
       tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
@@ -512,7 +512,7 @@ void ArraySchemaFx::load_and_check_array_schema(const std::string& path) {
   FILE* fout = fopen("fout.txt", "w");
   tiledb_array_schema_dump(ctx_, array_schema, fout);
   fclose(fout);
-#ifdef _WIN32
+#ifdef _MSC_VER
   CHECK(!system("FC gold_fout.txt fout.txt > nul"));
 #else
   CHECK(!system("diff gold_fout.txt fout.txt"));

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -32,7 +32,7 @@
  */
 
 #include "catch.hpp"
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/filesystem/win.h"
 #else
 #include "tiledb/sm/filesystem/posix.h"
@@ -61,7 +61,7 @@ struct DenseArrayFx {
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#ifdef _WIN32
+#ifdef _MSC_VER
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
       tiledb::sm::Win::current_dir() + "\\tiledb_test\\";

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -31,7 +31,7 @@
  */
 
 #include "catch.hpp"
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/filesystem/win.h"
 #else
 #include "tiledb/sm/filesystem/posix.h"
@@ -52,7 +52,7 @@ struct DenseVectorFx {
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#ifdef _WIN32
+#ifdef _MSC_VER
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
       tiledb::sm::Win::current_dir() + "\\tiledb_test\\";

--- a/test/src/unit-capi-kv.cc
+++ b/test/src/unit-capi-kv.cc
@@ -31,7 +31,7 @@
  */
 
 #include "catch.hpp"
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/filesystem/win.h"
 #else
 #include "tiledb/sm/filesystem/posix.h"
@@ -69,7 +69,7 @@ struct KVFx {
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#ifdef _WIN32
+#ifdef _MSC_VER
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
       tiledb::sm::Win::current_dir() + "\\tiledb_test\\";

--- a/test/src/unit-capi-object_mgmt.cc
+++ b/test/src/unit-capi-object_mgmt.cc
@@ -32,7 +32,7 @@
 
 #include "catch.hpp"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/filesystem/win.h"
 #else
 #include "tiledb/sm/filesystem/posix.h"
@@ -51,7 +51,7 @@ struct ObjectMgmtFx {
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#ifdef _WIN32
+#ifdef _MSC_VER
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
       tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
@@ -528,7 +528,7 @@ TEST_CASE_METHOD(
     // File
     remove_temp_dir(FILE_FULL_TEMP_DIR);
     create_hierarchy(FILE_FULL_TEMP_DIR);
-#ifdef _WIN32
+#ifdef _MSC_VER
     // `VFS::ls(...)` returns `file:///` URIs instead of Windows paths.
     golden_walk =
         get_golden_walk(tiledb::sm::Win::uri_from_path(FILE_FULL_TEMP_DIR));

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -32,7 +32,7 @@
  */
 
 #include "catch.hpp"
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/filesystem/win.h"
 #else
 #include "tiledb/sm/filesystem/posix.h"
@@ -61,7 +61,7 @@ struct SparseArrayFx {
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#ifdef _WIN32
+#ifdef _MSC_VER
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
       tiledb::sm::Win::current_dir() + "\\tiledb_test\\";

--- a/test/src/unit-capi-uri.cc
+++ b/test/src/unit-capi-uri.cc
@@ -35,7 +35,7 @@
 
 #include <string.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <Windows.h>
 static const unsigned PLATFORM_PATH_MAX = MAX_PATH;
 #elif __APPLE__
@@ -56,7 +56,7 @@ TEST_CASE("C API: Test URI", "[capi], [uri]") {
   unsigned path_length = PLATFORM_PATH_MAX;
   rc = tiledb_uri_to_path(ctx, "file:///my/path", path, &path_length);
   CHECK(rc == TILEDB_OK);
-#ifdef _WIN32
+#ifdef _MSC_VER
   CHECK(path_length == 8);
   CHECK(path[path_length] == '\0');
   CHECK(strlen(path) == path_length);
@@ -83,7 +83,7 @@ TEST_CASE("C API: Test URI", "[capi], [uri]") {
   path_length = PLATFORM_PATH_MAX;
   rc = tiledb_uri_to_path(ctx, "file:///C:/my/path", path, &path_length);
   CHECK(rc == TILEDB_OK);
-#ifdef _WIN32
+#ifdef _MSC_VER
   CHECK(path_length == 10);
   CHECK(path[path_length] == '\0');
   CHECK(strlen(path) == path_length);

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -34,7 +34,7 @@
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/misc/stats.h"
 #include "tiledb/sm/misc/utils.h"
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/filesystem/win.h"
 #else
 #include "tiledb/sm/filesystem/posix.h"
@@ -49,7 +49,7 @@ struct VFSFx {
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#ifdef _WIN32
+#ifdef _MSC_VER
   const std::string FILE_TEMP_DIR =
       tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
 #else
@@ -707,7 +707,7 @@ TEST_CASE_METHOD(VFSFx, "C API: Test VFS parallel I/O", "[capi], [vfs]") {
   } else {
     check_vfs(FILE_TEMP_DIR);
     CHECK(tiledb::sm::stats::all_stats.counter_vfs_read_num_parallelized > 0);
-#ifdef _WIN32
+#ifdef _MSC_VER
     CHECK(
         tiledb::sm::stats::all_stats.counter_vfs_win32_write_num_parallelized >
         0);

--- a/test/src/unit-uri.cc
+++ b/test/src/unit-uri.cc
@@ -33,7 +33,7 @@
 #include <catch.hpp>
 #include "tiledb/sm/misc/uri.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/filesystem/win.h"
 #else
 #include "tiledb/sm/filesystem/posix.h"
@@ -41,7 +41,7 @@
 
 using namespace tiledb::sm;
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 static const char PATH_SEPARATOR = '\\';
 static std::string current_dir() {
   return Win::current_dir();
@@ -102,7 +102,7 @@ TEST_CASE("URI: Test relative paths", "[uri]") {
   CHECK(URI::is_file(uri.to_string()));
   CHECK(uri.to_string().find("file:///") == 0);
   CHECK(uri.to_path() == current_dir() + PATH_SEPARATOR + "path1");
-#ifdef _WIN32
+#ifdef _MSC_VER
   CHECK(uri.to_string() == Win::uri_from_path(Win::current_dir()) + "/path1");
 #else
   CHECK(uri.to_string() == "file://" + Posix::current_dir() + "/path1");
@@ -115,7 +115,7 @@ TEST_CASE("URI: Test relative paths", "[uri]") {
 
 TEST_CASE("URI: Test URI to path", "[uri]") {
   URI uri = URI("file:///my/path");
-#ifdef _WIN32
+#ifdef _MSC_VER
   // Absolute paths with no drive letter are relative to the current working
   // directory's drive.
   CHECK(uri.to_path() == "\\my\\path");
@@ -124,7 +124,7 @@ TEST_CASE("URI: Test URI to path", "[uri]") {
 #endif
 
   uri = URI("file:///my/path/../relative/path");
-#ifdef _WIN32
+#ifdef _MSC_VER
   CHECK(uri.to_path() == "\\my\\relative\\path");
 #else
   CHECK(uri.to_path() == "/my/path/../relative/path");
@@ -140,7 +140,7 @@ TEST_CASE("URI: Test URI to path", "[uri]") {
   CHECK(uri.to_path() == "hdfs://relative/../path/on/hdfs");
 
   uri = URI("C:\\my\\path");
-#ifdef _WIN32
+#ifdef _MSC_VER
   CHECK(uri.to_string() == "file:///C:/my/path");
   CHECK(uri.to_path() == "C:\\my\\path");
 #else
@@ -151,14 +151,14 @@ TEST_CASE("URI: Test URI to path", "[uri]") {
 #endif
 
   uri = URI("file:///C:/my/path");
-#ifdef _WIN32
+#ifdef _MSC_VER
   CHECK(uri.to_path() == "C:\\my\\path");
 #else
   CHECK(uri.to_path() == "/C:/my/path");
 #endif
 }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 TEST_CASE("URI: Test Windows paths", "[uri]") {
   URI uri("C:\\path");

--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -30,7 +30,7 @@
  * Tests the Windows filesystem functionality.
  */
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 #include "catch.hpp"
 
@@ -219,4 +219,4 @@ TEST_CASE_METHOD(WinFx, "Test Windows filesystem", "[windows]") {
   CHECK(win_.is_file(URI(test_file_path + "2").to_path()));
 }
 
-#endif  // _WIN32
+#endif  // _MSC_VER

--- a/tiledb/sm/filesystem/filelock.h
+++ b/tiledb/sm/filesystem/filelock.h
@@ -36,7 +36,7 @@
 namespace tiledb {
 namespace sm {
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 typedef void* filelock_t;
 const filelock_t INVALID_FILELOCK = nullptr;
 #else

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -30,7 +30,7 @@
  * This file includes definitions of POSIX filesystem functions.
  */
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 
 #include "tiledb/sm/filesystem/posix.h"
 #include "tiledb/sm/misc/constants.h"
@@ -539,4 +539,4 @@ Status Posix::write_at(
 }  // namespace sm
 }  // namespace tiledb
 
-#endif  // !_WIN32
+#endif  // !_MSC_VER

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -33,7 +33,7 @@
 #ifndef TILEDB_POSIX_FILESYSTEM_H
 #define TILEDB_POSIX_FILESYSTEM_H
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 
 #include <ftw.h>
 #include <sys/types.h>
@@ -287,6 +287,6 @@ class Posix {
 }  // namespace sm
 }  // namespace tiledb
 
-#endif  // !_WIN32
+#endif  // !_MSC_VER
 
 #endif  // TILEDB_POSIX_FILESYSTEM_H

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -40,7 +40,7 @@
 #include "tiledb/sm/misc/stats.h"
 #include "tiledb/sm/misc/utils.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <Windows.h>
 #endif
 

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -82,7 +82,7 @@ std::string VFS::abs_path(const std::string& path) {
   STATS_FUNC_IN(vfs_abs_path);
   // workaround for older clang (llvm 3.5) compilers (issue #828)
   std::string path_copy = path;
-#ifdef _WIN32
+#ifdef _MSC_VER
   if (Win::is_win_path(path))
     return Win::uri_from_path(Win::abs_path(path));
   else if (URI::is_file(path))
@@ -116,7 +116,7 @@ Status VFS::create_dir(const URI& uri) const {
   }
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.create_dir(uri.to_path());
 #else
     return posix_.create_dir(uri.to_path());
@@ -148,7 +148,7 @@ Status VFS::touch(const URI& uri) const {
   STATS_FUNC_IN(vfs_create_file);
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.touch(uri.to_path());
 #else
     return posix_.touch(uri.to_path());
@@ -257,7 +257,7 @@ Status VFS::remove_dir(const URI& uri) const {
   STATS_FUNC_IN(vfs_remove_dir);
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.remove_dir(uri.to_path());
 #else
     return posix_.remove_dir(uri.to_path());
@@ -287,7 +287,7 @@ Status VFS::remove_file(const URI& uri) const {
   STATS_FUNC_IN(vfs_remove_file);
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.remove_file(uri.to_path());
 #else
     return posix_.remove_file(uri.to_path());
@@ -326,7 +326,7 @@ Status VFS::filelock_lock(const URI& uri, filelock_t* fd, bool shared) const {
   }
 
   if (uri.is_file())
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.filelock_lock(uri.to_path(), fd, shared);
 #else
     return posix_.filelock_lock(uri.to_path(), fd, shared);
@@ -367,7 +367,7 @@ Status VFS::filelock_unlock(const URI& uri, filelock_t fd) const {
   }
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.filelock_unlock(fd);
 #else
     return posix_.filelock_unlock(fd);
@@ -443,7 +443,7 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
   STATS_FUNC_IN(vfs_file_size);
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.file_size(uri.to_path(), size);
 #else
     return posix_.file_size(uri.to_path(), size);
@@ -474,7 +474,7 @@ Status VFS::is_dir(const URI& uri, bool* is_dir) const {
   STATS_FUNC_IN(vfs_is_dir);
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     *is_dir = win_.is_dir(uri.to_path());
 #else
     *is_dir = posix_.is_dir(uri.to_path());
@@ -508,7 +508,7 @@ Status VFS::is_file(const URI& uri, bool* is_file) const {
   STATS_FUNC_IN(vfs_is_file);
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     *is_file = win_.is_file(uri.to_path());
 #else
     *is_file = posix_.is_file(uri.to_path());
@@ -597,7 +597,7 @@ Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
 
   std::vector<std::string> paths;
   if (parent.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     RETURN_NOT_OK(win_.ls(parent.to_path(), &paths));
 #else
     RETURN_NOT_OK(posix_.ls(parent.to_path(), &paths));
@@ -640,7 +640,7 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
   // File
   if (old_uri.is_file()) {
     if (new_uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
       return win_.move_path(old_uri.to_path(), new_uri.to_path());
 #else
       return posix_.move_path(old_uri.to_path(), new_uri.to_path());
@@ -690,7 +690,7 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
   // File
   if (old_uri.is_file()) {
     if (new_uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
       return win_.move_path(old_uri.to_path(), new_uri.to_path());
 #else
       return posix_.move_path(old_uri.to_path(), new_uri.to_path());
@@ -776,7 +776,7 @@ Status VFS::read(
 Status VFS::read_impl(
     const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) const {
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.read(uri.to_path(), offset, buffer, nbytes);
 #else
     return posix_.read(uri.to_path(), offset, buffer, nbytes);
@@ -823,7 +823,7 @@ Status VFS::sync(const URI& uri) {
   STATS_FUNC_IN(vfs_sync);
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.sync(uri.to_path());
 #else
     return posix_.sync(uri.to_path());
@@ -890,7 +890,7 @@ Status VFS::close_file(const URI& uri) {
   STATS_FUNC_IN(vfs_close_file);
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.sync(uri.to_path());
 #else
     return posix_.sync(uri.to_path());
@@ -922,7 +922,7 @@ Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
   STATS_COUNTER_ADD(vfs_write_total_bytes, buffer_size);
 
   if (uri.is_file()) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return win_.write(uri.to_path(), buffer, buffer_size);
 #else
     return posix_.write(uri.to_path(), buffer, buffer_size);

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -336,7 +336,7 @@ class VFS {
   S3 s3_;
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   Win win_;
 #else
   Posix posix_;

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -29,7 +29,7 @@
  *
  * This file includes definitions of Windows filesystem functions.
  */
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 #include "tiledb/sm/filesystem/win.h"
 #include "tiledb/sm/misc/constants.h"
@@ -604,4 +604,4 @@ bool Win::is_win_path(const std::string& path) {
 }  // namespace sm
 }  // namespace tiledb
 
-#endif  // _WIN32
+#endif  // _MSC_VER

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -33,7 +33,7 @@
 #ifndef TILEDB_WIN_FILESYSTEM_H
 #define TILEDB_WIN_FILESYSTEM_H
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 #include <sys/types.h>
 #include <string>
@@ -275,6 +275,6 @@ class Win {
 }  // namespace sm
 }  // namespace tiledb
 
-#endif  // _WIN32
+#endif  // _MSC_VER
 
 #endif  // TILEDB_WIN_FILESYSTEM_H

--- a/tiledb/sm/global_state/openssl_state.cc
+++ b/tiledb/sm/global_state/openssl_state.cc
@@ -32,7 +32,7 @@
 
 #include "tiledb/sm/global_state/openssl_state.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/signal_handlers.cc
+++ b/tiledb/sm/global_state/signal_handlers.cc
@@ -36,7 +36,7 @@
 
 #include <signal.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <Windows.h>
 #include <io.h>
 #else
@@ -96,7 +96,7 @@ extern "C" void tiledb_signal_handler(int signum) {
   }
 }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 /* ********************************* */
 /*       Win32 implementations       */
 /* ********************************* */

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -41,7 +41,7 @@
 #include "tiledb/sm/c_api/tiledb_version.h"
 
 // Include files for platform path max definition.
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/misc/win_constants.h"
 #elif __APPLE__
 #include <sys/syslimits.h>
@@ -199,7 +199,7 @@ const uint64_t vfs_file_max_parallel_ops = vfs_num_threads;
 const unsigned uri_max_len = 256;
 
 /** The maximum file path length (depending on platform). */
-#ifndef _WIN32
+#ifndef _MSC_VER
 const unsigned path_max_len = PATH_MAX;
 #endif
 

--- a/tiledb/sm/misc/logger.cc
+++ b/tiledb/sm/misc/logger.cc
@@ -42,7 +42,7 @@ namespace sm {
 Logger::Logger() {
   logger_ = spdlog::get("tiledb");
   if (logger_ == nullptr) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     logger_ = spdlog::stdout_logger_mt("tiledb");
 #else
     logger_ = spdlog::stdout_color_mt("tiledb");

--- a/tiledb/sm/misc/uri.cc
+++ b/tiledb/sm/misc/uri.cc
@@ -35,7 +35,7 @@
 #include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "tiledb/sm/filesystem/win.h"
 #endif
 
@@ -162,7 +162,7 @@ URI URI::parent() const {
 
 std::string URI::to_path(const std::string& uri) {
   if (is_file(uri)) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return Win::path_from_uri(uri);
 #else
     return uri.substr(std::string("file://").size());

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -38,7 +38,7 @@
 #include <set>
 #include <sstream>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <sys/timeb.h>
 #include <sys/types.h>
 #else
@@ -679,7 +679,7 @@ std::string tile_extent_str(const void* tile_extent, Datatype type) {
 }
 
 uint64_t timestamp_ms() {
-#ifdef _WIN32
+#ifdef _MSC_VER
   struct _timeb tb;
   memset(&tb, 0, sizeof(struct _timeb));
   _ftime_s(&tb);

--- a/tiledb/sm/misc/uuid.cc
+++ b/tiledb/sm/misc/uuid.cc
@@ -35,7 +35,7 @@
 
 #include "tiledb/sm/misc/uuid.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <Rpc.h>
 #else
 #include <openssl/err.h>
@@ -50,7 +50,7 @@ namespace uuid {
 /** Mutex to guard UUID generation. */
 static std::mutex uuid_mtx;
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 /**
  * Generate a UUID using Win32 RPC API.
@@ -154,7 +154,7 @@ Status generate_uuid(std::string* uuid, bool hyphenate) {
     // OpenSSL is not threadsafe, so grab a lock here. We are locking in the
     // Windows case as well just to be careful.
     std::unique_lock<std::mutex> lck(uuid_mtx);
-#ifdef _WIN32
+#ifdef _MSC_VER
     RETURN_NOT_OK(generate_uuid_win32(&uuid_str));
 #else
     RETURN_NOT_OK(generate_uuid_openssl(&uuid_str));

--- a/tiledb/sm/misc/win_constants.cc
+++ b/tiledb/sm/misc/win_constants.cc
@@ -30,7 +30,7 @@
  * This file defines the Windows-specific TileDB constants.
  */
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 
 #include "tiledb/sm/misc/win_constants.h"
 
@@ -49,4 +49,4 @@ const unsigned path_max_len = MAX_PATH;
 }  // namespace sm
 }  // namespace tiledb
 
-#endif  // _WIN32
+#endif  // _MSC_VER


### PR DESCRIPTION
If you want TileDB to compile under Cygwin,
then all of the #if(n)def _WIN32 code lines
need to be converted t #if(n)def _MSC_VER.
The authors assumed that the _WIN32 flag was only
set by Visual Studio, but in fact it is also set
for Cygwin (a linux variant) and maybe Mingw.
To ensure that the _WIN32 conditionals are invoked
only when using Visual Studio, one needs to use _MSC_VER.