### PR TITLE
Add Internal functions for strings to enum types

### DIFF
--- a/tiledb/sm/enums/array_type.h
+++ b/tiledb/sm/enums/array_type.h
@@ -37,6 +37,7 @@
 #include <cassert>
 
 #include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {
@@ -59,6 +60,19 @@ inline const std::string& array_type_str(ArrayType array_type) {
       assert(0);
       return constants::empty_str;
   }
+}
+
+/** Returns the array type given a string representation. */
+inline Status array_type_enum(
+    const std::string& array_type_str, ArrayType* array_type_enum) {
+  if (array_type_str == constants::dense_str)
+    *array_type_enum = ArrayType::DENSE;
+  else if (array_type_str == constants::sparse_str)
+    *array_type_enum = ArrayType::SPARSE;
+  else {
+    return Status::Error("Invalid ArrayType " + array_type_str);
+  }
+  return Status::Ok();
 }
 
 }  // namespace sm

--- a/tiledb/sm/enums/compressor.h
+++ b/tiledb/sm/enums/compressor.h
@@ -35,6 +35,7 @@
 #define TILEDB_COMPRESSOR_H
 
 #include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/status.h"
 
 #include <cassert>
 
@@ -83,6 +84,40 @@ inline const std::string& compressor_str(Compressor type) {
   }
 }
 
+/** Returns the compressor based on the string representation. */
+inline Status compressor_enum(
+    const std::string& compressor_type_str, Compressor* compressor) {
+  if (compressor_type_str == constants::no_compression_str)
+    *compressor = Compressor::NO_COMPRESSION;
+  else if (compressor_type_str == constants::gzip_str)
+    *compressor = Compressor::GZIP;
+  else if (compressor_type_str == constants::zstd_str)
+    *compressor = Compressor::ZSTD;
+  else if (compressor_type_str == constants::lz4_str)
+    *compressor = Compressor::LZ4;
+  else if (compressor_type_str == constants::blosc_lz_str)
+    *compressor = Compressor::BLOSC_LZ;
+  else if (compressor_type_str == constants::blosc_lz4_str)
+    *compressor = Compressor::BLOSC_LZ4;
+  else if (compressor_type_str == constants::blosc_lz4hc_str)
+    *compressor = Compressor::BLOSC_LZ4HC;
+  else if (compressor_type_str == constants::blosc_snappy_str)
+    *compressor = Compressor::BLOSC_SNAPPY;
+  else if (compressor_type_str == constants::blosc_zlib_str)
+    *compressor = Compressor::BLOSC_ZLIB;
+  else if (compressor_type_str == constants::blosc_zstd_str)
+    *compressor = Compressor::BLOSC_ZSTD;
+  else if (compressor_type_str == constants::rle_str)
+    *compressor = Compressor::RLE;
+  else if (compressor_type_str == constants::bzip2_str)
+    *compressor = Compressor::BZIP2;
+  else if (compressor_type_str == constants::double_delta_str)
+    *compressor = Compressor::DOUBLE_DELTA;
+  else {
+    return Status::Error("Invalid Compressor " + compressor_type_str);
+  }
+  return Status::Ok();
+}
 }  // namespace sm
 }  // namespace tiledb
 

--- a/tiledb/sm/enums/datatype.h
+++ b/tiledb/sm/enums/datatype.h
@@ -35,6 +35,7 @@
 #define TILEDB_DATATYPE_H
 
 #include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/status.h"
 
 #include <cassert>
 
@@ -136,6 +137,51 @@ inline const std::string& datatype_str(Datatype type) {
       assert(0);
       return constants::empty_str;
   }
+}
+
+/** Returns the datatype given a string representation. */
+inline Status datatype_enum(
+    const std::string& datatype_str, Datatype* datatype) {
+  if (datatype_str == constants::int32_str)
+    *datatype = Datatype::INT32;
+  else if (datatype_str == constants::int64_str)
+    *datatype = Datatype::INT64;
+  else if (datatype_str == constants::float32_str)
+    *datatype = Datatype::FLOAT32;
+  else if (datatype_str == constants::float64_str)
+    *datatype = Datatype::FLOAT64;
+  else if (datatype_str == constants::char_str)
+    *datatype = Datatype::CHAR;
+  else if (datatype_str == constants::int8_str)
+    *datatype = Datatype::INT8;
+  else if (datatype_str == constants::uint8_str)
+    *datatype = Datatype::UINT8;
+  else if (datatype_str == constants::int16_str)
+    *datatype = Datatype::INT16;
+  else if (datatype_str == constants::uint16_str)
+    *datatype = Datatype::UINT16;
+  else if (datatype_str == constants::uint32_str)
+    *datatype = Datatype::UINT32;
+  else if (datatype_str == constants::uint64_str)
+    *datatype = Datatype::UINT64;
+  else if (datatype_str == constants::string_ascii_str)
+    *datatype = Datatype::STRING_ASCII;
+  else if (datatype_str == constants::string_utf8_str)
+    *datatype = Datatype::STRING_UTF8;
+  else if (datatype_str == constants::string_utf16_str)
+    *datatype = Datatype::STRING_UTF16;
+  else if (datatype_str == constants::string_utf32_str)
+    *datatype = Datatype::STRING_UTF32;
+  else if (datatype_str == constants::string_ucs2_str)
+    *datatype = Datatype::STRING_UCS2;
+  else if (datatype_str == constants::string_ucs4_str)
+    *datatype = Datatype::STRING_UCS4;
+  else if (datatype_str == constants::any_str)
+    *datatype = Datatype::ANY;
+  else {
+    return Status::Error("Invalid Datatype " + datatype_str);
+  }
+  return Status::Ok();
 }
 
 /** Returns true if the input datatype is a string type. */

--- a/tiledb/sm/enums/layout.h
+++ b/tiledb/sm/enums/layout.h
@@ -35,6 +35,7 @@
 #define TILEDB_LAYOUT_H
 
 #include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/status.h"
 
 #include <cassert>
 
@@ -63,6 +64,22 @@ inline const std::string& layout_str(Layout layout) {
       assert(0);
       return constants::empty_str;
   }
+}
+
+/** Returns the layout enum given a string representation. */
+inline Status layout_enum(const std::string& layout_str, Layout* layout) {
+  if (layout_str == constants::col_major_str)
+    *layout = Layout::COL_MAJOR;
+  else if (layout_str == constants::row_major_str)
+    *layout = Layout::ROW_MAJOR;
+  else if (layout_str == constants::global_order_str)
+    *layout = Layout::GLOBAL_ORDER;
+  else if (layout_str == constants::unordered_str)
+    *layout = Layout::UNORDERED;
+  else {
+    return Status::Error("Invalid Layout " + layout_str);
+  }
+  return Status::Ok();
 }
 
 }  // namespace sm

--- a/tiledb/sm/enums/query_type.h
+++ b/tiledb/sm/enums/query_type.h
@@ -36,6 +36,7 @@
 
 #include <cassert>
 #include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {
@@ -58,6 +59,19 @@ inline const std::string& query_type_str(QueryType query_type) {
       assert(0);
       return constants::empty_str;
   }
+}
+
+/** Returns the query type given a string representation. */
+inline Status query_type_enum(
+    const std::string& query_type_str, QueryType* query_type) {
+  if (query_type_str == constants::query_type_read_str)
+    *query_type = QueryType::READ;
+  else if (query_type_str == constants::query_type_write_str)
+    *query_type = QueryType::WRITE;
+  else {
+    return Status::Error("Invalid QueryType " + query_type_str);
+  }
+  return Status::Ok();
 }
 
 }  // namespace sm


### PR DESCRIPTION
Add Internal functions for strings to enum types. This is needed for json serialization. This isn't exposed via the c_api but I realized that the to_string isn't exposed either. #708 specifically is for exposing via c_api. Do we want to go ahead and add to_string/to_enum (from_string?) functions to c_api? I know 1.3.2 is slated next for more bug fixes not sure if we want to add these new api functions now or later?