### PR TITLE
Add query_status_str/enum function and constants

### DIFF
--- a/tiledb/sm/enums/query_status.h
+++ b/tiledb/sm/enums/query_status.h
@@ -34,6 +34,11 @@
 #ifndef TILEDB_QUERY_STATUS_H
 #define TILEDB_QUERY_STATUS_H
 
+#include <cassert>
+
+#include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/status.h"
+
 namespace tiledb {
 namespace sm {
 
@@ -43,6 +48,44 @@ enum class QueryStatus : char {
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_QUERY_STATUS_ENUM
 };
+
+/** Returns the string representation of the input querystatus type. */
+inline const std::string& query_status_str(QueryStatus query_status) {
+  switch (query_status) {
+    case QueryStatus::FAILED:
+      return constants::query_status_failed_str;
+    case QueryStatus::COMPLETED:
+      return constants::query_status_completed_str;
+    case QueryStatus::INPROGRESS:
+      return constants::query_status_inprogress_str;
+    case QueryStatus::INCOMPLETE:
+      return constants::query_status_incomplete_str;
+    case QueryStatus::UNINITIALIZED:
+      return constants::query_status_uninitialized_str;
+    default:
+      assert(0);
+      return constants::empty_str;
+  }
+}
+
+/** Returns the query status given a string representation. */
+inline Status query_status_enum(
+    const std::string& query_status_str, QueryStatus* query_status) {
+  if (query_status_str == constants::query_status_failed_str)
+    *query_status = QueryStatus::FAILED;
+  else if (query_status_str == constants::query_status_completed_str)
+    *query_status = QueryStatus::COMPLETED;
+  else if (query_status_str == constants::query_status_inprogress_str)
+    *query_status = QueryStatus::INPROGRESS;
+  else if (query_status_str == constants::query_status_incomplete_str)
+    *query_status = QueryStatus::INCOMPLETE;
+  else if (query_status_str == constants::query_status_uninitialized_str)
+    *query_status = QueryStatus::UNINITIALIZED;
+  else {
+    return Status::Error("Invalid QueryStatus " + query_status_str);
+  }
+  return Status::Ok();
+}
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -239,6 +239,20 @@ const std::string query_type_read_str = "READ";
 
 /** TILEDB_WRITE Query String **/
 const std::string query_type_write_str = "WRITE";
+/** TILEDB_FAILED Query String **/
+const std::string query_status_failed_str = "FAILED";
+
+/** TILEDB_COMPLETED Query String **/
+const std::string query_status_completed_str = "COMPLETED";
+
+/** TILEDB_INPROGRESS Query String **/
+const std::string query_status_inprogress_str = "INPROGRESS";
+
+/** TILEDB_INCOMPLETE Query String **/
+const std::string query_status_incomplete_str = "INCOMPLETE";
+
+/** TILEDB_UNINITIALIZED Query String **/
+const std::string query_status_uninitialized_str = "UNINITIALIZED";
 
 /** String describing GZIP. */
 const std::string gzip_str = "GZIP";

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -221,6 +221,21 @@ extern const std::string query_type_read_str;
 /** TILEDB_WRITE Query String **/
 extern const std::string query_type_write_str;
 
+/** TILEDB_FAILED Query String **/
+extern const std::string query_status_failed_str;
+
+/** TILEDB_COMPLETE Query String **/
+extern const std::string query_status_completed_str;
+
+/** TILEDB_INPROGRESS Query String **/
+extern const std::string query_status_inprogress_str;
+
+/** TILEDB_INCOMPLETE Query String **/
+extern const std::string query_status_incomplete_str;
+
+/** TILEDB_UNINITIALIZED Query String **/
+extern const std::string query_status_uninitialized_str;
+
 /** String describing GZIP. */
 extern const std::string gzip_str;
 


### PR DESCRIPTION
This add QueryStatus to string and from string to enum functions. These are needed serialization.

Closes #854