### PR TITLE
Return Ok when consolidating empty arrays.

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -447,3 +447,27 @@ TEST_CASE("C++ API: Read subarray with expanded domain", "[cppapi], [dense]") {
     }
   }
 }
+
+TEST_CASE(
+    "C++ API: Consolidation of empty arrays", "[cppapi], [consolidation]") {
+  Context ctx;
+  VFS vfs(ctx);
+  const std::string array_name = "cpp_unit_array";
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  REQUIRE_THROWS_AS(Array::consolidate(ctx, array_name), tiledb::TileDBError);
+
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "d", {{0, 3}}, 1));
+  ArraySchema schema(ctx, TILEDB_DENSE);
+  schema.set_domain(domain);
+  schema.add_attribute(Attribute::create<int>(ctx, "a"));
+  Array::create(array_name, schema);
+
+  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name));
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+}

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -82,6 +82,18 @@ void OpenArray::cnt_incr() {
   ++cnt_;
 }
 
+bool OpenArray::is_empty(uint64_t snapshot) const {
+  std::lock_guard<std::mutex> lck(mtx_);
+  for (uint64_t i = 0; i < fragment_metadata_.size(); ++i) {
+    if (snapshot < i)
+      break;
+
+    if (!fragment_metadata_[i].empty())
+      return false;
+  }
+  return true;
+}
+
 Status OpenArray::file_lock(VFS* vfs) {
   auto uri = array_uri_.join_path(constants::filelock_name);
   if (filelock_ == INVALID_FILELOCK)


### PR DESCRIPTION
Previously caused an assertion failure in debug builds.