### PR TITLE
Remove TILEDB_USE_STATIC_* cmake variables in favor of better searching.

### DIFF
--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -34,32 +34,36 @@
 # Include some common helper functions.
 include(TileDBCommon)
 
-# Search the path set during the superbuild for the EP.
-set(BZIP2_PATHS ${TILEDB_EP_INSTALL_PREFIX})
-
-find_path(BZIP2_INCLUDE_DIR
-  NAMES bzlib.h
-  PATHS ${BZIP2_PATHS}
-  PATH_SUFFIXES include
-  ${TILEDB_DEPS_NO_DEFAULT_PATH}
+# First check for a static version in the EP prefix.
+find_library(BZIP2_LIBRARIES
+  NAMES
+    libbz2static${CMAKE_STATIC_LIBRARY_SUFFIX}
+    libbz2${CMAKE_STATIC_LIBRARY_SUFFIX}
+  PATHS ${TILEDB_EP_INSTALL_PREFIX}
+  PATH_SUFFIXES lib
+  NO_DEFAULT_PATH
 )
 
-# Link statically if installed with the EP.
-if (TILEDB_USE_STATIC_BZIP2)
-  find_library(BZIP2_LIBRARIES
-    NAMES
-      libbz2static${CMAKE_STATIC_LIBRARY_SUFFIX}
-      libbz2${CMAKE_STATIC_LIBRARY_SUFFIX}
-    PATHS ${BZIP2_PATHS}
-    PATH_SUFFIXES lib
-    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+if (BZIP2_LIBRARIES)
+  set(BZIP2_STATIC_EP_FOUND TRUE)
+  find_path(BZIP2_INCLUDE_DIR
+    NAMES bzlib.h
+    PATHS ${TILEDB_EP_INSTALL_PREFIX}
+    PATH_SUFFIXES include
+    NO_DEFAULT_PATH
   )
 else()
+  set(BZIP2_STATIC_EP_FOUND FALSE)
+  # Static EP not found, search in system paths.
   find_library(BZIP2_LIBRARIES
     NAMES
       bz2 libbz2
-    PATHS ${BZIP2_PATHS}
     PATH_SUFFIXES lib bin
+    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+  )
+  find_path(BZIP2_INCLUDE_DIR
+    NAMES bzlib.h
+    PATH_SUFFIXES include
     ${TILEDB_DEPS_NO_DEFAULT_PATH}
   )
 endif()
@@ -104,9 +108,6 @@ if (NOT BZIP2_FOUND)
       )
     endif()
     list(APPEND TILEDB_EXTERNAL_PROJECTS ep_bzip2)
-    list(APPEND FORWARD_EP_CMAKE_ARGS
-      -DTILEDB_USE_STATIC_BZIP2=TRUE
-    )
   else()
     message(FATAL_ERROR "Unable to find Bzip2")
   endif()
@@ -121,6 +122,6 @@ if (BZIP2_FOUND AND NOT TARGET Bzip2::Bzip2)
 endif()
 
 # If we built a static EP, install it if required.
-if (TILEDB_USE_STATIC_BZIP2 AND TILEDB_INSTALL_STATIC_DEPS)
+if (BZIP2_STATIC_EP_FOUND AND TILEDB_INSTALL_STATIC_DEPS)
   install_target_libs(Bzip2::Bzip2)
 endif()

--- a/cmake/Modules/FindZstd_EP.cmake
+++ b/cmake/Modules/FindZstd_EP.cmake
@@ -35,32 +35,36 @@
 # Include some common helper functions.
 include(TileDBCommon)
 
-# Search the path set during the superbuild for the EP.
-set(ZSTD_PATHS ${TILEDB_EP_INSTALL_PREFIX})
-
-find_path(ZSTD_INCLUDE_DIR
-  NAMES zstd.h
-  PATHS ${ZSTD_PATHS}
-  PATH_SUFFIXES include
-  ${TILEDB_DEPS_NO_DEFAULT_PATH}
+# First check for a static version in the EP prefix.
+find_library(ZSTD_LIBRARIES
+  NAMES
+    libzstd${CMAKE_STATIC_LIBRARY_SUFFIX}
+    zstd_static${CMAKE_STATIC_LIBRARY_SUFFIX}
+  PATHS ${TILEDB_EP_INSTALL_PREFIX}
+  PATH_SUFFIXES lib
+  NO_DEFAULT_PATH
 )
 
-# Link statically if installed with the EP.
-if (TILEDB_USE_STATIC_ZSTD)
-  find_library(ZSTD_LIBRARIES
-    NAMES
-      libzstd${CMAKE_STATIC_LIBRARY_SUFFIX}
-      zstd_static${CMAKE_STATIC_LIBRARY_SUFFIX}
-    PATHS ${ZSTD_PATHS}
-    PATH_SUFFIXES lib
-    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+if (ZSTD_LIBRARIES)
+  set(ZSTD_STATIC_EP_FOUND TRUE)
+  find_path(ZSTD_INCLUDE_DIR
+    NAMES zstd.h
+    PATHS ${TILEDB_EP_INSTALL_PREFIX}
+    PATH_SUFFIXES include
+    NO_DEFAULT_PATH
   )
 else()
+  set(ZSTD_STATIC_EP_FOUND FALSE)
+  # Static EP not found, search in system paths.
   find_library(ZSTD_LIBRARIES
     NAMES
       zstd libzstd
-    PATHS ${ZSTD_PATHS}
     PATH_SUFFIXES lib bin
+    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+  )
+  find_path(ZSTD_INCLUDE_DIR
+    NAMES zstd.h
+    PATH_SUFFIXES include
     ${TILEDB_DEPS_NO_DEFAULT_PATH}
   )
 endif()
@@ -92,9 +96,6 @@ if (NOT ZSTD_FOUND)
       LOG_INSTALL TRUE
     )
     list(APPEND TILEDB_EXTERNAL_PROJECTS ep_zstd)
-    list(APPEND FORWARD_EP_CMAKE_ARGS
-      -DTILEDB_USE_STATIC_ZSTD=TRUE
-    )
   else()
     message(FATAL_ERROR "Unable to find Zstd")
   endif()
@@ -109,6 +110,6 @@ if (ZSTD_FOUND AND NOT TARGET Zstd::Zstd)
 endif()
 
 # If we built a static EP, install it if required.
-if (TILEDB_USE_STATIC_ZSTD AND TILEDB_INSTALL_STATIC_DEPS)
+if (ZSTD_STATIC_EP_FOUND AND TILEDB_INSTALL_STATIC_DEPS)
   install_target_libs(Zstd::Zstd)
 endif()


### PR DESCRIPTION
Closes #791.