### PR TITLE
Revert "Update conda install doc for linux64"

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -203,21 +203,11 @@ you may need to explicity add the conda path after activating the environment
 with ``conda activate tiledb`` (``conda activate`` sets the ``CONDA_PREFIX``
 environment variable)
 
-Linux (64 bit):
-
 .. code-block:: console
 
-   $ export CPATH=$CONDA_PREFIX/include:${CPATH}
-   $ export LIBRARY_PATH=$CONDA_PREFIX/lib64:${LIBRARY_PATH}
-   $ export LD_LIBRARY_PATH=$CONDA_PREFIX/lib64:${LD_LIBRARY_PATH}
-
-macOS:
-
-.. code-block:: console
-
-   $ export CPATH=$CONDA_PREFIX/include:${CPATH}
-   $ export LIBRARY_PATH=$CONDA_PREFIX/lib:${LIBRARY_PATH}
-   $ export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:${LD_LIBRARY_PATH}
+   $ export CPATH=$CONDA_PREFIX/include
+   $ export LIBRARY_PATH=$CONDA_PREFIX/lib
+   $ export LD_LIBRARY_PATH=$CONDA_PREFIX/lib
 
 Or, instead of exporting those environment variables, you can pass them as
 command line flags during compilation


### PR DESCRIPTION
Reverts TileDB-Inc/TileDB#849

lib64 is not on Conda's default search path which caused issues with python packaging.  A new compile time flag is provided to install to `lib` in the conda environment, and this will be backported to 1.3.2.