### PR TITLE
Change bzip2 EP URL.

### DIFF
--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -94,7 +94,7 @@ if (NOT BZIP2_FOUND)
       # alongside TileDB.
       ExternalProject_Add(ep_bzip2
         PREFIX "externals"
-        URL "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
+        URL "https://github.com/TileDB-Inc/bzip2/releases/download/1.0.6/bzip2-1.0.6.tar.gz"
         URL_HASH SHA1=3f89f861209ce81a6bab1fd1998c0ef311712002
         CONFIGURE_COMMAND ""
         BUILD_IN_SOURCE TRUE


### PR DESCRIPTION
bzip.org appears to be down, so we have rehosted the tarball on Github. The SHA1 has not changed.