### PR TITLE
FragmentMetadata tile size function now returns persisted size

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -517,35 +517,24 @@ uint64_t FragmentMetadata::file_var_offset(
   return tile_var_offsets_[attribute_id][tile_idx];
 }
 
-uint64_t FragmentMetadata::compressed_tile_size(
+uint64_t FragmentMetadata::persisted_tile_size(
     const std::string& attribute, uint64_t tile_idx) const {
   auto it = attribute_idx_map_.find(attribute);
   auto attribute_id = it->second;
-
-  // Check if the tile is not compressed
-  if (array_schema_->var_size(attribute)) {
-    if (constants::cell_var_offsets_compression == Compressor::NO_COMPRESSION)
-      return 0;  // Uncompressed offsets tile
-  } else {
-    if (array_schema_->compression(attribute) == Compressor::NO_COMPRESSION)
-      return 0;  // Uncompressed fix-sized value tile
-  }
-
   auto tile_num = this->tile_num();
+
   return (tile_idx != tile_num - 1) ?
              tile_offsets_[attribute_id][tile_idx + 1] -
                  tile_offsets_[attribute_id][tile_idx] :
              file_sizes_[attribute_id] - tile_offsets_[attribute_id][tile_idx];
 }
 
-uint64_t FragmentMetadata::compressed_tile_var_size(
+uint64_t FragmentMetadata::persisted_tile_var_size(
     const std::string& attribute, uint64_t tile_idx) const {
   auto it = attribute_idx_map_.find(attribute);
   auto attribute_id = it->second;
-  if (array_schema_->compression(attribute) == Compressor::NO_COMPRESSION)
-    return 0;
-
   auto tile_num = this->tile_num();
+
   return (tile_idx != tile_num - 1) ?
              tile_var_offsets_[attribute_id][tile_idx + 1] -
                  tile_var_offsets_[attribute_id][tile_idx] :

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -385,26 +385,27 @@ class FragmentMetadata {
       const std::string& attribute, uint64_t tile_idx) const;
 
   /**
-   * Returns the compressed tile size for a given attribute
-   * and tile index. If the attribute is var-sized, this will return
-   * the size of the offsets tile.
+   * Returns the size of the tile when it is persisted (e.g. the size of the
+   * compressed tile on disk) for a given attribute and tile index. If the
+   * attribute is var-sized, this will return the persisted size of the offsets
+   * tile.
    *
    * @param attribute The input attribute.
    * @param tile_idx The index of the tile in the metadata.
    * @return The tile size.
    */
-  uint64_t compressed_tile_size(
+  uint64_t persisted_tile_size(
       const std::string& attribute, uint64_t tile_idx) const;
 
   /**
-   * Returns the compressed tile size for a given var-sized attribute
-   * and tile index.
+   * Returns the size of the tile when it is persisted (e.g. the size of the
+   * compressed tile on disk) for a given var-sized attribute and tile index.
    *
    * @param attribute The inout attribute.
    * @param tile_idx The index of the tile in the metadata.
    * @return The tile size.
    */
-  uint64_t compressed_tile_var_size(
+  uint64_t persisted_tile_var_size(
       const std::string& attribute, uint64_t tile_idx) const;
 
   /**

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -1693,7 +1693,7 @@ Status Reader::read_tiles(
         &t,
         fragment_metadata_[tile->fragment_idx_]->file_offset(
             attribute, tile->tile_idx_),
-        fragment_metadata_[tile->fragment_idx_]->compressed_tile_size(
+        fragment_metadata_[tile->fragment_idx_]->persisted_tile_size(
             attribute, tile->tile_idx_),
         fragment_metadata_[tile->fragment_idx_]->tile_size(
             attribute, tile->tile_idx_),
@@ -1704,7 +1704,7 @@ Status Reader::read_tiles(
           &t_var,
           fragment_metadata_[tile->fragment_idx_]->file_var_offset(
               attribute, tile->tile_idx_),
-          fragment_metadata_[tile->fragment_idx_]->compressed_tile_var_size(
+          fragment_metadata_[tile->fragment_idx_]->persisted_tile_var_size(
               attribute, tile->tile_idx_),
           fragment_metadata_[tile->fragment_idx_]->tile_var_size(
               attribute, tile->tile_idx_),


### PR DESCRIPTION
…even when the tile is uncompressed.

More generally we will need the size of the tile on disk, not only when it is compressed. This will be useful for the filters.