### PR TITLE
Add Buffer::swap and fix realloc size tracking.

### DIFF
--- a/test/src/unit-buffer.cc
+++ b/test/src/unit-buffer.cc
@@ -96,3 +96,52 @@ TEST_CASE("Buffer: Test default constructor with write void*", "[buffer]") {
 
   delete buff;
 }
+
+TEST_CASE("Buffer: Test swap", "[buffer]") {
+  // Write a char array
+  Status st;
+  char data1[3] = {1, 2, 3};
+  Buffer buff1;
+  st = buff1.write(data1, sizeof(data1));
+  REQUIRE(st.ok());
+  CHECK(buff1.owns_data());
+  CHECK(buff1.offset() == 3);
+  CHECK(buff1.size() == sizeof(data1));
+  CHECK(buff1.alloced_size() == 3);
+  CHECK(std::memcmp(buff1.data(), &data1, sizeof(data1)) == 0);
+
+  char data2[5] = {4, 5, 6, 7, 8};
+  Buffer buff2;
+  st = buff2.write(data2, sizeof(data2));
+  CHECK(buff2.owns_data());
+  CHECK(std::memcmp(buff2.data(), &data2, sizeof(data2)) == 0);
+
+  st = buff1.swap(buff2);
+  REQUIRE(st.ok());
+  CHECK(buff1.owns_data());
+  CHECK(buff1.offset() == 5);
+  CHECK(buff1.size() == sizeof(data2));
+  CHECK(buff1.alloced_size() == 5);
+  CHECK(std::memcmp(buff1.data(), &data2, sizeof(data2)) == 0);
+  CHECK(buff2.owns_data());
+  CHECK(buff2.offset() == 3);
+  CHECK(buff2.size() == sizeof(data1));
+  CHECK(buff2.alloced_size() == 3);
+  CHECK(std::memcmp(buff2.data(), &data1, sizeof(data1)) == 0);
+
+  char data3[] = {9};
+  Buffer buff3(data3, sizeof(data3), false);
+  CHECK(!buff3.owns_data());
+  st = buff1.swap(buff3);
+  REQUIRE(st.ok());
+  CHECK(!buff1.owns_data());
+  CHECK(buff1.data() == &data3[0]);
+  CHECK(buff1.offset() == 0);
+  CHECK(buff1.size() == sizeof(data3));
+  CHECK(buff1.alloced_size() == 0);
+  CHECK(buff3.owns_data());
+  CHECK(buff3.offset() == 5);
+  CHECK(buff3.size() == sizeof(data2));
+  CHECK(buff3.alloced_size() == 5);
+  CHECK(std::memcmp(buff3.data(), &data2, sizeof(data2)) == 0);
+}

--- a/tiledb/sm/buffer/buffer.cc
+++ b/tiledb/sm/buffer/buffer.cc
@@ -88,6 +88,7 @@ void Buffer::advance_offset(uint64_t nbytes) {
 }
 
 void Buffer::advance_size(uint64_t nbytes) {
+  assert(owns_data_);
   size_ += nbytes;
 }
 
@@ -160,6 +161,7 @@ Status Buffer::realloc(uint64_t nbytes) {
       return LOG_STATUS(Status::BufferError(
           "Cannot allocate buffer; Memory allocation failed"));
     }
+    alloced_size_ = nbytes;
   } else if (nbytes > alloced_size_) {
     auto new_data = std::realloc(data_, nbytes);
     if (new_data == nullptr) {
@@ -167,9 +169,8 @@ Status Buffer::realloc(uint64_t nbytes) {
           "Cannot reallocate buffer; Memory allocation failed"));
     }
     data_ = new_data;
+    alloced_size_ = nbytes;
   }
-
-  alloced_size_ = nbytes;
 
   return Status::Ok();
 }
@@ -193,6 +194,15 @@ void Buffer::set_size(uint64_t size) {
 
 uint64_t Buffer::size() const {
   return size_;
+}
+
+Status Buffer::swap(Buffer& other) {
+  std::swap(alloced_size_, other.alloced_size_);
+  std::swap(data_, other.data_);
+  std::swap(offset_, other.offset_);
+  std::swap(owns_data_, other.owns_data_);
+  std::swap(size_, other.size_);
+  return Status::Ok();
 }
 
 Status Buffer::write(ConstBuffer* buff) {

--- a/tiledb/sm/buffer/buffer.h
+++ b/tiledb/sm/buffer/buffer.h
@@ -142,6 +142,16 @@ class Buffer {
   uint64_t size() const;
 
   /**
+   * Swaps this buffer with the other one. After swapping, this buffer's
+   * allocation will point to the other buffer's allocation (including size,
+   * offset, data ownership, etc).
+   *
+   * @param other Buffer to swap with.
+   * @return Status
+   */
+  Status swap(Buffer& other);
+
+  /**
    * Returns the value of type T at the input offset.
    *
    * @tparam T The type of the value to return.


### PR DESCRIPTION
Buffer::swap will be used for the upcoming filter pipeline.

Closes #910.