### PR TITLE
Remove compression fields from Tile class.

### DIFF
--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -253,14 +253,7 @@ TEST_CASE("Filter: Test empty pipeline", "[filter]") {
     CHECK(buff.write(&i, sizeof(uint64_t)).ok());
   CHECK(buff.size() == nelts * sizeof(uint64_t));
 
-  Tile tile(
-      Datatype::UINT64,
-      Compressor::NO_COMPRESSION,
-      -1,
-      sizeof(uint64_t),
-      0,
-      &buff,
-      false);
+  Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
   FilterPipeline pipeline;
   CHECK(pipeline.run_forward(&tile).ok());
@@ -303,14 +296,7 @@ TEST_CASE("Filter: Test simple in-place pipeline", "[filter]") {
     CHECK(buff.write(&i, sizeof(uint64_t)).ok());
   CHECK(buff.size() == nelts * sizeof(uint64_t));
 
-  Tile tile(
-      Datatype::UINT64,
-      Compressor::NO_COMPRESSION,
-      -1,
-      sizeof(uint64_t),
-      0,
-      &buff,
-      false);
+  Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
   // Save the original allocation so that we can check that after running
   // through the pipeline, the tile buffer points to a different memory
@@ -401,14 +387,7 @@ TEST_CASE("Filter: Test simple out-of-place pipeline", "[filter]") {
     CHECK(buff.write(&i, sizeof(uint64_t)).ok());
   CHECK(buff.size() == nelts * sizeof(uint64_t));
 
-  Tile tile(
-      Datatype::UINT64,
-      Compressor::NO_COMPRESSION,
-      -1,
-      sizeof(uint64_t),
-      0,
-      &buff,
-      false);
+  Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
   FilterPipeline pipeline;
   CHECK(
@@ -496,14 +475,7 @@ TEST_CASE("Filter: Test mixed in- and out-of-place pipeline", "[filter]") {
     CHECK(buff.write(&i, sizeof(uint64_t)).ok());
   CHECK(buff.size() == nelts * sizeof(uint64_t));
 
-  Tile tile(
-      Datatype::UINT64,
-      Compressor::NO_COMPRESSION,
-      -1,
-      sizeof(uint64_t),
-      0,
-      &buff,
-      false);
+  Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
   FilterPipeline pipeline;
   CHECK(pipeline.add_filter(std::unique_ptr<Filter>(new Add1InPlace())).ok());
@@ -553,14 +525,7 @@ TEST_CASE("Filter: Test compression", "[filter], [compression]") {
     CHECK(buff.write(&i, sizeof(uint64_t)).ok());
   CHECK(buff.size() == nelts * sizeof(uint64_t));
 
-  Tile tile(
-      Datatype::UINT64,
-      Compressor::NO_COMPRESSION,
-      -1,
-      sizeof(uint64_t),
-      0,
-      &buff,
-      false);
+  Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
   // Set up dummy array schema (needed by compressor filter for cell size, etc).
   uint32_t dim_dom[] = {1, 10};
@@ -661,14 +626,7 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter]") {
     CHECK(buff.write(&i, sizeof(uint64_t)).ok());
   CHECK(buff.size() == nelts * sizeof(uint64_t));
 
-  Tile tile(
-      Datatype::UINT64,
-      Compressor::NO_COMPRESSION,
-      -1,
-      sizeof(uint64_t),
-      0,
-      &buff,
-      false);
+  Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
   FilterPipeline pipeline;
   CHECK(pipeline.add_filter(std::unique_ptr<Filter>(new PseudoChecksumFilter()))
@@ -777,14 +735,7 @@ TEST_CASE("Filter: Test pipeline modify filter", "[filter]") {
     CHECK(buff.write(&i, sizeof(uint64_t)).ok());
   CHECK(buff.size() == nelts * sizeof(uint64_t));
 
-  Tile tile(
-      Datatype::UINT64,
-      Compressor::NO_COMPRESSION,
-      -1,
-      sizeof(uint64_t),
-      0,
-      &buff,
-      false);
+  Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
   FilterPipeline pipeline;
   CHECK(pipeline.add_filter(std::unique_ptr<Filter>(new Add1InPlace())).ok());
@@ -835,14 +786,7 @@ TEST_CASE("Filter: Test pipeline copy", "[filter]") {
     CHECK(buff.write(&i, sizeof(uint64_t)).ok());
   CHECK(buff.size() == nelts * sizeof(uint64_t));
 
-  Tile tile(
-      Datatype::UINT64,
-      Compressor::NO_COMPRESSION,
-      -1,
-      sizeof(uint64_t),
-      0,
-      &buff,
-      false);
+  Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
   FilterPipeline pipeline;
   CHECK(pipeline.add_filter(std::unique_ptr<Filter>(new Add1InPlace())).ok());
@@ -904,14 +848,7 @@ TEST_CASE("Filter: Test random pipeline", "[filter]") {
     CHECK(buff.write(&i, sizeof(uint64_t)).ok());
   CHECK(buff.size() == nelts * sizeof(uint64_t));
 
-  Tile tile(
-      Datatype::UINT64,
-      Compressor::NO_COMPRESSION,
-      -1,
-      sizeof(uint64_t),
-      0,
-      &buff,
-      false);
+  Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
   // List of potential filters to use
   std::vector<std::function<Filter*(void)>> constructors = {

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -1582,15 +1582,12 @@ Status Reader::init_tile(const std::string& attribute, Tile* tile) const {
   auto type = array_schema_->type(attribute);
   auto is_coords = (attribute == constants::coords);
   auto dim_num = (is_coords) ? array_schema_->dim_num() : 0;
-  auto compressor = array_schema_->compression(attribute);
-  auto compression_level = array_schema_->compression_level(attribute);
   auto cell_num_per_tile =
       (has_coords()) ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * cell_size;
 
   // Initialize
-  RETURN_NOT_OK(tile->init(
-      type, compressor, compression_level, tile_size, cell_size, dim_num));
+  RETURN_NOT_OK(tile->init(type, tile_size, cell_size, dim_num));
 
   return Status::Ok();
 }
@@ -1601,8 +1598,6 @@ Status Reader::init_tile(
   auto domain = array_schema_->domain();
   auto capacity = array_schema_->capacity();
   auto type = array_schema_->type(attribute);
-  auto compressor = array_schema_->compression(attribute);
-  auto compression_level = array_schema_->compression_level(attribute);
   auto cell_num_per_tile =
       (has_coords()) ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * constants::cell_var_offset_size;
@@ -1610,13 +1605,10 @@ Status Reader::init_tile(
   // Initialize
   RETURN_NOT_OK(tile->init(
       constants::cell_var_offset_type,
-      array_schema_->cell_var_offsets_compression(),
-      array_schema_->cell_var_offsets_compression_level(),
       tile_size,
       constants::cell_var_offset_size,
       0));
-  RETURN_NOT_OK(tile_var->init(
-      type, compressor, compression_level, tile_size, datatype_size(type), 0));
+  RETURN_NOT_OK(tile_var->init(type, tile_size, datatype_size(type), 0));
   return Status::Ok();
 }
 

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -1067,15 +1067,12 @@ Status Writer::init_tile(const std::string& attribute, Tile* tile) const {
   auto type = array_schema_->type(attribute);
   auto is_coords = (attribute == constants::coords);
   auto dim_num = (is_coords) ? array_schema_->dim_num() : 0;
-  auto compressor = array_schema_->compression(attribute);
-  auto compression_level = array_schema_->compression_level(attribute);
   auto cell_num_per_tile =
       (has_coords()) ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * cell_size;
 
   // Initialize
-  RETURN_NOT_OK(tile->init(
-      type, compressor, compression_level, tile_size, cell_size, dim_num));
+  RETURN_NOT_OK(tile->init(type, tile_size, cell_size, dim_num));
 
   return Status::Ok();
 }
@@ -1086,8 +1083,6 @@ Status Writer::init_tile(
   auto domain = array_schema_->domain();
   auto capacity = array_schema_->capacity();
   auto type = array_schema_->type(attribute);
-  auto compressor = array_schema_->compression(attribute);
-  auto compression_level = array_schema_->compression_level(attribute);
   auto cell_num_per_tile =
       (has_coords()) ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * constants::cell_var_offset_size;
@@ -1095,13 +1090,10 @@ Status Writer::init_tile(
   // Initialize
   RETURN_NOT_OK(tile->init(
       constants::cell_var_offset_type,
-      array_schema_->cell_var_offsets_compression(),
-      array_schema_->cell_var_offsets_compression_level(),
       tile_size,
       constants::cell_var_offset_size,
       0));
-  RETURN_NOT_OK(tile_var->init(
-      type, compressor, compression_level, tile_size, datatype_size(type), 0));
+  RETURN_NOT_OK(tile_var->init(type, tile_size, datatype_size(type), 0));
   return Status::Ok();
 }
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1193,8 +1193,6 @@ Status StorageManager::store_array_schema(ArraySchema* array_schema) {
   buff->reset_offset();
   auto tile = new Tile(
       constants::generic_tile_datatype,
-      constants::generic_tile_compressor,
-      constants::generic_tile_compression_level,
       constants::generic_tile_cell_size,
       0,
       buff,
@@ -1240,8 +1238,6 @@ Status StorageManager::store_fragment_metadata(FragmentMetadata* metadata) {
   buff->reset_offset();
   auto tile = new Tile(
       constants::generic_tile_datatype,
-      constants::generic_tile_compressor,
-      constants::generic_tile_compression_level,
       constants::generic_tile_cell_size,
       0,
       buff,

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -45,8 +45,6 @@ namespace sm {
 Tile::Tile() {
   buffer_ = nullptr;
   cell_size_ = 0;
-  compressor_ = Compressor::NO_COMPRESSION;
-  compression_level_ = -1;
   dim_num_ = 0;
   filtered_ = false;
   owns_buff_ = true;
@@ -58,8 +56,6 @@ Tile::Tile(unsigned int dim_num)
     : dim_num_(dim_num) {
   buffer_ = nullptr;
   cell_size_ = 0;
-  compressor_ = Compressor::NO_COMPRESSION;
-  compression_level_ = -1;
   filtered_ = false;
   owns_buff_ = true;
   pre_filtered_size_ = 0;
@@ -68,16 +64,12 @@ Tile::Tile(unsigned int dim_num)
 
 Tile::Tile(
     Datatype type,
-    Compressor compressor,
-    int compression_level,
     uint64_t cell_size,
     unsigned int dim_num,
     Buffer* buff,
     bool owns_buff)
     : buffer_(buff)
     , cell_size_(cell_size)
-    , compressor_(compressor)
-    , compression_level_(compression_level)
     , dim_num_(dim_num)
     , filtered_(false)
     , owns_buff_(owns_buff)
@@ -103,13 +95,8 @@ uint64_t Tile::cell_num() const {
   return size() / cell_size_;
 }
 
-Status Tile::init(
-    Datatype type,
-    Compressor compressor,
-    uint64_t cell_size,
-    unsigned int dim_num) {
+Status Tile::init(Datatype type, uint64_t cell_size, unsigned int dim_num) {
   cell_size_ = cell_size;
-  compressor_ = compressor;
   dim_num_ = dim_num;
   type_ = type;
 
@@ -123,14 +110,10 @@ Status Tile::init(
 
 Status Tile::init(
     Datatype type,
-    Compressor compressor,
-    int compression_level,
     uint64_t tile_size,
     uint64_t cell_size,
     unsigned int dim_num) {
   cell_size_ = cell_size;
-  compressor_ = compressor;
-  compression_level_ = compression_level;
   dim_num_ = dim_num;
   type_ = type;
 
@@ -153,14 +136,6 @@ Buffer* Tile::buffer() const {
 
 uint64_t Tile::cell_size() const {
   return cell_size_;
-}
-
-Compressor Tile::compressor() const {
-  return compressor_;
-}
-
-int Tile::compression_level() const {
-  return compression_level_;
 }
 
 void* Tile::cur_data() const {
@@ -335,8 +310,6 @@ Tile& Tile::operator=(const Tile& tile) {
   }
 
   cell_size_ = tile.cell_size_;
-  compressor_ = tile.compressor_;
-  compression_level_ = tile.compression_level_;
   dim_num_ = tile.dim_num_;
   filtered_ = tile.filtered_;
   owns_buff_ = tile.owns_buff_;

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -70,8 +70,6 @@ class Tile {
    * Constructor.
    *
    * @param type The type of the data to be stored.
-   * @param compression The compression type.
-   * @param compression_level The compression level.
    * @param cell_size The cell size.
    * @param dim_num The number of dimensions in case the tile stores
    *      coordinates.
@@ -83,8 +81,6 @@ class Tile {
    */
   Tile(
       Datatype type,
-      Compressor compression,
-      int compression_level,
       uint64_t cell_size,
       unsigned int dim_num,
       Buffer* buff,
@@ -107,24 +103,17 @@ class Tile {
    * Tile initializer.
    *
    * @param type The type of the data to be stored.
-   * @param compression The compression type.
    * @param cell_size The cell size.
    * @param dim_num The number of dimensions in case the tile stores
    *      coordinates.
    * @return Status
    */
-  Status init(
-      Datatype type,
-      Compressor compression,
-      uint64_t cell_size,
-      unsigned int dim_num);
+  Status init(Datatype type, uint64_t cell_size, unsigned int dim_num);
 
   /**
    * Tile initializer.
    *
    * @param type The type of the data to be stored.
-   * @param compression The compression type.
-   * @param compression_level The compression level.
    * @param tile_size The tile size. The internal buffer will be allocated
    *     that much space upon construction.
    * @param cell_size The cell size.
@@ -134,8 +123,6 @@ class Tile {
    */
   Status init(
       Datatype type,
-      Compressor compression,
-      int compression_level,
       uint64_t tile_size,
       uint64_t cell_size,
       unsigned int dim_num);
@@ -148,12 +135,6 @@ class Tile {
 
   /** Returns the cell size. */
   uint64_t cell_size() const;
-
-  /** Returns the tile compressor. */
-  Compressor compressor() const;
-
-  /** Returns the tile compression level. */
-  int compression_level() const;
 
   /** Returns the buffer data pointer at the current offset. */
   void* cur_data() const;
@@ -292,12 +273,6 @@ class Tile {
 
   /** The cell size. */
   uint64_t cell_size_;
-
-  /** The compression type. */
-  Compressor compressor_;
-
-  /** The compression level. */
-  int compression_level_;
 
   /**
    * The number of dimensions, in case the tile stores coordinates. It is 0


### PR DESCRIPTION
No longer needed as TileIO does not handle compression. Compression information is now stored in the filter pipelines per attribute.