### PR TITLE
Add C API types and functions for creating/adding filters.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,14 @@
 * Enable building TileDB in Cygwin environment on Windows #890
 * Added a simple benchmarking script and several benchmark programs #889
 
+## API additions
+
+### C API
+
+* Added `tiledb_filter_t` and `tiledb_filter_type_t` types
+* Added `tiledb_filter_*` functions
+* Added `tiledb_attribute_add_filter`, `tiledb_attribute_get_nfilters`, and `tiledb_attribute_get_filter_from_index` functions
+
 # TileDB v1.3.2 Release Notes
 
 ## Bug fixes

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -25,6 +25,8 @@ Types
     :project: TileDB-C
 .. doxygentypedef:: tiledb_query_t
     :project: TileDB-C
+.. doxygentypedef:: tiledb_filter_t
+    :project: TileDB-C
 .. doxygentypedef:: tiledb_kv_t
     :project: TileDB-C
 .. doxygentypedef:: tiledb_kv_schema_t
@@ -83,6 +85,8 @@ Enumerations
 .. doxygenenum:: tiledb_array_type_t
     :project: TileDB-C
 .. doxygenenum:: tiledb_layout_t
+    :project: TileDB-C
+.. doxygenenum:: tiledb_filter_type_t
     :project: TileDB-C
 .. doxygenenum:: tiledb_compressor_t
     :project: TileDB-C
@@ -226,6 +230,12 @@ Attribute
     :project: TileDB-C
 .. doxygenfunction:: tiledb_attribute_free
     :project: TileDB-C
+.. doxygenfunction:: tiledb_attribute_add_filter
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_attribute_get_nfilters
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_attribute_get_filter_from_index
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_attribute_set_compressor
     :project: TileDB-C
 .. doxygenfunction:: tiledb_attribute_set_cell_val_num
@@ -304,6 +314,21 @@ Query
 .. doxygenfunction:: tiledb_query_get_type
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_has_results
+    :project: TileDB-C
+
+Filters
+-------
+.. doxygenfunction:: tiledb_filter_alloc
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_filter_free
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_filter_set_compressor
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_filter_set_compression_level
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_filter_get_compressor
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_filter_get_compression_level
     :project: TileDB-C
 
 Group

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-capi-dense_neg.cc
   src/unit-capi-dense_vector.cc
   src/unit-capi-error.cc
+  src/unit-capi-filter.cc
   src/unit-capi-incomplete.cc
   src/unit-capi-kv.cc
   src/unit-capi-object_mgmt.cc

--- a/test/src/unit-capi-filter.cc
+++ b/test/src/unit-capi-filter.cc
@@ -1,0 +1,128 @@
+/**
+ * @file   unit-capi-filter.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C API filter.
+ */
+
+#include "catch.hpp"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/misc/constants.h"
+
+TEST_CASE("C API: Test filter set option", "[capi], [filter]") {
+  tiledb_ctx_t* ctx;
+  int rc = tiledb_ctx_alloc(nullptr, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_filter_t* filter;
+  rc = tiledb_filter_alloc(ctx, TILEDB_COMPRESSION, &filter);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Check valid options
+  rc = tiledb_filter_set_compressor(ctx, filter, TILEDB_BZIP2);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_filter_set_compression_level(ctx, filter, 5);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_filter_set_compressor(ctx, filter, TILEDB_DOUBLE_DELTA);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_compressor_t compr;
+  rc = tiledb_filter_get_compressor(ctx, filter, &compr);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(compr == TILEDB_DOUBLE_DELTA);
+
+  int level;
+  rc = tiledb_filter_get_compression_level(ctx, filter, &level);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(level == 5);
+
+  // Clean up
+  tiledb_filter_free(&filter);
+  tiledb_ctx_free(&ctx);
+}
+
+TEST_CASE("C API: Test filters on attribute", "[capi], [filter]") {
+  tiledb_ctx_t* ctx;
+  int rc = tiledb_ctx_alloc(nullptr, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_attribute_t* attr;
+  rc = tiledb_attribute_alloc(ctx, "a", TILEDB_INT32, &attr);
+  REQUIRE(rc == TILEDB_OK);
+
+  unsigned nfilters;
+  rc = tiledb_attribute_get_nfilters(ctx, attr, &nfilters);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(nfilters == 0);
+
+  tiledb_filter_t* filter_out;
+  rc = tiledb_attribute_get_filter_from_index(ctx, attr, 0, &filter_out);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(filter_out == nullptr);
+  rc = tiledb_attribute_get_filter_from_index(ctx, attr, 1, &filter_out);
+  REQUIRE(rc == TILEDB_ERR);
+
+  tiledb_filter_t* filter;
+  rc = tiledb_filter_alloc(ctx, TILEDB_COMPRESSION, &filter);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_filter_set_compressor(ctx, filter, TILEDB_BZIP2);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_filter_set_compression_level(ctx, filter, 5);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_attribute_add_filter(ctx, attr, filter);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_attribute_get_nfilters(ctx, attr, &nfilters);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(nfilters == 1);
+
+  rc = tiledb_attribute_get_filter_from_index(ctx, attr, 0, &filter_out);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(filter_out != nullptr);
+
+  tiledb_compressor_t compr;
+  rc = tiledb_filter_get_compressor(ctx, filter_out, &compr);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(compr == TILEDB_BZIP2);
+
+  int level;
+  rc = tiledb_filter_get_compression_level(ctx, filter_out, &level);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(level == 5);
+
+  tiledb_filter_free(&filter_out);
+
+  rc = tiledb_attribute_get_filter_from_index(ctx, attr, 1, &filter_out);
+  REQUIRE(rc == TILEDB_ERR);
+
+  // Clean up
+  tiledb_attribute_free(&attr);
+  tiledb_filter_free(&filter);
+  tiledb_ctx_free(&ctx);
+}

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -59,12 +59,11 @@ ArraySchema::ArraySchema() {
   std::memcpy(version_, constants::version, sizeof(version_));
 
   // Set up default filter pipelines for coords and offsets
-  coords_filters_.add_filter(std::unique_ptr<Filter>(new CompressionFilter(
-      constants::coords_compression, constants::coords_compression_level)));
-  cell_var_offsets_filters_.add_filter(
-      std::unique_ptr<Filter>(new CompressionFilter(
-          constants::cell_var_offsets_compression,
-          constants::cell_var_offsets_compression_level)));
+  coords_filters_.add_filter(CompressionFilter(
+      constants::coords_compression, constants::coords_compression_level));
+  cell_var_offsets_filters_.add_filter(CompressionFilter(
+      constants::cell_var_offsets_compression,
+      constants::cell_var_offsets_compression_level));
 }
 
 ArraySchema::ArraySchema(ArrayType array_type)
@@ -78,12 +77,11 @@ ArraySchema::ArraySchema(ArrayType array_type)
   std::memcpy(version_, constants::version, sizeof(version_));
 
   // Set up default filter pipelines for coords and offsets
-  coords_filters_.add_filter(std::unique_ptr<Filter>(new CompressionFilter(
-      constants::coords_compression, constants::coords_compression_level)));
-  cell_var_offsets_filters_.add_filter(
-      std::unique_ptr<Filter>(new CompressionFilter(
-          constants::cell_var_offsets_compression,
-          constants::cell_var_offsets_compression_level)));
+  coords_filters_.add_filter(CompressionFilter(
+      constants::coords_compression, constants::coords_compression_level));
+  cell_var_offsets_filters_.add_filter(CompressionFilter(
+      constants::cell_var_offsets_compression,
+      constants::cell_var_offsets_compression_level));
 }
 
 ArraySchema::ArraySchema(const ArraySchema* array_schema) {

--- a/tiledb/sm/array_schema/attribute.h
+++ b/tiledb/sm/array_schema/attribute.h
@@ -80,6 +80,14 @@ class Attribute {
   /* ********************************* */
 
   /**
+   * Add a copy of the given filter to the filter pipeline of this attribute.
+   *
+   * @param filter Filter to add
+   * @return Status
+   */
+  Status add_filter(const Filter& filter);
+
+  /**
    * Returns the size in bytes of one cell for this attribute. If the attribute
    * is variable-sized, this function returns the size in bytes of an offset.
    */

--- a/tiledb/sm/c_api/tiledb_enum.h
+++ b/tiledb/sm/c_api/tiledb_enum.h
@@ -142,6 +142,11 @@
     TILEDB_COMPRESSOR_ENUM(DOUBLE_DELTA),
 #endif
 
+#ifdef TILEDB_FILTER_TYPE_ENUM
+    /** Compression filter. */
+    TILEDB_FILTER_TYPE_ENUM(COMPRESSION),
+#endif
+
 #ifdef TILEDB_QUERY_STATUS_ENUM
     /** Query failed */
     TILEDB_QUERY_STATUS_ENUM(FAILED) = -1,

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -40,12 +40,20 @@
 #include "tiledb/sm/compressors/zstd_compressor.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/logger.h"
+#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/tile/tile.h"
 
 namespace tiledb {
 namespace sm {
 
-CompressionFilter::CompressionFilter(Compressor compressor, int level) {
+CompressionFilter::CompressionFilter()
+    : Filter(FilterType::COMPRESSION) {
+  compressor_ = Compressor::NO_COMPRESSION;
+  level_ = -1;
+}
+
+CompressionFilter::CompressionFilter(Compressor compressor, int level)
+    : Filter(FilterType::COMPRESSION) {
   compressor_ = compressor;
   level_ = level;
 }

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -61,6 +61,9 @@ namespace sm {
  */
 class CompressionFilter : public Filter {
  public:
+  /** Constructor. */
+  CompressionFilter();
+
   /**
    * Constructor.
    *

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_FILTER_H
 #define TILEDB_FILTER_H
 
+#include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_buffer.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/status.h"
@@ -50,13 +51,24 @@ namespace sm {
 class Filter {
  public:
   /** Constructor. */
-  Filter();
+  explicit Filter(FilterType type);
+
+  /** Destructor. */
+  virtual ~Filter() = default;
 
   /**
    * Returns a newly allocated clone of this Filter. The clone does not belong
    * to any pipeline. Caller is responsible for deletion of the clone.
    */
   Filter* clone() const;
+
+  /**
+   * Factory method to create a new Filter instance of the given type.
+   *
+   * @param type Filter type to create
+   * @return New Filter instance or nullptr on error.
+   */
+  static Filter* create(FilterType type);
 
   /**
    * Runs this filter in the "forward" direction (i.e. during write queries).
@@ -93,6 +105,9 @@ class Filter {
   /** Sets the pipeline instance that executes this filter. */
   void set_pipeline(const FilterPipeline* pipeline);
 
+  /** Returns the filter type. */
+  FilterType type() const;
+
  protected:
   /** Pointer to the pipeline instance that executes this filter. */
   const FilterPipeline* pipeline_;
@@ -103,6 +118,10 @@ class Filter {
    * to be cloned without knowing their derived types.
    */
   virtual Filter* clone_impl() const = 0;
+
+ private:
+  /** The filter type. */
+  FilterType type_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -75,12 +75,12 @@ class FilterPipeline {
   /** @} */
 
   /**
-   * Adds the given filter to the end of this pipeline.
+   * Adds a copy of the given filter to the end of this pipeline.
    *
    * @param filter Filter to add
    * @return Status
    */
-  Status add_filter(std::unique_ptr<Filter> filter);
+  Status add_filter(const Filter& filter);
 
   /** Returns pointer to the current Tile being processed by run/run_reverse. */
   const Tile* current_tile() const;
@@ -105,6 +105,14 @@ class FilterPipeline {
     }
     return nullptr;
   }
+
+  /**
+   * Returns a pointer to the filter in the pipeline at the given index.
+   *
+   * @param index Index of filter
+   * @return Pointer to filter instance in the pipeline
+   */
+  Filter* get_filter(unsigned index) const;
 
   /**
    * Runs the full pipeline on the given tile in the "forward" direction. The
@@ -174,6 +182,9 @@ class FilterPipeline {
    * @return Status
    */
   Status run_reverse(Tile* tile) const;
+
+  /** Returns the number of filters in the pipeline. */
+  unsigned size() const;
 
   /** Swaps the contents of this pipeline with the given pipeline. */
   void swap(FilterPipeline& other);

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -260,6 +260,9 @@ const std::string query_status_incomplete_str = "INCOMPLETE";
 /** TILEDB_UNINITIALIZED Query String **/
 const std::string query_status_uninitialized_str = "UNINITIALIZED";
 
+/** TILEDB_COMPRESSION Filter type string */
+const std::string filter_type_compression_str = "COMPRESSION";
+
 /** String describing GZIP. */
 const std::string gzip_str = "GZIP";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -242,6 +242,9 @@ extern const std::string query_status_incomplete_str;
 /** TILEDB_UNINITIALIZED Query String **/
 extern const std::string query_status_uninitialized_str;
 
+/** TILEDB_COMPRESSION Filter type string */
+extern const std::string filter_type_compression_str;
+
 /** String describing GZIP. */
 extern const std::string gzip_str;
 

--- a/tiledb/sm/tile/tile_io.cc
+++ b/tiledb/sm/tile/tile_io.cc
@@ -133,8 +133,8 @@ Status TileIO::read_generic(Tile** tile, uint64_t file_offset) {
     // Decompress
     FilterPipeline pipeline;
     RETURN_NOT_OK_ELSE(
-        pipeline.add_filter(std::unique_ptr<Filter>(new CompressionFilter(
-            (Compressor)header.compressor, header.compression_level))),
+        pipeline.add_filter(CompressionFilter(
+            (Compressor)header.compressor, header.compression_level)),
         delete *tile);
     RETURN_NOT_OK_ELSE(pipeline.run_reverse(*tile), delete *tile);
 
@@ -178,10 +178,9 @@ Status TileIO::write_generic(Tile* tile) {
 
   // Compress tile
   FilterPipeline pipeline;
-  RETURN_NOT_OK(
-      pipeline.add_filter(std::unique_ptr<Filter>(new CompressionFilter(
-          constants::generic_tile_compressor,
-          constants::generic_tile_compression_level))));
+  RETURN_NOT_OK(pipeline.add_filter(CompressionFilter(
+      constants::generic_tile_compressor,
+      constants::generic_tile_compression_level)));
   RETURN_NOT_OK(pipeline.run_forward(tile));
 
   RETURN_NOT_OK(write_generic_tile_header(tile, tile->buffer()->size()));


### PR DESCRIPTION
* Add initial filter C API and simple tests, supporting only compression currently.
* Attributes now are initialized with an empty pipeline (previously they began with a single-stage no-op compression filter).
* `tiledb_attribute_set_compressor` now adds a compression filter if one did not exist, or modifies it in-place if it did (this API will be deprecated, but will continue to work).
* Refactor `FilterPipeline` to make copies of filter instances before adding them.

No array schema changes with this PR.

Part of #156.