### PR TITLE
Change array metadata to serialize pipelines instead of only compression

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # In progress
 
+**Note:** TileDB v1.4.0 changes the on-disk array format. Existing arrays should be re-written using TileDB v1.4.0 before use.
+
 ## New features
 
 * Negative and real-valued domain types are now fully supported. #885

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -101,9 +101,8 @@ int Attribute::compression_level() const {
 // attribute_name_size (unsigned int)
 // attribute_name (string)
 // type (char)
-// compressor (char)
-// compression_level (int)
 // cell_val_num (unsigned int)
+// filter_pipeline (see FilterPipeline::serialize)
 Status Attribute::deserialize(ConstBuffer* buff) {
   // Load attribute name
   unsigned int attribute_name_size;
@@ -116,16 +115,11 @@ Status Attribute::deserialize(ConstBuffer* buff) {
   RETURN_NOT_OK(buff->read(&type, sizeof(char)));
   type_ = (Datatype)type;
 
-  // Load compressor
-  char compressor;
-  RETURN_NOT_OK(buff->read(&compressor, sizeof(char)));
-  set_compressor((Compressor)compressor);
-  int compressor_level;
-  RETURN_NOT_OK(buff->read(&compressor_level, sizeof(int)));
-  set_compression_level(compressor_level);
-
   // Load cell_val_num_
   RETURN_NOT_OK(buff->read(&cell_val_num_, sizeof(unsigned int)));
+
+  // Load filter pipeline
+  RETURN_NOT_OK(filters_.deserialize(buff));
 
   return Status::Ok();
 }
@@ -161,9 +155,8 @@ bool Attribute::is_anonymous() const {
 // attribute_name_size (unsigned int)
 // attribute_name (string)
 // type (char)
-// compressor (char)
-// compression_level (int)
 // cell_val_num (unsigned int)
+// filter_pipeline (see FilterPipeline::serialize)
 Status Attribute::serialize(Buffer* buff) {
   // Write attribute name
   auto attribute_name_size = (unsigned int)name_.size();
@@ -174,14 +167,11 @@ Status Attribute::serialize(Buffer* buff) {
   auto type = (char)type_;
   RETURN_NOT_OK(buff->write(&type, sizeof(char)));
 
-  // Write compressor
-  auto compressor_char = (char)compressor();
-  RETURN_NOT_OK(buff->write(&compressor_char, sizeof(char)));
-  int compressor_level = compression_level();
-  RETURN_NOT_OK(buff->write(&compressor_level, sizeof(int)));
-
   // Write cell_val_num_
   RETURN_NOT_OK(buff->write(&cell_val_num_, sizeof(unsigned int)));
+
+  // Write filter pipeline
+  RETURN_NOT_OK(filters_.serialize(buff));
 
   return Status::Ok();
 }

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -328,5 +328,22 @@ uint64_t CompressionFilter::overhead(uint64_t nbytes) const {
   }
 }
 
+Status CompressionFilter::serialize_impl(Buffer* buff) const {
+  auto compressor_char = static_cast<char>(compressor_);
+  RETURN_NOT_OK(buff->write(&compressor_char, sizeof(char)));
+  RETURN_NOT_OK(buff->write(&level_, sizeof(int)));
+
+  return Status::Ok();
+}
+
+Status CompressionFilter::deserialize_impl(ConstBuffer* buff) {
+  char compressor_char;
+  RETURN_NOT_OK(buff->read(&compressor_char, sizeof(char)));
+  compressor_ = static_cast<Compressor>(compressor_char);
+  RETURN_NOT_OK(buff->read(&level_, sizeof(int)));
+
+  return Status::Ok();
+}
+
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -113,8 +113,14 @@ class CompressionFilter : public Filter {
    */
   Status decompress_part(FilterBuffer* input, Buffer* output) const;
 
+  /** Deserializes this filter's metadata from the given buffer. */
+  Status deserialize_impl(ConstBuffer* buff) override;
+
   /** Computes the compression overhead on nbytes of the input data. */
   uint64_t overhead(uint64_t nbytes) const;
+
+  /** Serializes this filter's metadata to the given buffer. */
+  Status serialize_impl(Buffer* buff) const override;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -71,6 +71,15 @@ class Filter {
   static Filter* create(FilterType type);
 
   /**
+   * Deserializes a new Filter instance from the data in the given buffer.
+   *
+   * @param buff The buffer to deserialize from.
+   * @param filter New filter instance (caller's responsibility to free).
+   * @return Status
+   */
+  static Status deserialize(ConstBuffer* buff, Filter** filter);
+
+  /**
    * Runs this filter in the "forward" direction (i.e. during write queries).
    *
    * Note: the input buffer should not be modified directly. The only reason it
@@ -102,6 +111,14 @@ class Filter {
   virtual Status run_reverse(
       FilterBuffer* input, FilterBuffer* output) const = 0;
 
+  /**
+   * Serializes the filter metadata into a binary buffer.
+   *
+   * @param buff The buffer to serialize the data into.
+   * @return Status
+   */
+  Status serialize(Buffer* buff) const;
+
   /** Sets the pipeline instance that executes this filter. */
   void set_pipeline(const FilterPipeline* pipeline);
 
@@ -118,6 +135,30 @@ class Filter {
    * to be cloned without knowing their derived types.
    */
   virtual Filter* clone_impl() const = 0;
+
+  /**
+   * Deserialization function that can be implemented by a specific Filter
+   * subclass for filter-specific metadata.
+   *
+   * If a filter subclass has no specific metadata, it's not necessary to
+   * implement this method.
+   *
+   * @param buff The buffer to deserialize from
+   * @return Status
+   */
+  virtual Status deserialize_impl(ConstBuffer* buff);
+
+  /**
+   * Serialization function that can be implemented by a specific Filter
+   * subclass for filter-specific metadata.
+   *
+   * If a filter subclass has no specific metadata, it's not necessary to
+   * implement this method.
+   *
+   * @param buff The buffer to serialize the data into.
+   * @return Status
+   */
+  virtual Status serialize_impl(Buffer* buff) const;
 
  private:
   /** The filter type. */

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -86,6 +86,14 @@ class FilterPipeline {
   const Tile* current_tile() const;
 
   /**
+   * Populates the filter pipeline from the data in the input binary buffer.
+   *
+   * @param buff The buffer to deserialize from.
+   * @return Status
+   */
+  Status deserialize(ConstBuffer* buff);
+
+  /**
    * Returns pointer to the first instance of a filter in the pipeline with the
    * given filter subclass type.
    *
@@ -183,6 +191,14 @@ class FilterPipeline {
    */
   Status run_reverse(Tile* tile) const;
 
+  /**
+   * Serializes the pipeline metadata into a binary buffer.
+   *
+   * @param buff The buffer to serialize the data into.
+   * @return Status
+   */
+  Status serialize(Buffer* buff) const;
+
   /** Returns the number of filters in the pipeline. */
   unsigned size() const;
 
@@ -198,6 +214,9 @@ class FilterPipeline {
    * because it is the only state modified by those const functions.
    */
   mutable const Tile* current_tile_;
+
+  /** The max chunk size allowed within tiles. */
+  uint32_t max_chunk_size_;
 
   /**
    * Compute chunks of the given tile, used in the forward direction.


### PR DESCRIPTION
Previously array metadata consisted of explicit fields for compression and level. This generalizes the metadata format to serialize the filter pipelines themselves.

Part of #156