### PR TITLE
Several filter fixes

### DIFF
--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -243,7 +243,9 @@ Status CompressionFilter::decompress_part(
         "CompressionFilter error; output buffer too small."));
   }
 
-  ConstBuffer input_buffer(input->cur_data(), compressed_size);
+  ConstBuffer input_buffer(nullptr, 0);
+  RETURN_NOT_OK(input->get_const_buffer(compressed_size, &input_buffer));
+
   PreallocatedBuffer output_buffer(output->cur_data(), uncompressed_size);
 
   // Invoke the proper decompressor

--- a/tiledb/sm/filter/filter_buffer.h
+++ b/tiledb/sm/filter/filter_buffer.h
@@ -122,8 +122,16 @@ class FilterBuffer {
    */
   Status copy_to(void* dest) const;
 
-  /** Return a pointer to the data at the current global offset. */
-  void* cur_data() const;
+  /**
+   * Returns a ConstBuffer wrapping data at the current offset of the given
+   * length. Returns an error if this is not possible (e.g. the region would
+   * span multiple discontiguous regions of memory).
+   *
+   * @param nbytes Size of ConstBuffer
+   * @param buffer Set to the resulting ConstBuffer
+   * @return Status
+   */
+  Status get_const_buffer(uint64_t nbytes, ConstBuffer* buffer) const;
 
   /**
    * Initialize this FilterBuffer with a preallocated buffer view.
@@ -222,6 +230,17 @@ class FilterBuffer {
    * @return Status
    */
   Status write(const void* buffer, uint64_t nbytes);
+
+  /**
+   * Write a number of bytes from the given buffer at the current global offset.
+   *
+   * The given buffer's offset is not modified.
+   *
+   * @param buffer Buffer to copy from
+   * @param nbytes Number of bytes to copy
+   * @return Status
+   */
+  Status write(FilterBuffer* buffer, uint64_t nbytes);
 
  private:
   /**


### PR DESCRIPTION
- Check statuses in filter pipeline run methods
- Add FilterBuffer::write overload
- Replace FilterBuffer::cur_data with less misleading get_const_buffer().