### PR TITLE
Filter C API changes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,8 +24,8 @@
 
 ### C API
 
-* Added `tiledb_filter_t` `tiledb_filter_type_t`, and `tiledb_filter_list_t` types
-* Added `tiledb_filter_*` and `tiledb_filter_type_*` functions.
+* Added `tiledb_filter_t` `tiledb_filter_type_t`, `tiledb_filter_option_t`, and `tiledb_filter_list_t` types
+* Added `tiledb_filter_*` and `tiledb_filter_list_*` functions.
 * Added `tiledb_attribute_set_filter_list` function
 
 # TileDB v1.3.2 Release Notes

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -90,6 +90,8 @@ Enumerations
     :project: TileDB-C
 .. doxygenenum:: tiledb_filter_type_t
     :project: TileDB-C
+.. doxygenenum:: tiledb_filter_option_t
+    :project: TileDB-C
 .. doxygenenum:: tiledb_compressor_t
     :project: TileDB-C
 .. doxygenenum:: tiledb_walk_order_t
@@ -320,13 +322,9 @@ Filter
     :project: TileDB-C
 .. doxygenfunction:: tiledb_filter_free
     :project: TileDB-C
-.. doxygenfunction:: tiledb_filter_set_compressor
+.. doxygenfunction:: tiledb_filter_set_option
     :project: TileDB-C
-.. doxygenfunction:: tiledb_filter_set_compression_level
-    :project: TileDB-C
-.. doxygenfunction:: tiledb_filter_get_compressor
-    :project: TileDB-C
-.. doxygenfunction:: tiledb_filter_get_compression_level
+.. doxygenfunction:: tiledb_filter_get_option
     :project: TileDB-C
 
 Filter List

--- a/test/src/unit-capi-filter.cc
+++ b/test/src/unit-capi-filter.cc
@@ -40,24 +40,21 @@ TEST_CASE("C API: Test filter set option", "[capi], [filter]") {
   REQUIRE(rc == TILEDB_OK);
 
   tiledb_filter_t* filter;
-  rc = tiledb_filter_alloc(ctx, TILEDB_COMPRESSION, &filter);
+  rc = tiledb_filter_alloc(ctx, TILEDB_FILTER_BZIP2, &filter);
   REQUIRE(rc == TILEDB_OK);
 
-  // Check valid options
-  rc = tiledb_filter_set_compressor(ctx, filter, TILEDB_BZIP2);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_filter_set_compression_level(ctx, filter, 5);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_filter_set_compressor(ctx, filter, TILEDB_DOUBLE_DELTA);
+  int level = 5;
+  rc = tiledb_filter_set_option(ctx, filter, TILEDB_COMPRESSION_LEVEL, &level);
   REQUIRE(rc == TILEDB_OK);
 
-  tiledb_compressor_t compr;
-  rc = tiledb_filter_get_compressor(ctx, filter, &compr);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(compr == TILEDB_DOUBLE_DELTA);
+  rc = tiledb_filter_set_option(ctx, filter, TILEDB_COMPRESSION_LEVEL, nullptr);
+  REQUIRE(rc == TILEDB_ERR);
 
-  int level;
-  rc = tiledb_filter_get_compression_level(ctx, filter, &level);
+  rc = tiledb_filter_get_option(ctx, filter, TILEDB_COMPRESSION_LEVEL, nullptr);
+  REQUIRE(rc == TILEDB_ERR);
+
+  level = 0;
+  rc = tiledb_filter_get_option(ctx, filter, TILEDB_COMPRESSION_LEVEL, &level);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(level == 5);
 
@@ -90,11 +87,11 @@ TEST_CASE("C API: Test filter list", "[capi], [filter]") {
   REQUIRE(rc == TILEDB_ERR);
 
   tiledb_filter_t* filter;
-  rc = tiledb_filter_alloc(ctx, TILEDB_COMPRESSION, &filter);
+  rc = tiledb_filter_alloc(ctx, TILEDB_FILTER_BZIP2, &filter);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_filter_set_compressor(ctx, filter, TILEDB_BZIP2);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_filter_set_compression_level(ctx, filter, 5);
+
+  int level = 5;
+  rc = tiledb_filter_set_option(ctx, filter, TILEDB_COMPRESSION_LEVEL, &level);
   REQUIRE(rc == TILEDB_OK);
 
   rc = tiledb_filter_list_add_filter(ctx, filter_list, filter);
@@ -109,13 +106,8 @@ TEST_CASE("C API: Test filter list", "[capi], [filter]") {
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(filter_out != nullptr);
 
-  tiledb_compressor_t compr;
-  rc = tiledb_filter_get_compressor(ctx, filter_out, &compr);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(compr == TILEDB_BZIP2);
-
-  int level;
-  rc = tiledb_filter_get_compression_level(ctx, filter_out, &level);
+  level = 0;
+  rc = tiledb_filter_get_option(ctx, filter, TILEDB_COMPRESSION_LEVEL, &level);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(level == 5);
 
@@ -137,11 +129,11 @@ TEST_CASE("C API: Test filter list on attribute", "[capi], [filter]") {
   REQUIRE(rc == TILEDB_OK);
 
   tiledb_filter_t* filter;
-  rc = tiledb_filter_alloc(ctx, TILEDB_COMPRESSION, &filter);
+  rc = tiledb_filter_alloc(ctx, TILEDB_FILTER_BZIP2, &filter);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_filter_set_compressor(ctx, filter, TILEDB_BZIP2);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_filter_set_compression_level(ctx, filter, 5);
+
+  int level = 5;
+  rc = tiledb_filter_set_option(ctx, filter, TILEDB_COMPRESSION_LEVEL, &level);
   REQUIRE(rc == TILEDB_OK);
 
   tiledb_filter_list_t* filter_list;
@@ -174,13 +166,9 @@ TEST_CASE("C API: Test filter list on attribute", "[capi], [filter]") {
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(filter_out != nullptr);
 
-  tiledb_compressor_t compr;
-  rc = tiledb_filter_get_compressor(ctx, filter_out, &compr);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(compr == TILEDB_BZIP2);
-
-  int level;
-  rc = tiledb_filter_get_compression_level(ctx, filter_out, &level);
+  level = 0;
+  rc = tiledb_filter_get_option(
+      ctx, filter_out, TILEDB_COMPRESSION_LEVEL, &level);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(level == 5);
 

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -52,7 +52,7 @@ class Add1InPlace : public Filter {
  public:
   // Just use a dummy filter type
   Add1InPlace()
-      : Filter(FilterType::COMPRESSION) {
+      : Filter(FilterType::FILTER_NONE) {
   }
 
   Status run_forward(FilterBuffer* input, FilterBuffer* output) const override {
@@ -98,7 +98,7 @@ class Add1OutOfPlace : public Filter {
  public:
   // Just use a dummy filter type
   Add1OutOfPlace()
-      : Filter(FilterType::COMPRESSION) {
+      : Filter(FilterType::FILTER_NONE) {
   }
 
   Status run_forward(FilterBuffer* input, FilterBuffer* output) const override {
@@ -148,7 +148,7 @@ class AddNInPlace : public Filter {
  public:
   // Just use a dummy filter type
   AddNInPlace()
-      : Filter(FilterType::COMPRESSION) {
+      : Filter(FilterType::FILTER_NONE) {
     increment_ = 1;
   }
 
@@ -208,7 +208,7 @@ class PseudoChecksumFilter : public Filter {
  public:
   // Just use a dummy filter type
   PseudoChecksumFilter()
-      : Filter(FilterType::COMPRESSION) {
+      : Filter(FilterType::FILTER_NONE) {
   }
   Status run_forward(FilterBuffer* input, FilterBuffer* output) const override {
     auto input_size = input->size();

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -106,6 +106,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filter/filter_buffer.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filter/filter_pipeline.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filter/filter_storage.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filter/noop_filter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/fragment/fragment_metadata.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/global_state.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/openssl_state.cc

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -864,61 +864,39 @@ void tiledb_filter_free(tiledb_filter_t** filter) {
   }
 }
 
-int tiledb_filter_set_compressor(
+int tiledb_filter_set_option(
     tiledb_ctx_t* ctx,
     tiledb_filter_t* filter,
-    tiledb_compressor_t compressor) {
+    tiledb_filter_option_t option,
+    const void* value) {
   if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, filter) == TILEDB_ERR ||
-      check_filter_type(ctx, filter, TILEDB_COMPRESSION) == TILEDB_ERR)
+      sanity_check(ctx, filter) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  auto* f = static_cast<tiledb::sm::CompressionFilter*>(filter->filter_);
-  f->set_compressor(static_cast<tiledb::sm::Compressor>(compressor));
+  if (save_error(
+          ctx,
+          filter->filter_->set_option(
+              static_cast<tiledb::sm::FilterOption>(option), value)))
+    return TILEDB_ERR;
 
   // Success
   return TILEDB_OK;
 }
 
-int tiledb_filter_set_compression_level(
-    tiledb_ctx_t* ctx, tiledb_filter_t* filter, int compression_level) {
-  if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, filter) == TILEDB_ERR ||
-      check_filter_type(ctx, filter, TILEDB_COMPRESSION) == TILEDB_ERR)
-    return TILEDB_ERR;
-
-  auto* f = static_cast<tiledb::sm::CompressionFilter*>(filter->filter_);
-  f->set_compression_level(compression_level);
-
-  // Success
-  return TILEDB_OK;
-}
-
-int tiledb_filter_get_compressor(
+int tiledb_filter_get_option(
     tiledb_ctx_t* ctx,
     tiledb_filter_t* filter,
-    tiledb_compressor_t* compressor) {
+    tiledb_filter_option_t option,
+    void* value) {
   if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, filter) == TILEDB_ERR ||
-      check_filter_type(ctx, filter, TILEDB_COMPRESSION) == TILEDB_ERR)
+      sanity_check(ctx, filter) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  auto* f = static_cast<tiledb::sm::CompressionFilter*>(filter->filter_);
-  *compressor = static_cast<tiledb_compressor_t>(f->compressor());
-
-  // Success
-  return TILEDB_OK;
-}
-
-int tiledb_filter_get_compression_level(
-    tiledb_ctx_t* ctx, tiledb_filter_t* filter, int* compression_level) {
-  if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, filter) == TILEDB_ERR ||
-      check_filter_type(ctx, filter, TILEDB_COMPRESSION) == TILEDB_ERR)
+  if (save_error(
+          ctx,
+          filter->filter_->get_option(
+              static_cast<tiledb::sm::FilterOption>(option), value)))
     return TILEDB_ERR;
-
-  auto* f = static_cast<tiledb::sm::CompressionFilter*>(filter->filter_);
-  *compression_level = f->compression_level();
 
   // Success
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb_enum.h
+++ b/tiledb/sm/c_api/tiledb_enum.h
@@ -143,8 +143,37 @@
 #endif
 
 #ifdef TILEDB_FILTER_TYPE_ENUM
-    /** Compression filter. */
-    TILEDB_FILTER_TYPE_ENUM(COMPRESSION),
+    /** No-op filter */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_NONE),
+    /** Gzip compressor */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_GZIP),
+    /** Zstandard compressor */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_ZSTD),
+    /** LZ4 compressor */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_LZ4),
+    /** Run-length encoding compressor */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_RLE),
+    /** Bzip2 compressor */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_BZIP2),
+    /** Double-delta compressor */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_DOUBLE_DELTA),
+    /** Blosc compressor using LZ */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_BLOSC_LZ),
+    /** Blosc compressor using LZ4 */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_BLOSC_LZ4),
+    /** Blosc compressor using LZ4HC */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_BLOSC_LZ4HC),
+    /** Blosc compressor using Snappy */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_BLOSC_SNAPPY),
+    /** Blosc compressor using zlib */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_BLOSC_ZLIB),
+    /** Blosc compressor using Zstandard */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_BLOSC_ZSTD),
+#endif
+
+#ifdef TILEDB_FILTER_OPTION_ENUM
+    /** Compression level. Type: `int32_t`. */
+    TILEDB_FILTER_OPTION_ENUM(COMPRESSION_LEVEL),
 #endif
 
 #ifdef TILEDB_QUERY_STATUS_ENUM

--- a/tiledb/sm/enums/filter_option.h
+++ b/tiledb/sm/enums/filter_option.h
@@ -1,0 +1,54 @@
+/**
+ * @file filter_option.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This defines the TileDB FilterOption enum that maps to tiledb_filter_option_t
+ * C-API enum.
+ */
+
+#ifndef TILEDB_FILTER_OPTION_H
+#define TILEDB_FILTER_OPTION_H
+
+#include <cassert>
+#include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/status.h"
+
+namespace tiledb {
+namespace sm {
+
+/** Defines the filter type. */
+enum class FilterOption : char {
+#define TILEDB_FILTER_OPTION_ENUM(id) id
+#include "tiledb/sm/c_api/tiledb_enum.h"
+#undef TILEDB_FILTER_OPTION_ENUM
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_FILTER_OPTION_H

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -51,8 +51,30 @@ enum class FilterType : char {
 /** Returns the string representation of the input filter type. */
 inline const std::string& filter_type_str(FilterType filter_type) {
   switch (filter_type) {
-    case FilterType::COMPRESSION:
-      return constants::filter_type_compression_str;
+    case FilterType::FILTER_GZIP:
+      return constants::gzip_str;
+    case FilterType::FILTER_ZSTD:
+      return constants::zstd_str;
+    case FilterType::FILTER_LZ4:
+      return constants::lz4_str;
+    case FilterType::FILTER_BLOSC_LZ:
+      return constants::blosc_lz_str;
+    case FilterType::FILTER_BLOSC_LZ4:
+      return constants::blosc_lz4_str;
+    case FilterType::FILTER_BLOSC_LZ4HC:
+      return constants::blosc_lz4hc_str;
+    case FilterType::FILTER_BLOSC_SNAPPY:
+      return constants::blosc_snappy_str;
+    case FilterType::FILTER_BLOSC_ZLIB:
+      return constants::blosc_zlib_str;
+    case FilterType::FILTER_BLOSC_ZSTD:
+      return constants::blosc_zstd_str;
+    case FilterType::FILTER_RLE:
+      return constants::rle_str;
+    case FilterType::FILTER_BZIP2:
+      return constants::bzip2_str;
+    case FilterType::FILTER_DOUBLE_DELTA:
+      return constants::double_delta_str;
     default:
       assert(0);
       return constants::empty_str;
@@ -62,8 +84,30 @@ inline const std::string& filter_type_str(FilterType filter_type) {
 /** Returns the filter type given a string representation. */
 inline Status filter_type_enum(
     const std::string& filter_type_str, FilterType* filter_type) {
-  if (filter_type_str == constants::filter_type_compression_str)
-    *filter_type = FilterType::COMPRESSION;
+  if (filter_type_str == constants::gzip_str)
+    *filter_type = FilterType::FILTER_GZIP;
+  else if (filter_type_str == constants::zstd_str)
+    *filter_type = FilterType::FILTER_ZSTD;
+  else if (filter_type_str == constants::lz4_str)
+    *filter_type = FilterType::FILTER_LZ4;
+  else if (filter_type_str == constants::blosc_lz_str)
+    *filter_type = FilterType::FILTER_BLOSC_LZ;
+  else if (filter_type_str == constants::blosc_lz4_str)
+    *filter_type = FilterType::FILTER_BLOSC_LZ4;
+  else if (filter_type_str == constants::blosc_lz4hc_str)
+    *filter_type = FilterType::FILTER_BLOSC_LZ4HC;
+  else if (filter_type_str == constants::blosc_snappy_str)
+    *filter_type = FilterType::FILTER_BLOSC_SNAPPY;
+  else if (filter_type_str == constants::blosc_zlib_str)
+    *filter_type = FilterType::FILTER_BLOSC_ZLIB;
+  else if (filter_type_str == constants::blosc_zstd_str)
+    *filter_type = FilterType::FILTER_BLOSC_ZSTD;
+  else if (filter_type_str == constants::rle_str)
+    *filter_type = FilterType::FILTER_RLE;
+  else if (filter_type_str == constants::bzip2_str)
+    *filter_type = FilterType::FILTER_BZIP2;
+  else if (filter_type_str == constants::double_delta_str)
+    *filter_type = FilterType::FILTER_DOUBLE_DELTA;
   else {
     return Status::Error("Invalid FilterType " + filter_type_str);
   }

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -61,9 +61,6 @@ namespace sm {
  */
 class CompressionFilter : public Filter {
  public:
-  /** Constructor. */
-  CompressionFilter();
-
   /**
    * Constructor.
    *
@@ -71,6 +68,14 @@ class CompressionFilter : public Filter {
    * @param level Compression level to use
    */
   CompressionFilter(Compressor compressor, int level);
+
+  /**
+   * Constructor.
+   *
+   * @param compressor Compressor to use
+   * @param level Compression level to use
+   */
+  CompressionFilter(FilterType compressor, int level);
 
   /** Return the compressor used by this filter instance. */
   Compressor compressor() const;
@@ -107,6 +112,9 @@ class CompressionFilter : public Filter {
   /** Helper function to compress a single contiguous buffer (part). */
   Status compress_part(ConstBuffer* part, Buffer* output) const;
 
+  /** Return the FilterType corresponding to the given Compressor. */
+  static FilterType compressor_to_filter(Compressor compressor);
+
   /**
    * Helper function to decompress a single contiguous buffer (part), appending
    * onto the single output buffer.
@@ -116,8 +124,17 @@ class CompressionFilter : public Filter {
   /** Deserializes this filter's metadata from the given buffer. */
   Status deserialize_impl(ConstBuffer* buff) override;
 
+  /** Gets an option from this filter. */
+  Status get_option_impl(FilterOption option, void* value) const override;
+
+  /** Return the Compressor corresponding to the given FilterType. */
+  static Compressor filter_to_compressor(FilterType type);
+
   /** Computes the compression overhead on nbytes of the input data. */
   uint64_t overhead(uint64_t nbytes) const;
+
+  /** Sets an option on this filter. */
+  Status set_option_impl(FilterOption option, const void* value) override;
 
   /** Serializes this filter's metadata to the given buffer. */
   Status serialize_impl(Buffer* buff) const override;

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_FILTER_H
 #define TILEDB_FILTER_H
 
+#include "tiledb/sm/enums/filter_option.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_buffer.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
@@ -80,6 +81,15 @@ class Filter {
   static Status deserialize(ConstBuffer* buff, Filter** filter);
 
   /**
+   * Gets an option from this filter.
+   *
+   * @param option Option whose value to get
+   * @param value Buffer to store the value.
+   * @return Status
+   */
+  Status get_option(FilterOption option, void* value) const;
+
+  /**
    * Runs this filter in the "forward" direction (i.e. during write queries).
    *
    * Note: the input buffer should not be modified directly. The only reason it
@@ -112,6 +122,15 @@ class Filter {
       FilterBuffer* input, FilterBuffer* output) const = 0;
 
   /**
+   * Sets an option on this filter.
+   *
+   * @param option Option whose value to get
+   * @param value Buffer holding the value.
+   * @return Status
+   */
+  Status set_option(FilterOption option, const void* value);
+
+  /**
    * Serializes the filter metadata into a binary buffer.
    *
    * @param buff The buffer to serialize the data into.
@@ -128,6 +147,9 @@ class Filter {
  protected:
   /** Pointer to the pipeline instance that executes this filter. */
   const FilterPipeline* pipeline_;
+
+  /** The filter type. */
+  FilterType type_;
 
   /**
    * Clone function must implemented by each specific Filter subclass. This is
@@ -148,6 +170,12 @@ class Filter {
    */
   virtual Status deserialize_impl(ConstBuffer* buff);
 
+  /** Optional subclass specific get_option method. */
+  virtual Status get_option_impl(FilterOption option, void* value) const;
+
+  /** Optional subclass specific get_option method. */
+  virtual Status set_option_impl(FilterOption option, const void* value);
+
   /**
    * Serialization function that can be implemented by a specific Filter
    * subclass for filter-specific metadata.
@@ -159,10 +187,6 @@ class Filter {
    * @return Status
    */
   virtual Status serialize_impl(Buffer* buff) const;
-
- private:
-  /** The filter type. */
-  FilterType type_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/noop_filter.cc
+++ b/tiledb/sm/filter/noop_filter.cc
@@ -1,0 +1,60 @@
+/**
+ * @file   noop_filter.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class NoopFilter.
+ */
+
+#include "tiledb/sm/filter/noop_filter.h"
+#include "tiledb/sm/misc/logger.h"
+
+namespace tiledb {
+namespace sm {
+
+NoopFilter::NoopFilter()
+    : Filter(FilterType::FILTER_NONE) {
+}
+
+NoopFilter* NoopFilter::clone_impl() const {
+  return new NoopFilter;
+}
+
+Status NoopFilter::run_forward(
+    FilterBuffer* input, FilterBuffer* output) const {
+  RETURN_NOT_OK(output->append_view(input, 0, input->size()));
+  return Status::Ok();
+}
+
+Status NoopFilter::run_reverse(
+    FilterBuffer* input, FilterBuffer* output) const {
+  RETURN_NOT_OK(output->append_view(input, 0, input->size()));
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/filter/noop_filter.h
+++ b/tiledb/sm/filter/noop_filter.h
@@ -1,0 +1,70 @@
+/**
+ * @file   noop_filter.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares class NoopFilter.
+ */
+
+#ifndef TILEDB_NOOP_FILTER_H
+#define TILEDB_NOOP_FILTER_H
+
+#include "tiledb/sm/filter/filter.h"
+#include "tiledb/sm/misc/status.h"
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * A filter that does nothing. Input is passed unmodified to the output.
+ */
+class NoopFilter : public Filter {
+ public:
+  /**
+   * Constructor.
+   */
+  NoopFilter();
+
+  /**
+   * Run forward.
+   */
+  Status run_forward(FilterBuffer* input, FilterBuffer* output) const override;
+
+  /**
+   * Run reverse.
+   */
+  Status run_reverse(FilterBuffer* input, FilterBuffer* output) const override;
+
+ private:
+  /** Returns a new clone of this filter. */
+  NoopFilter* clone_impl() const override;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_NOOP_FILTER_H


### PR DESCRIPTION
- Remove notion of filter "categories." Filters are now all individual.
- Change filter option API to be more generic.
- Add no-op filter type (mostly for internal use).