### PR TITLE
Serialize filter pipeline in generic tile headers.

### DIFF
--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -36,11 +36,12 @@
 #include "tiledb/sm/enums/filter_option.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_buffer.h"
-#include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {
+
+class FilterPipeline;
 
 /**
  * A Filter processes or modifies a byte region, modifying it in place, or

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -34,6 +34,7 @@
 #define TILEDB_FILTER_PIPELINE_H
 
 #include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/sm/filter/filter.h"
 #include "tiledb/sm/filter/filter_buffer.h"
 #include "tiledb/sm/misc/status.h"
 
@@ -43,9 +44,6 @@
 namespace tiledb {
 namespace sm {
 
-/** Forward declarations for easier includes. */
-
-class Filter;
 class Tile;
 
 /**

--- a/tiledb/sm/tile/tile_io.cc
+++ b/tiledb/sm/tile/tile_io.cc
@@ -89,12 +89,15 @@ Status TileIO::is_generic_tile(
 
   uint64_t file_size;
   RETURN_NOT_OK(sm->vfs()->file_size(uri, &file_size));
-  if (file_size < GenericTileHeader::SIZE)
+  if (file_size < GenericTileHeader::BASE_SIZE)
     return Status::Ok();
 
   GenericTileHeader header;
   RETURN_NOT_OK(read_generic_tile_header(sm, uri, 0, &header));
-  if (file_size != GenericTileHeader::SIZE + header.persisted_size)
+
+  auto expected_size = GenericTileHeader::BASE_SIZE +
+                       header.filter_pipeline_size + header.persisted_size;
+  if (file_size != expected_size)
     return Status::Ok();
 
   *is_generic_tile = true;
@@ -111,11 +114,14 @@ Status TileIO::read_generic(Tile** tile, uint64_t file_offset) {
       (*tile)->init((Datatype)header.datatype, header.cell_size, 0),
       delete *tile);
 
+  auto tile_data_offset =
+      GenericTileHeader::BASE_SIZE + header.filter_pipeline_size;
+
   // Try the cache first.
   bool cache_hit;
   RETURN_NOT_OK(storage_manager_->read_from_cache(
       uri_,
-      file_offset + GenericTileHeader::SIZE,
+      file_offset + tile_data_offset,
       (*tile)->buffer(),
       header.tile_size,
       &cache_hit));
@@ -125,23 +131,18 @@ Status TileIO::read_generic(Tile** tile, uint64_t file_offset) {
     RETURN_NOT_OK_ELSE(
         storage_manager_->read(
             uri_,
-            file_offset + GenericTileHeader::SIZE,
+            file_offset + tile_data_offset,
             (*tile)->buffer(),
             header.persisted_size),
         delete *tile);
 
-    // Decompress
-    FilterPipeline pipeline;
-    RETURN_NOT_OK_ELSE(
-        pipeline.add_filter(CompressionFilter(
-            (Compressor)header.compressor, header.compression_level)),
-        delete *tile);
-    RETURN_NOT_OK_ELSE(pipeline.run_reverse(*tile), delete *tile);
+    // Filter
+    RETURN_NOT_OK_ELSE(header.filters.run_reverse(*tile), delete *tile);
 
     STATS_COUNTER_ADD(tileio_read_num_resulting_bytes, (*tile)->size());
 
     RETURN_NOT_OK(storage_manager_->write_to_cache(
-        uri_, file_offset + GenericTileHeader::SIZE, (*tile)->buffer()));
+        uri_, file_offset + tile_data_offset, (*tile)->buffer()));
   }
 
   return Status::Ok();
@@ -152,20 +153,33 @@ Status TileIO::read_generic_tile_header(
     const URI& uri,
     uint64_t file_offset,
     GenericTileHeader* header) {
-  // Read header from file
+  // Read the fixed-sized part of the header from file
   std::unique_ptr<Buffer> header_buff(new Buffer());
-  RETURN_NOT_OK(
-      sm->read(uri, file_offset, header_buff.get(), GenericTileHeader::SIZE));
+  RETURN_NOT_OK(sm->read(
+      uri, file_offset, header_buff.get(), GenericTileHeader::BASE_SIZE));
 
   // Read header individual values
   RETURN_NOT_OK(header_buff->read(&header->persisted_size, sizeof(uint64_t)));
   RETURN_NOT_OK(header_buff->read(&header->tile_size, sizeof(uint64_t)));
   RETURN_NOT_OK(header_buff->read(&header->datatype, sizeof(char)));
   RETURN_NOT_OK(header_buff->read(&header->cell_size, sizeof(uint64_t)));
-  RETURN_NOT_OK(header_buff->read(&header->compressor, sizeof(char)));
-  RETURN_NOT_OK(header_buff->read(&header->compression_level, sizeof(int)));
+  RETURN_NOT_OK(
+      header_buff->read(&header->filter_pipeline_size, sizeof(uint32_t)));
 
-  STATS_COUNTER_ADD(tileio_read_num_bytes_read, GenericTileHeader::SIZE);
+  // Read header filter pipeline.
+  header_buff->reset_size();
+  header_buff->reset_offset();
+  RETURN_NOT_OK(sm->read(
+      uri,
+      file_offset + GenericTileHeader::BASE_SIZE,
+      header_buff.get(),
+      header->filter_pipeline_size));
+  ConstBuffer cbuf(header_buff->data(), header_buff->size());
+  RETURN_NOT_OK(header->filters.deserialize(&cbuf));
+
+  STATS_COUNTER_ADD(
+      tileio_read_num_bytes_read,
+      GenericTileHeader::BASE_SIZE + header->filter_pipeline_size);
 
   return Status::Ok();
 }
@@ -176,14 +190,15 @@ Status TileIO::write_generic(Tile* tile) {
 
   STATS_COUNTER_ADD(tileio_write_num_input_bytes, tile->size());
 
-  // Compress tile
-  FilterPipeline pipeline;
-  RETURN_NOT_OK(pipeline.add_filter(CompressionFilter(
-      constants::generic_tile_compressor,
-      constants::generic_tile_compression_level)));
-  RETURN_NOT_OK(pipeline.run_forward(tile));
+  // Create a header
+  GenericTileHeader header;
+  RETURN_NOT_OK(init_generic_tile_header(tile, &header));
 
-  RETURN_NOT_OK(write_generic_tile_header(tile, tile->buffer()->size()));
+  // Filter tile
+  RETURN_NOT_OK(header.filters.run_forward(tile));
+  header.persisted_size = tile->buffer()->size();
+
+  RETURN_NOT_OK(write_generic_tile_header(&header));
   RETURN_NOT_OK(storage_manager_->write(uri_, tile->buffer()));
 
   STATS_COUNTER_ADD(tileio_write_num_bytes_written, tile->buffer()->size());
@@ -191,25 +206,34 @@ Status TileIO::write_generic(Tile* tile) {
   return Status::Ok();
 }
 
-Status TileIO::write_generic_tile_header(Tile* tile, uint64_t persisted_size) {
-  // Initializations
-  uint64_t tile_size = tile->size();
-  auto datatype = (char)tile->type();
-  uint64_t cell_size = tile->cell_size();
-  auto compressor = constants::generic_tile_compressor;
-  int compression_level = constants::generic_tile_compression_level;
-
+Status TileIO::write_generic_tile_header(GenericTileHeader* header) {
   // Write to buffer
   auto buff = new Buffer();
   RETURN_NOT_OK_ELSE(
-      buff->write(&persisted_size, sizeof(uint64_t)), delete buff);
-  RETURN_NOT_OK_ELSE(buff->write(&tile_size, sizeof(uint64_t)), delete buff);
-  RETURN_NOT_OK_ELSE(buff->write(&datatype, sizeof(char)), delete buff);
-  RETURN_NOT_OK_ELSE(buff->write(&cell_size, sizeof(uint64_t)), delete buff);
-  RETURN_NOT_OK_ELSE(buff->write(&compressor, sizeof(char)), delete buff);
-  RETURN_NOT_OK_ELSE(buff->write(&compression_level, sizeof(int)), delete buff);
+      buff->write(&header->persisted_size, sizeof(uint64_t)), delete buff);
+  RETURN_NOT_OK_ELSE(
+      buff->write(&header->tile_size, sizeof(uint64_t)), delete buff);
+  RETURN_NOT_OK_ELSE(buff->write(&header->datatype, sizeof(char)), delete buff);
+  RETURN_NOT_OK_ELSE(
+      buff->write(&header->cell_size, sizeof(uint64_t)), delete buff);
 
-  // Write to file
+  // Write placeholder value for pipeline size.
+  uint64_t pipeline_size_offset = buff->offset();
+  RETURN_NOT_OK_ELSE(
+      buff->write(&header->filter_pipeline_size, sizeof(uint32_t)),
+      delete buff);
+
+  // Write pipeline to buffer
+  auto orig_size = buff->size();
+  RETURN_NOT_OK_ELSE(header->filters.serialize(buff), delete buff);
+
+  // Write actual pipeline size over placeholder.
+  header->filter_pipeline_size =
+      static_cast<uint32_t>(buff->size() - orig_size);
+  *(static_cast<uint32_t*>(buff->value_ptr(pipeline_size_offset))) =
+      header->filter_pipeline_size;
+
+  // Write buffer to file
   Status st = storage_manager_->write(uri_, buff);
 
   STATS_COUNTER_ADD(tileio_write_num_input_bytes, buff->size());
@@ -218,6 +242,18 @@ Status TileIO::write_generic_tile_header(Tile* tile, uint64_t persisted_size) {
   delete buff;
 
   return st;
+}
+
+Status TileIO::init_generic_tile_header(
+    Tile* tile, GenericTileHeader* header) const {
+  header->tile_size = tile->size();
+  header->datatype = (char)tile->type();
+  header->cell_size = tile->cell_size();
+  RETURN_NOT_OK(header->filters.add_filter(CompressionFilter(
+      constants::generic_tile_compressor,
+      constants::generic_tile_compression_level)));
+
+  return Status::Ok();
 }
 
 }  // namespace sm


### PR DESCRIPTION
Also fix a forward declaration build issue.

This is to make encryption of generic tiles easier.