### PR TITLE
Use explicit bit widths for serialized datatypes.

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -370,15 +370,14 @@ bool ArraySchema::is_kv() const {
 
 // ===== FORMAT =====
 // version (uint32_t)
-// array_type (char)
-// is_kv (bool)
-// tile_order (char)
-// cell_order (char)
+// array_type (uint8_t)
+// tile_order (uint8_t)
+// cell_order (uint8_t)
 // capacity (uint64_t)
 // coords_filters (see FilterPipeline::serialize)
 // cell_var_offsets_filters (see FilterPipeline::serialize)
 // domain
-// attribute_num (unsigned int)
+// attribute_num (uint32_t)
 //   attribute #1
 //   attribute #2
 //   ...
@@ -387,14 +386,14 @@ Status ArraySchema::serialize(Buffer* buff) const {
   RETURN_NOT_OK(buff->write(&version_, sizeof(uint32_t)));
 
   // Write array type
-  auto array_type = (char)array_type_;
-  RETURN_NOT_OK(buff->write(&array_type, sizeof(char)));
+  auto array_type = (uint8_t)array_type_;
+  RETURN_NOT_OK(buff->write(&array_type, sizeof(uint8_t)));
 
   // Write tile and cell order
-  auto tile_order = (char)tile_order_;
-  RETURN_NOT_OK(buff->write(&tile_order, sizeof(char)));
-  auto cell_order = (char)cell_order_;
-  RETURN_NOT_OK(buff->write(&cell_order, sizeof(char)));
+  auto tile_order = (uint8_t)tile_order_;
+  RETURN_NOT_OK(buff->write(&tile_order, sizeof(uint8_t)));
+  auto cell_order = (uint8_t)cell_order_;
+  RETURN_NOT_OK(buff->write(&cell_order, sizeof(uint8_t)));
 
   // Write capacity
   RETURN_NOT_OK(buff->write(&capacity_, sizeof(uint64_t)));
@@ -409,8 +408,8 @@ Status ArraySchema::serialize(Buffer* buff) const {
   domain_->serialize(buff);
 
   // Write attributes
-  auto attribute_num = attributes_.size();
-  RETURN_NOT_OK(buff->write(&attribute_num, sizeof(unsigned int)));
+  auto attribute_num = (uint32_t)attributes_.size();
+  RETURN_NOT_OK(buff->write(&attribute_num, sizeof(uint32_t)));
   for (auto& attr : attributes_)
     RETURN_NOT_OK(attr->serialize(buff));
 
@@ -484,15 +483,14 @@ Status ArraySchema::add_attribute(const Attribute* attr, bool check_special) {
 
 // ===== FORMAT =====
 // version (uint32_t)
-// array_type (char)
-// is_kv (bool)
-// tile_order (char)
-// cell_order (char)
+// array_type (uint8_t)
+// tile_order (uint8_t)
+// cell_order (uint8_t)
 // capacity (uint64_t)
 // coords_filters (see FilterPipeline::serialize)
 // cell_var_offsets_filters (see FilterPipeline::serialize)
 // domain
-// attribute_num (unsigned int)
+// attribute_num (uint32_t)
 //   attribute #1
 //   attribute #2
 //   ...
@@ -503,18 +501,18 @@ Status ArraySchema::deserialize(ConstBuffer* buff, bool is_kv) {
   RETURN_NOT_OK(buff->read(&version_, sizeof(uint32_t)));
 
   // Load array type
-  char array_type;
-  RETURN_NOT_OK(buff->read(&array_type, sizeof(char)));
+  uint8_t array_type;
+  RETURN_NOT_OK(buff->read(&array_type, sizeof(uint8_t)));
   array_type_ = (ArrayType)array_type;
 
   // Load tile order
-  char tile_order;
-  RETURN_NOT_OK(buff->read(&tile_order, sizeof(char)));
+  uint8_t tile_order;
+  RETURN_NOT_OK(buff->read(&tile_order, sizeof(uint8_t)));
   tile_order_ = (Layout)tile_order;
 
   // Load cell order
-  char cell_order;
-  RETURN_NOT_OK(buff->read(&cell_order, sizeof(char)));
+  uint8_t cell_order;
+  RETURN_NOT_OK(buff->read(&cell_order, sizeof(uint8_t)));
   cell_order_ = (Layout)cell_order;
 
   // Load capacity
@@ -531,9 +529,9 @@ Status ArraySchema::deserialize(ConstBuffer* buff, bool is_kv) {
   RETURN_NOT_OK(domain_->deserialize(buff));
 
   // Load attributes
-  unsigned attribute_num;
-  RETURN_NOT_OK(buff->read(&attribute_num, sizeof(unsigned int)));
-  for (unsigned int i = 0; i < attribute_num; ++i) {
+  uint32_t attribute_num;
+  RETURN_NOT_OK(buff->read(&attribute_num, sizeof(uint32_t)));
+  for (uint32_t i = 0; i < attribute_num; ++i) {
     auto attr = new Attribute();
     RETURN_NOT_OK_ELSE(attr->deserialize(buff), delete attr);
     attributes_.emplace_back(attr);

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -94,25 +94,25 @@ int Attribute::compression_level() const {
 }
 
 // ===== FORMAT =====
-// attribute_name_size (unsigned int)
+// attribute_name_size (uint32_t)
 // attribute_name (string)
-// type (char)
-// cell_val_num (unsigned int)
+// type (uint8_t)
+// cell_val_num (uint32_t)
 // filter_pipeline (see FilterPipeline::serialize)
 Status Attribute::deserialize(ConstBuffer* buff) {
   // Load attribute name
-  unsigned int attribute_name_size;
-  RETURN_NOT_OK(buff->read(&attribute_name_size, sizeof(unsigned int)));
+  uint32_t attribute_name_size;
+  RETURN_NOT_OK(buff->read(&attribute_name_size, sizeof(uint32_t)));
   name_.resize(attribute_name_size);
   RETURN_NOT_OK(buff->read(&name_[0], attribute_name_size));
 
   // Load type
-  char type;
-  RETURN_NOT_OK(buff->read(&type, sizeof(char)));
+  uint8_t type;
+  RETURN_NOT_OK(buff->read(&type, sizeof(uint8_t)));
   type_ = (Datatype)type;
 
   // Load cell_val_num_
-  RETURN_NOT_OK(buff->read(&cell_val_num_, sizeof(unsigned int)));
+  RETURN_NOT_OK(buff->read(&cell_val_num_, sizeof(uint32_t)));
 
   // Load filter pipeline
   RETURN_NOT_OK(filters_.deserialize(buff));
@@ -148,23 +148,23 @@ bool Attribute::is_anonymous() const {
 }
 
 // ===== FORMAT =====
-// attribute_name_size (unsigned int)
+// attribute_name_size (uint32_t)
 // attribute_name (string)
-// type (char)
-// cell_val_num (unsigned int)
+// type (uint8_t)
+// cell_val_num (uint32_t)
 // filter_pipeline (see FilterPipeline::serialize)
 Status Attribute::serialize(Buffer* buff) {
   // Write attribute name
-  auto attribute_name_size = (unsigned int)name_.size();
-  RETURN_NOT_OK(buff->write(&attribute_name_size, sizeof(unsigned int)));
+  auto attribute_name_size = (uint32_t)name_.size();
+  RETURN_NOT_OK(buff->write(&attribute_name_size, sizeof(uint32_t)));
   RETURN_NOT_OK(buff->write(name_.c_str(), attribute_name_size));
 
   // Write type
-  auto type = (char)type_;
-  RETURN_NOT_OK(buff->write(&type, sizeof(char)));
+  auto type = (uint8_t)type_;
+  RETURN_NOT_OK(buff->write(&type, sizeof(uint8_t)));
 
   // Write cell_val_num_
-  RETURN_NOT_OK(buff->write(&cell_val_num_, sizeof(unsigned int)));
+  RETURN_NOT_OK(buff->write(&cell_val_num_, sizeof(uint32_t)));
 
   // Write filter pipeline
   RETURN_NOT_OK(filters_.serialize(buff));

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -447,20 +447,20 @@ int Domain::cell_order_cmp(const T* coords_a, const T* coords_b) const {
 }
 
 // ===== FORMAT =====
-// type (char)
-// dim_num (unsigned int)
+// type (uint8_t)
+// dim_num (uint32_t)
 // dimension #1
 // dimension #2
 // ...
 Status Domain::deserialize(ConstBuffer* buff) {
   // Load type
-  char type;
-  RETURN_NOT_OK(buff->read(&type, sizeof(char)));
+  uint8_t type;
+  RETURN_NOT_OK(buff->read(&type, sizeof(uint8_t)));
   type_ = static_cast<Datatype>(type);
 
   // Load dimensions
-  RETURN_NOT_OK(buff->read(&dim_num_, sizeof(unsigned int)));
-  for (unsigned int i = 0; i < dim_num_; ++i) {
+  RETURN_NOT_OK(buff->read(&dim_num_, sizeof(uint32_t)));
+  for (uint32_t i = 0; i < dim_num_; ++i) {
     auto dim = new Dimension();
     dim->deserialize(buff, type_);
     dimensions_.emplace_back(dim);
@@ -751,18 +751,18 @@ bool Domain::null_tile_extents() const {
 }
 
 // ===== FORMAT =====
-// type (char)
-// dim_num (unsigned int)
+// type (uint8_t)
+// dim_num (uint32_t)
 // dimension #1
 // dimension #2
 // ...
 Status Domain::serialize(Buffer* buff) {
   // Write type
-  auto type = static_cast<char>(type_);
-  RETURN_NOT_OK(buff->write(&type, sizeof(char)));
+  auto type = static_cast<uint8_t>(type_);
+  RETURN_NOT_OK(buff->write(&type, sizeof(uint8_t)));
 
   // Write dimensions
-  RETURN_NOT_OK(buff->write(&dim_num_, sizeof(unsigned int)));
+  RETURN_NOT_OK(buff->write(&dim_num_, sizeof(uint32_t)));
   for (auto dim : dimensions_)
     dim->serialize(buff);
 

--- a/tiledb/sm/enums/array_type.h
+++ b/tiledb/sm/enums/array_type.h
@@ -43,7 +43,7 @@ namespace tiledb {
 namespace sm {
 
 /** Defines the array type. */
-enum class ArrayType : char {
+enum class ArrayType : uint8_t {
 #define TILEDB_ARRAY_TYPE_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_ARRAY_TYPE_ENUM

--- a/tiledb/sm/enums/compressor.h
+++ b/tiledb/sm/enums/compressor.h
@@ -43,7 +43,7 @@ namespace tiledb {
 namespace sm {
 
 /** Defines the compressor type. */
-enum class Compressor : char {
+enum class Compressor : uint8_t {
 #define TILEDB_COMPRESSOR_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_COMPRESSOR_ENUM

--- a/tiledb/sm/enums/datatype.h
+++ b/tiledb/sm/enums/datatype.h
@@ -43,7 +43,7 @@ namespace tiledb {
 namespace sm {
 
 /** Defines a datatype. */
-enum class Datatype : char {
+enum class Datatype : uint8_t {
 #define TILEDB_DATATYPE_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_DATATYPE_ENUM

--- a/tiledb/sm/enums/encryption_type.h
+++ b/tiledb/sm/enums/encryption_type.h
@@ -42,7 +42,7 @@ namespace tiledb {
 namespace sm {
 
 /** Defines an encryption type. */
-enum class EncryptionType : char {
+enum class EncryptionType : uint8_t {
 #define TILEDB_ENCRYPTION_TYPE_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_ENCRYPTION_TYPE_ENUM

--- a/tiledb/sm/enums/filesystem.h
+++ b/tiledb/sm/enums/filesystem.h
@@ -38,7 +38,7 @@ namespace tiledb {
 namespace sm {
 
 /** Defines a filesystem. */
-enum class Filesystem : char {
+enum class Filesystem : uint8_t {
 #define TILEDB_FILESYSTEM_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_FILESYSTEM_ENUM

--- a/tiledb/sm/enums/filter_option.h
+++ b/tiledb/sm/enums/filter_option.h
@@ -42,7 +42,7 @@ namespace tiledb {
 namespace sm {
 
 /** Defines the filter type. */
-enum class FilterOption : char {
+enum class FilterOption : uint8_t {
 #define TILEDB_FILTER_OPTION_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_FILTER_OPTION_ENUM

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -46,7 +46,7 @@ namespace sm {
  *
  * Note: not all of these are exposed in the C API.
  */
-enum class FilterType : char {
+enum class FilterType : uint8_t {
 #define TILEDB_FILTER_TYPE_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_FILTER_TYPE_ENUM

--- a/tiledb/sm/enums/layout.h
+++ b/tiledb/sm/enums/layout.h
@@ -43,7 +43,7 @@ namespace tiledb {
 namespace sm {
 
 /** Defines a layout for the cell or tile order. */
-enum class Layout : char {
+enum class Layout : uint8_t {
 #define TILEDB_LAYOUT_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_LAYOUT_ENUM

--- a/tiledb/sm/enums/object_type.h
+++ b/tiledb/sm/enums/object_type.h
@@ -37,7 +37,7 @@
 namespace tiledb {
 namespace sm {
 
-enum class ObjectType : char {
+enum class ObjectType : uint8_t {
 #define TILEDB_OBJECT_TYPE_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_OBJECT_TYPE_ENUM

--- a/tiledb/sm/enums/query_status.h
+++ b/tiledb/sm/enums/query_status.h
@@ -43,7 +43,7 @@ namespace tiledb {
 namespace sm {
 
 /** Defines the query states (used in asynchronous queries). */
-enum class QueryStatus : char {
+enum class QueryStatus : uint8_t {
 #define TILEDB_QUERY_STATUS_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_QUERY_STATUS_ENUM

--- a/tiledb/sm/enums/query_type.h
+++ b/tiledb/sm/enums/query_type.h
@@ -42,7 +42,7 @@ namespace tiledb {
 namespace sm {
 
 /** Defines the query type. */
-enum class QueryType : char {
+enum class QueryType : uint8_t {
 #define TILEDB_QUERY_TYPE_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_QUERY_TYPE_ENUM

--- a/tiledb/sm/enums/vfs_mode.h
+++ b/tiledb/sm/enums/vfs_mode.h
@@ -37,7 +37,7 @@
 namespace tiledb {
 namespace sm {
 
-enum class VFSMode : char {
+enum class VFSMode : uint8_t {
 #define TILEDB_VFS_MODE_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_VFS_MODE_ENUM

--- a/tiledb/sm/enums/walk_order.h
+++ b/tiledb/sm/enums/walk_order.h
@@ -37,7 +37,7 @@
 namespace tiledb {
 namespace sm {
 
-enum class WalkOrder : char {
+enum class WalkOrder : uint8_t {
 #define TILEDB_WALK_ORDER_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"
 #undef TILEDB_WALK_ORDER_ENUM

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -443,18 +443,18 @@ uint64_t CompressionFilter::overhead(uint64_t nbytes) const {
 }
 
 Status CompressionFilter::serialize_impl(Buffer* buff) const {
-  auto compressor_char = static_cast<char>(compressor_);
-  RETURN_NOT_OK(buff->write(&compressor_char, sizeof(char)));
-  RETURN_NOT_OK(buff->write(&level_, sizeof(int)));
+  auto compressor_char = static_cast<uint8_t>(compressor_);
+  RETURN_NOT_OK(buff->write(&compressor_char, sizeof(uint8_t)));
+  RETURN_NOT_OK(buff->write(&level_, sizeof(int32_t)));
 
   return Status::Ok();
 }
 
 Status CompressionFilter::deserialize_impl(ConstBuffer* buff) {
-  char compressor_char;
-  RETURN_NOT_OK(buff->read(&compressor_char, sizeof(char)));
+  uint8_t compressor_char;
+  RETURN_NOT_OK(buff->read(&compressor_char, sizeof(uint8_t)));
   compressor_ = static_cast<Compressor>(compressor_char);
-  RETURN_NOT_OK(buff->read(&level_, sizeof(int)));
+  RETURN_NOT_OK(buff->read(&level_, sizeof(int32_t)));
 
   return Status::Ok();
 }

--- a/tiledb/sm/filter/filter.cc
+++ b/tiledb/sm/filter/filter.cc
@@ -102,8 +102,8 @@ Status Filter::set_option(FilterOption option, const void* value) {
 }
 
 Status Filter::deserialize(ConstBuffer* buff, Filter** filter) {
-  char type;
-  RETURN_NOT_OK(buff->read(&type, sizeof(char)));
+  uint8_t type;
+  RETURN_NOT_OK(buff->read(&type, sizeof(uint8_t)));
   uint32_t filter_metadata_len;
   RETURN_NOT_OK(buff->read(&filter_metadata_len, sizeof(uint32_t)));
 
@@ -126,12 +126,12 @@ Status Filter::deserialize(ConstBuffer* buff, Filter** filter) {
 }
 
 // ===== FORMAT =====
-// filter type (char)
-// filter metadata num bytes (unsigned int -- may be 0)
+// filter type (uint8_t)
+// filter metadata num bytes (uint32_t -- may be 0)
 // filter metadata (char[])
 Status Filter::serialize(Buffer* buff) const {
-  char type = static_cast<char>(type_);
-  RETURN_NOT_OK(buff->write(&type, sizeof(char)));
+  auto type = static_cast<uint8_t>(type_);
+  RETURN_NOT_OK(buff->write(&type, sizeof(uint8_t)));
 
   // Save a pointer to store the actual length of the metadata.
   uint32_t metadata_len = 0;

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -437,8 +437,8 @@ Status FilterPipeline::run_reverse(Tile* tile) const {
 }
 
 // ===== FORMAT =====
-// max_chunk_size (unsigned int)
-// num_filters (unsigned int)
+// max_chunk_size (uint32_t)
+// num_filters (uint32_t)
 // filter0 metadata (see Filter::serialize)
 // filter1...
 Status FilterPipeline::serialize(Buffer* buff) const {

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -39,8 +39,8 @@
 namespace tiledb {
 namespace sm {
 
-enum class Datatype : char;
-enum class Compressor : char;
+enum class Datatype : uint8_t;
+enum class Compressor : uint8_t;
 
 namespace constants {
 


### PR DESCRIPTION
This also changes the corresponding enum classes derive from `uint8_t`.