### PR TITLE
Catch internal exceptions when calling into C++ code.

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1139,9 +1139,8 @@ Status StorageManager::query_submit(Query* query) {
   STATS_FUNC_IN(sm_query_submit);
 
   // Process the query
-  increment_in_progress();
+  QueryInProgress in_progress(this);
   auto st = query->process();
-  decrement_in_progress();
 
   return st;
 

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -642,6 +642,33 @@ class StorageManager {
 
  private:
   /* ********************************* */
+  /*        PRIVATE DATATYPES          */
+  /* ********************************* */
+
+  /**
+   * Helper RAII struct that increments 'queries_in_progress' in the constructor
+   * and decrements in the destructor, on the given StorageManager instance.
+   *
+   * This ensures that the counter is decremented even in the case of
+   * exceptions.
+   */
+  struct QueryInProgress {
+    /** The StorageManager instance. */
+    StorageManager* sm;
+
+    /** Constructor. Calls increment_in_progress() on given StorageManager. */
+    QueryInProgress(StorageManager* sm)
+        : sm(sm) {
+      sm->increment_in_progress();
+    }
+
+    /** Destructor. Calls decrement_in_progress() on given StorageManager. */
+    ~QueryInProgress() {
+      sm->decrement_in_progress();
+    }
+  };
+
+  /* ********************************* */
   /*        PRIVATE ATTRIBUTES         */
   /* ********************************* */
 


### PR DESCRIPTION
This adds a extra anonymous function in each place `save_error` was used, but I verified that at least on my system (`Apple LLVM version 10.0.0 (clang-1000.10.44.2)`), the lambdas are inlined.

This also fixes a bug that could occur if an exception was thrown during query submit. Previously the "in progress" counter would never be decremented if an exception was thrown, and the `StorageManager` destructor would block infinitely waiting for the counter to be 0. The fix is to use an RAII helper class to decrement the counter in its destructor.

Closes #960.