### PR TITLE
move tbb runtime thread scheduler init to per process global state

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-lru_cache.cc
   src/unit-s3.cc
   src/unit-status.cc
+  src/unit-tbb.cc
   src/unit-threadpool.cc
   src/unit-uri.cc
   src/unit-uuid.cc
@@ -127,6 +128,10 @@ endif()
 if (TILEDB_TESTS_AWS_S3_CONFIG)
   message(STATUS "Tests built with AWS S3 config")
   target_compile_definitions(tiledb_unit PRIVATE -DTILEDB_TESTS_AWS_S3_CONFIG)
+endif()
+
+if (TILEDB_TBB)
+  target_compile_definitions(tiledb_unit PRIVATE -DHAVE_TBB)
 endif()
 
 # This is necessary only because we are linking directly to the core objects.

--- a/test/src/unit-tbb.cc
+++ b/test/src/unit-tbb.cc
@@ -1,0 +1,53 @@
+/**
+ * @file   unit-tbb.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for TileDB TBB thread runtime support
+ */
+
+#ifdef HAVE_TBB
+
+#include "catch.hpp"
+#include "tiledb/sm/cpp_api/tiledb"
+
+TEST_CASE("TileDB TBB negative number of set threads", "[tbb]") {
+  tiledb::Config config;
+  config["sm.num_tbb_threads"] = "-3";
+  CHECK_THROWS(tiledb::Context(config));
+}
+
+TEST_CASE("TileDB TBB different number of set threads per process", "[tbb]") {
+  // default number of TBB threads
+  auto ctx1 = tiledb::Context();
+
+  tiledb::Config config;
+  config["sm.num_tbb_threads"] = "1000";
+  CHECK_THROWS(tiledb::Context(config));
+}
+
+#endif

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -125,6 +125,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/global_state.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/openssl_state.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/signal_handlers.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/tbb_state.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/watchdog.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv_item.cc

--- a/tiledb/sm/global_state/global_state.cc
+++ b/tiledb/sm/global_state/global_state.cc
@@ -33,7 +33,9 @@
 #include "tiledb/sm/global_state/global_state.h"
 #include "tiledb/sm/global_state/openssl_state.h"
 #include "tiledb/sm/global_state/signal_handlers.h"
+#include "tiledb/sm/global_state/tbb_state.h"
 #include "tiledb/sm/global_state/watchdog.h"
+#include "tiledb/sm/misc/constants.h"
 
 namespace tiledb {
 namespace sm {
@@ -51,6 +53,11 @@ GlobalState::GlobalState() {
 
 Status GlobalState::initialize(Config* config) {
   std::unique_lock<std::mutex> lck(init_mtx_);
+
+  // initialize tbb with configured number of threads
+  RETURN_NOT_OK(init_tbb(config));
+
+  // run these operations once
   if (!initialized_) {
     if (config != nullptr) {
       config_ = *config;
@@ -62,6 +69,7 @@ Status GlobalState::initialize(Config* config) {
     RETURN_NOT_OK(init_openssl());
     initialized_ = true;
   }
+
   return Status::Ok();
 }
 

--- a/tiledb/sm/global_state/tbb_state.cc
+++ b/tiledb/sm/global_state/tbb_state.cc
@@ -1,0 +1,108 @@
+/**
+ * @file   tbb_state.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file declares the Intel TBB threading scheduler state, if TileDB is built
+ with Intel TBB.
+ */
+
+#include "tiledb/sm/global_state/tbb_state.h"
+
+#ifdef HAVE_TBB
+
+#include <tbb/task_scheduler_init.h>
+#include <sstream>
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+/** The TBB scheduler, used for controlling the number of TBB threads. */
+static std::unique_ptr<tbb::task_scheduler_init> tbb_scheduler_;
+
+/** The number of TBB threads the scheduler was configured with **/
+static int tbb_nthreads_;
+
+Status init_tbb(tiledb::sm::Config* config) {
+  int nthreads = config ? config->sm_params().num_tbb_threads_ :
+                          constants::num_tbb_threads;
+  if (nthreads == tbb::task_scheduler_init::automatic) {
+    nthreads = tbb::task_scheduler_init::default_num_threads();
+  }
+  if (nthreads < 1) {
+    std::stringstream msg;
+    msg << "TBB thread runtime must be initialized with >= 1 threads, got: "
+        << nthreads;
+    return Status::Error(msg.str());
+  }
+  if (!tbb_scheduler_) {
+    // initialize scheduler in process for a custom number of threads (upon
+    // first thread calling init_tbb)
+    try {
+      tbb_scheduler_ = std::unique_ptr<tbb::task_scheduler_init>(
+          new tbb::task_scheduler_init(nthreads));
+      tbb_nthreads_ = nthreads;
+    } catch (std::exception& err) {
+      std::stringstream msg;
+      msg << "TBB thread runtime initialization error: " << err.what();
+      return Status::Error(msg.str());
+    }
+  } else {
+    // if the scheduler has been initialized, check per process TBB invariants
+    if (nthreads != tbb_nthreads_) {
+      // if the scheduler has been initialized and the number of scheduled
+      // threads per process is different, error
+      std::stringstream msg;
+      msg << "TBB thread runtime must be initialized with the same number of "
+             "threads per process: "
+          << nthreads << " != " << tbb_nthreads_;
+      return Status::Error(msg.str());
+    }
+  }
+  return Status::Ok();
+}
+
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb
+
+#else
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+Status init_tbb(Config* config) {
+  return Status::OK();
+}
+
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb
+
+#endif

--- a/tiledb/sm/global_state/tbb_state.h
+++ b/tiledb/sm/global_state/tbb_state.h
@@ -1,0 +1,57 @@
+/**
+ * @file   tbb_state.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file declares the Intel TBB threading scheduler state, if TileDB is built
+ with Intel TBB.
+ */
+
+#ifndef TILEDB_TBB_STATE_H
+#define TILEDB_TBB_STATE_H
+
+#include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/storage_manager/config.h"
+
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+/**
+ * Initializes the Intel TBB thread runtime scheduler with a specified number of
+ * threads
+ *
+ * @param config TileDB Config object pointer (or nullptr)
+ * @return Status
+ */
+Status init_tbb(Config* config);
+
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb
+
+#endif

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -748,9 +748,6 @@ Status StorageManager::init(Config* config) {
   tile_cache_ = new LRUCache(sm_params.tile_cache_size_);
   vfs_ = new VFS();
   RETURN_NOT_OK(vfs_->init(config_.vfs_params()));
-#ifdef HAVE_TBB
-  RETURN_NOT_OK(init_tbb(sm_params));
-#endif
   auto& global_state = global_state::GlobalState::GetGlobalState();
   RETURN_NOT_OK(global_state.initialize(config));
   global_state.register_storage_manager(this);
@@ -1714,17 +1711,6 @@ Status StorageManager::get_fragment_uris(
 
   return Status::Ok();
 }
-
-#ifdef HAVE_TBB
-Status StorageManager::init_tbb(Config::SMParams& config) {
-  // use tbb's default scheduler if configured with default number of threads
-  if (config.num_tbb_threads_ != constants::num_tbb_threads) {
-    tbb_scheduler_ = std::unique_ptr<tbb::task_scheduler_init>(
-        new tbb::task_scheduler_init(config.num_tbb_threads_));
-  }
-  return Status::Ok();
-}
-#endif
 
 Status StorageManager::load_array_schema(
     const URI& array_uri,

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -43,10 +43,6 @@
 #include <string>
 #include <thread>
 
-#ifdef HAVE_TBB
-#include <tbb/task_scheduler_init.h>
-#endif
-
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/cache/lru_cache.h"
 #include "tiledb/sm/encryption/encryption.h"
@@ -747,11 +743,6 @@ class StorageManager {
   /** The storage manager's thread pool for Writers. */
   std::unique_ptr<ThreadPool> writer_thread_pool_;
 
-#ifdef HAVE_TBB
-  /** The TBB scheduler, used for controlling the number of TBB threads. */
-  std::unique_ptr<tbb::task_scheduler_init> tbb_scheduler_;
-#endif
-
   /** A tile cache. */
   LRUCache* tile_cache_;
 
@@ -878,16 +869,6 @@ class StorageManager {
 
   /** Increment the count of in-progress queries. */
   void increment_in_progress();
-
-#ifdef HAVE_TBB
-  /**
-   * Configures the TBB runtime. If TBB is not enabled, does nothing.
-   *
-   * @param config The configuration parameters
-   * @return Status
-   */
-  Status init_tbb(Config::SMParams& config);
-#endif
 
   /**
    * Loads the array schema into an open array.


### PR DESCRIPTION
Move TBB runtime initialization to global state to enforce that the same number of tbb threads are spawned per process.

Closes #893