### PR TITLE
Add documentation page on filters.

### DIFF
--- a/doc/source/gensidebar.py
+++ b/doc/source/gensidebar.py
@@ -90,6 +90,7 @@ def generate_sidebar(conf, conf_api):
     write('Sparse Arrays', 'tutorials/sparse-arrays')
     write('Multi-attribute Arrays', 'tutorials/multi-attribute-arrays')
     write('Variable-length Attributes', 'tutorials/variable-length-attributes')
+    write('Filters', 'tutorials/filters')
     write('Compression', 'tutorials/compression')
     write('Encryption', 'tutorials/encryption')
     write('Catching Errors', 'tutorials/errors')

--- a/doc/source/performance/performance-factors.rst
+++ b/doc/source/performance/performance-factors.rst
@@ -58,12 +58,13 @@ Dimensions vs. attributes
     on dimensions (i.e. a read query can specify only a subset of attributes should
     be read, but it must always specify all dimensions).
 
-Compression
-    Compression of attributes can reduce persistent storage consumption, but
-    at the expense of increased time to read/write tiles from/to the array. However,
-    tiles on disk that are smaller due to compression can be read from disk in
-    less time, which can improve performance. Finally, many compressors offer
-    different levels of compression, which can be used to fine-tune the tradeoff.
+Filtering
+    Filtering (such as compression) of attributes can reduce persistent storage
+    consumption, but at the expense of increased time to read/write tiles
+    from/to the array. However, tiles on disk that are smaller due to
+    compression can be read from disk in less time, which can improve
+    performance. Additionally, many compressors offer different levels of
+    compression, which can be used to fine-tune the tradeoff.
 
 Queries
 -------

--- a/doc/source/tutorials/compression.rst
+++ b/doc/source/tutorials/compression.rst
@@ -1,8 +1,8 @@
 Compression
 ===========
 
-In this tutorial you will learn all about compression in TileDB. It is
-highly recommended that you read the tutorials on attributes and
+In this tutorial you will learn more about compression in TileDB. It is
+highly recommended that you read the tutorials on attributes, filtering, and
 tiling dense/sparse arrays first.
 
 
@@ -13,13 +13,8 @@ Basic concepts and definitions
     :header: **Attribute-based compression**
 
     TileDB allows you to choose a different compression scheme for
-    each attribute.
-
-.. toggle-header::
-    :header: **Tile-based compression**
-
-    The data tile is the atomic unit of compression, i.e., each
-    data tile is compressed separately.
+    each attribute by using filter lists. Compression in TileDB always occurs
+    as a separate filter in a filter list.
 
 .. toggle-header::
     :header: **Compression tradeoff**
@@ -32,10 +27,11 @@ Compressing arrays
 ------------------
 
 The data types and values of the array cells most likely vary across attributes.
-Therefore, it is desirable to allow defining a different compression scheme
-per attribute, since different compressors may be more effective for different
-types of data. Here is how you specify the compressor when defining an attribute
-upon array creation:
+Therefore, it is desirable to allow defining a different compression scheme per
+attribute, since different compressors may be more effective for different
+types of data. Compression in TileDB always occurs as a separate filter in a
+filter list. You specify the compressor in the filter list when defining an
+attribute upon array creation.
 
 .. content-tabs::
 
@@ -47,7 +43,9 @@ upon array creation:
         Context ctx;
         ArraySchema schema(ctx, TILEDB_DENSE);
         auto a = Attribute::create<int>(ctx, "a");
-        a.set_compressor({TILEDB_GZIP, -1});
+        FilterList filters(ctx);
+        filters.add_filter({ctx, TILEDB_FILTER_GZIP});
+        a.filters(filters);
         schema.add_attribute(a);
 
    .. tab-container:: python
@@ -59,17 +57,11 @@ upon array creation:
         attr = tiledb.Attr(ctx, name="a", dtype=np.int32, compressor=("gzip", -1))
         schema = tiledb.ArraySchema(ctx, domain=dom, sparse=False, attrs=[attr])
 
-TileDB offers a variety of compressors to choose from (see below). Moreover,
-you can adjust the compression level (the second argument in the function
-setter above - ``-1`` means "default compression level"). If a compressor
-is not specified, TileDB will use no compression by default.
-
-When compressing the data tiles of an attribute, TileDB stores some
-necessary metadata in file ``__fragment_metadata.tdb``, such as the
-starting location of each compressed tile and the original tile size
-in the case of variable-length attributes (recall that the original tile
-size has fixed size for fixed-length attributes in *both* dense and
-sparse arrays).
+TileDB offers a variety of compressors to choose from (see below). Moreover, you
+can adjust the compression level (by setting the ``TILEDB_COMPRESSION_LEVEL``
+option on the compression filter, where ``-1`` means "default compression
+level"). If a compressor filter is not added to an attribute, TileDB will not
+compress that attribute.
 
 You can also specify a different compressor for the coordinates
 tiles as follows (the default is ZSTD with default compression level):
@@ -81,7 +73,9 @@ tiles as follows (the default is ZSTD with default compression level):
 
       .. code-block:: c++
 
-        schema.set_coords_compressor({TILEDB_LZ4, -1});
+        FilterList coords_filters(ctx);
+        coords_filters.add_filter({ctx, TILEDB_LZ4});
+        schema.set_coords_filter_list(coords_filters);
 
    .. tab-container:: python
       :title: Python
@@ -111,7 +105,9 @@ data tiles (the default is ZSTD with default compression level):
 
       .. code-block:: c++
 
-        schema.set_offsets_compressor({TILEDB_BZIP2, -1});
+        FilterList offsets_filters(ctx);
+        offsets_filters.add_filter({ctx, TILEDB_BZIP2});
+        schema.set_offsets_filter_list(offsets_filters);
 
    .. tab-container:: python
       :title: Python
@@ -172,7 +168,7 @@ course to storage consumption. As stated above, the choice of compressor
 is important for performance, but there is always a tradeoff between
 compression ratio and speed, which you need to adjust based on your
 application. Luckily for you, TileDB *parallelizes* internally both
-compression and decompression. However, parallelization takes effect
-when the data tile to be compressed/decompressed is large enough.
-See :ref:`performance/introduction` for more information on
-TileDB performance and how to tune it.
+compression and decompression (and filtering in general).
+However, parallelization takes effect when the data tile to be filtered is large
+enough. See :ref:`performance/introduction` for more information on TileDB
+performance and how to tune it.

--- a/doc/source/tutorials/filters.rst
+++ b/doc/source/tutorials/filters.rst
@@ -1,0 +1,373 @@
+.. _filters:
+
+Filters
+=======
+
+In this tutorial we will learn how to use TileDB filters. It is recommended to
+first read the tutorials on sparse arrays, multi-attribute arrays and
+variable-length attributes.
+
+.. table:: Full programs
+  :widths: auto
+
+  ====================================  =============================================================
+  **Program**                           **Links**
+  ------------------------------------  -------------------------------------------------------------
+  ``filters``                           |filterscpp|
+  ====================================  =============================================================
+
+.. |filterscpp| image:: ../figures/cpp.png
+   :align: middle
+   :width: 30
+   :target: {tiledb_src_root_url}/examples/cpp_api/filters.cc
+
+Basic concepts and definitions
+------------------------------
+
+.. toggle-header::
+    :header: **Filter**
+
+    A filter is used to transform attribute data before it is written to an
+    array. One filter performs one type of data transformation. An example of a
+    filter is the bzip2 compression filter, which transforms data by compressing
+    it with bzip2.
+
+.. toggle-header::
+    :header: **Filter list**
+
+    A filter list is an ordered list of zero or more filters. Filter lists can
+    be arbitrarily long, and are used to specify an ordered sequence of data
+    transformations that should be performed on attribute data. TileDB allows
+    you to set a different filter list for each attribute.
+
+.. toggle-header::
+    :header: **Tile chunk**
+
+    Recall that data tiles are the atomic unit of I/O in TileDB. Before writing,
+    data tiles are internally divided into multiple chunks by TileDB. The tile
+    chunk is the atomic unit of filtering, i.e., each chunk of a data tile is
+    filtered separately (and in parallel).
+
+
+Filter lists
+------------
+
+Filtering in TileDB allows you to specify an ordered list of data
+transformations, such as compression, that should be applied to attribute data
+before it is written to disk. Individual filters are added to filter lists,
+which are then set on attributes in the array schema.
+
+.. content-tabs::
+
+   .. tab-container:: cpp
+      :title: C++
+
+      To start, create a simple sparse array schema.
+
+      .. code-block:: c++
+
+        Context ctx;
+
+        // The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
+        Domain domain(ctx);
+        domain.add_dimension(Dimension::create<int>(ctx, "rows", {{1, 4}}, 4))
+            .add_dimension(Dimension::create<int>(ctx, "cols", {{1, 4}}, 4));
+
+        // The array will be sparse.
+        ArraySchema schema(ctx, TILEDB_SPARSE);
+        schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+
+      Next create two fixed-length attributes ``a1`` and ``a2``:
+
+      .. code-block:: c++
+
+        auto a1 = Attribute::create<uint32_t>(ctx, "a1");
+        auto a2 = Attribute::create<int32_t>(ctx, "a2");
+
+      Attribute ``a1`` will be filtered by bit width reduction followed by Zstd
+      compression. First, create ``Filter`` objects for the two filtering
+      operations:
+
+      .. code-block:: c++
+
+        Filter bit_width_reduction(ctx, TILEDB_FILTER_BIT_WIDTH_REDUCTION);
+        Filter compression_zstd(ctx, TILEDB_FILTER_ZSTD);
+
+      Next, create a ``FilterList`` object and add the two filters. Note that
+      the order you add ``Filter`` objects to a ``FilterList`` is the order that
+      the filtering will occur.
+
+      .. code-block:: c++
+
+        FilterList a1_filters(ctx);
+        a1_filters.add_filter(bit_width_reduction)
+            .add_filter(compression_zstd);
+
+      Now set the filter list on attribute ``a1``:
+
+      .. code-block:: c++
+
+        a1.set_filter_list(a1_filters);
+
+      Attribute ``a2`` will be filtered just with a single gzip compression
+      filter:
+
+      .. code-block:: c++
+
+        FilterList a2_filters(ctx);
+        a2_filters.add_filter({ctx, TILEDB_FILTER_GZIP});
+        a2.set_filter_list(a2_filters);
+
+      Note that ``Filter`` and ``FilterList`` objects can be reused. If instead
+      you wanted to use the same filter list for ``a2`` as was used in ``a1``
+      you could simply do:
+
+      .. code-block:: c++
+
+        a1.set_filter_list(a1_filters);
+        a2.set_filter_list(a1_filters);
+
+      Either way, add the attributes to the array schema and create the array:
+
+      .. code-block:: c++
+
+        schema.add_attribute(a1).add_attribute(a2);
+        Array::create(array_name, schema);
+
+      TileDB also allows you to set filter lists to be used on the offsets data
+      for variable-length attributes as well as the coordinates for sparse
+      fragments. For example, to set a filter list for the offsets you could do
+      the following:
+
+      .. code-block:: c++
+
+        FilterList offsets_filters(ctx);
+        offsets_filters.add_filter({ctx, TILEDB_FILTER_POSITIVE_DELTA})
+            .add_filter(bit_width_reduction)
+            .add_filter(compression_zstd);
+        schema.set_offsets_filter_list(offsets_filters);
+
+Now when data for attributes ``a1`` and ``a2`` is written to the array, the data
+will first be transformed by the filter lists you specified in the array schema.
+
+When reading from the array, the filtered data on disk is "unfiltered" through
+the same list of filters in reverse, producing the original data.
+
+When filtering the data tiles of an attribute, TileDB stores some
+necessary metadata in file ``__fragment_metadata.tdb``, such as the
+starting location of each filtered tile and the original tile size
+in the case of variable-length attributes (recall that the original tile
+size has fixed size for fixed-length attributes in *both* dense and
+sparse arrays).
+
+Filter options
+--------------
+
+Some filters have additional options that can be configured. For example, you
+can set the compression level as an option on the filters that perform
+compression.
+
+.. content-tabs::
+
+   .. tab-container:: cpp
+      :title: C++
+
+      To set the compression level to level 5 on a bzip2 compression filter:
+
+      .. code-block:: c++
+
+        Filter compression_bzip2(ctx, TILEDB_FILTER_BZIP2);
+        int level = 5;
+        compression_bzip2.set_option(TILEDB_COMPRESSION_LEVEL, &level);
+
+      You can also retrieve option values from filters:
+
+      .. code-block:: c++
+
+        int level_get;
+        compression_bzip2.get_option(TILEDB_COMPRESSION_LEVEL, &level_get);
+        // Now level_get == 5
+
+The options supported by each filter are documented below.
+
+Available filters
+-----------------
+
+TileDB supports a number of filters, and more will continue to be added in the
+future.
+
+Compression filters
+~~~~~~~~~~~~~~~~~~~
+
+There are several filters performing generic compression, which are the following:
+
+* ``TILEDB_FILTER_GZIP``: Compresses with `Gzip <http://www.zlib.net/>`__
+* ``TILEDB_FILTER_ZSTD``: Compresses with `Zstandard <http://facebook.github.io/zstd/>`__
+* ``TILEDB_FILTER_LZ4``: Compresses with `LZ4 <https://github.com/lz4/lz4>`__
+* ``TILEDB_FILTER_RLE``: Compresses with `run-length encoding <https://en.wikipedia.org/wiki/Run-length_encoding>`__
+* ``TILEDB_FILTER_BZIP2``: Compresses with `Bzip2 <http://www.bzip.org/>`__
+* ``TILEDB_FILTER_DOUBLE_DELTA``: Compresses with double-delta encoding
+
+All of these filters support one filter option to set the compression level,
+although some compressors such as RLE currently ignore the setting. The filter
+option is:
+
+* ``TILEDB_COMPRESSION_LEVEL`` (type ``int32_t``): The compression level to
+  use. Default: -1 (compressor-specific default).
+
+Byteshuffle
+~~~~~~~~~~~
+
+The filter ``TILEDB_FILTER_BYTESHUFFLE`` performs byte shuffling of data as a
+way to improve compression ratios. The
+`byte shuffle implementation <{tiledb_src_root_url}/external/include/blosc/shuffle.h>`_
+used by TileDB comes from the `Blosc <blosc.org>`_ project.
+
+The byte shuffling process rearranges the bytes of the input attribute cell
+values in a deterministic and reversible manner designed to result in long runs
+of similar bytes that can be compressed more effectively by a generic compressor
+than the original unshuffled elements. Typically this filter is not used
+on its own, but rather immediately followed by a compression filter in a filter
+list.
+
+For example, consider three 32-bit unsigned integer values ``1, 2, 3``, which
+have the following little-endian representation when stored adjacent in memory:
+
+.. code-block:: none
+
+    0x01 0x00 0x00 0x00 0x02 0x00 0x00 0x00 0x03 0x00 0x00 0x00
+
+The byte shuffle operation will rearrange the bytes of these integer elements in
+memory such that the resulting array of bytes will contain each element's first
+byte, followed by each element's second byte, etc. After shuffling the bytes
+would therefore be:
+
+.. code-block:: none
+
+    0x01 0x02 0x03 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+
+Note the longer run of zero-valued bytes, which will compress more efficiently.
+
+The byteshuffle filter does not support any options.
+
+Bitshuffle
+~~~~~~~~~~
+
+The filter ``TILEDB_FILTER_BITSHUFFLE`` performs
+`bit shuffling <https://www.sciencedirect.com/science/article/pii/S2213133715000694>`_
+of data as a way to improve compression ratios. The bitshuffle implementation
+used in TileDB comes from `<https://github.com/kiyo-masui/bitshuffle>`_.
+
+Bitshuffling is conceptually very similar to byteshuffling, but operates on the
+bit granularity rather than the byte granularity. Shuffling at the bit level
+can increase compression ratios even further than the byteshuffle filter, at the
+cost of increased computation to perform the shuffle.
+
+Typically this filter is not used on its own, but rather immediately
+followed by a compression filter in a filter list.
+
+Positive-delta encoding
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The filter ``TILEDB_FILTER_POSITIVE_DELTA`` performs positive-delta encoding.
+Positive-delta encoding is a form of delta encoding that only works when the
+delta value is positive. Positive-delta encoding can result in better
+compression ratios on the encoded data. Typically this filter is not used
+on its own, but rather immediately followed by a compression filter in a filter
+list.
+
+For example, if the data being filtered was the sequence of integers ``100, 104,
+108, 112, ...``, then the resulting positive-encoded data would be ``0, 4, 4,
+4, ...``. This encoding is advantageous in that producing long runs of repeated
+values can result in better compression ratios, if a compression filter is added
+after positive-delta encoding.
+
+The filter operates on a "window" of values at a time, which can help in some
+cases to produce longer runs of repeated delta values.
+
+The positive-delta encoding filter supports one option:
+
+* ``TILEDB_POSITIVE_DELTA_MAX_WINDOW`` (type ``uint32_t``): The window size in
+  bytes to use. Default: 1024.
+
+.. note::
+
+    Positive-delta encoding is particularly useful for the offsets of
+    variable-length attribute data, which by definition will always have
+    positive deltas. The above example of the form ``100, 104, 108, 112`` can
+    easily arise in the offsets, if for example you have a variable-length
+    attribute of 4-byte values with mostly single values per cell instead of a
+    variable number.
+
+
+Bit width reduction
+~~~~~~~~~~~~~~~~~~~
+
+The filter ``TILEDB_FILTER_BIT_WIDTH_REDUCTION`` performs bit-width reduction,
+which is a form of compression.
+
+Bit-width reduction examines a window of attribute values, and determines if all
+of the values in the window can be represented by a datatype of smaller byte size.
+If so, the values in the window are rewritten as values of the smaller datatype,
+potentially saving several bytes per cell.
+
+For example, consider an attribute with datatype ``uint64_t``. Initially, each
+cell of data for that attribute requires 8 bytes of storage. However, if you
+know that the actual value of the attribute is often 255 or less, those cells
+can be stored using just a single byte in the form of a ``uint8_t``, saving 7
+bytes of storage per cell. The bit-width reduction filter performs this analysis
+and compression automatically over windows of attribute data.
+
+Additionally, each cell value in a window is treated relative to the minimum
+value in that window. For example, if the window size was 3 cells, which had the
+values ``300, 350, 400``, the bit-width reduction filter would first determine
+that the minimum value in the window was ``300``, and the relative cell values
+were ``0, 50, 100``. These relative values are now less than 255 and can be
+represented by a ``uint8_t`` value.
+
+If possible, it can be a good idea to apply positive-delta encoding before
+bit-width reduction, as the positive-delta encoding may further increase the
+opportunities to store windows of data with a narrower datatype.
+
+The bit-width reduction filter supports one option:
+
+* ``TILEDB_BIT_WIDTH_MAX_WINDOW`` (type ``uint32_t``): The window size in
+  bytes to use. Default: 256.
+
+.. note::
+
+    Bit-width reduction only works on integral datatypes.
+
+
+Tile chunks
+-----------
+
+Before filtering each data tile of an attribute, TileDB internally divides the
+tile into disjoint chunks. These chunks are then filtered individually.
+
+Chunking tiles before filtering allows for better cache behavior in terms of
+temporal locality, as the chunk size can be chosen to fit within the L1 cache of
+your processor cores. This helps especially with multi-stage filter lists, as
+the output from the previous filter is likely to still be in L1 when used as
+input for the current filter.
+
+Chunking tiles also increases the amount of parallel compute that TileDB can
+make effective use of. By breaking a tile into individual chunks, each chunk can
+then be filtered in parallel, which can result in excellent CPU utilization
+when combined with the cache-friendly size of the chunks.
+
+The default chunk size used by TileDB is 64KB, which is the size of many common
+processor L1 caches. You can control the chunk size by changing the option on
+a filter list:
+
+.. content-tabs::
+
+   .. tab-container:: cpp
+      :title: C++
+
+      .. code-block:: c++
+
+        Context ctx;
+        FilterList filter_list(ctx);
+        // Use a max chunk size of 10,000 bytes for this filter list:
+        filter_list.set_max_chunk_size(10000);

--- a/doc/source/tutorials/multi-attribute-arrays.rst
+++ b/doc/source/tutorials/multi-attribute-arrays.rst
@@ -344,15 +344,16 @@ Let us look at the contents of the array of this example on disk.
    $ ls -l multi_attribute/__3f4622ed4ec1486ea3450f66c905f8cc_1529357638905/
    total 24
    -rwx------  1 stavros  staff  124 Jun 18 17:33 __fragment_metadata.tdb
-   -rwx------  1 stavros  staff   16 Jun 18 17:33 a1.tdb
-   -rwx------  1 stavros  staff  128 Jun 18 17:33 a2.tdb
+   -rwx------  1 stavros  staff   36 Jun 18 17:33 a1.tdb
+   -rwx------  1 stavros  staff  148 Jun 18 17:33 a2.tdb
 
 TileDB created two separate attribute files in fragment subdirectory
 ``__3f4622ed4ec1486ea3450f66c905f8cc_1529357638905``: ``a1.tdb`` that stores the cell values
-on attribute ``a1`` (observe the file size is ``16`` bytes, equal to the size
-required for storing 16 1-byte characters), and ``a2.tdb`` that stores the cell
-values on attribute ``a2`` (observe the file size is ``128`` bytes, equal to the
+on attribute ``a1`` (the file size is ``16`` bytes, equal to the size
+required for storing 16 1-byte characters, plus 20 bytes of metadata overhead),
+and ``a2.tdb`` that stores the cell
+values on attribute ``a2`` (the file size is ``128`` bytes, equal to the
 size required for storing 32 4-byte floats, recalling that each cell stores
-two floats).
+two floats, plus the 20 bytes of metadata).
 
 

--- a/doc/source/tutorials/parallelism.rst
+++ b/doc/source/tutorials/parallelism.rst
@@ -20,28 +20,30 @@ parallelization within the query. TileDB uses the
 `Intel Threaded Building Blocks <https://www.threadingbuildingblocks.org/>`__
 library for efficient scheduling and load balancing.
 
-Compression
-~~~~~~~~~~~
+Filtering
+~~~~~~~~~
 
-For compression during read queries, TileDB uses the following nested
-parallelism strategy::
+For filtering (such as compression) during read queries, TileDB uses the
+following nested parallelism strategy::
 
     parallel_for_each attribute being read:
       parallel_for_each tile of the attribute overlapping the subarray:
         parallel_for_each chunk of the tile:
-          decompress chunk
+          filter chunk
 
-The "chunks" of a tile are controlled by an internal TileDB parameter
-set to 64KB that is currently not modifiable by users. The nested parallelism
-in reads allows
-for maximum utilization of the available cores for decompression, in either
-the case where the query intersects few large tiles or many small tiles.
-For writes, TileDB uses the same strategy as reads::
+The "chunks" of a tile are controlled by a TileDB filter list parameter
+that defaults to 64KB. See the :ref:`filters` tutorial to see how.
+
+The nested parallelism in reads allows for maximum utilization of the available
+cores for filtering (e.g. decompression), in either the case where the query
+intersects few large tiles or many small tiles. For writes, TileDB uses the same
+strategy as reads::
+
 
     parallel_for_each attribute being written:
       parallel_for_each tile of the attribute being written:
         parallel_for_each chunk of the tile:
-          compress chunk
+          filter chunk
 
 The configuration parameter ``sm.num_async_threads`` controls the number of
 threads available for use by asynchronous queries. It does not impact the
@@ -52,7 +54,7 @@ not recommended to modify this configuration parameter from its default setting.
 I/O
 ~~~
 
-After the tiles are compressed during a write query (or before decompression
+After the tiles are filtered during a write query (or before filtering
 during read queries), I/O operations are issued
 to the underlying persistent storage via TileDB's virtual filesystem (VFS)
 layer. For write queries, the configuration parameter ``sm.num_writer_threads``

--- a/doc/source/tutorials/tiling-dense.rst
+++ b/doc/source/tutorials/tiling-dense.rst
@@ -33,7 +33,7 @@ Basic concepts and definitions
       dense TileDB arrays, for each space tile, there is a corresponding
       data tile **per attribute** that stores the values of the cells on
       this attribute contained in the space tile. A data tile is the
-      **atomic unit of I/O and compression**.
+      **atomic unit of I/O and filtering**.
 
 .. toggle-header::
     :header: **Tile order**

--- a/doc/source/tutorials/tiling-sparse.rst
+++ b/doc/source/tutorials/tiling-sparse.rst
@@ -57,7 +57,7 @@ would produce 4 data tiles with 3 (upper left), 12 (upper right),
    :align: center
    :scale: 30 %
 
-Recall that the data tile in TileDB is the atomic unit of IO and compression.
+Recall that the data tile in TileDB is the atomic unit of IO and filtering.
 The **tile size imbalance** that may result from space tiling can
 lead to ineffective compression (if numerous data tiles contain only a
 handful of values), and inefficient reads (if the subarray you wish

--- a/doc/source/tutorials/writing-dense.rst
+++ b/doc/source/tutorials/writing-dense.rst
@@ -390,29 +390,6 @@ in the figure below.
    :scale: 40 %
 
 
-Let us inspect the contents of the array folder, after running the above
-example:
-
-.. code-block:: bash
-
-  $ ls -l writing_dense_padding/
-  total 8
-  drwx------  4 stavros  staff  136 Jun 25 10:28 __76679576e9454d1eb08e8a2f5bf8fd29_1529936885146
-  -rwx------  1 stavros  staff  109 Jun 25 10:28 __array_schema.tdb
-  -rwx------  1 stavros  staff    0 Jun 25 10:28 __lock.tdb
-  $ ls -l writing_dense_padding/__76679576e9454d1eb08e8a2f5bf8fd29_1529936885146/
-  total 16
-  -rwx------  1 stavros  staff  106 Jun 25 10:28 __fragment_metadata.tdb
-  -rwx------  1 stavros  staff   32 Jun 25 10:28 a.tdb
-
-As expected, there is a single fragment subdirectory. Observe the size of
-attribute file ``a.tdb``, which is 32 bytes. Given that the attribute type
-is ``int32`` (and since there is no compression), this implies that 8 cell
-values were written to the file, i.e., *two tiles*. This confirms that
-*padding* applies only to partially written tiles, whereas completely
-empty tiles are not materialized at all.
-
-
 Multiple writes / Updates
 -------------------------
 
@@ -728,6 +705,6 @@ Writing and performance
 -----------------------
 
 The writing performance can be affected by various factors, such as the
-tiling, compression and query layout. See the
+tiling, filters and query layout. See the
 :ref:`performance/introduction` tutorial for
 more information about the TileDB performance.

--- a/examples/c_api/filters.c
+++ b/examples/c_api/filters.c
@@ -1,0 +1,227 @@
+/**
+ * @file   filters.c
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This is a part of the TileDB filters tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/filters.html
+ *
+ * When run, this program will create a 2D sparse array with several filters,
+ * write some data to it, and read a slice of the data back.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <tiledb/tiledb.h>
+
+// Name of array.
+const char* array_name = "filters_array";
+
+void create_array() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
+  int dim_domain[] = {1, 4, 1, 4};
+  int tile_extents[] = {4, 4};
+  tiledb_dimension_t* d1;
+  tiledb_dimension_alloc(
+      ctx, "rows", TILEDB_INT32, &dim_domain[0], &tile_extents[0], &d1);
+  tiledb_dimension_t* d2;
+  tiledb_dimension_alloc(
+      ctx, "cols", TILEDB_INT32, &dim_domain[2], &tile_extents[1], &d2);
+
+  // Create domain
+  tiledb_domain_t* domain;
+  tiledb_domain_alloc(ctx, &domain);
+  tiledb_domain_add_dimension(ctx, domain, d1);
+  tiledb_domain_add_dimension(ctx, domain, d2);
+
+  // Create two fixed-length attributes "a1" and "a2"
+  tiledb_attribute_t *a1, *a2;
+  tiledb_attribute_alloc(ctx, "a1", TILEDB_UINT32, &a1);
+  tiledb_attribute_alloc(ctx, "a2", TILEDB_INT32, &a2);
+
+  // a1 will be filtered by bit width reduction followed by zstd
+  // compression.
+  tiledb_filter_list_t* a1_filters;
+  tiledb_filter_list_alloc(ctx, &a1_filters);
+  tiledb_filter_t* bit_width_reduction;
+  tiledb_filter_alloc(
+      ctx, TILEDB_FILTER_BIT_WIDTH_REDUCTION, &bit_width_reduction);
+  tiledb_filter_t* compression_zstd;
+  tiledb_filter_alloc(ctx, TILEDB_FILTER_ZSTD, &compression_zstd);
+  tiledb_filter_list_add_filter(ctx, a1_filters, bit_width_reduction);
+  tiledb_filter_list_add_filter(ctx, a1_filters, compression_zstd);
+  tiledb_attribute_set_filter_list(ctx, a1, a1_filters);
+
+  // a2 will just have a single gzip compression filter.
+  tiledb_filter_list_t* a2_filters;
+  tiledb_filter_list_alloc(ctx, &a2_filters);
+  tiledb_filter_t* compression_gzip;
+  tiledb_filter_alloc(ctx, TILEDB_FILTER_GZIP, &compression_gzip);
+  tiledb_filter_list_add_filter(ctx, a2_filters, compression_gzip);
+  tiledb_attribute_set_filter_list(ctx, a2, a2_filters);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  tiledb_array_schema_alloc(ctx, TILEDB_SPARSE, &array_schema);
+  tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  tiledb_array_schema_set_domain(ctx, array_schema, domain);
+  tiledb_array_schema_add_attribute(ctx, array_schema, a1);
+  tiledb_array_schema_add_attribute(ctx, array_schema, a2);
+
+  // Create array
+  tiledb_array_create(ctx, array_name, array_schema);
+
+  // Clean up
+  tiledb_filter_free(&compression_gzip);
+  tiledb_filter_free(&compression_zstd);
+  tiledb_filter_free(&bit_width_reduction);
+  tiledb_filter_list_free(&a1_filters);
+  tiledb_filter_list_free(&a2_filters);
+  tiledb_attribute_free(&a1);
+  tiledb_attribute_free(&a2);
+  tiledb_dimension_free(&d1);
+  tiledb_dimension_free(&d2);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
+  tiledb_ctx_free(&ctx);
+}
+
+void write_array() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // Open array for writing
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, array_name, &array);
+  tiledb_array_open(ctx, array, TILEDB_WRITE);
+
+  // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
+  int coords[] = {1, 1, 2, 4, 2, 3};
+  uint64_t coords_size = sizeof(coords);
+  uint32_t data_a1[] = {1, 2, 3};
+  uint64_t data_a1_size = sizeof(data_a1);
+  int32_t data_a2[] = {-1, -2, -3};
+  uint64_t data_a2_size = sizeof(data_a2);
+
+  // Create the query
+  tiledb_query_t* query;
+  tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
+  tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
+  tiledb_query_set_buffer(ctx, query, "a1", data_a1, &data_a1_size);
+  tiledb_query_set_buffer(ctx, query, "a2", data_a2, &data_a2_size);
+  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+
+  // Submit query
+  tiledb_query_submit(ctx, query);
+
+  // Close array
+  tiledb_array_close(ctx, array);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+  tiledb_ctx_free(&ctx);
+}
+
+void read_array() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // Open array for reading
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, array_name, &array);
+  tiledb_array_open(ctx, array, TILEDB_READ);
+
+  // Slice only rows 1, 2 and cols 2, 3, 4
+  int subarray[] = {1, 2, 2, 4};
+
+  // Calculate maximum buffer sizes
+  uint64_t coords_size;
+  uint64_t data_size;
+  tiledb_array_max_buffer_size(ctx, array, "a1", subarray, &data_size);
+  tiledb_array_max_buffer_size(
+      ctx, array, TILEDB_COORDS, subarray, &coords_size);
+
+  // Prepare the vector that will hold the result
+  int* coords = (int*)malloc(coords_size);
+  int* data = (int*)malloc(data_size);
+
+  // Create query
+  tiledb_query_t* query;
+  tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
+  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
+  tiledb_query_set_buffer(ctx, query, "a1", data, &data_size);
+  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+
+  // Submit query
+  tiledb_query_submit(ctx, query);
+
+  // Close array
+  tiledb_array_close(ctx, array);
+
+  // Print out the results.
+  int result_num = (int)(data_size / sizeof(int));
+  for (int r = 0; r < result_num; r++) {
+    int i = coords[2 * r], j = coords[2 * r + 1];
+    int a = data[r];
+    printf("Cell (%d, %d) has a1 data %d\n", i, j, a);
+  }
+
+  // Clean up
+  free((void*)coords);
+  free((void*)data);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+  tiledb_ctx_free(&ctx);
+}
+
+int main() {
+  // Get object type
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+  tiledb_object_t type;
+  tiledb_object_type(ctx, array_name, &type);
+  tiledb_ctx_free(&ctx);
+
+  if (type != TILEDB_ARRAY) {
+    create_array();
+    write_array();
+  }
+
+  read_array();
+
+  return 0;
+}

--- a/examples/cpp_api/filters.cc
+++ b/examples/cpp_api/filters.cc
@@ -1,0 +1,150 @@
+/**
+ * @file   filters.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This is a part of the TileDB filters tutorial:
+ *   https://docs.tiledb.io/en/latest/tutorials/filters.html
+ *
+ * When run, this program will create a 2D sparse array with several filters,
+ * write some data to it, and read a slice of the data back.
+ *
+ */
+
+#include <iostream>
+#include <tiledb/tiledb>
+
+using namespace tiledb;
+
+// Name of array.
+std::string array_name("filters_array");
+
+void create_array() {
+  // Create a TileDB context.
+  Context ctx;
+
+  // The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{1, 4}}, 4))
+      .add_dimension(Dimension::create<int>(ctx, "cols", {{1, 4}}, 4));
+
+  // The array will be sparse.
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+
+  // Create two fixed-length attributes "a1" and "a2"
+  auto a1 = Attribute::create<uint32_t>(ctx, "a1");
+  auto a2 = Attribute::create<int32_t>(ctx, "a2");
+
+  // a1 will be filtered by bit width reduction followed by zstd
+  // compression.
+  Filter bit_width_reduction(ctx, TILEDB_FILTER_BIT_WIDTH_REDUCTION);
+  Filter compression_zstd(ctx, TILEDB_FILTER_ZSTD);
+  FilterList a1_filters(ctx);
+  a1_filters.add_filter(bit_width_reduction).add_filter(compression_zstd);
+  a1.set_filter_list(a1_filters);
+
+  // a2 will just have a single gzip compression filter.
+  FilterList a2_filters(ctx);
+  a2_filters.add_filter({ctx, TILEDB_FILTER_GZIP});
+  a2.set_filter_list(a2_filters);
+
+  // Add the attributes
+  schema.add_attribute(a1).add_attribute(a2);
+
+  // Create the (empty) array on disk.
+  Array::create(array_name, schema);
+}
+
+void write_array() {
+  Context ctx;
+
+  // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
+  std::vector<int> coords = {1, 1, 2, 4, 2, 3};
+  std::vector<uint32_t> data_a1 = {1, 2, 3};
+  std::vector<int32_t> data_a2 = {-1, -2, -3};
+
+  // Open the array for writing and create the query.
+  Array array(ctx, array_name, TILEDB_WRITE);
+  Query query(ctx, array, TILEDB_WRITE);
+  query.set_layout(TILEDB_UNORDERED)
+      .set_buffer("a1", data_a1)
+      .set_buffer("a2", data_a2)
+      .set_coordinates(coords);
+
+  // Perform the write and close the array.
+  query.submit();
+  array.close();
+}
+
+void read_array() {
+  Context ctx;
+
+  // Prepare the array for reading
+  Array array(ctx, array_name, TILEDB_READ);
+
+  // Slice only rows 1, 2 and cols 2, 3, 4
+  const std::vector<int> subarray = {1, 2, 2, 4};
+
+  // Prepare the vector that will hold the result.
+  // We take an upper bound on the result size, as we do not
+  // know a priori how big it is (since the array is sparse)
+  auto max_el = array.max_buffer_elements(subarray);
+  std::vector<uint32_t> data_a1(max_el["a1"].second);
+  std::vector<int> coords(max_el[TILEDB_COORDS].second);
+
+  // Prepare the query
+  Query query(ctx, array, TILEDB_READ);
+  query.set_subarray(subarray)
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_buffer("a1", data_a1)
+      .set_coordinates(coords);
+
+  // Submit the query and close the array.
+  query.submit();
+  array.close();
+
+  // Print out the results.
+  auto result_num = (int)query.result_buffer_elements()["a1"].second;
+  for (int r = 0; r < result_num; r++) {
+    int i = coords[2 * r], j = coords[2 * r + 1];
+    int a = data_a1[r];
+    std::cout << "Cell (" << i << ", " << j << ") has a1 data " << a << "\n";
+  }
+}
+
+int main() {
+  Context ctx;
+
+  if (Object::object(ctx, array_name).type() != Object::Type::Array) {
+    create_array();
+    write_array();
+  }
+
+  read_array();
+  return 0;
+}

--- a/tiledb/sm/cpp_api/filter.h
+++ b/tiledb/sm/cpp_api/filter.h
@@ -49,7 +49,8 @@ namespace tiledb {
  * @code{.cpp}
  * tiledb::Context ctx;
  * tiledb::Filter f(ctx, TILEDB_FILTER_ZSTD);
- * f.set_option(TILEDB_COMPRESSION_LEVEL, 5);
+ * int level = 5;
+ * f.set_option(TILEDB_COMPRESSION_LEVEL, &level);
  * @endcode
  */
 class Filter {
@@ -117,7 +118,8 @@ class Filter {
    *
    * @code{.cpp}
    * tiledb::Filter f(ctx, TILEDB_FILTER_ZSTD);
-   * f.set_option(TILEDB_COMPRESSION_LEVEL, 5);
+   * int level = 5;
+   * f.set_option(TILEDB_COMPRESSION_LEVEL, &level);
    * @endcode
    *
    * @param option Enumerated option to set.


### PR DESCRIPTION
Closes #987. This also adjusts some text in other tutorials to refer to filtering in general instead of compression.

Note that some references in the docs to exact file sizes on disk are no longer true, due to the extra metadata that the filter pipeline adds (even with no filters). I fixed the ones I knew about.