### PR TITLE
Add test for array compatiblity. #956

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
 
     - os: osx
 
+before_install:
+    - git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git test/inputs/arrays/read_compatibility_test
+
 install:
     # Install clangformat (v5.0)
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -60,3 +60,319 @@ TEST_CASE(
     REQUIRE(false);
   }
 }
+
+TEST_CASE(
+    "Backwards compatibility: Test reading arrays written with previous "
+    "version of tiledb",
+    "[backwards-compat]") {
+  Context ctx;
+  std::string compat_folder(arrays_dir + "/read_compatibility_test");
+  if (Object::object(ctx, compat_folder).type() != Object::Type::Group)
+    return;
+
+  std::string encryption_key = "unittestunittestunittestunittest";
+
+  tiledb::ObjectIter versions_iter(ctx, compat_folder);
+  for (const auto& groupVersions : versions_iter) {
+    tiledb::ObjectIter obj_iter(ctx, groupVersions.uri());
+    for (const auto& object : obj_iter) {
+      // REQUIRE(read_array(object.uri()))
+      Array* array;
+      // Check for if array is encrypted based on name for now
+      if (object.uri().find("_encryption_AES_256_GCM") != std::string::npos) {
+        array = new Array(
+            ctx,
+            object.uri(),
+            TILEDB_READ,
+            TILEDB_AES_256_GCM,
+            encryption_key.c_str(),
+            static_cast<uint32_t>(encryption_key.size() * sizeof(char)));
+      } else {
+        array = new Array(ctx, object.uri(), TILEDB_READ);
+      }
+      Query query(ctx, *array);
+
+      std::unordered_map<std::string, std::pair<uint64_t*, void*>> buffers;
+      for (auto attr : array->schema().attributes()) {
+        std::string attributeName = attr.first;
+        uint64_t* offsets = static_cast<uint64_t*>(malloc(sizeof(uint64_t)));
+        void* values = malloc(tiledb_datatype_size(attr.second.type()));
+        if (attr.second.variable_sized()) {
+          buffers.emplace(attributeName, std::make_pair(offsets, values));
+        } else {
+          buffers.emplace(attributeName, std::make_pair(nullptr, values));
+        }
+
+        switch (attr.second.type()) {
+          case TILEDB_INT8: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<int8_t*>(values), 1);
+              buffers.emplace(attributeName, std::make_pair(offsets, values));
+            } else {
+              query.set_buffer(attributeName, static_cast<int8_t*>(values), 1);
+              buffers.emplace(attributeName, std::make_pair(nullptr, values));
+            }
+            break;
+          }
+          case TILEDB_UINT8: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<uint8_t*>(values), 1);
+            } else {
+              query.set_buffer(attributeName, static_cast<uint8_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_INT16: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<int16_t*>(values), 1);
+            } else {
+              query.set_buffer(attributeName, static_cast<int16_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_UINT16: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<uint16_t*>(values), 1);
+            } else {
+              query.set_buffer(
+                  attributeName, static_cast<uint16_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_INT32: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<int32_t*>(values), 1);
+            } else {
+              query.set_buffer(attributeName, static_cast<int32_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_UINT32: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<uint32_t*>(values), 1);
+            } else {
+              query.set_buffer(
+                  attributeName, static_cast<uint32_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_INT64: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<int64_t*>(values), 1);
+            } else {
+              query.set_buffer(attributeName, static_cast<int64_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_UINT64: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<uint64_t*>(values), 1);
+            } else {
+              query.set_buffer(
+                  attributeName, static_cast<uint64_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_FLOAT32: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<float*>(values), 1);
+            } else {
+              query.set_buffer(attributeName, static_cast<float*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_FLOAT64: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<double*>(values), 1);
+            } else {
+              query.set_buffer(attributeName, static_cast<double*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_CHAR:
+          case TILEDB_STRING_ASCII:
+          case TILEDB_STRING_UTF8:
+          case TILEDB_STRING_UTF16:
+          case TILEDB_STRING_UTF32:
+          case TILEDB_STRING_UCS2:
+          case TILEDB_STRING_UCS4:
+          case TILEDB_ANY: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attributeName, offsets, 1, static_cast<char*>(values), 1);
+            } else {
+              query.set_buffer(attributeName, static_cast<char*>(values), 1);
+            }
+            break;
+          }
+        }
+      }
+
+      // Get domain to build coordinates
+      Domain domain = array->schema().domain();
+      uint64_t coordLength = domain.ndim();
+      uint64_t coordsSize = tiledb_datatype_size(domain.type()) * coordLength;
+      void* coordinates = malloc(coordLength);
+      void* expectedCoordinates =
+          malloc(tiledb_datatype_size(domain.type()) * coordLength);
+      switch (domain.type()) {
+        case TILEDB_INT8: {
+          query.set_coordinates(static_cast<int8_t*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<int8_t*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        case TILEDB_UINT8: {
+          query.set_coordinates(
+              static_cast<uint8_t*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<uint8_t*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        case TILEDB_INT16: {
+          query.set_coordinates(
+              static_cast<int16_t*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<int16_t*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        case TILEDB_UINT16: {
+          query.set_coordinates(
+              static_cast<uint16_t*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<uint16_t*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        case TILEDB_INT32: {
+          query.set_coordinates(
+              static_cast<int32_t*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<uint32_t*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        case TILEDB_UINT32: {
+          query.set_coordinates(
+              static_cast<uint32_t*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<uint32_t*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        case TILEDB_INT64: {
+          query.set_coordinates(
+              static_cast<int64_t*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<int64_t*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        case TILEDB_UINT64: {
+          query.set_coordinates(
+              static_cast<uint64_t*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<uint64_t*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        case TILEDB_FLOAT32: {
+          query.set_coordinates(static_cast<float*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<float*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        case TILEDB_FLOAT64: {
+          query.set_coordinates(static_cast<double*>(coordinates), coordLength);
+          for (size_t i = 0; i < coordLength; i++)
+            static_cast<double*>(expectedCoordinates)[i] = 1;
+          break;
+        }
+        default:
+          REQUIRE(false);
+      }
+
+      // Submit query
+      query.submit();
+
+      REQUIRE(memcmp(coordinates, expectedCoordinates, coordsSize) == 0);
+
+      // Check the results to make sure all values are set to 1
+      for (auto buff : buffers) {
+        std::pair<uint64_t*, void*> buffer = buff.second;
+        if (buffer.first != nullptr) {
+          REQUIRE(buffer.first[0] == 0);
+        }
+
+        Attribute attribute = array->schema().attribute(buff.first);
+        switch (attribute.type()) {
+          case TILEDB_INT8: {
+            REQUIRE(static_cast<int8_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_UINT8: {
+            REQUIRE(static_cast<int8_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_INT16: {
+            REQUIRE(static_cast<int16_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_UINT16: {
+            REQUIRE(static_cast<uint16_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_INT32: {
+            REQUIRE(static_cast<int32_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_UINT32: {
+            REQUIRE(static_cast<uint32_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_INT64: {
+            REQUIRE(static_cast<int64_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_UINT64: {
+            REQUIRE(static_cast<uint64_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_FLOAT32: {
+            REQUIRE(static_cast<float*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_FLOAT64: {
+            REQUIRE(static_cast<double*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_CHAR:
+          case TILEDB_STRING_ASCII:
+          case TILEDB_STRING_UTF8:
+          case TILEDB_STRING_UTF16:
+          case TILEDB_STRING_UTF32:
+          case TILEDB_STRING_UCS2:
+          case TILEDB_STRING_UCS4:
+          case TILEDB_ANY: {
+            REQUIRE(static_cast<char*>(buffer.second)[0] == '1');
+            break;
+          }
+        }
+
+        // Free buffers
+        if (buffer.first != nullptr) {
+          free(buffer.first);
+        }
+        if (buffer.second != nullptr) {
+          free(buffer.second);
+        }
+      }
+      delete array;
+    }
+  }
+}


### PR DESCRIPTION
This add a small application `test_array_builder` for building test arrays based on the current tiledb version to be used for unit testing of backwards compatibility.

A new unit test was added for opening and reading from these test arrays. "Backwards compatibility: Test reading arrays written with previous version of tiledb".

Closes #956