### PR TITLE
Fix unnecessary tile copy in global order write finalize.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 * Added missing check if coordinates obey the global order in global order sparse writes. [#1039](https://github.com/TileDB-Inc/TileDB/pull/1039)
 * Changed coordinates to always be split before filtering. #1054 
 * Added type-safe filter option methods to C++ API. #1062
+* Fixed performance bug during global order write finalization. #1065
 
 # TileDB v1.4.0 Release Notes
 

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -1214,9 +1214,11 @@ Status Writer::global_write_handle_last_tile() {
 
     if (!last_tile.empty()) {
       std::vector<Tile>& tiles = attribute_tiles[i];
-      tiles.push_back(last_tile);
+      // Note making shallow clones here, as it's not necessary to copy the
+      // underlying tile Buffers.
+      tiles.push_back(last_tile.clone(false));
       if (!last_tile_var.empty())
-        tiles.push_back(last_tile_var);
+        tiles.push_back(last_tile_var.clone(false));
       if (attr == constants::coords)
         RETURN_NOT_OK(compute_coords_metadata<T>(tiles, meta));
       RETURN_NOT_OK(filter_tiles(attr, &tiles));

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -86,11 +86,26 @@ class Tile {
       Buffer* buff,
       bool owns_buff);
 
-  /** Copy constructor. */
+  /**
+   * Copy constructor. This performs a deep copy (including potential memcpy of
+   * underlying buffers).
+   */
   Tile(const Tile& tile);
+
+  /** Move constructor. */
+  Tile(Tile&& tile);
 
   /** Destructor. */
   ~Tile();
+
+  /**
+   * Copy-assign operator. This performs a deep copy (including potential memcpy
+   * of underlying buffers).
+   */
+  Tile& operator=(const Tile& tile);
+
+  /** Move-assign operator. */
+  Tile& operator=(Tile&& tile);
 
   /* ********************************* */
   /*                API                */
@@ -142,6 +157,16 @@ class Tile {
 
   /** Returns the cell size. */
   uint64_t cell_size() const;
+
+  /**
+   * Returns a shallow or deep copy of this Tile.
+   *
+   * @param deep_copy If true, a deep copy is performed, including potentially
+   *    memcpying the underlying Buffer. If false, a shallow copy is performed,
+   *    which sets the clone's Buffer equal to Tile's buffer pointer.
+   * @return New Tile
+   */
+  Tile clone(bool deep_copy) const;
 
   /** Returns the buffer data pointer at the current offset. */
   void* cur_data() const;
@@ -270,9 +295,6 @@ class Tile {
    */
   void zip_coordinates();
 
-  /** Copy operator. */
-  Tile& operator=(const Tile& tile);
-
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -311,6 +333,9 @@ class Tile {
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(Tile& tile);
 };
 
 }  // namespace sm


### PR DESCRIPTION
Closes #1064.