### PR TITLE
Add missing aws key config documentation

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -434,6 +434,12 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.s3.region` <br>
  *    The S3 region, if S3 is enabled. <br>
  *    **Default**: us-east-1
+ * - `vfs.s3.aws_access_key_id` <br>
+ *    Set the AWS_ACCESS_KEY_ID <br>
+ *    **Default**: ""
+ * - `vfs.s3.aws_secret_access_key` <br>
+ *    Set the AWS_SECRET_ACCESS_KEY <br>
+ *    **Default**: ""
  * - `vfs.s3.scheme` <br>
  *    The S3 scheme (`http` or `https`), if S3 is enabled. <br>
  *    **Default**: https

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -288,6 +288,12 @@ class Config {
    * - `vfs.s3.region` <br>
    *    The S3 region, if S3 is enabled. <br>
    *    **Default**: us-east-1
+   * - `vfs.s3.aws_access_key_id` <br>
+   *    Set the AWS_ACCESS_KEY_ID <br>
+   *    **Default**: ""
+   * - `vfs.s3.aws_secret_access_key` <br>
+   *    Set the AWS_SECRET_ACCESS_KEY <br>
+   *    **Default**: ""
    * - `vfs.s3.scheme` <br>
    *    The S3 scheme (`http` or `https`), if S3 is enabled. <br>
    *    **Default**: https

--- a/tiledb/sm/storage_manager/config.h
+++ b/tiledb/sm/storage_manager/config.h
@@ -256,9 +256,11 @@ class Config {
    *    The S3 region, if S3 is enabled. <br>
    *    **Default**: us-east-1
    * - `vfs.s3.aws_access_key_id` <br>
-   *    Set the AWS_ACCESS_KEY_ID
+   *    Set the AWS_ACCESS_KEY_ID <br>
+   *    **Default**: ""
    * - `vfs.s3.aws_secret_access_key` <br>
-   *    Set the AWS_SECRET_ACCESS_KEY
+   *    Set the AWS_SECRET_ACCESS_KEY <br>
+   *    **Default**: ""
    * - `vfs.s3.scheme` <br>
    *    The S3 scheme (`http` or `https`), if S3 is enabled. <br>
    *    **Default**: https


### PR DESCRIPTION
Add missing aws key config documentation. Closes #1071