### PR TITLE
Show error when doc target doesn't exist (b/c Doxygen)

### DIFF
--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -178,4 +178,9 @@ if(DOXYGEN_FOUND)
     COMMENT "Generating API documentation with Doxygen" VERBATIM
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/doxyfile.in
   )
+else(DOXYGEN_FOUND)
+  add_custom_target(doc
+    _______doc
+    COMMENT "!! Docs cannot be built. Please install Doxygen and re-run cmake. !!" VERBATIM
+  )
 endif(DOXYGEN_FOUND)


### PR DESCRIPTION
The doc target currently isn't created unless Doxygen is installed, which causes `doc/local-build.sh` to  fail with a make error ("no target doc") that doesn't mention the underlying problem.