### PR TITLE
Don't link shared zlib when it was built w/ superbuild

### DIFF
--- a/cmake/Modules/FindZlib_EP.cmake
+++ b/cmake/Modules/FindZlib_EP.cmake
@@ -36,8 +36,13 @@ include(TileDBCommon)
 # Search the path set during the superbuild for the EP.
 set(ZLIB_PATHS ${TILEDB_EP_INSTALL_PREFIX})
 
-# First try the builtin find module.
-find_package(ZLIB QUIET ${TILEDB_DEPS_NO_DEFAULT_PATH})
+# Try the builtin find module unless built w/ EP superbuild
+#  Built-in module only supports shared zlib, so using it
+#  w/in superbuild we end up linking zlib.dll.
+#  https://gitlab.kitware.com/cmake/cmake/issues/18029)
+if (NOT TILEDB_ZLIB_EP_BUILT)
+  find_package(ZLIB QUIET ${TILEDB_DEPS_NO_DEFAULT_PATH})
+endif()
 
 # Next try finding the superbuild external project
 if (NOT ZLIB_FOUND)


### PR DESCRIPTION
The built-in module does not support zlibstatic, so it finds
zlib.lib/dll on the second pass (instead of zlibstatic)., i think  we should avoid linking zlib.dll
when building with superbuild, preferring zlibstatic. The binary releases do not link zlib.dll, and avoiding the linkage  simplifies binding distribution and reduces risk of dll conflict (esp on windows).