### PR TITLE
Preserve anonymous attributes in ArraySchema copy constructor

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -563,6 +563,29 @@ TEST_CASE("C++ API: Encrypted array", "[cppapi], [encryption]") {
     vfs.remove_dir(array_name);
 }
 
+TEST_CASE(
+    "C++ API: Open array with anonymous attribute",
+    "[cppapi], [cppapi-open-array-anon-attr]") {
+  Context ctx;
+  VFS vfs(ctx);
+  const std::string array_name = "cppapi_open_array_anon_attr";
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  // Create array
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "d", {{1, 4}}, 4));
+  ArraySchema schema(ctx, TILEDB_DENSE);
+  schema.set_domain(domain);
+  schema.add_attribute(Attribute::create<int>(ctx, ""));
+  Array::create(array_name, schema);
+
+  Array array(ctx, array_name, TILEDB_READ);
+  auto reloaded_schema = array.schema();
+
+  REQUIRE(reloaded_schema.attribute_num() == 1);
+}
+
 TEST_CASE("C++ API: Open array at", "[cppapi], [cppapi-open-array-at]") {
   Context ctx;
   VFS vfs(ctx);

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -108,7 +108,7 @@ ArraySchema::ArraySchema(const ArraySchema* array_schema) {
 
   for (auto attr : array_schema->attributes_) {
     if (attr->name() != constants::key_attr_name)
-      add_attribute(attr);
+      add_attribute(attr, false);
   }
   for (const auto& attr : attributes_)
     attribute_map_[attr->name()] = attr;


### PR DESCRIPTION
`ArraySchema::ArraySchema(const ArraySchema* array_schema)` calls `ArraySchema::add_attribute`, which checks for special names by default. This was causing an error when reading an array written with TileDB-Py's `from_numpy`, which creates anonymous attributes.

```
Cannot add attribute; Attribute names starting with '__' are reserved
```