### PR TITLE
Unblock 'S3::vfs_thread_pool_' worker threads for multipart upload requests

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -105,6 +105,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/hdfs_filesystem.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/posix.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3_thread_pool_executor.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/vfs.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/vfs_file_handle.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/win.cc

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.cc
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.cc
@@ -1,0 +1,88 @@
+/**
+ * @file   s3_thread_pool_executor.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the S3ThreadPoolExecutor class.
+ */
+
+#ifdef HAVE_S3
+
+#include <cassert>
+
+#include "tiledb/sm/filesystem/s3_thread_pool_executor.h"
+#include "tiledb/sm/misc/status.h"
+
+namespace tiledb {
+namespace sm {
+
+S3ThreadPoolExecutor::S3ThreadPoolExecutor(ThreadPool* const thread_pool)
+    : thread_pool_(thread_pool) {
+  assert(thread_pool_);
+}
+
+S3ThreadPoolExecutor::~S3ThreadPoolExecutor() {
+  std::unique_lock<std::mutex> lock_guard(tasks_lock_);
+  std::unordered_set<std::shared_ptr<std::future<Status>>> tasks =
+      std::move(tasks_);
+  tasks_.clear();
+  lock_guard.unlock();
+
+  // Wait for all outstanding tasks to complete.
+  for (auto& task : tasks) {
+    task->wait();
+    assert(task->get().ok());
+  }
+}
+
+bool S3ThreadPoolExecutor::SubmitToThread(std::function<void()>&& fn) {
+  std::shared_ptr<std::future<Status>> task_ptr =
+      std::make_shared<std::future<Status>>();
+  auto wrapped_fn = [this, fn, task_ptr]() -> Status {
+    fn();
+
+    std::unique_lock<std::mutex> lock_guard(tasks_lock_);
+    // If 'tasks_' is empty, the S3ThreadPoolExecutor instance is destructing.
+    if (!tasks_.empty()) {
+      tasks_.erase(task_ptr);
+    }
+    lock_guard.unlock();
+    return Status::Ok();
+  };
+
+  *task_ptr = std::move(thread_pool_->enqueue(wrapped_fn));
+  std::unique_lock<std::mutex> lock_guard(tasks_lock_);
+  tasks_.emplace(std::move(task_ptr));
+  lock_guard.unlock();
+
+  return true;
+}
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // HAVE_S3

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.h
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.h
@@ -1,0 +1,78 @@
+/**
+ * @file   s3_thread_pool_executor.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the S3ThreadPoolExecutor class.
+ */
+
+#ifndef TILEDB_S3_THREAD_POOL_EXECUTOR_H
+#define TILEDB_S3_THREAD_POOL_EXECUTOR_H
+
+#ifdef HAVE_S3
+
+#include <aws/core/utils/threading/Executor.h>
+#include <unordered_set>
+
+#include "tiledb/sm/misc/thread_pool.h"
+
+namespace tiledb {
+namespace sm {
+
+class S3ThreadPoolExecutor : public Aws::Utils::Threading::Executor {
+ public:
+  /** Constructor. */
+  explicit S3ThreadPoolExecutor(ThreadPool* thread_pool);
+
+  /** Destructor. */
+  ~S3ThreadPoolExecutor();
+
+  S3ThreadPoolExecutor(const S3ThreadPoolExecutor&) = delete;
+  S3ThreadPoolExecutor& operator=(const S3ThreadPoolExecutor&) = delete;
+  S3ThreadPoolExecutor(S3ThreadPoolExecutor&&) = delete;
+  S3ThreadPoolExecutor& operator=(S3ThreadPoolExecutor&&) = delete;
+
+ protected:
+  /** Derived from base class. */
+  bool SubmitToThread(std::function<void()>&&) override;
+
+ private:
+  /** The underlying threadpool. */
+  ThreadPool* const thread_pool_;
+
+  /** All future handles associated with outstanding tasks. */
+  std::unordered_set<std::shared_ptr<std::future<Status>>> tasks_;
+
+  /** Protects 'tasks_'. */
+  std::mutex tasks_lock_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // HAVE_S3
+#endif  // TILEDB_S3_THREAD_POOL_EXECUTOR_H


### PR DESCRIPTION
Closes #923

Currently, S3::write_multipart() individually dispatches each upload part request
to the S3::vfs_thread_pool_. The calling thread blocks until all requests have
completed. Each upload request blocks on the threadpool worker thread until
completion. This prevents the S3::vfs_thread_pool_ from doing other useful
work while AWS is handling the request.

Instead, let's just dispatch all upload part requests through the async
AWS client interface and wait for them to complete on the calling thread.
The end result is that we relieve congestion on the S3::vfs_thread_pool_
and only block the calling thread.

To do this, I've refactored S3::make_upload_part_req() into two routines:
S3::make_upload_part_req() and S3::get_make_upload_part_req().

Calling the first routine will return an opaque context that the caller
will pass into the second routine. The second routine will block
the calling thread until the part upload request completes.

Tests run: ./tiledb_unit *S3*

Notes:
- The 'vfs_thread_pool_' is now unused within the S3 class. It may be
removed from the class and constructor. However, I decided to leave this
alone for backwards compatibility since the constructor is a public
interface and it's just a pointer so the performance and memory footprint
is negligble.
- Made a few micro-optimizations