### PR TITLE
Add zlib dependency to awssdk

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -65,6 +65,9 @@ if (NOT AWSSDK_FOUND)
     if (TARGET ep_openssl)
       list(APPEND DEPENDS ep_openssl)
     endif()
+    if (TARGET ep_zlib)
+      list(APPEND DEPENDS ep_zlib)
+    endif()
 
     ExternalProject_Add(ep_awssdk
       PREFIX "externals"


### PR DESCRIPTION
Building 'ep_awssdk' directly fails with './bootstrap --enable-s3':

CMake Error at cmake/external_dependencies.cmake:10 (message):
  Could not find zlib
Call Stack (most recent call first):
  CMakeLists.txt:110 (include)

This dependency is hidden when doing a top-level 'make' because zlib is built
before awssdk.