### PR TITLE
Abort pending S3 multipart uploads on error path

### DIFF
--- a/tiledb/sm/global_state/unit_test_config.h
+++ b/tiledb/sm/global_state/unit_test_config.h
@@ -1,0 +1,141 @@
+/**
+ * @file   unit_test_config.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the UnitTestConfig class.
+ */
+
+#ifndef TILEDB_UNIT_TEST_CONFIG_H
+#define TILEDB_UNIT_TEST_CONFIG_H
+
+#include <cassert>
+
+#include "tiledb/sm/misc/macros.h"
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * A global singleton for communication between unit tests and their classes
+ * under test.
+ */
+class UnitTestConfig {
+ public:
+  /** Singleton instance. Thread-safe. */
+  static UnitTestConfig& instance() {
+    static UnitTestConfig self;
+    return self;
+  }
+
+  /** Wraps an attribute type to determine if it has been intentionally set. */
+  template <typename T>
+  class Attribute {
+   public:
+    /** Constructor. */
+    Attribute()
+        : set_(false) {
+    }
+
+    /** Destructor. */
+    ~Attribute() = default;
+
+    /**
+     * Returns true if the internal attribute has been set.
+     *
+     * @return bool
+     */
+    bool is_set() const {
+      return set_;
+    }
+
+    /**
+     * Sets the internal attribute.
+     *
+     * @param T the internal attribute value to set.
+     */
+    void set(const T& attr) {
+      attr_ = attr;
+      set_ = true;
+    }
+
+    /**
+     * Sets the internal attribute.
+     *
+     * @param T the internal attribute value to set.
+     */
+    void set(T&& attr) {
+      attr_ = std::move(attr);
+      set_ = true;
+    }
+
+    /**
+     * Unsets the internal attribute.
+     */
+    void reset() {
+      set_ = false;
+    }
+
+    /**
+     * Returns value of the internal attribute.
+     *
+     * @return T the internal attribute value.
+     */
+    T get() const {
+      assert(set_);
+      return attr_;
+    }
+
+   private:
+    DISABLE_COPY_AND_COPY_ASSIGN(Attribute);
+    DISABLE_MOVE_AND_MOVE_ASSIGN(Attribute);
+
+    /** True if 'attr_' has been set. */
+    bool set_;
+
+    /** Internal attribute. */
+    T attr_;
+  };
+
+  /** For every nth multipart upload request, return a non-OK status. */
+  Attribute<uint> s3_fail_every_nth_upload_request;
+
+ private:
+  /** Constructor. */
+  UnitTestConfig() = default;
+
+  /** Destructor. */
+  ~UnitTestConfig() = default;
+
+  DISABLE_COPY_AND_COPY_ASSIGN(UnitTestConfig);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(UnitTestConfig);
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_UNIT_TEST_CONFIG_H

--- a/tiledb/sm/misc/macros.h
+++ b/tiledb/sm/misc/macros.h
@@ -1,0 +1,59 @@
+/**
+ * @file   macros.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares common preprocessor macros.
+ */
+
+#ifndef TILEDB_MACROS_H
+#define TILEDB_MACROS_H
+
+/** Disables the copy constructor for class 'C'. */
+#define DISABLE_COPY(C) C(const C&) = delete
+
+/** Disables the copy-assign operator for class 'C'. */
+#define DISABLE_COPY_ASSIGN(C) C& operator=(const C&) = delete
+
+/** Disables the move constructor for class 'C'. */
+#define DISABLE_MOVE(C) C(C&&) = delete
+
+/** Disables the move-assign operator for class 'C'. */
+#define DISABLE_MOVE_ASSIGN(C) C& operator=(C&&) = delete
+
+/** Disables the copy constructor and assign operator for class 'C'. */
+#define DISABLE_COPY_AND_COPY_ASSIGN(C) \
+  DISABLE_COPY(C);                      \
+  DISABLE_COPY_ASSIGN(C)
+
+/** Disables the move-copy constructor and move-assign operator for class 'C'.
+ */
+#define DISABLE_MOVE_AND_MOVE_ASSIGN(C) \
+  DISABLE_MOVE(C);                      \
+  DISABLE_MOVE_ASSIGN(C)
+
+#endif  // TILEDB_MACROS_H


### PR DESCRIPTION
Closes #1068

1. Consolidates all state for a single upload multipart request into a single
   struct 'MultiPartUploadState'.
2. Refactored to support #1.
3. Introduced a shared Status that will be set to the last non-OK status
   from an individual part upload request. Defaults to OK.
4. When disconnecting or flushing an object, we'll invoke an 'Abort' request
   instead of a 'Complete' request if the shared state from #3 is non-OK.

Tests run: ./tiledb_unit *S3*