### PR TITLE
Disable 'S3ThreadPoolExecutor'

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -117,8 +117,6 @@ Status S3::init(const Config::S3Params& s3_config, ThreadPool* thread_pool) {
 
   client_config_ = std::unique_ptr<Aws::Client::ClientConfiguration>(
       new Aws::Client::ClientConfiguration);
-  client_config_->executor =
-      std::make_shared<S3ThreadPoolExecutor>(thread_pool);
   auto& config = *client_config_.get();
   if (!s3_config.region_.empty())
     config.region = s3_config.region_.c_str();


### PR DESCRIPTION
We're seeing occassional hangs in the unit tests.

From #s3:
When `VFS` destructs, it may destruct `thread_pool_` before `S3`. This leaves
the new S3ThreadPoolExecutor with a garbage 'vfs_thread_pool_' ptr. I would
normally expect some kind of segfault, but I wouldn't rule out a hang since the
behavior is technically undefined.

The bottom line is that I ran our unit tests hundreds of times (just using the AWS
`DefaultExecutor` instead our of `S3ThreadPoolExecutor`) without a hang. I think
for 1.5, we should just use the DefaultExecutor to reduce regression risk. I don't
see any of the locks or wait()s are hanging in the `S3ThreadPoolExecutor`, which
is why I suspect it is a lifetime issue.