### PR TITLE
Fix trivial warning in examples/c_api/vfs.c

### DIFF
--- a/examples/c_api/vfs.c
+++ b/examples/c_api/vfs.c
@@ -33,6 +33,7 @@
  * This program explores the various TileDB VFS tools.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -70,7 +71,13 @@ void dirs_files() {
   // Getting the file size
   uint64_t file_size;
   tiledb_vfs_file_size(ctx, vfs, "dir_A/file_A", &file_size);
-  printf("File size for 'dir_A/file_A': %llu\n", file_size);
+  char format_buf[256];
+  snprintf(
+      format_buf,
+      sizeof(format_buf),
+      "File size for 'dir_A/file_A': %%%s\n",
+      PRIu64);
+  printf(format_buf, file_size);
 
   // Moving files (moving directories is similar)
   printf("Moving file 'dir_A/file_A' to 'dir_A/file_B'\n");

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -903,7 +903,10 @@ Status StorageManager::get_fragment_info(
   uint64_t timestamp;
   assert(fragment_name.find_last_of('_') != std::string::npos);
   auto t_str = fragment_name.substr(fragment_name.find_last_of('_') + 1);
-  sscanf(t_str.c_str(), "%lld", (long long int*)&timestamp);
+  sscanf(
+      t_str.c_str(),
+      (std::string("%") + std::string(PRId64)).c_str(),
+      (long long int*)&timestamp);
 
   // Get fragment size
   uint64_t size;
@@ -1813,7 +1816,10 @@ void StorageManager::get_sorted_fragment_uris(
     // Get timestamp in the end of the name after '_'
     assert(fragment_name.find_last_of('_') != std::string::npos);
     t_str = fragment_name.substr(fragment_name.find_last_of('_') + 1);
-    sscanf(t_str.c_str(), "%lld", (long long int*)&t);
+    sscanf(
+        t_str.c_str(),
+        (std::string("%") + std::string(PRId64)).c_str(),
+        (long long int*)&t);
     if (t <= timestamp)
       sorted_fragment_uris->emplace_back(t, uri);
   }


### PR DESCRIPTION
This fixes:
/home/joe/Workspace/TileDB/examples/c_api/vfs.c:73:44: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
   printf("File size for 'dir_A/file_A': %llu\n", file_size);