### PR TITLE
Fix infinite loop in S3::ls() when the 'delimiter' is empty

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,7 @@
 * Preserve anonymous attributes in `ArraySchema` copy constructor. [#1144](https://github.com/TileDB-Inc/TileDB/pull/1144)
 * Fix non-virtual destructors in C++ API. [#1153](https://github.com/TileDB-Inc/TileDB/pull/1153)
 * Added zlib dependency to AWS SDK EP. [#1165](https://github.com/TileDB-Inc/TileDB/pull/1165)
+* Fixed a hang in the 'S3::ls()'. [#1183](https://github.com/TileDB-Inc/TileDB/pull/1182)
 * Many other small and miscellaneous bug fixes.
 
 ## API additions


### PR DESCRIPTION
From the documentation on Aws::String Aws::S3::Model::ListObjectsResult::GetNextMarker():
Note: This element is returned only if you have delimiter request parameter specified. If
response does not include the NextMaker and it is truncated, you can use the value of the
last Key in the response as the marker in the subsequent request to get the next set of
object keys.

So, when 1) the 'delimiter' attribute passed to S3::ls() is empty, and 2) the response
is truncated we get stuck in an infinite loop because we never set the correct marker
in the follow-up requests.