### PR TITLE
Upgrade to AWS C++ SDK 1.7.81

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@
 ############################################################
 
 cmake_minimum_required(VERSION 3.3)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 set(TILEDB_CMAKE_INPUTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/inputs")

--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -71,12 +71,12 @@ if (NOT AWSSDK_FOUND)
 
     ExternalProject_Add(ep_awssdk
       PREFIX "externals"
-      URL "https://github.com/aws/aws-sdk-cpp/archive/1.4.23.zip"
-      URL_HASH SHA1=32030b0fc44d956c1f0dc606044d555c155d40a6
+      URL "https://github.com/aws/aws-sdk-cpp/archive/1.7.81.zip"
+      URL_HASH SHA1=ea35fe7dcdace59014ebfd917f8cd696461c5413
       CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=Release
         -DENABLE_TESTING=OFF
-        -DBUILD_ONLY=s3\\;core
+        -DBUILD_ONLY=s3\\$<SEMICOLON>core
         -DBUILD_SHARED_LIBS=OFF
         -DCMAKE_INSTALL_BINDIR=lib
         -DENABLE_UNITY_BUILD=ON
@@ -102,6 +102,9 @@ endif ()
 if (AWSSDK_FOUND)
   set(AWS_SERVICES s3)
   AWSSDK_DETERMINE_LIBS_TO_LINK(AWS_SERVICES AWS_LINKED_LIBS)
+  list(APPEND AWS_LINKED_LIBS aws-c-common
+                              aws-c-event-stream
+                              aws-checksums)
   foreach (LIB ${AWS_LINKED_LIBS})
     find_library("AWS_FOUND_${LIB}"
       NAMES ${LIB}

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -138,6 +138,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/utils.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/uuid.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/win_constants.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/work_arounds.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/reader.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/writer.cc
@@ -268,6 +269,9 @@ if (TILEDB_S3)
     INTERFACE
       AWSSDK::aws-cpp-sdk-s3
       AWSSDK::aws-cpp-sdk-core
+      AWSSDK::aws-c-event-stream
+      AWSSDK::aws-checksums
+      AWSSDK::aws-c-common
   )
   if (NOT WIN32)
     # No Curl required on Windows.
@@ -408,6 +412,9 @@ if (TILEDB_STATIC)
   append_dep_lib(OpenSSL::Crypto)
   append_dep_lib(AWSSDK::aws-cpp-sdk-s3)
   append_dep_lib(AWSSDK::aws-cpp-sdk-core)
+  append_dep_lib(AWSSDK::aws-c-event-stream)
+  append_dep_lib(AWSSDK::aws-checksums)
+  append_dep_lib(AWSSDK::aws-c-common)
 
   # Spdlog is a special case because it is header-only.
   string(CONCAT TILEDB_STATIC_DEP_STRING

--- a/tiledb/sm/misc/work_arounds.cc
+++ b/tiledb/sm/misc/work_arounds.cc
@@ -1,0 +1,52 @@
+/**
+ * @file   work_arounds.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains one-off work arounds for external issues.
+ */
+
+// This is a work-around for a gcc bug that was fixed in v6.0:
+// https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899
+//
+// The C++ AWS SDK v1.7 introduced this bug into our build because it
+// references the hidden gcc symbol '__cpu_model'. To fix this, we
+// redefine it here with public visibility.
+//
+// The struct may not need to strictly match the definition in the gcc
+// library, but we're matching it here to be safe.
+//
+// For reference, the gcc definition can be found here:
+// https://github.com/gcc-mirror/gcc/blob/d353bf189d2bbaf4059f402ee4d2a5ea074c349f/libgcc/config/i386/cpuinfo.c
+#if __GNUC__ > 0 && __GNUC__ < 6
+__attribute__((visibility("default"))) struct __processor_model {
+  unsigned int __cpu_vendor;
+  unsigned int __cpu_type;
+  unsigned int __cpu_subtype;
+  unsigned int __cpu_features[1];
+} __cpu_model;
+#endif


### PR DESCRIPTION
This closes #1149.

As of 1.7, AWS builds three new libraries:
  aws-c-common
  aws-c-event-stream
  aws-checksums

These are now linked against from libtile_db.so

After the upgrade, I found that libtile_db.so contained the undefined symbols
from the static AWS SDK libraries. For example, here are some of the undefined
symbols that I identified within libaws-sdk-cpp-core.a:

DNS.cpp.o:
 U Aws::Utils::IsValidDnsLabel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
EnumParseOverflowContainer.cpp.o:
 U Aws::Utils::EnumParseOverflowContainer::StoreOverflow(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
EventStreamDecoder.cpp.o:
  U Aws::Utils::Event::EventStream::EventStream(Aws::Utils::Event::EventStreamDecoder&, unsigned long)
  U Aws::Utils::Event::EventStreamDecoder::~EventStreamDecoder()
  U Aws::Utils::Event::EventStreamDecoder::Reset()
  U Aws::Utils::Event::EventStreamDecoder::EventStreamDecoder(Aws::Utils::Event::EventStreamHandler*)
  U Aws::Utils::Event::EventStreamDecoder::~EventStreamDecoder()

The 'force_sym_resolution.cc' is a hack to resolve all of the above symbols. If we run into this
issue again, we can continue adding to the file.

I explained this in greater detail within the source file:
 * When compiling static libraries into shared libraries (for example, the shared libtiledb.so),
 * the linker may not embed unreferenced symbol definitions into the shared library. The shared
 * library may link correctly, but linking the shared library against an executable will throw
 * undefined reference errors.
 *
 * Ideally, we would unarchive each static library and link directly against the unarchived
 * object files. However, this process depends on OS system-specific tools (e.g. 'ar' on Linux).
 * Instead, this file is a hack to touch all of the undefined symbols. This will trick the
 * linker into resolving the undefined symbols in the shared library.

Additionally, I hit the following gcc bug with gcc-4.8 and gcc-5.3. It did
not reproduce on gcc-6:
https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899

I provided a work around in tiledb/sm/misc/work_arounds.cc, explained in the source.

Also note, this version of the AWS SDK has some accidental print statements to
std::out. I opened a PR against the AWS SDK to remove these:
https://github.com/aws/aws-sdk-cpp/pull/1108