### PR TITLE
Disable caching in unit-capi-kv.cc

### DIFF
--- a/test/src/unit-capi-kv.cc
+++ b/test/src/unit-capi-kv.cc
@@ -133,6 +133,17 @@ KVFx::KVFx() {
     REQUIRE(error == nullptr);
 #endif
   }
+  // Disable caching because deleted fragments are not correctly invalidated
+  // in the cache.
+  REQUIRE(
+      tiledb_config_set(
+          config, "sm.fragment_metadata_cache_size", "0", &error) == TILEDB_OK);
+  REQUIRE(
+      tiledb_config_set(config, "sm.tile_cache_size", "0", &error) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_config_set(config, "sm.array_schema_cache_size", "0", &error) ==
+      TILEDB_OK);
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
   vfs_ = nullptr;


### PR DESCRIPTION
In this test, we perform consolidation after multiple writes. The
fragments are deleted through the VFS. Currently, deleted fragments
are not invalidated properly and will cause this test to fail.