### PR TITLE
Fix lambda-captured `uri` within VFS::read()

### DIFF
--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -799,7 +799,7 @@ Status VFS::read(
       uint64_t thread_offset = offset + begin;
       auto thread_buffer = reinterpret_cast<char*>(buffer) + begin;
       results.push_back(thread_pool_->enqueue(
-          [this, &uri, thread_offset, thread_buffer, thread_nbytes]() {
+          [this, uri, thread_offset, thread_buffer, thread_nbytes]() {
             return read_impl(uri, thread_offset, thread_buffer, thread_nbytes);
           }));
     }


### PR DESCRIPTION
Wtihin VFS::read() we are scheduling a lambda on another thread that captures
the address of a variable, `uri`, on the scheduling thread. There is no guarantee
that `uri` will remain in-scope while the threadpool executes the lambda. We
need to either copy or move `uri` to the lambda.