### PR TITLE
Refactor 'cancel_all_tasks' out of 'ThreadPool'.

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -129,6 +129,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv_item.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv_iter.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/cancelable_tasks.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/constants.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/logger.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/stats.cc

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.cc
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.cc
@@ -75,6 +75,10 @@ bool S3ThreadPoolExecutor::SubmitToThread(std::function<void()>&& fn) {
   };
 
   *task_ptr = thread_pool_->enqueue(wrapped_fn);
+  if (!task_ptr->valid()) {
+    return false;
+  }
+
   std::unique_lock<std::mutex> lock_guard(tasks_lock_);
   tasks_.emplace(std::move(task_ptr));
   lock_guard.unlock();

--- a/tiledb/sm/misc/cancelable_tasks.cc
+++ b/tiledb/sm/misc/cancelable_tasks.cc
@@ -1,0 +1,102 @@
+/**
+ * @file   thread_pool.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the ThreadPool class.
+ */
+
+#include "tiledb/sm/misc/cancelable_tasks.h"
+
+namespace tiledb {
+namespace sm {
+
+CancelableTasks::CancelableTasks()
+    : outstanding_tasks_(0)
+    , should_cancel_(false) {
+}
+
+std::future<Status> CancelableTasks::enqueue(
+    ThreadPool* const thread_pool,
+    std::function<Status()>&& fn,
+    std::function<void()>&& on_cancel) {
+  std::function<Status()> wrapped_fn =
+      std::bind(&CancelableTasks::fn_wrapper, this, fn, on_cancel);
+
+  std::future<Status> task = thread_pool->enqueue(std::move(wrapped_fn));
+  if (task.valid()) {
+    std::unique_lock<std::mutex> lck(outstanding_tasks_mutex_);
+    ++outstanding_tasks_;
+  }
+
+  return task;
+}
+
+void CancelableTasks::cancel_all_tasks() {
+  {
+    std::unique_lock<std::mutex> lck(outstanding_tasks_mutex_);
+    should_cancel_ = true;
+  }
+
+  // Wait for all outstanding tasks to cancel.
+  {
+    std::unique_lock<std::mutex> lck(outstanding_tasks_mutex_);
+    outstanding_tasks_cv_.wait(
+        lck, [this]() { return outstanding_tasks_ == 0; });
+    should_cancel_ = false;
+  }
+}
+
+Status CancelableTasks::fn_wrapper(
+    const std::function<Status()>& fn, const std::function<void()>& on_cancel) {
+  std::unique_lock<std::mutex> lck(outstanding_tasks_mutex_);
+  if (should_cancel_) {
+    if (on_cancel) {
+      lck.unlock();
+      on_cancel();
+      lck.lock();
+    }
+    if (--outstanding_tasks_ == 0) {
+      outstanding_tasks_cv_.notify_all();
+    }
+    return Status::Error("Task cancelled before execution.");
+  } else {
+    lck.unlock();
+    Status st = fn();
+    lck.lock();
+    --outstanding_tasks_;
+    // If 'should_cancel_' became true when the lock was released to execute
+    // 'fn', we need to signal the CV.
+    if (should_cancel_ && outstanding_tasks_ == 0) {
+      outstanding_tasks_cv_.notify_all();
+    }
+    return st;
+  }
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/misc/cancelable_tasks.h
+++ b/tiledb/sm/misc/cancelable_tasks.h
@@ -1,0 +1,104 @@
+/**
+ * @file   cancelable_tasks.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the CancelableTasks class.
+ */
+
+#ifndef TILEDB_CANCELABLE_TASKS_H
+#define TILEDB_CANCELABLE_TASKS_H
+
+#include <functional>
+#include <iostream>
+
+#include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/misc/thread_pool.h"
+
+namespace tiledb {
+namespace sm {
+
+class CancelableTasks {
+ public:
+  /**
+   * Constructor.
+   */
+  CancelableTasks();
+
+  /**
+   * Destructor.
+   */
+  ~CancelableTasks() = default;
+
+  /**
+   * Enqueue a new task to be executed on the specified thread pool.
+   *
+   * @param function Task to be executed.
+   * @param function Optional routine to execute on cancelation.
+   * @return Future for the return value of the task.
+   */
+  std::future<Status> enqueue(
+      ThreadPool* thread_pool,
+      std::function<Status()>&& fn,
+      std::function<void()>&& on_cancel = nullptr);
+  /**
+   * Waits for all enqueued tasks to cancel. If a task is already running, it
+   * will run to completion.
+   */
+  void cancel_all_tasks();
+
+ private:
+  /**
+   * The wrapped task decorator. If all tasks have been cancelled, they will
+   * short-circuit here with an appropriate return value.
+   *
+   * @param function Task to be executed.
+   * @param function Optional routine to execute on cancelation.
+   * @return Status The returned status from 'fn', or a non-OK status if tasks
+   * were cancelled.
+   */
+  Status fn_wrapper(
+      const std::function<Status()>& fn,
+      const std::function<void()>& on_cancel);
+
+  /** The number of outstanding tasks */
+  uint32_t outstanding_tasks_;
+
+  /** Protects `outstanding_tasks_` */
+  std::mutex outstanding_tasks_mutex_;
+
+  /** For signal-and-waiting on `outstanding_tasks_` */
+  std::condition_variable outstanding_tasks_cv_;
+
+  /** True when all outstanding tasks should be cancelled */
+  bool should_cancel_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_CANCELABLE_TASKS_H

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -586,7 +586,7 @@ class StorageManager {
       bool* in_cache) const;
 
   /** Returns the Reader thread pool. */
-  ThreadPool* reader_thread_pool() const;
+  ThreadPool* reader_thread_pool();
 
   /**
    * Reads from a file into the input buffer.
@@ -628,7 +628,7 @@ class StorageManager {
   Status sync(const URI& uri);
 
   /** Returns the Writer thread pool. */
-  ThreadPool* writer_thread_pool() const;
+  ThreadPool* writer_thread_pool();
 
   /** Returns the virtual filesystem object. */
   VFS* vfs() const;
@@ -752,13 +752,17 @@ class StorageManager {
   std::condition_variable queries_in_progress_cv_;
 
   /** The storage manager's thread pool for async queries. */
-  std::unique_ptr<ThreadPool> async_thread_pool_;
+  ThreadPool async_thread_pool_;
 
   /** The storage manager's thread pool for Readers. */
-  std::unique_ptr<ThreadPool> reader_thread_pool_;
+  ThreadPool reader_thread_pool_;
 
   /** The storage manager's thread pool for Writers. */
-  std::unique_ptr<ThreadPool> writer_thread_pool_;
+  ThreadPool writer_thread_pool_;
+
+  /** Tracks all scheduled tasks that can be safely cancelled before execution.
+   */
+  CancelableTasks cancelable_tasks_;
 
   /** A tile cache. */
   LRUCache* tile_cache_;


### PR DESCRIPTION
The motiviation behind this change is that our ThreadPool::enqueue() routine
does not guarantee that the scheduled task will ever actually execute.

This can happen when ThreadPool::cancel_all_tasks() is invoked between the time
a task is enqueued and when one of the worker threads attempt to execute the task.

Currently, we check for cancellation by waiting-and-getting the returned std::future
from ThreadPool::enqueue(). For example:
std::future f = tp_.enqueue(...);
f.wait();
if (!f.get().ok()) {
  // It may have been cancelled
}

The limitation is that some asynchronous callers will never block on the returned
future, or may block using other methods. We saw this when attempting to integrate
our threadpool with the AWS SDK in S3ThreadPoolExecutor. Our tests were hanging
because the AWS SDK makes the assumption that all scheduled tasks would execute,
and we can not notify the SDK otherwise.

Consider this scenario:
std::semaphore sem(1);
tp_->enqueue([&sem]() { sem.relase(); });
// Some other thread invokes tp_->cancel_all_tasks(). This thread is hung.
sem.aquire();

To solve this, I've introduced a CancelableTasks class. This allows the caller to
schedule and track tasks scheduled among one or more threadpool instances. The
first use-case will be that we can implement the contract of
Aws::Utils::Threading::Executor::Submit() with the the 'VFS::thread_pool_', while
still allowing VFS::cancel_all_tasks() to avoid hanging the AWS SDK.

I've also expanded the ThreadPool::enqueue() contract to guarantee that the task
will eventually execute, if the returned std::future's ::valid() evaluates to true.
If it evalutes the false, it indicates that the task will never execute. I've
verified (or modified) that all existing uses of ThreadPool::enqueue() conform to
this contract.

Note that the S3ThreadPoolExecutor is still unused/disabled. I will enable it in
a follow-up patch.

I made other misc. changes that appeared to be vestiges of the C codebase (e.g.
using heap-allocated threadpools in storage manager, where a stack-allocated
class member makes more sense).

Tests run: make check