### PR TITLE
Fix S3 build on mac

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,10 @@ strategy:
       variables:
       TILEDB_HDFS: ON
       CXX: g++
-    #mac:
-    #  imageName: 'macOS-10.13'
+    mac:
+      imageName: 'macOS-10.13'
+      TILEDB_S3: ON
+      CXX: clang++
     #windows:
     #  imageName: 'vs2017-win2016'
   maxParallel: 4

--- a/scripts/azure-linux_mac.yaml
+++ b/scripts/azure-linux_mac.yaml
@@ -33,8 +33,19 @@ fi
 
 # Start minio server if S3 is enabled
 if [[ "$TILEDB_S3" == "ON" ]]; then
-  source scripts/install-minio.sh;
-  source scripts/run-minio.sh;
+  if [[ "$AGENT_OS" == "Linux" ]]; then
+    source scripts/install-minio.sh;
+    source scripts/run-minio.sh;
+  else
+    export AWS_ACCESS_KEY_ID=minio
+    export AWS_SECRET_ACCESS_KEY=miniosecretkey
+    export MINIO_ACCESS_KEY=$AWS_ACCESS_KEY
+    export MINIO_SECRET_KEY=$AWS_SECRET_ACCESS_KEY
+    # use minio repo rather than cask,
+    # as recommended by minio
+    brew install minio/stable/minio
+    minio server /tmp/minio-data &
+  fi
 fi
 
 mkdir -p $BUILD_REPOSITORY_LOCALPATH/build && cd $BUILD_REPOSITORY_LOCALPATH/build

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -365,6 +365,14 @@ if (WIN32)
   endforeach()
 endif()
 
+# macOS specific libraries
+if(APPLE)
+  if(TILEDB_S3)
+    # this is a transitive dependency for statically linking S3 SDK
+    target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE "-framework CoreFoundation")
+  endif()
+endif()
+
 # Copy over dependency info (e.g. include directories) to the core objects.
 target_compile_definitions(TILEDB_CORE_OBJECTS
   PRIVATE


### PR DESCRIPTION
This PR
- enables S3 build/test on mac using azure pipelines.

- fixes the following build error in the TILEDB_S3 build on mac, by linking CoreFoundation:
```
[100%] Linking CXX shared library libtiledb.dylib
Undefined symbols for architecture x86_64:
  "_CFAllocatorCreate", referenced from:
      _aws_wrapped_cf_allocator_new in libaws-c-common.a(common.c.o)
  "_CFRelease", referenced from:
      _aws_wrapped_cf_allocator_destroy in libaws-c-common.a(common.c.o)
  "___CFConstantStringClassReference", referenced from:
      CFString in libaws-c-common.a(common.c.o)
ld: symbol(s) not found for architecture x86_64
```