### PR TITLE
Fix std::string/Aws::String build issue

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -497,7 +497,7 @@ Status S3::ls(
       // The documentation states that "GetNextMarker" will be non-empty only
       // when the delimiter in the request is non-empty. When the delimiter is
       // non-empty, we must used the last returned key as the next marker.
-      std::string next_marker =
+      Aws::String next_marker =
           !delimiter.empty() ?
               list_objects_outcome.GetResult().GetNextMarker() :
               list_objects_outcome.GetResult().GetContents().back().GetKey();


### PR DESCRIPTION
We compile our AWS SDK with CUSTOM_MEMORY_MANAGEMENT=0, the
Aws::String typedefs to a standard std::string. When compiling
with CUSTOM_MEMORY_MANAGEMENT=1, we see this error:
https://github.com/TileDB-Inc/homebrew-stable/issues/19#issuecomment-480994220

This change fixes that build issue. This is really just a programming
error, I shouldn't have been using a std::string.