### PR TITLE
Fix S3 debug build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,7 @@ strategy:
     mac:
       imageName: 'macOS-10.13'
       TILEDB_S3: ON
+      TILEDB_DEBUG: ON
       CXX: clang++
     #windows:
     #  imageName: 'vs2017-win2016'

--- a/scripts/azure-linux_mac.yaml
+++ b/scripts/azure-linux_mac.yaml
@@ -24,6 +24,9 @@ fi;
 if [[ "$TILEDB_TBB" == "OFF" ]]; then
   bootstrap_args="${bootstrap_args} --disable-tbb";
 fi
+if [[ "$TILEDB_DEBUG" == "ON" ]]; then
+  bootstrap_args="${bootstrap_args} --enable-debug";
+fi
 
 # Start HDFS server if enabled
 if [[ "$TILEDB_HDFS" == "ON" ]]; then

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.cc
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.cc
@@ -64,7 +64,7 @@ Status S3ThreadPoolExecutor::Stop() {
 
   // Wait for all outstanding tasks to complete.
   for (auto& task : tasks) {
-    assert(task.valid());
+    assert(task->valid());
     task->wait();
     const Status st = task->get();
     if (!st.ok()) {


### PR DESCRIPTION
Fixes:
```
/Users/inorton/work/git/TileDB/tiledb/sm/filesystem/s3_thread_pool_executor.cc:67:16: error: no member named 'valid'
      in 'std::__1::shared_ptr<std::__1::future<tiledb::sm::Status> >'; did you mean to use '->' instead of '.'?
    assert(task.valid());
               ^
               ->
/usr/include/assert.h:93:25: note: expanded from macro 'assert'
    (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __FILE__, __LINE__, #e) : (void)0)
                        ^
1 error generated.
```