### PR TITLE
Remove false assertion in S3::ls()

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -490,13 +490,12 @@ Status S3::ls(
 
     is_done = !list_objects_outcome.GetResult().GetIsTruncated();
     if (!is_done) {
-      // If the response was truncated, it must contain at least one returned
-      // object.
-      assert(!list_objects_outcome.GetResult().GetContents().empty());
-
       // The documentation states that "GetNextMarker" will be non-empty only
       // when the delimiter in the request is non-empty. When the delimiter is
       // non-empty, we must used the last returned key as the next marker.
+      assert(
+          !delimiter.empty() ||
+          !list_objects_outcome.GetResult().GetContents().empty());
       Aws::String next_marker =
           !delimiter.empty() ?
               list_objects_outcome.GetResult().GetNextMarker() :


### PR DESCRIPTION
I assumed that part of the `ListObjects` AWS contract was that if the
response was truncated, it must contain at least one item. The documentation
is ambigious, but Isaiah was able to reproduce one of these empty-and-truncated
responses on AWS, GCS, and Minio. By removing this assert, we will continue to
make a following ListObjects call at the next marker. We still have an assertion
to check for the case where 1) the response is truncated and 2) it did not provide
a 'Next Marker'. This is clearly against the contract and should assert().