### PR TITLE
Fix Windows build with S3 enabled

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -126,4 +126,10 @@ if (AWSSDK_FOUND)
     endif()
 
   endforeach ()
+
+  # the AWSSDK does not include links to some transitive dependencies
+  # ref: github<dot>com/aws<slash>aws-sdk-cpp/issues/1074#issuecomment-466252911
+  if (WIN32)
+    list(APPEND AWS_EXTRA_LIBS userenv ws2_32 wininet winhttp bcrypt version)
+  endif()
 endif ()

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -178,7 +178,7 @@ set(TILEDB_EXTERNALS_SOURCES
 # Build core objects as a reusable object library
 ############################################################
 
-add_library(TILEDB_CORE_OBJECTS OBJECT 
+add_library(TILEDB_CORE_OBJECTS OBJECT
     ${TILEDB_CORE_SOURCES}
     ${TILEDB_EXTERNALS_SOURCES}
 )
@@ -269,7 +269,7 @@ endif()
 if (TILEDB_S3)
   message(STATUS "The TileDB library is compiled with S3 support.")
   find_package(Curl_EP REQUIRED)
-  find_package(AWSSDK_EP REQUIRED)
+  find_package(AWSSDK_EP REQUIRED COMPONENTS s3)
   target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
     INTERFACE
       AWSSDK::aws-cpp-sdk-s3
@@ -278,6 +278,7 @@ if (TILEDB_S3)
       AWSSDK::aws-checksums
       AWSSDK::aws-c-common
   )
+
   if (NOT WIN32)
     # No Curl required on Windows.
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
@@ -359,7 +360,7 @@ if (WIN32)
   set(WIN32_LIBS shlwapi rpcrt4 bcrypt)
 
   if (TILEDB_S3)
-    list(APPEND WIN32_LIBS bcrypt winhttp wininet userenv version)
+    list(APPEND WIN32_LIBS "${AWS_EXTRA_LIBS}")
   endif()
 
   foreach (LIB ${WIN32_LIBS})


### PR DESCRIPTION
Fixes build errors on Windows with S3 enabled:

<details>

```
-- Build files have been written to: D:/a/1/s/build/TileDB-dev/build
Microsoft (R) Build Engine version 15.9.21+g9802d43bc3 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Creating directories for 'tiledb'
  Building Custom Rule D:/a/1/s/build/TileDB-dev/CMakeLists.txt
  CMake does not need to re-run because D:/a/1/s/build/TileDB-dev/build/CMakeFiles/generate.stamp is up-to-date.
  No download step for 'tiledb'
  No update step for 'tiledb'
  No patch step for 'tiledb'
  Performing configure step for 'tiledb'
  -- Starting TileDB regular build.
  -- The TileDB library is compiled with stats enabled.
  -- The TileDB library is compiled with S3 support.
  -- Could NOT find Curl (missing: CURL_LIBRARIES CURL_INCLUDE_DIR) 
  -- Found AWS SDK for C++, Version: 1.7.81, Install Root:D:/a/1/s/build/TileDB-dev/build/externals/install, Platform Prefix:, Platform Dependent Libraries: Userenv;version;ws2_32;Bcrypt;Wininet;winhttp
  -- Found AWS lib: aws-cpp-sdk-s3
  -- Found AWS lib: aws-cpp-sdk-core
  -- Found AWS lib: Userenv
  -- Found AWS lib: version
  -- Found AWS lib: ws2_32
  -- Found AWS lib: Bcrypt
  -- Found AWS lib: Wininet
  -- Found AWS lib: winhttp
  -- Found AWS lib: aws-c-common
  -- Found AWS lib: aws-c-event-stream
  -- Found AWS lib: aws-checksums
  -- Found TBB imported target: TBB::tbb;TBB::tbbmalloc;TBB::tbbmalloc_proxy
  -- Found Zlib: D:/a/1/s/build/TileDB-dev/build/externals/install/lib/zlibstatic.lib
  -- Found Win32 lib shlwapi: C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/ShLwApi.Lib
  -- Found Win32 lib rpcrt4: C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/RpcRT4.Lib
  -- Found Win32 lib bcrypt: C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/bcrypt.lib
  -- Found Win32 lib bcrypt: C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/bcrypt.lib
  -- Found Win32 lib winhttp: C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/winhttp.lib
  -- Found Win32 lib wininet: C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/WinInet.Lib
  -- Found Win32 lib userenv: C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/UserEnv.Lib
  -- Found Win32 lib version: C:/Program Files (x86)/Windows Kits/10/Lib/10.0.14393.0/um/x64/Version.Lib
  -- Configuring done
  -- Generating done
  -- Build files have been written to: D:/a/1/s/build/TileDB-dev/build/tiledb
  Performing build step for 'tiledb'
  Microsoft (R) Build Engine version 15.9.21+g9802d43bc3 for .NET Framework
  Copyright (C) Microsoft Corporation. All rights reserved.
  
    TILEDB_CORE_OBJECTS.vcxproj -> D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\TILEDB_CORE_OBJECTS.dir\Release\TILEDB_CORE_OBJECTS.lib
       Creating library D:/a/1/s/build/TileDB-dev/build/tiledb/tiledb/Release/tiledb.lib and object D:/a/1/s/build/TileDB-dev/build/tiledb/tiledb/Release/tiledb.exp
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_default_allocator referenced in function "public: __cdecl Aws::Utils::Event::EventStreamDecoder::EventStreamDecoder(class Aws::Utils::Event::EventStreamHandler *)" (??0EventStreamDecoder@Event@Utils@Aws@@QEAA@PEAVEventStreamHandler@123@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_streaming_decoder_init referenced in function "public: __cdecl Aws::Utils::Event::EventStreamDecoder::EventStreamDecoder(class Aws::Utils::Event::EventStreamHandler *)" (??0EventStreamDecoder@Event@Utils@Aws@@QEAA@PEAVEventStreamHandler@123@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_streaming_decoder_clean_up referenced in function "public: __cdecl Aws::Utils::Event::EventStreamDecoder::~EventStreamDecoder(void)" (??1EventStreamDecoder@Event@Utils@Aws@@QEAA@XZ) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_header_value_as_string referenced in function "public: __cdecl Aws::Utils::Event::EventHeaderValue::EventHeaderValue(struct aws_event_stream_header_value_pair *)" (??0EventHeaderValue@Event@Utils@Aws@@QEAA@PEAUaws_event_stream_header_value_pair@@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_header_value_as_byte referenced in function "public: __cdecl Aws::Utils::Event::EventHeaderValue::EventHeaderValue(struct aws_event_stream_header_value_pair *)" (??0EventHeaderValue@Event@Utils@Aws@@QEAA@PEAUaws_event_stream_header_value_pair@@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_header_value_as_bool referenced in function "public: __cdecl Aws::Utils::Event::EventHeaderValue::EventHeaderValue(struct aws_event_stream_header_value_pair *)" (??0EventHeaderValue@Event@Utils@Aws@@QEAA@PEAUaws_event_stream_header_value_pair@@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_header_value_as_int16 referenced in function "public: __cdecl Aws::Utils::Event::EventHeaderValue::EventHeaderValue(struct aws_event_stream_header_value_pair *)" (??0EventHeaderValue@Event@Utils@Aws@@QEAA@PEAUaws_event_stream_header_value_pair@@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_header_value_as_int32 referenced in function "public: __cdecl Aws::Utils::Event::EventHeaderValue::EventHeaderValue(struct aws_event_stream_header_value_pair *)" (??0EventHeaderValue@Event@Utils@Aws@@QEAA@PEAUaws_event_stream_header_value_pair@@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_header_value_as_int64 referenced in function "public: __cdecl Aws::Utils::Event::EventHeaderValue::EventHeaderValue(struct aws_event_stream_header_value_pair *)" (??0EventHeaderValue@Event@Utils@Aws@@QEAA@PEAUaws_event_stream_header_value_pair@@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_header_value_as_bytebuf referenced in function "public: __cdecl Aws::Utils::Event::EventHeaderValue::EventHeaderValue(struct aws_event_stream_header_value_pair *)" (??0EventHeaderValue@Event@Utils@Aws@@QEAA@PEAUaws_event_stream_header_value_pair@@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_header_value_as_timestamp referenced in function "public: __cdecl Aws::Utils::Event::EventHeaderValue::EventHeaderValue(struct aws_event_stream_header_value_pair *)" (??0EventHeaderValue@Event@Utils@Aws@@QEAA@PEAUaws_event_stream_header_value_pair@@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_header_value_as_uuid referenced in function "public: __cdecl Aws::Utils::Event::EventHeaderValue::EventHeaderValue(struct aws_event_stream_header_value_pair *)" (??0EventHeaderValue@Event@Utils@Aws@@QEAA@PEAUaws_event_stream_header_value_pair@@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(EventStreamDecoder.obj) : error LNK2019: unresolved external symbol aws_event_stream_streaming_decoder_pump referenced in function "public: void __cdecl Aws::Utils::Event::EventStreamDecoder::Pump(class Aws::Utils::Array<unsigned char> const &)" (?Pump@EventStreamDecoder@Event@Utils@Aws@@QEAAXAEBV?$Array@E@34@@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(Net.obj) : error LNK2019: unresolved external symbol __imp_WSAStartup referenced in function "void __cdecl Aws::Net::InitNetwork(void)" (?InitNetwork@Net@Aws@@YAXXZ) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(Net.obj) : error LNK2019: unresolved external symbol __imp_WSACleanup referenced in function "void __cdecl Aws::Net::CleanupNetwork(void)" (?CleanupNetwork@Net@Aws@@YAXXZ) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_bind referenced in function "public: int __cdecl Aws::Net::SimpleUDP::Bind(struct sockaddr const *,unsigned __int64)const " (?Bind@SimpleUDP@Net@Aws@@QEBAHPEBUsockaddr@@_K@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_closesocket referenced in function "public: __cdecl Aws::Net::SimpleUDP::~SimpleUDP(void)" (??1SimpleUDP@Net@Aws@@QEAA@XZ) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_connect referenced in function "public: int __cdecl Aws::Net::SimpleUDP::Connect(struct sockaddr const *,unsigned __int64)" (?Connect@SimpleUDP@Net@Aws@@QEAAHPEBUsockaddr@@_K@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_ioctlsocket referenced in function "private: void __cdecl Aws::Net::SimpleUDP::CreateSocket(int,unsigned __int64,unsigned __int64,bool)" (?CreateSocket@SimpleUDP@Net@Aws@@AEAAXH_K0_N@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_htons referenced in function "public: int __cdecl Aws::Net::SimpleUDP::BindToLocalHost(unsigned short)const " (?BindToLocalHost@SimpleUDP@Net@Aws@@QEBAHG@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_recv referenced in function "public: int __cdecl Aws::Net::SimpleUDP::ReceiveData(unsigned char *,unsigned __int64)const " (?ReceiveData@SimpleUDP@Net@Aws@@QEBAHPEAE_K@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_recvfrom referenced in function "public: int __cdecl Aws::Net::SimpleUDP::ReceiveDataFrom(struct sockaddr *,unsigned __int64 *,unsigned char *,unsigned __int64)const " (?ReceiveDataFrom@SimpleUDP@Net@Aws@@QEBAHPEAUsockaddr@@PEA_KPEAE_K@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_send referenced in function "public: int __cdecl Aws::Net::SimpleUDP::SendData(unsigned char const *,unsigned __int64)const " (?SendData@SimpleUDP@Net@Aws@@QEBAHPEBE_K@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_sendto referenced in function "public: int __cdecl Aws::Net::SimpleUDP::SendDataTo(struct sockaddr const *,unsigned __int64,unsigned char const *,unsigned __int64)const " (?SendDataTo@SimpleUDP@Net@Aws@@QEBAHPEBUsockaddr@@_KPEBE1@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_setsockopt referenced in function "private: void __cdecl Aws::Net::SimpleUDP::CreateSocket(int,unsigned __int64,unsigned __int64,bool)" (?CreateSocket@SimpleUDP@Net@Aws@@AEAAXH_K0_N@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_socket referenced in function "private: void __cdecl Aws::Net::SimpleUDP::CreateSocket(int,unsigned __int64,unsigned __int64,bool)" (?CreateSocket@SimpleUDP@Net@Aws@@AEAAXH_K0_N@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_WSAGetLastError referenced in function "private: void __cdecl Aws::Net::SimpleUDP::CreateSocket(int,unsigned __int64,unsigned __int64,bool)" (?CreateSocket@SimpleUDP@Net@Aws@@AEAAXH_K0_N@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
aws-cpp-sdk-core.lib(SimpleUDP.obj) : error LNK2019: unresolved external symbol __imp_inet_pton referenced in function "public: int __cdecl Aws::Net::SimpleUDP::BindToLocalHost(unsigned short)const " (?BindToLocalHost@SimpleUDP@Net@Aws@@QEBAHG@Z) [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
..\..\externals\install\lib\aws-c-event-stream.lib : warning LNK4272: library machine type 'x86' conflicts with target machine type 'x64' [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
..\..\externals\install\lib\aws-checksums.lib : warning LNK4272: library machine type 'x86' conflicts with target machine type 'x64' [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
..\..\externals\install\lib\aws-c-common.lib : warning LNK4272: library machine type 'x86' conflicts with target machine type 'x64' [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\Release\tiledb.dll : fatal error LNK1120: 28 unresolved externals [D:\a\1\s\build\TileDB-dev\build\tiledb\tiledb\tiledb_shared.vcxproj] [D:\a\1\s\build\TileDB-dev\build\tiledb.vcxproj]
libtiledb_exists checking 'library_dirs': []
libtiledb_exists found: 'None'
Building libtiledb in directory D:\a\1\s\build\TileDB-dev\build...
CMake configure command: ['cmake', '-DCMAKE_INSTALL_PREFIX=D:\\a\\1\\s\\build\\TileDB-dev\\dist', '-DTILEDB_TESTS=OFF', '-DTILEDB_S3=ON', '-DTILEDB_HDFS=OFF', '-DTILEDB_INSTALL_LIBDIR=lib', '-DCMAKE_BUILD_TYPE=Release', '-A', 'x64', '-DMSVC_MP_FLAG=/MP4', 'D:\\a\\1\\s\\build\\TileDB-dev']
Traceback (most recent call last):
  File "setup.py", line 503, in <module>
    'Programming Language :: Python :: 3.6',
  File "C:\hostedtoolcache\windows\Python\3.7.2\x64\lib\site-packages\setuptools\__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "C:\hostedtoolcache\windows\Python\3.7.2\x64\lib\distutils\core.py", line 148, in setup
    dist.run_commands()
  File "C:\hostedtoolcache\windows\Python\3.7.2\x64\lib\distutils\dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "C:\hostedtoolcache\windows\Python\3.7.2\x64\lib\distutils\dist.py", line 985, in run_command
    cmd_obj.run()
  File "C:\hostedtoolcache\windows\Python\3.7.2\x64\lib\site-packages\setuptools\command\install.py", line 67, in run
    self.do_egg_install()
  File "C:\hostedtoolcache\windows\Python\3.7.2\x64\lib\site-packages\setuptools\command\install.py", line 109, in do_egg_install
    self.run_command('bdist_egg')
  File "C:\hostedtoolcache\windows\Python\3.7.2\x64\lib\distutils\cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "C:\hostedtoolcache\windows\Python\3.7.2\x64\lib\distutils\dist.py", line 985, in run_command
    cmd_obj.run()
  File "setup.py", line 362, in run
    find_or_install_libtiledb(self)
  File "setup.py", line 227, in find_or_install_libtiledb
    install_dir = build_libtiledb(src_dir)
  File "setup.py", line 202, in build_libtiledb
    subprocess.check_call(build_cmd, cwd=libtiledb_build_dir)
  File "C:\hostedtoolcache\windows\Python\3.7.2\x64\lib\subprocess.py", line 347, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmake', '--build', '.', '--config', 'Release']' returned non-zero exit status 1.
##[error]Cmd.exe exited with code '1'.
```

</details>

(The AWS SDK does not export a complete list of transitive dependencies.
See: github<dot>com/aws/aws-sdk-cpp/issues/1074#issuecomment-466252911)

