### PR TITLE
Bump curl to v7.64.1

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -105,7 +105,12 @@ if (AWSSDK_FOUND)
   list(APPEND AWS_LINKED_LIBS aws-c-common
                               aws-c-event-stream
                               aws-checksums)
+
   foreach (LIB ${AWS_LINKED_LIBS})
+    if (NOT ${LIB} MATCHES "aws-*")
+      continue()
+    endif()
+
     find_library("AWS_FOUND_${LIB}"
       NAMES ${LIB}
       PATHS ${AWSSDK_LIB_DIR}

--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -73,6 +73,7 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
 
   if (TARGET ep_openssl)
     set(DEPENDS ep_openssl)
+    set(with_ssl "--with-ssl=${TILEDB_EP_INSTALL_PREFIX}")
   endif()
 
   set(TILEDB_CURL_LIBS "-ldl -lpthread")
@@ -101,7 +102,7 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
         --enable-shared=no
         --disable-ldap
         --with-pic=yes
-        --with-ssl=${TILEDB_EP_INSTALL_PREFIX}
+        ${with_ssl}
     BUILD_IN_SOURCE TRUE
     BUILD_COMMAND $(MAKE)
     INSTALL_COMMAND $(MAKE) install

--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -91,8 +91,8 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
 
   ExternalProject_Add(ep_curl
     PREFIX "externals"
-    URL "https://curl.haxx.se/download/curl-7.59.0.zip"
-    URL_HASH SHA1=4558ff1b78396c57cf176e03f702ae87378fd776
+    URL "https://curl.haxx.se/download/curl-7.64.1.tar.gz"
+    URL_HASH SHA1=54ee48d81eb9f90d3efdc6cdf964bd0a23abc364
     CONFIGURE_COMMAND
       ${CMAKE_CURRENT_BINARY_DIR}/configure-curl.sh
       ${TILEDB_EP_BASE}/src/ep_curl/configure


### PR DESCRIPTION
Update curl version in order to get the following patch, which fixes use of HTTPS with S3 (via libcurl) in a static build, by allowing SSL feature checks to compile:

https://github.com/curl/curl/commit/0616dfa1e08c25ec8ff0f06c014bd3836b365049

(in particular, this fixes use of S3 in the PyPI linux build)

---

For future reference, the way I found this was:
- enabled CURL_VERBOSE in the AWS SDK: https://github.com/aws/aws-sdk-cpp/blob/87be4d1545a849031d28c8b8e4287b5d01adcfb3/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp#L418-L419 (I just removed the ifdefs locally and rebuild)
- this showed an error message from `CURL` that HTTPS was not available
- looked in the config.log for a local linux (Docker) build, and saw the following warning:
```
configure:25513: WARNING: SSL disabled, you will not be able to use HTTPS, FTPS, NTLM and more.
configure:25515: WARNING: Use --with-ssl, --with-gnutls, --with-polarssl, --with-cyassl, --with-nss, --with-schannel, --with-secure-transport, --with-mesalink or --with-amissl to address this.
```