### PR TITLE
WIP: Use new cmake variables for libcurl linkage. #1080

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -279,7 +279,7 @@ if (TILEDB_S3)
     # No Curl required on Windows.
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
       INTERFACE
-        Curl::Curl
+        CURL::libcurl
     )
   endif()
   add_definitions(-DHAVE_S3)
@@ -413,7 +413,7 @@ if (TILEDB_STATIC)
   endmacro()
 
   append_dep_lib(Bzip2::Bzip2)
-  append_dep_lib(Curl::Curl)
+  append_dep_lib(CURL::libcurl)
   append_dep_lib(LZ4::LZ4)
   append_dep_lib(TBB::tbb)
   append_dep_lib(Zlib::Zlib)


### PR DESCRIPTION
Switch curl superbuild to build with cmake instead of autotools. This create the cmake export targets.

When finding lib curl if the libcurl export exists, we use that, which if libcurl is new enough includes the link dependencies, so libtiledb can include them.

Note: I can't find a cmake equivalent of --enable-optimize for curl configuration