### PR TITLE
Implement rule-of-5 for Buffer class

### DIFF
--- a/test/src/unit-buffer.cc
+++ b/test/src/unit-buffer.cc
@@ -145,3 +145,44 @@ TEST_CASE("Buffer: Test swap", "[buffer]") {
   CHECK(buff3.alloced_size() == 5);
   CHECK(std::memcmp(buff3.data(), &data2, sizeof(data2)) == 0);
 }
+
+TEST_CASE("Buffer: Test move", "[buffer]") {
+  // Write a char array
+  Status st;
+  char data1[3] = {1, 2, 3};
+  Buffer buff1;
+  st = buff1.write(data1, sizeof(data1));
+  REQUIRE(st.ok());
+  CHECK(buff1.owns_data());
+  CHECK(buff1.offset() == 3);
+  CHECK(buff1.size() == sizeof(data1));
+  CHECK(buff1.alloced_size() == 3);
+  CHECK(std::memcmp(buff1.data(), &data1, sizeof(data1)) == 0);
+
+  // Move constructor
+  Buffer b = std::move(buff1);
+  CHECK(b.owns_data());
+  CHECK(b.offset() == 3);
+  CHECK(b.size() == 3);
+  CHECK(b.alloced_size() == 3);
+  CHECK(std::memcmp(b.data(), &data1, sizeof(data1)) == 0);
+  CHECK(buff1.owns_data());
+  CHECK(buff1.offset() == 0);
+  CHECK(buff1.size() == 0);
+  CHECK(buff1.alloced_size() == 0);
+  CHECK(buff1.data() == nullptr);
+
+  // Move-assign
+  Buffer b2;
+  b2 = std::move(b);
+  CHECK(b2.owns_data());
+  CHECK(b2.offset() == 3);
+  CHECK(b2.size() == 3);
+  CHECK(b2.alloced_size() == 3);
+  CHECK(std::memcmp(b2.data(), &data1, sizeof(data1)) == 0);
+  CHECK(b.owns_data());
+  CHECK(b.offset() == 0);
+  CHECK(b.size() == 0);
+  CHECK(b.alloced_size() == 0);
+  CHECK(b.data() == nullptr);
+}

--- a/test/src/unit-buffer.cc
+++ b/test/src/unit-buffer.cc
@@ -130,7 +130,7 @@ TEST_CASE("Buffer: Test swap", "[buffer]") {
   CHECK(std::memcmp(buff2.data(), &data1, sizeof(data1)) == 0);
 
   char data3[] = {9};
-  Buffer buff3(data3, sizeof(data3), false);
+  Buffer buff3(data3, sizeof(data3));
   CHECK(!buff3.owns_data());
   st = buff1.swap(buff3);
   REQUIRE(st.ok());

--- a/tiledb/sm/buffer/buffer.cc
+++ b/tiledb/sm/buffer/buffer.cc
@@ -57,13 +57,13 @@ Buffer::Buffer() {
   owns_data_ = true;
 }
 
-Buffer::Buffer(void* data, uint64_t size, bool owns_data)
-    : data_(data)
-    , owns_data_(owns_data)
-    , size_(size) {
+Buffer::Buffer(void* data, uint64_t size)
+    : Buffer() {
   offset_ = 0;
   alloced_size_ = 0;
   owns_data_ = false;
+  data_ = data;
+  size_ = size;
 }
 
 Buffer::Buffer(const Buffer& buff) {

--- a/tiledb/sm/buffer/buffer.h
+++ b/tiledb/sm/buffer/buffer.h
@@ -63,8 +63,18 @@ class Buffer {
    */
   Buffer(void* data, uint64_t size, bool owns_data);
 
-  /** Copy constructor. */
+  /**
+   * Copy constructor.
+   *
+   * If the given buffer owns its data, this new buffer will make its own copy
+   * of the given buffer's allocation. If the given buffer does not own its
+   * data, this new buffer will wrap the allocation without owning or
+   * copying it.
+   */
   Buffer(const Buffer& buff);
+
+  /** Move constructor. */
+  Buffer(Buffer&& buff);
 
   /** Destructor. */
   ~Buffer();
@@ -220,8 +230,11 @@ class Buffer {
    */
   Status write_with_shift(ConstBuffer* buff, uint64_t offset);
 
-  /** Copy operator. */
+  /** Copy-assign operator. */
   Buffer& operator=(const Buffer& buff);
+
+  /** Move-assign operator. */
+  Buffer& operator=(Buffer&& buff);
 
  private:
   /* ********************************* */

--- a/tiledb/sm/buffer/buffer.h
+++ b/tiledb/sm/buffer/buffer.h
@@ -53,15 +53,16 @@ class Buffer {
   Buffer();
 
   /**
-   * Constructor. Initializes a buffer with the input data and size.
+   * Constructor.
    *
-   * @param data The internal data of the buffer.
-   * @param size The size of the data.
-   * @param owns_data Indicates whether the object will own the data,
-   *     i.e., if it has permission to reallocate the data and
-   *     is responsible for freeing it.
+   * Initializes the buffer to "wrap" the input data and size. The buffer being
+   * constructed does not make a copy of the input data, and thus does not own
+   * it.
+   *
+   * @param data The data for the buffer to wrap.
+   * @param size The size (in bytes) of the data.
    */
-  Buffer(void* data, uint64_t size, bool owns_data);
+  Buffer(void* data, uint64_t size);
 
   /**
    * Copy constructor.

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -493,7 +493,7 @@ int32_t tiledb_buffer_set_data(
     return TILEDB_ERR;
 
   // Create a temporary Buffer object as a wrapper.
-  tiledb::sm::Buffer tmp_buffer(data, size, false);
+  tiledb::sm::Buffer tmp_buffer(data, size);
 
   // Swap with the given buffer.
   if (SAVE_ERROR_CATCH(ctx, buffer->buffer_->swap(tmp_buffer)))

--- a/tiledb/sm/filter/filter_buffer.cc
+++ b/tiledb/sm/filter/filter_buffer.cc
@@ -47,7 +47,7 @@ FilterBuffer::BufferOrView::BufferOrView(
   is_view_ = true;
   underlying_buffer_ = buffer;
   view_ = std::unique_ptr<Buffer>(
-      new Buffer((char*)buffer->data() + offset, nbytes, false));
+      new Buffer((char*)buffer->data() + offset, nbytes));
 }
 
 FilterBuffer::BufferOrView::BufferOrView(BufferOrView&& other) {
@@ -74,7 +74,7 @@ FilterBuffer::BufferOrView FilterBuffer::BufferOrView::get_view(
     BufferOrView new_view(underlying_buffer_);
     new_view.is_view_ = true;
     new_view.view_ = std::unique_ptr<Buffer>(
-        new Buffer((char*)view_->data() + offset, nbytes, false));
+        new Buffer((char*)view_->data() + offset, nbytes));
     return new_view;
   } else {
     return BufferOrView(underlying_buffer_, offset, nbytes);
@@ -123,7 +123,7 @@ Status FilterBuffer::init(void* data, uint64_t nbytes) {
     return LOG_STATUS(Status::FilterError(
         "FilterBuffer error; cannot init buffer: read-only."));
 
-  std::shared_ptr<Buffer> buffer(new Buffer(data, nbytes, false));
+  std::shared_ptr<Buffer> buffer(new Buffer(data, nbytes));
   offset_ = 0;
   buffers_.emplace_back(buffer);
   current_relative_offset_ = 0;

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -425,8 +425,8 @@ Status query_from_capnp(
       if (type == QueryType::READ) {
         // On reads, just set null pointers with accurate size so that the
         // server can introspect and allocate properly sized buffers separately.
-        Buffer offsets_buff(nullptr, fixedlen_size, false);
-        Buffer varlen_buff(nullptr, varlen_size, false);
+        Buffer offsets_buff(nullptr, fixedlen_size);
+        Buffer varlen_buff(nullptr, varlen_size);
         attr_state->fixed_len_size = fixedlen_size;
         attr_state->var_len_size = varlen_size;
         attr_state->fixed_len_data.swap(offsets_buff);
@@ -449,8 +449,8 @@ Status query_from_capnp(
           auto* offsets = reinterpret_cast<uint64_t*>(attribute_buffer_start);
           auto* varlen_data = attribute_buffer_start + fixedlen_size;
           attribute_buffer_start += fixedlen_size + varlen_size;
-          Buffer offsets_buff(offsets, fixedlen_size, false);
-          Buffer varlen_buff(varlen_data, varlen_size, false);
+          Buffer offsets_buff(offsets, fixedlen_size);
+          Buffer varlen_buff(varlen_data, varlen_size);
           attr_state->fixed_len_size = fixedlen_size;
           attr_state->var_len_size = varlen_size;
           attr_state->fixed_len_data.swap(offsets_buff);
@@ -464,8 +464,8 @@ Status query_from_capnp(
         } else {
           auto* data = attribute_buffer_start;
           attribute_buffer_start += fixedlen_size;
-          Buffer buff(data, fixedlen_size, false);
-          Buffer varlen_buff(nullptr, 0, false);
+          Buffer buff(data, fixedlen_size);
+          Buffer varlen_buff(nullptr, 0);
           attr_state->fixed_len_size = fixedlen_size;
           attr_state->var_len_size = varlen_size;
           attr_state->fixed_len_data.swap(buff);


### PR DESCRIPTION
Also remove a misleading argument (`owns_data`) from one of the Buffer constructors -- its value was being ignored and overwritten.