### PR TITLE
Update AWS SDK version to 1.7.108.

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -71,8 +71,8 @@ if (NOT AWSSDK_FOUND)
 
     ExternalProject_Add(ep_awssdk
       PREFIX "externals"
-      URL "https://github.com/aws/aws-sdk-cpp/archive/1.7.94.zip"
-      URL_HASH SHA1=171c0fa56e880d15c6b369cf66ec7eae4bf63659
+      URL "https://github.com/aws/aws-sdk-cpp/archive/1.7.108.zip"
+      URL_HASH SHA1=d07bae3fe924008b3117936963456dd314787abf
       CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=Release
         -DENABLE_TESTING=OFF


### PR DESCRIPTION
Fixes https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=442&view=logs

```
stream.c:315:5: error: implicit declaration of function 'AWS_ASSERT' [-Werror=implicit-function-declaration]
2019-05-21T17:51:44.4583403Z      AWS_ASSERT(buffer);
```

From https://github.com/aws/aws-sdk-cpp/issues/1145