### PR TITLE
Changes for zero-copy query serialization

### DIFF
--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -88,14 +88,21 @@ TILEDB_EXPORT int32_t tiledb_deserialize_array_schema(
     tiledb_array_schema_t** array_schema);
 
 /**
- * Serializes the given query
+ * Serializes the given query.
+ *
+ * Where possible the serialization is zero-copy. The returned buffer list
+ * contains an ordered list of pointers to buffers that logically contain the
+ * entire serialized query when concatenated.
+ *
+ * @note The caller must free the returned `tiledb_buffer_list_t`.
  *
  * @param ctx The TileDB context.
  * @param query The query.
  * @param serialization_type Type of serialization to use
  * @param client_side If set to 1, deserialize from "client-side" perspective.
  *    Else, "server-side."
- * @param buffer Buffer to serialize to
+ * @param buffer_list Will be set to a newly allocated buffer list containing
+ *    the serialized query.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int32_t tiledb_serialize_query(
@@ -103,7 +110,7 @@ TILEDB_EXPORT int32_t tiledb_serialize_query(
     const tiledb_query_t* query,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t* buffer);
+    tiledb_buffer_list_t** buffer_list);
 
 /**
  * Deserializes into an existing query from the given buffer.

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -40,6 +40,7 @@
 #include <string>
 
 #include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/sm/buffer/buffer_list.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/storage_manager/config.h"
 
@@ -86,7 +87,7 @@ class Curl {
   Status post_data(
       const std::string& url,
       SerializationType serialization_type,
-      Buffer* data,
+      const BufferList* data,
       Buffer* returned_data);
 
   /**

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -102,9 +102,12 @@ Status RestClient::post_array_schema_to_rest(
     const URI& uri, ArraySchema* array_schema) {
   STATS_FUNC_IN(rest_array_create);
 
-  Buffer serialized;
+  Buffer buff;
   RETURN_NOT_OK(serialization::array_schema_serialize(
-      array_schema, serialization_type_, &serialized));
+      array_schema, serialization_type_, &buff));
+  // Wrap in a list
+  BufferList serialized;
+  RETURN_NOT_OK(serialized.add_buffer(std::move(buff)));
 
   // Init curl and form the URL
   Curl curlc;
@@ -173,7 +176,7 @@ Status RestClient::submit_query_to_rest(const URI& uri, Query* query) {
   STATS_FUNC_IN(rest_query_submit);
 
   // Serialize data to send
-  Buffer serialized;
+  BufferList serialized;
   RETURN_NOT_OK(serialization::query_serialize(
       query, serialization_type_, true, &serialized));
 
@@ -203,7 +206,7 @@ Status RestClient::submit_query_to_rest(const URI& uri, Query* query) {
 
 Status RestClient::finalize_query_to_rest(const URI& uri, Query* query) {
   // Serialize data to send
-  Buffer serialized;
+  BufferList serialized;
   RETURN_NOT_OK(serialization::query_serialize(
       query, serialization_type_, true, &serialized));
 

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_SERIALIZATION_QUERY_H
 #define TILEDB_SERIALIZATION_QUERY_H
 
+#include "tiledb/sm/buffer/buffer_list.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/query/query.h"
 
@@ -51,7 +52,7 @@ Status query_serialize(
     Query* query,
     SerializationType serialize_type,
     bool clientside,
-    Buffer* serialized_buffer);
+    BufferList* serialized_buffer);
 
 /**
  * Deserialize a query


### PR DESCRIPTION
* Use libcurl read function to avoid initial copy of buffers for posting
* Change query serialization API to return a buffer list.