### PR TITLE
Automatically resubmit incomplete read queries to REST server

### DIFF
--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -1944,6 +1944,36 @@ TEST_CASE_METHOD(
     DenseArrayRESTFx,
     "C API: REST Test dense array, incomplete reads",
     "[capi], [dense], [rest], [incomplete]") {
+  // Disable incomplete resubmission
+  tiledb_ctx_free(&ctx_);
+  tiledb_error_t* error;
+  tiledb_config_t* config;
+  tiledb_config_alloc(&config, &error);
+  REQUIRE(
+      tiledb_config_set(config, "rest.resubmit_incomplete", "false", &error) ==
+      TILEDB_OK);
+
+  // Keep other REST server parameters the same
+  REQUIRE(
+      tiledb_config_set(
+          config, "rest.server_address", rest_server_uri_.c_str(), &error) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_config_set(
+          config, "rest.server_serialization_format", "CAPNP", &error) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_config_set(
+          config, "rest.username", rest_server_username_.c_str(), &error) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_config_set(
+          config, "rest.password", rest_server_password_.c_str(), &error) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
+  tiledb_config_free(&config);
+
   if (supports_s3_) {
     // S3
     create_temp_dir(S3_TEMP_DIR);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4951,6 +4951,7 @@ int32_t tiledb_deserialize_query(
               *buffer->buffer_,
               (tiledb::sm::SerializationType)serialize_type,
               client_side == 1,
+              nullptr,
               query->query_)))
     return TILEDB_ERR;
 

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -843,6 +843,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Authentication token for REST server (used instead of
  *    username/password). <br>
  *    **Default**: ""
+ * - `rest.resubmit_incomplete` <br>
+ *    If true, incomplete queries received from server are automatically
+ *    resubmitted before returning to user control. <br>
+ *    **Default**: "true"
  *
  * **Example:**
  *

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -168,6 +168,21 @@ Status convert(const std::string& str, float* value) {
   return Status::Ok();
 }
 
+Status convert(const std::string& str, bool* value) {
+  std::string lvalue = str;
+  std::transform(lvalue.begin(), lvalue.end(), lvalue.begin(), ::tolower);
+  if (lvalue == "true") {
+    *value = true;
+  } else if (lvalue == "false") {
+    *value = false;
+  } else {
+    return LOG_STATUS(Status::UtilsError(
+        "Failed to convert string to bool; Value not 'true' or 'false'"));
+  }
+
+  return Status::Ok();
+}
+
 bool is_int(const std::string& str) {
   // Check if empty
   if (str.empty())

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -70,6 +70,9 @@ Status convert(const std::string& str, uint32_t* value);
 /** Converts the input string into a `float` value. */
 Status convert(const std::string& str, float* value);
 
+/** Converts the input string into a `bool` value. */
+Status convert(const std::string& str, bool* value);
+
 /** Returns `true` if the input string is a (potentially signed) integer. */
 bool is_int(const std::string& str);
 

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -42,6 +42,24 @@ namespace sm {
 namespace serialization {
 
 /**
+ * Contains state related to copying data into user's query buffers for an
+ * attribute.
+ */
+struct QueryBufferCopyState {
+  /** Accumulated number of bytes copied into user's offset buffer. */
+  uint64_t offset_size;
+
+  /** Accumulated number of bytes copied into user's data buffer. */
+  uint64_t data_size;
+
+  /** Constructor. */
+  QueryBufferCopyState()
+      : offset_size(0)
+      , data_size(0) {
+  }
+};
+
+/**
  * Serialize a query
  *
  * @param query Query to serialize
@@ -55,16 +73,24 @@ Status query_serialize(
     BufferList* serialized_buffer);
 
 /**
- * Deserialize a query
+ * Deserialize a query. This takes a buffer containing serialized query
+ * information (read state, attribute data, query status, etc) and updates the
+ * given query to be equivalent to the serialized query.
  *
+ * @param serialized_buffer Buffer containing serialized query
+ * @param serialize_type Serialization type of serialized query
+ * @param clientside Whether deserialization should be performed from a client
+ *      or server perspective
+ * @param copy_state Map of copy state per attribute. If this is null, the
+ *      query's buffer sizes are updated directly. If it is not null, the buffer
+ *      sizes are not modified but the entries in the map are.
  * @param query Query to deserialize into
- * @param serialize_type format to deserialize from
- * @param serialized_buffer Buffer storing serialized query
  */
 Status query_deserialize(
     const Buffer& serialized_buffer,
     SerializationType serialize_type,
     bool clientside,
+    std::unordered_map<std::string, QueryBufferCopyState>* copy_state,
     Query* query);
 
 }  // namespace serialization

--- a/tiledb/sm/storage_manager/config.cc
+++ b/tiledb/sm/storage_manager/config.cc
@@ -738,19 +738,6 @@ void Config::set_default_param_values() {
   value.str(std::string());
 }
 
-Status Config::parse_bool(const std::string& value, bool* result) {
-  std::string lvalue = value;
-  std::transform(lvalue.begin(), lvalue.end(), lvalue.begin(), ::tolower);
-  if (lvalue == "true") {
-    *result = true;
-  } else if (lvalue == "false") {
-    *result = false;
-  } else {
-    return Status::ConfigError("cannot parse boolean value: " + value);
-  }
-  return Status::Ok();
-}
-
 Status Config::set_rest_server_address(const std::string& value) {
   rest_params_.server_address_ = value;
 
@@ -785,7 +772,7 @@ Status Config::set_rest_token(const std::string& value) {
 
 Status Config::set_sm_dedup_coords(const std::string& value) {
   bool v = false;
-  if (!parse_bool(value, &v).ok()) {
+  if (!utils::parse::convert(value, &v).ok()) {
     return LOG_STATUS(Status::ConfigError(
         "Cannot set parameter; Invalid dedup coords value"));
   }
@@ -795,7 +782,7 @@ Status Config::set_sm_dedup_coords(const std::string& value) {
 
 Status Config::set_sm_check_coord_dups(const std::string& value) {
   bool v = false;
-  if (!parse_bool(value, &v).ok()) {
+  if (!utils::parse::convert(value, &v).ok()) {
     return LOG_STATUS(Status::ConfigError(
         "Cannot set parameter; Invalid check coords duplicates value"));
   }
@@ -805,7 +792,7 @@ Status Config::set_sm_check_coord_dups(const std::string& value) {
 
 Status Config::set_sm_check_coord_oob(const std::string& value) {
   bool v = false;
-  if (!parse_bool(value, &v).ok()) {
+  if (!utils::parse::convert(value, &v).ok()) {
     return LOG_STATUS(Status::ConfigError(
         "Cannot set parameter; Invalid check out-of-bounds coords value"));
   }
@@ -815,7 +802,7 @@ Status Config::set_sm_check_coord_oob(const std::string& value) {
 
 Status Config::set_sm_check_global_order(const std::string& value) {
   bool v = false;
-  if (!parse_bool(value, &v).ok()) {
+  if (!utils::parse::convert(value, &v).ok()) {
     return LOG_STATUS(Status::ConfigError(
         "Cannot set parameter; Invalid check global order value"));
   }
@@ -825,7 +812,7 @@ Status Config::set_sm_check_global_order(const std::string& value) {
 
 Status Config::set_sm_enable_signal_handlers(const std::string& value) {
   bool v;
-  RETURN_NOT_OK(parse_bool(value, &v));
+  RETURN_NOT_OK(utils::parse::convert(value, &v));
   sm_params_.enable_signal_handlers_ = v;
 
   return Status::Ok();
@@ -1005,7 +992,7 @@ Status Config::set_vfs_s3_endpoint_override(const std::string& value) {
 
 Status Config::set_vfs_s3_use_virtual_addressing(const std::string& value) {
   bool v = false;
-  if (!parse_bool(value, &v).ok()) {
+  if (!utils::parse::convert(value, &v).ok()) {
     return LOG_STATUS(Status::ConfigError(
         "Cannot set parameter; Invalid S3 virtual addressing value"));
   }
@@ -1015,7 +1002,7 @@ Status Config::set_vfs_s3_use_virtual_addressing(const std::string& value) {
 
 Status Config::set_vfs_s3_use_multipart_upload(const std::string& value) {
   bool v = false;
-  if (!parse_bool(value, &v).ok()) {
+  if (!utils::parse::convert(value, &v).ok()) {
     return LOG_STATUS(Status::ConfigError(
         "Cannot set parameter; Invalid S3 multipart mode value"));
   }

--- a/tiledb/sm/storage_manager/config.h
+++ b/tiledb/sm/storage_manager/config.h
@@ -481,9 +481,6 @@ class Config {
   /** Populates `param_values_` map with the default values. */
   void set_default_param_values();
 
-  /** Normalizes and parses a string boolean value **/
-  Status parse_bool(const std::string& value, bool* result);
-
   /** Sets the dedup coordinates parameter. */
   Status set_sm_dedup_coords(const std::string& value);
 


### PR DESCRIPTION
 If the user buffers on the client are not big enough to hold all results from the server, an error is returned. **Therefore with this change, read queries to the REST server will always return to the user (a) complete; or (b) with an error status.**

* Config param `rest.resubmit_incomplete` added to disable automatic resubmission
* Tested with a modified version of the REST server running locally to limit the number of bytes allocated for query buffers server-side