### PR TITLE
Add config param `vfs.file.enable_filelocks`.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,7 @@
 * Added datatype `tiledb_buffer_t` and functions `tiledb_buffer_{alloc,free,get_type,set_type,get_data,set_data}`.
 * Added datatype `tiledb_buffer_list_t` and functions `tiledb_buffer_list_{alloc,free,get_num_buffers,get_total_size,get_buffer,flatten}`.
 * Added string conversion functions `tiledb_*_to_str()` and `tiledb_*_from_str()` for all public enum types.
+* Added config param `vfs.file.enable_filelocks`
 
 ### C++ API
 

--- a/doc/source/tutorials/config.rst
+++ b/doc/source/tutorials/config.rst
@@ -569,6 +569,8 @@ along with their description and default values.
                                                                       operations (any backend), per VFS instance.
     ``"vfs.file.max_parallel_ops"``           ``vfs.num_threads``     The maximum number of parallel operations on
                                                                       objects with ``file:///`` URIs.
+    ``"vfs.file.enable_filelocks"``           ``true``                If set to ``false``, file locking operations are
+                                                                      no-ops in VFS for ``file:///`` URIs.
     ``"vfs.min_batch_gap"``                   ``"512000"``            The minimum number of bytes between two VFS
                                                                       read batches.
     ``"vfs.min_batch_size"``                  ``"20971520"``          The minimum number of bytes in a VFS

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -209,6 +209,7 @@ void check_save_to_file() {
   ss << "sm.num_tbb_threads -1\n";
   ss << "sm.num_writer_threads 1\n";
   ss << "sm.tile_cache_size 10000000\n";
+  ss << "vfs.file.enable_filelocks true\n";
   ss << "vfs.file.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
   ss << "vfs.min_batch_gap 512000\n";
@@ -395,6 +396,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.min_parallel_size"] = "10485760";
   all_param_values["vfs.file.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
+  all_param_values["vfs.file.enable_filelocks"] = "true";
   all_param_values["vfs.s3.scheme"] = "https";
   all_param_values["vfs.s3.region"] = "us-east-1";
   all_param_values["vfs.s3.aws_access_key_id"] = "";
@@ -426,6 +428,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["min_parallel_size"] = "10485760";
   vfs_param_values["file.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
+  vfs_param_values["file.enable_filelocks"] = "true";
   vfs_param_values["s3.scheme"] = "https";
   vfs_param_values["s3.region"] = "us-east-1";
   vfs_param_values["s3.aws_access_key_id"] = "";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -50,5 +50,5 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 26);
+  CHECK(names.size() == 27);
 }

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1001,6 +1001,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The maximum number of parallel operations on objects with `file:///`
  *    URIs. <br>
  *    **Default**: `vfs.num_threads`
+ * - `vfs.file.enable_filelocks` <br>
+ *    If set to `false`, file locking operations are no-ops for `file:///` URIs
+ *    in VFS. <br>
+ *    **Default**: `true`
  * - `vfs.s3.region` <br>
  *    The S3 region, if S3 is enabled. <br>
  *    **Default**: us-east-1

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -327,6 +327,10 @@ class Config {
    *    The maximum number of parallel operations on objects with `file:///`
    *    URIs. <br>
    *    **Default**: `vfs.num_threads`
+   * - `vfs.file.enable_filelocks` <br>
+   *    If set to `false`, file locking operations are no-ops for `file:///`
+   *    URIs in VFS. <br>
+   *    **Default**: `true`
    * - `vfs.s3.region` <br>
    *    The S3 region, if S3 is enabled. <br>
    *    **Default**: us-east-1

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -356,6 +356,9 @@ Status VFS::remove_file(const URI& uri) const {
 Status VFS::filelock_lock(const URI& uri, filelock_t* fd, bool shared) const {
   STATS_FUNC_IN(vfs_filelock_lock);
 
+  if (!vfs_params_.file_params_.enable_filelocks_)
+    return Status::Ok();
+
   // Hold the lock while updating counts and performing the lock.
   std::unique_lock<std::mutex> lck(filelock_mtx_);
 
@@ -394,6 +397,9 @@ Status VFS::filelock_lock(const URI& uri, filelock_t* fd, bool shared) const {
 
 Status VFS::filelock_unlock(const URI& uri, filelock_t fd) const {
   STATS_FUNC_IN(vfs_filelock_unlock);
+
+  if (!vfs_params_.file_params_.enable_filelocks_)
+    return Status::Ok();
 
   // Hold the lock while updating counts and performing the unlock.
   std::unique_lock<std::mutex> lck(filelock_mtx_);

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -262,6 +262,9 @@ const uint64_t vfs_min_batch_size = 20 * 1024 * 1024;
 /** The default maximum number of parallel file:/// operations. */
 const uint64_t vfs_file_max_parallel_ops = vfs_num_threads;
 
+/** Whether or not filelocks are enabled for VFS. */
+const bool vfs_file_enable_filelocks = true;
+
 /** The maximum name length. */
 const uint32_t uri_max_len = 256;
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -250,6 +250,9 @@ extern const uint64_t vfs_min_batch_size;
 /** The default maximum number of parallel file:/// operations. */
 extern const uint64_t vfs_file_max_parallel_ops;
 
+/** Whether or not filelocks are enabled for VFS. */
+extern const bool vfs_file_enable_filelocks;
+
 /** The maximum name length. */
 extern const uint32_t uri_max_len;
 

--- a/tiledb/sm/storage_manager/config.cc
+++ b/tiledb/sm/storage_manager/config.cc
@@ -229,6 +229,8 @@ Status Config::set(const std::string& param, const std::string& value) {
     RETURN_NOT_OK(set_vfs_min_batch_size(value));
   } else if (param == "vfs.file.max_parallel_ops") {
     RETURN_NOT_OK(set_vfs_file_max_parallel_ops(value));
+  } else if (param == "vfs.file.enable_filelocks") {
+    RETURN_NOT_OK(set_vfs_file_enable_filelocks(value));
   } else if (param == "vfs.s3.region") {
     RETURN_NOT_OK(set_vfs_s3_region(value));
   } else if (param == "vfs.s3.aws_access_key_id") {
@@ -428,6 +430,12 @@ Status Config::unset(const std::string& param) {
         constants::vfs_file_max_parallel_ops;
     value << vfs_params_.file_params_.max_parallel_ops_;
     param_values_["vfs.file.max_parallel_ops"] = value.str();
+    value.str(std::string());
+  } else if (param == "vfs.file.enable_filelocks") {
+    vfs_params_.file_params_.enable_filelocks_ =
+        constants::vfs_file_enable_filelocks;
+    value << (vfs_params_.file_params_.enable_filelocks_ ? "true" : "false");
+    param_values_["vfs.file.enable_filelocks"] = value.str();
     value.str(std::string());
   } else if (param == "vfs.s3.region") {
     vfs_params_.s3_params_.region_ = constants::s3_region;
@@ -650,6 +658,10 @@ void Config::set_default_param_values() {
 
   value << vfs_params_.file_params_.max_parallel_ops_;
   param_values_["vfs.file.max_parallel_ops"] = value.str();
+  value.str(std::string());
+
+  value << (vfs_params_.file_params_.enable_filelocks_ ? "true" : "false");
+  param_values_["vfs.file.enable_filelocks"] = value.str();
   value.str(std::string());
 
   value << vfs_params_.s3_params_.region_;
@@ -958,6 +970,14 @@ Status Config::set_vfs_file_max_parallel_ops(const std::string& value) {
   uint64_t v;
   RETURN_NOT_OK(utils::parse::convert(value, &v));
   vfs_params_.file_params_.max_parallel_ops_ = v;
+
+  return Status::Ok();
+}
+
+Status Config::set_vfs_file_enable_filelocks(const std::string& value) {
+  bool v;
+  RETURN_NOT_OK(utils::parse::convert(value, &v));
+  vfs_params_.file_params_.enable_filelocks_ = v;
 
   return Status::Ok();
 }

--- a/tiledb/sm/storage_manager/config.h
+++ b/tiledb/sm/storage_manager/config.h
@@ -173,9 +173,11 @@ class Config {
 
   struct FileParams {
     uint64_t max_parallel_ops_;
+    bool enable_filelocks_;
 
     FileParams() {
       max_parallel_ops_ = constants::vfs_file_max_parallel_ops;
+      enable_filelocks_ = constants::vfs_file_enable_filelocks;
     }
   };
 
@@ -335,6 +337,10 @@ class Config {
    *    The maximum number of parallel operations on objects with `file:///`
    *    URIs. <br>
    *    **Default**: `vfs.num_threads`
+   * - `vfs.file.enable_filelocks` <br>
+   *    If set to `false`, file locking operations are no-ops for `file:///`
+   *    URIs in VFS. <br>
+   *    **Default**: `true`
    * - `vfs.s3.region` <br>
    *    The S3 region, if S3 is enabled. <br>
    *    **Default**: us-east-1
@@ -567,6 +573,9 @@ class Config {
 
   /** Sets the max number of allowed file:/// parallel operations. */
   Status set_vfs_file_max_parallel_ops(const std::string& value);
+
+  /** Sets the file locking enabled state. */
+  Status set_vfs_file_enable_filelocks(const std::string& value);
 
   /** Sets the S3 region. */
   Status set_vfs_s3_region(const std::string& value);


### PR DESCRIPTION
When `vfs.file.enable_filelocks` is set to false, the VFS file lock/unlock methods become no-ops.

Closes #1260.