### PR TITLE
Remove cast operators of C++ API objects to C API objects.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,6 +45,10 @@
 
 ## Breaking changes
 
+### C++ API
+
+* Removed cast operators of C++ API objects to their underlying C API objects. This helps prevent inadvertent memory issues such as double-frees.
+
 # TileDB v1.5.0 Release Notes
 
 The 1.5.0 release focuses on stability, performance, and usability improvements, as well a new consolidation algorithm.

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -121,14 +121,15 @@ class Array {
       uint32_t key_length)
       : ctx_(ctx)
       , schema_(ArraySchema(ctx, (tiledb_array_schema_t*)nullptr)) {
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
     tiledb_array_t* array;
-    ctx.handle_error(tiledb_array_alloc(ctx, array_uri.c_str(), &array));
+    ctx.handle_error(tiledb_array_alloc(c_ctx, array_uri.c_str(), &array));
     array_ = std::shared_ptr<tiledb_array_t>(array, deleter_);
     ctx.handle_error(tiledb_array_open_with_key(
-        ctx, array, query_type, encryption_type, encryption_key, key_length));
+        c_ctx, array, query_type, encryption_type, encryption_key, key_length));
 
     tiledb_array_schema_t* array_schema;
-    ctx.handle_error(tiledb_array_get_schema(ctx, array, &array_schema));
+    ctx.handle_error(tiledb_array_get_schema(c_ctx, array, &array_schema));
     schema_ = ArraySchema(ctx, array_schema);
   }
 
@@ -241,11 +242,12 @@ class Array {
       uint64_t timestamp)
       : ctx_(ctx)
       , schema_(ArraySchema(ctx, (tiledb_array_schema_t*)nullptr)) {
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
     tiledb_array_t* array;
-    ctx.handle_error(tiledb_array_alloc(ctx, array_uri.c_str(), &array));
+    ctx.handle_error(tiledb_array_alloc(c_ctx, array_uri.c_str(), &array));
     array_ = std::shared_ptr<tiledb_array_t>(array, deleter_);
     ctx.handle_error(tiledb_array_open_at_with_key(
-        ctx,
+        c_ctx,
         array,
         query_type,
         encryption_type,
@@ -254,7 +256,7 @@ class Array {
         timestamp));
 
     tiledb_array_schema_t* array_schema;
-    ctx.handle_error(tiledb_array_get_schema(ctx, array, &array_schema));
+    ctx.handle_error(tiledb_array_get_schema(c_ctx, array, &array_schema));
     schema_ = ArraySchema(ctx, array_schema);
   }
 
@@ -296,7 +298,8 @@ class Array {
   bool is_open() const {
     auto& ctx = ctx_.get();
     int open = 0;
-    ctx.handle_error(tiledb_array_is_open(ctx, array_.get(), &open));
+    ctx.handle_error(
+        tiledb_array_is_open(ctx.ptr().get(), array_.get(), &open));
     return bool(open);
   }
 
@@ -304,7 +307,7 @@ class Array {
   std::string uri() const {
     auto& ctx = ctx_.get();
     const char* uri = nullptr;
-    ctx.handle_error(tiledb_array_get_uri(ctx, array_.get(), &uri));
+    ctx.handle_error(tiledb_array_get_uri(ctx.ptr().get(), array_.get(), &uri));
     return std::string(uri);
   }
 
@@ -312,18 +315,14 @@ class Array {
   ArraySchema schema() const {
     auto& ctx = ctx_.get();
     tiledb_array_schema_t* schema;
-    ctx.handle_error(tiledb_array_get_schema(ctx, array_.get(), &schema));
+    ctx.handle_error(
+        tiledb_array_get_schema(ctx.ptr().get(), array_.get(), &schema));
     return ArraySchema(ctx, schema);
   }
 
   /** Returns a shared pointer to the C TileDB array object. */
   std::shared_ptr<tiledb_array_t> ptr() const {
     return array_;
-  }
-
-  /** Auxiliary operator for getting the underlying C TileDB object. */
-  operator tiledb_array_t*() const {
-    return array_.get();
   }
 
   /**
@@ -381,15 +380,17 @@ class Array {
       const void* encryption_key,
       uint32_t key_length) {
     auto& ctx = ctx_.get();
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
     ctx.handle_error(tiledb_array_open_with_key(
-        ctx,
+        c_ctx,
         array_.get(),
         query_type,
         encryption_type,
         encryption_key,
         key_length));
     tiledb_array_schema_t* array_schema;
-    ctx.handle_error(tiledb_array_get_schema(ctx, array_.get(), &array_schema));
+    ctx.handle_error(
+        tiledb_array_get_schema(c_ctx, array_.get(), &array_schema));
     schema_ = ArraySchema(ctx, array_schema);
   }
 
@@ -473,8 +474,9 @@ class Array {
       uint32_t key_length,
       uint64_t timestamp) {
     auto& ctx = ctx_.get();
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
     ctx.handle_error(tiledb_array_open_at_with_key(
-        ctx,
+        c_ctx,
         array_.get(),
         query_type,
         encryption_type,
@@ -482,7 +484,8 @@ class Array {
         key_length,
         timestamp));
     tiledb_array_schema_t* array_schema;
-    ctx.handle_error(tiledb_array_get_schema(ctx, array_.get(), &array_schema));
+    ctx.handle_error(
+        tiledb_array_get_schema(c_ctx, array_.get(), &array_schema));
     schema_ = ArraySchema(ctx, array_schema);
   }
 
@@ -528,9 +531,11 @@ class Array {
    */
   void reopen() {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_array_reopen(ctx, array_.get()));
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    ctx.handle_error(tiledb_array_reopen(c_ctx, array_.get()));
     tiledb_array_schema_t* array_schema;
-    ctx.handle_error(tiledb_array_get_schema(ctx, array_.get(), &array_schema));
+    ctx.handle_error(
+        tiledb_array_get_schema(c_ctx, array_.get(), &array_schema));
     schema_ = ArraySchema(ctx, array_schema);
   }
 
@@ -550,9 +555,11 @@ class Array {
    */
   void reopen_at(uint64_t timestamp) {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_array_reopen_at(ctx, array_.get(), timestamp));
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    ctx.handle_error(tiledb_array_reopen_at(c_ctx, array_.get(), timestamp));
     tiledb_array_schema_t* array_schema;
-    ctx.handle_error(tiledb_array_get_schema(ctx, array_.get(), &array_schema));
+    ctx.handle_error(
+        tiledb_array_get_schema(c_ctx, array_.get(), &array_schema));
     schema_ = ArraySchema(ctx, array_schema);
   }
 
@@ -560,7 +567,8 @@ class Array {
   uint64_t timestamp() const {
     auto& ctx = ctx_.get();
     uint64_t timestamp;
-    ctx.handle_error(tiledb_array_get_timestamp(ctx, array_.get(), &timestamp));
+    ctx.handle_error(
+        tiledb_array_get_timestamp(ctx.ptr().get(), array_.get(), &timestamp));
     return timestamp;
   }
 
@@ -575,7 +583,7 @@ class Array {
    */
   void close() {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_array_close(ctx, array_.get()));
+    ctx.handle_error(tiledb_array_close(ctx.ptr().get(), array_.get()));
   }
 
   /**
@@ -632,7 +640,7 @@ class Array {
       uint32_t key_length,
       const Config& config = Config()) {
     ctx.handle_error(tiledb_array_consolidate_with_key(
-        ctx,
+        ctx.ptr().get(),
         uri.c_str(),
         encryption_type,
         encryption_key,
@@ -707,9 +715,15 @@ class Array {
       const void* encryption_key,
       uint32_t key_length) {
     auto& ctx = schema.context();
-    ctx.handle_error(tiledb_array_schema_check(ctx, schema));
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    ctx.handle_error(tiledb_array_schema_check(c_ctx, schema.ptr().get()));
     ctx.handle_error(tiledb_array_create_with_key(
-        ctx, uri.c_str(), schema, encryption_type, encryption_key, key_length));
+        c_ctx,
+        uri.c_str(),
+        schema.ptr().get(),
+        encryption_type,
+        encryption_key,
+        key_length));
   }
 
   // clang-format off
@@ -754,8 +768,8 @@ class Array {
   static tiledb_encryption_type_t encryption_type(
       const Context& ctx, const std::string& array_uri) {
     tiledb_encryption_type_t encryption_type;
-    ctx.handle_error(
-        tiledb_array_encryption_type(ctx, array_uri.c_str(), &encryption_type));
+    ctx.handle_error(tiledb_array_encryption_type(
+        ctx.ptr().get(), array_uri.c_str(), &encryption_type));
     return encryption_type;
   }
 
@@ -790,7 +804,7 @@ class Array {
 
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_array_get_non_empty_domain(
-        ctx, array_.get(), buf.data(), &empty));
+        ctx.ptr().get(), array_.get(), buf.data(), &empty));
 
     if (empty)
       return ret;
@@ -841,6 +855,7 @@ class Array {
   std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
   max_buffer_elements(const std::vector<T>& subarray) {
     auto ctx = ctx_.get();
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
     impl::type_check<T>(schema_.domain().type(), 1);
 
     // Handle attributes
@@ -856,7 +871,7 @@ class Array {
       if (var) {
         uint64_t size_off, size_val;
         ctx.handle_error(tiledb_array_max_buffer_size_var(
-            ctx,
+            c_ctx,
             array_.get(),
             name.c_str(),
             subarray.data(),
@@ -866,7 +881,7 @@ class Array {
             size_off / TILEDB_OFFSET_SIZE, size_val / type_size);
       } else {
         ctx.handle_error(tiledb_array_max_buffer_size(
-            ctx, array_.get(), name.c_str(), subarray.data(), &attr_size));
+            c_ctx, array_.get(), name.c_str(), subarray.data(), &attr_size));
         ret[a.first] = std::pair<uint64_t, uint64_t>(0, attr_size / type_size);
       }
     }
@@ -874,7 +889,7 @@ class Array {
     // Handle coordinates
     type_size = tiledb_datatype_size(schema_.domain().type());
     ctx.handle_error(tiledb_array_max_buffer_size(
-        ctx, array_.get(), TILEDB_COORDS, subarray.data(), &attr_size));
+        c_ctx, array_.get(), TILEDB_COORDS, subarray.data(), &attr_size));
     ret[TILEDB_COORDS] =
         std::pair<uint64_t, uint64_t>(0, attr_size / type_size);
 
@@ -885,8 +900,8 @@ class Array {
   tiledb_query_type_t query_type() const {
     auto& ctx = ctx_.get();
     tiledb_query_type_t query_type;
-    ctx.handle_error(
-        tiledb_array_get_query_type(ctx, array_.get(), &query_type));
+    ctx.handle_error(tiledb_array_get_query_type(
+        ctx.ptr().get(), array_.get(), &query_type));
     return query_type;
   }
 

--- a/tiledb/sm/cpp_api/attribute.h
+++ b/tiledb/sm/cpp_api/attribute.h
@@ -137,7 +137,8 @@ class Attribute {
   std::string name() const {
     auto& ctx = ctx_.get();
     const char* name;
-    ctx.handle_error(tiledb_attribute_get_name(ctx, attr_.get(), &name));
+    ctx.handle_error(
+        tiledb_attribute_get_name(ctx.ptr().get(), attr_.get(), &name));
     return name;
   }
 
@@ -145,7 +146,8 @@ class Attribute {
   tiledb_datatype_t type() const {
     auto& ctx = ctx_.get();
     tiledb_datatype_t type;
-    ctx.handle_error(tiledb_attribute_get_type(ctx, attr_.get(), &type));
+    ctx.handle_error(
+        tiledb_attribute_get_type(ctx.ptr().get(), attr_.get(), &type));
     return type;
   }
 
@@ -169,8 +171,8 @@ class Attribute {
   uint64_t cell_size() const {
     auto& ctx = ctx_.get();
     uint64_t cell_size;
-    ctx.handle_error(
-        tiledb_attribute_get_cell_size(ctx, attr_.get(), &cell_size));
+    ctx.handle_error(tiledb_attribute_get_cell_size(
+        ctx.ptr().get(), attr_.get(), &cell_size));
     return cell_size;
   }
 
@@ -195,7 +197,8 @@ class Attribute {
   unsigned cell_val_num() const {
     auto& ctx = ctx_.get();
     unsigned num;
-    ctx.handle_error(tiledb_attribute_get_cell_val_num(ctx, attr_.get(), &num));
+    ctx.handle_error(
+        tiledb_attribute_get_cell_val_num(ctx.ptr().get(), attr_.get(), &num));
     return num;
   }
 
@@ -217,7 +220,8 @@ class Attribute {
    */
   Attribute& set_cell_val_num(unsigned num) {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_attribute_set_cell_val_num(ctx, attr_.get(), num));
+    ctx.handle_error(
+        tiledb_attribute_set_cell_val_num(ctx.ptr().get(), attr_.get(), num));
     return *this;
   }
 
@@ -235,8 +239,8 @@ class Attribute {
   FilterList filter_list() const {
     auto& ctx = ctx_.get();
     tiledb_filter_list_t* filter_list;
-    ctx.handle_error(
-        tiledb_attribute_get_filter_list(ctx, attr_.get(), &filter_list));
+    ctx.handle_error(tiledb_attribute_get_filter_list(
+        ctx.ptr().get(), attr_.get(), &filter_list));
     return FilterList(ctx, filter_list);
   }
 
@@ -250,19 +254,14 @@ class Attribute {
    */
   Attribute& set_filter_list(const FilterList& filter_list) {
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_attribute_set_filter_list(ctx, attr_.get(), filter_list));
+    ctx.handle_error(tiledb_attribute_set_filter_list(
+        ctx.ptr().get(), attr_.get(), filter_list.ptr().get()));
     return *this;
   }
 
   /** Returns the C TileDB attribute object pointer. */
   std::shared_ptr<tiledb_attribute_t> ptr() const {
     return attr_;
-  }
-
-  /** Auxiliary operator for getting the underlying C TileDB object. */
-  operator tiledb_attribute_t*() const {
-    return attr_.get();
   }
 
   /**
@@ -273,7 +272,7 @@ class Attribute {
    */
   void dump(FILE* out = stdout) const {
     ctx_.get().handle_error(
-        tiledb_attribute_dump(ctx_.get(), attr_.get(), out));
+        tiledb_attribute_dump(ctx_.get().ptr().get(), attr_.get(), out));
   }
 
   /* ********************************* */
@@ -360,7 +359,8 @@ class Attribute {
   void init_from_type(const std::string& name, tiledb_datatype_t type) {
     tiledb_attribute_t* attr;
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_attribute_alloc(ctx, name.c_str(), type, &attr));
+    ctx.handle_error(
+        tiledb_attribute_alloc(ctx.ptr().get(), name.c_str(), type, &attr));
     attr_ = std::shared_ptr<tiledb_attribute_t>(attr, deleter_);
   }
 };

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -213,11 +213,6 @@ class Config {
     return config_;
   }
 
-  /** Auxiliary operator for getting the underlying C TileDB object. */
-  operator tiledb_config_t*() const {
-    return config_.get();
-  }
-
   /** Sets a config parameter.
    *
    * **Parameters**

--- a/tiledb/sm/cpp_api/context.h
+++ b/tiledb/sm/cpp_api/context.h
@@ -93,7 +93,7 @@ class Context {
    */
   explicit Context(const Config& config) {
     tiledb_ctx_t* ctx;
-    if (tiledb_ctx_alloc(config, &ctx) != TILEDB_OK)
+    if (tiledb_ctx_alloc(config.ptr().get(), &ctx) != TILEDB_OK)
       throw TileDBError("[TileDB::C++API] Error: Failed to create context");
     ctx_ = std::shared_ptr<tiledb_ctx_t>(ctx, Context::free);
     error_handler_ = default_error_handler;
@@ -142,11 +142,6 @@ class Context {
   /** Returns the C TileDB context object. */
   std::shared_ptr<tiledb_ctx_t> ptr() const {
     return ctx_;
-  }
-
-  /** Auxiliary operator for getting the underlying C TileDB object. */
-  operator tiledb_ctx_t*() const {
-    return ctx_.get();
   }
 
   /**

--- a/tiledb/sm/cpp_api/dimension.h
+++ b/tiledb/sm/cpp_api/dimension.h
@@ -85,7 +85,8 @@ class Dimension {
   const std::string name() const {
     const char* name;
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_dimension_get_name(ctx, dim_.get(), &name));
+    ctx.handle_error(
+        tiledb_dimension_get_name(ctx.ptr().get(), dim_.get(), &name));
     return name;
   }
 
@@ -93,7 +94,8 @@ class Dimension {
   tiledb_datatype_t type() const {
     tiledb_datatype_t type;
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_dimension_get_type(ctx, dim_.get(), &type));
+    ctx.handle_error(
+        tiledb_dimension_get_type(ctx.ptr().get(), dim_.get(), &type));
     return type;
   }
 
@@ -308,11 +310,6 @@ class Dimension {
     return dim_;
   }
 
-  /** Auxiliary operator for getting the underlying C TileDB object. */
-  operator tiledb_dimension_t*() const {
-    return dim_.get();
-  }
-
   /* ********************************* */
   /*          STATIC FUNCTIONS         */
   /* ********************************* */
@@ -422,7 +419,8 @@ class Dimension {
   void* _domain() const {
     auto& ctx = ctx_.get();
     void* domain;
-    ctx.handle_error(tiledb_dimension_get_domain(ctx, dim_.get(), &domain));
+    ctx.handle_error(
+        tiledb_dimension_get_domain(ctx.ptr().get(), dim_.get(), &domain));
     return domain;
   }
 
@@ -430,8 +428,8 @@ class Dimension {
   void* _tile_extent() const {
     void* tile_extent;
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_dimension_get_tile_extent(ctx, dim_.get(), &tile_extent));
+    ctx.handle_error(tiledb_dimension_get_tile_extent(
+        ctx.ptr().get(), dim_.get(), &tile_extent));
     return tile_extent;
   }
 
@@ -451,7 +449,7 @@ class Dimension {
       const void* tile_extent) {
     tiledb_dimension_t* d;
     ctx.handle_error(tiledb_dimension_alloc(
-        ctx, name.c_str(), type, domain, tile_extent, &d));
+        ctx.ptr().get(), name.c_str(), type, domain, tile_extent, &d));
     return Dimension(ctx, d);
   }
 };

--- a/tiledb/sm/cpp_api/filter.h
+++ b/tiledb/sm/cpp_api/filter.h
@@ -75,7 +75,8 @@ class Filter {
   Filter(const Context& ctx, tiledb_filter_type_t filter_type)
       : ctx_(ctx) {
     tiledb_filter_t* filter;
-    ctx.handle_error(tiledb_filter_alloc(ctx, filter_type, &filter));
+    ctx.handle_error(
+        tiledb_filter_alloc(ctx.ptr().get(), filter_type, &filter));
     filter_ = std::shared_ptr<tiledb_filter_t>(filter, deleter_);
   }
 
@@ -99,11 +100,6 @@ class Filter {
   /* ********************************* */
   /*                 API               */
   /* ********************************* */
-
-  /** Auxiliary operator for getting the underlying C TileDB object. */
-  operator tiledb_filter_t*() const {
-    return filter_.get();
-  }
 
   /** Returns a shared pointer to the C TileDB domain object. */
   std::shared_ptr<tiledb_filter_t> ptr() const {
@@ -135,8 +131,8 @@ class Filter {
   Filter& set_option(tiledb_filter_option_t option, T value) {
     auto& ctx = ctx_.get();
     option_value_typecheck<T>(option);
-    ctx.handle_error(
-        tiledb_filter_set_option(ctx, filter_.get(), option, &value));
+    ctx.handle_error(tiledb_filter_set_option(
+        ctx.ptr().get(), filter_.get(), option, &value));
     return *this;
   }
 
@@ -164,8 +160,8 @@ class Filter {
    */
   Filter& set_option(tiledb_filter_option_t option, const void* value) {
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_filter_set_option(ctx, filter_.get(), option, value));
+    ctx.handle_error(tiledb_filter_set_option(
+        ctx.ptr().get(), filter_.get(), option, value));
     return *this;
   }
 
@@ -197,8 +193,8 @@ class Filter {
   void get_option(tiledb_filter_option_t option, T* value) {
     auto& ctx = ctx_.get();
     option_value_typecheck<T>(option);
-    ctx.handle_error(
-        tiledb_filter_get_option(ctx, filter_.get(), option, value));
+    ctx.handle_error(tiledb_filter_get_option(
+        ctx.ptr().get(), filter_.get(), option, value));
   }
 
   /**
@@ -227,15 +223,16 @@ class Filter {
    */
   void get_option(tiledb_filter_option_t option, void* value) {
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_filter_get_option(ctx, filter_.get(), option, value));
+    ctx.handle_error(tiledb_filter_get_option(
+        ctx.ptr().get(), filter_.get(), option, value));
   }
 
   /** Gets the filter type of this filter. */
   tiledb_filter_type_t filter_type() const {
     auto& ctx = ctx_.get();
     tiledb_filter_type_t type;
-    ctx.handle_error(tiledb_filter_get_type(ctx, filter_.get(), &type));
+    ctx.handle_error(
+        tiledb_filter_get_type(ctx.ptr().get(), filter_.get(), &type));
     return type;
   }
 

--- a/tiledb/sm/cpp_api/filter_list.h
+++ b/tiledb/sm/cpp_api/filter_list.h
@@ -75,7 +75,7 @@ class FilterList {
   FilterList(const Context& ctx)
       : ctx_(ctx) {
     tiledb_filter_list_t* filter_list;
-    ctx.handle_error(tiledb_filter_list_alloc(ctx, &filter_list));
+    ctx.handle_error(tiledb_filter_list_alloc(ctx.ptr().get(), &filter_list));
     filter_list_ = std::shared_ptr<tiledb_filter_list_t>(filter_list, deleter_);
   }
 
@@ -100,11 +100,6 @@ class FilterList {
   /*                 API               */
   /* ********************************* */
 
-  /** Auxiliary operator for getting the underlying C TileDB object. */
-  operator tiledb_filter_list_t*() const {
-    return filter_list_.get();
-  }
-
   /** Returns a shared pointer to the C TileDB domain object. */
   std::shared_ptr<tiledb_filter_list_t> ptr() const {
     return filter_list_;
@@ -127,8 +122,8 @@ class FilterList {
    */
   FilterList& add_filter(const Filter& filter) {
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_filter_list_add_filter(ctx, filter_list_.get(), filter));
+    ctx.handle_error(tiledb_filter_list_add_filter(
+        ctx.ptr().get(), filter_list_.get(), filter.ptr().get()));
     return *this;
   }
 
@@ -154,7 +149,7 @@ class FilterList {
     auto& ctx = ctx_.get();
     tiledb_filter_t* filter;
     ctx.handle_error(tiledb_filter_list_get_filter_from_index(
-        ctx, filter_list_.get(), filter_index, &filter));
+        ctx.ptr().get(), filter_list_.get(), filter_index, &filter));
     return Filter(ctx, filter);
   }
 
@@ -167,7 +162,7 @@ class FilterList {
     auto& ctx = ctx_.get();
     uint32_t max_chunk_size;
     ctx.handle_error(tiledb_filter_list_get_max_chunk_size(
-        ctx, filter_list_.get(), &max_chunk_size));
+        ctx.ptr().get(), filter_list_.get(), &max_chunk_size));
     return max_chunk_size;
   }
 
@@ -188,8 +183,8 @@ class FilterList {
   uint32_t nfilters() const {
     auto& ctx = ctx_.get();
     uint32_t nfilters;
-    ctx.handle_error(
-        tiledb_filter_list_get_nfilters(ctx, filter_list_.get(), &nfilters));
+    ctx.handle_error(tiledb_filter_list_get_nfilters(
+        ctx.ptr().get(), filter_list_.get(), &nfilters));
     return nfilters;
   }
 
@@ -202,7 +197,7 @@ class FilterList {
   FilterList& set_max_chunk_size(uint32_t max_chunk_size) {
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_filter_list_set_max_chunk_size(
-        ctx, filter_list_.get(), max_chunk_size));
+        ctx.ptr().get(), filter_list_.get(), max_chunk_size));
     return *this;
   }
 

--- a/tiledb/sm/cpp_api/group.h
+++ b/tiledb/sm/cpp_api/group.h
@@ -49,7 +49,7 @@ namespace tiledb {
  * @return void
  */
 inline void create_group(const Context& ctx, const std::string& group) {
-  ctx.handle_error(tiledb_group_create(ctx, group.c_str()));
+  ctx.handle_error(tiledb_group_create(ctx.ptr().get(), group.c_str()));
 }
 
 }  // namespace tiledb

--- a/tiledb/sm/cpp_api/object.h
+++ b/tiledb/sm/cpp_api/object.h
@@ -152,7 +152,7 @@ class Object {
    */
   static Object object(const Context& ctx, const std::string& uri) {
     tiledb_object_t type;
-    ctx.handle_error(tiledb_object_type(ctx, uri.c_str(), &type));
+    ctx.handle_error(tiledb_object_type(ctx.ptr().get(), uri.c_str(), &type));
     Object ret(type, uri);
     return ret;
   }
@@ -164,7 +164,7 @@ class Object {
    * @param uri The path to the object to be removed.
    */
   static void remove(const Context& ctx, const std::string& uri) {
-    ctx.handle_error(tiledb_object_remove(ctx, uri.c_str()));
+    ctx.handle_error(tiledb_object_remove(ctx.ptr().get(), uri.c_str()));
   }
 
   /**
@@ -177,7 +177,8 @@ class Object {
       const Context& ctx,
       const std::string& old_uri,
       const std::string& new_uri) {
-    ctx.handle_error(tiledb_object_move(ctx, old_uri.c_str(), new_uri.c_str()));
+    ctx.handle_error(
+        tiledb_object_move(ctx.ptr().get(), old_uri.c_str(), new_uri.c_str()));
   }
 
  private:

--- a/tiledb/sm/cpp_api/object_iter.h
+++ b/tiledb/sm/cpp_api/object_iter.h
@@ -212,9 +212,10 @@ class ObjectIter {
     ObjGetterData data(objs, array_, group_, kv_);
     if (recursive_) {
       ctx.handle_error(tiledb_object_walk(
-          ctx, root_.c_str(), walk_order_, obj_getter, &data));
+          ctx.ptr().get(), root_.c_str(), walk_order_, obj_getter, &data));
     } else {
-      ctx.handle_error(tiledb_object_ls(ctx, root_.c_str(), obj_getter, &data));
+      ctx.handle_error(
+          tiledb_object_ls(ctx.ptr().get(), root_.c_str(), obj_getter, &data));
     }
 
     return iterator(objs);

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -132,7 +132,8 @@ class Query {
       : ctx_(ctx)
       , schema_(array.schema()) {
     tiledb_query_t* q;
-    ctx.handle_error(tiledb_query_alloc(ctx, array, type, &q));
+    ctx.handle_error(
+        tiledb_query_alloc(ctx.ptr().get(), array.ptr().get(), type, &q));
     query_ = std::shared_ptr<tiledb_query_t>(q, deleter_);
   }
 
@@ -166,7 +167,8 @@ class Query {
       , schema_(array.schema()) {
     tiledb_query_t* q;
     auto type = array.query_type();
-    ctx.handle_error(tiledb_query_alloc(ctx, array, type, &q));
+    ctx.handle_error(
+        tiledb_query_alloc(ctx.ptr().get(), array.ptr().get(), type, &q));
     query_ = std::shared_ptr<tiledb_query_t>(q, deleter_);
   }
 
@@ -188,7 +190,8 @@ class Query {
   tiledb_query_type_t query_type() const {
     auto& ctx = ctx_.get();
     tiledb_query_type_t query_type;
-    ctx.handle_error(tiledb_query_get_type(ctx, query_.get(), &query_type));
+    ctx.handle_error(
+        tiledb_query_get_type(ctx.ptr().get(), query_.get(), &query_type));
     return query_type;
   }
 
@@ -215,7 +218,8 @@ class Query {
    */
   Query& set_layout(tiledb_layout_t layout) {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_query_set_layout(ctx, query_.get(), layout));
+    ctx.handle_error(
+        tiledb_query_set_layout(ctx.ptr().get(), query_.get(), layout));
     return *this;
   }
 
@@ -223,7 +227,8 @@ class Query {
   tiledb_layout_t query_layout() const {
     auto& ctx = ctx_.get();
     tiledb_layout_t query_layout;
-    ctx.handle_error(tiledb_query_get_layout(ctx, query_.get(), &query_layout));
+    ctx.handle_error(
+        tiledb_query_get_layout(ctx.ptr().get(), query_.get(), &query_layout));
     return query_layout;
   }
 
@@ -231,7 +236,8 @@ class Query {
   Status query_status() const {
     tiledb_query_status_t status;
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_query_get_status(ctx, query_.get(), &status));
+    ctx.handle_error(
+        tiledb_query_get_status(ctx.ptr().get(), query_.get(), &status));
     return to_status(status);
   }
 
@@ -242,7 +248,8 @@ class Query {
   bool has_results() const {
     int ret;
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_query_has_results(ctx, query_.get(), &ret));
+    ctx.handle_error(
+        tiledb_query_has_results(ctx.ptr().get(), query_.get(), &ret));
     return (bool)ret;
   }
 
@@ -267,7 +274,7 @@ class Query {
    */
   Status submit() {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_query_submit(ctx, query_.get()));
+    ctx.handle_error(tiledb_query_submit(ctx.ptr().get(), query_.get()));
     return query_status();
   }
 
@@ -291,7 +298,7 @@ class Query {
     std::function<void(void*)> wrapper = [&](void*) { callback(); };
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb::impl::tiledb_query_submit_async_func(
-        ctx, query_.get(), &wrapper, nullptr));
+        ctx.ptr().get(), query_.get(), &wrapper, nullptr));
   }
 
   /**
@@ -318,7 +325,7 @@ class Query {
    */
   void finalize() {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_query_finalize(ctx, query_.get()));
+    ctx.handle_error(tiledb_query_finalize(ctx.ptr().get(), query_.get()));
   }
 
   /**
@@ -418,7 +425,8 @@ class Query {
           "Subarray should have num_dims * 2 values: (low, high) for each "
           "dimension.");
     }
-    ctx.handle_error(tiledb_query_set_subarray(ctx, query_.get(), pairs));
+    ctx.handle_error(
+        tiledb_query_set_subarray(ctx.ptr().get(), query_.get(), pairs));
     subarray_cell_num_ = pairs[1] - pairs[0] + 1;
     for (unsigned i = 2; i < size - 1; i += 2) {
       subarray_cell_num_ *= (pairs[i + 1] - pairs[i] + 1);
@@ -524,7 +532,8 @@ class Query {
    */
   Query& set_subarray(Subarray& subarray) {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_query_set_subarray_2(ctx, query_.get(), subarray));
+    ctx.handle_error(tiledb_query_set_subarray_2(
+        ctx.ptr().get(), query_.get(), subarray.ptr().get()));
     return *this;
   }
 
@@ -862,7 +871,11 @@ class Query {
     buff_sizes_[attr] = std::pair<uint64_t, uint64_t>(0, size);
     element_sizes_[attr] = element_size;
     ctx.handle_error(tiledb_query_set_buffer(
-        ctx, query_.get(), attr.c_str(), buff, &(buff_sizes_[attr].second)));
+        ctx.ptr().get(),
+        query_.get(),
+        attr.c_str(),
+        buff,
+        &(buff_sizes_[attr].second)));
     return *this;
   }
 
@@ -892,7 +905,7 @@ class Query {
     element_sizes_[attr] = element_size;
     buff_sizes_[attr] = std::pair<uint64_t, uint64_t>(offset_size, data_size);
     ctx.handle_error(tiledb_query_set_buffer_var(
-        ctx,
+        ctx.ptr().get(),
         query_.get(),
         attr.c_str(),
         offsets,

--- a/tiledb/sm/cpp_api/subarray.h
+++ b/tiledb/sm/cpp_api/subarray.h
@@ -70,7 +70,8 @@ class Subarray {
   explicit Subarray(const Context& ctx, Array& array, tiledb_layout_t layout)
       : ctx_(ctx) {
     tiledb_subarray_t* subarray;
-    ctx.handle_error(tiledb_subarray_alloc(ctx, array, layout, &subarray));
+    ctx.handle_error(tiledb_subarray_alloc(
+        ctx.ptr().get(), array.ptr().get(), layout, &subarray));
     subarray_ = std::shared_ptr<tiledb_subarray_t>(subarray, deleter_);
   }
 
@@ -108,8 +109,8 @@ class Subarray {
    */
   Subarray& add_range(uint32_t dim_idx, const void* range) {
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_subarray_add_range(ctx, subarray_.get(), dim_idx, range));
+    ctx.handle_error(tiledb_subarray_add_range(
+        ctx.ptr().get(), subarray_.get(), dim_idx, range));
     return *this;
   }
 
@@ -131,7 +132,7 @@ class Subarray {
     auto& ctx = ctx_.get();
     uint64_t size = 0;
     ctx.handle_error(tiledb_subarray_get_est_result_size(
-        ctx, subarray_.get(), attr_name.c_str(), &size));
+        ctx.ptr().get(), subarray_.get(), attr_name.c_str(), &size));
     return size;
   }
 
@@ -157,18 +158,17 @@ class Subarray {
     auto& ctx = ctx_.get();
     uint64_t size_off = 0, size_val = 0;
     ctx.handle_error(tiledb_subarray_get_est_result_size_var(
-        ctx, subarray_.get(), attr_name.c_str(), &size_off, &size_val));
+        ctx.ptr().get(),
+        subarray_.get(),
+        attr_name.c_str(),
+        &size_off,
+        &size_val));
     return std::make_pair(size_off / sizeof(uint64_t), size_val);
   }
 
   /** Returns a shared pointer to the C TileDB subarray object. */
   std::shared_ptr<tiledb_subarray_t> ptr() const {
     return subarray_;
-  }
-
-  /** Auxiliary operator for getting the underlying C TileDB object. */
-  operator tiledb_subarray_t*() const {
-    return subarray_.get();
   }
 
  private:

--- a/tiledb/sm/cpp_api/vfs.h
+++ b/tiledb/sm/cpp_api/vfs.h
@@ -386,77 +386,87 @@ class VFS {
   /** Creates an object-store bucket with the input URI. */
   void create_bucket(const std::string& uri) const {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_vfs_create_bucket(ctx, vfs_.get(), uri.c_str()));
+    ctx.handle_error(
+        tiledb_vfs_create_bucket(ctx.ptr().get(), vfs_.get(), uri.c_str()));
   }
 
   /** Deletes an object-store bucket with the input URI. */
   void remove_bucket(const std::string& uri) const {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_vfs_remove_bucket(ctx, vfs_.get(), uri.c_str()));
+    ctx.handle_error(
+        tiledb_vfs_remove_bucket(ctx.ptr().get(), vfs_.get(), uri.c_str()));
   }
 
   /** Checks if an object-store bucket with the input URI exists. */
   bool is_bucket(const std::string& uri) const {
     auto& ctx = ctx_.get();
     int ret;
-    ctx.handle_error(tiledb_vfs_is_bucket(ctx, vfs_.get(), uri.c_str(), &ret));
+    ctx.handle_error(
+        tiledb_vfs_is_bucket(ctx.ptr().get(), vfs_.get(), uri.c_str(), &ret));
     return (bool)ret;
   }
 
   /** Empty a bucket **/
   void empty_bucket(const std::string& bucket) const {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_vfs_empty_bucket(ctx, vfs_.get(), bucket.c_str()));
+    ctx.handle_error(
+        tiledb_vfs_empty_bucket(ctx.ptr().get(), vfs_.get(), bucket.c_str()));
   }
 
   /** Check if a bucket is empty **/
   bool is_empty_bucket(const std::string& bucket) const {
     auto& ctx = ctx_.get();
     int empty;
-    ctx.handle_error(
-        tiledb_vfs_is_empty_bucket(ctx, vfs_.get(), bucket.c_str(), &empty));
+    ctx.handle_error(tiledb_vfs_is_empty_bucket(
+        ctx.ptr().get(), vfs_.get(), bucket.c_str(), &empty));
     return empty == 0;
   }
 
   /** Creates a directory with the input URI. */
   void create_dir(const std::string& uri) const {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_vfs_create_dir(ctx, vfs_.get(), uri.c_str()));
+    ctx.handle_error(
+        tiledb_vfs_create_dir(ctx.ptr().get(), vfs_.get(), uri.c_str()));
   }
 
   /** Checks if a directory with the input URI exists. */
   bool is_dir(const std::string& uri) const {
     auto& ctx = ctx_.get();
     int ret;
-    ctx.handle_error(tiledb_vfs_is_dir(ctx, vfs_.get(), uri.c_str(), &ret));
+    ctx.handle_error(
+        tiledb_vfs_is_dir(ctx.ptr().get(), vfs_.get(), uri.c_str(), &ret));
     return (bool)ret;
   }
 
   /** Removes a directory (recursively) with the input URI. */
   void remove_dir(const std::string& uri) const {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_vfs_remove_dir(ctx, vfs_.get(), uri.c_str()));
+    ctx.handle_error(
+        tiledb_vfs_remove_dir(ctx.ptr().get(), vfs_.get(), uri.c_str()));
   }
 
   /** Checks if a file with the input URI exists. */
   bool is_file(const std::string& uri) const {
     auto& ctx = ctx_.get();
     int ret;
-    ctx.handle_error(tiledb_vfs_is_file(ctx, vfs_.get(), uri.c_str(), &ret));
+    ctx.handle_error(
+        tiledb_vfs_is_file(ctx.ptr().get(), vfs_.get(), uri.c_str(), &ret));
     return (bool)ret;
   }
 
   /** Deletes a file with the input URI. */
   void remove_file(const std::string& uri) const {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_vfs_remove_file(ctx, vfs_.get(), uri.c_str()));
+    ctx.handle_error(
+        tiledb_vfs_remove_file(ctx.ptr().get(), vfs_.get(), uri.c_str()));
   }
 
   /** Retrieves the size of a directory with the input URI. */
   uint64_t dir_size(const std::string& uri) const {
     uint64_t ret;
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_vfs_dir_size(ctx, vfs_.get(), uri.c_str(), &ret));
+    ctx.handle_error(
+        tiledb_vfs_dir_size(ctx.ptr().get(), vfs_.get(), uri.c_str(), &ret));
     return ret;
   }
 
@@ -467,8 +477,8 @@ class VFS {
   std::vector<std::string> ls(const std::string& uri) const {
     std::vector<std::string> ret;
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_vfs_ls(ctx, vfs_.get(), uri.c_str(), ls_getter, &ret));
+    ctx.handle_error(tiledb_vfs_ls(
+        ctx.ptr().get(), vfs_.get(), uri.c_str(), ls_getter, &ret));
     return ret;
   }
 
@@ -476,7 +486,8 @@ class VFS {
   uint64_t file_size(const std::string& uri) const {
     uint64_t ret;
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_vfs_file_size(ctx, vfs_.get(), uri.c_str(), &ret));
+    ctx.handle_error(
+        tiledb_vfs_file_size(ctx.ptr().get(), vfs_.get(), uri.c_str(), &ret));
     return ret;
   }
 
@@ -484,20 +495,21 @@ class VFS {
   void move_file(const std::string& old_uri, const std::string& new_uri) const {
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_vfs_move_file(
-        ctx, vfs_.get(), old_uri.c_str(), new_uri.c_str()));
+        ctx.ptr().get(), vfs_.get(), old_uri.c_str(), new_uri.c_str()));
   }
 
   /** Renames a TileDB directory from an old URI to a new URI. */
   void move_dir(const std::string& old_uri, const std::string& new_uri) const {
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_vfs_move_dir(ctx, vfs_.get(), old_uri.c_str(), new_uri.c_str()));
+    ctx.handle_error(tiledb_vfs_move_dir(
+        ctx.ptr().get(), vfs_.get(), old_uri.c_str(), new_uri.c_str()));
   }
 
   /** Touches a file with the input URI, i.e., creates a new empty file. */
   void touch(const std::string& uri) const {
     auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_vfs_touch(ctx, vfs_.get(), uri.c_str()));
+    ctx.handle_error(
+        tiledb_vfs_touch(ctx.ptr().get(), vfs_.get(), uri.c_str()));
   }
 
   /** Get the underlying context **/
@@ -558,7 +570,7 @@ class VFS {
   /** Creates a TileDB C VFS object, using the input config. */
   void create_vfs(tiledb_config_t* config) {
     tiledb_vfs_t* vfs;
-    int rc = tiledb_vfs_alloc(ctx_.get(), config, &vfs);
+    int rc = tiledb_vfs_alloc(ctx_.get().ptr().get(), config, &vfs);
     if (rc != TILEDB_OK)
       throw std::runtime_error(
           "[TileDB::C++API] Error: Failed to create VFS object");
@@ -591,7 +603,8 @@ inline VFSFilebuf* VFSFilebuf::open(
 
   tiledb_vfs_fh_t* fh;
   auto& ctx = vfs_.get().context();
-  if (tiledb_vfs_open(ctx, vfs_.get().ptr().get(), uri.c_str(), mode, &fh) !=
+  if (tiledb_vfs_open(
+          ctx.ptr().get(), vfs_.get().ptr().get(), uri.c_str(), mode, &fh) !=
       TILEDB_OK) {
     return nullptr;
   }
@@ -607,7 +620,7 @@ inline VFSFilebuf* VFSFilebuf::open(
 inline VFSFilebuf* VFSFilebuf::close() {
   if (is_open()) {
     auto& ctx = vfs_.get().context();
-    ctx.handle_error(tiledb_vfs_close(ctx, fh_.get()));
+    ctx.handle_error(tiledb_vfs_close(ctx.ptr().get(), fh_.get()));
   }
   uri_ = "";
   fh_ = nullptr;
@@ -625,8 +638,11 @@ inline std::streamsize VFSFilebuf::xsgetn(char_type* s, std::streamsize n) {
     return traits_type::eof();
   auto& ctx = vfs_.get().context();
   if (tiledb_vfs_read(
-          ctx, fh_.get(), offset_, s, static_cast<uint64_t>(readlen)) !=
-      TILEDB_OK) {
+          ctx.ptr().get(),
+          fh_.get(),
+          offset_,
+          s,
+          static_cast<uint64_t>(readlen)) != TILEDB_OK) {
     return traits_type::eof();
   }
 
@@ -639,7 +655,8 @@ inline std::streamsize VFSFilebuf::xsputn(
   if (offset_ != 0 && offset_ != file_size())
     return traits_type::eof();
   auto& ctx = vfs_.get().context();
-  if (tiledb_vfs_write(ctx, fh_.get(), s, static_cast<uint64_t>(n)) !=
+  if (tiledb_vfs_write(
+          ctx.ptr().get(), fh_.get(), s, static_cast<uint64_t>(n)) !=
       TILEDB_OK) {
     return traits_type::eof();
   }


### PR DESCRIPTION
Closes #1011.

Note that this is technically an API breakage, although I would be surprised if many users were using this functionality.