### PR TITLE
Add array schema check that ensures non-null tile extents.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,9 +45,14 @@
 
 ## Breaking changes
 
+### C API
+
+* Not setting a dimension's tile extent when creating an array is now an error (previously it implied the whole domain).
+
 ### C++ API
 
 * Removed cast operators of C++ API objects to their underlying C API objects. This helps prevent inadvertent memory issues such as double-frees.
+* Not setting a dimension's tile extent when creating an array is now an error (previously it implied the whole domain).
 
 # TileDB v1.5.0 Release Notes
 

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -239,6 +239,8 @@ Status ArraySchema::check() const {
         Status::ArraySchemaError("Array schema check failed; Attributes "
                                  "and dimensions must have unique names"));
 
+  RETURN_NOT_OK(check_tile_extents());
+
   // Success
   return Status::Ok();
 }
@@ -665,6 +667,18 @@ bool ArraySchema::check_double_delta_compressor() const {
   }
 
   return true;
+}
+
+Status ArraySchema::check_tile_extents() const {
+  auto dim_num = domain_->dim_num();
+  for (unsigned i = 0; i < dim_num; i++) {
+    const auto* dim = domain_->dimension(i);
+    if (dim->tile_extent() == nullptr)
+      return LOG_STATUS(Status::ArraySchemaError(
+          "Array schema check failed; dimension '" + dim->name() +
+          "' has no tile extent set."));
+  }
+  return Status::Ok();
 }
 
 void ArraySchema::clear() {

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -362,6 +362,12 @@ class ArraySchema {
    */
   bool check_double_delta_compressor() const;
 
+  /**
+   * Checks that all dimensions have a non-null tile extent.
+   * @return Status
+   */
+  Status check_tile_extents() const;
+
   /** Clears all members. Use with caution! */
   void clear();
 


### PR DESCRIPTION
Closes #859.