### PR TITLE
Require dense reads and writes to always specify a subarray.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@
 * Support for direct writes without using the S3 multi-part API. Allows writing to
   Google Cloud Storage S3 compatibility mode. [#1219](https://github.com/TileDB-Inc/TileDB/pull/1219)
 * Removed 256-character length limit from URIs.
+* Dense reads and writes now always require a subarray to be set, to avoid confusion.
 
 ## Bug fixes
 

--- a/test/src/unit-capi-any.cc
+++ b/test/src/unit-capi-any.cc
@@ -217,6 +217,8 @@ void AnyFx::read_array(const std::string& array_name) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx, query, subarray);
+  REQUIRE(rc == TILEDB_OK);
 
   // Submit query
   rc = tiledb_query_submit(ctx, query);

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -870,9 +870,12 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   // Submit query
+  int64_t subarray_read[] = {1, 10};
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
   CHECK(rc == TILEDB_OK);
   rc =
       tiledb_query_set_buffer(ctx_, query, "a", buffer_read, &buffer_read_size);
@@ -920,6 +923,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
+  CHECK(rc == TILEDB_OK);
   rc =
       tiledb_query_set_buffer(ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
@@ -959,6 +964,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
   CHECK(rc == TILEDB_OK);
   rc =
       tiledb_query_set_buffer(ctx_, query, "a", buffer_read, &buffer_read_size);
@@ -1007,6 +1014,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
+  CHECK(rc == TILEDB_OK);
   rc =
       tiledb_query_set_buffer(ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
@@ -1031,6 +1040,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
   CHECK(rc == TILEDB_OK);
   rc =
       tiledb_query_set_buffer(ctx_, query, "a", buffer_read, &buffer_read_size);
@@ -1321,6 +1332,7 @@ TEST_CASE_METHOD(
   uint64_t buffer_a1_size = sizeof(buffer_a1);
 
   // Open array
+  int64_t subarray[] = {1, 10};
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
@@ -1332,6 +1344,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);
@@ -1359,6 +1373,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
   rc =
       tiledb_query_set_buffer(ctx_, query, "a", buffer_read, &buffer_read_size);

--- a/test/src/unit-capi-async.cc
+++ b/test/src/unit-capi-async.cc
@@ -570,6 +570,8 @@ void AsyncFx::read_dense_async() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer_var(

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -1866,6 +1866,8 @@ void ConsolidationFx::read_dense_vector() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a", a, &a_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_submit(ctx_, query);
@@ -1927,6 +1929,8 @@ void ConsolidationFx::read_dense_vector_with_gaps() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a", a, &a_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_submit(ctx_, query);
@@ -1980,6 +1984,7 @@ void ConsolidationFx::read_dense_vector_mixed() {
   REQUIRE(rc == TILEDB_OK);
 
   // Preparation
+  uint64_t subarray[] = {1, 410};
   int a[410];
   uint64_t a_size = sizeof(a);
 
@@ -1988,6 +1993,8 @@ void ConsolidationFx::read_dense_vector_mixed() {
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a", a, &a_size);
   CHECK(rc == TILEDB_OK);
@@ -2378,6 +2385,8 @@ void ConsolidationFx::read_dense_full_subarray_unordered() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer_var(
@@ -2488,6 +2497,8 @@ void ConsolidationFx::read_dense_subarray_full_unordered() {
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer_var(
@@ -2588,6 +2599,8 @@ void ConsolidationFx::read_dense_subarray_unordered_full() {
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -1976,6 +1976,7 @@ void DenseArrayFx::read_dense_vector_mixed(const std::string& array_name) {
   REQUIRE(rc == TILEDB_OK);
 
   // Preparation
+  uint64_t subarray[] = {1, 410};
   int a[410];
   uint64_t a_size = sizeof(a);
 
@@ -1984,6 +1985,8 @@ void DenseArrayFx::read_dense_vector_mixed(const std::string& array_name) {
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a", a, &a_size);
   CHECK(rc == TILEDB_OK);
@@ -2064,6 +2067,8 @@ void DenseArrayFx::read_dense_array_with_coords_full_global(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);
@@ -2177,6 +2182,8 @@ void DenseArrayFx::read_dense_array_with_coords_full_row(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer_var(
@@ -2287,6 +2294,8 @@ void DenseArrayFx::read_dense_array_with_coords_full_col(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_COL_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);
@@ -3166,6 +3175,9 @@ TEST_CASE_METHOD(
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
+  uint64_t subarray[] = {1, 4, 1, 4};
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
 
   // Aux variables
   uint64_t off[1];
@@ -3663,6 +3675,7 @@ TEST_CASE_METHOD(
   tiledb_query_free(&query);
 
   // Read whole array
+  uint64_t subarray_read[] = {1, 4, 1, 4};
   int c_a1[] = {INT_MIN,
                 INT_MIN,
                 INT_MIN,
@@ -3688,6 +3701,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(
       ctx_, query, attributes[0], read_a1, &read_a1_size);
@@ -3750,6 +3765,7 @@ TEST_CASE_METHOD(
   tiledb_query_free(&query);
 
   // Read whole array
+  uint64_t subarray_read[] = {1, 4, 1, 4};
   int c_a1[] = {INT_MIN,
                 1,
                 INT_MIN,
@@ -3779,6 +3795,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", read_a1, &read_a1_size);
   CHECK(rc == TILEDB_OK);
@@ -3844,6 +3862,7 @@ TEST_CASE_METHOD(
   tiledb_query_free(&query);
 
   // Read whole array
+  uint64_t subarray_read[] = {1, 4, 1, 4};
   int c_a1[] = {INT_MIN,
                 INT_MIN,
                 INT_MIN,
@@ -3869,6 +3888,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(
       ctx_, query, attributes[0], read_a1, &read_a1_size);
@@ -3951,6 +3972,7 @@ TEST_CASE_METHOD(
   tiledb_query_free(&query);
 
   // Read whole array
+  uint64_t subarray_read[] = {1, 4, 1, 4};
   int c_a[] = {1,
                2,
                3,
@@ -3976,6 +3998,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", read_a, &read_a_size);
   CHECK(rc == TILEDB_OK);
@@ -4316,6 +4340,7 @@ TEST_CASE_METHOD(
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
 
+  uint64_t subarray_read[] = {1, 4, 1, 4};
   int a[16];
   uint64_t a_size = sizeof(a);
   tiledb_query_t* query;
@@ -4325,6 +4350,8 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_COL_MAJOR);
   REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
+  CHECK(rc == TILEDB_OK);
   rc = submit_query_wrapper(array_name, query);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_finalize(ctx_, query);

--- a/test/src/unit-capi-dense_neg.cc
+++ b/test/src/unit-capi-dense_neg.cc
@@ -330,6 +330,7 @@ void DenseNegFx::write_dense_array_global(const std::string& path) {
   rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);
 
+  int64_t subarray[] = {-2, 1, -2, 1};
   int a[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
   uint64_t a_size = sizeof(a);
   tiledb_query_t* query;
@@ -338,6 +339,8 @@ void DenseNegFx::write_dense_array_global(const std::string& path) {
   rc = tiledb_query_set_buffer(ctx_, query, "a", a, &a_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_submit(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
@@ -467,6 +470,7 @@ void DenseNegFx::read_dense_array_global(const std::string& path) {
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
 
+  int64_t subarray[] = {-2, 1, -2, 1};
   int a[16];
   uint64_t a_size = sizeof(a);
   tiledb_query_t* query;
@@ -475,6 +479,8 @@ void DenseNegFx::read_dense_array_global(const std::string& path) {
   rc = tiledb_query_set_buffer(ctx_, query, "a", a, &a_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_submit(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
@@ -502,6 +508,7 @@ void DenseNegFx::read_dense_array_row(const std::string& path) {
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
 
+  int64_t subarray[] = {-2, 1, -2, 1};
   int a[16];
   uint64_t a_size = sizeof(a);
   tiledb_query_t* query;
@@ -510,6 +517,8 @@ void DenseNegFx::read_dense_array_row(const std::string& path) {
   rc = tiledb_query_set_buffer(ctx_, query, "a", a, &a_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_submit(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
@@ -537,6 +546,7 @@ void DenseNegFx::read_dense_array_col(const std::string& path) {
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
 
+  int64_t subarray[] = {-2, 1, -2, 1};
   int a[16];
   uint64_t a_size = sizeof(a);
   tiledb_query_t* query;
@@ -545,6 +555,8 @@ void DenseNegFx::read_dense_array_col(const std::string& path) {
   rc = tiledb_query_set_buffer(ctx_, query, "a", a, &a_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_COL_MAJOR);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_submit(ctx_, query);
   REQUIRE(rc == TILEDB_OK);

--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -1453,6 +1453,7 @@ TEST_CASE_METHOD(
   tiledb_query_free(&query);
 
   // Read whole array
+  uint64_t subarray_read[] = {1, 4, 1, 4};
   int c_a1[] = {INT_MIN,
                 INT_MIN,
                 INT_MIN,
@@ -1478,6 +1479,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(
       ctx_, query, attributes[0], read_a1, &read_a1_size);
@@ -1534,6 +1537,7 @@ TEST_CASE_METHOD(
   tiledb_query_free(&query);
 
   // Read whole array
+  uint64_t subarray[] = {1, 4, 1, 4};
   int c_a1[] = {INT_MIN,
                 1,
                 INT_MIN,
@@ -1563,6 +1567,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", read_a1, &read_a1_size);
   CHECK(rc == TILEDB_OK);
@@ -1622,6 +1628,7 @@ TEST_CASE_METHOD(
   tiledb_query_free(&query);
 
   // Read whole array
+  uint64_t subarray_read[] = {1, 4, 1, 4};
   int c_a1[] = {INT_MIN,
                 INT_MIN,
                 INT_MIN,
@@ -1647,6 +1654,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray_read);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(
       ctx_, query, attributes[0], read_a1, &read_a1_size);
@@ -1723,6 +1732,7 @@ TEST_CASE_METHOD(
   tiledb_query_free(&query);
 
   // Read whole array
+  uint64_t subarray[] = {1, 4, 1, 4};
   int c_a[] = {1,
                2,
                3,
@@ -1748,6 +1758,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(ctx_, query, "a1", read_a, &read_a_size);
   CHECK(rc == TILEDB_OK);

--- a/test/src/unit-capi-string.cc
+++ b/test/src/unit-capi-string.cc
@@ -285,6 +285,8 @@ void StringFx::read_array(const std::string& array_name) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx, query, subarray);
+  CHECK(rc == TILEDB_OK);
 
   // Submit query
   rc = tiledb_query_submit(ctx, query);

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -203,6 +203,9 @@ Status Reader::init() {
   if (attributes_.empty())
     return LOG_STATUS(
         Status::ReaderError("Cannot initialize reader; Attributes not set"));
+  if (array_schema_->dense() && !sparse_mode_ && !subarray_.is_set())
+    return LOG_STATUS(Status::ReaderError(
+        "Cannot initialize reader; Dense reads must have a subarray set"));
 
   // Get configuration parameters
   const char *memory_budget, *memory_budget_var;

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -772,12 +772,17 @@ Status Writer::check_global_order() const {
 }
 
 Status Writer::check_subarray() const {
-  if (subarray_ == nullptr)
-    return Status::Ok();
-
   if (array_schema_ == nullptr)
     return LOG_STATUS(
         Status::WriterError("Cannot check subarray; Array schema not set"));
+
+  if (subarray_ == nullptr) {
+    if (array_schema_->dense())
+      return LOG_STATUS(Status::WriterError(
+          "Cannot initialize query; Dense writes must specify a subarray"));
+    else
+      return Status::Ok();
+  }
 
   switch (array_schema_->domain()->type()) {
     case Datatype::INT8:

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -433,6 +433,13 @@ Subarray Subarray::get_subarray(uint64_t start, uint64_t end) const {
   return ret;
 }
 
+bool Subarray::is_set() const {
+  for (const auto& r : ranges_)
+    if (!r.has_default_range_)
+      return true;
+  return false;
+}
+
 bool Subarray::is_unary() const {
   if (range_num() != 1)
     return false;

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -332,6 +332,9 @@ class Subarray {
   /** Retrieves the number of ranges on the given dimension index. */
   Status get_range_num(uint32_t dim_idx, uint64_t* range_num) const;
 
+  /** Returns `true` if at least one dimension has non-default ranges set. */
+  bool is_set() const;
+
   /**
    * Returns ``true`` if the subarray is unary, which happens when it consists
    * of a single ND range **and** each 1D range is unary (i.e., consisting of


### PR DESCRIPTION
Closes #1116.

@Shelnutt2 can you check the backwards compat changes?