### PR TITLE
Renamed fragment URIs

### DIFF
--- a/doc/source/tutorials/dense-arrays.rst
+++ b/doc/source/tutorials/dense-arrays.rst
@@ -366,23 +366,24 @@ If we look into the array on disk after it has been written to, we will see some
 
 .. code-block:: bash
 
-   $ ls -l quickstart_dense/
+   $ ls -l quickstart_dense_array/
    total 8
-   drwx------  4 tyler  staff  136 Jun 11 18:30 __0c4739ed957b4f5eaf0b2738cb1bec1c_1528756214526
-   -rwx------  1 tyler  staff  164 Jun 11 18:30 __array_schema.tdb
-   -rwx------  1 tyler  staff    0 Jun 11 18:30 __lock.tdb
+   drwx------  4 stavros  staff  128 Jun 25 15:18 __1561490302161_1561490302161_15bab0281e2e44f2a803eb6f3001ed00
+   -rwx------  1 stavros  staff  149 Jun 25 15:18 __array_schema.tdb
+   -rwx------  1 stavros  staff    0 Jun 25 15:18 __lock.tdb
 
 The array directory and files ``__array_schema.tdb`` and ``__lock.tdb`` were written upon
-array creation, whereas subdirectory ``__0c4739ed957b4f5eaf0b2738cb1bec1c_1528756214526`` was
+array creation, whereas subdirectory 
+``__1561490302161_1561490302161_15bab0281e2e44f2a803eb6f3001ed00`` was
 created after array writting. This subdirectory, called **fragment**, contains the written
 cell values for attribute ``a`` in file ``a.tdb``, along with associated metadata:
 
 .. code-block:: bash
 
-    $ ls -l quickstart_dense/__0c4739ed957b4f5eaf0b2738cb1bec1c_1528756214526/
+    $ ls -l quickstart_dense_array/__1561490302161_1561490302161_15bab0281e2e44f2a803eb6f3001ed00/
     total 16
-    -rwx------  1 tyler  staff  117 Jun 11 18:30 __fragment_metadata.tdb
-    -rwx------  1 tyler  staff    4 Jun 11 18:30 a.tdb
+    -rwx------  1 stavros  staff  602 Jun 25 15:18 __fragment_metadata.tdb
+    -rwx------  1 stavros  staff   84 Jun 25 15:18 a.tdb
 
 The TileDB array hierarchy on disk and more details about fragments are discussed in
 later tutorials.

--- a/doc/source/tutorials/fragments-consolidation.rst
+++ b/doc/source/tutorials/fragments-consolidation.rst
@@ -89,13 +89,14 @@ contains three subdirectories with weird names:
         Cell (4, 2) has data -2147483648
         Cell (4, 3) has data -2147483648
         Cell (4, 4) has data -2147483648
-        $ ls -l fragments_consolidation/
+
+        $ ls -l fragments_consolidation_array/
         total 8
-        drwx------  5 stavros  staff  170 Dec 24 12:38 __13f149611c6541ad807d285dec1b1257_1545673114154
-        drwx------  4 stavros  staff  136 Dec 24 12:38 __374ef2b0dfef49688fd34cfb7e2ecad3_1545673114138
-        -rwx------  1 stavros  staff  149 Dec 24 12:38 __array_schema.tdb
-        drwx------  4 stavros  staff  136 Dec 24 12:38 __f42df6e8846543af8d43415ab3ef2f7d_1545673114147
-        -rwx------  1 stavros  staff    0 Dec 24 12:38 __lock.tdb
+        drwx------  4 stavros  staff  128 Jun 25 16:23 __1561494215438_1561494215438_f9041c73e04e4cb2b52734f1183508f4
+        drwx------  4 stavros  staff  128 Jun 25 16:23 __1561494215452_1561494215452_13a7d76455cc44fc893c650270d26ccf
+        drwx------  5 stavros  staff  160 Jun 25 16:23 __1561494215467_1561494215467_317c5aa1f6eb4e6880f3fda660b86507
+        -rwx------  1 stavros  staff  149 Jun 25 16:23 __array_schema.tdb
+        -rwx------  1 stavros  staff    0 Jun 25 16:23 __lock.tdb
 
    .. tab-container:: python
       :title: Python
@@ -119,30 +120,32 @@ contains three subdirectories with weird names:
          Cell (4, 2) has data -2147483648
          Cell (4, 3) has data -2147483648
          Cell (4, 4) has data -2147483648
-         $ ls -l fragments_consolidation/
+
+         $ ls -l fragments_consolidation_array/
          total 8
-         drwx------  5 stavros  staff  170 Dec 24 12:38 __13f149611c6541ad807d285dec1b1257_1545673114154
-         drwx------  4 stavros  staff  136 Dec 24 12:38 __374ef2b0dfef49688fd34cfb7e2ecad3_1545673114138
-         -rwx------  1 stavros  staff  149 Dec 24 12:38 __array_schema.tdb
-         drwx------  4 stavros  staff  136 Dec 24 12:38 __f42df6e8846543af8d43415ab3ef2f7d_1545673114147
-         -rwx------  1 stavros  staff    0 Dec 24 12:38 __lock.tdb
+         drwx------  4 stavros  staff  128 Jun 25 16:23 __1561494215438_1561494215438_f9041c73e04e4cb2b52734f1183508f4
+         drwx------  4 stavros  staff  128 Jun 25 16:23 __1561494215452_1561494215452_13a7d76455cc44fc893c650270d26ccf
+         drwx------  5 stavros  staff  160 Jun 25 16:23 __1561494215467_1561494215467_317c5aa1f6eb4e6880f3fda660b86507
+         -rwx------  1 stavros  staff  149 Jun 25 16:23 __array_schema.tdb
+         -rwx------  1 stavros  staff    0 Jun 25 16:23 __lock.tdb
 
 Each subdirectory corresponds to a **fragment**, i.e., to an array snapshot
 containing the cells written in a write operation. *How can we tell which
 fragment corresponds to which write?* In this example, this can be
 easily derived from the fragment name. The name has the following format::
 
-    __<uuid>_<timestamp>
+    __<timestamp>_<timestamp>_<uuid>
 
 The `UUID <https://en.wikipedia.org/wiki/Universally_unique_identifier>`_ is
 a *unique identifier*, specific to a process-thread pair. In a later tutorial
 we will explain that this enables concurrent threads/processes writing
 to the same array. The timestamp records the time
 when the fragment got created. Inspecting the fragment names, we derive that
-``__374ef2b0dfef49688fd34cfb7e2ecad3_1545673114138`` corresponds to the
-first write, ``__f42df6e8846543af8d43415ab3ef2f7d_1545673114147`` to the
-second, and ``__13f149611c6541ad807d285dec1b1257_1545673114154`` to the
-third, reading the fragment timestamps in ascending order.
+``__1561494215438_1561494215438_f9041c73e04e4cb2b52734f1183508f4`` 
+corresponds to the first write, 
+``__1561494215452_1561494215452_13a7d76455cc44fc893c650270d26ccf`` to the
+second, and ``__1561494215467_1561494215467_317c5aa1f6eb4e6880f3fda660b86507`` 
+to the third, reading the fragment timestamps in ascending order.
 
 There are two takeaways so far: (i) *every fragment is immutable*, i.e.,
 a subsequent write operation never overwrites a file of a previously
@@ -165,7 +168,7 @@ what happens each time a different fragment is deleted:
       .. code-block:: bash
 
         $ cp -R fragments_consolidation/ temp
-        $ rm -rf fragments_consolidation/__374ef2b0dfef49688fd34cfb7e2ecad3_1545673114138
+        $ rm -rf fragments_consolidation/__1561494215438_1561494215438_f9041c73e04e4cb2b52734f1183508f4
         $ ./fragments_consolidation_cpp
         Cell (1, 1) has data 201
         Cell (1, 2) has data -2147483648
@@ -185,7 +188,7 @@ what happens each time a different fragment is deleted:
         Cell (4, 4) has data -2147483648
         $ rm -rf fragments_consolidation
         $ cp -R temp fragments_consolidation
-        $ rm -rf fragments_consolidation/__f42df6e8846543af8d43415ab3ef2f7d_1545673114147
+        $ rm -rf fragments_consolidation/__1561494215452_1561494215452_13a7d76455cc44fc893c650270d26ccf
         $ ./fragments_consolidation_cpp
         Cell (1, 1) has data 201
         Cell (1, 2) has data 2
@@ -205,7 +208,7 @@ what happens each time a different fragment is deleted:
         Cell (4, 4) has data -2147483648
         $ rm -rf fragments_consolidation
         $ cp -R temp fragments_consolidation
-        $ rm -rf fragments_consolidation/__13f149611c6541ad807d285dec1b1257_1545673114154
+        $ rm -rf fragments_consolidation/__1561494215467_1561494215467_317c5aa1f6eb4e6880f3fda660b86507
         $ ./fragments_consolidation_cpp
         Cell (1, 1) has data 1
         Cell (1, 2) has data 2
@@ -231,7 +234,7 @@ what happens each time a different fragment is deleted:
       .. code-block:: bash
 
         $ cp -R fragments_consolidation/ temp
-        $ rm -rf fragments_consolidation/__374ef2b0dfef49688fd34cfb7e2ecad3_1545673114138
+        $ rm -rf fragments_consolidation/__1561494215438_1561494215438_f9041c73e04e4cb2b52734f1183508f4
         $ python fragments_consolidation.py
         Cell (1, 1) has data 201
         Cell (1, 2) has data -2147483648
@@ -251,7 +254,7 @@ what happens each time a different fragment is deleted:
         Cell (4, 4) has data -2147483648
         $ rm -rf fragments_consolidation
         $ cp -R temp fragments_consolidation
-        $ rm -rf fragments_consolidation/__f42df6e8846543af8d43415ab3ef2f7d_1545673114147
+        $ rm -rf fragments_consolidation/__1561494215452_1561494215452_13a7d76455cc44fc893c650270d26ccf
         $ python fragments_consolidation.py
         Cell (1, 1) has data 201
         Cell (1, 2) has data 2
@@ -271,7 +274,7 @@ what happens each time a different fragment is deleted:
         Cell (4, 4) has data -2147483648
         $ rm -rf fragments_consolidation
         $ cp -R temp fragments_consolidation
-        $ rm -rf fragments_consolidation/__13f149611c6541ad807d285dec1b1257_1545673114154
+        $ rm -rf fragments_consolidation/__1561494215467_1561494215467_317c5aa1f6eb4e6880f3fda660b86507
         $ python fragments_consolidation.py
         Cell (1, 1) has data 1
         Cell (1, 2) has data 2
@@ -376,16 +379,17 @@ to the program) consolidates the three fragments into one before reading.
         Cell (4, 2) has data -2147483648
         Cell (4, 3) has data -2147483648
         Cell (4, 4) has data -2147483648
-        $ ls -l fragments_consolidation
-        total 8
-        drwx------  4 stavros  staff  136 Dec 24 12:44 __9e57519eb78e40a48e96f0f7db75ee7c_1545673497211_1545673497172
-        -rwx------  1 stavros  staff  149 Dec 24 12:44 __array_schema.tdb
-        -rwx------  1 stavros  staff    0 Dec 24 12:44 __lock.tdb
-        $ ls -l fragments_consolidation_array/__9e57519eb78e40a48e96f0f7db75ee7c_1545673497211_1545673497172
-        total 16
-        -rwx------  1 stavros  staff  137 Dec 24 12:44 __fragment_metadata.tdb
-        -rwx------  1 stavros  staff  144 Dec 24 12:44 a.tdb
 
+        $ ls -l fragments_consolidation_array/
+        total 8
+        drwx------  4 stavros  staff  128 Jun 25 16:28 __1561494215438_1561494215467_1bc203276a1a42c29eb4358325a0f228
+        -rwx------  1 stavros  staff  149 Jun 25 16:23 __array_schema.tdb
+        -rwx------  1 stavros  staff    0 Jun 25 16:23 __lock.tdb
+
+        $ ls -l fragments_consolidation_array/__1561494215438_1561494215467_1bc203276a1a42c29eb4358325a0f228/
+        total 16
+        -rwx------  1 stavros  staff  613 Jun 25 16:28 __fragment_metadata.tdb
+        -rwx------  1 stavros  staff  144 Jun 25 16:28 a.tdb
 
    .. tab-container:: python
       :title: Python
@@ -409,30 +413,31 @@ to the program) consolidates the three fragments into one before reading.
         Cell (4, 2) has data -2147483648
         Cell (4, 3) has data -2147483648
         Cell (4, 4) has data -2147483648
-        $ ls -l fragments_consolidation
+
+        $ ls -l fragments_consolidation_array/
         total 8
-        drwx------  4 stavros  staff  136 Dec 24 12:44 __9e57519eb78e40a48e96f0f7db75ee7c_1545673497211_1545673497172
-        -rwx------  1 stavros  staff  149 Dec 24 12:44 __array_schema.tdb
-        -rwx------  1 stavros  staff    0 Dec 24 12:44 __lock.tdb
-        $ ls -l fragments_consolidation_array/__9e57519eb78e40a48e96f0f7db75ee7c_1545673497211_1545673497172
+        drwx------  4 stavros  staff  128 Jun 25 16:28 __1561494215438_1561494215467_1bc203276a1a42c29eb4358325a0f228
+        -rwx------  1 stavros  staff  149 Jun 25 16:23 __array_schema.tdb
+        -rwx------  1 stavros  staff    0 Jun 25 16:23 __lock.tdb
+
+        $ ls -l fragments_consolidation_array/__1561494215438_1561494215467_1bc203276a1a42c29eb4358325a0f228/
         total 16
-        -rwx------  1 stavros  staff  137 Dec 24 12:44 __fragment_metadata.tdb
-        -rwx------  1 stavros  staff  144 Dec 24 12:44 a.tdb
+        -rwx------  1 stavros  staff  613 Jun 25 16:28 __fragment_metadata.tdb
+        -rwx------  1 stavros  staff  144 Jun 25 16:28 a.tdb
+
 
 As expected, the result is the same as before.
 However, listing the contents of the array we now see a single fragment.
 This fragment merges the data of the three writes. We make two observations.
-First, the name is slightly different. The format now is::
+The name format is::
 
-    __<uuid>_<timestamp_merged>_<timestamp_last>
+    __<timestamp_first>_<timestamp_last>_<uuid>
 
-
-Here ``timestamp_merged`` is the time the merged fragment got created, whereas
-``timestamp_last`` is the timestamp of the latest fragment that got
-consolidated (i.e., the fragment corresponding to the third write in
-this example). In general, TileDB always uses the last timestamp in
-the fragment name in order to chronologically sort the fragments as they
-are being created during the reads.
+Here `timestamp_first` is the timestamp of the first fragment that was 
+consolidated (in the chronological order) and `timestamp_last` the 
+timestamp of the last fragment that was consolidated. In general, TileDB 
+always uses the first timestamp in
+the fragment name to chronologically sort the fragments during the reads.
 
 The second observation is that the merged fragment is *dense* (notice that
 ``__coords.tdb`` is missing). Upon consolidation, TileDB calculates the

--- a/doc/source/tutorials/kv.rst
+++ b/doc/source/tutorials/kv.rst
@@ -336,21 +336,21 @@ is a sparse array), and some files for the keys ``__key.tdb``, ``__key_type.tdb`
 
 .. code-block:: bash
 
-  $ ls -l map/
+  $ ls -l map_array/
   total 8
-  drwx------  9 stavros  staff  306 Jul  2 22:30 __1d43f59f015a4497aaeaffdc830549db_1530585002464
-  drwx------  9 stavros  staff  306 Jul  2 22:30 __d6924e6d0b174749a7cf0ba24f789137_1530585002473
-  -rwx------  1 stavros  staff  150 Jul  2 22:30 __kv_schema.tdb
-  -rwx------  1 stavros  staff    0 Jul  2 22:30 __lock.tdb
-  $ ls -l map/__1d43f59f015a4497aaeaffdc830549db_1530585002464
-  total 56
-  -rwx------  1 stavros  staff   98 Jul  2 22:30 __coords.tdb
-  -rwx------  1 stavros  staff  147 Jul  2 22:30 __fragment_metadata.tdb
-  -rwx------  1 stavros  staff   49 Jul  2 22:30 __key.tdb
-  -rwx------  1 stavros  staff   35 Jul  2 22:30 __key_type.tdb
-  -rwx------  1 stavros  staff   45 Jul  2 22:30 __key_var.tdb
-  -rwx------  1 stavros  staff    8 Jul  2 22:30 a1.tdb
-  -rwx------  1 stavros  staff    8 Jul  2 22:30 a2.tdb
+  drwx------  8 stavros  staff  256 Jun 25 16:09 __1561493369960_1561493369960_1013bbf6aa18488a94630fa050e4436d
+  drwx------  8 stavros  staff  256 Jun 25 16:09 __1561493369980_1561493369980_ae355229b13c4049af4abd6a1547e418
+  -rwx------  1 stavros  staff  188 Jun 25 16:09 __kv_schema.tdb
+  -rwx------  1 stavros  staff    0 Jun 25 16:09 __lock.tdb
+
+  $ ls -l map_array/__1561493369960_1561493369960_1013bbf6aa18488a94630fa050e4436d/
+  total 48
+  -rwx------  1 stavrospapadopoulos  staff   114 Jun 25 16:09 __coords.tdb
+  -rwx------  1 stavrospapadopoulos  staff  1332 Jun 25 16:09 __fragment_metadata.tdb
+  -rwx------  1 stavrospapadopoulos  staff    61 Jun 25 16:09 __key.tdb
+  -rwx------  1 stavrospapadopoulos  staff    59 Jun 25 16:09 __key_var.tdb
+  -rwx------  1 stavrospapadopoulos  staff    28 Jun 25 16:09 a1.tdb
+  -rwx------  1 stavrospapadopoulos  staff    28 Jun 25 16:09 a2.tdb
 
 Finally, notice that our example produces two fragments. This is because we
 flushed after adding two items, and then again after adding the third item.

--- a/doc/source/tutorials/multi-attribute-arrays.rst
+++ b/doc/source/tutorials/multi-attribute-arrays.rst
@@ -332,20 +332,21 @@ Let us look at the contents of the array of this example on disk.
 
 .. code-block:: bash
 
-   $ ls -l multi_attribute/
+   $ ls -l multi_attribute_array/
    total 8
-   drwx------  5 stavros  staff  170 Jun 18 17:33 __3f4622ed4ec1486ea3450f66c905f8cc_1529357638905
-   -rwx------  1 stavros  staff  186 Jun 18 17:33 __array_schema.tdb
-   -rwx------  1 stavros  staff    0 Jun 18 17:33 __lock.tdb
+   drwx------  5 stavros  staff  160 Jun 25 15:34 __1561491299419_1561491299419_fcb0ee91899142baad8a08049c0e2319
+   -rwx------  1 stavros  staff  159 Jun 25 15:34 __array_schema.tdb
+   -rwx------  1 stavros  staff    0 Jun 25 15:34 __lock.tdb
 
-   $ ls -l multi_attribute/__3f4622ed4ec1486ea3450f66c905f8cc_1529357638905/
+   $ ls -l multi_attribute_array/__1561491299419_1561491299419_fcb0ee91899142baad8a08049c0e2319/
    total 24
-   -rwx------  1 stavros  staff  124 Jun 18 17:33 __fragment_metadata.tdb
-   -rwx------  1 stavros  staff   36 Jun 18 17:33 a1.tdb
-   -rwx------  1 stavros  staff  148 Jun 18 17:33 a2.tdb
+   -rwx------  1 stavros  staff  939 Jun 25 15:34 __fragment_metadata.tdb
+   -rwx------  1 stavros  staff   36 Jun 25 15:34 a1.tdb
+   -rwx------  1 stavros  staff  148 Jun 25 15:34 a2.tdb
 
 TileDB created two separate attribute files in fragment subdirectory
-``__3f4622ed4ec1486ea3450f66c905f8cc_1529357638905``: ``a1.tdb`` that stores the cell values
+``__1561491299419_1561491299419_fcb0ee91899142baad8a08049c0e2319``: 
+``a1.tdb`` that stores the cell values
 on attribute ``a1`` (the file size is ``16`` bytes, equal to the size
 required for storing 16 1-byte characters, plus 20 bytes of metadata overhead),
 and ``a2.tdb`` that stores the cell

--- a/doc/source/tutorials/sparse-arrays.rst
+++ b/doc/source/tutorials/sparse-arrays.rst
@@ -344,25 +344,26 @@ If we look into the array on disk after it has been written to, we will see some
 
 .. code-block:: bash
 
-    $ ls -l my_array/
+    $ ls -l quickstart_sparse_array/
     total 8
-    drwx------  5 tyler  staff  170 Jun 12 10:32 __a71ac7b88bd84bd8897d156397eef603_1528813977859
-    -rwx------  1 tyler  staff  164 Jun 12 10:32 __array_schema.tdb
-    -rwx------  1 tyler  staff    0 Jun 12 10:32 __lock.tdb
+    drwx------  5 stavros  staff  160 Jun 25 15:22 __1561490578769_1561490578769_9e429a59930b4a9c83baa57eb2fb41a8
+    -rwx------  1 stavros  staff  153 Jun 25 15:22 __array_schema.tdb
+    -rwx------  1 stavros  staff    0 Jun 25 15:22 __lock.tdb
 
 The array directory and files ``__array_schema.tdb`` and ``__lock.tdb`` were written upon
-array creation, whereas subdirectory ``__a71ac7b88bd84bd8897d156397eef603_1528813977859`` was
+array creation, whereas subdirectory 
+``__1561490578769_1561490578769_9e429a59930b4a9c83baa57eb2fb41a8`` was
 created after array writting. This subdirectory, called **fragment**, contains the written
 cell values for attribute ``a`` in file ``a.tdb`` and the corresponding coordinates in
 a **separate** file ``__coords.tdb``, along with associated metadata:
 
 .. code-block:: bash
 
-    $ ls -l my_array/__a71ac7b88bd84bd8897d156397eef603_1528813977859/
+    $ ls -l quickstart_sparse_array/__1561490578769_1561490578769_9e429a59930b4a9c83baa57eb2fb41a8/
     total 24
-    -rwx------  1 tyler  staff  112 Jun 12 10:32 __coords.tdb
-    -rwx------  1 tyler  staff  124 Jun 12 10:32 __fragment_metadata.tdb
-    -rwx------  1 tyler  staff    4 Jun 12 10:32 a1.tdb
+    -rwx------  1 stavros  staff  106 Jun 25 15:22 __coords.tdb
+    -rwx------  1 stavros  staff  611 Jun 25 15:22 __fragment_metadata.tdb
+    -rwx------  1 stavros  staff   32 Jun 25 15:22 a.tdb
 
 The TileDB array hierarchy on disk and more details about fragments are discussed in
 later tutorials.

--- a/doc/source/tutorials/variable-length-attributes.rst
+++ b/doc/source/tutorials/variable-length-attributes.rst
@@ -280,19 +280,19 @@ Let us look at the contents of the array of this example on disk.
 
 .. code-block:: bash
 
-   $ ls -l variable_length/
+   $ ls -l variable_length_array/
    total 8
-   drwx------  7 stavros  staff  238 Jun 19 13:40 __45aba8bfac594505b3a92c83db4920be_1529430032040
-   -rwx------  1 stavros  staff  186 Jun 19 13:40 __array_schema.tdb
-   -rwx------  1 stavros  staff    0 Jun 19 13:40 __lock.tdb
+   drwx------  7 stavros  staff  224 Jun 25 15:38 __1561491531226_1561491531226_3e56db7d25a447708a73d3e578622ab4
+   -rwx------  1 stavros  staff  155 Jun 25 15:38 __array_schema.tdb
+   -rwx------  1 stavros  staff    0 Jun 25 15:38 __lock.tdb
 
-   $ ls -l variable_length/__45aba8bfac594505b3a92c83db4920be_1529430032040/
+   $ ls -l variable_length_array/__1561491531226_1561491531226_3e56db7d25a447708a73d3e578622ab4/
    total 40
-   -rwx------  1 stavros  staff  132 Jun 19 13:40 __fragment_metadata.tdb
-   -rwx------  1 stavros  staff   80 Jun 19 13:40 a1.tdb
-   -rwx------  1 stavros  staff   28 Jun 19 13:40 a1_var.tdb
-   -rwx------  1 stavros  staff   80 Jun 19 13:40 a2.tdb
-   -rwx------  1 stavros  staff  104 Jun 19 13:40 a2_var.tdb
+   -rwx------  1 stavros  staff  945 Jun 25 15:38 __fragment_metadata.tdb
+   -rwx------  1 stavros  staff  100 Jun 25 15:38 a1.tdb
+   -rwx------  1 stavros  staff   48 Jun 25 15:38 a1_var.tdb
+   -rwx------  1 stavros  staff  100 Jun 25 15:38 a2.tdb
+   -rwx------  1 stavro  staff  124 Jun 25 15:38 a2_var.tdb
 
 Observe that, contrary to the case of fixed-length attributes, TileDB stores **two**
 files for each variable-length attribute. Specifically, ``a1_var.tdb`` and ``a2_var.tdb``

--- a/doc/source/tutorials/writing-dense.rst
+++ b/doc/source/tutorials/writing-dense.rst
@@ -503,14 +503,12 @@ subfolders/fragments created:
 
 .. code-block:: bash
 
-  $ ls -l writing_dense_multiple/
+  $ ls -l multiple_writes_dense_array/
   total 8
-  drwx------  4 stavros  staff  136 Jun 25 14:51 __71c5c364bc4b4f49888668c912c4a01c_1529952665416
-  -rwx------  1 stavros  staff  109 Jun 25 14:51 __array_schema.tdb
-  drwx------  4 stavros  staff  136 Jun 25 14:51 __d13ece6b48ca470b8c42810cdf9d9206_1529952665410
-  -rwx------  1 stavros  staff    0 Jun 25 14:51 __lock.tdb
-
-
+  drwx------  4 stavros  staff  128 Jun 25 15:49 __1561492148493_1561492148493_52634f26a295445ca6c6dcfdafc8a967
+  drwx------  4 stavros  staff  128 Jun 25 15:49 __1561492148506_1561492148506_fef381c0326b49a59d6e74816416dfa1
+  -rwx------  1 stavros  staff  149 Jun 25 15:49 __array_schema.tdb
+  -rwx------  1 stavros  staff    0 Jun 25 15:49 __lock.tdb
 
 Writing sparse cells
 --------------------
@@ -589,16 +587,17 @@ Let us inspect the contents of the dense array after the write:
 
 .. code-block:: bash
 
-  $ ls -l writing_dense_sparse/
+  $ ls -l writing_dense_sparse_array/
   total 8
-  drwx------  5 stavros  staff  170 Jun 25 17:59 __88e0ebca9aa44442918ad93fa82209f2_1529963970336
-  -rwx------  1 stavros  staff  109 Jun 25 17:59 __array_schema.tdb
-  -rwx------  1 stavros  staff    0 Jun 25 17:59 __lock.tdb
-  $ ls -l writing_dense_sparse/__88e0ebca9aa44442918ad93fa82209f2_1529963970336/
+  drwx------  5 stavros  staff  160 Jun 25 15:50 __1561492235844_1561492235844_c033cea7bbc34f2bb425969a497f7bab
+  -rwx------  1 stavros  staff  149 Jun 25 15:50 __array_schema.tdb
+  -rwx------  1 stavros  staff    0 Jun 25 15:50 __lock.tdb
+
+  $ ls -l writing_dense_sparse_array/__1561492235844_1561492235844_c033cea7bbc34f2bb425969a497f7bab/
   total 24
-  -rwx------  1 stavros  staff   32 Jun 25 17:59 __coords.tdb
-  -rwx------  1 stavros  staff  110 Jun 25 17:59 __fragment_metadata.tdb
-  -rwx------  1 stavros  staff   16 Jun 25 17:59 a.tdb
+  -rwx------  1 stavros  staff  114 Jun 25 15:50 __coords.tdb
+  -rwx------  1 stavros  staff  610 Jun 25 15:50 __fragment_metadata.tdb
+  -rwx------  1 stavros  staff   36 Jun 25 15:50 a.tdb
 
 Observe that the
 coordinates were written explicitly in file ``__coords.tdb`` inside

--- a/doc/source/tutorials/writing-sparse.rst
+++ b/doc/source/tutorials/writing-sparse.rst
@@ -194,22 +194,24 @@ Let us see how the array directory looks like after the execution of the program
 
 .. code-block:: bash
 
-    $ ls -l writing_sparse_multiple/
+    $ ls -l multiple_writes_sparse_array/
     total 8
-    drwx------  5 stavros  staff  170 Jun 22 15:27 __35a9e44618d34f68a20ec0b5a51d17eb_1529695666920
-    drwx------  5 stavros  staff  170 Jun 22 15:27 __5f38614a64d94b97b607125965db3bdd_1529695666925
-    -rwx------  1 stavros  staff  115 Jun 22 15:27 __array_schema.tdb
-    -rwx------  1 stavros  staff    0 Jun 22 15:27 __lock.tdb
-    $ ls -l writing_sparse_multiple/__35a9e44618d34f68a20ec0b5a51d17eb_1529695666920
+    drwx------  5 stavros  staff  160 Jun 25 15:41 __1561491710236_1561491710236_3eadf863ae0443c7815857d055ed45c7
+    drwx------  5 stavros  staff  160 Jun 25 15:41 __1561491710249_1561491710249_a94a9605d30049939eb34f7ee6eb4708
+    -rwx------  1 stavros  staff  153 Jun 25 15:41 __array_schema.tdb
+    -rwx------  1 stavros  staff    0 Jun 25 15:41 __lock.tdb
+
+    $ ls -l multiple_writes_sparse_array/__1561491710236_1561491710236_3eadf863ae0443c7815857d055ed45c7/
     total 24
-    -rwx------  1 stavros  staff   90 Jun 22 15:27 __coords.tdb
-    -rwx------  1 stavros  staff  110 Jun 22 15:27 __fragment_metadata.tdb
-    -rwx------  1 stavros  staff   12 Jun 22 15:27 a.tdb
-    $ ls -l writing_sparse_multiple/__5f38614a64d94b97b607125965db3bdd_1529695666925
+    -rwx------  1 stavros  staff  106 Jun 25 15:41 __coords.tdb
+    -rwx------  1 stavros  staff  611 Jun 25 15:41 __fragment_metadata.tdb
+    -rwx------  1 stavros  staff   32 Jun 25 15:41 a.tdb
+
+    $ ls -l multiple_writes_sparse_array/__1561491710249_1561491710249_a94a9605d30049939eb34f7ee6eb4708/
     total 24
-    -rwx------  1 stavros  staff   82 Jun 22 15:27 __coords.tdb
-    -rwx------  1 stavros  staff  104 Jun 22 15:27 __fragment_metadata.tdb
-    -rwx------  1 stavros  staff    8 Jun 22 15:27 a.tdb
+    -rwx------  1 stavrospapadopoulos  staff   98 Jun 25 15:41 __coords.tdb
+    -rwx------  1 stavrospapadopoulos  staff  612 Jun 25 15:41 __fragment_metadata.tdb
+    -rwx------  1 stavrospapadopoulos  staff   28 Jun 25 15:41 a.tdb
 
 Notice that now there are *two* subdirectories under the array directory. Each
 subdirectory corresponds to a write operation and is called **fragment**. We
@@ -316,11 +318,12 @@ array directory:
    Cell (1, 1) has data 1
    Cell (2, 3) has data 3
    Cell (2, 4) has data 2
-   $ ls -l writing_sparse_global/
+
+   $ ls -l global_order_sparse_array/
    total 8
-   drwx------  5 stavros  staff  170 Jun 22 16:29 __01b96bab96a64c3b86e06417c16b0618_1529699391758
-   -rwx------  1 stavros  staff  115 Jun 22 16:29 __array_schema.tdb
-   -rwx------  1 stavros  staff    0 Jun 22 16:29 __lock.tdb
+   drwx------  5 stavros  staff  160 Jun 25 15:44 __1561491885787_1561491885787_eccb5f9e17c54fef90cedf633d47118c
+   -rwx------  1 stavros  staff  153 Jun 25 15:44 __array_schema.tdb
+   -rwx------  1 stavros  staff    0 Jun 25 15:44 __lock.tdb
 
 As expected, the array contains the same cells and values as ``quickstart_sparse``.
 Moreover, despite the fact that we submitted two write queries, only one

--- a/examples/cpp_api/writing_dense_multiple.cc
+++ b/examples/cpp_api/writing_dense_multiple.cc
@@ -40,7 +40,7 @@
 using namespace tiledb;
 
 // Name of array.
-std::string array_name("writing_dense_multiple_array");
+std::string array_name("multiple_writes_dense_array");
 
 void create_array() {
   // Create a TileDB context.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,6 +89,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-s3.cc
   src/unit-s3-no-multipart.cc
   src/unit-status.cc
+  src/unit-Consolidator.cc
   src/unit-Subarray.cc
   src/unit-SubarrayPartitioner-dense.cc
   src/unit-SubarrayPartitioner-error.cc

--- a/test/src/unit-Consolidator.cc
+++ b/test/src/unit-Consolidator.cc
@@ -1,0 +1,103 @@
+/**
+ * @file unit-Consolidator.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `Subarray` class.
+ */
+
+#include <catch.hpp>
+#include <iostream>
+#include "test/src/helpers.h"
+#include "tiledb/sm/storage_manager/consolidator.h"
+
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "Consolidator: Remove consolidate fragment URIs, remove none",
+    "[remove-consolidated-URIs][remove-none]") {
+  std::vector<TimestampedURI> uris;
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(0, 1));
+  Consolidator::remove_consolidated_fragment_uris(&uris);
+  CHECK(uris.size() == 1);
+  CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 1));
+
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 3));
+  Consolidator::remove_consolidated_fragment_uris(&uris);
+  CHECK(uris.size() == 2);
+  CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 1));
+  CHECK(uris[1].timestamp_range_ == std::pair<uint64_t, uint64_t>(2, 3));
+}
+
+TEST_CASE(
+    "Consolidator: Remove consolidate fragment URIs, remove one level at start",
+    "[remove-consolidated-URIs][remove-one-level-start]") {
+  std::vector<TimestampedURI> uris;
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(0, 0));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(0, 1));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(1, 1));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 2));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(3, 3));
+  Consolidator::remove_consolidated_fragment_uris(&uris);
+  CHECK(uris.size() == 3);
+  CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 1));
+  CHECK(uris[1].timestamp_range_ == std::pair<uint64_t, uint64_t>(2, 2));
+  CHECK(uris[2].timestamp_range_ == std::pair<uint64_t, uint64_t>(3, 3));
+}
+
+TEST_CASE(
+    "Consolidator: Remove consolidate fragment URIs, remove one level at "
+    "middle",
+    "[remove-consolidated-URIs][remove-one-level-middle]") {
+  std::vector<TimestampedURI> uris;
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(0, 0));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(1, 1));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 2));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 3));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(3, 3));
+  Consolidator::remove_consolidated_fragment_uris(&uris);
+  CHECK(uris.size() == 3);
+  CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 0));
+  CHECK(uris[1].timestamp_range_ == std::pair<uint64_t, uint64_t>(1, 1));
+  CHECK(uris[2].timestamp_range_ == std::pair<uint64_t, uint64_t>(2, 3));
+}
+
+TEST_CASE(
+    "Consolidator: Remove consolidate fragment URIs, remove two levels",
+    "[remove-consolidated-URIs][remove-two-levels]") {
+  std::vector<TimestampedURI> uris;
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(0, 0));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(0, 1));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(0, 3));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(1, 1));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 2));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 3));
+  uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(3, 3));
+  Consolidator::remove_consolidated_fragment_uris(&uris);
+  CHECK(uris.size() == 1);
+  CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 3));
+}

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -45,8 +45,8 @@ struct FragmentInfo {
   URI uri_;
   /** True if the fragment is sparse, and false if it is dense. */
   bool sparse_;
-  /** The creation timestamp of the fragment. */
-  uint64_t timestamp_;
+  /** The timestamp range of the fragment. */
+  std::pair<uint64_t, uint64_t> timestamp_range_;
   /** The size of the entire fragment directory. */
   uint64_t fragment_size_;
   /** The fragment's non-empty domain. */
@@ -63,7 +63,7 @@ struct FragmentInfo {
   FragmentInfo() {
     uri_ = URI("");
     sparse_ = false;
-    timestamp_ = 0;
+    timestamp_range_ = {0, 0};
     fragment_size_ = 0;
   }
 
@@ -71,13 +71,13 @@ struct FragmentInfo {
   FragmentInfo(
       const URI& uri,
       bool sparse,
-      uint64_t timestamp,
+      const std::pair<uint64_t, uint64_t>& timestamp_range,
       uint64_t fragment_size,
       const std::vector<uint8_t>& non_empty_domain,
       const std::vector<uint8_t>& expanded_non_empty_domain)
       : uri_(uri)
       , sparse_(sparse)
-      , timestamp_(timestamp)
+      , timestamp_range_(timestamp_range)
       , fragment_size_(fragment_size)
       , non_empty_domain_(non_empty_domain)
       , expanded_non_empty_domain_(expanded_non_empty_domain) {
@@ -117,7 +117,7 @@ struct FragmentInfo {
     FragmentInfo clone;
     clone.uri_ = uri_;
     clone.sparse_ = sparse_;
-    clone.timestamp_ = timestamp_;
+    clone.timestamp_range_ = timestamp_range_;
     clone.fragment_size_ = fragment_size_;
     clone.non_empty_domain_ = non_empty_domain_;
     clone.expanded_non_empty_domain_ = expanded_non_empty_domain_;
@@ -128,7 +128,7 @@ struct FragmentInfo {
   void swap(FragmentInfo& info) {
     std::swap(uri_, info.uri_);
     std::swap(sparse_, info.sparse_);
-    std::swap(timestamp_, info.timestamp_);
+    std::swap(timestamp_range_, info.timestamp_range_);
     std::swap(fragment_size_, info.fragment_size_);
     std::swap(non_empty_domain_, info.non_empty_domain_);
     std::swap(expanded_non_empty_domain_, info.expanded_non_empty_domain_);

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -60,13 +60,13 @@ FragmentMetadata::FragmentMetadata(
     StorageManager* storage_manager,
     const ArraySchema* array_schema,
     const URI& fragment_uri,
-    uint64_t timestamp,
+    const std::pair<uint64_t, uint64_t>& timestamp_range,
     bool dense)
     : storage_manager_(storage_manager)
     , array_schema_(array_schema)
     , dense_(dense)
     , fragment_uri_(fragment_uri)
-    , timestamp_(timestamp) {
+    , timestamp_range_(timestamp_range) {
   domain_ = nullptr;
   meta_file_size_ = 0;
   non_empty_domain_ = nullptr;
@@ -666,13 +666,17 @@ Status FragmentMetadata::tile_var_size(
   return Status::Ok();
 }
 
-uint64_t FragmentMetadata::timestamp() const {
-  return timestamp_;
+uint64_t FragmentMetadata::first_timestamp() const {
+  return timestamp_range_.first;
+}
+
+const std::pair<uint64_t, uint64_t>& FragmentMetadata::timestamp_range() const {
+  return timestamp_range_;
 }
 
 bool FragmentMetadata::operator<(const FragmentMetadata& metadata) const {
-  return (timestamp_ < metadata.timestamp_) ||
-         (timestamp_ == metadata.timestamp_ &&
+  return (timestamp_range_.first < metadata.timestamp_range_.first) ||
+         (timestamp_range_.first == metadata.timestamp_range_.first &&
           fragment_uri_ < metadata.fragment_uri_);
 }
 

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -61,15 +61,16 @@ class FragmentMetadata {
    * @param storage_manager A storage manager instance.
    * @param array_schema The schema of the array the fragment belongs to.
    * @param fragment_uri The fragment URI.
-   * @param timestamp The timestamp of the fragment creation. In TileDB,
+   * @param timestamp_range The timestamp range of the fragment.
+   *     In TileDB, timestamps are in ms elapsed since
+   *     1970-01-01 00:00:00 +0000 (UTC).
    * @param dense Indicates whether the fragment is dense or sparse.
-   *     timestamps are in ms elapsed since 1970-01-01 00:00:00 +0000 (UTC).
    */
   FragmentMetadata(
       StorageManager* storage_manager,
       const ArraySchema* array_schema,
       const URI& fragment_uri,
-      uint64_t timestamp,
+      const std::pair<uint64_t, uint64_t>& timestamp_range,
       bool dense = true);
 
   /** Destructor. */
@@ -420,8 +421,11 @@ class FragmentMetadata {
       uint64_t tile_idx,
       uint64_t* tile_size);
 
-  /** The creation timestamp of the fragment. */
-  uint64_t timestamp() const;
+  /** Returns the first timestamp of the fragment timestamp range. */
+  uint64_t first_timestamp() const;
+
+  /** Returns the fragment timestamp range. */
+  const std::pair<uint64_t, uint64_t>& timestamp_range() const;
 
   /**
    * Returns `true` if the timestamp of the first operand is smaller,
@@ -558,8 +562,8 @@ class FragmentMetadata {
   /** The format version of this metadata. */
   uint32_t version_;
 
-  /** The creation timestamp of the fragment. */
-  uint64_t timestamp_;
+  /** The timestamp range of the fragment. */
+  std::pair<uint64_t, uint64_t> timestamp_range_;
 
   /** Stores the generic tile offsets, facilitating loading. */
   GenericTileOffsets gt_offsets_;

--- a/tiledb/sm/misc/uri.h
+++ b/tiledb/sm/misc/uri.h
@@ -221,6 +221,29 @@ class URI {
   std::string uri_;
 };
 
+/**
+ * Used to stores a fragment URI, materializing its timestamp range
+ * for convenience.
+ */
+struct TimestampedURI {
+  URI uri_;
+  std::pair<uint64_t, uint64_t> timestamp_range_;
+
+  TimestampedURI(
+      const URI& uri, const std::pair<uint64_t, uint64_t>& timestamp_range)
+      : uri_(uri)
+      , timestamp_range_(timestamp_range) {
+  }
+
+  bool operator<(const TimestampedURI& uri) const {
+    return timestamp_range_.first < uri.timestamp_range_.first;
+  }
+
+  bool has_unary_timestamp_range() const {
+    return timestamp_range_.first == timestamp_range_.second;
+  }
+};
+
 }  // namespace sm
 }  // namespace tiledb
 

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -183,6 +183,29 @@ Status convert(const std::string& str, bool* value) {
   return Status::Ok();
 }
 
+std::pair<uint64_t, uint64_t> get_timestamp_range(
+    uint32_t version, const std::string& fragment_name) {
+  std::pair<uint64_t, uint64_t> ret = {0, 0};
+  if (version <= 2) {
+    assert(fragment_name.find_last_of('_') != std::string::npos);
+    auto t_str = fragment_name.substr(fragment_name.find_last_of('_') + 1);
+    sscanf(
+        t_str.c_str(),
+        (std::string("%") + std::string(PRId64)).c_str(),
+        (long long int*)&ret.first);
+  } else {
+    assert(fragment_name.find_last_of('_') != std::string::npos);
+    sscanf(
+        fragment_name.c_str(),
+        (std::string("__%") + std::string(PRId64) + "_%" + std::string(PRId64))
+            .c_str(),
+        (long long int*)&ret.first,
+        (long long int*)&ret.second);
+  }
+
+  return ret;
+}
+
 bool is_int(const std::string& str) {
   // Check if empty
   if (str.empty())

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -73,6 +73,15 @@ Status convert(const std::string& str, float* value);
 /** Converts the input string into a `bool` value. */
 Status convert(const std::string& str, bool* value);
 
+/**
+ * Retrieves the timestamp range from the input fragment
+ * name, based on the input version.
+ * For format version <= 2, only the range start is valid
+ * (the range end is ignored).
+ */
+std::pair<uint64_t, uint64_t> get_timestamp_range(
+    uint32_t version, const std::string& fragment_name);
+
 /** Returns `true` if the input string is a (potentially signed) integer. */
 bool is_int(const std::string& str);
 

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -267,6 +267,12 @@ Status Query::init() {
   return Status::Ok();
 }
 
+URI Query::first_fragment_uri() const {
+  if (type_ == QueryType::WRITE)
+    return URI();
+  return reader_.first_fragment_uri();
+}
+
 URI Query::last_fragment_uri() const {
   if (type_ == QueryType::WRITE)
     return URI();

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -246,6 +246,9 @@ class Query {
   /** Initializes the query. */
   Status init();
 
+  /** Returns the first fragment uri. */
+  URI first_fragment_uri() const;
+
   /** Returns the last fragment uri. */
   URI last_fragment_uri() const;
 

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -219,6 +219,12 @@ Status Reader::init() {
   return Status::Ok();
 }
 
+URI Reader::first_fragment_uri() const {
+  if (fragment_metadata_.empty())
+    return URI();
+  return fragment_metadata_.front()->fragment_uri();
+}
+
 URI Reader::last_fragment_uri() const {
   if (fragment_metadata_.empty())
     return URI();

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -220,6 +220,9 @@ class Reader {
       void** buffer_val,
       uint64_t** buffer_val_size) const;
 
+  /** Returns the first fragment uri. */
+  URI first_fragment_uri() const;
+
   /** Returns the last fragment uri. */
   URI last_fragment_uri() const;
 

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -87,7 +87,7 @@ void OpenArray::cnt_incr() {
 bool OpenArray::is_empty(uint64_t timestamp) const {
   std::lock_guard<std::mutex> lck(local_mtx_);
   return fragment_metadata_.empty() ||
-         (*fragment_metadata_.cbegin())->timestamp() > timestamp;
+         (*fragment_metadata_.cbegin())->first_timestamp() > timestamp;
 }
 
 Status OpenArray::file_lock(VFS* vfs) {

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -802,8 +802,7 @@ class StorageManager {
    *
    * @param open_array The open array object.
    * @param encryption_key The encryption key to use.
-   * @param fragments_to_load The fragments whose metadata to load. This
-   *     is a vector of pairs (timestamp, URI).
+   * @param fragments_to_load The fragments whose metadata to load.
    * @param fragment_metadata The fragment metadata retrieved in a
    *     vector.
    * @return Status
@@ -811,20 +810,21 @@ class StorageManager {
   Status load_fragment_metadata(
       OpenArray* open_array,
       const EncryptionKey& encryption_key,
-      const std::vector<std::pair<uint64_t, URI>>& fragments_to_load,
+      const std::vector<TimestampedURI>& fragments_to_load,
       std::vector<FragmentMetadata*>* fragment_metadata);
 
   /**
    * Gets the sorted fragment URIs based on the first input
-   * in ascending timestamp order, breaking ties with lexicographic sorting
-   * of UUID. Only the fragments with timestamp smaller than or equal to
-   * `timestamp` are considered. The sorted fragment URIs are stored in
-   * the second input, including the fragment timestamps.
+   * in ascending first timestamp order, breaking ties with lexicographic
+   * sorting of UUID. Only the fragments with timestamp smaller than or
+   * equal to `timestamp` are considered. The sorted fragment URIs are
+   * stored in the last input, including the fragment timestamps.
    */
   Status get_sorted_fragment_uris(
+      uint32_t version,
       const std::vector<URI>& fragment_uris,
       uint64_t timestamp,
-      std::vector<std::pair<uint64_t, URI>>* sorted_fragment_uris) const;
+      std::vector<TimestampedURI>* sorted_fragment_uris) const;
 
   /** Block until there are zero in-progress queries. */
   void wait_for_zero_in_progress();


### PR DESCRIPTION
**Changes**
- When creating a new fragment by writing to TileDB, the fragment name used to be `__<uuid>_<timestamp>`, where `timestamp` was the timestamp of the fragment creation. Now this is changed to `__<timestamp>_<timestamp>_<uuid>`.
- When creating a new fragment as a result of consolidating a set of (chronologically "adjacent") fragments, the fragment name used to be `__<uuid>_<timestamp_merged>_<timestamp_last>`, where `timestamp_merged` is the time of the consolidated fragment creation and `timestamp_last` is the timestamp of the last fragment in the order. Now this is changed to `__<timestamp_first>_<timestamp_last>_uuid`, where `timestamp_first` is the timestamp of the first consolidated fragment in the order.

**Correctness**
- Concurrent writes are still permitted without problems, since the fragment name is expected to always be unique.
- We always sort the fragments based on the first timestamp in the name (essentially lexicographically, which is now also chronological as well), so correctness is still guaranteed. Note that there can never be timestamp range overlaps between any two consolidated fragments at any time.

**Benefits**
- More intuitive: a fragment name indicates the time range of all writes it consolidates
- Easy chronological sorting with `ls` (since lexicographic == chronological with the new notation)
- Solves a performance issue due to S3's eventual consistency: after consolidation, TileDB deletes the old consolidated fragments. However, due to S3' eventual consistency, those fragments may still be valid (i.e., not physically deleted yet) when a new read arrives after consolidation. As a result, when opening the array, TileDB sees both the old fragments and the new fragment. Although this does not violate correctness (the new fragment contains the most up-to-date data and the old fragments will be "ignored"), there may be a potential performance impact. TileDB now uses the new timestamp ranges in the fragment names and ignores any potentially still existing old fragments after their consolidation.

Closes #1154