### PR TITLE
Azure CI: Restrict integration builds to merges and releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,9 @@
+trigger:
+  branches:
+    include:
+    - dev
+    - release-*
+
 jobs:
 - job:
   strategy:
@@ -26,7 +32,7 @@ jobs:
         imageName: 'ubuntu-16.04'
         TILEDB_SERIALIZATION: ON
         CXX: g++
-    maxParallel: 4
+
   pool:
     vmImage: $(imageName)
   steps:


### PR DESCRIPTION
Reduce CI build count by restricting 'CI build' (azure terminology) to the dev and release branches. PRs should still build separately, and our branch protection settings restrict merges to 1) passing CI 2) branch rebased against latest dev.

This cuts down the build count to 1 per PR push, plus 1 at merge, instead of 2 per PR push.