### PR TITLE
Missing spdlog include

### DIFF
--- a/tiledb/sm/misc/logger.cc
+++ b/tiledb/sm/misc/logger.cc
@@ -32,6 +32,8 @@
 
 #include "tiledb/sm/misc/logger.h"
 
+#include <spdlog/sinks/stdout_sinks.h>
+
 namespace tiledb {
 namespace sm {
 


### PR DESCRIPTION
I got a compilation error using the latest spdlog release 1.3.1 because the sink was not explicitely included