### PR TITLE
Fix S3 windows build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,6 @@ jobs:
         TILEDB_S3: ON
       VS2017:
         imageName: 'vs2017-win2016'
-        TILEDB_S3: ON
   pool:
     vmImage: $(imageName)
   steps:

--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -69,12 +69,21 @@ if (NOT AWSSDK_FOUND)
       list(APPEND DEPENDS ep_zlib)
     endif()
 
+    # Work around for: https://github.com/aws/aws-sdk-cpp/pull/1187
+    # AWS SDK builds it's "aws-common" dependencies using `execute_process` to run cmake directly,
+    # and does not pass the CMAKE_GENERATOR PLATFORM, so those projects default to Win32 builds,
+    # causing linkage errors.
+    if (CMAKE_GENERATOR MATCHES "Visual Studio 14.*" OR CMAKE_GENERATOR MATCHES "Visual Studio 15.*")
+      set(CMAKE_GENERATOR "${CMAKE_GENERATOR} Win64")
+      set(CMAKE_GENERATOR_PLATFORM "")
+    endif()
+
     ExternalProject_Add(ep_awssdk
       PREFIX "externals"
       URL "https://github.com/aws/aws-sdk-cpp/archive/1.7.108.zip"
       URL_HASH SHA1=d07bae3fe924008b3117936963456dd314787abf
       CMAKE_ARGS
-        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DENABLE_TESTING=OFF
         -DBUILD_ONLY=s3\\$<SEMICOLON>core
         -DBUILD_SHARED_LIBS=OFF

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -12,7 +12,7 @@ steps:
       $host.SetShouldExit(1)
     }
 
-    if ($env:TILEDB_S3 -eq "true") {
+    if ($env:TILEDB_S3 -eq "ON") {
       & "$env:BUILD_SOURCESDIRECTORY\bootstrap.ps1" -EnableS3 -EnableVerbose -EnableStaticTileDB
       & "$env:BUILD_SOURCESDIRECTORY\scripts\install-minio.ps1"
     } else {
@@ -27,18 +27,29 @@ steps:
     cmake --build . --config Release -- /verbosity:minimal
 
     if ($LastExitCode -ne 0) {
-       Write-Host "Build failed."
+       Write-Host "Build failed. CMake exit status: " $LastExitCocde
        $host.SetShouldExit($LastExitCode)
     }
   displayName: "Build"
 
 - powershell: |
+    $env:MINIO_ACCESS_KEY = "minio"
+    $env:MINIO_SECRET_KEY = "miniosecretkey"
+    $env:AWS_ACCESS_KEY_ID = "minio"
+    $env:AWS_SECRET_ACCESS_KEY = "miniosecretkey"
+
     cd $env:AGENT_BUILDDIRECTORY\build\tiledb
 
-    cmake --build . --target check --config Release -- /verbosity:minimal
+    # CMake exits with non-0 status if there are any warnings during the build, so
+    # build the unit test executable before running tests.
+    cmake --build tiledb --target tiledb_unit --config Release -- /verbosity:minimal
+    # Actually run tests
+    cd tiledb
+    ctest -C Release -V
+    cd ..
 
     if ($LastExitCode -ne 0) {
-       Write-Host "Tests failed."
+       Write-Host "Tests failed. CMake exit status: " $LastExitCocde
        $host.SetShouldExit($LastExitCode)
     }
 
@@ -119,6 +130,11 @@ steps:
   #    archiveFile: '$(Build.ArtifactStagingDirectory)/tiledb-windows-x64-$(Build.SourceVersion).zip'
   #    replaceExistingArchive: true
   #    verbose: # Optional
+
+- powershell: |
+    (Get-ChildItem -Path $env:BUILD_SOURCESDIRECTORY -Include *.log -Recurse).fullname | ForEach-Object {echo $_ ---; Get-Content $_; echo ===}
+  condition: failed() # only run this job if the build step failed
+  displayName: "Print log files (failed build only)"
 
 - task: PublishBuildArtifacts@1
   inputs:

--- a/scripts/install-minio.ps1
+++ b/scripts/install-minio.ps1
@@ -22,6 +22,8 @@ $TileDBRootDirectory = Split-Path -Parent (Get-ScriptsDirectory)
 $InstallPrefix = Join-Path $TileDBRootDirectory "dist"
 $StagingDirectory = Join-Path (Get-ScriptsDirectory) "deps-staging"
 
+New-Item -ItemType Directory -Path (Join-Path $InstallPrefix bin) -ea 0
+
 function DownloadFile([string] $URL, [string] $Dest) {
     Write-Host "Downloading $URL to $Dest..."
     Invoke-WebRequest -Uri $URL -OutFile $Dest

--- a/test/src/unit-capi-object_mgmt.cc
+++ b/test/src/unit-capi-object_mgmt.cc
@@ -51,21 +51,19 @@ struct ObjectMgmtFx {
   const std::string S3_PREFIX = "s3://";
   const std::string S3_BUCKET = S3_PREFIX + random_bucket_name("tiledb") + "/";
   const std::string S3_TEMP_DIR = S3_BUCKET + "tiledb_test/";
-#ifdef _WIN32
+#if defined(_WIN32)
   const std::string FILE_URI_PREFIX = "";
   const std::string FILE_TEMP_DIR =
       tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
   const std::string FILE_FULL_TEMP_DIR = FILE_TEMP_DIR;
-  const std::string GROUP = "group\\";
-  const std::string ARRAY = "array\\";
 #else
   const std::string FILE_URI_PREFIX = "file://";
   const std::string FILE_TEMP_DIR =
       tiledb::sm::Posix::current_dir() + "/tiledb_test/";
   const std::string FILE_FULL_TEMP_DIR = std::string("file://") + FILE_TEMP_DIR;
+#endif
   const std::string GROUP = "group/";
   const std::string ARRAY = "array/";
-#endif
 
   // TileDB context
   tiledb_ctx_t* ctx_;

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -161,7 +161,7 @@ TEST_CASE_METHOD(S3Fx, "Test S3 filesystem, file management", "[s3]") {
   CHECK(paths.size() == 5);
 
   // Check if a directory exists
-  bool is_dir;
+  bool is_dir = false;
   CHECK(s3_.is_dir(URI(file1), &is_dir).ok());
   CHECK(!is_dir);  // Not a dir
   CHECK(s3_.is_dir(URI(file4), &is_dir).ok());


### PR DESCRIPTION
- the main change here is to fix the build by working-around https://github.com/aws/aws-sdk-cpp/pull/1187
- also actually enable S3 testing on windows, which was not running due to a mismatch between what the azure yml was setting (`ON`) vs. what the runner script was checking (`true`)