### PR TITLE
Writes cannot be performed on arrays with a different version than the TileDB library

### DIFF
--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -443,3 +443,16 @@ TEST_CASE(
     }
   }
 }
+
+TEST_CASE(
+    "Backwards compatibility: Write to an array of older version",
+    "[backwards-compat][write-to-older-version]") {
+  std::string old_array_name(arrays_dir + "/non_split_coords_v1_4_0");
+  Context ctx;
+  try {
+    Array old_array(ctx, old_array_name, TILEDB_WRITE);
+    CHECK(false);
+  } catch (const std::exception& e) {
+    CHECK(true);
+  }
+}

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -274,14 +274,13 @@ const FilterPipeline* ArraySchema::coords_filters() const {
 
 Compressor ArraySchema::coords_compression() const {
   auto compressor = coords_filters_.get_filter<CompressionFilter>();
-  assert(compressor != nullptr);
-  return compressor->compressor();
+  return (compressor == nullptr) ? Compressor::NO_COMPRESSION :
+                                   compressor->compressor();
 }
 
 int ArraySchema::coords_compression_level() const {
   auto compressor = coords_filters_.get_filter<CompressionFilter>();
-  assert(compressor != nullptr);
-  return compressor->compression_level();
+  return (compressor == nullptr) ? -1 : compressor->compression_level();
 }
 
 uint64_t ArraySchema::coords_size() const {

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -423,7 +423,6 @@ void* Writer::subarray() const {
 
 Status Writer::write() {
   STATS_FUNC_IN(writer_write);
-
   if (check_coord_oob_)
     RETURN_NOT_OK(check_coord_oob());
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -322,6 +322,16 @@ Status StorageManager::array_open_for_writes(
     }
   }
 
+  // Check array version versus library version
+  if (open_array->array_schema()->version() != constants::format_version) {
+    std::stringstream err;
+    err << "Cannot open array for writes; Array format version (";
+    err << open_array->array_schema()->version();
+    err << ") is different from library format version (";
+    err << constants::format_version << ")";
+    return LOG_STATUS(Status::StorageManagerError(err.str()));
+  }
+
   // No fragment metadata to be loaded
 
   *array_schema = open_array->array_schema();


### PR DESCRIPTION
Closes #1310

Also fixes an old bug when dumping the array format when coordinates compressor is not set.