### PR TITLE
Improve error message for invalid array URI

### DIFF
--- a/tiledb/sm/misc/uri.cc
+++ b/tiledb/sm/misc/uri.cc
@@ -146,7 +146,7 @@ Status URI::get_rest_components(
     std::string* array_namespace, std::string* array_uri) const {
   const std::string prefix = "tiledb://";
   const auto error_st = Status::RestError(
-      "Invalid URI for REST service; expected format is "
+      "Invalid array URI for REST service; expected format is "
       "'tiledb://<namespace>/<array-name>' or "
       "'tiledb://<namespace>/<array-uri>'.");
 


### PR DESCRIPTION
Extremely trivial, but I hit this error message when
opening a rest-array for the first time:
[TileDB::REST] Error: Invalid URI for REST service; expected format is 'tiledb://namespace/array-name' or 'tiledb://namespace/array-uri'.

The phrasing "Invalid URI for REST service" made me think that I had
the wrong REST URI (e.g. "http://localhost:8080"), but the problem
was the array URI (e.g. "tiledb://my-array-name-without-namespace").

The problem was the array URI, not the REST URI, so I've changed this
error message to make that clearer.