### PR TITLE
Remove KV API usage from `impl::Deleter` class.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -60,6 +60,7 @@
 * Removed cast operators of C++ API objects to their underlying C API objects. This helps prevent inadvertent memory issues such as double-frees.
 * Removed ability to set `null` tile extents on dimensions. All dimensions must now have an explicit tile extent.
 * Changed argument `config` in `Array::consolidate()` from a const-ref to a pointer.
+* Removed default includes of `Map` and `MapSchema`. To use the deprecated KV API temporarily, include `<tiledb/map.h>` explicitly.
 
 # TileDB v1.5.0 Release Notes
 

--- a/examples/cpp_api/map.cc
+++ b/examples/cpp_api/map.cc
@@ -35,6 +35,7 @@
  *
  */
 
+#include <tiledb/map.h>
 #include <iostream>
 #include <tiledb/tiledb>
 

--- a/examples/cpp_api/object.cc
+++ b/examples/cpp_api/object.cc
@@ -47,6 +47,7 @@
  * move/remove TileDB objects.
  */
 
+#include <tiledb/map.h>
 #include <iostream>
 #include <tiledb/tiledb>
 

--- a/examples/cpp_api/quickstart_map.cc
+++ b/examples/cpp_api/quickstart_map.cc
@@ -35,6 +35,7 @@
  *
  */
 
+#include <tiledb/map.h>
 #include <iostream>
 #include <tiledb/tiledb>
 

--- a/test/src/unit-cppapi-map.cc
+++ b/test/src/unit-cppapi-map.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "tiledb/sm/cpp_api/map.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/misc/utils.h"
 

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "tiledb/sm/cpp_api/map.h"
 #include "tiledb/sm/cpp_api/tiledb"
 
 TEST_CASE("C++ API: Schema", "[cppapi]") {

--- a/tiledb/sm/cpp_api/deleter.h
+++ b/tiledb/sm/cpp_api/deleter.h
@@ -82,22 +82,6 @@ class Deleter {
     tiledb_array_schema_free(&p);
   }
 
-  void operator()(tiledb_kv_t* p) const {
-    tiledb_kv_free(&p);
-  }
-
-  void operator()(tiledb_kv_schema_t* p) const {
-    tiledb_kv_schema_free(&p);
-  }
-
-  void operator()(tiledb_kv_item_t* p) const {
-    tiledb_kv_item_free(&p);
-  }
-
-  void operator()(tiledb_kv_iter_t* p) const {
-    tiledb_kv_iter_free(&p);
-  }
-
   void operator()(tiledb_attribute_t* p) const {
     tiledb_attribute_free(&p);
   }

--- a/tiledb/sm/cpp_api/map.h
+++ b/tiledb/sm/cpp_api/map.h
@@ -286,7 +286,7 @@ class MapItem {
   std::shared_ptr<tiledb_kv_item_t> item_;
 
   /** Deleter for tiledb object **/
-  impl::Deleter deleter_;
+  impl::KVDeleter deleter_;
 
   /** Underlying Map **/
   Map* map_ = nullptr;
@@ -562,7 +562,7 @@ class MapIter : public std::iterator<std::forward_iterator_tag, MapItem> {
  private:
   /** Base map. **/
   Map* map_;
-  impl::Deleter deleter_;
+  impl::KVDeleter deleter_;
 
   /** Current item **/
   std::unique_ptr<MapItem> item_;
@@ -1520,7 +1520,7 @@ class Map {
   std::shared_ptr<tiledb_kv_t> kv_;
 
   /** Closes the map on destruction. **/
-  impl::Deleter deleter_;
+  impl::KVDeleter deleter_;
 
   /** URI **/
   std::string uri_;

--- a/tiledb/sm/cpp_api/tiledb
+++ b/tiledb/sm/cpp_api/tiledb
@@ -47,8 +47,6 @@
 #include "filter.h"
 #include "filter_list.h"
 #include "group.h"
-#include "map.h"
-#include "map_schema.h"
 #include "object.h"
 #include "object_iter.h"
 #include "query.h"


### PR DESCRIPTION
Closes #1354.