### PR TITLE
Add compile-time check for Curl HTTPS support

### DIFF
--- a/cmake/Modules/CheckCurlSSL.cmake
+++ b/cmake/Modules/CheckCurlSSL.cmake
@@ -1,0 +1,33 @@
+cmake_push_check_state()
+
+include(CheckCSourceRuns)
+
+set(CMAKE_REQUIRED_LIBRARIES ${CURL_APPEND_LIBS} ${OPENSSL_SSL_LIBRARY})
+set(CMAKE_REQUIRED_INCLUDES ${CURL_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
+
+# suppress warnings, this is a runtime check
+set(CMAKE_REQUIRED_FLAGS -w)
+
+if (NOT WIN32)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES -ldl -lpthread)
+endif()
+
+check_c_source_runs(
+  "#include <stdlib.h>
+  #include <curl/curl.h>
+  int main() {
+    curl_version_info_data* vers = curl_version_info(CURLVERSION_NOW);
+    if (!(vers->features & CURL_VERSION_SSL)) {
+      exit(1);
+    }
+    exit(0);
+  }"
+  TILEDB_CURL_HAS_SSL
+)
+
+if (NOT TILEDB_CURL_HAS_SSL)
+  message(FATAL_ERROR "Target libcurl does not provide SSL -- HTTPS will be broken! "
+                      "(override with TILEDB_CURL_HAS_SSL=1) "
+                      "Note: output of this check will be in CMakeFiles/CMake[Output,Error].log")
+endif()
+cmake_pop_check_state()

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -493,6 +493,14 @@ if (CURL_APPEND_LIBS)
     ${CURL_APPEND_LIBS})
 endif()
 
+# Ensure that Curl has SSL available.
+# HTTPS failures are layered under the AWS SDK, with limited
+# and unspecific error messages.
+# Note: to override this check, set TILEDB_CURL_HAS_SSL=1
+if (TILEDB_SERIALIZATION OR TILEDB_S3 AND NOT WIN32)
+  include(${CMAKE_SOURCE_DIR}/cmake/Modules/CheckCurlSSL.cmake)
+endif()
+
 ############################################################
 # Generated dependency information (for installation)
 ############################################################


### PR DESCRIPTION
This PR adds a check to ensure that the curl we are linking against has HTTPS enabled. Lack of HTTPS has bitten me and others a few times, and the failure mode is very opaque (though more tractable now with AWS logging).

verification: https://dev.azure.com/isaiahnorton/isaiahnorton/_build/results?buildId=310&view=logs&j=67abe246-7b8f-5019-2f4c-16a6f94f1067&t=111e48ad-0adf-5a6f-d1ca-4f53ab538f02&l=353