### PR TITLE
Implement basic array metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ doc/venv
 doc/source/__pycache__
 doc/source/_build
 doc/source/_sidebar.rst.inc
+doc/source/gensidebar.pyc
 examples/cmake_project/build

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+* Added array metadata.
+
 ## Improvements
 
 ## Deprecations

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -253,6 +253,20 @@ Array
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_encryption_type
     :project: TileDB-C
+.. doxygenfunction:: tiledb_array_put_metadata
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_get_metadata
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_get_metadata_from_index
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_get_metadata_num
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_delete_metadata
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_consolidate_metadata
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_consolidate_metadata_with_key
+    :project: TileDB-C
 
 Array Schema
 ------------

--- a/doc/source/gensidebar.py
+++ b/doc/source/gensidebar.py
@@ -90,6 +90,7 @@ def generate_sidebar(conf, conf_api):
     write('Sparse Arrays', 'tutorials/sparse-arrays')
     write('Multi-attribute Arrays', 'tutorials/multi-attribute-arrays')
     write('Variable-length Attributes', 'tutorials/variable-length-attributes')
+    write('Array Metadata', 'tutorials/array-metadata')
     write('Filters', 'tutorials/filters')
     write('Compression', 'tutorials/compression')
     write('Encryption', 'tutorials/encryption')

--- a/doc/source/tutorials/array-metadata.rst
+++ b/doc/source/tutorials/array-metadata.rst
@@ -1,0 +1,227 @@
+.. _array-metadata:
+
+Array Metadata
+==============
+
+In this tutorial we will learn how to write, read and consolidate array 
+metadata.
+
+.. table:: Full programs
+  :widths: auto
+
+  ====================================  =============================================================
+  **Program**                           **Links**
+  ------------------------------------  -------------------------------------------------------------
+  ``array_metadata``                    |arraymetadatacpp|
+  ====================================  =============================================================
+
+.. |arraymetadatacpp| image:: ../figures/cpp.png
+   :align: middle
+   :width: 30
+   :target: {tiledb_src_root_url}/examples/cpp_api/array_metadata.cc
+
+What is array metadata?
+-----------------------
+
+Array metadata is a collection of *key-value* pairs associated with an array.
+Each metadata item is of the form: ``key : (value_type, value_num, value)``,
+where ``key`` is a string key, ``value_type`` is the data type of the value,
+``value_num`` is the number of elements that constitute the value (can be
+more than one), and  ``value`` is the metadata value in binary form. 
+
+
+TileDB persistently stores the array metadata inside the array directory. However,
+note that TileDB loads *all* its metadata upon opening the array in read mode,
+which means that it assumes all the array metadata is small enough to be 
+maintained in main memory.
+
+Writing array metadata
+----------------------
+
+To write array metadata, the array must be opened in *write* mode. Here is
+an example: 
+
+.. content-tabs::
+
+   .. tab-container:: cpp
+      :title: C++
+
+      .. code-block:: c++
+
+        // Open array in write mode
+        Context ctx;
+        Array array(ctx, "my_array", TILEDB_WRITE);
+
+        // Write two metadata items
+        int v = 100;
+        array.put_metadata("aaa", TILEDB_INT32, 1, &v);
+        float f[] = {1.1f, 1.2f};
+        array.put_metadata("bb", TILEDB_FLOAT32, 2, f);
+        std::string str = "tiledb is awesome";
+        array.put_metadata("c", TILEDB_CHAR, str.size(), str.data());
+
+        // Close array - Important!
+        array.close()
+
+Note that the metadata gets flushed to persistent storage only upon 
+*closing* the array.
+
+Reading array metadata
+----------------------
+
+To read array metadata, the array must be opened in *read* mode. Here is
+an example:
+
+.. content-tabs::
+
+   .. tab-container:: cpp
+      :title: C++
+
+      .. code-block:: c++
+
+        // Open array in read mode
+        Context ctx;
+        Array array(ctx, "my_array", TILEDB_READ);
+
+        // Read metadata with key
+        tiledb_datatype_t value_type;
+        uint32_t value_num;
+        const void* value;
+        array.get_metadata("aaa", &v_type, &v_num, &v);
+
+        // Close array
+        array.close()
+
+You can also enumerate all array metadata as follows:
+
+.. content-tabs::
+
+   .. tab-container:: cpp
+      :title: C++
+
+      .. code-block:: c++
+
+        // Open array in read mode
+        Context ctx;
+        Array array(ctx, "my_array", TILEDB_READ);
+
+        // Get number of metadata items
+        uint64_t num = array.metadata_num();
+
+        // Loop getting metadata from index 
+        std::string key;
+        tiledb_datatype_t value_type;
+        uint32_t value_num;
+        const void* value;
+        for (uint64_t i = 0; i < num; ++i) { 
+          array.get_metadata_from_index(i, &key, &value_type, &value_num, &value);
+          // Do something with the metadata
+        }
+
+        // Close array
+        array.close()
+
+Deleting array metadata
+-----------------------
+
+TileDB allows you to delete metadata simply as shown in the example 
+below. The array must be opened in *write* mode and appropriately
+closed in the end so that the change gets flushed to persistent storage.
+Note also that you can mix writing/overwriting and deleting metadata
+in a single write session (i.e., between opening an array in write mode
+and closing it).
+
+.. content-tabs::
+
+   .. tab-container:: cpp
+      :title: C++
+
+      .. code-block:: c++
+
+        // Open array in write mode
+        Context ctx;
+        Array array(ctx, "my_array", TILEDB_WRITE);
+
+        // Delete metadata
+        array.delete_metadata("bb");
+
+        // Close array - Important!
+        array.close()
+
+On-disk structure
+-----------------
+
+Every array metadata write session (i.e., between opening the array in write mode,
+writing/deleting some metadata and closing the array) creates a timestamped
+array metadata file inside the ``__meta`` directory in the array directory:
+
+.. code-block:: bash
+
+    $ ls -l my_array/__meta/
+    total 8
+    -rwx------  1 stavros  staff  127 Sep  7 18:27 __1567895268179_1567895268179_87a009d6b2cf46b68d74621635863b45
+
+Notice that the file name has an identical structure to that of the fragment name
+(see :ref:`fragments-consolidation`), i.e., it consists of a timestamp
+range and a UUID. The same semantics for opening an array at a timestamp apply
+also to metadata as well, i.e., if the array is opened at a timestamp before 
+``1567895268179``, the above file will be ignored.
+
+Multiple separate write sessions (executed either serially or in parallel) create
+multiple timestamped metadata files, similar to fragments (and again no
+array locking is necessary here).
+
+.. code-block:: bash
+
+    $ ls -l my_array/__meta/
+    total 8
+    -rwx------  1 stavros  staff  127 Sep  7 18:27 __1567895268179_1567895268179_87a009d6b2cf46b68d74621635863b45
+    -rwx------  1 stavros  staff  127 Sep  7 19:21 __1567898509507_1567898509507_f0d9756d932540729059eabcfe6856d1
+
+Consolidating array metadata
+----------------------------
+
+To avoid the uncontrollable creation of numerous array metadata files, TileDB
+enables *consolidating* all files in one, similar again to fragment consoplidation:
+
+.. content-tabs::
+
+   .. tab-container:: cpp
+      :title: C++
+
+      .. code-block:: c++
+
+        Context ctx;
+        Array::consolidate_metadata(ctx, "my_array");
+
+Continuing the above example, the result of consolidation is:
+
+.. code-block:: bash
+
+    $ ls -l my_array/__meta/
+    total 8
+    -rwx------  1 stavros  staff  127 Sep  7 19:30 __1567895268179_1567898509507_7382ed6aef65427e8cc9b076e6970c61
+
+Notice that now the new file name contains a timestamp range that includes both the timestamps
+of the consolidated array metadata file names. This is again very similar to fragment 
+consolidation.
+
+Encrypting array metatadata
+---------------------------
+
+The metadata of the array inherit the encryption filters of the array.
+This means that if the array is encrypted, the array metadata will be
+encrypted as well. Similar to array writes/reads, in order to write/read
+array metadata the array must be opened with the encryption key 
+(see :ref:`encryption`). Finally,
+to consolidate the metadata of an encrypted array, you must use:
+
+.. content-tabs::
+
+   .. tab-container:: cpp
+      :title: C++
+
+      .. code-block:: c++
+
+        Context ctx;
+        Array::consolidate_metadata(ctx, "my_array", enc_type, key, key_len);

--- a/doc/source/tutorials/dense-arrays.rst
+++ b/doc/source/tutorials/dense-arrays.rst
@@ -371,6 +371,7 @@ If we look into the array on disk after it has been written to, we will see some
    drwx------  4 stavros  staff  128 Jun 25 15:18 __1561490302161_1561490302161_15bab0281e2e44f2a803eb6f3001ed00
    -rwx------  1 stavros  staff  149 Jun 25 15:18 __array_schema.tdb
    -rwx------  1 stavros  staff    0 Jun 25 15:18 __lock.tdb
+   drwx------  2 stavros  staff   64 Jun 25 15:18 __meta
 
 The array directory and files ``__array_schema.tdb`` and ``__lock.tdb`` were written upon
 array creation, whereas subdirectory 

--- a/doc/source/tutorials/format-description.rst
+++ b/doc/source/tutorials/format-description.rst
@@ -616,6 +616,34 @@ Array lock file
 
 The file ``__lock.tdb`` is always an empty file on disk.
 
+Array metadata file
+~~~~~~~~~~~~~~~~~~~
+
+The array metadata files are stored in folder ``<path_to_array>/__meta``. 
+Each file has name ``__t1_t2_uuid``, where ``uuid`` is the UUID of the
+process/thread that created it, and `t1` and `t2` indicate the
+timestamp range wthing which the array metadata were written (``t1`` equals
+``t2`` if the file was produced by a single write, and ``t1`` is smaller
+than ``t2`` if the file was produced from metadata consolidation).
+
+Each file stores a single generic tile with binary entries of the form:
+
++----------------------------------------+----------------------+--------------------------------------------------------+
+| **Field**                              | **Type**             | **Description**                                        |
++========================================+======================+========================================================+
+| Key length                             | ``uint32_t``         | The length of the key.                                 |
++----------------------------------------+----------------------+--------------------------------------------------------+
+| Key                                    | ``uint8_t[]``        | The key.                                               |
++----------------------------------------+----------------------+--------------------------------------------------------+
+| Deletion                               | ``char``             | ``1``/``0`` if it is a deletion/insertion.             | 
++----------------------------------------+----------------------+--------------------------------------------------------+
+| Value type                             | ``char``             | The value data type. Present only if ``del`` is ``0``. |
++----------------------------------------+----------------------+--------------------------------------------------------+
+| Number of values                       | ``uint32_t``         | The number of values. Present only if ``del`` is ``0``.|
++----------------------------------------+----------------------+--------------------------------------------------------+
+| Value                                  | ``uint8_t[]``        | The value. Present only if ``del`` is ``0``.           |
++----------------------------------------+----------------------+--------------------------------------------------------+
+
 Fragment metadata file
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/tutorials/fragments-consolidation.rst
+++ b/doc/source/tutorials/fragments-consolidation.rst
@@ -1,3 +1,5 @@
+.. _fragments-consolidation:
+
 Fragments and Consolidation
 ===========================
 
@@ -97,6 +99,7 @@ contains three subdirectories with weird names:
         drwx------  5 stavros  staff  160 Jun 25 16:23 __1561494215467_1561494215467_317c5aa1f6eb4e6880f3fda660b86507
         -rwx------  1 stavros  staff  149 Jun 25 16:23 __array_schema.tdb
         -rwx------  1 stavros  staff    0 Jun 25 16:23 __lock.tdb
+        drwx------  2 stavros  staff   64 Jun 25 16:23 __meta
 
    .. tab-container:: python
       :title: Python
@@ -128,6 +131,7 @@ contains three subdirectories with weird names:
          drwx------  5 stavros  staff  160 Jun 25 16:23 __1561494215467_1561494215467_317c5aa1f6eb4e6880f3fda660b86507
          -rwx------  1 stavros  staff  149 Jun 25 16:23 __array_schema.tdb
          -rwx------  1 stavros  staff    0 Jun 25 16:23 __lock.tdb
+         drwx------  2 stavros  staff   64 Jun 25 16:23 __meta
 
 Each subdirectory corresponds to a **fragment**, i.e., to an array snapshot
 containing the cells written in a write operation. *How can we tell which
@@ -385,6 +389,7 @@ to the program) consolidates the three fragments into one before reading.
         drwx------  4 stavros  staff  128 Jun 25 16:28 __1561494215438_1561494215467_1bc203276a1a42c29eb4358325a0f228
         -rwx------  1 stavros  staff  149 Jun 25 16:23 __array_schema.tdb
         -rwx------  1 stavros  staff    0 Jun 25 16:23 __lock.tdb
+        drwx------  2 stavros  staff   64 Jun 25 16:23 __meta
 
         $ ls -l fragments_consolidation_array/__1561494215438_1561494215467_1bc203276a1a42c29eb4358325a0f228/
         total 16
@@ -419,6 +424,7 @@ to the program) consolidates the three fragments into one before reading.
         drwx------  4 stavros  staff  128 Jun 25 16:28 __1561494215438_1561494215467_1bc203276a1a42c29eb4358325a0f228
         -rwx------  1 stavros  staff  149 Jun 25 16:23 __array_schema.tdb
         -rwx------  1 stavros  staff    0 Jun 25 16:23 __lock.tdb
+        drwx------  2 stavros  staff   64 Jun 25 16:23 __meta
 
         $ ls -l fragments_consolidation_array/__1561494215438_1561494215467_1bc203276a1a42c29eb4358325a0f228/
         total 16

--- a/doc/source/tutorials/multi-attribute-arrays.rst
+++ b/doc/source/tutorials/multi-attribute-arrays.rst
@@ -337,6 +337,7 @@ Let us look at the contents of the array of this example on disk.
    drwx------  5 stavros  staff  160 Jun 25 15:34 __1561491299419_1561491299419_fcb0ee91899142baad8a08049c0e2319
    -rwx------  1 stavros  staff  159 Jun 25 15:34 __array_schema.tdb
    -rwx------  1 stavros  staff    0 Jun 25 15:34 __lock.tdb
+   drwx------  2 stavros  staff   64 Jun 25 15:34 __meta
 
    $ ls -l multi_attribute_array/__1561491299419_1561491299419_fcb0ee91899142baad8a08049c0e2319/
    total 24

--- a/doc/source/tutorials/sparse-arrays.rst
+++ b/doc/source/tutorials/sparse-arrays.rst
@@ -349,6 +349,7 @@ If we look into the array on disk after it has been written to, we will see some
     drwx------  5 stavros  staff  160 Jun 25 15:22 __1561490578769_1561490578769_9e429a59930b4a9c83baa57eb2fb41a8
     -rwx------  1 stavros  staff  153 Jun 25 15:22 __array_schema.tdb
     -rwx------  1 stavros  staff    0 Jun 25 15:22 __lock.tdb
+    drwx------  2 stavros  staff   64 Jun 25 15:22 __meta
 
 The array directory and files ``__array_schema.tdb`` and ``__lock.tdb`` were written upon
 array creation, whereas subdirectory 

--- a/doc/source/tutorials/variable-length-attributes.rst
+++ b/doc/source/tutorials/variable-length-attributes.rst
@@ -359,6 +359,7 @@ Let us look at the contents of the array of this example on disk.
    drwx------  7 stavros  staff  224 Jun 25 15:38 __1561491531226_1561491531226_3e56db7d25a447708a73d3e578622ab4
    -rwx------  1 stavros  staff  155 Jun 25 15:38 __array_schema.tdb
    -rwx------  1 stavros  staff    0 Jun 25 15:38 __lock.tdb
+   drwx------  2 stavros  staff   64 Jun 25 15:38 __meta
 
    $ ls -l variable_length_array/__1561491531226_1561491531226_3e56db7d25a447708a73d3e578622ab4/
    total 40

--- a/doc/source/tutorials/writing-dense.rst
+++ b/doc/source/tutorials/writing-dense.rst
@@ -509,6 +509,7 @@ subfolders/fragments created:
   drwx------  4 stavros  staff  128 Jun 25 15:49 __1561492148506_1561492148506_fef381c0326b49a59d6e74816416dfa1
   -rwx------  1 stavros  staff  149 Jun 25 15:49 __array_schema.tdb
   -rwx------  1 stavros  staff    0 Jun 25 15:49 __lock.tdb
+  drwx------  2 stavros  staff   64 Jun 25 15:49 __meta
 
 Writing sparse cells
 --------------------
@@ -592,6 +593,7 @@ Let us inspect the contents of the dense array after the write:
   drwx------  5 stavros  staff  160 Jun 25 15:50 __1561492235844_1561492235844_c033cea7bbc34f2bb425969a497f7bab
   -rwx------  1 stavros  staff  149 Jun 25 15:50 __array_schema.tdb
   -rwx------  1 stavros  staff    0 Jun 25 15:50 __lock.tdb
+  drwx------  2 stavros  staff   64 Jun 25 15:50 __meta
 
   $ ls -l writing_dense_sparse_array/__1561492235844_1561492235844_c033cea7bbc34f2bb425969a497f7bab/
   total 24

--- a/doc/source/tutorials/writing-sparse.rst
+++ b/doc/source/tutorials/writing-sparse.rst
@@ -200,6 +200,7 @@ Let us see how the array directory looks like after the execution of the program
     drwx------  5 stavros  staff  160 Jun 25 15:41 __1561491710249_1561491710249_a94a9605d30049939eb34f7ee6eb4708
     -rwx------  1 stavros  staff  153 Jun 25 15:41 __array_schema.tdb
     -rwx------  1 stavros  staff    0 Jun 25 15:41 __lock.tdb
+    drwx------  2 stavros  staff   64 Jun 25 15:41 __meta
 
     $ ls -l multiple_writes_sparse_array/__1561491710236_1561491710236_3eadf863ae0443c7815857d055ed45c7/
     total 24
@@ -324,6 +325,7 @@ array directory:
    drwx------  5 stavros  staff  160 Jun 25 15:44 __1561491885787_1561491885787_eccb5f9e17c54fef90cedf633d47118c
    -rwx------  1 stavros  staff  153 Jun 25 15:44 __array_schema.tdb
    -rwx------  1 stavros  staff    0 Jun 25 15:44 __lock.tdb
+   drwx------  2 stavros  staff   64 Jun 25 15:44 __meta
 
 As expected, the array contains the same cells and values as ``quickstart_sparse``.
 Moreover, despite the fact that we submitted two write queries, only one

--- a/examples/c_api/array_metadata.c
+++ b/examples/c_api/array_metadata.c
@@ -1,0 +1,178 @@
+/**
+ * @file   array_metadata.c
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This program shows how to write, read and consolidate array metadata.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <tiledb/tiledb.h>
+
+// Name of array.
+const char* array_name = "array_metadata_array";
+
+void create_array() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // Create some array (it can be dense or sparse, with
+  // any number of dimensions and attributes).
+  int dim_domain[] = {1, 4, 1, 4};
+  int tile_extents[] = {4, 4};
+  tiledb_dimension_t* d1;
+  tiledb_dimension_alloc(
+      ctx, "rows", TILEDB_INT32, &dim_domain[0], &tile_extents[0], &d1);
+  tiledb_dimension_t* d2;
+  tiledb_dimension_alloc(
+      ctx, "cols", TILEDB_INT32, &dim_domain[2], &tile_extents[1], &d2);
+
+  // Create domain
+  tiledb_domain_t* domain;
+  tiledb_domain_alloc(ctx, &domain);
+  tiledb_domain_add_dimension(ctx, domain, d1);
+  tiledb_domain_add_dimension(ctx, domain, d2);
+
+  // Create a single attribute "a" so each (i,j) cell can store an integer
+  tiledb_attribute_t* a;
+  tiledb_attribute_alloc(ctx, "a", TILEDB_INT32, &a);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  tiledb_array_schema_alloc(ctx, TILEDB_SPARSE, &array_schema);
+  tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  tiledb_array_schema_set_domain(ctx, array_schema, domain);
+  tiledb_array_schema_add_attribute(ctx, array_schema, a);
+
+  // Create array
+  tiledb_array_create(ctx, array_name, array_schema);
+
+  // Clean up
+  tiledb_attribute_free(&a);
+  tiledb_dimension_free(&d1);
+  tiledb_dimension_free(&d2);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
+  tiledb_ctx_free(&ctx);
+}
+
+void write_array_metadata() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // Open array for writing
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, array_name, &array);
+  tiledb_array_open(ctx, array, TILEDB_WRITE);
+
+  // Write some metadata
+  int v = 100;
+  tiledb_array_put_metadata(ctx, array, "aaa", TILEDB_INT32, 1, &v);
+  float f[] = {1.1f, 1.2f};
+  tiledb_array_put_metadata(ctx, array, "bb", TILEDB_FLOAT32, 2, f);
+
+  // Close array - Important so that the metadata get flushed
+  tiledb_array_close(ctx, array);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_ctx_free(&ctx);
+}
+
+void read_array_metadata() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // Open array for reading
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, array_name, &array);
+  tiledb_array_open(ctx, array, TILEDB_READ);
+
+  // Read with key
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  const void* v;
+  tiledb_array_get_metadata(ctx, array, "aaa", &v_type, &v_num, &v);
+  printf("Details of item with key: '%s'\n", "aaa");
+  printf(
+      "- Value type: %s\n",
+      (v_type == TILEDB_INT32) ? "INT32" : "something went wrong");
+  printf("- Value num: %u\n", v_num);
+  printf("- Value: %i\n", *(const int*)v);
+
+  tiledb_array_get_metadata(ctx, array, "bb", &v_type, &v_num, &v);
+  printf("Details of item with key: '%s'\n", "bb");
+  printf(
+      "- Value type: %s\n",
+      (v_type == TILEDB_FLOAT32) ? "FLOAT32" : "something went wrong");
+  printf("- Value num: %u\n", v_num);
+  printf("- Value: %f, %f\n", ((const float*)v)[0], ((const float*)v)[1]);
+
+  // Enumerate all metadata items
+  uint64_t num = 0;
+  const char* key;
+  uint32_t key_len;
+  tiledb_array_get_metadata_num(ctx, array, &num);
+  printf("Enumerate all metadata items:\n");
+  for (uint64_t i = 0; i < num; ++i) {
+    tiledb_array_get_metadata_from_index(
+        ctx, array, i, &key, &key_len, &v_type, &v_num, &v);
+
+    printf("# Item %i\n", (int)i);
+    const char* v_type_str = (v_type == TILEDB_INT32) ? "INT32" : "FLOAT32";
+    printf("- Key: %.*s\n", key_len, key);
+    printf("- Value type: %s\n", v_type_str);
+    printf("- Value num: %u\n", v_num);
+    printf("- Value: ");
+    if (v_type == TILEDB_INT32) {
+      for (uint32_t j = 0; j < v_num; ++j)
+        printf("%i ", ((const int*)v)[j]);
+    } else if (v_type == TILEDB_FLOAT32) {
+      for (uint32_t j = 0; j < v_num; ++j)
+        printf("%f ", ((const float*)v)[j]);
+    }
+    printf("\n");
+  }
+
+  // Close array
+  tiledb_array_close(ctx, array);
+  tiledb_array_free(&array);
+  tiledb_ctx_free(&ctx);
+}
+
+int main() {
+  create_array();
+  write_array_metadata();
+  read_array_metadata();
+
+  return 0;
+}

--- a/examples/cpp_api/array_metadata.cc
+++ b/examples/cpp_api/array_metadata.cc
@@ -1,0 +1,140 @@
+/**
+ * @file   array_metadata.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This program shows how to write, read and consolidate array metadata.
+ */
+
+#include <iostream>
+#include <tiledb/tiledb>
+
+using namespace tiledb;
+
+// Name of array
+std::string array_name("array_metadata_array");
+
+void create_array() {
+  // Create a TileDB context.
+  Context ctx;
+
+  // Create some array (it can be dense or sparse, with
+  // any number of dimensions and attributes).
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{1, 4}}, 4))
+      .add_dimension(Dimension::create<int>(ctx, "cols", {{1, 4}}, 4));
+
+  // The array will be sparse.
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+
+  // Add a single attribute "a" so each (i,j) cell can store an integer.
+  schema.add_attribute(Attribute::create<int>(ctx, "a"));
+
+  // Create the (empty) array on disk.
+  Array::create(array_name, schema);
+}
+
+void write_array_metadata() {
+  // Create TileDB context
+  Context ctx;
+
+  // Open array for writing
+  Array array(ctx, array_name, TILEDB_WRITE);
+
+  // Write some metadata
+  int v = 100;
+  array.put_metadata("aaa", TILEDB_INT32, 1, &v);
+  float f[] = {1.1f, 1.2f};
+  array.put_metadata("bb", TILEDB_FLOAT32, 2, f);
+
+  // Close array - Important so that the metadata get flushed
+  array.close();
+}
+
+void read_array_metadata() {
+  // Create TileDB context
+  Context ctx;
+
+  // Open array for reading
+  Array array(ctx, array_name, TILEDB_READ);
+
+  // Read with key
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  const void* v;
+  array.get_metadata("aaa", &v_type, &v_num, &v);
+  std::cout << "Details of item with key: aaa\n";
+  std::cout << "- Value type: "
+            << ((v_type == TILEDB_INT32) ? "INT32" : "something went wrong")
+            << "\n";
+  std::cout << "- Value num: " << v_num << "\n";
+  std::cout << "- Value: " << *(const int*)v << "\n";
+
+  array.get_metadata("bb", &v_type, &v_num, &v);
+  std::cout << "Details of item with key: bb\n";
+  std::cout << "- Value type: "
+            << ((v_type == TILEDB_FLOAT32) ? "FLOAT32" : "something went wrong")
+            << "\n";
+  std::cout << "- Value num: " << v_num << "\n";
+  std::cout << "- Value: " << ((const float*)v)[0] << " "
+            << ((const float*)v)[1] << "\n";
+
+  // Enumerate all metadata items
+  std::string key;
+  uint64_t num = array.metadata_num();
+  printf("Enumerate all metadata items:\n");
+  for (uint64_t i = 0; i < num; ++i) {
+    array.get_metadata_from_index(i, &key, &v_type, &v_num, &v);
+
+    std::cout << "# Item " << i << "\n";
+    const char* v_type_str = (v_type == TILEDB_INT32) ? "INT32" : "FLOAT32";
+    std::cout << "- Key: " << key << "\n";
+    std::cout << "- Value type: " << v_type_str << "\n";
+    std::cout << "- Value num: " << v_num << "\n";
+    std::cout << "- Value: ";
+    if (v_type == TILEDB_INT32) {
+      for (uint32_t j = 0; j < v_num; ++j)
+        std::cout << ((const int*)v)[j] << " ";
+    } else if (v_type == TILEDB_FLOAT32) {
+      for (uint32_t j = 0; j < v_num; ++j)
+        std::cout << ((const float*)v)[j] << " ";
+    }
+    std::cout << "\n";
+  }
+
+  // Close array
+  array.close();
+}
+
+int main() {
+  create_array();
+  write_array_metadata();
+  read_array_metadata();
+
+  return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-capi-incomplete.cc
   src/unit-capi-incomplete-2.cc
   src/unit-capi-kv.cc
+  src/unit-capi-metadata.cc
   src/unit-capi-object_mgmt.cc
   src/unit-capi-query.cc
   src/unit-capi-query_2.cc
@@ -111,6 +112,7 @@ if (TILEDB_CPP_API)
     src/unit-cppapi-datetimes.cc
     src/unit-cppapi-filter.cc
     src/unit-cppapi-map.cc
+    src/unit-cppapi-metadata.cc
     src/unit-cppapi-query.cc
     src/unit-cppapi-schema.cc
     src/unit-cppapi-subarray.cc

--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -198,6 +198,99 @@ void create_array(
   tiledb_array_schema_free(&array_schema);
 }
 
+void create_array(
+    tiledb_ctx_t* ctx,
+    const std::string& array_name,
+    tiledb_encryption_type_t enc_type,
+    const char* key,
+    uint32_t key_len,
+    tiledb_array_type_t array_type,
+    const std::vector<std::string>& dim_names,
+    const std::vector<tiledb_datatype_t>& dim_types,
+    const std::vector<void*>& dim_domains,
+    const std::vector<void*>& tile_extents,
+    const std::vector<std::string>& attr_names,
+    const std::vector<tiledb_datatype_t>& attr_types,
+    const std::vector<uint32_t>& cell_val_num,
+    const std::vector<std::pair<tiledb_filter_type_t, int>>& compressors,
+    tiledb_layout_t tile_order,
+    tiledb_layout_t cell_order,
+    uint64_t capacity) {
+  // For easy reference
+  auto dim_num = dim_names.size();
+  auto attr_num = attr_names.size();
+
+  // Sanity checks
+  assert(dim_types.size() == dim_num);
+  assert(dim_domains.size() == dim_num);
+  assert(tile_extents.size() == dim_num);
+  assert(attr_types.size() == attr_num);
+  assert(cell_val_num.size() == attr_num);
+  assert(compressors.size() == attr_num);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  int rc = tiledb_array_schema_alloc(ctx, array_type, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_cell_order(ctx, array_schema, cell_order);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_tile_order(ctx, array_schema, tile_order);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_capacity(ctx, array_schema, capacity);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create dimensions and domain
+  tiledb_domain_t* domain;
+  rc = tiledb_domain_alloc(ctx, &domain);
+  REQUIRE(rc == TILEDB_OK);
+  for (size_t i = 0; i < dim_num; ++i) {
+    tiledb_dimension_t* d;
+    rc = tiledb_dimension_alloc(
+        ctx,
+        dim_names[i].c_str(),
+        dim_types[i],
+        dim_domains[i],
+        tile_extents[i],
+        &d);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_domain_add_dimension(ctx, domain, d);
+    REQUIRE(rc == TILEDB_OK);
+    tiledb_dimension_free(&d);
+  }
+
+  // Set domain to schema
+  rc = tiledb_array_schema_set_domain(ctx, array_schema, domain);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_domain_free(&domain);
+
+  // Create attributes
+  for (size_t i = 0; i < attr_num; ++i) {
+    tiledb_attribute_t* a;
+    rc = tiledb_attribute_alloc(ctx, attr_names[i].c_str(), attr_types[i], &a);
+    REQUIRE(rc == TILEDB_OK);
+    rc = set_attribute_compression_filter(
+        ctx, a, compressors[i].first, compressors[i].second);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_attribute_set_cell_val_num(ctx, a, cell_val_num[i]);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_array_schema_add_attribute(ctx, array_schema, a);
+    REQUIRE(rc == TILEDB_OK);
+    tiledb_attribute_free(&a);
+  }
+
+  // Check array schema
+  rc = tiledb_array_schema_check(ctx, array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create array
+  rc = tiledb_array_create_with_key(
+      ctx, array_name.c_str(), array_schema, enc_type, key, key_len);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_schema_free(&array_schema);
+}
+
 void create_s3_bucket(
     const std::string& bucket_name,
     bool s3_supported,

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -138,6 +138,47 @@ void create_array(
     uint64_t capacity);
 
 /**
+ * Helper method to create an encrypted array.
+ *
+ * @param ctx TileDB context.
+ * @param array_name The array name.
+ * @param enc_type The encryption type.
+ * @param key The key to encrypt the array with.
+ * @param key_len The key length.
+ * @param array_type The array type (dense or sparse).
+ * @param dim_names The names of dimensions.
+ * @param dim_types The types of dimensions.
+ * @param dim_domains The domains of dimensions.
+ * @param tile_extents The tile extents of dimensions.
+ * @param attr_names The names of attributes.
+ * @param attr_types The types of attributes.
+ * @param cell_val_num The number of values per cell of attributes.
+ * @param compressors The compressors of attributes.
+ * @param tile_order The tile order.
+ * @param cell_order The cell order.
+ * @param capacity The tile capacity.
+ */
+
+void create_array(
+    tiledb_ctx_t* ctx,
+    const std::string& array_name,
+    tiledb_encryption_type_t enc_type,
+    const char* key,
+    uint32_t key_len,
+    tiledb_array_type_t array_type,
+    const std::vector<std::string>& dim_names,
+    const std::vector<tiledb_datatype_t>& dim_types,
+    const std::vector<void*>& dim_domains,
+    const std::vector<void*>& tile_extents,
+    const std::vector<std::string>& attr_names,
+    const std::vector<tiledb_datatype_t>& attr_types,
+    const std::vector<uint32_t>& cell_val_num,
+    const std::vector<std::pair<tiledb_filter_type_t, int>>& compressors,
+    tiledb_layout_t tile_order,
+    tiledb_layout_t cell_order,
+    uint64_t capacity);
+
+/**
  * Helper method that creates a directory.
  *
  * @param path The name of the directory to be created.

--- a/test/src/unit-Consolidator.cc
+++ b/test/src/unit-Consolidator.cc
@@ -42,12 +42,12 @@ TEST_CASE(
     "[remove-consolidated-URIs][remove-none]") {
   std::vector<TimestampedURI> uris;
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(0, 1));
-  Consolidator::remove_consolidated_fragment_uris(&uris);
+  Consolidator::remove_consolidated_uris(&uris);
   CHECK(uris.size() == 1);
   CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 1));
 
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 3));
-  Consolidator::remove_consolidated_fragment_uris(&uris);
+  Consolidator::remove_consolidated_uris(&uris);
   CHECK(uris.size() == 2);
   CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 1));
   CHECK(uris[1].timestamp_range_ == std::pair<uint64_t, uint64_t>(2, 3));
@@ -62,7 +62,7 @@ TEST_CASE(
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(1, 1));
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 2));
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(3, 3));
-  Consolidator::remove_consolidated_fragment_uris(&uris);
+  Consolidator::remove_consolidated_uris(&uris);
   CHECK(uris.size() == 3);
   CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 1));
   CHECK(uris[1].timestamp_range_ == std::pair<uint64_t, uint64_t>(2, 2));
@@ -79,7 +79,7 @@ TEST_CASE(
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 2));
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 3));
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(3, 3));
-  Consolidator::remove_consolidated_fragment_uris(&uris);
+  Consolidator::remove_consolidated_uris(&uris);
   CHECK(uris.size() == 3);
   CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 0));
   CHECK(uris[1].timestamp_range_ == std::pair<uint64_t, uint64_t>(1, 1));
@@ -97,7 +97,7 @@ TEST_CASE(
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 2));
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(2, 3));
   uris.emplace_back(URI(), std::pair<uint64_t, uint64_t>(3, 3));
-  Consolidator::remove_consolidated_fragment_uris(&uris);
+  Consolidator::remove_consolidated_uris(&uris);
   CHECK(uris.size() == 1);
   CHECK(uris[0].timestamp_range_ == std::pair<uint64_t, uint64_t>(0, 3));
 }

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -33,6 +33,7 @@
 #include "catch.hpp"
 #include "test/src/helpers.h"
 #include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/misc/utils.h"
 
 #include <climits>
 #include <cstring>
@@ -3189,7 +3190,12 @@ int ConsolidationFx::get_dir_num(const char* path, void* data) {
   int is_dir;
   int rc = tiledb_vfs_is_dir(ctx, vfs, path, &is_dir);
   CHECK(rc == TILEDB_OK);
-  data_struct->dir_num += is_dir;
+  auto meta_dir =
+      std::string("/") + tiledb::sm::constants::array_metadata_folder_name;
+  if (!tiledb::sm::utils::parse::ends_with(path, meta_dir)) {
+    // Ignoring the meta folder
+    data_struct->dir_num += is_dir;
+  }
 
   return 1;
 }

--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -1,0 +1,928 @@
+/**
+ * @file unit-capi-metadata.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C API for array metadata.
+ */
+
+#include "test/src/helpers.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
+#include <catch.hpp>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+using namespace tiledb::sm;
+
+/* ********************************* */
+/*         STRUCT DEFINITION         */
+/* ********************************* */
+
+struct CMetadataFx {
+  tiledb_ctx_t* ctx_;
+  tiledb_vfs_t* vfs_;
+  bool s3_supported_, hdfs_supported_;
+  std::string temp_dir_;
+  const std::string s3_bucket_name_ =
+      "s3://" + random_bucket_name("tiledb") + "/";
+  std::string array_name_;
+  const char* ARRAY_NAME = "test_metadata";
+  tiledb_array_t* array_ = nullptr;
+  const char* key_ = "0123456789abcdeF0123456789abcdeF";
+  const uint32_t key_len_ =
+      (uint32_t)strlen("0123456789abcdeF0123456789abcdeF");
+  const tiledb_encryption_type_t enc_type_ = TILEDB_AES_256_GCM;
+
+  void create_default_array_1d();
+  void create_default_array_1d_with_key();
+
+  CMetadataFx();
+  ~CMetadataFx();
+};
+
+CMetadataFx::CMetadataFx() {
+  ctx_ = nullptr;
+  vfs_ = nullptr;
+  hdfs_supported_ = false;
+  s3_supported_ = false;
+
+  get_supported_fs(&s3_supported_, &hdfs_supported_);
+  create_ctx_and_vfs(s3_supported_, &ctx_, &vfs_);
+  create_s3_bucket(s3_bucket_name_, s3_supported_, ctx_, vfs_);
+
+// Create temporary directory based on the supported filesystem
+#ifdef _WIN32
+  temp_dir_ = tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
+#else
+  temp_dir_ = "file://" + tiledb::sm::Posix::current_dir() + "/tiledb_test/";
+#endif
+  if (s3_supported_)
+    temp_dir_ = s3_bucket_name_ + "tiledb/test/";
+  if (hdfs_supported_)
+    temp_dir_ = "hdfs:///tiledb_test/";
+  create_dir(temp_dir_, ctx_, vfs_);
+
+  array_name_ = temp_dir_ + ARRAY_NAME;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array_);
+  CHECK(rc == TILEDB_OK);
+}
+
+CMetadataFx::~CMetadataFx() {
+  tiledb_array_free(&array_);
+  remove_dir(temp_dir_, ctx_, vfs_);
+  tiledb_ctx_free(&ctx_);
+  tiledb_vfs_free(&vfs_);
+}
+
+void CMetadataFx::create_default_array_1d() {
+  uint64_t domain[] = {1, 10};
+  uint64_t tile_extent = 5;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"d"},
+      {TILEDB_UINT64},
+      {domain},
+      {&tile_extent},
+      {"a", "b", "c"},
+      {TILEDB_INT32, TILEDB_CHAR, TILEDB_FLOAT32},
+      {1, TILEDB_VAR_NUM, 2},
+      {::Compressor(TILEDB_FILTER_NONE, -1),
+       ::Compressor(TILEDB_FILTER_ZSTD, -1),
+       ::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      2);
+}
+
+void CMetadataFx::create_default_array_1d_with_key() {
+  uint64_t domain[] = {1, 10};
+  uint64_t tile_extent = 5;
+  create_array(
+      ctx_,
+      array_name_,
+      enc_type_,
+      key_,
+      key_len_,
+      TILEDB_DENSE,
+      {"d"},
+      {TILEDB_UINT64},
+      {domain},
+      {&tile_extent},
+      {"a", "b", "c"},
+      {TILEDB_INT32, TILEDB_CHAR, TILEDB_FLOAT32},
+      {1, TILEDB_VAR_NUM, 2},
+      {::Compressor(TILEDB_FILTER_NONE, -1),
+       ::Compressor(TILEDB_FILTER_ZSTD, -1),
+       ::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      2);
+}
+
+/* ********************************* */
+/*                TESTS              */
+/* ********************************* */
+
+TEST_CASE_METHOD(
+    CMetadataFx, "C API: Metadata, basic errors", "[capi][metadata][errors]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Put metadata on an array that is not opened
+  int v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "key", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_ERR);
+
+  // Write metadata on an array opened in READ mode
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_put_metadata(ctx_, array, "key", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_ERR);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Reopen array in WRITE mode
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write null key
+  rc = tiledb_array_put_metadata(ctx_, array, NULL, TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_ERR);
+
+  // Write null value
+  rc = tiledb_array_put_metadata(ctx_, array, "key", TILEDB_INT32, 1, NULL);
+  CHECK(rc == TILEDB_ERR);
+
+  // Write zero values
+  rc = tiledb_array_put_metadata(ctx_, array, "key", TILEDB_INT32, 0, &v);
+  CHECK(rc == TILEDB_ERR);
+
+  // Write value type ANY
+  rc = tiledb_array_put_metadata(ctx_, array, "key", TILEDB_ANY, 1, &v);
+  CHECK(rc == TILEDB_ERR);
+
+  // Write a correct item
+  rc = tiledb_array_put_metadata(ctx_, array, "key", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Open with key
+  rc = tiledb_array_open_with_key(
+      ctx_, array, TILEDB_READ, enc_type_, key_, key_len_);
+  CHECK(rc == TILEDB_ERR);
+
+  // Clean up
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    CMetadataFx, "C API: Metadata, write/read", "[capi][metadata][read]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create and open array in write mode
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write items
+  int32_t v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "aaa", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+  float f[] = {1.1f, 1.2f};
+  rc = tiledb_array_put_metadata(ctx_, array, "bb", TILEDB_FLOAT32, 2, f);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Open the array in read mode
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  rc = tiledb_array_get_metadata(ctx_, array, "aaa", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "bb", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "foo", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_r == nullptr);
+
+  uint64_t num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 2);
+
+  const char* key;
+  uint32_t key_len;
+  rc = tiledb_array_get_metadata_from_index(
+      ctx_, array, 10, &key, &key_len, &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_ERR);
+
+  rc = tiledb_array_get_metadata_from_index(
+      ctx_, array, 1, &key, &key_len, &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(key_len == strlen("bb"));
+  CHECK(!strncmp(key, "bb", strlen("bb")));
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    CMetadataFx, "C API: Metadata, UTF-8", "[capi][metadata][utf-8]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create and open array in write mode
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write UTF-8 (≥ holds 3 bytes)
+  int32_t v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "≥", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Open the array in read mode
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  rc = tiledb_array_get_metadata(ctx_, array, "≥", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+
+  const char* key;
+  uint32_t key_len;
+  rc = tiledb_array_get_metadata_from_index(
+      ctx_, array, 0, &key, &key_len, &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+  CHECK(key_len == strlen("≥"));
+  CHECK(!strncmp(key, "≥", strlen("≥")));
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    CMetadataFx, "C API: Metadata, delete", "[capi][metadata][delete]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create and open array in write mode
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write items
+  int32_t v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "aaa", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+  float f[] = {1.1f, 1.2f};
+  rc = tiledb_array_put_metadata(ctx_, array, "bb", TILEDB_FLOAT32, 2, f);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Prevent array metadata filename/timestamp conflicts
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Delete an item that exists and one that does not exist
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_delete_metadata(ctx_, array, "aaa");
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_delete_metadata(ctx_, array, "foo");
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Open the array in read mode
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  rc = tiledb_array_get_metadata(ctx_, array, "aaa", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_r == nullptr);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "bb", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "foo", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_r == nullptr);
+
+  uint64_t num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 1);
+
+  const char* key;
+  uint32_t key_len;
+  rc = tiledb_array_get_metadata_from_index(
+      ctx_, array, 0, &key, &key_len, &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(key_len == strlen("bb"));
+  CHECK(!strncmp(key, "bb", strlen("bb")));
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    CMetadataFx,
+    "C API: Metadata, multiple metadata and cosnolidate",
+    "[capi][metadata][multiple][consolidation]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create and open array in write mode
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write items
+  int32_t v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "aaa", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+  float f[] = {1.1f, 1.2f};
+  rc = tiledb_array_put_metadata(ctx_, array, "bb", TILEDB_FLOAT32, 2, f);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Prevent array metadata filename/timestamp conflicts
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Update
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_delete_metadata(ctx_, array, "aaa");
+  CHECK(rc == TILEDB_OK);
+  v = 10;
+  rc = tiledb_array_put_metadata(ctx_, array, "cccc", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Open the array in read mode
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  rc = tiledb_array_get_metadata(ctx_, array, "aaa", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_r == nullptr);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "bb", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "cccc", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 10);
+
+  uint64_t num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 2);
+
+  const char* key;
+  uint32_t key_len;
+  rc = tiledb_array_get_metadata_from_index(
+      ctx_, array, 0, &key, &key_len, &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(key_len == strlen("bb"));
+  CHECK(!strncmp(key, "bb", strlen("bb")));
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Consolidate
+  rc = tiledb_array_consolidate_metadata(ctx_, array_name_.c_str(), nullptr);
+  CHECK(rc == TILEDB_OK);
+
+  // Open the array in read mode
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 2);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Write once more
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write items
+  v = 50;
+  rc = tiledb_array_put_metadata(ctx_, array, "d", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Consolidate again
+  rc = tiledb_array_consolidate_metadata(ctx_, array_name_.c_str(), nullptr);
+  CHECK(rc == TILEDB_OK);
+
+  // Open the array in read mode
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 3);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "cccc", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 10);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "d", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 50);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    CMetadataFx, "C API: Metadata, open at", "[capi][metadata][open-at]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create and open array in write mode
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write items
+  int32_t v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "aaa", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+  float f[] = {1.1f, 1.2f};
+  rc = tiledb_array_put_metadata(ctx_, array, "bb", TILEDB_FLOAT32, 2, f);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Prevent array metadata filename/timestamp conflicts
+  auto timestamp = tiledb::sm::utils::time::timestamp_now_ms();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Update
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_delete_metadata(ctx_, array, "aaa");
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Open the array in read mode at a timestamp
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open_at(ctx_, array, TILEDB_READ, timestamp);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  rc = tiledb_array_get_metadata(ctx_, array, "aaa", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+
+  uint64_t num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 2);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    CMetadataFx, "C API: Metadata, reopen", "[capi][metadata][reopen]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create and open array in write mode
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write items
+  int32_t v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "aaa", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+  float f[] = {1.1f, 1.2f};
+  rc = tiledb_array_put_metadata(ctx_, array, "bb", TILEDB_FLOAT32, 2, f);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Prevent array metadata filename/timestamp conflicts
+  auto timestamp = tiledb::sm::utils::time::timestamp_now_ms();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Update
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_delete_metadata(ctx_, array, "aaa");
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Open the array in read mode at a timestamp
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open_at(ctx_, array, TILEDB_READ, timestamp);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  rc = tiledb_array_get_metadata(ctx_, array, "aaa", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+
+  uint64_t num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 2);
+
+  // Reopen
+  rc = tiledb_array_reopen(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Read
+  rc = tiledb_array_get_metadata(ctx_, array, "aaa", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_r == nullptr);
+
+  num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 1);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    CMetadataFx,
+    "C API: Metadata, encryption",
+    "[capi][metadata][encryption]") {
+  // Create default array
+  create_default_array_1d_with_key();
+
+  // Create and open array in write mode
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open_with_key(
+      ctx_, array, TILEDB_WRITE, enc_type_, key_, key_len_);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write items
+  int32_t v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "aaa", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+  float f[] = {1.1f, 1.2f};
+  rc = tiledb_array_put_metadata(ctx_, array, "bb", TILEDB_FLOAT32, 2, f);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Prevent array metadata filename/timestamp conflicts
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Update
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open_with_key(
+      ctx_, array, TILEDB_WRITE, enc_type_, key_, key_len_);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_delete_metadata(ctx_, array, "aaa");
+  CHECK(rc == TILEDB_OK);
+  v = 10;
+  rc = tiledb_array_put_metadata(ctx_, array, "cccc", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Open the array in read mode
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open_with_key(
+      ctx_, array, TILEDB_READ, enc_type_, key_, key_len_);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  rc = tiledb_array_get_metadata(ctx_, array, "aaa", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_r == nullptr);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "bb", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "cccc", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 10);
+
+  uint64_t num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 2);
+
+  const char* key;
+  uint32_t key_len;
+  rc = tiledb_array_get_metadata_from_index(
+      ctx_, array, 0, &key, &key_len, &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(key_len == strlen("bb"));
+  CHECK(!strncmp(key, "bb", strlen("bb")));
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Consolidate without key - error
+  rc = tiledb_array_consolidate_metadata(ctx_, array_name_.c_str(), nullptr);
+  CHECK(rc == TILEDB_ERR);
+
+  // Consolidate with key - ok
+  rc = tiledb_array_consolidate_metadata_with_key(
+      ctx_, array_name_.c_str(), enc_type_, key_, key_len_, nullptr);
+  CHECK(rc == TILEDB_OK);
+
+  // Open the array in read mode
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open_with_key(
+      ctx_, array, TILEDB_READ, enc_type_, key_, key_len_);
+  REQUIRE(rc == TILEDB_OK);
+
+  num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 2);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Write once more
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open_with_key(
+      ctx_, array, TILEDB_WRITE, enc_type_, key_, key_len_);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write items
+  v = 50;
+  rc = tiledb_array_put_metadata(ctx_, array, "d", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+
+  // Consolidate again
+  rc = tiledb_array_consolidate_metadata_with_key(
+      ctx_, array_name_.c_str(), enc_type_, key_, key_len_, nullptr);
+  CHECK(rc == TILEDB_OK);
+
+  // Open the array in read mode
+  rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open_with_key(
+      ctx_, array, TILEDB_READ, enc_type_, key_, key_len_);
+  REQUIRE(rc == TILEDB_OK);
+
+  num = 0;
+  rc = tiledb_array_get_metadata_num(ctx_, array, &num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(num == 3);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "cccc", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 10);
+
+  rc = tiledb_array_get_metadata(ctx_, array, "d", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 50);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+}

--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -926,3 +926,40 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   tiledb_array_free(&array);
 }
+
+TEST_CASE_METHOD(
+    CMetadataFx, "C API: Metadata, overwrite", "[capi][metadata][overwrite]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  CHECK(rc == TILEDB_OK);
+
+  // Write and overwrite
+  int64_t v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "aaa", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+  int64_t v2 = 10;
+  rc = tiledb_array_put_metadata(ctx_, array, "aaa", TILEDB_INT32, 1, &v2);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Read back
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+  const void* vback_ptr = NULL;
+  tiledb_datatype_t vtype;
+  uint32_t vnum = 0;
+  rc = tiledb_array_get_metadata(ctx_, array, "aaa", &vtype, &vnum, &vback_ptr);
+  CHECK(rc == TILEDB_OK);
+  CHECK(vtype == TILEDB_INT32);
+  CHECK(vnum == 1);
+  CHECK(*((int32_t*)vback_ptr) == 10);
+}

--- a/test/src/unit-cppapi-metadata.cc
+++ b/test/src/unit-cppapi-metadata.cc
@@ -1,0 +1,682 @@
+/**
+ * @file unit-cppapi-metadata.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C++ API for array metadata.
+ */
+
+#include "test/src/helpers.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/cpp_api/tiledb"
+
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
+#include <catch.hpp>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+using namespace tiledb;
+
+/* ********************************* */
+/*         STRUCT DEFINITION         */
+/* ********************************* */
+
+struct CPPMetadataFx {
+  tiledb_ctx_t* ctx_;
+  tiledb_vfs_t* vfs_;
+  bool s3_supported_, hdfs_supported_;
+  std::string temp_dir_;
+  const std::string s3_bucket_name_ =
+      "s3://" + random_bucket_name("tiledb") + "/";
+  std::string array_name_;
+  const char* ARRAY_NAME = "test_metadata";
+  tiledb_array_t* array_ = nullptr;
+  const char* key_ = "0123456789abcdeF0123456789abcdeF";
+  const uint32_t key_len_ =
+      (uint32_t)strlen("0123456789abcdeF0123456789abcdeF");
+  const tiledb_encryption_type_t enc_type_ = TILEDB_AES_256_GCM;
+
+  void create_default_array_1d();
+  void create_default_array_1d_with_key();
+
+  CPPMetadataFx();
+  ~CPPMetadataFx();
+};
+
+CPPMetadataFx::CPPMetadataFx() {
+  ctx_ = nullptr;
+  vfs_ = nullptr;
+  hdfs_supported_ = false;
+  s3_supported_ = false;
+
+  get_supported_fs(&s3_supported_, &hdfs_supported_);
+  create_ctx_and_vfs(s3_supported_, &ctx_, &vfs_);
+  create_s3_bucket(s3_bucket_name_, s3_supported_, ctx_, vfs_);
+
+// Create temporary directory based on the supported filesystem
+#ifdef _WIN32
+  temp_dir_ = tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
+#else
+  temp_dir_ = "file://" + tiledb::sm::Posix::current_dir() + "/tiledb_test/";
+#endif
+  create_dir(temp_dir_, ctx_, vfs_);
+
+  array_name_ = temp_dir_ + ARRAY_NAME;
+  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array_);
+  CHECK(rc == TILEDB_OK);
+}
+
+CPPMetadataFx::~CPPMetadataFx() {
+  tiledb_array_free(&array_);
+  remove_dir(temp_dir_, ctx_, vfs_);
+  tiledb_ctx_free(&ctx_);
+  tiledb_vfs_free(&vfs_);
+}
+
+void CPPMetadataFx::create_default_array_1d() {
+  uint64_t domain[] = {1, 10};
+  uint64_t tile_extent = 5;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"d"},
+      {TILEDB_UINT64},
+      {domain},
+      {&tile_extent},
+      {"a", "b", "c"},
+      {TILEDB_INT32, TILEDB_CHAR, TILEDB_FLOAT32},
+      {1, TILEDB_VAR_NUM, 2},
+      {::Compressor(TILEDB_FILTER_NONE, -1),
+       ::Compressor(TILEDB_FILTER_ZSTD, -1),
+       ::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      2);
+}
+
+void CPPMetadataFx::create_default_array_1d_with_key() {
+  uint64_t domain[] = {1, 10};
+  uint64_t tile_extent = 5;
+  create_array(
+      ctx_,
+      array_name_,
+      enc_type_,
+      key_,
+      key_len_,
+      TILEDB_DENSE,
+      {"d"},
+      {TILEDB_UINT64},
+      {domain},
+      {&tile_extent},
+      {"a", "b", "c"},
+      {TILEDB_INT32, TILEDB_CHAR, TILEDB_FLOAT32},
+      {1, TILEDB_VAR_NUM, 2},
+      {::Compressor(TILEDB_FILTER_NONE, -1),
+       ::Compressor(TILEDB_FILTER_ZSTD, -1),
+       ::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      2);
+}
+
+/* ********************************* */
+/*                TESTS              */
+/* ********************************* */
+
+TEST_CASE_METHOD(
+    CPPMetadataFx,
+    "C++ API: Metadata, basic errors",
+    "[cppapi][metadata][errors]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Put metadata in an array opened for reads - error
+  Context ctx;
+  Array array(ctx, std::string(array_name_), TILEDB_READ);
+  int v = 5;
+  CHECK_THROWS(array.put_metadata("key", TILEDB_INT32, 1, &v));
+  array.close();
+
+  // Reopen array in WRITE mode
+  array.open(TILEDB_WRITE);
+
+  // Write null value
+  CHECK_THROWS(array.put_metadata("key", TILEDB_INT32, 1, NULL));
+
+  // Write zero values
+  CHECK_THROWS(array.put_metadata("key", TILEDB_INT32, 0, &v));
+
+  // Write value type ANY
+  CHECK_THROWS(array.put_metadata("key", TILEDB_ANY, 1, &v));
+
+  // Write a correct item
+  array.put_metadata("key", TILEDB_INT32, 1, &v);
+
+  // Close array
+  array.close();
+
+  // Open with key
+  CHECK_THROWS(array.open(TILEDB_READ, enc_type_, key_, key_len_));
+}
+
+TEST_CASE_METHOD(
+    CPPMetadataFx,
+    "C++ API: Metadata, write/read",
+    "[cppapi][metadata][read]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Open array in write mode
+  Context ctx;
+  Array array(ctx, std::string(array_name_), TILEDB_WRITE);
+
+  // Write items
+  int32_t v = 5;
+  array.put_metadata("aaa", TILEDB_INT32, 1, &v);
+  float f[] = {1.1f, 1.2f};
+  array.put_metadata("bb", TILEDB_FLOAT32, 2, f);
+
+  // Close array
+  array.close();
+
+  // Open the array in read mode
+  array.open(TILEDB_READ);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  array.get_metadata("aaa", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+
+  array.get_metadata("bb", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+
+  array.get_metadata("foo", &v_type, &v_num, &v_r);
+  CHECK(v_r == nullptr);
+
+  uint64_t num = array.metadata_num();
+  CHECK(num == 2);
+
+  std::string key;
+  CHECK_THROWS(array.get_metadata_from_index(10, &key, &v_type, &v_num, &v_r));
+
+  array.get_metadata_from_index(1, &key, &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(key.size() == strlen("bb"));
+  CHECK(!strncmp(key.data(), "bb", strlen("bb")));
+
+  // Close array
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPMetadataFx, "C++ API: Metadata, UTF-8", "[cppapi][metadata][utf-8]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Open array in write mode
+  Context ctx;
+  Array array(ctx, std::string(array_name_), TILEDB_WRITE);
+
+  // Write UTF-8 (≥ holds 3 bytes)
+  int32_t v = 5;
+  array.put_metadata("≥", TILEDB_INT32, 1, &v);
+
+  // Close array
+  array.close();
+
+  // Open the array in read mode
+  array.open(TILEDB_READ);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  array.get_metadata("≥", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+
+  std::string key;
+  array.get_metadata_from_index(0, &key, &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+  CHECK(key.size() == strlen("≥"));
+  CHECK(!strncmp(key.data(), "≥", strlen("≥")));
+
+  // Close array
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPMetadataFx, "C++ API: Metadata, delete", "[cppapi][metadata][delete]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create and open array in write mode
+  Context ctx;
+  Array array(ctx, std::string(array_name_), TILEDB_WRITE);
+
+  // Write items
+  int32_t v = 5;
+  array.put_metadata("aaa", TILEDB_INT32, 1, &v);
+  float f[] = {1.1f, 1.2f};
+  array.put_metadata("bb", TILEDB_FLOAT32, 2, f);
+
+  // Close array
+  array.close();
+
+  // Prevent array metadata filename/timestamp conflicts
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Delete an item that exists and one that does not exist
+  array.open(TILEDB_WRITE);
+  array.delete_metadata("aaa");
+  array.delete_metadata("foo");
+  array.close();
+
+  // Open the array in read mode
+  array.open(TILEDB_READ);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  array.get_metadata("aaa", &v_type, &v_num, &v_r);
+  CHECK(v_r == nullptr);
+
+  array.get_metadata("bb", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+
+  array.get_metadata("foo", &v_type, &v_num, &v_r);
+  CHECK(v_r == nullptr);
+
+  uint64_t num = array.metadata_num();
+  CHECK(num == 1);
+
+  std::string key;
+  array.get_metadata_from_index(0, &key, &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(key.size() == strlen("bb"));
+  CHECK(!strncmp(key.data(), "bb", strlen("bb")));
+
+  // Close array
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPMetadataFx,
+    "C++ API: Metadata, multiple metadata and cosnolidate",
+    "[cppapi][metadata][multiple][consolidation]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create and open array in write mode
+  Context ctx;
+  Array array(ctx, array_name_, TILEDB_WRITE);
+
+  // Write items
+  int32_t v = 5;
+  array.put_metadata("aaa", TILEDB_INT32, 1, &v);
+  float f[] = {1.1f, 1.2f};
+  array.put_metadata("bb", TILEDB_FLOAT32, 2, f);
+
+  // Close array
+  array.close();
+
+  // Prevent array metadata filename/timestamp conflicts
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Update
+  array.open(TILEDB_WRITE);
+  array.delete_metadata("aaa");
+  v = 10;
+  array.put_metadata("cccc", TILEDB_INT32, 1, &v);
+  array.close();
+
+  // Open the array in read mode
+  array.open(TILEDB_READ);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  array.get_metadata("aaa", &v_type, &v_num, &v_r);
+  CHECK(v_r == nullptr);
+
+  array.get_metadata("bb", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+
+  array.get_metadata("cccc", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 10);
+
+  uint64_t num = array.metadata_num();
+  CHECK(num == 2);
+
+  std::string key;
+  array.get_metadata_from_index(0, &key, &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(key.size() == strlen("bb"));
+  CHECK(!strncmp(key.data(), "bb", strlen("bb")));
+
+  // Close array
+  array.close();
+
+  // Consolidate
+  Array::consolidate_metadata(ctx, array_name_, nullptr);
+
+  // Open the array in read mode
+  array.open(TILEDB_READ);
+
+  num = array.metadata_num();
+  CHECK(num == 2);
+
+  // Close array
+  array.close();
+
+  // Write once more
+  array.open(TILEDB_WRITE);
+
+  // Write items
+  v = 50;
+  array.put_metadata("d", TILEDB_INT32, 1, &v);
+
+  // Close array
+  array.close();
+
+  // Consolidate again
+  Array::consolidate_metadata(ctx, array_name_, nullptr);
+
+  // Open the array in read mode
+  array.open(TILEDB_READ);
+
+  num = array.metadata_num();
+  CHECK(num == 3);
+
+  array.get_metadata("cccc", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 10);
+
+  array.get_metadata("d", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 50);
+
+  // Close array
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPMetadataFx, "C++ Metadata, open at", "[cppapi][metadata][open-at]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Create and open array in write mode
+  Context ctx;
+  Array array(ctx, array_name_, TILEDB_WRITE);
+
+  // Write items
+  int32_t v = 5;
+  array.put_metadata("aaa", TILEDB_INT32, 1, &v);
+  float f[] = {1.1f, 1.2f};
+  array.put_metadata("bb", TILEDB_FLOAT32, 2, f);
+
+  // Close array
+  array.close();
+
+  // Prevent array metadata filename/timestamp conflicts
+  auto timestamp = tiledb::sm::utils::time::timestamp_now_ms();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Update
+  array.open(TILEDB_WRITE);
+  array.delete_metadata("aaa");
+  array.close();
+
+  // Open the array in read mode at a timestamp
+  array.open(TILEDB_READ, timestamp);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  array.get_metadata("aaa", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+
+  uint64_t num = array.metadata_num();
+  CHECK(num == 2);
+
+  // Close array
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPMetadataFx, "C++ Metadata, reopen", "[cppapi][metadata][reopen]") {
+  // Create default array
+  create_default_array_1d();
+
+  // Open array in write mode
+  Context ctx;
+  Array array(ctx, array_name_, TILEDB_WRITE);
+
+  // Write items
+  int32_t v = 5;
+  array.put_metadata("aaa", TILEDB_INT32, 1, &v);
+  float f[] = {1.1f, 1.2f};
+  array.put_metadata("bb", TILEDB_FLOAT32, 2, f);
+
+  // Close array
+  array.close();
+
+  // Prevent array metadata filename/timestamp conflicts
+  auto timestamp = tiledb::sm::utils::time::timestamp_now_ms();
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Update
+  array.open(TILEDB_WRITE);
+  array.delete_metadata("aaa");
+  array.close();
+
+  // Open the array in read mode at a timestamp
+  array.open(TILEDB_READ, timestamp);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  array.get_metadata("aaa", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+
+  uint64_t num = array.metadata_num();
+  CHECK(num == 2);
+
+  // Reopen
+  array.reopen();
+
+  // Read
+  array.get_metadata("aaa", &v_type, &v_num, &v_r);
+  CHECK(v_r == nullptr);
+
+  num = array.metadata_num();
+  CHECK(num == 1);
+
+  // Close array
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPMetadataFx,
+    "C++ Metadata, encryption",
+    "[cppapi][metadata][encryption]") {
+  // Create default array
+  create_default_array_1d_with_key();
+
+  // Create and open array in write mode
+  Context ctx;
+  Array array(ctx, array_name_, TILEDB_WRITE, enc_type_, key_, key_len_);
+
+  // Write items
+  int32_t v = 5;
+  array.put_metadata("aaa", TILEDB_INT32, 1, &v);
+  float f[] = {1.1f, 1.2f};
+  array.put_metadata("bb", TILEDB_FLOAT32, 2, f);
+
+  // Close array
+  array.close();
+
+  // Prevent array metadata filename/timestamp conflicts
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Update
+  array.open(TILEDB_WRITE, enc_type_, key_, key_len_);
+  array.delete_metadata("aaa");
+  v = 10;
+  array.put_metadata("cccc", TILEDB_INT32, 1, &v);
+  array.close();
+
+  // Open the array in read mode
+  array.open(TILEDB_READ, enc_type_, key_, key_len_);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  array.get_metadata("aaa", &v_type, &v_num, &v_r);
+  CHECK(v_r == nullptr);
+
+  array.get_metadata("bb", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+
+  array.get_metadata("cccc", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 10);
+
+  uint64_t num = array.metadata_num();
+  CHECK(num == 2);
+
+  std::string key;
+  array.get_metadata_from_index(0, &key, &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 2);
+  CHECK(((const float_t*)v_r)[0] == 1.1f);
+  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(key.size() == strlen("bb"));
+  CHECK(!strncmp(key.data(), "bb", strlen("bb")));
+
+  // Close array
+  array.close();
+
+  // Consolidate without key - error
+  CHECK_THROWS(Array::consolidate_metadata(ctx, array_name_, nullptr));
+
+  // Consolidate with key - ok
+  Array::consolidate_metadata(
+      ctx, array_name_, enc_type_, key_, key_len_, nullptr);
+
+  // Open the array in read mode
+  array.open(TILEDB_READ, enc_type_, key_, key_len_);
+
+  num = array.metadata_num();
+  CHECK(num == 2);
+
+  // Close array
+  array.close();
+
+  // Write once more
+  array.open(TILEDB_WRITE, enc_type_, key_, key_len_);
+
+  // Write items
+  v = 50;
+  array.put_metadata("d", TILEDB_INT32, 1, &v);
+
+  // Close array
+  array.close();
+
+  // Consolidate again
+  Array::consolidate_metadata(
+      ctx, array_name_, enc_type_, key_, key_len_, nullptr);
+
+  // Open the array in read mode
+  array.open(TILEDB_READ, enc_type_, key_, key_len_);
+
+  num = array.metadata_num();
+  CHECK(num == 3);
+
+  array.get_metadata("cccc", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 10);
+
+  array.get_metadata("d", &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 50);
+
+  // Close array
+  array.close();
+}

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -137,6 +137,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv_item.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/kv/kv_iter.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/metadata/metadata.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/cancelable_tasks.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/constants.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/logger.cc

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -34,6 +34,7 @@
 #define TILEDB_ARRAY_H
 
 #include "tiledb/sm/encryption/encryption_key.h"
+#include "tiledb/sm/metadata/metadata.h"
 #include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/storage_manager/open_array.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
@@ -227,6 +228,78 @@ class Array {
   /** Directly set the array URI. */
   Status set_uri(const std::string& uri);
 
+  /**
+   * Deletes metadata from an array opened in WRITE mode.
+   *
+   * @param key The key of the metadata item to be deleted.
+   * @return Status
+   */
+  Status delete_metadata(const char* key);
+
+  /**
+   * Puts metadata into an array opened in WRITE mode.
+   *
+   * @param key The key of the metadata item to be added. UTF-8 encodings
+   *     are acceptable.
+   * @param value_type The datatype of the value.
+   * @param value_num The value may consist of more than one items of the
+   *     same datatype. This argument indicates the number of items in the
+   *     value component of the metadata.
+   * @param value The metadata value in binary form.
+   * @return Status
+   */
+  Status put_metadata(
+      const char* key,
+      Datatype value_type,
+      uint32_t value_num,
+      const void* value);
+
+  /**
+   * Gets metadata from an array opened in READ mode. If the key does not
+   * exist, then `value` will be `nullptr`.
+   *
+   * @param key The key of the metadata item to be retrieved. UTF-8 encodings
+   *     are acceptable.
+   * @param value_type The datatype of the value.
+   * @param value_num The value may consist of more than one items of the
+   *     same datatype. This argument indicates the number of items in the
+   *     value component of the metadata.
+   * @param value The metadata value in binary form.
+   * @return Status
+   */
+  Status get_metadata(
+      const char* key,
+      Datatype* value_type,
+      uint32_t* value_num,
+      const void** value);
+
+  /**
+   * Gets metadata from an array opened in READ mode using an index.
+   *
+   * @param index The index used to retrieve the metadata.
+   * @param key The metadata key.
+   * @param key_len The metadata key length.
+   * @param value_type The datatype of the value.
+   * @param value_num The value may consist of more than one items of the
+   *     same datatype. This argument indicates the number of items in the
+   *     value component of the metadata.
+   * @param value The metadata value in binary form.
+   * @return Status
+   */
+  Status get_metadata(
+      uint64_t index,
+      const char** key,
+      uint32_t* key_len,
+      Datatype* value_type,
+      uint32_t* value_num,
+      const void** value);
+
+  /** Returns the number of array metadata items. */
+  Status get_metadata_num(uint64_t* num) const;
+
+  /** Returns the array metadata object. */
+  Metadata* metadata();
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -280,6 +353,9 @@ class Array {
 
   /** True if the array is remote (has `tiledb://` URI scheme). */
   bool remote_;
+
+  /** The array metadata. */
+  Metadata metadata_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3274,6 +3274,129 @@ int32_t tiledb_array_encryption_type(
   return TILEDB_OK;
 }
 
+int32_t tiledb_array_put_metadata(
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    const char* key,
+    tiledb_datatype_t value_type,
+    uint32_t value_num,
+    const void* value) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Put metadata
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          array->array_->put_metadata(
+              key,
+              static_cast<tiledb::sm::Datatype>(value_type),
+              value_num,
+              value)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_array_delete_metadata(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, const char* key) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Put metadata
+  if (SAVE_ERROR_CATCH(ctx, array->array_->delete_metadata(key)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_array_get_metadata(
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    const char* key,
+    tiledb_datatype_t* value_type,
+    uint32_t* value_num,
+    const void** value) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Get metadata
+  tiledb::sm::Datatype type;
+  if (SAVE_ERROR_CATCH(
+          ctx, array->array_->get_metadata(key, &type, value_num, value)))
+    return TILEDB_ERR;
+
+  *value_type = static_cast<tiledb_datatype_t>(type);
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_array_get_metadata_num(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t* num) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Get metadata num
+  if (SAVE_ERROR_CATCH(ctx, array->array_->get_metadata_num(num)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_array_get_metadata_from_index(
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    uint64_t index,
+    const char** key,
+    uint32_t* key_len,
+    tiledb_datatype_t* value_type,
+    uint32_t* value_num,
+    const void** value) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Get metadata
+  tiledb::sm::Datatype type;
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          array->array_->get_metadata(
+              index, key, key_len, &type, value_num, value)))
+    return TILEDB_ERR;
+
+  *value_type = static_cast<tiledb_datatype_t>(type);
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_array_consolidate_metadata(
+    tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config) {
+  return tiledb_array_consolidate_metadata_with_key(
+      ctx, array_uri, TILEDB_NO_ENCRYPTION, nullptr, 0, config);
+}
+
+int32_t tiledb_array_consolidate_metadata_with_key(
+    tiledb_ctx_t* ctx,
+    const char* array_uri,
+    tiledb_encryption_type_t encryption_type,
+    const void* encryption_key,
+    uint32_t key_length,
+    tiledb_config_t* config) {
+  // Sanity checks
+  if (sanity_check(ctx) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          ctx->ctx_->storage_manager()->array_metadata_consolidate(
+              array_uri,
+              static_cast<tiledb::sm::EncryptionType>(encryption_type),
+              encryption_key,
+              key_length,
+              (config == nullptr) ? nullptr : config->config_)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 /* ****************************** */
 /*         OBJECT MANAGEMENT      */
 /* ****************************** */

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -1,0 +1,267 @@
+/**
+ * @file   metadata.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class Metadata.
+ */
+
+#include "tiledb/sm/metadata/metadata.h"
+#include "tiledb/sm/misc/logger.h"
+#include "tiledb/sm/misc/utils.h"
+
+#include <iostream>
+
+namespace tiledb {
+namespace sm {
+
+/* ********************************* */
+/*     CONSTRUCTORS & DESTRUCTORS    */
+/* ********************************* */
+
+Metadata::Metadata() {
+  auto t = utils::time::timestamp_now_ms();
+  timestamp_range_ = std::make_pair(t, t);
+}
+
+Metadata::~Metadata() = default;
+
+/* ********************************* */
+/*                API                */
+/* ********************************* */
+
+void Metadata::clear() {
+  metadata_map_.clear();
+  metadata_index_.clear();
+  loaded_metadata_uris_.clear();
+  timestamp_range_ = std::make_pair(0, 0);
+}
+
+Status Metadata::deserialize(
+    const std::vector<std::shared_ptr<ConstBuffer>>& metadata_buffs) {
+  clear();
+
+  if (metadata_buffs.empty())
+    return Status::Ok();
+
+  uint32_t key_len;
+  std::string key;
+  char del;
+  size_t value_len;
+  for (const auto& buff : metadata_buffs) {
+    // Iterate over all items
+    buff->set_offset(0);
+    while (buff->offset() != buff->size()) {
+      RETURN_NOT_OK(buff->read(&key_len, sizeof(uint32_t)));
+      key.resize(key_len);
+      RETURN_NOT_OK(buff->read((void*)key.data(), key_len));
+      RETURN_NOT_OK(buff->read(&del, sizeof(char)));
+
+      // Handle deletion
+      if (del) {
+        metadata_map_.erase(key);
+        continue;
+      }
+
+      MetadataValue value_struct;
+      value_struct.del_ = del;
+      RETURN_NOT_OK(buff->read(&value_struct.type_, sizeof(char)));
+      RETURN_NOT_OK(buff->read(&value_struct.num_, sizeof(uint32_t)));
+      value_len = value_struct.num_ *
+                  datatype_size(static_cast<Datatype>(value_struct.type_));
+      value_struct.value_.resize(value_len);
+      RETURN_NOT_OK(buff->read((void*)value_struct.value_.data(), value_len));
+
+      // Insert to metadata
+      metadata_map_.emplace(
+          std::make_pair(std::string(key), std::move(value_struct)));
+    }
+  }
+
+  // Create metadata index for fast lookups from index
+  metadata_index_.resize(metadata_map_.size());
+  size_t i = 0;
+  for (auto& m : metadata_map_)
+    metadata_index_[i++] = std::make_pair(&(m.first), &(m.second));
+
+  // Note: `metadata_map_` and `metadata_index_` are immutable after this point
+
+  return Status::Ok();
+}
+
+Status Metadata::serialize(Buffer* buff) const {
+  // Do nothing if there are no metadata to serialize
+  if (metadata_map_.empty())
+    return Status::Ok();
+
+  for (const auto& meta : metadata_map_) {
+    auto key_len = (uint32_t)meta.first.size();
+    RETURN_NOT_OK(buff->write(&key_len, sizeof(uint32_t)));
+    RETURN_NOT_OK(buff->write(meta.first.data(), meta.first.size()));
+    const auto& value = meta.second;
+    RETURN_NOT_OK(buff->write(&value.del_, sizeof(char)));
+    if (!value.del_) {
+      RETURN_NOT_OK(buff->write(&value.type_, sizeof(char)));
+      RETURN_NOT_OK(buff->write(&value.num_, sizeof(uint32_t)));
+      RETURN_NOT_OK(buff->write(value.value_.data(), value.value_.size()));
+    }
+  }
+
+  return Status::Ok();
+}
+
+const std::pair<uint64_t, uint64_t>& Metadata::timestamp_range() const {
+  return timestamp_range_;
+}
+
+Status Metadata::del(const char* key) {
+  assert(key != nullptr);
+
+  std::unique_lock<std::mutex> lck(mtx_);
+
+  MetadataValue value;
+  value.del_ = 1;
+  metadata_map_.emplace(std::make_pair(std::string(key), std::move(value)));
+
+  return Status::Ok();
+}
+
+Status Metadata::put(
+    const char* key,
+    Datatype value_type,
+    uint32_t value_num,
+    const void* value) {
+  assert(key != nullptr);
+  assert(value_type != Datatype::ANY);
+  assert(value_num != 0);
+  assert(value != nullptr);
+
+  std::unique_lock<std::mutex> lck(mtx_);
+
+  size_t value_size = value_num * datatype_size(value_type);
+  MetadataValue value_struct;
+  value_struct.del_ = 0;
+  value_struct.type_ = static_cast<char>(value_type);
+  value_struct.num_ = value_num;
+  value_struct.value_.resize(value_size);
+  std::memcpy(value_struct.value_.data(), value, value_size);
+  metadata_map_.emplace(
+      std::make_pair(std::string(key), std::move(value_struct)));
+
+  return Status::Ok();
+}
+
+Status Metadata::get(
+    const char* key,
+    Datatype* value_type,
+    uint32_t* value_num,
+    const void** value) {
+  assert(key != nullptr);
+
+  auto it = metadata_map_.find(key);
+  if (it == metadata_map_.end()) {
+    // Key not found
+    *value = nullptr;
+    return Status::Ok();
+  }
+
+  // Key found
+  auto& value_struct = it->second;
+  *value_type = static_cast<Datatype>(value_struct.type_);
+  *value_num = value_struct.num_;
+  *value = (const void*)(value_struct.value_.data());
+
+  return Status::Ok();
+}
+
+Status Metadata::get(
+    uint64_t index,
+    const char** key,
+    uint32_t* key_len,
+    Datatype* value_type,
+    uint32_t* value_num,
+    const void** value) {
+  if (index >= metadata_index_.size())
+    return LOG_STATUS(
+        Status::MetadataError("Cannot get metadata; index out of bounds"));
+
+  // Get key
+  auto& key_str = *(metadata_index_[index].first);
+  *key = key_str.c_str();
+  *key_len = (uint32_t)key_str.size();
+
+  // Get value
+  auto& value_struct = *(metadata_index_[index].second);
+  *value_type = static_cast<Datatype>(value_struct.type_);
+  *value_num = value_struct.num_;
+  *value = (const void*)value_struct.value_.data();
+
+  return Status::Ok();
+}
+
+uint64_t Metadata::num() const {
+  return metadata_map_.size();
+}
+
+Status Metadata::set_loaded_metadata_uris(
+    const std::vector<TimestampedURI>& loaded_metadata_uris) {
+  if (loaded_metadata_uris.empty())
+    return Status::Ok();
+
+  loaded_metadata_uris_.clear();
+  for (const auto& uri : loaded_metadata_uris)
+    loaded_metadata_uris_.push_back(uri.uri_);
+
+  timestamp_range_.first = loaded_metadata_uris.front().timestamp_range_.first;
+  timestamp_range_.second = loaded_metadata_uris.back().timestamp_range_.second;
+
+  return Status::Ok();
+}
+
+const std::vector<URI>& Metadata::loaded_metadata_uris() const {
+  return loaded_metadata_uris_;
+}
+
+void Metadata::swap(Metadata* metadata) {
+  std::swap(metadata_map_, metadata->metadata_map_);
+  std::swap(metadata_index_, metadata->metadata_index_);
+  std::swap(timestamp_range_, metadata->timestamp_range_);
+  std::swap(loaded_metadata_uris_, metadata->loaded_metadata_uris_);
+}
+
+void Metadata::reset() {
+  clear();
+  auto t = utils::time::timestamp_now_ms();
+  timestamp_range_ = std::make_pair(t, t);
+}
+
+/* ********************************* */
+/*          PRIVATE METHODS          */
+/* ********************************* */
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -169,6 +169,7 @@ Status Metadata::put(
   value_struct.num_ = value_num;
   value_struct.value_.resize(value_size);
   std::memcpy(value_struct.value_.data(), value, value_size);
+  metadata_map_.erase(std::string(key));
   metadata_map_.emplace(
       std::make_pair(std::string(key), std::move(value_struct)));
 

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -1,0 +1,233 @@
+/**
+ * @file   metadata.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file defines class Metadata.
+ */
+
+#ifndef TILEDB_METADATA_H
+#define TILEDB_METADATA_H
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/misc/uri.h"
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * Handles writing/reading metadata. The persistent format of the metadata is:
+ * `0 (char) | key_len (uint32_t) | key (char*) | value_type (Datatype) |
+ *  value_num (uint32_t) | values (void*)`
+ * or
+ * `1 (char) | key_len (uint32_t) | key (char*) | value_type (Datatype) |
+ *  value_num (uint32_t) | values (void*)`
+ *
+ * The first char value is 1 if it is a deletion and 0 if it is an insertion.
+ */
+class Metadata {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  Metadata();
+
+  /** Destructor. */
+  ~Metadata();
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Clears the metadata. */
+  void clear();
+
+  /**
+   * Deserializes the input metadata buffers. Note that the buffers are
+   * assummed to be sorted on time. The function will take care of any
+   * deleted or overwritten metadata items considering the order.
+   */
+  Status deserialize(
+      const std::vector<std::shared_ptr<ConstBuffer>>& metadata_buffs);
+
+  /** Serializes all key-value metadata items into the input buffer. */
+  Status serialize(Buffer* buff) const;
+
+  /** Returns the timestamp range. */
+  const std::pair<uint64_t, uint64_t>& timestamp_range() const;
+
+  /**
+   * Deletes a metadata item.
+   *
+   * @param key The key of the metadata to be deleted.
+   * @return Status
+   */
+  Status del(const char* key);
+
+  /**
+   * Puts a metadata item as a key-value pair.
+   *
+   * @param key The metadata key.
+   * @param value_type The datatype of the value.
+   * @param value_num The number of items in the value part (they could be more
+   *     than one).
+   * @param value The metadata value.
+   * @return Status
+   */
+  Status put(
+      const char* key,
+      Datatype value_type,
+      uint32_t value_num,
+      const void* value);
+
+  /**
+   * Gets a metadata item as a key-value pair.
+   *
+   * @param key The metadata key.
+   * @param value_type The datatype of the value.
+   * @param value_num The number of items in the value part (they could be more
+   * than one).
+   * @param value The metadata value. It will be `nullptr` if the key does
+   *     not exist
+   * @return Status
+   */
+  Status get(
+      const char* key,
+      Datatype* value_type,
+      uint32_t* value_num,
+      const void** value);
+
+  /**
+   * Gets a metadata item as a key-value pair using an index.
+   *
+   * @param index The index used to retrieve the metadata.
+   * @param key The metadata key.
+   * @param key_len The metadata key length.
+   * @param value_type The datatype of the value.
+   * @param value_num The number of items in the value part (they could be more
+   * than one).
+   * @param value The metadata value. It will be `nullptr` if the key does
+   *     not exist
+   * @return Status
+   */
+  Status get(
+      uint64_t index,
+      const char** key,
+      uint32_t* key_len,
+      Datatype* value_type,
+      uint32_t* value_num,
+      const void** value);
+
+  /** Returns the number of metadata items. */
+  uint64_t num() const;
+
+  /**
+   * Sets the URIs of the metadata files that have been loaded
+   * to this object.
+   */
+  Status set_loaded_metadata_uris(
+      const std::vector<TimestampedURI>& loaded_metadata_uris);
+
+  /**
+   * Returns the URIs of the metadata files that have been loaded
+   * to this object.
+   */
+  const std::vector<URI>& loaded_metadata_uris() const;
+
+  /** Swaps the contents between the object and the input. */
+  void swap(Metadata* metadata);
+
+  /**
+   * Clears the metadata and assigns the current timestamp to
+   * its timestamp range.
+   */
+  void reset();
+
+ private:
+  /* ********************************* */
+  /*      PRIVATE TYPE DEFINITIONS     */
+  /* ********************************* */
+
+  struct MetadataValue {
+    /** 1 if it is a deletion and 0 if it is an insertion. */
+    char del_ = 0;
+    /** The value datatype. */
+    char type_ = 0;
+    /** The number of values. */
+    uint32_t num_ = 0;
+    /** The value in binary format. */
+    std::vector<uint8_t> value_;
+  };
+
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** A map from metadata key to metadata value. */
+  std::map<std::string, MetadataValue> metadata_map_;
+
+  /**
+   * A vector pointing to all the values in `metadata_map_`. It facilitates
+   * searching metadata from index. Used only for reading metadata (inapplicable
+   * when writing metadata).
+   */
+  std::vector<std::pair<const std::string*, MetadataValue*>> metadata_index_;
+
+  /** Mutex for thread-safety. */
+  mutable std::mutex mtx_;
+
+  /**
+   * The timestamp range covered by the metadata that was read or written.
+   * This is used to determine the metadata file name.
+   */
+  std::pair<uint64_t, uint64_t> timestamp_range_;
+
+  /**
+   * The URIs of the metadata files that have been loaded to this object.
+   * This is needed to know which files to delete upon consolidation.
+   */
+  std::vector<URI> loaded_metadata_uris_;
+
+  /* ********************************* */
+  /*          PRIVATE METHODS          */
+  /* ********************************* */
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_METADATA_H

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -101,6 +101,9 @@ const bool dedup_coords = false;
 /** The array schema file name. */
 const std::string array_schema_filename = "__array_schema.tdb";
 
+/** The array metadata folder name. */
+const std::string array_metadata_folder_name = "__meta";
+
 /** The key-value schema file name. */
 const std::string kv_schema_filename = "__kv_schema.tdb";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -91,6 +91,9 @@ extern const std::string filelock_name;
 /** The array schema file name. */
 extern const std::string array_schema_filename;
 
+/** The array metadata folder name. */
+extern const std::string array_metadata_folder_name;
+
 /** The key-value schema file name. */
 extern const std::string kv_schema_filename;
 

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -131,24 +131,45 @@ class Consolidator {
       uint32_t key_length,
       const Config* config);
 
+  /**
+   * Consolidates the metadata of the input array.
+   *
+   * @param array_name URI of array whose metadata to consolidate.
+   * @param encryption_type The encryption type of the array
+   * @param encryption_key If the array is encrypted, the private encryption
+   *    key. For unencrypted arrays, pass `nullptr`.
+   * @param key_length The length in bytes of the encryption key.
+   * @param config Configuration parameters for the consolidation
+   *     (`nullptr` means default).
+   * @return Status
+   */
+  Status consolidate_array_metadata(
+      const char* array_name,
+      EncryptionType encryption_type,
+      const void* encryption_key,
+      uint32_t key_length,
+      const Config* config);
+
   /* ********************************* */
   /*          STATIC FUNCTIONS         */
   /* ********************************* */
 
   /**
-   * Removes from the input the URIs of the fragments that have
-   * been consolidated. This is necessary on S3, where the deletion
-   * of the consolidated fragments may not have taken place before
-   * a read, in which case both the new and old fragments appear to
-   * exist. In this case, we need to make sure that the old
-   * fragments are ignored, otherwise performance will be impacted.
+   * Applicable to both fragment and array metadata URIs.
    *
-   * A fragment URI of the form `__t1_t2_uuid` is
+   * Removes from the input the URIs that have
+   * been consolidated. This is necessary on S3, where the deletion
+   * of the consolidated URIs may not have taken place before
+   * a read, in which case both the new and old URIs appear to
+   * exist. In this case, we need to make sure that the old
+   * URIs are ignored, otherwise performance will be impacted.
+   *
+   * A URI of the form `__t1_t2_uuid` is
    * ignored, if there is another fragment URI `__t1c_t2c_uuid`
    * such that `t1c <= t1 <= t2 <= t2c`.
    */
-  static void remove_consolidated_fragment_uris(
-      std::vector<TimestampedURI>* sorted_fragment_uris);
+  static void remove_consolidated_uris(
+      std::vector<TimestampedURI>* sorted_uris);
 
  private:
   /* ********************************* */

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -113,6 +113,12 @@ FragmentMetadata* OpenArray::fragment_metadata(const URI& uri) const {
   return (it == fragment_metadata_set_.end()) ? nullptr : it->second;
 }
 
+std::shared_ptr<ConstBuffer> OpenArray::array_metadata(const URI& uri) const {
+  std::lock_guard<std::mutex> lock(local_mtx_);
+  auto it = array_metadata_.find(uri.to_string());
+  return (it == array_metadata_.end()) ? nullptr : it->second;
+}
+
 void OpenArray::mtx_lock() {
   mtx_.lock();
 }
@@ -134,6 +140,13 @@ void OpenArray::insert_fragment_metadata(FragmentMetadata* metadata) {
   assert(metadata != nullptr);
   fragment_metadata_.insert(metadata);
   fragment_metadata_set_[metadata->fragment_uri().to_string()] = metadata;
+}
+
+void OpenArray::insert_array_metadata(
+    const URI& uri, const std::shared_ptr<ConstBuffer>& metadata) {
+  std::lock_guard<std::mutex> lock(local_mtx_);
+  assert(metadata != nullptr);
+  array_metadata_[uri.to_string()] = metadata;
 }
 
 /* ****************************** */

--- a/tiledb/sm/storage_manager/open_array.h
+++ b/tiledb/sm/storage_manager/open_array.h
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/encryption/encryption_key_validation.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
@@ -117,6 +118,12 @@ class OpenArray {
    */
   FragmentMetadata* fragment_metadata(const URI& uri) const;
 
+  /**
+   * Returns the constant buffer storing the serialized array metadata
+   * of the input URI, or `nullptr` if the array metadata do not exist.
+   */
+  std::shared_ptr<ConstBuffer> array_metadata(const URI& uri) const;
+
   /** Locks the array mutex. */
   void mtx_lock();
 
@@ -132,6 +139,13 @@ class OpenArray {
    * This function will guarantee that the ordering is maintained.
    */
   void insert_fragment_metadata(FragmentMetadata* metadata);
+
+  /**
+   * Inserts the input array metadata (serialized in a share constant
+   * buffer) with the input URI.
+   */
+  void insert_array_metadata(
+      const URI& uri, const std::shared_ptr<ConstBuffer>& metadata);
 
   /** Sets an array schema. */
   void set_array_schema(ArraySchema* array_schema);
@@ -176,6 +190,12 @@ class OpenArray {
    * loaded in `fragment_metadata_`.
    */
   std::unordered_map<std::string, FragmentMetadata*> fragment_metadata_set_;
+
+  /**
+   * A map of URI strings to array metadata. The map stores the serialized
+   * (decompressed, decrypted) array metadata into constant buffers.
+   */
+  std::unordered_map<std::string, std::shared_ptr<ConstBuffer>> array_metadata_;
 
   /**
    * A mutex used to lock the array for thread-safe open/close of the array

--- a/tiledb/sm/tile/tile_io.cc
+++ b/tiledb/sm/tile/tile_io.cc
@@ -106,7 +106,7 @@ Status TileIO::read_generic(
 
   if (encryption_key.encryption_type() !=
       (EncryptionType)header.encryption_type)
-    return LOG_STATUS(Status::Error(
+    return LOG_STATUS(Status::TileIOError(
         "Error reading generic tile; tile is encrypted with " +
         encryption_type_str((EncryptionType)header.encryption_type) +
         " but given key is for " +
@@ -268,13 +268,13 @@ Status TileIO::configure_encryption_filter(
     case EncryptionType::AES_256_GCM: {
       auto* f = header->filters.get_filter<EncryptionAES256GCMFilter>();
       if (f == nullptr)
-        return Status::Error(
+        return Status::TileIOError(
             "Error getting generic tile; no encryption filter.");
       RETURN_NOT_OK(f->set_key(encryption_key));
       break;
     }
     default:
-      return Status::Error(
+      return Status::TileIOError(
           "Error getting generic tile; invalid encryption type.");
   }
 


### PR DESCRIPTION
This PR implements basic array metadata. This metadata should be small enough to fit in main memory (they are loaded upon opening an array in READ mode). Writing/Reading/Consolidating array metadata follow the semantics of array writes/reads.