### PR TITLE
Query Submit V2, part 1

### DIFF
--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -332,6 +332,71 @@ T safe_mul(T a, T b);
 
 }  // namespace math
 
+/* ********************************* */
+/*          ENDIANNESS FUNCTIONS     */
+/* ********************************* */
+
+namespace endianness {
+
+/**
+ * Returns true if the current CPU architecture has little endian byte
+ * ordering, false for big endian.
+ */
+inline bool is_little_endian() {
+  const int n = 1;
+  return *(char*)&n == 1;
+}
+
+/**
+ * Returns true if the current CPU architecture has big endian byte
+ * ordering, false for little endian.
+ */
+inline bool is_big_endian() {
+  return !is_little_endian();
+}
+
+/**
+ * Decodes a little-endian ordered buffer 'data' into a native
+ * primitive type, T.
+ */
+template <class T>
+inline T decode_le(const void* const data) {
+  const T* const n = reinterpret_cast<const T* const>(data);
+  if (is_little_endian()) {
+    return *n;
+  }
+
+  T le_n;
+  char* const p = reinterpret_cast<char*>(&le_n);
+  for (std::size_t i = 0; i < sizeof(T); ++i) {
+    p[i] = *n >> ((sizeof(T) - i - 1) * 8);
+  }
+
+  return le_n;
+}
+
+/**
+ * Decodes a big-endian ordered buffer 'data' into a native
+ * primitive type, T.
+ */
+template <class T>
+inline T decode_be(const void* const data) {
+  const T* const n = reinterpret_cast<const T* const>(data);
+  if (is_big_endian()) {
+    return *n;
+  }
+
+  T be_n;
+  char* const p = reinterpret_cast<char*>(&be_n);
+  for (std::size_t i = 0; i < sizeof(T); ++i) {
+    p[i] = *n >> (i * 8);
+  }
+
+  return be_n;
+}
+
+}  // namespace endianness
+
 }  // namespace utils
 
 }  // namespace sm

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -137,10 +137,9 @@ class RestClient {
   SerializationType serialization_type_;
 
   /**
-   * If true (the default), automatically resubmit incomplete queries. This
-   * allows the server to return less data than the user buffers indicated, in
-   * which case the rest client can simply resubmit the incomplete query
-   * transparently to the user.
+   * If true (the default), automatically resubmit incomplete queries on the
+   * server-side. This garauntees that the user only receive a complete query
+   * result from the server.
    *
    * When this is turned on, it is currently an error if the user buffers on the
    * client are too small to receive all data received from the server


### PR DESCRIPTION
This is part 1 of 2 for modifying the core tiledb rest client to use the
new /v2/array/.../query/submit API. The differences between v2 and v1 are:

- For all query types, each returned serialized query (aka BufferList) is prefixed
with a little-endian ordered unsigned int that contains the total byte size of
the serialized query that follows it in the response buffer.
- When the 'read_all' request parameter is 'true', the server will continue
resubmitting incomplete queries until the request is complete. This guarantees
that the user will recieve a complete query request in the response.
- If the 'read_all' request required N number of query operations to
core tiledb on the server, the response buffer will be organized as follows:
<prefix><serialized query 1><size><serialized query 2>...<size><serialized query N>

This is part 1 of 2 because it does NOT:
- Process a buffered response
- Provide any sort of retry logic from the client.

In other words, this waits for the entire response to be received before it
starts processing (deserializing and copying results back to the user). The next
patch will make use of the curl library's `write_callback` to begin processing
the response as it receives it. I have yet to give any thought to how the
client will detect incomplete responses and appropriately restart a query
from the last receive serialized query object. I am not sure whether this
should be opaque or transparent to the user.

Note that this does make a copy for each serialized query to ensure 8-byte
alignment. This is not necessary if the buffer is already 8-byte aligned, but
this copy will be thrown away in favor of some sort of buffer pool for
handling the buffered response. I didn't bother trying to optimize this
path to prevent obfuscating the logic.

Also note that I think it would easiest to just re-use the `resubmit_complete` configuration parameter for backwards compatibility since the end-result should be similar to the user (receiving a large, completed response). Open to discussion.