### PR TITLE
Query Submit V2, part 2

### DIFF
--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -174,6 +174,36 @@ class RestClient {
           copy_state);
 
   /**
+   * Callback to invoke as partial, buffered response data is received from
+   * posting a query.
+   *
+   * This is not thread-safe. It expects the response data to be ordered. The
+   * response must contain serialized query objects, prefixed by an 8-byte
+   * unsigned integer that contains the byte-size of the serialized query object
+   * it is prefixing. The scratch space must be empty before the first
+   * invocation, and must not change until the last invocation has completed.
+   *
+   * @param reset True if the callback must wipe the in-memory state
+   * @param contents the partial response data
+   * @param content_nbytes the size of the response data in 'contents'
+   * @scratch scratch space to use between invocations of this callback
+   * @query the query object used for deserializing the serialized query
+   *    objects in the response data.
+   * @param copy_state Map of copy state per attribute. As attribute data is
+   *    copied into user buffers on reads, the state of each attribute in this
+   *    map is updated accordingly.
+   * @return Number of acknowledged bytes
+   */
+  size_t post_data_write_cb(
+      bool reset,
+      void* contents,
+      size_t content_nbytes,
+      Buffer* scratch,
+      Query* query,
+      std::unordered_map<std::string, serialization::QueryBufferCopyState>*
+          copy_state);
+
+  /**
    * Returns a string representation of the given subarray. The format is:
    *
    *   "dim0min,dim0max,dim1min,dim1max,..."


### PR DESCRIPTION
This is part 2 of the client-side handling of the /v2 query submit
requests.

This introduces a callback that the Curl object invokes as it
receives partial response data. The callback is defined by the 
RestClient object.

As each complete, serialized query object is recieved, the client
will deserialze each object and copy the response into the 'copy_state'.
There are two primary benefits to this design:
- Reduce total operational latency. The client does not wait for the 
  entire response to be recieved before processing it. It can also
  process the partial responses while the network is receiving the 
  remaining response data.
- Reduced memory consumption. This patch discards the serialized
  query objects as soon as they are recieved and processed. Consider
  the current scenario where the client recieves an entire 2GB response
  and copies ~2GB of buffers back into the copy state. With this patch,
  the peak memory consumption in this path should be reduced ~50% because
  the buffered response data size should be negligible (~16KB).
- When 'resubmit_incomplete_' is set but the request returns an incomplete
  query, an error is set to alert the client that they should retry the 
  returned query.

I also noted a few micro-optimizations in the comments of this patch.
These can be done in a part 3, but should not be required for releasing
1.7.

I also modified the query_deserialize() routine to respect the 
internal offset of the buffer to deserialize.