### PR TITLE
Fix warning for unsigned comparision in gcc9 for rest_client

### DIFF
--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -434,7 +434,7 @@ size_t RestClient::post_data_write_cb(
 
   bytes_processed += length;
 
-  assert(bytes_processed == content_nbytes);
+  assert(static_cast<size_t>(bytes_processed) == content_nbytes);
   return std::max(bytes_processed, 0L);
 }
 


### PR DESCRIPTION
Fix warning for unsigned comparison in gcc9 for rest_client.

@joe-maley I'm not sure if this is the best fix for this issue. You were using negative values for `bytes_processed` so casting to size_t (which is unsigned) might not produce the intended results. I looked at changing `bytes_processed` to be unsigned but that would require updating the logic you have with it being negative to start with if the scratch space isn't empty.