### PR TITLE
Fix missing virtual destructor in c++ schema base

### DIFF
--- a/tiledb/sm/cpp_api/schema_base.h
+++ b/tiledb/sm/cpp_api/schema_base.h
@@ -76,6 +76,7 @@ class Schema {
   Schema(Schema&&) = default;
   Schema& operator=(const Schema&) = default;
   Schema& operator=(Schema&&) = default;
+  virtual ~Schema() = default;
 
   /* ********************************* */
   /*          VIRTUAL INTERFACE        */


### PR DESCRIPTION
Fix missing virtual destructor in c++ schema base