### PR TITLE
Add runtime detection for CA Certs on Linux

### DIFF
--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -38,7 +38,6 @@
 #endif
 
 #include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <map>
 #include <set>

--- a/tiledb/sm/global_state/global_state.cc
+++ b/tiledb/sm/global_state/global_state.cc
@@ -77,6 +77,17 @@ Status GlobalState::init(const Config* config) {
     RETURN_NOT_OK(init_openssl());
     RETURN_NOT_OK(init_libcurl());
 
+#ifdef __linux__
+    // We attempt to find the linux ca cert bundle
+    // This only needs to happen one time, and then we will use the file found
+    // for each s3/rest call as appropriate
+    Posix posix;
+    ThreadPool tp;
+    tp.init();
+    posix.init(config_, &tp);
+    cert_file_ = utils::https::find_ca_certs_linux(posix);
+#endif
+
     initialized_ = true;
   }
 
@@ -96,6 +107,10 @@ void GlobalState::unregister_storage_manager(StorageManager* sm) {
 std::set<StorageManager*> GlobalState::storage_managers() {
   std::unique_lock<std::mutex> lck(storage_managers_mtx_);
   return storage_managers_;
+}
+
+const std::string& GlobalState::cert_file() {
+  return cert_file_;
 }
 }  // namespace global_state
 }  // namespace sm

--- a/tiledb/sm/global_state/global_state.h
+++ b/tiledb/sm/global_state/global_state.h
@@ -79,6 +79,13 @@ class GlobalState {
    */
   std::set<StorageManager*> storage_managers();
 
+  /**
+   * Getter for cert file
+   * @return detected cert file or empty if no cert file detected. Always empty
+   * string on non-linux platforms
+   */
+  const std::string& cert_file();
+
  private:
   /** The TileDB configuration parameters. */
   Config config_;
@@ -94,6 +101,9 @@ class GlobalState {
 
   /** Mutex protecting list of StorageManagers. */
   std::mutex storage_managers_mtx_;
+
+  /** Detected certificate file, currently only used on linux */
+  std::string cert_file_;
 
   /** Constructor. */
   GlobalState();

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -543,6 +543,20 @@ const void* fill_value(Datatype type) {
   return nullptr;
 }
 
+#ifdef __linux__
+/** Possible certificate files; stop after finding one.
+ * inspired by
+ * https://github.com/golang/go/blob/f0e940ebc985661f54d31c8d9ba31a553b87041b/src/crypto/x509/root_linux.go
+ */
+const std::array<std::string, 6> cert_files_linux = {
+    "/etc/ssl/certs/ca-certificates.crt",  // Debian/Ubuntu/Gentoo etc.
+    "/etc/pki/tls/certs/ca-bundle.crt",    // Fedora/RHEL 6
+    "/etc/ssl/ca-bundle.pem",              // OpenSUSE
+    "/etc/pki/tls/cacert.pem",             // OpenELEC
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",  // CentOS/RHEL 7
+    "/etc/ssl/cert.pem"                                   // Alpine Linux
+};
+#endif
 }  // namespace constants
 
 }  // namespace sm

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_CONSTANTS_H
 #define TILEDB_CONSTANTS_H
 
+#include <array>
 #include <cinttypes>
 #include <string>
 
@@ -475,6 +476,10 @@ extern const unsigned watchdog_thread_sleep_ms;
 /** Returns the empty fill value based on the input datatype. */
 const void* fill_value(Datatype type);
 
+#ifdef __linux__
+/** List of possible certificates files for libcurl */
+extern const std::array<std::string, 6> cert_files_linux;
+#endif
 }  // namespace constants
 
 }  // namespace sm

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -57,6 +57,22 @@ namespace sm {
 
 namespace utils {
 
+#ifdef __linux__
+namespace https {
+std::string find_ca_certs_linux(const Posix& posix) {
+  // Check ever cert file location to see if the certificate exists
+  for (const std::string& cert : constants::cert_files_linux) {
+    // Check if the file exists, any errors are treated as the file not existing
+    if (posix.is_file(cert)) {
+      return cert;
+    }
+  }
+  // Could not find the ca bundle
+  return "";
+}
+}  // namespace https
+#endif
+
 namespace parse {
 
 /* ********************************* */

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -45,10 +45,25 @@
 #include <string>
 #include <vector>
 
+#ifdef __linux__
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
 namespace tiledb {
 namespace sm {
-
 namespace utils {
+
+#ifdef __linux__
+namespace https {
+/**
+ * Check hard coded paths for possible ca certificates to set for curl
+ *
+ * @param vfs to use to check if cert paths exist
+ * @return ca cert bundle path or empty string if ca cert bundle was not found
+ */
+std::string find_ca_certs_linux(const Posix& posix);
+}  // namespace https
+#endif
 
 namespace parse {
 

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/rest/curl.h"
+#include "tiledb/sm/global_state/global_state.h"
 #include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/stats.h"
 #include "tiledb/sm/misc/utils.h"
@@ -195,6 +196,17 @@ Status Curl::init(const Config* config) {
     curl_easy_setopt(curl_.get(), CURLOPT_SSL_VERIFYHOST, 0);
     curl_easy_setopt(curl_.get(), CURLOPT_SSL_VERIFYPEER, 0);
   }
+
+#ifdef __linux__
+  // Get CA Cert bundle file from global state. This is initialized and cached
+  // if detected
+  const std::string cert_file =
+      global_state::GlobalState::GetGlobalState().cert_file();
+  // If we have detected a ca cert bundle let's set the curl option for CAPATH
+  if (!cert_file.empty()) {
+    curl_easy_setopt(curl_.get(), CURLOPT_CAPATH, cert_file.c_str());
+  }
+#endif
 
   return Status::Ok();
 }


### PR DESCRIPTION
This solves a major issue when we build libcurl as part of a super build on Linux. Curl at configuration/compile time detects the systems CA bundle path, and then hard codes this into the compiled lib. This causes issues when libtiledb has a statically linked libcurl and is copied between
linux systems (i.e pip or maven). Often then the hard coded CA bundle path is no longer valid and curl fails to handle SSL.

The solution is to at runtime try to detect the location of the CA cert bundle for the host os.

Currently the CA cert issues only exists on linux, so we only do runtime detection for linux.

I have left adding an config override for the REST server to another PR as #1392 is reworking on the config is handled internally.

[ch814]