### PR TITLE
Fix build with Apple Clang 11

### DIFF
--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -199,7 +199,7 @@ class ArraySchema : public Schema {
     schema_ = std::shared_ptr<tiledb_array_schema_t>(schema, deleter_);
   }
 
-  ArraySchema() = default;
+  ArraySchema() = delete;
   ArraySchema(const ArraySchema&) = default;
   ArraySchema(ArraySchema&&) = default;
   virtual ~ArraySchema() = default;

--- a/tiledb/sm/cpp_api/filter.h
+++ b/tiledb/sm/cpp_api/filter.h
@@ -91,7 +91,7 @@ class Filter {
     filter_ = std::shared_ptr<tiledb_filter_t>(filter, deleter_);
   }
 
-  Filter() = default;
+  Filter() = delete;
   Filter(const Filter&) = default;
   Filter(Filter&&) = default;
   Filter& operator=(const Filter&) = default;

--- a/tiledb/sm/cpp_api/filter_list.h
+++ b/tiledb/sm/cpp_api/filter_list.h
@@ -90,7 +90,7 @@ class FilterList {
     filter_list_ = std::shared_ptr<tiledb_filter_list_t>(filter_list, deleter_);
   }
 
-  FilterList() = default;
+  FilterList() = delete;
   FilterList(const FilterList&) = default;
   FilterList(FilterList&&) = default;
   FilterList& operator=(const FilterList&) = default;


### PR DESCRIPTION
IIUC, updated Clang now deletes the default constructor when a member is not
default-constructible, which makes sense. So we need to remove the Filter,
FilterList, and ArraySchema default constructors.