### PR TITLE
Fix Windows CI, fix 2 tests, add unit test completion indicator/check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
     matrix:
       VS2015:
         imageName: 'vs2015-win2012r2'
-        TILEDB_S3: ON
+        #TILEDB_S3: ON
       VS2017:
         imageName: 'vs2017-win2016'
         TILEDB_TOOLS: ON

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -198,7 +198,7 @@ steps:
 
 
 - bash: |
-    if [[ "TILEDB_CI_SUCCESS" -ne 1 ]]; then
+    if [[ "$TILEDB_CI_SUCCESS" -ne 1 ]]; then
       exit 1;
     fi
   displayName: 'Test status check'

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -198,6 +198,13 @@ steps:
 
 
 - bash: |
+    if [[ "TILEDB_CI_SUCCESS" -ne 1 ]]; then
+      exit 1;
+    fi
+  displayName: 'Test status check'
+
+
+- bash: |
     set -e pipefail
     # Display log files if the build failed
     echo "Dumping log files for failed build"

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -12,19 +12,20 @@ steps:
       $host.SetShouldExit(1)
     }
 
+    # TODO DEBUG move this back in the TILEDB_S3 section
+    & "$env:BUILD_SOURCESDIRECTORY\scripts\install-minio.ps1"
+
     if ($env:TILEDB_S3 -eq "ON") {
       & "$env:BUILD_SOURCESDIRECTORY\bootstrap.ps1" -EnableS3 -EnableVerbose -EnableStaticTileDB
-      & "$env:BUILD_SOURCESDIRECTORY\scripts\install-minio.ps1"
     } else {
       & "$env:BUILD_SOURCESDIRECTORY\bootstrap.ps1" -EnableVerbose -EnableStaticTileDB
     }
-
     if ($LastExitCode -ne 0) {
        Write-Host "Bootstrap failed."
        $host.SetShouldExit($LastExitCode)
     }
 
-    cmake --build . --config Release -- /verbosity:minimal
+    cmake --build $env:AGENT_BUILDDIRECTORY\build --config Release -- /verbosity:minimal
 
     if ($LastExitCode -ne 0) {
        Write-Host "Build failed. CMake exit status: " $LastExitCocde
@@ -42,61 +43,55 @@ steps:
 
     # CMake exits with non-0 status if there are any warnings during the build, so
     # build the unit test executable before running tests.
-    cmake --build tiledb --target tiledb_unit --config Release -- /verbosity:minimal
+    cmake --build $env:AGENT_BUILDDIRECTORY\build\tiledb --target tiledb_unit --config Release -- /verbosity:minimal
+
     # Actually run tests
-    cd tiledb
-    ctest -C Release -V
-    cd ..
+    cmake --build $env:AGENT_BUILDDIRECTORY\build\tiledb --target check --config Release -- /verbosity:minimal
 
     if ($LastExitCode -ne 0) {
        Write-Host "Tests failed. CMake exit status: " $LastExitCocde
        $host.SetShouldExit($LastExitCode)
     }
 
-    cmake --build . --target examples --config Release -- /verbosity:minimal
+    # Build the examples
+    cmake --build $env:AGENT_BUILDDIRECTORY\build --target examples --config Release -- /verbosity:minimal
 
     if ($LastExitCode -ne 0) {
-       Write-Host "Examples failed to build."
-       $host.SetShouldExit($LastExitCode)
+      Write-Host "Examples failed to build."
+      $host.SetShouldExit($LastExitCode)
     }
 
-    cmake --build . --target install --config Release
+    cmake --build $env:AGENT_BUILDDIRECTORY\build --target install-tiledb --config Release
 
     if ($LastExitCode -ne 0) {
-       Write-Host "Installation failed."
-       $host.SetShouldExit($LastExitCode)
+      Write-Host "Installation failed."
+      $host.SetShouldExit($LastExitCode)
     }
 
     $env:Path += ";$env:AGENT_BUILDDIRECTORY\s\dist\bin;$env:AGENT_BUILDDIRECTORY\build\externals\install\bin"
 
-    ls .\examples\c_api\Release
-
+    ls $env:AGENT_BUILDDIRECTORY\build\tiledb\examples\c_api\Release
+    
     try {
-       .\examples\c_api\Release\quickstart_dense_c.exe
+      $exepath = Join-Path $env:AGENT_BUILDDIRECTORY "build\tiledb\examples\c_api\Release\quickstart_dense_c.exe"
+      & $exepath
     } catch {
-       Write-Host "C API example failed. Error:"
-       Write-Host $_
-       $host.SetShouldExit(1)
-    }
-
-    if ($LastExitCode -ne 0) {
-      Write-Host "C API example failed."
+      Write-Host "C API example failed. Error:"
       Write-Host $_
-      $host.SetShouldExit($LastExitCode)
+      $host.SetShouldExit(1)
     }
 
-    rm -Recurse -Force quickstart_dense_array
-
     try {
-      .\examples\cpp_api\Release\quickstart_dense_cpp.exe
+      $exepath = Join-Path $env:AGENT_BUILDDIRECTORY "build\tiledb\examples\cpp_api\Release\quickstart_dense_cpp.exe"
+      & $exepath
     } catch {
-       Write-Host "C++ API example failed."
-       $host.SetShouldExit(1)
+      Write-Host "C++ API example failed."
+      $host.SetShouldExit(1)
     }
 
     if ($LastExitCode -ne 0) {
-       Write-Host "C++ API example failed."
-       $host.SetShouldExit($LastExitCode)
+      Write-Host "C++ API example failed."
+      $host.SetShouldExit($LastExitCode)
     }
 
     # Build examples
@@ -132,8 +127,8 @@ steps:
   #    verbose: # Optional
 
 - powershell: |
-  # tiledb_unit is configured to set a job-level variable TILEDB_CI_SUCCESS=1
-  # following the test run. If this variable is not set, the build should fail.
+    # tiledb_unit is configured to set a job-level variable TILEDB_CI_SUCCESS=1
+    # following the test run. If this variable is not set, the build should fail.
     if ($env:TILEDB_CI_SUCCESS -ne 1) {
       Write-Host "tiledb_unit sanity-check failed! Go check logs."
       $host.SetShouldExit(1)

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -132,6 +132,15 @@ steps:
   #    verbose: # Optional
 
 - powershell: |
+  # tiledb_unit is configured to set a job-level variable TILEDB_CI_SUCCESS=1
+  # following the test run. If this variable is not set, the build should fail.
+    if ($env:TILEDB_CI_SUCCESS -ne 1) {
+      Write-Host "tiledb_unit sanity-check failed! Go check logs."
+      $host.SetShouldExit(1)
+    }
+  displayName: "Test status check"
+
+- powershell: |
     (Get-ChildItem -Path $env:BUILD_SOURCESDIRECTORY -Include *.log -Recurse).fullname | ForEach-Object {echo $_ ---; Get-Content $_; echo ===}
   condition: failed() # only run this job if the build step failed
   displayName: "Print log files (failed build only)"

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -39,6 +39,9 @@ steps:
     $env:AWS_ACCESS_KEY_ID = "minio"
     $env:AWS_SECRET_ACCESS_KEY = "miniosecretkey"
 
+    # Clone backwards compatibility test arrays
+    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git  $env:BUILD_SOURCESDIRECTORY/test/inputs/arrays/read_compatibility_test
+
     cd $env:AGENT_BUILDDIRECTORY\build\tiledb
 
     # CMake exits with non-0 status if there are any warnings during the build, so

--- a/scripts/install-minio.ps1
+++ b/scripts/install-minio.ps1
@@ -21,7 +21,7 @@ function Get-ScriptsDirectory {
 $TileDBRootDirectory = Split-Path -Parent (Get-ScriptsDirectory)
 $InstallPrefix = Join-Path $TileDBRootDirectory "dist"
 $StagingDirectory = Join-Path (Get-ScriptsDirectory) "deps-staging"
-
+$CertsDirectory = Join-Path $TileDBRootDirectory "test/inputs/test_certs"
 New-Item -ItemType Directory -Path (Join-Path $InstallPrefix bin) -ea 0
 
 function DownloadFile([string] $URL, [string] $Dest) {
@@ -31,17 +31,17 @@ function DownloadFile([string] $URL, [string] $Dest) {
 
 function DownloadIfNotExists([string] $Path, [string] $URL) {
     if (!(Test-Path $Path)) {
-	# Minio uses TLS1.2
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-	DownloadFile $URL $Path
+        # Minio uses TLS1.2
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        DownloadFile $URL $Path
     }
 }
 function Install-Minio {
     $MinioRoot = (Join-Path $StagingDirectory "minio")
     $DownloadMinioDest = Join-Path $MinioRoot "minio.exe"
     if (!(Test-Path $MinioRoot)) {
-	New-Item -ItemType Directory -Path $MinioRoot
-	DownloadIfNotExists $DownloadMinioDest "https://dl.minio.io/server/minio/release/windows-amd64/minio.exe"
+        New-Item -ItemType Directory -Path $MinioRoot
+        DownloadIfNotExists $DownloadMinioDest "https://dl.minio.io/server/minio/release/windows-amd64/minio.exe"
     }
     Copy-Item $DownloadMinioDest (Join-Path $InstallPrefix "bin")
 }
@@ -58,17 +58,27 @@ function Run-Minio {
     $ServerConfigDir = Join-Path $InstallPrefix "etc\minio"
     $ServerDataDir = Join-Path $InstallPrefix "usr\local\share\minio"
     if (!(Test-Path $ServerDataDir)) {
-	New-Item -ItemType Directory -Path $ServerDataDir
+        New-Item -ItemType Directory -Path $ServerDataDir
     }
     if (!(Test-Path $ServerConfigDir)) {
-	New-Item -ItemType Directory -Path $ServerConfigDir
+        New-Item -ItemType Directory -Path $ServerConfigDir
     }
-    Start-Process -FilePath $ExePath -ArgumentList "server --address 127.0.0.1:9999 --config-dir `"$ServerConfigDir`" `"$ServerDataDir`""
+    Start-Process -FilePath $ExePath -ArgumentList "server --address 127.0.0.1:9999 --config-dir `"$ServerConfigDir`" --certs-dir `"$CertsDir`" `"$ServerDataDir`""
+
+    Start-Sleep 1.0
+
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        Write-Host "Checking Minio with '-SkipCertificateCheck':"
+        Invoke-WebRequest -Uri https://127.0.0.1:9999 -SkipCertificateCheck
+        Write-Host "--------------------------------------------------------------------------------"
+    } else {
+        Write-Host "Skipping minio check (powershell version < 6)"
+    }
 }
 
 function Install-All-Deps {
     if (!(Test-Path $StagingDirectory)) {
-	New-Item -ItemType Directory -Path $StagingDirectory
+        New-Item -ItemType Directory -Path $StagingDirectory
     }
     Install-Minio
     Export-Env

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -229,6 +229,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
 TEST_CASE("VFS: Test long paths (Win32)", "[vfs][windows]") {
   std::unique_ptr<VFS> vfs(new VFS);
   std::string tmpdir_base = tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
+  REQUIRE(vfs->init(nullptr, nullptr).ok());
   REQUIRE(vfs->create_dir(URI(tmpdir_base)).ok());
 
   SECTION("- Deep hierarchy") {

--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -35,11 +35,11 @@
 #include "catch.hpp"
 
 #include <cassert>
+#include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/win.h"
 #include "tiledb/sm/misc/stats.h"
 #include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/misc/thread_pool.h"
-#include "tiledb/sm/storage_manager/config.h"
 
 using namespace tiledb::sm;
 
@@ -59,13 +59,13 @@ struct WinFx {
   const std::string TEMP_DIR = Win::current_dir() + "/";
   Win win_;
   ThreadPool thread_pool_;
-  Config::VFSParams vfs_params_;
+  Config vfs_config_;
 
   WinFx() {
     // Make sure parallel reads/writes are tested.
-    vfs_params_.min_parallel_size_ = 100;
+    vfs_config_.set("vfs.min_parallel_size", "100");
     REQUIRE(thread_pool_.init(4).ok());
-    REQUIRE(win_.init(vfs_params_, &thread_pool_).ok());
+    REQUIRE(win_.init(vfs_config_, &thread_pool_).ok());
 
     if (path_exists(TEMP_DIR + "tiledb_test_dir"))
       REQUIRE(win_.remove_dir(TEMP_DIR + "tiledb_test_dir").ok());

--- a/test/src/unit.cc
+++ b/test/src/unit.cc
@@ -1,2 +1,22 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
+
+// Successful completion hook
+#include <cstdlib>
+#include <iostream>
+
+struct CICompletionStatusListener : Catch::TestEventListenerBase {
+  using TestEventListenerBase::TestEventListenerBase;  // inherit constructor
+
+  void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+    if (std::getenv("AGENT_NAME") != nullptr) {
+      if (testRunStats.totals.testCases.allOk() == 1) {
+        // set TILEDB_CI_SUCCESS job-level variable in azure pipelines
+        // note: this variable is only set in subsequest tasks.
+        std::cout << "##vso[task.setvariable variable=TILEDB_CI_SUCCESS]1"
+                  << std::endl;
+      }
+    }
+  }
+};
+CATCH_REGISTER_LISTENER(CICompletionStatusListener)

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -364,6 +364,8 @@ Status StorageManager::array_open_for_writes(
     err << open_array->array_schema()->version();
     err << ") is different from library format version (";
     err << constants::format_version << ")";
+    open_array->mtx_unlock();
+    array_close_for_writes(array_uri, encryption_key, nullptr);
     return LOG_STATUS(Status::StorageManagerError(err.str()));
   }
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1664,6 +1664,12 @@ Status StorageManager::get_array_metadata_uris(
   // Get all uris in the array metadata directory
   URI metadata_dir = array_uri.join_path(constants::array_metadata_folder_name);
   std::vector<URI> uris;
+
+  bool is_dir;
+  RETURN_NOT_OK(vfs_->is_dir(metadata_dir, &is_dir));
+  if (!is_dir)
+    return Status::Ok();
+
   RETURN_NOT_OK(vfs_->ls(metadata_dir.add_trailing_slash(), &uris));
 
   // Get only the metadata uris


### PR DESCRIPTION
- fixes Windows CI (incorrect test directory and other issues)
- 5f0623f adds a post-test event listener which writes the variable `TILEDB_CI_SUCCESS` to the Azure pipelines environment (note: this variable is only available in subsequent tasks). Also add separate task to verify that this variable has been set.
- fix two failing tests
  - d3b94e9 fixes a test failure due to calling VFS.ls_dir on a non-existent `__meta` directory (this is an error on Windows and will be made an error on POSIX in a follow-up PR)
  - 40515d8 fixes a test crash on Windows due to missing unlock in an error path