### PR TITLE
Fix assertion failures in S3 tests; allow 'run-minio.sh' to be sourced

### DIFF
--- a/scripts/run-minio.sh
+++ b/scripts/run-minio.sh
@@ -30,13 +30,15 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 die() {
-  echo "$@" 1>&2 ; popd 2>/dev/null; exit 1
+  echo "$@" 1>&2 ; popd 2>/dev/null;
+
+  if [[ "$BASH_SOURCE" = $0 ]]; then
+    # exit when *not* sourced (https://superuser.com/a/1288646)
+    exit 1;
+  fi
 }
 
 run_cask_minio() {
-  export MINIO_ACCESS_KEY=minio
-  export MINIO_SECRET_KEY=miniosecretkey
-
   # note: minio data directories *must* follow parameter arguments
   minio server --certs-dir=/tmp/minio-data/test_certs --address localhost:9999 /tmp/minio-data &
   [[ "$?" -eq "0" ]] || die "could not run minio server"
@@ -54,6 +56,8 @@ run_docker_minio() {
 export_aws_keys() {
   export AWS_ACCESS_KEY_ID=minio
   export AWS_SECRET_ACCESS_KEY=miniosecretkey
+  export MINIO_ACCESS_KEY=minio
+  export MINIO_SECRET_KEY=miniosecretkey
 }
 
 run() {

--- a/test/src/unit-s3-no-multipart.cc
+++ b/test/src/unit-s3-no-multipart.cc
@@ -99,6 +99,7 @@ S3DirectFx::~S3DirectFx() {
 
   // Delete bucket
   CHECK(s3_.remove_bucket(S3_BUCKET).ok());
+  s3_.disconnect();
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -95,6 +95,7 @@ S3Fx::~S3Fx() {
 
   // Delete bucket
   CHECK(s3_.remove_bucket(S3_BUCKET).ok());
+  s3_.disconnect();
 }
 
 std::string S3Fx::random_bucket_name(const std::string& prefix) {


### PR DESCRIPTION
- Fixes some asserts that @Shelnutt2 and I have run in to when building `tiledb_unit` in debug mode.
- Support `source scripts/run-minio.sh`, which starts docker and sets (test) credentials. Currently the script exits the shell on failure; the change here avoids exiting when sourced.