### PR TITLE
Add ctx_set_tag C and C++ API functions.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 
 * Added C API functions tiledb_query_get_{fragment_num,fragment_uri,fragment_timestamp_range}.
 * Added C++ API functions Query::{fragment_num,fragment_uri,fragment_timestamp_range}.
+* Added C API function `tiledb_ctx_set_tag` and C++ API `Context::set_tag()`.
 
 # TileDB v1.6.3 Release Notes
 

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -168,6 +168,8 @@ Context
     :project: TileDB-C
 .. doxygenfunction:: tiledb_ctx_cancel_tasks
     :project: TileDB-C
+.. doxygenfunction:: tiledb_ctx_set_tag
+    :project: TileDB-C
 
 Config
 ------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,6 +79,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-CellSlabIter.cc
   src/unit-compression-dd.cc
   src/unit-compression-rle.cc
+  src/unit-ctx.cc
   src/unit-encryption.cc
   src/unit-filter-buffer.cc
   src/unit-filter-pipeline.cc

--- a/test/src/unit-ctx.cc
+++ b/test/src/unit-ctx.cc
@@ -1,0 +1,87 @@
+/**
+ * @file   unit-ctx.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB Inc.
+ * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for TileDB context object.
+ */
+
+#include "catch.hpp"
+#include "test/src/helpers.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/cpp_api/tiledb"
+
+#include <cstring>
+#include <iostream>
+
+TEST_CASE("C API: Test context tags", "[capi][ctx-tags]") {
+  tiledb_ctx_t* ctx = nullptr;
+  REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
+  tiledb::sm::StorageManager* sm = ctx->ctx_->storage_manager();
+
+  // Check defaults
+  REQUIRE(sm->tags().size() == 1);
+  REQUIRE(sm->tags().at("tiledb-api-language") == "c");
+
+  // Check setter
+  REQUIRE(tiledb_ctx_set_tag(ctx, "tag1", "value1") == TILEDB_OK);
+  REQUIRE(sm->tags().size() == 2);
+  REQUIRE(sm->tags().at("tag1") == "value1");
+
+  REQUIRE(tiledb_ctx_set_tag(ctx, "tag2", "value2") == TILEDB_OK);
+  REQUIRE(sm->tags().size() == 3);
+  REQUIRE(sm->tags().at("tag2") == "value2");
+
+  REQUIRE(tiledb_ctx_set_tag(ctx, "tag1", "value3") == TILEDB_OK);
+  REQUIRE(sm->tags().size() == 3);
+  REQUIRE(sm->tags().at("tag1") == "value3");
+
+  tiledb_ctx_free(&ctx);
+}
+
+TEST_CASE("C++ API: Test context tags", "[cppapi][ctx-tags]") {
+  tiledb::Context ctx;
+  tiledb::sm::StorageManager* sm = ctx.ptr().get()->ctx_->storage_manager();
+
+  // Check defaults
+  REQUIRE(sm->tags().size() == 1);
+  REQUIRE(sm->tags().at("tiledb-api-language") == "c++");
+
+  // Check setter
+  REQUIRE_NOTHROW(ctx.set_tag("tag1", "value1"));
+  REQUIRE(sm->tags().size() == 2);
+  REQUIRE(sm->tags().at("tag1") == "value1");
+
+  REQUIRE_NOTHROW(ctx.set_tag("tag2", "value2"));
+  REQUIRE(sm->tags().size() == 3);
+  REQUIRE(sm->tags().at("tag2") == "value2");
+
+  REQUIRE_NOTHROW(ctx.set_tag("tag1", "value3"));
+  REQUIRE(sm->tags().size() == 3);
+  REQUIRE(sm->tags().at("tag1") == "value3");
+}

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1192,6 +1192,17 @@ int32_t tiledb_ctx_cancel_tasks(tiledb_ctx_t* ctx) {
   return TILEDB_OK;
 }
 
+int32_t tiledb_ctx_set_tag(
+    tiledb_ctx_t* ctx, const char* key, const char* value) {
+  if (sanity_check(ctx) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(ctx, ctx->ctx_->storage_manager()->set_tag(key, value)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 /* ****************************** */
 /*              GROUP             */
 /* ****************************** */

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1485,6 +1485,23 @@ TILEDB_EXPORT int32_t tiledb_ctx_is_supported_fs(
  */
 TILEDB_EXPORT int32_t tiledb_ctx_cancel_tasks(tiledb_ctx_t* ctx);
 
+/**
+ * Sets a string key-value "tag" on the given context.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_ctx_set_tag(ctx, "tag key", "tag value");
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param key The tag key
+ * @param value The tag value.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t
+tiledb_ctx_set_tag(tiledb_ctx_t* ctx, const char* key, const char* value);
+
 /* ********************************* */
 /*                GROUP              */
 /* ********************************* */

--- a/tiledb/sm/cpp_api/context.h
+++ b/tiledb/sm/cpp_api/context.h
@@ -85,6 +85,8 @@ class Context {
       throw TileDBError("[TileDB::C++API] Error: Failed to create context");
     ctx_ = std::shared_ptr<tiledb_ctx_t>(ctx, Context::free);
     error_handler_ = default_error_handler;
+
+    set_tag("tiledb-api-language", "c++");
   }
 
   /**
@@ -97,6 +99,8 @@ class Context {
       throw TileDBError("[TileDB::C++API] Error: Failed to create context");
     ctx_ = std::shared_ptr<tiledb_ctx_t>(ctx, Context::free);
     error_handler_ = default_error_handler;
+
+    set_tag("tiledb-api-language", "c++");
   }
 
   /* ********************************* */
@@ -187,6 +191,11 @@ class Context {
    */
   void cancel_tasks() const {
     handle_error(tiledb_ctx_cancel_tasks(ctx_.get()));
+  }
+
+  /** Sets a string/string KV tag on the context. */
+  void set_tag(const std::string& key, const std::string& value) {
+    handle_error(tiledb_ctx_set_tag(ctx_.get(), key.c_str(), value.c_str()));
   }
 
   /* ********************************* */

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -905,6 +905,11 @@ Status StorageManager::get_fragment_info(
   return array_close_for_reads(array_uri);
 }
 
+const std::unordered_map<std::string, std::string>& StorageManager::tags()
+    const {
+  return tags_;
+}
+
 Status StorageManager::get_fragment_info(
     const ArraySchema* array_schema,
     const EncryptionKey& encryption_key,
@@ -1040,6 +1045,8 @@ Status StorageManager::init(const Config* config) {
 #ifdef TILEDB_SERIALIZATION
   RETURN_NOT_OK(init_rest_client());
 #endif
+
+  RETURN_NOT_OK(set_default_tags());
 
   global_state.register_storage_manager(this);
 
@@ -1393,6 +1400,12 @@ Status StorageManager::read(
 
 ThreadPool* StorageManager::reader_thread_pool() {
   return &reader_thread_pool_;
+}
+
+Status StorageManager::set_tag(
+    const std::string& key, const std::string& value) {
+  tags_[key] = value;
+  return Status::Ok();
 }
 
 Status StorageManager::store_array_schema(
@@ -1836,6 +1849,11 @@ Status StorageManager::new_array_metadata_uri(
   *new_uri = array_uri.join_path(constants::array_metadata_folder_name)
                  .join_path(ss.str());
 
+  return Status::Ok();
+}
+
+Status StorageManager::set_default_tags() {
+  tags_["tiledb-api-language"] = "c";
   return Status::Ok();
 }
 

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -367,6 +367,9 @@ class StorageManager {
       const URI& fragment_uri,
       FragmentInfo* fragment_info);
 
+  /** Returns the current map of any set tags. */
+  const std::unordered_map<std::string, std::string>& tags() const;
+
   /**
    * Creates a TileDB group.
    *
@@ -605,6 +608,17 @@ class StorageManager {
       const URI& uri, uint64_t offset, Buffer* buffer, uint64_t nbytes) const;
 
   /**
+   * Sets a string/string KV "tag" on the storage manager instance.
+   *
+   * This is currently only meant for internal TileDB Inc. usage.
+   *
+   * @param key Tag key
+   * @param value Tag value
+   * @return Status
+   */
+  Status set_tag(const std::string& key, const std::string& value);
+
+  /**
    * Stores an array schema into persistent storage.
    *
    * @param array_schema The array metadata to be stored.
@@ -763,6 +777,9 @@ class StorageManager {
    */
   CancelableTasks cancelable_tasks_;
 
+  /** Tags for the context object. */
+  std::unordered_map<std::string, std::string> tags_;
+
   /** A tile cache. */
   LRUCache* tile_cache_;
 
@@ -911,6 +928,9 @@ class StorageManager {
       const URI& array_uri,
       const std::pair<uint64_t, uint64_t>& timestamp_range,
       URI* new_uri) const;
+
+  /** Sets default tag values on this StorageManager. */
+  Status set_default_tags();
 };
 
 }  // namespace sm


### PR DESCRIPTION
The only tag currently set by default is `tiledb-api-language`. The tags are
not used anywhere yet.

@joe-maley make sure that this API will do what you need. In a separate PR I'll make the necessary changes to include all tags as a ~cookie/cookies~ header/headers, I figured it'd be easier to review separately.