### PR TITLE
Bump Hadoop CI version to 3.1.3.

### DIFF
--- a/scripts/install-hadoop.sh
+++ b/scripts/install-hadoop.sh
@@ -27,7 +27,7 @@
 # Installs and configures HDFS.
 set -x
 
-HADOOP_VERSION="3.1.2"
+HADOOP_VERSION="3.1.3"
 
 die() {
   echo "$@" 1>&2 ; popd 2>/dev/null; exit 1


### PR DESCRIPTION
According to the mirror policy (https://www.apache.org/dev/mirrors) old releases
are moved to the archive, which has DL rate limiting.