### PR TITLE
Add missing cases for datetime attr/dim serialization support.

### DIFF
--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -1419,3 +1419,62 @@ TEST_CASE_METHOD(
   delete_array(array_name);
   remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
 }
+
+TEST_CASE_METHOD(
+    ArraySchemaFx,
+    "C API: Test array schema datetimes",
+    "[capi][array-schema][datetime]") {
+  SECTION("- No serialization") {
+    serialize_array_schema = false;
+  }
+  SECTION("- Serialization") {
+    serialize_array_schema = true;
+  }
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  int rc = tiledb_array_schema_alloc(ctx_, TILEDB_DENSE, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create dimension
+  tiledb_dimension_t* d1;
+  rc = tiledb_dimension_alloc(
+      ctx_, "", TILEDB_DATETIME_MS, &DIM_DOMAIN[0], &TILE_EXTENTS[0], &d1);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set domain
+  tiledb_domain_t* domain;
+  rc = tiledb_domain_alloc(ctx_, &domain);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, d1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_domain(ctx_, array_schema, domain);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set attributes
+  tiledb_attribute_t* attr1;
+  rc = tiledb_attribute_alloc(ctx_, "attr1", ATTR_TYPE, &attr1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_add_attribute(ctx_, array_schema, attr1);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_attribute_t* attr2;
+  rc = tiledb_attribute_alloc(ctx_, "attr2", TILEDB_DATETIME_DAY, &attr2);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_add_attribute(ctx_, array_schema, attr2);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create array
+  std::string array_name = FILE_URI_PREFIX + FILE_TEMP_DIR + "datetime-dims";
+  create_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
+  rc = array_create_wrapper(array_name, array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_attribute_free(&attr1);
+  tiledb_attribute_free(&attr2);
+  tiledb_dimension_free(&d1);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
+  delete_array(array_name);
+  remove_temp_dir(FILE_URI_PREFIX + FILE_TEMP_DIR);
+}

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -514,6 +514,19 @@ Status RestClient::subarray_to_str(
       case Datatype::UINT32:
         ss << ((const uint32_t*)subarray)[i];
         break;
+      case Datatype::DATETIME_YEAR:
+      case Datatype::DATETIME_MONTH:
+      case Datatype::DATETIME_WEEK:
+      case Datatype::DATETIME_DAY:
+      case Datatype::DATETIME_HR:
+      case Datatype::DATETIME_MIN:
+      case Datatype::DATETIME_SEC:
+      case Datatype::DATETIME_MS:
+      case Datatype::DATETIME_US:
+      case Datatype::DATETIME_NS:
+      case Datatype::DATETIME_PS:
+      case Datatype::DATETIME_FS:
+      case Datatype::DATETIME_AS:
       case Datatype::INT64:
         ss << ((const int64_t*)subarray)[i];
         break;

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -267,6 +267,19 @@ Status dimension_from_capnp(
         RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
         break;
       }
+      case Datatype::DATETIME_YEAR:
+      case Datatype::DATETIME_MONTH:
+      case Datatype::DATETIME_WEEK:
+      case Datatype::DATETIME_DAY:
+      case Datatype::DATETIME_HR:
+      case Datatype::DATETIME_MIN:
+      case Datatype::DATETIME_SEC:
+      case Datatype::DATETIME_MS:
+      case Datatype::DATETIME_US:
+      case Datatype::DATETIME_NS:
+      case Datatype::DATETIME_PS:
+      case Datatype::DATETIME_FS:
+      case Datatype::DATETIME_AS:
       case Datatype::INT64: {
         auto val = tile_extent_reader.getInt64();
         RETURN_NOT_OK((*dimension)->set_tile_extent(&val));

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -98,6 +98,19 @@ tiledb::sm::Status set_capnp_array_ptr(
     case tiledb::sm::Datatype::UINT32:
       builder.setUint32(kj::arrayPtr(static_cast<const uint32_t*>(ptr), size));
       break;
+    case tiledb::sm::Datatype::DATETIME_YEAR:
+    case tiledb::sm::Datatype::DATETIME_MONTH:
+    case tiledb::sm::Datatype::DATETIME_WEEK:
+    case tiledb::sm::Datatype::DATETIME_DAY:
+    case tiledb::sm::Datatype::DATETIME_HR:
+    case tiledb::sm::Datatype::DATETIME_MIN:
+    case tiledb::sm::Datatype::DATETIME_SEC:
+    case tiledb::sm::Datatype::DATETIME_MS:
+    case tiledb::sm::Datatype::DATETIME_US:
+    case tiledb::sm::Datatype::DATETIME_NS:
+    case tiledb::sm::Datatype::DATETIME_PS:
+    case tiledb::sm::Datatype::DATETIME_FS:
+    case tiledb::sm::Datatype::DATETIME_AS:
     case tiledb::sm::Datatype::INT64:
       builder.setInt64(kj::arrayPtr(static_cast<const int64_t*>(ptr), size));
       break;
@@ -151,6 +164,19 @@ tiledb::sm::Status set_capnp_scalar(
     case tiledb::sm::Datatype::UINT32:
       builder.setUint32(*static_cast<const uint32_t*>(value));
       break;
+    case tiledb::sm::Datatype::DATETIME_YEAR:
+    case tiledb::sm::Datatype::DATETIME_MONTH:
+    case tiledb::sm::Datatype::DATETIME_WEEK:
+    case tiledb::sm::Datatype::DATETIME_DAY:
+    case tiledb::sm::Datatype::DATETIME_HR:
+    case tiledb::sm::Datatype::DATETIME_MIN:
+    case tiledb::sm::Datatype::DATETIME_SEC:
+    case tiledb::sm::Datatype::DATETIME_MS:
+    case tiledb::sm::Datatype::DATETIME_US:
+    case tiledb::sm::Datatype::DATETIME_NS:
+    case tiledb::sm::Datatype::DATETIME_PS:
+    case tiledb::sm::Datatype::DATETIME_FS:
+    case tiledb::sm::Datatype::DATETIME_AS:
     case tiledb::sm::Datatype::INT64:
       builder.setInt64(*static_cast<const int64_t*>(value));
       break;
@@ -242,6 +268,19 @@ tiledb::sm::Status copy_capnp_list(
       if (reader.hasUint32())
         RETURN_NOT_OK(copy_capnp_list<uint32_t>(reader.getUint32(), buffer));
       break;
+    case tiledb::sm::Datatype::DATETIME_YEAR:
+    case tiledb::sm::Datatype::DATETIME_MONTH:
+    case tiledb::sm::Datatype::DATETIME_WEEK:
+    case tiledb::sm::Datatype::DATETIME_DAY:
+    case tiledb::sm::Datatype::DATETIME_HR:
+    case tiledb::sm::Datatype::DATETIME_MIN:
+    case tiledb::sm::Datatype::DATETIME_SEC:
+    case tiledb::sm::Datatype::DATETIME_MS:
+    case tiledb::sm::Datatype::DATETIME_US:
+    case tiledb::sm::Datatype::DATETIME_NS:
+    case tiledb::sm::Datatype::DATETIME_PS:
+    case tiledb::sm::Datatype::DATETIME_FS:
+    case tiledb::sm::Datatype::DATETIME_AS:
     case tiledb::sm::Datatype::INT64:
       if (reader.hasInt64())
         RETURN_NOT_OK(copy_capnp_list<int64_t>(reader.getInt64(), buffer));


### PR DESCRIPTION
Depends on https://github.com/TileDB-Inc/TileDB-Go/pull/88, no other server changes required.