### PR TITLE
Add support for serialized global order reads

### DIFF
--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -2752,9 +2752,9 @@ int DenseArrayFx::submit_query_wrapper(
   tiledb_buffer_list_t* buff_list1;
   int rc = tiledb_serialize_query(ctx_, query, TILEDB_CAPNP, 1, &buff_list1);
 
-  // Global order queries are not (yet) supported for serialization. Just
+  // Global order writes are not (yet) supported for serialization. Just
   // check that serialization is an error, and then execute the regular query.
-  if (layout == TILEDB_GLOBAL_ORDER) {
+  if (layout == TILEDB_GLOBAL_ORDER && query_type == TILEDB_WRITE) {
     REQUIRE(rc == TILEDB_ERR);
     tiledb_buffer_list_free(&buff_list1);
     return tiledb_query_submit(ctx_, query);

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -387,9 +387,10 @@ Status query_to_capnp(
   auto type = query.type();
   auto array = query.array();
 
-  if (layout == Layout::GLOBAL_ORDER)
-    return LOG_STATUS(Status::SerializationError(
-        "Cannot serialize; global order serialization not supported."));
+  if (layout == Layout::GLOBAL_ORDER && query.type() == QueryType::WRITE)
+    return LOG_STATUS(
+        Status::SerializationError("Cannot serialize; global order "
+                                   "serialization not supported for writes."));
 
   if (array == nullptr)
     return LOG_STATUS(


### PR DESCRIPTION
This allows global order read for dense array with serialization. Only global order writes are not supported.