### PR TITLE
Return incomplete queries.

### DIFF
--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -173,11 +173,9 @@ class RestClient {
    *    map is updated accordingly.
    * @return
    */
-  Status post_query_submit(
-      const URI& uri,
-      Query* query,
-      std::unordered_map<std::string, serialization::QueryBufferCopyState>*
-          copy_state);
+  using CopyState =
+      std::unordered_map<std::string, serialization::QueryBufferCopyState>;
+  Status post_query_submit(const URI& uri, Query* query, CopyState* copy_state);
 
   /**
    * Callback to invoke as partial, buffered response data is received from
@@ -206,8 +204,7 @@ class RestClient {
       size_t content_nbytes,
       Buffer* scratch,
       Query* query,
-      std::unordered_map<std::string, serialization::QueryBufferCopyState>*
-          copy_state);
+      CopyState* copy_state);
 
   /**
    * Returns a string representation of the given subarray. The format is:
@@ -233,10 +230,7 @@ class RestClient {
    * @return Status
    */
   Status update_attribute_buffer_sizes(
-      const std::unordered_map<
-          std::string,
-          serialization::QueryBufferCopyState>& copy_state,
-      Query* query) const;
+      const CopyState& copy_state, Query* query) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -57,6 +57,19 @@ struct QueryBufferCopyState {
       : offset_size(0)
       , data_size(0) {
   }
+
+  /** Copy constructor. */
+  QueryBufferCopyState(const QueryBufferCopyState& rhs)
+      : offset_size(rhs.offset_size)
+      , data_size(rhs.data_size) {
+  }
+
+  /** Assignment operator. */
+  QueryBufferCopyState& operator=(const QueryBufferCopyState& rhs) {
+    offset_size = rhs.offset_size;
+    data_size = rhs.data_size;
+    return *this;
+  }
 };
 
 /**


### PR DESCRIPTION
Changes:
1. A failed 'curlc.post_data()' does not necessarily imply that
   a 'submit_query_to_rest()' invocation will fail. Instead, we
   determine the failure status from the length of 'copy_state'.
   If 'copy_state' is empty, we were unable to get any valid
   query data from the server. If it is non-empty, we either
   received an incomplete or complete query. Both are equally
   valid to the caller.

   I am uncertain if we should consider 'submit_query_to_rest' to
   have failed if 'copy_state' is empty but 'curlc.post_data()' was
   OK.

2. The 'submit_query_to_rest()' now guarantees that 'copy_state'
   is unmutated if the internal 'deserialize_query()' fails for any
   reason (for example, if user buffers are too small). This makes
   a trivial copy to accomplish this.

3. Alias'd the CopyState data structure.