### PR TITLE
Allow incomplete query returns when user buffer is too small

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4172,7 +4172,8 @@ int32_t tiledb_deserialize_query(
               (tiledb::sm::SerializationType)serialize_type,
               client_side == 1,
               nullptr,
-              query->query_)))
+              query->query_,
+              nullptr)))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -198,6 +198,9 @@ class RestClient {
    * @param copy_state Map of copy state per attribute. As attribute data is
    *    copied into user buffers on reads, the state of each attribute in this
    *    map is updated accordingly.
+   * @param user_buffers_overflowed If mutated to true, the 'query' and
+   *    'copy_state' are in incomplete but valid states and may be returned
+   *    to the user regardless of the return status.
    * @return Number of acknowledged bytes
    */
   size_t post_data_write_cb(
@@ -207,7 +210,8 @@ class RestClient {
       Buffer* scratch,
       Query* query,
       std::unordered_map<std::string, serialization::QueryBufferCopyState>*
-          copy_state);
+          copy_state,
+      bool* user_buffers_overflowed);
 
   /**
    * Returns a string representation of the given subarray. The format is:

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -85,13 +85,16 @@ Status query_serialize(
  *      query's buffer sizes are updated directly. If it is not null, the buffer
  *      sizes are not modified but the entries in the map are.
  * @param query Query to deserialize into
+ * @param user_buffers_overflowed If non-null, set to true if the user buffer
+ *      was not large enough to deserialize the query.
  */
 Status query_deserialize(
     const Buffer& serialized_buffer,
     SerializationType serialize_type,
     bool clientside,
     std::unordered_map<std::string, QueryBufferCopyState>* copy_state,
-    Query* query);
+    Query* query,
+    bool* user_buffers_overflowed);
 
 }  // namespace serialization
 }  // namespace sm


### PR DESCRIPTION
This is a shameful, temporary hack to allow returning a valid,
incomplete query when the user buffer is too small to capture
the entire complete query from the server.

This is a fragile change because it depends on:
1. The 'copy_state' remaining unchanged before hitting the
   buffer size check within query_from_capnp().
2. The 'query' remaining unchanged before hitting the buffer size
   check within query_from_capnp().