### PR TITLE
Do not retry rest CURL requests

### DIFF
--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -39,7 +39,7 @@
 #include <cstring>
 
 // TODO: replace this with config option
-#define CURL_MAX_RETRIES 3
+#define CURL_MAX_RETRIES 0
 
 namespace tiledb {
 namespace sm {
@@ -318,7 +318,7 @@ Status Curl::make_curl_request_common(
         Status::RestError("Cannot make curl request; curl instance is null."));
 
   *curl_code = CURLE_OK;
-  for (uint8_t i = 0; i < CURL_MAX_RETRIES; i++) {
+  for (uint8_t i = 0; i <= CURL_MAX_RETRIES; i++) {
     WriteCbState write_cb_state;
     write_cb_state.arg = write_cb_arg;
 


### PR DESCRIPTION
Temporary work-around for this scenario:

1. User queries the REST server.
2. The REST server starts writing data.
3. The REST server trips the K8 memory limit and is killed.
4. The core's rest client recieves error CURLE_PARTIAL_FILE
   because the server was killed while it was writing data.
5. The core's rest client retries, but gets a different error,
   such as CURLE_COULDNT_CONNECT.
6. The CURLE_COULDNT_CONNECT error bubbles up the client,
   which is misleading because they may think they have a
   configuration error.

In the future, we could enable retries with some sort of
logic to return the first error message if the following
are CURLE_COULDNT_CONNECT.

Retrying isn't such a big deal anymore because the client
can retry with incomplete queries. We could remove this
retry path completely.