### PR TITLE
Conda-only: patch capnproto build to work with anaconda

### DIFF
--- a/cmake/Modules/FindCapnp_EP.cmake
+++ b/cmake/Modules/FindCapnp_EP.cmake
@@ -99,6 +99,7 @@ if (NOT CAPNP_FOUND)
           -DBUILD_TESTING=OFF
           "-DCMAKE_C_FLAGS=${CFLAGS_DEF}"
           "-DCMAKE_CXX_FLAGS=${CXXFLAGS_DEF}"
+          -DCMAKE_CXX_COMPILE_FEATURES=cxx_constexpr
           ${TILEDB_EP_BASE}/src/ep_capnp/c++
         UPDATE_COMMAND ""
         LOG_DOWNLOAD TRUE


### PR DESCRIPTION
This is a fake PR for informational purposes.

We are carrying (and need to update) this patch in the conda feedstock:
https://github.com/conda-forge/tiledb-feedstock/commit/c0dde941e6c827ea984284d9a36536e3b79cc519

This patch is needed to build on conda because conda-forge uses Clang versions built from upstream (LLVM/Clang), which identify as `Clang`. macOS SDK compilers are identified as `AppleClang`, and CMake only knows about compiler features for *that* version of Clang. With the upstream compilers, CMake returns the following for a feature check in capnproto:

```
-- stderr output is:
CMake Error at src/kj/CMakeLists.txt:62 (target_compile_features):
  target_compile_features no known features for CXX compiler

  "Clang"

  version 9.0.0.
```

(note: I don't think we should carry this patch in TileDB core, because normally we want correct compiler feature-checks. However, we *know* that the conda toolchain supports C++11, so it is safe to override the check)