### PR TITLE
Improve REST retry logic, part 1

### DIFF
--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -103,10 +103,12 @@ class Curl {
    * @param reset True if this is the first callback from a new request
    * @param contents Response data
    * @param content_nbytes Response data size in 'contents'
+   * @param skip_retries Output argument that can be set to 'true' to skip
+   *        retries in the curl layer.
    * @return Number of acknowledged bytes.
    */
   typedef std::function<size_t(
-      bool reset, void* contents, size_t content_nbytes)>
+      bool reset, void* contents, size_t content_nbytes, bool* skip_retries)>
       PostResponseCb;
 
   /**

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -192,6 +192,8 @@ class RestClient {
    * @param reset True if the callback must wipe the in-memory state
    * @param contents the partial response data
    * @param content_nbytes the size of the response data in 'contents'
+   * @param skip_retries Output argument that can be set to true to
+   *    prevent the curl layer from retrying this request.
    * @scratch scratch space to use between invocations of this callback
    * @query the query object used for deserializing the serialized query
    *    objects in the response data.
@@ -207,6 +209,7 @@ class RestClient {
       bool reset,
       void* contents,
       size_t content_nbytes,
+      bool* skip_retries,
       Buffer* scratch,
       Query* query,
       std::unordered_map<std::string, serialization::QueryBufferCopyState>*


### PR DESCRIPTION
This is the first step towards ensuring that
our REST submit() logic is 1) optimal, 2) does
not discard useful data and 3) returns useful
error messages.

For reference, this is the call stack from the
user's submit() to the point of deserializing an
individual query object:

RestClient::post_query_submit()
 Curl::post_data()
  Curl::post_data_common()
   Curl::make_curl_request()
    Curl::make_curl_request_common()
     R * curl_easy_perform()
      N * RestClient::post_data_write_cb()
       query_deserialize()

The post_data_write_cb() is called N times, where
each invocation contains some-or-all of the response
data. Note that in the default case, the response data
may contain multiple query objects. The callback may
contain a partial query object, a complete query object,
or more than a single complete query object.

The curl_easy_perform() is called R times, where R is more
than 1 in the event of a retry.

For this discussion, "useful data" refers to the
parsed buffers (and associated copy state) containing
at least one complete query object.

This change does three things:
1. In the event of 1 or more retries, we only return the
   error message from the first attempt. The hypothesis
   is that the first error message may be more useful than
   the retry error messages.

2. If there is a problem parsing the response data (for
   example, the response is corrupt or we do not have
   sufficient client-side buffer space to store the
   response), we restrict R to 1 to prevent wasting
   time on retries that we know will fail.

3. Most importantly, this prevents throwing out useful
   data before the user has a chance to see it. Refer to the
   above call stack for this example:
   1. Each invocation of 'curl_easy_perform' resets the
      'copy_state'. This is because to conform to the
      CURL write callback interface, we must handle a flag
      to reset our entire state at any time. This flag
      is initially set.
   2. Within the first call to curl_easy_perform(), we
      recieve 99 of 100 query objects. The connection dropped
      when reading the 100th query object. We have 99 query
      objects worth of useful data.
   3. On the retry of curl_easy_perform(), we reset the
      'copy_state', throwing out all useful data. This
      invocation immediately fails with 'unable to connect'.
   4. All future retries exhaust with 'unable to connect' as
      well.
   5. This bubbles up to the user as a non-OK status with out
      any useful data.

   The above problem is that, obviously, we have discarded 99
   query objects that the client could have caught and used in
   a resubmit.

   This patch prevents steps 3-5. Instead, we return a non-OK
   status with useful data.

   This isn't particularly useful in the current state, which is
   why this is "patch 1". The next patch will allow the scenario
   to become "return OK status with useful data", which indicates
   that the user is free to resubmit after parsing the useful data.