### PR TITLE
WIP: query_deserialize() transaction

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4172,8 +4172,7 @@ int32_t tiledb_deserialize_query(
               (tiledb::sm::SerializationType)serialize_type,
               client_side == 1,
               nullptr,
-              query->query_,
-              nullptr)))
+              query->query_)))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/misc/logger.h
+++ b/tiledb/sm/misc/logger.h
@@ -184,6 +184,12 @@ inline Status LOG_STATUS(const Status& st) {
 }
 #endif
 
+/** Logs an error and exits with a non-zero status. */
+inline void LOG_FATAL(const std::string& msg) {
+  global_logger().error(msg.c_str());
+  exit(1);
+}
+
 }  // namespace sm
 }  // namespace tiledb
 

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -174,10 +174,7 @@ class RestClient {
    * @return
    */
   Status post_query_submit(
-      const URI& uri,
-      Query* query,
-      std::unordered_map<std::string, serialization::QueryBufferCopyState>*
-          copy_state);
+      const URI& uri, Query* query, serialization::CopyState* copy_state);
 
   /**
    * Callback to invoke as partial, buffered response data is received from
@@ -200,9 +197,6 @@ class RestClient {
    * @param copy_state Map of copy state per attribute. As attribute data is
    *    copied into user buffers on reads, the state of each attribute in this
    *    map is updated accordingly.
-   * @param user_buffers_overflowed If mutated to true, the 'query' and
-   *    'copy_state' are in incomplete but valid states and may be returned
-   *    to the user regardless of the return status.
    * @return Number of acknowledged bytes
    */
   size_t post_data_write_cb(
@@ -212,9 +206,7 @@ class RestClient {
       bool* skip_retries,
       Buffer* scratch,
       Query* query,
-      std::unordered_map<std::string, serialization::QueryBufferCopyState>*
-          copy_state,
-      bool* user_buffers_overflowed);
+      serialization::CopyState* copy_state);
 
   /**
    * Returns a string representation of the given subarray. The format is:
@@ -240,10 +232,7 @@ class RestClient {
    * @return Status
    */
   Status update_attribute_buffer_sizes(
-      const std::unordered_map<
-          std::string,
-          serialization::QueryBufferCopyState>& copy_state,
-      Query* query) const;
+      const serialization::CopyState& copy_state, Query* query) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -57,7 +57,24 @@ struct QueryBufferCopyState {
       : offset_size(0)
       , data_size(0) {
   }
+
+  /** Copy constructor. */
+  QueryBufferCopyState(const QueryBufferCopyState& rhs)
+      : offset_size(rhs.offset_size)
+      , data_size(rhs.data_size) {
+  }
+
+  /** Assignment operator. */
+  QueryBufferCopyState& operator=(const QueryBufferCopyState& rhs) {
+    offset_size = rhs.offset_size;
+    data_size = rhs.data_size;
+    return *this;
+  }
 };
+
+/** Maps a buffer name to an associated QueryBufferCopyState. */
+using CopyState =
+    std::unordered_map<std::string, serialization::QueryBufferCopyState>;
 
 /**
  * Serialize a query
@@ -85,16 +102,13 @@ Status query_serialize(
  *      query's buffer sizes are updated directly. If it is not null, the buffer
  *      sizes are not modified but the entries in the map are.
  * @param query Query to deserialize into
- * @param user_buffers_overflowed If non-null, set to true if the user buffer
- *      was not large enough to deserialize the query.
  */
 Status query_deserialize(
     const Buffer& serialized_buffer,
     SerializationType serialize_type,
     bool clientside,
-    std::unordered_map<std::string, QueryBufferCopyState>* copy_state,
-    Query* query,
-    bool* user_buffers_overflowed);
+    CopyState* copy_state,
+    Query* query);
 
 }  // namespace serialization
 }  // namespace sm


### PR DESCRIPTION
This change ensures that if query_deserialize() returns
a non-OK status, both 'copy_state' and 'query' args are
in the same state that they entered the routine in.

Changes:
1. The existing query_deserialize() implementation has
   been moved to do_query_deserialize().
2. query_deserialize() maintains the same interface.
3. query_deserialize() makes a copy of the
   'copy_state'.
4. query_deserialize() serializes 'query' into a backup
   buffer.
5. query_deserialize() invokes do_query_deserialize(). If
   it fails, query_deserialize() will reset 'copy_state' to
   the copy in change #3 and it will deserialize the backup
   buffer from change #4 into 'query.
6. Reverts the logical changes in #1424 because we now handle
    all deserialization failures, not just user buffer overflow.

This is marked as a work-in-progress because it is untested, and
will not be checked in until tested.