### PR TITLE
CopyState double-free

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -927,7 +927,8 @@ Status query_deserialize(
   // Similarly, we must create a copy of 'copy_state'.
   std::unique_ptr<CopyState> original_copy_state = nullptr;
   if (copy_state) {
-    original_copy_state = std::unique_ptr<CopyState>(copy_state);
+    original_copy_state =
+        std::unique_ptr<CopyState>(new CopyState(*copy_state));
   }
 
   // Deserialize 'serialized_buffer'.


### PR DESCRIPTION
This fixes an issue where a deep copy was intended but only
a pointer copy was made. The unique_ptr<CopyState> segfaults
in its destructor with a double-free after the original
object has been freed.