### PR TITLE
Expand dimension domain in dense arrays

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
 
 ## Bug fixes
 
+* Fixed consolidation bug in dense arrays. Had to force the dimension domain of a dense array to expand such that the domain range becomes a multiple of the tile extent.
+
 ## API additions
 
 * Added C API functions tiledb_query_get_{fragment_num,fragment_uri,fragment_timestamp_range}.

--- a/examples/png_ingestion/src/main.cc
+++ b/examples/png_ingestion/src/main.cc
@@ -229,6 +229,7 @@ void ingest_png(const std::string& input_png, const std::string& array_path) {
   Array array(ctx, array_path, TILEDB_WRITE);
   Query query(ctx, array);
   query.set_layout(TILEDB_ROW_MAJOR)
+      .set_subarray<unsigned>({0, height - 1, 0, width - 1})
       .set_buffer("red", red)
       .set_buffer("green", green)
       .set_buffer("blue", blue)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,7 @@ if (TILEDB_CPP_API)
   list(APPEND TILEDB_TEST_SOURCES
     src/unit-cppapi-array.cc
     src/unit-cppapi-config.cc
+    src/unit-cppapi-consolidation.cc
     src/unit-cppapi-datetimes.cc
     src/unit-cppapi-filter.cc
     src/unit-cppapi-metadata.cc

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -87,9 +87,9 @@ struct ArraySchemaFx {
   const char* DIM2_NAME = "d2";
   const tiledb_datatype_t DIM_TYPE = TILEDB_INT64;
   const char* DIM_TYPE_STR = "INT64";
-  const int64_t DIM_DOMAIN[4] = {0, 99, 20, 60};
+  const int64_t DIM_DOMAIN[4] = {0, 99, 21, 60};
   const char* DIM1_DOMAIN_STR = "[0,99]";
-  const char* DIM2_DOMAIN_STR = "[20,60]";
+  const char* DIM2_DOMAIN_STR = "[21,60]";
   const uint64_t DIM_DOMAIN_SIZE = sizeof(DIM_DOMAIN) / DIM_NUM;
   const int64_t TILE_EXTENTS[2] = {10, 5};
   const char* DIM1_TILE_EXTENT_STR = "10";

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1,5 +1,5 @@
 /**
- * @file   unit-cppapi-schema.cc
+ * @file   unit-cppapi-array.cc
  *
  * @section LICENSE
  *
@@ -102,13 +102,13 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi]") {
     auto b = schema.domain().dimensions()[1].domain<int>();
     CHECK_THROWS(schema.domain().dimensions()[0].domain<unsigned>());
     CHECK(a.first == -100);
-    CHECK(a.second == 100);
+    CHECK(a.second == 109);
     CHECK(b.first == 0);
-    CHECK(b.second == 100);
+    CHECK(b.second == 104);
     CHECK_THROWS(schema.domain().dimensions()[0].tile_extent<unsigned>() == 10);
     CHECK(schema.domain().dimensions()[0].tile_extent<int>() == 10);
     CHECK(schema.domain().dimensions()[1].tile_extent<int>() == 5);
-    CHECK(schema.domain().cell_num() == 20301);
+    CHECK(schema.domain().cell_num() == 22050);
   }
   SECTION("Make Buffer") {
     Array array(ctx, "cpp_unit_array", TILEDB_WRITE);

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -1,0 +1,113 @@
+/**
+ * @file   unit-cppapi-consolidation.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Consolidation tests with the C++ API.
+ */
+
+#include "catch.hpp"
+#include "tiledb/sm/cpp_api/tiledb"
+
+using namespace tiledb;
+
+void remove_array(const std::string& array_name) {
+  Context ctx;
+  VFS vfs(ctx);
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+}
+
+void create_array(const std::string& array_name) {
+  Context ctx;
+  Domain domain(ctx);
+  auto d = Dimension::create<int>(ctx, "d", {{1, 3}}, 2);
+  domain.add_dimensions(d);
+  auto a = Attribute::create<int>(ctx, "a");
+  ArraySchema schema(ctx, TILEDB_DENSE);
+  schema.set_domain(domain);
+  schema.add_attributes(a);
+  Array::create(array_name, schema);
+}
+
+void write_array(
+    const std::string& array_name,
+    const std::vector<int>& subarray,
+    std::vector<int> values) {
+  Context ctx;
+  Array array(ctx, array_name, TILEDB_WRITE);
+  Query query(ctx, array, TILEDB_WRITE);
+  query.set_layout(TILEDB_ROW_MAJOR);
+  query.set_subarray(subarray);
+  query.set_buffer("a", values);
+  query.submit();
+  array.close();
+}
+
+void read_array(
+    const std::string& array_name,
+    const std::vector<int>& subarray,
+    const std::vector<int>& c_values) {
+  Context ctx;
+  Array array(ctx, array_name, TILEDB_READ);
+  Query query(ctx, array, TILEDB_READ);
+  query.set_layout(TILEDB_ROW_MAJOR);
+  query.set_subarray(subarray);
+  std::vector<int> values(10);
+  query.set_buffer("a", values);
+  query.submit();
+  array.close();
+  values.resize(query.result_buffer_elements()["a"].second);
+  CHECK(values.size() == c_values.size());
+  CHECK(values == c_values);
+}
+
+int num_fragments(const std::string& array_name) {
+  Context ctx;
+  VFS vfs(ctx);
+  return vfs.ls(array_name).size() - 3;  // Exclude array lock, __meta, schema
+}
+
+TEST_CASE(
+    "C++ API: Test consolidation with partial tiles",
+    "[cppapi][consolidation]") {
+  std::string array_name = "cppapi_consolidation";
+  remove_array(array_name);
+
+  create_array(array_name);
+  write_array(array_name, {1, 2}, {1, 2});
+  write_array(array_name, {3, 3}, {3});
+  CHECK(num_fragments(array_name) == 2);
+
+  Context ctx;
+  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name));
+  CHECK(num_fragments(array_name) == 1);
+
+  read_array(array_name, {1, 3}, {1, 2, 3});
+
+  remove_array(array_name);
+}

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -33,7 +33,7 @@
 #include "catch.hpp"
 #include "tiledb/sm/cpp_api/tiledb"
 
-TEST_CASE("C++ API: Schema", "[cppapi]") {
+TEST_CASE("C++ API: Schema", "[cppapi][array-schema]") {
   using namespace tiledb;
   Context ctx;
 
@@ -97,7 +97,7 @@ TEST_CASE("C++ API: Schema", "[cppapi]") {
     CHECK(dims[1].name() == "d2");
     CHECK_THROWS(dims[0].domain<uint32_t>());
     CHECK(dims[0].domain<int>().first == -100);
-    CHECK(dims[0].domain<int>().second == 100);
+    CHECK(dims[0].domain<int>().second == 109);
     CHECK_THROWS(dims[0].tile_extent<unsigned>());
     CHECK(dims[0].tile_extent<int>() == 10);
 

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -584,6 +584,12 @@ Status ArraySchema::set_domain(Domain* domain) {
     filter->set_compressor(constants::real_coords_compression);
     filter->set_compression_level(-1);
   }
+
+  // If the array is dense, the dimension domains must be multiple of the
+  // tile extents
+  if (array_type_ == ArrayType::DENSE)
+    domain_->expand_dim_domains_to_tile_extent_multiples();
+
   return Status::Ok();
 }
 

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -91,6 +91,13 @@ class Dimension {
   /** Dumps the dimension contents in ASCII form in the selected output. */
   void dump(FILE* out) const;
 
+  /** Expand the domain to be a multiple of the tile extent. */
+  void expand_domain_to_tile_extent_multiple();
+
+  /** Expand the domain to be a multiple of the tile extent. */
+  template <class T>
+  void expand_domain_to_tile_extent_multiple();
+
   /** Returns the dimension name. */
   const std::string& name() const;
 

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -610,6 +610,11 @@ void Domain::expand_domain(void* domain) const {
   }
 }
 
+void Domain::expand_dim_domains_to_tile_extent_multiples() {
+  for (auto& dim : dimensions_)
+    dim->expand_domain_to_tile_extent_multiple();
+}
+
 template <class T>
 void Domain::get_tile_coords(const T* coords, T* tile_coords) const {
   auto domain = (T*)domain_;

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -308,6 +308,12 @@ class Domain {
   }
 
   /**
+   * Epxands the domain of every dimension to be a multiple of the
+   * corresponding tile extent.
+   */
+  void expand_dim_domains_to_tile_extent_multiples();
+
+  /**
    * Returns the position of the input coordinates inside its corresponding
    * tile, based on the array cell order. Applicable only to **dense** arrays.
    *


### PR DESCRIPTION
Expand dimension domain in dense arrays such that the domain range becomes a multiple of the space tile extent. Fixes a bug in dense array consolidation, when the dimension domain range was not a multiple of the space tile extent.