### PR TITLE
Several internal Metadata class tweaks:

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -656,6 +656,10 @@ Metadata* Array::metadata() {
   return &metadata_;
 }
 
+const Metadata* Array::metadata() const {
+  return &metadata_;
+}
+
 /* ********************************* */
 /*          PRIVATE METHODS          */
 /* ********************************* */

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -303,6 +303,9 @@ class Array {
   /** Returns the array metadata object. */
   Metadata* metadata();
 
+  /** Returns the array metadata object. */
+  const Metadata* metadata() const;
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -184,7 +184,7 @@ Status Metadata::get(
     const char* key,
     Datatype* value_type,
     uint32_t* value_num,
-    const void** value) {
+    const void** value) const {
   assert(key != nullptr);
 
   auto it = metadata_map_.find(key);
@@ -215,7 +215,7 @@ Status Metadata::get(
     uint32_t* key_len,
     Datatype* value_type,
     uint32_t* value_num,
-    const void** value) {
+    const void** value) const {
   if (index >= metadata_index_.size())
     return LOG_STATUS(
         Status::MetadataError("Cannot get metadata; index out of bounds"));
@@ -286,6 +286,14 @@ void Metadata::reset() {
   clear();
   auto t = utils::time::timestamp_now_ms();
   timestamp_range_ = std::make_pair(t, t);
+}
+
+Metadata::iterator Metadata::begin() const {
+  return metadata_map_.cbegin();
+}
+
+Metadata::iterator Metadata::end() const {
+  return metadata_map_.cend();
 }
 
 /* ********************************* */

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -60,6 +60,25 @@ namespace sm {
 class Metadata {
  public:
   /* ********************************* */
+  /*       PUBLIC TYPE DEFINITIONS     */
+  /* ********************************* */
+
+  /** Represents a metadata value. */
+  struct MetadataValue {
+    /** 1 if it is a deletion and 0 if it is an insertion. */
+    char del_ = 0;
+    /** The value datatype. */
+    char type_ = 0;
+    /** The number of values. */
+    uint32_t num_ = 0;
+    /** The value in binary format. */
+    std::vector<uint8_t> value_;
+  };
+
+  /** Iterator type for iterating over metadata values. */
+  typedef std::map<std::string, MetadataValue>::const_iterator iterator;
+
+  /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
@@ -129,7 +148,7 @@ class Metadata {
       const char* key,
       Datatype* value_type,
       uint32_t* value_num,
-      const void** value);
+      const void** value) const;
 
   /**
    * Gets a metadata item as a key-value pair using an index.
@@ -150,7 +169,7 @@ class Metadata {
       uint32_t* key_len,
       Datatype* value_type,
       uint32_t* value_num,
-      const void** value);
+      const void** value) const;
 
   /** Returns the number of metadata items. */
   uint64_t num() const;
@@ -188,22 +207,13 @@ class Metadata {
    */
   void reset();
 
+  /** Returns an iterator to the beginning of the metadata. */
+  iterator begin() const;
+
+  /** Returns an iterator to the end of the metadata. */
+  iterator end() const;
+
  private:
-  /* ********************************* */
-  /*      PRIVATE TYPE DEFINITIONS     */
-  /* ********************************* */
-
-  struct MetadataValue {
-    /** 1 if it is a deletion and 0 if it is an insertion. */
-    char del_ = 0;
-    /** The value datatype. */
-    char type_ = 0;
-    /** The number of values. */
-    uint32_t num_ = 0;
-    /** The value in binary format. */
-    std::vector<uint8_t> value_;
-  };
-
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */


### PR DESCRIPTION
- Mark Metadata::get() functions as const.
- Add const override
- Expose MetadataValue and add iterator methods.

These are mainly to support the upcoming serialization of array metadata (which is why this is marked as a backport).