### PR TITLE
Cache REST array schema

### DIFF
--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -153,6 +153,15 @@ class RestClient {
   /** Collection of extra headers that are attached to REST requests. */
   std::unordered_map<std::string, std::string> extra_headers_;
 
+  // A cached array schema request return payload.
+  Buffer serialized_array_schema_;
+
+  // A write-lock on serialized_array_schema_.
+  std::mutex serialized_array_schema_lock_;
+
+  // True if 'serialized_array_schema_' should be invalidated.
+  bool invalidate_serialized_array_schema_;
+
   /* ********************************* */
   /*         PRIVATE METHODS           */
   /* ********************************* */


### PR DESCRIPTION
This saves about 500-1000ms on a REST query when using
the Python API. I've measured REST requests as quick as 2.2s
from my laptop with this patch.

The following line in my benchmark generates 3x requests to
get the array schema:
`with tiledb.open("tiledb://stavros/dense_X", ctx=tiledb.cloud.Ctx()) as A:`

This patch just caches the return value and re-uses it between the calls.
This is technical debt because the real fix will be to trace where the
3x calls are coming from and reduce it to 1. Some quick tracing revealed
1x of the calls are generated from `Array::open` and the other 2x are
called outside of the core at `tiledb_array_schema_load_with_key`.