### PR TITLE
Fix CURL cert file path override for REST

### DIFF
--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -212,9 +212,9 @@ Status Curl::init(
   // if detected
   const std::string cert_file =
       global_state::GlobalState::GetGlobalState().cert_file();
-  // If we have detected a ca cert bundle let's set the curl option for CAPATH
+  // If we have detected a ca cert bundle let's set the curl option for CAINFO
   if (!cert_file.empty()) {
-    curl_easy_setopt(curl_.get(), CURLOPT_CAPATH, cert_file.c_str());
+    curl_easy_setopt(curl_.get(), CURLOPT_CAINFO, cert_file.c_str());
   }
 #endif
 


### PR DESCRIPTION
GlobalState::cert_file is a single-file cert store, which corresponds
to CURLOPT_CAINFO. CURLOPT_CAPATH expects a directory.