### PR TITLE
Towards splitting coordinates in separate buffers and files

### DIFF
--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -4160,7 +4160,7 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     DenseArrayFx,
     "C API: Test dense array, check if coords exist in unordered writes",
-    "[capi], [dense], [dense-coords-exist-unordered]") {
+    "[capi][dense][coords-exist-unordered]") {
   SECTION("- No serialization") {
     serialize_query_ = false;
   }

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -388,7 +388,7 @@ TEST_CASE(
     vfs.remove_dir(array_name_1d);
 }
 
-TEST_CASE("C++ API: Read subarray with expanded domain", "[cppapi], [dense]") {
+TEST_CASE("C++ API: Read subarray with expanded domain", "[cppapi][dense]") {
   const std::vector<tiledb_layout_t> tile_layouts = {TILEDB_ROW_MAJOR,
                                                      TILEDB_COL_MAJOR},
                                      cell_layouts = {TILEDB_ROW_MAJOR,
@@ -455,8 +455,7 @@ TEST_CASE("C++ API: Read subarray with expanded domain", "[cppapi], [dense]") {
   }
 }
 
-TEST_CASE(
-    "C++ API: Consolidation of empty arrays", "[cppapi], [consolidation]") {
+TEST_CASE("C++ API: Consolidation of empty arrays", "[cppapi][consolidation]") {
   Context ctx;
   VFS vfs(ctx);
   const std::string array_name = "cpp_unit_array";
@@ -530,7 +529,7 @@ TEST_CASE(
     vfs.remove_dir(array_name);
 }
 
-TEST_CASE("C++ API: Encrypted array", "[cppapi], [encryption]") {
+TEST_CASE("C++ API: Encrypted array", "[cppapi][encryption]") {
   Context ctx;
   VFS vfs(ctx);
   const std::string array_name = "cpp_unit_array";
@@ -625,9 +624,7 @@ TEST_CASE("C++ API: Encrypted array", "[cppapi], [encryption]") {
     vfs.remove_dir(array_name);
 }
 
-TEST_CASE(
-    "C++ API: Encrypted array, std::string key",
-    "[cppapi][encryption][cppapi-encryption]") {
+TEST_CASE("C++ API: Encrypted array, std::string key", "[cppapi][encryption]") {
   Context ctx;
   VFS vfs(ctx);
   const std::string array_name = "cpp_unit_array";
@@ -711,7 +708,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API: Open array with anonymous attribute",
-    "[cppapi], [cppapi-open-array-anon-attr]") {
+    "[cppapi][open-array-anon-attr]") {
   Context ctx;
   VFS vfs(ctx);
   const std::string array_name = "cppapi_open_array_anon_attr";
@@ -736,7 +733,7 @@ TEST_CASE(
     vfs.remove_dir(array_name);
 }
 
-TEST_CASE("C++ API: Open array at", "[cppapi], [cppapi-open-array-at]") {
+TEST_CASE("C++ API: Open array at", "[cppapi][open-array-at]") {
   Context ctx;
   VFS vfs(ctx);
   const std::string array_name = "cppapi_open_array_at";
@@ -840,8 +837,7 @@ TEST_CASE("C++ API: Open array at", "[cppapi], [cppapi-open-array-at]") {
 }
 
 TEST_CASE(
-    "C++ API: Open encrypted array at",
-    "[cppapi], [cppapi-open-encrypted-array-at]") {
+    "C++ API: Open encrypted array at", "[cppapi][open-encrypted-array-at]") {
   const char key[] = "0123456789abcdeF0123456789abcdeF";
   uint32_t key_len = (uint32_t)strlen(key);
 
@@ -943,7 +939,8 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "C++ API: Writing single cell with global order", "[cppapi], [sparse]") {
+    "C++ API: Writing single cell with global order",
+    "[cppapi][sparse][global]") {
   const std::string array_name = "cpp_unit_array";
   Context ctx;
   VFS vfs(ctx);

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -76,6 +76,12 @@ class Dimension {
   /*                API                */
   /* ********************************* */
 
+  /** Returns the size (in bytes) of a coordinate in this dimension. */
+  uint64_t coord_size() const;
+
+  /** Returns the input coordinate in string format. */
+  std::string coord_to_str(const void* coord) const;
+
   /**
    * Populates the object members from the data in the input binary buffer.
    *
@@ -96,6 +102,33 @@ class Dimension {
 
   /** Returns true if this is an anonymous (unlabled) dimension **/
   bool is_anonymous() const;
+
+  /**
+   * Returns true if the input coordinate is out-of-bounds with respect
+   * to the dimension domain.
+   *
+   * @param coord The coordinate to be checked. It will properly be
+   *     type-cast to the dimension datatype.
+   * @param err_msg An error message to be retrieved in case the function
+   *     returns true.
+   * @return True if the input coordinates is out-of-bounds.
+   */
+  bool oob(const void* coord, std::string* err_msg) const;
+
+  /**
+   * Returns true if the input coordinate is out-of-bounds with respect
+   * to the dimension domain.
+   *
+   * @param dim The dimension to apply the oob check on.
+   * @param coord The coordinate to be checked. It will properly be
+   *     type-cast to the dimension datatype.
+   * @param err_msg An error message to be retrieved in case the function
+   *     returns true.
+   * @return True if the input coordinates is out-of-bounds.
+   */
+  template <class T>
+  static bool oob(
+      const Dimension* dim, const void* coord, std::string* err_msg);
 
   /**
    * Serializes the object members into a binary buffer.
@@ -148,6 +181,13 @@ class Dimension {
 
   /** The dimension type. */
   Datatype type_;
+
+  /**
+   * Stores the appropriate templated oob() function based on the
+   * dimension datatype.
+   */
+  std::function<bool(const Dimension* dim, const void*, std::string*)>
+      oob_func_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */
@@ -229,6 +269,9 @@ class Dimension {
    */
   template <class T>
   Status check_tile_extent() const;
+
+  /** Sets the templated oob function. */
+  void set_oob_func();
 };
 
 }  // namespace sm

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -225,6 +225,47 @@ class Domain {
   int cell_order_cmp(const T* coords_a, const T* coords_b) const;
 
   /**
+   * Checks the cell order of the input coordinates on the given dimension.
+   *
+   * @param The dimension to compare on.
+   * @param coord_buffs The input coordinates, given in separate buffers,
+   *     one per dimension. The buffers are sorted in the same order of the
+   *     dimensions as defined in the array schema.
+   * @param a The position of the first coordinate tuple across all buffers.
+   * @param b The position of the second coordinate tuple across all buffers.
+   * @param d The dimension index to compare on.
+   * @return One of the following:
+   *    - -1 if the first coordinates precede the second on the cell order
+   *    -  0 if the two coordinates have the same cell order
+   *    - +1 if the first coordinates succeed the second on the cell order
+   */
+  template <class T>
+  static int cell_order_cmp(
+      const Dimension* dim,
+      const std::vector<const void*>& coord_buffs,
+      uint64_t a,
+      uint64_t b,
+      unsigned d);
+
+  /**
+   * Checks the cell order of the input coordinates.
+   *
+   * @param coord_buffs The input coordinates, given n separate buffers,
+   *     one per dimension. The buffers are sorted in the same order of the
+   *     dimensions as defined in the array schema.
+   * @param a The position of the first coordinate tuple across all buffers.
+   * @param b The position of the second coordinate tuple across all buffers.
+   * @return One of the following:
+   *    - -1 if the first coordinates precede the second on the cell order
+   *    -  0 if the two coordinates have the same cell order
+   *    - +1 if the first coordinates succeed the second on the cell order
+   */
+  int cell_order_cmp(
+      const std::vector<const void*>& coord_buffs,
+      uint64_t a,
+      uint64_t b) const;
+
+  /**
    * Populates the object members from the data in the input binary buffer.
    *
    * @param buff The buffer to deserialize from.
@@ -608,6 +649,47 @@ class Domain {
   int tile_order_cmp(const T* coords_a, const T* coords_b) const;
 
   /**
+   * Checks the tile order of the input coordinates on the given dimension.
+   *
+   * @param The dimension to compare on.
+   * @param coord_buffs The input coordinates, given in separate buffers,
+   *     one per dimension. The buffers are sorted in the same order of the
+   *     dimensions as defined in the array schema.
+   * @param a The position of the first coordinate tuple across all buffers.
+   * @param b The position of the second coordinate tuple across all buffers.
+   * @param d The dimension index to compare on.
+   * @return One of the following:
+   *    - -1 if the first coordinates precede the second on the tile order
+   *    -  0 if the two coordinates have the same tile order
+   *    - +1 if the first coordinates succeed the second on the tile order
+   */
+  template <class T>
+  static int tile_order_cmp(
+      const Dimension* dim,
+      const std::vector<const void*>& coord_buffs,
+      uint64_t a,
+      uint64_t b,
+      unsigned d);
+
+  /**
+   * Checks the tile order of the input coordinates.
+   *
+   * @param coord_buffs The input coordinates, given n separate buffers,
+   *     one per dimension. The buffers are sorted in the same order of the
+   *     dimensions as defined in the array schema.
+   * @param a The position of the first coordinate tuple across all buffers.
+   * @param b The position of the second coordinate tuple across all buffers.
+   * @return One of the following:
+   *    - -1 if the first coordinates precede the second on the tile order
+   *    -  0 if the two coordinates have the same tile order
+   *    - +1 if the first coordinates succeed the second on the tile order
+   */
+  int tile_order_cmp(
+      const std::vector<const void*>& coord_buffs,
+      uint64_t a,
+      uint64_t b) const;
+
+  /**
    * Checks the tile order of the input tile coordinates.
    *
    * @tparam T The coordinates type.
@@ -733,6 +815,40 @@ class Domain {
   /** The tile order of the array the domain belongs to. */
   Layout tile_order_;
 
+  /**
+   * Vector of functions, one per dimension, for comparing the cell order of
+   * two coordinates. The inputs to the function are:
+   *
+   * - dim: The dimension to compare on.
+   * - coord_buffs: The coordinates, split in one buffer per dimensions.
+   * - a,b: The two positions of the coordinates to compare.
+   * - d: The dimension index to compare on.
+   */
+  std::vector<int (*)(
+      const Dimension* dim,
+      const std::vector<const void*>& coord_buffs,
+      uint64_t a,
+      uint64_t b,
+      unsigned d)>
+      cell_order_cmp_func_;
+
+  /**
+   * Vector of functions, one per dimension, for comparing the tile order of
+   * two coordinates. The inputs to the function are:
+   *
+   * - dim: The dimension to compare on.
+   * - coord_buffs: The coordinates, split in one buffer per dimensions.
+   * - a,b: The two positions of the coordinates to compare.
+   * - d: The dimension index to compare on.
+   */
+  std::vector<int (*)(
+      const Dimension* dim,
+      const std::vector<const void*>& coord_buffs,
+      uint64_t a,
+      uint64_t b,
+      unsigned d)>
+      tile_order_cmp_func_;
+
   /** The type of dimensions. */
   Datatype type_;
 
@@ -751,6 +867,9 @@ class Domain {
    */
   template <class T>
   void compute_cell_num_per_tile();
+
+  /** Prepares the comparator functions for each dimension. */
+  void set_tile_cell_order_cmp_funcs();
 
   /** Computes the tile domain. */
   void compute_tile_domain();

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -355,10 +355,6 @@ Status FilterPipeline::run_forward(Tile* tile) const {
 
   current_tile_ = tile;
 
-  // Split the coords if the tile stores coordinates.
-  if (tile->stores_coords())
-    tile->split_coordinates();
-
   // Compute the chunks.
   std::vector<std::pair<void*, uint32_t>> chunks;
   RETURN_NOT_OK(compute_tile_chunks(tile, &chunks));

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -839,6 +839,8 @@ void FragmentMetadata::get_subarray_tile_domain(
 
 template <class T>
 Status FragmentMetadata::expand_non_empty_domain(const T* mbr) {
+  std::lock_guard<std::mutex> lock(mtx_);
+
   if (non_empty_domain_ == nullptr) {
     auto domain_size = 2 * array_schema_->coords_size();
     non_empty_domain_ = std::malloc(domain_size);

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -676,6 +676,20 @@ void expand_mbr(T* mbr, const T* coords, unsigned int dim_num) {
 }
 
 template <class T>
+void expand_mbr(const std::vector<T*>& coords, const uint64_t pos, T* mbr) {
+  auto dim_num = (unsigned)coords.size();
+  for (unsigned int d = 0; d < dim_num; ++d) {
+    // Update lower bound on dimension i
+    if (mbr[2 * d] > coords[d][pos])
+      mbr[2 * d] = coords[d][pos];
+
+    // Update upper bound on dimension i
+    if (mbr[2 * d + 1] < coords[d][pos])
+      mbr[2 * d + 1] = coords[d][pos];
+  }
+}
+
+template <class T>
 void expand_mbr_with_mbr(T* mbr_a, const T* mbr_b, unsigned int dim_num) {
   for (unsigned int i = 0; i < dim_num; ++i) {
     // Update lower bound on dimension i
@@ -928,6 +942,27 @@ template void expand_mbr<uint32_t>(
     uint32_t* mbr, const uint32_t* coords, unsigned int dim_num);
 template void expand_mbr<uint64_t>(
     uint64_t* mbr, const uint64_t* coords, unsigned int dim_num);
+
+template void expand_mbr(
+    const std::vector<int8_t*>& coords, const uint64_t pos, int8_t* mbr);
+template void expand_mbr(
+    const std::vector<uint8_t*>& coords, const uint64_t pos, uint8_t* mbr);
+template void expand_mbr(
+    const std::vector<int16_t*>& coords, const uint64_t pos, int16_t* mbr);
+template void expand_mbr(
+    const std::vector<uint16_t*>& coords, const uint64_t pos, uint16_t* mbr);
+template void expand_mbr(
+    const std::vector<int32_t*>& coords, const uint64_t pos, int32_t* mbr);
+template void expand_mbr(
+    const std::vector<uint32_t*>& coords, const uint64_t pos, uint32_t* mbr);
+template void expand_mbr(
+    const std::vector<int64_t*>& coords, const uint64_t pos, int64_t* mbr);
+template void expand_mbr(
+    const std::vector<uint64_t*>& coords, const uint64_t pos, uint64_t* mbr);
+template void expand_mbr(
+    const std::vector<float*>& coords, const uint64_t pos, float* mbr);
+template void expand_mbr(
+    const std::vector<double*>& coords, const uint64_t pos, double* mbr);
 
 template void expand_mbr_with_mbr<int>(
     int* mbr_a, const int* mbr_b, unsigned int dim_num);

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -279,6 +279,22 @@ template <class T>
 void expand_mbr(T* mbr, const T* coords, unsigned int dim_num);
 
 /**
+ * Expands the input MBR with the input coordinates. The input coordinates
+ * are given as a vector of values, one per dimension, and a position in
+ * the vectors along the dimensions. The input MBR will be expanded using
+ * the values along the dimensions located at the input position.
+ *
+ * @tparam T The type of the MBR and coordinates.
+ * @param coords A vector of coordinate buffers, one per dimension.
+ * @param pos The position of the values in the coordinate buffers that
+ *     will be used to expand the MBR with.
+ * @param mbr The input MBR to be expanded.
+ * @return void
+ */
+template <class T>
+void expand_mbr(const std::vector<T*>& coords, const uint64_t pos, T* mbr);
+
+/**
  * Expands `mbr_a` so that it encompasses `mbr_b`.
  *
  * @tparam T The type of the MBR and coordinates.

--- a/tiledb/sm/query/types.h
+++ b/tiledb/sm/query/types.h
@@ -97,6 +97,71 @@ struct AttributeBuffer {
         (buffer_var_size_ != nullptr) ? *buffer_var_size : 0;
   }
 };
+
+/**
+ * Contains the buffer(s) and buffer size(s) for the coordinates of
+ * a dimension.
+ */
+struct CoordBuffer {
+  /**
+   * The coordinate buffer. In case the dimension is var-sized, this is
+   * the offsets buffer.
+   */
+  void* buffer_;
+  /**
+   * For a var-sized dimension, this is the data buffer. It is `nullptr`
+   * for fixed-sized dimensions.
+   */
+  void* buffer_var_;
+  /**
+   * The size (in bytes) of `buffer_`. Note that this size may be altered by
+   * a read query to reflect the useful data written in the buffer.
+   */
+  uint64_t* buffer_size_;
+  /**
+   * The size (in bytes) of `buffer_var_`. Note that this size may be altered
+   * by a read query to reflect the useful data written in the buffer.
+   */
+  uint64_t* buffer_var_size_;
+  /**
+   * This is the original size (in bytes) of `buffer_` (before
+   * potentially altered by the query).
+   */
+  uint64_t original_buffer_size_;
+  /**
+   * This is the original size (in bytes) of `buffer_var_` (before
+   * potentially altered by the query).
+   */
+  uint64_t original_buffer_var_size_;
+
+  /** Constructor. */
+  CoordBuffer() {
+    buffer_ = nullptr;
+    buffer_var_ = nullptr;
+    buffer_size_ = nullptr;
+    buffer_var_size_ = nullptr;
+    original_buffer_size_ = 0;
+    original_buffer_var_size_ = 0;
+  }
+
+  /** Constructor. */
+  CoordBuffer(
+      void* buffer,
+      void* buffer_var,
+      uint64_t* buffer_size,
+      uint64_t* buffer_var_size)
+      : buffer_(buffer)
+      , buffer_var_(buffer_var)
+      , buffer_size_(buffer_size)
+      , buffer_var_size_(buffer_var_size) {
+    original_buffer_size_ = *buffer_size;
+    original_buffer_var_size_ =
+        (buffer_var_size_ != nullptr) ? *buffer_var_size : 0;
+  }
+};
+
 }  // namespace sm
+
 }  // namespace tiledb
+
 #endif  // TILEDB_TYPES_H

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -287,6 +287,7 @@ void Tile::set_size(uint64_t size) {
 uint64_t Tile::size() const {
   return (buffer_ == nullptr) ? 0 : buffer_->size();
 }
+
 void Tile::split_coordinates() {
   assert(dim_num_ > 0);
 


### PR DESCRIPTION
Towards addressing #93. Split writer algorithms such that the dimension coordinates are split in different buffers and handled separately.