### PR TITLE
WIP: Hide Tile::data() and Tile::cur_data()

### DIFF
--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -406,6 +406,13 @@ TEST_CASE_METHOD(
       tile_coords,
       &result_space_tiles);
 
+  struct no_op_deleter {
+    void operator()(void* const rhs) {
+      if (rhs) {
+      }
+    }
+  };
+
   // Create result coordinates
   std::vector<ResultCoords<uint64_t>> result_coords;
   ResultTile result_tile_2_0(2, 0);
@@ -417,13 +424,31 @@ TEST_CASE_METHOD(
   uint64_t coords_3_9 = 9;
   uint64_t coords_3_12 = 12;
   uint64_t coords_3_19 = 19;
-  result_coords.emplace_back(&result_tile_2_0, &coords_2_3, 1);
-  result_coords.emplace_back(&result_tile_2_0, &coords_2_5, 3);
-  result_coords.emplace_back(&result_tile_3_0, &coords_3_8, 2);
-  result_coords.emplace_back(&result_tile_3_0, &coords_3_9, 3);
+  result_coords.emplace_back(
+      &result_tile_2_0,
+      std::shared_ptr<uint64_t>(&coords_2_3, no_op_deleter()),
+      1);
+  result_coords.emplace_back(
+      &result_tile_2_0,
+      std::shared_ptr<uint64_t>(&coords_2_5, no_op_deleter()),
+      3);
+  result_coords.emplace_back(
+      &result_tile_3_0,
+      std::shared_ptr<uint64_t>(&coords_3_8, no_op_deleter()),
+      2);
+  result_coords.emplace_back(
+      &result_tile_3_0,
+      std::shared_ptr<uint64_t>(&coords_3_9, no_op_deleter()),
+      3);
   result_coords.back().invalidate();
-  result_coords.emplace_back(&result_tile_3_1, &coords_3_12, 1);
-  result_coords.emplace_back(&result_tile_3_1, &coords_3_19, 2);
+  result_coords.emplace_back(
+      &result_tile_3_1,
+      std::shared_ptr<uint64_t>(&coords_3_12, no_op_deleter()),
+      1);
+  result_coords.emplace_back(
+      &result_tile_3_1,
+      std::shared_ptr<uint64_t>(&coords_3_19, no_op_deleter()),
+      2);
 
   // Check iterator
   ReadCellSlabIter<uint64_t> iter(
@@ -1185,6 +1210,13 @@ TEST_CASE_METHOD(
       tile_coords,
       &result_space_tiles);
 
+  struct no_op_deleter {
+    void operator()(void* const rhs) {
+      if (rhs) {
+      }
+    }
+  };
+
   // Create result coordinates
   std::vector<ResultCoords<uint64_t>> result_coords;
   ResultTile result_tile_3_0(3, 0);
@@ -1192,9 +1224,18 @@ TEST_CASE_METHOD(
   uint64_t coords_3_3_3[] = {3, 3};
   uint64_t coords_3_5_5[] = {5, 5};
   uint64_t coords_3_5_6[] = {5, 6};
-  result_coords.emplace_back(&result_tile_3_0, coords_3_3_3, 1);
-  result_coords.emplace_back(&result_tile_3_1, coords_3_5_5, 0);
-  result_coords.emplace_back(&result_tile_3_1, coords_3_5_6, 2);
+  result_coords.emplace_back(
+      &result_tile_3_0,
+      std::shared_ptr<uint64_t>(coords_3_3_3, no_op_deleter()),
+      1);
+  result_coords.emplace_back(
+      &result_tile_3_1,
+      std::shared_ptr<uint64_t>(coords_3_5_5, no_op_deleter()),
+      0);
+  result_coords.emplace_back(
+      &result_tile_3_1,
+      std::shared_ptr<uint64_t>(coords_3_5_6, no_op_deleter()),
+      2);
 
   // Check iterator
   ReadCellSlabIter<uint64_t> iter(

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -516,11 +516,6 @@ TEST_CASE("Filter: Test simple in-place pipeline", "[filter]") {
 
   Tile tile(Datatype::UINT64, sizeof(uint64_t), 0, &buff, false);
 
-  // Save the original allocation so that we can check that after running
-  // through the pipeline, the tile buffer points to a different memory
-  // region.
-  auto original_alloc = tile.data();
-
   FilterPipeline pipeline;
   CHECK(pipeline.add_filter(Add1InPlace()).ok());
 
@@ -529,7 +524,6 @@ TEST_CASE("Filter: Test simple in-place pipeline", "[filter]") {
 
     // Check new size and number of chunks
     CHECK(tile.buffer() == &buff);
-    CHECK(tile.data() != original_alloc);
     CHECK(
         buff.size() ==
         nelts * sizeof(uint64_t) + sizeof(uint64_t) + 3 * sizeof(uint32_t));

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -256,7 +256,8 @@ class FilterPipeline {
    * @return Status
    */
   Status compute_tile_chunks(
-      Tile* tile, std::vector<std::pair<void*, uint32_t>>* chunks) const;
+      Tile* tile,
+      std::vector<std::pair<std::shared_ptr<void>, uint32_t>>* chunks) const;
 
   /**
    * Run the given list of chunks forward through the pipeline.
@@ -266,7 +267,7 @@ class FilterPipeline {
    * @return Status
    */
   Status filter_chunks_forward(
-      const std::vector<std::pair<void*, uint32_t>>& chunks,
+      const std::vector<std::pair<std::shared_ptr<void>, uint32_t>>& chunks,
       Buffer* output) const;
 
   /**

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -67,11 +67,11 @@ class RowCmp {
    */
   bool operator()(const ResultCoords<T>& a, const ResultCoords<T>& b) const {
     for (unsigned int i = 0; i < dim_num_; ++i) {
-      if (a.coords_[i] < b.coords_[i])
+      if (a.coords_.get()[i] < b.coords_.get()[i])
         return true;
-      if (a.coords_[i] > b.coords_[i])
+      if (a.coords_.get()[i] > b.coords_.get()[i])
         return false;
-      // else a.coords_[i] == b.coords_[i] --> continue
+      // else a.coords_.get()[i] == b.coords_.get()[i] --> continue
     }
 
     return false;
@@ -104,11 +104,11 @@ class ColCmp {
    */
   bool operator()(const ResultCoords<T>& a, const ResultCoords<T>& b) const {
     for (unsigned int i = dim_num_ - 1;; --i) {
-      if (a.coords_[i] < b.coords_[i])
+      if (a.coords_.get()[i] < b.coords_.get()[i])
         return true;
-      if (a.coords_[i] > b.coords_[i])
+      if (a.coords_.get()[i] > b.coords_.get()[i])
         return false;
-      // else a.coords_[i] == b.coords_[i] --> continue
+      // else a.coords_.get()[i] == b.coords_.get()[i] --> continue
 
       if (i == 0)
         break;
@@ -161,7 +161,7 @@ class GlobalCmp {
     // else tile_cmp == 0 --> continue
 
     // Compare cell order
-    auto cell_cmp = domain_->cell_order_cmp(a.coords_, b.coords_);
+    auto cell_cmp = domain_->cell_order_cmp(a.coords_.get(), b.coords_.get());
     return cell_cmp == -1;
   }
 

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -438,6 +438,20 @@ inline T decode_be(const void* const data) {
 
 }  // namespace endianness
 
+/* ********************************* */
+/*          MISC FUNCTIONS           */
+/* ********************************* */
+
+namespace misc {
+
+struct c_deleter {
+  void operator()(void* const rhs) {
+    free(rhs);
+  }
+};
+
+}  // namespace misc
+
 }  // namespace utils
 
 }  // namespace sm

--- a/tiledb/sm/query/read_cell_slab_iter.cc
+++ b/tiledb/sm/query/read_cell_slab_iter.cc
@@ -239,13 +239,14 @@ void ReadCellSlabIter<T>::compute_result_cell_slabs(
     for (unsigned d = 0; d < dim_num; ++d) {
       if (d != slab_dim) {
         // No overlap
-        if ((*result_coords_)[i].coords_[d] != cell_slab_copy.coords_[d]) {
+        if ((*result_coords_)[i].coords_.get()[d] !=
+            cell_slab_copy.coords_[d]) {
           must_break = true;
           break;
         }
       } else if (
-          (*result_coords_)[i].coords_[d] < slab_start ||
-          (*result_coords_)[i].coords_[d] > slab_end) {
+          (*result_coords_)[i].coords_.get()[d] < slab_start ||
+          (*result_coords_)[i].coords_.get()[d] > slab_end) {
         must_break = true;
         break;
       }
@@ -255,8 +256,8 @@ void ReadCellSlabIter<T>::compute_result_cell_slabs(
       break;
 
     // Add left slab
-    if ((*result_coords_)[i].coords_[slab_dim] > slab_start) {
-      cell_slab_copy.length_ = (*result_coords_)[i].coords_[slab_dim] -
+    if ((*result_coords_)[i].coords_.get()[slab_dim] > slab_start) {
+      cell_slab_copy.length_ = (*result_coords_)[i].coords_.get()[slab_dim] -
                                cell_slab_copy.coords_[slab_dim];
       compute_result_cell_slabs_dense(cell_slab_copy, &result_space_tile);
     }
@@ -267,7 +268,7 @@ void ReadCellSlabIter<T>::compute_result_cell_slabs(
 
     // Update cell slab copy
     cell_slab_copy.coords_[slab_dim] =
-        (*result_coords_)[i].coords_[slab_dim] + 1;
+        (*result_coords_)[i].coords_.get()[slab_dim] + 1;
     cell_slab_copy.length_ = slab_end - cell_slab_copy.coords_[slab_dim] + 1;
     slab_start = cell_slab_copy.coords_[slab_dim];
     slab_end = (T)(slab_start + cell_slab_copy.length_ - 1);

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -58,7 +58,7 @@ struct ResultCoords {
    */
   ResultTile* tile_;
   /** The coordinates. */
-  const T* coords_;
+  std::shared_ptr<T> coords_;
   /** The coordinates of the tile in the global logical space. */
   const T* tile_coords_;
   /** The position of the coordinates in the tile. */
@@ -67,9 +67,9 @@ struct ResultCoords {
   bool valid_;
 
   /** Constructor. */
-  ResultCoords(ResultTile* tile, const T* coords, uint64_t pos)
+  ResultCoords(ResultTile* tile, std::shared_ptr<T> coords, uint64_t pos)
       : tile_(tile)
-      , coords_(coords)
+      , coords_(std::move(coords))
       , tile_coords_(nullptr)
       , pos_(pos)
       , valid_(true) {
@@ -96,7 +96,7 @@ struct ResultCoords {
     std::cout << "pos: " << pos_ << "\n";
     std::cout << "valid: " << valid_ << "\n";
     if (coords_ != nullptr)
-      std::cout << "first coord: " << coords_[0] << "\n";
+      std::cout << "first coord: " << coords_.get()[0] << "\n";
     if (tile_coords_ != nullptr)
       std::cout << "first tile coord: " << tile_coords_[0] << "\n";
   }

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -900,9 +900,16 @@ Status Writer::compute_coords_metadata(
 
   // Compute MBRs
   for (uint64_t tile_id = 0; tile_id < tiles.size(); tile_id++) {
-    const auto& tile = tiles[tile_id];
+    const Tile& tile = tiles[tile_id];
+
     // Initialize MBR with the first coords
-    auto data = (T*)tile.data();
+    const uint64_t size = sizeof(T) * dim_num;
+    const uint64_t offset = 0;
+    std::shared_ptr<uint64_t> tile_buffer(
+        (uint64_t*)malloc(size), utils::misc::c_deleter());
+    RETURN_NOT_OK(tile.read(tile_buffer.get(), size, offset));
+
+    auto data = (T*)tile_buffer.get();
     auto cell_num = tile.size() / coords_size;
     assert(cell_num > 0);
     for (unsigned i = 0; i < dim_num; ++i) {

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -204,6 +204,7 @@ uint64_t Tile::cell_size() const {
   return cell_size_;
 }
 
+#if 0
 void* Tile::cur_data() const {
   return buffer_->cur_data();
 }
@@ -211,6 +212,7 @@ void* Tile::cur_data() const {
 void* Tile::data() const {
   return buffer_->data();
 }
+#endif
 
 unsigned int Tile::dim_num() const {
   return dim_num_;
@@ -252,6 +254,16 @@ Status Tile::realloc(uint64_t nbytes) {
 Status Tile::read(void* buffer, uint64_t nbytes) {
   RETURN_NOT_OK(buffer_->read(buffer, nbytes));
 
+  return Status::Ok();
+}
+
+Status Tile::read(
+    void* const buffer, const uint64_t nbytes, const uint64_t offset) const {
+  if (nbytes + offset > buffer_->size()) {
+    return LOG_STATUS(
+        Status::BufferError("Read failed; Trying to read beyond buffer size"));
+  }
+  std::memcpy(buffer, (char*)buffer_->data() + offset, nbytes);
   return Status::Ok();
 }
 

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -168,12 +168,6 @@ class Tile {
    */
   Tile clone(bool deep_copy) const;
 
-  /** Returns the buffer data pointer at the current offset. */
-  void* cur_data() const;
-
-  /** Returns the tile data. */
-  void* data() const;
-
   /**
    * Sets `owns_buff_` to `false` and thus will not destroy the buffer
    * in the destructor.
@@ -220,6 +214,13 @@ class Tile {
 
   /** Reads from the tile into the input buffer *nbytes*. */
   Status read(void* buffer, uint64_t nbytes);
+
+  /**
+   * Reads from the tile at the given offset into the input
+   * buffer of size nbytes. Does not mutate the internal offset.
+   * Thread-safe among readers.
+   */
+  Status read(void* buffer, uint64_t nbytes, uint64_t offset) const;
 
   /** Resets the size and offset of the tile. */
   void reset();


### PR DESCRIPTION
This removes the Tile::data() and Tile::cur_data()
interfaces. Where possible, we now use Tile::read() --
which is not thread-safe. Within multi-reader scenarios,
e.g. the callback routines within `parallel_for` that
currently invoke Tile::data(), we must use a thread-safe
variant of Tile::read() which is now defined as:
Tile::read(void* buffer, uint64_t nbytes, uint64_t offset)

This is a WIP because there are failures in the unit test.
I'd prefer to have the general approach reviewed before I
started debugging the unit test failures.

Also not that the ResultCoords object currently takes a raw
pointer to an address of a Tile's internal buffer. Since this
is no longer exposed, we're now making a copy for
ResultCoords::coords_. To minimize code churn, I've converted
this raw pointer into a shared_ptr<T>, which may contain
multiple T objects. This is a little bit of an anti-pattern
because we should be using some type of container, e.g.
shared_ptr<vector<T>>. We may not need the shared pointer at all,
but I didn't want to risk regression.