### PR TITLE
Reduce external usage of Tile::buffer_.data()

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,7 +61,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-capi-filter.cc
   src/unit-capi-incomplete.cc
   src/unit-capi-incomplete-2.cc
-        src/unit-capi-metadata.cc
+  src/unit-capi-metadata.cc
   src/unit-capi-object_mgmt.cc
   src/unit-capi-query.cc
   src/unit-capi-query_2.cc
@@ -85,7 +85,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-hdfs-filesystem.cc
   src/unit-lru_cache.cc
   src/unit-Reader.cc
-        src/unit-ReadCellSlabIter.cc
+  src/unit-ReadCellSlabIter.cc
   src/unit-rtree.cc
   src/unit-s3.cc
   src/unit-s3-no-multipart.cc
@@ -97,6 +97,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-SubarrayPartitioner-sparse.cc
   src/unit-tbb.cc
   src/unit-threadpool.cc
+  src/unit-Tile.cc
   src/unit-TileDomain.cc
   src/unit-uri.cc
   src/unit-uuid.cc

--- a/test/src/unit-Tile.cc
+++ b/test/src/unit-Tile.cc
@@ -1,0 +1,86 @@
+/**
+ * @file unit-Tile.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `Tile` class.
+ */
+
+#include "tiledb/sm/tile/tile.h"
+
+#include <catch.hpp>
+#include <iostream>
+
+using namespace tiledb::sm;
+
+TEST_CASE("Tile: Test basic read", "[Tile][basic_read]") {
+  // Initialize the test Tile.
+  Tile tile;
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t cell_size = 0;
+  const unsigned int dim_num = 0;
+  CHECK(tile.init(format_version, data_type, cell_size, dim_num).ok());
+
+  // Create a buffer to write to the test Tile.
+  const uint32_t buffer_len = 128;
+  uint32_t buffer[buffer_len];
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer[i] = i;
+  }
+
+  // Write the buffer to the test Tile.
+  const uint64_t buffer_size = buffer_len * sizeof(uint32_t);
+  CHECK(tile.write(buffer, buffer_size).ok());
+
+  // Test a partial read at offset 8, which should be a uint32_t with
+  // a value of two.
+  uint32_t two = 0;
+  CHECK(tile.read(&two, sizeof(uint32_t), 8).ok());
+  CHECK(two == 2);
+
+  // Test a full read.
+  uint32_t read_buffer[buffer_len];
+  memset(read_buffer, 0, buffer_size);
+  uint64_t read_offset = 0;
+  CHECK(tile.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer, buffer_size) == 0);
+
+  // Test a read at an out-of-bounds offset.
+  memset(read_buffer, 0, buffer_size);
+  read_offset = buffer_size;
+  CHECK(!tile.read(read_buffer, buffer_size, read_offset).ok());
+
+  // Test a read at a valid offset but with a size that
+  // exceeds the written buffer size.
+  const uint32_t large_buffer_len = buffer_len * 2;
+  uint32_t large_read_buffer[large_buffer_len];
+  const uint64_t large_buffer_size = large_buffer_len * sizeof(uint32_t);
+  memset(large_read_buffer, 0, large_buffer_size);
+  read_offset = 0;
+  CHECK(!tile.read(large_read_buffer, large_buffer_size, read_offset).ok());
+}

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -519,7 +519,7 @@ TEST_CASE("Filter: Test simple in-place pipeline", "[filter]") {
   // Save the original allocation so that we can check that after running
   // through the pipeline, the tile buffer points to a different memory
   // region.
-  auto original_alloc = tile.data();
+  auto original_alloc = tile.internal_data();
 
   FilterPipeline pipeline;
   CHECK(pipeline.add_filter(Add1InPlace()).ok());
@@ -529,7 +529,7 @@ TEST_CASE("Filter: Test simple in-place pipeline", "[filter]") {
 
     // Check new size and number of chunks
     CHECK(tile.buffer() == &buff);
-    CHECK(tile.data() != original_alloc);
+    CHECK(tile.internal_data() != original_alloc);
     CHECK(
         buff.size() ==
         nelts * sizeof(uint64_t) + sizeof(uint64_t) + 3 * sizeof(uint32_t));

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -108,15 +108,16 @@ Status FilterPipeline::compute_tile_chunks(
                    uint64_t(bool(dim_tile_size % (chunk_size)));
 
   // Compute the chunks
-  tile->reset_offset();
+  uint64_t offset = 0;
   for (uint64_t i = 0; i < dim_num; i++) {
     for (uint64_t j = 0; j < chunk_num; j++) {
       // Compute the actual size of the chunk (may be smaller at the end of the
       // tile if the chunk size doesn't evenly divide).
       auto size = static_cast<uint32_t>(
           std::min(chunk_size, dim_tile_size - j * chunk_size));
-      chunks->emplace_back(tile->cur_data(), size);
-      tile->advance_offset(size);
+      chunks->emplace_back(
+          static_cast<char*>(tile->internal_data()) + offset, size);
+      offset += size;
     }
   }
 

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -986,7 +986,7 @@ Status Writer::compute_coords_metadata(
     for (unsigned d = 0; d < dim_num; ++d) {
       const auto& dim_name = array_schema_->dimension(d)->name();
       auto tiles_it = tiles.find(dim_name);
-      data[d] = (T*)(tiles_it->second[t].data());
+      data[d] = (T*)(tiles_it->second[t].internal_data());
     }
 
     // Initialize MBR with the first coords
@@ -2898,7 +2898,7 @@ Status Writer::zip_coord_tiles(
     for (unsigned d = 0; d < dim_num; ++d) {
       const auto& dim_name = array_schema_->dimension(d)->name();
       const auto& coord_tile = coord_tiles.find(dim_name)->second[t];
-      new_tile.write(coord_tile.data(), coord_tile.size());
+      new_tile.write(coord_tile);
     }
   }
 

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -204,11 +204,7 @@ uint64_t Tile::cell_size() const {
   return cell_size_;
 }
 
-void* Tile::cur_data() const {
-  return buffer_->cur_data();
-}
-
-void* Tile::data() const {
+void* Tile::internal_data() const {
   return buffer_->data();
 }
 
@@ -252,6 +248,16 @@ Status Tile::realloc(uint64_t nbytes) {
 Status Tile::read(void* buffer, uint64_t nbytes) {
   RETURN_NOT_OK(buffer_->read(buffer, nbytes));
 
+  return Status::Ok();
+}
+
+Status Tile::read(
+    void* const buffer, const uint64_t nbytes, const uint64_t offset) const {
+  if (nbytes + offset > buffer_->size()) {
+    return LOG_STATUS(
+        Status::TileError("Read failed; Trying to read beyond buffer size"));
+  }
+  std::memcpy(buffer, (char*)buffer_->data() + offset, nbytes);
   return Status::Ok();
 }
 
@@ -338,6 +344,10 @@ Status Tile::write(ConstBuffer* buf, uint64_t nbytes) {
 
 Status Tile::write(const void* data, uint64_t nbytes) {
   return buffer_->write(data, nbytes);
+}
+
+Status Tile::write(const Tile& rhs) {
+  return buffer_->write(rhs.buffer_->data(), rhs.size());
 }
 
 Status Tile::write_with_shift(ConstBuffer* buf, uint64_t offset) {

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -117,11 +117,11 @@ class Tile {
   /**
    * Tile initializer.
    *
+   * @param format_version The format version of the data in this tile.
    * @param type The type of the data to be stored.
    * @param cell_size The cell size.
    * @param dim_num The number of dimensions in case the tile stores
    *      coordinates.
-   * @param format_version The format version of the data in this tile.
    * @return Status
    */
   Status init(
@@ -133,13 +133,13 @@ class Tile {
   /**
    * Tile initializer.
    *
+   * @param format_version The format version of the data in this tile.
    * @param type The type of the data to be stored.
    * @param tile_size The tile size. The internal buffer will be allocated
    *     that much space upon construction.
    * @param cell_size The cell size.
    * @param dim_num The number of dimensions in case the tile stores
    *      coordinates.
-   * @param format_version The format version of the data in this tile.
    * @return Status
    */
   Status init(
@@ -168,11 +168,8 @@ class Tile {
    */
   Tile clone(bool deep_copy) const;
 
-  /** Returns the buffer data pointer at the current offset. */
-  void* cur_data() const;
-
-  /** Returns the tile data. */
-  void* data() const;
+  /** Returns the internal tile data. */
+  void* internal_data() const;
 
   /**
    * Sets `owns_buff_` to `false` and thus will not destroy the buffer
@@ -220,6 +217,13 @@ class Tile {
 
   /** Reads from the tile into the input buffer *nbytes*. */
   Status read(void* buffer, uint64_t nbytes);
+
+  /**
+   * Reads from the tile at the given offset into the input
+   * buffer of size nbytes. Does not mutate the internal offset.
+   * Thread-safe among readers.
+   */
+  Status read(void* buffer, uint64_t nbytes, uint64_t offset) const;
 
   /** Resets the size and offset of the tile. */
   void reset();
@@ -280,6 +284,9 @@ class Tile {
 
   /** Writes `nbytes` from `data` to the tile. */
   Status write(const void* data, uint64_t nbytes);
+
+  /** Writes the entire internal buffer of 'rhs' into the tile. */
+  Status write(const Tile& rhs);
 
   /**
    * Writes as much data as possibly can be read from the input buffer.


### PR DESCRIPTION
Changes:
1. Removes Tile::cur_data().
2. Renames Tile::data() to Tile::internal_data() to discourage
   use.
3. Introduces a thread-safe variant of Tile::read() at a
   specific offset.
4. Introduces Tile::write(const Tile& rhs) to allow writing
   from one tile to another without invoking Tile::internal_data().

The intent of this patch is to use Tile::read() whenever we can
avoid making extraneous copies. Specifically, this happens in the
copy_fixed_cells() and copy_var_cells() routines. We read directly
from the tile into the output buffers.