### PR TITLE
WIP: ChunkBuffers

### DIFF
--- a/test/src/unit-ChunkBuffers.cc
+++ b/test/src/unit-ChunkBuffers.cc
@@ -1,0 +1,742 @@
+/**
+ * @file unit-ChunkBuffers.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `ChunkBuffers` class.
+ */
+
+#include "tiledb/sm/tile/chunk_buffers.h"
+
+#include <catch.hpp>
+#include <iostream>
+
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "ChunkBuffers: Test default constructor",
+    "[ChunkBuffers][default_constructor]") {
+  // Test the default constructor and verify the empty state.
+  ChunkBuffers chunk_buffers;
+  CHECK(chunk_buffers.size() == 0);
+  CHECK(chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == 0);
+  void* buffer = nullptr;
+  CHECK(!chunk_buffers.internal_buffer(0, &buffer).ok());
+  CHECK(!buffer);
+}
+
+TEST_CASE(
+    "ChunkBuffers: Test discrete, fixed size IO",
+    "[ChunkBuffers][discrete_fixed_io]") {
+  // Instantiate a test ChunkBuffers.
+  ChunkBuffers chunk_buffers;
+
+  // Create a buffer to write to the test ChunkBuffers.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Attempt a write before initializing the test ChunkBuffers.
+  uint64_t write_offset = 0;
+  CHECK(!chunk_buffers.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Attempt a read before initializing the test ChunkBuffers.
+  uint64_t read_offset = 0;
+  uint64_t read_buffer[buffer_len];
+  CHECK(!chunk_buffers.read(read_buffer, buffer_size, read_offset).ok());
+
+  // Attempt an alloc before initializing the test ChunkBuffers.
+  size_t chunk_idx = 0;
+  void* chunk_buffer = nullptr;
+  CHECK(!chunk_buffers.alloc_discrete(chunk_idx, &chunk_buffer).ok());
+  CHECK(!chunk_buffer);
+
+  // Attempt a set before initializing the test ChunkBuffers.
+  chunk_buffer = nullptr;
+  CHECK(!chunk_buffers.set_contigious(chunk_buffer).ok());
+  CHECK(!chunk_buffer);
+
+  // Initialize the ChunkBuffers.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunk_buffers.init_fixed_size(false, buffer_size, chunk_size);
+  CHECK(chunk_buffers.size() == buffer_size);
+  CHECK(!chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == nchunks);
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    void* chunk_buffer;
+    CHECK(chunk_buffers.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(!chunk_buffer);
+  }
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  write_offset = 0;
+  CHECK(chunk_buffers.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Verify all chunks are allocated and that they do not overlap
+  // 'buffer' because they have been deep-copied.
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunk_buffers.internal_buffer_size(i, &internal_size).ok());
+    if (i < chunk_buffers.nchunks() - 1) {
+      CHECK(internal_size == chunk_size);
+    } else {
+      CHECK(internal_size == last_chunk_size);
+    }
+
+    CHECK(chunk_buffers.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(chunk_buffer != write_buffer);
+    if (chunk_buffer < write_buffer) {
+      CHECK(
+          static_cast<char*>(chunk_buffer) + chunk_size <=
+          reinterpret_cast<char*>(write_buffer));
+    } else {
+      CHECK(
+          reinterpret_cast<char*>(write_buffer) + buffer_size <=
+          static_cast<char*>(chunk_buffer));
+    }
+  }
+  // Read the third element, this will be of value '2'.
+  read_offset = 2 * sizeof(uint64_t);
+  uint64_t two = 0;
+  CHECK(chunk_buffers.read(&two, sizeof(uint64_t), read_offset).ok());
+  CHECK(two == 2);
+
+  // Read the 10th element, this will be of value '9'.
+  read_offset = 9 * sizeof(uint64_t);
+  uint64_t nine = 0;
+  CHECK(chunk_buffers.read(&nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine == 9);
+
+  // Read the 100th element, this will be of value '99'.
+  read_offset = 99 * sizeof(uint64_t);
+  uint64_t ninety_nine = 0;
+  CHECK(chunk_buffers.read(&ninety_nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(ninety_nine == 99);
+
+  // Overwrite the 100th element with value '900'.
+  write_offset = 99 * sizeof(uint64_t);
+  uint64_t nine_hundred = 900;
+  CHECK(
+      chunk_buffers.write(&nine_hundred, sizeof(uint64_t), write_offset).ok());
+
+  // Read the 100th element, this will be of value '900'.
+  read_offset = 99 * sizeof(uint64_t);
+  nine_hundred = 0;
+  CHECK(chunk_buffers.read(&nine_hundred, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine_hundred == 900);
+
+  // Overwrite the 100th element back to value '99'.
+  write_offset = 99 * sizeof(uint64_t);
+  ninety_nine = 99;
+  CHECK(chunk_buffers.write(&ninety_nine, sizeof(uint64_t), write_offset).ok());
+
+  // Read the entire written buffer.
+  read_offset = 0;
+  CHECK(chunk_buffers.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Free the chunk buffer, which will free all of the allocated
+  // buffers and return chunk_buffers into an uninitialized state.
+  chunk_buffers.free();
+  CHECK(chunk_buffers.size() == 0);
+  CHECK(chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == 0);
+
+  // Reinitialize the chunk buffers.
+  chunk_buffers.init_fixed_size(false, buffer_size, chunk_size);
+  CHECK(chunk_buffers.size() == buffer_size);
+  CHECK(!chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == nchunks);
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunk_buffers.internal_buffer_size(i, &internal_size).ok());
+    if (i < chunk_buffers.nchunks() - 1) {
+      CHECK(internal_size == chunk_size);
+    } else {
+      CHECK(internal_size == last_chunk_size);
+    }
+  }
+
+  // Allocate all chunks.
+  std::vector<void*> internal_chunk_buffers(chunk_buffers.nchunks());
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    CHECK(chunk_buffers.alloc_discrete(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    internal_chunk_buffers[i] = chunk_buffer;
+  }
+
+  // Verify all chunks are allocated and that they do not overlap
+  // 'buffer' because they have been deep-copied.
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunk_buffers.internal_buffer_size(i, &internal_size).ok());
+    if (i < chunk_buffers.nchunks() - 1) {
+      CHECK(internal_size == chunk_size);
+    } else {
+      CHECK(internal_size == last_chunk_size);
+    }
+
+    CHECK(chunk_buffers.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(chunk_buffer != write_buffer);
+    if (chunk_buffer < write_buffer) {
+      CHECK(
+          static_cast<char*>(chunk_buffer) + chunk_size <=
+          reinterpret_cast<char*>(write_buffer));
+    } else {
+      CHECK(
+          reinterpret_cast<char*>(write_buffer) + buffer_size <=
+          static_cast<char*>(chunk_buffer));
+    }
+  }
+
+  // Write to all chunks.
+  write_offset = 0;
+  CHECK(chunk_buffers.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Read the entire written buffer.
+  read_offset = 0;
+  CHECK(chunk_buffers.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Clear the ChunkBuffers. This will reset to an uninitialized state
+  // but will NOT free the underlying buffers.
+  chunk_buffers.clear();
+  CHECK(chunk_buffers.size() == 0);
+  CHECK(chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == 0);
+
+  // Free the internal buffers to prevent a memory leak.
+  for (const auto& internal_buffer : internal_chunk_buffers) {
+    free(internal_buffer);
+  }
+}
+
+TEST_CASE(
+    "ChunkBuffers: Test contigious, fixed size IO",
+    "[ChunkBuffers][contigious_fixed_io]") {
+  // Instantiate a test ChunkBuffers.
+  ChunkBuffers chunk_buffers;
+
+  // Create a buffer to write to the test ChunkBuffers.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkBuffers.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunk_buffers.init_fixed_size(true, buffer_size, chunk_size);
+  CHECK(chunk_buffers.size() == buffer_size);
+  CHECK(!chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == nchunks);
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    void* chunk_buffer;
+    CHECK(chunk_buffers.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(!chunk_buffer);
+  }
+
+  // Write the entire buffer. This will fail because a contigious buffer
+  // has not been set or allocated.
+  uint64_t write_offset = 0;
+  CHECK(!chunk_buffers.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Attempt to allocate a chunk. This will fail because contigious
+  // ChunkBuffers instances can not use the 'alloc_discrete' routine.
+  CHECK(!chunk_buffers.alloc_discrete(chunk_buffers.nchunks() / 2).ok());
+
+  // Set the contigious buffer.
+  CHECK(chunk_buffers.set_contigious(write_buffer).ok());
+
+  // Verify all chunks are allocated and that they're addressed match
+  // 'write_buffer' to ensure 'write_buffer' was not copied.
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunk_buffers.internal_buffer_size(i, &internal_size).ok());
+    if (i < chunk_buffers.nchunks() - 1) {
+      CHECK(internal_size == chunk_size);
+    } else {
+      CHECK(internal_size == last_chunk_size);
+    }
+
+    void* chunk_buffer = nullptr;
+    CHECK(chunk_buffers.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(
+        chunk_buffer ==
+        reinterpret_cast<char*>(write_buffer) + (i * chunk_size));
+  }
+
+  // Read the third element, this will be of value '2'.
+  uint64_t read_offset = 2 * sizeof(uint64_t);
+  uint64_t two = 0;
+  CHECK(chunk_buffers.read(&two, sizeof(uint64_t), read_offset).ok());
+  CHECK(two == 2);
+
+  // Read the 10th element, this will be of value '9'.
+  read_offset = 9 * sizeof(uint64_t);
+  uint64_t nine = 0;
+  CHECK(chunk_buffers.read(&nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine == 9);
+
+  // Read the 100th element, this will be of value '99'.
+  read_offset = 99 * sizeof(uint64_t);
+  uint64_t ninety_nine = 0;
+  CHECK(chunk_buffers.read(&ninety_nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(ninety_nine == 99);
+
+  // Overwrite the 100th element with value '900'.
+  write_offset = 99 * sizeof(uint64_t);
+  uint64_t nine_hundred = 900;
+  CHECK(
+      chunk_buffers.write(&nine_hundred, sizeof(uint64_t), write_offset).ok());
+
+  // Read the 100th element, this will be of value '900'.
+  read_offset = 99 * sizeof(uint64_t);
+  nine_hundred = 0;
+  CHECK(chunk_buffers.read(&nine_hundred, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine_hundred == 900);
+
+  // Overwrite the 100th element back to value '99'.
+  write_offset = 99 * sizeof(uint64_t);
+  ninety_nine = 99;
+  CHECK(chunk_buffers.write(&ninety_nine, sizeof(uint64_t), write_offset).ok());
+
+  // Read the entire written buffer.
+  uint64_t read_buffer[buffer_len];
+  read_offset = 0;
+  CHECK(chunk_buffers.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Clear the chunk buffer. This will not free the underlying buffer.
+  chunk_buffers.clear();
+  CHECK(chunk_buffers.size() == 0);
+  CHECK(chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == 0);
+}
+
+TEST_CASE(
+    "ChunkBuffers: Test discrete, variable sized IO",
+    "[ChunkBuffers][discrete_var_io]") {
+  // Instantiate a test ChunkBuffers.
+  ChunkBuffers chunk_buffers;
+
+  // Create a buffer to write to the test ChunkBuffers.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkBuffers with variable sized chunks.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  std::vector<uint32_t> var_chunk_sizes;
+  uint64_t remaining_bytes = buffer_size;
+  uint32_t chunk_size = sizeof(uint64_t);
+  while (remaining_bytes > 0) {
+    if (chunk_size > remaining_bytes) {
+      chunk_size = remaining_bytes;
+    }
+    var_chunk_sizes.emplace_back(chunk_size);
+    remaining_bytes -= chunk_size;
+    chunk_size += sizeof(uint64_t);
+  }
+  chunk_buffers.init_var_size(false, std::vector<uint32_t>(var_chunk_sizes));
+  CHECK(chunk_buffers.size() == buffer_size);
+  CHECK(!chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == var_chunk_sizes.size());
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    void* chunk_buffer;
+    CHECK(chunk_buffers.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(!chunk_buffer);
+  }
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  uint64_t write_offset = 0;
+  CHECK(chunk_buffers.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Verify all chunks are allocated and that they do not overlap
+  // 'buffer' because they have been deep-copied.
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunk_buffers.internal_buffer_size(i, &internal_size).ok());
+    CHECK(internal_size == var_chunk_sizes[i]);
+
+    void* chunk_buffer = nullptr;
+    CHECK(chunk_buffers.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(chunk_buffer != write_buffer);
+    if (chunk_buffer < write_buffer) {
+      CHECK(
+          static_cast<char*>(chunk_buffer) + internal_size <=
+          reinterpret_cast<char*>(write_buffer));
+    } else {
+      CHECK(
+          reinterpret_cast<char*>(write_buffer) + buffer_size <=
+          static_cast<char*>(chunk_buffer));
+    }
+  }
+
+  // Read the third element, this will be of value '2'.
+  uint64_t read_offset = 2 * sizeof(uint64_t);
+  uint64_t two = 0;
+  CHECK(chunk_buffers.read(&two, sizeof(uint64_t), read_offset).ok());
+  CHECK(two == 2);
+
+  // Read the 10th element, this will be of value '9'.
+  read_offset = 9 * sizeof(uint64_t);
+  uint64_t nine = 0;
+  CHECK(chunk_buffers.read(&nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine == 9);
+
+  // Read the 100th element, this will be of value '99'.
+  read_offset = 99 * sizeof(uint64_t);
+  uint64_t ninety_nine = 0;
+  CHECK(chunk_buffers.read(&ninety_nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(ninety_nine == 99);
+
+  // Overwrite the 100th element with value '900'.
+  write_offset = 99 * sizeof(uint64_t);
+  uint64_t nine_hundred = 900;
+  CHECK(
+      chunk_buffers.write(&nine_hundred, sizeof(uint64_t), write_offset).ok());
+
+  // Read the 100th element, this will be of value '900'.
+  read_offset = 99 * sizeof(uint64_t);
+  nine_hundred = 0;
+  CHECK(chunk_buffers.read(&nine_hundred, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine_hundred == 900);
+
+  // Overwrite the 100th element back to value '99'.
+  write_offset = 99 * sizeof(uint64_t);
+  ninety_nine = 99;
+  CHECK(chunk_buffers.write(&ninety_nine, sizeof(uint64_t), write_offset).ok());
+
+  // Read the entire written buffer.
+  uint64_t read_buffer[buffer_len];
+  read_offset = 0;
+  CHECK(chunk_buffers.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Free the chunk buffer, which will free all of the allocated
+  // buffers and return chunk_buffers into an uninitialized state.
+  chunk_buffers.free();
+  CHECK(chunk_buffers.size() == 0);
+  CHECK(chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == 0);
+}
+
+TEST_CASE(
+    "ChunkBuffers: Test contigious variable sized IO",
+    "[ChunkBuffers][contigious_var_io]") {
+  // Instantiate a test ChunkBuffers.
+  ChunkBuffers chunk_buffers;
+
+  // Create a buffer to write to the test ChunkBuffers.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkBuffers with variable sized chunks.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  std::vector<uint32_t> var_chunk_sizes;
+  uint64_t remaining_bytes = buffer_size;
+  uint32_t chunk_size = sizeof(uint64_t);
+  while (remaining_bytes > 0) {
+    if (chunk_size > remaining_bytes) {
+      chunk_size = remaining_bytes;
+    }
+    var_chunk_sizes.emplace_back(chunk_size);
+    remaining_bytes -= chunk_size;
+    chunk_size += sizeof(uint64_t);
+  }
+  chunk_buffers.init_var_size(true, std::vector<uint32_t>(var_chunk_sizes));
+  CHECK(chunk_buffers.size() == buffer_size);
+  CHECK(!chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == var_chunk_sizes.size());
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    void* chunk_buffer;
+    CHECK(chunk_buffers.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(!chunk_buffer);
+  }
+
+  // Write the entire buffer. This will fail because a contigious buffer
+  // has not been set or allocated.
+  uint64_t write_offset = 0;
+  CHECK(!chunk_buffers.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Attempt to allocate a chunk. This will fail because contigious
+  // ChunkBuffers instances can not use the 'alloc_discrete' routine.
+  CHECK(!chunk_buffers.alloc_discrete(chunk_buffers.nchunks() / 2).ok());
+
+  // Set the contigious buffer.
+  CHECK(chunk_buffers.set_contigious(write_buffer).ok());
+
+  // Verify all chunks are allocated and that they're addressed match
+  // 'write_buffer' to ensure 'write_buffer' was not copied.
+  uint64_t offset = 0;
+  for (size_t i = 0; i < chunk_buffers.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunk_buffers.internal_buffer_size(i, &internal_size).ok());
+    CHECK(internal_size == var_chunk_sizes[i]);
+
+    void* chunk_buffer = nullptr;
+    CHECK(chunk_buffers.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(chunk_buffer == reinterpret_cast<char*>(write_buffer) + offset);
+    offset += internal_size;
+  }
+
+  // Read the third element, this will be of value '2'.
+  uint64_t read_offset = 2 * sizeof(uint64_t);
+  uint64_t two = 0;
+  CHECK(chunk_buffers.read(&two, sizeof(uint64_t), read_offset).ok());
+  CHECK(two == 2);
+
+  // Read the 10th element, this will be of value '9'.
+  read_offset = 9 * sizeof(uint64_t);
+  uint64_t nine = 0;
+  CHECK(chunk_buffers.read(&nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine == 9);
+
+  // Read the 100th element, this will be of value '99'.
+  read_offset = 99 * sizeof(uint64_t);
+  uint64_t ninety_nine = 0;
+  CHECK(chunk_buffers.read(&ninety_nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(ninety_nine == 99);
+
+  // Overwrite the 100th element with value '900'.
+  write_offset = 99 * sizeof(uint64_t);
+  uint64_t nine_hundred = 900;
+  CHECK(
+      chunk_buffers.write(&nine_hundred, sizeof(uint64_t), write_offset).ok());
+
+  // Read the 100th element, this will be of value '900'.
+  read_offset = 99 * sizeof(uint64_t);
+  nine_hundred = 0;
+  CHECK(chunk_buffers.read(&nine_hundred, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine_hundred == 900);
+
+  // Overwrite the 100th element back to value '99'.
+  write_offset = 99 * sizeof(uint64_t);
+  ninety_nine = 99;
+  CHECK(chunk_buffers.write(&ninety_nine, sizeof(uint64_t), write_offset).ok());
+
+  // Read the entire written buffer.
+  uint64_t read_buffer[buffer_len];
+  read_offset = 0;
+  CHECK(chunk_buffers.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Clear the chunk buffer. This will not free the underlying buffer.
+  chunk_buffers.clear();
+  CHECK(chunk_buffers.size() == 0);
+  CHECK(chunk_buffers.empty());
+  CHECK(chunk_buffers.nchunks() == 0);
+}
+
+TEST_CASE(
+    "ChunkBuffers: Test copy constructor", "[ChunkBuffers][copy_constructor]") {
+  // Instantiate the first test ChunkBuffers.
+  ChunkBuffers chunk_buffers1;
+
+  // Create a buffer to write to the test ChunkBuffers.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkBuffers.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunk_buffers1.init_fixed_size(false, buffer_size, chunk_size);
+  CHECK(chunk_buffers1.size() == buffer_size);
+  CHECK(!chunk_buffers1.empty());
+  CHECK(chunk_buffers1.nchunks() == nchunks);
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  uint64_t write_offset = 0;
+  CHECK(chunk_buffers1.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Instantiate a second test ChunkBuffers with the copy constructor.
+  ChunkBuffers chunk_buffers2(chunk_buffers1);
+
+  // Verify all public attributes are identical.
+  CHECK(chunk_buffers2.nchunks() == chunk_buffers1.nchunks());
+  CHECK(chunk_buffers2.contigious() == chunk_buffers1.contigious());
+
+  // Read the entire written buffer from the second instance and verify
+  // the contents match the first instance.
+  uint64_t read_buffer[buffer_len];
+  uint64_t read_offset = 0;
+  CHECK(chunk_buffers2.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Ensure the internal data was deep-copied:
+  void* chunk_buffers1_chunk_0;
+  void* chunk_buffers2_chunk_0;
+  CHECK(chunk_buffers1.internal_buffer(0, &chunk_buffers1_chunk_0).ok());
+  CHECK(chunk_buffers2.internal_buffer(0, &chunk_buffers2_chunk_0).ok());
+  CHECK(chunk_buffers1_chunk_0 != chunk_buffers2_chunk_0);
+}
+
+TEST_CASE("ChunkBuffers: Test assignment", "[ChunkBuffers][assignment]") {
+  // Instantiate the first test ChunkBuffers.
+  ChunkBuffers chunk_buffers1;
+
+  // Create a buffer to write to the test ChunkBuffers.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkBuffers.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunk_buffers1.init_fixed_size(false, buffer_size, chunk_size);
+  CHECK(chunk_buffers1.size() == buffer_size);
+  CHECK(!chunk_buffers1.empty());
+  CHECK(chunk_buffers1.nchunks() == nchunks);
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  uint64_t write_offset = 0;
+  CHECK(chunk_buffers1.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Instantiate a second test ChunkBuffers with the assignment operator.
+  ChunkBuffers chunk_buffers2 = chunk_buffers1;
+
+  // Verify all public attributes are identical.
+  CHECK(chunk_buffers2.nchunks() == chunk_buffers1.nchunks());
+  CHECK(chunk_buffers2.contigious() == chunk_buffers1.contigious());
+
+  // Read the entire written buffer from the second instance and verify
+  // the contents match the first instance.
+  uint64_t read_buffer[buffer_len];
+  uint64_t read_offset = 0;
+  CHECK(chunk_buffers2.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Ensure the internal data was deep-copied:
+  void* chunk_buffers1_chunk_0;
+  void* chunk_buffers2_chunk_0;
+  CHECK(chunk_buffers1.internal_buffer(0, &chunk_buffers1_chunk_0).ok());
+  CHECK(chunk_buffers2.internal_buffer(0, &chunk_buffers2_chunk_0).ok());
+  CHECK(chunk_buffers1_chunk_0 != chunk_buffers2_chunk_0);
+}
+
+TEST_CASE("ChunkBuffers: Test shallow copy", "[ChunkBuffers][shallow_copy]") {
+  // Instantiate the first test ChunkBuffers.
+  ChunkBuffers chunk_buffers1;
+
+  // Create a buffer to write to the test ChunkBuffers.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkBuffers.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunk_buffers1.init_fixed_size(false, buffer_size, chunk_size);
+  CHECK(chunk_buffers1.size() == buffer_size);
+  CHECK(!chunk_buffers1.empty());
+  CHECK(chunk_buffers1.nchunks() == nchunks);
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  uint64_t write_offset = 0;
+  CHECK(chunk_buffers1.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Instantiate a second test ChunkBuffers with the shallow_copy routine.
+  ChunkBuffers chunk_buffers2 = chunk_buffers1.shallow_copy();
+
+  // Verify all public attributes are identical.
+  CHECK(chunk_buffers2.nchunks() == chunk_buffers1.nchunks());
+  CHECK(chunk_buffers2.contigious() == chunk_buffers1.contigious());
+
+  // Read the entire written buffer from the second instance and verify
+  // the contents match the first instance.
+  uint64_t read_buffer[buffer_len];
+  uint64_t read_offset = 0;
+  CHECK(chunk_buffers2.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Ensure the internal data was shallow-copied:
+  void* chunk_buffers1_chunk_0;
+  void* chunk_buffers2_chunk_0;
+  CHECK(chunk_buffers1.internal_buffer(0, &chunk_buffers1_chunk_0).ok());
+  CHECK(chunk_buffers2.internal_buffer(0, &chunk_buffers2_chunk_0).ok());
+  CHECK(chunk_buffers1_chunk_0 == chunk_buffers2_chunk_0);
+}

--- a/test/src/unit-Tile.cc
+++ b/test/src/unit-Tile.cc
@@ -37,25 +37,54 @@
 
 using namespace tiledb::sm;
 
-TEST_CASE("Tile: Test basic read", "[Tile][basic_read]") {
-  // Initialize the test Tile.
+TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
+  // Instantiate the test Tile.
   Tile tile;
+  CHECK(tile.empty());
+  CHECK(!tile.full());
+  CHECK(tile.size() == 0);
+
+  // Initialize the test Tile.
   const uint32_t format_version = 0;
   const Datatype data_type = Datatype::UINT32;
-  const uint64_t cell_size = 0;
-  const unsigned int dim_num = 0;
-  CHECK(tile.init(format_version, data_type, cell_size, dim_num).ok());
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(
+      tile.init(format_version, data_type, tile_size, cell_size, dim_num).ok());
+  CHECK(!tile.empty());
+  CHECK(!tile.full());
+  CHECK(tile.size() == tile_size);
+  CHECK(tile.owns_buff());
 
   // Create a buffer to write to the test Tile.
-  const uint32_t buffer_len = 128;
-  uint32_t buffer[buffer_len];
+  uint32_t* const write_buffer = static_cast<uint32_t*>(malloc(tile_size));
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
   for (uint32_t i = 0; i < buffer_len; ++i) {
-    buffer[i] = i;
+    write_buffer[i] = i;
   }
 
   // Write the buffer to the test Tile.
-  const uint64_t buffer_size = buffer_len * sizeof(uint32_t);
-  CHECK(tile.write(buffer, buffer_size).ok());
+  CHECK(tile.offset() == 0);
+  CHECK(tile.write(write_buffer, tile_size).ok());
+  CHECK(tile.offset() == tile_size);
+  CHECK(!tile.empty());
+  CHECK(tile.full());
+  CHECK(tile.size() == tile_size);
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile.chunk_buffers());
+  CHECK(tile.chunk_buffers()->nchunks() > 1);
+
+  // Verify that the internal chunk buffers are discrete (aka each chunk's
+  // buffer is individually managed).
+  CHECK(!tile.chunk_buffers()->contigious());
+
+  // Ensure the internal data was deep-copied:
+  void* tile_chunk_0;
+  CHECK(tile.chunk_buffers()->internal_buffer(0, &tile_chunk_0).ok());
+  CHECK(tile_chunk_0 != static_cast<void*>(write_buffer));
 
   // Test a partial read at offset 8, which should be a uint32_t with
   // a value of two.
@@ -63,24 +92,419 @@ TEST_CASE("Tile: Test basic read", "[Tile][basic_read]") {
   CHECK(tile.read(&two, sizeof(uint32_t), 8).ok());
   CHECK(two == 2);
 
+  // The last read should have not changed the internal offset.
+  CHECK(tile.offset() == tile_size);
+
+  // Perform a read at the current offset and verify we read 'two'
+  // again and that the offset has changed.
+  tile.set_offset(8);
+  two = 0;
+  CHECK(tile.read(&two, sizeof(uint32_t)).ok());
+  CHECK(two == 2);
+  CHECK(tile.offset() == 12);
+
   // Test a full read.
   uint32_t read_buffer[buffer_len];
-  memset(read_buffer, 0, buffer_size);
+  memset(read_buffer, 0, tile_size);
   uint64_t read_offset = 0;
-  CHECK(tile.read(read_buffer, buffer_size, read_offset).ok());
-  CHECK(memcmp(read_buffer, buffer, buffer_size) == 0);
+  CHECK(tile.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, tile_size) == 0);
+
+  // Verify the internal offset did not change.
+  CHECK(tile.offset() == 12);
+
+  // Test a write at a non-zero offset. Overwrite the two at offset 8.
+  tile.set_offset(0);
+  tile.advance_offset(8);
+  uint32_t magic = 5234549;
+  CHECK(tile.write(&magic, sizeof(uint32_t)).ok());
+  CHECK(tile.offset() == 12);
+
+  // Read the magic number to ensure the '2' value was overwritten.
+  two = 0;
+  CHECK(tile.read(&two, sizeof(uint32_t), 8).ok());
+  CHECK(two == magic);
+
+  // Restore the state without the magic number.
+  tile.set_offset(8);
+  two = 2;
+  CHECK(tile.write(&two, sizeof(uint32_t)).ok());
+  CHECK(tile.offset() == 12);
 
   // Test a read at an out-of-bounds offset.
-  memset(read_buffer, 0, buffer_size);
-  read_offset = buffer_size;
-  CHECK(!tile.read(read_buffer, buffer_size, read_offset).ok());
+  memset(read_buffer, 0, tile_size);
+  read_offset = tile_size;
+  CHECK(!tile.read(read_buffer, tile_size, read_offset).ok());
 
   // Test a read at a valid offset but with a size that
   // exceeds the written buffer size.
   const uint32_t large_buffer_len = buffer_len * 2;
   uint32_t large_read_buffer[large_buffer_len];
-  const uint64_t large_buffer_size = large_buffer_len * sizeof(uint32_t);
-  memset(large_read_buffer, 0, large_buffer_size);
+  const uint64_t large_tile_size = large_buffer_len * sizeof(uint32_t);
+  memset(large_read_buffer, 0, large_tile_size);
   read_offset = 0;
-  CHECK(!tile.read(large_read_buffer, large_buffer_size, read_offset).ok());
+  CHECK(!tile.read(large_read_buffer, large_tile_size, read_offset).ok());
+
+  // Test a write that exceeds the tile size.
+  tile.set_offset(tile_size);
+  CHECK(!tile.write(write_buffer, sizeof(uint32_t)).ok());
+
+  // Free the write buffer to ensure that it was deep-copied
+  // within the initial write.
+  uint32_t write_buffer_copy[buffer_len];
+  memcpy(write_buffer_copy, write_buffer, tile_size);
+  free(write_buffer);
+  memset(read_buffer, 0, tile_size);
+  read_offset = 0;
+  CHECK(tile.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer_copy, tile_size) == 0);
+}
+
+TEST_CASE("Tile: Test copy constructor", "[Tile][copy_constructor]") {
+  // Instantiate and initialize the first test Tile.
+  Tile tile1;
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(tile1.init(format_version, data_type, tile_size, cell_size, dim_num)
+            .ok());
+
+  // Create a buffer to write to the first test Tile.
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  uint32_t buffer[buffer_len];
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer[i] = i;
+  }
+
+  // Write the buffer to the first test Tile.
+  CHECK(tile1.write(buffer, tile_size).ok());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1.chunk_buffers());
+  CHECK(tile1.chunk_buffers()->nchunks() > 1);
+
+  // Instantiate a second test tile with the copy constructor.
+  Tile tile2(tile1);
+
+  // Verify all public attributes are identical.
+  CHECK(tile2.cell_size() == tile1.cell_size());
+  CHECK(tile2.cell_num() == tile1.cell_num());
+  CHECK(tile2.dim_num() == tile1.dim_num());
+  CHECK(tile2.empty() == tile1.empty());
+  CHECK(tile2.filtered() == tile1.filtered());
+  CHECK(tile2.format_version() == tile1.format_version());
+  CHECK(tile2.full() == tile1.full());
+  CHECK(tile2.offset() == tile1.offset());
+  CHECK(tile2.pre_filtered_size() == tile1.pre_filtered_size());
+  CHECK(tile2.size() == tile1.size());
+  CHECK(tile2.stores_coords() == tile1.stores_coords());
+  CHECK(tile2.type() == tile1.type());
+  CHECK(tile2.owns_buff() == tile1.owns_buff());
+
+  // Read the second test tile to verify it contains the data
+  // written to the first test tile.
+  uint32_t read_buffer[buffer_len];
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
+
+  // Ensure the internal data was deep-copied:
+  CHECK(tile1.chunk_buffers());
+  CHECK(tile2.chunk_buffers());
+  void* tile1_chunk_0;
+  void* tile2_chunk_0;
+  CHECK(tile1.chunk_buffers()->internal_buffer(0, &tile1_chunk_0).ok());
+  CHECK(tile2.chunk_buffers()->internal_buffer(0, &tile2_chunk_0).ok());
+  CHECK(tile1_chunk_0 != tile2_chunk_0);
+}
+
+TEST_CASE("Tile: Test move constructor", "[Tile][move_constructor]") {
+  // Instantiate and initialize the first test Tile.
+  Tile tile1;
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(tile1.init(format_version, data_type, tile_size, cell_size, dim_num)
+            .ok());
+
+  // Create a buffer to write to the first test Tile.
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  uint32_t buffer[buffer_len];
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer[i] = i;
+  }
+
+  // Write the buffer to the first test Tile.
+  CHECK(tile1.write(buffer, tile_size).ok());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1.chunk_buffers());
+  CHECK(tile1.chunk_buffers()->nchunks() > 1);
+
+  // Instantiate a second test tile with the copy constructor.
+  Tile tile2(tile1);
+
+  // Instantiate a third test tile with the move constructor.
+  Tile tile3(std::move(tile1));
+
+  // Verify all public attributes are identical.
+  CHECK(tile3.cell_size() == tile2.cell_size());
+  CHECK(tile3.cell_num() == tile2.cell_num());
+  CHECK(tile3.dim_num() == tile2.dim_num());
+  CHECK(tile3.empty() == tile2.empty());
+  CHECK(tile3.filtered() == tile2.filtered());
+  CHECK(tile3.format_version() == tile2.format_version());
+  CHECK(tile3.full() == tile2.full());
+  CHECK(tile3.offset() == tile2.offset());
+  CHECK(tile3.pre_filtered_size() == tile2.pre_filtered_size());
+  CHECK(tile3.size() == tile2.size());
+  CHECK(tile3.stores_coords() == tile2.stores_coords());
+  CHECK(tile3.type() == tile2.type());
+  CHECK(tile3.owns_buff() == tile2.owns_buff());
+
+  // Read the second test tile to verify it contains the data
+  // written to the first test tile.
+  uint32_t read_buffer[buffer_len];
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
+}
+
+TEST_CASE("Tile: Test assignment", "[Tile][assignment]") {
+  // Instantiate and initialize the first test Tile.
+  Tile tile1;
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(tile1.init(format_version, data_type, tile_size, cell_size, dim_num)
+            .ok());
+
+  // Create a buffer to write to the first test Tile.
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  uint32_t buffer[buffer_len];
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer[i] = i;
+  }
+
+  // Write the buffer to the first test Tile.
+  CHECK(tile1.write(buffer, tile_size).ok());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1.chunk_buffers());
+  CHECK(tile1.chunk_buffers()->nchunks() > 1);
+
+  // Assign the first test Tile to a second test Tile.
+  Tile tile2 = tile1;
+
+  // Verify all public attributes are identical.
+  CHECK(tile2.cell_size() == tile1.cell_size());
+  CHECK(tile2.cell_num() == tile1.cell_num());
+  CHECK(tile2.dim_num() == tile1.dim_num());
+  CHECK(tile2.empty() == tile1.empty());
+  CHECK(tile2.filtered() == tile1.filtered());
+  CHECK(tile2.format_version() == tile1.format_version());
+  CHECK(tile2.full() == tile1.full());
+  CHECK(tile2.offset() == tile1.offset());
+  CHECK(tile2.pre_filtered_size() == tile1.pre_filtered_size());
+  CHECK(tile2.size() == tile1.size());
+  CHECK(tile2.stores_coords() == tile1.stores_coords());
+  CHECK(tile2.type() == tile1.type());
+  CHECK(tile2.owns_buff() == tile1.owns_buff());
+
+  // Read the second test tile to verify it contains the data
+  // written to the first test tile.
+  uint32_t read_buffer[buffer_len];
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
+
+  // Ensure the internal data was deep-copied:
+  CHECK(tile1.chunk_buffers());
+  CHECK(tile2.chunk_buffers());
+  void* tile1_chunk_0;
+  void* tile2_chunk_0;
+  CHECK(tile1.chunk_buffers()->internal_buffer(0, &tile1_chunk_0).ok());
+  CHECK(tile2.chunk_buffers()->internal_buffer(0, &tile2_chunk_0).ok());
+  CHECK(tile1_chunk_0 != tile2_chunk_0);
+}
+
+TEST_CASE("Tile: Test move-assignment", "[Tile][move_assignment]") {
+  // Instantiate and initialize the first test Tile.
+  Tile tile1;
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(tile1.init(format_version, data_type, tile_size, cell_size, dim_num)
+            .ok());
+
+  // Create a buffer to write to the first test Tile.
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  uint32_t buffer[buffer_len];
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer[i] = i;
+  }
+
+  // Write the buffer to the first test Tile.
+  CHECK(tile1.write(buffer, tile_size).ok());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1.chunk_buffers());
+  CHECK(tile1.chunk_buffers()->nchunks() > 1);
+
+  // Instantiate a second test tile with the copy constructor.
+  Tile tile2(tile1);
+
+  // Instantiate a third test tile with the move constructor.
+  Tile tile3 = std::move(tile1);
+
+  // Verify all public attributes are identical.
+  CHECK(tile3.cell_size() == tile2.cell_size());
+  CHECK(tile3.cell_num() == tile2.cell_num());
+  CHECK(tile3.dim_num() == tile2.dim_num());
+  CHECK(tile3.empty() == tile2.empty());
+  CHECK(tile3.filtered() == tile2.filtered());
+  CHECK(tile3.format_version() == tile2.format_version());
+  CHECK(tile3.full() == tile2.full());
+  CHECK(tile3.offset() == tile2.offset());
+  CHECK(tile3.pre_filtered_size() == tile2.pre_filtered_size());
+  CHECK(tile3.size() == tile2.size());
+  CHECK(tile3.stores_coords() == tile2.stores_coords());
+  CHECK(tile3.type() == tile2.type());
+  CHECK(tile3.owns_buff() == tile2.owns_buff());
+
+  // Read the second test tile to verify it contains the data
+  // written to the first test tile.
+  uint32_t read_buffer[buffer_len];
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
+}
+
+TEST_CASE(
+    "Tile: Test buffer chunks value constructor",
+    "[Tile][buffer_chunks_value_constructor]") {
+  // Define test tile attributes.
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+
+  // Instantiate a Buffer instance. We will use this to test
+  // ownership and non-ownership from a Tile value constructor.
+  Buffer buffer;
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer.write(&i, sizeof(uint32_t));
+  }
+  CHECK(buffer.size() == tile_size);
+
+  ChunkBuffers chunk_buffers;
+  CHECK(Tile::buffer_to_contigious_fixed_chunks(
+            buffer, dim_num, cell_size, &chunk_buffers)
+            .ok());
+
+  // Instantiate the first test tile that does NOT own 'chunk_buffers'.
+  bool owns_buff = false;
+  std::unique_ptr<Tile> tile1(
+      new Tile(data_type, cell_size, dim_num, &chunk_buffers, owns_buff));
+  CHECK(tile1);
+  CHECK(!tile1->empty());
+  CHECK(!tile1->full());
+  CHECK(tile1->size() == tile_size);
+  CHECK(!tile1->owns_buff());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1->chunk_buffers());
+  CHECK(tile1->chunk_buffers()->nchunks() > 1);
+
+  // Verify that the internal chunk buffers are backed by a single,
+  // contigious buffer.
+  CHECK(tile1->chunk_buffers()->contigious());
+
+  // Verify that the internal buffer chunks are virtually contigious and
+  // that their addresses exactly match 'buffer'.
+  uint64_t offset = 0;
+  for (size_t i = 0; i < tile1->chunk_buffers()->nchunks(); ++i) {
+    void* chunk_buffer = nullptr;
+    CHECK(tile1->chunk_buffers()->internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    uint32_t chunk_buffer_size = 0;
+    CHECK(tile1->chunk_buffers()
+              ->internal_buffer_size(i, &chunk_buffer_size)
+              .ok());
+    CHECK(chunk_buffer_size > 0);
+    CHECK(
+        static_cast<char*>(chunk_buffer) ==
+        static_cast<char*>(buffer.data()) + offset);
+    offset += chunk_buffer_size;
+  }
+
+  // Test a full read.
+  uint32_t read_buffer[buffer_len];
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile1->read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer.data(), tile_size) == 0);
+
+  // Free tile1 and ensure that buffer is still valid.
+  uint32_t buffer_copy[buffer_len];
+  memcpy(buffer_copy, buffer.data(), tile_size);
+  tile1.release();
+  CHECK(memcmp(buffer_copy, buffer.data(), tile_size) == 0);
+
+  // Instantiate the second test tile that does own 'chunk_buffers'.
+  owns_buff = true;
+  std::unique_ptr<Tile> tile2(
+      new Tile(data_type, cell_size, dim_num, &chunk_buffers, owns_buff));
+  CHECK(tile2);
+  CHECK(!tile2->empty());
+  CHECK(!tile2->full());
+  CHECK(tile2->size() == tile_size);
+  CHECK(tile2->owns_buff());
+
+  // Verify that the internal buffer chunks are virtually contigious and
+  // that their addresses exactly match 'buffer'.
+  offset = 0;
+  for (size_t i = 0; i < tile2->chunk_buffers()->nchunks(); ++i) {
+    void* chunk_buffer = nullptr;
+    CHECK(tile2->chunk_buffers()->internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    uint32_t chunk_buffer_size = 0;
+    CHECK(tile2->chunk_buffers()
+              ->internal_buffer_size(i, &chunk_buffer_size)
+              .ok());
+    CHECK(chunk_buffer_size > 0);
+    CHECK(
+        static_cast<char*>(chunk_buffer) ==
+        static_cast<char*>(buffer.data()) + offset);
+    offset += chunk_buffer_size;
+  }
+
+  // Test a full read.
+  memset(read_buffer, 0, tile_size);
+  read_offset = 0;
+  CHECK(tile2->read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer.data(), tile_size) == 0);
+
+  // Disown 'buffer' because the destructor of 'tile2' will delete it.
+  buffer.disown_data();
+  tile2.release();
 }

--- a/tiledb/sm/tile/chunk_buffers.cc
+++ b/tiledb/sm/tile/chunk_buffers.cc
@@ -1,0 +1,429 @@
+/**
+ * @file chunk_buffers.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class ChunkBuffers.
+ */
+
+#include "tiledb/sm/tile/chunk_buffers.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace tiledb {
+namespace sm {
+
+ChunkBuffers::ChunkBuffers()
+    : contigious_(false)
+    , chunk_size_(0)
+    , last_chunk_size_(0)
+    , cached_size_(0) {
+}
+
+ChunkBuffers::ChunkBuffers(const ChunkBuffers& rhs) {
+  deep_copy(rhs);
+}
+
+ChunkBuffers& ChunkBuffers::operator=(const ChunkBuffers& rhs) {
+  deep_copy(rhs);
+  return *this;
+}
+
+ChunkBuffers::~ChunkBuffers() {
+}
+
+void ChunkBuffers::deep_copy(const ChunkBuffers& rhs) {
+  buffers_.reserve(rhs.buffers_.size());
+  for (size_t i = 0; i < rhs.buffers_.size(); ++i) {
+    const uint32_t buffer_size = rhs.get_chunk_size(i);
+    void* const buffer_copy = malloc(buffer_size);
+    memcpy(buffer_copy, rhs.buffers_[i], buffer_size);
+    buffers_.emplace_back(buffer_copy);
+  }
+
+  contigious_ = rhs.contigious_;
+  chunk_size_ = rhs.chunk_size_;
+  last_chunk_size_ = rhs.last_chunk_size_;
+  var_chunk_sizes_ = rhs.var_chunk_sizes_;
+  cached_size_ = rhs.cached_size_;
+}
+
+ChunkBuffers ChunkBuffers::shallow_copy() const {
+  ChunkBuffers copy;
+  copy.contigious_ = contigious_;
+  copy.buffers_ = buffers_;
+  copy.chunk_size_ = chunk_size_;
+  copy.last_chunk_size_ = last_chunk_size_;
+  copy.var_chunk_sizes_ = var_chunk_sizes_;
+  copy.cached_size_ = cached_size_;
+  return copy;
+}
+
+void ChunkBuffers::swap(ChunkBuffers* const rhs) {
+  std::swap(contigious_, rhs->contigious_);
+  std::swap(buffers_, rhs->buffers_);
+  std::swap(chunk_size_, rhs->chunk_size_);
+  std::swap(last_chunk_size_, rhs->last_chunk_size_);
+  std::swap(var_chunk_sizes_, rhs->var_chunk_sizes_);
+  std::swap(cached_size_, rhs->cached_size_);
+}
+
+void ChunkBuffers::free() {
+  if (contigious_) {
+    if (!buffers_.empty() && buffers_[0] != nullptr) {
+      free_contigious();
+    }
+  } else {
+    for (size_t i = 0; i < buffers_.size(); ++i) {
+      void* const buffer = buffers_[i];
+      if (buffer != nullptr) {
+        auto st = free_discrete(i);
+        if (!st.ok()) {
+          LOG_FATAL(st.message());
+        }
+      }
+    }
+  }
+
+  clear();
+}
+
+void ChunkBuffers::clear() {
+  buffers_.clear();
+  contigious_ = false;
+  chunk_size_ = 0;
+  last_chunk_size_ = 0;
+  var_chunk_sizes_.clear();
+  cached_size_ = 0;
+}
+
+uint64_t ChunkBuffers::size() const {
+  return cached_size_;
+}
+
+bool ChunkBuffers::empty() const {
+  return buffers_.empty();
+}
+
+size_t ChunkBuffers::nchunks() const {
+  return buffers_.size();
+}
+
+bool ChunkBuffers::contigious() const {
+  return contigious_;
+}
+
+Status ChunkBuffers::init_fixed_size(
+    const bool contigious,
+    const uint64_t total_size,
+    const uint32_t chunk_size) {
+  if (!buffers_.empty()) {
+    return LOG_STATUS(Status::TileError(
+        "Cannot init chunk buffers; Chunk buffers non-empty."));
+  }
+
+  contigious_ = contigious;
+  chunk_size_ = chunk_size;
+
+  // Calculate the last chunk size.
+  last_chunk_size_ = total_size % chunk_size_;
+  if (last_chunk_size_ == 0) {
+    last_chunk_size_ = chunk_size_;
+  }
+
+  // Calculate the number of chunks required.
+  const size_t nchunks = last_chunk_size_ == chunk_size_ ?
+                             total_size / chunk_size_ :
+                             total_size / chunk_size_ + 1;
+
+  buffers_.resize(nchunks);
+  cached_size_ = chunk_size_ * (buffers_.size() - 1) + last_chunk_size_;
+
+  return Status::Ok();
+}
+
+Status ChunkBuffers::init_var_size(
+    const bool contigious, std::vector<uint32_t>&& var_chunk_sizes) {
+  if (!buffers_.empty()) {
+    return LOG_STATUS(Status::TileError(
+        "Cannot init chunk buffers; Chunk buffers non-empty."));
+  }
+
+  contigious_ = contigious;
+  var_chunk_sizes_ = std::move(var_chunk_sizes);
+  buffers_.resize(var_chunk_sizes_.size());
+
+  assert(cached_size_ == 0);
+  for (const auto& var_chunk_size : var_chunk_sizes_) {
+    cached_size_ += var_chunk_size;
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkBuffers::alloc_discrete(
+    const size_t chunk_idx, void** const buffer) {
+  if (contigious_) {
+    return LOG_STATUS(
+        Status::TileError("Cannot alloc discrete internal chunk buffer; Chunk "
+                          "buffers are contigiously allocated"));
+  }
+
+  if (chunk_idx >= buffers_.size()) {
+    return LOG_STATUS(Status::TileError(
+        "Cannot alloc internal chunk buffer; Chunk index out of bounds"));
+  }
+
+  buffers_[chunk_idx] = malloc(get_chunk_size(chunk_idx));
+  if (!buffers_[chunk_idx]) {
+    LOG_FATAL("malloc() failed");
+  }
+
+  if (buffer) {
+    *buffer = buffers_[chunk_idx];
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkBuffers::free_discrete(const size_t chunk_idx) {
+  if (contigious_) {
+    return LOG_STATUS(
+        Status::TileError("Cannot free discrete internal chunk buffer; Chunk "
+                          "buffers are contigiously allocated"));
+  }
+
+  if (chunk_idx >= buffers_.size()) {
+    return LOG_STATUS(Status::TileError(
+        "Cannot free internal chunk buffer; Chunk index out of bounds"));
+  }
+
+  ::free(buffers_[chunk_idx]);
+  return Status::Ok();
+}
+
+Status ChunkBuffers::set_contigious(void* const buffer) {
+  if (!contigious_) {
+    return LOG_STATUS(
+        Status::TileError("Cannot alloc discrete internal chunk buffer; Chunk "
+                          "buffers are discretely allocated"));
+  }
+
+  if (buffers_.empty()) {
+    return LOG_STATUS(Status::TileError(
+        "Cannot set chunk buffers; Chunk buffers uninitialized."));
+  }
+
+  uint64_t offset = 0;
+  for (size_t i = 0; i < buffers_.size(); ++i) {
+    buffers_[i] = static_cast<char*>(buffer) + offset;
+    offset += get_chunk_size(i);
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkBuffers::free_contigious() {
+  // This asssumes buffers set with the set_contigious interface
+  // were allocated with malloc().
+  ::free(buffers_[0]);
+
+  return Status::Ok();
+}
+
+Status ChunkBuffers::internal_buffer(
+    const size_t chunk_idx, void** const buffer) const {
+  assert(buffer);
+
+  if (chunk_idx >= buffers_.size()) {
+    return LOG_STATUS(Status::TileError(
+        "Cannot get internal chunk buffer; Chunk index out of bounds"));
+  }
+
+  *buffer = buffers_[chunk_idx];
+  return Status::Ok();
+}
+
+Status ChunkBuffers::internal_buffer_size(
+    const size_t chunk_idx, uint32_t* const size) const {
+  assert(size);
+
+  if (chunk_idx >= buffers_.size()) {
+    return LOG_STATUS(Status::TileError(
+        "Cannot get internal chunk buffer size; Chunk index out of bounds"));
+  }
+
+  *size = get_chunk_size(chunk_idx);
+  return Status::Ok();
+}
+
+Status ChunkBuffers::read(
+    void* const buffer, const uint64_t nbytes, const uint64_t offset) const {
+  if ((offset + nbytes) > size()) {
+    return Status::TileError("Chunk read error; read out of bounds");
+  }
+
+  size_t chunk_idx;
+  size_t chunk_offset;
+  RETURN_NOT_OK(translate_logical_offset(offset, &chunk_idx, &chunk_offset));
+
+  uint64_t nbytes_read = 0;
+  while (nbytes_read < nbytes) {
+    const void* const chunk_buffer = buffers_[chunk_idx];
+    if (!chunk_buffer) {
+      return Status::TileError("Chunk read error; chunk unallocated");
+    }
+
+    const uint64_t nbytes_remaining = nbytes - nbytes_read;
+    const uint64_t cbytes_remaining = get_chunk_size(chunk_idx) - chunk_offset;
+    const uint64_t bytes_to_read = std::min(nbytes_remaining, cbytes_remaining);
+
+    memcpy(
+        static_cast<char*>(buffer) + nbytes_read,
+        static_cast<const char*>(chunk_buffer) + chunk_offset,
+        bytes_to_read);
+    nbytes_read += bytes_to_read;
+
+    chunk_offset = 0;
+    ++chunk_idx;
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkBuffers::write(
+    const void* const buffer, const uint64_t nbytes, const uint64_t offset) {
+  if ((offset + nbytes) > size()) {
+    return Status::TileError("Chunk write error; write out of bounds");
+  }
+
+  size_t chunk_idx;
+  size_t chunk_offset;
+  RETURN_NOT_OK(translate_logical_offset(offset, &chunk_idx, &chunk_offset));
+
+  uint64_t nbytes_written = 0;
+  while (nbytes_written < nbytes) {
+    void* chunk_buffer = buffers_[chunk_idx];
+    if (!chunk_buffer) {
+      if (contigious_) {
+        return Status::TileError("Chunk write error; unset contigious buffer");
+      } else {
+        RETURN_NOT_OK(alloc_discrete(chunk_idx, &chunk_buffer));
+        buffers_[chunk_idx] = chunk_buffer;
+      }
+    }
+
+    const uint64_t nbytes_remaining = nbytes - nbytes_written;
+    const uint64_t cbytes_remaining = get_chunk_size(chunk_idx) - chunk_offset;
+    const uint64_t bytes_to_write =
+        std::min(nbytes_remaining, cbytes_remaining);
+
+    memcpy(
+        static_cast<char*>(chunk_buffer) + chunk_offset,
+        static_cast<const char*>(buffer) + nbytes_written,
+        bytes_to_write);
+    nbytes_written += bytes_to_write;
+
+    chunk_offset = 0;
+    ++chunk_idx;
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkBuffers::write(const ChunkBuffers& rhs, const uint64_t offset) {
+  LOG_FATAL(
+      "ChunkBuffers::write(const ChunkBuffers &, uint64_t) unimplemented");
+
+  // TODO REMOVE: bypass compiler warning
+  if (offset || rhs.size()) {
+  }
+
+  return Status::Ok();
+}
+
+uint32_t ChunkBuffers::get_chunk_size(const size_t chunk_idx) const {
+  assert(chunk_idx < buffers_.size());
+  if (fixed_chunk_sizes()) {
+    return chunk_idx == (buffers_.size() - 1) ? last_chunk_size_ : chunk_size_;
+  } else {
+    return var_chunk_sizes_[chunk_idx];
+  }
+}
+
+bool ChunkBuffers::fixed_chunk_sizes() const {
+  return var_chunk_sizes_.empty();
+}
+
+Status ChunkBuffers::translate_logical_offset(
+    const uint64_t logical_offset,
+    size_t* const chunk_idx,
+    size_t* const chunk_offset) const {
+  assert(chunk_idx);
+  assert(chunk_offset);
+
+  // Optimize for the common case.
+  if (logical_offset == 0) {
+    *chunk_idx = 0;
+    *chunk_offset = 0;
+  }
+
+  if (fixed_chunk_sizes()) {
+    *chunk_idx = logical_offset / chunk_size_;
+    *chunk_offset = logical_offset % chunk_size_;
+  } else {
+    // The expectation is that the number of chunks is
+    // sufficiently small that we can perform an O(N)
+    // lookup. If the number of chunks is abnormally large,
+    // this could become a performance bottleneck. Let's
+    // assert() here that the number of chunks is less than
+    // 32k. That ensures we are operating on a 'var_chunk_sizes_'
+    // object that is roughly half the maximum size of a 256KB
+    // L1 cache.
+    assert(var_chunk_sizes_.size() < 32000);
+
+    // Lookup the index of the chunk that the logical offset
+    // intersects and compute the chunk offset to reach the
+    // logical offset.
+    *chunk_idx = 0;
+    uint64_t i = 0;
+    while (i < logical_offset) {
+      if (*chunk_idx >= buffers_.size()) {
+        return Status::TileError("Out of bounds logical offset");
+      }
+      i += var_chunk_sizes_[(*chunk_idx)++];
+    }
+    i -= var_chunk_sizes_[--(*chunk_idx)];
+    *chunk_offset = logical_offset - i;
+  }
+
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/tile/chunk_buffers.h
+++ b/tiledb/sm/tile/chunk_buffers.h
@@ -1,0 +1,322 @@
+/**
+ * @file chunk_buffers.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class ChunkBuffers.
+ *
+ * The ChunkBuffers class is used to represent a logically contigious buffer
+ * as a vector of individual buffers. These individual buffers are referred to
+ * as "chunk buffers". Each chunk buffer may be allocated individually, which
+ * will save memory in scenarios where the logically contigious buffer is
+ * sparsley allocated.
+ *
+ * After construction, the class must be initialized before performing IO. The
+ * initialization determines the following, independent usage paradigms:
+ *
+ * #1: Chunk Sizes: Fixed/Variable
+ * The chunk sizes must be either fixed or variable. An instance with fixed
+ * chunk sizes ensures that all chunk buffers are of equal size. The size of the
+ * last chunk buffer may be equal-to or less-than the other chunk sizes.
+ * Instances with fixed size chunks have a smaller memory footprint and have a
+ * smaller algorithmic complexity when performing IO. For variable sized chunks,
+ * each chunk size is independent from the others.
+ *
+ * #2: Chunk Buffer Addressing: Discrete/Contigious
+ * The addresses of the individual chunk buffers may or may not be virtually
+ * contigious. For example, the chunk addresses within a virtually contigious
+ * instance may be allocated at address 1024 and 1028, where the first chunk is
+ * of size 4. Non-contigious chunks (referred to as "discrete") may be allocated
+ * at any address. The trade-off is that the memory of each discrete chunk is
+ * managed individually, where contigious chunk buffers can be managed by the
+ * first chunk alone.
+ *
+ * #3: Memory Management: Internal/External
+ * The chunk buffers may be allocated and freed internally or externally.
+ * Internal memory management is exposed through the alloc_*() and free_*()
+ * routines. External memory management is exposed through the set_*() routines.
+ * Currently, this only supports external memory management for contigiously
+ * addressed buffers and internal memory management for discretely addressed
+ * buffers.
+ *
+ * Note that the ChunkBuffers class does NOT support any concept of ownership.
+ * It is up to the caller to free the instance before destruction.
+ */
+
+#ifndef TILEDB_CHUNK_BUFFERS_H
+#define TILEDB_CHUNK_BUFFERS_H
+
+#include "tiledb/sm/misc/logger.h"
+#include "tiledb/sm/misc/status.h"
+
+#include <cinttypes>
+#include <vector>
+
+namespace tiledb {
+namespace sm {
+
+class ChunkBuffers {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  ChunkBuffers();
+
+  /** Copy constructor. */
+  ChunkBuffers(const ChunkBuffers& rhs);
+
+  /** Destructor. */
+  ~ChunkBuffers();
+
+  /* ********************************* */
+  /*             OPERATORS             */
+  /* ********************************* */
+
+  /** Assignment operator. */
+  ChunkBuffers& operator=(const ChunkBuffers& rhs);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * ChunkBuffers fixed-size initializer. The last chunk size may be
+   * equal-to or less-than *chunk_size*.
+   *
+   * @param contigious Whether the internal chunk buffers are contigiously
+   *   or discretely addressed.
+   * @param total_size The total byte size of all chunks.
+   * @param chunk_size The byte size of each individual chunk.
+   * @return Status
+   */
+  Status init_fixed_size(
+      bool contigious, uint64_t total_size, uint32_t chunk_size);
+
+  /**
+   * ChunkBuffers variable-sized initializer.
+   *
+   * @param contigious Whether the internal chunk buffers are contigiously
+   *   or discretely addressed.
+   * @param chunk_sizes The size for each individual chunk.
+   * @return Status
+   */
+  Status init_var_size(bool contigious, std::vector<uint32_t>&& chunk_sizes);
+
+  /** Resets the state. Must be reinitialized before performing IO. */
+  void clear();
+
+  /**
+   * Resets the state and frees the internal buffers. Must be
+   * reinitialized before performing IO.
+   */
+  void free();
+
+  /** Returns a shallow copy of the current instance. */
+  ChunkBuffers shallow_copy() const;
+
+  /** Swaps the current instance with 'rhs'. */
+  void swap(ChunkBuffers* rhs);
+
+  /**
+   * Returns summation of each chunk size. If one or more chunks
+   * are unallocated, this number will be greater than the summation
+   * of each allocated buffer.
+   */
+  uint64_t size() const;
+
+  /** Returns true if there 0 initialized chunks. */
+  bool empty() const;
+
+  /**
+   * Returns the number of initialized chunks. This does not imply
+   * the number of allocated chunks.
+   */
+  size_t nchunks() const;
+
+  /**
+   * Returns true if the chunk buffers are contigiously addressed when
+   * allocated.
+   */
+  bool contigious() const;
+
+  /**
+   * Allocates the chunk at *chunk_idx* with the internal memory manager.
+   *
+   * @param chunk_idx The index of the chunk to allocate.
+   * @param buffer If non-NULL, this will be mutated to the address
+   *   to the newly allocated buffer. This is used as an optimization
+   *   to allow the caller to avoid calling *ChunkBuffers::internal_buffer()*
+   *   to fetch this address.
+   * @return Status
+   */
+  Status alloc_discrete(size_t chunk_idx, void** buffer = nullptr);
+
+  /**
+   * Frees the chunk at *chunk_idx* with the internal memory manager.
+   *
+   * @param chunk_idx The index of the chunk to free.
+   * @return Status
+   */
+  Status free_discrete(size_t chunk_idx);
+
+  /**
+   * Sets the contigious buffer to represent all chunks. This
+   * must be pf size equal to the total size of the logical
+   * buffer that this instance represents. Assumes *buffer*
+   * was allocated with *malloc*.
+   *
+   * @param buffer The buffer to represent all chunks.
+   * @return Status
+   */
+  Status set_contigious(void* buffer);
+
+  /**
+   * Frees the contigious buffer set with *ChunkBuffers::set_contigious()*.
+   * This assumes the buffer was allocated with *malloc*.
+   *
+   * @return Status
+   */
+  Status free_contigious();
+
+  /**
+   * Returns the internal buffer at 'chunk_idx'. A nullptr buffer
+   * indicates that the internal buffer is unallocated.
+   *
+   * @param chunk_idx The index of the chunk buffer to fetch.
+   * @param buffer The buffer address to mutate to the chunk buffer address.
+   * @return Status
+   */
+  Status internal_buffer(size_t chunk_idx, void** buffer) const;
+
+  /**
+   * Returns the size of internal buffer at 'chunk_idx'. Returns a non-OK
+   * status if the chunk buffer is unallocated.
+   *
+   * @param chunk_idx The index of the chunk buffer to fetch.
+   * @param size The size to mutate to the chunk buffer size.
+   * @return Status
+   */
+  Status internal_buffer_size(size_t chunk_idx, uint32_t* size) const;
+
+  /**
+   * Reads from the offset of the logical buffer that the chunk
+   * buffers represent. This makes a copy and will return a non-OK
+   * status if any subset of the region to read contains an unallocated
+   * chunk buffer.
+   *
+   * @param buffer The buffer to copy the output to.
+   * @param nbytes The number of bytes to read.
+   * @param offset The offset to read from.
+   * @return Status
+   */
+  Status read(void* buffer, uint64_t nbytes, uint64_t offset) const;
+
+  /**
+   * Writes a buffer into the the logical buffer that the
+   * chunk buffers represent. This will make as many copies
+   * as chunk buffers it writes to. For discretely addressed
+   * chunk buffers, they will be allocated as necessary. For
+   * contigiously addressed chunk buffers, this will return a
+   * non-OK status if attempting to write to an unallocated
+   * chunk buffer.
+   *
+   * @param buffer The buffer to write.
+   * @param nbytes The number of bytes to write.
+   * @param offset The offset to write from.
+   * @return Status
+   */
+  Status write(const void* buffer, uint64_t nbytes, uint64_t offset);
+
+  // TODO: unimplemented
+  Status write(const ChunkBuffers& rhs, uint64_t offset);
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** Whether the chunk buffers are contigiously or discretely allocated. */
+  bool contigious_;
+
+  /** The internal chunk buffers. */
+  std::vector<void*> buffers_;
+
+  /** The chunk size for fixed-size chunks. */
+  uint32_t chunk_size_;
+
+  /** The last chunk size for fixed-size chunks. */
+  uint32_t last_chunk_size_;
+
+  /** The chunk size for variable-sized chunks. */
+  std::vector<uint32_t> var_chunk_sizes_;
+
+  /**
+   * The summation of all chunk sizes. Recomputed when the
+   * chunk sizes change.
+   */
+  uint64_t cached_size_;
+
+  /* ********************************* */
+  /*          PRIVATE METHODS          */
+  /* ********************************* */
+
+  /** Mutates the current instance to a deep copy of *rhs*. */
+  void deep_copy(const ChunkBuffers& rhs);
+
+  /**
+   * Returns the chunk size at the given index.
+   *
+   * @param chunk_idx The index of the chunk.
+   * @return uint32_t
+   */
+  uint32_t get_chunk_size(size_t chunk_idx) const;
+
+  /** Returns true if chunks are of a fixed size. */
+  bool fixed_chunk_sizes() const;
+
+  /**
+   * Returns the chunk index and offset within the chunk
+   * that point to the given offset of the logical buffer
+   * that the chunks represent.
+   * Runs in O(1) for fixed size chunks and O(N) for
+   * variable-sized chunks.
+   *
+   * @param logical_offset The offset of the logical buffer.
+   * @param chunk_idx Mutated to the translated chunk index.
+   * @param chunk_offset Mutated to the translated chunk offset.
+   * @return Status
+   */
+  Status translate_logical_offset(
+      uint64_t logical_offset, size_t* chunk_idx, size_t* chunk_offset) const;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_CHUNK_BUFFERS_H


### PR DESCRIPTION
For early review: ChunkBuffers and associated unit tests.

This patch contains chunk_buffers.cc/h for use in selective
decompression. This also contains a passing unit-ChunkBuffers.cc test
and a modified unit-Tile.cc test that passes with the associated
changes to Tile that are NOT included in this review.

I have included a detailed explanation of the new class in its
header file (chunk_buffers.h), but for easy reference, I'll paste it here:

 * The ChunkBuffers class is used to represent a logically contigious buffer
 * as a vector of individual buffers. These individual buffers are referred to
 * as "chunk buffers". Each chunk buffer may be allocated individually, which
 * will save memory in scenarios where the logically contigious buffer is
 * sparsley allocated.
 *
 * After construction, the class must be initialized before performing IO. The
 * initialization determines the following, independent usage paradigms:
 *
 * #1: Chunk Sizes: Fixed/Variable
 * The chunk sizes must be either fixed or variable. An instance with fixed
 * chunk sizes ensures that all chunk buffers are of equal size. The size of the
 * last chunk buffer may be equal-to or less-than the other chunk sizes.
 * Instances with fixed size chunks have a smaller memory footprint and have a
 * smaller algorithmic complexity when performing IO. For variable sized chunks,
 * each chunk size is independent from the others.
 *
 * #2: Chunk Buffer Addressing: Discrete/Contigious
 * The addresses of the individual chunk buffers may or may not be virtually
 * contigious. For example, the chunk addresses within a virtually contigious
 * instance may be allocated at address 1024 and 1028, where the first chunk is
 * of size 4. Non-contigious chunks (referred to as "discrete") may be allocated
 * at any address. The trade-off is that the memory of each discrete chunk is
 * managed individually, where contigious chunk buffers can be managed by the
 * first chunk alone.
 *
 * #3: Memory Management: Internal/External
 * The chunk buffers may be allocated and freed internally or externally.
 * Internal memory management is exposed through the alloc_*() and free_*()
 * routines. External memory management is exposed through the set_*() routines.
 * Currently, this only supports external memory management for contigiously
 * addressed buffers and internal memory management for discretely addressed
 * buffers.
 *
 * Note that the ChunkBuffers class does NOT support any concept of ownership.
 * It is up to the caller to free the instance before destruction.