### PR TITLE
Don't re-export symbols from static libraries on Linux

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -646,6 +646,16 @@ if (TILEDB_STATIC)
   )
 endif()
 
+# Don't re-export symbols from static (archive) libraries
+#   Prevents conflicts with other versions of (e.g.) OpenSSL
+#   loaded in the same process namespace, which can cause
+#   crashes if the versions are not compatible.
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set_target_properties(tiledb_shared
+    PROPERTIES
+      LINK_FLAGS "-Wl,--exclude-libs=ALL")
+endif()
+
 ############################################################
 # Installation
 ############################################################


### PR DESCRIPTION
This change resolves a crash seen by a collaborator when using TileDB-Py wheels in an application linked against OpenSSL 1.0, caused by incompatibility between the symbols in `libtiledb` and the versions already loaded in the process namespace.

From https://linux.die.net/man/1/ld:
> --exclude-libs lib,lib,...
> Specifies a list of archive libraries from which symbols should not be automatically exported. The library names may be delimited by commas or colons. Specifying "--exclude-libs ALL" excludes symbols in all archive libraries from automatic export.

A little more background for review:
- we statically link some dependencies into `libtiledb.so`
  - by default, anything we can't find on the system
  - if `FORCE_BUILD_DEPS` is set, then we build *all* dependencies and statically link them *into* `libtiledb.so` (shared library)
- prior to this commit, symbols from those archive libraries (static libraries) were re-exported, due to the default behavior of ld on linux.