### PR TITLE
Split coordinates file into multiple files, one per dimension

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # In Progress
 
+## Disk Format
+
+* Removed file __coords.tdb that stored the zipped coordinates in sparse fragments
+* Now storing the coordinate tiles on each dimension in separate files
+* Changed fragment name format from `__t1_t2_uuid` to `__t1_t2_uuid_<format_version>`. That was necessary for backwards compatibility
+
 ## New features
 
 ## Improvements

--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -383,7 +383,7 @@ TEST_CASE(
             break;
           }
           case TILEDB_UINT8: {
-            REQUIRE(static_cast<int8_t*>(buffer.second)[0] == 1);
+            REQUIRE(static_cast<uint8_t*>(buffer.second)[0] == 1);
             break;
           }
           case TILEDB_INT16: {

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -3796,8 +3796,7 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test advanced consolidation, consolidatable #1",
-    "[capi], [consolidation], [consolidation-adv], "
-    "[consolidation-adv-consolidatable-1]") {
+    "[capi][consolidation][adv][consolidatable-1]") {
   remove_dense_vector();
   create_dense_vector();
   write_dense_vector_consolidatable_1();
@@ -3821,7 +3820,7 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
   rc = tiledb_config_set(
-      config, "sm.consolidation.step_size_ratio", "0.6", &error);
+      config, "sm.consolidation.step_size_ratio", "0.7", &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
 

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -85,7 +85,7 @@ struct CPPArrayFx {
   VFS vfs;
 };
 
-TEST_CASE("Config", "[cppapi]") {
+TEST_CASE("Config", "[cppapi][config]") {
   // Primarily to instansiate operator[]/= template
   tiledb::Config cfg;
   cfg["vfs.s3.region"] = "us-east-1a";
@@ -94,7 +94,7 @@ TEST_CASE("Config", "[cppapi]") {
   CHECK((std::string)cfg["vfs.s3.use_virtual_addressing"] == "true");
 }
 
-TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi]") {
+TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic]") {
   SECTION("Dimensions") {
     ArraySchema schema(ctx, "cpp_unit_array");
     CHECK(schema.domain().ndim() == 2);
@@ -337,8 +337,7 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi]") {
 }
 
 TEST_CASE(
-    "C++ API: Incorrect buffer size and offsets",
-    "[cppapi], [invalid-offsets]") {
+    "C++ API: Incorrect buffer size and offsets", "[cppapi][invalid-offsets]") {
   const std::string array_name_1d = "cpp_unit_array_1d";
   Context ctx;
   VFS vfs(ctx);

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -33,7 +33,7 @@
 #include "catch.hpp"
 #include "tiledb/sm/cpp_api/tiledb"
 
-TEST_CASE("C++ API: Schema", "[cppapi]") {
+TEST_CASE("C++ API: Schema", "[cppapi][schema]") {
   using namespace tiledb;
   Context ctx;
 
@@ -161,7 +161,7 @@ TEST_CASE("C++ API: Schema", "[cppapi]") {
   }
 }
 
-TEST_CASE("C++ API: Test schema virtual destructors", "[cppapi]") {
+TEST_CASE("C++ API: Test schema virtual destructors", "[cppapi][schema]") {
   tiledb::Context ctx;
   // Test that this generates no compiler warnings.
   std::unique_ptr<tiledb::ArraySchema> schema;

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -100,7 +100,7 @@ class ArraySchema {
    * Returns a constant pointer to the selected attribute (nullptr if it
    * does not exist).
    */
-  const Attribute* attribute(std::string name) const;
+  const Attribute* attribute(const std::string& name) const;
 
   /**
    * Returns the given attribute name as it would be stored in the schema. E.g.
@@ -143,11 +143,11 @@ class ArraySchema {
   /** Returns the cell order. */
   Layout cell_order() const;
 
-  /** Returns the size of cell on the input attribute. */
-  uint64_t cell_size(const std::string& attribute) const;
+  /** Returns the size of cell on the input attribute/dimension. */
+  uint64_t cell_size(const std::string& name) const;
 
-  /** Returns the number of values per cell of the input attribute. */
-  unsigned int cell_val_num(const std::string& attribute) const;
+  /** Returns the number of values per cell of the input attribute/dimension. */
+  unsigned int cell_val_num(const std::string& name) const;
 
   /**
    * Return a pointer to the pipeline used for offsets of variable-sized cells.
@@ -170,8 +170,11 @@ class ArraySchema {
    */
   Status check_attributes(const std::vector<std::string>& attributes) const;
 
-  /** Return the filter pipeline for the given attribute. */
-  const FilterPipeline* filters(const std::string& attribute) const;
+  /**
+   * Return the filter pipeline for the given attribute/dimension (can be
+   * TILEDB_COORDS).
+   */
+  const FilterPipeline* filters(const std::string& name) const;
 
   /** Return a pointer to the pipeline used for coordinates. */
   const FilterPipeline* coords_filters() const;
@@ -216,6 +219,12 @@ class ArraySchema {
    */
   Status has_attribute(const std::string& name, bool* has_attr) const;
 
+  /** Returns true if the input name is an attribute. */
+  bool is_attr(const std::string& name) const;
+
+  /** Returns true if the input name is a dimension. */
+  bool is_dim(const std::string& name) const;
+
   /**
    * Serializes the array schema object into a buffer.
    *
@@ -227,11 +236,11 @@ class ArraySchema {
   /** Returns the tile order. */
   Layout tile_order() const;
 
-  /** Returns the type of the i-th attribute. */
-  Datatype type(unsigned int i) const;
-
-  /** Returns the type of the input attribute (could be coordinates). */
-  Datatype type(const std::string& attribute) const;
+  /**
+   * Returns the type of the input attribute/dimension (could also be
+   * TILEDB_COORDS).
+   */
+  Datatype type(const std::string& name) const;
 
   /**
    * Returns *true* if the input attribute/dimension has variable-sized
@@ -326,9 +335,6 @@ class ArraySchema {
    */
   Layout cell_order_;
 
-  /** Stores the size of every attribute (plus coordinates). */
-  std::unordered_map<std::string, uint64_t> cell_sizes_;
-
   /** The filter pipeline run on offset tiles for var-length attributes. */
   FilterPipeline cell_var_offsets_filters_;
 
@@ -372,9 +378,6 @@ class ArraySchema {
 
   /** Clears all members. Use with caution! */
   void clear();
-
-  /** Computes and returns the size of an attribute (or coordinates). */
-  uint64_t compute_cell_size(const std::string& attribute) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -89,6 +89,11 @@ Dimension::~Dimension() {
 /*                API                */
 /* ********************************* */
 
+unsigned int Dimension::cell_val_num() const {
+  // TODO: in a future PR the user will be able to set this value
+  return 1;
+}
+
 uint64_t Dimension::coord_size() const {
   return datatype_size(type_);
 }
@@ -209,6 +214,12 @@ void Dimension::dump(FILE* out) const {
   fprintf(out, "- Name: %s\n", is_anonymous() ? "<anonymous>" : name_.c_str());
   fprintf(out, "- Domain: %s\n", domain_s.c_str());
   fprintf(out, "- Tile extent: %s\n", tile_extent_s.c_str());
+}
+
+const FilterPipeline* Dimension::filters() const {
+  // TODO: in a future PR, the user will be able to set separate
+  // TODO: filters for each dimension
+  return nullptr;
 }
 
 const std::string& Dimension::name() const {

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -38,6 +38,7 @@
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/compressor.h"
 #include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/status.h"
 
@@ -76,6 +77,9 @@ class Dimension {
   /*                API                */
   /* ********************************* */
 
+  /** Returns the number of values per cell. */
+  unsigned int cell_val_num() const;
+
   /** Returns the size (in bytes) of a coordinate in this dimension. */
   uint64_t coord_size() const;
 
@@ -96,6 +100,9 @@ class Dimension {
 
   /** Dumps the dimension contents in ASCII form in the selected output. */
   void dump(FILE* out) const;
+
+  /** Returns the filter pipeline of this dimension. */
+  const FilterPipeline* filters() const;
 
   /** Returns the dimension name. */
   const std::string& name() const;

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -428,8 +428,10 @@ Status FilterPipeline::run_reverse(Tile* tile) const {
   if (tile->stores_coords()) {
     // Note that format version < 2 only split the coordinates when compression
     // was used. See https://github.com/TileDB-Inc/TileDB/issues/1053
+    // For format version > 4, a tile never stores coordinates
     bool using_compression = get_filter<CompressionFilter>() != nullptr;
-    if (tile->format_version() > 1 || using_compression) {
+    auto version = tile->format_version();
+    if (version > 1 || using_compression) {
       tile->zip_coordinates();
     }
   }

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -428,7 +428,7 @@ const int32_t library_version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
 /** The TileDB serialization format version number. */
-const uint32_t format_version = 4;
+const uint32_t format_version = 5;
 
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
 const uint64_t max_tile_chunk_size = 64 * 1024;

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -253,11 +253,23 @@ std::pair<uint64_t, uint64_t> get_timestamp_range(
   return ret;
 }
 
-Status get_fragment_name_version(
-    const std::string& fragment_name, uint32_t* version) {
-  auto t_str = fragment_name.substr(fragment_name.find_last_of('_') + 1);
+Status get_fragment_name_version(const URI& uri, uint32_t* version) {
+  // Prepare fragment name string
+  std::string uri_str(uri.c_str());
+  if (uri_str.back() == '/')
+    uri_str.pop_back();
+  std::string name = URI(uri_str).last_path_part();
 
-  // The newest version has the 32-byte long UUID at the end
+  // First check if it is in version 3, which has 5 '_' in the name
+  size_t n = std::count(name.begin(), name.end(), '_');
+  if (n == 5) {
+    *version = 3;
+    return Status::Ok();
+  }
+
+  // Check if it is in version 1 or 2
+  // Version 2 has the 32-byte long UUID at the end
+  auto t_str = name.substr(name.find_last_of('_') + 1);
   *version = (t_str.size() == 32) ? 2 : 1;
 
   return Status::Ok();

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -105,11 +105,15 @@ std::pair<uint64_t, uint64_t> get_timestamp_range(
     uint32_t version, const std::string& fragment_name);
 
 /**
- * Retrieves the fragment name version. Version 1 corresponds to format
- * version <=2, and 2 to format version > 2.
+ * Retrieves the fragment name version.
+ *  - Version 1 corresponds to format versions 1 and 2
+ *      * __uuid_<t1>{_t2}
+ *  - Version 2 corresponds to version 3 and 4
+ *      * __t1_t2_uuid
+ *  - Version 3 corresponds to version 5 or higher
+ *      * __t1_t2_uuid_version
  */
-Status get_fragment_name_version(
-    const std::string& fragment_name, uint32_t* version);
+Status get_fragment_name_version(const URI& uri, uint32_t* version);
 
 /** Returns `true` if the input string is a (potentially signed) integer. */
 bool is_int(const std::string& str);

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -897,17 +897,17 @@ class Reader {
       const std::vector<ResultTile*>& result_tiles) const;
 
   /**
-   * Runs the input tile for the input attribute through the filter pipeline.
-   * The tile buffer is modified to contain the output of the pipeline.
+   * Runs the input tile for the input attribute or dimension through the
+   * filter pipeline. The tile buffer is modified to contain the output of the
+   * pipeline.
    *
-   * @param attribute The attribute the tile belong to.
+   * @param name The attribute/dimension the tile belong to.
    * @param tile The tile to be filtered.
    * @param offsets True if the tile to be filtered contains offsets for a
-   *    var-sized attribute.
+   *    var-sized attribute/dimension.
    * @return Status
    */
-  Status filter_tile(
-      const std::string& attribute, Tile* tile, bool offsets) const;
+  Status filter_tile(const std::string& name, Tile* tile, bool offsets) const;
 
   /**
    * Gets all the result coordinates of the input tile into `result_coords`.
@@ -1028,6 +1028,13 @@ class Reader {
    */
   template <class T>
   bool coords_overwritten(unsigned frag_idx, const T* coords) const;
+
+  /**
+   * Creates zipped coordinate tiles for TILEDB_COORDS. This is for backwards
+   * compatibility; it will be removed in a subsequent PR.
+   */
+  Status zip_coord_tiles(
+      const std::vector<ResultTile*>& tmp_result_tiles) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -839,16 +839,15 @@ Status Consolidator::compute_new_fragment_uri(
 
   // Get timestamp ranges
   uint32_t f_version;
-  RETURN_NOT_OK(
-      utils::parse::get_fragment_name_version(first_name, &f_version));
+  RETURN_NOT_OK(utils::parse::get_fragment_name_version(first, &f_version));
   auto t_first = utils::parse::get_timestamp_range(f_version, first_name);
-  RETURN_NOT_OK(utils::parse::get_fragment_name_version(last_name, &f_version));
+  RETURN_NOT_OK(utils::parse::get_fragment_name_version(last, &f_version));
   auto t_last = utils::parse::get_timestamp_range(f_version, last_name);
 
   // Create new URI
   std::stringstream ss;
   ss << first.parent().to_string() << "/__" << t_first.first << "_"
-     << t_last.second << "_" << uuid;
+     << t_last.second << "_" << uuid << "_" << constants::format_version;
 
   *new_uri = URI(ss.str());
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -906,7 +906,7 @@ Status StorageManager::get_fragment_info(
 
   uint32_t fragment_name_version;
   RETURN_NOT_OK(utils::parse::get_fragment_name_version(
-      fragment_name, &fragment_name_version));
+      fragment_uri, &fragment_name_version));
 
   // Get timestamp range
   auto timestamp_range =
@@ -1744,8 +1744,8 @@ Status StorageManager::load_fragment_metadata(
       URI coords_uri =
           sf.uri_.join_path(constants::coords + constants::file_suffix);
 
-      RETURN_NOT_OK(utils::parse::get_fragment_name_version(
-          sf.uri_.to_string(), &f_version));
+      RETURN_NOT_OK(
+          utils::parse::get_fragment_name_version(sf.uri_, &f_version));
 
       // Note that the fragment metadata version is >= the array schema
       // version. Therefore, the check below is defensive and will always
@@ -1793,7 +1793,7 @@ Status StorageManager::get_sorted_uris(
     assert(utils::parse::starts_with(name, "__"));
 
     // Get timestamp range
-    RETURN_NOT_OK(utils::parse::get_fragment_name_version(name, &f_version));
+    RETURN_NOT_OK(utils::parse::get_fragment_name_version(uri, &f_version));
     auto timestamp_range = utils::parse::get_timestamp_range(f_version, name);
     auto t = timestamp_range.first;
 


### PR DESCRIPTION
Towards addressing #93 

* Makes appropriate changes to Reader
* Ensures backwards compatibility
* Changed fragment name from `__t1_t2_uuid` to `__t1_t2_uuid_<format_version>`. That was necessary for backwards compatibility