### PR TITLE
Fix forward declarations on array and array schema

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -32,6 +32,7 @@
 
 #include "helpers.h"
 #include "catch.hpp"
+#include "tiledb/sm/subarray/subarray_partitioner.h"
 
 namespace tiledb {
 namespace test {

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -44,6 +44,10 @@
 
 namespace tiledb {
 
+namespace sm {
+class SubarrayPartitioner;
+}
+
 namespace test {
 
 // For easy reference

--- a/test/src/unit-Tile.cc
+++ b/test/src/unit-Tile.cc
@@ -30,6 +30,7 @@
  * Tests the `Tile` class.
  */
 
+#include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/tile/tile.h"
 
 #include <catch.hpp>

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -32,7 +32,10 @@
  */
 
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/filter/bit_width_reduction_filter.h"
 #include "tiledb/sm/filter/bitshuffle_filter.h"
 #include "tiledb/sm/filter/byteshuffle_filter.h"

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -34,14 +34,20 @@
 #define TILEDB_ARRAY_H
 
 #include "tiledb/sm/encryption/encryption_key.h"
+#include "tiledb/sm/fragment/fragment_info.h"
 #include "tiledb/sm/metadata/metadata.h"
 #include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/storage_manager/open_array.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
-#include "tiledb/sm/subarray/subarray.h"
+
+#include <atomic>
+#include <unordered_map>
 
 namespace tiledb {
 namespace sm {
+
+class ArraySchema;
+class FragmentMetadata;
+class StorageManager;
+enum class QueryType : uint8_t;
 
 /**
  * An array object to be opened for reads/writes. An ``Array`` instance

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -32,7 +32,14 @@
  */
 
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/enums/array_type.h"
+#include "tiledb/sm/enums/compressor.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/filter/compression_filter.h"
 #include "tiledb/sm/misc/logger.h"
 

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -36,19 +36,6 @@
 
 #define __STDC_FORMAT_MACROS
 
-#include <string>
-#include <typeinfo>
-#include <unordered_map>
-#include <vector>
-
-#include "tiledb/sm/array_schema/attribute.h"
-#include "tiledb/sm/array_schema/dimension.h"
-#include "tiledb/sm/array_schema/domain.h"
-#include "tiledb/sm/buffer/buffer.h"
-#include "tiledb/sm/enums/array_type.h"
-#include "tiledb/sm/enums/compressor.h"
-#include "tiledb/sm/enums/datatype.h"
-#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/status.h"
@@ -56,6 +43,17 @@
 
 namespace tiledb {
 namespace sm {
+
+class Attribute;
+class Buffer;
+class ConstBuffer;
+class Dimension;
+class Domain;
+
+enum class ArrayType : uint8_t;
+enum class Compressor : uint8_t;
+enum class Datatype : uint8_t;
+enum class Layout : uint8_t;
 
 /** Specifies the array schema. */
 class ArraySchema {

--- a/tiledb/sm/array_schema/attribute.h
+++ b/tiledb/sm/array_schema/attribute.h
@@ -33,16 +33,17 @@
 #ifndef TILEDB_ATTRIBUTE_H
 #define TILEDB_ATTRIBUTE_H
 
-#include <string>
-
-#include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/compressor.h"
-#include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {
+
+class Buffer;
+class ConstBuffer;
+
+enum class Datatype : uint8_t;
 
 /** Manipulates a TileDB attribute. */
 class Attribute {

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -31,7 +31,10 @@
  */
 
 #include "tiledb/sm/array_schema/domain.h"
+#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/buffer/const_buffer.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -33,18 +33,19 @@
 #ifndef TILEDB_DOMAIN_H
 #define TILEDB_DOMAIN_H
 
-#include "tiledb/sm/array_schema/dimension.h"
-#include "tiledb/sm/buffer/buffer.h"
-#include "tiledb/sm/enums/array_type.h"
-#include "tiledb/sm/enums/datatype.h"
-#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/status.h"
 
-#include <iostream>
 #include <vector>
 
 namespace tiledb {
 namespace sm {
+
+class Buffer;
+class ConstBuffer;
+class Dimension;
+
+enum class Datatype : uint8_t;
+enum class Layout : uint8_t;
 
 /** Defines an array domain, which consists of dimensions. */
 class Domain {

--- a/tiledb/sm/array_schema/tile_domain.h
+++ b/tiledb/sm/array_schema/tile_domain.h
@@ -33,7 +33,7 @@
 #ifndef TILEDB_TILE_DOMAIN_H
 #define TILEDB_TILE_DOMAIN_H
 
-#include <iostream>
+#include <algorithm>
 #include <vector>
 
 #include "tiledb/sm/enums/layout.h"

--- a/tiledb/sm/filter/bitshuffle_filter.cc
+++ b/tiledb/sm/filter/bitshuffle_filter.cc
@@ -30,9 +30,9 @@
  * This file defines class BitshuffleFilter.
  */
 
-#include "bitshuffle_core.h"
-
 #include "tiledb/sm/filter/bitshuffle_filter.h"
+#include "bitshuffle_core.h"
+#include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/tile/tile.h"
 

--- a/tiledb/sm/filter/byteshuffle_filter.cc
+++ b/tiledb/sm/filter/byteshuffle_filter.cc
@@ -30,9 +30,9 @@
  * This file defines class ByteshuffleFilter.
  */
 
-#include "blosc/shuffle.h"
-
 #include "tiledb/sm/filter/byteshuffle_filter.h"
+#include "blosc/shuffle.h"
+#include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/tile/tile.h"
 

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -36,6 +36,8 @@
 
 #include "tiledb/sm/misc/uri.h"
 
+#include <vector>
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_QUERY_H
 #define TILEDB_QUERY_H
 
+#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/enums/query_type.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"

--- a/tiledb/sm/query/read_cell_slab_iter.cc
+++ b/tiledb/sm/query/read_cell_slab_iter.cc
@@ -32,6 +32,7 @@
 
 #include "tiledb/sm/query/read_cell_slab_iter.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/misc/logger.h"
 
 #include <cassert>

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -31,6 +31,9 @@
  */
 
 #include "tiledb/sm/serialization/array_schema.h"
+#include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/compressor.h"
 #include "tiledb/sm/enums/datatype.h"
@@ -40,6 +43,8 @@
 #include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/stats.h"
 #include "tiledb/sm/serialization/capnp_utils.h"
+
+#include <set>
 
 #ifdef TILEDB_SERIALIZATION
 #include <capnp/compat/json.h>

--- a/tiledb/sm/subarray/cell_slab_iter.cc
+++ b/tiledb/sm/subarray/cell_slab_iter.cc
@@ -32,6 +32,8 @@
 
 #include "tiledb/sm/subarray/cell_slab_iter.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/misc/logger.h"
 
 #include <cassert>

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -32,7 +32,13 @@
 
 #include "tiledb/sm/subarray/subarray.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/array_schema/domain.h"
+#include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/rtree/rtree.h"
 
 #include <iomanip>

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -33,6 +33,9 @@
 #include "tiledb/sm/subarray/subarray_partitioner.h"
 #include <iomanip>
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/sm/array_schema/domain.h"
 
 /* ****************************** */
 /*             MACROS             */

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/tile/tile.h"
+#include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/logger.h"
 
 #include <iostream>


### PR DESCRIPTION
This change resolves missing forward declarations on header files which are located under [array](https://github.com/TileDB-Inc/TileDB/tree/dev/tiledb/sm/array) and [array_schema](https://github.com/TileDB-Inc/TileDB/tree/dev/tiledb/sm/array_schema) folders as a first part. 

The main idea behind this change is, when you have fix on only one header file, number of affected files should be minimum. However, without forward declaration it cannot be done properly. So, if incomplete-types are located in header files, they should be declarative and forwarded - not header file included -.

For review simplicity, only two folders are included into this pull request as first part. If accepted, other files will be refactored as well. Here is the list what I've done so far:

- If type is incomplete(Pointer, reference, enum class), these are declared in header files.
- Corresponding header files are only included in necessary-used implementation files.
- Include order has to be defined or negotiated, order of header file inclusions is not organized in many header files in the project. My proposal is [here](https://stackoverflow.com/a/2762596). I followed that in my changes.
- I have to touch other files where not located in those two folders because of dependency.