### PR TITLE
Lazy array metadata fetching

### DIFF
--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -295,16 +295,13 @@ class Array {
       const void** value);
 
   /** Returns the number of array metadata items. */
-  Status get_metadata_num(uint64_t* num) const;
+  Status get_metadata_num(uint64_t* num);
 
   /** Sets has_key == 1 and corresponding value_type if the array has key. */
   Status has_metadata_key(const char* key, Datatype* value_type, bool* has_key);
 
-  /** Returns the array metadata object. */
-  Metadata* metadata();
-
-  /** Returns the array metadata object. */
-  const Metadata* metadata() const;
+  /** Retrieves the array metadata object. */
+  Status metadata(Metadata** metadata);
 
  private:
   /* ********************************* */
@@ -362,6 +359,9 @@ class Array {
 
   /** The array metadata. */
   Metadata metadata_;
+
+  /** True if the array metadata is loaded. */
+  bool metadata_loaded_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -303,6 +303,18 @@ class Array {
   /** Retrieves the array metadata object. */
   Status metadata(Metadata** metadata);
 
+  /**
+   * Retrieves the array metadata object.
+   *
+   * @note This is potentially an unsafe operation
+   * it could have contention with locks from lazy loading of metadata.
+   * This should only be used by the serialization class
+   * (tiledb/sm/serialization/array_schema.cc). In that class we need to fetch
+   * the underlying Metadata object to set the values we are loading from REST.
+   * A lock should already by taken before load_metadata is called.
+   */
+  Metadata* metadata();
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -414,6 +426,12 @@ class Array {
       const T* subarray,
       std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*
           max_buffer_sizes) const;
+
+  /**
+   * Load array metadata, handles remote arrays vs non-remote arrays
+   * @return  Status
+   */
+  Status load_metadata();
 };
 
 }  // namespace sm

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -169,7 +169,7 @@ class Metadata {
       uint32_t* key_len,
       Datatype* value_type,
       uint32_t* value_num,
-      const void** value) const;
+      const void** value);
 
   /** Returns the number of metadata items. */
   uint64_t num() const;
@@ -246,6 +246,12 @@ class Metadata {
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
+
+  /**
+   * Build the metadata index vector from the metadata map
+   * @return Status
+   */
+  Status build_metadata_index();
 };
 
 }  // namespace sm

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -248,8 +248,7 @@ Status RestClient::get_array_metadata_from_rest(
       array, serialization_type_, returned_data);
 }
 
-Status RestClient::post_array_metadata_to_rest(
-    const URI& uri, const Array* array) {
+Status RestClient::post_array_metadata_to_rest(const URI& uri, Array* array) {
   if (array == nullptr)
     return LOG_STATUS(Status::RestError(
         "Error posting array metadata to REST; array is null."));
@@ -690,7 +689,7 @@ Status RestClient::get_array_metadata_from_rest(const URI&, uint64_t, Array*) {
       Status::RestError("Cannot use rest client; serialization not enabled."));
 }
 
-Status RestClient::post_array_metadata_to_rest(const URI&, const Array*) {
+Status RestClient::post_array_metadata_to_rest(const URI&, Array*) {
   return LOG_STATUS(
       Status::RestError("Cannot use rest client; serialization not enabled."));
 }

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -126,7 +126,7 @@ class RestClient {
    * @param array Array to update/post metadata for.
    * @return Status
    */
-  Status post_array_metadata_to_rest(const URI& uri, const Array* array);
+  Status post_array_metadata_to_rest(const URI& uri, Array* array);
 
   /**
    * Post a data query to rest server

--- a/tiledb/sm/serialization/array_schema.h
+++ b/tiledb/sm/serialization/array_schema.h
@@ -79,9 +79,7 @@ Status max_buffer_sizes_deserialize(
         buffer_sizes);
 
 Status array_metadata_serialize(
-    const Array* array,
-    SerializationType serialize_type,
-    Buffer* serialized_buffer);
+    Array* array, SerializationType serialize_type, Buffer* serialized_buffer);
 
 Status array_metadata_deserialize(
     Array* array,

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -121,12 +121,16 @@ Status Consolidator::consolidate_array_metadata(
   // Swap the in-memory metadata between the two arrays.
   // After that, the array for writes will store the (consolidated by
   // the way metadata loading works) metadata of the array for reads
-  auto metadata_r = array_for_reads.metadata();
-  auto metadata_w = array_for_writes.metadata();
+  Metadata* metadata_r;
+  RETURN_NOT_OK_ELSE(
+      array_for_reads.metadata(&metadata_r), array_for_reads.close());
+  Metadata* metadata_w;
+  RETURN_NOT_OK_ELSE(
+      array_for_writes.metadata(&metadata_w), array_for_reads.close());
   metadata_r->swap(metadata_w);
 
   // Metadata uris to delete
-  const auto to_delete = array_for_writes.metadata()->loaded_metadata_uris();
+  const auto to_delete = metadata_w->loaded_metadata_uris();
 
   // Close arrays
   RETURN_NOT_OK_ELSE(array_for_reads.close(), array_for_writes.close());

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -142,7 +142,6 @@ class StorageManager {
    *     array is opened.
    * @param fragment_metadata The fragment metadata to be retrieved
    *     after the array is opened.
-   * @param metadata The array metadata will be loaded here if not null.
    * @return Status
    */
   Status array_open_for_reads(
@@ -150,8 +149,7 @@ class StorageManager {
       uint64_t timestamp,
       const EncryptionKey& encryption_key,
       ArraySchema** array_schema,
-      std::vector<FragmentMetadata*>* fragment_metadata,
-      Metadata* metadata = nullptr);
+      std::vector<FragmentMetadata*>* fragment_metadata);
 
   /**
    * Opens an array for reads, focusing only on a given list of fragments.
@@ -200,7 +198,6 @@ class StorageManager {
    *     array is opened.
    * @param fragment_metadata The fragment metadata to be retrieved
    *     after the array is opened.
-   * @param metadata The array metadata to be loaded.
    * @return Status
    */
   Status array_reopen(
@@ -208,8 +205,7 @@ class StorageManager {
       uint64_t timestamp,
       const EncryptionKey& encryption_key,
       ArraySchema** array_schema,
-      std::vector<FragmentMetadata*>* fragment_metadata,
-      Metadata* metadata);
+      std::vector<FragmentMetadata*>* fragment_metadata);
 
   /**
    * Consolidates the fragments of an array into a single one.
@@ -450,6 +446,16 @@ class StorageManager {
       const URI& array_uri,
       const EncryptionKey& encryption_key,
       ArraySchema** array_schema);
+
+  /**
+   * Loads the array metadata from persistent storage that were created
+   * at or before `timestamp`.
+   */
+  Status load_array_metadata(
+      const URI& array_uri,
+      const EncryptionKey& encryption_key,
+      uint64_t timestamp,
+      Metadata* metadata);
 
   /** Removes a TileDB object (group, array). */
   Status object_remove(const char* path) const;


### PR DESCRIPTION
Lazily read the array metadata when requested for the first time, instead of fetching it in advance upon array opening.