### PR TITLE
Removed min-max macros and replaced with standard library functions

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -40,14 +40,6 @@
 #include <cassert>
 #include <iostream>
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#ifndef MIN
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#endif
-
 namespace tiledb {
 namespace sm {
 
@@ -858,7 +850,7 @@ Status Array::compute_max_buffer_sizes(
             continue;
 
           // Potentially rectify size
-          it.second.first = MIN(it.second.first, new_size);
+          it.second.first = std::min(it.second.first, new_size);
         }
       }
     }

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -43,13 +43,6 @@
 #include <limits>
 #include <sstream>
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 namespace tiledb {
 namespace sm {
 
@@ -282,7 +275,7 @@ Status Domain::split_subarray_global(
     } else {
       s1[2 * i] = s[2 * i];
       s1[2 * i + 1] =
-          s1[2 * i] + MAX(1, floor(tiles_apart / 2)) * tile_extents[i];
+          s1[2 * i] + std::max<T>(1, floor(tiles_apart / 2)) * tile_extents[i];
 
       if (std::numeric_limits<T>::is_integer) {
         s1[2 * i + 1] = floor_to_tile(s1[2 * i + 1], i) - 1;
@@ -720,13 +713,13 @@ void Domain::get_end_of_cell_slab(
                             tile_extents[dim_num_ - 1]) -
                            1;
       end[dim_num_ - 1] =
-          MIN(end[dim_num_ - 1], subarray[2 * (dim_num_ - 1) + 1]);
+          std::min(end[dim_num_ - 1], subarray[2 * (dim_num_ - 1) + 1]);
     } else {
       for (unsigned i = 0; i < dim_num_; ++i)
         end[i] = start[i];
       end[0] +=
           tile_extents[0] - ((start[0] - domain[0]) % tile_extents[0]) - 1;
-      end[0] = MIN(end[0], subarray[1]);
+      end[0] = std::min(end[0], subarray[1]);
     }
   } else {
     for (unsigned i = 0; i < dim_num_; ++i)

--- a/tiledb/sm/array_schema/tile_domain.h
+++ b/tiledb/sm/array_schema/tile_domain.h
@@ -38,13 +38,6 @@
 
 #include "tiledb/sm/enums/layout.h"
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 namespace tiledb {
 namespace sm {
 
@@ -193,8 +186,9 @@ class TileDomain {
     ret.resize(2 * dim_num_);
     auto tile_subarray = this->tile_subarray(tile_coords);
     for (unsigned i = 0; i < dim_num_; ++i) {
-      ret[2 * i] = MAX(tile_subarray[2 * i], domain_slice_[2 * i]);
-      ret[2 * i + 1] = MIN(tile_subarray[2 * i + 1], domain_slice_[2 * i + 1]);
+      ret[2 * i] = std::max(tile_subarray[2 * i], domain_slice_[2 * i]);
+      ret[2 * i + 1] =
+          std::min(tile_subarray[2 * i + 1], domain_slice_[2 * i + 1]);
     }
 
     return ret;

--- a/tiledb/sm/compressors/dd_compressor.cc
+++ b/tiledb/sm/compressors/dd_compressor.cc
@@ -39,8 +39,6 @@
 /* ****************************** */
 
 #define ABS(x) ((x) < 0) ? uint64_t(-(x)) : uint64_t(x)
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 namespace tiledb {
 namespace sm {
@@ -251,7 +249,7 @@ Status DoubleDelta::compute_bitsize(
     int64_t dd = cur_delta - prev_delta;
     delta_out_of_bounds |= (char)(cur_delta < 0 && prev_delta > 0 && dd > 0);
     delta_out_of_bounds |= (char)(cur_delta > 0 && prev_delta < 0 && dd < 0);
-    max = MAX(std::abs(dd), max);
+    max = std::max(std::abs(dd), max);
     prev_delta = cur_delta;
   }
   // Handle error
@@ -337,7 +335,7 @@ Status DoubleDelta::read_double_delta(
 
   // Read double delta
   int bits_left_to_read = bitsize;
-  int bits_to_read_from_chunk = MIN(*bit_in_chunk + 1, bits_left_to_read);
+  int bits_to_read_from_chunk = std::min(*bit_in_chunk + 1, bits_left_to_read);
   uint64_t tmp_chunk;
   int bit_in_dd = bitsize - 1;
   *double_delta = 0;
@@ -355,7 +353,7 @@ Status DoubleDelta::read_double_delta(
     if (*bit_in_chunk < 0 && buff->offset() != buff->size()) {
       RETURN_NOT_OK(buff->read(chunk, sizeof(uint64_t)));
       *bit_in_chunk = 63;
-      bits_to_read_from_chunk = MIN(*bit_in_chunk + 1, bits_left_to_read);
+      bits_to_read_from_chunk = std::min(*bit_in_chunk + 1, bits_left_to_read);
     }
   }
 
@@ -387,7 +385,7 @@ Status DoubleDelta::write_double_delta(
   // Write rest of bits
   int bits_left_to_write = bitsize;
   int bit_in_dd = bitsize - 1;
-  int bits_to_fill_in_chunk = MIN((*bit_in_chunk) + 1, bits_left_to_write);
+  int bits_to_fill_in_chunk = std::min((*bit_in_chunk) + 1, bits_left_to_write);
   uint64_t abs_dd = ABS(double_delta);
   uint64_t tmp_abs_dd;
 
@@ -406,7 +404,7 @@ Status DoubleDelta::write_double_delta(
       RETURN_NOT_OK(buff->write(chunk, sizeof(uint64_t)));
       *bit_in_chunk = 63;
       *chunk = 0;
-      bits_to_fill_in_chunk = MIN((*bit_in_chunk) + 1, bits_left_to_write);
+      bits_to_fill_in_chunk = std::min((*bit_in_chunk) + 1, bits_left_to_write);
     }
   }
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -42,13 +42,6 @@
 #include <cassert>
 #include <iostream>
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 namespace tiledb {
 namespace sm {
 
@@ -819,10 +812,10 @@ void FragmentMetadata::get_subarray_tile_domain(
 
   // Calculate subarray in tile domain
   for (unsigned int i = 0; i < dim_num; ++i) {
-    auto overlap = MAX(subarray[2 * i], domain[2 * i]);
+    auto overlap = std::max(subarray[2 * i], domain[2 * i]);
     subarray_tile_domain[2 * i] = (overlap - domain[2 * i]) / tile_extents[i];
 
-    overlap = MIN(subarray[2 * i + 1], domain[2 * i + 1]);
+    overlap = std::min(subarray[2 * i + 1], domain[2 * i + 1]);
     subarray_tile_domain[2 * i + 1] =
         (overlap - domain[2 * i]) / tile_extents[i];
   }

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -45,13 +45,6 @@
 #include <sys/time.h>
 #endif
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 namespace tiledb {
 namespace sm {
 
@@ -747,8 +740,8 @@ void overlap(const T* a, const T* b, unsigned dim_num, T* o, bool* overlap) {
   // Get overlap range
   *overlap = true;
   for (unsigned int i = 0; i < dim_num; ++i) {
-    o[2 * i] = MAX(a[2 * i], b[2 * i]);
-    o[2 * i + 1] = MIN(a[2 * i + 1], b[2 * i + 1]);
+    o[2 * i] = std::max(a[2 * i], b[2 * i]);
+    o[2 * i + 1] = std::min(a[2 * i + 1], b[2 * i + 1]);
     if (o[2 * i] > b[2 * i + 1] || o[2 * i + 1] < b[2 * i]) {
       *overlap = false;
       break;

--- a/tiledb/sm/query/query_macros.h
+++ b/tiledb/sm/query/query_macros.h
@@ -36,18 +36,6 @@
 namespace tiledb {
 namespace sm {
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#ifndef MIN
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#endif
-
-#ifndef MAX
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-#endif
-
 #ifndef RETURN_CANCEL_OR_ERROR
 /**
  * Returns an error status if the given Status is not Status::Ok, or

--- a/tiledb/sm/query/read_cell_slab_iter.cc
+++ b/tiledb/sm/query/read_cell_slab_iter.cc
@@ -39,13 +39,6 @@
 #include <iostream>
 #include <list>
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 namespace tiledb {
 namespace sm {
 
@@ -199,8 +192,8 @@ void ReadCellSlabIter<T>::compute_cell_slab_overlap(
   }
 
   // There is some overlap
-  T overlap_start = MAX(slab_start, frag_domain[2 * slab_dim]);
-  T overlap_end = MIN(slab_end, frag_domain[2 * slab_dim + 1]);
+  T overlap_start = std::max(slab_start, frag_domain[2 * slab_dim]);
+  T overlap_end = std::min(slab_end, frag_domain[2 * slab_dim + 1]);
   *slab_overlap = cell_slab.coords_;
   (*slab_overlap)[slab_dim] = overlap_start;
   *overlap_length = overlap_end - overlap_start + 1;

--- a/tiledb/sm/query/write_cell_slab_iter.cc
+++ b/tiledb/sm/query/write_cell_slab_iter.cc
@@ -37,13 +37,6 @@
 #include <cassert>
 #include <iostream>
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -40,18 +40,6 @@
 #include <iostream>
 #include <sstream>
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#ifndef MAX
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-#endif
-
-#ifndef MIN
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#endif
-
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -46,18 +46,6 @@
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/tile_io.h"
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#ifndef MAX
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-#endif
-
-#ifndef MIN
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#endif
-
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -43,14 +43,6 @@
 
 #include <iomanip>
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#ifndef MIN
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#endif
-
 namespace tiledb {
 namespace sm {
 
@@ -1030,8 +1022,8 @@ Status Subarray::compute_est_result_size(
     max_size_fixed =
         utils::math::safe_mul(cell_num, array_schema->cell_size(attr_name));
   }
-  ret.size_fixed_ = MIN(ret.size_fixed_, max_size_fixed);
-  ret.size_var_ = MIN(ret.size_var_, max_size_var);
+  ret.size_fixed_ = std::min<double>(ret.size_fixed_, max_size_fixed);
+  ret.size_var_ = std::min<double>(ret.size_var_, max_size_var);
 
   *result_size = ret;
 

--- a/tiledb/sm/tile/tile_io.cc
+++ b/tiledb/sm/tile/tile_io.cc
@@ -37,14 +37,6 @@
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/stats.h"
 
-/* ****************************** */
-/*             MACROS             */
-/* ****************************** */
-
-#ifndef MIN
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#endif
-
 namespace tiledb {
 namespace sm {
 


### PR DESCRIPTION
In many header and implementation files, _MIN_ and _MAX_ macros are defined for comparing values in order to decide which one is smaller or greater than the other.

So, standart library has already support such thing in std namespace so, **std::min** and **std::max** can be used instead of user-defined macros.

PS: Some of these comparisons have to be considered more precisely because their types are mismatched and they have to be fixed somehow in another PR. For solving current compilation errors, I fixed a few them but please look closer on those and correct me if I am wrong.