### PR TITLE
S3: add support for STS session tokens

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -186,6 +186,12 @@ void check_save_to_file() {
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
 
+  // Check that aws session token is not serialized.
+  rc = tiledb_config_set(
+      config, "vfs.s3.aws_session_token", "session_token", &error);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+
   rc = tiledb_config_save_to_file(config, "test_config.txt", &error);
   REQUIRE(rc == TILEDB_OK);
 
@@ -416,6 +422,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.s3.region"] = "us-east-1";
   all_param_values["vfs.s3.aws_access_key_id"] = "";
   all_param_values["vfs.s3.aws_secret_access_key"] = "";
+  all_param_values["vfs.s3.aws_session_token"] = "";
   all_param_values["vfs.s3.endpoint_override"] = "";
   all_param_values["vfs.s3.use_virtual_addressing"] = "true";
   all_param_values["vfs.s3.use_multipart_upload"] = "true";
@@ -452,6 +459,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.region"] = "us-east-1";
   vfs_param_values["s3.aws_access_key_id"] = "";
   vfs_param_values["s3.aws_secret_access_key"] = "";
+  vfs_param_values["s3.aws_session_token"] = "";
   vfs_param_values["s3.endpoint_override"] = "";
   vfs_param_values["s3.use_virtual_addressing"] = "true";
   vfs_param_values["s3.use_multipart_upload"] = "true";
@@ -480,6 +488,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["region"] = "us-east-1";
   s3_param_values["aws_access_key_id"] = "";
   s3_param_values["aws_secret_access_key"] = "";
+  s3_param_values["aws_session_token"] = "";
   s3_param_values["endpoint_override"] = "";
   s3_param_values["use_virtual_addressing"] = "true";
   s3_param_values["use_multipart_upload"] = "true";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -50,5 +50,5 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 31);
+  CHECK(names.size() == 32);
 }

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1000,6 +1000,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.s3.aws_secret_access_key` <br>
  *    Set the AWS_SECRET_ACCESS_KEY <br>
  *    **Default**: ""
+ * - `vfs.s3.aws_access_key_id` <br>
+ *    Set the AWS_SESSION_TOKEN <br>
+ *    **Default**: ""
  * - `vfs.s3.scheme` <br>
  *    The S3 scheme (`http` or `https`), if S3 is enabled. <br>
  *    **Default**: https

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -83,6 +83,7 @@ const std::string Config::VFS_FILE_ENABLE_FILELOCKS = "true";
 const std::string Config::VFS_S3_REGION = "us-east-1";
 const std::string Config::VFS_S3_AWS_ACCESS_KEY_ID = "";
 const std::string Config::VFS_S3_AWS_SECRET_ACCESS_KEY = "";
+const std::string Config::VFS_S3_AWS_SESSION_TOKEN = "";
 const std::string Config::VFS_S3_SCHEME = "https";
 const std::string Config::VFS_S3_ENDPOINT_OVERRIDE = "";
 const std::string Config::VFS_S3_USE_VIRTUAL_ADDRESSING = "true";
@@ -117,6 +118,7 @@ const std::set<std::string> Config::unserialized_params_ = {
     "vfs.s3.proxy_password",
     "vfs.s3.aws_access_key_id",
     "vfs.s3.aws_secret_access_key",
+    "vfs.s3.aws_session_token",
     "rest.username",
     "rest.password",
     "rest.token",
@@ -162,6 +164,7 @@ Config::Config() {
   param_values_["vfs.s3.region"] = VFS_S3_REGION;
   param_values_["vfs.s3.aws_access_key_id"] = VFS_S3_AWS_ACCESS_KEY_ID;
   param_values_["vfs.s3.aws_secret_access_key"] = VFS_S3_AWS_SECRET_ACCESS_KEY;
+  param_values_["vfs.s3.aws_session_token"] = VFS_S3_AWS_SESSION_TOKEN;
   param_values_["vfs.s3.scheme"] = VFS_S3_SCHEME;
   param_values_["vfs.s3.endpoint_override"] = VFS_S3_ENDPOINT_OVERRIDE;
   param_values_["vfs.s3.use_virtual_addressing"] =
@@ -373,6 +376,8 @@ Status Config::unset(const std::string& param) {
   } else if (param == "vfs.s3.aws_secret_access_key") {
     param_values_["vfs.s3.aws_secret_access_key"] =
         VFS_S3_AWS_SECRET_ACCESS_KEY;
+  } else if (param == "vfs.s3.aws_session_token") {
+    param_values_["vfs.s3.aws_session_token"] = VFS_S3_AWS_SESSION_TOKEN;
   } else if (param == "vfs.s3.logging_level") {
     param_values_["vfs.s3.logging_level"] = VFS_S3_LOGGING_LEVEL;
   } else if (param == "vfs.s3.scheme") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -173,6 +173,9 @@ class Config {
   /** S3 aws secret access key. */
   static const std::string VFS_S3_AWS_SECRET_ACCESS_KEY;
 
+  /** S3 aws session token. */
+  static const std::string VFS_S3_AWS_SESSION_TOKEN;
+
   /** S3 scheme (http for local minio, https for AWS S3). */
   static const std::string VFS_S3_SCHEME;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -335,6 +335,9 @@ class Config {
    * - `vfs.s3.aws_secret_access_key` <br>
    *    Set the AWS_SECRET_ACCESS_KEY <br>
    *    **Default**: ""
+   * - `vfs.s3.aws_session_token` <br>
+   *    Set the AWS_SESSION_TOKEN <br>
+   *    **Default**: ""
    * - `vfs.s3.scheme` <br>
    *    The S3 scheme (`http` or `https`), if S3 is enabled. <br>
    *    **Default**: https


### PR DESCRIPTION
Some AWS credentials are issued via the AWS STS, which requires to pass an additional "session token" to the AWSCredentials object.

- https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
- https://sdk.amazonaws.com/cpp/api/0.12.9/d4/d27/class_aws_1_1_auth_1_1_a_w_s_credentials.html (SetSessionToken)

Fixes issue raised by user in the forum: https://forum.tiledb.com/t/tile-db-s3-documentation/132/5

[ch1468]