### PR TITLE
Fix S3 build on Windows; enable S3 build w/out test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,10 +47,10 @@ jobs:
     matrix:
       VS2015:
         imageName: 'vs2015-win2012r2'
-        #TILEDB_S3: ON
+        TILEDB_S3: ON
       VS2017:
         imageName: 'vs2017-win2016'
-        TILEDB_TOOLS: ON
+        TILEDB_S3: ON
   pool:
     vmImage: $(imageName)
   steps:

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -13,7 +13,8 @@ steps:
     }
 
     # TODO DEBUG move this back in the TILEDB_S3 section
-    & "$env:BUILD_SOURCESDIRECTORY\scripts\install-minio.ps1"
+    # currently we do not run S3 tests on Windows because tests time out (minio+azure slow?)
+    #& "$env:BUILD_SOURCESDIRECTORY\scripts\install-minio.ps1"
 
     if ($env:TILEDB_S3 -eq "ON") {
       & "$env:BUILD_SOURCESDIRECTORY\bootstrap.ps1" -EnableS3 -EnableVerbose -EnableStaticTileDB
@@ -31,6 +32,13 @@ steps:
        Write-Host "Build failed. CMake exit status: " $LastExitCocde
        $host.SetShouldExit($LastExitCode)
     }
+
+    cmake --build $env:AGENT_BUILDDIRECTORY\build --target install-tiledb --config Release
+
+    if ($LastExitCode -ne 0) {
+      Write-Host "Installation failed."
+      $host.SetShouldExit($LastExitCode)
+    }
   displayName: "Build"
 
 - powershell: |
@@ -42,7 +50,10 @@ steps:
     # Clone backwards compatibility test arrays
     git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git  $env:BUILD_SOURCESDIRECTORY/test/inputs/arrays/read_compatibility_test
 
-    cd $env:AGENT_BUILDDIRECTORY\build\tiledb
+    if ($env:TILEDB_S3 -eq "ON") {
+      # update CMake to disable S3 for the test configuration, see minio note above
+      cmake -B $env:AGENT_BUILDDIRECTORY\build\tiledb -DTILEDB_S3=0 $env:AGENT_BUILDDIRECTORY\build\tiledb
+    }
 
     # CMake exits with non-0 status if there are any warnings during the build, so
     # build the unit test executable before running tests.
@@ -61,13 +72,6 @@ steps:
 
     if ($LastExitCode -ne 0) {
       Write-Host "Examples failed to build."
-      $host.SetShouldExit($LastExitCode)
-    }
-
-    cmake --build $env:AGENT_BUILDDIRECTORY\build --target install-tiledb --config Release
-
-    if ($LastExitCode -ne 0) {
-      Write-Host "Installation failed."
       $host.SetShouldExit($LastExitCode)
     }
 

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -123,6 +123,9 @@ ArrayFx::ArrayFx() {
         tiledb_config_set(
             config, "vfs.s3.ca_file", test_ca_file.c_str(), &error) ==
         TILEDB_OK);
+    REQUIRE(
+        tiledb_config_set(config, "vfs.s3.verify_ssl", "false", &error) ==
+        TILEDB_OK);
     REQUIRE(error == nullptr);
 #endif
   }
@@ -1328,6 +1331,9 @@ TEST_CASE_METHOD(
     REQUIRE(
         tiledb_config_set(
             config, "vfs.s3.ca_path", test_ca_path.c_str(), &error) ==
+        TILEDB_OK);
+    REQUIRE(
+        tiledb_config_set(config, "vfs.s3.verify_ssl", "false", &error) ==
         TILEDB_OK);
     REQUIRE(error == nullptr);
 #endif

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -50,6 +50,8 @@
 
 #ifdef _WIN32
 #include <Windows.h>
+#undef GetMessage  // workaround for
+                   // https://github.com/aws/aws-sdk-cpp/issues/402
 #endif
 
 #include "tiledb/sm/filesystem/s3.h"


### PR DESCRIPTION
This PR fixes the S3 build on Windows, which was broken due to header reordering in https://github.com/TileDB-Inc/TileDB/pull/1463, which created a conflict with a `Windows.h` definition of `GetMessage` -> `GetMessageA` (x-ref solution in https://github.com/aws/aws-sdk-cpp/issues/402).

The breakage was not noticed on CI because we do not currently run a build with S3 enabled on Windows, due to the S3 tests timing out when running against minio on Windows. I've verified that minio is running on CI, with a python script that queries the minio `live` and `ready` pages (ensures status 200). CI logs also indicate that a number of tests requiring S3 do pass (tests which would fail without minio running).

Locally, the tests finish successfully in a few minutes on my Windows laptop. I'm still unclear on the reason for the slowdown on azure.

For now, to catch future S3-related build issues, this PR enables `TILEDB_S3` for the windows builds, but disables the S3 compiler definition before building the tests, which causes the tests to run in the local configuration.