### PR TITLE
Add support for http compression of REST requests

### DIFF
--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -95,8 +95,9 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
     )
 
   else()
+    set(DEPENDS)
     if (TARGET ep_openssl)
-      set(DEPENDS ep_openssl)
+      list(APPEND DEPENDS ep_openssl)
       set(WITH_SSL "--with-ssl=${TILEDB_EP_INSTALL_PREFIX}")
     elseif (TILEDB_OPENSSL_DIR)
       # ensure that curl links against the same libSSL
@@ -105,6 +106,18 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
       message(WARNING "TileDB FindOpenSSL_EP did not set TILEDB_OPENSSL_DIR. Falling back to autotools detection.")
       # ensure that curl config errors out if SSL not available
       set(WITH_SSL "--with-ssl")
+    endif()
+
+    if (TARGET ep_zlib)
+      list(APPEND DEPENDS ep_zlib)
+      set(WITH_ZLIB "--with-zlib=${TILEDB_EP_INSTALL_PREFIX}")
+    elseif (TILEDB_ZLIB_DIR)
+      # ensure that curl links against the same libz
+      set(WITH_ZLIB "--with-zlib=${TILEDB_ZLIB_DIR}")
+    else()
+      message(WARNING "TileDB FindZlib_EP did not set TILEDB_ZLIB_DIR. Falling back to autotools detection.")
+      # ensure that curl config errors out if SSL not available
+      set(WITH_ZLIB "--with-zlib")
     endif()
 
     ExternalProject_Add(ep_curl
@@ -119,6 +132,7 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
           --disable-ldap
           --with-pic=yes
           ${WITH_SSL}
+          ${WITH_ZLIB}
       BUILD_IN_SOURCE TRUE
       BUILD_COMMAND $(MAKE)
       INSTALL_COMMAND $(MAKE) install

--- a/cmake/Modules/FindZlib_EP.cmake
+++ b/cmake/Modules/FindZlib_EP.cmake
@@ -101,6 +101,9 @@ if (NOT ZLIB_FOUND)
     list(APPEND FORWARD_EP_CMAKE_ARGS
       -DTILEDB_ZLIB_EP_BUILT=TRUE
     )
+
+    set(TILEDB_ZLIB_DIR "${TILEDB_EP_INSTALL_PREFIX}")
+
   else()
     message(FATAL_ERROR "Unable to find Zlib")
   endif()

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -196,6 +196,7 @@ void check_save_to_file() {
   REQUIRE(rc == TILEDB_OK);
 
   std::stringstream ss;
+  ss << "rest.http_compressor any\n";
   ss << "rest.server_address https://api.tiledb.com\n";
   ss << "rest.server_serialization_format CAPNP\n";
   ss << "sm.check_coord_dups true\n";
@@ -392,6 +393,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   std::map<std::string, std::string> all_param_values;
   all_param_values["rest.server_address"] = "https://api.tiledb.com";
   all_param_values["rest.server_serialization_format"] = "CAPNP";
+  all_param_values["rest.http_compressor"] = "any";
   all_param_values["sm.dedup_coords"] = "false";
   all_param_values["sm.check_coord_dups"] = "true";
   all_param_values["sm.check_coord_oob"] = "true";

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -50,6 +50,7 @@ namespace sm {
 const std::string Config::REST_SERVER_DEFAULT_ADDRESS =
     "https://api.tiledb.com";
 const std::string Config::REST_SERIALIZATION_DEFAULT_FORMAT = "CAPNP";
+const std::string Config::REST_SERVER_DEFAULT_HTTP_COMPRESSOR = "any";
 const std::string Config::SM_DEDUP_COORDS = "false";
 const std::string Config::SM_CHECK_COORD_DUPS = "true";
 const std::string Config::SM_CHECK_COORD_OOB = "true";
@@ -133,6 +134,7 @@ Config::Config() {
   param_values_["rest.server_address"] = REST_SERVER_DEFAULT_ADDRESS;
   param_values_["rest.server_serialization_format"] =
       REST_SERIALIZATION_DEFAULT_FORMAT;
+  param_values_["rest.http_compressor"] = REST_SERVER_DEFAULT_HTTP_COMPRESSOR;
   param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
   param_values_["sm.check_coord_dups"] = SM_CHECK_COORD_DUPS;
   param_values_["sm.check_coord_oob"] = SM_CHECK_COORD_OOB;
@@ -316,6 +318,8 @@ Status Config::unset(const std::string& param) {
   } else if (param == "rest.server_serialization_format") {
     param_values_["rest.server_serialization_format"] =
         REST_SERIALIZATION_DEFAULT_FORMAT;
+  } else if (param == "rest.http_compressor") {
+    param_values_["rest.http_compressor"] = REST_SERVER_DEFAULT_HTTP_COMPRESSOR;
   } else if (param == "sm.dedup_coords") {
     param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
   } else if (param == "sm.check_coord_dups") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -63,6 +63,9 @@ class Config {
   /** The default format for serialization. */
   static const std::string REST_SERIALIZATION_DEFAULT_FORMAT;
 
+  /** The default compressor for http requests with the rest server. */
+  static const std::string REST_SERVER_DEFAULT_HTTP_COMPRESSOR;
+
   /** If `true`, this will deduplicate coordinates upon sparse writes. */
   static const std::string SM_DEDUP_COORDS;
 

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -348,6 +348,25 @@ Status Curl::make_curl_request_common(
     /* set timeout */
     // curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
 
+    /* set compression */
+    const char* compressor = nullptr;
+    RETURN_NOT_OK(config_->get("rest.http_compressor", &compressor));
+
+    if (compressor != nullptr) {
+      // curl expects lowecase strings so let's convert
+      std::string comp(compressor);
+      std::locale loc;
+      for (std::string::size_type j = 0; j < comp.length(); ++j)
+        comp[j] = std::tolower(comp[j], loc);
+
+      if (comp != "none") {
+        if (comp == "any") {
+          comp = "";
+        }
+        curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, comp.c_str());
+      }
+    }
+
     /* enable location redirects */
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
 


### PR DESCRIPTION
This adds a new configuration parameter for http compression in lib curl. The superbuild of libcurl is also modified to add support for compression.

The default config is `any` which we translate to the appropriate curl setting (empty string) to let curl tell the server all encodings supported by curl. If curl doesn't support any compression, none will be used.

Currently `deflate` or `gzip` are supported compression types, serverside. `any` (default) can be used to let curl signal to the server all supported encodings. `none` can be used to force disable all http compression.