### PR TITLE
Do no use stdout as default file in dump() interfaces

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -333,6 +333,8 @@ unsigned int ArraySchema::dim_num() const {
 }
 
 void ArraySchema::dump(FILE* out) const {
+  if (out == nullptr)
+    out = stdout;
   fprintf(out, "- Array type: %s\n", array_type_str(array_type_).c_str());
   fprintf(out, "- Cell order: %s\n", layout_str(cell_order_).c_str());
   fprintf(out, "- Tile order: %s\n", layout_str(tile_order_).c_str());

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -122,6 +122,8 @@ Status Attribute::deserialize(ConstBuffer* buff) {
 }
 
 void Attribute::dump(FILE* out) const {
+  if (out == nullptr)
+    out = stdout;
   // Dump
   fprintf(out, "### Attribute ###\n");
   fprintf(out, "- Name: %s\n", is_anonymous() ? "<anonymous>" : name_.c_str());

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -204,6 +204,8 @@ void* Dimension::domain() const {
 }
 
 void Dimension::dump(FILE* out) const {
+  if (out == nullptr)
+    out = stdout;
   // Retrieve domain and tile extent strings
   std::string domain_s = utils::parse::domain_str(domain_, type_);
   std::string tile_extent_s =

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -619,6 +619,8 @@ const Dimension* Domain::dimension(std::string name) const {
 }
 
 void Domain::dump(FILE* out) const {
+  if (out == nullptr)
+    out = stdout;
   fprintf(out, "=== Domain ===\n");
   fprintf(out, "- Dimensions type: %s\n", datatype_str(type_).c_str());
 

--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -213,9 +213,10 @@ class ArraySchema : public Schema {
   /**
    * Dumps the array schema in an ASCII representation to an output.
    *
-   * @param out (Optional) File to dump output to. Defaults to `stdout`.
+   * @param out (Optional) File to dump output to. Defaults to `nullptr`
+   * which will lead to selection of `stdout`.
    */
-  void dump(FILE* out = stdout) const override {
+  void dump(FILE* out = nullptr) const override {
     auto& ctx = ctx_.get();
     ctx.handle_error(
         tiledb_array_schema_dump(ctx.ptr().get(), schema_.get(), out));

--- a/tiledb/sm/cpp_api/attribute.h
+++ b/tiledb/sm/cpp_api/attribute.h
@@ -268,9 +268,10 @@ class Attribute {
    * Dumps information about the attribute in an ASCII representation to an
    * output.
    *
-   * @param out (Optional) File to dump output to. Defaults to `stdout`.
+   * @param out (Optional) File to dump output to. Defaults to `nullptr`
+   * which will lead to selection of `stdout`.
    */
-  void dump(FILE* out = stdout) const {
+  void dump(FILE* out = nullptr) const {
     ctx_.get().handle_error(
         tiledb_attribute_dump(ctx_.get().ptr().get(), attr_.get(), out));
   }

--- a/tiledb/sm/cpp_api/domain.h
+++ b/tiledb/sm/cpp_api/domain.h
@@ -152,9 +152,10 @@ class Domain {
   /**
    * Dumps the domain in an ASCII representation to an output.
    *
-   * @param out (Optional) File to dump output to. Defaults to `stdout`.
+   * @param out (Optional) File to dump output to. Defaults to `nullptr`
+   * which will lead to selection of `stdout`.
    */
-  void dump(FILE* out = stdout) const {
+  void dump(FILE* out = nullptr) const {
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_domain_dump(ctx.ptr().get(), domain_.get(), out));
   }

--- a/tiledb/sm/cpp_api/stats.h
+++ b/tiledb/sm/cpp_api/stats.h
@@ -74,7 +74,7 @@ class Stats {
    *
    * @param out The output.
    */
-  static void dump(FILE* out = stdout) {
+  static void dump(FILE* out = nullptr) {
     check_error(tiledb_stats_dump(out), "error dumping stats");
   }
 


### PR DESCRIPTION
Currently, building the R package against the 'dev' library (and older versions) 
triggers a (harmless, but annoying as consistent) warning from the R
'linter' (ie R CMD check) as output for code called from R should go through
R's buffered stream (which is reasonable and commonly done).

So we default to NULL and if NULL is seen, switch to stdout in the function
body rather than interface. This way the R checks are 'clean' which is
preferable, and at no real cost to the library layer (apart from four if()
statements in code off any hot paths).

Example (using the `rcmdcheck` package for prettier printing and timing, 
see Travis for tiledb-r for standard output also showing the 'wart' on each run)

#### Before as at HEAD

[...]
✔  checking for portable use of $(BLAS_LIBS) and $(LAPACK_LIBS)
✔  checking compilation flags used
N  checking compiled code ...
   File ‘tiledb/libs/tiledb.so’:
     Found ‘stdout’, possibly from ‘stdout’ (C)
       Object: ‘libtiledb.o’
   
   Compiled code should not call entry points which might terminate R nor
   write to stdout/stderr instead of to the console, nor use Fortran I/O
   nor system RNGs.
   
   See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
✔  checking examples (558ms)
✔  checking for unstated dependencies in ‘tests’ ...
[...]


#### After ie with this PR

[...]
✔  checking compilation flags in Makevars ...
✔  checking for GNU extensions in Makefiles
✔  checking for portable use of $(BLAS_LIBS) and $(LAPACK_LIBS)
✔  checking compilation flags used
✔  checking compiled code ...
✔  checking examples (544ms)
✔  checking for unstated dependencies in ‘tests’ ...
─  checking tests ...
✔  Running ‘testthat.R’ (1.7s)
[...]


This is not urgent but the last bit missing from CH#1407.