### PR TITLE
Avoid unused serialization of array metadata

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -267,8 +267,6 @@ Status Array::close() {
     if (query_type_ == QueryType::READ) {
       RETURN_NOT_OK(storage_manager_->array_close_for_reads(array_uri_));
     } else {
-      Buffer metadata_buff;
-      RETURN_NOT_OK(metadata_.serialize(&metadata_buff));
       RETURN_NOT_OK(storage_manager_->array_close_for_writes(
           array_uri_, encryption_key_, &metadata_));
     }


### PR DESCRIPTION
On Array Close there was a call to serialize metadata which the results of was not used. Later in the call sequence in `array_close_for_writes` the metadata is serialized and written there.