### PR TITLE
Add cmd line arg '--vfs' to 'tiledb_unit'

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -37,6 +37,9 @@
 namespace tiledb {
 namespace test {
 
+// Command line arguments.
+extern std::string g_vfs;
+
 template <class T>
 void check_partitions(
     tiledb::sm::SubarrayPartitioner& partitioner,
@@ -382,6 +385,26 @@ void get_supported_fs(bool* s3_supported, bool* hdfs_supported) {
   rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
   REQUIRE(rc == TILEDB_OK);
   *hdfs_supported = (bool)is_supported;
+
+  // Override VFS support if the user used the '--vfs' command line argument.
+  if (!g_vfs.empty()) {
+    REQUIRE((g_vfs == "native" || g_vfs == "s3" || g_vfs == "hdfs"));
+
+    if (g_vfs == "native") {
+      *s3_supported = false;
+      *hdfs_supported = false;
+    }
+
+    if (g_vfs == "s3") {
+      *s3_supported = true;
+      *hdfs_supported = false;
+    }
+
+    if (g_vfs == "hdfs") {
+      *s3_supported = false;
+      *hdfs_supported = true;
+    }
+  }
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -37,6 +37,7 @@
 #include <iostream>
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include <Windows.h>
 #include "tiledb/sm/filesystem/win.h"
@@ -167,13 +168,7 @@ void ArrayFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  tiledb::test::get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }
@@ -426,7 +421,8 @@ TEST_CASE_METHOD(
 #ifdef _WIN32
   char path[MAX_PATH];
   unsigned length;
-  tiledb_uri_to_path(ctx_, uri, path, &length);
+  rc = tiledb_uri_to_path(ctx_, uri, path, &length);
+  CHECK(rc == TILEDB_OK);
   CHECK(!strcmp(path, array_name.c_str()));
 #else
   CHECK(!strcmp(uri, array_name.c_str()));

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -39,6 +39,7 @@
 #include <thread>
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -48,6 +49,8 @@
 #include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/misc/utils.h"
+
+using namespace tiledb::test;
 
 struct ArraySchemaFx {
   // Filesystem related
@@ -201,13 +204,7 @@ void ArraySchemaFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -32,6 +32,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -355,13 +356,7 @@ void DenseArrayFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-dense_neg.cc
+++ b/test/src/unit-capi-dense_neg.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -42,6 +43,8 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+using namespace tiledb::test;
 
 struct DenseNegFx {
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
@@ -151,13 +154,7 @@ void DenseNegFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -42,6 +43,8 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+using namespace tiledb::test;
 
 struct DenseVectorFx {
   std::string ATTR_NAME = "val";
@@ -153,13 +156,7 @@ void DenseVectorFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-object_mgmt.cc
+++ b/test/src/unit-capi-object_mgmt.cc
@@ -31,7 +31,7 @@
  */
 
 #include "catch.hpp"
-
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -44,6 +44,8 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+using namespace tiledb::test;
 
 struct ObjectMgmtFx {
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
@@ -159,13 +161,7 @@ void ObjectMgmtFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-query.cc
+++ b/test/src/unit-capi-query.cc
@@ -38,6 +38,7 @@
 #include <thread>
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -45,6 +46,8 @@
 #endif
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/misc/utils.h"
+
+using namespace tiledb::test;
 
 struct QueryFx {
   // Filesystem related
@@ -158,13 +161,7 @@ void QueryFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -36,6 +36,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -55,6 +56,8 @@
 #include <map>
 #include <sstream>
 #include <thread>
+
+using namespace tiledb::test;
 
 struct DenseArrayRESTFx {
   // Constant parameters
@@ -313,13 +316,7 @@ void DenseArrayRESTFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -32,6 +32,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -305,13 +306,7 @@ void SparseArrayFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-sparse_neg.cc
+++ b/test/src/unit-capi-sparse_neg.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -42,6 +43,8 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+using namespace tiledb::test;
 
 struct SparseNegFx {
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
@@ -149,13 +152,7 @@ void SparseNegFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-sparse_neg_2.cc
+++ b/test/src/unit-capi-sparse_neg_2.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -42,6 +43,8 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+using namespace tiledb::test;
 
 struct SparseNegFx2 {
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
@@ -148,13 +151,7 @@ void SparseNegFx2::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-sparse_real.cc
+++ b/test/src/unit-capi-sparse_real.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -42,6 +43,8 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+using namespace tiledb::test;
 
 struct SparseRealFx {
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
@@ -147,13 +150,7 @@ void SparseRealFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-sparse_real_2.cc
+++ b/test/src/unit-capi-sparse_real_2.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
 #else
@@ -42,6 +43,8 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+using namespace tiledb::test;
 
 struct SparseRealFx2 {
   const std::string HDFS_TEMP_DIR = "hdfs:///tiledb_test/";
@@ -146,13 +149,7 @@ void SparseRealFx2::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/misc/stats.h"
 #include "tiledb/sm/misc/utils.h"
@@ -43,6 +44,8 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+using namespace tiledb::test;
 
 struct VFSFx {
   const std::string HDFS_TEMP_DIR = "hdfs://localhost:9000/tiledb_test/";
@@ -100,13 +103,7 @@ void VFSFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_s3_ = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  supports_hdfs_ = (bool)is_supported;
+  get_supported_fs(&supports_s3_, &supports_hdfs_);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit.cc
+++ b/test/src/unit.cc
@@ -1,13 +1,73 @@
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
 #include <catch.hpp>
 
-// Successful completion hook
 #include <cstdlib>
 #include <iostream>
+#include <string>
+#include <vector>
+
+namespace tiledb {
+namespace test {
+
+// Command line arguments.
+std::string g_vfs;
+
+}  // namespace test
+}  // namespace tiledb
+
+int store_g_vfs(std::string&& vfs, std::vector<std::string> vfs_fs) {
+  if (!vfs.empty()) {
+    if (std::find(vfs_fs.begin(), vfs_fs.end(), vfs) == vfs_fs.end()) {
+      std::cerr << "Unknown --vfs argument: \"" << vfs << "\"";
+      return 1;
+    }
+
+    tiledb::test::g_vfs = std::move(vfs);
+  }
+
+  return 0;
+}
+
+int main(const int argc, char** const argv) {
+  Catch::Session session;
+
+  // Define acceptable VFS values.
+  const std::vector<std::string> vfs_fs = {"native", "s3", "hdfs"};
+
+  // Build a pipe-separated string of acceptable VFS values.
+  std::ostringstream vfs_fs_oss;
+  for (size_t i = 0; i < vfs_fs.size(); ++i) {
+    vfs_fs_oss << vfs_fs[i];
+    if (i != (vfs_fs.size() - 1)) {
+      vfs_fs_oss << "|";
+    }
+  }
+
+  // Add a '--vfs' command line argument to override the default VFS.
+  std::string vfs;
+  Catch::clara::Parser cli =
+      session.cli() |
+      Catch::clara::Opt(vfs, vfs_fs_oss.str())["--vfs"](
+          "Override the VFS filesystem to use for generic tests");
+
+  session.cli(cli);
+
+  int rc = session.applyCommandLine(argc, argv);
+  if (rc != 0)
+    return rc;
+
+  // Validate and store the VFS command line argument.
+  rc = store_g_vfs(std::move(vfs), std::move(vfs_fs));
+  if (rc != 0)
+    return rc;
+
+  return session.run();
+}
 
 struct CICompletionStatusListener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase;  // inherit constructor
 
+  // Successful completion hook
   void testRunEnded(Catch::TestRunStats const& testRunStats) override {
     if (std::getenv("AGENT_NAME") != nullptr) {
       if (testRunStats.totals.testCases.allOk() == 1) {


### PR DESCRIPTION
Currently, the unit tests determine which VFS filesystem from the build context
of the core library. For example: If the core library was built with "--enable-hdfs",
unit tests will use the HDFS VFS implementation. This command line argument
"--vfs" allows the user to override the VFS filesystem.

`./tiledb_unit --vfs native` will use either POSIX/Win VFS FS, even if the
core was built with S3 and/or HDFS support.

Note that the above will still run the S3 and/or HDFS specific unit tests. If
the user built with HDFS but does not wish to run ANY tests with HDFS, they
will need to use `./tiledb_unit ~[hdfs] --vfs native`. This is required because
the flag does not override the compile-time building of the FS-specific unit
tests. This seems OK since this shouldn't be commonly used.

Note that the command line argument now shows up with the `-h` flag.

```
./tiledb/test/tiledb_unit -h

Catch v2.2.1
usage:
  tiledb_unit [<test name|pattern|tags> ... ] options

where options are:
  ...
  --vfs <native|s3|hdfs>                    Override the VFS filesystem to
                                            use for generic tests

For more detailed usage please see the project docs
```