### PR TITLE
FileSystem::Azure misc changes

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -230,6 +230,10 @@ void check_save_to_file() {
   ss << "sm.num_tbb_threads -1\n";
   ss << "sm.num_writer_threads 1\n";
   ss << "sm.tile_cache_size 10000000\n";
+  ss << "vfs.azure.block_list_block_size 5242880\n";
+  ss << "vfs.azure.max_parallel_ops " << std::thread::hardware_concurrency()
+     << "\n";
+  ss << "vfs.azure.use_block_list_upload true\n";
   ss << "vfs.azure.use_https true\n";
   ss << "vfs.file.enable_filelocks true\n";
   ss << "vfs.file.max_parallel_ops " << std::thread::hardware_concurrency()
@@ -434,6 +438,10 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.azure.storage_account_name"] = "";
   all_param_values["vfs.azure.storage_account_key"] = "";
   all_param_values["vfs.azure.blob_endpoint"] = "";
+  all_param_values["vfs.azure.block_list_block_size"] = "5242880";
+  all_param_values["vfs.azure.max_parallel_ops"] =
+      std::to_string(std::thread::hardware_concurrency());
+  all_param_values["vfs.azure.use_block_list_upload"] = "true";
   all_param_values["vfs.azure.use_https"] = "true";
   all_param_values["vfs.file.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -475,6 +483,10 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["azure.storage_account_name"] = "";
   vfs_param_values["azure.storage_account_key"] = "";
   vfs_param_values["azure.blob_endpoint"] = "";
+  vfs_param_values["azure.block_list_block_size"] = "5242880";
+  vfs_param_values["azure.max_parallel_ops"] =
+      std::to_string(std::thread::hardware_concurrency());
+  vfs_param_values["azure.use_block_list_upload"] = "true";
   vfs_param_values["azure.use_https"] = "true";
   vfs_param_values["file.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -511,6 +523,10 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   azure_param_values["storage_account_name"] = "";
   azure_param_values["storage_account_key"] = "";
   azure_param_values["blob_endpoint"] = "";
+  azure_param_values["block_list_block_size"] = "5242880";
+  azure_param_values["max_parallel_ops"] =
+      std::to_string(std::thread::hardware_concurrency());
+  azure_param_values["use_block_list_upload"] = "true";
   azure_param_values["use_https"] = "true";
 
   std::map<std::string, std::string> s3_param_values;

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1000,6 +1000,15 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.azure.blob_endpoint` <br>
  *    Set the AZURE_BLOB_ENDPOINT <br>
  *    **Default**: ""
+ * - `vfs.azure.block_list_block_size` <br>
+ *    Set the VFS_AZURE_BLOCK_LIST_BLOCK_SIZE <br>
+ *    **Default**: "5242880"
+ * - `vfs.azure.max_parallel_ops` <br>
+ *    Set the VFS_AZURE_MAX_PARALLEL_OPS <br>
+ *    **Default**: `vfs.num_threads`
+ * - `vfs.azure.use_block_list_upload` <br>
+ *    Set the VFS_AZURE_USE_BLOCK_LIST_UPLOAD <br>
+ *    **Default**: "true"
  * - `vfs.azure.use_https` <br>
  *    Set the AZURE_USE_HTTPS <br>
  *    **Default**: "true"

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -85,6 +85,9 @@ const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_NAME = "";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_KEY = "";
 const std::string Config::VFS_AZURE_BLOB_ENDPOINT = "";
 const std::string Config::VFS_AZURE_USE_HTTPS = "true";
+const std::string Config::VFS_AZURE_MAX_PARALLEL_OPS = Config::VFS_NUM_THREADS;
+const std::string Config::VFS_AZURE_BLOCK_LIST_BLOCK_SIZE = "5242880";
+const std::string Config::VFS_AZURE_USE_BLOCK_LIST_UPLOAD = "true";
 const std::string Config::VFS_S3_REGION = "us-east-1";
 const std::string Config::VFS_S3_AWS_ACCESS_KEY_ID = "";
 const std::string Config::VFS_S3_AWS_SECRET_ACCESS_KEY = "";
@@ -175,6 +178,11 @@ Config::Config() {
       VFS_AZURE_STORAGE_ACCOUNT_KEY;
   param_values_["vfs.azure.blob_endpoint"] = VFS_AZURE_BLOB_ENDPOINT;
   param_values_["vfs.azure.use_https"] = VFS_AZURE_USE_HTTPS;
+  param_values_["vfs.azure.max_parallel_ops"] = VFS_AZURE_MAX_PARALLEL_OPS;
+  param_values_["vfs.azure.block_list_block_size"] =
+      VFS_AZURE_BLOCK_LIST_BLOCK_SIZE;
+  param_values_["vfs.azure.use_block_list_upload"] =
+      VFS_AZURE_USE_BLOCK_LIST_UPLOAD;
   param_values_["vfs.s3.region"] = VFS_S3_REGION;
   param_values_["vfs.s3.aws_access_key_id"] = VFS_S3_AWS_ACCESS_KEY_ID;
   param_values_["vfs.s3.aws_secret_access_key"] = VFS_S3_AWS_SECRET_ACCESS_KEY;
@@ -395,6 +403,14 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.azure.blob_endpoint"] = VFS_AZURE_BLOB_ENDPOINT;
   } else if (param == "vfs.azure.use_https") {
     param_values_["vfs.azure.use_https"] = VFS_AZURE_USE_HTTPS;
+  } else if (param == "vfs.azure.max_parallel_ops") {
+    param_values_["vfs.azure.max_parallel_ops"] = VFS_AZURE_MAX_PARALLEL_OPS;
+  } else if (param == "vfs.azure.block_list_block_size") {
+    param_values_["vfs.azure.block_list_block_size"] =
+        VFS_AZURE_BLOCK_LIST_BLOCK_SIZE;
+  } else if (param == "vfs.azure.use_block_list_upload") {
+    param_values_["vfs.azure.use_block_list_upload"] =
+        VFS_AZURE_USE_BLOCK_LIST_UPLOAD;
   } else if (param == "vfs.s3.region") {
     param_values_["vfs.s3.region"] = VFS_S3_REGION;
   } else if (param == "vfs.s3.aws_access_key_id") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -179,6 +179,15 @@ class Config {
   /** Azure use https. */
   static const std::string VFS_AZURE_USE_HTTPS;
 
+  /** Azure max parallel ops. */
+  static const std::string VFS_AZURE_MAX_PARALLEL_OPS;
+
+  /** Azure block list block size. */
+  static const std::string VFS_AZURE_BLOCK_LIST_BLOCK_SIZE;
+
+  /** Azure use block list upload. */
+  static const std::string VFS_AZURE_USE_BLOCK_LIST_UPLOAD;
+
   /** S3 region. */
   static const std::string VFS_S3_REGION;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -335,6 +335,15 @@ class Config {
    * - `vfs.azure.blob_endpoint` <br>
    *    Set the AZURE_BLOB_ENDPOINT <br>
    *    **Default**: ""
+   * - `vfs.azure.block_list_block_size` <br>
+   *    Set the VFS_AZURE_BLOCK_LIST_BLOCK_SIZE <br>
+   *    **Default**: "5242880"
+   * - `vfs.azure.max_parallel_ops` <br>
+   *    Set the VFS_AZURE_MAX_PARALLEL_OPS <br>
+   *    **Default**: `vfs.num_threads`
+   * - `vfs.azure.use_block_list_upload` <br>
+   *    Set the VFS_AZURE_USE_BLOCK_LIST_UPLOAD <br>
+   *    **Default**: "true"
    * - `vfs.azure.use_https` <br>
    *    Set the AZURE_USE_HTTPS <br>
    *    **Default**: "true"


### PR DESCRIPTION
This patch addresses a few of the TODO issues in the Azure VFS.

1. Aborts a block list upload if any of the individual block uploads fail.

2. Performs a zero-copy stream construction for uploading a single blob from
   a discrete buffer.

3. Adds a few more parameters to the config.