### PR TITLE
Concurrent chunked uploads

### DIFF
--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -50,5 +50,5 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 32);
+  CHECK(names.size() == 39);
 }

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -1115,7 +1115,8 @@ Status S3::write_multipart(
   // Ensure that each thread is responsible for exactly multipart_part_size_
   // bytes (except if this is the last write_multipart, in which case the final
   // thread should write less), and cap the number of parallel operations at the
-  // configured max number.
+  // configured max number. Length must be evenly divisible by
+  // multipart_part_size_ unless this is the last part.
   uint64_t num_ops = last_part ?
                          utils::math::ceil(length, multipart_part_size_) :
                          (length / multipart_part_size_);

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -209,7 +209,8 @@ Status Curl::init(
 
 #ifdef __linux__
   // Get CA Cert bundle file from global state. This is initialized and cached
-  // if detected
+  // if detected. We have only had issues with finding the certificate path on
+  // Linux.
   const std::string cert_file =
       global_state::GlobalState::GetGlobalState().cert_file();
   // If we have detected a ca cert bundle let's set the curl option for CAINFO


### PR DESCRIPTION
The is the last patch to the Azure FS to reach functional parity with the S3
FS.

This allows for the individual blocks in a block list upload to be uploaded in
parallel on the VFS thread pool.

Also note that I removed a TODO comment about parallelizing the read path
because the S3 FS does not support parallel/chunked reads.