### PR TITLE
Set array serialized schema version to format

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -677,6 +677,10 @@ void ArraySchema::set_tile_order(Layout tile_order) {
   tile_order_ = tile_order;
 }
 
+void ArraySchema::set_version(uint32_t version) {
+  version_ = version;
+}
+
 uint32_t ArraySchema::version() const {
   return version_;
 }

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -316,6 +316,9 @@ class ArraySchema {
   /** Sets the tile order. */
   void set_tile_order(Layout tile_order);
 
+  /** Set version of schema, only used for serialization */
+  void set_version(uint32_t version);
+
   /** Returns the array schema version. */
   uint32_t version() const;
 

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -362,7 +362,9 @@ Status array_schema_to_capnp(
         "Error serializing array schema; array schema is null."));
 
   array_schema_builder->setUri(array_schema->array_uri().to_string());
-  array_schema_builder->setVersion(kj::arrayPtr(constants::library_version, 3));
+  auto v = kj::heapArray<int32_t>(1);
+  v[0] = array_schema->version();
+  array_schema_builder->setVersion(v);
   array_schema_builder->setArrayType(
       array_type_str(array_schema->array_type()));
   array_schema_builder->setTileOrder(layout_str(array_schema->tile_order()));
@@ -417,6 +419,12 @@ Status array_schema_from_capnp(
   (*array_schema)->set_cell_order(layout);
   (*array_schema)->set_capacity(schema_reader.getCapacity());
   (*array_schema)->set_allows_dups(schema_reader.getAllowsDuplicates());
+  // Pre 1.8 TileDB serialized the version as the library version
+  // This would have been a list of size 3, so only set the version
+  // if the list size is 1, meaning tiledb 1.8 or later
+  if (schema_reader.hasVersion() && schema_reader.getVersion().size() == 1) {
+    (*array_schema)->set_version(schema_reader.getVersion()[0]);
+  }
 
   auto domain_reader = schema_reader.getDomain();
   std::unique_ptr<Domain> domain;


### PR DESCRIPTION
Previously we always set it to the library version and we did not use this on deserialization. This adds setting it to the proper format version and we deserialization the version and set it if it exists and
its length is one. The maintains compatibility between version.