### PR TITLE
Azure FS retry policy

### DIFF
--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -120,6 +120,13 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
       account, thread_pool_->num_threads());
 #endif
 
+  // The Azure SDK does not provide a way to configure the retry
+  // policy or construct a client with our own retry policy. This
+  // re-assigns the context with our own retry policy.
+  *client_->context() = azure::storage_lite::executor_context(
+      std::make_shared<azure::storage_lite::tinyxml2_parser>(),
+      std::make_shared<AzureRetryPolicy>());
+
   return Status::Ok();
 }
 

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -36,6 +36,7 @@
 #ifdef HAVE_AZURE
 #include <base64.h>
 #include <blob/blob_client.h>
+#include <retry.h>
 #include <storage_account.h>
 #include <storage_credential.h>
 #include <list>
@@ -279,6 +280,18 @@ class Azure {
   /* ********************************* */
   /*         PRIVATE DATATYPES         */
   /* ********************************* */
+
+  class AzureRetryPolicy final : public azure::storage_lite::retry_policy_base {
+   public:
+    azure::storage_lite::retry_info evaluate(
+        const azure::storage_lite::retry_context& context) const override {
+      if (context.numbers() < 3) {
+        return azure::storage_lite::retry_info(true, std::chrono::seconds(1));
+      }
+
+      return azure::storage_lite::retry_info(false, std::chrono::seconds(0));
+    }
+  };
 
   /** Contains all state associated with a block list upload transaction. */
   class BlockListUploadState {


### PR DESCRIPTION
This provides a trivial retry policy to override the default retry policy
that the Azure SDK client is constructed with. The default retry policy takes
about 26 minutes before timing out. We'll eventually make the retry time and
retry count configurable.