### PR TITLE
Improve error msg for global order writes failures

### DIFF
--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -712,6 +712,8 @@ Status Writer::check_global_order() const {
       ss << "Write failed; Coordinates " << coords_to_str(i);
       ss << " succeed " << coords_to_str(i + 1);
       ss << " in the global order";
+      if (tile_cmp > 0)
+        ss << " due to writes across tiles";
       return LOG_STATUS(Status::WriterError(ss.str()));
     }
     return Status::Ok();


### PR DESCRIPTION
This adds a small addition to indicate if it was the tile comparison that failed. This can help debug the problem that the write was not aligned to the tile boundaries properly.

Realized this would be helpful when I was debugging a tilevcf issue. 