### PR TITLE
Using chain constructor and in-class member initializations

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -55,22 +55,8 @@ namespace sm {
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
 
-ArraySchema::ArraySchema() {
-  allows_dups_ = false;
-  array_uri_ = URI();
-  array_type_ = ArrayType::DENSE;
-  capacity_ = constants::capacity;
-  cell_order_ = Layout::ROW_MAJOR;
-  domain_ = nullptr;
-  tile_order_ = Layout::ROW_MAJOR;
-  version_ = constants::format_version;
-
-  // Set up default filter pipelines for coords and offsets
-  coords_filters_.add_filter(CompressionFilter(
-      constants::coords_compression, constants::coords_compression_level));
-  cell_var_offsets_filters_.add_filter(CompressionFilter(
-      constants::cell_var_offsets_compression,
-      constants::cell_var_offsets_compression_level));
+ArraySchema::ArraySchema()
+    : ArraySchema(ArrayType::DENSE) {
 }
 
 ArraySchema::ArraySchema(ArrayType array_type)

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -47,25 +47,8 @@ namespace sm {
 /*     CONSTRUCTORS & DESTRUCTORS    */
 /* ********************************* */
 
-Dimension::Dimension() {
-  domain_ = nullptr;
-  tile_extent_ = nullptr;
-  type_ = Datatype::INT32;
-  set_ceil_to_tile_func();
-  set_compute_mbr_func();
-  set_crop_range_func();
-  set_domain_range_func();
-  set_expand_range_func();
-  set_expand_range_v_func();
-  set_expand_to_tile_func();
-  set_oob_func();
-  set_covered_func();
-  set_overlap_func();
-  set_overlap_ratio_func();
-  set_split_range_func();
-  set_splitting_value_func();
-  set_tile_num_func();
-  set_value_in_range_func();
+Dimension::Dimension()
+    : Dimension("", Datatype::INT32) {
 }
 
 Dimension::Dimension(const std::string& name, Datatype type)

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -51,15 +51,8 @@ namespace sm {
 /*     CONSTRUCTORS & DESTRUCTORS    */
 /* ********************************* */
 
-Domain::Domain() {
-  cell_order_ = Layout::ROW_MAJOR;
-  tile_order_ = Layout::ROW_MAJOR;
-  dim_num_ = 0;
-  type_ = Datatype::INT32;
-  cell_num_per_tile_ = 0;
-  domain_ = nullptr;
-  tile_extents_ = nullptr;
-  tile_domain_ = nullptr;
+Domain::Domain()
+    : Domain(Datatype::INT32) {
 }
 
 Domain::Domain(Datatype type)

--- a/tiledb/sm/buffer/buffer_list.cc
+++ b/tiledb/sm/buffer/buffer_list.cc
@@ -37,10 +37,10 @@
 namespace tiledb {
 namespace sm {
 
-BufferList::BufferList() {
-  current_buffer_index_ = 0;
-  current_relative_offset_ = 0;
-  offset_ = 0;
+BufferList::BufferList()
+    : current_buffer_index_(0)
+    , current_relative_offset_(0)
+    , offset_(0) {
 }
 
 Status BufferList::add_buffer(Buffer&& buffer) {


### PR DESCRIPTION
In array schema subcomponent, a few classes have been introduced with more than one constructors. Those are initialized with values which are almost same except a few of them.

In this case, code duplication might occur and it can be solved by using chain constructors to reduce code duplication in constructor member initialization phase.

To keep it simple in this pull request, I just checked that array schema subcomponent. 

Please review these changes, if everything is OK for you.

PS: If this solution fits for you, other subcomponents could be investigated and opened with respective PRs in next days.