### PR TITLE
Update MacOS version to 10.14 on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,11 +28,11 @@ jobs:
         TILEDB_STATIC: OFF
         CXX: g++
       macOS:
-        imageName: 'macOS-10.13'
+        imageName: 'macOS-10.14'
         TILEDB_S3: ON
         CXX: clang++
       macOS_azure:
-        imageName: 'macOS-10.13'
+        imageName: 'macOS-10.14'
         TILEDB_AZURE: ON
         CXX: clang++
       linux_asan:

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -18,6 +18,13 @@ steps:
 
 - bash: |
     set -e pipefail
+    open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+    sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -allowUntrusted -target /
+  condition: eq(variables['Agent.OS'], 'Darwin')
+  displayName: 'Install system headers (OSX only)'
+
+- bash: |
+    set -e pipefail
     # Install clang-format (v5.0)
     sudo scripts/install-clangformat.sh
     src=$BUILD_REPOSITORY_LOCALPATH
@@ -27,7 +34,6 @@ steps:
        -name "*.cc" -or -name "*.c" -or -name "*.h")
   condition: eq(variables['Agent.OS'], 'Linux')
   displayName: 'Check formatting (linux only)'
-
 
 - bash: |
     # DELETEME work-around for https://github.com/microsoft/azure-pipelines-image-generation/issues/969


### PR DESCRIPTION
Azure is dropping support for the 10.13 image on March 23rd. This bumps our
CI to use the next macOS release.