### PR TITLE
Remove vs2015-win2012r2 from CI.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 version: '{build}'
 image:
 - Visual Studio 2017
-- Visual Studio 2015
 environment:
   TILEDB_S3: false
 
@@ -11,11 +10,7 @@ build_script:
 
     cd build
 
-    if ($env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2015") {
-      $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-    } else {
-      $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-    }
+    $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
 
     if ($env:TILEDB_S3 -eq "true") {
       ..\bootstrap.ps1 -EnableS3 -EnableVerbose -EnableStaticTileDB

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,9 +54,6 @@ jobs:
 - job: Windows
   strategy:
     matrix:
-      VS2015:
-        imageName: 'vs2015-win2012r2'
-        TILEDB_S3: ON
       VS2017:
         imageName: 'vs2017-win2016'
         TILEDB_S3: ON

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -3,9 +3,7 @@ steps:
     mkdir $env:AGENT_BUILDDIRECTORY\build
     cd $env:AGENT_BUILDDIRECTORY\build
 
-    if ($env:imageName -eq "vs2015-win2012r2") {
-      $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-    } elseif ($env:imageName -eq "vs2017-win2016") {
+    if ($env:imageName -eq "vs2017-win2016") {
       $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
     } else {
       Write-Host "Unknown image name: '$($env:imageName)'"
@@ -152,4 +150,4 @@ steps:
     #pathtoPublish: '$(Build.ArtifactStagingDirectory)/tiledb-windows-x64-$(Build.SourceVersion).zip'
     pathtoPublish: '$(Agent.BuildDirectory)\s\dist\'
     artifactName: 'tiledb-windows-x64-$(Build.SourceVersion)'
-  condition: and(succeeded(), eq(variables['imageName'], 'vs2015-win2012r2'))
+  condition: and(succeeded(), eq(variables['imageName'], 'vs2017-win2016'))


### PR DESCRIPTION
This image is dropped on March 23rd. MS recommends replacing it with
vs2017-win2016 which we already use.