### PR TITLE
Fix heap-use-after-free in split_coords_buffer()

### DIFF
--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -2244,7 +2244,7 @@ Status Writer::split_coords_buffer() {
     if (buff.buffer_ == nullptr)
       RETURN_NOT_OK(Status::WriterError(
           "Cannot split coordinate buffers; memory allocation failed"));
-    buffers_.emplace(dim_name, buff);
+    buffers_[dim_name] = buff;
   }
 
   // Split coordinates


### PR DESCRIPTION
This issue manifests any time that a single instance of `Writer` invokes
`split_coords_buffer()` more than one time.

Consider an instance of `Writer` with a 1-dimensional array schema, where the
dimension name is "dim1".

First invocation of `split_coords_buffer()`:
  - `to_clean_` is empty.
  - `buffers_` does not have an element keyed at "dim1".
  - invokes clear_coord_buffers(), which is a no-op.
  - mallocs a buffer, let's call it call it <buffer1>.
  - stores <buffer1> in `to_clean_`.
  - creates a QueryBuffer object, lets call it <query_buffer1>.
  - assigns the internal buffer of <query_buffer1> to <buffer1>.
  - unordered_map::emplace()s <query_buffer1> into `buffers_` at key "dim1".
  - accesses <buffer1> through <query_buffer1> from `buffers_["dim1"]` in the
    "// Split coordinates" loop.

Second invocation of `split_coords_buffer()`:
  - `to_clean_` has a single element: <buffer1>.
  - `buffers_` has element <query_buffer1> keyed at "dim1".
  - invokes clear_coord_buffers(), which frees <buffer1> and empties `to_clean_`.
  - mallocs a buffer, let's call it call it <buffer2>.
  - stores <buffer2> in `to_clean_`.
  - creates a QueryBuffer object, lets call it <query_buffer2>.
  - assigns the internal buffer of <query_buffer2> to <buffer2>.
  - unordered_map::emplace()s <query_buffer2> into `buffers_` at key "dim1".
    *** This operation fails because emplace() does NOT overwrite an existing
        element at the same key. The failed status in the return value is
        unchecked. buffers_["dim1"] still points to <query_buffer1>, although
        we intend it to point to <query_buffer2>
  - accesses <buffer1> through <query_buffer1> from `buffers_["dim1"]` in the
    "// Split coordinates" loop, although <buffer1> has been freed.