### PR TITLE
Integrate Azure FS unit testing on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ install:
       fi
 
     # Start Azurite server if Azure is enabled
-    - if [[ ( "$TRAVIS_OS_NAME" == "linux" && "$TILEDB_AZURE" == "ON" ) ]]; then
+    - if [[ "$TILEDB_AZURE" == "ON" ]]; then
         source scripts/install-azurite.sh;
         source scripts/run-azurite.sh;
       fi

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -74,8 +74,8 @@ steps:
       source scripts/run-minio.sh;
     fi
 
-    # Start Azurite server on Linux if Azure is enabled
-    if [[ ( "$AGENT_OS" == "Linux" && "$TILEDB_AZURE" == "ON" ) ]]; then
+    # Start Azurite if Azure is enabled
+    if [[ "$TILEDB_AZURE" == "ON" ]]; then
       source scripts/install-azurite.sh;
       source scripts/run-azurite.sh;
     fi
@@ -158,14 +158,7 @@ steps:
       export ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.4
     fi
 
-    # We do not support Azurite on OSX. When Azure is enabled, skip the azure
-    # unit test and force the generic unit tests to use the native VFS
-    # implementation instead of the Azure backend.
-    if [[ ( "$AGENT_OS" == "Darwin" && "$TILEDB_AZURE" == "ON" ) ]]; then
-      ./tiledb/test/tiledb_unit --durations=yes --vfs native ~[azure]
-    else
-      make check
-    fi
+    make check
 
     # - bash: |
     pushd $BUILD_REPOSITORY_LOCALPATH/examples/cmake_project

--- a/scripts/install-azurite.sh
+++ b/scripts/install-azurite.sh
@@ -39,7 +39,8 @@ install_yum_pkgs() {
 }
 
 install_brew_pkgs() {
-  die "Azurite installation unsupported on OS X"
+  brew install node || brew link --overwrite node
+  npm install -g azurite
 }
 
 install_deps() {

--- a/scripts/run-azurite.sh
+++ b/scripts/run-azurite.sh
@@ -38,6 +38,15 @@ die() {
   fi
 }
 
+run_npm_azurite() {
+  azurite-blob \
+    --silent \
+    --location /tmp/azurite-data \
+    --debug /tmp/azurite-data/debug.log \
+    --blobPort 10000 \
+    --blobHost 0.0.0.0 &
+}
+
 run_docker_azurite() {
   docker run -d \
     -v /tmp/azurite-data:/data \
@@ -55,7 +64,7 @@ run() {
   cp -f -r $DIR/../test/inputs/test_certs /tmp/azurite-data
 
   if [[ "$AGENT_OS" == "Darwin" ]]; then
-    die "Azurite unsupported on OS X"
+    run_npm_azurite
   else
     run_docker_azurite
   fi


### PR DESCRIPTION
For Linux, we're using docker to run Azurite. Docker
is a little troublesome on OSX so this just runs Azurite
as a native node application.