### PR TITLE
CI: run Azurite natively on Linux

### DIFF
--- a/scripts/install-azurite.sh
+++ b/scripts/install-azurite.sh
@@ -31,31 +31,39 @@ die() {
 }
 
 install_apt_pkgs() {
-  sudo apt-get -y install docker || die "could not install docker dependency"
+  sudo apt-get -y install nodejs-dev node-gyp libssl1.0 npm || die "could not install nodejs dependency"
 }
 
 install_yum_pkgs() {
-  sudo yum -y install docker || die "could not install docker dependency"
+  sudo yum -y install nodejs || die "could not install nodejs dependency"
 }
 
 install_brew_pkgs() {
   brew install node || brew link --overwrite node
-  npm install -g azurite
 }
 
 install_deps() {
+  AZURITE_PACKAGE="azurite@3.5.0"
   if [[ $OSTYPE == linux* ]]; then
     if [ -n "$(command -v apt-get)" ]; then
       install_apt_pkgs
     elif [ -n "$(command -v yum)" ]; then
       install_yum_pkgs
     fi
+
+    sudo npm config set strict-ssl false
+    sudo npm cache clean -f
+    sudo npm install -g n
+    sudo n stable
+    sudo npm install -g $AZURITE_PACKAGE
   elif [[ $OSTYPE == darwin* ]]; then
     if [ -n "$(command -v brew)" ]; then
       install_brew_pkgs
     else
       die "homebrew is not installed!"
     fi
+
+    npm install -g $AZURITE_PACKAGE
   else
     die "unsupported package management system"
   fi

--- a/scripts/run-azurite.sh
+++ b/scripts/run-azurite.sh
@@ -24,21 +24,11 @@
 # SOFTWARE.
 #
 
-# Starts a azurite server and exports credentials to the environment
-# ('source' this script instead of executing).
+# Starts an Azurite server
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-die() {
-  echo "$@" 1>&2 ; popd 2>/dev/null;
-
-  if [[ "$BASH_SOURCE" = $0 ]]; then
-    # exit when *not* sourced (https://superuser.com/a/1288646)
-    exit 1;
-  fi
-}
-
-run_npm_azurite() {
+run_azurite() {
   azurite-blob \
     --silent \
     --location /tmp/azurite-data \
@@ -47,27 +37,11 @@ run_npm_azurite() {
     --blobHost 0.0.0.0 &
 }
 
-run_docker_azurite() {
-  docker run -d \
-    -v /tmp/azurite-data:/data \
-    -p 10000:10000 \
-    mcr.microsoft.com/azure-storage/azurite \
-    azurite-blob \
-    --blobPort 10000 \
-    --blobHost 0.0.0.0 \
-    --debug /data/debug.log \
-    --loose
-}
-
 run() {
   mkdir -p /tmp/azurite-data
   cp -f -r $DIR/../test/inputs/test_certs /tmp/azurite-data
 
-  if [[ "$AGENT_OS" == "Darwin" ]]; then
-    run_npm_azurite
-  else
-    run_docker_azurite
-  fi
+  run_azurite
 }
 
 run


### PR DESCRIPTION
This modifies the CI to run Azurite as a native nodejs application rather than
in docker. This brings it into parity with how we run Azurite on OSX.