### PR TITLE
Kill Azurite and Minio in CI

### DIFF
--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -146,12 +146,6 @@ steps:
       docker ps -a
     fi
 
-    if [[ ( "$AGENT_OS" == "Linux" && "$TILEDB_AZURE" == "ON" ) ]]; then
-      # make sure docker is still running...
-      printenv
-      docker ps -a
-    fi
-
     make -j4 -C tiledb tiledb_unit
 
     if [[ "$TILEDB_CI_ASAN" == "ON" ]]; then
@@ -159,6 +153,17 @@ steps:
     fi
 
     make check
+
+    # Kill the running Minio server, OSX only because Linux runs it within
+    # docker.
+    if [[ ( "$AGENT_OS" == "Darwin" && "$TILEDB_S3" == "ON" ) ]]; then
+      kill -9 $MINIO_PID
+    fi
+
+    # Kill the running Azurite server
+    if [[ "$TILEDB_AZURE" == "ON" ]]; then
+      kill -9 $AZURITE_PID
+    fi
 
     # - bash: |
     pushd $BUILD_REPOSITORY_LOCALPATH/examples/cmake_project

--- a/scripts/run-azurite.sh
+++ b/scripts/run-azurite.sh
@@ -35,6 +35,7 @@ run_azurite() {
     --debug /tmp/azurite-data/debug.log \
     --blobPort 10000 \
     --blobHost 0.0.0.0 &
+  export AZURITE_PID=$!
 }
 
 run() {

--- a/scripts/run-minio.sh
+++ b/scripts/run-minio.sh
@@ -41,6 +41,7 @@ die() {
 run_cask_minio() {
   # note: minio data directories *must* follow parameter arguments
   minio server --certs-dir=/tmp/minio-data/test_certs --address localhost:9999 /tmp/minio-data &
+  export MINIO_PID=$!
   [[ "$?" -eq "0" ]] || die "could not run minio server"
 }
 


### PR DESCRIPTION
This fixes the following CI warning:
The STDIO streams did not close within 10 seconds of the exit event from process '/bin/bash'. This may indicate a child process inherited the STDIO streams and has not yet exited.