### PR TITLE
Enable serialization with ASAN CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,7 @@ jobs:
         imageName: 'ubuntu-16.04'
         TILEDB_CI_ASAN: ON
         TILEDB_TBB: OFF
+        TILEDB_SERIALIZATION: ON
         CXX: g++-7
       linux_serialization:
         imageName: 'ubuntu-16.04'

--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -245,6 +245,9 @@ struct SerializationFx {
         serialized->end(),
         static_cast<const uint8_t*>(data),
         static_cast<const uint8_t*>(data) + num_bytes);
+
+    // Free buffer list
+    tiledb_buffer_list_free(&buff_list);
   }
 
   /**

--- a/tiledb/sm/global_state/tbb_state.cc
+++ b/tiledb/sm/global_state/tbb_state.cc
@@ -39,6 +39,7 @@
 #include <tbb/task_scheduler_init.h>
 #include <cassert>
 #include <cstdlib>
+#include <memory>
 #include <sstream>
 
 namespace tiledb {

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -38,6 +38,7 @@
 #include <curl/curl.h>
 #include <cstdlib>
 #include <functional>
+#include <memory>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
This add serialization to the ASAN build for azure ci. It includes a few fixes for compilation errors presented in testing or in ci of an ASAN build.