### PR TITLE
VFS path behavior unification

### DIFF
--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -32,6 +32,7 @@
 
 #include <atomic>
 #include <catch.hpp>
+#include "test/src/helpers.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/misc/stats.h"
 
@@ -319,3 +320,146 @@ TEST_CASE("VFS: Test long posix paths", "[vfs]") {
 }
 
 #endif
+
+TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
+  bool s3_supported = false;
+  bool hdfs_supported = false;
+  bool azure_supported = false;
+  tiledb::test::get_supported_fs(
+      &s3_supported, &hdfs_supported, &azure_supported);
+
+  std::vector<std::pair<URI, Config>> root_pairs;
+  if (s3_supported) {
+    Config config;
+    REQUIRE(config.set("vfs.s3.endpoint_override", "localhost:9999").ok());
+    REQUIRE(config.set("vfs.s3.scheme", "https").ok());
+    REQUIRE(config.set("vfs.s3.use_virtual_addressing", "false").ok());
+    REQUIRE(config.set("vfs.s3.verify_ssl", "false").ok());
+
+    root_pairs.emplace_back(
+        URI("s3://" + tiledb::test::random_name("vfs") + "/"),
+        std::move(config));
+  }
+  if (hdfs_supported) {
+    Config config;
+    root_pairs.emplace_back(
+        URI("hdfs:///" + tiledb::test::random_name("vfs") + "/"),
+        std::move(config));
+  }
+  if (azure_supported) {
+    Config config;
+    REQUIRE(
+        config.set("vfs.azure.storage_account_name", "devstoreaccount1").ok());
+    REQUIRE(config
+                .set(
+                    "vfs.azure.storage_account_key",
+                    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4"
+                    "I6tq/"
+                    "K1SZFPTOtr/KBHBeksoGMGw==")
+                .ok());
+    REQUIRE(
+        config
+            .set("vfs.azure.blob_endpoint", "127.0.0.1:10000/devstoreaccount1")
+            .ok());
+    REQUIRE(config.set("vfs.azure.use_https", "false").ok());
+
+    root_pairs.emplace_back(
+        URI("azure://" + tiledb::test::random_name("vfs") + "/"),
+        std::move(config));
+  }
+
+  Config config;
+#ifdef _WIN32
+  root_pairs.emplace_back(
+      URI(tiledb::sm::Win::current_dir() + "\\" +
+          tiledb::test::random_name("vfs") + "\\"),
+      std::move(config));
+#else
+  root_pairs.emplace_back(
+      URI(Posix::current_dir() + "/" + tiledb::test::random_name("vfs") + "/"),
+      std::move(config));
+#endif
+
+  for (const auto& root_pair : root_pairs) {
+    const URI& root = root_pair.first;
+    const Config& config = root_pair.second;
+
+    VFS vfs;
+    REQUIRE(vfs.init(nullptr, &config).ok());
+
+    bool exists = false;
+    if (root.is_s3() || root.is_azure()) {
+      REQUIRE(vfs.is_bucket(root, &exists).ok());
+      if (exists) {
+        REQUIRE(vfs.remove_bucket(root).ok());
+      }
+      REQUIRE(vfs.create_bucket(root).ok());
+    } else {
+      REQUIRE(vfs.is_dir(root, &exists).ok());
+      if (exists) {
+        REQUIRE(vfs.remove_dir(root).ok());
+      }
+      REQUIRE(vfs.create_dir(root).ok());
+    }
+
+    std::string dir1 = root.to_string() + "dir1";
+    REQUIRE(vfs.create_dir(URI(dir1)).ok());
+
+    std::string dir2 = root.to_string() + "dir1/dir2/";
+    REQUIRE(vfs.create_dir(URI(dir2)).ok());
+
+    URI file1(root.to_string() + "file1");
+    REQUIRE(vfs.touch(file1).ok());
+
+    URI file2(root.to_string() + "file2");
+    REQUIRE(vfs.touch(file2).ok());
+
+    URI file3(root.to_string() + "dir1/file3");
+    REQUIRE(vfs.touch(file3).ok());
+
+    URI file4(root.to_string() + "dir1/dir2/file4");
+    REQUIRE(vfs.touch(file4).ok());
+
+    URI file5(root.to_string() + "file5/");
+    REQUIRE(!vfs.touch(file5).ok());
+
+    std::vector<URI> uris;
+    REQUIRE(vfs.ls(root, &uris).ok());
+
+    std::vector<std::string> expected_uri_names = {"file1", "file2", "dir1"};
+
+    for (const auto& uri : uris) {
+      // Ensure that the URIs do not contain a trailing backslash.
+      REQUIRE(uri.to_string().back() != '/');
+
+      // Get the trailing file/dir name.
+      const size_t idx = uri.to_string().find_last_of('/');
+      REQUIRE(idx != std::string::npos);
+      const std::string trailing_name =
+          uri.to_string().substr(idx + 1, uri.to_string().length());
+
+      // Verify we expected this file/dir name.
+      const auto iter = std::find(
+          expected_uri_names.begin(), expected_uri_names.end(), trailing_name);
+      REQUIRE(iter != expected_uri_names.end());
+
+      // Erase it from the expected names vector to ensure
+      // we see each expected name exactly once.
+      REQUIRE(
+          std::count(
+              expected_uri_names.begin(),
+              expected_uri_names.end(),
+              trailing_name) == 1);
+      expected_uri_names.erase(iter);
+    }
+
+    // Verify we found all expected file/dir names.
+    REQUIRE(expected_uri_names.empty());
+
+    if (root.is_s3() || root.is_azure()) {
+      REQUIRE(vfs.remove_bucket(root).ok());
+    } else {
+      REQUIRE(vfs.remove_dir(root).ok());
+    }
+  }
+}

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -157,7 +157,7 @@ class Azure {
    * and the delimiter is `/`, the returned URIs will be
    *
    * - `foo/boo`
-   * - `foo/bar/`
+   * - `foo/bar`
    *
    * @param uri The prefix URI.
    * @param paths Pointer of a vector of URIs to store the retrieved paths.
@@ -582,6 +582,27 @@ class Azure {
       const std::string& container_name,
       const std::string& blob_path,
       bool* const is_blob) const;
+
+  /**
+   * Removes a leading slash from 'path' if it exists.
+   *
+   * @param path the string to remove the leading slash from.
+   */
+  std::string remove_front_slash(const std::string& path) const;
+
+  /**
+   * Adds a trailing slash from 'path' if it doesn't already have one.
+   *
+   * @param path the string to add the trailing slash to.
+   */
+  std::string add_trailing_slash(const std::string& path) const;
+
+  /**
+   * Removes a trailing slash from 'path' if it exists.
+   *
+   * @param path the string to remove the trailing slash from.
+   */
+  std::string remove_trailing_slash(const std::string& path) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/hdfs_filesystem.cc
+++ b/tiledb/sm/filesystem/hdfs_filesystem.cc
@@ -358,6 +358,11 @@ Status HDFS::is_file(const URI& uri, bool* is_file) {
 }
 
 Status HDFS::touch(const URI& uri) {
+  if (uri.to_string().back() == '/') {
+    return LOG_STATUS(Status::HDFSError(std::string(
+        "Cannot create file; URI is a directory: " + uri.to_string())));
+  }
+
   hdfsFS fs = nullptr;
   RETURN_NOT_OK(connect(&fs));
   hdfsFile writeFile =

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -106,6 +106,23 @@ void Posix::adjacent_slashes_dedup(std::string* path) {
 }
 
 std::string Posix::abs_path(const std::string& path) {
+  std::string resolved_path = abs_path_internal(path);
+
+  // Ensure the returned has the same postfix slash as 'path'.
+  if (utils::parse::ends_with(path, "/")) {
+    if (!utils::parse::ends_with(resolved_path, "/")) {
+      resolved_path = resolved_path + "/";
+    }
+  } else {
+    if (utils::parse::ends_with(resolved_path, "/")) {
+      resolved_path = resolved_path.substr(0, resolved_path.length() - 1);
+    }
+  }
+
+  return resolved_path;
+}
+
+std::string Posix::abs_path_internal(const std::string& path) {
   // Initialize current, home and root
   std::string current = current_dir();
   auto env_home_ptr = getenv("HOME");

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -235,6 +235,9 @@ class Posix {
 
   static bool both_slashes(char a, char b);
 
+  // Internal logic for 'abs_path()'.
+  static std::string abs_path_internal(const std::string& path);
+
   /**
    * It takes as input an **absolute** path, and returns it in its canonicalized
    * form, after appropriately replacing "./" and "../" in the path.

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -187,7 +187,7 @@ class S3 {
    * and the delimiter is `/`, the returned URIs will be
    *
    * - `foo/boo`
-   * - `foo/bar/`
+   * - `foo/bar`
    *
    * @param prefix The prefix URI.
    * @param paths Pointer of a vector of URIs to store the retrieved paths.
@@ -482,6 +482,12 @@ class S3 {
    * from the front if it exists.
    */
   std::string remove_front_slash(const std::string& path) const;
+
+  /**
+   * Returns the input `path` after removing a potential `/` character
+   * from the end if it exists.
+   */
+  std::string remove_trailing_slash(const std::string& path) const;
 
   /**
    * Writes the contents of the input buffer to the S3 object given by


### PR DESCRIPTION
This is a first step toward ensuring that the way we handle and report
paths are consistent among our VFS backends.

This patch introduces a unit test that ensures ls() and touch() are consistent
among the VFS backends. In the future, we can continue expanding this unit test
to test and correct other discrepancies. We'll use the posix behavior as the
target behavior.

A few changes:
- Ensures paths returned from ls() are without a trailing slash.
- Ensures the URI constructor does not drop a trailing slash in the scenario
  where a relative path is converted to an absolute path.
- Ensures touch() fails if the given URI has a trailing slash.

Closes #1447 