### PR TITLE
Azure FS: Conditional retry on HTTP code

### DIFF
--- a/cmake/Modules/FindAzureSDK_EP.cmake
+++ b/cmake/Modules/FindAzureSDK_EP.cmake
@@ -95,7 +95,7 @@ if (NOT AZURESDK_FOUND)
       URL "https://github.com/Azure/azure-storage-cpplite/archive/v0.2.0.zip"
       URL_HASH SHA1=058975ccac9b60b522c9f7fd044a3d2aaec9f893
       CMAKE_ARGS
-        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DBUILD_SHARED_LIBS=OFF
         -DBUILD_TESTS=OFF
         -DBUILD_SAMPLES=OFF

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -131,7 +131,7 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
   // re-assigns the context with our own retry policy.
   *client_->context() = azure::storage_lite::executor_context(
       std::make_shared<azure::storage_lite::tinyxml2_parser>(),
-      std::make_shared<AzureRetryPolicy>(under_test));
+      std::make_shared<AzureRetryPolicy>());
 
   return Status::Ok();
 }

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -454,6 +454,12 @@ const unsigned int s3_max_attempts = 1000;
 /** Milliseconds of wait time between S3 attempts. */
 const unsigned int s3_attempt_sleep_ms = 100;
 
+/** Maximum number of attempts to wait for an Azure response. */
+const unsigned int azure_max_attempts = 100;
+
+/** Milliseconds of wait time between Azure attempts. */
+const unsigned int azure_attempt_sleep_ms = 1000;
+
 /** An allocation tag used for logging. */
 const std::string s3_allocation_tag = "TileDB";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -441,6 +441,16 @@ extern const unsigned int s3_max_attempts;
 /** Milliseconds of wait time between S3 attempts. */
 extern const unsigned int s3_attempt_sleep_ms;
 
+/** Maximum number of attempts to wait for an Azure response. */
+extern const unsigned int azure_max_attempts;
+
+/**
+ * Milliseconds of wait time between Azure attempts. Currently,
+ * the Azure SDK only supports retries with a second-granularity.
+ * This number will be floored to the nearest second.
+ */
+extern const unsigned int azure_attempt_sleep_ms;
+
 /** An allocation tag used for logging. */
 extern const std::string s3_allocation_tag;
 


### PR DESCRIPTION
This modifies the retry path so that we only perform a retry on a server-side
error.

Consider the scenario where we want to check if an object exists. If the
object does not exist, we will receive a 404 and retry 2 more times with a
1 second delay between them.

With this patch, we will return after receiving the first 404.