### PR TITLE
Reduce S3/Azure timeout to 10s from 100s

### DIFF
--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -309,7 +309,7 @@ class Azure {
       if (context.numbers() < max_retries) {
         return azure::storage_lite::retry_info(
             true,
-            std::chrono::seconds(constants::azure_attempt_sleep_ms / 100));
+            std::chrono::seconds(constants::azure_attempt_sleep_ms / 1000));
       }
 
       // All retry attempts exhausted.

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -449,13 +449,13 @@ const std::string default_attr_name = "__attr";
 const std::string default_dim_name = "__dim";
 
 /** Maximum number of attempts to wait for an S3 response. */
-const unsigned int s3_max_attempts = 1000;
+const unsigned int s3_max_attempts = 100;
 
 /** Milliseconds of wait time between S3 attempts. */
 const unsigned int s3_attempt_sleep_ms = 100;
 
 /** Maximum number of attempts to wait for an Azure response. */
-const unsigned int azure_max_attempts = 100;
+const unsigned int azure_max_attempts = 10;
 
 /** Milliseconds of wait time between Azure attempts. */
 const unsigned int azure_attempt_sleep_ms = 1000;


### PR DESCRIPTION
Also fixes a bug in the ms-to-s conversion in Azure.