### PR TITLE
Fix assertion failures in debug build

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4015,6 +4015,9 @@ int32_t tiledb_vfs_ls(
   std::vector<tiledb::sm::URI> children;
   auto st = vfs->vfs_->ls(tiledb::sm::URI(path), &children);
 
+  if (!st.ok())
+    return TILEDB_ERR;
+
   // Apply the callback to every child
   int rc = 1;
   for (const auto& uri : children) {

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -132,6 +132,10 @@ S3::~S3() {
 /* ********************************* */
 
 Status S3::init(const Config& config, ThreadPool* const thread_pool) {
+  // already initialized
+  if (state_ == State::DISCONNECTED)
+    return Status::Ok();
+
   assert(state_ == State::UNINITIALIZED);
 
   if (thread_pool == nullptr) {

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.cc
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.cc
@@ -52,6 +52,9 @@ S3ThreadPoolExecutor::~S3ThreadPoolExecutor() {
 }
 
 Status S3ThreadPoolExecutor::Stop() {
+  if (state_ == State::STOPPED)
+    return Status::Ok();
+
   Status ret_st = Status::Ok();
 
   std::unique_lock<std::mutex> lock_guard(lock_);


### PR DESCRIPTION
Fixes some assertion failures. The main issue is that we call `vfs->init` repeatedly in `unit-vfs`, and some of the asserts block re-init'ing the internal S3 object. If the non-test changes are no good, the asserts can probably be avoided by making a separate `vfs` object in each test section. 

- Don't assert out when S3 class is already initialized or is stopped
- Add vfs.terminate calls to match vfs->init in test sections
- Add missing status check in tiledb_vfs_ls