### PR TITLE
GCS: Integrate GCS SDK into the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ option(TILEDB_FORCE_ALL_DEPS "If true, force superbuild to download and build al
 option(TILEDB_VERBOSE "Prints TileDB errors with verbosity" OFF)
 option(TILEDB_S3 "Enables S3/minio support using aws-cpp-sdk" OFF)
 option(TILEDB_AZURE "Enables Azure Storage support using azure-storage-cpp" OFF)
+option(TILEDB_GCS "Enables GCS Storage support using google-cloud-cpp" OFF)
 option(TILEDB_HDFS "Enables HDFS support using the official Hadoop JNI bindings" OFF)
 option(TILEDB_WERROR "Enables the -Werror flag during compilation." ON)
 option(TILEDB_CPP_API "Enables building of the TileDB C++ API." ON)

--- a/bootstrap
+++ b/bootstrap
@@ -53,6 +53,7 @@ Configuration:
     --enable-hdfs                   enables the hdfs storage backend
     --enable-s3                     enables the s3 storage backend
     --enable-azure                  enables the azure storage backend
+    --enable-gcs                    enables the gcs storage backend
     --enable-serialization          enables query serialization support
     --enable-tools                  enables TileDB CLI tools (experimental)
     --enable-ccache                 enables use of ccache (if present)
@@ -83,6 +84,7 @@ tiledb_verbose="OFF"
 tiledb_hdfs="OFF"
 tiledb_s3="OFF"
 tiledb_azure="OFF"
+tiledb_gcs="OFF"
 tiledb_werror="ON"
 tiledb_tests="ON"
 tiledb_cpp_api="ON"
@@ -117,6 +119,7 @@ while test $# != 0; do
     --enable-hdfs) tiledb_hdfs="ON";;
     --enable-s3) tiledb_s3="ON";;
     --enable-azure) tiledb_azure="ON";;
+    --enable-gcs) tiledb_gcs="ON";;
     --enable-serialization) tiledb_serialization="ON";;
     --enable-tools) tiledb_tools="ON";;
     --enable-ccache) tiledb_ccache="ON";;
@@ -137,6 +140,7 @@ for en in "${enables[@]}"; do
     verbose) tiledb_verbose="ON";;
     s3) tiledb_s3="ON";;
     azure) tiledb_azure="ON";;
+    gcs) tiledb_gcs="ON";;
     serialization) tiledb_serialization="ON";;
     tools) tiledb_tools="ON";;
     ccache) tiledb_ccache="ON";;
@@ -185,6 +189,7 @@ ${cmake} -DCMAKE_BUILD_TYPE=${build_type} \
     -DTILEDB_HDFS=${tiledb_hdfs} \
     -DTILEDB_S3=${tiledb_s3} \
     -DTILEDB_AZURE=${tiledb_azure} \
+    -DTILEDB_GCS=${tiledb_gcs} \
     -DTILEDB_SERIALIZATION=${tiledb_serialization} \
     -DTILEDB_TOOLS=${tiledb_tools} \
     -DTILEDB_WERROR=${tiledb_werror} \

--- a/cmake/Modules/FindAzureSDK_EP.cmake
+++ b/cmake/Modules/FindAzureSDK_EP.cmake
@@ -103,10 +103,9 @@ if (NOT AZURESDK_FOUND)
         -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         -DCMAKE_CXX_FLAGS=-fPIC
         -DCMAKE_C_FLAGS=-fPIC
-      #INSTALL_COMMAND $(MAKE) CXXFLAGS=-fPIC PREFIX=${TILEDB_EP_INSTALL_PREFIX} install
       PATCH_COMMAND
-        patch -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/remove-uuid-dep.patch &&
-        patch -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/azurite-support.patch
+        patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/remove-uuid-dep.patch &&
+        patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/azurite-support.patch
       LOG_DOWNLOAD TRUE
       LOG_CONFIGURE TRUE
       LOG_BUILD TRUE

--- a/cmake/Modules/FindGCSSDK_EP.cmake
+++ b/cmake/Modules/FindGCSSDK_EP.cmake
@@ -1,0 +1,128 @@
+#
+# FindGCSSDK_EP.cmake
+#
+#
+# The MIT License
+#
+# Copyright (c) 2018-2020 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# This module finds the GCS C++ SDK, installing it with an ExternalProject if
+# necessary. It then defines the imported targets GCSSDK::<component>, e.g.
+# GCSSDK::storage-client or GCSSDK::google_cloud_cpp_common.
+
+# Include some common helper functions.
+include(TileDBCommon)
+
+# If the EP was built, it will install the storage_client-config.cmake file,
+# which we can use with find_package. CMake uses CMAKE_PREFIX_PATH to locate find
+# modules.
+set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${TILEDB_EP_INSTALL_PREFIX}")
+
+if (TILEDB_SUPERBUILD)
+  if (NOT TILEDB_FORCE_ALL_DEPS)
+    find_package(storage_client CONFIG QUIET)
+  endif()
+else()
+  find_package(storage_client CONFIG QUIET)
+endif()
+
+if (NOT storage_client_FOUND)
+  if (TILEDB_SUPERBUILD)
+    message(STATUS "Could NOT find GCSSDK")
+    message(STATUS "Adding GCSSDK as an external project")
+
+    set(DEPENDS)
+    if (TARGET ep_curl)
+      list(APPEND DEPENDS ep_curl)
+    endif()
+    if (TARGET ep_openssl)
+      list(APPEND DEPENDS ep_openssl)
+    endif()
+    if (TARGET ep_zlib)
+      list(APPEND DEPENDS ep_zlib)
+    endif()
+
+    # Fetch the number of CPUs on the this sytem.
+    include(ProcessorCount)
+    processorcount(NCPU)
+
+    ExternalProject_Add(ep_gcssdk
+      PREFIX "externals"
+      URL "https://github.com/googleapis/google-cloud-cpp/archive/v0.20.0.zip"
+      URL_HASH SHA1=6e7931a0e62779dfbd07427373373bf1ad6f8686
+      BUILD_IN_SOURCE 1
+      PATCH_COMMAND patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/build.patch
+      CONFIGURE_COMMAND
+        cmake -Hsuper -Bcmake-out
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DBUILD_SHARED_LIBS=OFF
+        -DBUILD_SAMPLES=OFF
+      BUILD_COMMAND cmake --build cmake-out -- -j${NCPU}
+      INSTALL_COMMAND
+          cp -r ${TILEDB_EP_SOURCE_DIR}/ep_gcssdk/cmake-out/external/lib ${TILEDB_EP_INSTALL_PREFIX}
+        COMMAND
+          cp -r ${TILEDB_EP_SOURCE_DIR}/ep_gcssdk/cmake-out/external/include ${TILEDB_EP_INSTALL_PREFIX}
+      LOG_DOWNLOAD TRUE
+      LOG_CONFIGURE TRUE
+      LOG_BUILD TRUE
+      LOG_INSTALL TRUE
+      LOG_OUTPUT_ON_FAILURE ${TILEDB_LOG_OUTPUT_ON_FAILURE}
+      DEPENDS ${DEPENDS}
+    )
+
+    list(APPEND TILEDB_EXTERNAL_PROJECTS ep_gcssdk)
+    list(APPEND FORWARD_EP_CMAKE_ARGS
+      -DTILEDB_GCSSDK_EP_BUILT=TRUE
+    )
+
+  endif()
+endif()
+
+if (storage_client_FOUND)
+  # Build a list of all GCS libraries to link with.
+  list(APPEND GCSSDK_LINKED_LIBS "storage_client"
+                                 "google_cloud_cpp_common"
+                                 "crc32c")
+
+  foreach (LIB ${GCSSDK_LINKED_LIBS})
+    find_library(GCS_FOUND_${LIB}
+      NAMES lib${LIB}${CMAKE_STATIC_LIBRARY_SUFFIX}
+      PATHS ${TILEDB_EP_INSTALL_PREFIX}
+      PATH_SUFFIXES lib
+      ${TILEDB_DEPS_NO_DEFAULT_PATH}
+    )
+
+    message(STATUS "Found GCS lib: ${LIB} (${GCS_FOUND_${LIB}})")
+    if (NOT TARGET GCSSDK::${LIB})
+      add_library(GCSSDK::${LIB} UNKNOWN IMPORTED)
+      set_target_properties(GCSSDK::${LIB} PROPERTIES
+        IMPORTED_LOCATION "${GCS_FOUND_${LIB}}"
+        INTERFACE_INCLUDE_DIRECTORIES "${GCSSDK_INCLUDE_DIR}"
+      )
+    endif()
+
+    # If we built a static EP, install it if required.
+    if (TILEDB_GCSSDK_EP_BUILT AND TILEDB_INSTALL_STATIC_DEPS)
+      install_target_libs(GCSSDK::${LIB})
+    endif()
+
+  endforeach ()
+endif()

--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -29,6 +29,7 @@ set(INHERITED_CMAKE_ARGS
   -DTILEDB_VERBOSE=${TILEDB_VERBOSE}
   -DTILEDB_S3=${TILEDB_S3}
   -DTILEDB_AZURE=${TILEDB_AZURE}
+  -DTILEDB_GCS=${TILEDB_GCS}
   -DTILEDB_HDFS=${TILEDB_HDFS}
   -DTILEDB_WERROR=${TILEDB_WERROR}
   -DTILEDB_CPP_API=${TILEDB_CPP_API}
@@ -90,7 +91,7 @@ if (NOT WIN32)
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindOpenSSL_EP.cmake)
 endif()
 
-if (TILEDB_S3 OR TILEDB_AZURE OR TILEDB_SERIALIZATION)
+if (TILEDB_S3 OR TILEDB_AZURE OR TILEDB_GCS OR TILEDB_SERIALIZATION)
   # Need libcurl either with S3 or serialization support.
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindCurl_EP.cmake)
 endif()
@@ -103,6 +104,10 @@ endif()
 
 if (TILEDB_AZURE)
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindAzureSDK_EP.cmake)
+endif()
+
+if (TILEDB_GCS)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindGCSSDK_EP.cmake)
 endif()
 
 if (TILEDB_TBB)

--- a/cmake/inputs/patches/ep_gcssdk/build.patch
+++ b/cmake/inputs/patches/ep_gcssdk/build.patch
@@ -1,0 +1,339 @@
+From 2b9a750a5b00d3021aaceff1ac738a33b29c3da1 Mon Sep 17 00:00:00 2001
+From: Joe maley <joe@tiledb.io>
+Date: Wed, 11 Mar 2020 11:26:06 -0400
+Subject: GCS Build Patch for TileDB
+
+---
+ super/CMakeLists.txt                         |  9 ++-
+ super/external/c-ares.cmake                  |  2 +
+ super/external/crc32c.cmake                  |  2 +
+ super/external/curl.cmake                    | 64 --------------------
+ super/external/google-cloud-cpp-common.cmake |  2 +
+ super/external/googleapis.cmake              |  2 +
+ super/external/googletest.cmake              |  2 +
+ super/external/grpc.cmake                    |  5 +-
+ super/external/protobuf.cmake                |  4 +-
+ super/external/ssl.cmake                     | 26 --------
+ super/external/zlib.cmake                    | 47 --------------
+ 11 files changed, 21 insertions(+), 144 deletions(-)
+ delete mode 100644 super/external/curl.cmake
+ delete mode 100644 super/external/ssl.cmake
+ delete mode 100644 super/external/zlib.cmake
+
+diff --git a/super/CMakeLists.txt b/super/CMakeLists.txt
+index 9cc916aed..a5d2680e8 100644
+--- a/super/CMakeLists.txt
++++ b/super/CMakeLists.txt
+@@ -23,7 +23,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(GOOGLE_CLOUD_CPP_ROOT "${PROJECT_SOURCE_DIR}/..")
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+ 
+-include(external/curl)
+ include(external/crc32c)
+ include(external/grpc)
+ include(external/googleapis)
+@@ -35,7 +34,7 @@ set_external_project_build_parallel_level(PARALLEL)
+ set_external_project_vars()
+ 
+ set(GOOGLE_CLOUD_CPP_DEPENDENCIES_LIST
+-    grpc-project curl-project crc32c-project googleapis-project
++    grpc-project crc32c-project googleapis-project
+     googletest-project google-cloud-cpp-common-project)
+ 
+ include(ExternalProject)
+@@ -54,8 +53,12 @@ ExternalProject_Add(
+                -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
++               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
++               -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
++               -DBUILD_SAMPLES=${BUILD_SAMPLES}
++               -DCMAKE_CXX_FLAGS=-fPIC
++               -DCMAKE_C_FLAGS=-fPIC
+     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+-    TEST_COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+     LOG_DOWNLOAD OFF
+     LOG_CONFIGURE OFF
+     LOG_BUILD OFF
+diff --git a/super/external/c-ares.cmake b/super/external/c-ares.cmake
+index cc1c5c5b1..9fab0d6cb 100644
+--- a/super/external/c-ares.cmake
++++ b/super/external/c-ares.cmake
+@@ -41,6 +41,8 @@ if (NOT TARGET c-ares-project)
+                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
++                   -DCMAKE_CXX_FLAGS=-fPIC
++                   -DCMAKE_C_FLAGS=-fPIC
+         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+         LOG_DOWNLOAD ON
+         LOG_CONFIGURE ON
+diff --git a/super/external/crc32c.cmake b/super/external/crc32c.cmake
+index b0bc677e0..27f7368ee 100644
+--- a/super/external/crc32c.cmake
++++ b/super/external/crc32c.cmake
+@@ -44,6 +44,8 @@ if (NOT TARGET crc32c-project)
+                    -DCRC32C_BUILD_TESTS=OFF
+                    -DCRC32C_BUILD_BENCHMARKS=OFF
+                    -DCRC32C_USE_GLOG=OFF
++                   -DCMAKE_CXX_FLAGS=-fPIC
++                   -DCMAKE_C_FLAGS=-fPIC
+         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+         LOG_DOWNLOAD ON
+         LOG_CONFIGURE ON
+diff --git a/super/external/curl.cmake b/super/external/curl.cmake
+deleted file mode 100644
+index 6144037bc..000000000
+--- a/super/external/curl.cmake
++++ /dev/null
+@@ -1,64 +0,0 @@
+-# ~~~
+-# Copyright 2018 Google LLC
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-# ~~~
+-
+-include(external/c-ares)
+-include(external/ssl)
+-include(external/zlib)
+-
+-if (NOT TARGET curl-project)
+-    # Give application developers a hook to configure the version and hash
+-    # downloaded from GitHub.
+-    set(GOOGLE_CLOUD_CPP_CURL_URL
+-        "https://curl.haxx.se/download/curl-7.65.3.tar.gz")
+-    set(GOOGLE_CLOUD_CPP_CURL_SHA256
+-        "4376ac72b95572fb6c4fbffefb97c7ea0dd083e1974c0e44cd7e49396f454839")
+-
+-    set_external_project_build_parallel_level(PARALLEL)
+-    set_external_project_vars()
+-
+-    include(ExternalProject)
+-    ExternalProject_Add(
+-        curl-project
+-        DEPENDS c-ares-project ssl-project zlib-project
+-        EXCLUDE_FROM_ALL ON
+-        PREFIX "${CMAKE_BINARY_DIR}/external/curl"
+-        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+-        URL ${GOOGLE_CLOUD_CPP_CURL_URL}
+-        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CURL_SHA256}
+-                 LIST_SEPARATOR
+-                 |
+-        CMAKE_ARGS
+-            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
+-            -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+-            -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+-            # libcurl automatically enables a number of protocols. With static
+-            # libraries this is a problem. The indirect dependencies, such as
+-            # libldap, become hard to predict and manage. Setting HTTP_ONLY=ON
+-            # disables all optional protocols and meets our needs. If the
+-            # application needs a version of libcurl with other protocols
+-            # enabled they can compile against it by using find_package() and
+-            # defining the `curl_project` target.
+-            -DHTTP_ONLY=ON
+-            -DCMAKE_ENABLE_OPENSSL=ON
+-            -DENABLE_ARES=ON
+-            -DCMAKE_DEBUG_POSTFIX=
+-        BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+-        LOG_DOWNLOAD ON
+-        LOG_CONFIGURE ON
+-        LOG_BUILD ON
+-        LOG_INSTALL ON)
+-endif ()
+diff --git a/super/external/google-cloud-cpp-common.cmake b/super/external/google-cloud-cpp-common.cmake
+index 3d904d5df..60ad3b856 100644
+--- a/super/external/google-cloud-cpp-common.cmake
++++ b/super/external/google-cloud-cpp-common.cmake
+@@ -52,6 +52,8 @@ if (NOT TARGET google-cloud-cpp-common-project)
+             -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
+             -H<SOURCE_DIR>
+             -B<BINARY_DIR>
++            -DCMAKE_CXX_FLAGS=-fPIC
++            -DCMAKE_C_FLAGS=-fPIC
+         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+         LOG_DOWNLOAD ON
+         LOG_CONFIGURE ON
+diff --git a/super/external/googleapis.cmake b/super/external/googleapis.cmake
+index d487511ba..7ea9a3ba2 100644
+--- a/super/external/googleapis.cmake
++++ b/super/external/googleapis.cmake
+@@ -50,6 +50,8 @@ if (NOT TARGET googleapis-project)
+             -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+             -H<SOURCE_DIR>
+             -B<BINARY_DIR>
++            -DCMAKE_CXX_FLAGS=-fPIC
++            -DCMAKE_C_FLAGS=-fPIC
+         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+         LOG_DOWNLOAD ON
+         LOG_CONFIGURE ON
+diff --git a/super/external/googletest.cmake b/super/external/googletest.cmake
+index 357daae16..e3479f127 100644
+--- a/super/external/googletest.cmake
++++ b/super/external/googletest.cmake
+@@ -41,6 +41,8 @@ if (NOT TARGET googletest-project)
+                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
++                   -DCMAKE_CXX_FLAGS=-fPIC
++                   -DCMAKE_C_FLAGS=-fPIC
+         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+         LOG_DOWNLOAD ON
+         LOG_CONFIGURE ON
+diff --git a/super/external/grpc.cmake b/super/external/grpc.cmake
+index db41a566a..efe4f39fd 100644
+--- a/super/external/grpc.cmake
++++ b/super/external/grpc.cmake
+@@ -16,7 +16,6 @@
+ 
+ include(ExternalProjectHelper)
+ include(external/c-ares)
+-include(external/ssl)
+ include(external/protobuf)
+ 
+ if (NOT TARGET grpc-project)
+@@ -34,7 +33,7 @@ if (NOT TARGET grpc-project)
+     include(ExternalProject)
+     ExternalProject_Add(
+         grpc-project
+-        DEPENDS c-ares-project protobuf-project ssl-project
++        DEPENDS c-ares-project protobuf-project
+         EXCLUDE_FROM_ALL ON
+         PREFIX "${CMAKE_BINARY_DIR}/external/grpc"
+         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+@@ -51,6 +50,8 @@ if (NOT TARGET grpc-project)
+                    -DgRPC_SSL_PROVIDER=package
+                    -DgRPC_CARES_PROVIDER=package
+                    -DgRPC_PROTOBUF_PROVIDER=package
++                   -DCMAKE_CXX_FLAGS=-fPIC
++                   -DCMAKE_C_FLAGS=-fPIC
+         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+         LOG_DOWNLOAD ON
+         LOG_CONFIGURE ON
+diff --git a/super/external/protobuf.cmake b/super/external/protobuf.cmake
+index 5262f3e26..17390d76f 100644
+--- a/super/external/protobuf.cmake
++++ b/super/external/protobuf.cmake
+@@ -17,7 +17,6 @@
+ find_package(Threads REQUIRED)
+ 
+ include(ExternalProjectHelper)
+-include(external/zlib)
+ 
+ if (NOT TARGET protobuf-project)
+     # Give application developers a hook to configure the version and hash
+@@ -33,7 +32,6 @@ if (NOT TARGET protobuf-project)
+     include(ExternalProject)
+     ExternalProject_Add(
+         protobuf-project
+-        DEPENDS zlib-project
+         EXCLUDE_FROM_ALL ON
+         PREFIX "${CMAKE_BINARY_DIR}/external/protobuf"
+         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+@@ -57,6 +55,8 @@ if (NOT TARGET protobuf-project)
+             -Dprotobuf_DEBUG_POSTFIX=
+             -H<SOURCE_DIR>/cmake
+             -B<BINARY_DIR>
++            -DCMAKE_CXX_FLAGS=-fPIC
++            -DCMAKE_C_FLAGS=-fPIC
+         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+         LOG_DOWNLOAD ON
+         LOG_CONFIGURE ON
+diff --git a/super/external/ssl.cmake b/super/external/ssl.cmake
+deleted file mode 100644
+index 251eed2da..000000000
+--- a/super/external/ssl.cmake
++++ /dev/null
+@@ -1,26 +0,0 @@
+-# ~~~
+-# Copyright 2018 Google LLC
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-# ~~~
+-
+-if (NOT TARGET ssl-project)
+-    # For OpenSSL we don't really support external projects. OpenSSL build
+-    # system is notoriously finicky. Use vcpkg on Windows, or install OpenSSL
+-    # using your operating system packages instead.
+-    #
+-    # This file is here to simplify the definition of external projects, such as
+-    # curl and gRPC, that depend on a SSL library.
+-    find_package(OpenSSL REQUIRED)
+-    add_custom_target(ssl-project)
+-endif ()
+diff --git a/super/external/zlib.cmake b/super/external/zlib.cmake
+deleted file mode 100644
+index 1bf40cde2..000000000
+--- a/super/external/zlib.cmake
++++ /dev/null
+@@ -1,47 +0,0 @@
+-# ~~~
+-# Copyright 2018 Google LLC
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-# ~~~
+-
+-if (NOT TARGET zlib-project)
+-    # Give application developers a hook to configure the version and hash
+-    # downloaded from GitHub.
+-    set(GOOGLE_CLOUD_CPP_ZLIB_URL
+-        "https://github.com/madler/zlib/archive/v1.2.11.tar.gz")
+-    set(GOOGLE_CLOUD_CPP_ZLIB_SHA256
+-        "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff")
+-
+-    set_external_project_build_parallel_level(PARALLEL)
+-    set_external_project_vars()
+-
+-    include(ExternalProject)
+-    ExternalProject_Add(
+-        zlib-project
+-        EXCLUDE_FROM_ALL ON
+-        PREFIX "${CMAKE_BINARY_DIR}/external/zlib"
+-        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+-        URL ${GOOGLE_CLOUD_CPP_ZLIB_URL}
+-        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_ZLIB_SHA256}
+-                 LIST_SEPARATOR
+-                 |
+-        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
+-                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+-                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+-                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+-        BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
+-        LOG_DOWNLOAD ON
+-        LOG_CONFIGURE ON
+-        LOG_BUILD ON
+-        LOG_INSTALL ON)
+-endif ()
+-- 
+2.17.1
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-crypto.cc
   src/unit-filter-buffer.cc
   src/unit-filter-pipeline.cc
+  src/unit-gcs.cc
   src/unit-hdfs-filesystem.cc
   src/unit-lru_cache.cc
   src/unit-Reader.cc
@@ -189,6 +190,10 @@ endif()
 
 if (TILEDB_AZURE)
   target_compile_definitions(tiledb_unit PRIVATE -DHAVE_AZURE)
+endif()
+
+if (TILEDB_GCS)
+  target_compile_definitions(tiledb_unit PRIVATE -DHAVE_GCS)
 endif()
 
 if (TILEDB_TBB)

--- a/test/src/unit-gcs.cc
+++ b/test/src/unit-gcs.cc
@@ -1,0 +1,72 @@
+/**
+ * @file   unit-gcs.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for GCS API filesystem functions.
+ */
+
+#ifdef HAVE_GCS
+
+#include "catch.hpp"
+#include "tiledb/sm/config/config.h"
+#include "tiledb/sm/filesystem/gcs.h"
+#include "tiledb/sm/global_state/unit_test_config.h"
+#include "tiledb/sm/misc/thread_pool.h"
+#include "tiledb/sm/misc/utils.h"
+
+#include <sstream>
+
+using namespace tiledb::sm;
+
+struct GCSFx {
+  tiledb::sm::GCS gcs_;
+  ThreadPool thread_pool_;
+
+  GCSFx();
+  ~GCSFx();
+
+  static std::string random_container_name(const std::string& prefix);
+};
+
+GCSFx::GCSFx() {
+  Config config;
+  REQUIRE(thread_pool_.init(2).ok());
+  REQUIRE(gcs_.init(config, &thread_pool_).ok());
+}
+
+GCSFx::~GCSFx() {
+}
+
+std::string GCSFx::random_container_name(const std::string& prefix) {
+  std::stringstream ss;
+  ss << prefix << "-" << std::this_thread::get_id() << "-"
+     << tiledb::sm::utils::time::timestamp_now_ms();
+  return ss.str();
+}
+
+#endif

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -110,6 +110,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/crypto_openssl.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/crypto_win32.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/azure.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/gcs.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/hdfs_filesystem.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/posix.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3.cc
@@ -311,8 +312,21 @@ if (TILEDB_AZURE)
   add_definitions(-DHAVE_AZURE)
 endif()
 
+# GCS dependencies
+if (TILEDB_GCS)
+  message(STATUS "The TileDB library is compiled with GCS support.")
+  find_package(GCSSDK_EP REQUIRED COMPONENTS gcs)
+  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
+    INTERFACE
+      GCSSDK::storage_client
+      GCSSDK::google_cloud_cpp_common
+      GCSSDK::crc32c
+  )
+  add_definitions(-DHAVE_GCS)
+endif()
+
 # Libcurl
-if (TILEDB_S3 OR TILEDB_AZURE OR TILEDB_SERIALIZATION)
+if (TILEDB_S3 OR TILEDB_AZURE OR TILEDB_GCS OR TILEDB_SERIALIZATION)
   if (NOT WIN32)
     find_package(Curl_EP REQUIRED)
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
@@ -444,7 +458,7 @@ target_include_directories(TILEDB_CORE_OBJECTS
 #   - https://github.com/TileDB-Inc/TileDB/pull/1253
 # NOTE: just like the static dependencies in TileDBConfig create above
 #       (via TILEDB_DEP_STRING), this linkage embeds absolute paths.
-if ((TILEDB_S3 OR TILEDB_AZURE OR TILEDB_SERIALIZATION) AND NOT WIN32)
+if ((TILEDB_S3 OR TILEDB_AZURE OR TILEDB_GCS OR TILEDB_SERIALIZATION) AND NOT WIN32)
   if (TILEDB_CURL_EP_BUILT)
     set(CURL_CONFIG_BINARY "${TILEDB_EP_BASE}/install/bin/curl-config")
 
@@ -546,6 +560,9 @@ if (TILEDB_STATIC)
   append_dep_lib(AWSSDK::aws-checksums)
   append_dep_lib(AWSSDK::aws-c-common)
   append_dep_lib(AzureSDK::AzureSDK)
+  append_dep_lib(GCSSDK::storage_client)
+  append_dep_lib(GCSSDK::google_cloud_cpp_common)
+  append_dep_lib(GCSSDK::crc32c)
 
   # Spdlog is a special case because it is header-only.
   string(CONCAT TILEDB_STATIC_DEP_STRING

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -1,0 +1,63 @@
+/**
+ * @file   gcs.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements the GCS class.
+ */
+
+#ifdef HAVE_GCS
+
+#include "tiledb/sm/filesystem/gcs.h"
+
+namespace tiledb {
+namespace sm {
+
+/* ********************************* */
+/*     CONSTRUCTORS & DESTRUCTORS    */
+/* ********************************* */
+
+GCS::GCS() {
+}
+
+GCS::~GCS() {
+}
+
+/* ********************************* */
+/*                 API               */
+/* ********************************* */
+
+Status GCS::init(const Config& /*config*/, ThreadPool* const /*(thread_pool*/) {
+  client_ = google::cloud::storage::Client::CreateDefaultClient();
+
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -1,0 +1,80 @@
+/**
+ * @file   gcs.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the GCS class.
+ */
+
+#ifndef TILEDB_GCS_H
+#define TILEDB_GCS_H
+
+#ifdef HAVE_GCS
+
+#include "google/cloud/storage/client.h"
+#include "tiledb/sm/config/config.h"
+#include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/misc/thread_pool.h"
+
+namespace tiledb {
+namespace sm {
+
+class GCS {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  GCS();
+
+  /** Destructor. */
+  ~GCS();
+
+  /* ********************************* */
+  /*                 API               */
+  /* ********************************* */
+
+  /**
+   * Initializes and connects a GCS client.
+   *
+   * @param config Configuration parameters.
+   * @param thread_pool The parent VFS thread pool.
+   * @return Status
+   */
+  Status init(const Config& config, ThreadPool* thread_pool);
+
+ private:
+  google::cloud::StatusOr<google::cloud::storage::Client> client_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // HAVE_GCS
+#endif  // TILEDB_GCS_H


### PR DESCRIPTION
This also introduces the GCS class and a unit test to ensure the core
library and test executable correctly link with the SDK.