### PR TITLE
Session token and certs

### DIFF
--- a/doc/source/tutorials/config.rst
+++ b/doc/source/tutorials/config.rst
@@ -123,6 +123,7 @@ in this program and explain the output.
         "vfs.s3.request_timeout_ms" : "3000"
         "vfs.s3.scheme" : "https"
         "vfs.s3.use_virtual_addressing" : "true"
+        "vfs.s3.verify_ssl" : "true"
 
         VFS S3 settings:
         "aws_access_key_id" : ""
@@ -142,6 +143,7 @@ in this program and explain the output.
         "request_timeout_ms" : "3000"
         "scheme" : "https"
         "use_virtual_addressing" : "true"
+        "verify_ssl" : "true"
 
         Tile cache size after loading from file: 0
 
@@ -199,6 +201,7 @@ in this program and explain the output.
         "vfs.s3.request_timeout_ms" : "3000"
         "vfs.s3.scheme" : "https"
         "vfs.s3.use_virtual_addressing" : "true"
+        "vfs.s3.verify_ssl" : "true"
 
         VFS S3 settings:
         "aws_access_key_id" : ""
@@ -218,6 +221,7 @@ in this program and explain the output.
         "request_timeout_ms" : "3000"
         "scheme" : "https"
         "use_virtual_addressing" : "true"
+        "verify_ssl" : "true"
 
         Tile cache size after loading from file: 0
 
@@ -336,10 +340,13 @@ The corresponding output is (note that we ran this on a machine with
         "vfs.num_threads" : "8"
         "vfs.s3.aws_access_key_id" : ""
         "vfs.s3.aws_secret_access_key" : ""
+        "vfs.s3.ca_file" : ""
+        "vfs.s3.ca_path" : ""
         "vfs.s3.connect_max_tries" : "5"
         "vfs.s3.connect_scale_factor" : "25"
         "vfs.s3.connect_timeout_ms" : "3000"
         "vfs.s3.endpoint_override" : ""
+        "vfs.s3.logging_level" : "off"
         "vfs.s3.max_parallel_ops" : "8"
         "vfs.s3.multipart_part_size" : "5242880"
         "vfs.s3.proxy_host" : ""
@@ -351,6 +358,7 @@ The corresponding output is (note that we ran this on a machine with
         "vfs.s3.request_timeout_ms" : "3000"
         "vfs.s3.scheme" : "https"
         "vfs.s3.use_virtual_addressing" : "true"
+        "vfs.s3.verify_ssl" : "true"
 
 
 TileDB allows you also to iterate only over the config parameters
@@ -391,6 +399,8 @@ is *stripped* from the retrieved parameter names.
         VFS S3 settings:
         "aws_access_key_id" : ""
         "aws_secret_access_key" : ""
+        "ca_file" : ""
+        "ca_path" : ""
         "connect_max_tries" : "5"
         "connect_scale_factor" : "25"
         "connect_timeout_ms" : "3000"
@@ -406,6 +416,7 @@ is *stripped* from the retrieved parameter names.
         "request_timeout_ms" : "3000"
         "scheme" : "https"
         "use_virtual_addressing" : "true"
+        "verify_ssl" : "true"
 
 Saving/Loading config to/from file
 ----------------------------------
@@ -498,6 +509,7 @@ Inspecting the contents of the exported config file, we get the following:
   vfs.s3.request_timeout_ms 3000
   vfs.s3.scheme https
   vfs.s3.use_virtual_addressing true
+  vfs.s3.verify_ssl true
 
 Observe that config parameters that have an empty string as a value
 are not exported (e.g., ``vfs.s3.proxy_host``).
@@ -606,8 +618,10 @@ along with their description and default values.
     ``"vfs.s3.request_timeout_ms"``           ``"3000"``              The request timeout in ms. Any ``long`` value is
                                                                       acceptable.
     ``"vfs.s3.scheme"``                       ``"https"``             The S3 scheme.
-    ``"vfs.s3.use_virtual_addressing"``       ``"true"``              Determines whether to use virtual addressing
-                                                                      or not.
+    ``"vfs.s3.use_virtual_addressing"``       ``"true"``              Determines whether to use virtual addressing or not.
+    ``"vfs.s3.ca_file"``                      ``""``                  The path to a cURL-compatible certificate file.
+    ``"vfs.s3.ca_path"``                      ``""``                  The path to a cURL-compatible certificate directory.
+    ``"vfs.s3.verify_ssl"``                   ``"true"``              Enable certificate verification for HTTPS connections.
     ``"vfs.hdfs.kerb_ticket_cache_path"``     ``""``                  Path to the Kerberos ticket cache when connecting
                                                                       to an HDFS cluster.
     ``"vfs.hdfs.name_node_uri"``              ``""``                  Optional namenode URI to use (TileDB will use

--- a/examples/png_ingestion/src/main.cc
+++ b/examples/png_ingestion/src/main.cc
@@ -34,9 +34,9 @@
 #include <cassert>
 #include <cstdio>
 
-//#include <png.h>
+#include <png.h>
 // Note: on some macOS platforms with a brew-installed libpng, use this instead:
-#include <libpng16/png.h>
+//#include <libpng16/png.h>
 
 // Include the TileDB C++ API headers
 #include <tiledb/tiledb>

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -228,6 +228,7 @@ void check_save_to_file() {
   ss << "vfs.s3.request_timeout_ms 3000\n";
   ss << "vfs.s3.scheme https\n";
   ss << "vfs.s3.use_virtual_addressing true\n";
+  ss << "vfs.s3.verify_ssl true\n";
 
   std::ifstream ifs("test_config.txt");
   std::stringstream ss_file;
@@ -408,6 +409,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.s3.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.s3.multipart_part_size"] = "5242880";
+  all_param_values["vfs.s3.ca_file"] = "";
+  all_param_values["vfs.s3.ca_path"] = "";
   all_param_values["vfs.s3.connect_timeout_ms"] = "3000";
   all_param_values["vfs.s3.connect_max_tries"] = "5";
   all_param_values["vfs.s3.connect_scale_factor"] = "25";
@@ -417,6 +420,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.s3.proxy_port"] = "0";
   all_param_values["vfs.s3.proxy_scheme"] = "https";
   all_param_values["vfs.s3.proxy_username"] = "";
+  all_param_values["vfs.s3.verify_ssl"] = "true";
   all_param_values["vfs.hdfs.username"] = "stavros";
   all_param_values["vfs.hdfs.kerb_ticket_cache_path"] = "";
   all_param_values["vfs.hdfs.name_node_uri"] = "";
@@ -438,6 +442,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["s3.multipart_part_size"] = "5242880";
+  vfs_param_values["s3.ca_file"] = "";
+  vfs_param_values["s3.ca_path"] = "";
   vfs_param_values["s3.connect_timeout_ms"] = "3000";
   vfs_param_values["s3.connect_max_tries"] = "5";
   vfs_param_values["s3.connect_scale_factor"] = "25";
@@ -447,6 +453,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.proxy_port"] = "0";
   vfs_param_values["s3.proxy_scheme"] = "https";
   vfs_param_values["s3.proxy_username"] = "";
+  vfs_param_values["s3.verify_ssl"] = "true";
   vfs_param_values["hdfs.username"] = "stavros";
   vfs_param_values["hdfs.kerb_ticket_cache_path"] = "";
   vfs_param_values["hdfs.name_node_uri"] = "";
@@ -461,6 +468,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
   s3_param_values["multipart_part_size"] = "5242880";
+  s3_param_values["ca_file"] = "";
+  s3_param_values["ca_path"] = "";
   s3_param_values["connect_timeout_ms"] = "3000";
   s3_param_values["connect_max_tries"] = "5";
   s3_param_values["connect_scale_factor"] = "25";
@@ -470,6 +479,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["proxy_port"] = "0";
   s3_param_values["proxy_scheme"] = "https";
   s3_param_values["proxy_username"] = "";
+  s3_param_values["verify_ssl"] = "true";
 
   // Create an iterator and iterate over all parameters
   tiledb_config_iter_t* config_iter = nullptr;

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -185,6 +185,11 @@ void check_save_to_file() {
       config, "vfs.s3.aws_secret_access_key", "secret", &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
+  // Check that aws session token is not serialized.
+  rc = tiledb_config_set(
+      config, "vfs.s3.aws_session_token", "token", &error);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(error == nullptr);
 
   rc = tiledb_config_save_to_file(config, "test_config.txt", &error);
   REQUIRE(rc == TILEDB_OK);
@@ -219,6 +224,7 @@ void check_save_to_file() {
   ss << "vfs.s3.connect_max_tries 5\n";
   ss << "vfs.s3.connect_scale_factor 25\n";
   ss << "vfs.s3.connect_timeout_ms 3000\n";
+  ss << "vfs.s3.logging_level Off\n";
   ss << "vfs.s3.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
   ss << "vfs.s3.multipart_part_size 5242880\n";
@@ -404,6 +410,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.s3.region"] = "us-east-1";
   all_param_values["vfs.s3.aws_access_key_id"] = "";
   all_param_values["vfs.s3.aws_secret_access_key"] = "";
+  all_param_values["vfs.s3.aws_session_token"] = "";
   all_param_values["vfs.s3.endpoint_override"] = "";
   all_param_values["vfs.s3.use_virtual_addressing"] = "true";
   all_param_values["vfs.s3.max_parallel_ops"] =
@@ -421,6 +428,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.s3.proxy_scheme"] = "https";
   all_param_values["vfs.s3.proxy_username"] = "";
   all_param_values["vfs.s3.verify_ssl"] = "true";
+  all_param_values["vfs.s3.logging_level"] = "Off";
   all_param_values["vfs.hdfs.username"] = "stavros";
   all_param_values["vfs.hdfs.kerb_ticket_cache_path"] = "";
   all_param_values["vfs.hdfs.name_node_uri"] = "";
@@ -437,6 +445,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.region"] = "us-east-1";
   vfs_param_values["s3.aws_access_key_id"] = "";
   vfs_param_values["s3.aws_secret_access_key"] = "";
+  vfs_param_values["s3.aws_session_token"] = "";
   vfs_param_values["s3.endpoint_override"] = "";
   vfs_param_values["s3.use_virtual_addressing"] = "true";
   vfs_param_values["s3.max_parallel_ops"] =
@@ -454,6 +463,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.proxy_scheme"] = "https";
   vfs_param_values["s3.proxy_username"] = "";
   vfs_param_values["s3.verify_ssl"] = "true";
+  vfs_param_values["s3.logging_level"] = "Off";
   vfs_param_values["hdfs.username"] = "stavros";
   vfs_param_values["hdfs.kerb_ticket_cache_path"] = "";
   vfs_param_values["hdfs.name_node_uri"] = "";
@@ -463,6 +473,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["region"] = "us-east-1";
   s3_param_values["aws_access_key_id"] = "";
   s3_param_values["aws_secret_access_key"] = "";
+  s3_param_values["aws_session_token"] = "";
   s3_param_values["endpoint_override"] = "";
   s3_param_values["use_virtual_addressing"] = "true";
   s3_param_values["max_parallel_ops"] =
@@ -480,6 +491,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["proxy_scheme"] = "https";
   s3_param_values["proxy_username"] = "";
   s3_param_values["verify_ssl"] = "true";
+  s3_param_values["logging_level"] = "Off";
 
   // Create an iterator and iterate over all parameters
   tiledb_config_iter_t* config_iter = nullptr;

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -50,5 +50,5 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 25);
+  CHECK(names.size() == 31);
 }

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -50,5 +50,5 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 31);
+  CHECK(names.size() == 30);
 }

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -508,6 +508,16 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    vfs.s3.max_parallel_ops` bytes will be buffered before issuing multipart
  *    uploads in parallel. <br>
  *    **Default**: 5MB
+ * - `vfs.s3.ca_file` <br>
+ *    Path to SSL/TLS certificate file to be used by cURL for for S3 HTTPS
+ *    encryption. Follows cURL conventions:
+ *    https://curl.haxx.se/docs/manpage.html
+ *    **Default**: ""
+ * - `vfs.s3.ca_path` <br>
+ *    Path to SSL/TLS certificate directory to be used by cURL for S3 HTTPS
+ *    encryption. Follows cURL conventions:
+ *    https://curl.haxx.se/docs/manpage.html
+ *    **Default**: ""
  * - `vfs.s3.connect_timeout_ms` <br>
  *    The connection timeout in ms. Any `long` value is acceptable. <br>
  *    **Default**: 3000
@@ -538,6 +548,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The S3 proxy password. Note: this parameter is not serialized by
  *    `tiledb_config_save_to_file`. <br>
  *    **Default**: ""
+ * - `vfs.s3.verify_ssl` <br>
+ *    Enable HTTPS certificate verification. <br>
+ *    **Default**: true""
  * - `vfs.hdfs.name_node"` <br>
  *    Name node for HDFS. <br>
  *    **Default**: ""

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -356,6 +356,16 @@ class Config {
    *    vfs.s3.max_parallel_ops` bytes will be buffered before issuing multipart
    *    uploads in parallel. <br>
    *    **Default**: 5MB
+   * - `vfs.s3.ca_file` <br>
+   *    Path to SSL/TLS certificate file to be used by cURL for for S3 HTTPS
+   *    encryption. Follows cURL conventions:
+   *    https://curl.haxx.se/docs/manpage.html
+   *    **Default**: ""
+   * - `vfs.s3.ca_path` <br>
+   *    Path to SSL/TLS certificate directory to be used by cURL for S3 HTTPS
+   *    encryption. Follows cURL conventions:
+   *    https://curl.haxx.se/docs/manpage.html
+   *    **Default**: ""
    * - `vfs.s3.connect_timeout_ms` <br>
    *    The connection timeout in ms. Any `long` value is acceptable. <br>
    *    **Default**: 3000
@@ -366,6 +376,11 @@ class Config {
    *    The scale factor for exponential backofff when connecting to S3.
    *    Any `long` value is acceptable. <br>
    *    **Default**: 25
+   * - `vfs.s3.logging_level` <br>
+   *    The AWS SDK logging level. This is a process-global setting. The
+   *    configuration of the most recently constructed context will set
+   *    process state. Log files are written to the process working directory.
+   *    **Default**: off""
    * - `vfs.s3.request_timeout_ms` <br>
    *    The request timeout in ms. Any `long` value is acceptable. <br>
    *    **Default**: 3000
@@ -386,6 +401,9 @@ class Config {
    *    The proxy password. Note: this parameter is not serialized by
    *    `tiledb_config_save_to_file`. <br>
    *    **Default**: ""
+   * - `vfs.s3.verify_ssl` <br>
+   *    Enable HTTPS certificate verification. <br>
+   *    **Default**: true""
    * - `vfs.hdfs.name_node"` <br>
    *    Name node for HDFS. <br>
    *    **Default**: ""

--- a/tiledb/sm/cpp_api/vfs.h
+++ b/tiledb/sm/cpp_api/vfs.h
@@ -359,7 +359,7 @@ class VFS {
    */
   explicit VFS(const Context& ctx)
       : ctx_(ctx) {
-    create_vfs(nullptr);
+    create_vfs(ctx.config());
   }
 
   /**

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -149,11 +149,12 @@ Status S3::init(const Config::S3Params& s3_config, ThreadPool* thread_pool) {
     Aws::String secret_access_key(s3_config.aws_secret_access_key.c_str());
     if (!s3_config.aws_session_token.c_str()) {
       client_creds_ = std::unique_ptr<Aws::Auth::AWSCredentials>(
-        new Aws::Auth::AWSCredentials(access_key_id, secret_access_key));
+          new Aws::Auth::AWSCredentials(access_key_id, secret_access_key));
     } else {
       Aws::String session_token(s3_config.aws_session_token.c_str());
       client_creds_ = std::unique_ptr<Aws::Auth::AWSCredentials>(
-        new Aws::Auth::AWSCredentials(access_key_id, secret_access_key, session_token));
+          new Aws::Auth::AWSCredentials(
+              access_key_id, secret_access_key, session_token));
     }
   }
 

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -133,6 +133,9 @@ Status S3::init(const Config::S3Params& s3_config, ThreadPool* thread_pool) {
                                                   Aws::Http::Scheme::HTTPS;
   config.connectTimeoutMs = s3_config.connect_timeout_ms_;
   config.requestTimeoutMs = s3_config.request_timeout_ms_;
+  config.caFile = s3_config.ca_file_.c_str();
+  config.caPath = s3_config.ca_path_.c_str();
+  config.verifySSL = s3_config.verify_ssl_;
 
   config.retryStrategy = Aws::MakeShared<Aws::Client::DefaultRetryStrategy>(
       constants::s3_allocation_tag.c_str(),

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -144,8 +144,14 @@ Status S3::init(const Config::S3Params& s3_config, ThreadPool* thread_pool) {
       !s3_config.aws_secret_access_key.empty()) {
     Aws::String access_key_id(s3_config.aws_access_key_id.c_str());
     Aws::String secret_access_key(s3_config.aws_secret_access_key.c_str());
-    client_creds_ = std::unique_ptr<Aws::Auth::AWSCredentials>(
+    if (!s3_config.aws_session_token.c_str()) {
+      client_creds_ = std::unique_ptr<Aws::Auth::AWSCredentials>(
         new Aws::Auth::AWSCredentials(access_key_id, secret_access_key));
+    } else {
+      Aws::String session_token(s3_config.aws_session_token.c_str());
+      client_creds_ = std::unique_ptr<Aws::Auth::AWSCredentials>(
+        new Aws::Auth::AWSCredentials(access_key_id, secret_access_key, session_token));
+    }
   }
 
   return Status::Ok();

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -483,6 +483,12 @@ const std::string s3_allocation_tag = "TileDB";
 /** Use virtual addressing (false for minio, true for AWS S3). */
 const bool s3_use_virtual_addressing = true;
 
+/** Certificate file path. */
+const std::string s3_ca_file = "";
+
+/** Certificate directory path. */
+const std::string s3_ca_path = "";
+
 /** Connect timeout in milliseconds. */
 const long s3_connect_timeout_ms = 3000;
 
@@ -533,6 +539,12 @@ const std::string s3_proxy_username = "";
 
 /** S3 proxy password. */
 const std::string s3_proxy_password = "";
+
+/** S3 logging level. */
+const std::string s3_logging_level = "Off";
+
+/** Verify TLS/SSL certificates (true). */
+const bool s3_verify_ssl = true;
 
 /** HDFS default kerb ticket cache path. */
 const std::string hdfs_kerb_ticket_cache_path = "";

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -513,6 +513,9 @@ const std::string aws_access_key_id = "";
 /** S3 aws secret access key. */
 const std::string aws_secret_access_key = "";
 
+/** S3 aws session token. */
+const std::string aws_session_token = "";
+
 /** S3 endpoint override. */
 const std::string s3_endpoint_override = "";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -482,6 +482,9 @@ extern const long s3_connect_max_tries;
 /** Connect scale factor for exponential backoff. */
 extern const long s3_connect_scale_factor;
 
+/** S3 logging level. */
+extern const std::string s3_logging_level;
+
 /** Request timeout in milliseconds. */
 extern const long s3_request_timeout_ms;
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -494,6 +494,9 @@ extern const std::string aws_access_key_id;
 /** S3 aws secret access key. */
 extern const std::string aws_secret_access_key;
 
+/** S3 aws session token. */
+extern const std::string aws_session_token;
+
 /** S3 endpoint override. */
 extern const std::string s3_endpoint_override;
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -464,6 +464,15 @@ extern const std::string s3_allocation_tag;
 /** Use virtual addressing (false for minio, true for AWS S3). */
 extern const bool s3_use_virtual_addressing;
 
+/** Certificate file path. */
+extern const std::string s3_ca_file;
+
+/** Certificate directory path. */
+extern const std::string s3_ca_path;
+
+/** Certificate verification enabled. */
+extern const bool s3_verify_ssl;
+
 /** Connect timeout in milliseconds. */
 extern const long s3_connect_timeout_ms;
 

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -168,6 +168,21 @@ Status convert(const std::string& str, float* value) {
   return Status::Ok();
 }
 
+Status convert(const std::string& str, bool* value) {
+  std::string lvalue = str;
+  std::transform(lvalue.begin(), lvalue.end(), lvalue.begin(), ::tolower);
+  if (lvalue == "true") {
+    *value = true;
+  } else if (lvalue == "false") {
+    *value = false;
+  } else {
+    return LOG_STATUS(Status::UtilsError(
+        "Failed to convert string to bool; Value not 'true' or 'false'"));
+  }
+
+  return Status::Ok();
+}
+
 bool is_int(const std::string& str) {
   // Check if empty
   if (str.empty())

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -67,6 +67,9 @@ Status convert(const std::string& str, uint64_t* value);
 /** Converts the input string into a `uint32_t` value. */
 Status convert(const std::string& str, uint32_t* value);
 
+/** Converts the input string into a `bool` value. */
+Status convert(const std::string& str, bool* value);
+
 /** Converts the input string into a `float` value. */
 Status convert(const std::string& str, float* value);
 

--- a/tiledb/sm/storage_manager/config.cc
+++ b/tiledb/sm/storage_manager/config.cc
@@ -681,6 +681,10 @@ void Config::set_default_param_values() {
   param_values_["vfs.s3.aws_secret_access_key"] = value.str();
   value.str(std::string());
 
+  value << vfs_params_.s3_params_.aws_session_token;
+  param_values_["vfs.s3.aws_session_token"] = value.str();
+  value.str(std::string());
+
   value << vfs_params_.s3_params_.scheme_;
   param_values_["vfs.s3.scheme"] = value.str();
   value.str(std::string());

--- a/tiledb/sm/storage_manager/config.cc
+++ b/tiledb/sm/storage_manager/config.cc
@@ -479,14 +479,12 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.s3.multipart_part_size"] = value.str();
     value.str(std::string());
   } else if (param == "vfs.s3.ca_file") {
-    vfs_params_.s3_params_.ca_file_ =
-        constants::s3_ca_file;
+    vfs_params_.s3_params_.ca_file_ = constants::s3_ca_file;
     value << vfs_params_.s3_params_.ca_file_;
     param_values_["vfs.s3.ca_file"] = value.str();
     value.str(std::string());
   } else if (param == "vfs.s3.ca_path") {
-    vfs_params_.s3_params_.ca_path_ =
-        constants::s3_ca_path;
+    vfs_params_.s3_params_.ca_path_ = constants::s3_ca_path;
     value << vfs_params_.s3_params_.ca_path_;
     param_values_["vfs.s3.ca_path"] = value.str();
     value.str(std::string());
@@ -539,10 +537,8 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.s3.proxy_password"] = value.str();
     value.str(std::string());
   } else if (param == "vfs.s3.verify_ssl") {
-    vfs_params_.s3_params_.verify_ssl_ =
-        constants::s3_verify_ssl;
-    value
-        << ((vfs_params_.s3_params_.verify_ssl_) ? "true" : "false");
+    vfs_params_.s3_params_.verify_ssl_ = constants::s3_verify_ssl;
+    value << ((vfs_params_.s3_params_.verify_ssl_) ? "true" : "false");
     param_values_["vfs.s3.verify_ssl"] = value.str();
     value.str(std::string());
   } else if (param == "vfs.hdfs.name_node") {

--- a/tiledb/sm/storage_manager/config.cc
+++ b/tiledb/sm/storage_manager/config.cc
@@ -52,7 +52,8 @@ const std::set<std::string> Config::unserialized_params_ = {
     "vfs.s3.proxy_username",
     "vfs.s3.proxy_password",
     "vfs.s3.aws_access_key_id",
-    "vfs.s3.aws_secret_access_key"};
+    "vfs.s3.aws_secret_access_key",
+    "vfs.s3.aws_session_token"};
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -220,6 +221,8 @@ Status Config::set(const std::string& param, const std::string& value) {
     RETURN_NOT_OK(set_vfs_s3_aws_access_key_id(value));
   } else if (param == "vfs.s3.aws_secret_access_key") {
     RETURN_NOT_OK(set_vfs_s3_aws_secret_access_key(value));
+  } else if (param == "vfs.s3.aws_session_token") {
+    RETURN_NOT_OK(set_vfs_s3_aws_session_token(value));
   } else if (param == "vfs.s3.scheme") {
     RETURN_NOT_OK(set_vfs_s3_scheme(value));
   } else if (param == "vfs.s3.endpoint_override") {
@@ -432,6 +435,11 @@ Status Config::unset(const std::string& param) {
     vfs_params_.s3_params_.aws_secret_access_key = "";
     value << vfs_params_.s3_params_.aws_secret_access_key;
     param_values_["vfs.s3.aws_secret_access_key"] = value.str();
+    value.str(std::string());
+  } else if (param == "vfs.s3.aws_session_token") {
+    vfs_params_.s3_params_.aws_session_token = "";
+    value << vfs_params_.s3_params_.aws_session_token;
+    param_values_["vfs.s3.aws_session_token"] = value.str();
     value.str(std::string());
   } else if (param == "vfs.s3.scheme") {
     vfs_params_.s3_params_.scheme_ = constants::s3_scheme;
@@ -953,6 +961,11 @@ Status Config::set_vfs_s3_aws_access_key_id(const std::string& value) {
 
 Status Config::set_vfs_s3_aws_secret_access_key(const std::string& value) {
   vfs_params_.s3_params_.aws_secret_access_key = value;
+  return Status::Ok();
+}
+
+Status Config::set_vfs_s3_aws_session_token(const std::string& value) {
+  vfs_params_.s3_params_.aws_session_token = value;
   return Status::Ok();
 }
 

--- a/tiledb/sm/storage_manager/config.h
+++ b/tiledb/sm/storage_manager/config.h
@@ -593,6 +593,9 @@ class Config {
   /** Sets the S3 connect scale factor for exponential backoff. */
   Status set_vfs_s3_connect_scale_factor(const std::string& value);
 
+  /** Sets the S3 logging level. */
+  Status set_vfs_s3_logging_level(const std::string& value);
+
   /** Sets the S3 request timeout in milliseconds. */
   Status set_vfs_s3_request_timeout_ms(const std::string& value);
 

--- a/tiledb/sm/storage_manager/config.h
+++ b/tiledb/sm/storage_manager/config.h
@@ -110,6 +110,7 @@ class Config {
     std::string scheme_;
     std::string endpoint_override_;
     bool use_virtual_addressing_;
+    bool verify_ssl_;
     uint64_t max_parallel_ops_;
     uint64_t multipart_part_size_;
     long connect_timeout_ms_;
@@ -124,12 +125,16 @@ class Config {
     std::string aws_access_key_id;
     std::string aws_secret_access_key;
     std::string aws_session_token;
+    std::string logging_level_;
+    std::string ca_file_;
+    std::string ca_path_;
 
     S3Params() {
       region_ = constants::s3_region;
       scheme_ = constants::s3_scheme;
       endpoint_override_ = constants::s3_endpoint_override;
       use_virtual_addressing_ = constants::s3_use_virtual_addressing;
+      verify_ssl_ = constants::s3_verify_ssl;
       max_parallel_ops_ = constants::s3_max_parallel_ops;
       multipart_part_size_ = constants::s3_multipart_part_size;
       connect_timeout_ms_ = constants::s3_connect_timeout_ms;
@@ -144,6 +149,9 @@ class Config {
       aws_access_key_id = constants::aws_access_key_id;
       aws_secret_access_key = constants::aws_secret_access_key;
       aws_session_token = constants::aws_session_token;
+      logging_level_ = constants::s3_logging_level;
+      ca_file_ = constants::s3_ca_file;
+      ca_path_ = constants::s3_ca_path;
     }
   };
 
@@ -358,6 +366,16 @@ class Config {
    *    vfs.s3.max_parallel_ops` bytes will be buffered before issuing multipart
    *    uploads in parallel. <br>
    *    **Default**: 5MB
+   * - `vfs.s3.ca_path` <br>
+   *    Path to SSL/TLS certificate directory to be used by cURL for S3 HTTPS
+   *    encryption. Follows cURL conventions:
+   *    https://curl.haxx.se/docs/manpage.html <br>
+   *    **Default**: ""
+   * - `vfs.s3.ca_file` <br>
+   *    Path to SSL/TLS certificate file to be used by cURL for for S3 HTTPS
+   *    encryption. Follows cURL conventions:
+   *    https://curl.haxx.se/docs/manpage.html <br>
+   *    **Default**: ""
    * - `vfs.s3.connect_timeout_ms` <br>
    *    The connection timeout in ms. Any `long` value is acceptable. <br>
    *    **Default**: 3000
@@ -387,7 +405,10 @@ class Config {
    * - `vfs.s3.proxy_password` <br>
    *    The proxy password. Note: this parameter is not serialized by
    *    `tiledb_config_save_to_file`. <br>
-   *    **Default**: ""
+   *    **Default**: "
+   * - `vfs.s3.verify_ssl` <br>
+   *    Enable HTTPS certificate verification.<br>
+   *    **Default**: true""
    * - `vfs.hdfs.name_node"` <br>
    *    Name node for HDFS. <br>
    *    **Default**: ""
@@ -557,6 +578,12 @@ class Config {
   /** Sets the S3 multipart part size. */
   Status set_vfs_s3_multipart_part_size(const std::string& value);
 
+  /** Sets the S3 certificate file. */
+  Status set_vfs_s3_ca_file(const std::string& value);
+
+  /** Sets the S3 certificate directory. */
+  Status set_vfs_s3_ca_path(const std::string& value);
+
   /** Sets the S3 connect timeout in milliseconds. */
   Status set_vfs_s3_connect_timeout_ms(const std::string& value);
 
@@ -583,6 +610,9 @@ class Config {
 
   /** Sets the S3 proxy password. */
   Status set_vfs_s3_proxy_password(const std::string& value);
+
+  /** Sets the S3 verify_ssl. */
+  Status set_vfs_s3_verify_ssl(const std::string& value);
 
   /** Sets the HDFS namenode hostname and port (uri) */
   Status set_vfs_hdfs_name_node(const std::string& value);

--- a/tiledb/sm/storage_manager/config.h
+++ b/tiledb/sm/storage_manager/config.h
@@ -123,6 +123,7 @@ class Config {
     std::string proxy_password_;
     std::string aws_access_key_id;
     std::string aws_secret_access_key;
+    std::string aws_session_token;
 
     S3Params() {
       region_ = constants::s3_region;
@@ -142,6 +143,7 @@ class Config {
       proxy_password_ = constants::s3_proxy_password;
       aws_access_key_id = constants::aws_access_key_id;
       aws_secret_access_key = constants::aws_secret_access_key;
+      aws_session_token = constants::aws_session_token;
     }
   };
 
@@ -536,6 +538,9 @@ class Config {
 
   /** Sets the S3 AWS_SECRET_ACCESS_KEY. */
   Status set_vfs_s3_aws_secret_access_key(const std::string& value);
+
+  /** Sets the S3 AWS_SESSION_TOKEN. */
+  Status set_vfs_s3_aws_session_token(const std::string& value);
 
   /** Sets the S3 scheme. */
   Status set_vfs_s3_scheme(const std::string& value);


### PR DESCRIPTION
Summary:
- add support for AWS session token, various curl-related options

References
* https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
* https://sdk.amazonaws.com/cpp/api/LATEST/class_aws_1_1_auth_1_1_a_w_s_credentials.html
* https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html
* https://curl.haxx.se/libcurl/c/CURLOPT_CAPATH.html
* https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html