### PR TITLE
GCS VFS: Defer zero-copy buffers

### DIFF
--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -768,7 +768,6 @@ Status GCS::flush_object_direct(const URI& uri) {
   std::string object_path;
   RETURN_NOT_OK(parse_gcs_uri(uri, &bucket_name, &object_path));
 
-  // TODO: zero-copy from write cache buffer to 'write_buffer'.
   std::string write_buffer(
       static_cast<const char*>(write_cache_buffer->data()),
       write_cache_buffer->size());
@@ -818,7 +817,6 @@ Status GCS::read(
         stream.status().message() + ")")));
   }
 
-  // TODO: zero-copy
   stream.read(static_cast<char*>(buffer), length);
 
   if (!stream) {


### PR DESCRIPTION
The GCS SDK uses std::string objects to represent buffers within the IO
calls. The interfaces force the std::allocator<char> for the std::string so
it is not possible to override the allocator to eliminate excessive copies
in our VFS call stack.

I spent some time trying to patch the GCS SDK to allow for a custom allocator
(or just a `std::pair<char *, size_t>`) but it is not trivial.