### PR TITLE
Fix empty metadata indicator for index getter

### DIFF
--- a/test/src/unit-cppapi-metadata.cc
+++ b/test/src/unit-cppapi-metadata.cc
@@ -252,6 +252,12 @@ TEST_CASE_METHOD(
   CHECK(key.size() == strlen("bb"));
   CHECK(!strncmp(key.data(), "bb", strlen("bb")));
 
+  // idx 2 is 'zero_val'
+  array.get_metadata_from_index(2, &key, &v_type, &v_num, &v_r);
+  CHECK(v_type == TILEDB_FLOAT32);
+  CHECK(v_num == 1);
+  CHECK(v_r == nullptr);
+
   // Check has_key
   bool has_key;
   v_type = (tiledb_datatype_t)std::numeric_limits<int32_t>::max();

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -229,9 +229,14 @@ Status Metadata::get(
   // Get value
   auto& value_struct = *(metadata_index_[index].second);
   *value_type = static_cast<Datatype>(value_struct.type_);
-  *value_num = value_struct.num_;
-  *value = (*value_num) ? (const void*)value_struct.value_.data() : nullptr;
-
+  if (value_struct.num_ == 0) {
+    // zero-valued keys
+    *value_num = 1;
+    *value = nullptr;
+  } else {
+    *value_num = value_struct.num_;
+    *value = (const void*)(value_struct.value_.data());
+  }
   return Status::Ok();
 }
 


### PR DESCRIPTION
This harmonizes the return `value_num` of `tiledb_get_metadata` and `tiledb_get_metadata_from_index` when returning an empty (zero-length) metadata value.

Missing from https://github.com/TileDB-Inc/TileDB/pull/1438