### PR TITLE
Config: sm.skip_checksum_validation

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -229,6 +229,7 @@ void check_save_to_file() {
   ss << "sm.num_reader_threads 1\n";
   ss << "sm.num_tbb_threads -1\n";
   ss << "sm.num_writer_threads 1\n";
+  ss << "sm.skip_checksum_validation false\n";
   ss << "sm.tile_cache_size 10000000\n";
   ss << "vfs.azure.block_list_block_size 5242880\n";
   ss << "vfs.azure.max_parallel_ops " << std::thread::hardware_concurrency()
@@ -424,6 +425,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.num_reader_threads"] = "1";
   all_param_values["sm.num_writer_threads"] = "1";
   all_param_values["sm.num_tbb_threads"] = "-1";
+  all_param_values["sm.skip_checksum_validation"] = "false";
   all_param_values["sm.consolidation.amplification"] = "1.0";
   all_param_values["sm.consolidation.steps"] = "4294967295";
   all_param_values["sm.consolidation.step_min_frags"] = "4294967295";

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -68,6 +68,7 @@ const std::string Config::SM_NUM_TBB_THREADS =
 #else
 const std::string Config::SM_NUM_TBB_THREADS = "-1";
 #endif
+const std::string Config::SM_SKIP_CHECKSUM_VALIDATION = "false";
 const std::string Config::SM_CONSOLIDATION_AMPLIFICATION = "1.0";
 const std::string Config::SM_CONSOLIDATION_BUFFER_SIZE = "50000000";
 const std::string Config::SM_CONSOLIDATION_STEPS = "4294967295";
@@ -156,6 +157,7 @@ Config::Config() {
   param_values_["sm.num_reader_threads"] = SM_NUM_READER_THREADS;
   param_values_["sm.num_writer_threads"] = SM_NUM_WRITER_THREADS;
   param_values_["sm.num_tbb_threads"] = SM_NUM_TBB_THREADS;
+  param_values_["sm.skip_checksum_validation"] = SM_SKIP_CHECKSUM_VALIDATION;
   param_values_["sm.consolidation.amplification"] =
       SM_CONSOLIDATION_AMPLIFICATION;
   param_values_["sm.consolidation.buffer_size"] = SM_CONSOLIDATION_BUFFER_SIZE;

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -117,6 +117,9 @@ class Config {
   /** The number of threads allocated for TBB. */
   static const std::string SM_NUM_TBB_THREADS;
 
+  /** If `true`, checksum validation will be skipped on reads. */
+  static const std::string SM_SKIP_CHECKSUM_VALIDATION;
+
   /**
    * The factor by which the size of the dense fragment resulting
    * from consolidating a set of fragments (containing at least one

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -256,7 +256,10 @@ Status BitWidthReductionFilter::run_reverse(
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
-    FilterBuffer* output) const {
+    FilterBuffer* output,
+    const Config& config) const {
+  (void)config;
+
   auto tile_type = pipeline_->current_tile()->type();
   auto tile_type_size = static_cast<uint8_t>(datatype_size(tile_type));
 

--- a/tiledb/sm/filter/bit_width_reduction_filter.h
+++ b/tiledb/sm/filter/bit_width_reduction_filter.h
@@ -105,7 +105,8 @@ class BitWidthReductionFilter : public Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const override;
+      FilterBuffer* output,
+      const Config& config) const override;
 
   /** Set the max window size (in bytes) to use. */
   void set_max_window_size(uint32_t max_window_size);

--- a/tiledb/sm/filter/bitshuffle_filter.cc
+++ b/tiledb/sm/filter/bitshuffle_filter.cc
@@ -162,7 +162,10 @@ Status BitshuffleFilter::run_reverse(
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
-    FilterBuffer* output) const {
+    FilterBuffer* output,
+    const Config& config) const {
+  (void)config;
+
   auto tile_type = pipeline_->current_tile()->type();
   auto tile_type_size = static_cast<uint8_t>(datatype_size(tile_type));
 

--- a/tiledb/sm/filter/bitshuffle_filter.h
+++ b/tiledb/sm/filter/bitshuffle_filter.h
@@ -96,7 +96,8 @@ class BitshuffleFilter : public Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const override;
+      FilterBuffer* output,
+      const Config& config) const override;
 
  private:
   /** Returns a new clone of this filter. */

--- a/tiledb/sm/filter/byteshuffle_filter.cc
+++ b/tiledb/sm/filter/byteshuffle_filter.cc
@@ -107,7 +107,10 @@ Status ByteshuffleFilter::run_reverse(
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
-    FilterBuffer* output) const {
+    FilterBuffer* output,
+    const Config& config) const {
+  (void)config;
+
   // Get number of parts
   uint32_t num_parts;
   RETURN_NOT_OK(input_metadata->read(&num_parts, sizeof(uint32_t)));

--- a/tiledb/sm/filter/byteshuffle_filter.h
+++ b/tiledb/sm/filter/byteshuffle_filter.h
@@ -88,7 +88,8 @@ class ByteshuffleFilter : public Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const override;
+      FilterBuffer* output,
+      const Config& config) const override;
 
  private:
   /** Returns a new clone of this filter. */

--- a/tiledb/sm/filter/checksum_md5_filter.cc
+++ b/tiledb/sm/filter/checksum_md5_filter.cc
@@ -44,7 +44,6 @@ namespace sm {
 
 ChecksumMD5Filter::ChecksumMD5Filter()
     : Filter(FilterType::FILTER_CHECKSUM_MD5) {
-  skip_validation_ = false;
 }
 
 ChecksumMD5Filter* ChecksumMD5Filter::clone_impl() const {
@@ -95,7 +94,15 @@ Status ChecksumMD5Filter::run_reverse(
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
-    FilterBuffer* output) const {
+    FilterBuffer* output,
+    const Config& config) const {
+  // Fetch the skip checksum configuration parameter.
+  bool found;
+  bool skip_validation;
+  RETURN_NOT_OK(config.get<bool>(
+      "sm.skip_checksum_validation", &skip_validation, &found));
+  assert(found);
+
   // Set output buffer to input buffer
   RETURN_NOT_OK(output->append_view(input));
 
@@ -116,7 +123,7 @@ Status ChecksumMD5Filter::run_reverse(
         input_metadata->read(&metadata_checksummed_bytes, sizeof(uint64_t)));
 
     // Only fetch and store checksum if we are not going to skip it
-    if (!skip_validation_) {
+    if (!skip_validation) {
       Buffer buff;
       buff.realloc(Crypto::MD5_DIGEST_BYTES);
       RETURN_NOT_OK(
@@ -133,7 +140,7 @@ Status ChecksumMD5Filter::run_reverse(
         input_metadata->read(&data_checksummed_bytes, sizeof(uint64_t)));
 
     // Only fetch and store checksum if we are not going to skip it
-    if (!skip_validation_) {
+    if (!skip_validation) {
       Buffer buff;
       buff.realloc(Crypto::MD5_DIGEST_BYTES);
       RETURN_NOT_OK(
@@ -145,7 +152,7 @@ Status ChecksumMD5Filter::run_reverse(
   }
 
   // Only run checksums if we are not set to skip
-  if (!skip_validation_) {
+  if (!skip_validation) {
     // Now that the checksums are fetched we an run the actual comparisons
     // against the real metadata and data Need to save the metadata offset
     // before we loop through to check it
@@ -253,17 +260,6 @@ Status ChecksumMD5Filter::compare_checksum_part(
   }
 
   return Status::Ok();
-}
-
-bool ChecksumMD5Filter::skip_validation() const {
-  return skip_validation_;
-};
-
-/**
- * Sets skip validation parameter
- */
-void ChecksumMD5Filter::skip_validation(bool skip_validation) {
-  skip_validation_ = skip_validation;
 }
 
 }  // namespace sm

--- a/tiledb/sm/filter/checksum_md5_filter.h
+++ b/tiledb/sm/filter/checksum_md5_filter.h
@@ -94,23 +94,10 @@ class ChecksumMD5Filter : public Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const override;
-
-  /**
-   * Returns skip validation parameter
-   * @return skip_validation
-   */
-  bool skip_validation() const;
-
-  /**
-   * Sets skip validation parameter
-   */
-  void skip_validation(bool skip_validation);
+      FilterBuffer* output,
+      const Config& config) const override;
 
  private:
-  /** Skip validation of checksums on reverse */
-  bool skip_validation_;
-
   /** Returns a new clone of this filter. */
   ChecksumMD5Filter* clone_impl() const override;
 

--- a/tiledb/sm/filter/checksum_sha256_filter.h
+++ b/tiledb/sm/filter/checksum_sha256_filter.h
@@ -94,23 +94,10 @@ class ChecksumSHA256Filter : public Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const override;
-
-  /**
-   * Returns skip validation parameter
-   * @return skip_validation
-   */
-  bool skip_validation() const;
-
-  /**
-   * Sets skip validation parameter
-   */
-  void skip_validation(bool skip_validation);
+      FilterBuffer* output,
+      const Config& config) const override;
 
  private:
-  /** Skip validation of checksums on reverse */
-  bool skip_validation_;
-
   /** Returns a new clone of this filter. */
   ChecksumSHA256Filter* clone_impl() const override;
 

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -243,7 +243,10 @@ Status CompressionFilter::run_reverse(
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
-    FilterBuffer* output) const {
+    FilterBuffer* output,
+    const Config& config) const {
+  (void)config;
+
   // Easy case: no compression
   if (compressor_ == Compressor::NO_COMPRESSION) {
     RETURN_NOT_OK(output->append_view(input));

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -114,7 +114,8 @@ class CompressionFilter : public Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const override;
+      FilterBuffer* output,
+      const Config& config) const override;
 
   /** Set the compressor used by this filter instance. */
   void set_compressor(Compressor compressor);

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.cc
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.cc
@@ -139,7 +139,9 @@ Status EncryptionAES256GCMFilter::run_reverse(
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
-    FilterBuffer* output) const {
+    FilterBuffer* output,
+    const Config& config) const {
+  (void)config;
   if (key_bytes_ == nullptr)
     return LOG_STATUS(Status::FilterError("Encryption error; bad key."));
 

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.h
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.h
@@ -107,7 +107,8 @@ class EncryptionAES256GCMFilter : public Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const override;
+      FilterBuffer* output,
+      const Config& config) const override;
 
   /**
    * Return a pointer to the secret key set on this filter.

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_FILTER_H
 #define TILEDB_FILTER_H
 
+#include "tiledb/sm/config/config.h"
 #include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
@@ -136,7 +137,8 @@ class Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const = 0;
+      FilterBuffer* output,
+      const Config& config) const = 0;
 
   /**
    * Sets an option on this filter.

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -209,7 +209,7 @@ class FilterPipeline {
    * @param tile Tile to filter
    * @return Status
    */
-  Status run_reverse(Tile* tile) const;
+  Status run_reverse(Tile* tile, const Config& config) const;
 
   /**
    * Serializes the pipeline metadata into a binary buffer.
@@ -284,12 +284,14 @@ class FilterPipeline {
    * @param chunks Chunks to process. Format is
    *    (data ptr, filtered size, original size, metadata size).
    * @param output Buffer where output of last stage will be written.
+   * @param config The global config.
    * @return Status
    */
   Status filter_chunks_reverse(
       const std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>>&
           chunks,
-      Buffer* output) const;
+      Buffer* output,
+      const Config& config) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/noop_filter.cc
+++ b/tiledb/sm/filter/noop_filter.cc
@@ -67,7 +67,10 @@ Status NoopFilter::run_reverse(
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
-    FilterBuffer* output) const {
+    FilterBuffer* output,
+    const Config& config) const {
+  (void)config;
+
   RETURN_NOT_OK(output->append_view(input));
   RETURN_NOT_OK(output_metadata->append_view(input_metadata));
   return Status::Ok();

--- a/tiledb/sm/filter/noop_filter.h
+++ b/tiledb/sm/filter/noop_filter.h
@@ -68,7 +68,8 @@ class NoopFilter : public Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const override;
+      FilterBuffer* output,
+      const Config& config) const override;
 
  private:
   /** Returns a new clone of this filter. */

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -215,7 +215,10 @@ Status PositiveDeltaFilter::run_reverse(
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
-    FilterBuffer* output) const {
+    FilterBuffer* output,
+    const Config& config) const {
+  (void)config;
+
   auto tile_type = pipeline_->current_tile()->type();
 
   // If encoding wasn't applied, just return the input unmodified.

--- a/tiledb/sm/filter/positive_delta_filter.h
+++ b/tiledb/sm/filter/positive_delta_filter.h
@@ -96,7 +96,8 @@ class PositiveDeltaFilter : public Filter {
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
-      FilterBuffer* output) const override;
+      FilterBuffer* output,
+      const Config& config) const override;
 
   /** Set the max window size (in bytes) to use. */
   void set_max_window_size(uint32_t max_window_size);

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1462,7 +1462,8 @@ Status FragmentMetadata::load_v1_v2(const EncryptionKey& encryption_key) {
   // Read metadata
   TileIO tile_io(storage_manager_, fragment_metadata_uri);
   auto tile = (Tile*)nullptr;
-  RETURN_NOT_OK(tile_io.read_generic(&tile, 0, encryption_key));
+  RETURN_NOT_OK(tile_io.read_generic(
+      &tile, 0, encryption_key, storage_manager_->config()));
   tile->disown_buff();
   auto buff = tile->buffer();
   STATS_COUNTER_ADD(fragment_metadata_bytes_read, tile_io.file_size());
@@ -1675,7 +1676,8 @@ Status FragmentMetadata::read_generic_tile_from_file(
   // Read metadata
   TileIO tile_io(storage_manager_, fragment_metadata_uri);
   auto tile = (Tile*)nullptr;
-  RETURN_NOT_OK(tile_io.read_generic(&tile, offset, encryption_key));
+  RETURN_NOT_OK(tile_io.read_generic(
+      &tile, offset, encryption_key, storage_manager_->config()));
   tile->buffer()->swap(*buff);
   delete tile;
 

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -1668,7 +1668,7 @@ Status Reader::unfilter_tile(
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(
       &filters, array_->get_encryption_key()));
 
-  RETURN_NOT_OK(filters.run_reverse(tile));
+  RETURN_NOT_OK(filters.run_reverse(tile, storage_manager_->config()));
 
   tile->set_filtered(false);
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1046,7 +1046,7 @@ Status StorageManager::load_array_schema(
   auto tile_io = new TileIO(this, schema_uri);
   auto tile = (Tile*)nullptr;
   RETURN_NOT_OK_ELSE(
-      tile_io->read_generic(&tile, 0, encryption_key), delete tile_io);
+      tile_io->read_generic(&tile, 0, encryption_key, config_), delete tile_io);
   tile->disown_buff();
   auto buff = tile->buffer();
   delete tile;
@@ -1678,7 +1678,7 @@ Status StorageManager::load_array_metadata(
     if (metadata_buff == nullptr) {  // Array metadata does not exist - load it
       TileIO tile_io(this, uri);
       auto tile = (Tile*)nullptr;
-      RETURN_NOT_OK(tile_io.read_generic(&tile, 0, encryption_key));
+      RETURN_NOT_OK(tile_io.read_generic(&tile, 0, encryption_key, config_));
       tile->disown_buff();
       auto buff = tile->buffer();
       delete tile;

--- a/tiledb/sm/tile/tile_io.cc
+++ b/tiledb/sm/tile/tile_io.cc
@@ -93,7 +93,10 @@ Status TileIO::is_generic_tile(
 }
 
 Status TileIO::read_generic(
-    Tile** tile, uint64_t file_offset, const EncryptionKey& encryption_key) {
+    Tile** tile,
+    uint64_t file_offset,
+    const EncryptionKey& encryption_key,
+    const Config& config) {
   STATS_FUNC_IN(tileio_read_generic);
 
   GenericTileHeader header;
@@ -133,7 +136,7 @@ Status TileIO::read_generic(
       delete *tile);
 
   // Filter
-  RETURN_NOT_OK_ELSE(header.filters.run_reverse(*tile), delete *tile);
+  RETURN_NOT_OK_ELSE(header.filters.run_reverse(*tile, config), delete *tile);
 
   file_size_ = header.persisted_size;
   STATS_COUNTER_ADD(tileio_read_num_bytes_read, header.persisted_size);

--- a/tiledb/sm/tile/tile_io.h
+++ b/tiledb/sm/tile/tile_io.h
@@ -139,10 +139,14 @@ class TileIO {
    * @param tile The tile that will hold the read data.
    * @param file_offset The offset in the file to read from.
    * @param encryption_key The encryption key to use.
+   * @param config The storage manager's config.
    * @return Status
    */
   Status read_generic(
-      Tile** tile, uint64_t file_offset, const EncryptionKey& encryption_key);
+      Tile** tile,
+      uint64_t file_offset,
+      const EncryptionKey& encryption_key,
+      const Config& config);
 
   /**
    * Reads the generic tile header from the file.


### PR DESCRIPTION
This adds the 'sm.skip_checksum_validation' config option that will skip
checksum validation on reads for the md5 and sha256 filters.

Associated unit test has been added in test/src/unit-filter-pipeline.cc