### PR TITLE
Selective Unfiltering

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,6 +95,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-s3.cc
   src/unit-s3-no-multipart.cc
   src/unit-status.cc
+  src/unit-ChunkedBuffer.cc
   src/unit-Subarray.cc
   src/unit-SubarrayPartitioner-dense.cc
   src/unit-SubarrayPartitioner-error.cc

--- a/test/src/unit-ChunkedBuffer.cc
+++ b/test/src/unit-ChunkedBuffer.cc
@@ -1,0 +1,794 @@
+/**
+ * @file unit-ChunkedBuffer.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `ChunkedBuffer` class.
+ */
+
+#include "tiledb/sm/tile/chunked_buffer.h"
+
+#include <catch.hpp>
+#include <iostream>
+
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "ChunkedBuffer: Test default constructor",
+    "[ChunkedBuffer][default_constructor]") {
+  // Test the default constructor and verify the empty state.
+  ChunkedBuffer chunked_buffer;
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.nchunks() == 0);
+  void* buffer = nullptr;
+  CHECK(!chunked_buffer.internal_buffer(0, &buffer).ok());
+  CHECK(!buffer);
+}
+
+TEST_CASE(
+    "ChunkedBuffer: Test discrete, fixed size IO",
+    "[ChunkedBuffer][discrete_fixed_io]") {
+  // Instantiate a test ChunkedBuffer.
+  ChunkedBuffer chunked_buffer;
+
+  // Create a buffer to write to the test ChunkedBuffer.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Attempt a write before initializing the test ChunkedBuffer.
+  uint64_t write_offset = 0;
+  CHECK(!chunked_buffer.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Attempt a read before initializing the test ChunkedBuffer.
+  uint64_t read_offset = 0;
+  uint64_t* const read_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  CHECK(!chunked_buffer.read(read_buffer, buffer_size, read_offset).ok());
+
+  // Attempt an alloc before initializing the test ChunkedBuffer.
+  size_t chunk_idx = 0;
+  void* chunk_buffer = nullptr;
+  CHECK(!chunked_buffer.alloc_discrete(chunk_idx, &chunk_buffer).ok());
+  CHECK(!chunk_buffer);
+
+  // Attempt a set before initializing the test ChunkedBuffer.
+  chunk_buffer = nullptr;
+  CHECK(!chunked_buffer.set_contigious(chunk_buffer).ok());
+  CHECK(!chunk_buffer);
+
+  // Initialize the ChunkedBuffer.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunked_buffer.init_fixed_size(
+      ChunkedBuffer::BufferAddressing::DISCRETE, buffer_size, chunk_size);
+  CHECK(chunked_buffer.capacity() == buffer_size);
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.nchunks() == nchunks);
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    void* chunk_buffer;
+    CHECK(chunked_buffer.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(!chunk_buffer);
+  }
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  write_offset = 0;
+  CHECK(chunked_buffer.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Verify all chunks are allocated and that they do not overlap
+  // 'buffer' because they have been deep-copied.
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunked_buffer.internal_buffer_size(i, &internal_size).ok());
+    if (i < chunked_buffer.nchunks() - 1) {
+      CHECK(internal_size == chunk_size);
+    } else {
+      CHECK(internal_size == last_chunk_size);
+    }
+
+    CHECK(chunked_buffer.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(chunk_buffer != write_buffer);
+    if (chunk_buffer < write_buffer) {
+      CHECK(
+          static_cast<char*>(chunk_buffer) + chunk_size <=
+          reinterpret_cast<char*>(write_buffer));
+    } else {
+      CHECK(
+          reinterpret_cast<char*>(write_buffer) + buffer_size <=
+          static_cast<char*>(chunk_buffer));
+    }
+  }
+  // Read the third element, this will be of value '2'.
+  read_offset = 2 * sizeof(uint64_t);
+  uint64_t two = 0;
+  CHECK(chunked_buffer.read(&two, sizeof(uint64_t), read_offset).ok());
+  CHECK(two == 2);
+
+  // Read the 10th element, this will be of value '9'.
+  read_offset = 9 * sizeof(uint64_t);
+  uint64_t nine = 0;
+  CHECK(chunked_buffer.read(&nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine == 9);
+
+  // Read the 100th element, this will be of value '99'.
+  read_offset = 99 * sizeof(uint64_t);
+  uint64_t ninety_nine = 0;
+  CHECK(chunked_buffer.read(&ninety_nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(ninety_nine == 99);
+
+  // Overwrite the 100th element with value '900'.
+  write_offset = 99 * sizeof(uint64_t);
+  uint64_t nine_hundred = 900;
+  CHECK(
+      chunked_buffer.write(&nine_hundred, sizeof(uint64_t), write_offset).ok());
+
+  // Read the 100th element, this will be of value '900'.
+  read_offset = 99 * sizeof(uint64_t);
+  nine_hundred = 0;
+  CHECK(chunked_buffer.read(&nine_hundred, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine_hundred == 900);
+
+  // Overwrite the 100th element back to value '99'.
+  write_offset = 99 * sizeof(uint64_t);
+  ninety_nine = 99;
+  CHECK(
+      chunked_buffer.write(&ninety_nine, sizeof(uint64_t), write_offset).ok());
+
+  // Read the entire written buffer.
+  read_offset = 0;
+  CHECK(chunked_buffer.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Free the chunk buffer, which will free all of the allocated
+  // buffers and return chunked_buffer into an uninitialized state.
+  chunked_buffer.free();
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.nchunks() == 0);
+
+  // Reinitialize the chunk buffers.
+  chunked_buffer.init_fixed_size(
+      ChunkedBuffer::BufferAddressing::DISCRETE, buffer_size, chunk_size);
+  CHECK(chunked_buffer.capacity() == buffer_size);
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.nchunks() == nchunks);
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunked_buffer.internal_buffer_size(i, &internal_size).ok());
+    CHECK(internal_size == 0);
+
+    uint32_t internal_capacity = 0;
+    CHECK(chunked_buffer.internal_buffer_capacity(i, &internal_capacity).ok());
+    if (i < chunked_buffer.nchunks() - 1) {
+      CHECK(internal_capacity == chunk_size);
+    } else {
+      CHECK(internal_capacity == last_chunk_size);
+    }
+  }
+
+  // Allocate all chunks.
+  std::vector<void*> internal_chunked_buffer(chunked_buffer.nchunks());
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    CHECK(chunked_buffer.alloc_discrete(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    internal_chunked_buffer[i] = chunk_buffer;
+  }
+
+  // Verify all chunks are allocated and that they do not overlap
+  // 'buffer' because they have been deep-copied.
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunked_buffer.internal_buffer_size(i, &internal_size).ok());
+    CHECK(internal_size == 0);
+
+    uint32_t internal_capacity = 0;
+    CHECK(chunked_buffer.internal_buffer_capacity(i, &internal_capacity).ok());
+    if (i < chunked_buffer.nchunks() - 1) {
+      CHECK(internal_capacity == chunk_size);
+    } else {
+      CHECK(internal_capacity == last_chunk_size);
+    }
+
+    CHECK(chunked_buffer.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(chunk_buffer != write_buffer);
+    if (chunk_buffer < write_buffer) {
+      CHECK(
+          static_cast<char*>(chunk_buffer) + chunk_size <=
+          reinterpret_cast<char*>(write_buffer));
+    } else {
+      CHECK(
+          reinterpret_cast<char*>(write_buffer) + buffer_size <=
+          static_cast<char*>(chunk_buffer));
+    }
+  }
+
+  // Write to all chunks.
+  write_offset = 0;
+  CHECK(chunked_buffer.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Read the entire written buffer.
+  read_offset = 0;
+  CHECK(chunked_buffer.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Clear the ChunkedBuffer. This will reset to an uninitialized state
+  // but will NOT free the underlying buffers.
+  chunked_buffer.clear();
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.nchunks() == 0);
+
+  // Free the internal buffers to prevent a memory leak.
+  for (const auto& internal_buffer : internal_chunked_buffer) {
+    free(internal_buffer);
+  }
+
+  free(write_buffer);
+  free(read_buffer);
+}
+
+TEST_CASE(
+    "ChunkedBuffer: Test contigious, fixed size IO",
+    "[ChunkedBuffer][contigious_fixed_io]") {
+  // Instantiate a test ChunkedBuffer.
+  ChunkedBuffer chunked_buffer;
+
+  // Create a buffer to write to the test ChunkedBuffer.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkedBuffer.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunked_buffer.init_fixed_size(
+      ChunkedBuffer::BufferAddressing::CONTIGIOUS, buffer_size, chunk_size);
+  CHECK(chunked_buffer.capacity() == buffer_size);
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.nchunks() == nchunks);
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    void* chunk_buffer;
+    CHECK(chunked_buffer.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(!chunk_buffer);
+  }
+
+  // Write the entire buffer. This will fail because a contigious buffer
+  // has not been set or allocated.
+  uint64_t write_offset = 0;
+  CHECK(!chunked_buffer.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Attempt to allocate a chunk. This will fail because contigious
+  // ChunkedBuffer instances can not use the 'alloc_discrete' routine.
+  CHECK(!chunked_buffer.alloc_discrete(chunked_buffer.nchunks() / 2).ok());
+
+  // Set the contigious buffer.
+  CHECK(chunked_buffer.set_contigious(write_buffer).ok());
+  CHECK(chunked_buffer.set_size(buffer_size).ok());
+
+  // Verify all chunks are allocated and that they're addressed match
+  // 'write_buffer' to ensure 'write_buffer' was not copied.
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunked_buffer.internal_buffer_size(i, &internal_size).ok());
+    if (i < chunked_buffer.nchunks() - 1) {
+      CHECK(internal_size == chunk_size);
+    } else {
+      CHECK(internal_size == last_chunk_size);
+    }
+
+    void* chunk_buffer = nullptr;
+    CHECK(chunked_buffer.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(
+        chunk_buffer ==
+        reinterpret_cast<char*>(write_buffer) + (i * chunk_size));
+  }
+
+  // Read the third element, this will be of value '2'.
+  uint64_t read_offset = 2 * sizeof(uint64_t);
+  uint64_t two = 0;
+  CHECK(chunked_buffer.read(&two, sizeof(uint64_t), read_offset).ok());
+  CHECK(two == 2);
+
+  // Read the 10th element, this will be of value '9'.
+  read_offset = 9 * sizeof(uint64_t);
+  uint64_t nine = 0;
+  CHECK(chunked_buffer.read(&nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine == 9);
+
+  // Read the 100th element, this will be of value '99'.
+  read_offset = 99 * sizeof(uint64_t);
+  uint64_t ninety_nine = 0;
+  CHECK(chunked_buffer.read(&ninety_nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(ninety_nine == 99);
+
+  // Overwrite the 100th element with value '900'.
+  write_offset = 99 * sizeof(uint64_t);
+  uint64_t nine_hundred = 900;
+  CHECK(
+      chunked_buffer.write(&nine_hundred, sizeof(uint64_t), write_offset).ok());
+
+  // Read the 100th element, this will be of value '900'.
+  read_offset = 99 * sizeof(uint64_t);
+  nine_hundred = 0;
+  CHECK(chunked_buffer.read(&nine_hundred, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine_hundred == 900);
+
+  // Overwrite the 100th element back to value '99'.
+  write_offset = 99 * sizeof(uint64_t);
+  ninety_nine = 99;
+  CHECK(
+      chunked_buffer.write(&ninety_nine, sizeof(uint64_t), write_offset).ok());
+
+  // Read the entire written buffer.
+  uint64_t* const read_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  read_offset = 0;
+  CHECK(chunked_buffer.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Clear the chunk buffer. This will not free the underlying buffer.
+  chunked_buffer.clear();
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.nchunks() == 0);
+
+  free(write_buffer);
+  free(read_buffer);
+}
+
+TEST_CASE(
+    "ChunkedBuffer: Test discrete, variable sized IO",
+    "[ChunkedBuffer][discrete_var_io]") {
+  // Instantiate a test ChunkedBuffer.
+  ChunkedBuffer chunked_buffer;
+
+  // Create a buffer to write to the test ChunkedBuffer.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkedBuffer with variable sized chunks.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  std::vector<uint32_t> var_chunk_sizes;
+  uint64_t remaining_bytes = buffer_size;
+  uint32_t chunk_size = sizeof(uint64_t);
+  while (remaining_bytes > 0) {
+    if (chunk_size > remaining_bytes) {
+      chunk_size = remaining_bytes;
+    }
+    var_chunk_sizes.emplace_back(chunk_size);
+    remaining_bytes -= chunk_size;
+    chunk_size += sizeof(uint64_t);
+  }
+  chunked_buffer.init_var_size(
+      ChunkedBuffer::BufferAddressing::DISCRETE,
+      std::vector<uint32_t>(var_chunk_sizes));
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.capacity() == buffer_size);
+  CHECK(chunked_buffer.nchunks() == var_chunk_sizes.size());
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    void* chunk_buffer;
+    CHECK(chunked_buffer.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(!chunk_buffer);
+  }
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  uint64_t write_offset = 0;
+  CHECK(chunked_buffer.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Verify all chunks are allocated and that they do not overlap
+  // 'buffer' because they have been deep-copied.
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunked_buffer.internal_buffer_size(i, &internal_size).ok());
+    CHECK(internal_size == var_chunk_sizes[i]);
+
+    void* chunk_buffer = nullptr;
+    CHECK(chunked_buffer.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(chunk_buffer != write_buffer);
+    if (chunk_buffer < write_buffer) {
+      CHECK(
+          static_cast<char*>(chunk_buffer) + internal_size <=
+          reinterpret_cast<char*>(write_buffer));
+    } else {
+      CHECK(
+          reinterpret_cast<char*>(write_buffer) + buffer_size <=
+          static_cast<char*>(chunk_buffer));
+    }
+  }
+
+  // Read the third element, this will be of value '2'.
+  uint64_t read_offset = 2 * sizeof(uint64_t);
+  uint64_t two = 0;
+  CHECK(chunked_buffer.read(&two, sizeof(uint64_t), read_offset).ok());
+  CHECK(two == 2);
+
+  // Read the 10th element, this will be of value '9'.
+  read_offset = 9 * sizeof(uint64_t);
+  uint64_t nine = 0;
+  CHECK(chunked_buffer.read(&nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine == 9);
+
+  // Read the 100th element, this will be of value '99'.
+  read_offset = 99 * sizeof(uint64_t);
+  uint64_t ninety_nine = 0;
+  CHECK(chunked_buffer.read(&ninety_nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(ninety_nine == 99);
+
+  // Overwrite the 100th element with value '900'.
+  write_offset = 99 * sizeof(uint64_t);
+  uint64_t nine_hundred = 900;
+  CHECK(
+      chunked_buffer.write(&nine_hundred, sizeof(uint64_t), write_offset).ok());
+
+  // Read the 100th element, this will be of value '900'.
+  read_offset = 99 * sizeof(uint64_t);
+  nine_hundred = 0;
+  CHECK(chunked_buffer.read(&nine_hundred, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine_hundred == 900);
+
+  // Overwrite the 100th element back to value '99'.
+  write_offset = 99 * sizeof(uint64_t);
+  ninety_nine = 99;
+  CHECK(
+      chunked_buffer.write(&ninety_nine, sizeof(uint64_t), write_offset).ok());
+
+  // Read the entire written buffer.
+  uint64_t* const read_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  read_offset = 0;
+  CHECK(chunked_buffer.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Free the chunk buffer, which will free all of the allocated
+  // buffers and return chunked_buffer into an uninitialized state.
+  chunked_buffer.free();
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.nchunks() == 0);
+
+  free(write_buffer);
+  free(read_buffer);
+}
+
+TEST_CASE(
+    "ChunkedBuffer: Test contigious variable sized IO",
+    "[ChunkedBuffer][contigious_var_io]") {
+  // Instantiate a test ChunkedBuffer.
+  ChunkedBuffer chunked_buffer;
+
+  // Create a buffer to write to the test ChunkedBuffer.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkedBuffer with variable sized chunks.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  std::vector<uint32_t> var_chunk_sizes;
+  uint64_t remaining_bytes = buffer_size;
+  uint32_t chunk_size = sizeof(uint64_t);
+  while (remaining_bytes > 0) {
+    if (chunk_size > remaining_bytes) {
+      chunk_size = remaining_bytes;
+    }
+    var_chunk_sizes.emplace_back(chunk_size);
+    remaining_bytes -= chunk_size;
+    chunk_size += sizeof(uint64_t);
+  }
+  chunked_buffer.init_var_size(
+      ChunkedBuffer::BufferAddressing::CONTIGIOUS,
+      std::vector<uint32_t>(var_chunk_sizes));
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.capacity() == buffer_size);
+  CHECK(chunked_buffer.nchunks() == var_chunk_sizes.size());
+
+  // Verify all chunks are unallocated.
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    void* chunk_buffer;
+    CHECK(chunked_buffer.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(!chunk_buffer);
+  }
+
+  // Write the entire buffer. This will fail because a contigious buffer
+  // has not been set or allocated.
+  uint64_t write_offset = 0;
+  CHECK(!chunked_buffer.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Attempt to allocate a chunk. This will fail because contigious
+  // ChunkedBuffer instances can not use the 'alloc_discrete' routine.
+  CHECK(!chunked_buffer.alloc_discrete(chunked_buffer.nchunks() / 2).ok());
+
+  // Set the contigious buffer.
+  CHECK(chunked_buffer.set_contigious(write_buffer).ok());
+  CHECK(chunked_buffer.set_size(buffer_size).ok());
+
+  // Verify all chunks are allocated and that they're addressed match
+  // 'write_buffer' to ensure 'write_buffer' was not copied.
+  uint64_t offset = 0;
+  for (size_t i = 0; i < chunked_buffer.nchunks(); ++i) {
+    uint32_t internal_size = 0;
+    CHECK(chunked_buffer.internal_buffer_size(i, &internal_size).ok());
+    CHECK(internal_size == var_chunk_sizes[i]);
+
+    void* chunk_buffer = nullptr;
+    CHECK(chunked_buffer.internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    CHECK(chunk_buffer == reinterpret_cast<char*>(write_buffer) + offset);
+    offset += internal_size;
+  }
+
+  // Read the third element, this will be of value '2'.
+  uint64_t read_offset = 2 * sizeof(uint64_t);
+  uint64_t two = 0;
+  CHECK(chunked_buffer.read(&two, sizeof(uint64_t), read_offset).ok());
+  CHECK(two == 2);
+
+  // Read the 10th element, this will be of value '9'.
+  read_offset = 9 * sizeof(uint64_t);
+  uint64_t nine = 0;
+  CHECK(chunked_buffer.read(&nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine == 9);
+
+  // Read the 100th element, this will be of value '99'.
+  read_offset = 99 * sizeof(uint64_t);
+  uint64_t ninety_nine = 0;
+  CHECK(chunked_buffer.read(&ninety_nine, sizeof(uint64_t), read_offset).ok());
+  CHECK(ninety_nine == 99);
+
+  // Overwrite the 100th element with value '900'.
+  write_offset = 99 * sizeof(uint64_t);
+  uint64_t nine_hundred = 900;
+  CHECK(
+      chunked_buffer.write(&nine_hundred, sizeof(uint64_t), write_offset).ok());
+
+  // Read the 100th element, this will be of value '900'.
+  read_offset = 99 * sizeof(uint64_t);
+  nine_hundred = 0;
+  CHECK(chunked_buffer.read(&nine_hundred, sizeof(uint64_t), read_offset).ok());
+  CHECK(nine_hundred == 900);
+
+  // Overwrite the 100th element back to value '99'.
+  write_offset = 99 * sizeof(uint64_t);
+  ninety_nine = 99;
+  CHECK(
+      chunked_buffer.write(&ninety_nine, sizeof(uint64_t), write_offset).ok());
+
+  // Read the entire written buffer.
+  uint64_t* const read_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  read_offset = 0;
+  CHECK(chunked_buffer.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Clear the chunk buffer. This will not free the underlying buffer.
+  chunked_buffer.clear();
+  CHECK(chunked_buffer.size() == 0);
+  CHECK(chunked_buffer.nchunks() == 0);
+
+  free(write_buffer);
+  free(read_buffer);
+}
+
+TEST_CASE(
+    "ChunkedBuffer: Test copy constructor",
+    "[ChunkedBuffer][copy_constructor]") {
+  // Instantiate the first test ChunkedBuffer.
+  ChunkedBuffer chunked_buffer1;
+
+  // Create a buffer to write to the test ChunkedBuffer.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkedBuffer.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunked_buffer1.init_fixed_size(
+      ChunkedBuffer::BufferAddressing::DISCRETE, buffer_size, chunk_size);
+  CHECK(chunked_buffer1.size() == 0);
+  CHECK(chunked_buffer1.capacity() == buffer_size);
+  CHECK(chunked_buffer1.nchunks() == nchunks);
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  uint64_t write_offset = 0;
+  CHECK(chunked_buffer1.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Instantiate a second test ChunkedBuffer with the copy constructor.
+  ChunkedBuffer chunked_buffer2(chunked_buffer1);
+
+  // Verify all public attributes are identical.
+  CHECK(chunked_buffer2.nchunks() == chunked_buffer1.nchunks());
+  CHECK(
+      chunked_buffer2.buffer_addressing() ==
+      chunked_buffer1.buffer_addressing());
+  CHECK(chunked_buffer2.capacity() == chunked_buffer1.capacity());
+  CHECK(chunked_buffer2.size() == chunked_buffer1.size());
+
+  // Read the entire written buffer from the second instance and verify
+  // the contents match the first instance.
+  uint64_t* const read_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  uint64_t read_offset = 0;
+  CHECK(chunked_buffer2.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Ensure the internal data was deep-copied:
+  void* chunked_buffer1_chunk_0;
+  void* chunked_buffer2_chunk_0;
+  CHECK(chunked_buffer1.internal_buffer(0, &chunked_buffer1_chunk_0).ok());
+  CHECK(chunked_buffer2.internal_buffer(0, &chunked_buffer2_chunk_0).ok());
+  CHECK(chunked_buffer1_chunk_0 != chunked_buffer2_chunk_0);
+
+  free(write_buffer);
+  free(read_buffer);
+}
+
+TEST_CASE("ChunkedBuffer: Test assignment", "[ChunkedBuffer][assignment]") {
+  // Instantiate the first test ChunkedBuffer.
+  ChunkedBuffer chunked_buffer1;
+
+  // Create a buffer to write to the test ChunkedBuffer.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkedBuffer.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunked_buffer1.init_fixed_size(
+      ChunkedBuffer::BufferAddressing::DISCRETE, buffer_size, chunk_size);
+  CHECK(chunked_buffer1.size() == 0);
+  CHECK(chunked_buffer1.capacity() == buffer_size);
+  CHECK(chunked_buffer1.nchunks() == nchunks);
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  uint64_t write_offset = 0;
+  CHECK(chunked_buffer1.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Instantiate a second test ChunkedBuffer with the assignment operator.
+  ChunkedBuffer chunked_buffer2 = chunked_buffer1;
+
+  // Verify all public attributes are identical.
+  CHECK(chunked_buffer2.nchunks() == chunked_buffer1.nchunks());
+  CHECK(
+      chunked_buffer2.buffer_addressing() ==
+      chunked_buffer1.buffer_addressing());
+  CHECK(chunked_buffer2.capacity() == chunked_buffer1.capacity());
+  CHECK(chunked_buffer2.size() == chunked_buffer1.size());
+
+  // Read the entire written buffer from the second instance and verify
+  // the contents match the first instance.
+  uint64_t* const read_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  uint64_t read_offset = 0;
+  CHECK(chunked_buffer2.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Ensure the internal data was deep-copied:
+  void* chunked_buffer1_chunk_0;
+  void* chunked_buffer2_chunk_0;
+  CHECK(chunked_buffer1.internal_buffer(0, &chunked_buffer1_chunk_0).ok());
+  CHECK(chunked_buffer2.internal_buffer(0, &chunked_buffer2_chunk_0).ok());
+  CHECK(chunked_buffer1_chunk_0 != chunked_buffer2_chunk_0);
+
+  free(write_buffer);
+  free(read_buffer);
+}
+
+TEST_CASE("ChunkedBuffer: Test shallow copy", "[ChunkedBuffer][shallow_copy]") {
+  // Instantiate the first test ChunkedBuffer.
+  ChunkedBuffer chunked_buffer1;
+
+  // Create a buffer to write to the test ChunkedBuffer.
+  const int64_t buffer_size = 1024 * 1024 * 3;
+  uint64_t* const write_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  const uint64_t buffer_len = buffer_size / sizeof(uint64_t);
+  for (uint64_t i = 0; i < buffer_len; ++i) {
+    write_buffer[i] = i;
+  }
+
+  // Initialize the ChunkedBuffer.
+  CHECK(buffer_size % sizeof(uint64_t) == 0);
+  const size_t chunk_size = 1024 * 100;
+  CHECK(buffer_size % chunk_size != 0);
+  const size_t nchunks = (buffer_size / chunk_size) + 1;
+  const size_t last_chunk_size = buffer_size % chunk_size;
+  CHECK(chunk_size != last_chunk_size);
+  chunked_buffer1.init_fixed_size(
+      ChunkedBuffer::BufferAddressing::DISCRETE, buffer_size, chunk_size);
+  CHECK(chunked_buffer1.size() == 0);
+  CHECK(chunked_buffer1.capacity() == buffer_size);
+  CHECK(chunked_buffer1.nchunks() == nchunks);
+
+  // Write the entire buffer. This will allocate all of the chunks.
+  uint64_t write_offset = 0;
+  CHECK(chunked_buffer1.write(write_buffer, buffer_size, write_offset).ok());
+
+  // Instantiate a second test ChunkedBuffer with the shallow_copy routine.
+  ChunkedBuffer chunked_buffer2 = chunked_buffer1.shallow_copy();
+
+  // Verify all public attributes are identical.
+  CHECK(chunked_buffer2.nchunks() == chunked_buffer1.nchunks());
+  CHECK(
+      chunked_buffer2.buffer_addressing() ==
+      chunked_buffer1.buffer_addressing());
+  CHECK(chunked_buffer2.capacity() == chunked_buffer1.capacity());
+  CHECK(chunked_buffer2.size() == chunked_buffer1.size());
+
+  // Read the entire written buffer from the second instance and verify
+  // the contents match the first instance.
+  uint64_t* const read_buffer = static_cast<uint64_t*>(malloc(buffer_size));
+  uint64_t read_offset = 0;
+  CHECK(chunked_buffer2.read(read_buffer, buffer_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, buffer_size) == 0);
+
+  // Ensure the internal data was shallow-copied:
+  void* chunked_buffer1_chunk_0;
+  void* chunked_buffer2_chunk_0;
+  CHECK(chunked_buffer1.internal_buffer(0, &chunked_buffer1_chunk_0).ok());
+  CHECK(chunked_buffer2.internal_buffer(0, &chunked_buffer2_chunk_0).ok());
+  CHECK(chunked_buffer1_chunk_0 == chunked_buffer2_chunk_0);
+
+  free(write_buffer);
+  free(read_buffer);
+}

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -439,21 +439,36 @@ TEST_CASE_METHOD(
 
   std::vector<uint64_t> vec_2_0 = {1000, 3, 1000, 5};
   Buffer buff_2_0(&vec_2_0[0], vec_2_0.size() * sizeof(uint64_t));
-  Tile tile_2_0(Datatype::UINT64, sizeof(uint64_t), 0, &buff_2_0, false);
+  ChunkedBuffer chunked_buffer_2_0;
+  REQUIRE(Tile::buffer_to_contigious_fixed_chunks(
+              buff_2_0, 0, sizeof(uint64_t), &chunked_buffer_2_0)
+              .ok());
+  Tile tile_2_0(
+      Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_2_0, false);
   auto tile_pair = result_tile_2_0.tile_pair("d");
   REQUIRE(tile_pair != nullptr);
   tile_pair->first = tile_2_0;
 
   std::vector<uint64_t> vec_3_0 = {1000, 1000, 8, 9};
   Buffer buff_3_0(&vec_3_0[0], vec_3_0.size() * sizeof(uint64_t));
-  Tile tile_3_0(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_0, false);
+  ChunkedBuffer chunked_buffer_3_0;
+  REQUIRE(Tile::buffer_to_contigious_fixed_chunks(
+              buff_3_0, 0, sizeof(uint64_t), &chunked_buffer_3_0)
+              .ok());
+  Tile tile_3_0(
+      Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_0, false);
   tile_pair = result_tile_3_0.tile_pair("d");
   REQUIRE(tile_pair != nullptr);
   tile_pair->first = tile_3_0;
 
   std::vector<uint64_t> vec_3_1 = {1000, 12, 19, 1000};
   Buffer buff_3_1(&vec_3_1[0], vec_3_1.size() * sizeof(uint64_t));
-  Tile tile_3_1(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_1, false);
+  ChunkedBuffer chunked_buffer_3_1;
+  REQUIRE(Tile::buffer_to_contigious_fixed_chunks(
+              buff_3_1, 0, sizeof(uint64_t), &chunked_buffer_3_1)
+              .ok());
+  Tile tile_3_1(
+      Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_1, false);
   tile_pair = result_tile_3_1.tile_pair("d");
   REQUIRE(tile_pair != nullptr);
   tile_pair->first = tile_3_1;
@@ -1250,28 +1265,48 @@ TEST_CASE_METHOD(
 
   std::vector<uint64_t> vec_3_0_d1 = {1000, 3, 1000, 1000};
   Buffer buff_3_0_d1(&vec_3_0_d1[0], vec_3_0_d1.size() * sizeof(uint64_t));
-  Tile tile_3_0_d1(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_0_d1, false);
+  ChunkedBuffer chunked_buffer_3_0_d1;
+  REQUIRE(Tile::buffer_to_contigious_fixed_chunks(
+              buff_3_0_d1, 0, sizeof(uint64_t), &chunked_buffer_3_0_d1)
+              .ok());
+  Tile tile_3_0_d1(
+      Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_0_d1, false);
   auto tile_pair = result_tile_3_0.tile_pair("d1");
   REQUIRE(tile_pair != nullptr);
   tile_pair->first = tile_3_0_d1;
 
   std::vector<uint64_t> vec_3_0_d2 = {1000, 3, 1000, 1000};
   Buffer buff_3_0_d2(&vec_3_0_d2[0], vec_3_0_d2.size() * sizeof(uint64_t));
-  Tile tile_3_0_d2(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_0_d2, false);
+  ChunkedBuffer chunked_buffer_3_0_d2;
+  REQUIRE(Tile::buffer_to_contigious_fixed_chunks(
+              buff_3_0_d2, 0, sizeof(uint64_t), &chunked_buffer_3_0_d2)
+              .ok());
+  Tile tile_3_0_d2(
+      Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_0_d2, false);
   tile_pair = result_tile_3_0.tile_pair("d2");
   REQUIRE(tile_pair != nullptr);
   tile_pair->first = tile_3_0_d2;
 
   std::vector<uint64_t> vec_3_1_d1 = {5, 1000, 5, 1000};
   Buffer buff_3_1_d1(&vec_3_1_d1[0], vec_3_1_d1.size() * sizeof(uint64_t));
-  Tile tile_3_1_d1(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_1_d1, false);
+  ChunkedBuffer chunked_buffer_3_1_d1;
+  REQUIRE(Tile::buffer_to_contigious_fixed_chunks(
+              buff_3_1_d1, 0, sizeof(uint64_t), &chunked_buffer_3_1_d1)
+              .ok());
+  Tile tile_3_1_d1(
+      Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_1_d1, false);
   tile_pair = result_tile_3_1.tile_pair("d1");
   REQUIRE(tile_pair != nullptr);
   tile_pair->first = tile_3_1_d1;
 
   std::vector<uint64_t> vec_3_1_d2 = {5, 1000, 6, 1000};
   Buffer buff_3_1_d2(&vec_3_1_d2[0], vec_3_1_d2.size() * sizeof(uint64_t));
-  Tile tile_3_1_d2(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_1_d2, false);
+  ChunkedBuffer chunked_buffer_3_1_d2;
+  REQUIRE(Tile::buffer_to_contigious_fixed_chunks(
+              buff_3_1_d2, 0, sizeof(uint64_t), &chunked_buffer_3_1_d2)
+              .ok());
+  Tile tile_3_1_d2(
+      Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_1_d2, false);
   tile_pair = result_tile_3_1.tile_pair("d2");
   REQUIRE(tile_pair != nullptr);
   tile_pair->first = tile_3_1_d2;

--- a/test/src/unit-Tile.cc
+++ b/test/src/unit-Tile.cc
@@ -38,31 +38,58 @@
 
 using namespace tiledb::sm;
 
-TEST_CASE("Tile: Test basic read", "[Tile][basic_read]") {
-  // Initialize the test Tile.
+TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
+  // Instantiate the test Tile.
   Tile tile;
+  CHECK(tile.empty());
+  CHECK(!tile.full());
+  CHECK(tile.size() == 0);
+
+  // Initialize the test Tile.
   const uint32_t format_version = 0;
   const Datatype data_type = Datatype::UINT32;
-  const uint64_t cell_size = 0;
-  const unsigned int dim_num = 0;
-  CHECK(tile.init(
-                format_version,
-                data_type,
-                cell_size,
-                dim_num,
-                true /* filtered */)
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(tile.init_unfiltered(
+                format_version, data_type, tile_size, cell_size, dim_num)
             .ok());
+  CHECK(tile.empty());
+  CHECK(!tile.full());
+  CHECK(tile.size() == 0);
+  CHECK(tile.chunked_buffer()->capacity() == tile_size);
+  CHECK(tile.owns_buff());
 
   // Create a buffer to write to the test Tile.
-  const uint32_t buffer_len = 128;
-  uint32_t buffer[buffer_len];
+  uint32_t* const write_buffer = static_cast<uint32_t*>(malloc(tile_size));
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
   for (uint32_t i = 0; i < buffer_len; ++i) {
-    buffer[i] = i;
+    write_buffer[i] = i;
   }
 
   // Write the buffer to the test Tile.
-  const uint64_t buffer_size = buffer_len * sizeof(uint32_t);
-  CHECK(tile.write(buffer, buffer_size).ok());
+  CHECK(tile.offset() == 0);
+  CHECK(tile.write(write_buffer, tile_size).ok());
+  CHECK(tile.offset() == tile_size);
+  CHECK(!tile.empty());
+  CHECK(tile.full());
+  CHECK(tile.size() == tile_size);
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile.chunked_buffer());
+  CHECK(tile.chunked_buffer()->nchunks() > 1);
+
+  // Verify that the internal chunk buffers are discrete (aka each chunk's
+  // buffer is individually managed).
+  CHECK(
+      tile.chunked_buffer()->buffer_addressing() ==
+      ChunkedBuffer::BufferAddressing::DISCRETE);
+
+  // Ensure the internal data was deep-copied:
+  void* tile_chunk_0;
+  CHECK(tile.chunked_buffer()->internal_buffer(0, &tile_chunk_0).ok());
+  CHECK(tile_chunk_0 != static_cast<void*>(write_buffer));
 
   // Test a partial read at offset 8, which should be a uint32_t with
   // a value of two.
@@ -70,24 +97,443 @@ TEST_CASE("Tile: Test basic read", "[Tile][basic_read]") {
   CHECK(tile.read(&two, sizeof(uint32_t), 8).ok());
   CHECK(two == 2);
 
+  // The last read should have not changed the internal offset.
+  CHECK(tile.offset() == tile_size);
+
+  // Perform a read at the current offset and verify we read 'two'
+  // again and that the offset has changed.
+  tile.set_offset(8);
+  two = 0;
+  CHECK(tile.read(&two, sizeof(uint32_t)).ok());
+  CHECK(two == 2);
+  CHECK(tile.offset() == 12);
+
   // Test a full read.
-  uint32_t read_buffer[buffer_len];
-  memset(read_buffer, 0, buffer_size);
+  uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
+  memset(read_buffer, 0, tile_size);
   uint64_t read_offset = 0;
-  CHECK(tile.read(read_buffer, buffer_size, read_offset).ok());
-  CHECK(memcmp(read_buffer, buffer, buffer_size) == 0);
+  CHECK(tile.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer, tile_size) == 0);
+
+  // Verify the internal offset did not change.
+  CHECK(tile.offset() == 12);
+
+  // Test a write at a non-zero offset. Overwrite the two at offset 8.
+  tile.set_offset(0);
+  tile.advance_offset(8);
+  uint32_t magic = 5234549;
+  CHECK(tile.write(&magic, sizeof(uint32_t)).ok());
+  CHECK(tile.offset() == 12);
+
+  // Read the magic number to ensure the '2' value was overwritten.
+  two = 0;
+  CHECK(tile.read(&two, sizeof(uint32_t), 8).ok());
+  CHECK(two == magic);
+
+  // Restore the state without the magic number.
+  tile.set_offset(8);
+  two = 2;
+  CHECK(tile.write(&two, sizeof(uint32_t)).ok());
+  CHECK(tile.offset() == 12);
 
   // Test a read at an out-of-bounds offset.
-  memset(read_buffer, 0, buffer_size);
-  read_offset = buffer_size;
-  CHECK(!tile.read(read_buffer, buffer_size, read_offset).ok());
+  memset(read_buffer, 0, tile_size);
+  read_offset = tile_size;
+  CHECK(!tile.read(read_buffer, tile_size, read_offset).ok());
 
   // Test a read at a valid offset but with a size that
   // exceeds the written buffer size.
-  const uint32_t large_buffer_len = buffer_len * 2;
-  uint32_t large_read_buffer[large_buffer_len];
-  const uint64_t large_buffer_size = large_buffer_len * sizeof(uint32_t);
+  const uint32_t large_buffer_size = tile_size * 2;
+  uint32_t* const large_read_buffer =
+      static_cast<uint32_t*>(malloc(large_buffer_size));
   memset(large_read_buffer, 0, large_buffer_size);
   read_offset = 0;
   CHECK(!tile.read(large_read_buffer, large_buffer_size, read_offset).ok());
+
+  // Free the write buffer to ensure that it was deep-copied
+  // within the initial write.
+  uint32_t* const write_buffer_copy = static_cast<uint32_t*>(malloc(tile_size));
+  memcpy(write_buffer_copy, write_buffer, tile_size);
+  free(write_buffer);
+  memset(read_buffer, 0, tile_size);
+  read_offset = 0;
+  CHECK(tile.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, write_buffer_copy, tile_size) == 0);
+
+  free(read_buffer);
+  free(large_read_buffer);
+  free(write_buffer_copy);
+}
+
+TEST_CASE("Tile: Test copy constructor", "[Tile][copy_constructor]") {
+  // Instantiate and initialize the first test Tile.
+  Tile tile1;
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(tile1
+            .init_unfiltered(
+                format_version, data_type, tile_size, cell_size, dim_num)
+            .ok());
+
+  // Create a buffer to write to the first test Tile.
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  uint32_t* const buffer = static_cast<uint32_t*>(malloc(tile_size));
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer[i] = i;
+  }
+
+  // Write the buffer to the first test Tile.
+  CHECK(tile1.write(buffer, tile_size).ok());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1.chunked_buffer());
+  CHECK(tile1.chunked_buffer()->nchunks() > 1);
+
+  // Instantiate a second test tile with the copy constructor.
+  Tile tile2(tile1);
+
+  // Verify all public attributes are identical.
+  CHECK(tile2.cell_size() == tile1.cell_size());
+  CHECK(tile2.cell_num() == tile1.cell_num());
+  CHECK(tile2.dim_num() == tile1.dim_num());
+  CHECK(tile2.empty() == tile1.empty());
+  CHECK(tile2.filtered() == tile1.filtered());
+  CHECK(tile2.format_version() == tile1.format_version());
+  CHECK(tile2.full() == tile1.full());
+  CHECK(tile2.offset() == tile1.offset());
+  CHECK(tile2.pre_filtered_size() == tile1.pre_filtered_size());
+  CHECK(tile2.size() == tile1.size());
+  CHECK(tile2.stores_coords() == tile1.stores_coords());
+  CHECK(tile2.type() == tile1.type());
+  CHECK(tile2.owns_buff() == tile1.owns_buff());
+
+  // Read the second test tile to verify it contains the data
+  // written to the first test tile.
+  uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
+
+  // Ensure the internal data was deep-copied:
+  CHECK(tile1.chunked_buffer());
+  CHECK(tile2.chunked_buffer());
+  void* tile1_chunk_0;
+  void* tile2_chunk_0;
+  CHECK(tile1.chunked_buffer()->internal_buffer(0, &tile1_chunk_0).ok());
+  CHECK(tile2.chunked_buffer()->internal_buffer(0, &tile2_chunk_0).ok());
+  CHECK(tile1_chunk_0 != tile2_chunk_0);
+
+  free(buffer);
+  free(read_buffer);
+}
+
+TEST_CASE("Tile: Test move constructor", "[Tile][move_constructor]") {
+  // Instantiate and initialize the first test Tile.
+  Tile tile1;
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(tile1
+            .init_unfiltered(
+                format_version, data_type, tile_size, cell_size, dim_num)
+            .ok());
+
+  // Create a buffer to write to the first test Tile.
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  uint32_t* const buffer = static_cast<uint32_t*>(malloc(tile_size));
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer[i] = i;
+  }
+
+  // Write the buffer to the first test Tile.
+  CHECK(tile1.write(buffer, tile_size).ok());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1.chunked_buffer());
+  CHECK(tile1.chunked_buffer()->nchunks() > 1);
+
+  // Instantiate a second test tile with the copy constructor.
+  Tile tile2(tile1);
+
+  // Instantiate a third test tile with the move constructor.
+  Tile tile3(std::move(tile1));
+
+  // Verify all public attributes are identical.
+  CHECK(tile3.cell_size() == tile2.cell_size());
+  CHECK(tile3.cell_num() == tile2.cell_num());
+  CHECK(tile3.dim_num() == tile2.dim_num());
+  CHECK(tile3.empty() == tile2.empty());
+  CHECK(tile3.filtered() == tile2.filtered());
+  CHECK(tile3.format_version() == tile2.format_version());
+  CHECK(tile3.full() == tile2.full());
+  CHECK(tile3.offset() == tile2.offset());
+  CHECK(tile3.pre_filtered_size() == tile2.pre_filtered_size());
+  CHECK(tile3.size() == tile2.size());
+  CHECK(tile3.stores_coords() == tile2.stores_coords());
+  CHECK(tile3.type() == tile2.type());
+  CHECK(tile3.owns_buff() == tile2.owns_buff());
+
+  // Read the second test tile to verify it contains the data
+  // written to the first test tile.
+  uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
+
+  free(buffer);
+  free(read_buffer);
+}
+
+TEST_CASE("Tile: Test assignment", "[Tile][assignment]") {
+  // Instantiate and initialize the first test Tile.
+  Tile tile1;
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(tile1
+            .init_unfiltered(
+                format_version, data_type, tile_size, cell_size, dim_num)
+            .ok());
+
+  // Create a buffer to write to the first test Tile.
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  uint32_t* const buffer = static_cast<uint32_t*>(malloc(tile_size));
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer[i] = i;
+  }
+
+  // Write the buffer to the first test Tile.
+  CHECK(tile1.write(buffer, tile_size).ok());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1.chunked_buffer());
+  CHECK(tile1.chunked_buffer()->nchunks() > 1);
+
+  // Assign the first test Tile to a second test Tile.
+  Tile tile2 = tile1;
+
+  // Verify all public attributes are identical.
+  CHECK(tile2.cell_size() == tile1.cell_size());
+  CHECK(tile2.cell_num() == tile1.cell_num());
+  CHECK(tile2.dim_num() == tile1.dim_num());
+  CHECK(tile2.empty() == tile1.empty());
+  CHECK(tile2.filtered() == tile1.filtered());
+  CHECK(tile2.format_version() == tile1.format_version());
+  CHECK(tile2.full() == tile1.full());
+  CHECK(tile2.offset() == tile1.offset());
+  CHECK(tile2.pre_filtered_size() == tile1.pre_filtered_size());
+  CHECK(tile2.size() == tile1.size());
+  CHECK(tile2.stores_coords() == tile1.stores_coords());
+  CHECK(tile2.type() == tile1.type());
+  CHECK(tile2.owns_buff() == tile1.owns_buff());
+
+  // Read the second test tile to verify it contains the data
+  // written to the first test tile.
+  uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
+
+  // Ensure the internal data was deep-copied:
+  CHECK(tile1.chunked_buffer());
+  CHECK(tile2.chunked_buffer());
+  void* tile1_chunk_0;
+  void* tile2_chunk_0;
+  CHECK(tile1.chunked_buffer()->internal_buffer(0, &tile1_chunk_0).ok());
+  CHECK(tile2.chunked_buffer()->internal_buffer(0, &tile2_chunk_0).ok());
+  CHECK(tile1_chunk_0 != tile2_chunk_0);
+
+  free(buffer);
+  free(read_buffer);
+}
+
+TEST_CASE("Tile: Test move-assignment", "[Tile][move_assignment]") {
+  // Instantiate and initialize the first test Tile.
+  Tile tile1;
+  const uint32_t format_version = 0;
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+  CHECK(tile1
+            .init_unfiltered(
+                format_version, data_type, tile_size, cell_size, dim_num)
+            .ok());
+
+  // Create a buffer to write to the first test Tile.
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  uint32_t* const buffer = static_cast<uint32_t*>(malloc(tile_size));
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer[i] = i;
+  }
+
+  // Write the buffer to the first test Tile.
+  CHECK(tile1.write(buffer, tile_size).ok());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1.chunked_buffer());
+  CHECK(tile1.chunked_buffer()->nchunks() > 1);
+
+  // Instantiate a second test tile with the copy constructor.
+  Tile tile2(tile1);
+
+  // Instantiate a third test tile with the move constructor.
+  Tile tile3 = std::move(tile1);
+
+  // Verify all public attributes are identical.
+  CHECK(tile3.cell_size() == tile2.cell_size());
+  CHECK(tile3.cell_num() == tile2.cell_num());
+  CHECK(tile3.dim_num() == tile2.dim_num());
+  CHECK(tile3.empty() == tile2.empty());
+  CHECK(tile3.filtered() == tile2.filtered());
+  CHECK(tile3.format_version() == tile2.format_version());
+  CHECK(tile3.full() == tile2.full());
+  CHECK(tile3.offset() == tile2.offset());
+  CHECK(tile3.pre_filtered_size() == tile2.pre_filtered_size());
+  CHECK(tile3.size() == tile2.size());
+  CHECK(tile3.stores_coords() == tile2.stores_coords());
+  CHECK(tile3.type() == tile2.type());
+  CHECK(tile3.owns_buff() == tile2.owns_buff());
+
+  // Read the second test tile to verify it contains the data
+  // written to the first test tile.
+  uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
+
+  free(buffer);
+  free(read_buffer);
+}
+
+TEST_CASE(
+    "Tile: Test buffer chunks value constructor",
+    "[Tile][buffer_chunks_value_constructor]") {
+  // Define test tile attributes.
+  const Datatype data_type = Datatype::UINT32;
+  const uint64_t tile_size = 1024 * 1024;
+  const uint64_t cell_size = sizeof(uint32_t);
+  const unsigned int dim_num = 1;
+
+  // Instantiate a Buffer instance. We will use this to test
+  // ownership and non-ownership from a Tile value constructor.
+  Buffer buffer;
+  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
+  for (uint32_t i = 0; i < buffer_len; ++i) {
+    buffer.write(&i, sizeof(uint32_t));
+  }
+  CHECK(buffer.size() == tile_size);
+
+  ChunkedBuffer chunked_buffer;
+  CHECK(Tile::buffer_to_contigious_fixed_chunks(
+            buffer, dim_num, cell_size, &chunked_buffer)
+            .ok());
+
+  // Instantiate the first test tile that does NOT own 'chunked_buffer'.
+  bool owns_buff = false;
+  std::unique_ptr<Tile> tile1(
+      new Tile(data_type, cell_size, dim_num, &chunked_buffer, owns_buff));
+  CHECK(tile1);
+  CHECK(tile1->size() == tile_size);
+  CHECK(!tile1->full());
+  CHECK(tile1->chunked_buffer()->capacity() == tile_size);
+  CHECK(!tile1->owns_buff());
+
+  // Verify that we are testing a sufficiently large buffer to test
+  // multiple internal buffer chunks.
+  CHECK(tile1->chunked_buffer());
+  CHECK(tile1->chunked_buffer()->nchunks() > 1);
+
+  // Verify that the internal chunk buffers are backed by a single,
+  // contigious buffer.
+  CHECK(
+      tile1->chunked_buffer()->buffer_addressing() ==
+      ChunkedBuffer::BufferAddressing::CONTIGIOUS);
+
+  // Verify that the internal buffer chunks are virtually contigious and
+  // that their addresses exactly match 'buffer'.
+  uint64_t offset = 0;
+  for (size_t i = 0; i < tile1->chunked_buffer()->nchunks(); ++i) {
+    void* chunk_buffer = nullptr;
+    CHECK(tile1->chunked_buffer()->internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    uint32_t chunk_buffer_size = 0;
+    CHECK(tile1->chunked_buffer()
+              ->internal_buffer_size(i, &chunk_buffer_size)
+              .ok());
+    CHECK(chunk_buffer_size > 0);
+    CHECK(
+        static_cast<char*>(chunk_buffer) ==
+        static_cast<char*>(buffer.data()) + offset);
+    offset += chunk_buffer_size;
+  }
+
+  // Test a full read.
+  uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
+  memset(read_buffer, 0, tile_size);
+  uint64_t read_offset = 0;
+  CHECK(tile1->read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer.data(), tile_size) == 0);
+
+  // Free tile1 and ensure that buffer is still valid.
+  uint32_t* const buffer_copy = static_cast<uint32_t*>(malloc(tile_size));
+  memcpy(buffer_copy, buffer.data(), tile_size);
+  tile1.release();
+  CHECK(memcmp(buffer_copy, buffer.data(), tile_size) == 0);
+
+  // Instantiate the second test tile that does own 'chunked_buffer'.
+  owns_buff = true;
+  std::unique_ptr<Tile> tile2(
+      new Tile(data_type, cell_size, dim_num, &chunked_buffer, owns_buff));
+  CHECK(tile2);
+  CHECK(!tile2->empty());
+  CHECK(!tile2->full());
+  CHECK(tile2->size() == tile_size);
+  CHECK(tile2->owns_buff());
+
+  // Verify that the internal buffer chunks are virtually contigious and
+  // that their addresses exactly match 'buffer'.
+  offset = 0;
+  for (size_t i = 0; i < tile2->chunked_buffer()->nchunks(); ++i) {
+    void* chunk_buffer = nullptr;
+    CHECK(tile2->chunked_buffer()->internal_buffer(i, &chunk_buffer).ok());
+    CHECK(chunk_buffer);
+    uint32_t chunk_buffer_size = 0;
+    CHECK(tile2->chunked_buffer()
+              ->internal_buffer_size(i, &chunk_buffer_size)
+              .ok());
+    CHECK(chunk_buffer_size > 0);
+    CHECK(
+        static_cast<char*>(chunk_buffer) ==
+        static_cast<char*>(buffer.data()) + offset);
+    offset += chunk_buffer_size;
+  }
+
+  // Test a full read.
+  memset(read_buffer, 0, tile_size);
+  read_offset = 0;
+  CHECK(tile2->read(read_buffer, tile_size, read_offset).ok());
+  CHECK(memcmp(read_buffer, buffer.data(), tile_size) == 0);
+
+  // Disown 'buffer' because the destructor of 'tile2' will delete it.
+  buffer.disown_data();
+  tile2.release();
+
+  free(buffer_copy);
+  free(read_buffer);
 }

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -167,6 +167,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/cell_slab_iter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray_partitioner.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/chunked_buffer.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile_io.cc
 )

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -234,20 +234,20 @@ class Dimension {
    * Computes the minimum bounding range of the values stored in
    * `tile`. Applicable only to fixed-size dimensions.
    */
-  void compute_mbr(const Tile& tile, Range* mbr) const;
+  Status compute_mbr(const Tile& tile, Range* mbr) const;
 
   /**
    * Computed the minimum bounding range of the values stored in
    * `tile`.
    */
   template <class T>
-  static void compute_mbr(const Tile& tile, Range* mbr);
+  static Status compute_mbr(const Tile& tile, Range* mbr);
 
   /**
    * Computes the minimum bounding range of the values stored in
    * `tile_val`. Applicable only to var-sized dimensions.
    */
-  void compute_mbr_var(
+  Status compute_mbr_var(
       const Tile& tile_off, const Tile& tile_val, Range* mbr) const;
 
   /**
@@ -255,7 +255,7 @@ class Dimension {
    * `tile_val`. Applicable only to var-sized dimensions.
    */
   template <class T>
-  static void compute_mbr_var(
+  static Status compute_mbr_var(
       const Tile& tile_off, const Tile& tile_val, Range* mbr);
 
   /**
@@ -508,13 +508,13 @@ class Dimension {
    * Stores the appropriate templated compute_mbr() function based on the
    * dimension datatype.
    */
-  std::function<void(const Tile&, Range*)> compute_mbr_func_;
+  std::function<Status(const Tile&, Range*)> compute_mbr_func_;
 
   /**
    * Stores the appropriate templated compute_mbr_var() function based on the
    * dimension datatype.
    */
-  std::function<void(const Tile&, const Tile&, Range*)> compute_mbr_var_func_;
+  std::function<Status(const Tile&, const Tile&, Range*)> compute_mbr_var_func_;
 
   /**
    * Stores the appropriate templated crop_range() function based on the

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -88,60 +88,36 @@ void FilterPipeline::clear() {
   filters_.clear();
 }
 
-Status FilterPipeline::compute_tile_chunks(
-    Tile* tile, std::vector<std::pair<void*, uint32_t>>* chunks) const {
-  // For coordinate tiles, we treat each dimension separately (chunks won't
-  // cross dimension boundaries, since the coordinates have been split).
-  // Attribute tiles are treated as a whole.
-  auto dim_num = tile->stores_coords() ? tile->dim_num() : 1;
-  auto dim_tile_size = tile->size() / dim_num;
-  auto dim_cell_size = tile->cell_size() / dim_num;
-
-  // Compute a chunk size as a multiple of the cell size, ensuring that the
-  // chunk contains always at least 1 cell.
-  uint64_t chunk_size = std::min((uint64_t)max_chunk_size_, dim_tile_size);
-  chunk_size = chunk_size / dim_cell_size * dim_cell_size;
-  chunk_size = std::max(chunk_size, dim_cell_size);
-  if (chunk_size > std::numeric_limits<uint32_t>::max())
-    return LOG_STATUS(
-        Status::FilterError("Filter error; chunk size exceeds uint32_t"));
-
-  // Compute number of chunks
-  auto chunk_num = dim_tile_size / (chunk_size) +
-                   uint64_t(bool(dim_tile_size % (chunk_size)));
-
-  // Compute the chunks
-  chunks->reserve(dim_num * chunk_num);
-  uint64_t offset = 0;
-  for (uint64_t i = 0; i < dim_num; i++) {
-    for (uint64_t j = 0; j < chunk_num; j++) {
-      // Compute the actual size of the chunk (may be smaller at the end of the
-      // tile if the chunk size doesn't evenly divide).
-      auto size = static_cast<uint32_t>(
-          std::min(chunk_size, dim_tile_size - j * chunk_size));
-      chunks->emplace_back(
-          static_cast<char*>(tile->internal_data()) + offset, size);
-      offset += size;
-    }
-  }
-
-  return Status::Ok();
-}
-
 const Tile* FilterPipeline::current_tile() const {
   return current_tile_;
 }
 
 Status FilterPipeline::filter_chunks_forward(
-    const std::vector<std::pair<void*, uint32_t>>& chunks,
-    Buffer* output) const {
+    const ChunkedBuffer& input, Buffer* output) const {
+  assert(output);
+
+  // We will only filter chunks that contain data at or below
+  // the logical chunked buffer size.
+  size_t populated_nchunks = input.nchunks();
+  if (input.size() != input.capacity()) {
+    populated_nchunks = 0;
+    for (uint64_t i = 0; i < input.nchunks(); ++i) {
+      uint32_t chunk_buffer_size;
+      RETURN_NOT_OK(input.internal_buffer_size(i, &chunk_buffer_size));
+      if (chunk_buffer_size == 0) {
+        break;
+      }
+      ++populated_nchunks;
+    }
+  }
+
   // Vector storing the input and output of the final pipeline stage for each
   // chunk.
   std::vector<std::pair<FilterBufferPair, FilterBufferPair>> final_stage_io(
-      chunks.size());
+      populated_nchunks);
 
   // Run each chunk through the entire pipeline.
-  auto statuses = parallel_for(0, chunks.size(), [&](uint64_t i) {
+  auto statuses = parallel_for(0, populated_nchunks, [&](uint64_t i) {
     // TODO(ttd): can we instead allocate one FilterStorage per thread?
     // or make it threadsafe?
     FilterStorage storage;
@@ -149,8 +125,11 @@ Status FilterPipeline::filter_chunks_forward(
     FilterBuffer input_metadata(&storage), output_metadata(&storage);
 
     // First filter's input is the original chunk.
-    const auto& chunk_input = chunks[i];
-    RETURN_NOT_OK(input_data.init(chunk_input.first, chunk_input.second));
+    void* chunk_buffer = nullptr;
+    RETURN_NOT_OK(input.internal_buffer(i, &chunk_buffer));
+    uint32_t chunk_buffer_size;
+    RETURN_NOT_OK(input.internal_buffer_size(i, &chunk_buffer_size));
+    RETURN_NOT_OK(input_data.init(chunk_buffer, chunk_buffer_size));
 
     // Apply the filters sequentially.
     for (auto it = filters_.begin(), ite = filters_.end(); it != ite; ++it) {
@@ -187,7 +166,6 @@ Status FilterPipeline::filter_chunks_forward(
     io_input.second.swap(input_data);
     io_output.first.swap(output_metadata);
     io_output.second.swap(output_data);
-
     return Status::Ok();
   });
 
@@ -195,10 +173,9 @@ Status FilterPipeline::filter_chunks_forward(
   for (auto st : statuses)
     RETURN_NOT_OK(st);
 
-  // Compute the destination offset of each processed chunk in the final output
-  // buffer.
-  uint64_t offset = output->offset();
   uint64_t total_processed_size = 0;
+  std::vector<uint32_t> var_chunk_sizes(final_stage_io.size());
+  uint64_t offset = sizeof(uint64_t);
   std::vector<uint64_t> offsets(final_stage_io.size());
   for (uint64_t i = 0; i < final_stage_io.size(); i++) {
     auto& final_stage_output_metadata = final_stage_io[i].first.first;
@@ -212,21 +189,30 @@ Status FilterPipeline::filter_chunks_forward(
           "Filter error; filtered chunk size exceeds uint32_t"));
 
     // Leave space for the chunk sizes and the data itself.
-    auto space_required = 3 * sizeof(uint32_t) +
-                          final_stage_output_data.size() +
-                          final_stage_output_metadata.size();
+    const uint32_t space_required = 3 * sizeof(uint32_t) +
+                                    final_stage_output_data.size() +
+                                    final_stage_output_metadata.size();
+
+    total_processed_size += space_required;
+    var_chunk_sizes[i] = space_required;
     offsets[i] = offset;
     offset += space_required;
-    total_processed_size += space_required;
   }
 
+  // Allocate enough space in 'output' to store the leading uint64_t
+  // prefix containing the number of chunks and the 'total_processed_size'.
+  RETURN_NOT_OK(output->realloc(sizeof(uint64_t) + total_processed_size));
+
+  // Write the leading prefix that contains the number of chunks.
+  RETURN_NOT_OK(output->write(&populated_nchunks, sizeof(uint64_t)));
+
   // Concatenate all processed chunks into the final output buffer.
-  RETURN_NOT_OK(output->realloc(output->size() + total_processed_size));
   statuses = parallel_for(0, final_stage_io.size(), [&](uint64_t i) {
     auto& final_stage_output_metadata = final_stage_io[i].first.first;
     auto& final_stage_output_data = final_stage_io[i].first.second;
     auto filtered_size = (uint32_t)final_stage_output_data.size();
-    auto orig_chunk_size = chunks[i].second;
+    uint32_t orig_chunk_size;
+    RETURN_NOT_OK(input.internal_buffer_size(i, &orig_chunk_size));
     auto metadata_size = (uint32_t)final_stage_output_metadata.size();
     void* dest = output->data(offsets[i]);
     uint64_t dest_offset = 0;
@@ -261,25 +247,58 @@ Status FilterPipeline::filter_chunks_forward(
 }
 
 Status FilterPipeline::filter_chunks_reverse(
-    const std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>>& chunks,
-    Buffer* output,
+    const std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>>& input,
+    ChunkedBuffer* const output,
     const Config& config) const {
-  // Precompute the offsets for the final chunks in the shared output buffer.
-  std::vector<uint64_t> chunk_dest_offsets(chunks.size());
-  uint64_t chunk_dest_offset = 0;
-  for (uint64_t i = 0; i < chunks.size(); i++) {
-    chunk_dest_offsets[i] = chunk_dest_offset;
-    chunk_dest_offset += std::get<2>(chunks[i]);
+  // Precompute the sizes of the final output chunks.
+  int64_t chunk_size = 0;
+  uint64_t total_size = 0;
+  std::vector<uint32_t> chunk_sizes(input.size());
+  for (size_t i = 0; i < input.size(); i++) {
+    const uint32_t orig_chunk_size = std::get<2>(input[i]);
+    chunk_sizes[i] = orig_chunk_size;
+    total_size += orig_chunk_size;
+
+    if (i == 0) {
+      chunk_size = orig_chunk_size;
+    } else if (orig_chunk_size != chunk_size) {
+      chunk_size = -1;
+    }
+  }
+
+  // Initialize the output chunked buffer. For zipped coordinate tiles, we will
+  // store them in a contigious buffer because we will not perform selective
+  // decompression on them.
+  const ChunkedBuffer::BufferAddressing buffer_addressing =
+      current_tile_->stores_coords() ?
+          ChunkedBuffer::BufferAddressing::CONTIGIOUS :
+          ChunkedBuffer::BufferAddressing::DISCRETE;
+  if (chunk_size == -1) {
+    RETURN_NOT_OK(
+        output->init_var_size(buffer_addressing, std::move(chunk_sizes)));
+  } else {
+    RETURN_NOT_OK(
+        output->init_fixed_size(buffer_addressing, total_size, chunk_size));
+  }
+
+  // We will perform lazy allocation for discrete chunk buffers. For contigious
+  // chunk buffers, we will allocate the buffer now.
+  if (buffer_addressing == ChunkedBuffer::BufferAddressing::CONTIGIOUS) {
+    void* buffer = malloc(total_size);
+    if (buffer == nullptr) {
+      return Status::FilterError("malloc() failed");
+    }
+    output->set_contigious(buffer);
   }
 
   // Run each chunk through the entire pipeline.
-  auto statuses = parallel_for(0, chunks.size(), [&](uint64_t i) {
-    const auto& chunk_input = chunks[i];
-    uint32_t filtered_chunk_len = std::get<1>(chunk_input);
-    uint32_t orig_chunk_len = std::get<2>(chunk_input);
-    uint32_t metadata_len = std::get<3>(chunk_input);
-    void* metadata = std::get<0>(chunk_input);
-    void* chunk_data = (char*)metadata + metadata_len;
+  auto statuses = parallel_for(0, input.size(), [&](uint64_t i) {
+    const auto& chunk_input = input[i];
+    const uint32_t filtered_chunk_len = std::get<1>(chunk_input);
+    const uint32_t orig_chunk_len = std::get<2>(chunk_input);
+    const uint32_t metadata_len = std::get<3>(chunk_input);
+    void* const metadata = std::get<0>(chunk_input);
+    void* const chunk_data = (char*)metadata + metadata_len;
 
     // TODO(ttd): can we instead allocate one FilterStorage per thread?
     // or make it threadsafe?
@@ -293,7 +312,13 @@ Status FilterPipeline::filter_chunks_reverse(
 
     // If the pipeline is empty, just copy input to output.
     if (filters_.empty()) {
-      RETURN_NOT_OK(input_data.copy_to(output->data(chunk_dest_offsets[i])));
+      void* output_chunk_buffer;
+      if (buffer_addressing == ChunkedBuffer::BufferAddressing::DISCRETE) {
+        RETURN_NOT_OK(output->alloc_discrete(i, &output_chunk_buffer));
+      } else {
+        RETURN_NOT_OK(output->internal_buffer(i, &output_chunk_buffer));
+      }
+      RETURN_NOT_OK(input_data.copy_to(output_chunk_buffer));
       return Status::Ok();
     }
 
@@ -314,8 +339,14 @@ Status FilterPipeline::filter_chunks_reverse(
       // Final filter: output directly into the shared output buffer.
       bool last_filter = filter_idx == 0;
       if (last_filter) {
-        void* dest = output->data(chunk_dest_offsets[i]);
-        RETURN_NOT_OK(output_data.set_fixed_allocation(dest, orig_chunk_len));
+        void* output_chunk_buffer;
+        if (buffer_addressing == ChunkedBuffer::BufferAddressing::DISCRETE) {
+          RETURN_NOT_OK(output->alloc_discrete(i, &output_chunk_buffer));
+        } else {
+          RETURN_NOT_OK(output->internal_buffer(i, &output_chunk_buffer));
+        }
+        RETURN_NOT_OK(output_data.set_fixed_allocation(
+            output_chunk_buffer, orig_chunk_len));
       }
 
       RETURN_NOT_OK(f->run_reverse(
@@ -342,9 +373,10 @@ Status FilterPipeline::filter_chunks_reverse(
   for (auto st : statuses)
     RETURN_NOT_OK(st);
 
-  // Ensure the final size is set to the sum of unfiltered chunk sizes.
-  output->set_offset(chunk_dest_offset);
-  output->set_size(chunk_dest_offset);
+  // Since we did not use the 'write' interface above, the 'output' size
+  // will still be 0. We wrote the entire capacity of the output buffer,
+  // set it here.
+  RETURN_NOT_OK(output->set_size(output->capacity()));
 
   return Status::Ok();
 }
@@ -365,24 +397,18 @@ Status FilterPipeline::run_forward(Tile* tile) const {
 
   current_tile_ = tile;
 
-  // Compute the chunks.
-  std::vector<std::pair<void*, uint32_t>> chunks;
-  RETURN_NOT_OK(compute_tile_chunks(tile, &chunks));
-  uint64_t num_chunks = chunks.size();
-  if (num_chunks == 0)
-    return Status::FilterError("Filter error; tile has 0 chunks.");
+  // Run the filters over all the chunks and store the result in
+  // 'filtered_buffer_chunks'.
+  const Status st =
+      filter_chunks_forward(*tile->chunked_buffer(), tile->filtered_buffer());
+  if (!st.ok()) {
+    tile->filtered_buffer()->clear();
+    return st;
+  }
 
-  // Allocate a buffer to hold the end result (the concatentated, filtered
-  // chunks), and write the number of chunks.
-  Buffer filtered_tile;
-  filtered_tile.realloc(tile->buffer()->size());
-  RETURN_NOT_OK(filtered_tile.write(&num_chunks, sizeof(uint64_t)));
-
-  // Run the filters over all the chunks into the filtered_tile buffer.
-  RETURN_NOT_OK(filter_chunks_forward(chunks, &filtered_tile));
-
-  // Replace the tile's buffer with the filtered buffer.
-  RETURN_NOT_OK(tile->buffer()->swap(filtered_tile));
+  // The contents of 'chunked_buffer' have been filtered and stored
+  // in 'filtered_buffer'. We can safely free 'chunked_buffer'.
+  tile->chunked_buffer()->free();
 
   return Status::Ok();
 
@@ -392,46 +418,52 @@ Status FilterPipeline::run_forward(Tile* tile) const {
 Status FilterPipeline::run_reverse(Tile* tile, const Config& config) const {
   STATS_FUNC_IN(filter_pipeline_run_reverse);
 
-  auto tile_buff = tile->buffer();
-  if (tile_buff == nullptr)
+  Buffer* const filtered_buffer = tile->filtered_buffer();
+  if (filtered_buffer == nullptr)
     return LOG_STATUS(
         Status::FilterError("Filter error; tile has null buffer."));
+
+  assert(tile->chunked_buffer());
+  assert(tile->chunked_buffer()->capacity() == 0);
+  if (tile->chunked_buffer()->capacity() > 0)
+    return LOG_STATUS(Status::FilterError(
+        "Filter error; tile has allocated uncompressed chunk buffers."));
 
   current_tile_ = tile;
 
   // First make a pass over the tile to get the chunk information.
-  tile_buff->reset_offset();
+  filtered_buffer->reset_offset();
   uint64_t num_chunks;
-  RETURN_NOT_OK(tile_buff->read(&num_chunks, sizeof(uint64_t)));
-  std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>> chunks(
+  RETURN_NOT_OK(filtered_buffer->read(&num_chunks, sizeof(uint64_t)));
+  std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>> filtered_chunks(
       num_chunks);
   uint64_t total_orig_size = 0;
   for (uint64_t i = 0; i < num_chunks; i++) {
     uint32_t filtered_chunk_size, orig_chunk_size, metadata_size;
-    RETURN_NOT_OK(tile_buff->read(&orig_chunk_size, sizeof(uint32_t)));
-    RETURN_NOT_OK(tile_buff->read(&filtered_chunk_size, sizeof(uint32_t)));
-    RETURN_NOT_OK(tile_buff->read(&metadata_size, sizeof(uint32_t)));
-    chunks[i] = std::make_tuple(
-        tile_buff->cur_data(),
+    RETURN_NOT_OK(filtered_buffer->read(&orig_chunk_size, sizeof(uint32_t)));
+    RETURN_NOT_OK(
+        filtered_buffer->read(&filtered_chunk_size, sizeof(uint32_t)));
+    RETURN_NOT_OK(filtered_buffer->read(&metadata_size, sizeof(uint32_t)));
+    filtered_chunks[i] = std::make_tuple(
+        filtered_buffer->cur_data(),
         filtered_chunk_size,
         orig_chunk_size,
         metadata_size);
-    tile_buff->advance_offset(metadata_size + filtered_chunk_size);
+    filtered_buffer->advance_offset(metadata_size + filtered_chunk_size);
     total_orig_size += orig_chunk_size;
   }
-  assert(tile_buff->offset() == tile_buff->size());
+  assert(filtered_buffer->offset() == filtered_buffer->size());
 
-  // Allocate a buffer to hold the end result (the assembled, unfiltered
-  // chunks).
-  Buffer unfiltered_tile;
-  RETURN_NOT_OK(unfiltered_tile.realloc(total_orig_size));
+  const Status st =
+      filter_chunks_reverse(filtered_chunks, tile->chunked_buffer(), config);
+  if (!st.ok()) {
+    tile->chunked_buffer()->free();
+    return st;
+  }
 
-  // Run the filters in reverse over all the chunks into the unfiltered_tile
-  // buffer.
-  RETURN_NOT_OK(filter_chunks_reverse(chunks, &unfiltered_tile, config));
-
-  // Replace the tile's buffer with the unfiltered buffer.
-  RETURN_NOT_OK(tile->buffer()->swap(unfiltered_tile));
+  // Clear the filtered buffer now that we have reverse-filtered it into
+  // 'tile->chunked_buffer()'.
+  filtered_buffer->clear();
 
   // Zip the coords.
   if (tile->stores_coords()) {
@@ -441,7 +473,7 @@ Status FilterPipeline::run_reverse(Tile* tile, const Config& config) const {
     bool using_compression = get_filter<CompressionFilter>() != nullptr;
     auto version = tile->format_version();
     if (version > 1 || using_compression) {
-      tile->zip_coordinates();
+      RETURN_NOT_OK(tile->zip_coordinates());
     }
   }
 

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -40,6 +40,7 @@
 #include "tiledb/sm/filter/filter.h"
 #include "tiledb/sm/filter/filter_buffer.h"
 #include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/tile/chunked_buffer.h"
 
 namespace tiledb {
 namespace sm {
@@ -258,39 +259,28 @@ class FilterPipeline {
   uint32_t max_chunk_size_;
 
   /**
-   * Compute chunks of the given tile, used in the forward direction.
-   *
-   * @param tile Tile to compute chunks for
-   * @param chunks Output parameter storing the computed chunks
-   * @return Status
-   */
-  Status compute_tile_chunks(
-      Tile* tile, std::vector<std::pair<void*, uint32_t>>* chunks) const;
-
-  /**
    * Run the given list of chunks forward through the pipeline.
    *
-   * @param chunks Chunks to process
-   * @param output Buffer where output of last stage will be written.
+   * @param input chunked buffer to process.
+   * @param output buffer where output of the last stage
+   *    will be written.
    * @return Status
    */
   Status filter_chunks_forward(
-      const std::vector<std::pair<void*, uint32_t>>& chunks,
-      Buffer* output) const;
+      const ChunkedBuffer& input, Buffer* output) const;
 
   /**
    * Run the given list of chunks in reverse through the pipeline.
    *
-   * @param chunks Chunks to process. Format is
-   *    (data ptr, filtered size, original size, metadata size).
-   * @param output Buffer where output of last stage will be written.
+   * @param input Filtered chunk buffers to reverse.
+   * @param output Chunked buffer where output of the last stage
+   *    will be written.
    * @param config The global config.
    * @return Status
    */
   Status filter_chunks_reverse(
-      const std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>>&
-          chunks,
-      Buffer* output,
+      const std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>>& input,
+      ChunkedBuffer* output,
       const Config& config) const;
 };
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1549,13 +1549,18 @@ Status FragmentMetadata::load_v1_v2(const EncryptionKey& encryption_key) {
   auto tile = (Tile*)nullptr;
   RETURN_NOT_OK(tile_io.read_generic(
       &tile, 0, encryption_key, storage_manager_->config()));
-  tile->disown_buff();
-  auto buff = tile->buffer();
-  STATS_COUNTER_ADD(fragment_metadata_bytes_read, tile_io.file_size());
+
+  auto chunked_buffer = tile->chunked_buffer();
+  Buffer buff;
+  RETURN_NOT_OK(buff.realloc(chunked_buffer->size()));
+  buff.set_size(chunked_buffer->size());
+  RETURN_NOT_OK_ELSE(
+      chunked_buffer->read(buff.data(), buff.size(), 0), delete tile);
   delete tile;
+  STATS_COUNTER_ADD(fragment_metadata_bytes_read, tile_io.file_size());
 
   // Deserialize
-  ConstBuffer cbuff(buff);
+  ConstBuffer cbuff(&buff);
   RETURN_NOT_OK(load_version(&cbuff));
   RETURN_NOT_OK(load_non_empty_domain(&cbuff, version_));
   RETURN_NOT_OK(load_mbrs(&cbuff));
@@ -1566,8 +1571,6 @@ Status FragmentMetadata::load_v1_v2(const EncryptionKey& encryption_key) {
   RETURN_NOT_OK(load_last_tile_cell_num(&cbuff));
   RETURN_NOT_OK(load_file_sizes(&cbuff, version_));
   RETURN_NOT_OK(load_file_var_sizes(&cbuff, version_));
-
-  delete buff;
 
   return Status::Ok();
 }
@@ -1736,7 +1739,9 @@ Status FragmentMetadata::store_rtree(
     const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_rtree(&buff));
-  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, &buff, nbytes));
+  RETURN_NOT_OK(
+      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+
   return Status::Ok();
 }
 
@@ -1796,10 +1801,15 @@ Status FragmentMetadata::read_generic_tile_from_file(
 
   // Read metadata
   TileIO tile_io(storage_manager_, fragment_metadata_uri);
-  auto tile = (Tile*)nullptr;
+  Tile* tile = nullptr;
   RETURN_NOT_OK(tile_io.read_generic(
       &tile, offset, encryption_key, storage_manager_->config()));
-  tile->buffer()->swap(*buff);
+
+  const auto chunked_buffer = tile->chunked_buffer();
+  buff->realloc(chunked_buffer->size());
+  buff->set_size(chunked_buffer->size());
+  RETURN_NOT_OK_ELSE(
+      chunked_buffer->read(buff->data(), buff->size(), 0), delete tile);
   delete tile;
 
   return Status::Ok();
@@ -1819,16 +1829,26 @@ Status FragmentMetadata::read_file_footer(Buffer* buff) const {
 }
 
 Status FragmentMetadata::write_generic_tile_to_file(
-    const EncryptionKey& encryption_key, Buffer* buff, uint64_t* nbytes) const {
+    const EncryptionKey& encryption_key,
+    Buffer&& buff,
+    uint64_t* nbytes) const {
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
-  buff->reset_offset();
+
+  ChunkedBuffer* const chunked_buffer = new ChunkedBuffer();
+  RETURN_NOT_OK_ELSE(
+      Tile::buffer_to_contigious_fixed_chunks(
+          buff, 0, constants::generic_tile_cell_size, chunked_buffer),
+      delete chunked_buffer);
+  buff.disown_data();
+
   Tile tile(
       constants::generic_tile_datatype,
       constants::generic_tile_cell_size,
       0,
-      buff,
-      false);
+      chunked_buffer,
+      true);
+
   TileIO tile_io(storage_manager_, fragment_metadata_uri);
   RETURN_NOT_OK(tile_io.write_generic(&tile, encryption_key, nbytes));
 
@@ -1853,7 +1873,8 @@ Status FragmentMetadata::store_tile_offsets(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_offsets(idx, &buff));
-  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, &buff, nbytes));
+  RETURN_NOT_OK(
+      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
 
   return Status::Ok();
 }
@@ -1887,7 +1908,8 @@ Status FragmentMetadata::store_tile_var_offsets(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_var_offsets(idx, &buff));
-  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, &buff, nbytes));
+  RETURN_NOT_OK(
+      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
 
   return Status::Ok();
 }
@@ -1923,7 +1945,8 @@ Status FragmentMetadata::store_tile_var_sizes(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_var_sizes(idx, &buff));
-  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, &buff, nbytes));
+  RETURN_NOT_OK(
+      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
 
   return Status::Ok();
 }

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -910,7 +910,7 @@ class FragmentMetadata {
    */
   Status write_generic_tile_to_file(
       const EncryptionKey& encryption_key,
-      Buffer* buff,
+      Buffer&& buff,
       uint64_t* nbytes) const;
 
   /**

--- a/tiledb/sm/misc/status.h
+++ b/tiledb/sm/misc/status.h
@@ -88,6 +88,7 @@ enum class StatusCode : char {
   Compression,
   Tile,
   TileIO,
+  ChunkedBuffer,
   Buffer,
   Query,
   VFS,
@@ -214,6 +215,11 @@ class Status {
   /** Return a TileIOError error class Status with a given message **/
   static Status TileIOError(const std::string& msg) {
     return Status(StatusCode::TileIO, msg, -1);
+  }
+
+  /** Return a ChunkedBufferError error class Status with a given message **/
+  static Status ChunkedBufferError(const std::string& msg) {
+    return Status(StatusCode::ChunkedBuffer, msg, -1);
   }
 
   /** Return a BufferError error class Status with a given message **/

--- a/tiledb/sm/misc/uri.cc
+++ b/tiledb/sm/misc/uri.cc
@@ -252,20 +252,20 @@ std::string URI::to_string() const {
   return uri_;
 }
 
+bool URI::operator==(const URI& uri) const {
+  return uri_ == uri.uri_;
+}
+
+bool URI::operator!=(const URI& uri) const {
+  return !operator==(uri);
+}
+
 bool URI::operator<(const URI& uri) const {
   return uri_ < uri.uri_;
 }
 
 bool URI::operator>(const URI& uri) const {
   return uri_ > uri.uri_;
-}
-
-bool URI::operator==(const URI& uri) const {
-  return uri_ == uri.uri_;
-}
-
-bool URI::operator!=(const URI& uri) const {
-  return uri_ != uri.uri_;
 }
 
 }  // namespace sm

--- a/tiledb/sm/misc/uri.h
+++ b/tiledb/sm/misc/uri.h
@@ -237,16 +237,16 @@ class URI {
   std::string to_string() const;
 
   /** For comparing URIs alphanumerically. */
-  bool operator<(const URI& uri) const;
-
-  /** For comparing URIs alphanumerically. */
-  bool operator>(const URI& uri) const;
-
-  /** For comparing URIs alphanumerically. */
   bool operator==(const URI& uri) const;
 
   /** For comparing URIs alphanumerically. */
   bool operator!=(const URI& uri) const;
+
+  /** For comparing URIs alphanumerically. */
+  bool operator<(const URI& uri) const;
+
+  /** For comparing URIs alphanumerically. */
+  bool operator>(const URI& uri) const;
 
  private:
   /* ********************************* */
@@ -277,6 +277,15 @@ struct TimestampedURI {
 
   bool has_unary_timestamp_range() const {
     return timestamp_range_.first == timestamp_range_.second;
+  }
+};
+
+/**
+ * URI hash operator.
+ */
+struct URIHasher {
+  std::size_t operator()(const URI& uri) const {
+    return std::hash<std::string>()(uri.to_string());
   }
 };
 

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -568,7 +568,7 @@ Status Reader::compute_result_cell_slabs(
   }
   uint64_t start_pos = it->pos_;
   uint64_t end_pos = start_pos;
-  auto tile = it->tile_;
+  ResultTile* tile = it->tile_;
 
   // Scan the coordinates and compute ranges
   it = skip_invalid_elements(++it, coords_end);
@@ -655,6 +655,7 @@ Status Reader::compute_range_result_coords(
     // Compute tile coordinate
     return Status::Ok();
   });
+
   for (auto st : statuses)
     RETURN_NOT_OK(st);
 
@@ -915,7 +916,6 @@ Status Reader::copy_fixed_cells(
         }
       }
     }
-
     return Status::Ok();
   });
 
@@ -976,15 +976,25 @@ Status Reader::copy_var_cells(
     const auto& var_offsets = var_offsets_per_cs[cs_idx];
 
     // Get tile information, if the range is nonempty.
-    uint64_t* tile_offsets = nullptr;
+    std::vector<uint64_t> tile_offsets;
     Tile* tile_var = nullptr;
     uint64_t tile_cell_num = 0;
     if (cs.tile_ != nullptr) {
-      const auto tile_pair = cs.tile_->tile_pair(name);
-      Tile* const tile = &tile_pair->first;
+      std::pair<tiledb::sm::Tile, tiledb::sm::Tile>* const tile_pair =
+          cs.tile_->tile_pair(name);
+      const auto& tile = &tile_pair->first;
       tile_var = &tile_pair->second;
-      tile_offsets = (uint64_t*)tile->internal_data();
       tile_cell_num = tile->cell_num();
+
+      // Build the tile offsets.
+      tile_offsets.reserve(tile_cell_num);
+      uint64_t tile_offset;
+      uint64_t read_offset = 0;
+      for (size_t cell_idx = 0; cell_idx < tile_cell_num; ++cell_idx) {
+        RETURN_NOT_OK(tile->read(&tile_offset, sizeof(uint64_t), read_offset));
+        read_offset += sizeof(uint64_t);
+        tile_offsets.emplace_back(tile_offset);
+      }
     }
 
     // Copy each cell in the range
@@ -1058,16 +1068,26 @@ Status Reader::compute_var_cell_destinations(
     (*var_offsets_per_cs)[cs_idx].resize(cs.length_);
 
     // Get tile information, if the range is nonempty.
-    uint64_t* tile_offsets = nullptr;
+    std::vector<uint64_t> tile_offsets;
     uint64_t tile_cell_num = 0;
     uint64_t tile_var_size = 0;
     if (cs.tile_ != nullptr) {
-      const auto tile_pair = cs.tile_->tile_pair(name);
-      const auto& tile = tile_pair->first;
-      const auto& tile_var = tile_pair->second;
-      tile_offsets = (uint64_t*)tile.internal_data();
-      tile_cell_num = tile.cell_num();
-      tile_var_size = tile_var.size();
+      std::pair<tiledb::sm::Tile, tiledb::sm::Tile>* const tile_pair =
+          cs.tile_->tile_pair(name);
+      const auto& tile = &tile_pair->first;
+      const auto& tile_var = &tile_pair->second;
+      tile_cell_num = tile->cell_num();
+      tile_var_size = tile_var->size();
+
+      // Build the tile offsets.
+      tile_offsets.reserve(tile_cell_num);
+      uint64_t tile_offset;
+      uint64_t read_offset = 0;
+      for (size_t cell_idx = 0; cell_idx < tile_cell_num; ++cell_idx) {
+        RETURN_NOT_OK(tile->read(&tile_offset, sizeof(uint64_t), read_offset));
+        read_offset += sizeof(uint64_t);
+        tile_offsets.emplace_back(tile_offset);
+      }
     }
 
     // Compute the destinations for each cell in the range.
@@ -1637,7 +1657,8 @@ Status Reader::unfilter_tiles(
 
       // Skip non-existent attributes/dimensions (e.g. coords in the
       // dense case).
-      if (tile_pair == nullptr || tile_pair->first.empty())
+      if (tile_pair == nullptr ||
+          tile_pair->first.filtered_buffer()->size() == 0)
         return Status::Ok();
 
       // Get information about the tile in its fragment
@@ -1653,7 +1674,8 @@ Status Reader::unfilter_tiles(
       if (t.filtered()) {
         // Store the filtered buffer in the tile cache.
         RETURN_NOT_OK(storage_manager_->write_to_cache(
-            tile_attr_uri, tile_attr_offset, t.buffer()));
+            tile_attr_uri, tile_attr_offset, t.filtered_buffer()));
+
         // Unfilter the tile buffer within the 't' instance.
         RETURN_NOT_OK(unfilter_tile(name, &t, var_size));
       }
@@ -1666,7 +1688,8 @@ Status Reader::unfilter_tiles(
 
         // Store the filtered buffer in the tile cache.
         RETURN_NOT_OK(storage_manager_->write_to_cache(
-            tile_attr_var_uri, tile_attr_var_offset, t_var.buffer()));
+            tile_attr_var_uri, tile_attr_var_offset, t_var.filtered_buffer()));
+
         // Unfilter the tile buffer within the 't_var' instance.
         RETURN_NOT_OK(unfilter_tile(name, &t_var, false));
       }
@@ -1685,7 +1708,7 @@ Status Reader::unfilter_tiles(
 
 Status Reader::unfilter_tile(
     const std::string& name, Tile* tile, bool offsets) const {
-  // Get a copy of the appropriate unfilter pipeline.
+  // Get a copy of the appropriate filter pipeline.
   FilterPipeline filters =
       (offsets ? array_schema_->cell_var_offsets_filters() :
                  array_schema_->filters(name));
@@ -1695,8 +1718,6 @@ Status Reader::unfilter_tile(
       &filters, array_->get_encryption_key()));
 
   RETURN_NOT_OK(filters.run_reverse(tile, storage_manager_->config()));
-
-  tile->set_filtered(false);
 
   STATS_COUNTER_ADD(reader_num_bytes_after_unfiltering, tile->size());
 
@@ -1783,24 +1804,13 @@ Status Reader::init_read_state() {
 Status Reader::init_tile(
     uint32_t format_version, const std::string& name, Tile* tile) const {
   // For easy reference
-  auto domain = array_schema_->domain();
   auto cell_size = array_schema_->cell_size(name);
-  auto capacity = array_schema_->capacity();
   auto type = array_schema_->type(name);
   auto is_coords = (name == constants::coords);
   auto dim_num = (is_coords) ? array_schema_->dim_num() : 0;
-  auto cell_num_per_tile =
-      (has_coords()) ? capacity : domain->cell_num_per_tile();
-  auto tile_size = cell_num_per_tile * cell_size;
 
   // Initialize
-  RETURN_NOT_OK(tile->init(
-      format_version,
-      type,
-      tile_size,
-      cell_size,
-      dim_num,
-      true /* filtered */));
+  RETURN_NOT_OK(tile->init_filtered(format_version, type, cell_size, dim_num));
 
   return Status::Ok();
 }
@@ -1811,28 +1821,16 @@ Status Reader::init_tile(
     Tile* tile,
     Tile* tile_var) const {
   // For easy reference
-  auto domain = array_schema_->domain();
-  auto capacity = array_schema_->capacity();
   auto type = array_schema_->type(name);
-  auto cell_num_per_tile =
-      (has_coords()) ? capacity : domain->cell_num_per_tile();
-  auto tile_size = cell_num_per_tile * constants::cell_var_offset_size;
 
   // Initialize
-  RETURN_NOT_OK(tile->init(
+  RETURN_NOT_OK(tile->init_filtered(
       format_version,
       constants::cell_var_offset_type,
-      tile_size,
       constants::cell_var_offset_size,
-      0,
-      true /* filtered */));
-  RETURN_NOT_OK(tile_var->init(
-      format_version,
-      type,
-      tile_size,
-      datatype_size(type),
-      0,
-      true /* filtered */));
+      0));
+  RETURN_NOT_OK(
+      tile_var->init_filtered(format_version, type, datatype_size(type), 0));
   return Status::Ok();
 }
 
@@ -1859,16 +1857,19 @@ Status Reader::read_tiles(
 Status Reader::read_tiles(
     const std::string& name,
     const std::vector<ResultTile*>& result_tiles,
-    std::vector<std::future<Status>>* tasks) const {
+    std::vector<std::future<Status>>* const tasks) const {
+  // Shortcut for empty tile vec
+  if (result_tiles.empty())
+    return Status::Ok();
+
   // For each tile, read from its fragment.
-  bool var_size = array_schema_->var_size(name);
-  auto num_tiles = static_cast<uint64_t>(result_tiles.size());
-  auto encryption_key = array_->encryption_key();
+  const bool var_size = array_schema_->var_size(name);
+  const auto encryption_key = array_->encryption_key();
 
   // Gather the unique fragments indexes for which there are tiles
   std::unordered_set<uint32_t> fragment_idxs_set;
-  for (uint64_t i = 0; i < num_tiles; i++)
-    fragment_idxs_set.emplace(result_tiles[i]->frag_idx());
+  for (const auto& tile : result_tiles)
+    fragment_idxs_set.emplace(tile->frag_idx());
 
   // Put fragment indexes in a vector
   std::vector<uint32_t> fragment_idxs_vec;
@@ -1921,24 +1922,23 @@ Status Reader::read_tiles(
 
   // Populate the list of regions per file to be read.
   std::map<URI, std::vector<std::tuple<uint64_t, void*, uint64_t>>> all_regions;
-  for (uint64_t i = 0; i < num_tiles; i++) {
-    auto& tile = result_tiles[i];
-    auto& fragment = fragment_metadata_[tile->frag_idx()];
-    auto format_version = fragment->format_version();
+  for (const auto& tile : result_tiles) {
+    FragmentMetadata* const fragment = fragment_metadata_[tile->frag_idx()];
+    const uint32_t format_version = fragment->format_version();
 
     // Applicable for zipped coordinates only to versions < 5
     if (name == constants::coords && format_version >= 5)
       continue;
 
     // Applicable to separate coordinates only to versions >= 5
-    auto is_dim = array_schema_->is_dim(name);
+    const bool is_dim = array_schema_->is_dim(name);
     if (is_dim && format_version < 5)
       continue;
 
     // Initialize the tile(s)
     if (is_dim) {
-      auto dim_num = array_schema_->dim_num();
-      for (unsigned d = 0; d < dim_num; ++d) {
+      const uint64_t dim_num = array_schema_->dim_num();
+      for (uint64_t d = 0; d < dim_num; ++d) {
         if (array_schema_->dimension(d)->name() == name) {
           tile->init_coord_tile(name, d);
           break;
@@ -1947,20 +1947,21 @@ Status Reader::read_tiles(
     } else {
       tile->init_attr_tile(name);
     }
-    auto tile_pair = tile->tile_pair(name);
+
+    ResultTile::TilePair* const tile_pair = tile->tile_pair(name);
     assert(tile_pair != nullptr);
-    auto& t = tile_pair->first;
-    auto& t_var = tile_pair->second;
+    Tile* const t = &tile_pair->first;
+    Tile* const t_var = &tile_pair->second;
     if (!var_size) {
-      RETURN_NOT_OK(init_tile(format_version, name, &t));
+      RETURN_NOT_OK(init_tile(format_version, name, t));
     } else {
-      RETURN_NOT_OK(init_tile(format_version, name, &t, &t_var));
+      RETURN_NOT_OK(init_tile(format_version, name, t, t_var));
     }
 
     // Get information about the tile in its fragment
     auto tile_attr_uri = fragment->uri(name);
-    uint64_t tile_attr_offset;
     auto tile_idx = tile->tile_idx();
+    uint64_t tile_attr_offset;
     RETURN_NOT_OK(fragment->file_offset(
         *encryption_key, name, tile_idx, &tile_attr_offset));
     uint64_t tile_persisted_size;
@@ -1972,19 +1973,18 @@ Status Reader::read_tiles(
     RETURN_NOT_OK(storage_manager_->read_from_cache(
         tile_attr_uri,
         tile_attr_offset,
-        t.buffer(),
+        t->filtered_buffer(),
         tile_persisted_size,
         &cache_hit));
     if (cache_hit) {
-      t.set_filtered(true);
       STATS_COUNTER_ADD(reader_attr_tile_cache_hits, 1);
     } else {
       // Add the region of the fragment to be read.
-      RETURN_NOT_OK(t.buffer()->realloc(tile_persisted_size));
-      t.buffer()->set_size(tile_persisted_size);
-      t.buffer()->reset_offset();
+      RETURN_NOT_OK(t->filtered_buffer()->realloc(tile_persisted_size));
+      t->filtered_buffer()->set_size(tile_persisted_size);
+      t->filtered_buffer()->reset_offset();
       all_regions[tile_attr_uri].emplace_back(
-          tile_attr_offset, t.buffer()->data(), tile_persisted_size);
+          tile_attr_offset, t->filtered_buffer()->data(), tile_persisted_size);
 
       STATS_COUNTER_ADD(reader_num_tile_bytes_read, tile_persisted_size);
     }
@@ -1998,28 +1998,30 @@ Status Reader::read_tiles(
       RETURN_NOT_OK(fragment->persisted_tile_var_size(
           *encryption_key, name, tile_idx, &tile_var_persisted_size));
 
+      Buffer cached_var_buffer;
       RETURN_NOT_OK(storage_manager_->read_from_cache(
           tile_attr_var_uri,
           tile_attr_var_offset,
-          t_var.buffer(),
+          t_var->filtered_buffer(),
           tile_var_persisted_size,
           &cache_hit));
 
       if (cache_hit) {
-        t_var.set_filtered(true);
         STATS_COUNTER_ADD(reader_attr_tile_cache_hits, 1);
       } else {
         // Add the region of the fragment to be read.
-        RETURN_NOT_OK(t_var.buffer()->realloc(tile_var_persisted_size));
-        t_var.buffer()->set_size(tile_var_persisted_size);
-        t_var.buffer()->reset_offset();
+        RETURN_NOT_OK(
+            t_var->filtered_buffer()->realloc(tile_var_persisted_size));
+        t_var->filtered_buffer()->set_size(tile_var_persisted_size);
+        t_var->filtered_buffer()->reset_offset();
         all_regions[tile_attr_var_uri].emplace_back(
             tile_attr_var_offset,
-            t_var.buffer()->data(),
+            t_var->filtered_buffer()->data(),
             tile_var_persisted_size);
 
         STATS_COUNTER_ADD(reader_num_tile_bytes_read, tile_var_persisted_size);
-        STATS_COUNTER_ADD(reader_num_var_cell_bytes_read, tile_persisted_size);
+        STATS_COUNTER_ADD(
+            reader_num_var_cell_bytes_read, tile_var_persisted_size);
         STATS_COUNTER_ADD(
             reader_num_var_cell_bytes_read, tile_var_persisted_size);
       }
@@ -2039,7 +2041,8 @@ Status Reader::read_tiles(
   }
 
   STATS_COUNTER_ADD(
-      reader_num_attr_tiles_touched, ((var_size ? 2 : 1) * num_tiles));
+      reader_num_attr_tiles_touched,
+      ((var_size ? 2 : 1) * result_tiles.size()));
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_READER_H
 #define TILEDB_READER_H
 
+#include <forward_list>
 #include <future>
 #include <list>
 #include <map>
@@ -877,13 +878,16 @@ class Reader {
    * Filters the tiles on a particular attribute/dimension from all input
    * fragments based on the tile info in `result_tiles`.
    *
-   * @param name Attribute/dimension whose tiles will be unfiltered
-   * @param result_tiles Vector containing the tiles to be unfiltered
+   * @param name Attribute/dimension whose tiles will be unfiltered.
+   * @param result_tiles Vector containing the tiles to be unfiltered.
+   * @param result_cell_slabs The result cell slabs to use for selective
+   *    unfiltering. This is optional and will be ignored if NULL.
    * @return Status
    */
   Status unfilter_tiles(
       const std::string& name,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<ResultTile*>& result_tiles,
+      const std::vector<ResultCellSlab>* result_cell_slabs = nullptr) const;
 
   /**
    * Runs the input tile for the input attribute or dimension through the
@@ -894,9 +898,16 @@ class Reader {
    * @param tile The tile to be unfiltered.
    * @param offsets True if the tile to be unfiltered contains offsets for a
    *    var-sized attribute/dimension.
+   * @param result_cell_slab_ranges Result cell slab ranges sorted in ascending
+   *    order.
    * @return Status
    */
-  Status unfilter_tile(const std::string& name, Tile* tile, bool offsets) const;
+  Status unfilter_tile(
+      const std::string& name,
+      Tile* tile,
+      bool offsets,
+      const std::forward_list<std::pair<uint64_t, uint64_t>>*
+          result_cell_slab_ranges) const;
 
   /**
    * Gets all the result coordinates of the input tile into `result_coords`.

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -132,16 +132,25 @@ const void* ResultTile::coord(uint64_t pos, unsigned dim_idx) const {
   // Handle separate coordinate tiles
   const auto& coord_tile = coord_tiles_[dim_idx].second.first;
   if (!coord_tile.empty()) {
-    auto coord_buff = (const unsigned char*)coord_tile.internal_data();
-    return &coord_buff[pos * coord_tile.cell_size()];
+    const uint64_t offset = pos * coord_tile.cell_size();
+    void* buffer = nullptr;
+    const Status st = coord_tile.chunked_buffer()->internal_buffer_from_offset(
+        offset, &buffer);
+    assert(st.ok());
+    return buffer;
   }
 
   // Handle zipped coordinates tile
   if (!coords_tile_.first.empty()) {
     auto coords_size = coords_tile_.first.cell_size();
     auto coord_size = coords_size / coords_tile_.first.dim_num();
-    auto coords_buff = (const unsigned char*)coords_tile_.first.internal_data();
-    return &coords_buff[pos * coords_size + dim_idx * coord_size];
+    const uint64_t offset = pos * coords_size + dim_idx * coord_size;
+    void* buffer = nullptr;
+    const Status st =
+        coords_tile_.first.chunked_buffer()->internal_buffer_from_offset(
+            offset, &buffer);
+    assert(st.ok());
+    return buffer;
   }
 
   return nullptr;
@@ -155,13 +164,28 @@ std::string ResultTile::coord_string(uint64_t pos, unsigned dim_idx) const {
   auto cell_num = coord_tile_off.cell_num();
   auto val_size = coord_tile_val.size();
 
-  auto coord_buff_off = (const uint64_t*)coord_tile_off.internal_data();
-  auto coord_buff_val = (const char*)coord_tile_val.internal_data();
-  auto offset = coord_buff_off[pos];
-  auto next_offset = (pos == cell_num - 1) ? val_size : coord_buff_off[pos + 1];
+  uint64_t offset = 0;
+  Status st = coord_tile_off.chunked_buffer()->read(
+      &offset, sizeof(uint64_t), pos * sizeof(uint64_t));
+  assert(st.ok());
+
+  uint64_t next_offset = 0;
+  if (pos == cell_num - 1) {
+    next_offset = val_size;
+  } else {
+    st = coord_tile_off.chunked_buffer()->read(
+        &next_offset, sizeof(uint64_t), (pos + 1) * sizeof(uint64_t));
+    assert(st.ok());
+  }
+
   auto size = next_offset - offset;
 
-  return std::string(&coord_buff_val[offset], size);
+  void* buffer = nullptr;
+  st = coord_tile_val.chunked_buffer()->internal_buffer_from_offset(
+      offset, &buffer);
+  assert(st.ok());
+
+  return std::string(static_cast<char*>(buffer), size);
 }
 
 bool ResultTile::coord_in_rect(uint64_t pos, const NDRange& rect) const {

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -923,7 +923,7 @@ class Writer {
    */
   Status write_all_tiles(
       FragmentMetadata* frag_meta,
-      const std::unordered_map<std::string, std::vector<Tile>>& tiles) const;
+      std::unordered_map<std::string, std::vector<Tile>>* tiles) const;
 
   /**
    * Writes the input tiles for the input attribute/dimension to storage.
@@ -936,7 +936,7 @@ class Writer {
   Status write_tiles(
       const std::string& name,
       FragmentMetadata* frag_meta,
-      const std::vector<Tile>& tiles) const;
+      std::vector<Tile>* tiles) const;
 
   /**
    * Returns the i-th coordinates in the coordinate buffers in string

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -31,7 +31,11 @@
  * This file implements the StorageManager class.
  */
 
-#include "tiledb/sm/storage_manager/storage_manager.h"
+#include <algorithm>
+#include <functional>
+#include <iostream>
+#include <sstream>
+
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/cache/lru_cache.h"
@@ -49,6 +53,7 @@
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/storage_manager/consolidator.h"
 #include "tiledb/sm/storage_manager/open_array.h"
+#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/tile.h"
 #include "tiledb/sm/tile/tile_io.h"
 
@@ -374,7 +379,6 @@ Status StorageManager::array_open_for_writes(
   }
 
   // No fragment metadata to be loaded
-
   *array_schema = open_array->array_schema();
 
   // Unlock the array mutex
@@ -1454,27 +1458,27 @@ Status StorageManager::load_array_schema(
 
   URI schema_uri = array_uri.join_path(constants::array_schema_filename);
 
-  auto tile_io = new TileIO(this, schema_uri);
-  auto tile = (Tile*)nullptr;
+  TileIO tile_io(this, schema_uri);
+  Tile* tile = nullptr;
+  RETURN_NOT_OK(tile_io.read_generic(&tile, 0, encryption_key, config_));
+
+  auto chunked_buffer = tile->chunked_buffer();
+  Buffer buff;
+  buff.realloc(chunked_buffer->size());
+  buff.set_size(chunked_buffer->size());
   RETURN_NOT_OK_ELSE(
-      tile_io->read_generic(&tile, 0, encryption_key, config_), delete tile_io);
-  tile->disown_buff();
-  auto buff = tile->buffer();
+      chunked_buffer->read(buff.data(), buff.size(), 0), delete tile);
   delete tile;
-  delete tile_io;
 
   // Deserialize
-  auto cbuff = new ConstBuffer(buff);
+  ConstBuffer cbuff(&buff);
   *array_schema = new ArraySchema();
   (*array_schema)->set_array_uri(array_uri);
-  Status st = (*array_schema)->deserialize(cbuff);
-  delete cbuff;
+  Status st = (*array_schema)->deserialize(&cbuff);
   if (!st.ok()) {
     delete *array_schema;
     *array_schema = nullptr;
   }
-
-  delete buff;
 
   return st;
 }
@@ -1779,6 +1783,12 @@ Status StorageManager::read(
   return Status::Ok();
 }
 
+Status StorageManager::read(
+    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) const {
+  RETURN_NOT_OK(vfs_->read(uri, offset, buffer, nbytes));
+  return Status::Ok();
+}
+
 ThreadPool* StorageManager::reader_thread_pool() {
   return &reader_thread_pool_;
 }
@@ -1800,33 +1810,35 @@ Status StorageManager::store_array_schema(
   URI schema_uri = array_uri.join_path(constants::array_schema_filename);
 
   // Serialize
-  auto buff = new Buffer();
-  RETURN_NOT_OK_ELSE(array_schema->serialize(buff), delete buff);
+  Buffer buff;
+  RETURN_NOT_OK(array_schema->serialize(&buff));
 
   // Delete file if it exists already
   bool exists;
   RETURN_NOT_OK(is_file(schema_uri, &exists));
   if (exists)
-    RETURN_NOT_OK_ELSE(vfs_->remove_file(schema_uri), delete buff);
+    RETURN_NOT_OK(vfs_->remove_file(schema_uri));
+
+  ChunkedBuffer chunked_buffer;
+  RETURN_NOT_OK(Tile::buffer_to_contigious_fixed_chunks(
+      buff, 0, constants::generic_tile_cell_size, &chunked_buffer));
+  buff.disown_data();
 
   // Write to file
-  buff->reset_offset();
-  auto tile = new Tile(
+  Tile tile(
       constants::generic_tile_datatype,
       constants::generic_tile_cell_size,
       0,
-      buff,
+      &chunked_buffer,
       false);
-  auto tile_io = new TileIO(this, schema_uri);
+  TileIO tile_io(this, schema_uri);
   uint64_t nbytes;
-  Status st = tile_io->write_generic(tile, encryption_key, &nbytes);
+  Status st = tile_io.write_generic(&tile, encryption_key, &nbytes);
   (void)nbytes;
   if (st.ok())
     st = close_file(schema_uri);
 
-  delete tile;
-  delete tile_io;
-  delete buff;
+  chunked_buffer.free();
 
   return st;
 }
@@ -1851,23 +1863,27 @@ Status StorageManager::store_array_metadata(
   URI array_metadata_uri;
   RETURN_NOT_OK(array_metadata->get_uri(array_uri, &array_metadata_uri));
 
-  // Write to file
-  metadata_buff.reset_offset();
-  auto tile = new Tile(
+  ChunkedBuffer* const chunked_buffer = new ChunkedBuffer();
+  RETURN_NOT_OK_ELSE(
+      Tile::buffer_to_contigious_fixed_chunks(
+          metadata_buff, 0, constants::generic_tile_cell_size, chunked_buffer),
+      delete chunked_buffer);
+  metadata_buff.disown_data();
+
+  Tile tile(
       constants::generic_tile_datatype,
       constants::generic_tile_cell_size,
       0,
-      &metadata_buff,
-      false);
-  auto tile_io = new TileIO(this, array_metadata_uri);
-  uint64_t nbytes;
-  Status st = tile_io->write_generic(tile, encryption_key, &nbytes);
-  (void)nbytes;
-  if (st.ok())
-    st = close_file(array_metadata_uri);
+      chunked_buffer,
+      true);
 
-  delete tile;
-  delete tile_io;
+  TileIO tile_io(this, array_metadata_uri);
+  uint64_t nbytes;
+  Status st = tile_io.write_generic(&tile, encryption_key, &nbytes);
+  (void)nbytes;
+  if (st.ok()) {
+    st = close_file(array_metadata_uri);
+  }
 
   return st;
 }
@@ -2062,9 +2078,18 @@ Status StorageManager::load_array_metadata(
       TileIO tile_io(this, uri);
       auto tile = (Tile*)nullptr;
       RETURN_NOT_OK(tile_io.read_generic(&tile, 0, encryption_key, config_));
-      tile->disown_buff();
-      auto buff = tile->buffer();
+
+      auto chunked_buffer = tile->chunked_buffer();
+      Buffer* const buff = new Buffer();
+      RETURN_NOT_OK(buff->realloc(chunked_buffer->size()));
+      buff->set_size(chunked_buffer->size());
+      RETURN_NOT_OK_ELSE(
+          chunked_buffer->read(buff->data(), buff->size(), 0), [&]() {
+            delete tile;
+            delete buff;
+          }());
       delete tile;
+
       metadata_buff = std::make_shared<ConstBuffer>(buff);
       open_array->insert_array_metadata(uri, metadata_buff);
     }
@@ -2159,9 +2184,14 @@ Status StorageManager::load_consolidated_fragment_meta(
     return Status::Ok();
 
   TileIO tile_io(this, uri);
-  auto tile = (Tile*)nullptr;
+  Tile* tile = nullptr;
   RETURN_NOT_OK(tile_io.read_generic(&tile, 0, enc_key, config_));
-  tile->buffer()->swap(*f_buff);
+
+  auto chunked_buffer = tile->chunked_buffer();
+  f_buff->realloc(chunked_buffer->size());
+  f_buff->set_size(chunked_buffer->size());
+  RETURN_NOT_OK_ELSE(
+      chunked_buffer->read(f_buff->data(), f_buff->size(), 0), delete tile);
   delete tile;
 
   uint32_t fragment_num;

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -59,6 +59,7 @@ namespace sm {
 class Array;
 class ArraySchema;
 class Buffer;
+class ChunkedBuffer;
 class Consolidator;
 class EncryptionKey;
 class FragmentMetadata;
@@ -770,6 +771,18 @@ class StorageManager {
    */
   Status read(
       const URI& uri, uint64_t offset, Buffer* buffer, uint64_t nbytes) const;
+
+  /**
+   * Reads from a file into the raw input buffer.
+   *
+   * @param uri The URI file to read from.
+   * @param offset The offset in the file the read will start from.
+   * @param buffer The buffer to write into.
+   * @param nbytes The number of bytes to read.
+   * @return Status.
+   */
+  Status read(
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) const;
 
   /**
    * Sets a string/string KV "tag" on the storage manager instance.

--- a/tiledb/sm/tile/chunked_buffer.cc
+++ b/tiledb/sm/tile/chunked_buffer.cc
@@ -1,0 +1,644 @@
+/**
+ * @file chunked_buffer.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class ChunkedBuffer.
+ */
+
+#include "tiledb/sm/tile/chunked_buffer.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace tiledb {
+namespace sm {
+
+ChunkedBuffer::ChunkedBuffer()
+    : buffer_addressing_(BufferAddressing::DISCRETE)
+    , chunk_size_(0)
+    , last_chunk_size_(0)
+    , capacity_(0)
+    , size_(0) {
+}
+
+ChunkedBuffer::ChunkedBuffer(const ChunkedBuffer& rhs) {
+  deep_copy(rhs);
+}
+
+ChunkedBuffer& ChunkedBuffer::operator=(const ChunkedBuffer& rhs) {
+  deep_copy(rhs);
+  return *this;
+}
+
+ChunkedBuffer::~ChunkedBuffer() {
+}
+
+void ChunkedBuffer::deep_copy(const ChunkedBuffer& rhs) {
+  buffers_.reserve(rhs.buffers_.size());
+  for (size_t i = 0; i < rhs.buffers_.size(); ++i) {
+    const uint32_t buffer_size = rhs.get_chunk_capacity(i);
+    void* const buffer_copy = std::malloc(buffer_size);
+    std::memcpy(buffer_copy, rhs.buffers_[i], buffer_size);
+    buffers_.emplace_back(buffer_copy);
+  }
+
+  buffer_addressing_ = rhs.buffer_addressing_;
+  chunk_size_ = rhs.chunk_size_;
+  last_chunk_size_ = rhs.last_chunk_size_;
+  var_chunk_sizes_ = rhs.var_chunk_sizes_;
+  capacity_ = rhs.capacity_;
+  size_ = rhs.size_;
+}
+
+ChunkedBuffer ChunkedBuffer::shallow_copy() const {
+  ChunkedBuffer copy;
+  copy.buffer_addressing_ = buffer_addressing_;
+  copy.buffers_ = buffers_;
+  copy.chunk_size_ = chunk_size_;
+  copy.last_chunk_size_ = last_chunk_size_;
+  copy.var_chunk_sizes_ = var_chunk_sizes_;
+  copy.capacity_ = capacity_;
+  copy.size_ = size_;
+  return copy;
+}
+
+void ChunkedBuffer::swap(ChunkedBuffer* const rhs) {
+  std::swap(buffer_addressing_, rhs->buffer_addressing_);
+  std::swap(buffers_, rhs->buffers_);
+  std::swap(chunk_size_, rhs->chunk_size_);
+  std::swap(last_chunk_size_, rhs->last_chunk_size_);
+  std::swap(var_chunk_sizes_, rhs->var_chunk_sizes_);
+  std::swap(capacity_, rhs->capacity_);
+  std::swap(size_, rhs->size_);
+}
+
+void ChunkedBuffer::free() {
+  if (buffer_addressing_ == BufferAddressing::CONTIGIOUS) {
+    if (!buffers_.empty() && buffers_[0] != nullptr) {
+      free_contigious();
+    }
+  } else {
+    for (size_t i = 0; i < buffers_.size(); ++i) {
+      void* const buffer = buffers_[i];
+      if (buffer != nullptr) {
+        auto st = free_discrete(i);
+        if (!st.ok()) {
+          LOG_FATAL(st.message());
+        }
+      }
+    }
+  }
+
+  clear();
+}
+
+void ChunkedBuffer::clear() {
+  buffers_.clear();
+  buffer_addressing_ = BufferAddressing::DISCRETE;
+  chunk_size_ = 0;
+  last_chunk_size_ = 0;
+  var_chunk_sizes_.clear();
+  capacity_ = 0;
+  size_ = 0;
+}
+
+uint64_t ChunkedBuffer::size() const {
+  return size_;
+}
+
+Status ChunkedBuffer::set_size(const uint64_t size) {
+  if (size > capacity_) {
+    return Status::ChunkedBufferError("Cannot set size; size exceeds capacity");
+  }
+
+  size_ = size;
+
+  return Status::Ok();
+}
+
+uint64_t ChunkedBuffer::capacity() const {
+  return capacity_;
+}
+
+size_t ChunkedBuffer::nchunks() const {
+  return buffers_.size();
+}
+
+ChunkedBuffer::BufferAddressing ChunkedBuffer::buffer_addressing() const {
+  return buffer_addressing_;
+}
+
+Status ChunkedBuffer::init_fixed_size(
+    const BufferAddressing buffer_addressing,
+    const uint64_t total_size,
+    const uint32_t chunk_size) {
+  if (!buffers_.empty()) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot init chunk buffers; Chunk buffers non-empty."));
+  }
+
+  if (total_size == 0) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot init chunk buffers; Total size must be non-zero."));
+  }
+
+  if (chunk_size == 0) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot init chunk buffers; Chunk size must be non-zero."));
+  }
+
+  buffer_addressing_ = buffer_addressing;
+  chunk_size_ = chunk_size;
+
+  // Calculate the last chunk size.
+  last_chunk_size_ = total_size % chunk_size_;
+  if (last_chunk_size_ == 0) {
+    last_chunk_size_ = chunk_size_;
+  }
+
+  // Calculate the number of chunks required.
+  const size_t nchunks = last_chunk_size_ == chunk_size_ ?
+                             total_size / chunk_size_ :
+                             total_size / chunk_size_ + 1;
+
+  buffers_.resize(nchunks);
+
+  capacity_ = chunk_size_ * (buffers_.size() - 1) + last_chunk_size_;
+
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::init_var_size(
+    const BufferAddressing buffer_addressing,
+    std::vector<uint32_t>&& var_chunk_sizes) {
+  if (!buffers_.empty()) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot init chunk buffers; Chunk buffers non-empty."));
+  }
+
+  if (var_chunk_sizes.empty()) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot init chunk buffers; Var chunk sizes must be non-empty."));
+  }
+
+  buffer_addressing_ = buffer_addressing;
+  var_chunk_sizes_ = std::move(var_chunk_sizes);
+  buffers_.resize(var_chunk_sizes_.size());
+
+  capacity_ = 0;
+  for (const auto& var_chunk_size : var_chunk_sizes_) {
+    if (var_chunk_size == 0) {
+      clear();
+      return LOG_STATUS(Status::ChunkedBufferError(
+          "Cannot init chunk buffers; Var chunk size must be non-empty."));
+    }
+
+    capacity_ += var_chunk_size;
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::alloc_discrete(
+    const size_t chunk_idx, void** const buffer) {
+  if (buffer_addressing_ != BufferAddressing::DISCRETE) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot alloc discrete internal chunk buffer; Chunk buffers are not "
+        "discretely allocated"));
+  }
+
+  if (chunk_idx >= buffers_.size()) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot alloc internal chunk buffer; Chunk index out of bounds"));
+  }
+
+  buffers_[chunk_idx] = std::malloc(get_chunk_capacity(chunk_idx));
+  if (!buffers_[chunk_idx]) {
+    LOG_FATAL("malloc() failed");
+  }
+
+  if (buffer) {
+    *buffer = buffers_[chunk_idx];
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::free_discrete(const size_t chunk_idx) {
+  if (buffer_addressing_ != BufferAddressing::DISCRETE) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot free discrete internal chunk buffer; Chunk buffers are not "
+        "discretely allocated"));
+  }
+
+  if (chunk_idx >= buffers_.size()) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot free internal chunk buffer; Chunk index out of bounds"));
+  }
+
+  ::free(buffers_[chunk_idx]);
+
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::set_contigious(void* const buffer) {
+  if (buffer == nullptr) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot set contigious chunk buffers; Input buffer is null."));
+  }
+
+  if (buffer_addressing_ != BufferAddressing::CONTIGIOUS) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot alloc discrete internal chunk buffer; Chunk buffers are not "
+        "contigiously allocated."));
+  }
+
+  if (buffers_.empty()) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot set contigious chunk buffers; Chunk buffers uninitialized."));
+  }
+
+  uint64_t offset = 0;
+  for (size_t i = 0; i < buffers_.size(); ++i) {
+    buffers_[i] = static_cast<char*>(buffer) + offset;
+    offset += get_chunk_capacity(i);
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::get_contigious(void** const buffer) const {
+  if (buffer_addressing_ != BufferAddressing::CONTIGIOUS) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot get contigious internal chunk buffer; Chunk buffers are not "
+        "contigiouly allocated"));
+  }
+
+  return internal_buffer(0, buffer);
+}
+
+Status ChunkedBuffer::free_contigious() {
+  if (buffers_[0] == nullptr) {
+    return Status::ChunkedBufferError(
+        "Cannot free contigious internal chunk buffer; The internal chunk "
+        "buffer is unallocated");
+  }
+
+  // This asssumes buffers set with the set_contigious interface
+  // were allocated with malloc().
+  ::free(buffers_[0]);
+
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::internal_buffer_from_offset(
+    const uint64_t offset, void** const buffer) const {
+  if (offset >= size_) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot get internal chunk buffer; Offset out of bounds"));
+  }
+
+  if (buffer_addressing_ == BufferAddressing::CONTIGIOUS) {
+    RETURN_NOT_OK(get_contigious(buffer));
+    *buffer = static_cast<char*>(*buffer) + offset;
+    return Status::Ok();
+  }
+
+  size_t chunk_idx;
+  size_t chunk_offset;
+  RETURN_NOT_OK(translate_logical_offset(offset, &chunk_idx, &chunk_offset));
+  RETURN_NOT_OK(internal_buffer(chunk_idx, buffer));
+  *buffer = static_cast<char*>(*buffer) + chunk_offset;
+
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::internal_buffer(
+    const size_t chunk_idx, void** const buffer) const {
+  assert(buffer);
+
+  if (chunk_idx >= buffers_.size()) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot get internal chunk buffer; Chunk index out of bounds"));
+  }
+
+  *buffer = buffers_[chunk_idx];
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::internal_buffer_capacity(
+    const size_t chunk_idx, uint32_t* const capacity) const {
+  assert(capacity);
+
+  if (chunk_idx >= buffers_.size()) {
+    return LOG_STATUS(
+        Status::ChunkedBufferError("Cannot get internal chunk buffer capacity; "
+                                   "Chunk index out of bounds"));
+  }
+
+  *capacity = get_chunk_capacity(chunk_idx);
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::internal_buffer_size(
+    const size_t chunk_idx, uint32_t* const size) const {
+  assert(size);
+
+  if (chunk_idx >= buffers_.size()) {
+    return LOG_STATUS(Status::ChunkedBufferError(
+        "Cannot get internal chunk buffer size; Chunk index out of bounds"));
+  }
+
+  *size = get_chunk_size(chunk_idx);
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::read(
+    void* const buffer, const uint64_t nbytes, const uint64_t offset) {
+  if ((offset + nbytes) > size()) {
+    return Status::ChunkedBufferError("Chunk read error; read out of bounds");
+  }
+
+  // As an optimization, we can directly copy the entire requested number
+  // of bytes if the chunked buffers are contigiously allocated.
+  if (buffer_addressing_ == BufferAddressing::CONTIGIOUS) {
+    void* chunk_buffer;
+    RETURN_NOT_OK(get_contigious(&chunk_buffer));
+    std::memcpy(
+        static_cast<char*>(buffer),
+        static_cast<char*>(chunk_buffer) + offset,
+        nbytes);
+    return Status::Ok();
+  }
+
+  size_t chunk_idx;
+  size_t chunk_offset;
+  RETURN_NOT_OK(translate_logical_offset(offset, &chunk_idx, &chunk_offset));
+
+  uint64_t nbytes_read = 0;
+  while (nbytes_read < nbytes) {
+    const void* const chunk_buffer = buffers_[chunk_idx];
+    if (!chunk_buffer) {
+      return Status::ChunkedBufferError("Chunk read error; chunk unallocated");
+    }
+
+    const uint64_t nbytes_remaining = nbytes - nbytes_read;
+    const uint64_t cbytes_remaining =
+        get_chunk_capacity(chunk_idx) - chunk_offset;
+    const uint64_t bytes_to_read = std::min(nbytes_remaining, cbytes_remaining);
+
+    std::memcpy(
+        static_cast<char*>(buffer) + nbytes_read,
+        static_cast<const char*>(chunk_buffer) + chunk_offset,
+        bytes_to_read);
+    nbytes_read += bytes_to_read;
+
+    chunk_offset = 0;
+    ++chunk_idx;
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::ensure_capacity(const uint64_t requested_capacity) {
+  if (requested_capacity <= capacity_) {
+    return Status::Ok();
+  }
+
+  if (capacity_ == 0) {
+    return Status::ChunkedBufferError(
+        "Ensure capacity failed; Chunk buffers uninitialized");
+  }
+
+  if (fixed_chunk_sizes()) {
+    // Calculate the new last chunk size.
+    const uint32_t orig_last_chunk_size = last_chunk_size_;
+    last_chunk_size_ = requested_capacity % chunk_size_;
+    if (last_chunk_size_ == 0) {
+      last_chunk_size_ = chunk_size_;
+    }
+
+    // Calculate the new number of chunks required.
+    const size_t nchunks = last_chunk_size_ == chunk_size_ ?
+                               requested_capacity / chunk_size_ :
+                               requested_capacity / chunk_size_ + 1;
+
+    assert(buffers_.size() <= nchunks);
+
+    // For contigiously allocated buffers, reallocate to the capacity
+    // if set. For discretely allocated buffers, reallocate the last
+    // chunk size if it was previously allocated.
+    if (buffer_addressing_ == BufferAddressing::CONTIGIOUS) {
+      void* buffer;
+      RETURN_NOT_OK(get_contigious(&buffer));
+      if (buffer) {
+        uint64_t realloc_size = capacity_;
+        while (realloc_size < requested_capacity)
+          realloc_size *= 2;
+        void* const realloced_buffer = std::realloc(buffer, realloc_size);
+        if (!realloced_buffer) {
+          return Status::ChunkedBufferError(
+              "Ensure capacity failed; realloc() failed.");
+        }
+        RETURN_NOT_OK(set_contigious(realloced_buffer));
+      }
+    } else {
+      assert(buffer_addressing_ == BufferAddressing::DISCRETE);
+      const uint64_t realloc_size =
+          buffers_.size() == nchunks ? last_chunk_size_ : chunk_size_;
+      if (realloc_size != orig_last_chunk_size) {
+        assert(realloc_size > orig_last_chunk_size);
+        const size_t last_chunk_idx = buffers_.size() - 1;
+        void* buffer;
+        RETURN_NOT_OK(internal_buffer(last_chunk_idx, &buffer));
+        if (buffer) {
+          void* const realloced_buffer = std::realloc(buffer, realloc_size);
+          if (!realloced_buffer) {
+            return Status::ChunkedBufferError(
+                "Ensure capacity failed; realloc() failed.");
+          }
+          buffers_[last_chunk_idx] = realloced_buffer;
+        }
+      }
+    }
+
+    // Update the capacity.
+    buffers_.resize(nchunks);
+    capacity_ = chunk_size_ * (buffers_.size() - 1) + last_chunk_size_;
+  } else {
+    // There is not a curent use-case for reallocating var-sized chunk
+    // buffers.
+    assert(false);
+    return Status::ChunkedBufferError(
+        "Ensure capacity failed; realloc unsupported for var-sized chunk "
+        "buffers.");
+  }
+
+  return Status::Ok();
+}
+
+Status ChunkedBuffer::write(
+    const void* const buffer, const uint64_t nbytes, const uint64_t offset) {
+  RETURN_NOT_OK(ensure_capacity(offset + nbytes));
+
+  if ((offset + nbytes) > capacity()) {
+    return Status::ChunkedBufferError("Chunk write error; write out of bounds");
+  }
+
+  // As an optimization, we can directly copy the entire number of
+  // bytes to write if the chunked buffers are contigiously allocated.
+  if (buffer_addressing_ == BufferAddressing::CONTIGIOUS) {
+    void* chunk_buffer;
+    RETURN_NOT_OK(get_contigious(&chunk_buffer));
+    if (!chunk_buffer) {
+      return Status::ChunkedBufferError(
+          "Chunk write error; unset contigious buffer");
+    }
+
+    std::memcpy(
+        static_cast<char*>(chunk_buffer) + offset,
+        static_cast<const char*>(buffer),
+        nbytes);
+    return Status::Ok();
+  }
+
+  size_t chunk_idx;
+  size_t chunk_offset;
+  RETURN_NOT_OK(translate_logical_offset(offset, &chunk_idx, &chunk_offset));
+
+  uint64_t nbytes_written = 0;
+  while (nbytes_written < nbytes) {
+    void* chunk_buffer = buffers_[chunk_idx];
+    if (!chunk_buffer) {
+      if (buffer_addressing_ == BufferAddressing::CONTIGIOUS) {
+        return Status::ChunkedBufferError(
+            "Chunk write error; unset contigious buffer");
+      } else {
+        RETURN_NOT_OK(alloc_discrete(chunk_idx, &chunk_buffer));
+        buffers_[chunk_idx] = chunk_buffer;
+      }
+    }
+    const uint64_t nbytes_remaining = nbytes - nbytes_written;
+    const uint64_t cbytes_remaining =
+        get_chunk_capacity(chunk_idx) - chunk_offset;
+    const uint64_t bytes_to_write =
+        std::min(nbytes_remaining, cbytes_remaining);
+
+    std::memcpy(
+        static_cast<char*>(chunk_buffer) + chunk_offset,
+        static_cast<const char*>(buffer) + nbytes_written,
+        bytes_to_write);
+    nbytes_written += bytes_to_write;
+
+    chunk_offset = 0;
+    ++chunk_idx;
+
+    // Update the size cursor if necessary.
+    if (offset + nbytes_written > size_) {
+      size_ = offset + nbytes_written;
+    }
+  }
+
+  assert(nbytes_written == nbytes);
+
+  return Status::Ok();
+}
+
+uint32_t ChunkedBuffer::get_chunk_capacity(const size_t chunk_idx) const {
+  assert(chunk_idx < buffers_.size());
+  if (fixed_chunk_sizes()) {
+    return chunk_idx == (buffers_.size() - 1) ? last_chunk_size_ : chunk_size_;
+  } else {
+    return var_chunk_sizes_[chunk_idx];
+  }
+}
+
+uint32_t ChunkedBuffer::get_chunk_size(const size_t chunk_idx) const {
+  assert(chunk_idx < buffers_.size());
+
+  // Calculate the total capacity leading up to this chunk.
+  uint64_t leading_capacity = 0;
+  for (size_t i = 0; i < chunk_idx; ++i) {
+    leading_capacity += get_chunk_capacity(i);
+  }
+
+  const uint32_t chunk_capacity = get_chunk_capacity(chunk_idx);
+
+  if (size() <= leading_capacity) {
+    return 0;
+  }
+
+  if (size() >= leading_capacity + chunk_capacity) {
+    return chunk_capacity;
+  }
+
+  return size() - leading_capacity;
+}
+
+bool ChunkedBuffer::fixed_chunk_sizes() const {
+  return var_chunk_sizes_.empty();
+}
+
+Status ChunkedBuffer::translate_logical_offset(
+    const uint64_t logical_offset,
+    size_t* const chunk_idx,
+    size_t* const chunk_offset) const {
+  assert(chunk_idx);
+  assert(chunk_offset);
+
+  // Optimize for the common case.
+  if (logical_offset == 0) {
+    *chunk_idx = 0;
+    *chunk_offset = 0;
+    return Status::Ok();
+  }
+
+  if (fixed_chunk_sizes()) {
+    *chunk_idx = logical_offset / chunk_size_;
+    *chunk_offset = logical_offset % chunk_size_;
+  } else {
+    // Lookup the index of the chunk that the logical offset
+    // intersects and compute the chunk offset to reach the
+    // logical offset.
+    *chunk_idx = 0;
+    uint64_t i = 0;
+    while (i <= logical_offset) {
+      if (*chunk_idx >= buffers_.size()) {
+        return Status::ChunkedBufferError("Out of bounds logical offset");
+      }
+      i += var_chunk_sizes_[(*chunk_idx)++];
+    }
+    i -= var_chunk_sizes_[--(*chunk_idx)];
+    *chunk_offset = logical_offset - i;
+  }
+
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/tile/chunked_buffer.h
+++ b/tiledb/sm/tile/chunked_buffer.h
@@ -1,0 +1,382 @@
+/**
+ * @file chunked_buffer.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2019 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class ChunkedBuffer.
+ *
+ * The ChunkedBuffer class is used to represent a logically contigious buffer
+ * as a vector of individual buffers. These individual buffers are referred to
+ * as "chunk buffers". Each chunk buffer may be allocated individually, which
+ * will save memory in scenarios where the logically contigious buffer is
+ * sparsley allocated.
+ *
+ * After construction, the class must be initialized before performing IO. The
+ * initialization determines the following, independent usage paradigms:
+ *
+ * #1: Chunk Sizes: Fixed/Variable
+ * The chunk sizes must be either fixed or variable. An instance with fixed
+ * chunk sizes ensures that all chunk buffers are of equal size. The size of the
+ * last chunk buffer may be equal-to or less-than the other chunk sizes.
+ * Instances with fixed size chunks have a smaller memory footprint and have a
+ * smaller algorithmic complexity when performing IO. For variable sized chunks,
+ * each chunk size is independent from the others.
+ *
+ * #2: Chunk Buffer Addressing: Discrete/Contigious
+ * The addresses of the individual chunk buffers may or may not be virtually
+ * contigious. For example, the chunk addresses within a virtually contigious
+ * instance may be allocated at address 1024 and 1028, where the first chunk is
+ * of size 4. Non-contigious chunks (referred to as "discrete") may be allocated
+ * at any address. The trade-off is that the memory of each discrete chunk is
+ * managed individually, where contigious chunk buffers can be managed by the
+ * first chunk alone.
+ *
+ * #3: Memory Management: Internal/External
+ * The chunk buffers may be allocated and freed internally or externally.
+ * Internal memory management is exposed through the alloc_*() and free_*()
+ * routines. External memory management is exposed through the set_*() routines.
+ * Currently, this only supports external memory management for contigiously
+ * addressed buffers and internal memory management for discretely addressed
+ * buffers.
+ *
+ * Note that the ChunkedBuffer class does NOT support any concept of ownership.
+ * It is up to the caller to free the instance before destruction.
+ */
+
+#ifndef TILEDB_chunked_buffer_H
+#define TILEDB_chunked_buffer_H
+
+#include "tiledb/sm/misc/logger.h"
+#include "tiledb/sm/misc/status.h"
+
+#include <cinttypes>
+#include <vector>
+
+namespace tiledb {
+namespace sm {
+
+class ChunkedBuffer {
+ public:
+  enum BufferAddressing { CONTIGIOUS, DISCRETE };
+
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  ChunkedBuffer();
+
+  /** Copy constructor. */
+  ChunkedBuffer(const ChunkedBuffer& rhs);
+
+  /** Destructor. */
+  ~ChunkedBuffer();
+
+  /* ********************************* */
+  /*             OPERATORS             */
+  /* ********************************* */
+
+  /** Assignment operator. */
+  ChunkedBuffer& operator=(const ChunkedBuffer& rhs);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * ChunkedBuffer fixed-size initializer. The last chunk size may be
+   * equal-to or less-than *chunk_size*.
+   *
+   * @param buffer_addressing The internal buffer addressing type.
+   * @param total_size The total byte size of all chunks.
+   * @param chunk_size The byte size of each individual chunk.
+   * @return Status
+   */
+  Status init_fixed_size(
+      BufferAddressing buffer_addressing,
+      uint64_t total_size,
+      uint32_t chunk_size);
+
+  /**
+   * ChunkedBuffer variable-sized initializer.
+   *
+   * @param buffer_addressing The internal buffer addressing type.
+   * @param chunk_sizes The size for each individual chunk.
+   * @return Status
+   */
+  Status init_var_size(
+      BufferAddressing buffer_addressing, std::vector<uint32_t>&& chunk_sizes);
+
+  /** Resets the state. Must be reinitialized before performing IO. */
+  void clear();
+
+  /**
+   * Resets the state and frees the internal buffers. Must be
+   * reinitialized before performing IO.
+   */
+  void free();
+
+  /** Returns a shallow copy of the current instance. */
+  ChunkedBuffer shallow_copy() const;
+
+  /** Swaps the current instance with 'rhs'. */
+  void swap(ChunkedBuffer* rhs);
+
+  /**
+   * Returns the logical size. The returned size does not garauntee that
+   * all bytes within the range [0, size] are allocated. This is a logical
+   * cursor to the index immediately after the last written byte.
+   */
+  uint64_t size() const;
+
+  /**
+   * Sets the logical size. This must be less than or equal to the
+   * capacity. This does not perform any additional allocations.
+   */
+  Status set_size(uint64_t size);
+
+  /**
+   * Returns the summation of all chunk sizes. This does not consider
+   * whether an individual chunk is allocated. The returned value may
+   * be interpretted as the maximum number of bytes that may be allocated
+   * within this instance.
+   */
+  uint64_t capacity() const;
+
+  /**
+   * Returns the number of initialized chunks. This does not imply
+   * the number of allocated chunks.
+   */
+  size_t nchunks() const;
+
+  /**
+   * Returns the internal buffer addressing type.
+   */
+  BufferAddressing buffer_addressing() const;
+
+  /**
+   * Allocates the chunk at *chunk_idx* with the internal memory manager.
+   *
+   * @param chunk_idx The index of the chunk to allocate.
+   * @param buffer If non-NULL, this will be mutated to the address
+   *   to the newly allocated buffer. This is used as an optimization
+   *   to allow the caller to avoid calling *ChunkedBuffer::internal_buffer()*
+   *   to fetch this address.
+   * @return Status
+   */
+  Status alloc_discrete(size_t chunk_idx, void** buffer = nullptr);
+
+  /**
+   * Frees the chunk at *chunk_idx* with the internal memory manager.
+   *
+   * @param chunk_idx The index of the chunk to free.
+   * @return Status
+   */
+  Status free_discrete(size_t chunk_idx);
+
+  /**
+   * Sets the contigious buffer to represent all chunks. This
+   * must be pf size equal to the total size of the logical
+   * buffer that this instance represents. Assumes *buffer*
+   * was allocated with *malloc*.
+   *
+   * @param buffer The buffer to represent all chunks.
+   * @return Status
+   */
+  Status set_contigious(void* buffer);
+
+  /**
+   * Returns the address of the first chunk, which is garaunteed
+   * to be contigious in the range of [0, this->capacity()). Returns
+   * an error for instances with non-contigious buffer addressing.
+   */
+  Status get_contigious(void** buffer) const;
+
+  /**
+   * Frees the contigious buffer set with *ChunkedBuffer::set_contigious()*.
+   * This assumes the buffer was allocated with *malloc*.
+   *
+   * @return Status
+   */
+  Status free_contigious();
+
+  /**
+   * Returns a pointer to an internal chunked buffer from a logical offset.
+   * For example, if there are two chunked buffers of size 10 and the logical
+   * offset is 15, this will return the address of the second chunked buffer
+   * + 5.
+   *
+   * @param offset The logical offset into
+   * @param buffer The buffer address to mutate to the chunk buffer address.
+   * @return Status
+   */
+  Status internal_buffer_from_offset(uint64_t offset, void** buffer) const;
+
+  /**
+   * Returns the internal buffer at 'chunk_idx'. A nullptr buffer
+   * indicates that the internal buffer is unallocated.
+   *
+   * @param chunk_idx The index of the chunk buffer to fetch.
+   * @param buffer The buffer address to mutate to the chunk buffer address.
+   * @return Status
+   */
+  Status internal_buffer(size_t chunk_idx, void** buffer) const;
+
+  /**
+   * Returns the capacity of internal buffer at 'chunk_idx'.
+   *
+   * @param chunk_idx The index of the chunk buffer to fetch.
+   * @param capacity The capacity to mutate to the chunk buffer capacity.
+   * @return Status
+   */
+  Status internal_buffer_capacity(size_t chunk_idx, uint32_t* capacity) const;
+
+  /**
+   * Returns the size of the internal buffer at 'chunk_idx'.
+   *
+   * @param chunk_idx The index of the chunk buffer to fetch.
+   * @param size The size to mutate to the chunk buffer size.
+   * @return Status
+   */
+  Status internal_buffer_size(size_t chunk_idx, uint32_t* size) const;
+
+  /**
+   * Reads from the offset of the logical buffer that the chunk
+   * buffers represent. This makes a copy and will return a non-OK
+   * status if any subset of the region to read contains an unallocated
+   * chunk buffer.
+   *
+   * @param buffer The buffer to copy the output to.
+   * @param nbytes The number of bytes to read.
+   * @param offset The offset to read from.
+   * @return Status
+   */
+  Status read(void* buffer, uint64_t nbytes, uint64_t offset);
+
+  /**
+   * Writes a buffer into the the logical buffer that the
+   * chunk buffers represent. This will make as many copies
+   * as chunk buffers it writes to. For discretely addressed
+   * chunk buffers, they will be allocated as necessary. For
+   * contigiously addressed chunk buffers, this will return a
+   * non-OK status if attempting to write to an unallocated
+   * chunk buffer.
+   *
+   * @param buffer The buffer to write.
+   * @param nbytes The number of bytes to write.
+   * @param offset The offset to write from.
+   * @return Status
+   */
+  Status write(const void* buffer, uint64_t nbytes, uint64_t offset);
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The internal buffer addressing type. */
+  BufferAddressing buffer_addressing_;
+
+  /** The internal chunk buffers. */
+  std::vector<void*> buffers_;
+
+  /** The chunk size for fixed-size chunks. */
+  uint32_t chunk_size_;
+
+  /** The last chunk size for fixed-size chunks. */
+  uint32_t last_chunk_size_;
+
+  /** The chunk size for variable-sized chunks. */
+  std::vector<uint32_t> var_chunk_sizes_;
+
+  /**
+   * The summation of all chunk sizes. Recomputed when the
+   * chunk sizes change.
+   */
+  uint64_t capacity_;
+
+  /**
+   * The logical size reflecting the highest written byte.
+   */
+  uint64_t size_;
+
+  /* ********************************* */
+  /*          PRIVATE METHODS          */
+  /* ********************************* */
+
+  /** Mutates the current instance to a deep copy of *rhs*. */
+  void deep_copy(const ChunkedBuffer& rhs);
+
+  /**
+   * Ensures that the capacity is greater than or equal to
+   * 'requested_capacity'.
+   *
+   * @param chunk_idx The index of the chunk.
+   * @return uint32_t
+   */
+  Status ensure_capacity(uint64_t requested_capacity);
+
+  /**
+   * Returns the chunk capacity at the given index.
+   *
+   * @param chunk_idx The index of the chunk.
+   * @return uint32_t
+   */
+  uint32_t get_chunk_capacity(size_t chunk_idx) const;
+
+  /**
+   * Returns the chunk size at the given index.
+   *
+   * @param chunk_idx The index of the chunk.
+   * @return uint32_t
+   */
+  uint32_t get_chunk_size(size_t chunk_idx) const;
+
+  /** Returns true if chunks are of a fixed size. */
+  bool fixed_chunk_sizes() const;
+
+  /**
+   * Returns the chunk index and offset within the chunk
+   * that point to the given offset of the logical buffer
+   * that the chunks represent.
+   * Runs in O(1) for fixed size chunks and O(N) for
+   * variable-sized chunks.
+   *
+   * @param logical_offset The offset of the logical buffer.
+   * @param chunk_idx Mutated to the translated chunk index.
+   * @param chunk_offset Mutated to the translated chunk offset.
+   * @return Status
+   */
+  Status translate_logical_offset(
+      uint64_t logical_offset, size_t* chunk_idx, size_t* chunk_offset) const;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_chunked_buffer_H


### PR DESCRIPTION
This change allows for non-coordinate tiles to skip unfiltering on chunks
that do not intersect a read query. This depends on vectorizing the tile
buffer so that memory is not allocated for skipped chunks.