### PR TITLE
Changed default thread configs

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -227,9 +227,9 @@ void check_save_to_file() {
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.num_async_threads 1\n";
-  ss << "sm.num_reader_threads 1\n";
+  ss << "sm.num_reader_threads " << std::thread::hardware_concurrency() << "\n";
   ss << "sm.num_tbb_threads -1\n";
-  ss << "sm.num_writer_threads 1\n";
+  ss << "sm.num_writer_threads " << std::thread::hardware_concurrency() << "\n";
   ss << "sm.skip_checksum_validation false\n";
   ss << "sm.tile_cache_size 10000000\n";
   ss << "sm.vacuum.mode fragments\n";
@@ -428,8 +428,12 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.memory_budget_var"] = "10737418240";
   all_param_values["sm.enable_signal_handlers"] = "true";
   all_param_values["sm.num_async_threads"] = "1";
-  all_param_values["sm.num_reader_threads"] = "1";
-  all_param_values["sm.num_writer_threads"] = "1";
+  all_param_values["sm.num_reader_threads"] =
+      std::to_string(std::thread::hardware_concurrency());
+  ;
+  all_param_values["sm.num_writer_threads"] =
+      std::to_string(std::thread::hardware_concurrency());
+  ;
   all_param_values["sm.num_tbb_threads"] = "-1";
   all_param_values["sm.skip_checksum_validation"] = "false";
   all_param_values["sm.consolidation.amplification"] = "1.0";

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -60,8 +60,10 @@ const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
 const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
 const std::string Config::SM_ENABLE_SIGNAL_HANDLERS = "true";
 const std::string Config::SM_NUM_ASYNC_THREADS = "1";
-const std::string Config::SM_NUM_READER_THREADS = "1";
-const std::string Config::SM_NUM_WRITER_THREADS = "1";
+const std::string Config::SM_NUM_READER_THREADS =
+    utils::parse::to_str(std::thread::hardware_concurrency());
+const std::string Config::SM_NUM_WRITER_THREADS =
+    utils::parse::to_str(std::thread::hardware_concurrency());
 #ifdef HAVE_TBB
 const std::string Config::SM_NUM_TBB_THREADS =
     utils::parse::to_str((int)tbb::task_scheduler_init::automatic);


### PR DESCRIPTION
Changed default values for configs `sm.num_{reader,writer}_threads` to number of available cores.