### PR TITLE
Fix non-empty domain for rest arrays

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -693,6 +693,7 @@ const NDRange& Array::non_empty_domain() {
 }
 
 void Array::set_non_empty_domain(const NDRange& non_empty_domain) {
+  std::lock_guard<std::mutex> lock{mtx_};
   non_empty_domain_ = non_empty_domain;
 }
 
@@ -841,7 +842,6 @@ Status Array::load_metadata() {
 }
 
 Status Array::load_remote_non_empty_domain() {
-  std::lock_guard<std::mutex> lock{mtx_};
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
@@ -856,6 +856,7 @@ Status Array::compute_non_empty_domain() {
   if (remote_) {
     RETURN_NOT_OK(load_remote_non_empty_domain());
   } else if (!fragment_metadata_.empty()) {
+    std::lock_guard<std::mutex> lock{mtx_};
     const auto& frag0_dom = fragment_metadata_[0]->non_empty_domain();
     non_empty_domain_.assign(frag0_dom.begin(), frag0_dom.end());
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -163,9 +163,6 @@ Status RestClient::get_array_non_empty_domain(
   if (array == nullptr)
     return LOG_STATUS(
         Status::RestError("Cannot get array non-empty domain; array is null"));
-  if (array->array_schema() == nullptr)
-    return LOG_STATUS(Status::RestError(
-        "Cannot get array non-empty domain; array schema is null"));
   if (array->array_uri().to_string().empty())
     return LOG_STATUS(Status::RestError(
         "Cannot get array non-empty domain; array URI is empty"));

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -724,8 +724,9 @@ Status StorageManager::array_get_non_empty_domain(
     return LOG_STATUS(Status::StorageManagerError(
         "Cannot get non-empty domain; Array object is null"));
 
-  if (open_arrays_for_reads_.find(array->array_uri().to_string()) ==
-      open_arrays_for_reads_.end())
+  if (!array->is_remote() &&
+      open_arrays_for_reads_.find(array->array_uri().to_string()) ==
+          open_arrays_for_reads_.end())
     return LOG_STATUS(Status::StorageManagerError(
         "Cannot get non-empty domain; Array not opened for reads"));
 


### PR DESCRIPTION
This fixes an error on checking the array is open and fixes mutex deadlock and missing deadlock on computing the non-empty domain. Previously the `compute_non_empty_domain()` function was called in the constructor, which did not require the locking, since we moved it out of the constructor we should have been locking to protect multi-thread  access.

The remote array path locks the mutex only in the setter to avoid deadlocks with fetching the array URI.