### PR TITLE
Thread-safe Catch2 Macros:

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -37,6 +37,8 @@
 #include "tiledb/sm/misc/uri.h"
 #include "tiledb/sm/subarray/subarray_partitioner.h"
 
+std::mutex catch2_macro_mutex;
+
 namespace tiledb {
 namespace test {
 

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -40,9 +40,27 @@
 #include "tiledb/sm/subarray/subarray.h"
 #include "tiledb_serialization.h"
 
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <thread>
+
+// A mutex for protecting the thread-unsafe Catch2 macros.
+extern std::mutex catch2_macro_mutex;
+
+// A thread-safe variant of the CHECK macro.
+#define CHECK_SAFE(a)                                     \
+  {                                                       \
+    std::lock_guard<std::mutex> lock(catch2_macro_mutex); \
+    CHECK(a);                                             \
+  }
+
+// A thread-safe variant of the REQUIRE macro.
+#define REQUIRE_SAFE(a)                                   \
+  {                                                       \
+    std::lock_guard<std::mutex> lock(catch2_macro_mutex); \
+    REQUIRE(a);                                           \
+  }
 
 namespace tiledb {
 

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -993,27 +993,27 @@ void DenseArrayFx::write_dense_subarray_2D(
   // Open array
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
-  CHECK(rc == TILEDB_OK);
+  CHECK_SAFE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, query_type);
-  CHECK(rc == TILEDB_OK);
+  CHECK_SAFE(rc == TILEDB_OK);
 
   // Create query
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, array, query_type, &query);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(
       ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, query_layout);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
 
   // Submit query
   rc = submit_query_wrapper(array_name, query);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
   rc = tiledb_query_finalize(ctx_, query);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
 
   // Close array
   rc = tiledb_array_close(ctx_, array);

--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -625,31 +625,31 @@ void DenseArrayRESTFx::write_dense_subarray_2D(
   // Open array
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
-  CHECK(rc == TILEDB_OK);
+  CHECK_SAFE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, query_type);
-  CHECK(rc == TILEDB_OK);
+  CHECK_SAFE(rc == TILEDB_OK);
 
   // Create query
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, array, query_type, &query);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
   rc = tiledb_query_set_buffer(
       ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, query_layout);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
 
   // Submit query
   rc = tiledb_query_submit(ctx_, query);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
   rc = tiledb_query_finalize(ctx_, query);
-  REQUIRE(rc == TILEDB_OK);
+  REQUIRE_SAFE(rc == TILEDB_OK);
 
   // Close array
   rc = tiledb_array_close(ctx_, array);
-  CHECK(rc == TILEDB_OK);
+  CHECK_SAFE(rc == TILEDB_OK);
 
   // Clean up
   tiledb_array_free(&array);

--- a/test/src/unit-uuid.cc
+++ b/test/src/unit-uuid.cc
@@ -35,6 +35,7 @@
 #include <thread>
 #include <vector>
 
+#include "test/src/helpers.h"
 #include "tiledb/sm/global_state/global_state.h"
 #include "tiledb/sm/misc/uuid.h"
 
@@ -63,8 +64,8 @@ TEST_CASE("UUID: Test generate", "[uuid]") {
     for (unsigned i = 0; i < nthreads; i++) {
       threads.emplace_back([&uuids, i]() {
         std::string& uuid = uuids[i];
-        REQUIRE(uuid::generate_uuid(&uuid).ok());
-        REQUIRE(uuid.length() == 36);
+        REQUIRE_SAFE(uuid::generate_uuid(&uuid).ok());
+        REQUIRE_SAFE(uuid.length() == 36);
       });
     }
     for (auto& t : threads) {


### PR DESCRIPTION
The concurrent write units were occassionally crashing with a segfault. The
trace in the core indicated that the Catch2 REQUIRE macro was not thread safe.

I confirmed this with the public documentation here:
https://github.com/catchorg/Catch2/blob/master/docs/limitations.md#thread-safe-assertions

For this patch, I've introduced thread-safe variants of the REQUIRE and CHECK
macros: REQUIRE_SAFE and CHECK_SAFE. These macros use a global mutex to protect
the Catch2 macro that they wrap.