### PR TITLE
Deprecate tiledb_array_consolidate_metadata{_with_key}

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -34,6 +34,8 @@
 * Various reader parallelizations that boosted read performance significantly.
 
 ## Deprecations
+* The TileDB tiledb_array_consolidate_metadata and tiledb_array_consolidate_metadata_with_key C-API routines have been deprecated and will be [removed entirely](https://github.com/TileDB-Inc/TileDB/issues/1591) in a future release. The tiledb_array_consolidate and tiledb_array_consolidate_with_key routines achieve the same behavior when the "sm.consolidation.mode" parameter of the configuration argument is equivalent to "array_meta".
+* The TileDB Array::consolidate_metadata CPP-API routine has been deprecated and will be [removed entirely](https://github.com/TileDB-Inc/TileDB/issues/1591) in a future release. The Array::consolidate routine achieves the same behavior when the "sm.consolidation.mode" parameter of the configuration argument is equivalent to "array_meta".
 
 ## Bug fixes
 

--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -563,11 +563,6 @@ TEST_CASE_METHOD(
   tiledb_array_free(&array);
 
   // Consolidate
-  SECTION("tiledb_array_consolidate_metadata") {
-    rc = tiledb_array_consolidate_metadata(ctx_, array_name_.c_str(), nullptr);
-    CHECK(rc == TILEDB_OK);
-  }
-
   SECTION("tiledb_array_consolidate") {
     // Configuration for consolidating array metadata
     tiledb_config_t* config = nullptr;
@@ -656,8 +651,16 @@ TEST_CASE_METHOD(
   tiledb_array_free(&array);
 
   // Consolidate again
-  rc = tiledb_array_consolidate_metadata(ctx_, array_name_.c_str(), nullptr);
+  tiledb_config_t* config = nullptr;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(config, "sm.consolidation.mode", "array_meta", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_array_consolidate(ctx_, array_name_.c_str(), config);
   CHECK(rc == TILEDB_OK);
+  tiledb_config_free(&config);
 
   // Open the array in read mode
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
@@ -933,13 +936,29 @@ TEST_CASE_METHOD(
   tiledb_array_free(&array);
 
   // Consolidate without key - error
-  rc = tiledb_array_consolidate_metadata(ctx_, array_name_.c_str(), nullptr);
+  tiledb_config_t* config = nullptr;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(config, "sm.consolidation.mode", "array_meta", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_array_consolidate(ctx_, array_name_.c_str(), config);
   CHECK(rc == TILEDB_ERR);
+  tiledb_config_free(&config);
 
   // Consolidate with key - ok
-  rc = tiledb_array_consolidate_metadata_with_key(
-      ctx_, array_name_.c_str(), enc_type_, key_, key_len_, nullptr);
+  config = nullptr;
+  error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(config, "sm.consolidation.mode", "array_meta", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_array_consolidate_with_key(
+      ctx_, array_name_.c_str(), enc_type_, key_, key_len_, config);
   CHECK(rc == TILEDB_OK);
+  tiledb_config_free(&config);
 
   // Open the array in read mode
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
@@ -976,9 +995,17 @@ TEST_CASE_METHOD(
   tiledb_array_free(&array);
 
   // Consolidate again
-  rc = tiledb_array_consolidate_metadata_with_key(
-      ctx_, array_name_.c_str(), enc_type_, key_, key_len_, nullptr);
+  config = nullptr;
+  error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(config, "sm.consolidation.mode", "array_meta", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_array_consolidate_with_key(
+      ctx_, array_name_.c_str(), enc_type_, key_, key_len_, config);
   CHECK(rc == TILEDB_OK);
+  tiledb_config_free(&config);
 
   // Open the array in read mode
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);

--- a/test/src/unit-cppapi-metadata.cc
+++ b/test/src/unit-cppapi-metadata.cc
@@ -33,6 +33,7 @@
 #include "test/src/helpers.h"
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/config/config.h"
 #include "tiledb/sm/cpp_api/tiledb"
 
 #ifdef _WIN32
@@ -440,7 +441,9 @@ TEST_CASE_METHOD(
   array.close();
 
   // Consolidate
-  Array::consolidate_metadata(ctx, array_name_, nullptr);
+  Config consolidation_cfg;
+  consolidation_cfg["sm.consolidation.mode"] = "array_meta";
+  Array::consolidate(ctx, array_name_, &consolidation_cfg);
 
   // Open the array in read mode
   array.open(TILEDB_READ);
@@ -462,7 +465,7 @@ TEST_CASE_METHOD(
   array.close();
 
   // Consolidate again
-  Array::consolidate_metadata(ctx, array_name_, nullptr);
+  Array::consolidate(ctx, array_name_, &consolidation_cfg);
 
   // Open the array in read mode
   array.open(TILEDB_READ);
@@ -653,11 +656,13 @@ TEST_CASE_METHOD(
   array.close();
 
   // Consolidate without key - error
-  CHECK_THROWS(Array::consolidate_metadata(ctx, array_name_, nullptr));
+  Config consolidation_cfg;
+  consolidation_cfg["sm.consolidation.mode"] = "array_meta";
+  CHECK_THROWS(Array::consolidate(ctx, array_name_, &consolidation_cfg));
 
   // Consolidate with key - ok
-  Array::consolidate_metadata(
-      ctx, array_name_, enc_type_, key_, key_len_, nullptr);
+  Array::consolidate(
+      ctx, array_name_, enc_type_, key_, key_len_, &consolidation_cfg);
 
   // Open the array in read mode
   array.open(TILEDB_READ, enc_type_, key_, key_len_);
@@ -680,7 +685,7 @@ TEST_CASE_METHOD(
 
   // Consolidate again
   Array::consolidate_metadata(
-      ctx, array_name_, enc_type_, key_, key_len_, nullptr);
+      ctx, array_name_, enc_type_, key_, key_len_, &consolidation_cfg);
 
   // Open the array in read mode
   array.open(TILEDB_READ, enc_type_, key_, key_len_);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3613,8 +3613,21 @@ int32_t tiledb_array_has_metadata_key(
 
 int32_t tiledb_array_consolidate_metadata(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config) {
-  return tiledb_array_consolidate_metadata_with_key(
-      ctx, array_uri, TILEDB_NO_ENCRYPTION, nullptr, 0, config);
+  // Sanity checks
+  if (sanity_check(ctx) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          ctx->ctx_->storage_manager()->array_metadata_consolidate(
+              array_uri,
+              static_cast<tiledb::sm::EncryptionType>(TILEDB_NO_ENCRYPTION),
+              nullptr,
+              0,
+              (config == nullptr) ? nullptr : config->config_)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
 }
 
 int32_t tiledb_array_consolidate_metadata_with_key(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -4042,31 +4042,47 @@ TILEDB_EXPORT int32_t tiledb_array_create_with_key(
     uint32_t key_length);
 
 /**
- * Consolidates the fragments of an array into a single fragment.
+ * Depending on the consoliation mode in the config, consolidates either the
+ * fragment files, fragment metadata files, or array metadata files into a
+ * single file.
+ *
+ * You must first finalize all queries to the array before consolidation can
+ * begin (as consolidation temporarily acquires an exclusive lock on the array).
  *
  * **Example:**
  *
  * @code{.c}
- * tiledb_array_consolidate(ctx, "hdfs:///tiledb_arrays/my_array", nullptr);
+ * tiledb_array_consolidate(
+ *     ctx, "hdfs:///tiledb_arrays/my_array", nullptr);
  * @endcode
  *
  * @param ctx The TileDB context.
- * @param array_uri The name of the TileDB array to be consolidated.
+ * @param array_uri The name of the TileDB array whose metadata will
+ *     be consolidated.
  * @param config Configuration parameters for the consolidation
  *     (`nullptr` means default, which will use the config from `ctx`).
+ *     The `sm.consolidation.mode` parameter determines which type of
+ *     consolidation to perform.
+ *
  * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
  */
 TILEDB_EXPORT int32_t tiledb_array_consolidate(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config);
 
 /**
- * Consolidates the fragments of an encrypted array into a single fragment.
+ * Depending on the consoliation mode in the config, consolidates either the
+ * fragment files, fragment metadata files, or array metadata files into a
+ * single file.
+ *
+ * You must first finalize all queries to the array before consolidation can
+ * begin (as consolidation temporarily acquires an exclusive lock on the array).
  *
  * **Example:**
  *
  * @code{.c}
  * uint8_t key[32] = ...;
- * tiledb_array_consolidate_with_key(ctx, "hdfs:///tiledb_arrays/my_array",
+ * tiledb_array_consolidate_with_key(
+ *     ctx, "hdfs:///tiledb_arrays/my_array",
  *     TILEDB_AES_256_GCM, key, sizeof(key), nullptr);
  * @endcode
  *
@@ -4077,6 +4093,8 @@ TILEDB_EXPORT int32_t tiledb_array_consolidate(
  * @param key_length Length in bytes of the encryption key.
  * @param config Configuration parameters for the consolidation
  *     (`nullptr` means default, which will use the config from `ctx`).
+ *     The `sm.consolidation.mode` parameter determines which type of
+ *     consolidation to perform.
  *
  * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
  */
@@ -4597,7 +4615,7 @@ TILEDB_EXPORT int32_t tiledb_array_has_metadata_key(
  *     (`nullptr` means default, which will use the config from `ctx`).
  * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
  */
-TILEDB_EXPORT int32_t tiledb_array_consolidate_metadata(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_consolidate_metadata(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config);
 
 /**
@@ -4625,7 +4643,7 @@ TILEDB_EXPORT int32_t tiledb_array_consolidate_metadata(
  *
  * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
  */
-TILEDB_EXPORT int32_t tiledb_array_consolidate_metadata_with_key(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_consolidate_metadata_with_key(
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_encryption_type_t encryption_type,

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -1182,7 +1182,14 @@ class Array {
       const Context& ctx,
       const std::string& uri,
       Config* const config = nullptr) {
-    consolidate_metadata(ctx, uri, TILEDB_NO_ENCRYPTION, nullptr, 0, config);
+    Config local_cfg;
+    Config* config_aux = config;
+    if (!config_aux) {
+      config_aux = &local_cfg;
+    }
+
+    (*config)["sm.consolidation.mode"] = "array_meta";
+    consolidate(ctx, uri, TILEDB_NO_ENCRYPTION, nullptr, 0, config_aux);
   }
 
   /**
@@ -1219,13 +1226,15 @@ class Array {
       const void* encryption_key,
       uint32_t key_length,
       Config* const config = nullptr) {
-    ctx.handle_error(tiledb_array_consolidate_metadata_with_key(
-        ctx.ptr().get(),
-        uri.c_str(),
-        encryption_type,
-        encryption_key,
-        key_length,
-        config ? config->ptr().get() : nullptr));
+    Config local_cfg;
+    Config* config_aux = config;
+    if (!config_aux) {
+      config_aux = &local_cfg;
+    }
+
+    (*config)["sm.consolidation.mode"] = "array_meta";
+    consolidate(
+        ctx, uri, encryption_type, encryption_key, key_length, config_aux);
   }
 
   // clang-format off
@@ -1253,13 +1262,20 @@ class Array {
       tiledb_encryption_type_t encryption_type,
       const std::string& encryption_key,
       Config* const config = nullptr) {
-    return consolidate_metadata(
+    Config local_cfg;
+    Config* config_aux = config;
+    if (!config_aux) {
+      config_aux = &local_cfg;
+    }
+
+    (*config)["sm.consolidation.mode"] = "array_meta";
+    consolidate(
         ctx,
         uri,
         encryption_type,
         encryption_key.data(),
         (uint32_t)encryption_key.size(),
-        config);
+        config_aux);
   }
 
   /**


### PR DESCRIPTION
This deprecates the following APIs:
tiledb_array_consolidate_metadata
tiledb_array_consolidate_metadata_with_key
Array::consolidate_metadata

References to these routines have been removed from both the source and unit
tests.