### PR TITLE
Fix bootstrap.ps1 presence check for [string] params

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -173,13 +173,13 @@ if ($EnableBuildDeps.IsPresent) {
 
 # Set TileDB prefix
 $InstallPrefix = $DefaultPrefix
-if ($Prefix.IsPresent) {
+if (![string]::IsNullOrEmpty($Prefix)) {
     $InstallPrefix = $Prefix
 }
 
 # Set TileDB dependency directory string
 $DependencyDir = $DefaultDependency
-if ($Dependency.IsPresent) {
+if (![string]::IsNullOrEmpty($Dependency)) {
     $DependencyDir = $Dependency
 }
 


### PR DESCRIPTION
IsPresent does not work for [string] parameters, so these options
were effectively a no-op.