### PR TITLE
Add support for environmental variables for config

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,7 @@
 * Added special files with the same name as a fragment directory and an added suffix ".ok", to indicate a committed fragment. This improved the performance of opening an array on object stores significantly, as it avoids an extra REST request per fragment.
 * Added functionality to consolidation, which allows consolidating the fragment metadata footers in a single file by toggling a new config parameter. This leads to a huge performance boost when opening an array, as it avoids fetching a separate footer per fragment from storage.
 * Various reader parallelizations that boosted read performance significantly.
+* Configuration parameters can now be read from environmental variables. `vfs.s3.session_token` -> `TILEDB_VFS_S3_SESSION_TOKEN`. The prefix of `TILEDB_` is configurable via `config.env_var_prefix`. [#1600](https://github.com/TileDB-Inc/TileDB/pull/1600)
 
 ## Deprecations
 * The TileDB tiledb_array_consolidate_metadata and tiledb_array_consolidate_metadata_with_key C-API routines have been deprecated and will be [removed entirely](https://github.com/TileDB-Inc/TileDB/issues/1591) in a future release. The tiledb_array_consolidate and tiledb_array_consolidate_with_key routines achieve the same behavior when the "sm.consolidation.mode" parameter of the configuration argument is equivalent to "array_meta".

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -209,6 +209,7 @@ void check_save_to_file() {
   REQUIRE(rc == TILEDB_OK);
 
   std::stringstream ss;
+  ss << "config.env_var_prefix TILEDB_\n";
   ss << "rest.http_compressor any\n";
   ss << "rest.server_address https://api.tiledb.com\n";
   ss << "rest.server_serialization_format CAPNP\n";
@@ -416,6 +417,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
 
   // Prepare maps
   std::map<std::string, std::string> all_param_values;
+  all_param_values["config.env_var_prefix"] = "TILEDB_";
   all_param_values["rest.server_address"] = "https://api.tiledb.com";
   all_param_values["rest.server_serialization_format"] = "CAPNP";
   all_param_values["rest.http_compressor"] = "any";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -30,8 +30,18 @@
  * Util Tests for C++ API.
  */
 
+#include <thread>
+
 #include "catch.hpp"
 #include "tiledb/sm/cpp_api/tiledb"
+
+int setenv_local(const char* __name, const char* __value) {
+#ifdef _WIN32
+  return _putenv_s(__name, __value);
+#else
+  return ::setenv(__name, __value, 1);
+#endif
+}
 
 TEST_CASE("C++ API: Config", "[cppapi], [cppapi-config]") {
   tiledb::Config config;
@@ -51,4 +61,47 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
   }
   // Check number of VFS params in default config object.
   CHECK(names.size() == 43);
+}
+
+TEST_CASE(
+    "C++ API: Config Environment Variables", "[cppapi], [cppapi-config]") {
+  tiledb::Config config;
+  auto readInvalidKey = [&config]() { std::string result1 = config["foo"]; };
+  REQUIRE_THROWS_AS(readInvalidKey(), tiledb::TileDBError);
+
+  setenv_local("TILEDB_FOO", "bar");
+  std::string result1 = config["foo"];
+  CHECK(result1 == "bar");
+
+  setenv_local("TILEDB_FOO", "bar2");
+  std::string result2 = config["foo"];
+  CHECK(result2 == "bar2");
+
+  config["config.env_var_prefix"] = "TILEDB_TEST_";
+  auto readInvalidKey2 = [&config]() { std::string result2 = config["foo"]; };
+  REQUIRE_THROWS_AS(readInvalidKey2(), tiledb::TileDBError);
+
+  setenv_local("TILEDB_TEST_FOO", "bar3");
+  std::string result3 = config["foo"];
+  CHECK(result3 == "bar3");
+}
+
+TEST_CASE(
+    "C++ API: Config Environment Variables Default Override",
+    "[cppapi], [cppapi-config]") {
+  tiledb::Config config;
+
+  unsigned int threads = std::thread::hardware_concurrency();
+  std::string result1 = config["vfs.num_threads"];
+  CHECK(result1 == std::to_string(threads));
+
+  std::string value2 = std::to_string(threads + 1);
+  setenv_local("TILEDB_VFS_NUM_THREADS", value2.c_str());
+  std::string result2 = config["vfs.num_threads"];
+  CHECK(result2 == value2);
+
+  std::string value3 = std::to_string(threads + 2);
+  config["vfs.num_threads"] = value3;
+  std::string result3 = config["vfs.num_threads"];
+  CHECK(result3 == value3);
 }

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -66,6 +66,9 @@ class Config {
   /** The default compressor for http requests with the rest server. */
   static const std::string REST_SERVER_DEFAULT_HTTP_COMPRESSOR;
 
+  /** The prefix to use for checking for parameter environmental variables. */
+  static const std::string CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
+
   /** If `true`, this will deduplicate coordinates upon sparse writes. */
   static const std::string SM_DEDUP_COORDS;
 
@@ -386,6 +389,45 @@ class Config {
    * `param` is not a system configuration parameter, the function is a noop.
    */
   Status sanity_check(const std::string& param, const std::string& value) const;
+
+  /**
+   * Convert a parameter in the form of "a.b.c" to expected env string of
+   * "A_B_C"
+   * @param param
+   * @return converted string
+   */
+  std::string convert_to_env_param(const std::string& param) const;
+
+  /**
+   * Get an environmental variable
+   * @param param to fetch
+   * @param found pointer to bool to set if env parameter was found or not
+   * @return parameter value if found or nullptr if not found
+   */
+  const char* get_from_env(const std::string& param, bool* found) const;
+
+  /**
+   * Get an parameter from config variable
+   * @param param to fetch
+   * @param found pointer to bool to set if parameter was found or not
+   * @return parameter value if found or nullptr if not found
+   */
+  const char* get_from_config(const std::string& param, bool* found) const;
+
+  /**
+   * Get a configuration parameter from config object or environmental variables
+   *
+   * The order we look for values are
+   * 1. user set config parameters
+   * 2. env variables
+   * 3. default config value
+   *
+   * @param param parameter to fetch
+   * @param found pointer to bool to set if parameter was found or not
+   * @return parameter value if found or empty string if not
+   */
+  const char* get_from_config_or_env(
+      const std::string& param, bool* found) const;
 };
 
 }  // namespace sm


### PR DESCRIPTION
Environmental variables are now supported for setting config options.

The prefix of `TILEDB_` is used by default but is configurable with `config.env_var_prefix`. Config parameters are converted from `a.b.c` syntax to `A_B_C`. So for a parameter of `vfs.num_threads` the environmental variable of `TILEDB_VFS_NUM_THREADS` is looked for.

The order we look for values are:
  1. user set config parameters
  2. env variables
  3. default config value