### PR TITLE
Benchmarks for Selective Unfiltering

### DIFF
--- a/test/benchmarking/src/CMakeLists.txt
+++ b/test/benchmarking/src/CMakeLists.txt
@@ -63,6 +63,8 @@ set(BENCHMARKS
   bench_dense_tile_cache
   bench_dense_write_large_tile
   bench_dense_write_small_tile
+  bench_large_io
+  bench_selective_unfiltering
   bench_sparse_read_large_tile
   bench_sparse_read_small_tile
   bench_sparse_tile_cache

--- a/test/benchmarking/src/bench_large_io.cc
+++ b/test/benchmarking/src/bench_large_io.cc
@@ -1,0 +1,195 @@
+/**
+ * @file   bench_large_io.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Benchmark IO on dense/sparse arrays with fixed/var-sized attributes.
+ */
+
+#include <tiledb/tiledb>
+
+#include "benchmark.h"
+
+using namespace tiledb;
+
+class Benchmark : public BenchmarkBase {
+ protected:
+  virtual void setup() {
+    FilterList filters(ctx_);
+    filters.add_filter({ctx_, TILEDB_FILTER_BYTESHUFFLE})
+        .add_filter({ctx_, TILEDB_FILTER_BZIP2});
+
+    // Setup the dense array.
+    ArraySchema d_schema(ctx_, TILEDB_DENSE);
+    Domain d_domain(ctx_);
+    d_domain.add_dimension(Dimension::create<uint32_t>(
+        ctx_, "d1", {{1, dense_array_rows}}, tile_rows));
+    d_domain.add_dimension(Dimension::create<uint32_t>(
+        ctx_, "d2", {{1, dense_array_cols}}, tile_cols));
+    d_schema.set_domain(d_domain);
+    d_schema.add_attribute(Attribute::create<int32_t>(ctx_, "a", filters));
+    d_schema.add_attribute(Attribute::create<int32_t>(ctx_, "b"));
+    d_schema.add_attribute(
+        Attribute::create<std::vector<int>>(ctx_, "c", filters));
+    Array::create(dense_array_uri_, d_schema);
+
+    data_a_.resize(dense_array_rows * dense_array_cols);
+    data_b_.resize(data_a_.size());
+    off_c_.resize(data_a_.size());
+    data_c_.resize(data_a_.size() * 2);
+    for (uint64_t i = 0; i < data_a_.size(); i++) {
+      data_a_[i] = 1 * i;
+      data_b_[i] = 2 * i;
+      off_c_[i] = (2 * i) * sizeof(int);
+      data_c_[2 * i] = i;
+      data_c_[(2 * i) + 1] = i;
+    }
+
+    // Setup the sparse array.
+    ArraySchema s_schema(ctx_, TILEDB_SPARSE);
+    Domain s_domain(ctx_);
+    s_domain.add_dimension(Dimension::create<uint32_t>(
+        ctx_,
+        "d1",
+        {{1, std::numeric_limits<uint32_t>::max() - tile_rows}},
+        tile_rows));
+    s_domain.add_dimension(Dimension::create<uint32_t>(
+        ctx_,
+        "d2",
+        {{1, std::numeric_limits<uint32_t>::max() - tile_cols}},
+        tile_cols));
+    s_schema.set_domain(s_domain);
+    s_schema.add_attribute(Attribute::create<int32_t>(ctx_, "a", filters));
+    s_schema.add_attribute(Attribute::create<int32_t>(ctx_, "b"));
+    s_schema.add_attribute(
+        Attribute::create<std::vector<int>>(ctx_, "c", filters));
+    Array::create(sparse_array_uri_, s_schema);
+
+    // RNG coords are expensive to generate. Just make the data "sparse"
+    // by skipping a few cells between each nonempty cell.
+    const unsigned skip = 2;
+    for (uint32_t i = 1; i < sparse_max_row; i += skip) {
+      for (uint32_t j = 1; j < sparse_max_col; j += skip) {
+        sparse_coords_.push_back(i);
+        sparse_coords_.push_back(j);
+      }
+    }
+  }
+
+  virtual void teardown() {
+    VFS vfs(ctx_);
+    if (vfs.is_dir(dense_array_uri_))
+      vfs.remove_dir(dense_array_uri_);
+    if (vfs.is_dir(sparse_array_uri_))
+      vfs.remove_dir(sparse_array_uri_);
+  }
+
+  virtual void pre_run() {
+  }
+
+  virtual void run() {
+    // Write the dense array 1 time.
+    Array d_write_array(ctx_, dense_array_uri_, TILEDB_WRITE);
+    Query d_write_query(ctx_, d_write_array, TILEDB_WRITE);
+    d_write_query.set_subarray({1u, dense_array_rows, 1u, dense_array_cols})
+        .set_layout(TILEDB_ROW_MAJOR)
+        .set_buffer("a", data_a_)
+        .set_buffer("b", data_b_)
+        .set_buffer("c", off_c_, data_c_);
+    d_write_query.submit();
+    d_write_array.close();
+
+    // Write the sparse array 1 time.
+    Array s_write_array(ctx_, sparse_array_uri_, TILEDB_WRITE);
+    Query s_write_query(ctx_, s_write_array);
+    s_write_query.set_layout(TILEDB_UNORDERED)
+        .set_buffer("a", data_a_)
+        .set_buffer("b", data_b_)
+        .set_buffer("c", off_c_, data_c_)
+        .set_coordinates(sparse_coords_);
+    s_write_query.submit();
+    s_write_array.close();
+
+    // Read the entire dense array 2 times.
+    for (int i = 0; i < 2; ++i) {
+      Array array(ctx_, dense_array_uri_, TILEDB_READ);
+      Query query(ctx_, array);
+      query.set_subarray({1u, dense_array_rows, 1u, dense_array_cols})
+          .set_layout(TILEDB_ROW_MAJOR)
+          .set_buffer("a", data_a_)
+          .set_buffer("b", data_b_)
+          .set_buffer("c", off_c_, data_c_);
+      query.submit();
+      array.close();
+    }
+
+    // Read the entire sparse array 2 times.
+    for (int i = 0; i < 2; ++i) {
+      Array array(ctx_, sparse_array_uri_, TILEDB_READ);
+      auto non_empty = array.non_empty_domain<uint32_t>();
+      std::vector<uint32_t> subarray = {non_empty[0].second.first,
+                                        non_empty[0].second.second,
+                                        non_empty[1].second.first,
+                                        non_empty[1].second.second};
+
+      auto max_elements = array.max_buffer_elements(subarray);
+      data_a_.resize(max_elements["a"].second);
+      sparse_coords_.resize(max_elements[TILEDB_COORDS].second);
+
+      Query query(ctx_, array);
+      query.set_subarray(subarray)
+          .set_layout(TILEDB_ROW_MAJOR)
+          .set_buffer("a", data_a_)
+          .set_buffer("b", data_b_)
+          .set_buffer("c", off_c_, data_c_)
+          .set_coordinates(sparse_coords_);
+      query.submit();
+      array.close();
+    }
+  }
+
+ private:
+  const std::string dense_array_uri_ = "dense_bench_array";
+  const std::string sparse_array_uri_ = "sparse_bench_array";
+  const unsigned dense_array_rows = 6000, dense_array_cols = 6000;
+  const unsigned sparse_max_row = 12000, sparse_max_col = 12000;
+  const unsigned tile_rows = 2000, tile_cols = 2000;
+
+  Context ctx_;
+
+  std::vector<int> data_a_;
+  std::vector<int> data_b_;
+  std::vector<uint64_t> off_c_;
+  std::vector<int> data_c_;
+
+  std::vector<uint32_t> sparse_coords_;
+};
+
+int main(int argc, char** argv) {
+  Benchmark bench;
+  return bench.main(argc, argv);
+}

--- a/test/benchmarking/src/bench_selective_unfiltering.cc
+++ b/test/benchmarking/src/bench_selective_unfiltering.cc
@@ -1,0 +1,158 @@
+/**
+ * @file   bench_selective_unfiltering.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Benchmark selective unfiltering on a dense array.
+ */
+
+#include <tiledb/tiledb>
+
+#include "benchmark.h"
+
+using namespace tiledb;
+
+class Benchmark : public BenchmarkBase {
+ public:
+  Benchmark()
+      : BenchmarkBase() {
+    // Set the max tile cache size to 0B -- this reduces memory
+    // so that we can properly benchmark memory saved by
+    // selective unfiltering.
+    Config config;
+    config["sm.tile_cache_size"] = "0";
+    ctx_ = std::unique_ptr<Context>(new Context(config));
+  }
+
+ protected:
+  virtual void setup() {
+    FilterList filters(*ctx_);
+    filters.add_filter({*ctx_, TILEDB_FILTER_BYTESHUFFLE})
+        .add_filter({*ctx_, TILEDB_FILTER_BZIP2});
+
+    // Setup the dense array.
+    ArraySchema d_schema(*ctx_, TILEDB_DENSE);
+    Domain d_domain(*ctx_);
+    d_domain.add_dimension(Dimension::create<uint32_t>(
+        *ctx_, "d1", {{1, dense_array_rows}}, tile_rows));
+    d_domain.add_dimension(Dimension::create<uint32_t>(
+        *ctx_, "d2", {{1, dense_array_cols}}, tile_cols));
+    d_schema.set_domain(d_domain);
+    d_schema.add_attribute(Attribute::create<int32_t>(*ctx_, "a", filters));
+    d_schema.add_attribute(Attribute::create<int32_t>(*ctx_, "b"));
+    d_schema.add_attribute(
+        Attribute::create<std::vector<int>>(*ctx_, "c", filters));
+    Array::create(dense_array_uri_, d_schema);
+  }
+
+  virtual void teardown() {
+    VFS vfs(*ctx_);
+    if (vfs.is_dir(dense_array_uri_))
+      vfs.remove_dir(dense_array_uri_);
+  }
+
+  virtual void pre_run() {
+    std::vector<int> data_a;
+    std::vector<int> data_b;
+    std::vector<uint64_t> off_c;
+    std::vector<int> data_c;
+
+    data_a.resize(dense_array_rows * dense_array_cols);
+    data_b.resize(data_a.size());
+    off_c.resize(data_a.size());
+    data_c.resize(data_a.size() * 2);
+    for (uint64_t i = 0; i < data_a.size(); i++) {
+      data_a[i] = 1;
+      data_b[i] = 1;
+      off_c[i] = (2 * i) * sizeof(int);
+      data_c[2 * i] = 1;
+      data_c[(2 * i) + 1] = 1;
+    }
+
+    // Write the dense array 1 time.
+    Array d_write_array(*ctx_, dense_array_uri_, TILEDB_WRITE);
+    Query d_write_query(*ctx_, d_write_array, TILEDB_WRITE);
+    d_write_query.set_subarray({1u, dense_array_rows, 1u, dense_array_cols})
+        .set_layout(TILEDB_ROW_MAJOR)
+        .set_buffer("a", data_a)
+        .set_buffer("b", data_b)
+        .set_buffer("c", off_c, data_c);
+    d_write_query.submit();
+    d_write_array.close();
+  }
+
+  virtual void run() {
+    std::vector<int> data_a;
+    std::vector<int> data_b;
+    std::vector<uint64_t> off_c;
+    std::vector<int> data_c;
+
+    const unsigned query_rows = dense_array_rows / tile_rows;
+    const unsigned query_cols = dense_array_cols / tile_cols;
+    const unsigned subarray_size = 5;
+
+    data_a.resize(query_rows * query_cols * subarray_size * subarray_size);
+    data_b.resize(query_rows * query_cols * subarray_size * subarray_size);
+    off_c.resize(query_rows * query_cols * subarray_size * subarray_size);
+    data_c.resize(query_rows * query_cols * subarray_size * subarray_size * 2);
+
+    // Read the array 20 times.
+    for (int i = 0; i < 20; ++i) {
+      Array array(*ctx_, dense_array_uri_, TILEDB_READ);
+      Query query(*ctx_, array);
+
+      for (int j = 0; j < query_rows; ++j) {
+        query.add_range(
+            0, (j * tile_rows) + 1, (j * tile_rows) + subarray_size);
+      }
+
+      for (int j = 0; j < query_cols; ++j) {
+        query.add_range(
+            1, (j * tile_cols) + 1, (j * tile_cols) + subarray_size);
+      }
+
+      query.set_layout(TILEDB_ROW_MAJOR)
+          .set_buffer("a", data_a)
+          .set_buffer("b", data_b)
+          .set_buffer("c", off_c, data_c);
+      query.submit();
+      array.close();
+    }
+  }
+
+ private:
+  const std::string dense_array_uri_ = "dense_bench_array";
+  const unsigned dense_array_rows = 6000, dense_array_cols = 6000;
+  const unsigned tile_rows = 2000, tile_cols = 2000;
+
+  std::unique_ptr<Context> ctx_;
+};
+
+int main(int argc, char** argv) {
+  Benchmark bench;
+  return bench.main(argc, argv);
+}

--- a/test/benchmarking/src/benchmark.h
+++ b/test/benchmarking/src/benchmark.h
@@ -83,7 +83,8 @@ class BenchmarkBase {
   void print_task(
       const std::string& name,
       const uint64_t* ms,
-      const std::vector<uint64_t>* mem_samples_mb);
+      const std::vector<uint64_t>* mem_samples_mb,
+      uint64_t baseline_mem_mb);
 
   /**
    * Samples the current processes's used virtual memory every 50ms


### PR DESCRIPTION
This introduces two benchmarks that I've used while verifying selective
unfiltering.

1. bench_large_io.cc
This benchmark reads/writes to dense/sparse arrays with a large tile extent
size. Both arrays have fixed and var-sized data.

With selective unfiltering, this runs in ~83.5 seconds. Without selective
unfiltering, this runs in ~81 seconds. I interpret this as a ~3% slowdown due
to overhead in 1) vectorizing the value tiles and 2) performing the intersection
logic to determine if a tile should be selectively unfiltered.

2. bench_selective_unfiltering.cc
This benchmark creates a dense array with fixed and var-sized data. The benchmark
section only records runtime and memory statistics for 20 serial reads, where
each reach is a multi-range query designed to intersect each tile in the array
but only one chunk. Each tile has roughly 40 chunks. Tile cache disabled.

This benchmark was sufficient to determine that both peak and average
memory is reduced with selective unfiltered. Here are the results:

// Selective unfiltering
“runtime_ms”: “6784"
“peak_mem_mb”: “206"
“avg_mem_mb”: “177"

// Without selective unfiltering (aka dev branch)
“runtime_ms”: “14901"
“peak_mem_mb”: “367"
“avg_mem_mb”: “265"

The above are single samples and not an average. The runtimes seem to vary
+/-20%, but the memory usage remains nearly identical between runs.