### PR TITLE
Add missing query var range getters

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -52,6 +52,8 @@
 * Added C API functions `tiledb_array_get_non_empty_domain_var_size_from_{index,name}`
 * Added C API functions `tiledb_array_get_non_empty_domain_var_from_{index,name}`
 * Added C API function `tiledb_array_add_range_var`
+* Added C API function `tiledb_array_get_range_var_size`
+* Added C API function `tiledb_array_get_range_var`
 * Added C++ API functions `Dimension::set_cell_val_num` and `Dimension::cell_val_num`.
 * Added C++ API functions `Dimension::set_filter_list` and `Dimension::filter_list`.
 * Added C++ API functions `Array::non_empty_domain(unsigned idx)` and `Array::non_empty_domain(const std::string& name)`.
@@ -60,6 +62,7 @@
 * Added C++ API function `Array::vacuum`.
 * Added C++ API functions `Array::non_empty_domain_var` (from index and name).
 * Added C++ API function `add_range` with string inputs.
+* Added C++ API function `range` with string outputs.
 
 ## API removals
 

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -813,6 +813,35 @@ void StringDimsFx::read_array_1d(
       ctx, query, 0, start.data(), start.size(), end.data(), end.size());
   CHECK(rc == TILEDB_OK);
 
+  // Check range num
+  uint64_t range_num;
+  rc = tiledb_query_get_range_num(ctx_, query, 0, &range_num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(range_num == 1);
+
+  // Check getting range from an invalid range index
+  uint64_t start_size = 0, end_size = 0;
+  rc = tiledb_query_get_range_var_size(
+      ctx_, query, 0, 2, &start_size, &end_size);
+  CHECK(rc == TILEDB_ERR);
+  std::vector<char> start_data(start_size);
+  std::vector<char> end_data(end_size);
+  rc = tiledb_query_get_range_var(
+      ctx_, query, 0, 2, start_data.data(), end_data.data());
+  CHECK(rc == TILEDB_ERR);
+
+  // Check ranges
+  rc = tiledb_query_get_range_var_size(
+      ctx_, query, 0, 0, &start_size, &end_size);
+  CHECK(rc == TILEDB_OK);
+  start_data.resize(start_size);
+  end_data.resize(end_size);
+  rc = tiledb_query_get_range_var(
+      ctx_, query, 0, 0, start_data.data(), end_data.data());
+  CHECK(rc == TILEDB_OK);
+  CHECK(std::string(start_data.data(), start_data.size()) == start);
+  CHECK(std::string(end_data.data(), end_data.size()) == end);
+
   // Set query buffers
   uint64_t d_off_size = d_off->size() * sizeof(uint64_t);
   uint64_t d_val_size = d_val->size();
@@ -878,6 +907,47 @@ void StringDimsFx::read_array_2d(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_add_range(ctx, query, 1, &d2_start, &d2_end, nullptr);
   CHECK(rc == TILEDB_OK);
+
+  // Check range num d1
+  uint64_t range_num;
+  rc = tiledb_query_get_range_num(ctx_, query, 0, &range_num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(range_num == 1);
+  // Check range num d2
+  rc = tiledb_query_get_range_num(ctx_, query, 1, &range_num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(range_num == 1);
+
+  // Check getting range from an invalid range index
+  uint64_t d1_start_size = 0, d1_end_size = 0;
+  rc = tiledb_query_get_range_var_size(
+      ctx_, query, 0, 2, &d1_start_size, &d1_end_size);
+  CHECK(rc == TILEDB_ERR);
+  std::vector<char> d1_start_data(d1_start_size);
+  std::vector<char> d1_end_data(d1_end_size);
+  rc = tiledb_query_get_range_var(
+      ctx_, query, 0, 2, d1_start_data.data(), d1_end_data.data());
+  CHECK(rc == TILEDB_ERR);
+
+  // Check ranges
+  rc = tiledb_query_get_range_var_size(
+      ctx_, query, 0, 0, &d1_start_size, &d1_end_size);
+  CHECK(rc == TILEDB_OK);
+  d1_start_data.resize(d1_start_size);
+  d1_end_data.resize(d1_end_size);
+  rc = tiledb_query_get_range_var(
+      ctx_, query, 0, 0, d1_start_data.data(), d1_end_data.data());
+  CHECK(rc == TILEDB_OK);
+  CHECK(std::string(d1_start_data.data(), d1_start_data.size()) == d1_start);
+  CHECK(std::string(d1_end_data.data(), d1_end_data.size()) == d1_end);
+
+  const void *d2_start_data, *d2_end_data, *stride;
+  rc = tiledb_query_get_range(
+      ctx_, query, 1, 0, &d2_start_data, &d2_end_data, &stride);
+  CHECK(rc == TILEDB_OK);
+  CHECK(*(int32_t*)d2_start_data == d2_start);
+  CHECK(*(int32_t*)d2_end_data == d2_end);
+  CHECK(stride == nullptr);
 
   // Set query buffers
   uint64_t d1_off_size = d1_off->size() * sizeof(uint64_t);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1170,6 +1170,13 @@ TEST_CASE(
   CHECK_THROWS(query_r.add_range(1, s1, s2));
   CHECK_THROWS(query_r.add_range(0, "", s2));
   CHECK_THROWS(query_r.add_range(0, s1, ""));
+
+  // Check range
+  CHECK_THROWS(query_r.range(1, 1));
+  std::array<std::string, 2> range = query_r.range(0, 0);
+  CHECK(range[0] == s1);
+  CHECK(range[1] == s2);
+
   std::string data;
   data.resize(10);
   std::vector<uint64_t> offsets(4);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2827,6 +2827,42 @@ int32_t tiledb_query_get_range(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_get_range_var_size(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    uint32_t dim_idx,
+    uint64_t range_idx,
+    uint64_t* start_size,
+    uint64_t* end_size) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          query->query_->get_range_var_size(
+              dim_idx, range_idx, start_size, end_size)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_get_range_var(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    uint32_t dim_idx,
+    uint64_t range_idx,
+    void* start,
+    void* end) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx, query->query_->get_range_var(dim_idx, range_idx, start, end)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_get_est_result_size(
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3534,6 +3534,64 @@ TILEDB_EXPORT int32_t tiledb_query_get_range(
     const void** stride);
 
 /**
+ * Retrieves a range's start and end size for a given variable-length
+ * dimensions at a given range index.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint64_t start_size;
+ * uint64_t end_size;
+ * tiledb_query_get_range_var_size(
+ *     ctx, query, dim_idx, range_idx, &start_size, &end_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param query The query.
+ * @param dim_idx The index of the dimension to retrieve the range from.
+ * @param range_idx The index of the range to retrieve.
+ * @param start_size range start size in bytes
+ * @param end_size range end size in bytes
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_range_var_size(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    uint32_t dim_idx,
+    uint64_t range_idx,
+    uint64_t* start_size,
+    uint64_t* end_size);
+
+/**
+ * Retrieves a specific range of the query subarray along a given
+ * variable-length dimension.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * const void* start;
+ * const void* end;
+ * tiledb_query_get_range(
+ *     ctx, query, dim_idx, range_idx, &start, &end);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param query The query.
+ * @param dim_idx The index of the dimension to retrieve the range from.
+ * @param range_idx The index of the range to retrieve.
+ * @param start The range start to retrieve.
+ * @param end The range end to retrieve.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_range_var(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    uint32_t dim_idx,
+    uint64_t range_idx,
+    void* start,
+    void* end);
+
+/**
  * Retrieves the estimated result size for a fixed-sized attribute/dimension.
  *
  * **Example:**

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -154,6 +154,34 @@ class Query {
       const void** stride) const;
 
   /**
+   * Retrieves a range's sizes for a variable-length dimension
+   *
+   * @param dim_idx The dimension to retrieve the range from.
+   * @param range_idx The id of the range to retrieve.
+   * @param start_size range start size in bytes
+   * @param end_size range end size in bytes
+   * @return Status
+   */
+  Status get_range_var_size(
+      unsigned dim_idx,
+      uint64_t range_idx,
+      uint64_t* start_size,
+      uint64_t* end_size) const;
+
+  /**
+   * Retrieves a range from a variable-length dimension in the form (start,
+   * end).
+   *
+   * @param dim_idx The dimension to retrieve the range from.
+   * @param range_idx The id of the range to retrieve.
+   * @param start The range start to retrieve.
+   * @param end The range end to retrieve.
+   * @return Status
+   */
+  Status get_range_var(
+      unsigned dim_idx, uint64_t range_idx, void* start, void* end) const;
+
+  /**
    * Gets the estimated result size (in bytes) for the input fixed-sized
    * attribute/dimension.
    */

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -128,6 +128,14 @@ Status Reader::get_range(
   return subarray_.get_range(dim_idx, range_idx, start, end);
 }
 
+Status Reader::get_range_var_size(
+    unsigned dim_idx,
+    uint64_t range_idx,
+    uint64_t* start_size,
+    uint64_t* end_size) const {
+  return subarray_.get_range_var_size(dim_idx, range_idx, start_size, end_size);
+}
+
 Status Reader::get_est_result_size(const char* name, uint64_t* size) {
   return subarray_.get_est_result_size(name, size);
 }

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -148,6 +148,21 @@ class Reader {
       const void** stride) const;
 
   /**
+   * Retrieves a range's sizes for a variable-length dimension
+   *
+   * @param dim_idx The dimension to retrieve the range from.
+   * @param range_idx The id of the range to retrieve.
+   * @param start_size range start size in bytes
+   * @param end_size range end size in bytes
+   * @return Status
+   */
+  Status get_range_var_size(
+      unsigned dim_idx,
+      uint64_t range_idx,
+      uint64_t* start_size,
+      uint64_t* end_size) const;
+
+  /**
    * Gets the estimated result size (in bytes) for the input fixed-sized
    * attribute/dimension.
    */

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -344,6 +344,34 @@ Status Subarray::get_range(
   return Status::Ok();
 }
 
+Status Subarray::get_range_var_size(
+    uint32_t dim_idx,
+    uint64_t range_idx,
+    uint64_t* start,
+    uint64_t* end) const {
+  auto schema = array_->array_schema();
+  auto dim_num = schema->dim_num();
+  if (dim_idx >= dim_num)
+    return LOG_STATUS(Status::SubarrayError(
+        "Cannot get var range size; Invalid dimension index"));
+
+  auto dim = schema->domain()->dimension(dim_idx);
+  if (!dim->var_size())
+    return LOG_STATUS(Status::SubarrayError(
+        "Cannot get var range size; Dimension " + dim->name() +
+        " is not var sized"));
+
+  auto range_num = ranges_[dim_idx].size();
+  if (range_idx >= range_num)
+    return LOG_STATUS(Status::SubarrayError(
+        "Cannot get var range size; Invalid range index"));
+
+  *start = ranges_[dim_idx][range_idx].start_size();
+  *end = ranges_[dim_idx][range_idx].end_size();
+
+  return Status::Ok();
+}
+
 Status Subarray::get_range_num(uint32_t dim_idx, uint64_t* range_num) const {
   auto dim_num = array_->array_schema()->dim_num();
   if (dim_idx >= dim_num)

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -305,6 +305,23 @@ class Subarray {
       const void** start,
       const void** end) const;
 
+  /**
+   * Retrieves a range's start and end size for a given variable-length
+   * dimensions at a given range index.
+   *
+   *
+   * @param dim_idx The dimension to retrieve the range from.
+   * @param range_idx The id of the range to retrieve.
+   * @param start_size range start size in bytes
+   * @param end_size range end size in bytes
+   * @return Status
+   */
+  Status get_range_var_size(
+      uint32_t dim_idx,
+      uint64_t range_idx,
+      uint64_t* start_size,
+      uint64_t* end_size) const;
+
   /** Retrieves the number of ranges on the given dimension index. */
   Status get_range_num(uint32_t dim_idx, uint64_t* range_num) const;
 


### PR DESCRIPTION
Add missing query var range getters. 

Two new c-api functions are added:
`tiledb_query_get_range_var_size`
`tiledb_query_get_range_var`

One new cpp-api function is added:
`std::array<std::string, 2> Query::Range`