### PR TITLE
Support split buffs w/zipped coords in Tile Reader

### DIFF
--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -72,6 +72,27 @@ void set_query_coords(
   std::free(subarray);
 }
 
+template <typename T>
+void set_query_dimension_buffer(
+    const Domain& domain,
+    const uint64_t dim_idx,
+    Query* query,
+    void** buffer,
+    void** expected_buffer) {
+  Dimension dimension = domain.dimension(dim_idx);
+  // Make the buffer size a bit larger because the estimator
+  // works on the zipped coords size
+  const uint64_t buffer_size =
+      tiledb_datatype_size(dimension.type()) * domain.ndim();
+  *buffer = std::malloc(buffer_size);
+  *expected_buffer = std::malloc(buffer_size);
+  static_cast<T*>(*expected_buffer)[0] = 1;
+
+  auto dom = dimension.domain<T>();
+  query->set_buffer<T>(dimension.name(), static_cast<T*>(*buffer), buffer_size);
+  query->add_range(dim_idx, dom.first, dom.second);
+}
+
 }  // namespace
 
 TEST_CASE(
@@ -119,7 +140,7 @@ TEST_CASE(
 TEST_CASE(
     "Backwards compatibility: Test reading arrays written with previous "
     "version of tiledb",
-    "[backwards-compat]") {
+    "[backwards-compat][coords]") {
   Context ctx;
   std::string compat_folder(arrays_dir + "/read_compatibility_test");
   if (Object::object(ctx, compat_folder).type() != Object::Type::Group)
@@ -128,8 +149,8 @@ TEST_CASE(
   std::string encryption_key = "unittestunittestunittestunittest";
 
   tiledb::ObjectIter versions_iter(ctx, compat_folder);
-  for (const auto& groupVersions : versions_iter) {
-    tiledb::ObjectIter obj_iter(ctx, groupVersions.uri());
+  for (const auto& group_versions : versions_iter) {
+    tiledb::ObjectIter obj_iter(ctx, group_versions.uri());
     for (const auto& object : obj_iter) {
       // REQUIRE(read_array(object.uri()))
       Array* array;
@@ -149,108 +170,124 @@ TEST_CASE(
 
       std::unordered_map<std::string, std::pair<uint64_t*, void*>> buffers;
       for (auto attr : array->schema().attributes()) {
-        std::string attributeName = attr.first;
+        std::string attribute_name = attr.first;
         uint64_t* offsets = static_cast<uint64_t*>(malloc(sizeof(uint64_t)));
         void* values = malloc(tiledb_datatype_size(attr.second.type()));
         if (attr.second.variable_sized()) {
-          buffers.emplace(attributeName, std::make_pair(offsets, values));
+          buffers.emplace(attribute_name, std::make_pair(offsets, values));
         } else {
-          buffers.emplace(attributeName, std::make_pair(nullptr, values));
+          buffers.emplace(attribute_name, std::make_pair(nullptr, values));
         }
 
         switch (attr.second.type()) {
           case TILEDB_INT8: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<int8_t*>(values), 1);
-              buffers.emplace(attributeName, std::make_pair(offsets, values));
+                  attribute_name, offsets, 1, static_cast<int8_t*>(values), 1);
+              buffers.emplace(attribute_name, std::make_pair(offsets, values));
             } else {
-              query.set_buffer(attributeName, static_cast<int8_t*>(values), 1);
-              buffers.emplace(attributeName, std::make_pair(nullptr, values));
+              query.set_buffer(attribute_name, static_cast<int8_t*>(values), 1);
+              buffers.emplace(attribute_name, std::make_pair(nullptr, values));
             }
             break;
           }
           case TILEDB_UINT8: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<uint8_t*>(values), 1);
+                  attribute_name, offsets, 1, static_cast<uint8_t*>(values), 1);
             } else {
-              query.set_buffer(attributeName, static_cast<uint8_t*>(values), 1);
+              query.set_buffer(
+                  attribute_name, static_cast<uint8_t*>(values), 1);
             }
             break;
           }
           case TILEDB_INT16: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<int16_t*>(values), 1);
+                  attribute_name, offsets, 1, static_cast<int16_t*>(values), 1);
             } else {
-              query.set_buffer(attributeName, static_cast<int16_t*>(values), 1);
+              query.set_buffer(
+                  attribute_name, static_cast<int16_t*>(values), 1);
             }
             break;
           }
           case TILEDB_UINT16: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<uint16_t*>(values), 1);
+                  attribute_name,
+                  offsets,
+                  1,
+                  static_cast<uint16_t*>(values),
+                  1);
             } else {
               query.set_buffer(
-                  attributeName, static_cast<uint16_t*>(values), 1);
+                  attribute_name, static_cast<uint16_t*>(values), 1);
             }
             break;
           }
           case TILEDB_INT32: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<int32_t*>(values), 1);
+                  attribute_name, offsets, 1, static_cast<int32_t*>(values), 1);
             } else {
-              query.set_buffer(attributeName, static_cast<int32_t*>(values), 1);
+              query.set_buffer(
+                  attribute_name, static_cast<int32_t*>(values), 1);
             }
             break;
           }
           case TILEDB_UINT32: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<uint32_t*>(values), 1);
+                  attribute_name,
+                  offsets,
+                  1,
+                  static_cast<uint32_t*>(values),
+                  1);
             } else {
               query.set_buffer(
-                  attributeName, static_cast<uint32_t*>(values), 1);
+                  attribute_name, static_cast<uint32_t*>(values), 1);
             }
             break;
           }
           case TILEDB_INT64: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<int64_t*>(values), 1);
+                  attribute_name, offsets, 1, static_cast<int64_t*>(values), 1);
             } else {
-              query.set_buffer(attributeName, static_cast<int64_t*>(values), 1);
+              query.set_buffer(
+                  attribute_name, static_cast<int64_t*>(values), 1);
             }
             break;
           }
           case TILEDB_UINT64: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<uint64_t*>(values), 1);
+                  attribute_name,
+                  offsets,
+                  1,
+                  static_cast<uint64_t*>(values),
+                  1);
             } else {
               query.set_buffer(
-                  attributeName, static_cast<uint64_t*>(values), 1);
+                  attribute_name, static_cast<uint64_t*>(values), 1);
             }
             break;
           }
           case TILEDB_FLOAT32: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<float*>(values), 1);
+                  attribute_name, offsets, 1, static_cast<float*>(values), 1);
             } else {
-              query.set_buffer(attributeName, static_cast<float*>(values), 1);
+              query.set_buffer(attribute_name, static_cast<float*>(values), 1);
             }
             break;
           }
           case TILEDB_FLOAT64: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<double*>(values), 1);
+                  attribute_name, offsets, 1, static_cast<double*>(values), 1);
             } else {
-              query.set_buffer(attributeName, static_cast<double*>(values), 1);
+              query.set_buffer(attribute_name, static_cast<double*>(values), 1);
             }
             break;
           }
@@ -269,9 +306,10 @@ TEST_CASE(
           case TILEDB_DATETIME_AS: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<int64_t*>(values), 1);
+                  attribute_name, offsets, 1, static_cast<int64_t*>(values), 1);
             } else {
-              query.set_buffer(attributeName, static_cast<int64_t*>(values), 1);
+              query.set_buffer(
+                  attribute_name, static_cast<int64_t*>(values), 1);
             }
             break;
           }
@@ -286,9 +324,9 @@ TEST_CASE(
           case TILEDB_ANY: {
             if (attr.second.variable_sized()) {
               query.set_buffer(
-                  attributeName, offsets, 1, static_cast<char*>(values), 1);
+                  attribute_name, offsets, 1, static_cast<char*>(values), 1);
             } else {
-              query.set_buffer(attributeName, static_cast<char*>(values), 1);
+              query.set_buffer(attribute_name, static_cast<char*>(values), 1);
             }
             break;
           }
@@ -298,49 +336,49 @@ TEST_CASE(
       // Get domain to build coordinates
       Domain domain = array->schema().domain();
       uint64_t ndim = domain.ndim();
-      uint64_t coordsSize = tiledb_datatype_size(domain.type()) * ndim;
-      void *coordinates = nullptr, *expectedCoordinates = nullptr;
+      uint64_t coords_size = tiledb_datatype_size(domain.type()) * ndim;
+      void *coordinates = nullptr, *expected_coordinates = nullptr;
 
       switch (domain.type()) {
         case TILEDB_INT8:
           set_query_coords<int8_t>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_UINT8:
           set_query_coords<uint8_t>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_INT16:
           set_query_coords<int16_t>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_UINT16:
           set_query_coords<uint16_t>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_INT32:
           set_query_coords<int32_t>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_UINT32:
           set_query_coords<uint32_t>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_INT64:
           set_query_coords<int64_t>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_UINT64:
           set_query_coords<uint64_t>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_FLOAT32:
           set_query_coords<float>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_FLOAT64:
           set_query_coords<double>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_DATETIME_YEAR:
         case TILEDB_DATETIME_MONTH:
@@ -356,7 +394,7 @@ TEST_CASE(
         case TILEDB_DATETIME_FS:
         case TILEDB_DATETIME_AS:
           set_query_coords<int64_t>(
-              domain, &query, &coordinates, &expectedCoordinates);
+              domain, &query, &coordinates, &expected_coordinates);
           break;
         default:
           REQUIRE(false);
@@ -365,9 +403,9 @@ TEST_CASE(
       // Submit query
       query.submit();
 
-      REQUIRE(memcmp(coordinates, expectedCoordinates, coordsSize) == 0);
+      REQUIRE(memcmp(coordinates, expected_coordinates, coords_size) == 0);
       std::free(coordinates);
-      std::free(expectedCoordinates);
+      std::free(expected_coordinates);
 
       // Check the results to make sure all values are set to 1
       for (auto buff : buffers) {
@@ -505,5 +543,378 @@ TEST_CASE(
     }
   } catch (const std::exception& e) {
     CHECK(false);
+  }
+}
+
+TEST_CASE(
+    "Backwards compatibility: Test reading arrays written with previous "
+    "version of tiledb using split buffers",
+    "[backwards-compat][split-buffers]") {
+  Context ctx;
+  std::string compat_folder(arrays_dir + "/read_compatibility_test");
+  if (Object::object(ctx, compat_folder).type() != Object::Type::Group)
+    return;
+
+  std::string encryption_key = "unittestunittestunittestunittest";
+
+  tiledb::ObjectIter versions_iter(ctx, compat_folder);
+  for (const auto& group_versions : versions_iter) {
+    tiledb::ObjectIter obj_iter(ctx, group_versions.uri());
+    for (const auto& object : obj_iter) {
+      // REQUIRE(read_array(object.uri()))
+      Array* array;
+      // Check for if array is encrypted based on name for now
+      if (object.uri().find("_encryption_AES_256_GCM") != std::string::npos) {
+        array = new Array(
+            ctx,
+            object.uri(),
+            TILEDB_READ,
+            TILEDB_AES_256_GCM,
+            encryption_key.c_str(),
+            static_cast<uint32_t>(encryption_key.size() * sizeof(char)));
+      } else {
+        array = new Array(ctx, object.uri(), TILEDB_READ);
+      }
+      Query query(ctx, *array);
+
+      std::unordered_map<std::string, std::pair<uint64_t*, void*>> buffers;
+      for (auto attr : array->schema().attributes()) {
+        std::string attribute_name = attr.first;
+        uint64_t* offsets = static_cast<uint64_t*>(malloc(sizeof(uint64_t)));
+        void* values = malloc(tiledb_datatype_size(attr.second.type()));
+        if (attr.second.variable_sized()) {
+          buffers.emplace(attribute_name, std::make_pair(offsets, values));
+        } else {
+          buffers.emplace(attribute_name, std::make_pair(nullptr, values));
+        }
+
+        switch (attr.second.type()) {
+          case TILEDB_INT8: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name, offsets, 1, static_cast<int8_t*>(values), 1);
+              buffers.emplace(attribute_name, std::make_pair(offsets, values));
+            } else {
+              query.set_buffer(attribute_name, static_cast<int8_t*>(values), 1);
+              buffers.emplace(attribute_name, std::make_pair(nullptr, values));
+            }
+            break;
+          }
+          case TILEDB_UINT8: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name, offsets, 1, static_cast<uint8_t*>(values), 1);
+            } else {
+              query.set_buffer(
+                  attribute_name, static_cast<uint8_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_INT16: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name, offsets, 1, static_cast<int16_t*>(values), 1);
+            } else {
+              query.set_buffer(
+                  attribute_name, static_cast<int16_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_UINT16: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name,
+                  offsets,
+                  1,
+                  static_cast<uint16_t*>(values),
+                  1);
+            } else {
+              query.set_buffer(
+                  attribute_name, static_cast<uint16_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_INT32: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name, offsets, 1, static_cast<int32_t*>(values), 1);
+            } else {
+              query.set_buffer(
+                  attribute_name, static_cast<int32_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_UINT32: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name,
+                  offsets,
+                  1,
+                  static_cast<uint32_t*>(values),
+                  1);
+            } else {
+              query.set_buffer(
+                  attribute_name, static_cast<uint32_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_INT64: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name, offsets, 1, static_cast<int64_t*>(values), 1);
+            } else {
+              query.set_buffer(
+                  attribute_name, static_cast<int64_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_UINT64: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name,
+                  offsets,
+                  1,
+                  static_cast<uint64_t*>(values),
+                  1);
+            } else {
+              query.set_buffer(
+                  attribute_name, static_cast<uint64_t*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_FLOAT32: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name, offsets, 1, static_cast<float*>(values), 1);
+            } else {
+              query.set_buffer(attribute_name, static_cast<float*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_FLOAT64: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name, offsets, 1, static_cast<double*>(values), 1);
+            } else {
+              query.set_buffer(attribute_name, static_cast<double*>(values), 1);
+            }
+            break;
+          }
+          case TILEDB_DATETIME_YEAR:
+          case TILEDB_DATETIME_MONTH:
+          case TILEDB_DATETIME_WEEK:
+          case TILEDB_DATETIME_DAY:
+          case TILEDB_DATETIME_HR:
+          case TILEDB_DATETIME_MIN:
+          case TILEDB_DATETIME_SEC:
+          case TILEDB_DATETIME_MS:
+          case TILEDB_DATETIME_US:
+          case TILEDB_DATETIME_NS:
+          case TILEDB_DATETIME_PS:
+          case TILEDB_DATETIME_FS:
+          case TILEDB_DATETIME_AS: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name, offsets, 1, static_cast<int64_t*>(values), 1);
+            } else {
+              query.set_buffer(
+                  attribute_name, static_cast<int64_t*>(values), 1);
+            }
+            break;
+          }
+
+          case TILEDB_CHAR:
+          case TILEDB_STRING_ASCII:
+          case TILEDB_STRING_UTF8:
+          case TILEDB_STRING_UTF16:
+          case TILEDB_STRING_UTF32:
+          case TILEDB_STRING_UCS2:
+          case TILEDB_STRING_UCS4:
+          case TILEDB_ANY: {
+            if (attr.second.variable_sized()) {
+              query.set_buffer(
+                  attribute_name, offsets, 1, static_cast<char*>(values), 1);
+            } else {
+              query.set_buffer(attribute_name, static_cast<char*>(values), 1);
+            }
+            break;
+          }
+        }
+      }
+
+      // Get domain to build dimension buffers
+      Domain domain = array->schema().domain();
+      uint64_t ndim = domain.ndim();
+      // Store one buffer per dimension
+      std::vector<void*> dim_buffers(ndim);
+      std::vector<void*> dim_expected_buffers(ndim);
+      for (uint64_t i = 0; i < ndim; ++i) {
+        Dimension dim = domain.dimension(i);
+        void *buffer = nullptr, *expected_results = nullptr;
+        switch (dim.type()) {
+          case TILEDB_INT8:
+            set_query_dimension_buffer<int8_t>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_UINT8:
+            set_query_dimension_buffer<uint8_t>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_INT16:
+            set_query_dimension_buffer<int16_t>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_UINT16:
+            set_query_dimension_buffer<uint16_t>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_INT32:
+            set_query_dimension_buffer<int32_t>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_UINT32:
+            set_query_dimension_buffer<uint32_t>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_INT64:
+            set_query_dimension_buffer<int64_t>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_UINT64:
+            set_query_dimension_buffer<uint64_t>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_FLOAT32:
+            set_query_dimension_buffer<float>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_FLOAT64:
+            set_query_dimension_buffer<double>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          case TILEDB_DATETIME_YEAR:
+          case TILEDB_DATETIME_MONTH:
+          case TILEDB_DATETIME_WEEK:
+          case TILEDB_DATETIME_DAY:
+          case TILEDB_DATETIME_HR:
+          case TILEDB_DATETIME_MIN:
+          case TILEDB_DATETIME_SEC:
+          case TILEDB_DATETIME_MS:
+          case TILEDB_DATETIME_US:
+          case TILEDB_DATETIME_NS:
+          case TILEDB_DATETIME_PS:
+          case TILEDB_DATETIME_FS:
+          case TILEDB_DATETIME_AS:
+            set_query_dimension_buffer<int64_t>(
+                domain, i, &query, &buffer, &expected_results);
+            break;
+          default:
+            REQUIRE(false);
+        }
+        dim_buffers[i] = buffer;
+        dim_expected_buffers[i] = expected_results;
+      }
+
+      // Submit query
+      query.submit();
+
+      for (uint64_t i = 0; i < ndim; ++i) {
+        auto& buff = dim_buffers[i];
+        auto& expected_results = dim_expected_buffers[i];
+        Dimension dimension = domain.dimension(i);
+        const uint64_t buffer_size = tiledb_datatype_size(dimension.type());
+        REQUIRE(memcmp(buff, expected_results, buffer_size) == 0);
+        std::free(buff);
+        std::free(expected_results);
+      }
+
+      // Check the results to make sure all values are set to 1
+      for (auto buff : buffers) {
+        std::pair<uint64_t*, void*> buffer = buff.second;
+        if (buffer.first != nullptr) {
+          REQUIRE(buffer.first[0] == 0);
+        }
+
+        Attribute attribute = array->schema().attribute(buff.first);
+        switch (attribute.type()) {
+          case TILEDB_INT8: {
+            REQUIRE(static_cast<int8_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_UINT8: {
+            REQUIRE(static_cast<uint8_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_INT16: {
+            REQUIRE(static_cast<int16_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_UINT16: {
+            REQUIRE(static_cast<uint16_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_INT32: {
+            REQUIRE(static_cast<int32_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_UINT32: {
+            REQUIRE(static_cast<uint32_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_INT64: {
+            REQUIRE(static_cast<int64_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_UINT64: {
+            REQUIRE(static_cast<uint64_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_FLOAT32: {
+            REQUIRE(static_cast<float*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_FLOAT64: {
+            REQUIRE(static_cast<double*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_DATETIME_YEAR:
+          case TILEDB_DATETIME_MONTH:
+          case TILEDB_DATETIME_WEEK:
+          case TILEDB_DATETIME_DAY:
+          case TILEDB_DATETIME_HR:
+          case TILEDB_DATETIME_MIN:
+          case TILEDB_DATETIME_SEC:
+          case TILEDB_DATETIME_MS:
+          case TILEDB_DATETIME_US:
+          case TILEDB_DATETIME_NS:
+          case TILEDB_DATETIME_PS:
+          case TILEDB_DATETIME_FS:
+          case TILEDB_DATETIME_AS: {
+            REQUIRE(static_cast<int64_t*>(buffer.second)[0] == 1);
+            break;
+          }
+          case TILEDB_CHAR:
+          case TILEDB_STRING_ASCII:
+          case TILEDB_STRING_UTF8:
+          case TILEDB_STRING_UTF16:
+          case TILEDB_STRING_UTF32:
+          case TILEDB_STRING_UCS2:
+          case TILEDB_STRING_UCS4:
+          case TILEDB_ANY: {
+            REQUIRE(static_cast<char*>(buffer.second)[0] == '1');
+            break;
+          }
+        }
+
+        // Free buffers
+        if (buffer.first != nullptr) {
+          free(buffer.first);
+        }
+        if (buffer.second != nullptr) {
+          free(buffer.second);
+        }
+      }
+      delete array;
+    }
   }
 }


### PR DESCRIPTION
This is a third case which comes up with backwards compatibility in which the user has asked for split buffers but the array has zipped coordinates.

Unit tests were added to the backwards compatibility tests for this case.