### PR TITLE
Add support for serialization of est_result_size

### DIFF
--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -333,6 +333,7 @@ int ArraySchemaFx::tiledb_array_get_non_empty_domain_wrapper(
           &domain,
           is_empty) == TILEDB_OK);
 
+  tiledb_buffer_free(&buff);
   return TILEDB_OK;
 }
 
@@ -370,6 +371,7 @@ int ArraySchemaFx::tiledb_array_get_non_empty_domain_from_index_wrapper(
           (tiledb_serialization_type_t)tiledb::sm::SerializationType::CAPNP,
           1) == TILEDB_OK);
 
+  tiledb_buffer_free(&buff);
   return tiledb_array_get_non_empty_domain_from_index(
       ctx, array, index, domain, is_empty);
 }
@@ -408,6 +410,7 @@ int ArraySchemaFx::tiledb_array_get_non_empty_domain_from_name_wrapper(
           (tiledb_serialization_type_t)tiledb::sm::SerializationType::CAPNP,
           1) == TILEDB_OK);
 
+  tiledb_buffer_free(&buff);
   return tiledb_array_get_non_empty_domain_from_name(
       ctx, array, name, domain, is_empty);
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4659,6 +4659,57 @@ int32_t tiledb_deserialize_array_metadata(
   return TILEDB_OK;
 }
 
+int32_t tiledb_serialize_query_est_result_sizes(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    tiledb_buffer_t** buffer) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Allocate buffer
+  if (tiledb_buffer_alloc(ctx, buffer) != TILEDB_OK ||
+      sanity_check(ctx, *buffer) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          tiledb::sm::serialization::query_est_result_size_serialize(
+              query->query_,
+              (tiledb::sm::SerializationType)serialize_type,
+              client_side == 1,
+              (*buffer)->buffer_)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_deserialize_query_est_result_sizes(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    const tiledb_buffer_t* buffer) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR ||
+      sanity_check(ctx, query) == TILEDB_ERR ||
+      sanity_check(ctx, buffer) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          tiledb::sm::serialization::query_est_result_size_deserialize(
+              *buffer->buffer_,
+              (tiledb::sm::SerializationType)serialize_type,
+              client_side == 1,
+              query->query_)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 /* ****************************** */
 /*            C++ API             */
 /* ****************************** */

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4701,10 +4701,10 @@ int32_t tiledb_deserialize_query_est_result_sizes(
   if (SAVE_ERROR_CATCH(
           ctx,
           tiledb::sm::serialization::query_est_result_size_deserialize(
-              *buffer->buffer_,
+              query->query_,
               (tiledb::sm::SerializationType)serialize_type,
               client_side == 1,
-              query->query_)))
+              *buffer->buffer_)))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -297,6 +297,44 @@ TILEDB_EXPORT int32_t tiledb_deserialize_array_metadata(
     tiledb_serialization_type_t serialization_type,
     const tiledb_buffer_t* buffer);
 
+/**
+ * Serializes the given query's estimated result sizes map.
+ *
+ * @note The caller must free the returned `tiledb_buffer_list_t`.
+ *
+ * @param ctx The TileDB context.
+ * @param query The query to get the estimated result sizes of.
+ * @param serialization_type Type of serialization to use
+ * @param client_side currently unused
+ * @param buffer Will be set to a newly allocated buffer containing
+ *    the serialized query estimated result sizes.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_serialize_query_est_result_sizes(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    tiledb_buffer_t** buffer);
+
+/**
+ * Deserializes into an existing query from the given buffer.
+ *
+ *
+ * @param ctx The TileDB context.
+ * @param query The query object to deserialize into (must be pre-allocated).
+ * @param serialization_type Type of deserialization to use
+ * @param client_side currently unused
+ * @param buffer Buffer to deserialize from
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_deserialize_query_est_result_sizes(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    const tiledb_buffer_t* buffer);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -231,6 +231,16 @@ Status Query::get_est_result_size(
   return reader_.get_est_result_size(name, size_off, size_val);
 }
 
+std::unordered_map<std::string, Subarray::ResultSize>
+Query::get_est_result_size_map() {
+  return reader_.get_est_result_size_map();
+}
+
+std::unordered_map<std::string, Subarray::MemorySize>
+Query::get_max_mem_size_map() {
+  return reader_.get_max_mem_size_map();
+}
+
 Status Query::get_written_fragment_num(uint32_t* num) const {
   if (type_ != QueryType::WRITE)
     return LOG_STATUS(Status::WriterError(
@@ -558,6 +568,16 @@ Status Query::set_buffer(
       buffer_val,
       buffer_val_size,
       check_null_buffers);
+}
+
+Status Query::set_est_result_size(
+    std::unordered_map<std::string, Subarray::ResultSize>& est_result_size,
+    std::unordered_map<std::string, Subarray::MemorySize>& max_mem_size) {
+  if (type_ == QueryType::WRITE)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set estimated result size; Operation currently "
+        "unsupported for write queries"));
+  return reader_.set_est_result_size(est_result_size, max_mem_size);
 }
 
 Status Query::set_layout(Layout layout) {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -295,6 +295,19 @@ class Query {
       const std::string& attribute, SerializationState::AttrState** state);
 
   /**
+   * Used by serialization to get the map of result sizes
+   * @return
+   */
+  std::unordered_map<std::string, Subarray::ResultSize>
+  get_est_result_size_map();
+
+  /**
+   * Used by serialization to get the map of max mem sizes
+   * @return
+   */
+  std::unordered_map<std::string, Subarray::MemorySize> get_max_mem_size_map();
+
+  /**
    * Returns `true` if the query has results. Applicable only to read
    * queries (it returns `false` for write queries).
    */
@@ -376,6 +389,17 @@ class Query {
       void* buffer_val,
       uint64_t* buffer_val_size,
       bool check_null_buffers = true);
+
+  /**
+   * Used by serialization to set the estimated result size
+   *
+   * @param est_result_size map to set
+   * @param max_mem_size map to set
+   * @return Status
+   */
+  Status set_est_result_size(
+      std::unordered_map<std::string, Subarray::ResultSize>& est_result_size,
+      std::unordered_map<std::string, Subarray::MemorySize>& max_mem_size);
 
   /**
    * Sets the cell layout of the query. The function will return an error

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -2265,5 +2265,21 @@ void Reader::get_result_tile_stats(
   STATS_ADD_COUNTER(stats::Stats::CounterType::READ_CELL_NUM, cell_num);
 }
 
+Status Reader::set_est_result_size(
+    std::unordered_map<std::string, Subarray::ResultSize>& est_result_size,
+    std::unordered_map<std::string, Subarray::MemorySize>& max_mem_size) {
+  return subarray_.set_est_result_size(est_result_size, max_mem_size);
+}
+
+std::unordered_map<std::string, Subarray::ResultSize>
+Reader::get_est_result_size_map() {
+  return subarray_.get_est_result_size_map();
+}
+
+std::unordered_map<std::string, Subarray::MemorySize>
+Reader::get_max_mem_size_map() {
+  return subarray_.get_max_mem_size_map();
+}
+
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -2276,6 +2276,10 @@ Reader::get_est_result_size_map() {
   return subarray_.get_est_result_size_map();
 }
 
+bool Reader::est_result_size_computed() {
+  return subarray_.est_result_size_computed();
+}
+
 std::unordered_map<std::string, Subarray::MemorySize>
 Reader::get_max_mem_size_map() {
   return subarray_.get_max_mem_size_map();

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -199,6 +199,9 @@ class Reader {
       std::unordered_map<std::string, Subarray::ResultSize>& est_result_size,
       std::unordered_map<std::string, Subarray::MemorySize>& max_mem_size);
 
+  /** returns whether the estimated result size has been computed or not */
+  bool est_result_size_computed();
+
   /** Returns the array schema. */
   const ArraySchema* array_schema() const;
 

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -175,6 +175,30 @@ class Reader {
   Status get_est_result_size(
       const char* name, uint64_t* size_off, uint64_t* size_val);
 
+  /**
+   * Used by serialization to get the map of result sizes
+   * @return
+   */
+  std::unordered_map<std::string, Subarray::ResultSize>
+  get_est_result_size_map();
+
+  /**
+   * Used by serialization to get the map of max mem sizes
+   * @return
+   */
+  std::unordered_map<std::string, Subarray::MemorySize> get_max_mem_size_map();
+
+  /**
+   * Used by serialization to set the estimated result size
+   *
+   * @param est_result_size map to set
+   * @param max_mem_size map to set
+   * @return Status
+   */
+  Status set_est_result_size(
+      std::unordered_map<std::string, Subarray::ResultSize>& est_result_size,
+      std::unordered_map<std::string, Subarray::MemorySize>& max_mem_size);
+
   /** Returns the array schema. */
   const ArraySchema* array_schema() const;
 

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -148,6 +148,14 @@ class RestClient {
    */
   Status finalize_query_to_rest(const URI& uri, Query* query);
 
+  /**
+   * Get array's non_empty domain from rest server
+   *
+   * @param array Array model to fetch and set non empty domain on
+   * @return Status Ok() on success Error() on failures
+   */
+  Status get_query_est_result_sizes(const URI& uri, Query* query);
+
  private:
   /* ********************************* */
   /*        PRIVATE ATTRIBUTES         */

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1052,10 +1052,10 @@ Status query_est_result_size_serialize(
 }
 
 Status query_est_result_size_deserialize(
-    const Buffer& serialized_buffer,
+    Query* query,
     SerializationType serialize_type,
     bool clientside,
-    Query* query) {
+    const Buffer& serialized_buffer) {
   try {
     switch (serialize_type) {
       case SerializationType::JSON: {

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -161,10 +161,10 @@ Status query_est_result_size_serialize(
  * @return Status
  */
 Status query_est_result_size_deserialize(
-    const Buffer& serialized_buffer,
+    Query* query,
     SerializationType serialize_type,
     bool clientside,
-    Query* query);
+    const Buffer& serialized_buffer);
 
 }  // namespace serialization
 }  // namespace sm

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -135,6 +135,37 @@ Status query_deserialize(
     CopyState* copy_state,
     Query* query);
 
+/**
+ * Serialize an estimated result size map for all fields from a query object
+ *
+ * @param query Query to get est
+ * @param serialize_type
+ * @param clientside
+ * @param serialized_buffer
+ * @return
+ */
+Status query_est_result_size_serialize(
+    Query* query,
+    SerializationType serialize_type,
+    bool clientside,
+    Buffer* serialized_buffer);
+
+/**
+ * Deserialize estimated result sizes into the query object
+ *
+ * @param serialized_buffer Buffer containing serialized query
+ * @param serialize_type Serialization type of serialized query
+ * @param clientside Whether deserialization should be performed from a client
+ *      or server persective
+ * @param query Query to deserialize into
+ * @return Status
+ */
+Status query_est_result_size_deserialize(
+    const Buffer& serialized_buffer,
+    SerializationType serialize_type,
+    bool clientside,
+    Query* query);
+
 }  // namespace serialization
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/serialization/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/tiledb-rest.capnp.c++
@@ -3186,6 +3186,245 @@ const ::capnp::_::RawSchema s_926fe1c3b12ed651 = {
   0, 5, i_926fe1c3b12ed651, nullptr, nullptr, { &s_926fe1c3b12ed651, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<95> b_8cd4e323f1feea3b = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+     59, 234, 254, 241,  35, 227, 212, 140,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  50,   1,   0,   0,
+     37,   0,   0,   0,  39,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     65,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  69, 115, 116, 105, 109,  97,
+    116, 101, 100,  82, 101, 115, 117, 108,
+    116,  83, 105, 122, 101,   0,   0,   0,
+      8,   0,   0,   0,   1,   0,   1,   0,
+    105,  82,  86, 133, 118,  70, 200, 146,
+      9,   0,   0,   0,  90,   0,   0,   0,
+     34,  28,  89,  38, 105, 145, 167, 189,
+      9,   0,   0,   0,  90,   0,   0,   0,
+     82, 101, 115, 117, 108, 116,  83, 105,
+    122, 101,   0,   0,   0,   0,   0,   0,
+     77, 101, 109, 111, 114, 121,  83, 105,
+    122, 101,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  98,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     40,   0,   0,   0,   3,   0,   1,   0,
+    124,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    121,   0,   0,   0,  98,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    120,   0,   0,   0,   3,   0,   1,   0,
+    204,   0,   0,   0,   2,   0,   1,   0,
+    114, 101, 115, 117, 108, 116,  83, 105,
+    122, 101, 115,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    140, 113, 113, 174, 148, 193, 121, 241,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   1,   0,
+      1,   0,   0,   0,  31,   0,   0,   0,
+      4,   0,   0,   0,   2,   0,   1,   0,
+    140, 113, 113, 174, 148, 193, 121, 241,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0,  39,   0,   0,   0,
+      8,   0,   0,   0,   1,   0,   1,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   1,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   3,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    105,  82,  86, 133, 118,  70, 200, 146,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    109, 101, 109, 111, 114, 121,  83, 105,
+    122, 101, 115,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    140, 113, 113, 174, 148, 193, 121, 241,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   1,   0,
+      1,   0,   0,   0,  31,   0,   0,   0,
+      4,   0,   0,   0,   2,   0,   1,   0,
+    140, 113, 113, 174, 148, 193, 121, 241,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0,  39,   0,   0,   0,
+      8,   0,   0,   0,   1,   0,   1,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   1,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   3,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+     34,  28,  89,  38, 105, 145, 167, 189,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_8cd4e323f1feea3b = b_8cd4e323f1feea3b.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_8cd4e323f1feea3b[] = {
+  &s_f179c194ae71718c,
+};
+static const uint16_t m_8cd4e323f1feea3b[] = {1, 0};
+static const uint16_t i_8cd4e323f1feea3b[] = {0, 1};
+KJ_CONSTEXPR(const) ::capnp::_::RawBrandedSchema::Dependency bd_8cd4e323f1feea3b[] = {
+  { 16777216,  ::tiledb::sm::serialization::capnp::Map< ::capnp::Text,  ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::_capnpPrivate::brand() },
+  { 16777217,  ::tiledb::sm::serialization::capnp::Map< ::capnp::Text,  ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::_capnpPrivate::brand() },
+};
+const ::capnp::_::RawSchema s_8cd4e323f1feea3b = {
+  0x8cd4e323f1feea3b, b_8cd4e323f1feea3b.words, 95, d_8cd4e323f1feea3b, m_8cd4e323f1feea3b,
+  1, 2, i_8cd4e323f1feea3b, nullptr, nullptr, { &s_8cd4e323f1feea3b, nullptr, bd_8cd4e323f1feea3b, 0, sizeof(bd_8cd4e323f1feea3b) / sizeof(bd_8cd4e323f1feea3b[0]), nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<52> b_92c8467685565269 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    105,  82,  86, 133, 118,  70, 200, 146,
+     38,   0,   0,   0,   1,   0,   2,   0,
+     59, 234, 254, 241,  35, 227, 212, 140,
+      0,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0, 138,   1,   0,   0,
+     45,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  69, 115, 116, 105, 109,  97,
+    116, 101, 100,  82, 101, 115, 117, 108,
+    116,  83, 105, 122, 101,  46,  82, 101,
+    115, 117, 108, 116,  83, 105, 122, 101,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  82,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     40,   0,   0,   0,   3,   0,   1,   0,
+     52,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     49,   0,   0,   0,  66,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     44,   0,   0,   0,   3,   0,   1,   0,
+     56,   0,   0,   0,   2,   0,   1,   0,
+    115, 105, 122, 101,  70, 105, 120, 101,
+    100,   0,   0,   0,   0,   0,   0,   0,
+     11,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     11,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    115, 105, 122, 101,  86,  97, 114,   0,
+     11,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     11,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_92c8467685565269 = b_92c8467685565269.words;
+#if !CAPNP_LITE
+static const uint16_t m_92c8467685565269[] = {0, 1};
+static const uint16_t i_92c8467685565269[] = {0, 1};
+const ::capnp::_::RawSchema s_92c8467685565269 = {
+  0x92c8467685565269, b_92c8467685565269.words, 52, nullptr, m_92c8467685565269,
+  0, 2, i_92c8467685565269, nullptr, nullptr, { &s_92c8467685565269, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<52> b_bda7916926591c22 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+     34,  28,  89,  38, 105, 145, 167, 189,
+     38,   0,   0,   0,   1,   0,   2,   0,
+     59, 234, 254, 241,  35, 227, 212, 140,
+      0,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0, 138,   1,   0,   0,
+     45,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  69, 115, 116, 105, 109,  97,
+    116, 101, 100,  82, 101, 115, 117, 108,
+    116,  83, 105, 122, 101,  46,  77, 101,
+    109, 111, 114, 121,  83, 105, 122, 101,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  82,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     40,   0,   0,   0,   3,   0,   1,   0,
+     52,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     49,   0,   0,   0,  66,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     44,   0,   0,   0,   3,   0,   1,   0,
+     56,   0,   0,   0,   2,   0,   1,   0,
+    115, 105, 122, 101,  70, 105, 120, 101,
+    100,   0,   0,   0,   0,   0,   0,   0,
+      9,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      9,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    115, 105, 122, 101,  86,  97, 114,   0,
+      9,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      9,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_bda7916926591c22 = b_bda7916926591c22.words;
+#if !CAPNP_LITE
+static const uint16_t m_bda7916926591c22[] = {0, 1};
+static const uint16_t i_bda7916926591c22[] = {0, 1};
+const ::capnp::_::RawSchema s_bda7916926591c22 = {
+  0xbda7916926591c22, b_bda7916926591c22.words, 52, nullptr, m_bda7916926591c22,
+  0, 2, i_bda7916926591c22, nullptr, nullptr, { &s_bda7916926591c22, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 }  // namespace schemas
 }  // namespace capnp
 
@@ -3442,6 +3681,30 @@ constexpr uint16_t ArrayMetadata::MetadataEntry::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind ArrayMetadata::MetadataEntry::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* ArrayMetadata::MetadataEntry::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// EstimatedResultSize
+constexpr uint16_t EstimatedResultSize::_capnpPrivate::dataWordSize;
+constexpr uint16_t EstimatedResultSize::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind EstimatedResultSize::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* EstimatedResultSize::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// EstimatedResultSize::ResultSize
+constexpr uint16_t EstimatedResultSize::ResultSize::_capnpPrivate::dataWordSize;
+constexpr uint16_t EstimatedResultSize::ResultSize::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind EstimatedResultSize::ResultSize::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* EstimatedResultSize::ResultSize::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// EstimatedResultSize::MemorySize
+constexpr uint16_t EstimatedResultSize::MemorySize::_capnpPrivate::dataWordSize;
+constexpr uint16_t EstimatedResultSize::MemorySize::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind EstimatedResultSize::MemorySize::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* EstimatedResultSize::MemorySize::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 

--- a/tiledb/sm/serialization/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/tiledb-rest.capnp.h
@@ -47,6 +47,9 @@ CAPNP_DECLARE_SCHEMA(9be1921b07e6cd2d);
 CAPNP_DECLARE_SCHEMA(f01116579e9ea98e);
 CAPNP_DECLARE_SCHEMA(9737dcafdfce31bb);
 CAPNP_DECLARE_SCHEMA(926fe1c3b12ed651);
+CAPNP_DECLARE_SCHEMA(8cd4e323f1feea3b);
+CAPNP_DECLARE_SCHEMA(92c8467685565269);
+CAPNP_DECLARE_SCHEMA(bda7916926591c22);
 
 }  // namespace schemas
 }  // namespace capnp
@@ -654,6 +657,59 @@ struct ArrayMetadata::MetadataEntry {
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(926fe1c3b12ed651, 1, 3)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct EstimatedResultSize {
+  EstimatedResultSize() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+  struct ResultSize;
+  struct MemorySize;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(8cd4e323f1feea3b, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct EstimatedResultSize::ResultSize {
+  ResultSize() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(92c8467685565269, 2, 0)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct EstimatedResultSize::MemorySize {
+  MemorySize() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(bda7916926591c22, 2, 0)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -4955,6 +5011,364 @@ class ArrayMetadata::MetadataEntry::Builder {
 class ArrayMetadata::MetadataEntry::Pipeline {
  public:
   typedef MetadataEntry Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class EstimatedResultSize::Reader {
+ public:
+  typedef EstimatedResultSize Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasResultSizes() const;
+  inline ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+      Reader
+      getResultSizes() const;
+
+  inline bool hasMemorySizes() const;
+  inline ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+      Reader
+      getMemorySizes() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class EstimatedResultSize::Builder {
+ public:
+  typedef EstimatedResultSize Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasResultSizes();
+  inline ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+      Builder
+      getResultSizes();
+  inline void setResultSizes(
+      ::tiledb::sm::serialization::capnp::Map<
+          ::capnp::Text,
+          ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+          Reader value);
+  inline ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+      Builder
+      initResultSizes();
+  inline void adoptResultSizes(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Map<
+          ::capnp::Text,
+          ::tiledb::sm::serialization::capnp::EstimatedResultSize::
+              ResultSize>>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>>
+  disownResultSizes();
+
+  inline bool hasMemorySizes();
+  inline ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+      Builder
+      getMemorySizes();
+  inline void setMemorySizes(
+      ::tiledb::sm::serialization::capnp::Map<
+          ::capnp::Text,
+          ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+          Reader value);
+  inline ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+      Builder
+      initMemorySizes();
+  inline void adoptMemorySizes(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Map<
+          ::capnp::Text,
+          ::tiledb::sm::serialization::capnp::EstimatedResultSize::
+              MemorySize>>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>>
+  disownMemorySizes();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class EstimatedResultSize::Pipeline {
+ public:
+  typedef EstimatedResultSize Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+      Pipeline
+      getResultSizes();
+  inline ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+      Pipeline
+      getMemorySizes();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class EstimatedResultSize::ResultSize::Reader {
+ public:
+  typedef ResultSize Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline double getSizeFixed() const;
+
+  inline double getSizeVar() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class EstimatedResultSize::ResultSize::Builder {
+ public:
+  typedef ResultSize Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline double getSizeFixed();
+  inline void setSizeFixed(double value);
+
+  inline double getSizeVar();
+  inline void setSizeVar(double value);
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class EstimatedResultSize::ResultSize::Pipeline {
+ public:
+  typedef ResultSize Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class EstimatedResultSize::MemorySize::Reader {
+ public:
+  typedef MemorySize Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline ::uint64_t getSizeFixed() const;
+
+  inline ::uint64_t getSizeVar() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class EstimatedResultSize::MemorySize::Builder {
+ public:
+  typedef MemorySize Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline ::uint64_t getSizeFixed();
+  inline void setSizeFixed(::uint64_t value);
+
+  inline ::uint64_t getSizeVar();
+  inline void setSizeVar(::uint64_t value);
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class EstimatedResultSize::MemorySize::Pipeline {
+ public:
+  typedef MemorySize Pipelines;
 
   inline Pipeline(decltype(nullptr))
       : _typeless(nullptr) {
@@ -9759,6 +10173,232 @@ inline bool ArrayMetadata::MetadataEntry::Builder::getDel() {
 inline void ArrayMetadata::MetadataEntry::Builder::setDel(bool value) {
   _builder.setDataField<bool>(
       ::capnp::bounded<32>() * ::capnp::ELEMENTS, value);
+}
+
+inline bool EstimatedResultSize::Reader::hasResultSizes() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool EstimatedResultSize::Builder::hasResultSizes() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::Reader
+EstimatedResultSize::Reader::getResultSizes() const {
+  return ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>>::
+      get(_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+    Builder
+    EstimatedResultSize::Builder::getResultSizes() {
+  return ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>>::
+      get(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+    Pipeline
+    EstimatedResultSize::Pipeline::getResultSizes() {
+  return ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+      Pipeline(_typeless.getPointerField(0));
+}
+#endif  // !CAPNP_LITE
+inline void EstimatedResultSize::Builder::setResultSizes(
+    ::tiledb::sm::serialization::capnp::Map<
+        ::capnp::Text,
+        ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+        Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>>::
+      set(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>::
+    Builder
+    EstimatedResultSize::Builder::initResultSizes() {
+  return ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>>::
+      init(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void EstimatedResultSize::Builder::adoptResultSizes(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Map<
+        ::capnp::Text,
+        ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>>&&
+        value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>>
+EstimatedResultSize::Builder::disownResultSizes() {
+  return ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::ResultSize>>::
+      disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool EstimatedResultSize::Reader::hasMemorySizes() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool EstimatedResultSize::Builder::hasMemorySizes() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::Reader
+EstimatedResultSize::Reader::getMemorySizes() const {
+  return ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>>::
+      get(_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+    Builder
+    EstimatedResultSize::Builder::getMemorySizes() {
+  return ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>>::
+      get(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+    Pipeline
+    EstimatedResultSize::Pipeline::getMemorySizes() {
+  return ::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+      Pipeline(_typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void EstimatedResultSize::Builder::setMemorySizes(
+    ::tiledb::sm::serialization::capnp::Map<
+        ::capnp::Text,
+        ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+        Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>>::
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>::
+    Builder
+    EstimatedResultSize::Builder::initMemorySizes() {
+  return ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>>::
+      init(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void EstimatedResultSize::Builder::adoptMemorySizes(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Map<
+        ::capnp::Text,
+        ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>>&&
+        value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Map<
+    ::capnp::Text,
+    ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>>
+EstimatedResultSize::Builder::disownMemorySizes() {
+  return ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Map<
+      ::capnp::Text,
+      ::tiledb::sm::serialization::capnp::EstimatedResultSize::MemorySize>>::
+      disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+
+inline double EstimatedResultSize::ResultSize::Reader::getSizeFixed() const {
+  return _reader.getDataField<double>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+
+inline double EstimatedResultSize::ResultSize::Builder::getSizeFixed() {
+  return _builder.getDataField<double>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+inline void EstimatedResultSize::ResultSize::Builder::setSizeFixed(
+    double value) {
+  _builder.setDataField<double>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
+}
+
+inline double EstimatedResultSize::ResultSize::Reader::getSizeVar() const {
+  return _reader.getDataField<double>(
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
+}
+
+inline double EstimatedResultSize::ResultSize::Builder::getSizeVar() {
+  return _builder.getDataField<double>(
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
+}
+inline void EstimatedResultSize::ResultSize::Builder::setSizeVar(double value) {
+  _builder.setDataField<double>(
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
+}
+
+inline ::uint64_t EstimatedResultSize::MemorySize::Reader::getSizeFixed()
+    const {
+  return _reader.getDataField<::uint64_t>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+
+inline ::uint64_t EstimatedResultSize::MemorySize::Builder::getSizeFixed() {
+  return _builder.getDataField<::uint64_t>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+inline void EstimatedResultSize::MemorySize::Builder::setSizeFixed(
+    ::uint64_t value) {
+  _builder.setDataField<::uint64_t>(
+      ::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
+}
+
+inline ::uint64_t EstimatedResultSize::MemorySize::Reader::getSizeVar() const {
+  return _reader.getDataField<::uint64_t>(
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
+}
+
+inline ::uint64_t EstimatedResultSize::MemorySize::Builder::getSizeVar() {
+  return _builder.getDataField<::uint64_t>(
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS);
+}
+inline void EstimatedResultSize::MemorySize::Builder::setSizeVar(
+    ::uint64_t value) {
+  _builder.setDataField<::uint64_t>(
+      ::capnp::bounded<1>() * ::capnp::ELEMENTS, value);
 }
 
 }  // namespace capnp

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -973,6 +973,34 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
   return Status::Ok();
 }
 
+std::unordered_map<std::string, Subarray::ResultSize>
+Subarray::get_est_result_size_map() {
+  // If the result sizes have not been computed, compute them first
+  if (!est_result_size_computed_)
+    compute_est_result_size();
+
+  return est_result_size_;
+}
+
+std::unordered_map<std::string, Subarray::MemorySize>
+Subarray::get_max_mem_size_map() {
+  // If the result sizes have not been computed, compute them first
+  if (!est_result_size_computed_)
+    compute_est_result_size();
+
+  return max_mem_size_;
+}
+
+Status Subarray::set_est_result_size(
+    std::unordered_map<std::string, ResultSize>& est_result_size,
+    std::unordered_map<std::string, MemorySize>& max_mem_size) {
+  est_result_size_ = est_result_size;
+  max_mem_size_ = max_mem_size;
+  est_result_size_computed_ = true;
+
+  return Status::Ok();
+}
+
 /* ****************************** */
 /*          PRIVATE METHODS       */
 /* ****************************** */

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1122,6 +1122,10 @@ Status Subarray::compute_est_result_size() {
   STATS_END_TIMER(stats::Stats::TimerType::READ_COMPUTE_EST_RESULT_SIZE)
 }
 
+bool Subarray::est_result_size_computed() {
+  return est_result_size_computed_;
+}
+
 Status Subarray::compute_relevant_fragment_est_result_sizes(
     const EncryptionKey* encryption_key,
     const ArraySchema* array_schema,

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -536,6 +536,29 @@ class Subarray {
       std::vector<std::vector<ResultSize>>* result_sizes,
       std::vector<std::vector<MemorySize>>* mem_sizes);
 
+  /**
+   * Used by serialization to set the estimated result size
+   *
+   * @param est_result_size map to set
+   * @param max_mem_size map to set
+   * @return Status
+   */
+  Status set_est_result_size(
+      std::unordered_map<std::string, ResultSize>& est_result_size,
+      std::unordered_map<std::string, MemorySize>& max_mem_size);
+
+  /**
+   * Used by serialization to get the map of result sizes
+   * @return
+   */
+  std::unordered_map<std::string, ResultSize> get_est_result_size_map();
+
+  /**
+   * Used by serialization to get the map of max mem sizes
+   * @return
+   */
+  std::unordered_map<std::string, MemorySize> get_max_mem_size_map();
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -364,6 +364,9 @@ class Subarray {
   Status get_est_result_size(
       const char* name, uint64_t* size_off, uint64_t* size_val);
 
+  /** returns whether the estimated result size has been computed or not */
+  bool est_result_size_computed();
+
   /*
    * Gets the maximum memory required to produce the result (in bytes)
    * for the input fixed-sized attribute/dimensiom.


### PR DESCRIPTION
Support is added by exposing the underlying unordered maps for estimates result size and max memory sizes. This will allow for one serialization/rest call to store estimates for all attributes/dimensions/coords.

If the user has a remote array, we now check in `Query::est_result_size` if the estimated sizes have been loaded or not to prevent multiple rest calls.

Lastly a few new unit tests were added and a few asan fixes were bundled in for missing free's for other serialization unit tests.

Note: The new functions are not thread safe, but the query object itself is not thread safe so I don't believe its a problem.