### PR TITLE
Fix overriding buffer w/split buffs and coords

### DIFF
--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -254,9 +254,10 @@ Status ResultTile::read(
     auto buff = static_cast<unsigned char*>(buffer);
     auto cell_size = coords_tile_.first.cell_size();
     auto dim_size = cell_size / domain_->dim_num();
-    uint64_t offset = dim_size * (dim_offset);
+    uint64_t offset = pos * cell_size + dim_size * dim_offset;
     for (uint64_t c = 0; c < len; ++c) {
-      RETURN_NOT_OK(coords_tile_.first.read(buff + c, dim_size, offset));
+      RETURN_NOT_OK(
+          coords_tile_.first.read(buff + (c * dim_size), dim_size, offset));
       offset += cell_size;
     }
   };


### PR DESCRIPTION
In compatibility with coords and split buffers we need to properly shift the buffer we are copying into. We also need to account for the position argument that is based into the reader.

This was missed in the backwards compatibility tests because they only fetch a single value from the array.

Unfortunately not all compatibility test have more than one value in the array, so we are unable to adjust the unit tests at this time. We need to modify the compatibility arrays to all have 2+ cells worth of data. This will be done in a follow up PR at a later time.