### PR TITLE
Fix failure in unit-ChunkedBuffer

### DIFF
--- a/test/src/unit-ChunkedBuffer.cc
+++ b/test/src/unit-ChunkedBuffer.cc
@@ -123,7 +123,8 @@ TEST_CASE(
     CHECK(chunk_buffer != write_buffer);
     if (chunk_buffer < write_buffer) {
       CHECK(
-          static_cast<void*>(static_cast<char*>(chunk_buffer) + chunk_size) <=
+          static_cast<void*>(
+              static_cast<char*>(chunk_buffer) + internal_size) <=
           write_buffer);
     } else {
       CHECK(
@@ -229,7 +230,8 @@ TEST_CASE(
     CHECK(chunk_buffer != write_buffer);
     if (chunk_buffer < write_buffer) {
       CHECK(
-          static_cast<void*>(static_cast<char*>(chunk_buffer) + chunk_size) <=
+          static_cast<void*>(
+              static_cast<char*>(chunk_buffer) + internal_size) <=
           write_buffer);
     } else {
       CHECK(


### PR DESCRIPTION
This fixes:
1: /Users/runner/runners/2.166.4/work/1/s/test/src/unit-ChunkedBuffer.cc:127: FAILED:
1:   CHECK( static_cast<void*>(static_cast<char*>(chunk_buffer) + chunk_size) <= write_buffer )
1: with expansion:
1:   0x000000011310b000 <= 0x0000000113107000

The test is verifying that the source and destination buffer in a write do not
overlap. The size of the destination buffer is incorrect for the last internal
buffer.

This is flaky due to randomness in the memory address of the source buffer.