### PR TITLE
Deprecate zipped-coords API

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -415,8 +415,14 @@ tiledb_vfs_mode_from_str(const char* str, tiledb_vfs_mode_t* vfs_mode);
 #define TILEDB_OOM (-2)
 /**@}*/
 
-/** Returns a special name indicating the coordinates attribute. */
-TILEDB_EXPORT const char* tiledb_coords();
+/**
+ * Returns a special name indicating the coordinates attribute.
+ *
+ * The coordinate buffer has been deprecated. Set the coordinates for
+ * each individual dimension with the `set_buffer` API. Consult the current
+ * documentation for more information.
+ */
+TILEDB_DEPRECATED_EXPORT const char* tiledb_coords();
 
 /** Returns a special value indicating a variable number of elements. */
 TILEDB_EXPORT uint32_t tiledb_var_num();

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -756,6 +756,10 @@ class Query {
   /**
    * Set the coordinate buffer.
    *
+   * The coordinate buffer has been deprecated. Set the coordinates for
+   * each individual dimension with the `set_buffer` API. Consult the current
+   * documentation for more information.
+   *
    * **Example:**
    * @code{.cpp}
    * tiledb::Context ctx;
@@ -773,12 +777,17 @@ class Query {
    * @param size The number of elements in the coordinate array buffer
    * **/
   template <typename T>
-  Query& set_coordinates(T* buf, uint64_t size) {
+  TILEDB_DEPRECATED Query& set_coordinates(T* buf, uint64_t size) {
     impl::type_check<T>(schema_.domain().type());
     return set_buffer(TILEDB_COORDS, buf, size);
   }
 
-  /** Set the coordinate buffer for unordered queries
+  /**
+   * Set the coordinate buffer for unordered queries.
+   *
+   * The coordinate buffer has been deprecated. Set the coordinates for
+   * each individual dimension with the `set_buffer` API. Consult the current
+   * documentation for more information.
    *
    * **Example:**
    * @code{.cpp}
@@ -794,7 +803,7 @@ class Query {
    * @param buf Coordinate vector
    * **/
   template <typename Vec>
-  Query& set_coordinates(Vec& buf) {
+  TILEDB_DEPRECATED Query& set_coordinates(Vec& buf) {
     return set_coordinates(buf.data(), buf.size());
   }
 


### PR DESCRIPTION
Uses the `TILEDB_DEPRECATED` macro to tag the deprecated routines with
`__attribute__((deprecated))`

Our unit tests and examples already build with the following flag that
supresses the warnings when we use them:
-Wno-deprecated-declarations