### PR TITLE
Deprecate max_buffer_size APIs

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -4460,7 +4460,7 @@ TILEDB_EXPORT int32_t tiledb_array_get_non_empty_domain_var_from_name(
  * @param buffer_size The buffer size (in bytes) to be retrieved.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int32_t tiledb_array_max_buffer_size(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_max_buffer_size(
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* name,
@@ -4493,7 +4493,7 @@ TILEDB_EXPORT int32_t tiledb_array_max_buffer_size(
  * @param buffer_val_size The values buffer size (in bytes) to be retrieved.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int32_t tiledb_array_max_buffer_size_var(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_max_buffer_size_var(
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* name,

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -1108,8 +1108,9 @@ class Array {
    *     number of elements for that attribute in the given subarray.
    */
   template <typename T>
-  std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
-  max_buffer_elements(const std::vector<T>& subarray) {
+  TILEDB_DEPRECATED
+      std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
+      max_buffer_elements(const std::vector<T>& subarray) {
     auto ctx = ctx_.get();
     tiledb_ctx_t* c_ctx = ctx.ptr().get();
     impl::type_check<T>(schema_.domain().type(), 1);


### PR DESCRIPTION
Deprecates
tiledb_array_max_buffer_size
tiledb_array_max_buffer_size_var
Array::max_buffer_elements