### PR TITLE
Add C ptr constructor for ::Array and ::Ctx in C++ API

### DIFF
--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -284,6 +284,32 @@ class Array {
             timestamp) {
   }
 
+  /**
+   * Constructor. Creates a TileDB Array instance wrapping the given pointer.
+   * @param ctx tiledb::Context
+   * @param own=true If false, disables underlying cleanup upon destruction.
+   * @throws TileDBError if construction fails
+   */
+  Array(const Context& ctx, tiledb_array_t* carray, bool own = true)
+      : ctx_(ctx)
+      , schema_(ArraySchema(ctx, (tiledb_array_schema_t*)nullptr)) {
+    if (carray == nullptr)
+      throw TileDBError(
+          "[TileDB::C++API] Error: Failed to create Array from null pointer");
+
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+
+    tiledb_array_schema_t* array_schema;
+    ctx.handle_error(tiledb_array_get_schema(c_ctx, carray, &array_schema));
+    schema_ = ArraySchema(ctx, array_schema);
+
+    array_ = std::shared_ptr<tiledb_array_t>(carray, [own](tiledb_array_t* p) {
+      if (own) {
+        tiledb_array_free(&p);
+      }
+    });
+  }
+
   Array(const Array&) = default;
   Array(Array&&) = default;
   Array& operator=(const Array&) = default;

--- a/tiledb/sm/cpp_api/context.h
+++ b/tiledb/sm/cpp_api/context.h
@@ -103,6 +103,26 @@ class Context {
     set_tag("x-tiledb-api-language", "c++");
   }
 
+  /**
+   * Constructor. Creates a TileDB context from the given pointer.
+   * @param own=true If false, disables underlying cleanup upon destruction.
+   * @throws TileDBError if construction fails
+   */
+  Context(tiledb_ctx_t* ctx, bool own = true) {
+    if (ctx == nullptr)
+      throw TileDBError(
+          "[TileDB::C++API] Error: Failed to create Context from pointer");
+
+    ctx_ = std::shared_ptr<tiledb_ctx_t>(ctx, [own](tiledb_ctx_t* p) {
+      if (own) {
+        Context::free(p);
+      }
+    });
+
+    error_handler_ = default_error_handler;
+
+    set_tag("x-tiledb-api-language", "c++");
+  }
   /* ********************************* */
   /*                API                */
   /* ********************************* */


### PR DESCRIPTION
This allows one to use an existing C-level `tiledb_array_t*` or `tiledb_ctx_t*` with the C++ API.