### PR TITLE
Remove deprecated max buffer size APIs from unit tests

### DIFF
--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -119,11 +119,10 @@ TEST_CASE(
   std::string array_uri(arrays_dir + "/non_split_coords_v1_4_0");
   Array array(ctx, array_uri, TILEDB_READ);
   std::vector<int> subarray = {1, 4, 10, 10};
-  auto max_el = array.max_buffer_elements(subarray);
   std::vector<int> a_read;
-  a_read.resize(max_el["a"].second);
+  a_read.resize(4);
   std::vector<int> coords_read;
-  coords_read.resize(max_el[TILEDB_COORDS].second);
+  coords_read.resize(8);
 
   Query query_r(ctx, array);
   query_r.set_subarray(subarray)

--- a/test/src/unit-capi-any.cc
+++ b/test/src/unit-capi-any.cc
@@ -198,11 +198,9 @@ void AnyFx::read_array(const std::string& array_name) {
   CHECK(rc == TILEDB_OK);
 
   // Get maximum buffer sizes
-  uint64_t size_off, size_val;
+  uint64_t size_off = 32;
+  uint64_t size_val = 32;
   uint64_t subarray[] = {1, 4};
-  rc = tiledb_array_max_buffer_size_var(
-      ctx, array, "a1", subarray, &size_off, &size_val);
-  CHECK(rc == TILEDB_OK);
 
   // Prepare cell buffers
   auto buffer_a1_off = new uint64_t[size_off / sizeof(uint64_t)];

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -1868,7 +1868,7 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   CHECK(type == TILEDB_INT32);
 
-  // Get non-empty domain and max buffer size should error out
+  // Get non-empty domain should error out
   tiledb_array_t* array;
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   REQUIRE(rc == TILEDB_OK);
@@ -1878,13 +1878,7 @@ TEST_CASE_METHOD(
   int is_empty = false;
   rc = tiledb_array_get_non_empty_domain_wrapper(ctx_, array, dom, &is_empty);
   REQUIRE(rc == TILEDB_ERR);
-  uint64_t size, size_var;
   void* subarray = nullptr;
-  rc = tiledb_array_max_buffer_size(ctx_, array, "d1", subarray, &size);
-  REQUIRE(rc == TILEDB_ERR);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "d1", subarray, &size, &size_var);
-  REQUIRE(rc == TILEDB_ERR);
 
   // Get non-empty domain per dimension
   dom = nullptr;
@@ -1910,6 +1904,7 @@ TEST_CASE_METHOD(
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_ERR);
   void* buff = nullptr;
+  uint64_t size = 1024;
   rc = tiledb_query_set_buffer(ctx_, query, TILEDB_COORDS, buff, &size);
   REQUIRE(rc == TILEDB_ERR);
 

--- a/test/src/unit-capi-async.cc
+++ b/test/src/unit-capi-async.cc
@@ -547,18 +547,11 @@ void AsyncFx::read_dense_async() {
   CHECK(rc == TILEDB_OK);
 
   // Calculate maximum buffer sizes for each attribute
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size;
+  uint64_t buffer_a1_size = 64;
+  uint64_t buffer_a2_off_size = 128;
+  uint64_t buffer_a2_val_size = 56;
+  uint64_t buffer_a3_size = 128;
   uint64_t subarray[] = {1, 4, 1, 4};
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -646,21 +639,11 @@ void AsyncFx::read_sparse_async() {
   CHECK(rc == TILEDB_OK);
 
   // Calculate maximum buffer sizes for each attribute
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size;
-  uint64_t subarray[] = {1, 4, 1, 4};
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size);
-  CHECK(rc == TILEDB_OK);
+  uint64_t buffer_a1_size = 32;
+  uint64_t buffer_a2_off_size = 64;
+  uint64_t buffer_a2_val_size = 20;
+  uint64_t buffer_a3_size = 64;
+  uint64_t buffer_coords_size = 128;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -2240,17 +2240,10 @@ void ConsolidationFx::read_dense_full_subarray_unordered() {
 
   // Compute max buffer sizes
   uint64_t subarray[] = {1, 4, 1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
+  uint64_t buffer_a1_size = 64;
+  uint64_t buffer_a2_off_size = 128;
+  uint64_t buffer_a2_val_size = 114;
+  uint64_t buffer_a3_size = 128;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -2352,17 +2345,10 @@ void ConsolidationFx::read_dense_subarray_full_unordered() {
 
   // Compute max buffer sizes
   uint64_t subarray[] = {1, 4, 1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
+  uint64_t buffer_a1_size = 64;
+  uint64_t buffer_a2_off_size = 128;
+  uint64_t buffer_a2_val_size = 114;
+  uint64_t buffer_a3_size = 128;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -2455,17 +2441,10 @@ void ConsolidationFx::read_dense_subarray_unordered_full() {
 
   // Compute max buffer sizes
   uint64_t subarray[] = {1, 4, 1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
+  uint64_t buffer_a1_size = 64;
+  uint64_t buffer_a2_off_size = 128;
+  uint64_t buffer_a2_val_size = 114;
+  uint64_t buffer_a3_size = 128;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -2551,21 +2530,11 @@ void ConsolidationFx::read_sparse_full_unordered() {
   REQUIRE(rc == TILEDB_OK);
 
   // Compute max buffer sizes
-  uint64_t subarray[] = {1, 4, 1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size);
-  CHECK(rc == TILEDB_OK);
+  uint64_t buffer_a1_size = 64;
+  uint64_t buffer_a2_off_size = 176;
+  uint64_t buffer_a2_val_size = 51;
+  uint64_t buffer_a3_size = 128;
+  uint64_t buffer_coords_size = 256;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -2655,21 +2624,11 @@ void ConsolidationFx::read_sparse_unordered_full() {
   REQUIRE(rc == TILEDB_OK);
 
   // Compute max buffer sizes
-  uint64_t subarray[] = {1, 4, 1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size);
-  CHECK(rc == TILEDB_OK);
+  uint64_t buffer_a1_size = 64;
+  uint64_t buffer_a2_off_size = 176;
+  uint64_t buffer_a2_val_size = 54;
+  uint64_t buffer_a3_size = 128;
+  uint64_t buffer_coords_size = 256;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -2098,30 +2098,13 @@ void DenseArrayFx::read_dense_array_with_coords_full_global(
 
   // Compute max buffer sizes
   uint64_t subarray[] = {1, 4, 1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size = 0, buffer_d1_size = 0,
-                      buffer_d2_size = 0;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
-  if (split_coords) {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d1", subarray, &buffer_d1_size);
-    CHECK(rc == TILEDB_OK);
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d2", subarray, &buffer_d2_size);
-    CHECK(rc == TILEDB_OK);
-  } else {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size);
-    CHECK(rc == TILEDB_OK);
-  }
+  uint64_t buffer_a1_size = 64;
+  uint64_t buffer_a2_off_size = 128;
+  uint64_t buffer_a2_val_size = 56;
+  uint64_t buffer_a3_size = 128;
+  uint64_t buffer_coords_size = 256;
+  uint64_t buffer_d1_size = 128;
+  uint64_t buffer_d2_size = 128;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -2243,30 +2226,13 @@ void DenseArrayFx::read_dense_array_with_coords_full_row(
 
   // Compute max buffer sizes
   uint64_t subarray[] = {1, 4, 1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size = 0, buffer_d1_size = 0,
-                      buffer_d2_size = 0;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
-  if (split_coords) {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d1", subarray, &buffer_d1_size);
-    CHECK(rc == TILEDB_OK);
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d2", subarray, &buffer_d2_size);
-    CHECK(rc == TILEDB_OK);
-  } else {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size);
-    CHECK(rc == TILEDB_OK);
-  }
+  uint64_t buffer_a1_size = 64;
+  uint64_t buffer_a2_off_size = 128;
+  uint64_t buffer_a2_val_size = 56;
+  uint64_t buffer_a3_size = 128;
+  uint64_t buffer_coords_size = 256;
+  uint64_t buffer_d1_size = 128;
+  uint64_t buffer_d2_size = 128;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -2387,30 +2353,13 @@ void DenseArrayFx::read_dense_array_with_coords_full_col(
 
   // Compute max buffer sizes
   uint64_t subarray[] = {1, 4, 1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size = 0, buffer_d1_size = 0,
-                      buffer_d2_size = 0;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
-  if (split_coords) {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d1", subarray, &buffer_d1_size);
-    CHECK(rc == TILEDB_OK);
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d2", subarray, &buffer_d2_size);
-    CHECK(rc == TILEDB_OK);
-  } else {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size);
-    CHECK(rc == TILEDB_OK);
-  }
+  uint64_t buffer_a1_size = 64;
+  uint64_t buffer_a2_off_size = 128;
+  uint64_t buffer_a2_val_size = 56;
+  uint64_t buffer_a3_size = 128;
+  uint64_t buffer_coords_size = 256;
+  uint64_t buffer_d1_size = 128;
+  uint64_t buffer_d2_size = 128;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -2534,30 +2483,13 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_global(
 
   // Compute max buffer sizes
   uint64_t subarray[] = {3, 4, 2, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size = 0, buffer_d1_size = 0,
-                      buffer_d2_size = 0;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
-  if (split_coords) {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d1", subarray, &buffer_d1_size);
-    CHECK(rc == TILEDB_OK);
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d2", subarray, &buffer_d2_size);
-    CHECK(rc == TILEDB_OK);
-  } else {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size);
-    CHECK(rc == TILEDB_OK);
-  }
+  uint64_t buffer_a1_size = 24;
+  uint64_t buffer_a2_off_size = 48;
+  uint64_t buffer_a2_val_size = 26;
+  uint64_t buffer_a3_size = 48;
+  uint64_t buffer_coords_size = 96;
+  uint64_t buffer_d1_size = 48;
+  uint64_t buffer_d2_size = 48;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -2679,30 +2611,13 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_row(
 
   // Compute max buffer sizes
   uint64_t subarray[] = {3, 4, 2, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size = 0, buffer_d1_size = 0,
-                      buffer_d2_size = 0;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
-  if (split_coords) {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d1", subarray, &buffer_d1_size);
-    CHECK(rc == TILEDB_OK);
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d2", subarray, &buffer_d2_size);
-    CHECK(rc == TILEDB_OK);
-  } else {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size);
-    CHECK(rc == TILEDB_OK);
-  }
+  uint64_t buffer_a1_size = 24;
+  uint64_t buffer_a2_off_size = 48;
+  uint64_t buffer_a2_val_size = 26;
+  uint64_t buffer_a3_size = 48;
+  uint64_t buffer_coords_size = 96;
+  uint64_t buffer_d1_size = 48;
+  uint64_t buffer_d2_size = 48;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -2824,30 +2739,13 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_col(
 
   // Compute max buffer sizes
   uint64_t subarray[] = {3, 4, 2, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size = 0, buffer_d1_size = 0,
-                      buffer_d2_size = 0;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a3", subarray, &buffer_a3_size);
-  CHECK(rc == TILEDB_OK);
-  if (split_coords) {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d1", subarray, &buffer_d1_size);
-    CHECK(rc == TILEDB_OK);
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, "d2", subarray, &buffer_d2_size);
-    CHECK(rc == TILEDB_OK);
-  } else {
-    rc = tiledb_array_max_buffer_size(
-        ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size);
-    CHECK(rc == TILEDB_OK);
-  }
+  uint64_t buffer_a1_size = 24;
+  uint64_t buffer_a2_off_size = 48;
+  uint64_t buffer_a2_val_size = 26;
+  uint64_t buffer_a3_size = 48;
+  uint64_t buffer_coords_size = 96;
+  uint64_t buffer_d1_size = 48;
+  uint64_t buffer_d2_size = 48;
 
   // Prepare cell buffers
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
@@ -3638,7 +3536,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_ERR);
 
   // Getting the non-empty domain should fail for an array opened for writes
-  uint64_t subarray[] = {1, 4, 1, 4};
   uint64_t domain[4];
   int is_empty = false;
   rc = tiledb_array_get_non_empty_domain(ctx_, array, domain, &is_empty);
@@ -3648,12 +3545,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_ERR);
   rc = tiledb_array_get_non_empty_domain_from_name(
       ctx_, array, "d1", domain, &is_empty);
-  CHECK(rc == TILEDB_ERR);
-
-  // Getting the max buffer sizes should fail for an array opened for writes
-  uint64_t buffer_a1_size;
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, "a1", subarray, &buffer_a1_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check query type

--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -1418,26 +1418,11 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_array_open(ctx_, array, TILEDB_READ) == TILEDB_OK);
 
   uint64_t subarray[] = {1, 4, 1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_size, buffer_coords_size;
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, "a1", subarray, &buffer_a1_size) == TILEDB_OK);
-  REQUIRE(
-      tiledb_array_max_buffer_size_var(
-          ctx_,
-          array,
-          "a2",
-          subarray,
-          &buffer_a2_off_size,
-          &buffer_a2_val_size) == TILEDB_OK);
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, "a3", subarray, &buffer_a3_size) == TILEDB_OK);
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, TILEDB_COORDS, subarray, &buffer_coords_size) ==
-      TILEDB_OK);
+  uint64_t buffer_a1_size = 1024;
+  uint64_t buffer_a2_off_size = 1024;
+  uint64_t buffer_a2_val_size = 1024;
+  uint64_t buffer_a3_size = 1024;
+  uint64_t buffer_coords_size = 1024;
 
   auto buffer_a1 = (int*)malloc(buffer_a1_size);
   auto buffer_a2_off = (uint64_t*)malloc(buffer_a2_off_size);
@@ -2199,17 +2184,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
-  std::array<uint64_t, 4> subarray_check{1, 4, 1, 4};
-  uint64_t buff_size = 0;
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, "a1", subarray_check.data(), &buff_size) == TILEDB_OK);
-  REQUIRE(buff_size == 0);
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, TILEDB_COORDS, subarray_check.data(), &buff_size) ==
-      TILEDB_OK);
-  REQUIRE(buff_size == 0);
   REQUIRE(tiledb_array_close(ctx_, array) == TILEDB_OK);
   tiledb_array_free(&array);
 
@@ -2221,64 +2195,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
-  subarray_check = {1, 4, 1, 4};
-  uint64_t num_cells = (subarray_check[1] - subarray_check[0] + 1) *
-                       (subarray_check[3] - subarray_check[2] + 1);
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, "a1", subarray_check.data(), &buff_size) == TILEDB_OK);
-  REQUIRE(buff_size == num_cells * sizeof(int32_t));
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, "a2", subarray_check.data(), &buff_size) == TILEDB_ERR);
-  uint64_t buff_off_size = 0;
-  REQUIRE(
-      tiledb_array_max_buffer_size_var(
-          ctx_,
-          array,
-          "a2",
-          subarray_check.data(),
-          &buff_off_size,
-          &buff_size) == TILEDB_OK);
-  REQUIRE(buff_off_size == num_cells * sizeof(uint64_t));
-  REQUIRE(buff_size == 56);
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, "a3", subarray_check.data(), &buff_size) == TILEDB_OK);
-  REQUIRE(buff_size == num_cells * 2 * sizeof(float));
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, TILEDB_COORDS, subarray_check.data(), &buff_size) ==
-      TILEDB_OK);
-  REQUIRE(buff_size == num_cells * 2 * sizeof(uint64_t));
-
-  // Check again with different subarray
-  subarray_check = {2, 3, 2, 3};
-  num_cells = (subarray_check[1] - subarray_check[0] + 1) *
-              (subarray_check[3] - subarray_check[2] + 1);
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, "a1", subarray_check.data(), &buff_size) == TILEDB_OK);
-  REQUIRE(buff_size == num_cells * sizeof(int32_t));
-  REQUIRE(
-      tiledb_array_max_buffer_size_var(
-          ctx_,
-          array,
-          "a2",
-          subarray_check.data(),
-          &buff_off_size,
-          &buff_size) == TILEDB_OK);
-  REQUIRE(buff_off_size == num_cells * sizeof(uint64_t));
-  REQUIRE(buff_size == 44);
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, "a3", subarray_check.data(), &buff_size) == TILEDB_OK);
-  REQUIRE(buff_size == num_cells * 2 * sizeof(float));
-  REQUIRE(
-      tiledb_array_max_buffer_size(
-          ctx_, array, TILEDB_COORDS, subarray_check.data(), &buff_size) ==
-      TILEDB_OK);
-  REQUIRE(buff_size == num_cells * 2 * sizeof(uint64_t));
 
   // Clean up
   REQUIRE(tiledb_array_close(ctx_, array) == TILEDB_OK);

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -501,12 +501,7 @@ int* SparseArrayFx::read_sparse_array_2D(
   }
 
   // Prepare the buffers that will store the result
-  uint64_t buffer_size;
-  int64_t s[] = {domain_0_lo, domain_0_hi, domain_1_lo, domain_1_hi};
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, ATTR_NAME.c_str(), s, &buffer_size);
-
-  CHECK(rc == TILEDB_OK);
+  uint64_t buffer_size = 100 * 1024 * 1024;
   auto buffer = new int[buffer_size / sizeof(int)];
   REQUIRE(buffer != nullptr);
 
@@ -2156,11 +2151,7 @@ void SparseArrayFx::check_sparse_array_no_results(
   CHECK(rc == TILEDB_OK);
 
   // Prepare the buffers that will store the result
-  uint64_t buffer_size;
-  uint64_t s[] = {1, 2, 1, 2};
-  rc = tiledb_array_max_buffer_size(ctx_, array, "a1", s, &buffer_size);
-  CHECK(rc == TILEDB_OK);
-
+  uint64_t buffer_size = 0;
   auto buffer = new int[buffer_size / sizeof(int)];
   REQUIRE(buffer != nullptr);
 
@@ -2891,18 +2882,11 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   // Get max buffer sizes for empty query
-  uint64_t s[] = {1, 1, 3, 3};
-  uint64_t a1_size, a2_off_size, a2_size, a3_size, coords_size;
-  rc = tiledb_array_max_buffer_size(ctx_, array, "a1", s, &a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", s, &a2_off_size, &a2_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(ctx_, array, "a3", s, &a3_size);
-  CHECK(rc == TILEDB_OK);
-  rc =
-      tiledb_array_max_buffer_size(ctx_, array, TILEDB_COORDS, s, &coords_size);
-  CHECK(rc == TILEDB_OK);
+  uint64_t a1_size = 4;
+  uint64_t a2_off_size = 16;
+  uint64_t a2_size = 7;
+  uint64_t a3_size = 8;
+  uint64_t coords_size = 16;
 
   // Set attribute buffers
   auto a1 = (int*)malloc(a1_size);
@@ -2952,18 +2936,12 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
 
-  // Get max buffer sizes for non-empty query
-  uint64_t subarray_2[] = {1, 1, 1, 2};
-  rc = tiledb_array_max_buffer_size(ctx_, array, "a1", subarray_2, &a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx_, array, "a2", subarray_2, &a2_off_size, &a2_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(ctx_, array, "a3", subarray_2, &a3_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size(
-      ctx_, array, TILEDB_COORDS, subarray_2, &coords_size);
-  CHECK(rc == TILEDB_OK);
+  // Set max buffer sizes for non-empty query
+  a1_size = 8;
+  a2_off_size = 16;
+  a2_size = 3;
+  a3_size = 16;
+  coords_size = 32;
 
   // Set attribute buffers
   a1 = (int*)malloc(a1_size);

--- a/test/src/unit-capi-string.cc
+++ b/test/src/unit-capi-string.cc
@@ -242,17 +242,11 @@ void StringFx::read_array(const std::string& array_name) {
 
   // Compute max buffer sizes
   uint64_t subarray[] = {1, 4};
-  uint64_t buffer_a1_size, buffer_a2_off_size, buffer_a2_val_size,
-      buffer_a3_off_size, buffer_a3_val_size;
-  rc =
-      tiledb_array_max_buffer_size(ctx, array, "a1", subarray, &buffer_a1_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx, array, "a2", subarray, &buffer_a2_off_size, &buffer_a2_val_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_array_max_buffer_size_var(
-      ctx, array, "a3", subarray, &buffer_a3_off_size, &buffer_a3_val_size);
-  CHECK(rc == TILEDB_OK);
+  uint64_t buffer_a1_size = 1024;
+  uint64_t buffer_a2_off_size = 1024;
+  uint64_t buffer_a2_val_size = 1024;
+  uint64_t buffer_a3_off_size = 1024;
+  uint64_t buffer_a3_val_size = 1024;
 
   // Prepare cell buffers
   void* buffer_a1 = std::malloc(buffer_a1_size);
@@ -297,11 +291,6 @@ void StringFx::read_array(const std::string& array_name) {
   REQUIRE(rc == TILEDB_OK);
 
   // Check results
-  CHECK(buffer_a1_size == sizeof(UTF8_STRINGS) - UTF8_NULL_SIZE);
-  CHECK(buffer_a2_off_size == 4 * sizeof(uint64_t));
-  CHECK(buffer_a2_val_size == sizeof(UTF8_STRINGS_VAR) - UTF8_NULL_SIZE);
-  CHECK(buffer_a3_off_size == 4 * sizeof(uint64_t));
-  CHECK(buffer_a3_val_size == sizeof(UTF16_STRINGS_VAR) - UTF16_NULL_SIZE);
   CHECK(!std::memcmp(
       buffer_a1, UTF8_STRINGS, sizeof(UTF8_STRINGS) - UTF8_NULL_SIZE));
   CHECK(!std::memcmp(

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -1678,12 +1678,8 @@ TEST_CASE_METHOD(
   // Get non-empty domain and array max buffer sizes
   int32_t dom[4];
   int32_t is_empty;
-  uint64_t size;
+  uint64_t size = 1024;
   rc = tiledb_array_get_non_empty_domain(ctx_, array, dom, &is_empty);
-  CHECK(rc == TILEDB_ERR);
-  rc = tiledb_array_max_buffer_size(ctx_, array, "a", dom, &size);
-  CHECK(rc == TILEDB_ERR);
-  rc = tiledb_array_max_buffer_size_var(ctx_, array, "a", dom, &size, &size);
   CHECK(rc == TILEDB_ERR);
 
   // Set subarray and buffer

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -184,31 +184,13 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic]") {
 
       Array array(ctx, "cpp_unit_array", TILEDB_READ);
 
-      auto buff_el = array.max_buffer_elements(subarray);
-
-      CHECK(buff_el.count("a1"));
-      CHECK(buff_el.count("a2"));
-      CHECK(buff_el.count("a3"));
-      CHECK(buff_el.count("a4"));
-      CHECK(buff_el.count("a5"));
-      CHECK(buff_el["a1"].first == 0);
-      CHECK(buff_el["a1"].second >= 2);
-      CHECK(buff_el["a2"].first == 2);
-      CHECK(buff_el["a2"].second >= 7);
-      CHECK(buff_el["a3"].first == 0);
-      CHECK(buff_el["a3"].second >= 4);
-      CHECK(buff_el["a4"].first == 2);
-      CHECK(buff_el["a4"].second >= 3);
-      CHECK(buff_el["a5"].first == 0);
-      CHECK(buff_el["a5"].second >= 2);
-
-      a1.resize(buff_el["a1"].second);
-      a2buf.first.resize(buff_el["a2"].first);
-      a2buf.second.resize(buff_el["a2"].second);
-      a1.resize(buff_el["a3"].second);
-      a4buf.first.resize(buff_el["a4"].first);
-      a4buf.second.resize(buff_el["a4"].second);
-      a1.resize(buff_el["a5"].second);
+      a1.resize(2);
+      a2buf.first.resize(2);
+      a2buf.second.resize(57);
+      a1.resize(32);
+      a4buf.first.resize(2);
+      a4buf.second.resize(122);
+      a1.resize(48);
 
       Query query(ctx, array);
 

--- a/test/src/unit-cppapi-checksum.cc
+++ b/test/src/unit-cppapi-checksum.cc
@@ -103,12 +103,11 @@ static void run_checksum_test(tiledb_filter_type_t filter_type) {
   // Sanity check reading before corrupting data
   array.open(TILEDB_READ);
   std::vector<int> subarray = {0, 10, 0, 10};
-  auto buff_el = array.max_buffer_elements(subarray);
   std::vector<int> coords_read(4);
-  std::vector<int> a1_read(buff_el["a1"].second);
-  std::vector<uint64_t> a2_read_off(buff_el["a2"].first);
+  std::vector<int> a1_read(2);
+  std::vector<uint64_t> a2_read_off(2);
   std::string a2_read_data;
-  a2_read_data.resize(buff_el["a2"].second);
+  a2_read_data.resize(7);
   Query query_r(ctx2, array);
   query_r.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
@@ -174,12 +173,11 @@ static void run_checksum_test(tiledb_filter_type_t filter_type) {
   // {1, 2}
   array.open(TILEDB_READ);
   subarray = {0, 10, 0, 10};
-  auto buff_el2 = array.max_buffer_elements(subarray);
   std::vector<int32_t> coords_read2(4);
-  std::vector<int32_t> a1_read2(buff_el["a1"].second);
-  std::vector<uint64_t> a2_read_off2(buff_el["a2"].first);
+  std::vector<int32_t> a1_read2(2);
+  std::vector<uint64_t> a2_read_off2(2);
   std::string a2_read_data2;
-  a2_read_data2.resize(buff_el["a2"].second);
+  a2_read_data2.resize(7);
   Query query_r2(ctx, array);
   query_r2.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)

--- a/test/src/unit-cppapi-filter.cc
+++ b/test/src/unit-cppapi-filter.cc
@@ -191,11 +191,10 @@ TEST_CASE("C++ API: Filter lists on array", "[cppapi], [filter]") {
   // Sanity check reading
   array.open(TILEDB_READ);
   std::vector<int> subarray = {0, 10, 0, 10};
-  auto buff_el = array.max_buffer_elements(subarray);
-  std::vector<int> a1_read(buff_el["a1"].second);
-  std::vector<uint64_t> a2_read_off(buff_el["a2"].first);
+  std::vector<int> a1_read(2);
+  std::vector<uint64_t> a2_read_off(2);
   std::string a2_read_data;
-  a2_read_data.resize(buff_el["a2"].second);
+  a2_read_data.resize(7);
   Query query_r(ctx, array);
   query_r.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -222,11 +222,9 @@ TEST_CASE(
   // Open array
   Array array(ctx, "sparse_array", TILEDB_READ);
 
-  // Get non-empty domain and max buffer elements should error out
+  // Get non-empty domain should error out
   CHECK_THROWS(array.non_empty_domain<int32_t>());
   std::vector<int32_t> subarray = {1, 2, 1, 3};
-  CHECK_THROWS(array.max_buffer_elements(subarray));
-  CHECK_THROWS(array.max_buffer_elements(subarray));
 
   // Query checks
   Query query(ctx, array, TILEDB_READ);

--- a/test/src/unit-cppapi-updates.cc
+++ b/test/src/unit-cppapi-updates.cc
@@ -95,11 +95,10 @@ TEST_CASE(
   Query query(ctx, array);
 
   std::vector<int> subarray = {rowmin, rowmax, colmin, colmax};
-  auto buff_el = array.max_buffer_elements(subarray);
   std::vector<uint64_t> r_offsets_a1;
-  r_offsets_a1.resize(buff_el["a1"].first);
+  r_offsets_a1.resize(100);
   std::vector<int> r_data_a1;
-  r_data_a1.resize(buff_el["a1"].second);
+  r_data_a1.resize(300);
 
   query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)


### PR DESCRIPTION
This removes uses of the following APIs in the unit tests:
tiledb_array_max_buffer_size
tiledb_array_max_buffer_size_var
Array::max_buffer_elements

The values the APIs fetched have been hard-coded into the unit tests. If
multiple tests passed through the same API, the largest returned value has
been hard-coded. I guessed on the 1024 size for the rest unit test, though.