### PR TITLE
Allow setting zipped coords multiple times

### DIFF
--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -2624,11 +2624,6 @@ void Writer::clean_up(const URI& uri) {
 }
 
 Status Writer::set_coords_buffer(void* buffer, uint64_t* buffer_size) {
-  // Error if setting non-existing coordinates after initialization
-  if (initialized_ && has_coords_)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set coordinates after initialization")));
-
   if (coord_buffer_is_set_)
     return LOG_STATUS(Status::WriterError(
         std::string("Cannot set zipped coordinates buffer after having set "


### PR DESCRIPTION
For backwards compatibility, this removes the error path for setting the
zipped coords multiple times. We will still error-out if the user attempts to
set zipped coords after setting split coords.