### PR TITLE
Remove zipped coords from examples

### DIFF
--- a/examples/c_api/filters.c
+++ b/examples/c_api/filters.c
@@ -123,8 +123,9 @@ void write_array() {
   tiledb_array_open(ctx, array, TILEDB_WRITE);
 
   // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-  int coords[] = {1, 1, 2, 4, 2, 3};
-  uint64_t coords_size = sizeof(coords);
+  int coords_rows[] = {1, 2, 2};
+  int coords_cols[] = {1, 4, 3};
+  uint64_t coords_size = sizeof(coords_rows);
   uint32_t data_a1[] = {1, 2, 3};
   uint64_t data_a1_size = sizeof(data_a1);
   int32_t data_a2[] = {-1, -2, -3};
@@ -136,7 +137,8 @@ void write_array() {
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   tiledb_query_set_buffer(ctx, query, "a1", data_a1, &data_a1_size);
   tiledb_query_set_buffer(ctx, query, "a2", data_a2, &data_a2_size);
-  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "rows", coords_rows, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "cols", coords_cols, &coords_size);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -164,11 +166,12 @@ void read_array() {
   int subarray[] = {1, 2, 2, 4};
 
   // Set maximum buffer sizes
-  uint64_t coords_size = 24;
+  uint64_t coords_size = 12;
   uint64_t data_size = 12;
 
   // Prepare the vector that will hold the result
-  int* coords = (int*)malloc(coords_size);
+  int* coords_rows = (int*)malloc(coords_size);
+  int* coords_cols = (int*)malloc(coords_size);
   int* data = (int*)malloc(data_size);
 
   // Create query
@@ -177,7 +180,8 @@ void read_array() {
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_buffer(ctx, query, "a1", data, &data_size);
-  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "rows", coords_rows, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "cols", coords_cols, &coords_size);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -188,13 +192,15 @@ void read_array() {
   // Print out the results.
   int result_num = (int)(data_size / sizeof(int));
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     printf("Cell (%d, %d) has a1 data %d\n", i, j, a);
   }
 
   // Clean up
-  free((void*)coords);
+  free((void*)coords_rows);
+  free((void*)coords_cols);
   free((void*)data);
   tiledb_array_free(&array);
   tiledb_query_free(&query);

--- a/examples/c_api/fragments_consolidation.c
+++ b/examples/c_api/fragments_consolidation.c
@@ -167,8 +167,9 @@ void write_array_3() {
   tiledb_array_open(ctx, array, TILEDB_WRITE);
 
   // Prepare some data for the array
-  int coords[] = {1, 1, 3, 4};
-  uint64_t coords_size = sizeof(coords);
+  int coords_rows[] = {1, 3};
+  int coords_cols[] = {1, 4};
+  uint64_t coords_size = sizeof(coords_rows);
   int data[] = {201, 202};
   uint64_t data_size = sizeof(data);
 
@@ -177,7 +178,8 @@ void write_array_3() {
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   tiledb_query_set_buffer(ctx, query, "a", data, &data_size);
-  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "rows", coords_rows, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "cols", coords_cols, &coords_size);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -205,11 +207,12 @@ void read_array() {
   int subarray[] = {1, 4, 1, 4};
 
   // Set maximum buffer sizes
-  uint64_t coords_size = 128;
+  uint64_t coords_size = 64;
   uint64_t data_size = 64;
 
   // Prepare the vectors that will hold the result
-  int coords[32];
+  int coords_rows[16];
+  int coords_cols[16];
   int data[16];
 
   // Create query
@@ -218,7 +221,8 @@ void read_array() {
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_buffer(ctx, query, "a", data, &data_size);
-  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "rows", coords_rows, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "cols", coords_cols, &coords_size);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -229,7 +233,8 @@ void read_array() {
   // Print out the results.
   int result_num = (int)(data_size / sizeof(int));
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     printf("Cell (%d, %d) has data %d\n", i, j, a);
   }

--- a/examples/c_api/quickstart_sparse.c
+++ b/examples/c_api/quickstart_sparse.c
@@ -94,8 +94,9 @@ void write_array() {
   tiledb_array_open(ctx, array, TILEDB_WRITE);
 
   // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-  int coords[] = {1, 1, 2, 4, 2, 3};
-  uint64_t coords_size = sizeof(coords);
+  int coords_rows[] = {1, 2, 2};
+  int coords_cols[] = {1, 4, 3};
+  uint64_t coords_size = sizeof(coords_rows);
   int data[] = {1, 2, 3};
   uint64_t data_size = sizeof(data);
 
@@ -104,7 +105,8 @@ void write_array() {
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   tiledb_query_set_buffer(ctx, query, "a", data, &data_size);
-  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "rows", coords_rows, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "cols", coords_cols, &coords_size);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -132,11 +134,12 @@ void read_array() {
   int subarray[] = {1, 2, 2, 4};
 
   // Set maximum buffer sizes
-  uint64_t coords_size = 24;
+  uint64_t coords_size = 12;
   uint64_t data_size = 12;
 
   // Prepare the vector that will hold the result
-  int* coords = (int*)malloc(coords_size);
+  int* coords_rows = (int*)malloc(coords_size);
+  int* coords_cols = (int*)malloc(coords_size);
   int* data = (int*)malloc(data_size);
 
   // Create query
@@ -145,7 +148,8 @@ void read_array() {
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_buffer(ctx, query, "a", data, &data_size);
-  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "rows", coords_rows, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "cols", coords_cols, &coords_size);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -156,13 +160,15 @@ void read_array() {
   // Print out the results.
   int result_num = (int)(data_size / sizeof(int));
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     printf("Cell (%d, %d) has data %d\n", i, j, a);
   }
 
   // Clean up
-  free((void*)coords);
+  free((void*)coords_rows);
+  free((void*)coords_cols);
   free((void*)data);
   tiledb_array_free(&array);
   tiledb_query_free(&query);

--- a/examples/c_api/reading_dense_layouts.c
+++ b/examples/c_api/reading_dense_layouts.c
@@ -144,8 +144,9 @@ void read_array(tiledb_layout_t layout) {
   int subarray[] = {1, 2, 2, 4};
 
   // Prepare the vectors that will hold the results
-  int coords[12];
-  uint64_t coords_size = sizeof(coords);
+  int coords_rows[6];
+  int coords_cols[6];
+  uint64_t coords_size = sizeof(coords_rows);
   int data[6];
   uint64_t data_size = sizeof(data);
 
@@ -155,7 +156,8 @@ void read_array(tiledb_layout_t layout) {
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, layout);
   tiledb_query_set_buffer(ctx, query, "a", data, &data_size);
-  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "rows", coords_rows, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "cols", coords_cols, &coords_size);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -166,7 +168,8 @@ void read_array(tiledb_layout_t layout) {
   // Print out the results.
   int result_num = (int)(data_size / sizeof(int));
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     printf("Cell (%d, %d) has data %d\n", i, j, a);
   }

--- a/examples/c_api/writing_dense_sparse.c
+++ b/examples/c_api/writing_dense_sparse.c
@@ -95,8 +95,9 @@ void write_array() {
   tiledb_array_open(ctx, array, TILEDB_WRITE);
 
   // Prepare some data for the array
-  int coords[] = {1, 2, 2, 1, 4, 3, 1, 4};
-  uint64_t coords_size = sizeof(coords);
+  int coords_rows[] = {1, 2, 4, 1};
+  int coords_cols[] = {2, 1, 3, 4};
+  uint64_t coords_size = sizeof(coords_rows);
   int data[] = {1, 2, 3, 4};
   uint64_t data_size = sizeof(data);
 
@@ -105,7 +106,8 @@ void write_array() {
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
   tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
   tiledb_query_set_buffer(ctx, query, "a", data, &data_size);
-  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "rows", coords_rows, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "cols", coords_cols, &coords_size);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -133,8 +135,9 @@ void read_array() {
   int subarray[] = {1, 4, 1, 4};
 
   // Prepare the vector that will hold the result (of size 16 elements)
-  int coords[32];
-  uint64_t coords_size = sizeof(coords);
+  int coords_rows[16];
+  int coords_cols[16];
+  uint64_t coords_size = sizeof(coords_rows);
   int data[16];
   uint64_t data_size = sizeof(data);
 
@@ -144,7 +147,8 @@ void read_array() {
   tiledb_query_set_subarray(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_buffer(ctx, query, "a", data, &data_size);
-  tiledb_query_set_buffer(ctx, query, TILEDB_COORDS, coords, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "rows", coords_rows, &coords_size);
+  tiledb_query_set_buffer(ctx, query, "cols", coords_cols, &coords_size);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -154,7 +158,8 @@ void read_array() {
 
   // Print out the results.
   for (int r = 0; r < 16; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     printf("Cell (%d, %d) has data %d\n", i, j, a);
   }

--- a/examples/cpp_api/async.cc
+++ b/examples/cpp_api/async.cc
@@ -63,7 +63,8 @@ void write_array() {
   Context ctx;
 
   // Prepare some data for the array
-  std::vector<int> coords = {1, 1, 2, 1, 2, 2, 4, 3};
+  std::vector<int> coords_rows = {1, 2, 2, 4};
+  std::vector<int> coords_cols = {1, 1, 2, 3};
   std::vector<int> data = {1, 2, 3, 4};
 
   // Open the array for writing and create the query.
@@ -71,7 +72,8 @@ void write_array() {
   Query query(ctx, array);
   query.set_layout(TILEDB_GLOBAL_ORDER)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit query asynchronously with callback
   query.submit_async(
@@ -94,14 +96,16 @@ void read_array() {
   Array array(ctx, array_name, TILEDB_READ);
   const std::vector<int> subarray = {1, 4, 1, 4};
   std::vector<int> data(4);
-  std::vector<int> coords(8);
+  std::vector<int> coords_rows(4);
+  std::vector<int> coords_cols(4);
 
   // Prepare the query
   Query query(ctx, array, TILEDB_READ);
   query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit query asynchronously with callback
   query.submit_async([]() { std::cout << "Callback: Read query completed\n"; });
@@ -116,7 +120,8 @@ void read_array() {
   // Print out the results.
   auto result_num = (int)query.result_buffer_elements()["a"].second;
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     std::cout << "Cell (" << i << ", " << j << ") has data " << a << "\n";
   }

--- a/examples/cpp_api/filters.cc
+++ b/examples/cpp_api/filters.cc
@@ -80,7 +80,8 @@ void write_array() {
   Context ctx;
 
   // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-  std::vector<int> coords = {1, 1, 2, 4, 2, 3};
+  std::vector<int> coords_rows = {1, 2, 2};
+  std::vector<int> coords_cols = {1, 4, 3};
   std::vector<uint32_t> data_a1 = {1, 2, 3};
   std::vector<int32_t> data_a2 = {-1, -2, -3};
 
@@ -90,7 +91,8 @@ void write_array() {
   query.set_layout(TILEDB_UNORDERED)
       .set_buffer("a1", data_a1)
       .set_buffer("a2", data_a2)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Perform the write and close the array.
   query.submit();
@@ -110,14 +112,16 @@ void read_array() {
   // We take an upper bound on the result size, as we do not
   // know a priori how big it is (since the array is sparse)
   std::vector<uint32_t> data_a1(3);
-  std::vector<int> coords(6);
+  std::vector<int> coords_rows(3);
+  std::vector<int> coords_cols(3);
 
   // Prepare the query
   Query query(ctx, array, TILEDB_READ);
   query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_buffer("a1", data_a1)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit the query and close the array.
   query.submit();
@@ -126,7 +130,8 @@ void read_array() {
   // Print out the results.
   auto result_num = (int)query.result_buffer_elements()["a1"].second;
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data_a1[r];
     std::cout << "Cell (" << i << ", " << j << ") has a1 data " << a << "\n";
   }

--- a/examples/cpp_api/fragments_consolidation.cc
+++ b/examples/cpp_api/fragments_consolidation.cc
@@ -104,14 +104,16 @@ void write_array_3() {
 
   // Prepare some data for the array
   std::vector<int> data = {201, 202};
-  std::vector<int> coords = {1, 1, 3, 4};
+  std::vector<int> coords_rows = {1, 3};
+  std::vector<int> coords_cols = {1, 4};
 
   // Open the array for writing and create the query.
   Array array(ctx, array_name, TILEDB_WRITE);
   Query query(ctx, array);
   query.set_layout(TILEDB_UNORDERED)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Perform the write and close the array.
   query.submit();
@@ -129,14 +131,16 @@ void read_array() {
 
   // Prepare the vector that will hold the result
   std::vector<int> data(16);
-  std::vector<int> coords(32);
+  std::vector<int> coords_rows(16);
+  std::vector<int> coords_cols(16);
 
   // Prepare the query
   Query query(ctx, array);
   query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit the query and close the array.
   query.submit();
@@ -144,7 +148,8 @@ void read_array() {
 
   // Print out the results.
   for (int r = 0; r < 16; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     std::cout << "Cell (" << i << ", " << j << ") has data " << a << "\n";
   }

--- a/examples/cpp_api/quickstart_sparse.cc
+++ b/examples/cpp_api/quickstart_sparse.cc
@@ -63,7 +63,8 @@ void write_array() {
   Context ctx;
 
   // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
-  std::vector<int> coords = {1, 1, 2, 4, 2, 3};
+  std::vector<int> coords_rows = {1, 2, 2};
+  std::vector<int> coords_cols = {1, 4, 3};
   std::vector<int> data = {1, 2, 3};
 
   // Open the array for writing and create the query.
@@ -71,7 +72,8 @@ void write_array() {
   Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_UNORDERED)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Perform the write and close the array.
   query.submit();
@@ -91,14 +93,16 @@ void read_array() {
   // We take an upper bound on the result size, as we do not
   // know a priori how big it is (since the array is sparse)
   std::vector<int> data(3);
-  std::vector<int> coords(6);
+  std::vector<int> coords_rows(3);
+  std::vector<int> coords_cols(3);
 
   // Prepare the query
   Query query(ctx, array, TILEDB_READ);
   query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit the query and close the array.
   query.submit();
@@ -107,7 +111,8 @@ void read_array() {
   // Print out the results.
   auto result_num = (int)query.result_buffer_elements()["a"].second;
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     std::cout << "Cell (" << i << ", " << j << ") has data " << a << "\n";
   }

--- a/examples/cpp_api/reading_dense_layouts.cc
+++ b/examples/cpp_api/reading_dense_layouts.cc
@@ -97,14 +97,16 @@ void read_array(tiledb_layout_t layout) {
 
   // Prepare the vectors that will hold the results
   std::vector<int> data(6);
-  std::vector<int> coords(12);
+  std::vector<int> coords_rows(6);
+  std::vector<int> coords_cols(6);
 
   // Prepare the query
   Query query(ctx, array);
   query.set_subarray(subarray)
       .set_layout(layout)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit the query and close the array.
   query.submit();
@@ -112,7 +114,8 @@ void read_array(tiledb_layout_t layout) {
 
   // Print out the results.
   for (int r = 0; r < 6; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     std::cout << "Cell (" << i << ", " << j << ") has data " << a << "\n";
   }

--- a/examples/cpp_api/reading_sparse_layouts.cc
+++ b/examples/cpp_api/reading_sparse_layouts.cc
@@ -64,7 +64,8 @@ void write_array() {
   Context ctx;
 
   // Prepare data for writing.
-  std::vector<int> coords = {1, 1, 1, 2, 2, 2, 1, 4, 2, 3, 2, 4};
+  std::vector<int> coords_rows = {1, 1, 2, 1, 2, 2};
+  std::vector<int> coords_cols = {1, 2, 2, 4, 3, 4};
   std::vector<int> data = {1, 2, 3, 4, 5, 6};
 
   // Open the array for writing and create the query.
@@ -72,7 +73,8 @@ void write_array() {
   Query query(ctx, array);
   query.set_layout(TILEDB_GLOBAL_ORDER)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Perform the write and close the array.
   query.submit();
@@ -99,14 +101,16 @@ void read_array(tiledb_layout_t layout) {
 
   // Prepare buffers that will hold the results
   std::vector<int> data(6);
-  std::vector<int> coords(12);
+  std::vector<int> coords_rows(6);
+  std::vector<int> coords_cols(6);
 
   // Prepare the query
   Query query(ctx, array, TILEDB_READ);
   query.set_subarray(subarray)
       .set_layout(layout)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit the query and close the array.
   query.submit();
@@ -115,7 +119,8 @@ void read_array(tiledb_layout_t layout) {
   // Print out the results.
   auto result_num = (int)query.result_buffer_elements()["a"].second;
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     std::cout << "Cell (" << i << ", " << j << ") has data " << a << "\n";
   }

--- a/examples/cpp_api/writing_dense_sparse.cc
+++ b/examples/cpp_api/writing_dense_sparse.cc
@@ -66,14 +66,16 @@ void write_array() {
 
   // Prepare some data for the array
   std::vector<int> data = {1, 2, 3, 4};
-  std::vector<int> coords = {1, 2, 2, 1, 4, 3, 1, 4};
+  std::vector<int> coords_rows = {1, 2, 4, 1};
+  std::vector<int> coords_cols = {2, 1, 3, 4};
 
   // Open the array for writing and create the query.
   Array array(ctx, array_name, TILEDB_WRITE);
   Query query(ctx, array);
   query.set_layout(TILEDB_UNORDERED)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Perform the write and close the array.
   query.submit();
@@ -91,14 +93,16 @@ void read_array() {
 
   // Prepare the buffers
   std::vector<int> data(16);
-  std::vector<int> coords(32);
+  std::vector<int> coords_rows(16);
+  std::vector<int> coords_cols(16);
 
   // Prepare the query
   Query query(ctx, array);
   query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit the query and close the array.
   query.submit();
@@ -106,7 +110,8 @@ void read_array() {
 
   // Print out the results.
   for (int r = 0; r < 16; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     std::cout << "Cell (" << i << ", " << j << ") has data " << a << "\n";
   }

--- a/examples/cpp_api/writing_sparse_global.cc
+++ b/examples/cpp_api/writing_sparse_global.cc
@@ -110,14 +110,16 @@ void read_array() {
   // We take an upper bound on the result size, as we do not
   // know a priori how big it is (since the array is sparse)
   std::vector<int> data(3);
-  std::vector<int> coords(6);
+  std::vector<int> coords_rows(3);
+  std::vector<int> coords_cols(3);
 
   // Prepare the query
   Query query(ctx, array);
   query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit the query and close the array.
   query.submit();
@@ -126,7 +128,8 @@ void read_array() {
   // Print out the results.
   auto result_num = (int)query.result_buffer_elements()["a"].second;
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     std::cout << "Cell (" << i << ", " << j << ") has data " << a << "\n";
   }

--- a/examples/cpp_api/writing_sparse_multiple.cc
+++ b/examples/cpp_api/writing_sparse_multiple.cc
@@ -65,21 +65,25 @@ void write_array() {
   Array array(ctx, array_name, TILEDB_WRITE);
 
   // First write
-  std::vector<int> coords_1 = {1, 1, 2, 4, 2, 3};
+  std::vector<int> coords_rows_1 = {1, 2, 2};
+  std::vector<int> coords_cols_1 = {1, 4, 3};
   std::vector<int> data_1 = {1, 2, 3};
   Query query_1(ctx, array);
   query_1.set_layout(TILEDB_UNORDERED)
       .set_buffer("a", data_1)
-      .set_coordinates(coords_1);
+      .set_buffer("rows", coords_rows_1)
+      .set_buffer("cols", coords_cols_1);
   query_1.submit();
 
   // Second write
-  std::vector<int> coords_2 = {4, 1, 2, 4};
+  std::vector<int> coords_rows_2 = {4, 2};
+  std::vector<int> coords_cols_2 = {1, 4};
   std::vector<int> data_2 = {4, 20};
   Query query_2(ctx, array);
   query_2.set_layout(TILEDB_UNORDERED)
       .set_buffer("a", data_2)
-      .set_coordinates(coords_2);
+      .set_buffer("rows", coords_rows_2)
+      .set_buffer("cols", coords_cols_2);
   query_2.submit();
 
   // Close the array
@@ -95,14 +99,16 @@ void read_array() {
   // Prepare the buffers
   const std::vector<int> subarray = {1, 4, 1, 4};
   std::vector<int> data(5);
-  std::vector<int> coords(100);
+  std::vector<int> coords_rows(50);
+  std::vector<int> coords_cols(50);
 
   // Prepare the query
   Query query(ctx, array);
   query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_buffer("a", data)
-      .set_coordinates(coords);
+      .set_buffer("rows", coords_rows)
+      .set_buffer("cols", coords_cols);
 
   // Submit the query and close the array.
   query.submit();
@@ -111,7 +117,8 @@ void read_array() {
   // Print out the results.
   auto result_num = (int)query.result_buffer_elements()["a"].second;
   for (int r = 0; r < result_num; r++) {
-    int i = coords[2 * r], j = coords[2 * r + 1];
+    int i = coords_rows[r];
+    int j = coords_cols[r];
     int a = data[r];
     std::cout << "Cell (" << i << ", " << j << ") has data " << a << "\n";
   }


### PR DESCRIPTION
This replaces the zipped coords API with the split coords API.