### PR TITLE
Add option to use AWS SDK from /usr to support S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ doc/source/_build
 doc/source/_sidebar.rst.inc
 doc/source/gensidebar.pyc
 examples/cmake_project/build
+#
+local
+GPATH
+GRTAGS
+GTAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ option(TILEDB_SUPERBUILD "If true, perform a superbuild (builds all missing depe
 option(TILEDB_FORCE_ALL_DEPS "If true, force superbuild to download and build all dependencies, even those installed on the system." OFF)
 option(TILEDB_VERBOSE "Prints TileDB errors with verbosity" OFF)
 option(TILEDB_S3 "Enables S3/minio support using aws-cpp-sdk" OFF)
+option(TILEDB_S3_USR "Enables S3/minio support using aws-cpp-sdk from /usr" OFF)
 option(TILEDB_AZURE "Enables Azure Storage support using azure-storage-cpp" OFF)
 option(TILEDB_GCS "Enables GCS Storage support using google-cloud-cpp" OFF)
 option(TILEDB_HDFS "Enables HDFS support using the official Hadoop JNI bindings" OFF)

--- a/bootstrap
+++ b/bootstrap
@@ -52,6 +52,7 @@ Configuration:
     --enable-verbose                enable verbose status messages
     --enable-hdfs                   enables the hdfs storage backend
     --enable-s3                     enables the s3 storage backend
+    --enable-s3-usr                 enables the s3 storage backend used via /usr
     --enable-azure                  enables the azure storage backend
     --enable-gcs                    enables the gcs storage backend
     --enable-serialization          enables query serialization support
@@ -83,6 +84,7 @@ build_type="Release"
 tiledb_verbose="OFF"
 tiledb_hdfs="OFF"
 tiledb_s3="OFF"
+tiledb_s3_usr="OFF"
 tiledb_azure="OFF"
 tiledb_gcs="OFF"
 tiledb_werror="ON"
@@ -118,6 +120,7 @@ while test $# != 0; do
     --enable-verbose) tiledb_verbose="ON";;
     --enable-hdfs) tiledb_hdfs="ON";;
     --enable-s3) tiledb_s3="ON";;
+    --enable-s3-usr) tiledb_s3_usr="ON";;
     --enable-azure) tiledb_azure="ON";;
     --enable-gcs) tiledb_gcs="ON";;
     --enable-serialization) tiledb_serialization="ON";;
@@ -139,6 +142,7 @@ for en in "${enables[@]}"; do
     coverage) build_type="Coverage";;
     verbose) tiledb_verbose="ON";;
     s3) tiledb_s3="ON";;
+    s3-usr) tiledb_s3_usr="ON";;
     azure) tiledb_azure="ON";;
     gcs) tiledb_gcs="ON";;
     serialization) tiledb_serialization="ON";;
@@ -188,6 +192,7 @@ ${cmake} -DCMAKE_BUILD_TYPE=${build_type} \
     -DTILEDB_VERBOSE=${tiledb_verbose} \
     -DTILEDB_HDFS=${tiledb_hdfs} \
     -DTILEDB_S3=${tiledb_s3} \
+    -DTILEDB_S3_USR=${tiledb_s3_usr} \
     -DTILEDB_AZURE=${tiledb_azure} \
     -DTILEDB_GCS=${tiledb_gcs} \
     -DTILEDB_SERIALIZATION=${tiledb_serialization} \

--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -39,6 +39,11 @@ set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "${TILEDB_EP_INSTALL_PREFIX}")
 # Try searching for the SDK in the EP prefix.
 set(AWSSDK_ROOT_DIR "${TILEDB_EP_INSTALL_PREFIX}")
 
+# Unless S3 via /usr is selected
+if (TILEDB_S3_USR)
+  set(AWSSDK_ROOT_DIR "/usr")
+endif()
+
 # Check to see if the SDK is installed (which provides the find module).
 # This will either use the system-installed AWSSDK find module (if present),
 # or the superbuild-installed find module.

--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -66,6 +66,12 @@ if (TILEDB_CCACHE)
   )
 endif()
 
+if (TILEDB_S3_USR)
+  list(APPEND INHERITED_CMAKE_ARGS
+    -DTILEDB_S3_USR=${TILEDB_S3_USR}
+  )
+endif()
+
 ############################################################
 # Set up external projects for dependencies
 ############################################################


### PR DESCRIPTION
This small PR allows use of the parts of the AWS C++ SDK that our build requires to be supplied from an installation in `/usr`.   This could either be a full installation of the SDK if the user has it, or a limited of just the S3 components.  

The key motivation is a smaller build setup resulting in S3 use but without requiring us to digest the 350mb blob of the full SDK.

I have been using this on several platforms for over two months on several platforms, and keep rebase it on top of `dev`.  The CMake integration is at present somewhat minimal and could probably be tweaked by someone with better CMake skills.  Use of S3 then requires two switches to enable s3 support, namely `--enable-s3` as before as well as a second `--enable-s3-usr` to enable the `/usr` location and not consider the local build directory.  This could be changed to have the second option imply the first but for now it simpler and more defensive to use both.

