### PR TITLE
Fix overflow in check_tile_extent()

### DIFF
--- a/test/src/unit-cppapi-datetimes.cc
+++ b/test/src/unit-cppapi-datetimes.cc
@@ -98,8 +98,8 @@ TEST_CASE("C++ API: Datetime dimension", "[cppapi][datetime]") {
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
-  int64_t domain[] = {0, std::numeric_limits<int64_t>::max() - 1};
   int64_t tile_extent = int64_t(1e6);
+  int64_t domain[] = {0, std::numeric_limits<int64_t>::max() - tile_extent};
   auto dim =
       Dimension::create(ctx, "d0", TILEDB_DATETIME_MS, domain, &tile_extent);
   Array::create(

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -33,6 +33,8 @@
 #include "catch.hpp"
 #include "tiledb/sm/cpp_api/tiledb"
 
+#include <limits>
+
 TEST_CASE("C++ API: Schema", "[cppapi][schema]") {
   using namespace tiledb;
   Context ctx;
@@ -238,4 +240,105 @@ TEST_CASE(
   // Clean up
   VFS vfs(ctx);
   vfs.remove_dir("sparse_array");
+}
+
+TEST_CASE(
+    "C++ API: Schema, Dimension ranges", "[cppapi][schema][dimension-ranges]") {
+  using namespace tiledb;
+  tiledb::Context ctx;
+
+  // Test creating dimensions with signed, unsigned, 32-bit, and 64-bit integer
+  // domain types.
+
+  SECTION("int32 domain [-10, -5]") {
+    const int32_t domain[2] = {-10, -5};
+    const int32_t tile_extent = 5;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_INT32, domain, &tile_extent));
+  }
+
+  SECTION("int32 domain [-10, 5]") {
+    const int32_t domain[2] = {-10, 5};
+    const int32_t tile_extent = 5;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_INT32, domain, &tile_extent));
+  }
+
+  SECTION("int32 domain [5, 10]") {
+    const int32_t domain[2] = {5, 10};
+    const int32_t tile_extent = 5;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_INT32, domain, &tile_extent));
+  }
+
+  SECTION("int32 domain [min, max]") {
+    int32_t domain[2] = {std::numeric_limits<int32_t>::lowest(),
+                         std::numeric_limits<int32_t>::max()};
+    const int32_t tile_extent = 5;
+    domain[1] -= tile_extent;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_INT32, domain, &tile_extent));
+  }
+
+  SECTION("int64 domain [-10, -5]") {
+    const int64_t domain[2] = {-10, -5};
+    const int64_t tile_extent = 5;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_INT64, domain, &tile_extent));
+  }
+
+  SECTION("int64 domain [-10, 5]") {
+    const int64_t domain[2] = {-10, 5};
+    const int64_t tile_extent = 5;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_INT64, domain, &tile_extent));
+  }
+
+  SECTION("int64 domain [5, 10]") {
+    const int64_t domain[2] = {5, 10};
+    const int64_t tile_extent = 5;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_INT64, domain, &tile_extent));
+  }
+
+  SECTION("int64 domain [min, max]") {
+    int64_t domain[2] = {std::numeric_limits<int64_t>::lowest(),
+                         std::numeric_limits<int64_t>::max()};
+    const int64_t tile_extent = 5;
+    domain[1] -= tile_extent;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_INT64, domain, &tile_extent));
+  }
+
+  SECTION("uint32 domain [5, 10]") {
+    const uint32_t domain[2] = {5, 10};
+    const uint32_t tile_extent = 5;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_UINT32, domain, &tile_extent));
+  }
+
+  SECTION("uint32 domain [min, max]") {
+    uint32_t domain[2] = {std::numeric_limits<uint32_t>::lowest(),
+                          std::numeric_limits<uint32_t>::max()};
+    const uint32_t tile_extent = 5;
+    domain[1] -= tile_extent;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_UINT32, domain, &tile_extent));
+  }
+
+  SECTION("uint64 domain [5, 10]") {
+    const uint64_t domain[2] = {5, 10};
+    const uint64_t tile_extent = 5;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_UINT64, domain, &tile_extent));
+  }
+
+  SECTION("uint64 domain [min, max]") {
+    uint64_t domain[2] = {std::numeric_limits<uint64_t>::lowest(),
+                          std::numeric_limits<uint64_t>::max()};
+    const uint64_t tile_extent = 5;
+    domain[1] -= tile_extent;
+    CHECK_NOTHROW(tiledb::Dimension::create(
+        ctx, "d1", TILEDB_UINT64, domain, &tile_extent));
+  }
 }

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -673,6 +673,21 @@ class Dimension {
   template <class T>
   Status check_tile_extent() const;
 
+  /**
+   * Returns an error if the set tile extent exceeds the
+   * upper floor.
+   */
+  template <typename T>
+  Status check_tile_extent_upper_floor(const T* domain, T tile_extent) const;
+
+  /**
+   * The internal work routine for `check_tile_extent_upper_floor`
+   * that accepts a template type for the floor type.
+   */
+  template <typename T_EXTENT, typename T_FLOOR>
+  Status check_tile_extent_upper_floor_internal(
+      const T_EXTENT* domain, T_EXTENT tile_extent) const;
+
   /** Returns the domain in string format. */
   std::string domain_str() const;
 


### PR DESCRIPTION
Within `Dimension::check_tile_extent<T>()`, the following variable has a type
deduction from `auto` to `uint64_t`:
auto upper_floor =
          ((range - 1) / (*tile_extent)) * (*tile_extent) + domain[0];

If `domain[0]` is negative, it may overflow the upper_floor. A trivial example
would be a domain with a range of [-10, -5] with a tile extent size of 5. The
above calculation comes out to -5, which overflows to (MAXINT64 - 5).

If we force the type of `upper_floor` to uint64_t, it solves the above issue
but causes overflow if the tile extent is an unsigned type with a domain
that overflows the uint64_t.

This patch adds both a path for unsigned and signed extent tile types. The
upper_floor type must match the sign of the extent tile type.

This also uncovered a bug in the unit-cppapi-datetimes.cc where the domain
exceeds the expanded upper bound but the check was a false-negative.