### PR TITLE
Remove xlock in FragmentMetadata::store

### DIFF
--- a/test/src/unit-cppapi-query.cc
+++ b/test/src/unit-cppapi-query.cc
@@ -130,3 +130,61 @@ TEST_CASE(
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 }
+
+TEST_CASE(
+    "C++ API: Write on open read array", "[cppapi][query][write-on-open]") {
+  const std::string array_name = "cpp_unit_array";
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  // Create the array
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 3}}, 4))
+      .add_dimension(Dimension::create<int>(ctx, "cols", {{0, 3}}, 4));
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  schema.add_attribute(Attribute::create<int>(ctx, "a"));
+  Array::create(array_name, schema);
+
+  // Write some initial data and close the array.
+  std::vector<int> data_w = {1, 2, 3, 4};
+  std::vector<int> coords_w = {0, 0, 1, 1, 2, 2, 3, 3};
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w);
+  query_w.set_coordinates(coords_w)
+      .set_layout(TILEDB_UNORDERED)
+      .set_buffer("a", data_w);
+  query_w.submit();
+  query_w.finalize();
+  array_w.close();
+
+  // Open and read an array without closing it.
+  Array array1(ctx, array_name, TILEDB_READ);
+  Query query1(ctx, array1);
+  int range[] = {1, 2};
+  query1.add_range(0, range[0], range[1]).add_range(1, range[0], range[1]);
+  auto est_size = query1.est_result_size("a");
+  std::vector<int> data(est_size);
+  query1.set_layout(TILEDB_ROW_MAJOR).set_buffer("a", data);
+  query1.submit();
+  REQUIRE(query1.result_buffer_elements()["a"].second == 2);
+  REQUIRE(data[0] == 2);
+  REQUIRE(data[1] == 3);
+  query1.finalize();
+
+  // Open and write to the same array without closing it.
+  Array array2(ctx, array_name, TILEDB_WRITE);
+  Query query2(ctx, array2);
+  query2.set_coordinates(coords_w)
+      .set_layout(TILEDB_UNORDERED)
+      .set_buffer("a", data_w);
+  query2.submit();
+  query2.finalize();
+
+  // Close both arrays.
+  array1.close();
+  array2.close();
+}

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -444,9 +444,6 @@ Status FragmentMetadata::store(const EncryptionKey& encryption_key) {
   if (!is_dir)
     return Status::Ok();
 
-  // Exclusively lock the array
-  RETURN_NOT_OK(storage_manager_->array_xlock(array_uri));
-
   // Store R-Tree
   gt_offsets_.rtree_ = offset;
   RETURN_NOT_OK_ELSE(store_rtree(encryption_key, &nbytes), clean_up());
@@ -483,12 +480,7 @@ Status FragmentMetadata::store(const EncryptionKey& encryption_key) {
   RETURN_NOT_OK_ELSE(store_footer(encryption_key), clean_up());
 
   // Close file
-  auto st = storage_manager_->close_file(fragment_metadata_uri);
-
-  // Unlock array
-  auto st2 = storage_manager_->array_xunlock(array_uri);
-
-  return !st.ok() ? st : st2;
+  return storage_manager_->close_file(fragment_metadata_uri);
 
   STATS_END_TIMER(stats::Stats::TimerType::WRITE_STORE_FRAG_META)
 }


### PR DESCRIPTION
This allows writing to an open read array from the same context object.