### PR TITLE
Fix hang on open array v1.6

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1147,7 +1147,9 @@ Status FragmentMetadata::load_mbrs(ConstBuffer* buff) {
   }
 
   // Build R-tree bottom-up
-  rtree_.build_tree();
+  if (mbr_num > 0) {
+    rtree_.build_tree();
+  }
 
   sparse_tile_num_ = mbr_num;
 

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -96,6 +96,7 @@ Status RTree::build_tree() {
   assert(levels_.size() == 1);
 
   auto leaf_num = levels_[0].size();
+  assert(leaf_num >= 1);
   if (leaf_num == 1)
     return Status::Ok();
 


### PR DESCRIPTION
For arrays with a fragment version v1 or v2, only build the rtree if it has one
or more MBRs, otherwise the build_rtree() routine hangs.