### PR TITLE
Allow empty values for variable length attributes

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-capi-dense_neg.cc
   src/unit-capi-dense_vector.cc
   src/unit-duplicates.cc
+  src/unit-capi-empty-var-length.cc
   src/unit-capi-enum_values.cc
   src/unit-capi-error.cc
   src/unit-capi-filter.cc

--- a/test/src/unit-capi-empty-var-length.cc
+++ b/test/src/unit-capi-empty-var-length.cc
@@ -1,0 +1,419 @@
+/**
+ * @file   unit-capi-empty-var-length.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for TileDB's support for empty var length values at the C API level.
+ */
+
+#include "catch.hpp"
+#include "test/src/helpers.h"
+#include "tiledb/sm/c_api/tiledb.h"
+
+#include <cstring>
+#include <iostream>
+
+using namespace tiledb::test;
+
+float buffer_a1[4] = {0.0f, 0.1f, 0.2f, 0.3f};
+int32_t buffer_a3[4] = {1, 2, 3, 4};
+const char UTF8_STRINGS_VAR_FOR_EMPTY[] = u8"aαbββcγγγdδδδδ";
+uint64_t UTF8_NULL_SIZE_FOR_EMPTY = sizeof(u8"");
+uint64_t UTF8_OFFSET_0_FOR_EMPTY = 0;
+uint64_t UTF8_OFFSET_1_FOR_EMPTY = sizeof(u8"aα") - UTF8_NULL_SIZE_FOR_EMPTY;
+uint64_t UTF8_OFFSET_2_FOR_EMPTY = sizeof(u8"aαbββ") - UTF8_NULL_SIZE_FOR_EMPTY;
+uint64_t UTF8_OFFSET_3_FOR_EMPTY =
+    sizeof(u8"aαbββcγγγ") - UTF8_NULL_SIZE_FOR_EMPTY;
+
+struct StringEmptyFx {
+  void create_array(const std::string& array_name);
+  void delete_array(const std::string& array_name);
+  void read_array(const std::string& array_name);
+  void write_array(const std::string& array_name);
+};
+
+// Create a simple dense 1D array with three string attributes
+void StringEmptyFx::create_array(const std::string& array_name) {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  int rc = tiledb_ctx_alloc(nullptr, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create dimensions
+  uint64_t dim_domain[] = {1, 8};
+  uint64_t tile_extent = 2;
+  tiledb_dimension_t* d1;
+  rc = tiledb_dimension_alloc(
+      ctx, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extent, &d1);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create domain
+  tiledb_domain_t* domain;
+  rc = tiledb_domain_alloc(ctx, &domain);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx, domain, d1);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create fixed-sized UTF-8 attribute
+  tiledb_attribute_t* a1;
+  rc = tiledb_attribute_alloc(ctx, "a1", TILEDB_FLOAT32, &a1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_attribute_set_cell_val_num(ctx, a1, TILEDB_VAR_NUM);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create variable-sized UTF-8 attribute
+  tiledb_attribute_t* a2;
+  rc = tiledb_attribute_alloc(ctx, "a2", TILEDB_STRING_UTF8, &a2);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_attribute_set_cell_val_num(ctx, a2, TILEDB_VAR_NUM);
+  REQUIRE(rc == TILEDB_OK);
+  rc = set_attribute_compression_filter(ctx, a2, TILEDB_FILTER_GZIP, -1);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create variable-sized UTF-16 attribute
+  tiledb_attribute_t* a3;
+  rc = tiledb_attribute_alloc(ctx, "a3", TILEDB_INT32, &a3);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_attribute_set_cell_val_num(ctx, a3, TILEDB_VAR_NUM);
+  REQUIRE(rc == TILEDB_OK);
+  rc = set_attribute_compression_filter(ctx, a3, TILEDB_FILTER_ZSTD, -1);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  rc = tiledb_array_schema_alloc(ctx, TILEDB_SPARSE, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_domain(ctx, array_schema, domain);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_add_attribute(ctx, array_schema, a1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_add_attribute(ctx, array_schema, a2);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_add_attribute(ctx, array_schema, a3);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Check array schema
+  rc = tiledb_array_schema_check(ctx, array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create array
+  rc = tiledb_array_create(ctx, array_name.c_str(), array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_attribute_free(&a1);
+  tiledb_attribute_free(&a2);
+  tiledb_attribute_free(&a3);
+  tiledb_dimension_free(&d1);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
+  tiledb_ctx_free(&ctx);
+}
+
+void StringEmptyFx::write_array(const std::string& array_name) {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  int rc = tiledb_ctx_alloc(nullptr, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Prepare buffers
+  uint64_t buffer_a1_size = sizeof(buffer_a1);
+  uint64_t buffer_a1_offsets[] = {0 * sizeof(int32_t),
+                                  1 * sizeof(int32_t),
+                                  2 * sizeof(int32_t),
+                                  2 * sizeof(int32_t),
+                                  3 * sizeof(int32_t)};
+  uint64_t buffer_a1_offsets_size = sizeof(buffer_a1_offsets);
+
+  uint64_t buffer_a2_offsets[] = {UTF8_OFFSET_0_FOR_EMPTY,
+                                  UTF8_OFFSET_1_FOR_EMPTY,
+                                  UTF8_OFFSET_2_FOR_EMPTY,
+                                  UTF8_OFFSET_3_FOR_EMPTY,
+                                  UTF8_OFFSET_3_FOR_EMPTY};
+  uint64_t buffer_a2_offsets_size = sizeof(buffer_a2_offsets);
+  uint64_t buffer_a2_size =
+      sizeof(UTF8_STRINGS_VAR_FOR_EMPTY) - UTF8_NULL_SIZE_FOR_EMPTY;
+  void* buffer_a2 = std::malloc(buffer_a2_size);
+  uint64_t buffer_a3_offsets[] = {0 * sizeof(float),
+                                  1 * sizeof(float),
+                                  2 * sizeof(float),
+                                  3 * sizeof(float),
+                                  4 * sizeof(float)};
+  uint64_t buffer_a3_offsets_size = sizeof(buffer_a3_offsets);
+  uint64_t buffer_a3_size = sizeof(buffer_a3);
+  std::memcpy(
+      buffer_a2,
+      UTF8_STRINGS_VAR_FOR_EMPTY,
+      sizeof(UTF8_STRINGS_VAR_FOR_EMPTY) - UTF8_NULL_SIZE_FOR_EMPTY);
+
+  uint64_t buffer_d1[5] = {1, 2, 3, 4, 5};
+  uint64_t buffer_size_d1 = sizeof(buffer_d1);
+
+  // Open array
+  tiledb_array_t* array;
+  rc = tiledb_array_alloc(ctx, array_name.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx, array, TILEDB_WRITE);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer(ctx, query, "d1", buffer_d1, &buffer_size_d1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      "a1",
+      buffer_a1_offsets,
+      &buffer_a1_offsets_size,
+      buffer_a1,
+      &buffer_a1_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      "a2",
+      buffer_a2_offsets,
+      &buffer_a2_offsets_size,
+      buffer_a2,
+      &buffer_a2_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      "a3",
+      buffer_a3_offsets,
+      &buffer_a3_offsets_size,
+      buffer_a3,
+      &buffer_a3_size);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Submit query
+  rc = tiledb_query_submit(ctx, query);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_finalize(ctx, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+  tiledb_ctx_free(&ctx);
+  std::free(buffer_a2);
+}
+
+void StringEmptyFx::read_array(const std::string& array_name) {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  int rc = tiledb_ctx_alloc(nullptr, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Open array
+  tiledb_array_t* array;
+  rc = tiledb_array_alloc(ctx, array_name.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set subarray
+  uint64_t subarray[] = {1, 5};
+  rc = tiledb_query_set_subarray(ctx, query, subarray);
+  CHECK(rc == TILEDB_OK);
+
+  // Set buffer
+  uint64_t buffer_d1_size = 1024;
+  uint64_t buffer_a1_val_size = 1024;
+  uint64_t buffer_a1_off_size = 1024;
+  uint64_t buffer_a2_off_size = 1024;
+  uint64_t buffer_a2_val_size = 1024;
+  uint64_t buffer_a3_off_size = 1024;
+  uint64_t buffer_a3_val_size = 1024;
+
+  // Check est_result_sizes
+  rc = tiledb_query_get_est_result_size(ctx, query, "d1", &buffer_d1_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_get_est_result_size_var(
+      ctx, query, "a1", &buffer_a1_off_size, &buffer_a1_val_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_get_est_result_size_var(
+      ctx, query, "a2", &buffer_a2_off_size, &buffer_a2_val_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_get_est_result_size_var(
+      ctx, query, "a3", &buffer_a3_off_size, &buffer_a3_val_size);
+  REQUIRE(rc == TILEDB_OK);
+
+  CHECK(buffer_d1_size == 5 * sizeof(uint64_t));
+  // est_result_size should return 4 element for the values since one is empty
+  CHECK(buffer_a1_val_size == 4 * sizeof(float));
+  // we will get 5 offsets
+  CHECK(buffer_a1_off_size == 5 * sizeof(uint64_t));
+
+  // Again we expect 4 element for the values since one is empty
+  CHECK(
+      buffer_a2_val_size ==
+      sizeof(UTF8_STRINGS_VAR_FOR_EMPTY) - UTF8_NULL_SIZE_FOR_EMPTY);
+  // we will get 5 offsets
+  CHECK(buffer_a2_off_size == 5 * sizeof(uint64_t));
+
+  // Again we expect 4 element for the values since one is empty
+  CHECK(buffer_a3_val_size == 4 * sizeof(int32_t));
+  // we will get 5 offsets
+  CHECK(buffer_a3_off_size == 5 * sizeof(uint64_t));
+
+  // Prepare cell buffers
+  void* buffer_d1 = std::malloc(buffer_d1_size);
+  void* buffer_a1_val = std::malloc(buffer_a1_val_size);
+  auto* buffer_a1_off = (uint64_t*)std::malloc(buffer_a1_off_size);
+  auto buffer_a2_off = (uint64_t*)std::malloc(buffer_a2_off_size);
+  void* buffer_a2_val = std::malloc(buffer_a2_val_size);
+  auto buffer_a3_off = (uint64_t*)std::malloc(buffer_a3_off_size);
+  void* buffer_a3_val = std::malloc(buffer_a3_val_size);
+
+  rc = tiledb_query_set_buffer(ctx, query, "d1", buffer_d1, &buffer_d1_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      "a1",
+      buffer_a1_off,
+      &buffer_a1_off_size,
+      buffer_a1_val,
+      &buffer_a1_val_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      "a2",
+      buffer_a2_off,
+      &buffer_a2_off_size,
+      buffer_a2_val,
+      &buffer_a2_val_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_buffer_var(
+      ctx,
+      query,
+      "a3",
+      buffer_a3_off,
+      &buffer_a3_off_size,
+      buffer_a3_val,
+      &buffer_a3_val_size);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Submit query
+  rc = tiledb_query_submit(ctx, query);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_finalize(ctx, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Check results
+  CHECK(!std::memcmp(buffer_a1_val, buffer_a1, sizeof(buffer_a1)));
+  CHECK(buffer_a1_off[0] == 0 * sizeof(int32_t));
+  CHECK(buffer_a1_off[1] == 1 * sizeof(int32_t));
+  CHECK(buffer_a1_off[2] == 2 * sizeof(int32_t));
+  CHECK(buffer_a1_off[3] == 2 * sizeof(int32_t));
+  CHECK(buffer_a1_off[4] == 3 * sizeof(int32_t));
+
+  CHECK(!std::memcmp(
+      buffer_a2_val,
+      UTF8_STRINGS_VAR_FOR_EMPTY,
+      sizeof(UTF8_STRINGS_VAR_FOR_EMPTY) - UTF8_NULL_SIZE_FOR_EMPTY));
+  CHECK(buffer_a2_off[0] == UTF8_OFFSET_0_FOR_EMPTY);
+  CHECK(buffer_a2_off[1] == UTF8_OFFSET_1_FOR_EMPTY);
+  CHECK(buffer_a2_off[2] == UTF8_OFFSET_2_FOR_EMPTY);
+  CHECK(buffer_a2_off[3] == UTF8_OFFSET_3_FOR_EMPTY);
+  CHECK(buffer_a2_off[4] == UTF8_OFFSET_3_FOR_EMPTY);
+
+  CHECK(!std::memcmp(buffer_a3_val, buffer_a3, sizeof(buffer_a3)));
+  CHECK(buffer_a3_off[0] == 0 * sizeof(float));
+  CHECK(buffer_a3_off[1] == 1 * sizeof(float));
+  CHECK(buffer_a3_off[2] == 2 * sizeof(float));
+  CHECK(buffer_a3_off[3] == 3 * sizeof(float));
+  CHECK(buffer_a3_off[4] == 4 * sizeof(float));
+
+  // Close array
+  rc = tiledb_array_close(ctx, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+  tiledb_ctx_free(&ctx);
+  std::free(buffer_d1);
+  std::free(buffer_a1_off);
+  std::free(buffer_a1_val);
+  std::free(buffer_a2_off);
+  std::free(buffer_a2_val);
+  std::free(buffer_a3_off);
+  std::free(buffer_a3_val);
+}
+
+void StringEmptyFx::delete_array(const std::string& array_name) {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  int rc = tiledb_ctx_alloc(nullptr, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Remove array
+  tiledb_object_t type;
+  rc = tiledb_object_type(ctx, array_name.c_str(), &type);
+  REQUIRE(rc == TILEDB_OK);
+  if (type == TILEDB_ARRAY) {
+    rc = tiledb_object_remove(ctx, array_name.c_str());
+    REQUIRE(rc == TILEDB_OK);
+  }
+
+  // Clean up
+  tiledb_ctx_free(&ctx);
+}
+
+TEST_CASE_METHOD(
+    StringEmptyFx, "C API: Test empty support", "[capi][empty-var-length]") {
+  std::string array_name = "empty_string";
+  delete_array(array_name);
+  create_array(array_name);
+  write_array(array_name);
+  read_array(array_name);
+  delete_array(array_name);
+}

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -2090,18 +2090,19 @@ void SparseArrayFx::check_invalid_offsets(const std::string& array_name) {
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
 
-  // Check duplicate offsets error
+  // Check empty single cell error
   buffer_a2[0] = 0;
-  buffer_a2[1] = 4;
-  buffer_a2[2] = 4;
+
+  uint64_t a2_buffer_size = 0;
+  uint64_t a2_buffer_offset_size = 1 * sizeof(uint64_t);
   rc = tiledb_query_set_buffer_var(
       ctx_,
       query,
       "a2",
       (uint64_t*)buffers[0],
-      &buffer_sizes[0],
+      &a2_buffer_offset_size,
       buffers[1],
-      &buffer_sizes[1]);
+      &a2_buffer_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check non-ascending offsets error
@@ -2121,7 +2122,7 @@ void SparseArrayFx::check_invalid_offsets(const std::string& array_name) {
   // Check out-of-bounds offsets error
   buffer_a2[0] = 0;
   buffer_a2[1] = 4;
-  buffer_a2[2] = 7;
+  buffer_a2[2] = 8;
   rc = tiledb_query_set_buffer_var(
       ctx_,
       query,

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -380,10 +380,6 @@ TEST_CASE(
     q.set_layout(TILEDB_GLOBAL_ORDER);
     q.set_coordinates(coord);
     REQUIRE_THROWS(q.set_buffer("a", a_offset, a));
-
-    a = {0, 1, 2};
-    a_offset = {0, 1, 1};
-    REQUIRE_THROWS(q.set_buffer("a", a_offset, a));
   }
 
   array.close();

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -484,18 +484,26 @@ Status Query::check_var_attr_offsets(
     return Status::Ok();
 
   uint64_t prev_offset = buffer_off[0];
-  if (prev_offset >= *buffer_val_size)
+  // Allow the initial offset to be equal to the size, this indicates
+  // the first and only value in the buffer is to be empty
+  if (prev_offset > *buffer_val_size)
     return LOG_STATUS(Status::QueryError(
         "Invalid offsets; offset " + std::to_string(prev_offset) +
         " specified for buffer of size " + std::to_string(*buffer_val_size)));
+  else if (prev_offset == *buffer_val_size)
+    return LOG_STATUS(Status::QueryError(
+        "Invalid offsets; zero length single cell writes are not supported"));
 
   for (uint64_t i = 1; i < num_offsets; i++) {
-    if (buffer_off[i] <= prev_offset)
+    if (buffer_off[i] < prev_offset)
       return LOG_STATUS(
           Status::QueryError("Invalid offsets; offsets must be given in "
                              "strictly ascending order."));
 
-    if (buffer_off[i] >= *buffer_val_size)
+    // Allow the last offset to be equal to the size, this indicates the last
+    // value is to be empty
+    if (buffer_off[i] > *buffer_val_size ||
+        (buffer_off[i] == *buffer_val_size && i != num_offsets - 1))
       return LOG_STATUS(Status::QueryError(
           "Invalid offsets; offset " + std::to_string(buffer_off[i]) +
           " specified for buffer of size " + std::to_string(*buffer_val_size)));


### PR DESCRIPTION
The ascending order check for offsets is relaxed to allow two or more succeeding values to have the same offset. This allows for a zero length value to on one more cells of a variable length attribute.

Currently writing a single empty value is not supported. Empty cells must be part of a write that includes at least 1 cell with values.

Consider the following examples:

Write to 4 cells (1-4) where the 4th cell of a1 is empty

d1 = {1, 2, 3, 4}
a1_data = {1, 2, 3}
a1_offsets = {0, 1, 2, 3}

write to 4 cells (1-4) where the 2nd cell of a1 is empty

d1 = {1, 2, 3, 4}
a1_data = {1, 2, 3}
a1_offsets = {0, 1, 1, 2}