### PR TITLE
Robust retries for S3 request-limit retries

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -248,11 +248,10 @@ Status S3::init(const Config& config, ThreadPool* const thread_pool) {
   client_config.caPath = ca_path.c_str();
   client_config.verifySSL = verify_ssl;
 
-  client_config.retryStrategy =
-      Aws::MakeShared<Aws::Client::DefaultRetryStrategy>(
-          constants::s3_allocation_tag.c_str(),
-          (long)connect_max_tries,
-          (long)connect_scale_factor);
+  client_config.retryStrategy = Aws::MakeShared<S3RetryStrategy>(
+      constants::s3_allocation_tag.c_str(),
+      connect_max_tries,
+      connect_scale_factor);
 
 #ifdef __linux__
   // If the user has not set a s3 ca file or ca path then let's attempt to set

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -173,6 +173,7 @@ void Stats::reset() {
   counter_stats_[CounterType::WRITE_CELL_NUM] = 0;
   counter_stats_[CounterType::WRITE_ARRAY_META_SIZE] = 0;
   counter_stats_[CounterType::WRITE_OPS_NUM] = 0;
+  counter_stats_[CounterType::VFS_S3_SLOW_DOWN_RETRIES] = 0;
 }
 
 void Stats::dump(FILE* out) const {
@@ -191,6 +192,8 @@ void Stats::dump(std::string* out) const {
   ss << dump_write();
   ss << "\n";
   ss << dump_consolidate();
+  ss << "\n";
+  ss << dump_vfs();
 
   auto dbg_secs = timer_stats_.find(TimerType::DBG)->second;
   if (dbg_secs != 0)
@@ -239,7 +242,6 @@ std::string Stats::dump_write() const {
       timer_stats_.find(TimerType::WRITE_PREPARE_AND_FILTER_TILES)->second;
   auto write_array_meta =
       timer_stats_.find(TimerType::WRITE_ARRAY_META)->second;
-
   auto write_num = counter_stats_.find(CounterType::WRITE_NUM)->second;
   auto write_attr_num =
       counter_stats_.find(CounterType::WRITE_ATTR_NUM)->second;
@@ -708,6 +710,19 @@ std::string Stats::dump_consolidate() const {
         &ss,
         "  * Time to consolidate fragment metadata: ",
         consolidate_frag_meta);
+  }
+
+  return ss.str();
+}
+
+std::string Stats::dump_vfs() const {
+  auto s3_slow_down_retries =
+      counter_stats_.find(CounterType::VFS_S3_SLOW_DOWN_RETRIES)->second;
+  std::stringstream ss;
+
+  if (s3_slow_down_retries > 0) {
+    ss << "==== VFS ====\n\n";
+    write(&ss, "- S3 SLOW_DOWN retries: ", s3_slow_down_retries);
   }
 
   return ss.str();

--- a/tiledb/sm/stats/stats.h
+++ b/tiledb/sm/stats/stats.h
@@ -170,6 +170,7 @@ class Stats {
     WRITE_CELL_NUM,
     WRITE_ARRAY_META_SIZE,
     WRITE_OPS_NUM,
+    VFS_S3_SLOW_DOWN_RETRIES,
   };
 
   /* ****************************** */
@@ -236,6 +237,9 @@ class Stats {
 
   /** Dump the current read stats. */
   std::string dump_read() const;
+
+  /** Dump the current vfs stats. */
+  std::string dump_vfs() const;
 
   /**
    * Writes the input message and seconds to the string stream, only if


### PR DESCRIPTION
This patch provides a retry handler that is identical to the existing, default
handler with an exception for CoreErrors::SLOW_DOWN. For this error, we will
unconditionally retry every 1.25-1.75 seconds.

The motivation for this patch is to allow the TileDB client to remain functional
even when performance may be bottlenecked on this error. The server returns
this error when we exceed a fixed number of requests per second. The client
will eventually make progress.