### PR TITLE
Remove two unneeded semicolons noticed by the -pedantic flag

### DIFF
--- a/tiledb/sm/cpp_api/dimension.h
+++ b/tiledb/sm/cpp_api/dimension.h
@@ -154,7 +154,7 @@ class Dimension {
     impl::type_check<T>(type(), 1);
     auto d = (const T*)_domain();
     return std::pair<T, T>(d[0], d[1]);
-  };
+  }
 
   /**
    * Returns a string representation of the domain.

--- a/tiledb/sm/cpp_api/utils.h
+++ b/tiledb/sm/cpp_api/utils.h
@@ -378,7 +378,7 @@ std::vector<T> flatten(const V& vec) {
         std::copy(std::begin(i), std::end(i), std::back_inserter(ret));
       });
   return ret;
-};
+}
 
 namespace impl {
 


### PR DESCRIPTION
Simple removal of two semicolons creating unnecessary line noise in some R package builds where `-pedantic` is enabled (and cannot be turned off as a system `CXXFLAGS` value).

Should have no side-effects.