### PR TITLE
Improve GCS build

### DIFF
--- a/cmake/inputs/patches/ep_gcssdk/build.patch
+++ b/cmake/inputs/patches/ep_gcssdk/build.patch
@@ -91,7 +91,7 @@ index 9cc916aed..8f9ac1eb1 100644
      googletest-project google-cloud-cpp-common-project)
  
  include(ExternalProject)
-@@ -54,8 +53,14 @@ ExternalProject_Add(
+@@ -54,8 +53,15 @@ ExternalProject_Add(
                 -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
                 -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                 -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -102,6 +102,7 @@ index 9cc916aed..8f9ac1eb1 100644
 +               -DCMAKE_C_FLAGS=-fPIC
 +               -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}
 +               -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF
++               -DBUILD_TESTING=${BUILD_TESTING}
      BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
 -    TEST_COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
      LOG_DOWNLOAD OFF

--- a/cmake/inputs/patches/ep_gcssdk/disable_examples.patch
+++ b/cmake/inputs/patches/ep_gcssdk/disable_examples.patch
@@ -1,0 +1,124 @@
+From 95e54c03d877f89cab681e8ac3c747ca017a22ea Mon Sep 17 00:00:00 2001
+From: Seth Shelnutt <Shelnutt2@gmail.com>
+Date: Fri, 22 May 2020 15:29:11 -0400
+Subject: [PATCH] All cloud examples should be wrapped in BUILD_TESTING
+
+---
+ google/cloud/examples/CMakeLists.txt         | 18 +++---
+ google/cloud/storage/examples/CMakeLists.txt | 62 ++++++++++----------
+ 2 files changed, 41 insertions(+), 39 deletions(-)
+
+diff --git a/google/cloud/examples/CMakeLists.txt b/google/cloud/examples/CMakeLists.txt
+index c9f4a4a02..595168720 100644
+--- a/google/cloud/examples/CMakeLists.txt
++++ b/google/cloud/examples/CMakeLists.txt
+@@ -14,13 +14,15 @@
+ # limitations under the License.
+ # ~~~
+ 
+-find_package(google_cloud_cpp_common CONFIG REQUIRED)
+-find_package(google_cloud_cpp_grpc_utils CONFIG REQUIRED)
++if (BUILD_TESTING)
++  find_package(google_cloud_cpp_common CONFIG REQUIRED)
++  find_package(google_cloud_cpp_grpc_utils CONFIG REQUIRED)
+ 
+-# Pick the right MSVC runtime libraries.
+-include(SelectMSVCRuntime)
++  # Pick the right MSVC runtime libraries.
++  include(SelectMSVCRuntime)
+ 
+-add_executable(gcs2cbt gcs2cbt.cc)
+-target_link_libraries(
+-    gcs2cbt bigtable_client storage_client google_cloud_cpp_grpc_utils
+-    google_cloud_cpp_common_options)
++  add_executable(gcs2cbt gcs2cbt.cc)
++  target_link_libraries(
++      gcs2cbt bigtable_client storage_client google_cloud_cpp_grpc_utils
++      google_cloud_cpp_common_options)
++endif()
+diff --git a/google/cloud/storage/examples/CMakeLists.txt b/google/cloud/storage/examples/CMakeLists.txt
+index 6dca71fad..8354bc739 100644
+--- a/google/cloud/storage/examples/CMakeLists.txt
++++ b/google/cloud/storage/examples/CMakeLists.txt
+@@ -18,47 +18,47 @@
+ # to keep this particular file as simple as possible, as it is intended to be
+ # part of the examples.
+ 
+-add_executable(storage_bucket_samples storage_bucket_samples.cc)
+-target_link_libraries(storage_bucket_samples storage_client
+-                      storage_common_options)
++if (BUILD_TESTING)
++    add_executable(storage_bucket_samples storage_bucket_samples.cc)
++    target_link_libraries(storage_bucket_samples storage_client
++                          storage_common_options)
+ 
+-add_executable(storage_bucket_acl_samples storage_bucket_acl_samples.cc)
+-target_link_libraries(storage_bucket_acl_samples storage_client
+-                      storage_common_options)
++    add_executable(storage_bucket_acl_samples storage_bucket_acl_samples.cc)
++    target_link_libraries(storage_bucket_acl_samples storage_client
++                          storage_common_options)
+ 
+-add_executable(storage_bucket_iam_samples storage_bucket_iam_samples.cc)
+-target_link_libraries(storage_bucket_iam_samples storage_client
+-                      storage_common_options)
++    add_executable(storage_bucket_iam_samples storage_bucket_iam_samples.cc)
++    target_link_libraries(storage_bucket_iam_samples storage_client
++                          storage_common_options)
+ 
+-if (BUILD_TESTING)
+     add_executable(storage_client_mock_samples storage_client_mock_samples.cc)
+     target_link_libraries(
+         storage_client_mock_samples storage_client storage_common_options
+         GTest::gmock_main GTest::gmock GTest::gtest)
+-endif ()
+ 
+-add_executable(storage_default_object_acl_samples
+-               storage_default_object_acl_samples.cc)
+-target_link_libraries(storage_default_object_acl_samples storage_client
+-                      storage_common_options)
++    add_executable(storage_default_object_acl_samples
++                   storage_default_object_acl_samples.cc)
++    target_link_libraries(storage_default_object_acl_samples storage_client
++                          storage_common_options)
+ 
+-add_executable(storage_object_samples storage_object_samples.cc)
+-target_link_libraries(storage_object_samples storage_client
+-                      storage_common_options)
++    add_executable(storage_object_samples storage_object_samples.cc)
++    target_link_libraries(storage_object_samples storage_client
++                          storage_common_options)
+ 
+-add_executable(storage_object_acl_samples storage_object_acl_samples.cc)
+-target_link_libraries(storage_object_acl_samples storage_client
+-                      storage_common_options)
++    add_executable(storage_object_acl_samples storage_object_acl_samples.cc)
++    target_link_libraries(storage_object_acl_samples storage_client
++                          storage_common_options)
+ 
+-add_executable(storage_notification_samples storage_notification_samples.cc)
+-target_link_libraries(storage_notification_samples storage_client
+-                      storage_common_options)
++    add_executable(storage_notification_samples storage_notification_samples.cc)
++    target_link_libraries(storage_notification_samples storage_client
++                          storage_common_options)
+ 
+-add_executable(storage_quickstart storage_quickstart.cc)
+-target_link_libraries(storage_quickstart storage_client storage_common_options
+-                      google_cloud_cpp_common_options)
++    add_executable(storage_quickstart storage_quickstart.cc)
++    target_link_libraries(storage_quickstart storage_client storage_common_options
++                          google_cloud_cpp_common_options)
+ 
+-add_executable(storage_service_account_samples
+-               storage_service_account_samples.cc)
+-target_link_libraries(storage_service_account_samples storage_client
+-                      storage_common_options)
++    add_executable(storage_service_account_samples
++                   storage_service_account_samples.cc)
++    target_link_libraries(storage_service_account_samples storage_client
++                          storage_common_options)
++endif ()
+-- 
+2.26.2
+

--- a/cmake/inputs/patches/ep_gcssdk/disable_tests.patch
+++ b/cmake/inputs/patches/ep_gcssdk/disable_tests.patch
@@ -1,0 +1,23 @@
+From 4749df2b03e70218870dab48b83d090af2451027 Mon Sep 17 00:00:00 2001
+From: Seth Shelnutt <Shelnutt2@gmail.com>
+Date: Fri, 22 May 2020 14:06:41 -0400
+Subject: [PATCH] Add option to disable tests
+
+---
+ CMakeLists.txt       | 1 +
+ super/CMakeLists.txt | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c9275541b..0d0058b27 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -143,6 +143,7 @@ mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
+ 
+ # Enable testing in this directory so we can do a top-level `make test`. This
+ # also includes the BUILD_TESTING option, which is on by default.
++option(BUILD_TESTING "" OFF)
+ include(CTest)
+ 
+ # Each subproject adds dependencies to this target to have their docs generated.
+2.26.2

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -319,9 +319,7 @@ if (TILEDB_GCS)
   find_package(GCSSDK_EP REQUIRED COMPONENTS gcs)
   target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
     INTERFACE
-      GCSSDK::storage_client
-      GCSSDK::google_cloud_cpp_common
-      GCSSDK::crc32c
+       storage_client
   )
   add_definitions(-DHAVE_GCS)
 endif()


### PR DESCRIPTION
This adds a new patch to the GCS build which disables tests. The patch will be upstreamed so hopefully we'll be able to drop it eventually. This also adjust the installation and configuration of GCS to install directly into the TILEDB_EP_INSTALL_PREFIX folder. This resolves errors
with the previous copying of `lib` vs `lib64`.

The second commit in this PR switches GCS to use cmake target if it exists instead of always using a custom target. This help by including all the needed dependencies in the target instead of us requiring to maintain the list of needed libs. If the cmake target is acceptable I can squash into a single commit.

This is based on #1654, I'll rebase once that is merged.