### PR TITLE
Ubuntu's capnp-dev package is missing targets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -35,8 +35,10 @@
 * Fix typo in GCS cmake file for superbuild [#1665](https://github.com/TileDB-Inc/TileDB/pull/1665)
 * Don't error on GCS client init failure [#1667](https://github.com/TileDB-Inc/TileDB/pull/1667)
 * Don't include curl's linking to ssl, avoids build issue on fresh macos 10.14/10.15 installs [#1671](https://github.com/TileDB-Inc/TileDB/pull/1671)
+* Handle ubuntu's cap'n proto package not providing cmake targets [#1659](https://github.com/TileDB-Inc/TileDB/pull/1659)
 
 ## Bug fixes
+
 * The C++ Attribute::create API now correctly builds from an STL array [#1670](https://github.com/TileDB-Inc/TileDB/pull/1670)
 * Allow opening arrays with read-only permission on posix filesystems [#1676](https://github.com/TileDB-Inc/TileDB/pull/1676)
 


### PR DESCRIPTION
We need to handle a capnproto install without targets by checking for the `CAPNP_LIBRARIES` and making sure all needed libraries are available. Ubuntu 18.04's capnproto 0.6.1 package is missing the libcapnp-json so we need to use super build in that case.

Note: This does not solve the problem of checking for capnproto version mismatches. I'll open a story to do this as a followup.

This is based on #1658 to avoid rebase conflicts. I'll rebase once that one is merged.

[ch2388]