### PR TITLE
C/CPP stats raw-dump API

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4325,6 +4325,28 @@ int32_t tiledb_stats_dump_str(char** out) {
   return TILEDB_OK;
 }
 
+int32_t tiledb_stats_raw_dump(FILE* out) {
+  tiledb::sm::stats::all_stats.raw_dump(out);
+  return TILEDB_OK;
+}
+
+int32_t tiledb_stats_raw_dump_str(char** out) {
+  if (out == nullptr)
+    return TILEDB_ERR;
+
+  std::string str;
+  tiledb::sm::stats::all_stats.raw_dump(&str);
+
+  *out = static_cast<char*>(std::malloc(str.size() + 1));
+  if (*out == nullptr)
+    return TILEDB_ERR;
+
+  std::memcpy(*out, str.data(), str.size());
+  (*out)[str.size()] = '\0';
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_stats_free_str(char** out) {
   if (out != nullptr) {
     std::free(*out);

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -5414,7 +5414,7 @@ TILEDB_EXPORT int32_t tiledb_stats_disable();
 TILEDB_EXPORT int32_t tiledb_stats_reset();
 
 /**
- * Dump all internal statistics counters to to some output (e.g.,
+ * Dump all internal statistics counters to some output (e.g.,
  * file or stdout).
  *
  * @param out The output.
@@ -5439,6 +5439,33 @@ TILEDB_EXPORT int32_t tiledb_stats_dump(FILE* out);
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int32_t tiledb_stats_dump_str(char** out);
+
+/**
+ * Dump all raw internal statistics counters to some output (e.g.,
+ * file or stdout).
+ *
+ * @param out The output.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_stats_raw_dump(FILE* out);
+
+/**
+ * Dump all raw internal statistics counters to an output string. The caller is
+ * responsible for freeing the resulting string.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * char *stats_str;
+ * tiledb_stats_raw_dump_str(&stats_str);
+ * // ...
+ * tiledb_stats_raw_free_str(&stats_str);
+ * @endcode
+ *
+ * @param out Will be set to point to an allocated string containing the stats.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_stats_raw_dump_str(char** out);
 
 /**
  *

--- a/tiledb/sm/cpp_api/stats.h
+++ b/tiledb/sm/cpp_api/stats.h
@@ -70,7 +70,7 @@ class Stats {
   }
 
   /**
-   * Dump all statistics counters to to some output (e.g., file or stdout).
+   * Dump all statistics counters to some output (e.g., file or stdout).
    *
    * @param out The output.
    */
@@ -86,6 +86,27 @@ class Stats {
   static void dump(std::string* out) {
     char* c_str = nullptr;
     check_error(tiledb_stats_dump_str(&c_str), "error dumping stats");
+    *out = std::string(c_str);
+    check_error(tiledb_stats_free_str(&c_str), "error freeing stats string");
+  }
+
+  /**
+   * Dump all raw statistics counters to some output (e.g., file or stdout).
+   *
+   * @param out The output.
+   */
+  static void raw_dump(FILE* out = nullptr) {
+    check_error(tiledb_stats_raw_dump(out), "error dumping stats");
+  }
+
+  /**
+   * Dump all raw statistics counters to a string.
+   *
+   * @param out The output.
+   */
+  static void raw_dump(std::string* out) {
+    char* c_str = nullptr;
+    check_error(tiledb_stats_raw_dump_str(&c_str), "error dumping stats");
     *out = std::string(c_str);
     check_error(tiledb_stats_free_str(&c_str), "error freeing stats string");
   }

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -76,104 +76,12 @@ void Stats::reset() {
   std::unique_lock<std::mutex> lck(mtx_);
 
   timer_stats_.clear();
-  timer_stats_[TimerType::CONSOLIDATE_FRAGS] = 0;
-  timer_stats_[TimerType::CONSOLIDATE_ARRAY_META] = 0;
-  timer_stats_[TimerType::CONSOLIDATE_FRAG_META] = 0;
-  timer_stats_[TimerType::READ_ARRAY_OPEN] = 0;
-  timer_stats_[TimerType::READ_FILL_DENSE_COORDS] = 0;
-  timer_stats_[TimerType::READ_LOAD_ARRAY_SCHEMA] = 0;
-  timer_stats_[TimerType::READ_LOAD_ARRAY_META] = 0;
-  timer_stats_[TimerType::READ_LOAD_FRAG_META] = 0;
-  timer_stats_[TimerType::READ_LOAD_CONSOLIDATED_FRAG_META] = 0;
-  timer_stats_[TimerType::READ_ATTR_TILES] = 0;
-  timer_stats_[TimerType::READ_COORD_TILES] = 0;
-  timer_stats_[TimerType::READ_UNFILTER_ATTR_TILES] = 0;
-  timer_stats_[TimerType::READ_UNFILTER_COORD_TILES] = 0;
-  timer_stats_[TimerType::READ_COPY_ATTR_VALUES] = 0;
-  timer_stats_[TimerType::READ_COPY_COORDS] = 0;
-  timer_stats_[TimerType::READ_COPY_FIXED_ATTR_VALUES] = 0;
-  timer_stats_[TimerType::READ_COPY_FIXED_COORDS] = 0;
-  timer_stats_[TimerType::READ_COPY_VAR_ATTR_VALUES] = 0;
-  timer_stats_[TimerType::READ_COPY_VAR_COORDS] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_TILE_OVERLAP] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_TILE_COORDS] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_RESULT_COORDS] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_RANGE_RESULT_COORDS] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_SPARSE] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_DENSE] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_SPARSE_RESULT_TILES] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_EST_RESULT_SIZE] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_RELEVANT_TILE_OVERLAP] = 0;
-  timer_stats_[TimerType::READ_LOAD_RELEVANT_RTREES] = 0;
-  timer_stats_[TimerType::READ_COMPUTE_RELEVANT_FRAGS] = 0;
-  timer_stats_[TimerType::READ_INIT_STATE] = 0;
-  timer_stats_[TimerType::READ_NEXT_PARTITION] = 0;
-  timer_stats_[TimerType::READ_SPLIT_CURRENT_PARTITION] = 0;
-  timer_stats_[TimerType::READ] = 0;
-  timer_stats_[TimerType::DBG] = 0;
-  timer_stats_[TimerType::WRITE] = 0;
-  timer_stats_[TimerType::WRITE_SPLIT_COORDS_BUFF] = 0;
-  timer_stats_[TimerType::WRITE_CHECK_COORD_OOB] = 0;
-  timer_stats_[TimerType::WRITE_SORT_COORDS] = 0;
-  timer_stats_[TimerType::WRITE_CHECK_COORD_DUPS] = 0;
-  timer_stats_[TimerType::WRITE_COMPUTE_COORD_DUPS] = 0;
-  timer_stats_[TimerType::WRITE_PREPARE_TILES] = 0;
-  timer_stats_[TimerType::WRITE_COMPUTE_COORD_META] = 0;
-  timer_stats_[TimerType::WRITE_FILTER_TILES] = 0;
-  timer_stats_[TimerType::WRITE_TILES] = 0;
-  timer_stats_[TimerType::WRITE_STORE_FRAG_META] = 0;
-  timer_stats_[TimerType::WRITE_FINALIZE] = 0;
-  timer_stats_[TimerType::WRITE_CHECK_GLOBAL_ORDER] = 0;
-  timer_stats_[TimerType::WRITE_INIT_TILE_ITS] = 0;
-  timer_stats_[TimerType::WRITE_COMPUTE_CELL_RANGES] = 0;
-  timer_stats_[TimerType::WRITE_PREPARE_AND_FILTER_TILES] = 0;
-  timer_stats_[TimerType::WRITE_ARRAY_META] = 0;
+  for (uint64_t i = 0; i != static_cast<uint64_t>(TimerType::__SIZE); ++i)
+    timer_stats_[static_cast<TimerType>(i)] = 0;
 
   counter_stats_.clear();
-  counter_stats_[CounterType::READ_ARRAY_SCHEMA_SIZE] = 0;
-  counter_stats_[CounterType::READ_ARRAY_META_SIZE] = 0;
-  counter_stats_[CounterType::CONSOLIDATED_FRAG_META_SIZE] = 0;
-  counter_stats_[CounterType::READ_FRAG_META_SIZE] = 0;
-  counter_stats_[CounterType::READ_RTREE_SIZE] = 0;
-  counter_stats_[CounterType::READ_TILE_OFFSETS_SIZE] = 0;
-  counter_stats_[CounterType::READ_TILE_VAR_OFFSETS_SIZE] = 0;
-  counter_stats_[CounterType::READ_TILE_VAR_SIZES_SIZE] = 0;
-  counter_stats_[CounterType::READ_NUM] = 0;
-  counter_stats_[CounterType::READ_BYTE_NUM] = 0;
-  counter_stats_[CounterType::READ_UNFILTERED_BYTE_NUM] = 0;
-  counter_stats_[CounterType::READ_ATTR_NUM] = 0;
-  counter_stats_[CounterType::READ_ATTR_FIXED_NUM] = 0;
-  counter_stats_[CounterType::READ_ATTR_VAR_NUM] = 0;
-  counter_stats_[CounterType::READ_DIM_NUM] = 0;
-  counter_stats_[CounterType::READ_DIM_FIXED_NUM] = 0;
-  counter_stats_[CounterType::READ_DIM_VAR_NUM] = 0;
-  counter_stats_[CounterType::READ_DIM_ZIPPED_NUM] = 0;
-  counter_stats_[CounterType::READ_OVERLAP_TILE_NUM] = 0;
-  counter_stats_[CounterType::READ_LOOP_NUM] = 0;
-  counter_stats_[CounterType::READ_RESULT_NUM] = 0;
-  counter_stats_[CounterType::READ_CELL_NUM] = 0;
-  counter_stats_[CounterType::READ_OPS_NUM] = 0;
-  counter_stats_[CounterType::WRITE_NUM] = 0;
-  counter_stats_[CounterType::WRITE_ATTR_NUM] = 0;
-  counter_stats_[CounterType::WRITE_ATTR_FIXED_NUM] = 0;
-  counter_stats_[CounterType::WRITE_ATTR_VAR_NUM] = 0;
-  counter_stats_[CounterType::WRITE_DIM_NUM] = 0;
-  counter_stats_[CounterType::WRITE_DIM_FIXED_NUM] = 0;
-  counter_stats_[CounterType::WRITE_DIM_VAR_NUM] = 0;
-  counter_stats_[CounterType::WRITE_DIM_ZIPPED_NUM] = 0;
-  counter_stats_[CounterType::WRITE_BYTE_NUM] = 0;
-  counter_stats_[CounterType::WRITE_FILTERED_BYTE_NUM] = 0;
-  counter_stats_[CounterType::WRITE_RTREE_SIZE] = 0;
-  counter_stats_[CounterType::WRITE_TILE_OFFSETS_SIZE] = 0;
-  counter_stats_[CounterType::WRITE_TILE_VAR_OFFSETS_SIZE] = 0;
-  counter_stats_[CounterType::WRITE_TILE_VAR_SIZES_SIZE] = 0;
-  counter_stats_[CounterType::WRITE_FRAG_META_FOOTER_SIZE] = 0;
-  counter_stats_[CounterType::WRITE_ARRAY_SCHEMA_SIZE] = 0;
-  counter_stats_[CounterType::WRITE_TILE_NUM] = 0;
-  counter_stats_[CounterType::WRITE_CELL_NUM] = 0;
-  counter_stats_[CounterType::WRITE_ARRAY_META_SIZE] = 0;
-  counter_stats_[CounterType::WRITE_OPS_NUM] = 0;
-  counter_stats_[CounterType::VFS_S3_SLOW_DOWN_RETRIES] = 0;
+  for (uint64_t i = 0; i != static_cast<uint64_t>(CounterType::__SIZE); ++i)
+    counter_stats_[static_cast<CounterType>(i)] = 0;
 }
 
 void Stats::dump(FILE* out) const {
@@ -200,6 +108,65 @@ void Stats::dump(std::string* out) const {
     ss << "\nDebugging time: " << dbg_secs << " secs\n";
 
   *out = ss.str();
+}
+
+void Stats::raw_dump(FILE* out) const {
+  if (out == nullptr)
+    out = stdout;
+
+  std::string output;
+  Stats::raw_dump(&output);
+  fprintf(out, "%s", output.c_str());
+}
+
+void Stats::raw_dump(std::string* out) const {
+  std::stringstream ss;
+
+  ss << "{\n";
+
+  // Dump timer stats
+  const std::vector<std::string> timer_names =
+      parse_enum_names(TimerTypeNames_);
+  for (uint64_t i = 0; i != static_cast<uint64_t>(TimerType::__SIZE); ++i) {
+    // The first stat is a special where we do not need to prepend a comma
+    // to the end of the previous stat.
+    if (i == 0) {
+      ss << "  \"" << timer_names[i]
+         << "\": " << timer_stats_.find(static_cast<TimerType>(i))->second;
+    } else {
+      ss << ",\n  \"" << timer_names[i]
+         << "\": " << timer_stats_.find(static_cast<TimerType>(i))->second;
+    }
+  }
+
+  // Dump counter stats
+  const std::vector<std::string> counter_names =
+      parse_enum_names(CounterTypeNames_);
+  for (uint64_t i = 0; i != static_cast<uint64_t>(CounterType::__SIZE); ++i) {
+    ss << ",\n  \"" << counter_names[i]
+       << "\": " << counter_stats_.find(static_cast<CounterType>(i))->second;
+  }
+
+  ss << "\n}\n";
+
+  *out = ss.str();
+}
+
+std::vector<std::string> Stats::parse_enum_names(
+    const std::string& enum_names) const {
+  std::vector<std::string> parsed_enum_names;
+
+  std::string tmp;
+  std::stringstream ss(enum_names);
+  while (getline(ss, tmp, ',')) {
+    if (parsed_enum_names.empty()) {
+      parsed_enum_names.push_back(tmp);
+    } else {
+      parsed_enum_names.push_back(tmp.substr(1));
+    }
+  }
+
+  return parsed_enum_names;
 }
 
 void Stats::set_enabled(bool enabled) {

--- a/tiledb/sm/stats/stats.h
+++ b/tiledb/sm/stats/stats.h
@@ -40,10 +40,20 @@
 #include <chrono>
 #include <iomanip>
 #include <iostream>
-#include <map>
 #include <mutex>
 #include <sstream>
 #include <thread>
+#include <unordered_map>
+#include <vector>
+
+// Define an enum named <TypeName> and a comma-separated
+// string named <TypeName>Names_ containing the stat names.
+#define DEFINE_TILEDB_STATS(TypeName, ...)           \
+ private:                                            \
+  const std::string TypeName##Names_ = #__VA_ARGS__; \
+                                                     \
+ public:                                             \
+  enum class TypeName { __VA_ARGS__, __SIZE }
 
 namespace tiledb {
 namespace sm {
@@ -70,108 +80,108 @@ class Stats {
   /* ****************************** */
 
   /** Enumerates the stat timer types. */
-  enum class TimerType {
-    CONSOLIDATE_FRAGS,
-    CONSOLIDATE_ARRAY_META,
-    CONSOLIDATE_FRAG_META,
-    READ_ARRAY_OPEN,
-    READ_FILL_DENSE_COORDS,
-    READ_LOAD_ARRAY_SCHEMA,
-    READ_LOAD_ARRAY_META,
-    READ_LOAD_FRAG_META,
-    READ_LOAD_CONSOLIDATED_FRAG_META,
-    READ_ATTR_TILES,
-    READ_COORD_TILES,
-    READ_UNFILTER_ATTR_TILES,
-    READ_UNFILTER_COORD_TILES,
-    READ_COPY_ATTR_VALUES,
-    READ_COPY_COORDS,
-    READ_COPY_FIXED_ATTR_VALUES,
-    READ_COPY_FIXED_COORDS,
-    READ_COPY_VAR_ATTR_VALUES,
-    READ_COPY_VAR_COORDS,
-    READ_COMPUTE_EST_RESULT_SIZE,
-    READ_COMPUTE_RESULT_COORDS,
-    READ_COMPUTE_RANGE_RESULT_COORDS,
-    READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_SPARSE,
-    READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_DENSE,
-    READ_COMPUTE_SPARSE_RESULT_TILES,
-    READ_COMPUTE_TILE_OVERLAP,
-    READ_COMPUTE_TILE_COORDS,
-    READ_COMPUTE_RELEVANT_TILE_OVERLAP,
-    READ_LOAD_RELEVANT_RTREES,
-    READ_COMPUTE_RELEVANT_FRAGS,
-    READ_INIT_STATE,
-    READ_NEXT_PARTITION,
-    READ_SPLIT_CURRENT_PARTITION,
-    READ,
-    DBG,
-    WRITE,
-    WRITE_SPLIT_COORDS_BUFF,
-    WRITE_CHECK_COORD_OOB,
-    WRITE_SORT_COORDS,
-    WRITE_CHECK_COORD_DUPS,
-    WRITE_COMPUTE_COORD_DUPS,
-    WRITE_PREPARE_TILES,
-    WRITE_COMPUTE_COORD_META,
-    WRITE_FILTER_TILES,
-    WRITE_TILES,
-    WRITE_STORE_FRAG_META,
-    WRITE_FINALIZE,
-    WRITE_CHECK_GLOBAL_ORDER,
-    WRITE_INIT_TILE_ITS,
-    WRITE_COMPUTE_CELL_RANGES,
-    WRITE_PREPARE_AND_FILTER_TILES,
-    WRITE_ARRAY_META,
-  };
+  DEFINE_TILEDB_STATS(
+      TimerType,
+      CONSOLIDATE_FRAGS,
+      CONSOLIDATE_ARRAY_META,
+      CONSOLIDATE_FRAG_META,
+      READ_ARRAY_OPEN,
+      READ_FILL_DENSE_COORDS,
+      READ_LOAD_ARRAY_SCHEMA,
+      READ_LOAD_ARRAY_META,
+      READ_LOAD_FRAG_META,
+      READ_LOAD_CONSOLIDATED_FRAG_META,
+      READ_ATTR_TILES,
+      READ_COORD_TILES,
+      READ_UNFILTER_ATTR_TILES,
+      READ_UNFILTER_COORD_TILES,
+      READ_COPY_ATTR_VALUES,
+      READ_COPY_COORDS,
+      READ_COPY_FIXED_ATTR_VALUES,
+      READ_COPY_FIXED_COORDS,
+      READ_COPY_VAR_ATTR_VALUES,
+      READ_COPY_VAR_COORDS,
+      READ_COMPUTE_EST_RESULT_SIZE,
+      READ_COMPUTE_RESULT_COORDS,
+      READ_COMPUTE_RANGE_RESULT_COORDS,
+      READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_SPARSE,
+      READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_DENSE,
+      READ_COMPUTE_SPARSE_RESULT_TILES,
+      READ_COMPUTE_TILE_OVERLAP,
+      READ_COMPUTE_TILE_COORDS,
+      READ_COMPUTE_RELEVANT_TILE_OVERLAP,
+      READ_LOAD_RELEVANT_RTREES,
+      READ_COMPUTE_RELEVANT_FRAGS,
+      READ_INIT_STATE,
+      READ_NEXT_PARTITION,
+      READ_SPLIT_CURRENT_PARTITION,
+      READ,
+      DBG,
+      WRITE,
+      WRITE_SPLIT_COORDS_BUFF,
+      WRITE_CHECK_COORD_OOB,
+      WRITE_SORT_COORDS,
+      WRITE_CHECK_COORD_DUPS,
+      WRITE_COMPUTE_COORD_DUPS,
+      WRITE_PREPARE_TILES,
+      WRITE_COMPUTE_COORD_META,
+      WRITE_FILTER_TILES,
+      WRITE_TILES,
+      WRITE_STORE_FRAG_META,
+      WRITE_FINALIZE,
+      WRITE_CHECK_GLOBAL_ORDER,
+      WRITE_INIT_TILE_ITS,
+      WRITE_COMPUTE_CELL_RANGES,
+      WRITE_PREPARE_AND_FILTER_TILES,
+      WRITE_ARRAY_META);
 
   /** Enumerates the stat counter types. */
-  enum class CounterType {
-    READ_ARRAY_SCHEMA_SIZE,
-    CONSOLIDATED_FRAG_META_SIZE,
-    READ_FRAG_META_SIZE,
-    READ_RTREE_SIZE,
-    READ_TILE_OFFSETS_SIZE,
-    READ_TILE_VAR_OFFSETS_SIZE,
-    READ_TILE_VAR_SIZES_SIZE,
-    READ_ARRAY_META_SIZE,
-    READ_NUM,
-    READ_BYTE_NUM,
-    READ_UNFILTERED_BYTE_NUM,
-    READ_ATTR_NUM,
-    READ_ATTR_FIXED_NUM,
-    READ_ATTR_VAR_NUM,
-    READ_DIM_NUM,
-    READ_DIM_FIXED_NUM,
-    READ_DIM_VAR_NUM,
-    READ_DIM_ZIPPED_NUM,
-    READ_OVERLAP_TILE_NUM,
-    READ_RESULT_NUM,
-    READ_CELL_NUM,
-    READ_LOOP_NUM,
-    READ_OPS_NUM,
-    WRITE_NUM,
-    WRITE_ATTR_NUM,
-    WRITE_ATTR_FIXED_NUM,
-    WRITE_ATTR_VAR_NUM,
-    WRITE_DIM_NUM,
-    WRITE_DIM_FIXED_NUM,
-    WRITE_DIM_VAR_NUM,
-    WRITE_DIM_ZIPPED_NUM,
-    WRITE_BYTE_NUM,
-    WRITE_FILTERED_BYTE_NUM,
-    WRITE_RTREE_SIZE,
-    WRITE_TILE_OFFSETS_SIZE,
-    WRITE_TILE_VAR_OFFSETS_SIZE,
-    WRITE_TILE_VAR_SIZES_SIZE,
-    WRITE_FRAG_META_FOOTER_SIZE,
-    WRITE_ARRAY_SCHEMA_SIZE,
-    WRITE_TILE_NUM,
-    WRITE_CELL_NUM,
-    WRITE_ARRAY_META_SIZE,
-    WRITE_OPS_NUM,
-    VFS_S3_SLOW_DOWN_RETRIES,
-  };
+  DEFINE_TILEDB_STATS(
+      CounterType,
+      READ_ARRAY_SCHEMA_SIZE,
+      CONSOLIDATED_FRAG_META_SIZE,
+      READ_FRAG_META_SIZE,
+      READ_RTREE_SIZE,
+      READ_TILE_OFFSETS_SIZE,
+      READ_TILE_VAR_OFFSETS_SIZE,
+      READ_TILE_VAR_SIZES_SIZE,
+      READ_ARRAY_META_SIZE,
+      READ_NUM,
+      READ_BYTE_NUM,
+      READ_UNFILTERED_BYTE_NUM,
+      READ_ATTR_NUM,
+      READ_ATTR_FIXED_NUM,
+      READ_ATTR_VAR_NUM,
+      READ_DIM_NUM,
+      READ_DIM_FIXED_NUM,
+      READ_DIM_VAR_NUM,
+      READ_DIM_ZIPPED_NUM,
+      READ_OVERLAP_TILE_NUM,
+      READ_RESULT_NUM,
+      READ_CELL_NUM,
+      READ_LOOP_NUM,
+      READ_OPS_NUM,
+      WRITE_NUM,
+      WRITE_ATTR_NUM,
+      WRITE_ATTR_FIXED_NUM,
+      WRITE_ATTR_VAR_NUM,
+      WRITE_DIM_NUM,
+      WRITE_DIM_FIXED_NUM,
+      WRITE_DIM_VAR_NUM,
+      WRITE_DIM_ZIPPED_NUM,
+      WRITE_BYTE_NUM,
+      WRITE_FILTERED_BYTE_NUM,
+      WRITE_RTREE_SIZE,
+      WRITE_TILE_OFFSETS_SIZE,
+      WRITE_TILE_VAR_OFFSETS_SIZE,
+      WRITE_TILE_VAR_SIZES_SIZE,
+      WRITE_FRAG_META_FOOTER_SIZE,
+      WRITE_ARRAY_SCHEMA_SIZE,
+      WRITE_TILE_NUM,
+      WRITE_CELL_NUM,
+      WRITE_ARRAY_META_SIZE,
+      WRITE_OPS_NUM,
+      VFS_S3_SLOW_DOWN_RETRIES);
 
   /* ****************************** */
   /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -208,7 +218,25 @@ class Stats {
   /** Dump the current stats to the given string. */
   void dump(std::string* out) const;
 
+  /** Dump the current raw stats to the given file as a JSON. */
+  void raw_dump(FILE* out) const;
+
+  /** Dump the current raw stats to the given string as a JSON. */
+  void raw_dump(std::string* out) const;
+
  private:
+  /* ****************************** */
+  /*       PRIVATE DATATYPES        */
+  /* ****************************** */
+
+  /** An STL hasher for enum definitions. */
+  struct EnumHasher {
+    template <typename T>
+    std::size_t operator()(T t) const {
+      return static_cast<std::size_t>(t);
+    }
+  };
+
   /* ****************************** */
   /*       PRIVATE ATTRIBUTES       */
   /* ****************************** */
@@ -217,10 +245,10 @@ class Stats {
   bool enabled_;
 
   /** A map of timer stats, measured in seconds. */
-  std::map<TimerType, double> timer_stats_;
+  std::unordered_map<TimerType, double, EnumHasher> timer_stats_;
 
   /** A map of counter stats. */
-  std::map<CounterType, uint64_t> counter_stats_;
+  std::unordered_map<CounterType, uint64_t, EnumHasher> counter_stats_;
 
   /** Mutex to protext in multi-threading scenarios. */
   std::mutex mtx_;
@@ -240,6 +268,10 @@ class Stats {
 
   /** Dump the current vfs stats. */
   std::string dump_vfs() const;
+
+  /** Parse a comma-separated string of enum names. */
+  std::vector<std::string> parse_enum_names(
+      const std::string& enum_names) const;
 
   /**
    * Writes the input message and seconds to the string stream, only if


### PR DESCRIPTION
This introduces the raw_dump() routine to reflectively dump all stats as a
JSON.

Example output:
```
{
  "CONSOLIDATE_FRAGS": 0,
  "CONSOLIDATE_ARRAY_META": 0,
  "CONSOLIDATE_FRAG_META": 0,
  "READ_ARRAY_OPEN": 0,
  "READ_FILL_DENSE_COORDS": 0,
  "READ_LOAD_ARRAY_SCHEMA": 0,
  "READ_LOAD_ARRAY_META": 0,
  "READ_LOAD_FRAG_META": 0,
  "READ_LOAD_CONSOLIDATED_FRAG_META": 0,
  "READ_ATTR_TILES": 0,
  "READ_COORD_TILES": 0,
  "READ_UNFILTER_ATTR_TILES": 0,
  "READ_UNFILTER_COORD_TILES": 0,
  "READ_COPY_ATTR_VALUES": 0,
  "READ_COPY_COORDS": 0,
  "READ_COPY_FIXED_ATTR_VALUES": 0,
  "READ_COPY_FIXED_COORDS": 0,
  "READ_COPY_VAR_ATTR_VALUES": 0,
  "READ_COPY_VAR_COORDS": 0,
  "READ_COMPUTE_EST_RESULT_SIZE": 0,
  "READ_COMPUTE_RESULT_COORDS": 0,
  "READ_COMPUTE_RANGE_RESULT_COORDS": 0,
  "READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_SPARSE": 0,
  "READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_DENSE": 0,
  "READ_COMPUTE_SPARSE_RESULT_TILES": 0,
  "READ_COMPUTE_TILE_OVERLAP": 0,
  "READ_COMPUTE_TILE_COORDS": 0,
  "READ_COMPUTE_RELEVANT_TILE_OVERLAP": 0,
  "READ_LOAD_RELEVANT_RTREES": 0,
  "READ_COMPUTE_RELEVANT_FRAGS": 0,
  "READ_INIT_STATE": 0,
  "READ_NEXT_PARTITION": 0,
  "READ_SPLIT_CURRENT_PARTITION": 0,
  "READ": 0,
  "DBG": 0,
  "WRITE": 0,
  "WRITE_SPLIT_COORDS_BUFF": 0,
  "WRITE_CHECK_COORD_OOB": 0,
  "WRITE_SORT_COORDS": 0,
  "WRITE_CHECK_COORD_DUPS": 0,
  "WRITE_COMPUTE_COORD_DUPS": 0,
  "WRITE_PREPARE_TILES": 0,
  "WRITE_COMPUTE_COORD_META": 0,
  "WRITE_FILTER_TILES": 0,
  "WRITE_TILES": 0,
  "WRITE_STORE_FRAG_META": 0,
  "WRITE_FINALIZE": 0,
  "WRITE_CHECK_GLOBAL_ORDER": 0,
  "WRITE_INIT_TILE_ITS": 0,
  "WRITE_COMPUTE_CELL_RANGES": 0,
  "WRITE_PREPARE_AND_FILTER_TILES": 0,
  "WRITE_ARRAY_META": 0,
  "READ_ARRAY_SCHEMA_SIZE": 0,
  "CONSOLIDATED_FRAG_META_SIZE": 0,
  "READ_FRAG_META_SIZE": 0,
  "READ_RTREE_SIZE": 0,
  "READ_TILE_OFFSETS_SIZE": 0,
  "READ_TILE_VAR_OFFSETS_SIZE": 0,
  "READ_TILE_VAR_SIZES_SIZE": 0,
  "READ_ARRAY_META_SIZE": 0,
  "READ_NUM": 0,
  "READ_BYTE_NUM": 0,
  "READ_UNFILTERED_BYTE_NUM": 0,
  "READ_ATTR_NUM": 0,
  "READ_ATTR_FIXED_NUM": 0,
  "READ_ATTR_VAR_NUM": 0,
  "READ_DIM_NUM": 0,
  "READ_DIM_FIXED_NUM": 0,
  "READ_DIM_VAR_NUM": 0,
  "READ_DIM_ZIPPED_NUM": 0,
  "READ_OVERLAP_TILE_NUM": 0,
  "READ_RESULT_NUM": 0,
  "READ_CELL_NUM": 0,
  "READ_LOOP_NUM": 0,
  "READ_OPS_NUM": 0,
  "WRITE_NUM": 0,
  "WRITE_ATTR_NUM": 0,
  "WRITE_ATTR_FIXED_NUM": 0,
  "WRITE_ATTR_VAR_NUM": 0,
  "WRITE_DIM_NUM": 0,
  "WRITE_DIM_FIXED_NUM": 0,
  "WRITE_DIM_VAR_NUM": 0,
  "WRITE_DIM_ZIPPED_NUM": 0,
  "WRITE_BYTE_NUM": 0,
  "WRITE_FILTERED_BYTE_NUM": 0,
  "WRITE_RTREE_SIZE": 0,
  "WRITE_TILE_OFFSETS_SIZE": 0,
  "WRITE_TILE_VAR_OFFSETS_SIZE": 0,
  "WRITE_TILE_VAR_SIZES_SIZE": 0,
  "WRITE_FRAG_META_FOOTER_SIZE": 0,
  "WRITE_ARRAY_SCHEMA_SIZE": 0,
  "WRITE_TILE_NUM": 0,
  "WRITE_CELL_NUM": 0,
  "WRITE_ARRAY_META_SIZE": 0,
  "WRITE_OPS_NUM": 0,
  "VFS_S3_SLOW_DOWN_RETRIES": 0
}
```