### PR TITLE
Add vacuum files to list of Fragment URIs on open

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -117,6 +117,7 @@ if (TILEDB_CPP_API)
     src/unit-cppapi-checksum.cc
     src/unit-cppapi-config.cc
     src/unit-cppapi-consolidation.cc
+    src/unit-cppapi-consolidation-sparse.cc
     src/unit-cppapi-datetimes.cc
     src/unit-cppapi-filter.cc
     src/unit-cppapi-metadata.cc

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -624,6 +624,13 @@ class StorageManager {
   Status is_file(const URI& uri, bool* is_file) const;
 
   /**
+   * Check if a URI is a vacuum file or not based on the file suffix
+   * @param uri
+   * @return true is vacuum file, false otherwise
+   */
+  bool is_vacuum_file(const URI& uri) const;
+
+  /**
    * Loads the schema of an array from persistent storage into memory.
    *
    * @param array_uri The URI path of the array.


### PR DESCRIPTION
The vacuum files are then used in sorting to remove stale fragments so their metadata is not loaded and they are not considered in the query. Previously it was assumed these files would be in the list of fragment URIs but they were filtered out.

New unit tests are added for the case of running consolidation without vacuuming.