### PR TITLE
Always check ranges in read for multiple fragments

### DIFF
--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -845,11 +845,12 @@ Status Reader::compute_sparse_result_tiles(
           if (result_tile_map->find(pair) == result_tile_map->end()) {
             result_tiles->emplace_back(f, t, domain);
             (*result_tile_map)[pair] = result_tiles->size() - 1;
-            if (f > first_fragment[r])
-              (*single_fragment)[r] = false;
-            else
-              first_fragment[r] = f;
           }
+          // Always check range for multiple fragments
+          if (f > first_fragment[r])
+            (*single_fragment)[r] = false;
+          else
+            first_fragment[r] = f;
         }
       }
 
@@ -862,11 +863,12 @@ Status Reader::compute_sparse_result_tiles(
         if (result_tile_map->find(pair) == result_tile_map->end()) {
           result_tiles->emplace_back(f, t, domain);
           (*result_tile_map)[pair] = result_tiles->size() - 1;
-          if (f > first_fragment[r])
-            (*single_fragment)[r] = false;
-          else
-            first_fragment[r] = f;
         }
+        // Always check range for multiple fragments
+        if (f > first_fragment[r])
+          (*single_fragment)[r] = false;
+        else
+          first_fragment[r] = f;
       }
     }
   }


### PR DESCRIPTION
If there are multiple ranges and these ranges are satisfied by a single tile inside a fragment we might incorrectly leave later ranges as being from a single fragment. With overlap we were only counting a
fragment+tile for the first range we saw it for. Thus we might miss that a following range was included in more than one fragment. This case happened when a user consolidated the array but did not vacuum. This results in two tiles satisfying a range.

If a range is marked as being only from a single fragment the de-duplication process is not run, and multiple records could be returned.