### PR TITLE
Upload build artifacts for releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,80 +3,176 @@ trigger:
     include:
     - dev
     - release-*
+    - refs/tags/*
 pr:
   branches:
     include:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string
+stages:
+  - stage: CI
+    condition: not(or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), contains(variables['Build.SourceBranchName'], 'release-')))
+    jobs:
+    - job:
+      strategy:
+        matrix:
+          linux_s3:
+            imageName: 'ubuntu-16.04'
+            TILEDB_S3: ON
+            TILEDB_STATIC: OFF
+            CXX: g++
+          linux_hdfs:
+            imageName: 'ubuntu-16.04'
+            TILEDB_HDFS: ON
+            CXX: g++
+          linux_azure:
+            imageName: 'ubuntu-16.04'
+            TILEDB_AZURE: ON
+            TILEDB_STATIC: OFF
+            CXX: g++
+          linux_gcs:
+            imageName: 'ubuntu-16.04'
+            TILEDB_GCS: ON
+            TILEDB_STATIC: OFF
+            CXX: g++
+          macOS:
+            imageName: 'macOS-10.14'
+            TILEDB_S3: ON
+            CXX: clang++
+          macOS_azure:
+            imageName: 'macOS-10.14'
+            TILEDB_AZURE: ON
+            CXX: clang++
+          macOS_gcs:
+            imageName: 'macOS-10.14'
+            TILEDB_GCS: ON
+            CXX: clang++
+          linux_asan:
+            imageName: 'ubuntu-16.04'
+            TILEDB_CI_ASAN: ON
+            TILEDB_TBB: OFF
+            TILEDB_SERIALIZATION: ON
+            CXX: g++-7
+          linux_serialization:
+            imageName: 'ubuntu-16.04'
+            TILEDB_SERIALIZATION: ON
+            TILEDB_S3: ON
+            CXX: g++
 
-jobs:
-- job:
-  strategy:
-    matrix:
-      linux_s3:
-        imageName: 'ubuntu-16.04'
-        TILEDB_S3: ON
-        TILEDB_STATIC: OFF
-        CXX: g++
-      linux_hdfs:
-        imageName: 'ubuntu-16.04'
-        TILEDB_HDFS: ON
-        CXX: g++
-      linux_azure:
-        imageName: 'ubuntu-16.04'
-        TILEDB_AZURE: ON
-        TILEDB_STATIC: OFF
-        CXX: g++
-      linux_gcs:
-        imageName: 'ubuntu-16.04'
-        TILEDB_GCS: ON
-        TILEDB_STATIC: OFF
-        CXX: g++
-      macOS:
-        imageName: 'macOS-10.14'
-        TILEDB_S3: ON
-        CXX: clang++
-      macOS_azure:
-        imageName: 'macOS-10.14'
-        TILEDB_AZURE: ON
-        CXX: clang++
-      macOS_gcs:
-        imageName: 'macOS-10.14'
-        TILEDB_GCS: ON
-        CXX: clang++
-      linux_asan:
-        imageName: 'ubuntu-16.04'
-        TILEDB_CI_ASAN: ON
-        TILEDB_TBB: OFF
-        TILEDB_SERIALIZATION: ON
-        CXX: g++-7
-      linux_serialization:
-        imageName: 'ubuntu-16.04'
-        TILEDB_SERIALIZATION: ON
-        TILEDB_S3: ON
-        CXX: g++
+      pool:
+        vmImage: $(imageName)
+      steps:
+      - template: scripts/azure-linux_mac.yml
 
-  pool:
-    vmImage: $(imageName)
-  steps:
-  - template: scripts/azure-linux_mac.yml
+    - job: CentOS6_manylinux1
+      container:
+        image: quay.io/pypa/manylinux1_x86_64
+      variables:
+        CXX: g++
+        TILEDB_FORCE_BUILD_DEPS: ON
+        TILEDB_BUILD_ENABLE: "s3,azure,serialization,static-tiledb"
+      steps:
+      - template: scripts/azure-centos6.yml
 
-- job: CentOS6_manylinux1
-  container:
-    image: quay.io/pypa/manylinux1_x86_64
-  variables:
-    CXX: g++
-    TILEDB_FORCE_BUILD_DEPS: ON
-    TILEDB_BUILD_ENABLE: "s3,azure,serialization,static-tiledb"
-  steps:
-  - template: scripts/azure-centos6.yml
+    - job: Windows
+      strategy:
+        matrix:
+          VS2017:
+            imageName: 'vs2017-win2016'
+            TILEDB_S3: ON
+      pool:
+        vmImage: $(imageName)
+      steps:
+      - template: scripts/azure-windows.yml
 
-- job: Windows
-  strategy:
-    matrix:
-      VS2017:
-        imageName: 'vs2017-win2016'
-        TILEDB_S3: ON
-  pool:
-    vmImage: $(imageName)
-  steps:
-  - template: scripts/azure-windows.yml
+  - stage: Build_Release
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    variables:
+      TILEDB_S3: ON
+      TILEDB_AZURE: ON
+      TILEDB_GCS: ON
+      TILEDB_HDFS: ON
+      TILEDB_STATIC: OFF
+      TILEDB_SERIALIZATION: ON
+      TILEDB_FORCE_BUILD_DEPS: ON
+      MACOSX_DEPLOYMENT_TARGET: 10.9
+    jobs:
+     - job:
+       strategy:
+         matrix:
+           linux:
+             imageName: 'ubuntu-16.04'
+             CXX: g++
+             ARTIFACT_OS: 'linux'
+       pool:
+         vmImage: $(imageName)
+       steps:
+         - template: scripts/azure-linux_mac-release.yml
+     - job:
+       strategy:
+         matrix:
+           macOS:
+             imageName: 'macOS-10.14'
+             CXX: clang++
+             ARTIFACT_OS: 'macos'
+             TILEDB_S3: ON
+             TILEDB_AZURE: ON
+             TILEDB_GCS: ON
+             TILEDB_HDFS: ON
+             TILEDB_STATIC: OFF
+             TILEDB_SERIALIZATION: ON
+             # Disable forcing all dependencies. openssl being forced on osx is not working
+             # This will be adjusted but osx ships with openssl libraries so this should be okay for now
+             TILEDB_FORCE_BUILD_DEPS: OFF
+       pool:
+         vmImage: $(imageName)
+       steps:
+         - template: scripts/azure-linux_mac-release.yml
+
+     - job: Windows
+       strategy:
+         matrix:
+           VS2017:
+             imageName: 'vs2017-win2016'
+             # Only S3 variable is currently supported in boostrap powershell
+             TILEDB_S3: ON
+#             TILEDB_AZURE: OFF
+#             TILEDB_GCS: OFF
+#             TILEDB_HDFS: OFF
+             TILEDB_STATIC: OFF
+#             TILEDB_SERIALIZATION: OFF
+             TILEDB_FORCE_BUILD_DEPS: ON
+             ARTIFACT_OS: 'windows'
+       pool:
+         vmImage: $(imageName)
+       steps:
+         - template: scripts/azure-windows-release.yml
+
+  - stage: Github_Release
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    jobs:
+     - job:
+       steps:
+        # First download artifacts
+       - task: DownloadBuildArtifacts@0
+         inputs:
+          downloadType: 'specific'
+       - script: |
+           echo $sourceVersion
+           commitHash=${sourceVersion:0:7}
+           echo $commitHash
+           echo "##vso[task.setvariable variable=commitHash]$commitHash" ## Set variable for using in other tasks.
+         env: { sourceVersion: $(Build.SourceVersion) }
+         displayName: Git Hash 7-digit
+       - task: GithubRelease@0
+         condition: succeeded() # only run this job if the build step succeeded
+         displayName: 'Add artifacts to GitHub Release'
+         inputs:
+           gitHubConnection: TileDB-Inc-Release
+           repositoryName: TileDB-Inc/TileDB
+           addChangeLog: false
+           action: edit
+           tag: $(Build.SourceBranchName)
+           assets: |
+             $(Build.ArtifactStagingDirectory)/tiledb-linux-$(Build.SourceBranchName)-$(commitHash).tar.gz/tiledb-linux-$(Build.SourceBranchName)-$(commitHash).tar.gz
+             $(Build.ArtifactStagingDirectory)/tiledb-macos-$(Build.SourceBranchName)-$(commitHash).tar.gz/tiledb-macos-$(Build.SourceBranchName)-$(commitHash).tar.gz
+             $(Build.ArtifactStagingDirectory)/tiledb-windows-$(Build.SourceBranchName)-$(commitHash).zip/tiledb-windows-$(Build.SourceBranchName)-$(commitHash).zip

--- a/scripts/azure-linux_mac-release.yml
+++ b/scripts/azure-linux_mac-release.yml
@@ -1,0 +1,135 @@
+steps:
+- bash: |
+    echo "'uname -s' is:"
+    echo "uname: " $(uname)
+    echo "uname -m: " $(uname -m)
+    echo "uname -r:" $(uname -r)
+    echo "uname -s: " $(uname -s)
+    echo "uname -v: " $(uname -v)
+    printenv
+  displayName: 'Print env'
+
+- bash: |
+    set -e pipefail
+    # Install doxygen *before* running cmake
+    sudo apt-get install doxygen
+  condition: eq(variables['Agent.OS'], 'Linux')
+  displayName: 'Install doxygen (linux only)'
+
+- bash: |
+    set -e pipefail
+    brew uninstall --ignore-dependencies lz4
+  condition: eq(variables['Agent.OS'], 'Darwin')
+  displayName: 'Uninstall lz4 for curl (OSX only)'
+
+- bash: |
+    set -e pipefail
+    open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+    sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -allowUntrusted -target /
+  condition: eq(variables['Agent.OS'], 'Darwin')
+  displayName: 'Install system headers (OSX only)'
+
+- bash: |
+    # DELETEME work-around for https://github.com/microsoft/azure-pipelines-image-generation/issues/969
+    sudo chown root.root /
+
+    # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
+    #   - openssl configure uses ENV{SYSTEM} if available:
+    #     https://github.com/openssl/openssl/blob/6d745d740d37d680ff696486218b650512bbbbc6/config#L56
+    #   - error description:
+    #     https://developercommunity.visualstudio.com/content/problem/602584/openssl-build-error-when-using-pipelines.htm
+    unset SYSTEM
+
+    # azure bash does not treat intermediate failure as error
+    # https://github.com/Microsoft/azure-pipelines-yaml/issues/135
+    set -e pipefail
+
+    git config --global user.name 'Azure Pipeline'
+    git config --global user.email 'no-reply@tiledb.io'
+
+    # Set up arguments for bootstrap.sh
+    BUILD_BINARIESDIRECTORY=${BUILD_BINARIESDIRECTORY:-$BUILD_REPOSITORY_LOCALPATH/dist}
+    bootstrap_args="--prefix=${BUILD_BINARIESDIRECTORY} --disable-tests";
+
+    # Enable TILEDB_STATIC by default
+    [ "$TILEDB_STATIC" ] || TILEDB_STATIC=ON
+    if [[ "$TILEDB_STATIC" == "ON" ]]; then
+      bootstrap_args="${bootstrap_args} --enable-static-tiledb";
+    fi
+    if [[ "$TILEDB_HDFS" == "ON" ]]; then
+      bootstrap_args="${bootstrap_args} --enable-hdfs";
+    fi;
+    if [[ "$TILEDB_S3" == "ON" ]]; then
+      bootstrap_args="${bootstrap_args} --enable-s3";
+    fi;
+    if [[ "$TILEDB_AZURE" == "ON" ]]; then
+      bootstrap_args="${bootstrap_args} --enable-azure";
+    fi;
+    if [[ "$TILEDB_GCS" == "ON" ]]; then
+      bootstrap_args="${bootstrap_args} --enable-gcs";
+    fi;
+    if [[ "$TILEDB_TBB" == "OFF" ]]; then
+      bootstrap_args="${bootstrap_args} --disable-tbb";
+    fi
+    if [[ "$TILEDB_TOOLS" == "ON" ]]; then
+      bootstrap_args="${bootstrap_args} --enable-tools";
+    fi
+    if [[ "$TILEDB_DEBUG" == "ON" ]]; then
+      bootstrap_args="${bootstrap_args} --enable-debug";
+    fi
+    if [[ "$TILEDB_CI_ASAN" == "ON" ]]; then
+      # Add address sanitizer flag if necessary
+      bootstrap_args="${bootstrap_args} --enable-sanitizer=address --enable-debug";
+    fi
+    if [[ "$TILEDB_CI_TSAN" == "ON" ]]; then
+      # Add thread sanitizer flag if necessary
+      bootstrap_args="${bootstrap_args} --enable-sanitizer=thread --enable-debug";
+    fi
+    if [[ "$TILEDB_SERIALIZATION" == "ON" ]]; then
+      # Add serialization flag if necessary
+      bootstrap_args="${bootstrap_args} --enable-serialization";
+    fi
+    if [[ "$TILEDB_FORCE_BUILD_DEPS" == "ON" ]]; then
+      # Add superbuild flag
+      bootstrap_args="${bootstrap_args} --force-build-all-deps";
+    fi
+
+    # displayName: 'Install dependencies'
+
+    mkdir -p $BUILD_REPOSITORY_LOCALPATH/build
+    cd $BUILD_REPOSITORY_LOCALPATH/build
+
+    # Configure and build TileDB
+    echo "Bootstrapping with '$bootstrap_args'"
+    $BUILD_REPOSITORY_LOCALPATH/bootstrap $bootstrap_args
+
+    make -j4
+    make -C tiledb install
+  displayName: 'Build libtiledb'
+
+- script: |
+      echo $sourceVersion
+      commitHash=${sourceVersion:0:7}
+      echo $commitHash
+      echo "##vso[task.setvariable variable=commitHash]$commitHash" ## Set variable for using in other tasks.
+  env: { sourceVersion: $(Build.SourceVersion) }
+  displayName: Git Hash 7-digit
+
+# Archive files
+# Compress files into .7z, .tar.gz, or .zip
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: '$(Build.BinariesDirectory)'
+    includeRootFolder: false
+    archiveType: 'tar' # Options: zip, 7z, tar, wim
+    tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
+    archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz
+    replaceExistingArchive: true
+    verbose: true # Optional
+  condition: succeeded()
+
+- task: PublishBuildArtifacts@1
+  inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz'
+      artifactName: 'tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz'
+  condition: succeeded()

--- a/scripts/azure-windows-release.yml
+++ b/scripts/azure-windows-release.yml
@@ -1,0 +1,63 @@
+steps:
+- script: |
+      echo $(Build.SourceVersion)
+      set TestVar=$(Build.SourceVersion)
+      set $commitHash=%TestVar:~0,7%
+      echo %$commitHash%
+      echo ##vso[task.setvariable variable=commitHash]%$commitHash%
+  env: { sourceVersion: $(Build.SourceVersion) }
+  displayName: Git Hash 7-digit
+
+- powershell: |
+    mkdir $env:AGENT_BUILDDIRECTORY\build
+    cd $env:AGENT_BUILDDIRECTORY\build
+
+    if ($env:imageName -eq "vs2017-win2016") {
+      $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+    } else {
+      Write-Host "Unknown image name: '$($env:imageName)'"
+      $host.SetShouldExit(1)
+    }
+
+    if ($env:TILEDB_S3 -eq "ON") {
+      & "$env:BUILD_SOURCESDIRECTORY\bootstrap.ps1" -EnableS3 -EnableVerbose
+    } else {
+      & "$env:BUILD_SOURCESDIRECTORY\bootstrap.ps1" -EnableVerbose
+    }
+    if ($LastExitCode -ne 0) {
+       Write-Host "Bootstrap failed."
+       $host.SetShouldExit($LastExitCode)
+    }
+
+    cmake --build $env:AGENT_BUILDDIRECTORY\build --config Release -- /verbosity:minimal
+
+    if ($LastExitCode -ne 0) {
+       Write-Host "Build failed. CMake exit status: " $LastExitCocde
+       $host.SetShouldExit($LastExitCode)
+    }
+
+    cmake --build $env:AGENT_BUILDDIRECTORY\build --target install-tiledb --config Release
+
+    if ($LastExitCode -ne 0) {
+      Write-Host "Installation failed."
+      $host.SetShouldExit($LastExitCode)
+    }
+  displayName: "Build"
+
+# Archive files
+# Compress files into .7z, .tar.gz, or .zip
+- task: ArchiveFiles@2
+  inputs:
+      rootFolderOrFile: '$(Agent.BuildDirectory)\s\dist\'
+      includeRootFolder: false
+      archiveType: 'zip' # Options: zip, 7z, tar, wim
+      archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).zip
+      replaceExistingArchive: true
+      verbose: true # Optional
+  condition: succeeded()
+
+- task: PublishBuildArtifacts@1
+  inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)\tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).zip'
+      artifactName: 'tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).zip'
+  condition: succeeded()


### PR DESCRIPTION
On release Azure pipelines will now build Linux, MacOS and Windows tarballs (or zip for windows). All features are enabled on Linux and MacOS and for Windows just S3 is enabled for now.