### PR TITLE
 Don't error on GCS client init failure

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,7 @@
 ## Improvements
 
 * Fix typo in GCS cmake file for superbuild [#1665](https://github.com/TileDB-Inc/TileDB/pull/1665)
+* Don't error on GCS client init failure [#1667](https://github.com/TileDB-Inc/TileDB/pull/1667)
 
 # TileDB v2.0.3 Release Notes
 

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -73,7 +73,8 @@ Status GCS::init(const Config& config, ThreadPool* const thread_pool) {
   // env variable GOOGLE_APPLICATION_CREDENTIALS
   client_ = google::cloud::storage::Client::CreateDefaultClient();
   if (!client_) {
-    return LOG_STATUS(Status::GCSError("Failed to initialize GCS Client; " + client_.status().message()));
+    return LOG_STATUS(Status::GCSError(
+        "Failed to initialize GCS Client; " + client_.status().message()));
   }
 
   bool found;

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -73,7 +73,7 @@ Status GCS::init(const Config& config, ThreadPool* const thread_pool) {
   // env variable GOOGLE_APPLICATION_CREDENTIALS
   client_ = google::cloud::storage::Client::CreateDefaultClient();
   if (!client_) {
-    return LOG_STATUS(Status::GCSError("Failed to initialize GCS Client."));
+    return LOG_STATUS(Status::GCSError("Failed to initialize GCS Client; " + client_.status().message()));
   }
 
   bool found;

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -910,7 +910,16 @@ Status VFS::init(const Config* ctx_config, const Config* vfs_config) {
 #endif
 
 #ifdef HAVE_GCS
-  RETURN_NOT_OK(gcs_.init(config_, &thread_pool_));
+  Status st = gcs_.init(config_, &thread_pool_);
+  if (!st.ok()) {
+    // We should print some warning here, this LOG_STATUS only prints in
+    // verbose mode. Since this is called in the init of the context, we
+    // can't return the error through the normal set it on the context.
+    LOG_STATUS(Status::GCSError(
+        "GCS failed to initialize, GCS support will not be available in this "
+        "context: " +
+        st.message()));
+  }
 #endif
 
 #ifdef WIN32


### PR DESCRIPTION
Unlike AWS and Azure the GCS SDK errors out if client credentials are not found. This causes a problem in that if the library is compiled with GCS support the context will always fail to init if GCS support is compiled in. This PR addresses this by checking the status and logging instead of returning the error in vfs init.