### PR TITLE
STL array type handler

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -62,8 +62,8 @@ struct CPPArrayFx {
 
     auto a1 = Attribute::create<int>(ctx, "a1");          // (int, 1)
     auto a2 = Attribute::create<std::string>(ctx, "a2");  // (char, VAR_NUM)
-    auto a3 = Attribute::create<std::array<double, 2>>(
-        ctx, "a3");  // (char, sizeof(std::array<double,2>)
+    auto a3 =
+        Attribute::create<std::array<double, 2>>(ctx, "a3");  // (double, 2)
     auto a4 =
         Attribute::create<std::vector<Point>>(ctx, "a4");  // (char, VAR_NUM)
     auto a5 = Attribute::create<Point>(ctx, "a5");  // (char, sizeof(Point))

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -95,7 +95,7 @@ TEST_CASE("C++ API: Schema", "[cppapi][schema]") {
         schema.attribute("a1").filter_list().filter(0).filter_type() ==
         TILEDB_FILTER_LZ4);
     CHECK(schema.attribute("a2").cell_val_num() == TILEDB_VAR_NUM);
-    CHECK(schema.attribute("a3").cell_val_num() == 16);
+    CHECK(schema.attribute("a3").cell_val_num() == 2);
     CHECK(schema.attribute("a4").cell_val_num() == TILEDB_VAR_NUM);
     CHECK(schema.attribute("a4").type() == TILEDB_UINT32);
 
@@ -155,7 +155,7 @@ TEST_CASE("C++ API: Schema", "[cppapi][schema]") {
         schema.attribute("a1").filter_list().filter(0).filter_type() ==
         TILEDB_FILTER_LZ4);
     CHECK(schema.attribute("a2").cell_val_num() == TILEDB_VAR_NUM);
-    CHECK(schema.attribute("a3").cell_val_num() == 16);
+    CHECK(schema.attribute("a3").cell_val_num() == 2);
     CHECK(schema.attribute("a4").cell_val_num() == TILEDB_VAR_NUM);
     CHECK(schema.attribute("a4").type() == TILEDB_UINT32);
     CHECK(schema.allows_dups() == true);

--- a/test/src/unit-cppapi-type.cc
+++ b/test/src/unit-cppapi-type.cc
@@ -39,7 +39,7 @@ struct MyData {
   double c[3];
 };
 
-TEST_CASE("C++ API: Types", "[cppapi]") {
+TEST_CASE("C++ API: Types", "[cppapi][types]") {
   using namespace tiledb;
   Context ctx;
 
@@ -105,9 +105,23 @@ TEST_CASE("C++ API: Types", "[cppapi]") {
       TILEDB_STRING_UTF8, TILEDB_VAR_NUM));
   CHECK_THROWS(impl::type_check<std::vector<uint32_t>>(
       TILEDB_STRING_UTF8, TILEDB_VAR_NUM));
+  CHECK_THROWS(impl::type_check<std::array<int8_t, 1>>(
+      TILEDB_STRING_ASCII, TILEDB_VAR_NUM));
+  CHECK_THROWS(impl::type_check<std::array<uint8_t, 1>>(
+      TILEDB_STRING_ASCII, TILEDB_VAR_NUM));
+  CHECK_THROWS(impl::type_check<std::array<uint32_t, 1>>(
+      TILEDB_STRING_ASCII, TILEDB_VAR_NUM));
+  CHECK_THROWS(impl::type_check<std::array<int8_t, 1>>(
+      TILEDB_STRING_UTF8, TILEDB_VAR_NUM));
+  CHECK_THROWS(impl::type_check<std::array<uint8_t, 1>>(
+      TILEDB_STRING_UTF8, TILEDB_VAR_NUM));
+  CHECK_THROWS(impl::type_check<std::array<uint32_t, 1>>(
+      TILEDB_STRING_UTF8, TILEDB_VAR_NUM));
 
   CHECK_NOTHROW(
       impl::type_check<std::vector<char>>(TILEDB_STRING_ASCII, TILEDB_VAR_NUM));
+  CHECK_NOTHROW(impl::type_check<std::array<char, 1>>(
+      TILEDB_STRING_ASCII, TILEDB_VAR_NUM));
 
   auto a1 = Attribute::create<int>(ctx, "a1");
   auto a2 = Attribute::create<float>(ctx, "a2");
@@ -116,6 +130,8 @@ TEST_CASE("C++ API: Types", "[cppapi]") {
   auto a5 = Attribute::create<MyData[5]>(ctx, "a5");
   auto a6 = Attribute::create<std::vector<MyData>>(ctx, "a6");
   auto a7 = Attribute::create<std::string>(ctx, "a7");
+  auto a8 = Attribute::create<double>(ctx, "a8");
+  auto a9 = Attribute::create<std::array<double, 5>>(ctx, "a9");
 
   CHECK(a1.type() == TILEDB_INT32);
   CHECK(a2.type() == TILEDB_FLOAT32);
@@ -124,6 +140,8 @@ TEST_CASE("C++ API: Types", "[cppapi]") {
   CHECK(a5.type() == TILEDB_CHAR);
   CHECK(a6.type() == TILEDB_CHAR);
   CHECK(a7.type() == TILEDB_CHAR);
+  CHECK(a8.type() == TILEDB_FLOAT64);
+  CHECK(a9.type() == TILEDB_FLOAT64);
 
   CHECK(a1.cell_val_num() == 1);
   CHECK(a2.cell_val_num() == 1);
@@ -134,4 +152,6 @@ TEST_CASE("C++ API: Types", "[cppapi]") {
       5 * (sizeof(int) + sizeof(float) + sizeof(double[3])));
   CHECK(a6.cell_val_num() == TILEDB_VAR_NUM);
   CHECK(a7.cell_val_num() == TILEDB_VAR_NUM);
+  CHECK(a8.cell_val_num() == 1);
+  CHECK(a9.cell_val_num() == 5);
 }


### PR DESCRIPTION
This fixes a bug where std::array attributes are handled as a char array
regardless of type.