### PR TITLE
Build macOS w/force all deps for release artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,26 +103,10 @@ stages:
              imageName: 'ubuntu-16.04'
              CXX: g++
              ARTIFACT_OS: 'linux'
-       pool:
-         vmImage: $(imageName)
-       steps:
-         - template: scripts/azure-linux_mac-release.yml
-     - job:
-       strategy:
-         matrix:
            macOS:
              imageName: 'macOS-10.14'
              CXX: clang++
              ARTIFACT_OS: 'macos'
-             TILEDB_S3: ON
-             TILEDB_AZURE: ON
-             TILEDB_GCS: ON
-             TILEDB_HDFS: ON
-             TILEDB_STATIC: OFF
-             TILEDB_SERIALIZATION: ON
-             # Disable forcing all dependencies. openssl being forced on osx is not working
-             # This will be adjusted but osx ships with openssl libraries so this should be okay for now
-             TILEDB_FORCE_BUILD_DEPS: OFF
        pool:
          vmImage: $(imageName)
        steps:

--- a/scripts/azure-linux_mac-release.yml
+++ b/scripts/azure-linux_mac-release.yml
@@ -18,9 +18,9 @@ steps:
 
 - bash: |
     set -e pipefail
-    brew uninstall --ignore-dependencies lz4
+    brew uninstall --ignore-dependencies libidn2 brotli rtmpdump
   condition: eq(variables['Agent.OS'], 'Darwin')
-  displayName: 'Uninstall lz4 for curl (OSX only)'
+  displayName: 'Uninstall brew packages for curl (OSX only)'
 
 - bash: |
     set -e pipefail


### PR DESCRIPTION
Now that the openssl problem on macOS was solved we can build a complete standalone library.

We need to uninstall idn2, brotli and rtmpdump from the CI env so curl doesn't pick it up.