### PR TITLE
Posix VFS lock file permissions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -38,6 +38,7 @@
 
 ## Bug fixes
 * The C++ Attribute::create API now correctly builds from an STL array [#1670](https://github.com/TileDB-Inc/TileDB/pull/1670)
+* Allow opening arrays with read-only permission on posix filesystems [#1676](https://github.com/TileDB-Inc/TileDB/pull/1676)
 
 # TileDB v2.0.3 Release Notes
 

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -256,7 +256,7 @@ Status Posix::filelock_lock(
   fl.l_pid = getpid();
 
   // Open the file
-  *fd = ::open(filename.c_str(), O_RDWR);
+  *fd = ::open(filename.c_str(), shared ? O_RDONLY : O_WRONLY);
   if (*fd == -1) {
     return LOG_STATUS(Status::IOError(
         "Cannot open filelock '" + filename + "'; " + strerror(errno)));


### PR DESCRIPTION
We are unable to acquire a readlock without write permissions on the lock file.
This opens the lock file with the corresponding permission type.