### PR TITLE
Remove libz linkage from curl append libs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -36,6 +36,7 @@
 * Don't error on GCS client init failure [#1667](https://github.com/TileDB-Inc/TileDB/pull/1667)
 * Don't include curl's linking to ssl, avoids build issue on fresh macos 10.14/10.15 installs [#1671](https://github.com/TileDB-Inc/TileDB/pull/1671)
 * Handle ubuntu's cap'n proto package not providing cmake targets [#1659](https://github.com/TileDB-Inc/TileDB/pull/1659)
+* Don't include curl's linking to libz, avoids build issue with double libz linkage [#1682](https://github.com/TileDB-Inc/TileDB/pull/1682)
 
 ## Bug fixes
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -493,7 +493,7 @@ if ((TILEDB_S3 OR TILEDB_AZURE OR TILEDB_GCS OR TILEDB_SERIALIZATION) AND NOT WI
           # Make a list. The variable passed to target_link_libraries *must* be a list.
           string(REGEX REPLACE "[ \t\r\n]" ";" CURL_APPEND_LIBS ${CURL_APPEND_LIBS})
 
-          message(STATUS "Adding transitive Curl library links to TileDB targets: '${CURL_APPEND_LIBS}'")
+          message(STATUS "Computed initial transitive Curl library links to TileDB targets: '${CURL_APPEND_LIBS}'")
         endif()
       endif()
   endif()
@@ -509,7 +509,9 @@ if (CURL_APPEND_LIBS)
   # ends up trying to link against the system shared library while we already
   # linked the static lib from TileDB supper build.
   # End result, we remove the -lssl and -lcrypto from the list of curl extra libs
-  list(REMOVE_ITEM CURL_APPEND_LIBS "-lssl" "-lcrypto")
+  # The same problem exists for libz, so we remove -lz also.
+  list(REMOVE_ITEM CURL_APPEND_LIBS "-lssl" "-lcrypto" "-lz")
+  message(STATUS "Adding final transitive Curl library links to TileDB targets: '${CURL_APPEND_LIBS}'")
   target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
     INTERFACE
     ${CURL_APPEND_LIBS})


### PR DESCRIPTION
Just like with openssl, with libz we must remove curl's manual setting of `-lz` to avoid linking against the system library.