### PR TITLE
Reduce branching in coordinate sort path

### DIFF
--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -210,6 +210,7 @@ int Domain::cell_order_cmp(
   return 0;
 }
 
+template <bool Z>
 int Domain::cell_order_cmp(
     unsigned dim_idx, const ResultCoords& a, const ResultCoords& b) const {
   // Handle variable-sized dimensions
@@ -225,8 +226,8 @@ int Domain::cell_order_cmp(
   }
 
   assert(cell_order_cmp_func_2_[dim_idx] != nullptr);
-  auto coord_a = a.coord(dim_idx);
-  auto coord_b = b.coord(dim_idx);
+  auto coord_a = a.coord<Z>(dim_idx);
+  auto coord_b = b.coord<Z>(dim_idx);
   return cell_order_cmp_func_2_[dim_idx](coord_a, coord_b);
 }
 
@@ -1620,6 +1621,11 @@ template uint64_t Domain::stride<int64_t>(Layout subarray_layout) const;
 template uint64_t Domain::stride<uint64_t>(Layout subarray_layout) const;
 template uint64_t Domain::stride<float>(Layout subarray_layout) const;
 template uint64_t Domain::stride<double>(Layout subarray_layout) const;
+
+template int Domain::cell_order_cmp<true>(
+    unsigned dim_idx, const ResultCoords& a, const ResultCoords& b) const;
+template int Domain::cell_order_cmp<false>(
+    unsigned dim_idx, const ResultCoords& a, const ResultCoords& b) const;
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -104,7 +104,7 @@ class Domain {
    * of a regular tile grid, this function assumes that the cells are in the
    * same regular tile.
    *
-   * @tparam T The coordinates type.
+   * @tparam Z True if either coordinate may be zipped.
    * @param dim_idx The dimension to compare the coordinates on.
    * @param a The first input coordinates.
    * @param b The second input coordinates.
@@ -113,6 +113,7 @@ class Domain {
    *    -  0 if the two coordinates are identical
    *    - +1 if the first coordinate succeeds the second
    */
+  template <bool Z>
   int cell_order_cmp(
       unsigned dim_idx, const ResultCoords& a, const ResultCoords& b) const;
 

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -45,7 +45,11 @@
 namespace tiledb {
 namespace sm {
 
-/** Wrapper of comparison function for sorting coords on row-major order. */
+/**
+ * Wrapper of comparison function for sorting coords on row-major order.
+ * Template parameter `Z` is true if any coordinate may be zipped.
+ */
+template <bool Z>
 class RowCmp {
  public:
   /** Constructor. */
@@ -63,7 +67,7 @@ class RowCmp {
    */
   bool operator()(const ResultCoords& a, const ResultCoords& b) const {
     for (unsigned int d = 0; d < dim_num_; ++d) {
-      auto res = domain_->cell_order_cmp(d, a, b);
+      auto res = domain_->cell_order_cmp<Z>(d, a, b);
 
       if (res == -1)
         return true;
@@ -82,7 +86,11 @@ class RowCmp {
   unsigned dim_num_;
 };
 
-/** Wrapper of comparison function for sorting coords on col-major order. */
+/**
+ * Wrapper of comparison function for sorting coords on col-major order.
+ * Template parameter `Z` is true if any coordinate may be zipped.
+ */
+template <bool Z>
 class ColCmp {
  public:
   /** Constructor. */
@@ -100,7 +108,7 @@ class ColCmp {
    */
   bool operator()(const ResultCoords& a, const ResultCoords& b) const {
     for (unsigned int d = dim_num_ - 1;; --d) {
-      auto res = domain_->cell_order_cmp(d, a, b);
+      auto res = domain_->cell_order_cmp<Z>(d, a, b);
 
       if (res == -1)
         return true;
@@ -125,7 +133,9 @@ class ColCmp {
 /**
  * Wrapper of comparison function for sorting coords on the global order
  * of some domain.
+ * Template parameter `Z` is true if any coordinate may be zipped.
  */
+template <bool Z>
 class GlobalCmp {
  public:
   /**
@@ -168,7 +178,7 @@ class GlobalCmp {
         if (domain_->dimension(d)->var_size())
           continue;
 
-        auto res = domain_->tile_order_cmp(d, a.coord(d), b.coord(d));
+        auto res = domain_->tile_order_cmp(d, a.coord<Z>(d), b.coord<Z>(d));
 
         if (res == -1)
           return true;
@@ -183,7 +193,7 @@ class GlobalCmp {
         if (domain_->dimension(d)->var_size())
           continue;
 
-        auto res = domain_->tile_order_cmp(d, a.coord(d), b.coord(d));
+        auto res = domain_->tile_order_cmp(d, a.coord<Z>(d), b.coord<Z>(d));
 
         if (res == -1)
           return true;
@@ -199,7 +209,7 @@ class GlobalCmp {
     // Compare cell order
     if (cell_order_ == Layout::ROW_MAJOR) {
       for (unsigned d = 0; d < dim_num_; ++d) {
-        auto res = domain_->cell_order_cmp(d, a, b);
+        auto res = domain_->cell_order_cmp<Z>(d, a, b);
 
         if (res == -1)
           return true;
@@ -210,7 +220,7 @@ class GlobalCmp {
     } else {  // COL_MAJOR
       assert(cell_order_ == Layout::COL_MAJOR);
       for (unsigned d = dim_num_ - 1;; --d) {
-        auto res = domain_->cell_order_cmp(d, a, b);
+        auto res = domain_->cell_order_cmp<Z>(d, a, b);
 
         if (res == -1)
           return true;

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -593,6 +593,8 @@ class Reader {
    *     result coordinates come from a single fragment.
    * @param result_tile_map This is an auxialiary map that helps finding the
    *     result tiles of each range.
+   * @param has_zipped_coords true if any of the elements in `result_coords`
+   *        are zipped.
    * @param result_tiles The result tiles to read the coordinates from.
    * @param range_result_coords The result coordinates to be retrieved.
    *     It contains a vector for each range of the subarray.
@@ -601,6 +603,7 @@ class Reader {
   Status compute_range_result_coords(
       const std::vector<bool>& single_fragment,
       const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
+      bool has_zipped_coords,
       std::vector<ResultTile>* result_tiles,
       std::vector<std::vector<ResultCoords>>* range_result_coords);
 
@@ -647,6 +650,8 @@ class Reader {
    * deduplicated and sorted on the specified subarray layout.
    *
    * @param range_result_coords The result coordinates for each subarray range.
+   * @param has_zipped_coords true if any of the elements in `result_coords`
+   *        are zipped.
    * @param result_coords The final (subarray) result coordinates to be
    *     retrieved.
    * @return Status
@@ -656,6 +661,7 @@ class Reader {
    */
   Status compute_subarray_coords(
       std::vector<std::vector<ResultCoords>>* range_result_coords,
+      bool has_zipped_coords,
       std::vector<ResultCoords>* result_coords);
 
   /**
@@ -1060,10 +1066,14 @@ class Reader {
    *
    * @param result_coords The coordinates to sort.
    * @param layout The layout to sort into.
+   * @param has_zipped_coords true if any of the elements in `result_coords`
+   *        are zipped.
    * @return Status
    */
   Status sort_result_coords(
-      std::vector<ResultCoords>* result_coords, Layout layout) const;
+      std::vector<ResultCoords>* result_coords,
+      Layout layout,
+      bool has_zipped_coords) const;
 
   /** Performs a read on a sparse array. */
   Status sparse_read();

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -84,15 +84,21 @@ struct ResultCoords {
     return tile_->coord_string(pos_, dim_idx);
   }
 
+  const void* coord(unsigned dim_idx) const {
+    return tile_->coord(pos_, dim_idx);
+  }
+
   /**
    * Returns the coordinate at the object's position `pos_` from the object's
    * tile `tile_` on the given dimension.
    *
+   * @tparam Z True if either coordinate may be zipped.
    * @param dim_idx The index of the dimension to retrieve the coordinate for.
    * @return A constant pointer to the requested coordinate.
    */
+  template <bool Z>
   const void* coord(unsigned dim_idx) const {
-    return tile_->coord(pos_, dim_idx);
+    return tile_->coord<Z>(pos_, dim_idx);
   }
 
   /**

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -135,6 +135,17 @@ class ResultTile {
   const void* coord(uint64_t pos, unsigned dim_idx) const;
 
   /**
+   * Returns a constant pointer to the coordinate at position `pos` for
+   * dimension `dim_idx`. When template parameter `Z` is true, the
+   * implementation will check if the coordinate is either zipped or
+   * unzipped. When template parameter `Z` is false, the caller knows
+   * that the coordinate is unzipped. This is an optimization that
+   * avoids a branch to check if the coordinate is zipped or not.
+   */
+  template <bool Z>
+  const void* coord(uint64_t pos, unsigned dim_idx) const;
+
+  /**
    * Returns the string coordinate at position `pos` for
    * dimension `dim_idx`. Applicable only to string dimensions.
    */

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -2341,8 +2341,10 @@ Status Writer::sort_coords(std::vector<uint64_t>* cell_pos) const {
   for (uint64_t i = 0; i < coords_num_; ++i)
     (*cell_pos)[i] = i;
 
-  // Sort the coordinates in global order
-  parallel_sort(cell_pos->begin(), cell_pos->end(), GlobalCmp(domain, &buffs));
+  // Sort the coordinates in global order. The template parameter <false>
+  // indicates that we are only sorting unzipped coordinates.
+  parallel_sort(
+      cell_pos->begin(), cell_pos->end(), GlobalCmp<false>(domain, &buffs));
 
   return Status::Ok();
 


### PR DESCRIPTION
This optimizes the coordinate sort path in scenarios where _all_ coordinates
are unzipped.

Currently, the ResultTile::coord() routine branches to determine whether it
is fetching a zipped or unzipped coordinate. This patch overloads the routine
with a `template <bool>` signature, where the template parameter determines
whether the coordinate is unzipped or potentially zipped. When the parameter
is false, it skips the branch and assumes the coordinate is unzipped. When
the parameter is true, it checks (so: unchanged behavior).

When one or more of the fragments are unzipped, the behavior is unchanged and
there is not a performance improvement.