### PR TITLE
Fix metadata buffer leak in array-open

### DIFF
--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -89,7 +89,7 @@ Status Metadata::generate_uri(const URI& array_uri) {
 }
 
 Status Metadata::deserialize(
-    const std::vector<std::shared_ptr<ConstBuffer>>& metadata_buffs) {
+    const std::vector<std::shared_ptr<Buffer>>& metadata_buffs) {
   clear();
 
   if (metadata_buffs.empty())

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -108,7 +108,7 @@ class Metadata {
    * deleted or overwritten metadata items considering the order.
    */
   Status deserialize(
-      const std::vector<std::shared_ptr<ConstBuffer>>& metadata_buffs);
+      const std::vector<std::shared_ptr<Buffer>>& metadata_buffs);
 
   /** Serializes all key-value metadata items into the input buffer. */
   Status serialize(Buffer* buff) const;

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -116,7 +116,7 @@ FragmentMetadata* OpenArray::fragment_metadata(const URI& uri) const {
   return (it == fragment_metadata_set_.end()) ? nullptr : it->second;
 }
 
-std::shared_ptr<ConstBuffer> OpenArray::array_metadata(const URI& uri) const {
+std::shared_ptr<Buffer> OpenArray::array_metadata(const URI& uri) const {
   std::lock_guard<std::mutex> lock(local_mtx_);
   auto it = array_metadata_.find(uri.to_string());
   return (it == array_metadata_.end()) ? nullptr : it->second;
@@ -146,7 +146,7 @@ void OpenArray::insert_fragment_metadata(FragmentMetadata* metadata) {
 }
 
 void OpenArray::insert_array_metadata(
-    const URI& uri, const std::shared_ptr<ConstBuffer>& metadata) {
+    const URI& uri, const std::shared_ptr<Buffer>& metadata) {
   std::lock_guard<std::mutex> lock(local_mtx_);
   assert(metadata != nullptr);
   array_metadata_[uri.to_string()] = metadata;

--- a/tiledb/sm/storage_manager/open_array.h
+++ b/tiledb/sm/storage_manager/open_array.h
@@ -49,7 +49,7 @@ namespace tiledb {
 namespace sm {
 
 class ArraySchema;
-class ConstBuffer;
+class Buffer;
 class VFS;
 
 enum class QueryType : uint8_t;
@@ -127,7 +127,7 @@ class OpenArray {
    * Returns the constant buffer storing the serialized array metadata
    * of the input URI, or `nullptr` if the array metadata do not exist.
    */
-  std::shared_ptr<ConstBuffer> array_metadata(const URI& uri) const;
+  std::shared_ptr<Buffer> array_metadata(const URI& uri) const;
 
   /** Locks the array mutex. */
   void mtx_lock();
@@ -150,7 +150,7 @@ class OpenArray {
    * buffer) with the input URI.
    */
   void insert_array_metadata(
-      const URI& uri, const std::shared_ptr<ConstBuffer>& metadata);
+      const URI& uri, const std::shared_ptr<Buffer>& metadata);
 
   /** Sets an array schema. */
   void set_array_schema(ArraySchema* array_schema);
@@ -200,7 +200,7 @@ class OpenArray {
    * A map of URI strings to array metadata. The map stores the serialized
    * (decompressed, decrypted) array metadata into constant buffers.
    */
-  std::unordered_map<std::string, std::shared_ptr<ConstBuffer>> array_metadata_;
+  std::unordered_map<std::string, std::shared_ptr<Buffer>> array_metadata_;
 
   /**
    * A mutex used to lock the array for thread-safe open/close of the array


### PR DESCRIPTION
This fixes the following within StorageManager::load_array_metadata():
1. A direct memory leak of a `Buffer` object introduced with the chunked buffers
  patch.
2. An long-standing indirect memory leak of the metadata buffers.

For #1, an auxiliary `Buffer` object is created to store the contents of a
read from a chunked buffer. The `Buffer` object is never deleted.

For #2, the raw buffers inside of the `Buffer` object are passed into a
`ConstBuffer`. However, the `ConstBuffer` does not take ownership or free them.
The buffers are never freed while the `ConstBuffer` references them because of
leak #1. For this patch, I've replaced the `ConstBuffer` objects with `Buffer`
objects so that the `OpenArray` instance can take ownership of the metadata
buffers and free them appropriately.

Note that before the chunked buffer patch, we had a similar pattern where the
`Tile` buffer was disowned, but never freed by the `ConstBuffer`. This may be
affecting older core builds.