### PR TITLE
Optimize multi-fragment unfiltering, part 1

### DIFF
--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -424,17 +424,17 @@ Status FilterPipeline::run_forward(Tile* tile) const {
 Status FilterPipeline::run_reverse(
     Tile* tile,
     const Config& config,
-    const std::forward_list<std::pair<uint64_t, uint64_t>>*
-        result_cell_slab_ranges) const {
+    const std::vector<std::pair<uint64_t, uint64_t>>* result_cell_slab_ranges)
+    const {
   assert(tile->filtered());
 
   if (!result_cell_slab_ranges) {
     return run_reverse_internal(tile, config, nullptr);
   } else {
     uint64_t cells_processed = 0;
-    std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator cs_it =
+    std::vector<std::pair<uint64_t, uint64_t>>::const_iterator cs_it =
         result_cell_slab_ranges->cbegin();
-    std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator cs_end =
+    std::vector<std::pair<uint64_t, uint64_t>>::const_iterator cs_end =
         result_cell_slab_ranges->cend();
 
     std::function<Status(uint64_t, bool*)> skip_fn = std::bind(
@@ -455,8 +455,8 @@ Status FilterPipeline::run_reverse(
     Tile* tile,
     Tile* tile_var,
     const Config& config,
-    const std::forward_list<std::pair<uint64_t, uint64_t>>*
-        result_cell_slab_ranges) const {
+    const std::vector<std::pair<uint64_t, uint64_t>>* result_cell_slab_ranges)
+    const {
   assert(!tile->filtered());
   assert(tile_var->filtered());
 
@@ -472,9 +472,9 @@ Status FilterPipeline::run_reverse(
     const uint64_t d_off_len = tile->size() / sizeof(uint64_t);
     uint64_t cells_processed = 0;
     uint64_t cells_size_processed = 0;
-    std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator cs_it =
+    std::vector<std::pair<uint64_t, uint64_t>>::const_iterator cs_it =
         result_cell_slab_ranges->cbegin();
-    std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator cs_end =
+    std::vector<std::pair<uint64_t, uint64_t>>::const_iterator cs_end =
         result_cell_slab_ranges->cend();
 
     std::function<Status(uint64_t, bool*)> skip_fn = std::bind(
@@ -497,10 +497,8 @@ Status FilterPipeline::skip_chunk_reversal_fixed(
     const uint64_t chunk_length,
     uint64_t* const cells_processed,
     const uint64_t cell_size,
-    std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator* const
-        cs_it,
-    const std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator&
-        cs_end,
+    std::vector<std::pair<uint64_t, uint64_t>>::const_iterator* const cs_it,
+    const std::vector<std::pair<uint64_t, uint64_t>>::const_iterator& cs_end,
     bool* const skip) const {
   assert(cells_processed);
   assert(cs_it);
@@ -530,10 +528,8 @@ Status FilterPipeline::skip_chunk_reversal_var(
     const uint64_t d_off_len,
     uint64_t* const cells_processed,
     uint64_t* const cells_size_processed,
-    std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator* const
-        cs_it,
-    const std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator&
-        cs_end,
+    std::vector<std::pair<uint64_t, uint64_t>>::const_iterator* const cs_it,
+    const std::vector<std::pair<uint64_t, uint64_t>>::const_iterator& cs_end,
     bool* const skip) const {
   assert(d_off);
   assert(cells_processed);
@@ -593,10 +589,8 @@ Status FilterPipeline::skip_chunk_reversal_var(
 Status FilterPipeline::skip_chunk_reversal_common(
     const uint64_t chunk_cell_start,
     const uint64_t chunk_cell_end,
-    std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator* const
-        cs_it,
-    const std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator&
-        cs_end,
+    std::vector<std::pair<uint64_t, uint64_t>>::const_iterator* const cs_it,
+    const std::vector<std::pair<uint64_t, uint64_t>>::const_iterator& cs_end,
     bool* const skip) const {
   while (*cs_it != cs_end) {
     // Define inclusive cell index bounds for the cell slab range under

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -33,7 +33,6 @@
 #ifndef TILEDB_FILTER_PIPELINE_H
 #define TILEDB_FILTER_PIPELINE_H
 
-#include <forward_list>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -218,14 +217,14 @@ class FilterPipeline {
   Status run_reverse(
       Tile* tile,
       const Config& config,
-      const std::forward_list<std::pair<uint64_t, uint64_t>>*
+      const std::vector<std::pair<uint64_t, uint64_t>>*
           result_cell_slab_ranges = nullptr) const;
 
   Status run_reverse(
       Tile* tile,
       Tile* tile_var,
       const Config& config,
-      const std::forward_list<std::pair<uint64_t, uint64_t>>*
+      const std::vector<std::pair<uint64_t, uint64_t>>*
           result_cell_slab_ranges = nullptr) const;
 
   Status run_reverse_internal(
@@ -326,9 +325,8 @@ class FilterPipeline {
       uint64_t chunk_length,
       uint64_t* cells_processed,
       uint64_t cell_size,
-      std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator* cs_it,
-      const std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator&
-          cs_end,
+      std::vector<std::pair<uint64_t, uint64_t>>::const_iterator* cs_it,
+      const std::vector<std::pair<uint64_t, uint64_t>>::const_iterator& cs_end,
       bool* skip) const;
 
   /**
@@ -354,9 +352,8 @@ class FilterPipeline {
       uint64_t d_off_size,
       uint64_t* cells_processed,
       uint64_t* cells_size_processed,
-      std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator* cs_it,
-      const std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator&
-          cs_end,
+      std::vector<std::pair<uint64_t, uint64_t>>::const_iterator* cs_it,
+      const std::vector<std::pair<uint64_t, uint64_t>>::const_iterator& cs_end,
       bool* skip) const;
 
   /**
@@ -374,9 +371,8 @@ class FilterPipeline {
   Status skip_chunk_reversal_common(
       uint64_t chunk_cell_start,
       uint64_t chunk_cell_end,
-      std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator* cs_it,
-      const std::forward_list<std::pair<uint64_t, uint64_t>>::const_iterator&
-          cs_end,
+      std::vector<std::pair<uint64_t, uint64_t>>::const_iterator* cs_it,
+      const std::vector<std::pair<uint64_t, uint64_t>>::const_iterator& cs_end,
       bool* skip) const;
 };
 

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -33,11 +33,11 @@
 #ifndef TILEDB_READER_H
 #define TILEDB_READER_H
 
-#include <forward_list>
 #include <future>
 #include <list>
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "tiledb/sm/array_schema/tile_domain.h"
 #include "tiledb/sm/misc/status.h"
@@ -947,8 +947,8 @@ class Reader {
   Status unfilter_tile(
       const std::string& name,
       Tile* tile,
-      const std::forward_list<std::pair<uint64_t, uint64_t>>*
-          result_cell_slab_ranges) const;
+      const std::vector<std::pair<uint64_t, uint64_t>>* result_cell_slab_ranges)
+      const;
 
   /**
    * Runs the input var-sized tile for the input attribute or dimension through
@@ -966,8 +966,8 @@ class Reader {
       const std::string& name,
       Tile* tile,
       Tile* tile_var,
-      const std::forward_list<std::pair<uint64_t, uint64_t>>*
-          result_cell_slab_ranges) const;
+      const std::vector<std::pair<uint64_t, uint64_t>>* result_cell_slab_ranges)
+      const;
 
   /**
    * Gets all the result coordinates of the input tile into `result_coords`.


### PR DESCRIPTION
This patch improves the execution time of the attribute unfiltering path.

```
// Current
Total read query time (array open + init state + read): 15.0957 secs
  Time to unfilter attribute tiles: 8.86625 secs
```

```
// With this patch
Total read query time (array open + init state + read): 7.32202 secs
  Time to unfilter attribute tiles: 1.80354 secs
```

The issue is that the destruction time of `forward_list` is obscenely
slow within my OSX environrment. On the Linux environment that I
originally wrote this in, the `forward_list` did not cause a performance
problem. This patch just replaces the `forward_list` with a `vector`.

I have titled this as a "part 1" because I have tentatively explored
multi-threading the `unfilter_tiles` path and have observed a speedup.
More on this later.


This improves performance on Linux as well, it's just not as significant:
```
// Current
Total read query time (array open + init state + read): 8.1482 secs
  Time to unfilter attribute tiles: 2.50095 secs
```
```
// With patch
Total read query time (array open + init state + read): 5.49465 secs
  Time to unfilter attribute tiles: 0.898189 secs
```