### PR TITLE
Optimize `copy_cells`, part 1

### DIFF
--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -493,6 +493,23 @@ class Reader {
 
  private:
   /* ********************************* */
+  /*         PRIVATE DATATYPES         */
+  /* ********************************* */
+
+  /**
+   * Contains data structures for re-use between invocations of
+   * `copy_cells`. The intent is to reduce CPU time spent allocating
+   * and deallocating expensive data structures.
+   */
+  struct CopyCellsContextCache {
+    /** An input for `compute_var_cell_destinations`. */
+    std::vector<std::vector<uint64_t>> offset_offsets_per_cs;
+
+    /** An input for `compute_var_cell_destinations`. */
+    std::vector<std::vector<uint64_t>> var_offsets_per_cs;
+  };
+
+  /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
@@ -687,12 +704,15 @@ class Reader {
    *     cell slabs are all contiguous. Otherwise, each cell in the
    *     result cell slabs are `stride` cells apart from each other.
    * @param result_cell_slabs The result cell slabs to copy cells for.
+   * @param ctx_cache An opaque context cache that may be shared between
+   *     calls to improve performance.
    * @return Status
    */
   Status copy_cells(
       const std::string& attribute,
       uint64_t stride,
-      const std::vector<ResultCellSlab>& result_cell_slabs);
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      CopyCellsContextCache* ctx_cache);
 
   /**
    * Copies the cells for the input **fixed-sized** attribute/dimension and
@@ -719,12 +739,15 @@ class Reader {
    *     cell slabs are all contiguous. Otherwise, each cell in the
    *     result cell slabs are `stride` cells apart from each other.
    * @param result_cell_slabs The result cell slabs to copy cells for.
+   * @param ctx_cache An opaque context cache that may be shared between
+   *     calls to improve performance.
    * @return Status
    */
   Status copy_var_cells(
       const std::string& name,
       uint64_t stride,
-      const std::vector<ResultCellSlab>& result_cell_slabs);
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      CopyCellsContextCache* ctx_cache);
 
   /**
    * Computes offsets into destination buffers for the given


### PR DESCRIPTION
Copying variable cells is particularly expensive because it has to construct
and destruct the following two variables:
```
std::vector<std::vector<uint64_t>> offset_offsets_per_cs;
std::vector<std::vector<uint64_t>> var_offsets_per_cs;
```

Most of the expensive is spent constructing and deconstructing the
`vector<uint64_t>` elements. This patch caches both of these variables for
re-use between calls to `copy_var_cells` within a single read. This works
out well because the top-level array is the same size between attributes (the
number of result cell slabs).

In the multi-fragment read scenario that I'm currently testing, this provides
a significant reduction in execution time:
```
// Without the patch
Time to copy var-sized attribute values: 2.97894 secs
```

```
// With the patch
Time to copy var-sized attribute values: 0.988014 secs
```

While this provides a `2s` speedup in this path, I only observe a `1s` speedup
in total read time. This is because the destruction of the above two variables
is still expensive: it's just been moved into the `copy_attribute_values`
path:
```
// Without the patch
Time to copy result attribute values: 4.8275 secs
```

```
// With the patch
Time to copy result attribute values: 3.80167 secs
```

There will be a follow-up patch to optimize for minimizing destruction time.