### PR TITLE
Optimize `copy_cells`, part 2

### DIFF
--- a/tiledb/sm/global_state/global_state.cc
+++ b/tiledb/sm/global_state/global_state.cc
@@ -50,6 +50,8 @@ namespace tiledb {
 namespace sm {
 namespace global_state {
 
+extern int tbb_nthreads_;
+
 GlobalState& GlobalState::GetGlobalState() {
   // This is thread-safe in C++11.
   static GlobalState globalState;
@@ -120,6 +122,14 @@ std::set<StorageManager*> GlobalState::storage_managers() {
 const std::string& GlobalState::cert_file() {
   return cert_file_;
 }
+
+int GlobalState::tbb_threads() {
+  if (!initialized_)
+    return 0;
+
+  return tbb_nthreads_;
+}
+
 }  // namespace global_state
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/global_state/global_state.h
+++ b/tiledb/sm/global_state/global_state.h
@@ -92,6 +92,13 @@ class GlobalState {
    */
   const std::string& cert_file();
 
+  /**
+   * Gets the number of threads that TBB was initialized with. Returns
+   * 0 if TBB is disabled or the global state has not been initialized.
+   * @return the number of configured TBB threads.
+   */
+  int tbb_threads();
+
  private:
   /** The TileDB configuration parameters. */
   Config config_;

--- a/tiledb/sm/global_state/tbb_state.cc
+++ b/tiledb/sm/global_state/tbb_state.cc
@@ -50,7 +50,7 @@ namespace global_state {
 static std::unique_ptr<tbb::task_scheduler_init> tbb_scheduler_;
 
 /** The number of TBB threads the scheduler was configured with **/
-static int tbb_nthreads_;
+int tbb_nthreads_;
 
 Status init_tbb(const Config* config) {
   int nthreads;
@@ -95,6 +95,7 @@ Status init_tbb(const Config* config) {
       return Status::Error(msg.str());
     }
   }
+
   return Status::Ok();
 }
 
@@ -107,6 +108,8 @@ Status init_tbb(const Config* config) {
 namespace tiledb {
 namespace sm {
 namespace global_state {
+
+int tbb_nthreads_ = 0;
 
 Status init_tbb(const Config* config) {
   (void)config;


### PR DESCRIPTION
This patch optimizes the `copy_cells` path for multi-fragment reads. The
following benchmarks are for the multi-fragment read scenario discussed
offline:

```
// Current
Read time: 4.75082 secs
  * Time to copy result attribute values: 3.54192 secs
    > Time to read attribute tiles: 0.311707 secs
    > Time to unfilter attribute tiles: 0.370434 secs
    > Time to copy fixed-sized attribute values: 0.898421 secs
    > Time to copy var-sized attribute values: 0.954925 secs
```

```
// With this patch
Read time: 3.04627 secs
  * Time to copy result attribute values: 1.83972 secs
    > Time to read attribute tiles: 0.274928 secs
    > Time to unfilter attribute tiles: 0.38196 secs
    > Time to copy fixed-sized attribute values: 0.517415 secs
    > Time to copy var-sized attribute values: 0.461847 secs
```

For context, here are the benchmark results for the single-fragment read. The
stats are similar with and without this patch:
```
Read time: 1.86883 secs
  * Time to copy result attribute values: 1.19411 secs
    > Time to read attribute tiles: 0.304055 secs
    > Time to unfilter attribute tiles: 0.351332 secs
    > Time to copy fixed-sized attribute values: 0.289661 secs
    > Time to copy var-sized attribute values: 0.142405 secs
```

This patch does three things:
1. Converts the `offset_offsets_per_cs` and `var_offsets_per_cs` in the var-sized
   path from a 2D array (vector<vector<uint64_t>>) to a 1D array (vector<uint64_t).
   The big win is construction and destruction time for the nested vector
   elements.
2. Partitions cell copying for both fixed and var-sized paths. The motivation
   is to reduce contention on the TBB threads and minimize time spent context
   switching between the individual cell slab copies.
3. Added a context cache for the fixed size path, similar to the existing
   var-sized context cache.