### PR TITLE
Add git hash header generation and tiledb_source_version C API

### DIFF
--- a/test/src/unit-capi-version.cc
+++ b/test/src/unit-capi-version.cc
@@ -46,3 +46,12 @@ TEST_CASE("C API: Test version", "[capi], [version]") {
   CHECK(minor == tiledb::sm::constants::library_version[1]);
   CHECK(rev == tiledb::sm::constants::library_version[2]);
 }
+
+TEST_CASE("C API: Test source version", "[capi], [version]") {
+  char version[40];
+  tiledb_source_version(version);
+
+  CHECK(
+      std::string(version, 40) ==
+      tiledb::sm::constants::library_source_version);
+}

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -34,6 +34,38 @@
 cmake_policy(SET CMP0063 NEW)
 
 ############################################################
+# Generate cpp with git commit hash
+############################################################
+
+find_package(Git)
+if(Git_FOUND)
+  set(TILEDB_GITVER_FILE "${CMAKE_CURRENT_BINARY_DIR}/tiledb_git_sha.h")
+  set(TILEDB_GITVER_TEMP "${CMAKE_CURRENT_BINARY_DIR}/tiledb_git_sha.tmp")
+
+  # always run this target to check for changes.
+  add_custom_target(_GEN_GITVER ALL
+    # write git hash to temp file
+    COMMAND ${CMAKE_COMMAND} -E echo         "#define _tiledb_xstr(s) #s"             > "${TILEDB_GITVER_TEMP}"
+    COMMAND ${CMAKE_COMMAND} -E echo         "#define _tiledb_str(s) _tiledb_xstr(s)" >> "${TILEDB_GITVER_TEMP}"
+    COMMAND ${CMAKE_COMMAND} -E echo_append  "#define TILEDB_GIT_HASH "               >> "${TILEDB_GITVER_TEMP}"
+    COMMAND                                  ${GIT_EXECUTABLE} rev-parse HEAD         >> "${TILEDB_GITVER_TEMP}"
+
+    # overwrite real file *only if different*
+    # to avoid unnecessary recompilation
+
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${TILEDB_GITVER_TEMP}" "${TILEDB_GITVER_FILE}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Generating TILEDB_GIT_HASH"
+    VERBATIM
+    )
+
+  add_custom_command(OUTPUT ${TILEDB_GITVER_FILE}
+                     DEPENDS _GEN_GITVER)
+else()
+  set(TILEDB_GITVER_FILE "")
+endif()
+
+############################################################
 # Source files
 ###########################################################
 
@@ -172,6 +204,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/chunked_buffer.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/generic_tile_io.cc
+  ${TILEDB_GITVER_FILE}
 )
 
 if (TILEDB_SERIALIZATION)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -183,6 +183,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/uuid.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/win_constants.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/work_arounds.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/source_version.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/reader.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/result_tile.cc

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -471,6 +471,14 @@ TILEDB_EXPORT uint64_t tiledb_timestamp_now_ms();
  */
 TILEDB_EXPORT void tiledb_version(int32_t* major, int32_t* minor, int32_t* rev);
 
+/**
+ *  Retrieves the source version string of the TileDB library currently being
+ * used. currently this is the 40-char git SHA1 hash of the repository."
+ *
+ *  @param version_string Will store the 40-char SHA1.
+ */
+TILEDB_EXPORT void tiledb_source_version(char* version_string);
+
 /* ********************************* */
 /*           TILEDB TYPES            */
 /* ********************************* */

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -35,6 +35,7 @@
 #include <thread>
 
 #include "tiledb/sm/c_api/tiledb_version.h"
+#include "tiledb_git_sha.h"
 
 // Include files for platform path max definition.
 #ifdef _WIN32
@@ -447,6 +448,9 @@ const std::string vfsmode_append_str = "VFS_APPEND";
 /** The version in format { major, minor, revision }. */
 const int32_t library_version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
+
+/** The string representation for the source version hash. */
+const std::string library_source_version = _tiledb_str(TILEDB_GIT_HASH);
 
 /** The TileDB serialization format version number. */
 const uint32_t format_version = 6;

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -435,6 +435,9 @@ extern const std::string vfsmode_append_str;
 /** The TileDB library version in format { major, minor, revision }. */
 extern const int32_t library_version[3];
 
+/** The TileDB library version in format { major, minor, revision }. */
+extern const std::string library_source_version;
+
 /** The TileDB serialization format version number. */
 extern const uint32_t format_version;
 

--- a/tiledb/sm/misc/source_version.cc
+++ b/tiledb/sm/misc/source_version.cc
@@ -1,0 +1,11 @@
+#include <string.h>
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb_git_sha.h"
+
+extern "C" {
+
+void tiledb_source_version(char* version_string) {
+  const char* _sha1 = _tiledb_str(TILEDB_GIT_HASH);
+  strncpy(version_string, _sha1, 40);
+};
+}


### PR DESCRIPTION
- Adds always-run build target to generate 'tiledb_git_sha.h'
  Generates a header recording the current git hash of the TileDB source directory.
- Add `tiledb_source_version` C API and test.

Questions before merging:
- [ ] How to support/accommodate non-git source directories (eg release source bundles)
- [ ] C++ API
- [x] fix windows build issue (dependency ordering: generation step needs to run first)

---
[ch2634]