### PR TITLE
Add AWSSDK patch for compiling on gcc8+

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -80,6 +80,8 @@ if (NOT AWSSDK_FOUND)
         -DCUSTOM_MEMORY_MANAGEMENT=0
         -DCMAKE_PREFIX_PATH=${TILEDB_EP_INSTALL_PREFIX}
         -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
+      PATCH_COMMAND
+        patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/remove-werror-to-allow-compiling-on-gcc8.patch
       UPDATE_COMMAND ""
       LOG_DOWNLOAD TRUE
       LOG_CONFIGURE TRUE

--- a/cmake/inputs/patches/ep_awssdk/remove-werror-to-allow-compiling-on-gcc8.patch
+++ b/cmake/inputs/patches/ep_awssdk/remove-werror-to-allow-compiling-on-gcc8.patch
@@ -1,0 +1,25 @@
+From 962dd7e49511f0ad95704c142b87fdea998ad016 Mon Sep 17 00:00:00 2001
+From: Seth Shelnutt <seth@tiledb.io>
+Date: Fri, 26 Jun 2020 08:07:58 -0400
+Subject: [PATCH] Remove -Werror to allow compiling on gcc8+
+
+---
+ cmake/compiler_settings.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/compiler_settings.cmake b/cmake/compiler_settings.cmake
+index 1aca987ce9..ca28352903 100644
+--- a/cmake/compiler_settings.cmake
++++ b/cmake/compiler_settings.cmake
+@@ -49,7 +49,7 @@ macro(set_gcc_flags)
+ endmacro()
+ 
+ macro(set_gcc_warnings)
+-    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-Werror" "-pedantic" "-Wextra")
++    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-pedantic" "-Wextra")
+     if(COMPILER_CLANG)
+         if(PLATFORM_ANDROID)
+             # when using clang with libc and API lower than 21 we need to include Android support headers and ignore the gnu-include-next warning.
+-- 
+2.27.0
+

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -186,8 +186,7 @@ void check_save_to_file() {
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
   // Check that aws session token is not serialized.
-  rc = tiledb_config_set(
-      config, "vfs.s3.aws_session_token", "token", &error);
+  rc = tiledb_config_set(config, "vfs.s3.aws_session_token", "token", &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
 


### PR DESCRIPTION
Add AWSSDK patch for compiling on gcc8+ for `libtiledbvcf` branch.