### PR TITLE
Port curl static linkage fix

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -375,6 +375,77 @@ target_include_directories(TILEDB_CORE_OBJECTS
 )
 
 ############################################################
+# Append Curl linking information
+############################################################
+
+# Find curl link dependencies.
+# This needs to be done after curl is built because we use
+# curl-config to query the dependency libraries and then add
+# those to the target. Ref:
+#   - https://github.com/TileDB-Inc/TileDB/issues/1080
+#   - https://github.com/TileDB-Inc/TileDB/pull/1253
+# NOTE: just like the static dependencies in TileDBConfig create above
+#       (via TILEDB_DEP_STRING), this linkage embeds absolute paths.
+if (TILEDB_S3 AND NOT WIN32)
+  if (TILEDB_CURL_EP_BUILT)
+    set(CURL_CONFIG_BINARY "${TILEDB_EP_BASE}/install/bin/curl-config")
+
+      if (NOT EXISTS "${CURL_CONFIG_BINARY}")
+        message(WARNING "Missing '${CURL_CONFIG_BINARY}': TileDB targets may have linker errors!")
+      else()
+        message(STATUS "Found curl-config: '${CURL_CONFIG_BINARY}'")
+
+        if(${CURL_LIBRARIES} MATCHES "${CMAKE_SHARED_LIBRARY_SUFFIX}$")
+          execute_process(
+                  COMMAND ${CURL_CONFIG_BINARY} --libs
+                  OUTPUT_VARIABLE CURL_APPEND_LIBS
+                  RESULT_VARIABLE CMD_RESULT
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
+
+        else()
+          execute_process(
+            COMMAND ${CURL_CONFIG_BINARY} --static-libs
+            OUTPUT_VARIABLE CURL_APPEND_LIBS
+            RESULT_VARIABLE CMD_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
+        endif()
+
+        if (NOT CMD_RESULT EQUAL 0)
+          message(WARNING
+            "TileDB::tiledb_static link target may lack transitive link dependencies"
+            "'${CURL_CONFIG_BINARY} --static-libs' failed with error: "
+            "${CMD_RESULT}")
+        elseif (CURL_APPEND_LIBS)
+          # ^ must check output, because it might be empty and break regex below
+          # Make a list. The variable passed to target_link_libraries *must* be a list.
+          string(REGEX REPLACE "[ \t\r\n]" ";" CURL_APPEND_LIBS ${CURL_APPEND_LIBS})
+
+          message(STATUS "Computed initial transitive Curl library links to TileDB targets: '${CURL_APPEND_LIBS}'")
+        endif()
+      endif()
+  endif()
+endif()
+
+if (CURL_APPEND_LIBS)
+  # OpenSSL is always linked on POSIX for encryption. If we include curl's
+  # linkage we might double link if we built openssl in superbuild
+  # but the system library exists. This happens on macOS 10.14 and 10.15
+  # where openssl is deprecated but the library still ships. OpenSSL headers
+  # are not shipped, thus we build a superbuild of openssl. The -lcrypto then
+  # ends up trying to link against the system shared library while we already
+  # linked the static lib from TileDB supper build.
+  # End result, we remove the -lssl and -lcrypto from the list of curl extra libs
+  # The same problem exists for libz, so we remove -lz also.
+  list(REMOVE_ITEM CURL_APPEND_LIBS "-lssl" "-lcrypto" "-lz")
+  message(STATUS "Adding final transitive Curl library links to TileDB targets: '${CURL_APPEND_LIBS}'")
+  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
+    INTERFACE
+    ${CURL_APPEND_LIBS})
+endif()
+
+############################################################
 # Generated dependency information (for installation)
 ############################################################
 


### PR DESCRIPTION
This ports the latest curl static linkage configuration from TileDB 2.0 to the libtiledbvcf branch. When forcing a superbuild, this is needed as on some platforms the resulting libtiledb is missing linkage needed for curl.

Based on:
26284d9f6d631d93a2d91ea37c41f27d6c833020
9b1b8af0863ed68996d2f31db761c13a0201b2f4
e089bff7e78b1659dc21ba11ce429147cfe53477
653d556691df856d5568626929eef3cd6b2969d0
c199b7bbfa4be6fb9863b24f50d21f341aa757c7
617fb17b7f2337201ff97a96098fa273f7e316a0