### PR TITLE
Add new config option `vfs.file.posix_permissions`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,12 @@
 
 * Added functions `Attribute::{set,get}_fill_value` to get/set default fill values
 
+# TileDB v2.0.6 Release Notes
+
+## Improvements
+
+* Add new config option `vfs.file.posix_permissions` [#1710](https://github.com/TileDB-Inc/TileDB/pull/1710)
+
 # TileDB v2.0.5 Release Notes
 
 ## Improvements

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -242,6 +242,7 @@ void check_save_to_file() {
   ss << "vfs.file.enable_filelocks true\n";
   ss << "vfs.file.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
+  ss << "vfs.file.posix_permissions 755\n";
   ss << "vfs.gcs.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
   ss << "vfs.gcs.multi_part_size 5242880\n";
@@ -465,6 +466,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.azure.use_block_list_upload"] = "true";
   all_param_values["vfs.azure.use_https"] = "true";
+  all_param_values["vfs.file.posix_permissions"] = "755";
   all_param_values["vfs.file.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.file.enable_filelocks"] = "true";
@@ -515,6 +517,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["azure.use_block_list_upload"] = "true";
   vfs_param_values["azure.use_https"] = "true";
+  vfs_param_values["file.posix_permissions"] = "755";
   vfs_param_values["file.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["file.enable_filelocks"] = "true";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -60,7 +60,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 43);
+  CHECK(names.size() == 44);
 }
 
 TEST_CASE(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -989,6 +989,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.min_batch_gap` <br>
  *    The minimum number of bytes between two VFS read batches.<br>
  *    **Default**: 500KB
+ * - `vfs.file.posix_permissions` <br>
+ *    permissions to use for posix file system with file or dir creation.<br>
+ *    **Default**: 755
  * - `vfs.file.max_parallel_ops` <br>
  *    The maximum number of parallel operations on objects with `file:///`
  *    URIs. <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -85,6 +85,7 @@ const std::string Config::VFS_NUM_THREADS =
 const std::string Config::VFS_MIN_PARALLEL_SIZE = "10485760";
 const std::string Config::VFS_MIN_BATCH_GAP = "512000";
 const std::string Config::VFS_MIN_BATCH_SIZE = "20971520";
+const std::string Config::VFS_FILE_POSIX_PERMISSIONS = "755";
 const std::string Config::VFS_FILE_MAX_PARALLEL_OPS = Config::VFS_NUM_THREADS;
 const std::string Config::VFS_FILE_ENABLE_FILELOCKS = "true";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_NAME = "";
@@ -184,6 +185,7 @@ Config::Config() {
   param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
+  param_values_["vfs.file.posix_permissions"] = VFS_FILE_POSIX_PERMISSIONS;
   param_values_["vfs.file.max_parallel_ops"] = VFS_FILE_MAX_PARALLEL_OPS;
   param_values_["vfs.file.enable_filelocks"] = VFS_FILE_ENABLE_FILELOCKS;
   param_values_["vfs.azure.storage_account_name"] =
@@ -414,6 +416,8 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   } else if (param == "vfs.min_batch_size") {
     param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
+  } else if (param == "vfs.file.posix_permissions") {
+    param_values_["vfs.file.posix_permissions"] = VFS_FILE_POSIX_PERMISSIONS;
   } else if (param == "vfs.file.max_parallel_ops") {
     param_values_["vfs.file.max_parallel_ops"] = VFS_FILE_MAX_PARALLEL_OPS;
   } else if (param == "vfs.file.enable_filelocks") {
@@ -578,6 +582,8 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_batch_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
+  } else if (param == "vfs.file.posix_permissions") {
+    RETURN_NOT_OK(utils::parse::convert(value, &v32));
   } else if (param == "vfs.file.max_parallel_ops") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.file.enable_filelocks") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -184,6 +184,9 @@ class Config {
   /** The default minimum number of bytes in a batched VFS read operation. */
   static const std::string VFS_MIN_BATCH_SIZE;
 
+  /** The default posix permissions for file or dir creations */
+  static const std::string VFS_FILE_POSIX_PERMISSIONS;
+
   /** The default maximum number of parallel file:/// operations. */
   static const std::string VFS_FILE_MAX_PARALLEL_OPS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -318,6 +318,9 @@ class Config {
    * - `vfs.min_batch_gap` <br>
    *    The minimum number of bytes between two VFS read batches.<br>
    *    **Default**: 500KB
+   * - `vfs.file.posix_permissions` <br>
+   *    permissions to use for posix file system with file or dir creation.<br>
+   *    **Default**: 755
    * - `vfs.file.max_parallel_ops` <br>
    *    The maximum number of parallel operations on objects with `file:///`
    *    URIs. <br>

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -294,6 +294,13 @@ class Posix {
    */
   static Status write_at(
       int fd, uint64_t file_offset, const void* buffer, uint64_t buffer_size);
+
+  /**
+   * Parse config to get posix permissions for creating new files or folder
+   * @param permissions parsed permissions are set to this parameter
+   * @return Status
+   */
+  Status get_posix_permissions(uint32_t* permissions) const;
 };
 
 }  // namespace sm


### PR DESCRIPTION
This new config option allows the user to set the permissions used when creating new files on a posix file system. We default permissions to 755 now. The config parameter is a string in octal format, for example "0644" or "755".

Fixes #1709 