### PR TITLE
Check ENV for config values with config_iter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -36,6 +36,10 @@
 
 * Add new config option `vfs.file.posix_permissions` [#1710](https://github.com/TileDB-Inc/TileDB/pull/1710)
 
+## Bug fixes
+
+* Return possible env config variables in config iter [#1714](https://github.com/TileDB-Inc/TileDB/pull/1714)
+
 # TileDB v2.0.5 Release Notes
 
 ## Improvements

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -90,18 +90,26 @@ TEST_CASE(
     "C++ API: Config Environment Variables Default Override",
     "[cppapi], [cppapi-config]") {
   tiledb::Config config;
+  const std::string key = "vfs.num_threads";
 
   unsigned int threads = std::thread::hardware_concurrency();
-  std::string result1 = config["vfs.num_threads"];
+  const std::string result1 = config[key];
   CHECK(result1 == std::to_string(threads));
 
-  std::string value2 = std::to_string(threads + 1);
+  const std::string value2 = std::to_string(threads + 1);
   setenv_local("TILEDB_VFS_NUM_THREADS", value2.c_str());
-  std::string result2 = config["vfs.num_threads"];
+  const std::string result2 = config[key];
   CHECK(result2 == value2);
 
-  std::string value3 = std::to_string(threads + 2);
-  config["vfs.num_threads"] = value3;
-  std::string result3 = config["vfs.num_threads"];
+  // Check iterator
+  for (auto& c : config) {
+    if (c.first == key) {
+      CHECK(c.second == value2);
+    }
+  }
+
+  const std::string value3 = std::to_string(threads + 2);
+  config[key] = value3;
+  const std::string result3 = config[key];
   CHECK(result3 == value3);
 }

--- a/tiledb/sm/config/config_iter.cc
+++ b/tiledb/sm/config/config_iter.cc
@@ -42,7 +42,8 @@ namespace sm {
 
 ConfigIter::ConfigIter(const Config* config, const std::string& prefix)
     : param_values_(config->param_values())
-    , prefix_(prefix) {
+    , prefix_(prefix)
+    , config_(config) {
   it_ = param_values_.get().begin();
   next_while_not_prefix();
 }
@@ -90,7 +91,12 @@ void ConfigIter::next_while_not_prefix() {
 
   if (it_ != param_values_.get().end()) {
     param_ = it_->first.substr(prefix_.size());
-    value_ = it_->second;
+    bool found;
+    value_ = config_->get(param_, &found);
+    // If for some reason the param is missing from the config, use the original
+    // one from values map
+    if (!found)
+      value_ = it_->second;
   }
 }
 

--- a/tiledb/sm/config/config_iter.h
+++ b/tiledb/sm/config/config_iter.h
@@ -99,6 +99,9 @@ class ConfigIter {
   /** Current value. */
   std::string value_;
 
+  /** Config */
+  const Config* config_;
+
   /* ********************************* */
   /*         PRIVATE METHODS           */
   /* ********************************* */


### PR DESCRIPTION
This fixes a problem where in python default values are printed instead of the user set ENV config parameters. The iterator still only iterates over set or defaulted config parameters. We don't iterate over all env variables at this point, that is left to a future change if a user requests it. There is no c++ standard for listing all env variables, so we'd have to ifdef windows/posix in the future.