### PR TITLE
Only install docker if it does not exist for CI

### DIFF
--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -31,11 +31,17 @@ die() {
 }
 
 install_apt_pkgs() {
-  sudo apt-get -y install docker || die "could not install docker dependency"
+  if ! command -v docker &> /dev/null
+  then
+    sudo apt-get -y install docker || die "could not install docker dependency"
+  fi
 }
 
 install_yum_pkgs() {
-  sudo yum -y install docker || die "could not install docker dependency"
+  if ! command -v docker &> /dev/null
+  then
+    sudo yum -y install docker || die "could not install docker dependency"
+  fi
 }
 
 install_brew_pkgs() {


### PR DESCRIPTION
Azure pipelines updated their images and installed `moby`, which conflicts with `docker` package. This results in a broken docker instance if we try to install `docker` from apt. Instead of forcing installation, we now only attempt to install if docker does not exist.