### PR TITLE
Bump AWSSDK to 1.8.6

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@
 ## Improvements
 
 * Source built curl only need HTTP support [#1712](https://github.com/TileDB-Inc/TileDB/pull/1712)
+* AWS SDK version bumped to 1.8.6 [#1718](https://github.com/TileDB-Inc/TileDB/pull/1718)
 
 ## Deprecations
 

--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -96,8 +96,8 @@ if (NOT AWSSDK_FOUND)
 
     ExternalProject_Add(ep_awssdk
       PREFIX "externals"
-      URL "https://github.com/aws/aws-sdk-cpp/archive/1.7.108.zip"
-      URL_HASH SHA1=d07bae3fe924008b3117936963456dd314787abf
+      URL "https://github.com/aws/aws-sdk-cpp/archive/1.8.6.zip"
+      URL_HASH SHA1=5f4f58adabe2c7a241d49cb3ab2c96962fed1466
       CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${AWS_CMAKE_BUILD_TYPE}
         -DENABLE_TESTING=OFF


### PR DESCRIPTION
Confirmed this would fix #1713 (AWS has updated their execinfo detection logic).

~~Running CI check to make sure tests pass.~~