### PR TITLE
Split folder and directory posix permission config

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 
 * Source built curl only need HTTP support [#1712](https://github.com/TileDB-Inc/TileDB/pull/1712)
 * AWS SDK version bumped to 1.8.6 [#1718](https://github.com/TileDB-Inc/TileDB/pull/1718)
+* Split posix permissions into files and folers permissions [#1719](https://github.com/TileDB-Inc/TileDB/pull/1719)
 
 ## Deprecations
 

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -242,7 +242,8 @@ void check_save_to_file() {
   ss << "vfs.file.enable_filelocks true\n";
   ss << "vfs.file.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
-  ss << "vfs.file.posix_permissions 755\n";
+  ss << "vfs.file.posix_directory_permissions 755\n";
+  ss << "vfs.file.posix_file_permissions 644\n";
   ss << "vfs.gcs.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
   ss << "vfs.gcs.multi_part_size 5242880\n";
@@ -466,7 +467,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.azure.use_block_list_upload"] = "true";
   all_param_values["vfs.azure.use_https"] = "true";
-  all_param_values["vfs.file.posix_permissions"] = "755";
+  all_param_values["vfs.file.posix_file_permissions"] = "644";
+  all_param_values["vfs.file.posix_directory_permissions"] = "755";
   all_param_values["vfs.file.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.file.enable_filelocks"] = "true";
@@ -517,7 +519,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["azure.use_block_list_upload"] = "true";
   vfs_param_values["azure.use_https"] = "true";
-  vfs_param_values["file.posix_permissions"] = "755";
+  vfs_param_values["file.posix_file_permissions"] = "644";
+  vfs_param_values["file.posix_directory_permissions"] = "755";
   vfs_param_values["file.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["file.enable_filelocks"] = "true";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -60,7 +60,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 44);
+  CHECK(names.size() == 45);
 }
 
 TEST_CASE(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -989,8 +989,11 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.min_batch_gap` <br>
  *    The minimum number of bytes between two VFS read batches.<br>
  *    **Default**: 500KB
- * - `vfs.file.posix_permissions` <br>
- *    permissions to use for posix file system with file or dir creation.<br>
+ * - `vfs.file.posix_file_permissions` <br>
+ *    permissions to use for posix file system with file creation.<br>
+ *    **Default**: 644
+ * - `vfs.file.posix_directory_permissions` <br>
+ *    permissions to use for posix file system with directory creation.<br>
  *    **Default**: 755
  * - `vfs.file.max_parallel_ops` <br>
  *    The maximum number of parallel operations on objects with `file:///`

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -85,7 +85,8 @@ const std::string Config::VFS_NUM_THREADS =
 const std::string Config::VFS_MIN_PARALLEL_SIZE = "10485760";
 const std::string Config::VFS_MIN_BATCH_GAP = "512000";
 const std::string Config::VFS_MIN_BATCH_SIZE = "20971520";
-const std::string Config::VFS_FILE_POSIX_PERMISSIONS = "755";
+const std::string Config::VFS_FILE_POSIX_FILE_PERMISSIONS = "644";
+const std::string Config::VFS_FILE_POSIX_DIRECTORY_PERMISSIONS = "755";
 const std::string Config::VFS_FILE_MAX_PARALLEL_OPS = Config::VFS_NUM_THREADS;
 const std::string Config::VFS_FILE_ENABLE_FILELOCKS = "true";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_NAME = "";
@@ -185,7 +186,10 @@ Config::Config() {
   param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
-  param_values_["vfs.file.posix_permissions"] = VFS_FILE_POSIX_PERMISSIONS;
+  param_values_["vfs.file.posix_file_permissions"] =
+      VFS_FILE_POSIX_FILE_PERMISSIONS;
+  param_values_["vfs.file.posix_directory_permissions"] =
+      VFS_FILE_POSIX_DIRECTORY_PERMISSIONS;
   param_values_["vfs.file.max_parallel_ops"] = VFS_FILE_MAX_PARALLEL_OPS;
   param_values_["vfs.file.enable_filelocks"] = VFS_FILE_ENABLE_FILELOCKS;
   param_values_["vfs.azure.storage_account_name"] =
@@ -416,8 +420,12 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   } else if (param == "vfs.min_batch_size") {
     param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
-  } else if (param == "vfs.file.posix_permissions") {
-    param_values_["vfs.file.posix_permissions"] = VFS_FILE_POSIX_PERMISSIONS;
+  } else if (param == "vfs.file.posix_file_permissions") {
+    param_values_["vfs.file.posix_file_permissions"] =
+        VFS_FILE_POSIX_FILE_PERMISSIONS;
+  } else if (param == "vfs.file.posix_directory_permissions") {
+    param_values_["vfs.file.posix_directory_permissions"] =
+        VFS_FILE_POSIX_DIRECTORY_PERMISSIONS;
   } else if (param == "vfs.file.max_parallel_ops") {
     param_values_["vfs.file.max_parallel_ops"] = VFS_FILE_MAX_PARALLEL_OPS;
   } else if (param == "vfs.file.enable_filelocks") {
@@ -582,7 +590,9 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_batch_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
-  } else if (param == "vfs.file.posix_permissions") {
+  } else if (param == "vfs.file.posix_file_permissions") {
+    RETURN_NOT_OK(utils::parse::convert(value, &v32));
+  } else if (param == "vfs.file.posix_directory_permissions") {
     RETURN_NOT_OK(utils::parse::convert(value, &v32));
   } else if (param == "vfs.file.max_parallel_ops") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -184,8 +184,11 @@ class Config {
   /** The default minimum number of bytes in a batched VFS read operation. */
   static const std::string VFS_MIN_BATCH_SIZE;
 
-  /** The default posix permissions for file or dir creations */
-  static const std::string VFS_FILE_POSIX_PERMISSIONS;
+  /** The default posix permissions for file creations */
+  static const std::string VFS_FILE_POSIX_FILE_PERMISSIONS;
+
+  /** The default posix permissions for directory creations */
+  static const std::string VFS_FILE_POSIX_DIRECTORY_PERMISSIONS;
 
   /** The default maximum number of parallel file:/// operations. */
   static const std::string VFS_FILE_MAX_PARALLEL_OPS;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -318,7 +318,10 @@ class Config {
    * - `vfs.min_batch_gap` <br>
    *    The minimum number of bytes between two VFS read batches.<br>
    *    **Default**: 500KB
-   * - `vfs.file.posix_permissions` <br>
+   * - `vfs.file.posix_file_permissions` <br>
+   *    permissions to use for posix file system with file or dir creation.<br>
+   *    **Default**: 644
+   * - `vfs.file.posix_directory_permissions` <br>
    *    permissions to use for posix file system with file or dir creation.<br>
    *    **Default**: 755
    * - `vfs.file.max_parallel_ops` <br>

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -166,7 +166,7 @@ Status Posix::create_dir(const std::string& path) const {
   }
 
   uint32_t permissions = 0;
-  RETURN_NOT_OK(get_posix_permissions(&permissions));
+  RETURN_NOT_OK(get_posix_directory_permissions(&permissions));
 
   if (mkdir(path.c_str(), permissions) != 0) {
     return LOG_STATUS(Status::IOError(
@@ -178,7 +178,7 @@ Status Posix::create_dir(const std::string& path) const {
 
 Status Posix::touch(const std::string& filename) const {
   uint32_t permissions = 0;
-  RETURN_NOT_OK(get_posix_permissions(&permissions));
+  RETURN_NOT_OK(get_posix_file_permissions(&permissions));
 
   int fd = ::open(filename.c_str(), O_WRONLY | O_CREAT | O_SYNC, permissions);
   if (fd == -1 || ::close(fd) != 0) {
@@ -435,15 +435,16 @@ Status Posix::read(
 
 Status Posix::sync(const std::string& path) {
   uint32_t permissions = 0;
-  RETURN_NOT_OK(get_posix_permissions(&permissions));
 
   // Open file
   int fd = -1;
-  if (is_dir(path))  // DIRECTORY
+  if (is_dir(path)) {  // DIRECTORY
+    RETURN_NOT_OK(get_posix_directory_permissions(&permissions));
     fd = open(path.c_str(), O_RDONLY, permissions);
-  else if (is_file(path))  // FILE
+  } else if (is_file(path)) {  // FILE
+    RETURN_NOT_OK(get_posix_file_permissions(&permissions));
     fd = open(path.c_str(), O_WRONLY | O_APPEND | O_CREAT, permissions);
-  else
+  } else
     return Status::Ok();  // If file does not exist, exit
 
   // Handle error
@@ -484,7 +485,7 @@ Status Posix::write(
   assert(found);
 
   uint32_t permissions = 0;
-  RETURN_NOT_OK(get_posix_permissions(&permissions));
+  RETURN_NOT_OK(get_posix_file_permissions(&permissions));
 
   // Get file offset (equal to file size)
   Status st;
@@ -579,11 +580,24 @@ Status Posix::write_at(
   return Status::Ok();
 }
 
-Status Posix::get_posix_permissions(uint32_t* permissions) const {
+Status Posix::get_posix_file_permissions(uint32_t* permissions) const {
   // Get config params
   bool found = false;
   std::string posix_permissions =
-      config_.get().get("vfs.file.posix_permissions", &found);
+      config_.get().get("vfs.file.posix_file_permissions", &found);
+  assert(found);
+
+  // Permissions are passed in octal notation by the user
+  *permissions = std::strtol(posix_permissions.c_str(), NULL, 8);
+
+  return Status::Ok();
+}
+
+Status Posix::get_posix_directory_permissions(uint32_t* permissions) const {
+  // Get config params
+  bool found = false;
+  std::string posix_permissions =
+      config_.get().get("vfs.file.posix_directory_permissions", &found);
   assert(found);
 
   // Permissions are passed in octal notation by the user

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -296,11 +296,18 @@ class Posix {
       int fd, uint64_t file_offset, const void* buffer, uint64_t buffer_size);
 
   /**
-   * Parse config to get posix permissions for creating new files or folder
+   * Parse config to get posix permissions for creating new files
    * @param permissions parsed permissions are set to this parameter
    * @return Status
    */
-  Status get_posix_permissions(uint32_t* permissions) const;
+  Status get_posix_file_permissions(uint32_t* permissions) const;
+
+  /**
+   * Parse config to get posix permissions for creating new directories
+   * @param permissions parsed permissions are set to this parameter
+   * @return Status
+   */
+  Status get_posix_directory_permissions(uint32_t* permissions) const;
 };
 
 }  // namespace sm


### PR DESCRIPTION
Directories need the executable bit set, so finer control is given by splitting the posix permission config into one for files and one for directories. This allows files to be created without the executable bit.

This is, in a way a breaking change since I've removed the old configuration option. I thought best to remove the ambiguous option and force the new specific options. I can however adjust the PR to leave the old option, and add the new directory one only, if there is consensus. Note: the break is only if a user was manually overriding the default config value introduced in 2.0.6. If the user was not overriding, there is no breakage.