### PR TITLE
Reader::compute_result_coords sub-partitioner

### DIFF
--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -481,6 +481,9 @@ const std::string special_name_prefix = "__";
 /** Number of milliseconds between watchdog thread wakeups. */
 const unsigned watchdog_thread_sleep_ms = 1000;
 
+/** The target sub-partitioner budget for computing result coordinates. */
+const uint64_t sub_partitioner_memory_budget = 1024 * 1024 * 5;
+
 const void* fill_value(Datatype type) {
   switch (type) {
     case Datatype::INT8:

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -472,6 +472,9 @@ extern const std::string special_name_prefix;
 /** Number of milliseconds between watchdog thread wakeups. */
 extern const unsigned watchdog_thread_sleep_ms;
 
+/** The target sub-partitioner budget for computing result coordinates. */
+extern const uint64_t sub_partitioner_memory_budget;
+
 /** Returns the empty fill value based on the input datatype. */
 const void* fill_value(Datatype type);
 

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -611,6 +611,7 @@ class Reader {
    * Retrieves the coordinates that overlap the input N-dimensional range
    * from the input result tile.
    *
+   * @param subarray The subarray to operate on.
    * @param frag_idx The id of the fragment that the result tile belongs to.
    * @param tile The result tile.
    * @param range_idx The range id.
@@ -618,6 +619,7 @@ class Reader {
    * @return Status
    */
   Status compute_range_result_coords(
+      Subarray* subarray,
       unsigned frag_idx,
       ResultTile* tile,
       uint64_t range_idx,
@@ -627,6 +629,7 @@ class Reader {
    * Computes the result coordinates for each range of the query
    * subarray.
    *
+   * @param subarray The subarray to operate on.
    * @param single_fragment For each range, it indicates whether all
    *     result coordinates come from a single fragment.
    * @param result_tile_map This is an auxialiary map that helps finding the
@@ -637,6 +640,7 @@ class Reader {
    * @return Status
    */
   Status compute_range_result_coords(
+      Subarray* subarray,
       const std::vector<bool>& single_fragment,
       const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
       std::vector<ResultTile>* result_tiles,
@@ -646,6 +650,7 @@ class Reader {
    * Computes the result coordinates of a given range of the query
    * subarray.
    *
+   * @param subarray The subarray to operate on.
    * @param range_idx The range to focus on.
    * @param result_tile_map This is an auxialiary map that helps finding the
    *     result_tiles overlapping with each range.
@@ -655,6 +660,7 @@ class Reader {
    * @return Status
    */
   Status compute_range_result_coords(
+      Subarray* subarray,
       uint64_t range_idx,
       const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
       std::vector<ResultTile>* result_tiles,
@@ -664,6 +670,7 @@ class Reader {
    * Computes the result coordinates of a given range of the query
    * subarray.
    *
+   * @param subarray The subarray to operate on.
    * @param range_idx The range to focus on.
    * @param fragment_idx The fragment to focus on.
    * @param result_tile_map This is an auxialiary map that helps finding the
@@ -674,6 +681,7 @@ class Reader {
    * @return Status
    */
   Status compute_range_result_coords(
+      Subarray* subarray,
       uint64_t range_idx,
       uint32_t fragment_idx,
       const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
@@ -1152,12 +1160,15 @@ class Reader {
   /**
    * Sorts the input result coordinates according to the subarray layout.
    *
-   * @param result_coords The coordinates to sort.
+   * @param iter_begin The start position of the coordinates to sort.
+   * @param iter_end The end position of the coordinates to sort.
    * @param layout The layout to sort into.
    * @return Status
    */
   Status sort_result_coords(
-      std::vector<ResultCoords>* result_coords, Layout layout) const;
+      std::vector<ResultCoords>::iterator iter_begin,
+      std::vector<ResultCoords>::iterator iter_end,
+      Layout layout) const;
 
   /** Performs a read on a sparse array. */
   Status sparse_read();


### PR DESCRIPTION
This patch introduces a sub-partitioner to compute and sort the range
result coords. The motiviation is to partition the elements sorted in
parallel_sort (which runs in O(N * LOG(N)) time complexity). In the current
scenario that I'm testing, this improves multi-fragment reads from ~2.9s
to ~2.4s. The single-fragment read runs in ~1.8s. This reduces the total
multi-fragment read overhead from 61% to 33%.

// Single-fragment
```
- Read time: 1.81197 secs
  * Time to compute next partition: 0.059505 secs
  * Time to compute result coordinates: 0.427879 secs
    > Time to compute sparse result tiles: 0.00213199 secs
    > Time to read coordinate tiles: 0.0205255 secs
    > Time to unfilter coordinate tiles: 0.0236447 secs
    > Time to compute range result coordinates: 0.126082 secs
  * Time to compute sparse result cell slabs: 0.0142938 secs
  * Time to copy result attribute values: 1.27557 secs
    > Time to read attribute tiles: 0.325302 secs
    > Time to unfilter attribute tiles: 0.376115 secs
    > Time to copy fixed-sized attribute values: 0.324924 secs
    > Time to copy var-sized attribute values: 0.146791 secs
  * Time to copy result coordinates: 0.0475786 secs
    > Time to copy fixed-sized coordinates: 0.0238743 secs

- Total read query time (array open + init state + read): 1.81201 secs
```

// Multi-fragment
```
- Read time: 2.40146 secs
  * Time to compute next partition: 0.0846776 secs
  * Time to compute result coordinates: 0.701766 secs
    > Time to compute sparse result tiles: 0.00235241 secs
    > Time to read coordinate tiles: 0.0225933 secs
    > Time to unfilter coordinate tiles: 0.0239695 secs
    > Time to compute range result coordinates: 0.101788 secs
  * Time to compute sparse result cell slabs: 0.0431639 secs
  * Time to copy result attribute values: 1.56159 secs
    > Time to read attribute tiles: 0.338785 secs
    > Time to unfilter attribute tiles: 0.397662 secs
    > Time to copy fixed-sized attribute values: 0.356104 secs
    > Time to copy var-sized attribute values: 0.313703 secs
  * Time to copy result coordinates: 0.0425039 secs
    > Time to copy fixed-sized coordinates: 0.0271955 secs

- Total read query time (array open + init state + read): 2.4015 secs
```

// Multi-fragment (without this patch)
```
- Read time: 2.91803 secs
  * Time to compute next partition: 0.0418832 secs
  * Time to compute result coordinates: 0.988186 secs
    > Time to compute sparse result tiles: 0.00240205 secs
    > Time to read coordinate tiles: 0.0225808 secs
    > Time to unfilter coordinate tiles: 0.0243308 secs
    > Time to compute range result coordinates: 0.287352 secs
  * Time to compute sparse result cell slabs: 0.0378204 secs
  * Time to copy result attribute values: 1.76864 secs
    > Time to read attribute tiles: 0.343348 secs
    > Time to unfilter attribute tiles: 0.41717 secs
    > Time to copy fixed-sized attribute values: 0.436063 secs
    > Time to copy var-sized attribute values: 0.386814 secs
  * Time to copy result coordinates: 0.0684334 secs
    > Time to copy fixed-sized coordinates: 0.0382354 secs

- Total read query time (array open + init state + read): 2.91808 secs
```