### PR TITLE
Fix compute_mbr for var-sized dimensions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,12 @@
 
 * Added functions `Attribute::{set,get}_fill_value` to get/set default fill values
 
+# TileDB v2.0.7 Release Notes
+
+## Bug fixes
+
+* Fixed error "[TileDB::ChunkedBuffer] Error: Chunk read error; chunk unallocated error" that may occur when writing var-sized attributes. [#1732](https://github.com/TileDB-Inc/TileDB/pull/1732)
+
 # TileDB v2.0.6 Release Notes
 
 ## Improvements

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -374,51 +374,23 @@ bool Dimension::coincides_with_tiles(const Range& r) const {
 template <class T>
 Status Dimension::compute_mbr(const Tile& tile, Range* mbr) {
   assert(mbr != nullptr);
-  ChunkedBuffer* const chunked_buffer = tile.chunked_buffer();
   auto cell_num = tile.cell_num();
   assert(cell_num > 0);
 
-  size_t chunk_idx = 0;
-  size_t chunk_offset = 0;
+  // The chunked buffers in the write path are always contiguous.
+  void* tile_buffer = nullptr;
+  ChunkedBuffer* const chunked_buffer = tile.chunked_buffer();
+  RETURN_NOT_OK(chunked_buffer->get_contiguous(&tile_buffer));
+  assert(tile_buffer != nullptr);
 
-  // Fetch the first internal buffer.
-  void* buffer;
-  RETURN_NOT_OK(chunked_buffer->internal_buffer(chunk_idx, &buffer));
+  // Initialize MBR with the first tile values
+  const T* const data = static_cast<T*>(tile_buffer);
+  T res[] = {data[0], data[0]};
+  mbr->set_range(res, sizeof(res));
 
-  for (uint64_t c = 0; c < cell_num; ++c) {
-    // Move to the next internal chunk buffer if the offset exceeds the
-    // current chunk buffer's size.
-    uint32_t chunk_size;
-    RETURN_NOT_OK(chunked_buffer->internal_buffer_size(chunk_idx, &chunk_size));
-    if (chunk_offset >= chunk_size) {
-      ++chunk_idx;
-      chunk_offset = 0;
-
-      // Fetch the next internal buffer and its associated size.
-      RETURN_NOT_OK(chunked_buffer->internal_buffer(chunk_idx, &buffer));
-      RETURN_NOT_OK(
-          chunked_buffer->internal_buffer_size(chunk_idx, &chunk_size));
-    }
-
-    // Sanity check we have sufficient space to perform our random access
-    // read of 'buffer'.
-    if (chunk_size < (chunk_offset + sizeof(T))) {
-      return LOG_STATUS(Status::DimensionError(
-          "Out of bounds read to internal chunk buffer of size " +
-          std::to_string(chunk_size)));
-    }
-
-    const T* const v = static_cast<T*>(
-        static_cast<void*>(static_cast<char*>(buffer) + chunk_offset));
-    chunk_offset += sizeof(T);
-
-    if (c == 0) {
-      T res[] = {*v, *v};
-      mbr->set_range(res, sizeof(res));
-    } else {
-      expand_range_v<T>(v, mbr);
-    }
-  }
+  // Expand the MBR with the rest tile values
+  for (uint64_t c = 1; c < cell_num; ++c)
+    expand_range_v<T>(&data[c], mbr);
 
   return Status::Ok();
 }
@@ -432,62 +404,34 @@ template <>
 Status Dimension::compute_mbr_var<char>(
     const Tile& tile_off, const Tile& tile_val, Range* mbr) {
   assert(mbr != nullptr);
-  ChunkedBuffer* const chunked_buffer_off = tile_off.chunked_buffer();
-  ChunkedBuffer* const chunked_buffer_val = tile_val.chunked_buffer();
   auto d_val_size = tile_val.size();
   auto cell_num = tile_off.cell_num();
   assert(cell_num > 0);
 
-  // Offset tiles are always contiguously allocated.
-  void* tmp_buffer;
-  RETURN_NOT_OK(chunked_buffer_off->get_contiguous(&tmp_buffer));
-  uint64_t* const d_off = static_cast<uint64_t*>(tmp_buffer);
+  // The chunked buffers in the write path are always contiguous.
+  void* tile_buffer_off = nullptr;
+  ChunkedBuffer* const chunked_buffer_off = tile_off.chunked_buffer();
+  RETURN_NOT_OK(chunked_buffer_off->get_contiguous(&tile_buffer_off));
+  assert(tile_buffer_off != nullptr);
 
-  size_t chunk_idx = 0;
-  RETURN_NOT_OK(chunked_buffer_val->internal_buffer(chunk_idx, &tmp_buffer));
-  char* d_val = static_cast<char*>(tmp_buffer);
+  // The chunked buffers in the write path are always contiguous.
+  void* tile_buffer_val = nullptr;
+  ChunkedBuffer* const chunked_buffer_val = tile_val.chunked_buffer();
+  RETURN_NOT_OK(chunked_buffer_val->get_contiguous(&tile_buffer_val));
+  assert(tile_buffer_val != nullptr);
+
+  uint64_t* const d_off = static_cast<uint64_t*>(tile_buffer_off);
+  char* const d_val = static_cast<char*>(tile_buffer_val);
 
   // Initialize MBR with the first tile values
   auto size_0 = (cell_num == 1) ? d_val_size : d_off[1];
   mbr->set_range_var(d_val, size_0, d_val, size_0);
 
   // Expand the MBR with the rest tile values
-  size_t chunk_bytes_processed = 0;
   for (uint64_t c = 1; c < cell_num; ++c) {
-    // Offset values are guaranteed to be in ascending order.
-    assert(chunk_bytes_processed <= d_off[c]);
-
-    // iterate until 'chunk_idx_val' contains 'd_off_c0'
-    uint32_t chunk_size;
-    while (true) {
-      RETURN_NOT_OK(
-          chunked_buffer_val->internal_buffer_size(chunk_idx, &chunk_size));
-      if ((d_off[c] - chunk_bytes_processed) < chunk_size) {
-        break;
-      }
-
-      ++chunk_idx;
-      chunk_bytes_processed += chunk_size;
-    }
-
-    // Fetch the next internal buffer of 'chunked_buffer_val' and its
-    // associated size.
-    RETURN_NOT_OK(chunked_buffer_val->internal_buffer(chunk_idx, &tmp_buffer));
-    d_val = static_cast<char*>(tmp_buffer);
-
-    // Sanity check we have sufficient space to perform our random access
-    // read of 'd_val'.
-    const size_t chunk_offset = d_off[c] - chunk_bytes_processed;
-    const uint64_t size =
+    auto size =
         (c == cell_num - 1) ? d_val_size - d_off[c] : d_off[c + 1] - d_off[c];
-    if (chunk_size < (chunk_offset + size)) {
-      return LOG_STATUS(Status::DimensionError(
-          "Out of bounds read to internal chunk buffer of size " +
-          std::to_string(chunk_size)));
-    }
-
-    const char* const v = d_val + chunk_offset;
-    expand_range_var_v(v, size, mbr);
+    expand_range_var_v(&d_val[d_off[c]], size, mbr);
   }
 
   return Status::Ok();


### PR DESCRIPTION
There is a mistake in the logic of `compute_mbr` and `compute_mbr_var` that
assumes that the var-sized cells in the value tile do not span more than one
chunked buffer. If a var-sized cell contains 2 integer values, it is only true
that the bytes for an individual integer value do not span a chunked buffer.
The first integer value may be at the end of one chunked buffer and the second
integer may be on the next chunked buffer.

This could be easily fixed, but I also noticed that the write path (where these
functions are called) guarantees that tile chunked buffers will always be
contiguous. In this scenario, we can just revert both `compute_mbr` and
`compute_mbr_var` to the logic before the chunked buffer patch (commit hash
4b4b502a0d27e8dfd51df674527df31a271caac8).