### PR TITLE
Fix detection of system installs of Catch2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -39,6 +39,7 @@
 
 * Fixed error "Error: Out of bounds read to internal chunk buffer of size 65536" that may occur when writing var-sized attributes. [#1732](https://github.com/TileDB-Inc/TileDB/pull/1732)
 * Fixed error "Error: Chunk read error; chunk unallocated error" that may occur when reading arrays with more than one dimension. [#1736](https://github.com/TileDB-Inc/TileDB/pull/1736)
+* Fix Catch2 detection of system install [#1733](https://github.com/TileDB-Inc/TileDB/pull/1733)
 
 # TileDB v2.0.6 Release Notes
 

--- a/cmake/Modules/FindCatch_EP.cmake
+++ b/cmake/Modules/FindCatch_EP.cmake
@@ -27,17 +27,18 @@
 # Finds the Catch library, installing with an ExternalProject as necessary.
 # This module defines:
 #   - CATCH_INCLUDE_DIR, directory containing headers
-#   - CATCH_FOUND, whether Catch has been found
+#   - CATCH2_FOUND, whether Catch has been found
 #   - The Catch::Catch imported target
 
 # Search the path set during the superbuild for the EP.
 message(STATUS "searching for catch in ${TILEDB_EP_SOURCE_DIR}")
-set(CATCH_PATHS ${TILEDB_EP_SOURCE_DIR}/ep_catch/single_include/catch2)
+set(CATCH_PATHS ${TILEDB_EP_SOURCE_DIR}/ep_catch/single_include)
 
 if (NOT TILEDB_FORCE_ALL_DEPS OR TILEDB_CATCH_EP_BUILT)
   find_path(CATCH_INCLUDE_DIR
     NAMES catch.hpp
     PATHS ${CATCH_PATHS}
+    PATH_SUFFIXES "catch2"
     ${TILEDB_DEPS_NO_DEFAULT_PATH}
   )
 endif()
@@ -47,7 +48,7 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(Catch2
   REQUIRED_VARS CATCH_INCLUDE_DIR
 )
 
-if (NOT CATCH_FOUND AND TILEDB_SUPERBUILD)
+if (NOT CATCH2_FOUND AND TILEDB_SUPERBUILD)
   message(STATUS "Adding Catch as an external project")
   ExternalProject_Add(ep_catch
     PREFIX "externals"


### PR DESCRIPTION
Fix detection of system installs of Catch2 by properly checking for `catch2` path prefix and checking the correct status variable.

This fixes #1731