### PR TITLE
Sort cell slab ranges for ND arrays

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,7 +37,8 @@
 
 ## Bug fixes
 
-* Fixed error "[TileDB::ChunkedBuffer] Error: Chunk read error; chunk unallocated error" that may occur when writing var-sized attributes. [#1732](https://github.com/TileDB-Inc/TileDB/pull/1732)
+* Fixed error "Error: Out of bounds read to internal chunk buffer of size 65536" that may occur when writing var-sized attributes. [#1732](https://github.com/TileDB-Inc/TileDB/pull/1732)
+* Fixed error "Error: Chunk read error; chunk unallocated error" that may occur when reading arrays with more than one dimension. [#1736](https://github.com/TileDB-Inc/TileDB/pull/1736)
 
 # TileDB v2.0.6 Release Notes
 


### PR DESCRIPTION
The selective decompression intersection algorithm requires cell slab ranges
to be sorted in ascending order. This is true for 1D arrays, but not for ND
arrays. In this scenario, we must sort them.

The ranges are sorted in vectors that have already been partitioned per-tile.
This should keep the sort runtimes relatively quick. In the future, we can
benchmark this on large arrays+queries and measure its timing. With this sort,
we now may coalesce cell ranges as a future optimization.

If the N*LOG(N) sorting is too slow, the alternative approach is to leave them
unsorted and perform O(N*M) range-chunk intersection comparisons, where M is
the number of chunks. If the number of chunks is less than LOG(N), this may
be faster.

This solves the following error message:
[TileDB::ChunkedBuffer] Error: Chunk read error; chunk unallocated error