### PR TITLE
Fix size_t 8-byte assumption

### DIFF
--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -98,7 +98,7 @@ Status FilterPipeline::filter_chunks_forward(
 
   // We will only filter chunks that contain data at or below
   // the logical chunked buffer size.
-  size_t populated_nchunks = input.nchunks();
+  uint64_t populated_nchunks = input.nchunks();
   if (input.size() != input.capacity()) {
     populated_nchunks = 0;
     for (uint64_t i = 0; i < input.nchunks(); ++i) {


### PR DESCRIPTION
The on-disk format requires the number of chunks to be written as 8 bytes. On
a 32-bit linux, size_t is 4-bytes.