### PR TITLE
GCC 10.1 now includes avx intrinsics

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -46,6 +46,7 @@
 * Use libtiledb-detected certificate path for Google Cloud Storage, for better linux binary/wheel portability. [#1741](https://github.com/TileDB-Inc/TileDB/pull/1741)
 * Fixed a small memory leak when opening arrays. [#1690](https://github.com/TileDB-Inc/TileDB/pull/1690)
 * Fixed an overflow in the partioning path that may result in a hang or poor read performance. [#1725](https://github.com/TileDB-Inc/TileDB/pull/1725)[#1707](https://github.com/TileDB-Inc/TileDB/pull/1707)
+* Fix compilation on gcc 10.1 for blosc [#1740](https://github.com/TileDB-Inc/TileDB/pull/1740)
 
 ## Improvements
 

--- a/external/src/blosc/shuffle-avx2.cc
+++ b/external/src/blosc/shuffle-avx2.cc
@@ -39,9 +39,9 @@ static void printymm(__m256i ymm0)
 }
 #endif
 
-/* GCC doesn't include the split load/store intrinsics
+/* GCC pre 10.1 doesn't include the split load/store intrinsics
    needed for the tiled shuffle, so define them here. */
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC) && !((__GNUC__ == 10 && __GNUC_MINOR__ >= 1) || __GNUC__ > 10)
 static inline __m256i
 __attribute__((__always_inline__))
 _mm256_loadu2_m128i(const __m128i* const hiaddr, const __m128i* const loaddr)


### PR DESCRIPTION
GCC 10.1 now includes avx intrinsics per https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91341#c3. This fixes a error on build with duplicate implementations of `_mm256_loadu2_m128i`/`_mm256_storeu2_m128i`.


```
[  0%] Building CXX object tiledb/CMakeFiles/TILEDB_CORE_OBJECTS.dir/__/external/src/blosc/shuffle-avx2.cc.o
/home/seth/git/TileDB/external/src/blosc/shuffle-avx2.cc:47:1: error: ‘__m256i _mm256_loadu2_m128i(const __m128i*, const __m128i*)’ redeclared inline without ‘gnu_inline’ attribute
   47 | _mm256_loadu2_m128i(const __m128i* const hiaddr, const __m128i* const loaddr)
      | ^~~~~~~~~~~~~~~~~~~
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/include/immintrin.h:51,
                 from /home/seth/git/TileDB/tiledb/../external/include/blosc/blosc-common.h:81,
                 from /home/seth/git/TileDB/tiledb/../external/include/blosc/shuffle-generic.h:20,
                 from /home/seth/git/TileDB/external/src/blosc/shuffle-avx2.cc:11:
/usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/include/avxintrin.h:1573:1: note: ‘__m256i _mm256_loadu2_m128i(const __m128i_u*, const __m128i_u*)’ previously defined here
 1573 | _mm256_loadu2_m128i (__m128i_u const *__PH, __m128i_u const *__PL)
      | ^~~~~~~~~~~~~~~~~~~
/home/seth/git/TileDB/external/src/blosc/shuffle-avx2.cc:55:1: error: ‘void _mm256_storeu2_m128i(__m128i*, __m128i*, __m256i)’ redeclared inline without ‘gnu_inline’ attribute
   55 | _mm256_storeu2_m128i(__m128i* const hiaddr, __m128i* const loaddr, const __m256i a)
      | ^~~~~~~~~~~~~~~~~~~~
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/include/immintrin.h:51,
                 from /home/seth/git/TileDB/tiledb/../external/include/blosc/blosc-common.h:81,
                 from /home/seth/git/TileDB/tiledb/../external/include/blosc/shuffle-generic.h:20,
                 from /home/seth/git/TileDB/external/src/blosc/shuffle-avx2.cc:11:
/usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/include/avxintrin.h:1580:1: note: ‘void _mm256_storeu2_m128i(__m128i_u*, __m128i_u*, __m256i)’ previously defined here
 1580 | _mm256_storeu2_m128i (__m128i_u *__PH, __m128i_u *__PL, __m256i __A)
      | ^~~~~~~~~~~~~~~~~~~~
gmake[3]: *** [tiledb/CMakeFiles/TILEDB_CORE_OBJECTS.dir/build.make:1266: tiledb/CMakeFiles/TILEDB_CORE_OBJECTS.dir/__/external/src/blosc/shuffle-avx2.cc.o] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:309: tiledb/CMakeFiles/TILEDB_CORE_OBJECTS.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:588: examples/c_api/CMakeFiles/quickstart_dense_c.dir/rule] Error 2
```