### PR TITLE
[backport release-2.0.7] GCC 10.1 now includes avx intrinsics

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,11 @@
 * Fixed an overflow in the partioning path that may result in a hang or poor read performance. [#1725](https://github.com/TileDB-Inc/TileDB/pull/1725)[#1707](https://github.com/TileDB-Inc/TileDB/pull/1707)
 * Fix Catch2 detection of system install [#1733](https://github.com/TileDB-Inc/TileDB/pull/1733)
 * Use libtiledb-detected certificate path for Google Cloud Storage, for better linux binary/wheel portability. [#1741](https://github.com/TileDB-Inc/TileDB/pull/1741)
+* Fix compilation on gcc 10.1 for blosc [#1740](https://github.com/TileDB-Inc/TileDB/pull/1740)
+
+## Improvements
+
+* Various performance optimizations in the read path. [#1689](https://github.com/TileDB-Inc/TileDB/pull/1689) [#1692](https://github.com/TileDB-Inc/TileDB/pull/1692) [#1693](https://github.com/TileDB-Inc/TileDB/pull/1693) [#1694](https://github.com/TileDB-Inc/TileDB/pull/1694) [#1695](https://github.com/TileDB-Inc/TileDB/pull/1695)
 
 # TileDB v2.0.6 Release Notes
 

--- a/external/src/blosc/shuffle-avx2.cc
+++ b/external/src/blosc/shuffle-avx2.cc
@@ -39,9 +39,9 @@ static void printymm(__m256i ymm0)
 }
 #endif
 
-/* GCC doesn't include the split load/store intrinsics
+/* GCC pre 10.1 doesn't include the split load/store intrinsics
    needed for the tiled shuffle, so define them here. */
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC) && !((__GNUC__ == 10 && __GNUC_MINOR__ >= 1) || __GNUC__ > 10)
 static inline __m256i
 __attribute__((__always_inline__))
 _mm256_loadu2_m128i(const __m128i* const hiaddr, const __m128i* const loaddr)


### PR DESCRIPTION
GCC 10.1 now includes avx intrinsics