### PR TITLE
Fix undefined behavior within load_tile_var_sizes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -49,6 +49,7 @@
 * Fixed a small memory leak when opening arrays. [#1690](https://github.com/TileDB-Inc/TileDB/pull/1690)
 * Fixed an overflow in the partioning path that may result in a hang or poor read performance. [#1725](https://github.com/TileDB-Inc/TileDB/pull/1725)[#1707](https://github.com/TileDB-Inc/TileDB/pull/1707)
 * Fix compilation on gcc 10.1 for blosc [#1740](https://github.com/TileDB-Inc/TileDB/pull/1740)
+* Fixed a rare hang in the usage of `load_tile_var_sizes`. [#1748](https://github.com/TileDB-Inc/TileDB/pull/1748)
 
 
 # TileDB v2.0.6 Release Notes

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1672,18 +1672,17 @@ Status Subarray::load_relevant_fragment_tile_var_sizes(
   if (var_names.empty())
     return Status::Ok();
 
-  // Load in parallel all tile var sizes metadata across fragments
-  auto statuses = parallel_for_2d(
-      0,
-      relevant_fragments_.size(),
-      0,
-      var_names.size(),
-      [&](unsigned i, uint64_t j) {
-        auto f = relevant_fragments_[i];
-        return meta[f]->load_tile_var_sizes(*encryption_key, var_names[j]);
-      });
-  for (auto st : statuses)
-    RETURN_NOT_OK(st);
+  // Load all metadata for tile var sizes among fragments.
+  for (const auto& var_name : var_names) {
+    const auto statuses =
+        parallel_for(0, relevant_fragments_.size(), [&](const size_t i) {
+          auto f = relevant_fragments_[i];
+          return meta[f]->load_tile_var_sizes(*encryption_key, var_name);
+        });
+
+    for (const auto& st : statuses)
+      RETURN_NOT_OK(st);
+  }
 
   return Status::Ok();
 }


### PR DESCRIPTION
The `load_tile_var_sizes` is not thread-safe between TBB tasks because it
locks with an stdlib mutex. This change ensures that access to FragmentMetadata
instances are serialized.