### PR TITLE
Misc. Range::end_size() fix

### DIFF
--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -156,6 +156,8 @@ class Range {
    * Non-zero only for var-sized ranges.
    */
   uint64_t end_size() const {
+    if (range_start_size_ == 0)
+      return 0;
     return range_.size() - range_start_size_;
   }
 


### PR DESCRIPTION
The `Range::end_size()` contract states that it will return non-zero for
var-sized ranges only. For fixed-sized ranges, it currently returns the range
size instead of 0.

This is not immediately causing a problem and will not be needed for an
in-progress patch.