### PR TITLE
Coalesce Subarray Ranges

### DIFF
--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -90,6 +90,14 @@ class Range {
     std::memcpy(&range_[0], r, r_size);
   }
 
+  /** Sets a fixed-sized range `[r1, r2]`. */
+  void set_range(const void* r1, const void* r2, uint64_t range_size) {
+    range_.resize(range_size);
+    std::memcpy(&range_[0], r1, (range_size / 2));
+    auto c = (char*)(&range_[0]);
+    std::memcpy(c + (range_size / 2), r2, (range_size / 2));
+  }
+
   /** Sets a var-sized range serialized in `r`. */
   void set_range(const void* r, uint64_t r_size, uint64_t range_start_size) {
     range_.resize(r_size);

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -725,7 +725,7 @@ class Subarray {
    * @param frag_idx The fragment id.
    * @param dense Whether the fragment is dense or sparse.
    * @param range_num The number of ranges.
-   *
+   * @return Status
    */
   Status compute_relevant_fragment_tile_overlap(
       FragmentMetadata* meta,
@@ -739,6 +739,21 @@ class Subarray {
    */
   Status load_relevant_fragment_tile_var_sizes(
       const std::vector<std::string>& names) const;
+
+  /**
+   * Coalesces contiguous ranges within ``ranges_``.
+   */
+  void coalesce_ranges();
+
+  /**
+   * Coalesces contiguous ranges within ``ranges_`` at the given
+   * dimension index.
+   *
+   * @tparam T The dimension data type.
+   * @param dim_idx The index into ``ranges_``.
+   */
+  template <class T>
+  void coalesce_dim_ranges(size_t dim_idx);
 };
 
 }  // namespace sm


### PR DESCRIPTION
This patch will coalesce contiguous ranges with discrete data types at the
start of computing tile overlap. This ensures that ranges are coalesced
before they are used in both the read path and result size estimation path.
Additionally, tile overlap is only available for recompute if the ranges change.
This ensures that we do not needlessly rerun the computation to coalesce the
same ranges.

I am currently testing a multi-range index read query. A query that reads an
entire 40MB 2D dense array with a single range in 4 seconds. A query that
reads the same array with 10mil ranges runs in 40 seconds. With this patch,
the 40 seconds are reduced to 4.5 seconds. So computing and coalescing 10 mil
ranges takes about a half second, but saves 36 seconds in my scenario.