### PR TITLE
Improve initialization safety for GCS and VFS

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -41,7 +41,12 @@
 
 ## Improvements
 
+* Lazy initialization for GCS backend [#1752](https://github.com/TileDB-Inc/TileDB/pull/1752)
 * Add additional release artifacts which include disabling TBB [#1753](https://github.com/TileDB-Inc/TileDB/pull/1753)
+
+## Bug fixes
+
+* Fix crash during GCS backend initialization due to upstream bug. [#1752](https://github.com/TileDB-Inc/TileDB/pull/1752)
 
 # TileDB v2.0.7 Release Notes
 

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -276,6 +276,11 @@ class GCS {
   /*         PRIVATE DATATYPES         */
   /* ********************************* */
 
+  /**
+   * Identifies the current state of this class.
+   */
+  enum State { UNINITIALIZED, INITIALIZED };
+
   /** Contains all state associated with a part list upload transaction. */
   class MultiPartUploadState {
    public:
@@ -329,6 +334,15 @@ class GCS {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
+  /** The current state. */
+  State state_;
+
+  /**
+   * Mutex protecting client initialization. This is mutable so that nominally
+   * const functions can call init_client().
+   */
+  mutable std::mutex client_init_mtx_;
+
   /** The VFS thread pool. */
   ThreadPool* thread_pool_;
 
@@ -366,6 +380,13 @@ class GCS {
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
+
+  /**
+   * Initializes the client, if it has not already been initialized.
+   *
+   * @return Status
+   */
+  Status init_client() const;
 
   /**
    * Parses a URI into a bucket name and object path. For example,


### PR DESCRIPTION
- Improve exception safety for GCS backend initialization: try/catch around the initialization block. Fixes crash due to unexpected exception in the GCS SDK (x-ref: https://github.com/googleapis/google-cloud-cpp/issues/4729)
- Implement lazy initialization for GCS, as in #1084 
- ~Add check for valid backend initialization before all VFS operations~

---
[ch2851]