### PR TITLE
Update CI and Built Artifact creation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,8 @@
 
 ## Deprecations
 
+* Support for MacOS older than 10.13 is being dropped when using the AWS SDK. Prebuilt Binaries now target 10.13 [#1753](https://github.com/TileDB-Inc/TileDB/pull/1753)
+
 ## Bug fixes
 
 * Fixed bug in setting a fill value for var-sized attributes.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -35,6 +35,12 @@
 
 * Added functions `Attribute::{set,get}_fill_value` to get/set default fill values
 
+# TileDB v2.0.8 Release Notes
+
+## Improvements
+
+* Add additional release artifacts which include disabling TBB [#1753](https://github.com/TileDB-Inc/TileDB/pull/1753)
+
 # TileDB v2.0.7 Release Notes
 
 ## Improvements

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ stages:
       TILEDB_STATIC: OFF
       TILEDB_SERIALIZATION: ON
       TILEDB_FORCE_BUILD_DEPS: ON
-      MACOSX_DEPLOYMENT_TARGET: 10.9
+      MACOSX_DEPLOYMENT_TARGET: 10.13
     jobs:
      - job:
        strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ stages:
       - template: scripts/azure-windows.yml
 
   - stage: Build_Release
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), eq(variables['Build.SourceBranch'], 'dev'))
     variables:
       TILEDB_S3: ON
       TILEDB_AZURE: ON

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ stages:
       - template: scripts/azure-windows.yml
 
   - stage: Build_Release
-    condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), eq(variables['Build.SourceBranch'], 'dev'))
+    condition: or(or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), eq(variables['Build.SourceBranch'], 'dev')), startsWith(variables['Build.SourceBranch'], 'release-'))
     variables:
       TILEDB_S3: ON
       TILEDB_AZURE: ON

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,32 +156,32 @@ stages:
          vmImage: $(imageName)
        steps:
          - template: scripts/azure-windows-release.yml
-  - ${{ if eq(variables.Build.Repository.Name, 'TileDB-Inc/TileDB') }}:
-    - stage: Github_Release
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
-      jobs:
-       - job:
-         steps:
-          # First download artifacts
-         - task: DownloadBuildArtifacts@0
-           inputs:
-            downloadType: 'specific'
-         - script: |
-             echo $sourceVersion
-             commitHash=${sourceVersion:0:7}
-             echo $commitHash
-             echo "##vso[task.setvariable variable=commitHash]$commitHash" ## Set variable for using in other tasks.
-           env: { sourceVersion: $(Build.SourceVersion) }
-           displayName: Git Hash 7-digit
-         - task: GithubRelease@0
-           condition: succeeded() # only run this job if the build step succeeded
-           displayName: 'Add artifacts to GitHub Release'
-           inputs:
-             gitHubConnection: TileDB-Inc-Release
-             repositoryName: TileDB-Inc/TileDB
-             addChangeLog: false
-             action: edit
-             tag: $(Build.SourceBranchName)
-             assets: |
-               $(Build.ArtifactStagingDirectory)/full/*
-               $(Build.ArtifactStagingDirectory)/without_tbb/*
+
+  - stage: Github_Release
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    jobs:
+     - job:
+       steps:
+        # First download artifacts
+       - task: DownloadBuildArtifacts@0
+         inputs:
+          downloadType: 'specific'
+       - script: |
+           echo $sourceVersion
+           commitHash=${sourceVersion:0:7}
+           echo $commitHash
+           echo "##vso[task.setvariable variable=commitHash]$commitHash" ## Set variable for using in other tasks.
+         env: { sourceVersion: $(Build.SourceVersion) }
+         displayName: Git Hash 7-digit
+       - task: GithubRelease@0
+         condition: succeeded() # only run this job if the build step succeeded
+         displayName: 'Add artifacts to GitHub Release'
+         inputs:
+           gitHubConnection: TileDB-Inc-Release
+           repositoryName: TileDB-Inc/TileDB
+           addChangeLog: false
+           action: edit
+           tag: $(Build.SourceBranchName)
+           assets: |
+             $(Build.ArtifactStagingDirectory)/full/*
+             $(Build.ArtifactStagingDirectory)/without_tbb/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string
 stages:
   - stage: CI
-    condition: not(or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), contains(variables['Build.SourceBranchName'], 'release-')))
+    condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags'))
     jobs:
     - job:
       strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,14 +99,30 @@ stages:
      - job:
        strategy:
          matrix:
+           linux_without_tbb:
+             imageName: 'ubuntu-16.04'
+             CXX: g++
+             TILEDB_TBB: OFF
+             ARTIFACT_OS: 'linux'
+             ARTIFACT_EXTRAS: 'without_tbb'
            linux:
              imageName: 'ubuntu-16.04'
              CXX: g++
+             TILEDB_TBB: ON
              ARTIFACT_OS: 'linux'
+             ARTIFACT_EXTRAS: 'full'
+           macOS_without_tbb:
+             imageName: 'macOS-10.14'
+             CXX: clang++
+             TILEDB_TBB: OFF
+             ARTIFACT_OS: 'macos'
+             ARTIFACT_EXTRAS: 'without_tbb'
            macOS:
              imageName: 'macOS-10.14'
              CXX: clang++
+             TILEDB_TBB: ON
              ARTIFACT_OS: 'macos'
+             ARTIFACT_EXTRAS: 'full'
        pool:
          vmImage: $(imageName)
        steps:
@@ -124,8 +140,18 @@ stages:
 #             TILEDB_HDFS: OFF
              TILEDB_STATIC: OFF
 #             TILEDB_SERIALIZATION: OFF
+             TILEDB_TBB: ON
              TILEDB_FORCE_BUILD_DEPS: ON
              ARTIFACT_OS: 'windows'
+             ARTIFACT_EXTRAS: 'full'
+           VS2017_without_tbb:
+             imageName: 'vs2017-win2016'
+             TILEDB_S3: ON
+             TILEDB_TBB: OFF
+             TILEDB_STATIC: OFF
+             TILEDB_FORCE_BUILD_DEPS: ON
+             ARTIFACT_OS: 'windows'
+             ARTIFACT_EXTRAS: 'without_tbb'
        pool:
          vmImage: $(imageName)
        steps:
@@ -157,6 +183,5 @@ stages:
              action: edit
              tag: $(Build.SourceBranchName)
              assets: |
-               $(Build.ArtifactStagingDirectory)/tiledb-linux-$(Build.SourceBranchName)-$(commitHash).tar.gz/tiledb-linux-$(Build.SourceBranchName)-$(commitHash).tar.gz
-               $(Build.ArtifactStagingDirectory)/tiledb-macos-$(Build.SourceBranchName)-$(commitHash).tar.gz/tiledb-macos-$(Build.SourceBranchName)-$(commitHash).tar.gz
-               $(Build.ArtifactStagingDirectory)/tiledb-windows-$(Build.SourceBranchName)-$(commitHash).zip/tiledb-windows-$(Build.SourceBranchName)-$(commitHash).zip
+               $(Build.ArtifactStagingDirectory)/full/*
+               $(Build.ArtifactStagingDirectory)/without_tbb/*

--- a/scripts/azure-linux_mac-release.yml
+++ b/scripts/azure-linux_mac-release.yml
@@ -123,7 +123,7 @@ steps:
     includeRootFolder: false
     archiveType: 'tar' # Options: zip, 7z, tar, wim
     tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
-    archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz
+    archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash)-$(ARTIFACT_EXTRAS).tar.gz
     replaceExistingArchive: true
     verbose: true # Optional
   condition: succeeded()
@@ -134,19 +134,19 @@ steps:
     includeRootFolder: false
     archiveType: 'tar' # Options: zip, 7z, tar, wim
     tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
-    archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir.tar.gz
+    archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir-$(ARTIFACT_EXTRAS).tar.gz
     replaceExistingArchive: true
     verbose: true # Optional
   condition: succeeded()
 
 - task: PublishBuildArtifacts@1
   inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz'
-      artifactName: 'tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).tar.gz'
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash)-$(ARTIFACT_EXTRAS).tar.gz'
+      artifactName: '$(ARTIFACT_EXTRAS)'
   condition: succeeded()
 
 - task: PublishBuildArtifacts@1
   inputs:
-    pathtoPublish: '$(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir.tar.gz'
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir-$(ARTIFACT_EXTRAS).tar.gz'
     artifactName: 'build-dirs'
   condition: succeeded()

--- a/scripts/azure-windows-release.yml
+++ b/scripts/azure-windows-release.yml
@@ -19,8 +19,10 @@ steps:
       $host.SetShouldExit(1)
     }
 
-    if ($env:TILEDB_S3 -eq "ON") {
+    if ($env:TILEDB_S3 -eq "ON" -And $env:TILEDB_TBB -eq "ON") {
       & "$env:BUILD_SOURCESDIRECTORY\bootstrap.ps1" -EnableS3 -EnableVerbose
+    } elseif ($env:TILEDB_S3 -eq "ON" -And $env:TILEDB_TBB -eq "OFF") {
+      & "$env:BUILD_SOURCESDIRECTORY\bootstrap.ps1" -EnableS3 -EnableVerbose -DisableTBB
     } else {
       & "$env:BUILD_SOURCESDIRECTORY\bootstrap.ps1" -EnableVerbose
     }
@@ -51,7 +53,7 @@ steps:
       rootFolderOrFile: '$(Agent.BuildDirectory)\s\dist\'
       includeRootFolder: false
       archiveType: 'zip' # Options: zip, 7z, tar, wim
-      archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).zip
+      archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash)-$(ARTIFACT_EXTRAS).zip
       replaceExistingArchive: true
       verbose: true # Optional
   condition: succeeded()
@@ -61,19 +63,19 @@ steps:
     rootFolderOrFile: '$(Agent.BuildDirectory)\s\'
     includeRootFolder: false
     archiveType: 'zip' # Options: zip, 7z, tar, wim
-    archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir.zip
+    archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir-$(ARTIFACT_EXTRAS).zip
     replaceExistingArchive: true
     verbose: true # Optional
   condition: succeeded()
 
 - task: PublishBuildArtifacts@1
   inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)\tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).zip'
-      artifactName: 'tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash).zip'
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)\tiledb-$(ARTIFACT_OS)-$(Build.SourceBranchName)-$(commitHash)-$(ARTIFACT_EXTRAS).zip'
+      artifactName: '$(ARTIFACT_EXTRAS)'
   condition: succeeded()
 
 - task: PublishBuildArtifacts@1
   inputs:
-    pathtoPublish: '$(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir.zip'
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir-$(ARTIFACT_EXTRAS).zip'
     artifactName: 'build-dirs'
   condition: succeeded()


### PR DESCRIPTION
Update CI and Built Artifact creation to enable non-TBB builds, improve azure pipeline script, build artifacts for merged to dev and run CI tests on release branch pushes.