### PR TITLE
Recursive ThreadPool

### DIFF
--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -129,7 +129,7 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
           account_name, credential, use_https, blob_endpoint);
 
   // Construct the Azure SDK blob client with a concurrency level
-  // equal to 'thread_pool_->num_threads'. Internally, the client
+  // equal to 'thread_pool_->concurrency_level'. Internally, the client
   // will allocate an equal number of libcurl sessions with
   // 'curl_easy_init'. This ensures that our 'thread_pool_' threads
   // will not block on the blob client's internal request queue
@@ -141,10 +141,10 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
   const std::string cert_file =
       global_state::GlobalState::GetGlobalState().cert_file();
   client_ = std::make_shared<azure::storage_lite::blob_client>(
-      account, thread_pool_->num_threads(), cert_file);
+      account, thread_pool_->concurrency_level(), cert_file);
 #else
   client_ = std::make_shared<azure::storage_lite::blob_client>(
-      account, thread_pool_->num_threads());
+      account, thread_pool_->concurrency_level());
 #endif
 
   // The Azure SDK does not provide a way to configure the retry

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.h
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.h
@@ -36,6 +36,7 @@
 #ifdef HAVE_S3
 
 #include <aws/core/utils/threading/Executor.h>
+#include <mutex>
 #include <unordered_set>
 
 #include "tiledb/sm/misc/thread_pool.h"
@@ -84,7 +85,7 @@ class S3ThreadPoolExecutor : public Aws::Utils::Threading::Executor {
   std::unordered_set<std::shared_ptr<std::future<Status>>> tasks_;
 
   /** Protects 'state_' and 'tasks_'. */
-  std::mutex lock_;
+  std::recursive_mutex lock_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/misc/status.cc
+++ b/tiledb/sm/misc/status.cc
@@ -222,6 +222,9 @@ std::string Status::code_to_string() const {
     case StatusCode::SerializationError:
       type = "[TileDB::Serialization] Error";
       break;
+    case StatusCode::ThreadPoolError:
+      type = "[TileDB::ThreadPool] Error";
+      break;
     default:
       type = "[TileDB::?] Error:";
   }

--- a/tiledb/sm/misc/status.h
+++ b/tiledb/sm/misc/status.h
@@ -122,7 +122,8 @@ enum class StatusCode : char {
   CellSlabIterError,
   RestError,
   SerializationError,
-  ChecksumError
+  ChecksumError,
+  ThreadPoolError
 };
 
 class Status {
@@ -388,6 +389,11 @@ class Status {
   /** Return a SerializationError error class Status with a given message **/
   static Status SerializationError(const std::string& msg) {
     return Status(StatusCode::SerializationError, msg, -1);
+  }
+
+  /** Return a ThreadPoolError error class Status with a given message **/
+  static Status ThreadPoolError(const std::string& msg) {
+    return Status(StatusCode::ThreadPoolError, msg, -1);
   }
 
   /** Returns true iff the status indicates success **/


### PR DESCRIPTION
This patch allows recusive usage of a single ThreadPool instance without deadlock.
While this is a pre-requisite for using a ThreadPool to replace the TBB scheduler,
it does provide a minor but immediate optimization for achieving the same level
of concurrency with one less OS thread.

Consider the following deadlock scenario with our current implementation of
ThreadPool:

```
ThreadPool tp;
tp.init(1 /* num_threads */);

auto outer_task = tp.enqueue([&]() {
  auto inner_task = tp.enqueue([]() {
    foo();
  });
  tp.wait_all_tasks(inner_task);
});

tp.wait_all_tasks(outer_task);
```

In this scenario, we hang on `tp.wait_all_tasks(inner_task);`. The `outer_task`
is running on the single worker thread within `tp`. The `out_task` makes recusive
usage of `tp` to enqueue `inner_task`. The single worker thread will never
make progress waiting on `inner_task` because it can not be scheduled.

This patch changes the behavior of the `ThreadPool:wait_all*()` routines. As
these routines iterate through their tasks to wait on, they will work on
pending tasks if the task they are waiting on has not completed. This ensures
they will never deadlock.

In the above scenario, the call to `tp.wait_all_tasks(inner_task);` would make
progress by executing `inner_task` before waiting on it.

Note that the ThreadPool::init() now accepts a `concurrency_level` instead of
`num_threads`. The motiviation for this is that I expect `tp.init(1)` to be
serial. In this scenario, there are no worker threads. All enqueued work
tasks are executed immediately.