### PR TITLE
Rename ThreadPool::enqueue to ThreadPool::execute

### DIFF
--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -1067,7 +1067,7 @@ Status Azure::write_blocks(
           thread_buffer_len,
           block_id);
       std::future<Status> task =
-          thread_pool_->enqueue(std::move(upload_block_fn));
+          thread_pool_->execute(std::move(upload_block_fn));
       tasks.emplace_back(std::move(task));
     }
 

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -827,7 +827,7 @@ Status GCS::write_parts(
           thread_buffer,
           thread_buffer_len);
       std::future<Status> task =
-          thread_pool_->enqueue(std::move(upload_part_fn));
+          thread_pool_->execute(std::move(upload_part_fn));
       tasks.emplace_back(std::move(task));
     }
 
@@ -965,7 +965,7 @@ void GCS::delete_parts(
   for (const auto& part_path : part_paths) {
     std::function<Status()> delete_part_fn =
         std::bind(&GCS::delete_part, this, bucket_name, part_path);
-    std::future<Status> task = thread_pool_->enqueue(std::move(delete_part_fn));
+    std::future<Status> task = thread_pool_->execute(std::move(delete_part_fn));
     tasks.emplace_back(std::move(task));
   }
 

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -528,7 +528,7 @@ Status Posix::write(
       uint64_t thread_nbytes = end - begin + 1;
       uint64_t thread_file_offset = file_offset + begin;
       auto thread_buffer = reinterpret_cast<const char*>(buffer) + begin;
-      results.push_back(vfs_thread_pool_->enqueue(
+      results.push_back(vfs_thread_pool_->execute(
           [fd, thread_file_offset, thread_buffer, thread_nbytes]() {
             return write_at(
                 fd, thread_file_offset, thread_buffer, thread_nbytes);

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.cc
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.cc
@@ -102,10 +102,10 @@ bool S3ThreadPoolExecutor::SubmitToThread(std::function<void()>&& fn) {
     return false;
   }
 
-  // 'ThreadPool::enqueue' may execute 'wrapped_fn' on this thread.
+  // 'ThreadPool::execute' may invoke 'wrapped_fn' on this thread.
   // Although we are holding 'lock_', it is safe because it is a
   // recursive mutex.
-  *task_ptr = thread_pool_->enqueue(wrapped_fn);
+  *task_ptr = thread_pool_->execute(wrapped_fn);
   if (!task_ptr->valid()) {
     return false;
   }

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -1181,7 +1181,7 @@ Status VFS::read(
       uint64_t thread_nbytes = end - begin + 1;
       uint64_t thread_offset = offset + begin;
       auto thread_buffer = reinterpret_cast<char*>(buffer) + begin;
-      auto task = cancelable_tasks_.enqueue(
+      auto task = cancelable_tasks_.execute(
           &thread_pool_,
           [this, uri, thread_offset, thread_buffer, thread_nbytes]() {
             return read_impl(uri, thread_offset, thread_buffer, thread_nbytes);
@@ -1266,7 +1266,7 @@ Status VFS::read_all(
   for (const auto& batch : batches) {
     URI uri_copy = uri;
     BatchedRead batch_copy = batch;
-    auto task = thread_pool->enqueue([uri_copy, batch_copy, this]() {
+    auto task = thread_pool->execute([uri_copy, batch_copy, this]() {
       Buffer buffer;
       RETURN_NOT_OK(buffer.realloc(batch_copy.nbytes));
       RETURN_NOT_OK(

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -316,7 +316,7 @@ class VFS {
    * @param uri The URI of the file.
    * @param regions The list of regions to read. Each region is a tuple
    *    `(file_offset, dest_buffer, nbytes)`.
-   * @param thread_pool Thread pool to enqueue async read tasks to.
+   * @param thread_pool Thread pool to execute async read tasks to.
    * @param tasks Vector to which new async read tasks are pushed.
    * @return Status
    */

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -479,7 +479,7 @@ Status Win::write(
       uint64_t thread_nbytes = end - begin + 1;
       uint64_t thread_file_offset = file_offset + begin;
       auto thread_buffer = reinterpret_cast<const char*>(buffer) + begin;
-      results.push_back(vfs_thread_pool_->enqueue(
+      results.push_back(vfs_thread_pool_->execute(
           [file_h, thread_file_offset, thread_buffer, thread_nbytes]() {
             return write_at(
                 file_h, thread_file_offset, thread_buffer, thread_nbytes);

--- a/tiledb/sm/misc/cancelable_tasks.cc
+++ b/tiledb/sm/misc/cancelable_tasks.cc
@@ -41,14 +41,14 @@ CancelableTasks::CancelableTasks()
     , should_cancel_(false) {
 }
 
-std::future<Status> CancelableTasks::enqueue(
+std::future<Status> CancelableTasks::execute(
     ThreadPool* const thread_pool,
     std::function<Status()>&& fn,
     std::function<void()>&& on_cancel) {
   std::function<Status()> wrapped_fn =
       std::bind(&CancelableTasks::fn_wrapper, this, fn, on_cancel);
 
-  std::future<Status> task = thread_pool->enqueue(std::move(wrapped_fn));
+  std::future<Status> task = thread_pool->execute(std::move(wrapped_fn));
   if (task.valid()) {
     std::unique_lock<std::mutex> lck(outstanding_tasks_mutex_);
     ++outstanding_tasks_;

--- a/tiledb/sm/misc/cancelable_tasks.h
+++ b/tiledb/sm/misc/cancelable_tasks.h
@@ -58,18 +58,19 @@ class CancelableTasks {
   ~CancelableTasks() = default;
 
   /**
-   * Enqueue a new task to be executed on the specified thread pool.
+   * Execute a task on the specified thread pool.
    *
    * @param function Task to be executed.
    * @param function Optional routine to execute on cancelation.
    * @return Future for the return value of the task.
    */
-  std::future<Status> enqueue(
+  std::future<Status> execute(
       ThreadPool* thread_pool,
       std::function<Status()>&& fn,
       std::function<void()>&& on_cancel = nullptr);
+
   /**
-   * Waits for all enqueued tasks to cancel. If a task is already running, it
+   * Waits for all pending tasks to cancel. If a task is already running, it
    * will run to completion.
    */
   void cancel_all_tasks();

--- a/tiledb/sm/misc/thread_pool.cc
+++ b/tiledb/sm/misc/thread_pool.cc
@@ -81,10 +81,10 @@ Status ThreadPool::init(const uint64_t concurrency_level) {
   return st;
 }
 
-std::future<Status> ThreadPool::enqueue(std::function<Status()>&& function) {
+std::future<Status> ThreadPool::execute(std::function<Status()>&& function) {
   if (concurrency_level_ == 0) {
     std::future<Status> invalid_future;
-    LOG_ERROR("Cannot enqueue task; thread pool uninitialized.");
+    LOG_ERROR("Cannot execute task; thread pool uninitialized.");
     return invalid_future;
   }
 
@@ -92,7 +92,7 @@ std::future<Status> ThreadPool::enqueue(std::function<Status()>&& function) {
 
   if (should_terminate_) {
     std::future<Status> invalid_future;
-    LOG_ERROR("Cannot enqueue task; thread pool has terminated.");
+    LOG_ERROR("Cannot execute task; thread pool has terminated.");
     return invalid_future;
   }
 

--- a/tiledb/sm/misc/thread_pool.h
+++ b/tiledb/sm/misc/thread_pool.h
@@ -73,21 +73,22 @@ class ThreadPool {
   Status init(uint64_t concurrency_level = 1);
 
   /**
-   * Enqueue a new task to be executed. If the returned `future` object
+   * Schedule a new task to be executed. If the returned `future` object
    * is valid, `function` is guaranteed to execute. The 'function' may
-   * execute on the calling thread.
+   * execute immediately on the calling thread. To avoid deadlock, `function`
+   * should not aquire non-recursive locks held by the calling thread.
    *
    * @param function Task function to execute.
    * @return Future for the return value of the task.
    */
-  std::future<Status> enqueue(std::function<Status()>&& function);
+  std::future<Status> execute(std::function<Status()>&& function);
 
   /** Return the maximum level of concurrency. */
   uint64_t concurrency_level() const;
 
   /**
    * Wait on all the given tasks to complete. This is safe to call recusively
-   * and may execute enqueued tasks on this thread while waiting.
+   * and may execute pending tasks on the calling thread while waiting.
    *
    * @param tasks Task list to wait on.
    * @return Status::Ok if all tasks returned Status::Ok, otherwise the first
@@ -97,8 +98,8 @@ class ThreadPool {
 
   /**
    * Wait on all the given tasks to complete, return a vector of their return
-   * Status. This is safe to call recusively and may execute enqueued tasks
-   * on this thread while waiting.
+   * Status. This is safe to call recusively and may execute pending tasks
+   * on the calling thread while waiting.
    *
    * @param tasks Task list to wait on
    * @return Vector of each task's Status.

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -2542,7 +2542,7 @@ Status Writer::write_all_tiles(
   std::vector<std::future<Status>> tasks;
   for (auto& it : *tiles) {
     tasks.push_back(
-        storage_manager_->writer_thread_pool()->enqueue([&, this]() {
+        storage_manager_->writer_thread_pool()->execute([&, this]() {
           RETURN_CANCEL_OR_ERROR(write_tiles(it.first, frag_meta, &it.second));
           return Status::Ok();
         }));

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1030,7 +1030,7 @@ Status StorageManager::array_xunlock(const URI& array_uri) {
 }
 
 Status StorageManager::async_push_query(Query* query) {
-  cancelable_tasks_.enqueue(
+  cancelable_tasks_.execute(
       &async_thread_pool_,
       [this, query]() {
         // Process query.


### PR DESCRIPTION
This is a non-functional change that just renames ThreadPool::enqueue to
ThreadPool::execute. The motiviation for this patch is:
- We don't use a traditional FIFO queue for scheduling tasks anymore (it is
LIFO).
- The 'enqueue' name gives the impression that the tasks are always queued for
future execution. With a concurrency_level == 1, tasks may execute immediately.
This is an important distinction for reasoning about how locks behave. Consider
the following:

```
std::mutex my_mutex;
my_mutex.lock();
my_tp.enqueue([&]() {
  my_mutex.lock();
  // critical section
  my_mutex.unlock();
});
my_mutex.unlock();
```

In this snippet, we will deadlock if `enqueue` executes on the calling thread.
While this is contrived example and there are easy workarounds (for example,
using a std::recursive_mutex or releasing the lock before calling ::enqueue),
the `enqueue` name is misleading.

Recall that `wait_all*` has similar behavior (may execute tasks on the calling
thread) which is a necessary requirement for recursive use of a single ThreadPool
instance.