### PR TITLE
Remove deprecated export tag on 'tiledb_coords'.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,6 +30,7 @@
 ## Bug fixes
 
 * Fixed bug in setting a fill value for var-sized attributes.
+* Fixed a bug where the cpp headers would always produce compile-time warnings about using the deprecated c-api "tiledb_coords()" [#1764](https://github.com/TileDB-Inc/TileDB/pull/1764)
 
 ## API additions
 

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -422,7 +422,7 @@ tiledb_vfs_mode_from_str(const char* str, tiledb_vfs_mode_t* vfs_mode);
  * each individual dimension with the `set_buffer` API. Consult the current
  * documentation for more information.
  */
-TILEDB_DEPRECATED_EXPORT const char* tiledb_coords();
+TILEDB_EXPORT const char* tiledb_coords();
 
 /** Returns a special value indicating a variable number of elements. */
 TILEDB_EXPORT uint32_t tiledb_var_num();


### PR DESCRIPTION
While we have deprecated the use of the named-coords, we still reference the
'tiledb_coords()' c-api through the 'TILEDB_COORDS' macro in the cpp-api. When
including the cpp-api header, the compiler will always throw warnings about
use of the deprecated 'tiledb_coords()' API.