### PR TITLE
Remove use of TILEDB_COORDS in cpp-api

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,6 +30,7 @@
 ## Bug fixes
 
 * Fixed bug in setting a fill value for var-sized attributes.
+* Fixed a bug where the cpp headers would always produce compile-time warnings about using the deprecated c-api "tiledb_coords()" [#1765](https://github.com/TileDB-Inc/TileDB/pull/1765)
 
 ## API additions
 

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -1115,7 +1115,7 @@ class Array {
    * std::vector<int> data_a1(max_elements["a1"].second);
    *
    * // In sparse reads, coords are also fixed-sized attributes.
-   * std::vector<int> coords(max_elements[TILEDB_COORDS].second);
+   * std::vector<int> coords(max_elements["__coords"].second);
    *
    * // In variable attributes, e.g. std::string type, need two buffers,
    * // one for offsets and one for cell data.
@@ -1125,7 +1125,7 @@ class Array {
    *
    * @tparam T The domain datatype
    * @param subarray Targeted subarray.
-   * @return A map of attribute name (including `TILEDB_COORDS`) to
+   * @return A map of attribute name (including `"__coords"`) to
    *     the maximum number of elements that can be read in the given subarray.
    *     For each attribute, a pair of numbers are returned. The first,
    *     for variable-length attributes, is the maximum number of offsets
@@ -1172,9 +1172,8 @@ class Array {
     // Handle coordinates
     type_size = tiledb_datatype_size(schema_.domain().type());
     ctx.handle_error(tiledb_array_max_buffer_size(
-        c_ctx, array_.get(), TILEDB_COORDS, subarray.data(), &attr_size));
-    ret[TILEDB_COORDS] =
-        std::pair<uint64_t, uint64_t>(0, attr_size / type_size);
+        c_ctx, array_.get(), "__coords", subarray.data(), &attr_size));
+    ret["__coords"] = std::pair<uint64_t, uint64_t>(0, attr_size / type_size);
 
     return ret;
   }

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -363,7 +363,7 @@ class Query {
    * auto num_a1_elements = result_el["a1"].second;
    *
    * // Coords are also fixed-sized.
-   * auto num_coords = result_el[TILEDB_COORDS].second;
+   * auto num_coords = result_el["__coords"].second;
    *
    * // In variable attributes, e.g. std::string type, need two buffers,
    * // one for offsets and one for cell data ("elements").
@@ -382,7 +382,7 @@ class Query {
       auto attr_name = b_it.first;
       auto size_pair = b_it.second;
       auto var =
-          ((attr_name != TILEDB_COORDS) &&
+          ((attr_name != "__coords") &&
            ((schema_.has_attribute(attr_name) &&
              schema_.attribute(attr_name).cell_val_num() == TILEDB_VAR_NUM) ||
             (schema_.domain().has_dimension(attr_name) &&
@@ -779,7 +779,7 @@ class Query {
   template <typename T>
   TILEDB_DEPRECATED Query& set_coordinates(T* buf, uint64_t size) {
     impl::type_check<T>(schema_.domain().type());
-    return set_buffer(TILEDB_COORDS, buf, size);
+    return set_buffer("__coords", buf, size);
   }
 
   /**
@@ -832,7 +832,7 @@ class Query {
     // Checks
     auto is_attr = schema_.has_attribute(name);
     auto is_dim = schema_.domain().has_dimension(name);
-    if (name != TILEDB_COORDS && !is_attr && !is_dim)
+    if (name != "__coords" && !is_attr && !is_dim)
       throw TileDBError(
           std::string("Cannot set buffer; Attribute/Dimension '") + name +
           "' does not exist");
@@ -840,7 +840,7 @@ class Query {
       impl::type_check<T>(schema_.attribute(name).type());
     else if (is_dim)
       impl::type_check<T>(schema_.domain().dimension(name).type());
-    else if (name == TILEDB_COORDS)
+    else if (name == "__coords")
       impl::type_check<T>(schema_.domain().type());
 
     return set_buffer(name, buff, nelements, sizeof(T));
@@ -882,14 +882,14 @@ class Query {
     // Checks
     auto is_attr = schema_.has_attribute(name);
     auto is_dim = schema_.domain().has_dimension(name);
-    if (name != TILEDB_COORDS && !is_attr && !is_dim)
+    if (name != "__coords" && !is_attr && !is_dim)
       throw TileDBError(
           std::string("Cannot set buffer; Attribute/Dimension '") + name +
           "' does not exist");
 
     // Compute element size (in bytes).
     size_t element_size = 0;
-    if (name == TILEDB_COORDS)
+    if (name == "__coords")
       element_size = tiledb_datatype_size(schema_.domain().type());
     else if (is_attr)
       element_size = tiledb_datatype_size(schema_.attribute(name).type());


### PR DESCRIPTION
The TILEDB_COORDS macro invokes `tiledb_coords()` which is tagged for
compile-time deprecation. To avoid compile-time warnings when importing the
cpp-api, we must not use the TILEDB_COORDS macro. This patch hard-codes the
"__coords" name. This is reasonably safe because the named-coordinate attribute
exists for backwards compatability and will not be changed in the future.