### PR TITLE
Refactor threading model

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
 
 ## New features
 
+* Added configuration option "sm.compute_concurrency_level" [#1766](https://github.com/TileDB-Inc/TileDB/pull/1766)
+* Added configuration option "sm.io_concurrency_level" [#1766](https://github.com/TileDB-Inc/TileDB/pull/1766)
 * Added configuration option "sm.sub_partitioner_memory_budget" [#1729](https://github.com/TileDB-Inc/TileDB/pull/1729)
 
 ## Improvements
@@ -24,6 +26,10 @@
 
 ## Deprecations
 
+* Deprecated config option "sm.num_async_threads" [#1766](https://github.com/TileDB-Inc/TileDB/pull/1766)
+* Deprecated config option "sm.num_reader_threads" [#1766](https://github.com/TileDB-Inc/TileDB/pull/1766)
+* Deprecated config option "sm.num_writer_threads" [#1766](https://github.com/TileDB-Inc/TileDB/pull/1766)
+* Deprecated config option "sm.num_vfs_threads" [#1766](https://github.com/TileDB-Inc/TileDB/pull/1766)
 * Support for MacOS older than 10.13 is being dropped when using the AWS SDK. Prebuilt Binaries now target 10.13 [#1753](https://github.com/TileDB-Inc/TileDB/pull/1753)
 * Use of Intel's Thread Building Blocks (TBB) will be discontinued in the future. It is now disabled by default [#1762](https://github.com/TileDB-Inc/TileDB/pull/1762)
 

--- a/test/src/unit-SubarrayPartitioner-dense.cc
+++ b/test/src/unit-SubarrayPartitioner-dense.cc
@@ -264,8 +264,10 @@ void SubarrayPartitionerDenseFx::test_subarray_partitioner(
   Subarray subarray;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
 
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_);
+      subarray, memory_budget_, memory_budget_var_, &tp);
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), budget);
   CHECK(st.ok());
 
@@ -283,8 +285,10 @@ void SubarrayPartitionerDenseFx::test_subarray_partitioner(
   Subarray subarray;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
 
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_);
+      subarray, memory_budget_, memory_budget_var_, &tp);
 
   // Note: this is necessary, otherwise the subarray partitioner does
   // not check if the memory budget is exceeded for attributes whose
@@ -555,8 +559,10 @@ TEST_CASE_METHOD(
 
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
 
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_);
+      subarray, memory_budget_, memory_budget_var_, &tp);
   auto st = subarray_partitioner.set_result_budget("a", 100 * sizeof(int));
   CHECK(st.ok());
   st = subarray_partitioner.set_result_budget("b", 1, 1);

--- a/test/src/unit-SubarrayPartitioner-error.cc
+++ b/test/src/unit-SubarrayPartitioner-error.cc
@@ -140,8 +140,10 @@ TEST_CASE_METHOD(
   SubarrayRanges<uint64_t> ranges = {};
   Layout subarray_layout = Layout::GLOBAL_ORDER;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_);
+      subarray, memory_budget_, memory_budget_var_, &tp);
   uint64_t budget, budget_off, budget_val;
 
   auto st = subarray_partitioner.get_result_budget("a", &budget);

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -355,8 +355,10 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
   Subarray subarray;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
 
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_);
+      subarray, memory_budget_, memory_budget_var_, &tp);
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), budget);
   CHECK(st.ok());
 
@@ -376,8 +378,10 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
   Subarray subarray;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
 
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget, memory_budget_var);
+      subarray, memory_budget, memory_budget_var, &tp);
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), result_budget);
   CHECK(st.ok());
 
@@ -395,8 +399,10 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
   Subarray subarray;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
 
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_);
+      subarray, memory_budget_, memory_budget_var_, &tp);
 
   // Note: this is necessary, otherwise the subarray partitioner does
   // not check if the memory budget is exceeded for attributes whose
@@ -667,8 +673,10 @@ TEST_CASE_METHOD(
 
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
 
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_);
+      subarray, memory_budget_, memory_budget_var_, &tp);
   auto st = subarray_partitioner.set_result_budget("a", 100);
   CHECK(st.ok());
   st = subarray_partitioner.set_result_budget("b", 1, 1);
@@ -2259,7 +2267,10 @@ TEST_CASE_METHOD(
   tiledb::sm::Range r;
   r.set_str_range("bb", "bb");
   subarray.add_range(0, r);
-  SubarrayPartitioner partitioner(subarray, memory_budget_, memory_budget_var_);
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
+  SubarrayPartitioner partitioner(
+      subarray, memory_budget_, memory_budget_var_, &tp);
   auto st = partitioner.set_result_budget("d", 10);
   CHECK(!st.ok());
   uint64_t budget = 0;
@@ -2286,7 +2297,7 @@ TEST_CASE_METHOD(
   r.set_str_range("a", "bb");
   subarray_full.add_range(0, r);
   SubarrayPartitioner partitioner_full(
-      subarray_full, memory_budget_, memory_budget_var_);
+      subarray_full, memory_budget_, memory_budget_var_, &tp);
   st = partitioner_full.set_result_budget("d", 16, 4);
   CHECK(st.ok());
   CHECK(partitioner_full.get_result_budget("d", &budget_off, &budget_val).ok());
@@ -2306,7 +2317,7 @@ TEST_CASE_METHOD(
   r.set_str_range("a", "bb");
   subarray_split.add_range(0, r);
   SubarrayPartitioner partitioner_split(
-      subarray_split, memory_budget_, memory_budget_var_);
+      subarray_split, memory_budget_, memory_budget_var_, &tp);
   st = partitioner_split.set_result_budget("d", 10, 4);
   CHECK(st.ok());
   CHECK(
@@ -2336,7 +2347,7 @@ TEST_CASE_METHOD(
   r.set_str_range("bb", "cc");
   subarray_no_split.add_range(0, r);
   SubarrayPartitioner partitioner_no_split(
-      subarray_no_split, memory_budget_, memory_budget_var_);
+      subarray_no_split, memory_budget_, memory_budget_var_, &tp);
   st = partitioner_no_split.set_result_budget("d", 16, 10);
   CHECK(st.ok());
   CHECK(partitioner_no_split.get_result_budget("d", &budget_off, &budget_val)
@@ -2358,7 +2369,7 @@ TEST_CASE_METHOD(
   r.set_str_range("bb", "cc");
   subarray_split_2.add_range(0, r);
   SubarrayPartitioner partitioner_split_2(
-      subarray_split_2, memory_budget_, memory_budget_var_);
+      subarray_split_2, memory_budget_, memory_budget_var_, &tp);
   st = partitioner_split_2.set_result_budget("d", 8, 10);
   CHECK(st.ok());
   CHECK(partitioner_split_2.get_result_budget("d", &budget_off, &budget_val)
@@ -2485,7 +2496,10 @@ TEST_CASE_METHOD(
   tiledb::sm::Range r;
   r.set_str_range("cc", "ccd");
   subarray.add_range(0, r);
-  SubarrayPartitioner partitioner(subarray, memory_budget_, memory_budget_var_);
+  ThreadPool tp;
+  CHECK(tp.init(4).ok());
+  SubarrayPartitioner partitioner(
+      subarray, memory_budget_, memory_budget_var_, &tp);
   auto st = partitioner.set_result_budget("d", 10, 4);
   CHECK(st.ok());
   CHECK(partitioner.get_result_budget("d", &budget_off, &budget_val).ok());

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -216,6 +216,8 @@ void check_save_to_file() {
   ss << "sm.check_coord_dups true\n";
   ss << "sm.check_coord_oob true\n";
   ss << "sm.check_global_order true\n";
+  ss << "sm.compute_concurrency_level " << std::thread::hardware_concurrency()
+     << "\n";
   ss << "sm.consolidation.amplification 1.0\n";
   ss << "sm.consolidation.buffer_size 50000000\n";
   ss << "sm.consolidation.mode fragments\n";
@@ -225,12 +227,11 @@ void check_save_to_file() {
   ss << "sm.consolidation.steps 4294967295\n";
   ss << "sm.dedup_coords false\n";
   ss << "sm.enable_signal_handlers true\n";
+  ss << "sm.io_concurrency_level " << std::thread::hardware_concurrency()
+     << "\n";
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
-  ss << "sm.num_async_threads 1\n";
-  ss << "sm.num_reader_threads " << std::thread::hardware_concurrency() << "\n";
   ss << "sm.num_tbb_threads -1\n";
-  ss << "sm.num_writer_threads " << std::thread::hardware_concurrency() << "\n";
   ss << "sm.skip_checksum_validation false\n";
   ss << "sm.sub_partitioner_memory_budget 0\n";
   ss << "sm.tile_cache_size 10000000\n";
@@ -252,7 +253,6 @@ void check_save_to_file() {
   ss << "vfs.min_batch_gap 512000\n";
   ss << "vfs.min_batch_size 20971520\n";
   ss << "vfs.min_parallel_size 10485760\n";
-  ss << "vfs.num_threads " << std::thread::hardware_concurrency() << "\n";
   ss << "vfs.s3.connect_max_tries 5\n";
   ss << "vfs.s3.connect_scale_factor 25\n";
   ss << "vfs.s3.connect_timeout_ms 3000\n";
@@ -433,11 +433,10 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.memory_budget_var"] = "10737418240";
   all_param_values["sm.sub_partitioner_memory_budget"] = "0";
   all_param_values["sm.enable_signal_handlers"] = "true";
-  all_param_values["sm.num_async_threads"] = "1";
-  all_param_values["sm.num_reader_threads"] =
+  all_param_values["sm.compute_concurrency_level"] =
       std::to_string(std::thread::hardware_concurrency());
   ;
-  all_param_values["sm.num_writer_threads"] =
+  all_param_values["sm.io_concurrency_level"] =
       std::to_string(std::thread::hardware_concurrency());
   ;
   all_param_values["sm.num_tbb_threads"] = "-1";
@@ -451,8 +450,6 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.consolidation.mode"] = "fragments";
   all_param_values["sm.vacuum.mode"] = "fragments";
 
-  all_param_values["vfs.num_threads"] =
-      std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.min_batch_gap"] = "512000";
   all_param_values["vfs.min_batch_size"] = "20971520";
   all_param_values["vfs.min_parallel_size"] = "10485760";
@@ -503,8 +500,6 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.hdfs.name_node_uri"] = "";
 
   std::map<std::string, std::string> vfs_param_values;
-  vfs_param_values["num_threads"] =
-      std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["min_batch_gap"] = "512000";
   vfs_param_values["min_batch_size"] = "20971520";
   vfs_param_values["min_parallel_size"] = "10485760";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -60,7 +60,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 45);
+  CHECK(names.size() == 44);
 }
 
 TEST_CASE(
@@ -90,14 +90,14 @@ TEST_CASE(
     "C++ API: Config Environment Variables Default Override",
     "[cppapi], [cppapi-config]") {
   tiledb::Config config;
-  const std::string key = "vfs.num_threads";
+  const std::string key = "sm.io_concurrency_level";
 
   unsigned int threads = std::thread::hardware_concurrency();
   const std::string result1 = config[key];
   CHECK(result1 == std::to_string(threads));
 
   const std::string value2 = std::to_string(threads + 1);
-  setenv_local("TILEDB_VFS_NUM_THREADS", value2.c_str());
+  setenv_local("TILEDB_SM_IO_CONCURRENCY_LEVEL", value2.c_str());
   const std::string result2 = config[key];
   CHECK(result2 == value2);
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -683,10 +683,6 @@ Status Array::metadata(Metadata** metadata) {
   return Status::Ok();
 }
 
-uint64_t Array::num_threads() const {
-  return storage_manager_->num_threads();
-}
-
 const NDRange& Array::non_empty_domain() {
   if (!non_empty_domain_computed_) {
     // Compute non-empty domain

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -302,9 +302,6 @@ class Array {
    */
   Metadata* metadata();
 
-  /** Returns the number of threads used for parallel execution. */
-  uint64_t num_threads() const;
-
   /** Returns the non-empty domain of the opened array.
    *  If the non_empty_domain has not been computed or loaded
    *  it will be loaded first

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3895,9 +3895,13 @@ int32_t tiledb_vfs_alloc(
   }
 
   // Initialize VFS object
+  auto compute_tp = ctx->ctx_->storage_manager()->compute_tp();
+  auto io_tp = ctx->ctx_->storage_manager()->io_tp();
   auto vfs_config = config ? config->config_ : nullptr;
   auto ctx_config = ctx->ctx_->storage_manager()->config();
-  if (SAVE_ERROR_CATCH(ctx, (*vfs)->vfs_->init(&ctx_config, vfs_config))) {
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          (*vfs)->vfs_->init(compute_tp, io_tp, &ctx_config, vfs_config))) {
     delete (*vfs)->vfs_;
     delete vfs;
     return TILEDB_ERR;
@@ -4500,7 +4504,8 @@ int32_t tiledb_deserialize_query(
               (tiledb::sm::SerializationType)serialize_type,
               client_side == 1,
               nullptr,
-              query->query_)))
+              query->query_,
+              ctx->ctx_->storage_manager()->compute_tp())))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -61,10 +61,9 @@ const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
 const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
 const std::string Config::SM_SUB_PARTITIONER_MEMORY_BUDGET = "0";
 const std::string Config::SM_ENABLE_SIGNAL_HANDLERS = "true";
-const std::string Config::SM_NUM_ASYNC_THREADS = "1";
-const std::string Config::SM_NUM_READER_THREADS =
+const std::string Config::SM_COMPUTE_CONCURRENCY_LEVEL =
     utils::parse::to_str(std::thread::hardware_concurrency());
-const std::string Config::SM_NUM_WRITER_THREADS =
+const std::string Config::SM_IO_CONCURRENCY_LEVEL =
     utils::parse::to_str(std::thread::hardware_concurrency());
 #ifdef HAVE_TBB
 const std::string Config::SM_NUM_TBB_THREADS =
@@ -81,24 +80,25 @@ const std::string Config::SM_CONSOLIDATION_STEP_MAX_FRAGS = "4294967295";
 const std::string Config::SM_CONSOLIDATION_STEP_SIZE_RATIO = "0.0";
 const std::string Config::SM_CONSOLIDATION_MODE = "fragments";
 const std::string Config::SM_VACUUM_MODE = "fragments";
-const std::string Config::VFS_NUM_THREADS =
-    utils::parse::to_str(std::thread::hardware_concurrency());
 const std::string Config::VFS_MIN_PARALLEL_SIZE = "10485760";
 const std::string Config::VFS_MIN_BATCH_GAP = "512000";
 const std::string Config::VFS_MIN_BATCH_SIZE = "20971520";
 const std::string Config::VFS_FILE_POSIX_FILE_PERMISSIONS = "644";
 const std::string Config::VFS_FILE_POSIX_DIRECTORY_PERMISSIONS = "755";
-const std::string Config::VFS_FILE_MAX_PARALLEL_OPS = Config::VFS_NUM_THREADS;
+const std::string Config::VFS_FILE_MAX_PARALLEL_OPS =
+    Config::SM_IO_CONCURRENCY_LEVEL;
 const std::string Config::VFS_FILE_ENABLE_FILELOCKS = "true";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_NAME = "";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_KEY = "";
 const std::string Config::VFS_AZURE_BLOB_ENDPOINT = "";
 const std::string Config::VFS_AZURE_USE_HTTPS = "true";
-const std::string Config::VFS_AZURE_MAX_PARALLEL_OPS = Config::VFS_NUM_THREADS;
+const std::string Config::VFS_AZURE_MAX_PARALLEL_OPS =
+    Config::SM_IO_CONCURRENCY_LEVEL;
 const std::string Config::VFS_AZURE_BLOCK_LIST_BLOCK_SIZE = "5242880";
 const std::string Config::VFS_AZURE_USE_BLOCK_LIST_UPLOAD = "true";
 const std::string Config::VFS_GCS_PROJECT_ID = "";
-const std::string Config::VFS_GCS_MAX_PARALLEL_OPS = Config::VFS_NUM_THREADS;
+const std::string Config::VFS_GCS_MAX_PARALLEL_OPS =
+    Config::SM_IO_CONCURRENCY_LEVEL;
 const std::string Config::VFS_GCS_MULTI_PART_SIZE = "5242880";
 const std::string Config::VFS_GCS_USE_MULTI_PART_UPLOAD = "true";
 const std::string Config::VFS_S3_REGION = "us-east-1";
@@ -109,7 +109,8 @@ const std::string Config::VFS_S3_SCHEME = "https";
 const std::string Config::VFS_S3_ENDPOINT_OVERRIDE = "";
 const std::string Config::VFS_S3_USE_VIRTUAL_ADDRESSING = "true";
 const std::string Config::VFS_S3_USE_MULTIPART_UPLOAD = "true";
-const std::string Config::VFS_S3_MAX_PARALLEL_OPS = Config::VFS_NUM_THREADS;
+const std::string Config::VFS_S3_MAX_PARALLEL_OPS =
+    Config::SM_IO_CONCURRENCY_LEVEL;
 const std::string Config::VFS_S3_MULTIPART_PART_SIZE = "5242880";
 const std::string Config::VFS_S3_CA_FILE = "";
 const std::string Config::VFS_S3_CA_PATH = "";
@@ -168,9 +169,8 @@ Config::Config() {
   param_values_["sm.sub_partitioner_memory_budget"] =
       SM_SUB_PARTITIONER_MEMORY_BUDGET;
   param_values_["sm.enable_signal_handlers"] = SM_ENABLE_SIGNAL_HANDLERS;
-  param_values_["sm.num_async_threads"] = SM_NUM_ASYNC_THREADS;
-  param_values_["sm.num_reader_threads"] = SM_NUM_READER_THREADS;
-  param_values_["sm.num_writer_threads"] = SM_NUM_WRITER_THREADS;
+  param_values_["sm.compute_concurrency_level"] = SM_COMPUTE_CONCURRENCY_LEVEL;
+  param_values_["sm.io_concurrency_level"] = SM_IO_CONCURRENCY_LEVEL;
   param_values_["sm.num_tbb_threads"] = SM_NUM_TBB_THREADS;
   param_values_["sm.skip_checksum_validation"] = SM_SKIP_CHECKSUM_VALIDATION;
   param_values_["sm.consolidation.amplification"] =
@@ -185,7 +185,6 @@ Config::Config() {
   param_values_["sm.consolidation.steps"] = SM_CONSOLIDATION_STEPS;
   param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
   param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
-  param_values_["vfs.num_threads"] = VFS_NUM_THREADS;
   param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
@@ -389,12 +388,11 @@ Status Config::unset(const std::string& param) {
         SM_SUB_PARTITIONER_MEMORY_BUDGET;
   } else if (param == "sm.enable_signal_handlers") {
     param_values_["sm.enable_signal_handlers"] = SM_ENABLE_SIGNAL_HANDLERS;
-  } else if (param == "sm.num_async_threads") {
-    param_values_["sm.num_async_threads"] = SM_NUM_ASYNC_THREADS;
-  } else if (param == "sm.num_reader_threads") {
-    param_values_["sm.num_reader_threads"] = SM_NUM_READER_THREADS;
-  } else if (param == "sm.num_writer_threads") {
-    param_values_["sm.num_writer_threads"] = SM_NUM_WRITER_THREADS;
+  } else if (param == "sm.compute_concurrency_level") {
+    param_values_["sm.compute_concurrency_level"] =
+        SM_COMPUTE_CONCURRENCY_LEVEL;
+  } else if (param == "sm.io_concurrency_level") {
+    param_values_["sm.io_concurrency_level"] = SM_IO_CONCURRENCY_LEVEL;
   } else if (param == "sm.num_tbb_threads") {
     param_values_["sm.num_tbb_threads"] = SM_NUM_TBB_THREADS;
   } else if (param == "sm.consolidation.amplification") {
@@ -418,8 +416,6 @@ Status Config::unset(const std::string& param) {
     param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
   } else if (param == "sm.vacuum.mode") {
     param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
-  } else if (param == "vfs.num_threads") {
-    param_values_["vfs.num_threads"] = VFS_NUM_THREADS;
   } else if (param == "vfs.min_parallel_size") {
     param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   } else if (param == "vfs.min_batch_gap") {
@@ -570,11 +566,9 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "sm.enable_signal_handlers") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
-  } else if (param == "sm.num_async_threads") {
+  } else if (param == "sm.compute_concurrency_level") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
-  } else if (param == "sm.num_reader_threads") {
-    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
-  } else if (param == "sm.num_writer_threads") {
+  } else if (param == "sm.io_concurrency_level") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "sm.num_tbb_threads") {
     RETURN_NOT_OK(utils::parse::convert(value, &vint));
@@ -590,8 +584,6 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &v32));
   } else if (param == "sm.consolidation.step_size_ratio") {
     RETURN_NOT_OK(utils::parse::convert(value, &vf));
-  } else if (param == "vfs.num_threads") {
-    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_parallel_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_batch_gap") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -118,14 +118,11 @@ class Config {
   /** Whether or not the signal handlers are installed. */
   static const std::string SM_ENABLE_SIGNAL_HANDLERS;
 
-  /** The number of threads allocated per StorageManager for async queries. */
-  static const std::string SM_NUM_ASYNC_THREADS;
+  /** The maximum concurrency level for compute-bound operations. */
+  static const std::string SM_COMPUTE_CONCURRENCY_LEVEL;
 
-  /** The number of threads allocated per StorageManager for the Reader pool. */
-  static const std::string SM_NUM_READER_THREADS;
-
-  /** The number of threads allocated per StorageManager for the Writer pool. */
-  static const std::string SM_NUM_WRITER_THREADS;
+  /** The maximum concurrency level for io-bound operations. */
+  static const std::string SM_IO_CONCURRENCY_LEVEL;
 
   /** The number of threads allocated for TBB. */
   static const std::string SM_NUM_TBB_THREADS;
@@ -179,9 +176,6 @@ class Config {
    *     - "array_meta": only the array metadata will be vacuumed
    */
   static const std::string SM_VACUUM_MODE;
-
-  /** The default number of allocated VFS threads. */
-  static const std::string VFS_NUM_THREADS;
 
   /** The default minimum number of bytes in a parallel VFS operation. */
   static const std::string VFS_MIN_PARALLEL_SIZE;

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -261,7 +261,11 @@ class VFS {
    * @param config Configuration parameters
    * @return Status
    */
-  Status init(const Config* ctx_config, const Config* vfs_config);
+  Status init(
+      ThreadPool* compute_tp,
+      ThreadPool* io_tp,
+      const Config* ctx_config,
+      const Config* vfs_config);
 
   /**
    * Terminates the virtual system. Must only be called if init() returned
@@ -443,8 +447,11 @@ class VFS {
   /** The set with the supported filesystems. */
   std::set<Filesystem> supported_fs_;
 
-  /** Thread pool for parallel I/O operations. */
-  ThreadPool thread_pool_;
+  /** Thread pool for compute-bound tasks. */
+  ThreadPool* compute_tp_;
+
+  /** Thread pool for io-bound tasks. */
+  ThreadPool* io_tp_;
 
   /** Wrapper for tracking and canceling certain tasks on 'thread_pool' */
   CancelableTasks cancelable_tasks_;

--- a/tiledb/sm/global_state/global_state.cc
+++ b/tiledb/sm/global_state/global_state.cc
@@ -40,6 +40,7 @@
 
 #ifdef __linux__
 #include "tiledb/sm/filesystem/posix.h"
+#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/utils.h"
 #endif
 
@@ -51,8 +52,6 @@ namespace global_state {
 
 #ifdef HAVE_TBB
 extern int tbb_nthreads_;
-#else
-extern std::shared_ptr<ThreadPool> global_tp_;
 #endif
 
 GlobalState& GlobalState::GetGlobalState() {
@@ -133,15 +132,7 @@ int GlobalState::tbb_threads() {
 #ifdef HAVE_TBB
   return tbb_nthreads_;
 #else
-  return global_tp_->concurrency_level();
-#endif
-}
-
-std::shared_ptr<ThreadPool> GlobalState::tp() {
-#ifdef HAVE_TBB
-  return nullptr;
-#else
-  return global_tp_;
+  return 0;
 #endif
 }
 

--- a/tiledb/sm/global_state/global_state.h
+++ b/tiledb/sm/global_state/global_state.h
@@ -39,7 +39,6 @@
 
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
 
 namespace tiledb {
 namespace sm {
@@ -99,12 +98,6 @@ class GlobalState {
    * @return the number of configured TBB threads.
    */
   int tbb_threads();
-
-  /**
-   * Returns the global ThreadPool instance for use when TBB is disabled.
-   * @return The thread pool instance.
-   */
-  std::shared_ptr<ThreadPool> tp();
 
  private:
   /** The TileDB configuration parameters. */

--- a/tiledb/sm/global_state/tbb_state.cc
+++ b/tiledb/sm/global_state/tbb_state.cc
@@ -33,51 +33,18 @@
 
 #include "tiledb/sm/global_state/tbb_state.h"
 #include "tiledb/sm/config/config.h"
-#include "tiledb/sm/misc/thread_pool.h"
-
-#include <cassert>
-#include <sstream>
 
 #ifdef HAVE_TBB
+
 #include <tbb/task_scheduler_init.h>
+#include <cassert>
 #include <cstdlib>
 #include <memory>
-#endif
+#include <sstream>
 
 namespace tiledb {
 namespace sm {
 namespace global_state {
-
-Status get_nthreads(const Config* const config, int* const nthreads) {
-  if (!config) {
-    *nthreads = std::strtol(Config::SM_NUM_TBB_THREADS.c_str(), nullptr, 10);
-  } else {
-    bool found = false;
-    RETURN_NOT_OK(config->get<int>("sm.num_tbb_threads", nthreads, &found));
-    assert(found);
-  }
-
-#ifdef HAVE_TBB
-  if (*nthreads == tbb::task_scheduler_init::automatic) {
-    *nthreads = tbb::task_scheduler_init::default_num_threads();
-  }
-#else
-  if (*nthreads <= 0) {
-    *nthreads = std::thread::hardware_concurrency();
-  }
-#endif
-
-  if (*nthreads < 1) {
-    std::stringstream msg;
-    msg << "TBB thread runtime must be initialized with >= 1 threads, got: "
-        << *nthreads;
-    return Status::Error(msg.str());
-  }
-
-  return Status::Ok();
-}
-
-#ifdef HAVE_TBB
 
 /** The TBB scheduler, used for controlling the number of TBB threads. */
 static std::unique_ptr<tbb::task_scheduler_init> tbb_scheduler_;
@@ -85,10 +52,25 @@ static std::unique_ptr<tbb::task_scheduler_init> tbb_scheduler_;
 /** The number of TBB threads the scheduler was configured with **/
 int tbb_nthreads_;
 
-Status init_tbb(const Config* const config) {
+Status init_tbb(const Config* config) {
   int nthreads;
-  RETURN_NOT_OK(get_nthreads(config, &nthreads));
+  if (!config) {
+    nthreads = std::strtol(Config::SM_NUM_TBB_THREADS.c_str(), nullptr, 10);
+  } else {
+    bool found = false;
+    RETURN_NOT_OK(config->get<int>("sm.num_tbb_threads", &nthreads, &found));
+    assert(found);
+  }
 
+  if (nthreads == tbb::task_scheduler_init::automatic) {
+    nthreads = tbb::task_scheduler_init::default_num_threads();
+  }
+  if (nthreads < 1) {
+    std::stringstream msg;
+    msg << "TBB thread runtime must be initialized with >= 1 threads, got: "
+        << nthreads;
+    return Status::Error(msg.str());
+  }
   if (!tbb_scheduler_) {
     // initialize scheduler in process for a custom number of threads (upon
     // first thread calling init_tbb)
@@ -117,39 +99,25 @@ Status init_tbb(const Config* const config) {
   return Status::Ok();
 }
 
+}  // namespace global_state
+}  // namespace sm
+}  // namespace tiledb
+
 #else
 
-/** The ThreadPool to use when TBB is disabled. */
-std::shared_ptr<ThreadPool> global_tp_;
+namespace tiledb {
+namespace sm {
+namespace global_state {
+
+int tbb_nthreads_ = 0;
 
 Status init_tbb(const Config* config) {
-  int nthreads;
-  RETURN_NOT_OK(get_nthreads(config, &nthreads));
-
-  if (!global_tp_) {
-    global_tp_ = std::make_shared<ThreadPool>();
-    const Status st = global_tp_->init(nthreads);
-    if (!st.ok()) {
-      global_tp_ = nullptr;
-    }
-    RETURN_NOT_OK(st);
-  } else {
-    // If the thread pool has already been initialized, check
-    // invariants.
-    if (nthreads != static_cast<int>(global_tp_->concurrency_level())) {
-      std::stringstream msg;
-      msg << "Global thread pool must be initialized with the same number of "
-             "threads: "
-          << nthreads << " != " << global_tp_->concurrency_level();
-      return Status::Error(msg.str());
-    }
-  }
-
+  (void)config;
   return Status::Ok();
 }
-
-#endif
 
 }  // namespace global_state
 }  // namespace sm
 }  // namespace tiledb
+
+#endif

--- a/tiledb/sm/misc/thread_pool.h
+++ b/tiledb/sm/misc/thread_pool.h
@@ -38,6 +38,7 @@
 #include <mutex>
 #include <stack>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "tiledb/sm/misc/status.h"
@@ -128,6 +129,12 @@ class ThreadPool {
   /** When true, all pending tasks will remain unscheduled. */
   bool should_terminate_;
 
+  /** Indexes thread ids to the ThreadPool instance they belong to. */
+  static std::unordered_map<std::thread::id, ThreadPool*> tp_index_;
+
+  /** Protects 'tp_index_'. */
+  static std::mutex tp_index_lock_;
+
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
@@ -145,6 +152,15 @@ class ThreadPool {
 
   /** The worker thread routine. */
   static void worker(ThreadPool& pool);
+
+  // Add indexes from each thread to this instance.
+  void add_tp_index();
+
+  // Remove indexes from each thread to this instance.
+  void remove_tp_index();
+
+  // Lookup the thread pool instance from the calling thread.
+  ThreadPool* lookup_tp();
 };
 
 }  // namespace sm

--- a/tiledb/sm/misc/thread_pool.h
+++ b/tiledb/sm/misc/thread_pool.h
@@ -114,7 +114,7 @@ class ThreadPool {
 
   uint64_t concurrency_level_;
 
-  /** Protects `task_stack_` */
+  /** Protects `task_stack_` and `idle_threads_`. */
   std::mutex task_stack_mutex_;
 
   /** Notifies work threads to check `task_stack_` for work. */
@@ -122,6 +122,12 @@ class ThreadPool {
 
   /** Pending tasks in LIFO ordering. */
   std::stack<std::packaged_task<Status()>> task_stack_;
+
+  /**
+   * The number of threads waiting for the `task_stack_` to
+   * become non-empty.
+   */
+  uint64_t idle_threads_;
 
   /** The worker threads. */
   std::vector<std::thread> threads_;

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -591,59 +591,60 @@ Status Writer::check_coord_dups(const std::vector<uint64_t>& cell_pos) const {
     buffs_var_sizes[d] = buffers_.find(dim_name)->second.buffer_var_size_;
   }
 
-  auto statuses = parallel_for(1, coords_num_, [&](uint64_t i) {
-    // Check for duplicate in adjacent cells
-    bool found_dup = true;
-    for (unsigned d = 0; d < dim_num; ++d) {
-      auto dim = array_schema_->dimension(d);
-      if (!dim->var_size()) {  // Fixed-sized dimensions
-        if (memcmp(
-                buffs[d] + cell_pos[i] * coord_sizes[d],
-                buffs[d] + cell_pos[i - 1] * coord_sizes[d],
-                coord_sizes[d]) != 0) {  // Not the same
-          found_dup = false;
-          break;
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 1, coords_num_, [&](uint64_t i) {
+        // Check for duplicate in adjacent cells
+        bool found_dup = true;
+        for (unsigned d = 0; d < dim_num; ++d) {
+          auto dim = array_schema_->dimension(d);
+          if (!dim->var_size()) {  // Fixed-sized dimensions
+            if (memcmp(
+                    buffs[d] + cell_pos[i] * coord_sizes[d],
+                    buffs[d] + cell_pos[i - 1] * coord_sizes[d],
+                    coord_sizes[d]) != 0) {  // Not the same
+              found_dup = false;
+              break;
+            }
+          } else {
+            auto offs = (uint64_t*)buffs[d];
+            auto a = cell_pos[i];
+            auto b = cell_pos[i - 1];
+            auto off_a = offs[a];
+            auto off_b = offs[b];
+            auto off_a_plus_1 =
+                (a == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[a + 1];
+            auto off_b_plus_1 =
+                (b == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[b + 1];
+            auto size_a = off_a_plus_1 - off_a;
+            auto size_b = off_b_plus_1 - off_b;
+
+            // Compare sizes
+            if (size_a != size_b) {  // Not same
+              found_dup = false;
+              break;
+            }
+
+            // Compare var values
+            if (memcmp(
+                    buffs_var[d] + off_a,
+                    buffs_var[d] + off_b,
+                    size_a) != 0) {  // Not the same
+              found_dup = false;
+              break;
+            }
+          }
         }
-      } else {
-        auto offs = (uint64_t*)buffs[d];
-        auto a = cell_pos[i];
-        auto b = cell_pos[i - 1];
-        auto off_a = offs[a];
-        auto off_b = offs[b];
-        auto off_a_plus_1 =
-            (a == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[a + 1];
-        auto off_b_plus_1 =
-            (b == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[b + 1];
-        auto size_a = off_a_plus_1 - off_a;
-        auto size_b = off_b_plus_1 - off_b;
 
-        // Compare sizes
-        if (size_a != size_b) {  // Not same
-          found_dup = false;
-          break;
+        // Found duplicate
+        if (found_dup) {
+          std::stringstream ss;
+          ss << "Duplicate coordinates " << coords_to_str(cell_pos[i]);
+          ss << " are not allowed";
+          return Status::WriterError(ss.str());
         }
 
-        // Compare var values
-        if (memcmp(
-                buffs_var[d] + off_a,
-                buffs_var[d] + off_b,
-                size_a) != 0) {  // Not the same
-          found_dup = false;
-          break;
-        }
-      }
-    }
-
-    // Found duplicate
-    if (found_dup) {
-      std::stringstream ss;
-      ss << "Duplicate coordinates " << coords_to_str(cell_pos[i]);
-      ss << " are not allowed";
-      return Status::WriterError(ss.str());
-    }
-
-    return Status::Ok();
-  });
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses)
@@ -685,53 +686,54 @@ Status Writer::check_coord_dups() const {
     buffs_var_sizes[d] = buffers_.find(dim_name)->second.buffer_var_size_;
   }
 
-  auto statuses = parallel_for(1, coords_num_, [&](uint64_t i) {
-    // Check for duplicate in adjacent cells
-    bool found_dup = true;
-    for (unsigned d = 0; d < dim_num; ++d) {
-      auto dim = array_schema_->dimension(d);
-      if (!dim->var_size()) {  // Fixed-sized dimensions
-        if (memcmp(
-                buffs[d] + i * coord_sizes[d],
-                buffs[d] + (i - 1) * coord_sizes[d],
-                coord_sizes[d]) != 0) {  // Not the same
-          found_dup = false;
-          break;
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 1, coords_num_, [&](uint64_t i) {
+        // Check for duplicate in adjacent cells
+        bool found_dup = true;
+        for (unsigned d = 0; d < dim_num; ++d) {
+          auto dim = array_schema_->dimension(d);
+          if (!dim->var_size()) {  // Fixed-sized dimensions
+            if (memcmp(
+                    buffs[d] + i * coord_sizes[d],
+                    buffs[d] + (i - 1) * coord_sizes[d],
+                    coord_sizes[d]) != 0) {  // Not the same
+              found_dup = false;
+              break;
+            }
+          } else {
+            auto offs = (uint64_t*)buffs[d];
+            auto off_i_plus_1 =
+                (i == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[i + 1];
+            auto size_i_minus_1 = offs[i] - offs[i - 1];
+            auto size_i = off_i_plus_1 - offs[i];
+
+            // Compare sizes
+            if (size_i != size_i_minus_1) {  // Not same
+              found_dup = false;
+              break;
+            }
+
+            // Compare var values
+            if (memcmp(
+                    buffs_var[d] + offs[i - 1],
+                    buffs_var[d] + offs[i],
+                    size_i) != 0) {  // Not the same
+              found_dup = false;
+              break;
+            }
+          }
         }
-      } else {
-        auto offs = (uint64_t*)buffs[d];
-        auto off_i_plus_1 =
-            (i == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[i + 1];
-        auto size_i_minus_1 = offs[i] - offs[i - 1];
-        auto size_i = off_i_plus_1 - offs[i];
 
-        // Compare sizes
-        if (size_i != size_i_minus_1) {  // Not same
-          found_dup = false;
-          break;
+        // Found duplicate
+        if (found_dup) {
+          std::stringstream ss;
+          ss << "Duplicate coordinates " << coords_to_str(i);
+          ss << " are not allowed";
+          return Status::WriterError(ss.str());
         }
 
-        // Compare var values
-        if (memcmp(
-                buffs_var[d] + offs[i - 1],
-                buffs_var[d] + offs[i],
-                size_i) != 0) {  // Not the same
-          found_dup = false;
-          break;
-        }
-      }
-    }
-
-    // Found duplicate
-    if (found_dup) {
-      std::stringstream ss;
-      ss << "Duplicate coordinates " << coords_to_str(i);
-      ss << " are not allowed";
-      return Status::WriterError(ss.str());
-    }
-
-    return Status::Ok();
-  });
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses)
@@ -768,8 +770,13 @@ Status Writer::check_coord_oob() const {
   }
 
   // Check if all coordinates fall in the domain in parallel
-  auto statuses =
-      parallel_for_2d(0, coords_num_, 0, dim_num, [&](uint64_t c, unsigned d) {
+  auto statuses = parallel_for_2d(
+      storage_manager_->compute_tp(),
+      0,
+      coords_num_,
+      0,
+      dim_num,
+      [&](uint64_t c, unsigned d) {
         auto dim = array_schema_->dimension(d);
         if (datatype_is_string(dim->type()))
           return Status::Ok();
@@ -807,22 +814,24 @@ Status Writer::check_global_order() const {
 
   // Check if all coordinates fall in the domain in parallel
   auto domain = array_schema_->domain();
-  auto statuses = parallel_for(0, coords_num_ - 1, [&](uint64_t i) {
-    auto tile_cmp = domain->tile_order_cmp(buffs, i, i + 1);
-    auto fail = (tile_cmp > 0) || ((tile_cmp == 0) &&
-                                   domain->cell_order_cmp(buffs, i, i + 1) > 0);
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 0, coords_num_ - 1, [&](uint64_t i) {
+        auto tile_cmp = domain->tile_order_cmp(buffs, i, i + 1);
+        auto fail =
+            (tile_cmp > 0) ||
+            ((tile_cmp == 0) && domain->cell_order_cmp(buffs, i, i + 1) > 0);
 
-    if (fail) {
-      std::stringstream ss;
-      ss << "Write failed; Coordinates " << coords_to_str(i);
-      ss << " succeed " << coords_to_str(i + 1);
-      ss << " in the global order";
-      if (tile_cmp > 0)
-        ss << " due to writes across tiles";
-      return Status::WriterError(ss.str());
-    }
-    return Status::Ok();
-  });
+        if (fail) {
+          std::stringstream ss;
+          ss << "Write failed; Coordinates " << coords_to_str(i);
+          ss << " succeed " << coords_to_str(i + 1);
+          ss << " in the global order";
+          if (tile_cmp > 0)
+            ss << " due to writes across tiles";
+          return Status::WriterError(ss.str());
+        }
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses)
@@ -904,57 +913,58 @@ Status Writer::compute_coord_dups(
   }
 
   std::mutex mtx;
-  auto statuses = parallel_for(1, coords_num_, [&](uint64_t i) {
-    // Check for duplicate in adjacent cells
-    bool found_dup = true;
-    for (unsigned d = 0; d < dim_num; ++d) {
-      auto dim = array_schema_->dimension(d);
-      if (!dim->var_size()) {  // Fixed-sized dimensions
-        if (memcmp(
-                buffs[d] + cell_pos[i] * coord_sizes[d],
-                buffs[d] + cell_pos[i - 1] * coord_sizes[d],
-                coord_sizes[d]) != 0) {  // Not the same
-          found_dup = false;
-          break;
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 1, coords_num_, [&](uint64_t i) {
+        // Check for duplicate in adjacent cells
+        bool found_dup = true;
+        for (unsigned d = 0; d < dim_num; ++d) {
+          auto dim = array_schema_->dimension(d);
+          if (!dim->var_size()) {  // Fixed-sized dimensions
+            if (memcmp(
+                    buffs[d] + cell_pos[i] * coord_sizes[d],
+                    buffs[d] + cell_pos[i - 1] * coord_sizes[d],
+                    coord_sizes[d]) != 0) {  // Not the same
+              found_dup = false;
+              break;
+            }
+          } else {
+            auto offs = (uint64_t*)buffs[d];
+            auto a = cell_pos[i];
+            auto b = cell_pos[i - 1];
+            auto off_a = offs[a];
+            auto off_b = offs[b];
+            auto off_a_plus_1 =
+                (a == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[a + 1];
+            auto off_b_plus_1 =
+                (b == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[b + 1];
+            auto size_a = off_a_plus_1 - off_a;
+            auto size_b = off_b_plus_1 - off_b;
+
+            // Compare sizes
+            if (size_a != size_b) {  // Not same
+              found_dup = false;
+              break;
+            }
+
+            // Compare var values
+            if (memcmp(
+                    buffs_var[d] + off_a,
+                    buffs_var[d] + off_b,
+                    size_a) != 0) {  // Not the same
+              found_dup = false;
+              break;
+            }
+          }
         }
-      } else {
-        auto offs = (uint64_t*)buffs[d];
-        auto a = cell_pos[i];
-        auto b = cell_pos[i - 1];
-        auto off_a = offs[a];
-        auto off_b = offs[b];
-        auto off_a_plus_1 =
-            (a == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[a + 1];
-        auto off_b_plus_1 =
-            (b == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[b + 1];
-        auto size_a = off_a_plus_1 - off_a;
-        auto size_b = off_b_plus_1 - off_b;
 
-        // Compare sizes
-        if (size_a != size_b) {  // Not same
-          found_dup = false;
-          break;
+        // Found duplicate
+        if (found_dup) {
+          std::lock_guard<std::mutex> lock(mtx);
+          coord_dups->insert(cell_pos[i]);
         }
 
-        // Compare var values
-        if (memcmp(
-                buffs_var[d] + off_a,
-                buffs_var[d] + off_b,
-                size_a) != 0) {  // Not the same
-          found_dup = false;
-          break;
-        }
-      }
-    }
-
-    // Found duplicate
-    if (found_dup) {
-      std::lock_guard<std::mutex> lock(mtx);
-      coord_dups->insert(cell_pos[i]);
-    }
-
-    return Status::Ok();
-  });
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses)
@@ -993,51 +1003,52 @@ Status Writer::compute_coord_dups(std::set<uint64_t>* coord_dups) const {
   }
 
   std::mutex mtx;
-  auto statuses = parallel_for(1, coords_num_, [&](uint64_t i) {
-    // Check for duplicate in adjacent cells
-    bool found_dup = true;
-    for (unsigned d = 0; d < dim_num; ++d) {
-      auto dim = array_schema_->dimension(d);
-      if (!dim->var_size()) {  // Fixed-sized dimensions
-        if (memcmp(
-                buffs[d] + i * coord_sizes[d],
-                buffs[d] + (i - 1) * coord_sizes[d],
-                coord_sizes[d]) != 0) {  // Not the same
-          found_dup = false;
-          break;
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 1, coords_num_, [&](uint64_t i) {
+        // Check for duplicate in adjacent cells
+        bool found_dup = true;
+        for (unsigned d = 0; d < dim_num; ++d) {
+          auto dim = array_schema_->dimension(d);
+          if (!dim->var_size()) {  // Fixed-sized dimensions
+            if (memcmp(
+                    buffs[d] + i * coord_sizes[d],
+                    buffs[d] + (i - 1) * coord_sizes[d],
+                    coord_sizes[d]) != 0) {  // Not the same
+              found_dup = false;
+              break;
+            }
+          } else {
+            auto offs = (uint64_t*)buffs[d];
+            auto off_i_plus_1 =
+                (i == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[i + 1];
+            auto size_i_minus_1 = offs[i] - offs[i - 1];
+            auto size_i = off_i_plus_1 - offs[i];
+
+            // Compare sizes
+            if (size_i != size_i_minus_1) {  // Not same
+              found_dup = false;
+              break;
+            }
+
+            // Compare var values
+            if (memcmp(
+                    buffs_var[d] + offs[i - 1],
+                    buffs_var[d] + offs[i],
+                    size_i) != 0) {  // Not the same
+              found_dup = false;
+              break;
+            }
+          }
         }
-      } else {
-        auto offs = (uint64_t*)buffs[d];
-        auto off_i_plus_1 =
-            (i == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[i + 1];
-        auto size_i_minus_1 = offs[i] - offs[i - 1];
-        auto size_i = off_i_plus_1 - offs[i];
 
-        // Compare sizes
-        if (size_i != size_i_minus_1) {  // Not same
-          found_dup = false;
-          break;
+        // Found duplicate
+        if (found_dup) {
+          std::lock_guard<std::mutex> lock(mtx);
+          coord_dups->insert(i);
         }
 
-        // Compare var values
-        if (memcmp(
-                buffs_var[d] + offs[i - 1],
-                buffs_var[d] + offs[i],
-                size_i) != 0) {  // Not the same
-          found_dup = false;
-          break;
-        }
-      }
-    }
-
-    // Found duplicate
-    if (found_dup) {
-      std::lock_guard<std::mutex> lock(mtx);
-      coord_dups->insert(i);
-    }
-
-    return Status::Ok();
-  });
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses) {
@@ -1071,24 +1082,25 @@ Status Writer::compute_coords_metadata(
   auto dim_num = array_schema_->dim_num();
 
   // Compute MBRs
-  auto statuses = parallel_for(0, tile_num, [&](uint64_t t) {
-    NDRange mbr(dim_num);
-    std::vector<const void*> data(dim_num);
-    for (unsigned d = 0; d < dim_num; ++d) {
-      auto dim = array_schema_->dimension(d);
-      const auto& dim_name = dim->name();
-      auto tiles_it = tiles.find(dim_name);
-      assert(tiles_it != tiles.end());
-      if (!dim->var_size())
-        dim->compute_mbr(tiles_it->second[t], &mbr[d]);
-      else
-        dim->compute_mbr_var(
-            tiles_it->second[2 * t], tiles_it->second[2 * t + 1], &mbr[d]);
-    }
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 0, tile_num, [&](uint64_t t) {
+        NDRange mbr(dim_num);
+        std::vector<const void*> data(dim_num);
+        for (unsigned d = 0; d < dim_num; ++d) {
+          auto dim = array_schema_->dimension(d);
+          const auto& dim_name = dim->name();
+          auto tiles_it = tiles.find(dim_name);
+          assert(tiles_it != tiles.end());
+          if (!dim->var_size())
+            dim->compute_mbr(tiles_it->second[t], &mbr[d]);
+          else
+            dim->compute_mbr_var(
+                tiles_it->second[2 * t], tiles_it->second[2 * t + 1], &mbr[d]);
+        }
 
-    meta->set_mbr(t, mbr);
-    return Status::Ok();
-  });
+        meta->set_mbr(t, mbr);
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses)
@@ -1191,13 +1203,14 @@ Status Writer::filter_tiles(
 
   // Coordinates
   auto num = buffers_.size();
-  auto statuses = parallel_for(0, num, [&](uint64_t i) {
-    auto buff_it = buffers_.begin();
-    std::advance(buff_it, i);
-    const auto& name = buff_it->first;
-    RETURN_CANCEL_OR_ERROR(filter_tiles(name, &((*tiles)[name])));
-    return Status::Ok();
-  });
+  auto statuses =
+      parallel_for(storage_manager_->compute_tp(), 0, num, [&](uint64_t i) {
+        auto buff_it = buffers_.begin();
+        std::advance(buff_it, i);
+        const auto& name = buff_it->first;
+        RETURN_CANCEL_OR_ERROR(filter_tiles(name, &((*tiles)[name])));
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses)
@@ -1238,7 +1251,7 @@ Status Writer::filter_tile(
       &filters, array_->get_encryption_key()));
 
   assert(!tile->filtered());
-  RETURN_NOT_OK(filters.run_forward(tile));
+  RETURN_NOT_OK(filters.run_forward(tile, storage_manager_->compute_tp()));
   assert(tile->filtered());
 
   tile->set_pre_filtered_size(orig_size);
@@ -1412,24 +1425,25 @@ Status Writer::filter_last_tiles(
 
   // Prepare the tiles first
   uint64_t num = buffers_.size();
-  auto statuses = parallel_for(0, num, [&](uint64_t i) {
-    auto buff_it = buffers_.begin();
-    std::advance(buff_it, i);
-    const auto& name = &(buff_it->first);
+  auto statuses =
+      parallel_for(storage_manager_->compute_tp(), 0, num, [&](uint64_t i) {
+        auto buff_it = buffers_.begin();
+        std::advance(buff_it, i);
+        const auto& name = &(buff_it->first);
 
-    auto& last_tile = global_write_state_->last_tiles_[*name].first;
-    auto& last_tile_var = global_write_state_->last_tiles_[*name].second;
+        auto& last_tile = global_write_state_->last_tiles_[*name].first;
+        auto& last_tile_var = global_write_state_->last_tiles_[*name].second;
 
-    if (!last_tile.empty()) {
-      std::vector<Tile>& tiles_ref = (*tiles)[*name];
-      // Note making shallow clones here, as it's not necessary to copy the
-      // underlying tile Buffers.
-      tiles_ref.push_back(last_tile.clone(false));
-      if (!last_tile_var.empty())
-        tiles_ref.push_back(last_tile_var.clone(false));
-    }
-    return Status::Ok();
-  });
+        if (!last_tile.empty()) {
+          std::vector<Tile>& tiles_ref = (*tiles)[*name];
+          // Note making shallow clones here, as it's not necessary to copy the
+          // underlying tile Buffers.
+          tiles_ref.push_back(last_tile.clone(false));
+          if (!last_tile_var.empty())
+            tiles_ref.push_back(last_tile_var.clone(false));
+        }
+        return Status::Ok();
+      });
 
   // Check statuses
   for (auto& st : statuses)
@@ -1758,30 +1772,32 @@ Status Writer::prepare_and_filter_attr_tiles(
     (*attr_tiles)[it.first] = std::vector<Tile>();
 
   uint64_t attr_num = buffers_.size();
-  auto statuses = parallel_for(0, attr_num, [&](uint64_t i) {
-    auto buff_it = buffers_.begin();
-    std::advance(buff_it, i);
-    const auto& attr = buff_it->first;
-    auto& tiles = (*attr_tiles)[attr];
-    RETURN_CANCEL_OR_ERROR(prepare_tiles(attr, write_cell_ranges, &tiles));
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 0, attr_num, [&](uint64_t i) {
+        auto buff_it = buffers_.begin();
+        std::advance(buff_it, i);
+        const auto& attr = buff_it->first;
+        auto& tiles = (*attr_tiles)[attr];
+        RETURN_CANCEL_OR_ERROR(prepare_tiles(attr, write_cell_ranges, &tiles));
 
-    /*
-        if (i == 0) {
-          // Gather stats
-          const uint64_t tile_num = write_cell_ranges.size();
-          uint64_t cell_num = 0;
-          auto var_size = array_schema_->var_size(attr);
-          for (size_t t = 0; t < tile_num; ++t)
-            cell_num += var_size ? tiles[2 * t].cell_num() :
-       tiles[t].cell_num();
-          STATS_ADD_COUNTER(stats::Stats::CounterType::WRITE_CELL_NUM,
-       cell_num); STATS_ADD_COUNTER(stats::Stats::CounterType::WRITE_TILE_NUM,
-       tile_num);
-        }
-    */
-    RETURN_CANCEL_OR_ERROR(filter_tiles(attr, &tiles));
-    return Status::Ok();
-  });
+        /*
+            if (i == 0) {
+              // Gather stats
+              const uint64_t tile_num = write_cell_ranges.size();
+              uint64_t cell_num = 0;
+              auto var_size = array_schema_->var_size(attr);
+              for (size_t t = 0; t < tile_num; ++t)
+                cell_num += var_size ? tiles[2 * t].cell_num() :
+           tiles[t].cell_num();
+              STATS_ADD_COUNTER(stats::Stats::CounterType::WRITE_CELL_NUM,
+           cell_num);
+           STATS_ADD_COUNTER(stats::Stats::CounterType::WRITE_TILE_NUM,
+           tile_num);
+            }
+        */
+        RETURN_CANCEL_OR_ERROR(filter_tiles(attr, &tiles));
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses)
@@ -1802,14 +1818,15 @@ Status Writer::prepare_full_tiles(
     (*tiles)[it.first] = std::vector<Tile>();
 
   auto num = buffers_.size();
-  auto statuses = parallel_for(0, num, [&](uint64_t i) {
-    auto buff_it = buffers_.begin();
-    std::advance(buff_it, i);
-    const auto& name = buff_it->first;
-    RETURN_CANCEL_OR_ERROR(
-        prepare_full_tiles(name, coord_dups, &(*tiles)[name]));
-    return Status::Ok();
-  });
+  auto statuses =
+      parallel_for(storage_manager_->compute_tp(), 0, num, [&](uint64_t i) {
+        auto buff_it = buffers_.begin();
+        std::advance(buff_it, i);
+        const auto& name = buff_it->first;
+        RETURN_CANCEL_OR_ERROR(
+            prepare_full_tiles(name, coord_dups, &(*tiles)[name]));
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses)
@@ -2177,14 +2194,15 @@ Status Writer::prepare_tiles(
 
   // Prepare tiles for all attributes and coordinates
   auto buffer_num = buffers_.size();
-  auto statuses = parallel_for(0, buffer_num, [&](uint64_t i) {
-    auto buff_it = buffers_.begin();
-    std::advance(buff_it, i);
-    const auto& name = buff_it->first;
-    RETURN_CANCEL_OR_ERROR(
-        prepare_tiles(name, cell_pos, coord_dups, &((*tiles)[name])));
-    return Status::Ok();
-  });
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 0, buffer_num, [&](uint64_t i) {
+        auto buff_it = buffers_.begin();
+        std::advance(buff_it, i);
+        const auto& name = buff_it->first;
+        RETURN_CANCEL_OR_ERROR(
+            prepare_tiles(name, cell_pos, coord_dups, &((*tiles)[name])));
+        return Status::Ok();
+      });
 
   // Check all statuses
   for (auto& st : statuses)
@@ -2342,7 +2360,11 @@ Status Writer::sort_coords(std::vector<uint64_t>* cell_pos) const {
     (*cell_pos)[i] = i;
 
   // Sort the coordinates in global order
-  parallel_sort(cell_pos->begin(), cell_pos->end(), GlobalCmp(domain, &buffs));
+  parallel_sort(
+      storage_manager_->compute_tp(),
+      cell_pos->begin(),
+      cell_pos->end(),
+      GlobalCmp(domain, &buffs));
 
   return Status::Ok();
 
@@ -2541,16 +2563,14 @@ Status Writer::write_all_tiles(
 
   std::vector<std::future<Status>> tasks;
   for (auto& it : *tiles) {
-    tasks.push_back(
-        storage_manager_->writer_thread_pool()->execute([&, this]() {
-          RETURN_CANCEL_OR_ERROR(write_tiles(it.first, frag_meta, &it.second));
-          return Status::Ok();
-        }));
+    tasks.push_back(storage_manager_->io_tp()->execute([&, this]() {
+      RETURN_CANCEL_OR_ERROR(write_tiles(it.first, frag_meta, &it.second));
+      return Status::Ok();
+    }));
   }
 
   // Wait for writes and check all statuses
-  auto statuses =
-      storage_manager_->writer_thread_pool()->wait_all_status(tasks);
+  auto statuses = storage_manager_->io_tp()->wait_all_status(tasks);
   for (auto& st : statuses)
     RETURN_NOT_OK(st);
 

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -37,6 +37,7 @@
 #include <unordered_map>
 
 #include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/serialization/query.h"
 
 namespace tiledb {
@@ -54,7 +55,7 @@ class RestClient {
   RestClient();
 
   /** Initialize the REST client with the given config. */
-  Status init(const Config* config);
+  Status init(const Config* config, ThreadPool* compute_tp);
 
   /** Sets a header that will be attached to all requests. */
   Status set_header(const std::string& name, const std::string& value);
@@ -163,6 +164,9 @@ class RestClient {
 
   /** The TileDB config options (contains server and auth info). */
   const Config* config_;
+
+  /** The thread pool for compute-bound tasks. */
+  ThreadPool* compute_tp_;
 
   /** Rest server config param. */
   std::string rest_server_;

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -36,6 +36,7 @@
 #include <unordered_map>
 
 #include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/misc/thread_pool.h"
 
 namespace tiledb {
 namespace sm {
@@ -133,7 +134,8 @@ Status query_deserialize(
     SerializationType serialize_type,
     bool clientside,
     CopyState* copy_state,
-    Query* query);
+    Query* query,
+    ThreadPool* compute_tp);
 
 /**
  * Serialize an estimated result size map for all fields from a query object

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -501,10 +501,11 @@ Status Consolidator::consolidate_fragment_meta(
 
   // Serialize all fragment metadata footers in parallel
   std::vector<Buffer> buffs(meta.size());
-  auto statuses = parallel_for(0, buffs.size(), [&](size_t i) {
-    RETURN_NOT_OK(meta[i]->write_footer(&buffs[i]));
-    return Status::Ok();
-  });
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 0, buffs.size(), [&](size_t i) {
+        RETURN_NOT_OK(meta[i]->write_footer(&buffs[i]));
+        return Status::Ok();
+      });
   for (const auto& st : statuses)
     RETURN_NOT_OK(st);
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -529,30 +529,33 @@ Status StorageManager::array_vacuum_fragments(const char* array_name) {
 
   // Delete the ok files
   RETURN_NOT_OK(array_xlock(array_uri));
-  auto statuses = parallel_for(0, to_vacuum.size(), [&, this](size_t i) {
-    auto uri = URI(to_vacuum[i].to_string() + constants::ok_file_suffix);
-    RETURN_NOT_OK(vfs_->remove_file(uri));
+  auto statuses =
+      parallel_for(&compute_tp_, 0, to_vacuum.size(), [&, this](size_t i) {
+        auto uri = URI(to_vacuum[i].to_string() + constants::ok_file_suffix);
+        RETURN_NOT_OK(vfs_->remove_file(uri));
 
-    return Status::Ok();
-  });
+        return Status::Ok();
+      });
   for (const auto& st : statuses)
     RETURN_NOT_OK_ELSE(st, array_xunlock(array_uri));
   RETURN_NOT_OK(array_xunlock(array_uri));
 
   // Delete fragment directories
-  statuses = parallel_for(0, to_vacuum.size(), [&, this](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_dir(to_vacuum[i]));
+  statuses =
+      parallel_for(&compute_tp_, 0, to_vacuum.size(), [&, this](size_t i) {
+        RETURN_NOT_OK(vfs_->remove_dir(to_vacuum[i]));
 
-    return Status::Ok();
-  });
+        return Status::Ok();
+      });
   for (const auto& st : statuses)
     RETURN_NOT_OK(st);
 
   // Delete vacuum files
-  statuses = parallel_for(0, vac_uris.size(), [&, this](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_file(vac_uris[i]));
-    return Status::Ok();
-  });
+  statuses =
+      parallel_for(&compute_tp_, 0, vac_uris.size(), [&, this](size_t i) {
+        RETURN_NOT_OK(vfs_->remove_file(vac_uris[i]));
+        return Status::Ok();
+      });
   for (const auto& st : statuses)
     RETURN_NOT_OK(st);
 
@@ -580,10 +583,11 @@ Status StorageManager::array_vacuum_fragment_meta(const char* array_name) {
 
   // Vacuum after exclusively locking the array
   RETURN_NOT_OK(array_xlock(array_uri));
-  auto statuses = parallel_for(0, to_vacuum.size(), [&, this](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_file(to_vacuum[i]));
-    return Status::Ok();
-  });
+  auto statuses =
+      parallel_for(&compute_tp_, 0, to_vacuum.size(), [&, this](size_t i) {
+        RETURN_NOT_OK(vfs_->remove_file(to_vacuum[i]));
+        return Status::Ok();
+      });
   for (const auto& st : statuses)
     RETURN_NOT_OK_ELSE(st, array_xunlock(array_uri));
   RETURN_NOT_OK(array_xunlock(array_uri));
@@ -609,20 +613,22 @@ Status StorageManager::array_vacuum_array_meta(const char* array_name) {
 
   // Delete the array metadata files
   RETURN_NOT_OK(array_xlock(array_uri));
-  auto statuses = parallel_for(0, to_vacuum.size(), [&, this](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_file(to_vacuum[i]));
+  auto statuses =
+      parallel_for(&compute_tp_, 0, to_vacuum.size(), [&, this](size_t i) {
+        RETURN_NOT_OK(vfs_->remove_file(to_vacuum[i]));
 
-    return Status::Ok();
-  });
+        return Status::Ok();
+      });
   for (const auto& st : statuses)
     RETURN_NOT_OK_ELSE(st, array_xunlock(array_uri));
   RETURN_NOT_OK(array_xunlock(array_uri));
 
   // Delete vacuum files
-  statuses = parallel_for(0, vac_uris.size(), [&, this](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_file(vac_uris[i]));
-    return Status::Ok();
-  });
+  statuses =
+      parallel_for(&compute_tp_, 0, vac_uris.size(), [&, this](size_t i) {
+        RETURN_NOT_OK(vfs_->remove_file(vac_uris[i]));
+        return Status::Ok();
+      });
   for (const auto& st : statuses)
     RETURN_NOT_OK(st);
 
@@ -1031,7 +1037,7 @@ Status StorageManager::array_xunlock(const URI& array_uri) {
 
 Status StorageManager::async_push_query(Query* query) {
   cancelable_tasks_.execute(
-      &async_thread_pool_,
+      &compute_tp_,
       [this, query]() {
         // Process query.
         Status st = query_submit(query);
@@ -1219,7 +1225,7 @@ Status StorageManager::get_fragment_uris(
 
   // Get only the committed fragment uris
   std::vector<int> is_fragment(uris.size(), 0);
-  auto statuses = parallel_for(0, uris.size(), [&](size_t i) {
+  auto statuses = parallel_for(&compute_tp_, 0, uris.size(), [&](size_t i) {
     if (utils::parse::starts_with(uris[i].last_path_part(), "."))
       return Status::Ok();
     RETURN_NOT_OK(this->is_fragment(uris[i], ok_uris, &is_fragment[i]));
@@ -1339,30 +1345,15 @@ Status StorageManager::init(const Config* config) {
   if (config != nullptr)
     config_ = *config;
 
+  RETURN_NOT_OK(init_thread_pools());
+
   // Get config params
   bool found = false;
-  uint64_t num_async_threads = 0;
-  RETURN_NOT_OK(config_.get<uint64_t>(
-      "sm.num_async_threads", &num_async_threads, &found));
-  assert(found);
-  uint64_t num_reader_threads = 0;
-  RETURN_NOT_OK(config_.get<uint64_t>(
-      "sm.num_reader_threads", &num_reader_threads, &found));
-  assert(found);
-  uint64_t num_writer_threads = 0;
-  RETURN_NOT_OK(config_.get<uint64_t>(
-      "sm.num_writer_threads", &num_writer_threads, &found));
-  assert(found);
   uint64_t tile_cache_size = 0;
   RETURN_NOT_OK(
       config_.get<uint64_t>("sm.tile_cache_size", &tile_cache_size, &found));
   assert(found);
-  RETURN_NOT_OK(config_.get<int>("sm.num_tbb_threads", &num_threads_, &found));
-  assert(found);
 
-  RETURN_NOT_OK(async_thread_pool_.init(num_async_threads));
-  RETURN_NOT_OK(reader_thread_pool_.init(num_reader_threads));
-  RETURN_NOT_OK(writer_thread_pool_.init(num_writer_threads));
   tile_cache_ = new LRUCache(tile_cache_size);
 
   // GlobalState must be initialized before `vfs->init` because S3::init calls
@@ -1371,7 +1362,7 @@ Status StorageManager::init(const Config* config) {
   RETURN_NOT_OK(global_state.init(config));
 
   vfs_ = new VFS();
-  RETURN_NOT_OK(vfs_->init(&config_, nullptr));
+  RETURN_NOT_OK(vfs_->init(&compute_tp_, &io_tp_, &config_, nullptr));
 #ifdef TILEDB_SERIALIZATION
   RETURN_NOT_OK(init_rest_client());
 #endif
@@ -1381,6 +1372,105 @@ Status StorageManager::init(const Config* config) {
   global_state.register_storage_manager(this);
 
   return Status::Ok();
+}
+
+Status StorageManager::init_thread_pools() {
+  // The "sm.num_async_threads", "sm.num_reader_threads",
+  // "sm.num_writer_threads", and "sm.num_vfs_threads" have
+  // been removed. If they are set, we will log an error message.
+  // To error on the side of maintaining high-performance for
+  // existing users, we will take the maximum thread count
+  // among all of these configurations and set them to the new
+  // "sm.compute_concurrency_level" and "sm.io_concurrency_level".
+  uint64_t max_thread_count = 0;
+
+  bool found;
+  uint64_t num_async_threads = 0;
+  RETURN_NOT_OK(config_.get<uint64_t>(
+      "sm.num_async_threads", &num_async_threads, &found));
+  if (found) {
+    max_thread_count = std::max(max_thread_count, num_async_threads);
+    LOG_STATUS(Status::StorageManagerError(
+        "Config parameter \"sm.num_async_threads\" has been removed; use "
+        "config parameter \"sm.compute_concurrency_level\"."));
+  }
+
+  uint64_t num_reader_threads = 0;
+  RETURN_NOT_OK(config_.get<uint64_t>(
+      "sm.num_reader_threads", &num_reader_threads, &found));
+  if (found) {
+    max_thread_count = std::max(max_thread_count, num_reader_threads);
+    LOG_STATUS(Status::StorageManagerError(
+        "Config parameter \"sm.num_reader_threads\" has been removed; use "
+        "config parameter \"sm.compute_concurrency_level\"."));
+  }
+
+  uint64_t num_writer_threads = 0;
+  RETURN_NOT_OK(config_.get<uint64_t>(
+      "sm.num_writer_threads", &num_writer_threads, &found));
+  if (found) {
+    max_thread_count = std::max(max_thread_count, num_writer_threads);
+    LOG_STATUS(Status::StorageManagerError(
+        "Config parameter \"sm.num_writer_threads\" has been removed; use "
+        "config parameter \"sm.compute_concurrency_level\"."));
+  }
+
+  uint64_t num_vfs_threads = 0;
+  RETURN_NOT_OK(
+      config_.get<uint64_t>("sm.num_vfs_threads", &num_vfs_threads, &found));
+  if (found) {
+    max_thread_count = std::max(max_thread_count, num_vfs_threads);
+    LOG_STATUS(Status::StorageManagerError(
+        "Config parameter \"sm.num_vfs_threads\" has been removed; use "
+        "config parameter \"sm.io_concurrency_level\"."));
+  }
+
+  // Fetch the compute and io concurrency levels.
+  uint64_t compute_concurrency_level = 0;
+  RETURN_NOT_OK(config_.get<uint64_t>(
+      "sm.compute_concurrency_level", &compute_concurrency_level, &found));
+  assert(found);
+  uint64_t io_concurrency_level = 0;
+  RETURN_NOT_OK(config_.get<uint64_t>(
+      "sm.io_concurrency_level", &io_concurrency_level, &found));
+  assert(found);
+
+#ifndef HAVE_TBB
+  // The "sm.num_tbb_threads" has been deprecated when TBB is disabled.
+  // Now that TBB is disabled by default, users may still be setting this
+  // configuration parameter larger than the default value. In this scenario,
+  // we will override the compute and io concurrency levels if the configured
+  // tbb threads are greater. We will do this silently because the
+  // "sm.num_tbb_threads" still has a default value in the config. When we
+  // remove TBB, we will also remove this configuration parameter.
+  int num_tbb_threads = 0;
+  RETURN_NOT_OK(
+      config_.get<int>("sm.num_tbb_threads", &num_tbb_threads, &found));
+  assert(found);
+  if (num_tbb_threads > 0)
+    max_thread_count =
+        std::max(max_thread_count, static_cast<uint64_t>(num_tbb_threads));
+#endif
+
+  // If 'max_thread_count' is larger than the compute or io concurrency levels,
+  // use that instead.
+  compute_concurrency_level =
+      std::max(max_thread_count, compute_concurrency_level);
+  io_concurrency_level = std::max(max_thread_count, io_concurrency_level);
+
+  // Initialize the thread pools.
+  RETURN_NOT_OK(compute_tp_.init(compute_concurrency_level));
+  RETURN_NOT_OK(io_tp_.init(io_concurrency_level));
+
+  return Status::Ok();
+}
+
+ThreadPool* StorageManager::compute_tp() {
+  return &compute_tp_;
+}
+
+ThreadPool* StorageManager::io_tp() {
+  return &io_tp_;
 }
 
 RestClient* StorageManager::rest_client() const {
@@ -1774,10 +1864,6 @@ Status StorageManager::read(
   return Status::Ok();
 }
 
-ThreadPool* StorageManager::reader_thread_pool() {
-  return &reader_thread_pool_;
-}
-
 Status StorageManager::set_tag(
     const std::string& key, const std::string& value) {
   tags_[key] = value;
@@ -1892,10 +1978,6 @@ Status StorageManager::sync(const URI& uri) {
   return vfs_->sync(uri);
 }
 
-ThreadPool* StorageManager::writer_thread_pool() {
-  return &writer_thread_pool_;
-}
-
 VFS* StorageManager::vfs() const {
   return vfs_;
 }
@@ -1911,7 +1993,7 @@ Status StorageManager::init_rest_client() {
   RETURN_NOT_OK(config_.get("rest.server_address", &server_address));
   if (server_address != nullptr) {
     rest_client_.reset(new RestClient);
-    RETURN_NOT_OK(rest_client_->init(&config_));
+    RETURN_NOT_OK(rest_client_->init(&config_, &compute_tp_));
   }
 
   return Status::Ok();
@@ -1952,12 +2034,6 @@ Status StorageManager::write(const URI& uri, Buffer* buffer) const {
 
 Status StorageManager::write(const URI& uri, void* data, uint64_t size) const {
   return vfs_->write(uri, data, size);
-}
-
-int StorageManager::num_threads() const {
-  if (num_threads_ < 0)
-    return DEFAULT_CONCURRENCY;
-  return num_threads_;
 }
 
 /* ****************************** */
@@ -2069,7 +2145,7 @@ Status StorageManager::load_array_metadata(
   auto metadata_num = array_metadata_to_load.size();
   std::vector<std::shared_ptr<Buffer>> metadata_buffs;
   metadata_buffs.resize(metadata_num);
-  auto statuses = parallel_for(0, metadata_num, [&](size_t m) {
+  auto statuses = parallel_for(&compute_tp_, 0, metadata_num, [&](size_t m) {
     const auto& uri = array_metadata_to_load[m].uri_;
     auto metadata_buff = open_array->array_metadata(uri);
     if (metadata_buff == nullptr) {  // Array metadata does not exist - load it
@@ -2123,7 +2199,7 @@ Status StorageManager::load_fragment_metadata(
   auto fragment_num = fragments_to_load.size();
   fragment_metadata->resize(fragment_num);
   uint32_t f_version;
-  auto statuses = parallel_for(0, fragment_num, [&](size_t f) {
+  auto statuses = parallel_for(&compute_tp_, 0, fragment_num, [&](size_t f) {
     const auto& sf = fragments_to_load[f];
     auto array_schema = open_array->array_schema();
     auto metadata = open_array->fragment_metadata(sf.uri_);
@@ -2305,21 +2381,22 @@ Status StorageManager::get_uris_to_vacuum(
 
   // Compute fragment URIs to vacuum as a bitmap vector
   std::vector<int32_t> to_vacuum_vec(uris.size(), 0);
-  auto statuses = parallel_for(0, vac_uris->size(), [&, this](size_t i) {
-    uint64_t size = 0;
-    RETURN_NOT_OK(vfs_->file_size((*vac_uris)[i], &size));
-    std::string names;
-    names.resize(size);
-    RETURN_NOT_OK(vfs_->read((*vac_uris)[i], 0, &names[0], size));
-    std::stringstream ss(names);
-    for (std::string uri_str; std::getline(ss, uri_str);) {
-      auto it = uris_map.find(uri_str);
-      if (it != uris_map.end())
-        to_vacuum_vec[it->second] = 1;
-    }
+  auto statuses =
+      parallel_for(&compute_tp_, 0, vac_uris->size(), [&, this](size_t i) {
+        uint64_t size = 0;
+        RETURN_NOT_OK(vfs_->file_size((*vac_uris)[i], &size));
+        std::string names;
+        names.resize(size);
+        RETURN_NOT_OK(vfs_->read((*vac_uris)[i], 0, &names[0], size));
+        std::stringstream ss(names);
+        for (std::string uri_str; std::getline(ss, uri_str);) {
+          auto it = uris_map.find(uri_str);
+          if (it != uris_map.end())
+            to_vacuum_vec[it->second] = 1;
+        }
 
-    return Status::Ok();
-  });
+        return Status::Ok();
+      });
   for (const auto& st : statuses)
     RETURN_NOT_OK(st);
 

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -37,6 +37,7 @@
 
 #include <unordered_map>
 #include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/subarray/subarray.h"
 
 namespace tiledb {
@@ -154,7 +155,8 @@ class SubarrayPartitioner {
   SubarrayPartitioner(
       const Subarray& subarray,
       uint64_t memory_budget,
-      uint64_t memory_budget_var);
+      uint64_t memory_budget_var,
+      ThreadPool* compute_tp);
 
   /** Destructor. */
   ~SubarrayPartitioner();
@@ -299,6 +301,9 @@ class SubarrayPartitioner {
 
   /** The memory budget for the var-sized attributes. */
   uint64_t memory_budget_var_;
+
+  /** The thread pool for compute-bound tasks. */
+  ThreadPool* compute_tp_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/tile/tile_io.cc
+++ b/tiledb/sm/tile/tile_io.cc
@@ -132,7 +132,9 @@ Status TileIO::read_generic(
 
   // Unfilter
   assert((*tile)->filtered());
-  RETURN_NOT_OK_ELSE(header.filters.run_reverse(*tile, config), delete *tile);
+  RETURN_NOT_OK_ELSE(
+      header.filters.run_reverse(*tile, storage_manager_->compute_tp(), config),
+      delete *tile);
   assert(!(*tile)->filtered());
 
   file_size_ = header.persisted_size;
@@ -185,7 +187,8 @@ Status TileIO::write_generic(
 
   // Filter tile
   assert(!tile->filtered());
-  RETURN_NOT_OK(header.filters.run_forward(tile));
+  RETURN_NOT_OK(
+      header.filters.run_forward(tile, storage_manager_->compute_tp()));
   header.persisted_size = tile->filtered_buffer()->size();
   assert(tile->filtered());
 


### PR DESCRIPTION
Removes:
- global_tp_ (the replacement TBB thread pool)
- StorageManager::async_thread_pool_
- StorageManager::reader_thread_pool_
- StorageManager::writer_thread_pool_
- VFS::thread_pool_

Adds:
- StorageManager::compute_tp_
- StorageManager::io_tp_

Usage changes:
1. Our three parallel functions (`parallel_sort`, `parallel_for[_2d]`) now use
   the `StorageManager::compute_tp_`.
2. Both the `Reader::read_tiles()` and `Writer::write_tiles()` now execute on
   `StorageManager::io_tp_`.
3. The VFS is now initalized with a thread pool, where the storage manager
   initializes it with the `StorageManager::io_tp_`. This means that both the
   VFS and Reader/Writer io paths execute on the same thread pool. There was
   previously a deadlock scenario if both used the same thread pool, but that
   is no longer an issue now that the threadpools are recursive.
4. The async queries are executed on `StorageManager::compute_tp_`.

Config changes:
- Adds configuration parameters for the compute and IO thread pool "concurrency
  levels". A level of "1" is serial execution while all other levels have a
  maximum concurrency of N but allocate N-1 OS threads.
- Deprecate the async/reader/writer/vfs thread num configurations. If any of
  these are set and larger than the new "sm.compute_concurrency_level" and
  "sm.io_concurrency_level", the old values will be used instead. The motiviation
  is so that existing users will not see a drop in performance if they are
  currently using larger-than-default values.