### PR TITLE
Add link with fmt if existing spdlog is found and fmt exists

### DIFF
--- a/cmake/Modules/FindSpdlog_EP.cmake
+++ b/cmake/Modules/FindSpdlog_EP.cmake
@@ -67,6 +67,10 @@ endif()
 
 if (SPDLOG_FOUND AND NOT TARGET Spdlog::Spdlog)
   add_library(Spdlog::Spdlog INTERFACE IMPORTED)
+  find_package(fmt)
+  if (${fmt_FOUND})
+    target_link_libraries(Spdlog::Spdlog INTERFACE fmt::fmt)
+  endif()
   set_target_properties(Spdlog::Spdlog PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${SPDLOG_INCLUDE_DIR}"
   )


### PR DESCRIPTION
Followed Isaiah Norton's advice to move linking to cmake/Modules/FindSpdlog_EP.cmake