### PR TITLE
Adding msys2 CI for mingw builds

### DIFF
--- a/.github/workflows/mingw-w64-tiledb/PKGBUILD
+++ b/.github/workflows/mingw-w64-tiledb/PKGBUILD
@@ -1,0 +1,52 @@
+_realname=tiledb
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.9000
+pkgrel=1
+pkgdesc="Storage management library for sparse and dense array data (mingw-w64)"
+arch=("any")
+url="https://tiledb.com/"
+license=("MIT")
+depends=("${MINGW_PACKAGE_PREFIX}-lz4"
+         "${MINGW_PACKAGE_PREFIX}-aws-sdk-cpp"
+         "${MINGW_PACKAGE_PREFIX}-bzip2"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-zstd")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-curl")
+options=("staticlibs" "strip")
+source_dir="$TILEDB_HOME"
+
+build() {
+  [[ -d ${source_dir}/build-${MINGW_CHOST} ]] && rm -rf ${source_dir}/build-${MINGW_CHOST}
+  mkdir -p ${source_dir}/build-${MINGW_CHOST} && cd ${source_dir}/build-${MINGW_CHOST}
+
+  if [ "$CARCH" == "i686" ]; then
+  export CFLAGS="-mfpmath=sse -msse2"
+  export CXXFLAGS="-mfpmath=sse -msse2"
+  fi
+
+  export MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX="
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DTILEDB_STATIC=ON \
+    -DTILEDB_TBB=OFF \
+    -DTILEDB_S3=ON \
+    ..
+  make
+  make -C tiledb
+}
+
+package() {
+  cd ${source_dir}/build-${MINGW_CHOST}
+  make DESTDIR="${pkgdir}" -C tiledb install
+}
+
+check (){
+  cd ${source_dir}/build-${MINGW_CHOST}
+  #make check
+}

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,0 +1,39 @@
+name: msys2
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include: [
+          { msystem: MINGW64, arch: x86_64 },
+          { msystem: MINGW32, arch: i686 }
+        ]
+      fail-fast: false
+    steps:
+      - name: Prepare git
+        run: git config --global core.autocrlf false
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          install: mingw-w64-${{ matrix.arch }}-toolchain make patch
+          update: true
+      - name: Building TileDB
+        run: cd .github/workflows/mingw-w64-tiledb && makepkg-mingw --noconfirm --syncdeps
+        env:
+          TILEDB_HOME: ${{ github.workspace }}
+          MINGW_INSTALLS: ${{ matrix.msystem }}
+          PKGEXT: ".pkg.tar.xz"
+        shell: msys2 {0}
+      - name: "Upload binaries"
+        uses: actions/upload-artifact@v2
+        with:
+          name: mingw-w64-${{ matrix.arch }}-tiledb
+          path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*


### PR DESCRIPTION
@ihnorton as discussed, some example CI based on upstream msys2 and GHA.

You can grab the output binaries as artifacts form the GHA build below.
