### PR TITLE
Recursive ThreadPool::execute()

### DIFF
--- a/tiledb/sm/misc/thread_pool.h
+++ b/tiledb/sm/misc/thread_pool.h
@@ -114,7 +114,7 @@ class ThreadPool {
 
   uint64_t concurrency_level_;
 
-  /** Protects `task_stack_` */
+  /** Protects `task_stack_` and `idle_threads_`. */
   std::mutex task_stack_mutex_;
 
   /** Notifies work threads to check `task_stack_` for work. */
@@ -122,6 +122,12 @@ class ThreadPool {
 
   /** Pending tasks in LIFO ordering. */
   std::stack<std::packaged_task<Status()>> task_stack_;
+
+  /**
+   * The number of threads waiting for the `task_stack_` to
+   * become non-empty.
+   */
+  uint64_t idle_threads_;
 
   /** The worker threads. */
   std::vector<std::thread> threads_;


### PR DESCRIPTION
Currently, we break recursive deadlock in the ThreadPool:wait*() routines. This
works well for the type of "execute-and-wait" model we use. For instance:
```
ThreadPool tp;
auto task = tp.execute(...);
tp.wait_all(task);
```

We are currently unable to break recursive deadlock if the threadpool user does
not use our "wait" routine. For instance:
```
condition_variable cv;
auto task = tp.execute([&]() {
  cv.signal_all();
});
cv.wait(...);
```

The S3 client uses the above style of synchronization. With our compute/io
threadpool refactor, we encounter recursive deadlock. This patch allows breaking
recursive deadlock on the call to ThreadPool::execute().

With this patch, ThreadPool::execute() checks if 1) the calling thread belongs
to the thread pool instance and 2) all other threads are non-idle.