### PR TITLE
Recursive ThreadPools

### DIFF
--- a/test/src/unit-threadpool.cc
+++ b/test/src/unit-threadpool.cc
@@ -32,6 +32,7 @@
 
 #include <atomic>
 #include <catch.hpp>
+#include <iostream>
 #include "tiledb/sm/misc/cancelable_tasks.h"
 #include "tiledb/sm/misc/thread_pool.h"
 
@@ -46,14 +47,16 @@ TEST_CASE("ThreadPool: Test empty", "[threadpool]") {
 
 TEST_CASE("ThreadPool: Test single thread", "[threadpool]") {
   int result = 0;
-  std::vector<std::future<Status>> results;
+  std::vector<ThreadPool::Task> results;
   ThreadPool pool;
   REQUIRE(pool.init().ok());
   for (int i = 0; i < 100; i++) {
-    results.push_back(pool.execute([&result]() {
+    ThreadPool::Task task = pool.execute([&result]() {
       result++;
       return Status::Ok();
-    }));
+    });
+    REQUIRE(task.valid());
+    results.emplace_back(std::move(task));
   }
   CHECK(pool.wait_all(results).ok());
   CHECK(result == 100);
@@ -61,7 +64,7 @@ TEST_CASE("ThreadPool: Test single thread", "[threadpool]") {
 
 TEST_CASE("ThreadPool: Test multiple threads", "[threadpool]") {
   std::atomic<int> result(0);
-  std::vector<std::future<Status>> results;
+  std::vector<ThreadPool::Task> results;
   ThreadPool pool;
   REQUIRE(pool.init(4).ok());
   for (int i = 0; i < 100; i++) {
@@ -76,7 +79,7 @@ TEST_CASE("ThreadPool: Test multiple threads", "[threadpool]") {
 
 TEST_CASE("ThreadPool: Test wait status", "[threadpool]") {
   std::atomic<int> result(0);
-  std::vector<std::future<Status>> results;
+  std::vector<ThreadPool::Task> results;
   ThreadPool pool;
   REQUIRE(pool.init(4).ok());
   for (int i = 0; i < 100; i++) {
@@ -95,7 +98,7 @@ TEST_CASE("ThreadPool: Test no wait", "[threadpool]") {
     REQUIRE(pool.init(4).ok());
     std::atomic<int> result(0);
     for (int i = 0; i < 5; i++) {
-      std::future<Status> task = pool.execute([&result]() {
+      ThreadPool::Task task = pool.execute([&result]() {
         result++;
         std::this_thread::sleep_for(std::chrono::seconds(1));
         return Status::Ok();
@@ -114,7 +117,7 @@ TEST_CASE(
     CancelableTasks cancelable_tasks;
     REQUIRE(pool.init(2).ok());
     std::atomic<int> result(0);
-    std::vector<std::future<Status>> tasks;
+    std::vector<ThreadPool::Task> tasks;
 
     for (int i = 0; i < 5; i++) {
       tasks.push_back(cancelable_tasks.execute(&pool, [&result]() {
@@ -144,7 +147,7 @@ TEST_CASE(
     CancelableTasks cancelable_tasks;
     REQUIRE(pool.init(2).ok());
     std::atomic<int> result(0), num_cancelled(0);
-    std::vector<std::future<Status>> tasks;
+    std::vector<ThreadPool::Task> tasks;
 
     for (int i = 0; i < 5; i++) {
       tasks.push_back(cancelable_tasks.execute(
@@ -205,12 +208,12 @@ TEST_CASE("ThreadPool: Test recursion", "[threadpool]") {
   std::atomic<int> result(0);
   const size_t num_tasks = 100;
   const size_t num_nested_tasks = 10;
-  std::vector<std::future<Status>> tasks;
+  std::vector<ThreadPool::Task> tasks;
   for (size_t i = 0; i < num_tasks; ++i) {
     auto task = pool.execute([&]() {
-      std::vector<std::future<Status>> inner_tasks;
+      std::vector<ThreadPool::Task> inner_tasks;
       for (size_t j = 0; j < num_nested_tasks; ++j) {
-        auto inner_task = pool.execute([&result]() {
+        auto inner_task = pool.execute([&]() {
           ++result;
           return Status::Ok();
         });
@@ -230,16 +233,15 @@ TEST_CASE("ThreadPool: Test recursion", "[threadpool]") {
   CHECK(result == (num_tasks * num_nested_tasks));
 
   // Test a top-level execute-and-wait with async-style inner tasks.
-  result = 0;
   std::condition_variable cv;
   std::mutex cv_mutex;
   tasks.clear();
   for (size_t i = 0; i < num_tasks; ++i) {
     auto task = pool.execute([&]() {
       for (size_t j = 0; j < num_nested_tasks; ++j) {
-        pool.execute([&result, &cv, &cv_mutex]() {
+        pool.execute([&]() {
+          std::unique_lock<std::mutex> ul(cv_mutex);
           if (--result == 0) {
-            std::unique_lock<std::mutex> ul(cv_mutex);
             cv.notify_all();
           }
           return Status::Ok();
@@ -254,9 +256,110 @@ TEST_CASE("ThreadPool: Test recursion", "[threadpool]") {
   }
 
   CHECK(pool.wait_all(tasks).ok());
-  std::unique_lock<std::mutex> ul(cv_mutex);
 
   // Wait all inner tasks to complete.
+  std::unique_lock<std::mutex> ul(cv_mutex);
+  while (result > 0)
+    cv.wait(ul);
+}
+
+TEST_CASE("ThreadPool: Test recursion, two pools", "[threadpool]") {
+  ThreadPool pool_a;
+  ThreadPool pool_b;
+
+  SECTION("- One thread") {
+    REQUIRE(pool_a.init(1).ok());
+    REQUIRE(pool_b.init(1).ok());
+  }
+
+  SECTION("- Two threads") {
+    REQUIRE(pool_a.init(2).ok());
+    REQUIRE(pool_b.init(2).ok());
+  }
+
+  SECTION("- Ten threads") {
+    REQUIRE(pool_a.init(10).ok());
+    REQUIRE(pool_b.init(2).ok());
+  }
+
+  // Test recursive execute-and-wait.
+  std::atomic<int> result(0);
+  const size_t num_tasks_a = 10;
+  const size_t num_tasks_b = 10;
+  const size_t num_tasks_c = 10;
+  std::vector<ThreadPool::Task> tasks_a;
+  for (size_t i = 0; i < num_tasks_a; ++i) {
+    auto task_a = pool_a.execute([&]() {
+      std::vector<ThreadPool::Task> tasks_b;
+      for (size_t j = 0; j < num_tasks_b; ++j) {
+        auto task_b = pool_b.execute([&]() {
+          std::vector<ThreadPool::Task> tasks_c;
+          for (size_t k = 0; k < num_tasks_b; ++k) {
+            auto task_c = pool_a.execute([&result]() {
+              ++result;
+              return Status::Ok();
+            });
+
+            tasks_c.emplace_back(std::move(task_c));
+          }
+
+          pool_a.wait_all(tasks_c);
+          return Status::Ok();
+        });
+
+        tasks_b.emplace_back(std::move(task_b));
+      }
+
+      pool_b.wait_all(tasks_b).ok();
+      return Status::Ok();
+    });
+
+    CHECK(task_a.valid());
+    tasks_a.emplace_back(std::move(task_a));
+  }
+  CHECK(pool_a.wait_all(tasks_a).ok());
+  CHECK(result == (num_tasks_a * num_tasks_b * num_tasks_c));
+
+  // Test a top-level execute-and-wait with async-style inner tasks.
+  std::condition_variable cv;
+  std::mutex cv_mutex;
+  tasks_a.clear();
+  for (size_t i = 0; i < num_tasks_a; ++i) {
+    auto task_a = pool_a.execute([&]() {
+      std::vector<ThreadPool::Task> tasks_b;
+      for (size_t j = 0; j < num_tasks_b; ++j) {
+        auto task_b = pool_b.execute([&]() {
+          std::vector<ThreadPool::Task> tasks_c;
+          for (size_t k = 0; k < num_tasks_b; ++k) {
+            auto task_c = pool_a.execute([&]() {
+              if (--result == 0) {
+                std::unique_lock<std::mutex> ul(cv_mutex);
+                cv.notify_all();
+              }
+              return Status::Ok();
+            });
+
+            tasks_c.emplace_back(std::move(task_c));
+          }
+
+          pool_a.wait_all(tasks_c);
+          return Status::Ok();
+        });
+
+        tasks_b.emplace_back(std::move(task_b));
+      }
+
+      pool_b.wait_all(tasks_b).ok();
+      return Status::Ok();
+    });
+
+    CHECK(task_a.valid());
+    tasks_a.emplace_back(std::move(task_a));
+  }
+  CHECK(pool_a.wait_all(tasks_a).ok());
+
+  // Wait all inner tasks to complete.
+  std::unique_lock<std::mutex> ul(cv_mutex);
   while (result > 0)
     cv.wait(ul);
 }

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -61,7 +61,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
   REQUIRE(vfs->terminate().ok());
 
   std::vector<std::tuple<uint64_t, void*, uint64_t>> batches;
-  std::vector<std::future<Status>> tasks;
+  std::vector<ThreadPool::Task> tasks;
 
   SECTION("- Default config") {
     // Check reading in one batch: single read operation.

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -519,7 +519,7 @@ Status Posix::write(
       return LOG_STATUS(Status::IOError(errmsg.str()));
     }
   } else {
-    std::vector<std::future<Status>> results;
+    std::vector<ThreadPool::Task> results;
     uint64_t thread_write_nbytes = utils::math::ceil(buffer_size, num_ops);
     for (uint64_t i = 0; i < num_ops; i++) {
       uint64_t begin = i * thread_write_nbytes,
@@ -528,7 +528,7 @@ Status Posix::write(
       uint64_t thread_nbytes = end - begin + 1;
       uint64_t thread_file_offset = file_offset + begin;
       auto thread_buffer = reinterpret_cast<const char*>(buffer) + begin;
-      results.push_back(vfs_thread_pool_->execute(
+      results.emplace_back(vfs_thread_pool_->execute(
           [fd, thread_file_offset, thread_buffer, thread_nbytes]() {
             return write_at(
                 fd, thread_file_offset, thread_buffer, thread_nbytes);

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.h
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.h
@@ -36,6 +36,7 @@
 #ifdef HAVE_S3
 
 #include <aws/core/utils/threading/Executor.h>
+#include <condition_variable>
 #include <mutex>
 #include <unordered_set>
 
@@ -81,11 +82,14 @@ class S3ThreadPoolExecutor : public Aws::Utils::Threading::Executor {
   /** The current state. */
   State state_;
 
-  /** All future handles associated with outstanding tasks. */
-  std::unordered_set<std::shared_ptr<std::future<Status>>> tasks_;
+  /** The number of outstanding tasks. */
+  uint64_t outstanding_tasks_;
 
-  /** Protects 'state_' and 'tasks_'. */
-  std::recursive_mutex lock_;
+  /** Protects 'state_' and `outstanding_tasks_`. */
+  std::mutex lock_;
+
+  /** Notifies `Stop()` when all outstanding tasks have completed. */
+  std::condition_variable cv_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -1174,7 +1174,7 @@ Status VFS::read(
   if (num_ops == 1) {
     return read_impl(uri, offset, buffer, nbytes);
   } else {
-    std::vector<std::future<Status>> results;
+    std::vector<ThreadPool::Task> results;
     uint64_t thread_read_nbytes = utils::math::ceil(nbytes, num_ops);
 
     for (uint64_t i = 0; i < num_ops; i++) {
@@ -1249,7 +1249,7 @@ Status VFS::read_all(
     const URI& uri,
     const std::vector<std::tuple<uint64_t, void*, uint64_t>>& regions,
     ThreadPool* thread_pool,
-    std::vector<std::future<Status>>* tasks) {
+    std::vector<ThreadPool::Task>* tasks) {
   if (!init_)
     return LOG_STATUS(Status::VFSError("Cannot read all; VFS not initialized"));
 

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -328,7 +328,7 @@ class VFS {
       const URI& uri,
       const std::vector<std::tuple<uint64_t, void*, uint64_t>>& regions,
       ThreadPool* thread_pool,
-      std::vector<std::future<Status>>* tasks);
+      std::vector<ThreadPool::Task>* tasks);
 
   /** Checks if a given filesystem is supported. */
   bool supports_fs(Filesystem fs) const;

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -470,7 +470,7 @@ Status Win::write(
           Status::IOError(std::string("Cannot write to file '") + path));
     }
   } else {
-    std::vector<std::future<Status>> results;
+    std::vector<ThreadPool::Task> results;
     uint64_t thread_write_nbytes = utils::math::ceil(buffer_size, num_ops);
     for (uint64_t i = 0; i < num_ops; i++) {
       uint64_t begin = i * thread_write_nbytes,

--- a/tiledb/sm/misc/cancelable_tasks.cc
+++ b/tiledb/sm/misc/cancelable_tasks.cc
@@ -41,14 +41,14 @@ CancelableTasks::CancelableTasks()
     , should_cancel_(false) {
 }
 
-std::future<Status> CancelableTasks::execute(
+ThreadPool::Task CancelableTasks::execute(
     ThreadPool* const thread_pool,
     std::function<Status()>&& fn,
     std::function<void()>&& on_cancel) {
   std::function<Status()> wrapped_fn =
       std::bind(&CancelableTasks::fn_wrapper, this, fn, on_cancel);
 
-  std::future<Status> task = thread_pool->execute(std::move(wrapped_fn));
+  ThreadPool::Task task = thread_pool->execute(std::move(wrapped_fn));
   if (task.valid()) {
     std::unique_lock<std::mutex> lck(outstanding_tasks_mutex_);
     ++outstanding_tasks_;

--- a/tiledb/sm/misc/cancelable_tasks.h
+++ b/tiledb/sm/misc/cancelable_tasks.h
@@ -35,15 +35,13 @@
 
 #include <condition_variable>
 #include <functional>
-#include <future>
 #include <mutex>
 
 #include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/misc/thread_pool.h"
 
 namespace tiledb {
 namespace sm {
-
-class ThreadPool;
 
 class CancelableTasks {
  public:
@@ -62,9 +60,9 @@ class CancelableTasks {
    *
    * @param function Task to be executed.
    * @param function Optional routine to execute on cancelation.
-   * @return Future for the return value of the task.
+   * @return Task for the return value of the task.
    */
-  std::future<Status> execute(
+  ThreadPool::Task execute(
       ThreadPool* thread_pool,
       std::function<Status()>&& fn,
       std::function<void()>&& on_cancel = nullptr);

--- a/tiledb/sm/misc/parallel_functions.h
+++ b/tiledb/sm/misc/parallel_functions.h
@@ -144,17 +144,17 @@ void parallel_sort(
     std::iter_swap(middle, (end - 1));
 
     // Step #3: Recursively sort the left and right partitions.
-    std::vector<std::future<Status>> tasks;
+    std::vector<ThreadPool::Task> tasks;
     if (begin != middle) {
       std::function<Status()> quick_sort_left =
           std::bind(quick_sort, depth + 1, begin, middle);
-      std::future<Status> left_task = tp->execute(std::move(quick_sort_left));
+      ThreadPool::Task left_task = tp->execute(std::move(quick_sort_left));
       tasks.emplace_back(std::move(left_task));
     }
     if (middle != end) {
       std::function<Status()> quick_sort_right =
           std::bind(quick_sort, depth + 1, middle + 1, end);
-      std::future<Status> right_task = tp->execute(std::move(quick_sort_right));
+      ThreadPool::Task right_task = tp->execute(std::move(quick_sort_right));
       tasks.emplace_back(std::move(right_task));
     }
 
@@ -233,7 +233,7 @@ std::vector<Status> parallel_for(
   // Execute a bound instance of `execute_subrange` for each
   // subrange on the global thread pool.
   uint64_t fn_iter = 0;
-  std::vector<std::future<Status>> tasks;
+  std::vector<ThreadPool::Task> tasks;
   tasks.reserve(concurrency_level);
   for (size_t i = 0; i < concurrency_level; ++i) {
     const uint64_t task_subrange_len =
@@ -384,7 +384,7 @@ std::vector<Status> parallel_for_2d(
 
   // Execute a bound instance of `execute_subrange_ij` for each
   // 2D subarray on the global thread pool.
-  std::vector<std::future<Status>> tasks;
+  std::vector<ThreadPool::Task> tasks;
   tasks.reserve(concurrency_level * concurrency_level);
   for (const auto& subrange_i : subranges_i) {
     for (const auto& subrange_j : subranges_j) {

--- a/tiledb/sm/misc/thread_pool.h
+++ b/tiledb/sm/misc/thread_pool.h
@@ -34,13 +34,15 @@
 #define TILEDB_THREAD_POOL_H
 
 #include <condition_variable>
-#include <future>
 #include <mutex>
 #include <stack>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
+#include "tiledb/sm/misc/logger.h"
+#include "tiledb/sm/misc/macros.h"
 #include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
@@ -50,7 +52,84 @@ namespace sm {
  * A recusive-safe thread pool.
  */
 class ThreadPool {
+ private:
+  /* ********************************* */
+  /*          PRIVATE DATATYPES        */
+  /* ********************************* */
+
+  // Forward-declaration.
+  struct TaskState;
+
+  // Forward-declaration.
+  class PackagedTask;
+
  public:
+  /* ********************************* */
+  /*          PUBLIC DATATYPES         */
+  /* ********************************* */
+
+  class Task {
+   public:
+    /** Constructor. */
+    Task()
+        : task_state_(nullptr) {
+    }
+
+    /** Move constructor. */
+    Task(Task&& rhs) {
+      task_state_ = std::move(rhs.task_state_);
+    }
+
+    /** Move-assign operator. */
+    Task& operator=(Task&& rhs) {
+      task_state_ = std::move(rhs.task_state_);
+      return *this;
+    }
+
+    /** Returns true if this instance is associated with a valid task. */
+    bool valid() {
+      return task_state_ != nullptr;
+    }
+
+   private:
+    /** Value constructor. */
+    Task(const std::shared_ptr<TaskState>& task_state)
+        : task_state_(std::move(task_state)) {
+    }
+
+    DISABLE_COPY_AND_COPY_ASSIGN(Task);
+
+    /** Blocks until the task has completed or there are other tasks to service.
+     */
+    void wait() {
+      std::unique_lock<std::mutex> ul(task_state_->return_st_mutex_);
+      if (!task_state_->return_st_set_ && !task_state_->check_task_stack_)
+        task_state_->cv_.wait(ul);
+    }
+
+    /** Returns true if the associated task has completed. */
+    bool done() {
+      std::lock_guard<std::mutex> lg(task_state_->return_st_mutex_);
+      return task_state_->return_st_set_;
+    }
+
+    /**
+     * Returns the result value from the task. If the task
+     * has not completed, it will wait.
+     */
+    Status get() {
+      wait();
+      std::lock_guard<std::mutex> lg(task_state_->return_st_mutex_);
+      return task_state_->return_st_;
+    }
+
+    /** The shared task state between futures and their associated task. */
+    std::shared_ptr<TaskState> task_state_;
+
+    friend ThreadPool;
+    friend PackagedTask;
+  };
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -74,15 +153,15 @@ class ThreadPool {
   Status init(uint64_t concurrency_level = 1);
 
   /**
-   * Schedule a new task to be executed. If the returned `future` object
+   * Schedule a new task to be executed. If the returned `Task` object
    * is valid, `function` is guaranteed to execute. The 'function' may
    * execute immediately on the calling thread. To avoid deadlock, `function`
    * should not aquire non-recursive locks held by the calling thread.
    *
    * @param function Task function to execute.
-   * @return Future for the return value of the task.
+   * @return Task for the return status of the task.
    */
-  std::future<Status> execute(std::function<Status()>&& function);
+  Task execute(std::function<Status()>&& function);
 
   /** Return the maximum level of concurrency. */
   uint64_t concurrency_level() const;
@@ -95,7 +174,7 @@ class ThreadPool {
    * @return Status::Ok if all tasks returned Status::Ok, otherwise the first
    * error status is returned
    */
-  Status wait_all(std::vector<std::future<Status>>& tasks);
+  Status wait_all(std::vector<Task>& tasks);
 
   /**
    * Wait on all the given tasks to complete, return a vector of their return
@@ -105,13 +184,113 @@ class ThreadPool {
    * @param tasks Task list to wait on
    * @return Vector of each task's Status.
    */
-  std::vector<Status> wait_all_status(std::vector<std::future<Status>>& tasks);
+  std::vector<Status> wait_all_status(std::vector<Task>& tasks);
 
  private:
+  /* ********************************* */
+  /*          PRIVATE DATATYPES        */
+  /* ********************************* */
+
+  struct TaskState {
+    /** Constructor. */
+    TaskState()
+        : return_st_()
+        , check_task_stack_(false)
+        , return_st_set_(false) {
+    }
+
+    DISABLE_COPY_AND_COPY_ASSIGN(TaskState);
+    DISABLE_MOVE_AND_MOVE_ASSIGN(TaskState);
+
+    /** The return status from an executed task. */
+    Status return_st_;
+
+    bool check_task_stack_;
+
+    /** True if the `return_st_` has been set. */
+    bool return_st_set_;
+
+    /** Waits for a task to complete. */
+    std::condition_variable cv_;
+
+    /** Protects `return_st_`, `return_st_set_`, and `cv_`. */
+    std::mutex return_st_mutex_;
+  };
+
+  class PackagedTask {
+   public:
+    /** Constructor. */
+    PackagedTask()
+        : fn_(nullptr)
+        , task_state_(nullptr) {
+    }
+
+    /** Value constructor. */
+    template <class Fn_T>
+    explicit PackagedTask(Fn_T&& fn) {
+      fn_ = std::move(fn);
+      task_state_ = std::make_shared<TaskState>();
+    }
+
+    /** Move constructor. */
+    PackagedTask(PackagedTask&& rhs) {
+      fn_ = std::move(rhs.fn_);
+      task_state_ = std::move(rhs.task_state_);
+    }
+
+    /** Move-assign operator. */
+    PackagedTask& operator=(PackagedTask&& rhs) {
+      fn_ = std::move(rhs.fn_);
+      task_state_ = std::move(rhs.task_state_);
+      return *this;
+    }
+
+    void reset() {
+      fn_ = std::function<Status()>();
+      task_state_ = nullptr;
+    }
+
+    /** Function-call operator. */
+    void operator()() {
+      const Status r = fn_();
+      {
+        std::lock_guard<std::mutex> lg(task_state_->return_st_mutex_);
+        task_state_->return_st_set_ = true;
+        task_state_->return_st_ = r;
+      }
+      task_state_->cv_.notify_all();
+
+      reset();
+    }
+
+    /** Returns the future associated with this task. */
+    ThreadPool::Task get_future() {
+      return Task(task_state_);
+    }
+
+    /** Returns true if this instance has a valid task. */
+    bool valid() const {
+      return fn_ && task_state_ != nullptr;
+    }
+
+   private:
+    DISABLE_COPY_AND_COPY_ASSIGN(PackagedTask);
+
+    /** The packaged function. */
+    std::function<Status()> fn_;
+
+    /** The task state to share with futures. */
+    std::shared_ptr<TaskState> task_state_;
+  };
+
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
+  /**
+   * The maximum level of concurrency among a single waiter and all
+   * of the the `threads_`.
+   */
   uint64_t concurrency_level_;
 
   /** Protects `task_stack_` and `idle_threads_`. */
@@ -121,7 +300,7 @@ class ThreadPool {
   std::condition_variable task_stack_cv_;
 
   /** Pending tasks in LIFO ordering. */
-  std::stack<std::packaged_task<Status()>> task_stack_;
+  std::stack<PackagedTask> task_stack_;
 
   /**
    * The number of threads waiting for the `task_stack_` to
@@ -134,6 +313,18 @@ class ThreadPool {
 
   /** When true, all pending tasks will remain unscheduled. */
   bool should_terminate_;
+
+  /** All tasks that threads in this instance are waiting on. */
+  struct BlockedTasksHasher {
+    size_t operator()(const std::shared_ptr<TaskState>& task) const {
+      return reinterpret_cast<size_t>(task.get());
+    }
+  };
+  std::unordered_set<std::shared_ptr<TaskState>, BlockedTasksHasher>
+      blocked_tasks_;
+
+  /** Protects `blocked_tasks_`. */
+  std::mutex blocked_tasks_mutex_;
 
   /** Indexes thread ids to the ThreadPool instance they belong to. */
   static std::unordered_map<std::thread::id, ThreadPool*> tp_index_;
@@ -151,7 +342,7 @@ class ThreadPool {
    * to perform work on this thread rather than waiting, the primary
    * motiviation is to prevent deadlock when tasks are enqueued recursively.
    */
-  Status wait_or_work(std::future<Status>&& task);
+  Status wait_or_work(Task&& task);
 
   /** Terminate the threads in the thread pool. */
   void terminate();

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -2263,7 +2263,7 @@ Status Reader::read_tiles(
     return Status::Ok();
 
   // Read the tiles asynchronously
-  std::vector<std::future<Status>> tasks;
+  std::vector<ThreadPool::Task> tasks;
   RETURN_CANCEL_OR_ERROR(read_tiles(name, result_tiles, &tasks));
 
   // Wait for the reads to finish and check statuses.
@@ -2279,7 +2279,7 @@ Status Reader::read_tiles(
 Status Reader::read_tiles(
     const std::string& name,
     const std::vector<ResultTile*>& result_tiles,
-    std::vector<std::future<Status>>* const tasks) const {
+    std::vector<ThreadPool::Task>* const tasks) const {
   // Shortcut for empty tile vec
   if (result_tiles.empty())
     return Status::Ok();

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -1148,7 +1148,7 @@ class Reader {
   Status read_tiles(
       const std::string& name,
       const std::vector<ResultTile*>& result_tiles,
-      std::vector<std::future<Status>>* tasks) const;
+      std::vector<ThreadPool::Task>* tasks) const;
 
   /**
    * Resets the buffer sizes to the original buffer sizes. This is because

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -2561,7 +2561,7 @@ Status Writer::write_all_tiles(
 
   assert(!tiles->empty());
 
-  std::vector<std::future<Status>> tasks;
+  std::vector<ThreadPool::Task> tasks;
   for (auto& it : *tiles) {
     tasks.push_back(storage_manager_->io_tp()->execute([&, this]() {
       RETURN_CANCEL_OR_ERROR(write_tiles(it.first, frag_meta, &it.second));


### PR DESCRIPTION
Currently, ThreadPool instances are only recursive with their own isntance. This
patch allows multiple ThreadPool instances to recurse among themselves without
the potential for bottlenecking (either in performance reduction or a deadlock)
on available threads.

For instance, ThreadPool instances A and B may be called in any order:
```
A->execute([&]() {
  B->execute([&]() {
    A->execute([&]() {
      foo();
    });
  });
});
```

The motiviation for this patch is to allow us to use our `compute_tp` and
`io_tp` without worrying about their order in a call stack. This patch reduces
the runtime of our `bench_large_io` from 280587ms to 269621.

See the new unit tests in `unit-threadpool.cc` for more examples.

---

Design and Implementation:

Currently, executing a task on a ThreadPool returns an `std::future`. This patch
modifies the return value to a new ThreadPool::Task object. This object is
a relatively opaque handle that forces the caller to use the ThreadPool::wait_*
routines.

The motivation for this patch is to allow the ThreadPool to wake up a thread
blocked on ThreadPool::Task::wait() in scenarios where the task has not
completed. It is not possible to wake up a thread blocked on an std::future::wait().

Within the ThreadPool::execute() task, it now notifies a blocked ThreadPool::task
in the ThreadPool::wait*() path to wake up and check the call stack.