### PR TITLE
CI: remove work-around for AZP bug

### DIFF
--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -36,9 +36,6 @@ steps:
   displayName: 'Check formatting (linux only)'
 
 - bash: |
-    # DELETEME work-around for https://github.com/microsoft/azure-pipelines-image-generation/issues/969
-    sudo chown root.root /
-
     # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
     #   - openssl configure uses ENV{SYSTEM} if available:
     #     https://github.com/openssl/openssl/blob/6d745d740d37d680ff696486218b650512bbbbc6/config#L56

--- a/scripts/install-azurite.sh
+++ b/scripts/install-azurite.sh
@@ -39,7 +39,10 @@ install_yum_pkgs() {
 }
 
 install_brew_pkgs() {
-  brew install node || brew link --overwrite node
+  # Now installed on AZP images by default
+  if [[ `which node` == "" ]]; then
+    brew install node || brew link --overwrite node
+  fi
 }
 
 install_deps() {


### PR DESCRIPTION
Should fix CI failure in https://github.com/TileDB-Inc/TileDB/pull/1776

[edit]: also make `node` installation conditional,  because it is now available by default in the AZP image, and the brew link step fails when trying to link.