### PR TITLE
Don't notify watchdog thread in destructor on mingw platform

### DIFF
--- a/tiledb/sm/global_state/watchdog.cc
+++ b/tiledb/sm/global_state/watchdog.cc
@@ -23,7 +23,9 @@ Watchdog::~Watchdog() {
   {
     std::unique_lock<std::mutex> lck(mtx_);
     should_exit_ = true;
+#ifndef __MINGW32__
     cv_.notify_one();
+#endif
   }
   thread_.join();
 }


### PR DESCRIPTION
Fixes https://github.com/TileDB-Inc/TileDB-R/issues/155

When TileDB is compiled as a DLL and loaded by R, the ~Watchdog
destructor hangs process exit in `pthread_cond_destroy` if the
condition_variable is signaled. There are some limitations on
signaling during the DLL unload process, in particular when
compiled with mingw-w64 and libstdc++.

This call can be avoided on mingw-w64 because all other threads
will have been exited by the runtime, by the time the destructor
is called.

We have not seen this issue on MSVC, and the minimal reproducer
works fine when compiled w/ MSVC.