### PR TITLE
C/CPP-API to get fragment URIs

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -727,7 +727,7 @@ void read_array(
   tiledb_query_free(&query);
 }
 
-int32_t num_fragments(const std::string& array_name) {
+std::vector<std::string> get_fragments(const std::string& array_name) {
   Context ctx;
   VFS vfs(ctx);
 
@@ -735,15 +735,20 @@ int32_t num_fragments(const std::string& array_name) {
   auto uris = vfs.ls(array_name);
 
   // Exclude '__meta' folder and any file with a suffix
-  int ret = 0;
+  std::vector<std::string> fragment_uris;
   for (const auto& uri : uris) {
     auto name = tiledb::sm::URI(uri).remove_trailing_slash().last_path_part();
     if (name != tiledb::sm::constants::array_metadata_folder_name &&
-        name.find_first_of('.') == std::string::npos)
-      ++ret;
+        name.find_first_of('.') == std::string::npos) {
+      fragment_uris.emplace_back(uri);
+    }
   }
 
-  return ret;
+  return fragment_uris;
+}
+
+int32_t num_fragments(const std::string& array_name) {
+  return get_fragments(array_name).size();
 }
 
 template void check_subarray<int8_t>(

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -396,6 +396,12 @@ void read_array(
     const QueryBuffers& buffers);
 
 /**
+ * Returns the fragment URIs in the input array (either commited or
+ * uncommited), appropriately excluding special files and subdirectories.
+ */
+std::vector<std::string> get_fragments(const std::string& array_name);
+
+/**
  * Returns the number of fragments in the input array,
  * appropriately excluding special files and subdirectories.
  */

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -4801,6 +4801,32 @@ TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_consolidate_metadata_with_key(
     uint32_t key_length,
     tiledb_config_t* config);
 
+/**
+ * Returns an array of commited fragment uris for `array_uri`. The
+ * array does not need to be open.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * char** fragment_uris;
+ * uint32_t fragment_uris_len;
+ * tiledb_array_get_fragments(
+ *   ctx, "s3://tiledb_bucket/my_array", &fragment_uris, &fragment_uris_len);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_uri The array whose fragments will be retrieved.
+ * @param fragment_uris An array of c-string elements, where each element
+ *        is the uri of a commited fragment.
+ * @param fragment_uris_len The number of elements in `fragment_uris`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_get_fragments(
+    tiledb_ctx_t* ctx,
+    const char* array_uri,
+    char*** fragment_uris,
+    uint32_t* fragment_uris_len);
+
 /* ********************************* */
 /*          OBJECT MANAGEMENT        */
 /* ********************************* */

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -1442,6 +1442,24 @@ class Array {
     std::memcpy((void*)key->data(), key_c, key_len);
   }
 
+  /** Returns commited fragment URIs associated with this array. */
+  std::vector<std::string> get_fragment_uris() {
+    const std::string array_uri = uri();
+    auto& ctx = ctx_.get();
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    char** c_fragment_uris;
+    uint32_t c_fragment_uris_len;
+    ctx.handle_error(tiledb_array_get_fragments(
+        c_ctx, array_uri.c_str(), &c_fragment_uris, &c_fragment_uris_len));
+
+    std::vector<std::string> fragment_uris;
+    fragment_uris.reserve(c_fragment_uris_len);
+    for (uint32_t i = 0; i < c_fragment_uris_len; ++i)
+      fragment_uris.emplace_back(c_fragment_uris[i]);
+  
+    return fragment_uris;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -522,10 +522,16 @@ class StorageManager {
       FragmentInfo* fragment_info);
 
   /**
+   * Retrieves all the fragment URIs of an array.
+   */
+  Status get_fragment_uris(
+      const URI& array_uri, std::vector<URI>* fragment_uris) const;
+
+  /**
    * Retrieves all the fragment URIs of an array, along with the latest
    * consolidated fragment metadata URI `meta_uri`.
    */
-  Status get_fragment_uris(
+  Status get_fragment_uris_ext(
       const URI& array_uri,
       std::vector<URI>* fragment_uris,
       URI* meta_uri) const;
@@ -1119,6 +1125,14 @@ class StorageManager {
       const std::vector<URI>& uris,
       uint64_t timestamp,
       std::vector<TimestampedURI>* sorted_uris) const;
+
+  /**
+   * Retrieves all the fragment URIs from `uris` and stores them
+   * inside `fragment_uris`. This an internal work routine for
+   * `get_fragment_uris` and `get_fragment_uris_ext`.
+   */
+  Status get_fragment_uris_internal(
+      const std::vector<URI>& uris, std::vector<URI>* fragment_uris) const;
 
   /**
    * It computes the URIs `to_vacuum` from the input `uris`, considering


### PR DESCRIPTION
This introduces the C-API `tiledb_array_get_fragments` and the CPP-API
`std::vector<std::string> get_fragment_uris()`.

Each will return a list of absolute URIs to the commited fragments for the
given array. For example:
file:///root/Workspace/TileDB/build/cpp_unit_fragment_uris/__1598533581433_1598533581457_17715cac9f074523a41aac78f712ab55_6