### PR TITLE
Lazy init GCS client in GCS::is_empty_bucket

### DIFF
--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -221,6 +221,7 @@ Status GCS::is_empty_bucket(const URI& uri, bool* is_empty) const {
 }
 
 Status GCS::is_bucket(const URI& uri, bool* const is_bucket) const {
+  RETURN_NOT_OK(init_client());
   assert(is_bucket);
 
   if (!uri.is_gcs()) {


### PR DESCRIPTION
The `GCS::is_empty_bucket` routine is missing a lazy init of the client, which
segfaults if it is the first used public API.