### PR TITLE
VFS Read-Ahead Cache

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,8 @@
 * Added configuration option "sm.compute_concurrency_level" [#1766](https://github.com/TileDB-Inc/TileDB/pull/1766)
 * Added configuration option "sm.io_concurrency_level" [#1766](https://github.com/TileDB-Inc/TileDB/pull/1766)
 * Added configuration option "sm.sub_partitioner_memory_budget" [#1729](https://github.com/TileDB-Inc/TileDB/pull/1729)
+* Added configuration option "vfs.read_ahead_size" [#1785](https://github.com/TileDB-Inc/TileDB/pull/1785)
+* Added configuration option "vfs.read_ahead_cache_size" [#1785](https://github.com/TileDB-Inc/TileDB/pull/1785)
 
 ## Improvements
 
@@ -24,6 +26,7 @@
 * Enabled parallelization with native system threads when TBB is disabled [#1760](https://github.com/TileDB-Inc/TileDB/pull/1760)
 * Subarray ranges will be automatically coalesced as they are added [#1755](https://github.com/TileDB-Inc/TileDB/pull/1755)
 * Update GCS SDK to v1.16.0 to fixes multiple bugs reported [#1768](https://github.com/TileDB-Inc/TileDB/pull/1768)
+* Read-ahead cache for cloud-storage backends [#1785](https://github.com/TileDB-Inc/TileDB/pull/1785)
 
 ## Deprecations
 

--- a/test/src/unit-azure.cc
+++ b/test/src/unit-azure.cc
@@ -288,7 +288,9 @@ TEST_CASE_METHOD(
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  REQUIRE(azure_.read(URI(largefile), 0, read_buffer, 26).ok());
+  uint64_t bytes_read;
+  REQUIRE(azure_.read(URI(largefile), 0, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -299,7 +301,9 @@ TEST_CASE_METHOD(
   REQUIRE(allok);
 
   // Read from a different offset
-  REQUIRE(azure_.read(URI(largefile), 11, read_buffer, 26).ok());
+  REQUIRE(
+      azure_.read(URI(largefile), 11, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {
@@ -396,7 +400,10 @@ TEST_CASE_METHOD(
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  REQUIRE(azure_.read(URI(large_file), 0, read_buffer, 26).ok());
+  uint64_t bytes_read;
+  REQUIRE(
+      azure_.read(URI(large_file), 0, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -407,7 +414,9 @@ TEST_CASE_METHOD(
   REQUIRE(allok);
 
   // Read from a different offset
-  REQUIRE(azure_.read(URI(large_file), 11, read_buffer, 26).ok());
+  REQUIRE(
+      azure_.read(URI(large_file), 11, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -253,6 +253,8 @@ void check_save_to_file() {
   ss << "vfs.min_batch_gap 512000\n";
   ss << "vfs.min_batch_size 20971520\n";
   ss << "vfs.min_parallel_size 10485760\n";
+  ss << "vfs.read_ahead_cache_size 10485760\n";
+  ss << "vfs.read_ahead_size 102400\n";
   ss << "vfs.s3.connect_max_tries 5\n";
   ss << "vfs.s3.connect_scale_factor 25\n";
   ss << "vfs.s3.connect_timeout_ms 3000\n";
@@ -453,6 +455,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.min_batch_gap"] = "512000";
   all_param_values["vfs.min_batch_size"] = "20971520";
   all_param_values["vfs.min_parallel_size"] = "10485760";
+  all_param_values["vfs.read_ahead_size"] = "102400";
+  all_param_values["vfs.read_ahead_cache_size"] = "10485760";
   all_param_values["vfs.gcs.project_id"] = "";
   all_param_values["vfs.gcs.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -503,6 +507,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["min_batch_gap"] = "512000";
   vfs_param_values["min_batch_size"] = "20971520";
   vfs_param_values["min_parallel_size"] = "10485760";
+  vfs_param_values["read_ahead_size"] = "102400";
+  vfs_param_values["read_ahead_cache_size"] = "10485760";
   vfs_param_values["gcs.project_id"] = "";
   vfs_param_values["gcs.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -60,7 +60,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 44);
+  CHECK(names.size() == 46);
 }
 
 TEST_CASE(

--- a/test/src/unit-gcs.cc
+++ b/test/src/unit-gcs.cc
@@ -276,7 +276,9 @@ TEST_CASE_METHOD(
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  REQUIRE(gcs_.read(URI(largefile), 0, read_buffer, 26).ok());
+  uint64_t bytes_read;
+  REQUIRE(gcs_.read(URI(largefile), 0, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -287,7 +289,8 @@ TEST_CASE_METHOD(
   REQUIRE(allok);
 
   // Read from a different offset
-  REQUIRE(gcs_.read(URI(largefile), 11, read_buffer, 26).ok());
+  REQUIRE(gcs_.read(URI(largefile), 11, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {
@@ -351,7 +354,9 @@ TEST_CASE_METHOD(
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  REQUIRE(gcs_.read(URI(smallfile), 0, read_buffer, 26).ok());
+  uint64_t bytes_read;
+  REQUIRE(gcs_.read(URI(smallfile), 0, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -362,7 +367,8 @@ TEST_CASE_METHOD(
   REQUIRE(allok);
 
   // Read from a different offset
-  REQUIRE(gcs_.read(URI(smallfile), 11, read_buffer, 26).ok());
+  REQUIRE(gcs_.read(URI(smallfile), 11, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {
@@ -433,7 +439,9 @@ TEST_CASE_METHOD(
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  REQUIRE(gcs_.read(URI(largefile), 0, read_buffer, 26).ok());
+  uint64_t bytes_read;
+  REQUIRE(gcs_.read(URI(largefile), 0, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -444,7 +452,8 @@ TEST_CASE_METHOD(
   REQUIRE(allok);
 
   // Read from a different offset
-  REQUIRE(gcs_.read(URI(largefile), 11, read_buffer, 26).ok());
+  REQUIRE(gcs_.read(URI(largefile), 11, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {
@@ -508,7 +517,9 @@ TEST_CASE_METHOD(
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  REQUIRE(gcs_.read(URI(smallfile), 0, read_buffer, 26).ok());
+  uint64_t bytes_read;
+  REQUIRE(gcs_.read(URI(smallfile), 0, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -519,7 +530,8 @@ TEST_CASE_METHOD(
   REQUIRE(allok);
 
   // Read from a different offset
-  REQUIRE(gcs_.read(URI(smallfile), 11, read_buffer, 26).ok());
+  REQUIRE(gcs_.read(URI(smallfile), 11, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {
@@ -575,7 +587,9 @@ TEST_CASE_METHOD(
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  REQUIRE(gcs_.read(URI(largefile), 0, read_buffer, 26).ok());
+  uint64_t bytes_read;
+  REQUIRE(gcs_.read(URI(largefile), 0, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -586,7 +600,8 @@ TEST_CASE_METHOD(
   REQUIRE(allok);
 
   // Read from a different offset
-  REQUIRE(gcs_.read(URI(largefile), 11, read_buffer, 26).ok());
+  REQUIRE(gcs_.read(URI(largefile), 11, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {

--- a/test/src/unit-s3-no-multipart.cc
+++ b/test/src/unit-s3-no-multipart.cc
@@ -152,7 +152,9 @@ TEST_CASE_METHOD(
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  CHECK(s3_.read(URI(largefile), 0, read_buffer, 26).ok());
+  uint64_t bytes_read;
+  CHECK(s3_.read(URI(largefile), 0, read_buffer, 26, 0, &bytes_read).ok());
+  assert(26 == bytes_read);
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -163,7 +165,8 @@ TEST_CASE_METHOD(
   CHECK(allok);
 
   // Read from a different offset
-  CHECK(s3_.read(URI(largefile), 11, read_buffer, 26).ok());
+  CHECK(s3_.read(URI(largefile), 11, read_buffer, 26, 0, &bytes_read).ok());
+  assert(26 == bytes_read);
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -262,7 +262,9 @@ TEST_CASE_METHOD(S3Fx, "Test S3 filesystem, file I/O", "[s3]") {
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  CHECK(s3_.read(URI(largefile), 0, read_buffer, 26).ok());
+  uint64_t bytes_read = 0;
+  CHECK(s3_.read(URI(largefile), 0, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -273,7 +275,8 @@ TEST_CASE_METHOD(S3Fx, "Test S3 filesystem, file I/O", "[s3]") {
   CHECK(allok);
 
   // Read from a different offset
-  CHECK(s3_.read(URI(largefile), 11, read_buffer, 26).ok());
+  CHECK(s3_.read(URI(largefile), 11, read_buffer, 26, 0, &bytes_read).ok());
+  CHECK(26 == bytes_read);
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {

--- a/tiledb/sm/cache/lru_cache.h
+++ b/tiledb/sm/cache/lru_cache.h
@@ -66,6 +66,37 @@ class LRUCache {
    * is public for unit test purposes only.
    */
   struct LRUCacheItem {
+    /* ********************************* */
+    /*            CONSTRUCTORS           */
+    /* ********************************* */
+
+    /** Value Constructor. */
+    LRUCacheItem(const K& key, V&& object, const uint64_t size)
+        : key_(key)
+        , object_(std::move(object))
+        , size_(size) {
+    }
+
+    DISABLE_MOVE(LRUCacheItem);
+
+    /* ********************************* */
+    /*             OPERATORS             */
+    /* ********************************* */
+
+    /** Move-Assign Operator. */
+    LRUCacheItem& operator=(LRUCacheItem&& other) {
+      key_ = other.key_;
+      object_ = std::move(other.object_);
+      size_ = other.size_;
+      return *this;
+    }
+
+    DISABLE_COPY_AND_COPY_ASSIGN(LRUCacheItem);
+
+    /* ********************************* */
+    /*             ATTRIBUTES            */
+    /* ********************************* */
+
     /** The key that maps to the object. */
     K key_;
 
@@ -146,14 +177,8 @@ class LRUCache {
         item_ll_.splice(item_ll_.end(), item_ll_, node, std::next(node));
       }
     } else {  // Key does not exist
-      // Create a new cache item
-      LRUCacheItem new_item;
-      new_item.key_ = key;
-      new_item.object_ = std::move(object);
-      new_item.size_ = size;
-
       // Create new node in linked list
-      item_ll_.emplace_back(new_item);
+      item_ll_.emplace_back(key, std::move(object), size);
 
       // Create new element in the hash table
       item_map_[key] = --(item_ll_.end());
@@ -280,7 +305,7 @@ class LRUCache {
   void evict() {
     assert(!item_ll_.empty());
 
-    auto item = item_ll_.front();
+    auto& item = item_ll_.front();
     item_map_.erase(item.key_);
     size_ -= item.size_;
     item_ll_.pop_front();

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -88,6 +88,8 @@ const std::string Config::VFS_FILE_POSIX_DIRECTORY_PERMISSIONS = "755";
 const std::string Config::VFS_FILE_MAX_PARALLEL_OPS =
     Config::SM_IO_CONCURRENCY_LEVEL;
 const std::string Config::VFS_FILE_ENABLE_FILELOCKS = "true";
+const std::string Config::VFS_READ_AHEAD_SIZE = "102400";          // 100KiB
+const std::string Config::VFS_READ_AHEAD_CACHE_SIZE = "10485760";  // 10MiB;
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_NAME = "";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_KEY = "";
 const std::string Config::VFS_AZURE_BLOB_ENDPOINT = "";
@@ -188,6 +190,8 @@ Config::Config() {
   param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
+  param_values_["vfs.read_ahead_size"] = VFS_READ_AHEAD_SIZE;
+  param_values_["vfs.read_ahead_cache_size"] = VFS_READ_AHEAD_CACHE_SIZE;
   param_values_["vfs.file.posix_file_permissions"] =
       VFS_FILE_POSIX_FILE_PERMISSIONS;
   param_values_["vfs.file.posix_directory_permissions"] =
@@ -422,6 +426,10 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   } else if (param == "vfs.min_batch_size") {
     param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
+  } else if (param == "vfs.read_ahead_size") {
+    param_values_["vfs.read_ahead_size"] = VFS_READ_AHEAD_SIZE;
+  } else if (param == "vfs.read_ahead_cache_size") {
+    param_values_["vfs.read_ahead_cache_size"] = VFS_READ_AHEAD_CACHE_SIZE;
   } else if (param == "vfs.file.posix_file_permissions") {
     param_values_["vfs.file.posix_file_permissions"] =
         VFS_FILE_POSIX_FILE_PERMISSIONS;
@@ -589,6 +597,10 @@ Status Config::sanity_check(
   } else if (param == "vfs.min_batch_gap") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_batch_size") {
+    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
+  } else if (param == "vfs.read_ahead_size") {
+    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
+  } else if (param == "vfs.read_ahead_cache_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.file.posix_file_permissions") {
     RETURN_NOT_OK(utils::parse::convert(value, &v32));

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -200,6 +200,12 @@ class Config {
   /** Whether or not filelocks are enabled for VFS. */
   static const std::string VFS_FILE_ENABLE_FILELOCKS;
 
+  /** The maximum size (in bytes) to read-ahead in the VFS. */
+  static const std::string VFS_READ_AHEAD_SIZE;
+
+  /** The maximum size (in bytes) of the VFS read-ahead cache . */
+  static const std::string VFS_READ_AHEAD_CACHE_SIZE;
+
   /** Azure storage account name. */
   static const std::string VFS_AZURE_STORAGE_ACCOUNT_NAME;
 

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -209,10 +209,17 @@ class Azure {
    * @param offset The offset in the object from which the read will start.
    * @param buffer The buffer into which the data will be written.
    * @param length The size of the data to be read from the object.
+   * @param read_ahead_length The additional length to read ahead.
+   * @param length_returned Returns the total length read into `buffer`.
    * @return Status
    */
   Status read(
-      const URI& uri, off_t offset, void* buffer, uint64_t length) const;
+      const URI& uri,
+      off_t offset,
+      void* buffer,
+      uint64_t length,
+      uint64_t read_ahead_length,
+      uint64_t* length_returned) const;
 
   /**
    * Deletes a container.

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -249,10 +249,17 @@ class GCS {
    * @param offset The offset in the object from which the read will start.
    * @param buffer The buffer into which the data will be written.
    * @param length The size of the data to be read from the object.
+   * @param read_ahead_length The additional length to read ahead.
+   * @param length_returned Returns the total length read into `buffer`.
    * @return Status
    */
   Status read(
-      const URI& uri, off_t offset, void* buffer, uint64_t length) const;
+      const URI& uri,
+      off_t offset,
+      void* buffer,
+      uint64_t length,
+      uint64_t read_ahead_length,
+      uint64_t* length_returned) const;
 
   /**
    * Returns the size of the input object with a given URI in bytes.

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -241,10 +241,17 @@ class S3 {
    * @param offset The offset in the object from which the read will start.
    * @param buffer The buffer into which the data will be written.
    * @param length The size of the data to be read from the object.
+   * @param read_ahead_length The additional length to read ahead.
+   * @param length_returned Returns the total length read into `buffer`.
    * @return Status
    */
   Status read(
-      const URI& uri, off_t offset, void* buffer, uint64_t length) const;
+      const URI& uri,
+      off_t offset,
+      void* buffer,
+      uint64_t length,
+      uint64_t read_ahead_length,
+      uint64_t* length_returned) const;
 
   /**
    * Deletes a bucket.

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -2447,10 +2447,18 @@ Status Reader::read_tiles(
     }
   }
 
+  // Do not use the read-ahead cache because tiles will be
+  // cached in the tile cache.
+  const bool use_read_ahead = false;
+
   // Enqueue all regions to be read.
   for (const auto& item : all_regions) {
     RETURN_NOT_OK(storage_manager_->vfs()->read_all(
-        item.first, item.second, storage_manager_->io_tp(), tasks));
+        item.first,
+        item.second,
+        storage_manager_->io_tp(),
+        tasks,
+        use_read_ahead));
   }
 
   return Status::Ok();


### PR DESCRIPTION
VFS Read-Ahead Cache

This introduces a read-ahead cache within VFS::read(). This is an LRU cache
that maintains a single cached buffer for an arbitrary number unique URIs, not
to exceed 10MiB (by default). Each cached buffer has a max size of 100KiB (by
default). These parameters can be tweaked with the following config items:

`vfs.read_ahead_size` (100KiB default)
`vfs.read_ahead_cache_size` (10Mib default)

The motiviation for this patch is to optimize IO patterns of small, relatively
sequential reads against cloud storage backends. Only the S3, Azure, and GCS
backends utilize this read cache. The POSIX/Windows/HDFS backends are
unaffected by this patch.

Both performing and caching the read-ahead incur a performance penalty:
1. We must read more than the requested bytes.
2. We must make a copy of the read buffer (one to store in the cache, one to
return to the user).

We will only perform a read-ahead if the requested read is smaller than the
default 100KB cached buffer size. IO patterns of large reads will be unaffected.
The assumption is that fragment data is large and that reading fragment
data will not incur a performance penalty. Additionally, reads to tile data
are bypassed because tiles have their own separate tile cache.

On the recent S3 workload we've been discussing, this read cache has a 78%
hit rate, where every cache hit is in the fragment metadata. I've observed a
best-case runtime of 6.5s with this patch, and a 27s runtime without this
patch.