### PR TITLE
Invalidate read-ahead cache in VFS::write()

### DIFF
--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -1670,6 +1670,12 @@ Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
         Status::VFSError("TileDB was built without HDFS support"));
 #endif
   }
+
+  // Invalidate read cache entries for `uri`. We only attempt this for cloud
+  // storage backends.
+  bool tmp;
+  RETURN_NOT_OK(read_ahead_cache_->invalidate(uri, &tmp));
+
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.write(uri, buffer, buffer_size);

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -568,6 +568,24 @@ class VFS {
           uri.to_string(), std::move(ra_buffer), size);
     }
 
+    /**
+     * Invalidates and evicts the object in the cache with the given key.
+     *
+     * @param uri The URI associated with the buffer to invalidate.
+     * @param success Set to `true` if the object was removed successfully; if
+     *    the object did not exist in the cache, set to `false`.
+     * @return Status
+     */
+    Status invalidate(const URI& uri, bool* const success) {
+      assert(success);
+
+      // Protect access to the derived LRUCache routines.
+      std::lock_guard<std::mutex> lg(lru_mtx_);
+
+      return LRUCache<std::string, ReadAheadBuffer>::invalidate(
+          uri.to_string(), success);
+    }
+
    private:
     /* ********************************* */
     /*         PRIVATE ATTRIBUTES        */


### PR DESCRIPTION
When we write to the VFS for a cloud backend, we should attempt to invalidate
the associated buffer in the read-ahead cache.