### PR TITLE
Checkout v1.7.0 unit test arrays for backwards compatibility

### DIFF
--- a/scripts/azure-centos6.yml
+++ b/scripts/azure-centos6.yml
@@ -46,7 +46,7 @@ steps:
     git config --global user.email 'no-reply@tiledb.io'
 
     # Clone Unit-Test-Arrays
-    git clone -q https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git test/inputs/arrays/read_compatibility_test
+    git clone -q https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 1.7.0 test/inputs/arrays/read_compatibility_test
 
 
     # Set up bootstrap args

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -50,7 +50,7 @@ steps:
     git config --global user.name 'Azure Pipeline'
     git config --global user.email 'no-reply@tiledb.io'
 
-    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git test/inputs/arrays/read_compatibility_test
+    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 1.7.0 test/inputs/arrays/read_compatibility_test
     #   displayName: 'Clone Unit-Test-Arrays'
 
     # - bash: |

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -46,7 +46,7 @@ steps:
     $env:AWS_SECRET_ACCESS_KEY = "miniosecretkey"
 
     # Clone backwards compatibility test arrays
-    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git  $env:BUILD_SOURCESDIRECTORY/test/inputs/arrays/read_compatibility_test
+    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 1.7.0  $env:BUILD_SOURCESDIRECTORY/test/inputs/arrays/read_compatibility_test
 
     if ($env:TILEDB_S3 -eq "ON") {
       # update CMake to disable S3 for the test configuration, see minio note above


### PR DESCRIPTION
The recently merged v2.0.0 arrays have broken some of the unit tests on CI.
This patch checks out the v1.7.0 release to unblock CI.