### PR TITLE
Preload Tile Offsets

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -453,6 +453,16 @@ class FragmentMetadata {
   Status load_tile_var_sizes(
       const EncryptionKey& encryption_key, const std::string& name);
 
+  /**
+   * Loads tile offsets for the attribute/dimension names.
+   *
+   * @param encryption_key The key the array got opened with.
+   * @param names The attribute/dimension names.
+   * @return Status
+   */
+  Status load_tile_offsets(
+      const EncryptionKey& encryption_key, std::vector<std::string>&& names);
+
  private:
   /* ********************************* */
   /*          TYPE DEFINITIONS         */

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -1120,6 +1120,15 @@ class Reader {
       Tile* tile_var) const;
 
   /**
+   * Loads offsets for each attribute/dimension name into
+   * their associated element in `fragment_metadata_`.
+   *
+   * @param names The attribute/dimension names.
+   * @return Status
+   */
+  Status load_offsets(const std::vector<std::string>& names);
+
+  /**
    * Retrieves the tiles on a particular attribute or dimension and stores it
    * in the appropriate result tile.
    *


### PR DESCRIPTION
Particularly for cloud storage backends, loading tile offsets is a performance
sensitive path. Sequential reads perform much better than random reads because
they make better use of the read-ahead cache. This patch aims to increase
the number of sequential reads when loading tile offsets.

Currently, tile offsets are loaded in the following path:
```
for each attribute:
  read_tiles
    parallel_for each fragment:
      load_tile_offsets
    parallel_for each fragment:
      load_var_tile_offsets
```

This patch refactors it to:
```
parallel_for each fragment:
  for each attribute:
    load_tile_offsets
    load_var_tile_offsets
for each attribute:
  read_tiles
```

By inverting the order in which we iterate fragments and attributes, we can
sort the attributes by their index in the fragment metadaa file. By loading
attributes in ascending order of their offsets, we ensure a sequential read
to maximum hits in the read-ahead cache.

Additionally, this defers loading var offsets until all fixed offsets have
been loaded. This is because the fixed offsets exist before the var size
offsets in the file format: https://github.com/TileDB-Inc/TileDB/blob/dev/format_spec/fragment.md

Most importantly, this is a pre-requisite to parallelizing the read_tiles()
for each attribute. When read_tiles are parallel, we can't control the order
that they are executed and therefore load tiles, which may reduce hits in
the read-ahead.