### PR TITLE
C++ Query::get_buffer

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1232,7 +1232,6 @@ TEST_CASE(
   std::vector<uint64_t> offsets(4);
   query_r.set_buffer("d", offsets, data);
   query_r.submit();
-  std::cout << "Data read: " << data << std::endl;
   CHECK(data == "aabbccdddd");
   std::vector<uint64_t> c_offsets = {0, 2, 4, 6};
   CHECK(offsets == c_offsets);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -133,6 +133,12 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic]") {
 
     std::vector<int> subarray = {0, 1, 0, 0};
 
+    uint64_t buf_back_elem_size;
+    void* buf_back;
+    uint64_t buf_back_nelem = 0;
+    uint64_t* offsets_back;
+    uint64_t offsets_back_nelem = 0;
+
     REQUIRE(
         Array::encryption_type(ctx, "cpp_unit_array") == TILEDB_NO_ENCRYPTION);
 
@@ -159,6 +165,26 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic]") {
       query.set_layout(TILEDB_ROW_MAJOR);
 
       REQUIRE(query.submit() == Query::Status::COMPLETE);
+
+      // check a1 buffers
+      query.get_buffer("a1", &buf_back, &buf_back_nelem, &buf_back_elem_size);
+      REQUIRE(buf_back == a1.data());
+      REQUIRE(buf_back_nelem == 2);
+      REQUIRE(buf_back_elem_size == sizeof(int));
+
+      // check a2 buffers
+      query.get_buffer(
+          "a2",
+          &offsets_back,
+          &offsets_back_nelem,
+          &buf_back,
+          &buf_back_nelem,
+          &buf_back_elem_size);
+      REQUIRE(buf_back == a2buf.second.data());
+      REQUIRE(buf_back_nelem == 7);
+      REQUIRE(buf_back_elem_size == sizeof(char));
+      REQUIRE(offsets_back == a2buf.first.data());
+      REQUIRE(offsets_back_nelem == 2);
 
       CHECK(!query.has_results());
 

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3247,7 +3247,9 @@ TILEDB_EXPORT int32_t tiledb_query_set_buffer_var(
  * @param name The attribute/dimension to get the buffer for. Note that the
  *     zipped coordinates have special name `TILEDB_COORDS`.
  * @param buffer The buffer to retrieve.
- * @param buffer_size A pointer to the size of the buffer.
+ * @param buffer_size A pointer to the size of the buffer. Note that this is
+ *     a double pointer and returns the original variable address from
+ *     `set_buffer`.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int32_t tiledb_query_get_buffer(
@@ -3277,9 +3279,13 @@ TILEDB_EXPORT int32_t tiledb_query_get_buffer(
  * @param query The TileDB query.
  * @param name The attribute/dimension to set the buffer for.
  * @param buffer_off The offsets buffer to be retrieved.
- * @param buffer_off_size A pointer to the size of the offsets buffer.
+ * @param buffer_off_size A pointer to the size of the offsets buffer. Note that
+ *     this is a `uint_64**` pointer and returns the original variable address
+ * from `set_buffer`.
  * @param buffer_val The values buffer to be retrieved.
- * @param buffer_val_size A pointer to the size of the values buffer.
+ * @param buffer_val_size A pointer to the size of the values buffer. Note that
+ *     this is a `uint_64**` pointer and returns the original variable address
+ * from `set_buffer`.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int32_t tiledb_query_get_buffer_var(


### PR DESCRIPTION
Equivalent to the existing `tiledb_query_get_buffer` and `tiledb_query_get_buffer_var` in the C API.