### PR TITLE
Concurrent Reader::read_tiles()

### DIFF
--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -481,6 +481,9 @@ const std::string special_name_prefix = "__";
 /** Number of milliseconds between watchdog thread wakeups. */
 const unsigned watchdog_thread_sleep_ms = 1000;
 
+/** Maximum number of concurrent attribute reads. */
+const unsigned concurrent_attr_reads = 2;
+
 const void* fill_value(Datatype type) {
   switch (type) {
     case Datatype::INT8:

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -472,6 +472,9 @@ extern const std::string special_name_prefix;
 /** Number of milliseconds between watchdog thread wakeups. */
 extern const unsigned watchdog_thread_sleep_ms;
 
+/** Maximum number of concurrent attribute reads. */
+extern const unsigned concurrent_attr_reads;
+
 /** Returns the empty fill value based on the input datatype. */
 const void* fill_value(Datatype type);
 

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -37,6 +37,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <queue>
 #include <vector>
 
 #include "tiledb/sm/array_schema/tile_domain.h"
@@ -496,38 +497,290 @@ class Reader {
   /*         PRIVATE DATATYPES         */
   /* ********************************* */
 
-  struct CopyFixedCellsContextCache {
+  class CopyFixedCellsContextCache {
+   public:
+    /** Constructor. */
+    CopyFixedCellsContextCache()
+        : initialized_(false)
+        , num_cs_(0) {
+    }
+
+    /** Destructor. */
+    ~CopyFixedCellsContextCache() = default;
+
+    DISABLE_COPY_AND_COPY_ASSIGN(CopyFixedCellsContextCache);
+    DISABLE_MOVE_AND_MOVE_ASSIGN(CopyFixedCellsContextCache);
+
     /**
-     * Maps the index of each cell slab to its offset in the
-     * output buffer.
+     * Initializes this instance on the first invocation, otherwise
+     * this is a no-op.
+     *
+     * @param result_cell_slabs The cell slabs.
+     * @param num_copy_threads The number of threads used in the copy path.
      */
-    std::vector<uint64_t> cs_offsets;
+    void initialize(
+        const std::vector<ResultCellSlab>& result_cell_slabs,
+        const int num_copy_threads) {
+      // Without locking the `mutex_`, check if this instance
+      // has been initialized.
+      if (initialized_)
+        return;
+
+      std::lock_guard<std::mutex> lg(mutex_);
+
+      // Re-check if this instance has been initialized.
+      if (initialized_)
+        return;
+
+      // Store the number of cell slabs.
+      num_cs_ = result_cell_slabs.size();
+
+      // Calculate the partition sizes.
+      const uint64_t num_cs_partitions =
+          std::min<uint64_t>(num_copy_threads, num_cs_);
+      const uint64_t cs_per_partition = num_cs_ / num_cs_partitions;
+      const uint64_t cs_per_partition_carry = num_cs_ % num_cs_partitions;
+
+      // Calculate the partition offsets.
+      uint64_t num_cs_partitioned = 0;
+      cs_partitions_.reserve(num_cs_partitions);
+      for (uint64_t i = 0; i < num_cs_partitions; ++i) {
+        const uint64_t num_cs_in_partition =
+            cs_per_partition + ((i < cs_per_partition_carry) ? 1 : 0);
+        num_cs_partitioned += num_cs_in_partition;
+        cs_partitions_.emplace_back(num_cs_partitioned);
+      }
+
+      initialized_ = true;
+    }
+
+    /** Returns the `cs_partitions_`. */
+    const std::vector<size_t>* cs_partitions() const {
+      // We do protect this with `mutex_` because it is only
+      // mutated on initialization.
+      return &cs_partitions_;
+    }
+
+    /** Returns a pre-sized vector to store cell slab offsets. */
+    std::unique_ptr<std::vector<uint64_t>> get_cs_offsets() {
+      std::lock_guard<std::mutex> lg(mutex_);
+
+      // Re-use a vector in the `cs_offsets_cache_` if possible,
+      // otherwise create a new vector of size `num_cs_`.
+      std::unique_ptr<std::vector<uint64_t>> cs_offsets;
+      if (!cs_offsets_cache_.empty()) {
+        cs_offsets = std::move(cs_offsets_cache_.front());
+        assert(cs_offsets->size() == num_cs_);
+        cs_offsets_cache_.pop();
+      } else {
+        cs_offsets =
+            std::unique_ptr<std::vector<uint64_t>>(new std::vector<uint64_t>());
+        cs_offsets->resize(num_cs_);
+      }
+
+      return cs_offsets;
+    }
+
+    /** Returns a vector fetched from `get_cs_offsets`. */
+    void cache_cs_offsets(std::unique_ptr<std::vector<uint64_t>>&& cs_offsets) {
+      assert(cs_offsets->size() == num_cs_);
+      std::lock_guard<std::mutex> lg(mutex_);
+      cs_offsets_cache_.push(std::move(cs_offsets));
+    }
+
+   private:
+    /** Protects all member variables. */
+    std::mutex mutex_;
+
+    /** True if the context cache has been initialized. */
+    bool initialized_;
 
     /**
      * Logical partitions of `cs_offsets`. Each element is the
      * partition's starting index.
      */
-    std::vector<size_t> cs_partitions;
+    std::vector<size_t> cs_partitions_;
+
+    /** The number of cell slabs. */
+    size_t num_cs_;
+
+    /**
+     * A pool of vectors that maps the index of each cell slab
+     * to its offset in the output buffer.
+     */
+    std::queue<std::unique_ptr<std::vector<uint64_t>>> cs_offsets_cache_;
   };
 
-  struct CopyVarCellsContextCache {
-    /**
-     * Maps each cell slab to its offset for its attribute offsets.
-     */
-    std::vector<uint64_t> offset_offsets_per_cs;
+  class CopyVarCellsContextCache {
+   public:
+    /** Constructor. */
+    CopyVarCellsContextCache()
+        : initialized_(false)
+        , total_cs_length_(0) {
+    }
+
+    /** Destructor. */
+    ~CopyVarCellsContextCache() = default;
+
+    DISABLE_COPY_AND_COPY_ASSIGN(CopyVarCellsContextCache);
+    DISABLE_MOVE_AND_MOVE_ASSIGN(CopyVarCellsContextCache);
 
     /**
-     * Maps each cell slab to its offset for its variable-length data.
+     * Initializes this instance on the first invocation, otherwise
+     * this is a no-op.
+     *
+     * @param result_cell_slabs The cell slabs.
+     * @param num_copy_threads The number of threads used in the copy path.
      */
-    std::vector<uint64_t> var_offsets_per_cs;
+    void initialize(
+        const std::vector<ResultCellSlab>& result_cell_slabs,
+        const int num_copy_threads) {
+      // Without locking the `mutex_`, check if this instance
+      // has been initialized.
+      if (initialized_)
+        return;
+
+      std::lock_guard<std::mutex> lg(mutex_);
+
+      // Re-check if this instance has been initialized.
+      if (initialized_)
+        return;
+
+      // Calculate the partition range.
+      const uint64_t num_cs = result_cell_slabs.size();
+      const uint64_t num_cs_partitions =
+          std::min<uint64_t>(num_copy_threads, num_cs);
+      const uint64_t cs_per_partition = num_cs / num_cs_partitions;
+      const uint64_t cs_per_partition_carry = num_cs % num_cs_partitions;
+
+      // Compute the boundary between each partition. Each boundary
+      // is represented by an `std::pair` that contains the total
+      // length of each cell slab in the leading partition and an
+      // exclusive cell slab index that ends the partition.
+      uint64_t next_partition_idx = cs_per_partition;
+      if (cs_per_partition_carry > 0)
+        ++next_partition_idx;
+
+      total_cs_length_ = 0;
+      cs_partitions_.reserve(num_cs_partitions);
+      for (uint64_t cs_idx = 0; cs_idx < num_cs; cs_idx++) {
+        if (cs_idx == next_partition_idx) {
+          cs_partitions_.emplace_back(total_cs_length_, cs_idx);
+
+          // The final partition may contain extra cell slabs that did
+          // not evenly divide into the partition range. Set the
+          // `next_partition_idx` to zero and build the last boundary
+          // after this for-loop.
+          if (cs_partitions_.size() == num_cs_partitions) {
+            next_partition_idx = 0;
+          } else {
+            next_partition_idx += cs_per_partition;
+            if (cs_idx < (cs_per_partition_carry - 1))
+              ++next_partition_idx;
+          }
+        }
+
+        total_cs_length_ += result_cell_slabs[cs_idx].length_;
+      }
+
+      // Store the final boundary.
+      cs_partitions_.emplace_back(total_cs_length_, num_cs);
+    }
+
+    /** Returns the `cs_partitions_`. */
+    const std::vector<std::pair<size_t, size_t>>* cs_partitions() const {
+      // We do protect this with `mutex_` because it is only
+      // mutated on initialization.
+      return &cs_partitions_;
+    }
+
+    /** Returns a pre-sized vector to store offset-offsets per cell slab. */
+    std::unique_ptr<std::vector<uint64_t>> get_offset_offsets_per_cs() {
+      std::lock_guard<std::mutex> lg(mutex_);
+
+      // Re-use a vector in the `offset_offsets_per_cs_cache_` if possible,
+      // otherwise create a new vector of size `total_cs_length_`.
+      std::unique_ptr<std::vector<uint64_t>> offset_offsets_per_cs;
+      if (!offset_offsets_per_cs_cache_.empty()) {
+        offset_offsets_per_cs = std::move(offset_offsets_per_cs_cache_.front());
+        assert(offset_offsets_per_cs->size() == total_cs_length_);
+        offset_offsets_per_cs_cache_.pop();
+      } else {
+        offset_offsets_per_cs =
+            std::unique_ptr<std::vector<uint64_t>>(new std::vector<uint64_t>());
+        offset_offsets_per_cs->resize(total_cs_length_);
+      }
+
+      return offset_offsets_per_cs;
+    }
+
+    /** Returns a vector fetched from `get_offset_offsets_per_cs`. */
+    void cache_offset_offsets_per_cs(
+        std::unique_ptr<std::vector<uint64_t>>&& offset_offsets_per_cs) {
+      assert(offset_offsets_per_cs->size() == total_cs_length_);
+      std::lock_guard<std::mutex> lg(mutex_);
+      offset_offsets_per_cs_cache_.push(std::move(offset_offsets_per_cs));
+    }
+
+    /** Returns a pre-sized vector to store var-offsets per cell slab. */
+    std::unique_ptr<std::vector<uint64_t>> get_var_offsets_per_cs() {
+      std::lock_guard<std::mutex> lg(mutex_);
+
+      // Re-use a vector in the `var_offsets_per_cs_cache_` if possible,
+      // otherwise create a new vector of size `total_cs_length_`.
+      std::unique_ptr<std::vector<uint64_t>> var_offsets_per_cs;
+      if (!var_offsets_per_cs_cache_.empty()) {
+        var_offsets_per_cs = std::move(var_offsets_per_cs_cache_.front());
+        assert(var_offsets_per_cs->size() == total_cs_length_);
+        var_offsets_per_cs_cache_.pop();
+      } else {
+        var_offsets_per_cs =
+            std::unique_ptr<std::vector<uint64_t>>(new std::vector<uint64_t>());
+        var_offsets_per_cs->resize(total_cs_length_);
+      }
+
+      return var_offsets_per_cs;
+    }
+
+    /** Returns a vector fetched from `get_var_offsets_per_cs`. */
+    void cache_var_offsets_per_cs(
+        std::unique_ptr<std::vector<uint64_t>>&& var_offsets_per_cs) {
+      assert(var_offsets_per_cs->size() == total_cs_length_);
+      std::lock_guard<std::mutex> lg(mutex_);
+      var_offsets_per_cs_cache_.push(std::move(var_offsets_per_cs));
+    }
+
+   private:
+    /** Protects all member variables. */
+    std::mutex mutex_;
+
+    /** True if the context cache has been initialized. */
+    bool initialized_;
 
     /**
-     * Logical partitions of both `offset_offsets_per_cs` and
+     * Logical partitions for both `offset_offsets_per_cs` and
      * `var_offsets_per_cs`. Each element contains a pair, where the
      * first pair-element is the partition's starting index and the
      * second pair-element is the number of cell slabs in the partition.
      */
-    std::vector<std::pair<size_t, size_t>> cs_partitions;
+    std::vector<std::pair<size_t, size_t>> cs_partitions_;
+
+    /** The total size of all cell slabs. */
+    size_t total_cs_length_;
+
+    /**
+     * A pool of vectors that maps each cell slab to its offset
+     * for its attribute offsets.
+     */
+    std::queue<std::unique_ptr<std::vector<uint64_t>>>
+        offset_offsets_per_cs_cache_;
+
+    /**
+     * A pool of vectors that maps each cell slab to its offset
+     * for its variable-length data.
+     */
+    std::queue<std::unique_ptr<std::vector<uint64_t>>>
+        var_offsets_per_cs_cache_;
   };
 
   /* ********************************* */
@@ -577,6 +830,9 @@ class Reader {
 
   /** The memory budget for the var-sized attributes. */
   uint64_t memory_budget_var_;
+
+  /** Protects result tiles. */
+  mutable std::mutex result_tiles_mutex_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */
@@ -764,7 +1020,8 @@ class Reader {
    *     cell slabs are all contiguous. Otherwise, each cell in the
    *     result cell slabs are `stride` cells apart from each other.
    * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param ctx_cache The context cache containing partition information.
+   * @param cs_offsets The cell slab offsets.
+   * @param cs_partitions The cell slab partitions to operate on.
    * @return Status
    */
   Status copy_partitioned_fixed_cells(
@@ -772,7 +1029,8 @@ class Reader {
       const std::string* name,
       uint64_t stride,
       const std::vector<ResultCellSlab>* result_cell_slabs,
-      const CopyFixedCellsContextCache* ctx_cache);
+      const std::vector<uint64_t>& cs_offsets,
+      const std::vector<size_t>& cs_partitions);
 
   /**
    * Copies the cells for the input **var-sized** attribute/dimension and result
@@ -845,7 +1103,11 @@ class Reader {
    *     cell slabs are all contiguous. Otherwise, each cell in the
    *     result cell slabs are `stride` cells apart from each other.
    * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param ctx_cache The context cache containing partition information.
+   * @param offset_offsets_per_cs Maps each cell slab to its offset
+   *     for its attribute offsets.
+   * @param var_offsets_per_cs Maps each cell slab to its offset
+   *     for its variable-length data.
+   * @param cs_partitions The cell slab partitions to operate on.
    * @return Status
    */
   Status copy_partitioned_var_cells(
@@ -853,7 +1115,9 @@ class Reader {
       const std::string* name,
       uint64_t stride,
       const std::vector<ResultCellSlab>* result_cell_slabs,
-      CopyVarCellsContextCache* ctx_cache);
+      const std::vector<uint64_t>* offset_offsets_per_cs,
+      const std::vector<uint64_t>* var_offsets_per_cs,
+      const std::vector<std::pair<size_t, size_t>>* cs_partitions);
 
   /**
    * Computes the result space tiles based on the input subarray.
@@ -1120,13 +1384,53 @@ class Reader {
       Tile* tile_var) const;
 
   /**
-   * Loads offsets for each attribute/dimension name into
+   * Loads tile offsets for each attribute/dimension name into
    * their associated element in `fragment_metadata_`.
    *
    * @param names The attribute/dimension names.
    * @return Status
    */
-  Status load_offsets(const std::vector<std::string>& names);
+  Status load_tile_offsets(const std::vector<std::string>& names);
+
+  /**
+   * Concurrently executes `read_tiles` for each name in `names`. This
+   * must be the entry point for reading attribute tiles because it
+   * generates stats for reading attributes.
+   *
+   * @param names The attribute names.
+   * @param result_tiles The retrieved tiles will be stored inside the
+   *     `ResultTile` instances in this vector.
+   * @return Status
+   */
+  Status read_attribute_tiles(
+      const std::vector<std::string>& names,
+      const std::vector<ResultTile*>& result_tiles) const;
+
+  /**
+   * Concurrently executes `read_tiles` for each name in `names`. This
+   * must be the entry point for reading coordinate tiles because it
+   * generates stats for reading coordinates.
+   *
+   * @param names The coordinate/dimension names.
+   * @param result_tiles The retrieved tiles will be stored inside the
+   *     `ResultTile` instances in this vector.
+   * @return Status
+   */
+  Status read_coordinate_tiles(
+      const std::vector<std::string>& names,
+      const std::vector<ResultTile*>& result_tiles) const;
+
+  /**
+   * Concurrently executes `read_tiles` for each name in `names`.
+   *
+   * @param names The attribute/dimension names.
+   * @param result_tiles The retrieved tiles will be stored inside the
+   *     `ResultTile` instances in this vector.
+   * @return Status
+   */
+  Status read_tiles(
+      const std::vector<std::string>& names,
+      const std::vector<ResultTile*>& result_tiles) const;
 
   /**
    * Retrieves the tiles on a particular attribute or dimension and stores it


### PR DESCRIPTION
Currently, reading/unfiltering/copying tiles are performed serially among
attribute names within Reader::copy_attribute_values():
```
for (const auto& name : names) {
  read_tiles(name, result_tiles);
  unfilter_tiles(name, result_tiles, &cs_ranges);
  if (!array_schema_->var_size(name))
    copy_fixed_cells(name, stride, result_cell_slabs, &fixed_ctx_cache);
  else
    copy_var_cells(name, stride, result_cell_slabs, &var_ctx_cache);
  clear_tiles(name, result_tiles);
}
```

Parallelizing the entire for-loop has a few problems:
1. Each iteration requires a large amount of temporary memory to buffer reads
   into before they are copied into `buffers_` and cleared within clear_tiles().
   This memory can not be shared among parallel iterations, so memory bloat
   scales linearly with the number of parallel iterations.
2. `read_tiles`, `unfilter_tiles`, `copy_fixed_cells`, `copy_var_cells`, and
   `clear_tiles` are thread-unsafe because of unprotected access to the
    individual `ResultTile` elements within `result_tiles`.
3. `copy_fixed_cells` and `copy_var_cells` are thread-unsafe because the
   `fixed_ctx_cache` and `var_ctx_cache` are thread-unsafe.

Problem #1: This patch restricts the number of parallel iterations to 2. This
is a hard-coded value that I will justify later in this commit message.

Problem #2: We can achieve thread-safety with a mutex for each ResultTile
element. Even if we tolerate the memory overhead associated with allocating a
mutex for each ResultTile, the CPU time spent locking at this granularity
is unacceptably high within the `copy_fixed_cells` and `copy_var_cells` paths.
However, it is experimentally negligible for the other paths. This is enough
of a penalty that I have decided to use a single lock to protect all elements.
This effectively serializes all routines, except for the IO tasks within
`read_tiles`.

Problem #3: I have made the context caches thread safe, although they are still
accessed in serial. This is mostly because I had to write this code before I
was able to test that parallelizing `copy_*_cells` was too expensive with
per-ResulTile mutexes. I have decided to leave it in this patch because it is
zero-harm and required for future improvements.

I have been testing this in an IO-bound workload (using an S3 backend). Due to
the large variance in S3 request times, I ran my test many times and collected
the best-case numbers.

// Execution times:
Without this patch: 4.5s
With this patch, 1 parallel iteration: 4.5s
With this patch, 2 parallel iteration: 3.4s
With this patch, 3 parallel iteration: 3.4s
With this patch, 4 parallel iteration: 3.2s
With this patch, 6 parallel iteration: 3.2s
With this patch, 8 parallel iteration: 3.3s
With this patch, 12 parallel iteration: 3.7s

Given the above, it does seem that the number of parallel iterations should
be configurable. For more than 2 parallel iterations, we linearly scale memory
bloat with little-to-gain in execution time. However, with just 2 parallel
iterations, we receive a 32% speed-up.

Future Improvments:
- Modify ThreadPool::execute() to allow limiting the number of parallel iterations
for an arbitrary number of tasks. This patch uses a step-wise execution of
parallel reads. In other words: both parallel iterations must complete before
the next pair of `read_tiles()` can execute. Ideally, the 3rd iteration should
start immediately after one of the first two complete.

- Increase the granularity of protection on ResultTiles. I have a couple ideas
but they would be large and out of scope for this patch.

- Revisit the read path for dimensions. Right now, there is no limit to the
number of dimensions read at one time. If we have a large number of dimensions,
we will have a memory bottleneck.