### PR TITLE
Switch to pkgconfig metadata for cURL OpenSSL lookup

### DIFF
--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -99,7 +99,8 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
     set(DEPENDS)
     if (TARGET ep_openssl)
       list(APPEND DEPENDS ep_openssl)
-      set(WITH_SSL "--with-ssl=${TILEDB_EP_INSTALL_PREFIX}")
+      set(WITH_SSL "--with-ssl")
+      set(SSL_PKG_CONFIG_PATH "${TILEDB_EP_INSTALL_PREFIX}/lib/pkgconfig:${TILEDB_EP_INSTALL_PREFIX}/lib64/pkgconfig")
     elseif (TILEDB_OPENSSL_DIR)
       # ensure that curl links against the same libSSL
       set(WITH_SSL "--with-ssl=${TILEDB_OPENSSL_DIR}")
@@ -126,7 +127,7 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
       URL "https://curl.haxx.se/download/curl-7.71.1.tar.gz"
       URL_HASH SHA1=9c032e134c7684f34f98afaf9974f048da893930
       CONFIGURE_COMMAND
-        ${TILEDB_EP_BASE}/src/ep_curl/configure
+        ${CMAKE_COMMAND} -E env PKG_CONFIG_PATH=${SSL_PKG_CONFIG_PATH} ${TILEDB_EP_BASE}/src/ep_curl/configure
           --prefix=${TILEDB_EP_INSTALL_PREFIX}
           --enable-optimize
           --enable-shared=no


### PR DESCRIPTION
The pkgconfig style is the preferred way to correctly set the library
and include search paths for building cURL with OpenSSL support.  This
style has the distinct advantage of supporting multilib [1].

  1. https://github.com/TileDB-Inc/TileDB-Java/commit/3ecd3436297a3952137eb07f464fae6855fe835c