### PR TITLE
kt/add tiledb query get array API call

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -465,7 +465,7 @@ The 1.6.0 release adds the major new feature of non-continuous range slicing, as
 
 ### C++ API
 
-* Added functions `Query::{query_layout, add_range, range, range_num, query_array}`.
+* Added functions `Query::{query_layout, add_range, range, range_num, array}`.
 ## Breaking changes
 
 ### C API

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -460,6 +460,8 @@ The 1.6.0 release adds the major new feature of non-continuous range slicing, as
 * Added string conversion functions `tiledb_*_to_str()` and `tiledb_*_from_str()` for all public enum types.
 * Added config param `vfs.file.enable_filelocks`
 * Added datatypes `TILEDB_DATETIME_*`
+* Added function `tiledb_query_get_array`
+
 
 ### C++ API
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -463,8 +463,7 @@ The 1.6.0 release adds the major new feature of non-continuous range slicing, as
 
 ### C++ API
 
-* Added functions `Query::{query_layout, add_range, range, range_num}`.
-
+* Added functions `Query::{query_layout, add_range, range, range_num, query_array}`.
 ## Breaking changes
 
 ### C API

--- a/test/src/unit-capi-query.cc
+++ b/test/src/unit-capi-query.cc
@@ -31,6 +31,7 @@
  * Tests for the C API tiledb_query_t spec.
  */
 
+#include <tiledb/sm/c_api/tiledb_struct_def.h>
 #include <cassert>
 #include <cstring>
 #include <iostream>
@@ -563,6 +564,57 @@ TEST_CASE_METHOD(
   rc = tiledb_query_get_layout(ctx_, query, &layout);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(layout == TILEDB_UNORDERED);
+
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_query_free(&query);
+  tiledb_array_free(&array);
+  remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    QueryFx,
+    "C API: Test query get array",
+    "[capi], [query], [query-get-array]") {
+  std::string temp_dir = FILE_URI_PREFIX + FILE_TEMP_DIR;
+  std::string array_name = temp_dir + "query_get_array";
+  create_temp_dir(temp_dir);
+  create_array(array_name);
+
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_t rarray;
+  rc = tiledb_query_get_array(ctx_, query, &rarray);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(rarray.array_ == array->array_);
+
+  tiledb_array_schema_t* rschema;
+  rc = tiledb_array_get_schema(ctx_, &rarray, &rschema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Get schema members
+  uint64_t rcapacity;
+  rc = tiledb_array_schema_get_capacity(ctx_, rschema, &rcapacity);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(rcapacity == 10000);
+
+  tiledb_layout_t layout;
+  rc = tiledb_array_schema_get_cell_order(ctx_, rschema, &layout);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(layout == TILEDB_ROW_MAJOR);
+
+  rc = tiledb_array_schema_get_tile_order(ctx_, rschema, &layout);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(layout == TILEDB_ROW_MAJOR);
 
   rc = tiledb_array_close(ctx_, array);
   REQUIRE(rc == TILEDB_OK);

--- a/test/src/unit-capi-query.cc
+++ b/test/src/unit-capi-query.cc
@@ -592,13 +592,13 @@ TEST_CASE_METHOD(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
 
   REQUIRE(rc == TILEDB_OK);
-  tiledb_array_t rarray;
+  tiledb_array_t* rarray;
   rc = tiledb_query_get_array(ctx_, query, &rarray);
   REQUIRE(rc == TILEDB_OK);
-  CHECK(rarray.array_ == array->array_);
+  CHECK(rarray->array_ == array->array_);
 
   tiledb_array_schema_t* rschema;
-  rc = tiledb_array_get_schema(ctx_, &rarray, &rschema);
+  rc = tiledb_array_get_schema(ctx_, rarray, &rschema);
   REQUIRE(rc == TILEDB_OK);
 
   // Get schema members

--- a/test/src/unit-cppapi-query.cc
+++ b/test/src/unit-cppapi-query.cc
@@ -89,7 +89,7 @@ TEST_CASE("C++ API: Test get query array", "[cppapi][query]") {
   Array array(ctx, array_name, TILEDB_READ);
   Query query(ctx, array);
 
-  Array rquery = query.query_array();
+  Array rquery = query.array();
   // The two arrays are of the same query type
   REQUIRE(array.query_type() == TILEDB_READ);
   REQUIRE(rquery.query_type() == TILEDB_READ);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2786,16 +2786,16 @@ int32_t tiledb_query_get_layout(
 }
 
 int32_t tiledb_query_get_array(
-    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** query_array) {
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** array) {
   // Sanity check
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
     return TILEDB_ERR;
 
   // Create array datatype
-  *query_array = new (std::nothrow) tiledb_array_t;
+  *array = new (std::nothrow) tiledb_array_t;
 
   // Get array
-  (*query_array)->array_ = query->query_->array();
+  (*array)->array_ = query->query_->array();
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2785,6 +2785,17 @@ int32_t tiledb_query_get_layout(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_get_array(
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t* query_array) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Get array
+  query_array->array_ = query->query_->array();
+
+  return TILEDB_OK;
+}
 int32_t tiledb_query_add_range(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2786,13 +2786,16 @@ int32_t tiledb_query_get_layout(
 }
 
 int32_t tiledb_query_get_array(
-    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t* query_array) {
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** query_array) {
   // Sanity check
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
     return TILEDB_ERR;
 
+  //Create array datatype
+  *query_array = new (std::nothrow) tiledb_array_t;
+
   // Get array
-  query_array->array_ = query->query_->array();
+  (*query_array)->array_ = query->query_->array();
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2791,7 +2791,7 @@ int32_t tiledb_query_get_array(
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  //Create array datatype
+  // Create array datatype
   *query_array = new (std::nothrow) tiledb_array_t;
 
   // Get array

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3515,6 +3515,23 @@ TILEDB_EXPORT int32_t tiledb_query_get_layout(
     tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_layout_t* query_layout);
 
 /**
+ * Retrieves the query array.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_t query_array;
+ * tiledb_query_get_array(ctx, query, &query_array);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The query.
+ * @param query_array The query array to be retrieved.
+ * @return `TILEDB_OK` upon success, and `TILEDB_ERR` upon error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_array(
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t* query_array);
+/**
  * Adds a 1D range along a subarray dimension, which is in the form
  * (start, end, stride). The datatype of the range components
  * must be the same as the type of the domain of the array in the query.

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3520,7 +3520,7 @@ TILEDB_EXPORT int32_t tiledb_query_get_layout(
  * **Example:**
  *
  * @code{.c}
- * tiledb_array_t query_array;
+ * tiledb_array_t* query_array;
  * tiledb_query_get_array(ctx, query, &query_array);
  * @endcode
  *
@@ -3530,7 +3530,7 @@ TILEDB_EXPORT int32_t tiledb_query_get_layout(
  * @return `TILEDB_OK` upon success, and `TILEDB_ERR` upon error.
  */
 TILEDB_EXPORT int32_t tiledb_query_get_array(
-    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t* query_array);
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** query_array);
 /**
  * Adds a 1D range along a subarray dimension, which is in the form
  * (start, end, stride). The datatype of the range components

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3520,17 +3520,17 @@ TILEDB_EXPORT int32_t tiledb_query_get_layout(
  * **Example:**
  *
  * @code{.c}
- * tiledb_array_t* query_array;
- * tiledb_query_get_array(ctx, query, &query_array);
+ * tiledb_array_t* array;
+ * tiledb_query_get_array(ctx, query, &array);
  * @endcode
  *
  * @param ctx The TileDB context.
  * @param query The query.
- * @param query_array The query array to be retrieved.
+ * @param array The query array to be retrieved.
  * @return `TILEDB_OK` upon success, and `TILEDB_ERR` upon error.
  */
 TILEDB_EXPORT int32_t tiledb_query_get_array(
-    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** query_array);
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** array);
 /**
  * Adds a 1D range along a subarray dimension, which is in the form
  * (start, end, stride). The datatype of the range components

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -45,7 +45,6 @@
 #include "type.h"
 #include "utils.h"
 
-#include <tiledb/sm/c_api/tiledb_struct_def.h>
 #include <algorithm>
 #include <cassert>
 #include <functional>

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -45,6 +45,7 @@
 #include "type.h"
 #include "utils.h"
 
+#include <tiledb/sm/c_api/tiledb_struct_def.h>
 #include <algorithm>
 #include <cassert>
 #include <functional>

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -42,7 +42,6 @@
 #include "deleter.h"
 #include "exception.h"
 #include "tiledb.h"
-#include "tiledb_struct_def.h"
 #include "type.h"
 #include "utils.h"
 
@@ -235,9 +234,9 @@ class Query {
   /** Returns the array of the query. */
   Array query_array() {
     auto& ctx = ctx_.get();
-    tiledb_array_t* c_query_array = new (std::nothrow) tiledb_array_t;
+    tiledb_array_t* c_query_array;
     ctx.handle_error(
-        tiledb_query_get_array(ctx.ptr().get(), query_.get(), c_query_array));
+        tiledb_query_get_array(ctx.ptr().get(), query_.get(), &c_query_array));
     return Array(ctx, c_query_array, false);
   }
 

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -44,8 +44,8 @@
 #include "tiledb.h"
 #include "type.h"
 #include "utils.h"
+#include "tiledb_struct_def.h"
 
-#include <tiledb/sm/c_api/tiledb_struct_def.h>
 #include <algorithm>
 #include <cassert>
 #include <functional>

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -129,6 +129,7 @@ class Query {
    */
   Query(const Context& ctx, const Array& array, tiledb_query_type_t type)
       : ctx_(ctx)
+      , array_(array)
       , schema_(array.schema()) {
     tiledb_query_t* q;
     ctx.handle_error(
@@ -163,6 +164,7 @@ class Query {
    */
   Query(const Context& ctx, const Array& array)
       : ctx_(ctx)
+      , array_(array)
       , schema_(array.schema()) {
     tiledb_query_t* q;
     auto type = array.query_type();
@@ -232,12 +234,8 @@ class Query {
   }
 
   /** Returns the array of the query. */
-  Array array() {
-    auto& ctx = ctx_.get();
-    tiledb_array_t* c_query_array;
-    ctx.handle_error(
-        tiledb_query_get_array(ctx.ptr().get(), query_.get(), &c_query_array));
-    return Array(ctx, c_query_array, false);
+  const Array& array() {
+    return array_;
   }
 
   /** Returns the query status. */
@@ -1230,6 +1228,9 @@ class Query {
 
   /** The TileDB context. */
   std::reference_wrapper<const Context> ctx_;
+
+  /** The TileDB array. */
+  std::reference_wrapper<const Array> array_;
 
   /** Deleter wrapper. */
   impl::Deleter deleter_;

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -42,9 +42,9 @@
 #include "deleter.h"
 #include "exception.h"
 #include "tiledb.h"
+#include "tiledb_struct_def.h"
 #include "type.h"
 #include "utils.h"
-#include "tiledb_struct_def.h"
 
 #include <algorithm>
 #include <cassert>

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -45,6 +45,7 @@
 #include "type.h"
 #include "utils.h"
 
+#include <tiledb/sm/c_api/tiledb_struct_def.h>
 #include <algorithm>
 #include <cassert>
 #include <functional>
@@ -229,6 +230,15 @@ class Query {
     ctx.handle_error(
         tiledb_query_get_layout(ctx.ptr().get(), query_.get(), &query_layout));
     return query_layout;
+  }
+
+  /** Returns the array of the query. */
+  Array query_array() {
+    auto& ctx = ctx_.get();
+    tiledb_array_t* c_query_array = new (std::nothrow) tiledb_array_t;
+    ctx.handle_error(
+        tiledb_query_get_array(ctx.ptr().get(), query_.get(), c_query_array));
+    return Array(ctx, c_query_array, false);
   }
 
   /** Returns the query status. */

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -232,7 +232,7 @@ class Query {
   }
 
   /** Returns the array of the query. */
-  Array query_array() {
+  Array array() {
     auto& ctx = ctx_.get();
     tiledb_array_t* c_query_array;
     ctx.handle_error(


### PR DESCRIPTION
This PR concerns the task [Add `tiledb_query_get_array` function](https://app.clubhouse.io/tiledb-inc/story/2783).

The `ctx`, `array`, and `query_type` are known to the caller. The caller should be able to fetch/get any of these from a query object. The array is not copied into the query, so it is not any more dangerous to not copy it back out in a `getter` because the caller could retain the raw array pointer from construction time. The `getter` is just for convenience.

- The `getter` in C_API passes-by-pointer the `tiledb_array_t` and its value is populated by the function call.

- For the CXX_API however the user of the API should be agnostic to the aforementioned inner structures. The `Array` object of `tiledb` namespace is not the same as the inner representation of `sm::Array`. So the CXX_API call is designed to return a newly created `Array` object using the already existing constructors by carrying the pointer of the inner array representation alongside with its schema upon the call of `query_array` API function.