### PR TITLE
Only serialize Array URI if client side

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -42,6 +42,7 @@
 
 * Fixed bug in setting a fill value for var-sized attributes.
 * Fixed a bug where the cpp headers would always produce compile-time warnings about using the deprecated c-api "tiledb_coords()" [#1765](https://github.com/TileDB-Inc/TileDB/pull/1765)
+* Only serialize the Array URI in the array schema client size. [#1806](https://github.com/TileDB-Inc/TileDB/pull/1806)
 
 ## API additions
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4411,9 +4411,6 @@ int32_t tiledb_serialize_array_schema(
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
     tiledb_buffer_t** buffer) {
-  // Currently unused:
-  (void)client_side;
-
   // Sanity check
   if (sanity_check(ctx) == TILEDB_ERR ||
       sanity_check(ctx, array_schema) == TILEDB_ERR)
@@ -4429,7 +4426,8 @@ int32_t tiledb_serialize_array_schema(
           tiledb::sm::serialization::array_schema_serialize(
               array_schema->array_schema_,
               (tiledb::sm::SerializationType)serialize_type,
-              (*buffer)->buffer_)))
+              (*buffer)->buffer_,
+              client_side)))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -80,7 +80,7 @@ TILEDB_EXPORT int32_t tiledb_serialization_type_from_str(
  * @param ctx The TileDB context.
  * @param array_schema The array schema to serialize.
  * @param serialization_type Type of serialization to use
- * @param client_side If set to 1, deserialize from "client-side" perspective.
+ * @param client_side If set to 1, serialize from "client-side" perspective.
  *    Else, "server-side."
  * @param buffer Will be set to a newly allocated buffer containing the
  *      serialized max buffer sizes.

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -121,7 +121,7 @@ Status RestClient::post_array_schema_to_rest(
     const URI& uri, ArraySchema* array_schema) {
   Buffer buff;
   RETURN_NOT_OK(serialization::array_schema_serialize(
-      array_schema, serialization_type_, &buff));
+      array_schema, serialization_type_, &buff, false));
   // Wrap in a list
   BufferList serialized;
   RETURN_NOT_OK(serialized.add_buffer(std::move(buff)));

--- a/tiledb/sm/serialization/array_schema.h
+++ b/tiledb/sm/serialization/array_schema.h
@@ -48,10 +48,20 @@ enum class SerializationType : uint8_t;
 
 namespace serialization {
 
+/**
+ * Serialize an array schema via Cap'n Prto
+ * @param array_schema schema object to serialize
+ * @param serialize_type format to serialize into Cap'n Proto or JSON
+ * @param serialized_buffer buffer to store serialized bytes in
+ * @param client_side indicate if client or server side. If server side we won't
+ * serialize the array URI
+ * @return
+ */
 Status array_schema_serialize(
     ArraySchema* array_schema,
     SerializationType serialize_type,
-    Buffer* serialized_buffer);
+    Buffer* serialized_buffer,
+    const bool client_side);
 
 Status array_schema_deserialize(
     ArraySchema** array_schema,


### PR DESCRIPTION
We should avoid returning the absolute array URI in the schema when sending from server to client. Only serialize the array if we are client side, in which case the URI was already known to open the array.