### PR TITLE
Raise overridable CMake error if the source, build, or install paths …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,24 @@ set(TILEDB_VERSION_PATCH ${CMAKE_MATCH_1})
 
 set(TILEDB_VERSION "${TILEDB_VERSION_MAJOR}.${TILEDB_VERSION_MINOR}.${TILEDB_VERSION_PATCH}")
 ############################################################
+# Check for regex characters in the most important paths
+# fixes https://github.com/TileDB-Inc/TileDB/issues/1799
+option(TILEDB_ALLOW_REGEX_CHAR_PATH "If true, allow regex characters in source, build, or install path." FALSE)
+mark_as_advanced(TILEDB_ALLOW_REGEX_CHAR_PATH)
+set(REGEX_CHARS "[\\^\\$\\+\\*\\?\\|\\(\\)]") # note: must be escaped, and regex doesn't work with \[\] entries
+set(REGEX_CHAR_PATH_MSG " contains a REGEX character and may break CMakeList processing. Please use"
+                        " a different path, or set TILEDB_ALLOW_REGEX_CHAR_PATH to override.")
+if (NOT TILEDB_ALLOW_REGEX_CHAR_PATH)
+  if (CMAKE_CURRENT_SOURCE_DIR MATCHES ${REGEX_CHARS})
+    message(FATAL_ERROR "CMAKE_CURRENT_SOURCE_DIR ${REGEX_CHAR_PATH_MSG}:\n  '${CMAKE_CURRENT_SOURCE_DIR}'")
+  elseif (CMAKE_CURRENT_SOURCE_DIR MATCHES ${REGEX_CHARS})
+    message(FATAL_ERROR "CMAKE_CURRENT_BINARY_DIR ${REGEX_CHAR_PATH_MSG}:\n  '${CMAKE_CURRENT_BINARY_DIR}'")
+  elseif (CMAKE_CURRENT_SOURCE_DIR MATCHES ${REGEX_CHARS})
+    message(FATAL_ERROR "CMAKE_INSTALL_PREFIX ${REGEX_CHAR_PATH_MSG}:\n  '${CMAKE_INSTALL_PREFIX}'")
+  endif()
+endif()
 
-
+############################################################
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 set(TILEDB_CMAKE_INPUTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake/inputs")

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -43,7 +43,7 @@
 
 * Fixed bug in setting a fill value for var-sized attributes.
 * Fixed a bug where the cpp headers would always produce compile-time warnings about using the deprecated c-api "tiledb_coords()" [#1765](https://github.com/TileDB-Inc/TileDB/pull/1765)
-* Only serialize the Array URI in the array schema client size. [#1806](https://github.com/TileDB-Inc/TileDB/pull/1806)
+* Only serialize the Array URI in the array schema client side. [#1806](https://github.com/TileDB-Inc/TileDB/pull/1806)
 
 ## API additions
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,7 @@
 * Update GCS SDK to v1.16.0 to fixes multiple bugs reported [#1768](https://github.com/TileDB-Inc/TileDB/pull/1768)
 * Read-ahead cache for cloud-storage backends [#1785](https://github.com/TileDB-Inc/TileDB/pull/1785)
 * Allow multiple empty values at the end of a variable-length write [#1805](https://github.com/TileDB-Inc/TileDB/pull/1805)
+* Build system will raise overridable error if important paths contain regex character [#1808](https://github.com/TileDB-Inc/TileDB/pull/1808)
 
 ## Deprecations
 


### PR DESCRIPTION
…contain REGEX characters

fixes https://github.com/TileDB-Inc/TileDB/issues/1799