### PR TITLE
Target haswell or AVX2 for prebuilt libraries

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,6 +29,7 @@
 * Read-ahead cache for cloud-storage backends [#1785](https://github.com/TileDB-Inc/TileDB/pull/1785)
 * Allow multiple empty values at the end of a variable-length write [#1805](https://github.com/TileDB-Inc/TileDB/pull/1805)
 * Build system will raise overridable error if important paths contain regex character [#1808](https://github.com/TileDB-Inc/TileDB/pull/1808)
+* Prebuilt artifacts for release now target `haswell` for minimum architecture for linux/macos and `AVX2` for msvcc [#1809](https://github.com/TileDB-Inc/TileDB/pull/1809)
 
 ## Deprecations
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,6 +94,8 @@ stages:
       TILEDB_SERIALIZATION: ON
       TILEDB_FORCE_BUILD_DEPS: ON
       MACOSX_DEPLOYMENT_TARGET: 10.13
+      CFLAGS: "-march=haswell"
+      CXXFLAGS: "-march=haswell"
     jobs:
      - job:
        strategy:
@@ -143,6 +145,7 @@ stages:
              TILEDB_FORCE_BUILD_DEPS: ON
              ARTIFACT_OS: 'windows'
              ARTIFACT_EXTRAS: 'full'
+             CL: "/arch:AVX2"
            VS2017_without_tbb:
              imageName: 'vs2017-win2016'
              TILEDB_S3: ON
@@ -151,6 +154,7 @@ stages:
              TILEDB_FORCE_BUILD_DEPS: ON
              ARTIFACT_OS: 'windows'
              ARTIFACT_EXTRAS: 'without_tbb'
+             CL: "/arch:AVX2"
        pool:
          vmImage: $(imageName)
        steps:


### PR DESCRIPTION
Prebuilt artifacts that we publish for releases will now target `haswell` for linux and macos and `AVX2` for windows to allow for greater compatibility while maintaining the performance of AVX optimizations.