### PR TITLE
Add TileDB <> Arrow import and export functionality

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@
 * Added configuration option "sm.sub_partitioner_memory_budget" [#1729](https://github.com/TileDB-Inc/TileDB/pull/1729)
 * Added configuration option "vfs.read_ahead_size" [#1785](https://github.com/TileDB-Inc/TileDB/pull/1785)
 * Added configuration option "vfs.read_ahead_cache_size" [#1785](https://github.com/TileDB-Inc/TileDB/pull/1785)
+* Added support for getting/setting Apache Arrow buffers from a Query [#1816](https://github.com/TileDB-Inc/TileDB/pull/1816)
 
 ## Improvements
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,7 @@ stages:
             imageName: 'ubuntu-16.04'
             TILEDB_AZURE: ON
             TILEDB_STATIC: OFF
+            TILEDB_TESTS_ENABLE_ARROW: ON
             CXX: g++
           linux_gcs:
             imageName: 'ubuntu-16.04'
@@ -37,6 +38,7 @@ stages:
           macOS:
             imageName: 'macOS-10.14'
             TILEDB_S3: ON
+            TILEDB_TESTS_ENABLE_ARROW: ON
             CXX: clang++
           macOS_azure:
             imageName: 'macOS-10.14'
@@ -78,6 +80,7 @@ stages:
           VS2017:
             imageName: 'vs2017-win2016'
             TILEDB_S3: ON
+            TILEDB_TESTS_ENABLE_ARROW: ON
       pool:
         vmImage: $(imageName)
       steps:

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -9,6 +9,18 @@ steps:
     printenv
   displayName: 'Print env'
 
+# Need this for virtualenv and arrow tests if enabled
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+
+- bash: |
+    set -e pipefail
+    python -m pip install --upgrade pip virtualenv
+    if [[ "$TILEDB_TESTS_ENABLE_ARROW" == "ON" ]]; then
+      pip install pyarrow pybind11 numpy
+    fi
+
 - bash: |
     set -e pipefail
     # Install doxygen *before* running cmake
@@ -255,12 +267,6 @@ steps:
       done;
   condition: failed() # only run this job if the build step failed
   displayName: "Print log files (failed build only)"
-
-
-# Need this for virtualenv
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '3.x'
 
 - bash: |
     set -e pipefail

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -1,4 +1,16 @@
 steps:
+
+# Need this for virtualenv
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+
+- bash: |
+    set -e pipefail
+    if [[ "$TILEDB_TESTS_ENABLE_ARROW" == "ON" ]]; then
+      pip install pyarrow pybind11 numpy
+    fi
+
 - powershell: |
     mkdir $env:AGENT_BUILDDIRECTORY\build
     cd $env:AGENT_BUILDDIRECTORY\build

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,52 @@ find_package(Catch_EP REQUIRED)
 option(TILEDB_TESTS_AWS_S3_CONFIG "Use an S3 config appropriate for AWS in tests" OFF)
 option(TILEDB_TESTS_ENABLE_REST "Enables REST tests (requires running REST server)" OFF)
 
+# Arrow integration test config and dependencies
+# Override from environment if not set in cache
+if (NOT DEFINED $CACHE{TILEDB_TESTS_ENABLE_ARROW})
+  if ($ENV{TILEDB_TESTS_ENABLE_ARROW})
+    message(STATUS "Enabling Apache Arrow integration test")
+    # Technically this would be an "option", but we want conditional override from ENV
+    set(TILEDB_TESTS_ENABLE_ARROW ON CACHE BOOL "Enable Arrow tests (requires Python with pyarrow and numpy)")
+    mark_as_advanced(TILEDB_TESTS_ENABLE_ARROW)
+  endif()
+endif()
+
+if (${TILEDB_TESTS_ENABLE_ARROW})
+  find_package(Python COMPONENTS Interpreter Development REQUIRED)
+  find_package(pybind11)
+
+  # If we can't find the pybind11 cmake config (not available in pypi yet)
+  # try to find with the current executable.
+  if (NOT ${pybind11_FOUND})
+    # Get the include arguments from the python executable (has "-I" compiler option)
+    execute_process(COMMAND  ${Python_EXECUTABLE} -m pybind11 --includes
+                    OUTPUT_VARIABLE CMD_PYBIND11_INCLUDE
+                    RESULT_VARIABLE CMD_PYBIND11_RESULT
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (${CMD_PYBIND11_RESULT})
+      message(FATAL_ERROR "Unable to find pybind11 via cmake or 'python3 -m pybind11 --includes'")
+    endif()
+
+    # Convert args to list
+    separate_arguments(CMD_PARSED_INCLUDES NATIVE_COMMAND ${CMD_PYBIND11_INCLUDE})
+    # Remove the "-I" from each include
+    foreach(INCL_PATH IN LISTS CMD_PARSED_INCLUDES)
+      string(REPLACE "-I" "" INCL_PATH ${INCL_PATH})
+      list(APPEND PYBIND11_INCLUDE_DIRECTORIES ${INCL_PATH})
+    endforeach()
+
+    file(TO_CMAKE_PATH ${Python_SITELIB} SAFE_Python_SITELIB)
+    set(pybind11_FOUND TRUE CACHE BOOL "pybind11 include path found")
+    add_library(pybind11::embed INTERFACE IMPORTED)
+    target_include_directories(pybind11::embed INTERFACE ${PYBIND11_INCLUDE_DIRECTORIES})
+    target_link_libraries(pybind11::embed INTERFACE Python::Python)
+    target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_SITELIB_PATH="${SAFE_Python_SITELIB}")
+  endif()
+  file(TO_CMAKE_PATH ${CMAKE_CURRENT_BINARY_DIR} SAFE_CURRENT_BINARY_DIR)
+  target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_UNIT_PATH="${SAFE_CURRENT_BINARY_DIR}")
+endif()
+
 # Include TileDB core header directories
 set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 # Include the C API directory so that the C++ 'tiledb' file can directly
@@ -145,6 +191,12 @@ if (TILEDB_TESTS_ENABLE_REST)
   )
 endif()
 
+if (TILEDB_TESTS_ENABLE_ARROW)
+  list(APPEND TILEDB_TEST_SOURCES
+    src/unit-arrow.cc
+  )
+endif()
+
 # unit test executable
 add_executable(
   tiledb_unit EXCLUDE_FROM_ALL
@@ -207,6 +259,13 @@ endif()
 
 if (TILEDB_SERIALIZATION)
   target_compile_definitions(tiledb_unit PRIVATE -DTILEDB_SERIALIZATION)
+endif()
+
+if (TILEDB_TESTS_ENABLE_ARROW)
+  target_link_libraries(tiledb_unit PRIVATE pybind11::embed)
+
+  # install the python helper next to the executable for import
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/unit_arrow.py" "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)
 endif()
 
 # This is necessary only because we are linking directly to the core objects.

--- a/test/src/unit-arrow.cc
+++ b/test/src/unit-arrow.cc
@@ -291,8 +291,8 @@ TEST_CASE("Arrow IO integration tests", "[arrow]") {
     CHECK(query->query_status() == Query::Status::COMPLETE);
 
     for (size_t i = 0; i < data_len; i++) {
-      free(vec_array[i]);
-      free(vec_schema[i]);
+      std::free(vec_array[i]);
+      std::free(vec_schema[i]);
     }
   }
 

--- a/test/src/unit-arrow.cc
+++ b/test/src/unit-arrow.cc
@@ -50,7 +50,6 @@ struct CPPArrayFx {
   CPPArrayFx(std::string uri, const uint64_t col_size)
       : vfs(ctx)
       , uri(uri) {
-
     if (vfs.is_dir(uri))
       vfs.remove_dir(uri);
 
@@ -112,7 +111,7 @@ struct CPPArrayFx {
     }
   }
 
-private:
+ private:
   Context ctx;
   VFS vfs;
   std::string uri;
@@ -226,7 +225,7 @@ TEST_CASE("Arrow IO integration tests", "[arrow]") {
   py::module py_sys = py::module::import("sys");
 
 #ifdef TILEDB_PYTHON_UNIT_PATH
-    // append the tiledb_unit exe dir so that we can import the helper
+  // append the tiledb_unit exe dir so that we can import the helper
   py_sys.attr("path").attr("insert")(1, TILEDB_PYTHON_UNIT_PATH);
 #endif
 #ifdef TILEDB_PYTHON_SITELIB_PATH
@@ -246,7 +245,7 @@ TEST_CASE("Arrow IO integration tests", "[arrow]") {
   data_len = py::len(py_data_arrays);
   ds_import = py_data_source.attr("import_result");
 
-  //SECTION("Test writing data via ArrowAdapter from pyarrow arrays")
+  // SECTION("Test writing data via ArrowAdapter from pyarrow arrays")
   {
     /*
      * Test write
@@ -297,7 +296,7 @@ TEST_CASE("Arrow IO integration tests", "[arrow]") {
   // TODO: Ideally these scopes should be separate Catch2 SECTION blocks.
   // However, there is an unexplained crash due to an early destructor
   // when both brace scopes are converted to SECTIONs.
-  //SECTION("Test reading data back via ArrowAdapter into pyarrow arrays")
+  // SECTION("Test reading data back via ArrowAdapter into pyarrow arrays")
   {
     /*
      * Test read
@@ -306,7 +305,7 @@ TEST_CASE("Arrow IO integration tests", "[arrow]") {
     Array array(ctx, uri, TILEDB_READ);
     std::shared_ptr<Query> query(new Query(ctx, array));
     query->set_layout(TILEDB_COL_MAJOR);
-    query->add_range(0, (int32_t)0, (int32_t)(col_size-1));
+    query->add_range(0, (int32_t)0, (int32_t)(col_size - 1));
 
     std::vector<void*> data_buffers;
     std::vector<uint64_t*> offset_buffers;

--- a/test/src/unit-arrow.cc
+++ b/test/src/unit-arrow.cc
@@ -1,0 +1,371 @@
+/**
+ * @file   unit-arrow_io.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2020 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for the TileDB Arrow integration.
+ */
+
+#include "catch.hpp"
+#include "helpers.h"
+#include "tiledb/sm/cpp_api/arrowio"
+#include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/uri.h"
+#include "tiledb/sm/misc/utils.h"
+
+#include <pybind11/embed.h>
+#include <pybind11/pybind11.h>
+
+using namespace tiledb;
+namespace py = pybind11;
+
+namespace {
+struct CPPArrayFx {
+ public:
+  CPPArrayFx(std::string uri, const uint64_t col_size = 111)
+      : vfs(ctx)
+      , uri_(uri) {
+    using namespace tiledb;
+
+    if (vfs.is_dir(uri))
+      vfs.remove_dir(uri);
+
+    const uint64_t d1_tile = 10;
+
+    Domain domain(ctx);
+    auto d1 =
+        Dimension::create<int>(ctx, "d1", {{0, (int)col_size - 1}}, d1_tile);
+    domain.add_dimensions(d1);
+
+    std::vector<Attribute> attrs;
+    attrs.insert(
+        attrs.end(),
+        {Attribute::create<int8_t>(ctx, "int8"),
+         Attribute::create<int16_t>(ctx, "int16"),
+         Attribute::create<int32_t>(ctx, "int32"),
+         Attribute::create<int64_t>(ctx, "int64"),
+
+         Attribute::create<uint8_t>(ctx, "uint8"),
+         Attribute::create<uint16_t>(ctx, "uint16"),
+         Attribute::create<uint32_t>(ctx, "uint32"),
+         Attribute::create<uint64_t>(ctx, "uint64"),
+
+         Attribute::create<float>(ctx, "float32"),
+         Attribute::create<double>(ctx, "float64")});
+
+    // must be constructed manually to get TILEDB_STRING_UTF8 type
+    {
+      auto str_attr = Attribute(ctx, "utf_string1", TILEDB_STRING_UTF8);
+      str_attr.set_cell_val_num(TILEDB_VAR_NUM);
+      attrs.push_back(str_attr);
+    }
+    {
+      auto str_attr = Attribute(ctx, "utf_string2", TILEDB_STRING_UTF8);
+      str_attr.set_cell_val_num(TILEDB_VAR_NUM);
+      attrs.push_back(str_attr);
+    }
+
+    // must be constructed manually to get TILEDB_DATETIME_NS type
+    auto datetimens_attr = Attribute(ctx, "datetime_ns", TILEDB_DATETIME_NS);
+    attrs.push_back(datetimens_attr);
+
+    FilterList filters(ctx);
+    filters.add_filter({ctx, TILEDB_FILTER_LZ4});
+
+    ArraySchema schema(ctx, TILEDB_DENSE);
+    schema.set_domain(domain);
+    schema.set_cell_order(TILEDB_ROW_MAJOR);
+    schema.set_tile_order(TILEDB_ROW_MAJOR);
+    for (auto attr : attrs) {
+      attr.set_filter_list(filters);
+      schema.add_attribute(attr);
+    }
+
+    Array::create(uri, schema);
+  }
+
+  ~CPPArrayFx() {
+    if (vfs.is_dir(uri_)) {
+      vfs.remove_dir(uri_);
+    }
+  }
+
+  Context ctx;
+  VFS vfs;
+  std::string uri_;
+};
+
+void free_query_buffers(std::shared_ptr<tiledb::Query> query) {
+  auto schema = query->array().schema();
+  void* data;
+  uint64_t data_nelem;
+  uint64_t elem_size;
+  uint64_t* offsets;
+  uint64_t offset_nelem;
+
+  for (auto attr_iter : schema.attributes()) {
+    auto name = attr_iter.first;
+    auto attr = attr_iter.second;
+
+    if (attr.cell_val_num() != TILEDB_VAR_NUM) {
+      query->get_buffer(name, &data, &data_nelem, &elem_size);
+      free(data);
+    } else {
+      query->get_buffer(
+          name, &offsets, &offset_nelem, &data, &data_nelem, &elem_size);
+      free(data);
+      free(offsets);
+    }
+  }
+
+  for (auto dim : schema.domain().dimensions()) {
+    auto name = dim.name();
+
+    if (dim.cell_val_num() != TILEDB_VAR_NUM) {
+      query->get_buffer(name, &data, &data_nelem, &elem_size);
+      free(data);
+    } else {
+      query->get_buffer(
+          name, &offsets, &offset_nelem, &data, &data_nelem, &elem_size);
+      free(data);
+      free(offsets);
+    }
+  }
+}
+
+void allocate_query_buffers(std::shared_ptr<tiledb::Query> query) {
+  auto schema = query->array().schema();
+
+  bool has_ranges = false;
+  for (uint64_t dim_idx = 0; dim_idx < schema.domain().ndim(); dim_idx++) {
+    if (query->range_num(dim_idx) > 0) {
+      has_ranges = true;
+      break;
+    }
+  }
+  if (!has_ranges) {
+    throw tiledb::TileDBError("No ranges set for query!");
+  }
+
+  for (auto attr_iter : schema.attributes()) {
+    auto name = attr_iter.first;
+    auto attr = attr_iter.second;
+
+    if (attr.cell_val_num() != TILEDB_VAR_NUM) {
+      auto est_size = query->est_result_size(attr.name());
+      void* data = malloc(est_size);
+      query->set_buffer(name, data, est_size);
+    } else {
+      auto est_size_var = query->est_result_size_var(attr.name());
+      void* data = malloc(est_size_var.second);
+      uint64_t* offsets =
+          (uint64_t*)malloc(est_size_var.first * sizeof(uint64_t));
+      query->set_buffer(
+          name, offsets, est_size_var.first, data, est_size_var.second);
+    }
+  }
+
+  for (auto dim : schema.domain().dimensions()) {
+    auto name = dim.name();
+
+    if (dim.cell_val_num() != TILEDB_VAR_NUM) {
+      auto est_size = query->est_result_size(dim.name());
+      void* data = malloc(est_size);
+      query->set_buffer(name, data, est_size);
+    } else {
+      auto est_size_var = query->est_result_size_var(dim.name());
+      void* data = malloc(est_size_var.second);
+      uint64_t* offsets =
+          (uint64_t*)malloc(est_size_var.first * sizeof(uint64_t));
+      query->set_buffer(
+          name, offsets, est_size_var.first, data, est_size_var.second);
+    }
+  }
+}
+
+};  // namespace
+
+TEST_CASE("Arrow IO integration tests", "[arrow]") {
+  std::string uri("test_arrow_io");
+  const uint64_t col_size = 10;
+
+  CPPArrayFx _fx(uri, col_size);
+
+  py::scoped_interpreter guard{};
+  py::object py_data_source;
+  py::object py_data_arrays;
+  py::object py_data_names;
+  py::object ds_import;
+  size_t data_len = 0;
+
+  // create (arrow) schema and array from pyarrow RecordBatch
+  try {
+    py::module py_sys = py::module::import("sys");
+
+#ifdef TILEDB_PYTHON_UNIT_PATH
+    // append the tiledb_unit exe dir so that we can import the helper
+    py_sys.attr("path").attr("insert")(1, TILEDB_PYTHON_UNIT_PATH);
+#endif
+#ifdef TILEDB_PYTHON_SITELIB_PATH
+    // append the site-packages path from cmake
+    // this is not necessary with conda
+    py_sys.attr("path").attr("insert")(1, TILEDB_PYTHON_SITELIB_PATH);
+#endif
+
+    // import the arrow helper
+    py::module unit_arrow = py::module::import("unit_arrow");
+
+    // this class generates random test data for each attribute
+    auto h_data_source = unit_arrow.attr("DataFactory");
+    py_data_source = h_data_source(py::int_(col_size));
+    py_data_names = py_data_source.attr("names");
+    py_data_arrays = py_data_source.attr("arrays");
+    data_len = py::len(py_data_arrays);
+    ds_import = py_data_source.attr("import_result");
+  } catch (std::exception& e) {
+    std::cerr << std::string("[pybind11 error] ") + e.what() << std::endl;
+    CHECK(false);
+  } catch (...) {
+    std::cerr << "[pybind11 error] unknown exception!" << std::endl;
+    CHECK(false);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  using namespace tiledb;
+
+  {
+    /*
+     * Test write
+     */
+
+    Context ctx;
+    Array array(ctx, uri, TILEDB_WRITE);
+    std::shared_ptr<Query> query(new Query(ctx, array));
+    query->set_layout(TILEDB_COL_MAJOR);
+    query->add_range(0, 0, 9);
+
+    std::vector<ArrowArray*> vec_array;
+    std::vector<ArrowSchema*> vec_schema;
+    vec_array.resize(data_len);
+    vec_schema.resize(data_len);
+
+    for (size_t i = 0; i < data_len; i++) {
+      vec_array[i] = (ArrowArray*)malloc(sizeof(ArrowArray));
+      vec_schema[i] = (ArrowSchema*)malloc(sizeof(ArrowSchema));
+    }
+
+    tiledb::arrow::ArrowAdapter adapter(query);
+
+    for (size_t i = 0; i < data_len; i++) {
+      auto py_i = py::int_(i);
+      auto pa_name = py_data_names[py_i].cast<std::string>();
+      auto pa_array = py_data_arrays[py_i];
+
+      try {
+        pa_array.attr("_export_to_c")(
+            py::int_((uint64_t)(vec_array.at(i))),
+            py::int_((uint64_t)(vec_schema.at(i))));
+      } catch (std::exception& e) {
+        std::cerr << "unexpected error: " << e.what() << std::endl;
+      }
+      adapter.import_buffer(
+          pa_name.c_str(), (void*)vec_array.at(i), (void*)vec_schema.at(i));
+    }
+    query->submit();
+    CHECK(query->query_status() == Query::Status::COMPLETE);
+
+    for (size_t i = 0; i < data_len; i++) {
+      free(vec_array[i]);
+      free(vec_schema[i]);
+    }
+  }
+
+  {
+    /*
+     * Test read
+     */
+    Context ctx;
+    Array array(ctx, uri, TILEDB_READ);
+    std::shared_ptr<Query> query(new Query(ctx, array));
+    query->set_layout(TILEDB_COL_MAJOR);
+    query->add_range(0, 0, 9);
+
+    std::vector<void*> data_buffers;
+    std::vector<uint64_t*> offset_buffers;
+
+    allocate_query_buffers(query);
+    query->submit();
+    assert(query->query_status() == Query::Status::COMPLETE);
+
+    std::vector<ArrowArray*> vec_array;
+    std::vector<ArrowSchema*> vec_schema;
+    vec_array.resize(data_len);
+    vec_schema.resize(data_len);
+
+    for (size_t i = 0; i < data_len; i++) {
+      vec_array[i] = (ArrowArray*)malloc(sizeof(ArrowArray));
+      vec_schema[i] = (ArrowSchema*)malloc(sizeof(ArrowSchema));
+    }
+
+    tiledb::arrow::ArrowAdapter adapter(query);
+
+    for (size_t i = 0; i < data_len; i++) {
+      auto py_i = py::int_(i);
+      auto pa_name = py_data_names[py_i].cast<std::string>();
+      auto pa_array = py_data_arrays[py_i];
+
+      adapter.export_buffer(
+          pa_name.c_str(), (void*)(vec_array.at(i)), (void*)(vec_schema.at(i)));
+
+      ds_import(
+          pa_name,
+          py::int_((ptrdiff_t)(vec_array.at(i))),
+          py::int_((ptrdiff_t)(vec_schema.at(i))));
+    }
+
+    // check the data
+    CHECK(py_data_source.attr("check")().cast<bool>());
+
+    for (size_t i = 0; i < data_len; i++) {
+      auto arw_array = vec_array.at(i);
+      auto arw_schema = vec_schema.at(i);
+      // ensure released
+      CHECK(arw_array->release == nullptr);
+      CHECK(arw_schema->release == nullptr);
+    }
+
+    // free structs
+    for (auto array_p : vec_array)
+      free(array_p);
+
+    for (auto schema_p : vec_schema)
+      free(schema_p);
+
+    free_query_buffers(query);
+  }
+}

--- a/test/src/unit_arrow.py
+++ b/test/src/unit_arrow.py
@@ -114,4 +114,5 @@ class DataFactory():
 
       res_val = self.results[key]
       assert_array_equal(val, res_val)
+
     return True

--- a/test/src/unit_arrow.py
+++ b/test/src/unit_arrow.py
@@ -1,0 +1,119 @@
+import numpy as np
+import pyarrow as pa
+import numpy as np
+import sys, os
+import tempfile
+import random
+
+from numpy.testing import assert_array_equal
+
+# ************************************************************************** #
+#          Data generators                                                   #
+# ************************************************************************** #
+
+# python 2 vs 3 compatibility
+if sys.hexversion >= 0x3000000:
+    getchr = chr
+else:
+    getchr = unichr
+
+def gen_chr(max, printable=False):
+    while True:
+        # TODO we exclude 0x0 here because the key API does not embedded NULL
+        s = getchr(random.randrange(1, max))
+        if printable and not s.isprintable():
+            continue
+        if len(s) > 0:
+            break
+    return s
+
+def rand_datetime64_array(size, start=None, stop=None, dtype=None):
+    if not dtype:
+        dtype = np.dtype('M8[ns]')
+
+    # generate randint inbounds on the range of the dtype
+    units = np.datetime_data(dtype)[0]
+    intmin, intmax = np.iinfo(np.int64).min, np.iinfo(np.int64).max
+
+    if start is None:
+        start = np.datetime64(intmin + 1, units)
+    else:
+        start = np.datetime64(start)
+    if stop is None:
+        stop = np.datetime64(intmax, units)
+    else:
+        stop = np.datetime64(stop)
+
+    arr = np.random.randint(
+        start.astype(dtype).astype(np.int64), stop.astype(dtype).astype(np.int64),
+        size=size, dtype=np.int64
+    )
+    arr.sort()
+
+    return arr.astype(dtype)
+
+def rand_utf8(size=5):
+    return u''.join([gen_chr(0xD7FF) for _ in range(0, size)])
+
+# ************************************************************************** #
+#           Test class                                                       #
+# ************************************************************************** #
+
+class DataFactory():
+  def __init__(self, col_size):
+    self.results = {}
+    self.col_size = col_size
+    self.create()
+
+  def __len__(self):
+    if not self.data:
+      raise ValueError("Uninitialized data")
+    return len(self.data)
+
+  def create(self):
+    # generate test data for all columns
+    col_size = self.col_size
+    self.data = {}
+
+    for dt in (np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64):
+        key = np.dtype(dt).name
+        dtinfo = np.iinfo(dt)
+        self.data[key] = np.random.randint(dtinfo.min, dtinfo.max, size=col_size, dtype=dt)
+
+    for dt in (np.float32, np.float64):
+        key = np.dtype(dt).name
+        self.data[key] = np.random.rand(col_size).astype(dt)
+
+    # var-len (strings)
+    self.data['utf_string1'] = np.array([rand_utf8(np.random.randint(1, 100))
+                                       for _ in range(col_size)])
+
+    # another version with some important cells set to empty
+    self.data['utf_string2'] = np.array([rand_utf8(np.random.randint(0, 100))
+                                       for _ in range(col_size)])
+    self.data['utf_string2'][0] = ''
+    self.data['utf_string2'][1] = ''
+    self.data['utf_string2'][3] = ''
+    self.data['utf_string2'][-1] = ''
+    self.data['utf_string2'][-2] = '' #-> TODO core bug
+    self.data['utf_string2'][-3] = ''
+
+    self.data['datetime_ns'] = rand_datetime64_array(col_size)
+
+    ##########################################################################
+
+    self.arrays = [pa.array(val) for val in self.data.values()]
+    self.names = list(self.data.keys())
+
+  def import_result(self, name, c_array, c_schema):
+    self.results[name] = pa.Array._import_from_c(c_array, c_schema)
+
+  def check(self):
+    for key,val in self.data.items():
+      assert (key in self.results), "Expected key '{}' not found in results!".format(key)
+
+      res_val = self.results[key]
+      assert_array_equal(val, res_val)
+    return True
+
+d = DataFactory(10)

--- a/test/src/unit_arrow.py
+++ b/test/src/unit_arrow.py
@@ -95,7 +95,7 @@ class DataFactory():
     self.data['utf_string2'][1] = ''
     self.data['utf_string2'][3] = ''
     self.data['utf_string2'][-1] = ''
-    self.data['utf_string2'][-2] = '' #-> TODO core bug
+    self.data['utf_string2'][-2] = ''
     self.data['utf_string2'][-3] = ''
 
     self.data['datetime_ns'] = rand_datetime64_array(col_size)
@@ -115,5 +115,3 @@ class DataFactory():
       res_val = self.results[key]
       assert_array_equal(val, res_val)
     return True
-
-d = DataFactory(10)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -78,6 +78,8 @@ if (TILEDB_CPP_API)
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/utils.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/version.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/vfs.h
+    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/arrowio
+    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/arrow_io_impl.h
   )
 else()
   message(STATUS "TileDB C++ API is not built.")

--- a/tiledb/sm/cpp_api/arrow_io_impl.h
+++ b/tiledb/sm/cpp_api/arrow_io_impl.h
@@ -1,0 +1,834 @@
+/**
+ * @file   arrow_io_impl.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines TileDB interoperation functionality with Apache Arrow.
+ */
+
+#ifndef TILEDB_ARROW_H
+#define TILEDB_ARROW_H
+
+/* ************************************************************************ */
+/*
+ * Arrow C Data Interface
+ * Apache License 2.0
+ * source: https://arrow.apache.org/docs/format/CDataInterface.html
+ */
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+  // Array type description
+  const char* format;
+  const char* name;
+  const char* metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema** children;
+  struct ArrowSchema* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowSchema*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+struct ArrowArray {
+  // Array data description
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void** buffers;
+  struct ArrowArray** children;
+  struct ArrowArray* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowArray*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+/* End Arrow C API */
+/* ************************************************************************ */
+
+/* ************************************************************************ */
+/* Begin TileDB Arrow IO internal implementation */
+
+#include <memory>
+
+/* ****************************** */
+/*      Error context helper      */
+/* ****************************** */
+
+using _TileDBError = tiledb::TileDBError;
+#ifndef NDEBUG
+#define TDB_LERROR(m)                                                     \
+  _TileDBError(                                                           \
+      std::string(m) + " (" + __FILE__ + ":" + std::to_string(__LINE__) + \
+      ")");
+#else
+#define TDB_LERROR tiledb::TileDBError
+#endif
+
+namespace tiledb {
+namespace arrow {
+
+using Status = tiledb::sm::Status;
+
+/* ****************************** */
+/*       Helper types             */
+/* ****************************** */
+
+// Arrow format and representation
+struct ArrowInfo {
+  std::string fmt_;
+  std::string rep_;
+
+  ArrowInfo(std::string fmt, std::string rep = std::string())
+      : fmt_(fmt)
+      , rep_(rep){};
+};
+
+// TileDB type information
+struct TypeInfo {
+  tiledb_datatype_t type;
+  uint64_t elem_size;
+  uint32_t cell_val_num;
+
+  // is this represented as "Arrow large"
+  bool arrow_large;
+};
+
+struct BufferInfo {
+ public:
+  TypeInfo tdbtype;
+  bool is_var;
+  uint64_t elem_num;    // element count
+  void* data;           // data pointer
+  uint64_t offset_num;  // # offsets, always uint64_t
+  uint64_t* offsets;
+  uint64_t elem_size;
+};
+
+/* ****************************** */
+/*        Type conversions        */
+/* ****************************** */
+
+// Get Arrow format from TileDB BufferInfo
+ArrowInfo tiledb_buffer_arrow_fmt(BufferInfo bufferinfo, bool use_list = true) {
+  auto typeinfo = bufferinfo.tdbtype;
+  auto cell_val_num = typeinfo.cell_val_num;
+
+  // TODO support List<T> for simple scalar T
+  (void)use_list;
+  /*
+  if (use_list && cell_val_num == TILEDB_VAR_NUM) {
+    switch(typeinfo.type) {
+      case TILEDB_STRING_UTF8:
+      case TILEDB_STRING_ASCII:
+        break;
+      case TILEDB_INT8:
+      case TILEDB_INT16:
+      case TILEDB_INT32:
+      case TILEDB_INT64:
+      case TILEDB_UINT8:
+      case TILEDB_UINT16:
+      case TILEDB_UINT32:
+      case TILEDB_UINT64:
+      case TILEDB_FLOAT32:
+      case TILEDB_FLOAT64:
+        return ArrowInfo("+l");
+      default:
+        throw TDB_LERROR(
+          "TileDB-Arrow: List<T> translation not yet supported for var-length
+  TileDB type ('"
+          + tiledb::impl::type_to_str(typeinfo.type) + "')");
+    }
+  }
+  */
+
+  switch (typeinfo.type) {
+    ////////////////////////////////////////////////////////////////////////
+    // NOTE: should export as arrow's "large utf8" because TileDB offsets
+    //       are natively uint64_t. However: our offset buffers are 1 elem
+    //       short of the expected length for an arrow offset buffer.
+    //       For now, we transform to int32_it in place and export "u"
+    case TILEDB_STRING_ASCII:
+    case TILEDB_STRING_UTF8:
+      return ArrowInfo("u");
+    case TILEDB_CHAR:
+      return ArrowInfo("z");
+      ////////////////////////////////////////////////////////////////////////
+
+    case TILEDB_INT32:
+      return ArrowInfo("i");
+    case TILEDB_INT64:
+      return ArrowInfo("l");
+    case TILEDB_FLOAT32:
+      return ArrowInfo("f");
+    case TILEDB_FLOAT64:
+      return ArrowInfo("g");
+    case TILEDB_INT8:
+      return ArrowInfo("c");
+    case TILEDB_UINT8:
+      return ArrowInfo("C");
+    case TILEDB_INT16:
+      return ArrowInfo("s");
+    case TILEDB_UINT16:
+      return ArrowInfo("S");
+    case TILEDB_UINT32:
+      return ArrowInfo("I");
+    case TILEDB_UINT64:
+      return ArrowInfo("L");
+
+    // make sure this matches below
+    case TILEDB_DATETIME_NS:
+      return ArrowInfo("tsn:");
+    case TILEDB_DATETIME_MS:
+      return ArrowInfo("tdm");
+
+    // TODO: these could potentially be rep'd w/ additional
+    //       language-specific metadata
+    case TILEDB_DATETIME_YEAR:
+    case TILEDB_DATETIME_MONTH:
+    case TILEDB_DATETIME_WEEK:
+    case TILEDB_DATETIME_DAY:
+    case TILEDB_DATETIME_HR:
+    case TILEDB_DATETIME_MIN:
+    case TILEDB_DATETIME_SEC:
+    case TILEDB_DATETIME_US:
+    case TILEDB_DATETIME_PS:
+    case TILEDB_DATETIME_FS:
+    case TILEDB_DATETIME_AS:
+    case TILEDB_STRING_UTF16:
+    case TILEDB_STRING_UTF32:
+    case TILEDB_STRING_UCS2:
+    case TILEDB_STRING_UCS4:
+    case TILEDB_ANY:
+    default:
+      break;
+  }
+  throw TDB_LERROR(
+      "TileDB-Arrow: tiledb datatype not understood ('" +
+      tiledb::impl::type_to_str(typeinfo.type) +
+      "', cell_val_num: " + std::to_string(cell_val_num) + ")");
+}
+
+TypeInfo arrow_type_to_tiledb(ArrowSchema* arw_schema) {
+  auto fmt = std::string(arw_schema->format);
+  bool large = false;
+  if (fmt == "+l") {
+    large = false;
+    assert(arw_schema->n_children == 1);
+    arw_schema = arw_schema->children[0];
+  } else if (fmt == "+L") {
+    large = true;
+    assert(arw_schema->n_children == 1);
+    arw_schema = arw_schema->children[0];
+  }
+
+  if (fmt == "i")
+    return {TILEDB_INT32, 4, 1, large};
+  else if (fmt == "l")
+    return {TILEDB_INT64, 8, 1, large};
+  else if (fmt == "f")
+    return {TILEDB_FLOAT32, 4, 1, large};
+  else if (fmt == "g")
+    return {TILEDB_FLOAT64, 8, 1, large};
+  else if (fmt == "c")
+    return {TILEDB_INT8, 1, 1, large};
+  else if (fmt == "C")
+    return {TILEDB_UINT8, 1, 1, large};
+  else if (fmt == "s")
+    return {TILEDB_INT16, 2, 1, large};
+  else if (fmt == "S")
+    return {TILEDB_UINT16, 2, 1, large};
+  else if (fmt == "I")
+    return {TILEDB_UINT32, 4, 1, large};
+  else if (fmt == "L")
+    return {TILEDB_UINT64, 8, 1, large};
+  // this is kind of a hack
+  // technically 'tsn:' is timezone-specific, which we don't support
+  // however, the blank (no suffix) base is interconvertible w/ datetime64
+  else if (fmt == "tsn:")
+    return {TILEDB_DATETIME_NS, 8, 1, large};
+  else if (fmt == "z" || fmt == "Z")
+    return {TILEDB_CHAR, 1, TILEDB_VAR_NUM, fmt == "Z"};
+  else if (fmt == "u" || fmt == "U")
+    return {TILEDB_STRING_UTF8, 1, TILEDB_VAR_NUM, fmt == "U"};
+  else
+    throw tiledb::TileDBError(
+        "[TileDB-Arrow]: Unknown or unsupported Arrow format string '" + fmt +
+        "'");
+}
+
+TypeInfo tiledb_dt_info(const tiledb::ArraySchema& schema, std::string name) {
+  if (schema.has_attribute(name)) {
+    auto attr = schema.attribute(name);
+
+    auto retval = TypeInfo();
+    retval.type = attr.type(),
+    retval.elem_size = tiledb::impl::type_size(attr.type()),
+    retval.cell_val_num = attr.cell_val_num(), retval.arrow_large = false;
+    return retval;
+  } else if (schema.domain().has_dimension(name)) {
+    auto dom = schema.domain();
+    auto dim = dom.dimension(name);
+
+    auto retval = TypeInfo();
+    retval.type = dim.type();
+    retval.elem_size = tiledb::impl::type_size(dim.type());
+    retval.cell_val_num = dim.cell_val_num();
+    retval.arrow_large = false;
+    return retval;
+
+  } else {
+    throw TDB_LERROR("Schema does not have attribute named '" + name + "'");
+  }
+}
+
+/* ****************************** */
+/*        Helper functions        */
+/* ****************************** */
+
+// Reorder offsets into Arrow-compatible format
+// NOTE: this currently hard-codes an inplace conversion from
+//       uint64 (TileDB) to int32 ("arrow small") only
+void offsets_to_arrow(BufferInfo binfo) {
+  size_t elem_size = binfo.elem_size;
+
+  uint64_t* offsets = binfo.offsets;
+  int32_t* offsets_i32 = (int32_t*)binfo.offsets;
+
+  uint64_t idx = 1;  // important: don't divide by 0
+  while (idx < binfo.offset_num) {
+    // we must check for zeros here to handle a run of empty
+    // values (zero-length) at the start of the buffer
+    // note that given the i32 conversion, we can simply
+    // skip the assignment because
+    //   offsets[idx] == 0 => offsets_i32[i:i+1] == 0
+    if (offsets[idx] != 0)
+      offsets_i32[idx] = (int32_t)(offsets[idx] / elem_size);
+    ++idx;
+  }
+  offsets_i32[idx] = binfo.elem_num;
+}
+
+void check_arrow_schema(ArrowSchema* arw_schema) {
+  if (arw_schema == nullptr)
+    TDB_LERROR("[ArrowIO]: Invalid ArrowSchema object!");
+
+  // sanity check the arrow schema
+  if (arw_schema->release == nullptr)
+    TDB_LERROR(
+        "[ArrowIO]: Invalid ArrowSchema: cannot import released schema.");
+  if (arw_schema->format != std::string("+s"))
+    TDB_LERROR("[ArrowIO]: Unsupported ArrowSchema: must be struct (+s).");
+  if (arw_schema->n_children < 1)
+    TDB_LERROR("[ArrowIO]: Unsupported ArrowSchema with 0 children.");
+  if (arw_schema->children == nullptr)
+    TDB_LERROR(
+        "[ArrowIO]: Invalid ArrowSchema with n_children>0 and children==NULL");
+}
+
+/* ****************************** */
+/*  Arrow C API Struct wrappers   */
+/* ****************************** */
+
+// NOTE: These structs manage the lifetime of the contained C structs.
+// CAUTION: they do *not* manage the lifetime of the underlying buffers.
+
+struct CPPArrowSchema {
+  /*
+   * Initialize a CPPArrowSchema object
+   *
+   * The lifetime of this object is controlled by the
+   * release callback set in the ArrowSchema.
+   *
+   * Note that an ArrowSchema is *movable*, provided
+   * the release callback of the source is set to null.
+   */
+  CPPArrowSchema(
+      std::string name,
+      std::string format,
+      std::string metadata,
+      int64_t flags,
+      std::vector<ArrowSchema*> children,
+      std::shared_ptr<CPPArrowSchema> dictionary)
+      : format_(format)
+      , name_(name)
+      , metadata_(metadata)
+      , children_(children)
+      , dictionary_(dictionary) {
+    flags_ = flags;
+    n_children_ = children.size();
+
+    schema_ = (ArrowSchema*)malloc(sizeof(ArrowSchema));
+    if (schema_ == nullptr)
+      throw tiledb::TileDBError("Failed to allocate ArrowSchema");
+
+    // Initialize ArrowSchema with data *owned by this object*
+    // Type description
+    schema_->format = format_.c_str();
+    schema_->name = name_.c_str();
+    schema_->metadata = metadata.c_str();
+    schema_->flags = flags;
+    schema_->n_children = n_children_;
+
+    // Cross-refs
+    schema_->children = nullptr;
+    schema_->dictionary = nullptr;
+
+    // Release callback
+    schema_->release = ([](ArrowSchema* schema_p) {
+      assert(schema_p->release != nullptr);
+
+      // Release children
+      for (int64_t i = 0; i < schema_p->n_children; i++) {
+        ArrowSchema* child_schema = schema_p->children[i];
+        child_schema->release(child_schema);
+        assert(child_schema->release == NULL);
+      }
+
+      // Release dictionary
+      struct ArrowSchema* dict = schema_p->dictionary;
+      if (dict != NULL && dict->release != NULL) {
+        dict->release(dict);
+        assert(dict->release == NULL);
+      }
+
+      // mark the ArrowSchema struct as released
+      schema_p->release = NULL;
+
+      delete (CPPArrowSchema*)(schema_p->private_data);
+    });
+
+    // Private data for release callback
+    schema_->private_data = this;
+
+    if (n_children_ > 0) {
+      schema_->children = (ArrowSchema**)children.data();
+    }
+
+    if (dictionary) {
+      schema_->dictionary = dictionary.get()->ptr();
+    }
+  }
+
+  /*
+   * CPPArrowSchema destructor
+   *
+   * This destructor is invoked via the ArrowSchema.release
+   * callback. Owned member data is released via default destructors.
+   */
+  ~CPPArrowSchema() = default;
+
+  /*
+   * Exports the ArrowSchema to a pre-allocated target struct
+   *
+   * This function frees the array_.
+   * The lifetime of all other member variables is controlled
+   * by the ArrowSchema.release callback, which frees the
+   * CPPArrowSchema structure (via ArrowSchema.private_data).
+   */
+  void export_ptr(ArrowSchema* schema_out) {
+    memcpy(schema_out, schema_, sizeof(ArrowSchema));
+    free(schema_);
+    schema_ = nullptr;
+  }
+
+  ArrowSchema* mutable_ptr() {
+    assert(schema_ != nullptr);
+    return schema_;
+  }
+
+  ArrowSchema* ptr() const {
+    assert(schema_ != nullptr);
+    return schema_;
+  }
+
+ private:
+  ArrowSchema* schema_;
+  std::string format_;
+  std::string name_;
+  std::string metadata_;
+  int64_t flags_;
+  int64_t n_children_;
+  std::vector<ArrowSchema*> children_;
+  std::shared_ptr<CPPArrowSchema> dictionary_;
+};
+
+struct CPPArrowArray {
+  /*
+   * Initialize a CPPArrowSchema object
+   *
+   * The lifetime of this object is controlled by the
+   * release callback set in the ArrowSchema.
+   *
+   * Note that an ArrowSchema is *movable*, provided
+   * the release callback of the source is set to null.
+   */
+  CPPArrowArray(
+      int64_t elem_num,
+      int64_t null_num,
+      int64_t offset,
+      std::vector<std::shared_ptr<CPPArrowArray>> children,
+      std::shared_ptr<CPPArrowArray> dictionary,
+      std::vector<void*> buffers)
+      : array_((ArrowArray*)malloc(sizeof(ArrowArray))) {
+    (void)dictionary;  // not supported by TileDB
+
+    array_ = (ArrowArray*)malloc(sizeof(ArrowArray));
+    if (array_ == nullptr)
+      throw tiledb::TileDBError("Failed to allocate ArrowArray");
+
+    // Data description
+    array_->length = elem_num;
+    array_->null_count = null_num;
+    array_->offset = offset;
+    array_->n_buffers = (int64_t)buffers.size();
+    array_->n_children = (int64_t)children.size();
+    array_->buffers = nullptr;
+    array_->children = nullptr;
+    array_->dictionary = nullptr;
+    // Bookkeeping
+    array_->release = ([](ArrowArray* array_p) {
+      assert(array_p->release != nullptr);
+
+      // Release children
+      for (int64_t i = 0; i < array_p->n_children; i++) {
+        ArrowArray* child_array = array_p->children[i];
+        child_array->release(child_array);
+        assert(child_array->release == nullptr);
+      }
+
+      // Release dictionary
+      struct ArrowArray* dict = array_p->dictionary;
+      if (dict != NULL && dict->release != NULL) {
+        dict->release(dict);
+        assert(dict->release == NULL);
+      }
+
+      // mark the ArrowArray struct as released
+      array_p->release = nullptr;
+
+      delete (CPPArrowArray*)(array_p->private_data);
+    });
+    array_->private_data = this;
+
+    buffers_ = buffers;
+    array_->buffers = (const void**)buffers_.data();
+  }
+
+  /*
+   * CPPArrowArray destructor
+   *
+   * This destructor is invoked via the ArrowArray.release
+   * callback. Owned member data is released via default destructors.
+   */
+  ~CPPArrowArray() = default;
+
+  void export_ptr(ArrowArray* array) {
+    memcpy(array, array_, sizeof(ArrowArray));
+    free(array_);
+    array_ = nullptr;
+  }
+
+  ArrowArray* ptr() const {
+    assert(array_ != nullptr);
+    return array_;
+  }
+
+  ArrowArray* mutable_ptr() {
+    assert(array_ != nullptr);
+    return array_;
+  }
+
+ private:
+  ArrowArray* array_;
+  std::vector<void*> buffers_;
+};
+
+/* ****************************** */
+/*         Arrow Importer         */
+/* ****************************** */
+
+class ArrowImporter {
+ public:
+  ArrowImporter(std::shared_ptr<tiledb::Query> query);
+  ~ArrowImporter();
+
+  void import_(std::string name, ArrowArray* array, ArrowSchema* schema);
+
+ private:
+  std::shared_ptr<tiledb::Query> query_;
+  std::vector<void*> offset_buffers_;  //
+
+};  // class ArrowExporter
+
+ArrowImporter::ArrowImporter(std::shared_ptr<tiledb::Query> query) {
+  query_ = query;
+}
+
+ArrowImporter::~ArrowImporter() {
+  for (auto p : offset_buffers_) {
+    free(p);
+  }
+}
+
+void ArrowImporter::import_(
+    std::string name, ArrowArray* arw_array, ArrowSchema* arw_schema) {
+  auto typeinfo = arrow_type_to_tiledb(arw_schema);
+
+  // buffer conversion
+
+  if (typeinfo.cell_val_num == TILEDB_VAR_NUM) {
+    assert(arw_array->n_buffers == 3);
+
+    const void* p_offsets_arw =
+        (void*)arw_array->buffers[1];                   // note: cast away const
+    const void* p_data = (void*)arw_array->buffers[2];  // note: cast away const
+    uint64_t data_num = arw_array->length;              // <- number of elements
+    uint64_t data_nbytes = 0;
+
+    uint64_t* p_offsets =
+        (uint64_t*)malloc(arw_array->length * sizeof(uint64_t));
+    offset_buffers_.push_back((void*)p_offsets);
+
+    if (typeinfo.arrow_large) {
+      int64_t* p_offsets_int64 = (int64_t*)p_offsets_arw;
+      // the Arrow offsets buffer has length+1 elements
+      for (size_t i = 0; i < (size_t)data_num; i++) {
+        p_offsets[i] = p_offsets_int64[i] * typeinfo.elem_size;
+      }
+      data_nbytes = p_offsets_int64[data_num] * typeinfo.elem_size;
+    } else {
+      int32_t* p_offsets_int32 = (int32_t*)p_offsets_arw;
+      // the Arrow offsets buffer has length+1 elements
+      for (size_t i = 0; i < (size_t)data_num; i++) {
+        p_offsets[i] = p_offsets_int32[i] * typeinfo.elem_size;
+      }
+      data_nbytes = p_offsets_int32[data_num] * typeinfo.elem_size;
+    }
+    query_->set_buffer(
+        name, (uint64_t*)p_offsets, data_num, (void*)p_data, data_nbytes);
+  } else {
+    // fixed-size attribute (not TILEDB_VAR_NUM)
+    assert(arw_array->n_buffers == 2);
+
+    const void* p_data = (void*)arw_array->buffers[1];  // note: cast away const
+    uint64_t data_num = arw_array->length;
+
+    query_->set_buffer(name, (void*)p_data, data_num);
+  }
+}
+
+/* ****************************** */
+/*         Arrow Exporter         */
+/* ****************************** */
+
+class ArrowExporter {
+ public:
+  ArrowExporter(std::shared_ptr<tiledb::Query> query);
+
+  void export_(std::string name, ArrowArray* array, ArrowSchema* schema);
+
+  BufferInfo buffer_info(std::string name);
+
+  std::unique_ptr<CPPArrowSchema> buffer_schema(std::string name);
+
+ private:
+  std::shared_ptr<tiledb::Query> query_;
+};
+
+// ArrowExporter implementation
+ArrowExporter::ArrowExporter(std::shared_ptr<tiledb::Query> query) {
+  query_ = query;
+}
+
+BufferInfo ArrowExporter::buffer_info(std::string name) {
+  void* data = nullptr;
+  uint64_t data_nelem = 0;
+  uint64_t* offsets = nullptr;
+  uint64_t offsets_nelem = 0;
+  uint64_t elem_size = 0;
+
+  auto typeinfo = tiledb_dt_info(query_->array().schema(), name);
+
+  auto result_elts = query_->result_buffer_elements();
+  auto result_elt_iter = result_elts.find(name);
+  if (result_elt_iter == result_elts.end()) {
+    TDB_LERROR("No results found for attribute '" + name + "'");
+  }
+
+  bool is_var = (result_elt_iter->second.first != 0);
+
+  // NOTE: result sizes are in bytes
+  if (is_var) {
+    query_->get_buffer(
+        name, &offsets, &offsets_nelem, &data, &data_nelem, &elem_size);
+  } else {
+    query_->get_buffer(name, &data, &data_nelem, &elem_size);
+  }
+
+  auto retval = BufferInfo();
+  retval.tdbtype = typeinfo;
+  retval.is_var = is_var;
+  retval.elem_num = data_nelem;
+  retval.data = data;
+  retval.offset_num = (is_var ? offsets_nelem : 1);
+  retval.offsets = offsets;
+  retval.elem_size = elem_size;
+
+  return retval;
+}
+
+int64_t flags_for_buffer(BufferInfo binfo) {
+  /*  TODO, use these defs from arrow_cdefs.h -- currently not applicable.
+      #define ARROW_FLAG_DICTIONARY_ORDERED 1
+      #define ARROW_FLAG_NULLABLE 2
+      #define ARROW_FLAG_MAP_KEYS_SORTED 4
+  */
+  (void)binfo;
+  return 0;
+}
+
+void ArrowExporter::export_(
+    std::string name, ArrowArray* array, ArrowSchema* schema) {
+  auto bufferinfo = this->buffer_info(name);
+  // TODO add checks?:
+  // -  .elem_num < INT64_MAX
+  // - check that the length of a var-len element does not exceed INT32_MAX
+  //   currently we export as "u" and "b" (int32 offsets) rather than
+  //   "U and "B" (int64 offsets)
+
+  if (schema == nullptr || array == nullptr) {
+    throw tiledb::TileDBError(
+        "ArrowExporter: received invalid pointer to output array or schema.");
+  }
+
+  auto arrow_fmt = tiledb_buffer_arrow_fmt(bufferinfo);
+  auto arrow_flags = flags_for_buffer(bufferinfo);
+
+  // lifetime:
+  //   - address is stored in ArrowSchema.private_data
+  //   - delete is called by lambda stored in ArrowSchema.release
+  CPPArrowSchema* cpp_schema =
+      new CPPArrowSchema(name, arrow_fmt.fmt_, "", arrow_flags, {}, {});
+
+  std::vector<void*> buffers;
+  if (bufferinfo.is_var) {
+    offsets_to_arrow(bufferinfo);  // convert in-place
+    buffers = {NULL, bufferinfo.offsets, bufferinfo.data};
+  } else {
+    cpp_schema =
+        new CPPArrowSchema(name, arrow_fmt.fmt_, "", arrow_flags, {}, {});
+    buffers = {NULL, bufferinfo.data};
+  }
+  cpp_schema->export_ptr(schema);
+
+  auto cpp_arrow_array = new CPPArrowArray(
+      (bufferinfo.is_var ? bufferinfo.offset_num : bufferinfo.elem_num),
+      0,  // null_num
+      0,
+      {},
+      {},
+      buffers);
+  cpp_arrow_array->export_ptr(array);
+}
+
+/* End TileDB Arrow IO internal implementation */
+/* ************************************************************************ */
+
+/* ************************************************************************ */
+/* Begin TileDB Arrow IO public API implementation */
+
+ArrowAdapter::ArrowAdapter(std::shared_ptr<tiledb::Query> query) {
+  importer_ = new ArrowImporter(query);
+  if (!importer_) {
+    throw tiledb::TileDBError(
+        "[TileDB-Arrow] Failed to allocate ArrowImporter!");
+  }
+  exporter_ = new ArrowExporter(query);
+  if (!exporter_) {
+    delete importer_;
+    throw tiledb::TileDBError(
+        "[TileDB-Arrow] Failed to allocate ArrowImporter!");
+  }
+}
+
+void ArrowAdapter::export_buffer(
+    const char* name, void* arrow_array, void* arrow_schema) {
+  exporter_->export_(
+      name, (ArrowArray*)arrow_array, (ArrowSchema*)arrow_schema);
+}
+
+void ArrowAdapter::import_buffer(
+    const char* name, void* arrow_array, void* arrow_schema) {
+  importer_->import_(
+      name, (ArrowArray*)arrow_array, (ArrowSchema*)arrow_schema);
+}
+
+ArrowAdapter::~ArrowAdapter() {
+  delete importer_;
+  delete exporter_;
+}
+
+void query_get_buffer_arrow_array(
+    std::shared_ptr<Query> query,
+    std::string name,
+    void* v_arw_array,
+    void* v_arw_schema) {
+  ArrowExporter exporter(query);
+
+  exporter.export_(name, (ArrowArray*)v_arw_array, (ArrowSchema*)v_arw_schema);
+}
+
+void query_set_buffer_arrow_array(
+    std::shared_ptr<Query> query,
+    std::string name,
+    void* v_arw_array,
+    void* v_arw_schema) {
+  auto arw_schema = (ArrowSchema*)v_arw_schema;
+  auto arw_array = (ArrowArray*)v_arw_array;
+  check_arrow_schema(arw_schema);
+
+  ArrowImporter importer(query);
+  importer.import_(name, arw_array, arw_schema);
+}
+
+};  // end namespace arrow
+};  // end namespace tiledb
+
+/* End TileDB Arrow IO public API implementation */
+/* ************************************************************************ */
+
+#endif  // TILEDB_ARROW_H

--- a/tiledb/sm/cpp_api/arrow_io_impl.h
+++ b/tiledb/sm/cpp_api/arrow_io_impl.h
@@ -534,7 +534,7 @@ struct CPPArrowArray {
       // mark the ArrowArray struct as released
       array_p->release = nullptr;
 
-      delete static_cast<CPPArrowArray*>((array_p->private_data));
+      delete static_cast<CPPArrowArray*>(array_p->private_data);
     });
     array_->private_data = this;
 

--- a/tiledb/sm/cpp_api/arrow_io_impl.h
+++ b/tiledb/sm/cpp_api/arrow_io_impl.h
@@ -285,7 +285,8 @@ TypeInfo arrow_type_to_tiledb(ArrowSchema* arw_schema) {
         "'");
 }
 
-TypeInfo tiledb_dt_info(const tiledb::ArraySchema& schema, const std::string& name) {
+TypeInfo tiledb_dt_info(
+    const tiledb::ArraySchema& schema, const std::string& name) {
   if (schema.has_attribute(name)) {
     auto attr = schema.attribute(name);
 
@@ -499,7 +500,6 @@ struct CPPArrowArray {
       int64_t offset,
       std::vector<std::shared_ptr<CPPArrowArray>> children,
       std::vector<void*> buffers) {
-
     array_ = static_cast<ArrowArray*>(std::malloc(sizeof(ArrowArray)));
     if (array_ == nullptr)
       throw tiledb::TileDBError("Failed to allocate ArrowArray");
@@ -549,7 +549,7 @@ struct CPPArrowArray {
    * callback. Owned member data is released via default destructors.
    */
   ~CPPArrowArray() {
-    if (array_  != nullptr) {
+    if (array_ != nullptr) {
       // did not export
       std::free(array_);
     }
@@ -612,10 +612,9 @@ void ArrowImporter::import_(
   if (typeinfo.cell_val_num == TILEDB_VAR_NUM) {
     assert(arw_array->n_buffers == 3);
 
-    const void* p_offsets_arw =
-        const_cast<void*>(arw_array->buffers[1]);
+    const void* p_offsets_arw = const_cast<void*>(arw_array->buffers[1]);
     const void* p_data = const_cast<void*>(arw_array->buffers[2]);
-    uint64_t data_num = arw_array->length;              // <- number of elements
+    uint64_t data_num = arw_array->length;  // <- number of elements
     uint64_t data_nbytes = 0;
 
     uint64_t* p_offsets =
@@ -768,7 +767,8 @@ void ArrowExporter::export_(
 /* Begin TileDB Arrow IO public API implementation */
 
 ArrowAdapter::ArrowAdapter(std::shared_ptr<tiledb::Query> query)
-: importer_(nullptr), exporter_(nullptr) {
+    : importer_(nullptr)
+    , exporter_(nullptr) {
   importer_ = new ArrowImporter(query);
   if (!importer_) {
     throw tiledb::TileDBError(

--- a/tiledb/sm/cpp_api/arrowio
+++ b/tiledb/sm/cpp_api/arrowio
@@ -1,0 +1,106 @@
+/**
+ * vim: set ft=cpp:
+ * @file   arrow_io.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the experimental TileDB interoperation with Apache Arrow.
+ */
+
+#include <memory>
+
+#include "tiledb"
+
+namespace tiledb {
+namespace arrow {
+
+class ArrowImporter;
+class ArrowExporter;
+
+/**
+ * Adapter to export TileDB (read) Query results to Apache Arrow buffers
+ * and import Arrow buffers into a TileDB (write) Query.
+ *
+ * This adapter exports buffers conforming to the Arrow C Data Interface
+ * as documented at:
+ *
+ *   https://arrow.apache.org/docs/format/CDataInterface.html
+ *
+ */
+
+class ArrowAdapter {
+public:
+  /* Constructs an ArrowAdapter wrapping the given TileDB C++ Query */
+  ArrowAdapter(std::shared_ptr<tiledb::Query> query);
+  ~ArrowAdapter();
+
+  /**
+   * Exports named Query buffer to ArrowArray/ArrowSchema struct pair,
+   * as defined in the Arrow C Data Interface.
+   *
+   * @param name The name of the buffer to export.
+   * @param arrow_array Pointer to pre-allocated ArrowArray struct
+   * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
+   * @throws tiledb::TileDBError with error-specific message.
+   */
+  void export_buffer(const char* name, void* arrow_array, void* arrow_schema);
+
+  /**
+   * Set named Query buffer from ArrowArray/ArrowSchema struct pair
+   * representing external data buffers conforming to the
+   * Arrow C Data Interface.
+   *
+   * @param name The name of the buffer to export.
+   * @param arrow_array Pointer to pre-allocated ArrowArray struct
+   * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
+   * @throws tiledb::TileDBError with error-specific message.
+   */
+  void import_buffer(const char* name, void* arrow_array, void* arrow_schema);
+
+private:
+  ArrowImporter* importer_;
+  ArrowExporter* exporter_;
+};
+
+TILEDB_EXPORT
+void query_get_buffer_arrow_array(
+    std::shared_ptr<tiledb::Query> query,
+    std::string name,
+    void** arrow_array,
+    void** arrow_schema);
+
+TILEDB_EXPORT
+void query_set_buffer_arrow_array(
+    std::shared_ptr<Query> query,
+    std::string name,
+    void* arrow_array,
+    void* arrow_schema);
+
+};  // end namespace arrow
+};  // end namespace tiledb
+
+#include "arrow_io_impl.h"

--- a/tiledb/sm/cpp_api/arrowio
+++ b/tiledb/sm/cpp_api/arrowio
@@ -1,12 +1,12 @@
 /**
  * vim: set ft=cpp:
- * @file   arrow_io.h
+ * @file   arrowio
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2020 TileDB, Inc.
+ * @copyright Copyright (c) 2020 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,7 +55,7 @@ class ArrowExporter;
 class ArrowAdapter {
 public:
   /* Constructs an ArrowAdapter wrapping the given TileDB C++ Query */
-  ArrowAdapter(std::shared_ptr<tiledb::Query> query);
+  ArrowAdapter(std::shared_ptr<Query> query);
   ~ArrowAdapter();
 
   /**
@@ -85,20 +85,6 @@ private:
   ArrowImporter* importer_;
   ArrowExporter* exporter_;
 };
-
-TILEDB_EXPORT
-void query_get_buffer_arrow_array(
-    std::shared_ptr<tiledb::Query> query,
-    std::string name,
-    void** arrow_array,
-    void** arrow_schema);
-
-TILEDB_EXPORT
-void query_set_buffer_arrow_array(
-    std::shared_ptr<Query> query,
-    std::string name,
-    void* arrow_array,
-    void* arrow_schema);
 
 };  // end namespace arrow
 };  // end namespace tiledb


### PR DESCRIPTION
This commit adds an experimental C++ API for importing/exporting Apache Arrow
buffers from/to a TileDB Query. The import/export functionality uses the
header-only Arrow C Data Interface [1] to avoid any build/link dependency.

All public functionality is exported and documented in the 'tiledb/arrowio' header.

The tiledb::arrow::ArrowAdapter class wraps a TileDB C++ API Query and provides
functions to:
  - export read query buffers as ArrowArray/ArrowSchema pairs
  - set write query buffers from ArrowArray/ArrowSchema pairs

Testing strategy
----------------

This commit adds a conditionally-compiled unit-arrow.cc unit test. Compilation
is currently controlled by setting the TILEDB_TESTS_ENABLE_ARROW=ON environment
variable.

The unit test is designed as follows:

- when Arrow test is enabled, the tiledb_unit target requires python to be available,
   with packages pyarrow, numpy, and pybind11 installed. pyarrow provides the runtime
  interface with libarrow, using the `pyarrow.Array._import_from_c/_export_to_c`
  functions
- unit-arrow is implemented as a standard Catch2 test, conditionally
  compiled
- test creates a TileDB Array with predefined schema
- unit-arrow and associated cmake changes utilizes pybind11 to link against ("embed")
  libpython from tiledb_unit, allowing the unit test to call out to helper functionality
  defined in 'unit_arrow.py'
  - DataFactory class in unit_arrow.py creates set of pyarrow arrays of expected
    type with randomly generated data (via NumPy)

- data buffers are set for write query from DataFactory arrays
  - uses pyarrow.Array._export_to_c helper function to set corresponding
    ArrowArray/ArrowSchema struct, which is then passed to tiledb ArrowImporter

- after write query completes, the test creates a read query, sets buffers, and
  submits
- test then uses tiledb ArrowAdapter to create ArrowArray/ArrowSchema
  pair from Query buffers, and passes these `pyarrow.Array._import_from_c`
  function to create pyarrow Arrays wrapping these buffers
- all arrays in result dataset are then compared to original dataset (via NumPy)

Notes:
- currently (v2.5.0) pybind11 from PyPI does not include CMake
  configuration files. In this case, a pybind11 target is created with
  necessary information. After the next pybind11 release, the `find_package(pybind11)`
  call should work correctly in any virtual environment with pybind11
  installed, and the custom target setup section of `test/CMakeLists.txt` may
  be removed

---
[1] https://arrow.apache.org/docs/format/CDataInterface.html