### PR TITLE
Add comment about github release stage section

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,6 +139,7 @@ stages:
        steps:
          - template: scripts/azure-windows-release.yml
 
+  # NOTE: this section cannot be conditional because `Build.Repository.Name` is an agent-scoped variable.
   - stage: Github_Release
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     jobs:


### PR DESCRIPTION
This allows azure pipelines CI scripts to be run in a project on a fork. Otherwise, the pipeline verifier  errors out with the following message:

```
There was a resource authorization issue: "The pipeline is not valid. Job Job1: Step GitHubRelease input gitHubConnection references service connection TileDB-Inc-Release which could not be found. The service connection does not exist or has not been authorized for use. For authorization details, refer to https://aka.ms/yamlauthz."
```