### PR TITLE
Update unit-backwards_compat for v2.0.0, part 2

### DIFF
--- a/scripts/azure-centos6.yml
+++ b/scripts/azure-centos6.yml
@@ -46,7 +46,7 @@ steps:
     git config --global user.email 'no-reply@tiledb.io'
 
     # Clone Unit-Test-Arrays
-    git clone -q https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-2 test/inputs/arrays/read_compatibility_test
+    git clone -q https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-3 test/inputs/arrays/read_compatibility_test
 
 
     # Set up bootstrap args

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -50,7 +50,7 @@ steps:
     git config --global user.name 'Azure Pipeline'
     git config --global user.email 'no-reply@tiledb.io'
 
-    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-2 test/inputs/arrays/read_compatibility_test
+    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-3 test/inputs/arrays/read_compatibility_test
     #   displayName: 'Clone Unit-Test-Arrays'
 
     # - bash: |

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -46,7 +46,7 @@ steps:
     $env:AWS_SECRET_ACCESS_KEY = "miniosecretkey"
 
     # Clone backwards compatibility test arrays
-    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-2 $env:BUILD_SOURCESDIRECTORY/test/inputs/arrays/read_compatibility_test
+    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-3 $env:BUILD_SOURCESDIRECTORY/test/inputs/arrays/read_compatibility_test
 
     if ($env:TILEDB_S3 -eq "ON") {
       # update CMake to disable S3 for the test configuration, see minio note above

--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -194,8 +194,22 @@ TEST_CASE(
         array = new Array(ctx, object.uri(), TILEDB_READ);
       }
 
-      // Skip domain types that are unsupported with zipped coordinates.
+      // Skip arrays with heterogeneous dimension types.
       Domain domain = array->schema().domain();
+      REQUIRE(domain.ndim() > 0);
+      tiledb_datatype_t last_datatype = domain.dimension(0).type();
+      bool heterogeneous = false;
+      for (uint32_t i = 1; i < domain.ndim(); ++i) {
+        if (domain.dimension(i).type() != last_datatype) {
+          heterogeneous = true;
+          break;
+        }
+      }
+
+      if (heterogeneous)
+        continue;
+
+      // Skip domain types that are unsupported with zipped coordinates.
       if (domain.type() == TILEDB_STRING_ASCII) {
         continue;
       }


### PR DESCRIPTION
This updates the unit-backwards_compat for v2.0.0 arrays. This depends on both
a tagged release of the new arrays at `2.0.0-3`. This adds support for heterogenous
dimensions.