### PR TITLE
Update comments for `vfs.azure.blob_endpoint` config

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1011,8 +1011,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Set the Azure Storage Account key. <br>
  *    **Default**: ""
  * - `vfs.azure.blob_endpoint` <br>
- *    Set the Azure Storage Blob endpoint. This should not include an
- *    http:// or https:// prefix. <br>
+ *    Overrides the default Azure Storage Blob endpoint. If empty, the endpoint
+ *    will be constructed from the storage account name. This should not include
+ *    an http:// or https:// prefix. <br>
  *    **Default**: ""
  * - `vfs.azure.block_list_block_size` <br>
  *    The block size (in bytes) used in Azure blob block list writes.

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -340,8 +340,9 @@ class Config {
    *    Set the Azure Storage Account key. <br>
    *    **Default**: ""
    * - `vfs.azure.blob_endpoint` <br>
-   *    Set the Azure Storage Blob endpoint. This should not include an
-   *    http:// or https:// prefix. <br>
+   *    Overrides the default Azure Storage Blob endpoint. If empty, the
+   * endpoint will be constructed from the storage account name. This should not
+   * include an http:// or https:// prefix. <br>
    *    **Default**: ""
    * - `vfs.azure.block_list_block_size` <br>
    *    The block size (in bytes) used in Azure blob block list writes.


### PR DESCRIPTION
Changes the wording to indicate that this config should be only used to override
the default.

More info has been added to the real docs:
https://docs.tiledb.com/main/solutions/tiledb-embedded/backends/azure-blob-storage