### PR TITLE
Suppress warnings from `find_package(fmt)`

### DIFF
--- a/cmake/Modules/FindSpdlog_EP.cmake
+++ b/cmake/Modules/FindSpdlog_EP.cmake
@@ -67,7 +67,7 @@ endif()
 
 if (SPDLOG_FOUND AND NOT TARGET Spdlog::Spdlog)
   add_library(Spdlog::Spdlog INTERFACE IMPORTED)
-  find_package(fmt)
+  find_package(fmt QUIET)
   if (${fmt_FOUND})
     target_link_libraries(Spdlog::Spdlog INTERFACE fmt::fmt)
   endif()


### PR DESCRIPTION
It's not an error if we are unable to find the `fmt` package when building
the Spdlog external project. This changes hides:
```
CMake Warning at cmake/Modules/FindSpdlog_EP.cmake:70 (find_package):
  By not providing "Findfmt.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "fmt", but
  CMake did not find one.
  Could not find a package configuration file provided by "fmt" with any of
  the following names:
    fmtConfig.cmake
    fmt-config.cmake
  Add the installation prefix of "fmt" to CMAKE_PREFIX_PATH or set "fmt_DIR"
  to a directory containing one of the above files.  If "fmt" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  tiledb/CMakeLists.txt:393 (find_package)
```