### PR TITLE
Remove building 'without_tbb' artifacts

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -42,6 +42,7 @@
 * Deprecated config option "sm.num_vfs_threads" [#1766](https://github.com/TileDB-Inc/TileDB/pull/1766)
 * Support for MacOS older than 10.13 is being dropped when using the AWS SDK. Prebuilt Binaries now target 10.13 [#1753](https://github.com/TileDB-Inc/TileDB/pull/1753)
 * Use of Intel's Thread Building Blocks (TBB) will be discontinued in the future. It is now disabled by default [#1762](https://github.com/TileDB-Inc/TileDB/pull/1762)
+* No longer building release artifacts with Intel's Thread Building Blocks (TBB) enabled [#1825](https://github.com/TileDB-Inc/TileDB/pull/1825)
 
 ## Bug fixes
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,28 +103,14 @@ stages:
      - job:
        strategy:
          matrix:
-           linux_without_tbb:
-             imageName: 'ubuntu-16.04'
-             CXX: g++
-             TILEDB_TBB: OFF
-             ARTIFACT_OS: 'linux'
-             ARTIFACT_EXTRAS: 'without_tbb'
            linux:
              imageName: 'ubuntu-16.04'
              CXX: g++
-             TILEDB_TBB: ON
              ARTIFACT_OS: 'linux'
              ARTIFACT_EXTRAS: 'full'
-           macOS_without_tbb:
-             imageName: 'macOS-10.14'
-             CXX: clang++
-             TILEDB_TBB: OFF
-             ARTIFACT_OS: 'macos'
-             ARTIFACT_EXTRAS: 'without_tbb'
            macOS:
              imageName: 'macOS-10.14'
              CXX: clang++
-             TILEDB_TBB: ON
              ARTIFACT_OS: 'macos'
              ARTIFACT_EXTRAS: 'full'
        pool:
@@ -144,19 +130,9 @@ stages:
 #             TILEDB_HDFS: OFF
              TILEDB_STATIC: OFF
 #             TILEDB_SERIALIZATION: OFF
-             TILEDB_TBB: ON
              TILEDB_FORCE_BUILD_DEPS: ON
              ARTIFACT_OS: 'windows'
              ARTIFACT_EXTRAS: 'full'
-             CL: "/arch:AVX2"
-           VS2017_without_tbb:
-             imageName: 'vs2017-win2016'
-             TILEDB_S3: ON
-             TILEDB_TBB: OFF
-             TILEDB_STATIC: OFF
-             TILEDB_FORCE_BUILD_DEPS: ON
-             ARTIFACT_OS: 'windows'
-             ARTIFACT_EXTRAS: 'without_tbb'
              CL: "/arch:AVX2"
        pool:
          vmImage: $(imageName)
@@ -190,4 +166,3 @@ stages:
            tag: $(Build.SourceBranchName)
            assets: |
              $(Build.ArtifactStagingDirectory)/full/*
-             $(Build.ArtifactStagingDirectory)/without_tbb/*


### PR DESCRIPTION
The normal artifacts now build without `TILEDB_TBB: ON`, which now defaults
to off.