### PR TITLE
Remove GCS-detected zlib shared library linkage

### DIFF
--- a/cmake/Modules/FindZlib_EP.cmake
+++ b/cmake/Modules/FindZlib_EP.cmake
@@ -110,7 +110,7 @@ if (NOT ZLIB_FOUND)
 endif()
 
 if (ZLIB_FOUND AND NOT TARGET Zlib::Zlib)
-  message(STATUS "Found Zlib: ${ZLIB_LIBRARIES}")
+  message(STATUS "Found Zlib, adding imported target: ${ZLIB_LIBRARIES}")
   add_library(Zlib::Zlib UNKNOWN IMPORTED)
   set_target_properties(Zlib::Zlib PROPERTIES
     IMPORTED_LOCATION "${ZLIB_LIBRARIES}"

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -324,6 +324,18 @@ if (TILEDB_GCS)
        storage_client
   )
   add_definitions(-DHAVE_GCS)
+
+  # work around for GCS finding the shared version of zlib: we will see the Zlib::Zlib
+  # transitive linkage later, and we can use the correct version there.
+  unset(ZLIB_FOUND)
+  unset(ZLIB_LIBRARIES)
+  unset(ZLIB_INCLUDE_DIR)
+
+  get_target_property(_GCS_INTERFACE_LIBS storage_client INTERFACE_LINK_LIBRARIES)
+  if ("ZLIB::ZLIB" IN_LIST _GCS_INTERFACE_LIBS)
+    list(REMOVE_ITEM _GCS_INTERFACE_LIBS "ZLIB::ZLIB")
+    set_property(TARGET storage_client PROPERTY INTERFACE_LINK_LIBRARIES "${_GCS_INTERFACE_LIBS}")
+  endif()
 endif()
 
 # Libcurl


### PR DESCRIPTION
Remove GCS-detected variables and targets and use our own instead.
This fixes a problem with macOS linkage where GCS cmake causes us to
dynamically link zlib.