### PR TITLE
Move thread pools from StorageManager to Context

### DIFF
--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -46,6 +46,9 @@ Context::Context()
 }
 
 Context::~Context() {
+  // Delete the `storage_manager_` to ensure it is destructed
+  // before the `compute_tp_` and `io_tp_` objects that it
+  // references.
   delete storage_manager_;
 }
 
@@ -53,13 +56,17 @@ Context::~Context() {
 /*                API             */
 /* ****************************** */
 
-Status Context::init(Config* config) {
+Status Context::init(Config* const config) {
   if (storage_manager_ != nullptr)
     return LOG_STATUS(Status::ContextError(
         "Cannot initialize context; Context already initialized"));
 
+  // Initialize `compute_tp_` and `io_tp_`.
+  RETURN_NOT_OK(init_thread_pools(config));
+
   // Create storage manager
-  storage_manager_ = new (std::nothrow) tiledb::sm::StorageManager();
+  storage_manager_ =
+      new (std::nothrow) tiledb::sm::StorageManager(&compute_tp_, &io_tp_);
   if (storage_manager_ == nullptr)
     return LOG_STATUS(Status::ContextError(
         "Cannot initialize contextl Storage manager allocation failed"));
@@ -80,6 +87,110 @@ void Context::save_error(const Status& st) {
 
 StorageManager* Context::storage_manager() const {
   return storage_manager_;
+}
+
+ThreadPool* Context::compute_tp() const {
+  return &compute_tp_;
+}
+
+ThreadPool* Context::io_tp() const {
+  return &io_tp_;
+}
+
+Status Context::init_thread_pools(Config* const config) {
+  // If `config` is null, use a default-constructed config.
+  Config tmp_config;
+  if (config != nullptr)
+    tmp_config = *config;
+
+  // The "sm.num_async_threads", "sm.num_reader_threads",
+  // "sm.num_writer_threads", and "sm.num_vfs_threads" have
+  // been removed. If they are set, we will log an error message.
+  // To error on the side of maintaining high-performance for
+  // existing users, we will take the maximum thread count
+  // among all of these configurations and set them to the new
+  // "sm.compute_concurrency_level" and "sm.io_concurrency_level".
+  uint64_t max_thread_count = 0;
+
+  bool found;
+  uint64_t num_async_threads = 0;
+  RETURN_NOT_OK(tmp_config.get<uint64_t>(
+      "sm.num_async_threads", &num_async_threads, &found));
+  if (found) {
+    max_thread_count = std::max(max_thread_count, num_async_threads);
+    LOG_STATUS(Status::StorageManagerError(
+        "Config parameter \"sm.num_async_threads\" has been removed; use "
+        "config parameter \"sm.compute_concurrency_level\"."));
+  }
+
+  uint64_t num_reader_threads = 0;
+  RETURN_NOT_OK(tmp_config.get<uint64_t>(
+      "sm.num_reader_threads", &num_reader_threads, &found));
+  if (found) {
+    max_thread_count = std::max(max_thread_count, num_reader_threads);
+    LOG_STATUS(Status::StorageManagerError(
+        "Config parameter \"sm.num_reader_threads\" has been removed; use "
+        "config parameter \"sm.compute_concurrency_level\"."));
+  }
+
+  uint64_t num_writer_threads = 0;
+  RETURN_NOT_OK(tmp_config.get<uint64_t>(
+      "sm.num_writer_threads", &num_writer_threads, &found));
+  if (found) {
+    max_thread_count = std::max(max_thread_count, num_writer_threads);
+    LOG_STATUS(Status::StorageManagerError(
+        "Config parameter \"sm.num_writer_threads\" has been removed; use "
+        "config parameter \"sm.compute_concurrency_level\"."));
+  }
+
+  uint64_t num_vfs_threads = 0;
+  RETURN_NOT_OK(
+      tmp_config.get<uint64_t>("sm.num_vfs_threads", &num_vfs_threads, &found));
+  if (found) {
+    max_thread_count = std::max(max_thread_count, num_vfs_threads);
+    LOG_STATUS(Status::StorageManagerError(
+        "Config parameter \"sm.num_vfs_threads\" has been removed; use "
+        "config parameter \"sm.io_concurrency_level\"."));
+  }
+
+  // Fetch the compute and io concurrency levels.
+  uint64_t compute_concurrency_level = 0;
+  RETURN_NOT_OK(tmp_config.get<uint64_t>(
+      "sm.compute_concurrency_level", &compute_concurrency_level, &found));
+  assert(found);
+  uint64_t io_concurrency_level = 0;
+  RETURN_NOT_OK(tmp_config.get<uint64_t>(
+      "sm.io_concurrency_level", &io_concurrency_level, &found));
+  assert(found);
+
+#ifndef HAVE_TBB
+  // The "sm.num_tbb_threads" has been deprecated when TBB is disabled.
+  // Now that TBB is disabled by default, users may still be setting this
+  // configuration parameter larger than the default value. In this scenario,
+  // we will override the compute and io concurrency levels if the configured
+  // tbb threads are greater. We will do this silently because the
+  // "sm.num_tbb_threads" still has a default value in the config. When we
+  // remove TBB, we will also remove this configuration parameter.
+  int num_tbb_threads = 0;
+  RETURN_NOT_OK(
+      tmp_config.get<int>("sm.num_tbb_threads", &num_tbb_threads, &found));
+  assert(found);
+  if (num_tbb_threads > 0)
+    max_thread_count =
+        std::max(max_thread_count, static_cast<uint64_t>(num_tbb_threads));
+#endif
+
+  // If 'max_thread_count' is larger than the compute or io concurrency levels,
+  // use that instead.
+  compute_concurrency_level =
+      std::max(max_thread_count, compute_concurrency_level);
+  io_concurrency_level = std::max(max_thread_count, io_concurrency_level);
+
+  // Initialize the thread pools.
+  RETURN_NOT_OK(compute_tp_.init(compute_concurrency_level));
+  RETURN_NOT_OK(io_tp_.init(io_concurrency_level));
+
+  return Status::Ok();
 }
 
 }  // namespace sm

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -73,6 +73,12 @@ class Context {
   /** Returns the storage manager. */
   StorageManager* storage_manager() const;
 
+  /** Returns the thread pool for compute-bound tasks. */
+  ThreadPool* compute_tp() const;
+
+  /** Returns the thread pool for io-bound tasks. */
+  ThreadPool* io_tp() const;
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -86,6 +92,24 @@ class Context {
 
   /** The storage manager. */
   StorageManager* storage_manager_;
+
+  /** The thread pool for compute-bound tasks. */
+  mutable ThreadPool compute_tp_;
+
+  /** The thread pool for io-bound tasks. */
+  mutable ThreadPool io_tp_;
+
+  /* ********************************* */
+  /*         PRIVATE METHODS           */
+  /* ********************************* */
+
+  /**
+   * Initializes the thread pools.
+   *
+   * @param config The configuration parameters.
+   * @return Status
+   */
+  Status init_thread_pools(Config* config);
 };
 
 }  // namespace sm

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -109,7 +109,7 @@ class StorageManager {
   /* ********************************* */
 
   /** Constructor. */
-  StorageManager();
+  StorageManager(ThreadPool* compute_tp, ThreadPool* io_tp);
 
   /** Destructor. */
   ~StorageManager();
@@ -549,14 +549,6 @@ class StorageManager {
    */
   Status init(const Config* config);
 
-  /**
-   * Initializes the storage manager's thread pools.
-   *
-   * @param config The configuration parameters.
-   * @return Status
-   */
-  Status init_thread_pools();
-
   /** Returns the thread pool for compute-bound tasks. */
   ThreadPool* compute_tp();
 
@@ -961,10 +953,10 @@ class StorageManager {
   std::condition_variable queries_in_progress_cv_;
 
   /** The thread pool for compute-bound tasks. */
-  mutable ThreadPool compute_tp_;
+  ThreadPool* const compute_tp_;
 
   /** The thread pool for io-bound tasks. */
-  mutable ThreadPool io_tp_;
+  ThreadPool* const io_tp_;
 
   /** Tracks all scheduled tasks that can be safely cancelled before execution.
    */


### PR DESCRIPTION
In preparation for sharing outside of the StorageManager, this moves the
thread pools from the StorageManager to the Context class.