### PR TITLE
Disable nghttp2 in curl config

### DIFF
--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -132,6 +132,7 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
           --enable-optimize
           --enable-shared=no
           --with-pic=yes
+          --without-nghttp2
           --disable-dict
           --disable-file
           --disable-ftp


### PR DESCRIPTION
This causes overlinkage in the static builds on macOS, because nghttp2 is detected
in the build image.