### PR TITLE
Remove extraneous assert in LRUCache

### DIFF
--- a/tiledb/sm/cache/lru_cache.h
+++ b/tiledb/sm/cache/lru_cache.h
@@ -120,9 +120,6 @@ class LRUCache {
   explicit LRUCache(const uint64_t max_size)
       : max_size_(max_size)
       , size_(0) {
-    assert(max_size_ > 0);
-    if (max_size_ == 0)
-      LOG_FATAL("LRUCache initialized without capacity.");
   }
 
   /** Destructor. */


### PR DESCRIPTION
This removes an assert and related LOG_FATAL if an LRUCache is initialized
with a 0 max size.