### PR TITLE
consolidate_metadata bug fix

### DIFF
--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -1214,7 +1214,7 @@ class Array {
       config_aux = &local_cfg;
     }
 
-    (*config)["sm.consolidation.mode"] = "array_meta";
+    (*config_aux)["sm.consolidation.mode"] = "array_meta";
     consolidate(ctx, uri, TILEDB_NO_ENCRYPTION, nullptr, 0, config_aux);
   }
 


### PR DESCRIPTION
The same bug remains in the other two overloaded `consolidate_metadata` functions, which I will leave up to you guys to fix.