### PR TITLE
File re-organization

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -46,6 +46,7 @@
 * Build system will raise overridable error if important paths contain regex character [#1808](https://github.com/TileDB-Inc/TileDB/pull/1808)
 * Prebuilt artifacts for release now target `haswell` for minimum architecture for linux/macos and `AVX2` for msvcc [#1809](https://github.com/TileDB-Inc/TileDB/pull/1809)
 * Lazily create AWS ClientConfiguration to avoid slow context creations for non S3 usage after the AWS SDK version bump [#1821](https://github.com/TileDB-Inc/TileDB/pull/1821)
+* Moved `Status`, `ThreadPool`, and `Logger` classes from folder `tiledb/sm` to `tiledb/common` [#1843](https://github.com/TileDB-Inc/TileDB/pull/1843)
 
 ## Deprecations
 

--- a/test/src/unit-SubarrayPartitioner-dense.cc
+++ b/test/src/unit-SubarrayPartitioner-dense.cc
@@ -43,6 +43,7 @@
 #include <catch.hpp>
 #include <iostream>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 using namespace tiledb::test;
 

--- a/test/src/unit-SubarrayPartitioner-error.cc
+++ b/test/src/unit-SubarrayPartitioner-error.cc
@@ -43,6 +43,7 @@
 #include <catch.hpp>
 #include <iostream>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 using namespace tiledb::test;
 

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -43,6 +43,7 @@
 #include <catch.hpp>
 #include <iostream>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 using namespace tiledb::test;
 

--- a/test/src/unit-azure.cc
+++ b/test/src/unit-azure.cc
@@ -33,15 +33,16 @@
 #ifdef HAVE_AZURE
 
 #include "catch.hpp"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/azure.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <fstream>
 #include <thread>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 struct AzureFx {

--- a/test/src/unit-buffer.cc
+++ b/test/src/unit-buffer.cc
@@ -36,6 +36,7 @@
 #include <catch.hpp>
 #include <iostream>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 TEST_CASE("Buffer: Test default constructor with write void*", "[buffer]") {

--- a/test/src/unit-compression-rle.cc
+++ b/test/src/unit-compression-rle.cc
@@ -40,16 +40,16 @@
 #include <cstring>
 #include <iostream>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 TEST_CASE("Compression-RLE: Test invalid format", "[compression], [rle]") {
   // Initializations
   auto input = new ConstBuffer(nullptr, 0);
   auto compressed = new Buffer();
-  tiledb::sm::Status st;
 
   // Test empty buffer
-  st = tiledb::sm::RLE::compress(sizeof(int), input, compressed);
+  auto st = tiledb::sm::RLE::compress(sizeof(int), input, compressed);
   CHECK(!st.ok());
   delete input;
 
@@ -113,7 +113,7 @@ TEST_CASE("Compression-RLE: Test all values the same", "[compression], [rle]") {
   uint64_t run_size = 6;
   auto compressed = new Buffer();
   auto decompressed = new Buffer();
-  tiledb::sm::Status st;
+  Status st;
 
   int data[100];
   REQUIRE(st.ok());
@@ -153,7 +153,7 @@ TEST_CASE(
     "[compression], [rle]") {
   // Initializations
   uint64_t run_size = 6;
-  tiledb::sm::Status st;
+  Status st;
 
   // Prepare data
   int data[110];
@@ -198,7 +198,7 @@ TEST_CASE(
   // Initializations
   uint64_t run_size = 6;
   auto decompressed = new Buffer();
-  tiledb::sm::Status st;
+  Status st;
 
   // Prepare data
   int data[70030];
@@ -240,7 +240,7 @@ TEST_CASE(
     "Compression-RLE: Test compression/decompression with type double:2",
     "[compression], [rle]") {
   // Initializations
-  tiledb::sm::Status st;
+  Status st;
   uint64_t value_size = 2 * sizeof(double);
   uint64_t run_size = value_size + 2;
 

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -57,6 +57,7 @@
 #include <iostream>
 #include <random>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 /**

--- a/test/src/unit-gcs.cc
+++ b/test/src/unit-gcs.cc
@@ -33,14 +33,15 @@
 #ifdef HAVE_GCS
 
 #include "catch.hpp"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/gcs.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <sstream>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 struct GCSFx {

--- a/test/src/unit-hdfs-filesystem.cc
+++ b/test/src/unit-hdfs-filesystem.cc
@@ -40,6 +40,7 @@
 #include <fstream>
 #include <iostream>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 using namespace tiledb::sm::hdfs;
 

--- a/test/src/unit-lru_cache.cc
+++ b/test/src/unit-lru_cache.cc
@@ -34,6 +34,7 @@
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/cache/buffer_lru_cache.h"
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 #define CACHE_SIZE 10 * sizeof(int)

--- a/test/src/unit-s3-no-multipart.cc
+++ b/test/src/unit-s3-no-multipart.cc
@@ -33,15 +33,16 @@
 #ifdef HAVE_S3
 
 #include "catch.hpp"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/s3.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <fstream>
 #include <thread>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 struct S3DirectFx {

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -33,15 +33,16 @@
 #ifdef HAVE_S3
 
 #include "catch.hpp"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/s3.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <fstream>
 #include <thread>
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 struct S3Fx {

--- a/test/src/unit-status.cc
+++ b/test/src/unit-status.cc
@@ -31,9 +31,9 @@
  */
 
 #include <catch.hpp>
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 
-using namespace tiledb::sm;
+using namespace tiledb::common;
 
 TEST_CASE("Status: Test ok", "[status]") {
   Status st = Status::Ok();

--- a/test/src/unit-threadpool.cc
+++ b/test/src/unit-threadpool.cc
@@ -33,9 +33,10 @@
 #include <atomic>
 #include <catch.hpp>
 #include <iostream>
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/misc/cancelable_tasks.h"
-#include "tiledb/sm/misc/thread_pool.h"
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 TEST_CASE("ThreadPool: Test empty", "[threadpool]") {

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -35,6 +35,7 @@
 #include "test/src/helpers.h"
 #include "tiledb/sm/filesystem/vfs.h"
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 TEST_CASE("VFS: Test read batching", "[vfs]") {

--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -35,11 +35,12 @@
 #include "catch.hpp"
 
 #include <cassert>
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/win.h"
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
 
+using namespace tiledb::common;
 using namespace tiledb::sm;
 
 static bool starts_with(const std::string& value, const std::string& prefix) {

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -87,6 +87,9 @@ endif()
 
 # List of all core source files
 set(TILEDB_CORE_SOURCES
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/logger.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/status.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/thread_pool.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/array_schema.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/attribute.cc
@@ -143,9 +146,6 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/metadata/metadata.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/cancelable_tasks.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/constants.cc
-  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/logger.cc
-  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/status.cc
-  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/thread_pool.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/uri.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/utils.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/uuid.cc

--- a/tiledb/common/logger.cc
+++ b/tiledb/common/logger.cc
@@ -30,12 +30,12 @@
  * This file implements class Logger.
  */
 
-#include "tiledb/sm/misc/logger.h"
+#include "tiledb/common/logger.h"
 
 #include <spdlog/sinks/stdout_sinks.h>
 
 namespace tiledb {
-namespace sm {
+namespace common {
 
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -80,5 +80,5 @@ Logger& global_logger() {
   return l;
 }
 
-}  // namespace sm
+}  // namespace common
 }  // namespace tiledb

--- a/tiledb/common/logger.h
+++ b/tiledb/common/logger.h
@@ -38,10 +38,10 @@
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 
 namespace tiledb {
-namespace sm {
+namespace common {
 
 /** Definition of class Logger. */
 class Logger {
@@ -190,7 +190,7 @@ inline void LOG_FATAL(const std::string& msg) {
   exit(1);
 }
 
-}  // namespace sm
+}  // namespace common
 }  // namespace tiledb
 
 #endif  // TILEDB_LOGGER_H

--- a/tiledb/common/status.cc
+++ b/tiledb/common/status.cc
@@ -45,11 +45,11 @@
  * external synchronization.
  */
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 #include <cassert>
 
 namespace tiledb {
-namespace sm {
+namespace common {
 
 Status::Status(StatusCode code, const std::string& msg, int16_t posix_code) {
   assert(code != StatusCode::Ok);
@@ -240,5 +240,5 @@ int16_t Status::posix_code() const {
   return code;
 }
 
-}  // namespace sm
+}  // namespace common
 }  // namespace tiledb

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -56,7 +56,7 @@
 #include <string>
 
 namespace tiledb {
-namespace sm {
+namespace common {
 
 #define RETURN_NOT_OK(s) \
   do {                   \
@@ -467,7 +467,8 @@ inline void Status::operator=(const Status& s) {
     state_ = (s.state_ == nullptr) ? nullptr : copy_state(s.state_);
   }
 }
-}  // namespace sm
+
+}  // namespace common
 }  // namespace tiledb
 
 #endif  // TILEDB_STATUS_H

--- a/tiledb/common/thread_pool.cc
+++ b/tiledb/common/thread_pool.cc
@@ -32,11 +32,11 @@
 
 #include <cassert>
 
-#include "tiledb/sm/misc/logger.h"
-#include "tiledb/sm/misc/thread_pool.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/common/thread_pool.h"
 
 namespace tiledb {
-namespace sm {
+namespace common {
 
 // Define the static ThreadPool member variables.
 std::unordered_map<std::thread::id, ThreadPool*> ThreadPool::tp_index_;
@@ -355,5 +355,5 @@ ThreadPool* ThreadPool::lookup_tp() {
   return nullptr;
 }
 
-}  // namespace sm
+}  // namespace common
 }  // namespace tiledb

--- a/tiledb/common/thread_pool.h
+++ b/tiledb/common/thread_pool.h
@@ -41,12 +41,12 @@
 #include <unordered_set>
 #include <vector>
 
-#include "tiledb/sm/misc/logger.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/macros.h"
-#include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
-namespace sm {
+namespace common {
 
 /**
  * A recusive-safe thread pool.
@@ -360,7 +360,7 @@ class ThreadPool {
   ThreadPool* lookup_tp();
 };
 
-}  // namespace sm
+}  // namespace common
 }  // namespace tiledb
 
 #endif  // TILEDB_THREAD_POOL_H

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/array/array.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -41,13 +42,14 @@
 #include "tiledb/sm/enums/query_type.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
 #include <cassert>
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -37,10 +37,12 @@
 #include <unordered_map>
 #include <vector>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/crypto/encryption_key.h"
 #include "tiledb/sm/fragment/fragment_info.h"
 #include "tiledb/sm/metadata/metadata.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -32,6 +32,7 @@
  */
 
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
@@ -42,12 +43,13 @@
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/filter/compression_filter.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <cassert>
 #include <iostream>
 #include <set>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -38,10 +38,12 @@
 
 #include <unordered_map>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/misc/uri.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -31,17 +31,19 @@
  */
 
 #include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/enums/compressor.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/compression_filter.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <cassert>
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/array_schema/attribute.h
+++ b/tiledb/sm/array_schema/attribute.h
@@ -33,9 +33,11 @@
 #ifndef TILEDB_ATTRIBUTE_H
 #define TILEDB_ATTRIBUTE_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/misc/types.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -41,6 +41,8 @@
 #include <cassert>
 #include <iostream>
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -36,10 +36,12 @@
 #include <sstream>
 #include <string>
 
-#include "tiledb/sm/misc/logger.h"
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -31,18 +31,20 @@
  */
 
 #include "tiledb/sm/array_schema/domain.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/layout.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <cassert>
 #include <iostream>
 #include <limits>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -33,11 +33,13 @@
 #ifndef TILEDB_DOMAIN_H
 #define TILEDB_DOMAIN_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/query/result_coords.h"
 
 #include <vector>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/buffer/buffer.cc
+++ b/tiledb/sm/buffer/buffer.cc
@@ -31,10 +31,12 @@
  */
 
 #include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/const_buffer.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/buffer/buffer.h
+++ b/tiledb/sm/buffer/buffer.h
@@ -35,7 +35,9 @@
 
 #include <cinttypes>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/buffer/buffer_list.cc
+++ b/tiledb/sm/buffer/buffer_list.cc
@@ -31,8 +31,10 @@
  */
 
 #include "tiledb/sm/buffer/buffer_list.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
-#include "tiledb/sm/misc/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/buffer/buffer_list.h
+++ b/tiledb/sm/buffer/buffer_list.h
@@ -35,7 +35,9 @@
 
 #include <vector>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/buffer/const_buffer.cc
+++ b/tiledb/sm/buffer/const_buffer.cc
@@ -35,6 +35,8 @@
 
 #include <iostream>
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/buffer/const_buffer.h
+++ b/tiledb/sm/buffer/const_buffer.h
@@ -35,7 +35,9 @@
 
 #include <cinttypes>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/buffer/preallocated_buffer.cc
+++ b/tiledb/sm/buffer/preallocated_buffer.cc
@@ -31,7 +31,9 @@
  */
 
 #include "tiledb/sm/buffer/preallocated_buffer.h"
-#include "tiledb/sm/misc/logger.h"
+#include "tiledb/common/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/buffer/preallocated_buffer.h
+++ b/tiledb/sm/buffer/preallocated_buffer.h
@@ -35,7 +35,9 @@
 
 #include <cinttypes>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/cache/buffer_lru_cache.cc
+++ b/tiledb/sm/cache/buffer_lru_cache.cc
@@ -31,12 +31,14 @@
  */
 
 #include "tiledb/sm/cache/buffer_lru_cache.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/cache/buffer_lru_cache.h
+++ b/tiledb/sm/cache/buffer_lru_cache.h
@@ -33,12 +33,14 @@
 #ifndef TILEDB_BUFFER_LRU_CACHE_H
 #define TILEDB_BUFFER_LRU_CACHE_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/cache/lru_cache.h"
-#include "tiledb/sm/misc/status.h"
 
 #include <list>
 #include <map>
 #include <mutex>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/cache/lru_cache.h
+++ b/tiledb/sm/cache/lru_cache.h
@@ -33,13 +33,15 @@
 #ifndef TILEDB_LRU_CACHE_H
 #define TILEDB_LRU_CACHE_H
 
-#include "tiledb/sm/misc/logger.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/macros.h"
-#include "tiledb/sm/misc/status.h"
 
 #include <list>
 #include <mutex>
 #include <unordered_map>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/bzip_compressor.cc
+++ b/tiledb/sm/compressors/bzip_compressor.cc
@@ -31,12 +31,14 @@
  */
 
 #include "tiledb/sm/compressors/bzip_compressor.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <bzlib.h>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/bzip_compressor.h
+++ b/tiledb/sm/compressors/bzip_compressor.h
@@ -33,7 +33,9 @@
 #ifndef TILEDB_BZIP_COMPRESSOR_H
 #define TILEDB_BZIP_COMPRESSOR_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/dd_compressor.cc
+++ b/tiledb/sm/compressors/dd_compressor.cc
@@ -31,17 +31,19 @@
  */
 
 #include "tiledb/sm/compressors/dd_compressor.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/enums/datatype.h"
-#include "tiledb/sm/misc/logger.h"
 
 /* ****************************** */
 /*             MACROS             */
 /* ****************************** */
 
 #define ABS(x) ((x) < 0) ? uint64_t(-(x)) : uint64_t(x)
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/dd_compressor.h
+++ b/tiledb/sm/compressors/dd_compressor.h
@@ -33,7 +33,9 @@
 #ifndef TILEDB_DOUBLE_DELTA_H
 #define TILEDB_DOUBLE_DELTA_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/gzip_compressor.cc
+++ b/tiledb/sm/compressors/gzip_compressor.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/compressors/gzip_compressor.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <zlib.h>
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/gzip_compressor.h
+++ b/tiledb/sm/compressors/gzip_compressor.h
@@ -33,9 +33,11 @@
 #ifndef TILEDB_GZIP_H
 #define TILEDB_GZIP_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 
 #include <cmath>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/lz4_compressor.cc
+++ b/tiledb/sm/compressors/lz4_compressor.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/compressors/lz4_compressor.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <lz4.h>
 #include <limits>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/lz4_compressor.h
+++ b/tiledb/sm/compressors/lz4_compressor.h
@@ -33,7 +33,9 @@
 #ifndef TILEDB_LZ4_COMPRESSOR_H
 #define TILEDB_LZ4_COMPRESSOR_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/rle_compressor.cc
+++ b/tiledb/sm/compressors/rle_compressor.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/compressors/rle_compressor.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <cassert>
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/rle_compressor.h
+++ b/tiledb/sm/compressors/rle_compressor.h
@@ -33,7 +33,9 @@
 #ifndef TILEDB_RLE_COMPRESSOR_H
 #define TILEDB_RLE_COMPRESSOR_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/zstd_compressor.cc
+++ b/tiledb/sm/compressors/zstd_compressor.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/compressors/zstd_compressor.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <zstd.h>
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/compressors/zstd_compressor.h
+++ b/tiledb/sm/compressors/zstd_compressor.h
@@ -33,7 +33,9 @@
 #ifndef TILEDB_ZSTD_H
 #define TILEDB_ZSTD_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -31,14 +31,16 @@
  */
 
 #include "tiledb/sm/config/config.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <fstream>
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -37,11 +37,13 @@
 #include <tbb/task_scheduler_init.h>
 #endif
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 
 #include <map>
 #include <set>
 #include <string>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/crypto.cc
+++ b/tiledb/sm/crypto/crypto.cc
@@ -31,16 +31,18 @@
  */
 
 #include "tiledb/sm/crypto/crypto.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
-#include "tiledb/sm/misc/logger.h"
 
 #ifdef _WIN32
 #include "tiledb/sm/crypto/crypto_win32.h"
 #else
 #include "tiledb/sm/crypto/crypto_openssl.h"
 #endif
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/crypto.h
+++ b/tiledb/sm/crypto/crypto.h
@@ -33,7 +33,9 @@
 #ifndef TILEDB_CRYPTO_H
 #define TILEDB_CRYPTO_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/crypto_openssl.cc
+++ b/tiledb/sm/crypto/crypto_openssl.cc
@@ -33,17 +33,19 @@
 #ifndef _WIN32
 
 #include "tiledb/sm/crypto/crypto_openssl.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/crypto/crypto.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/md5.h>
 #include <openssl/rand.h>
 #include <openssl/sha.h>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/crypto_openssl.h
+++ b/tiledb/sm/crypto/crypto_openssl.h
@@ -35,7 +35,9 @@
 
 #ifndef _WIN32
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/crypto_win32.cc
+++ b/tiledb/sm/crypto/crypto_win32.cc
@@ -33,15 +33,17 @@
 #ifdef _WIN32
 
 #include "tiledb/sm/crypto/crypto_win32.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/crypto/crypto.h"
-#include "tiledb/sm/misc/logger.h"
 
 #ifndef NT_SUCCESS
 #define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
 #endif
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/crypto_win32.h
+++ b/tiledb/sm/crypto/crypto_win32.h
@@ -38,7 +38,9 @@
 #include <windows.h>
 
 #include <bcrypt.h>
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/encryption_key.cc
+++ b/tiledb/sm/crypto/encryption_key.cc
@@ -31,9 +31,11 @@
  */
 
 #include "tiledb/sm/crypto/encryption_key.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/crypto/crypto.h"
 #include "tiledb/sm/enums/encryption_type.h"
-#include "tiledb/sm/misc/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/encryption_key.h
+++ b/tiledb/sm/crypto/encryption_key.h
@@ -33,9 +33,11 @@
 #ifndef TILEDB_ENCRYPTION_KEY_H
 #define TILEDB_ENCRYPTION_KEY_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/encryption_key_validation.cc
+++ b/tiledb/sm/crypto/encryption_key_validation.cc
@@ -31,11 +31,13 @@
  */
 
 #include "tiledb/sm/crypto/encryption_key_validation.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/crypto/crypto.h"
 #include "tiledb/sm/crypto/encryption_key.h"
 #include "tiledb/sm/enums/encryption_type.h"
-#include "tiledb/sm/misc/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/crypto/encryption_key_validation.h
+++ b/tiledb/sm/crypto/encryption_key_validation.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_ENCRYPTION_KEY_VALIDATION_H
 #define TILEDB_ENCRYPTION_KEY_VALIDATION_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/buffer/buffer.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/array_type.h
+++ b/tiledb/sm/enums/array_type.h
@@ -36,8 +36,8 @@
 
 #include <cassert>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/compressor.h
+++ b/tiledb/sm/enums/compressor.h
@@ -34,10 +34,12 @@
 #ifndef TILEDB_COMPRESSOR_H
 #define TILEDB_COMPRESSOR_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 
 #include <cassert>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/datatype.h
+++ b/tiledb/sm/enums/datatype.h
@@ -34,10 +34,12 @@
 #ifndef TILEDB_DATATYPE_H
 #define TILEDB_DATATYPE_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 
 #include <cassert>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/encryption_type.h
+++ b/tiledb/sm/enums/encryption_type.h
@@ -35,8 +35,8 @@
 #define TILEDB_ENCRYPTION_TYPE_H
 
 #include <cassert>
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/filter_option.h
+++ b/tiledb/sm/enums/filter_option.h
@@ -35,8 +35,8 @@
 #define TILEDB_FILTER_OPTION_H
 
 #include <cassert>
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -35,8 +35,10 @@
 #define TILEDB_FILTER_TYPE_H
 
 #include <cassert>
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/layout.h
+++ b/tiledb/sm/enums/layout.h
@@ -34,10 +34,12 @@
 #ifndef TILEDB_LAYOUT_H
 #define TILEDB_LAYOUT_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 
 #include <cassert>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/query_status.h
+++ b/tiledb/sm/enums/query_status.h
@@ -36,8 +36,8 @@
 
 #include <cassert>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/query_type.h
+++ b/tiledb/sm/enums/query_type.h
@@ -35,8 +35,8 @@
 #define TILEDB_QUERY_TYPE_H
 
 #include <cassert>
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/enums/serialization_type.h
+++ b/tiledb/sm/enums/serialization_type.h
@@ -35,8 +35,8 @@
 #define TILEDB_SERIALIZATION_TYPE_H
 
 #include <cassert>
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -35,10 +35,12 @@
 #include <put_block_list_request_base.h>
 #include <future>
 
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/filesystem/azure.h"
 #include "tiledb/sm/global_state/global_state.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -42,12 +42,14 @@
 #include <list>
 #include <unordered_map>
 
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/uri.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -39,10 +39,12 @@
 #include <sstream>
 #include <unordered_set>
 
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/filesystem/gcs.h"
 #include "tiledb/sm/global_state/global_state.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -37,12 +37,14 @@
 
 #include <google/cloud/storage/client.h>
 
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/uri.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/hdfs_filesystem.cc
+++ b/tiledb/sm/filesystem/hdfs_filesystem.cc
@@ -41,9 +41,9 @@
 #ifdef HAVE_HDFS
 
 #include "tiledb/sm/filesystem/hdfs_filesystem.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/uri.h"
 #include "tiledb/sm/misc/utils.h"
 
@@ -52,6 +52,8 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/hdfs_filesystem.h
+++ b/tiledb/sm/filesystem/hdfs_filesystem.h
@@ -39,9 +39,11 @@
 #include <string>
 #include <vector>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 
 #include "hadoop/hdfs.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -33,9 +33,9 @@
 #ifndef _WIN32
 
 #include "tiledb/sm/filesystem/posix.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/logger.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <dirent.h>
@@ -45,6 +45,8 @@
 #include <future>
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -42,14 +42,15 @@
 #include <string>
 #include <vector>
 
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/filelock.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {
-
-class ThreadPool;
 
 /**
  * This class implements the POSIX filesystem functions.

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -43,8 +43,8 @@
 #include <iostream>
 #include "tiledb/sm/global_state/global_state.h"
 
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #ifdef _WIN32
@@ -75,6 +75,8 @@ Aws::Utils::Logging::LogLevel aws_log_name_to_level(std::string loglevel) {
     return Aws::Utils::Logging::LogLevel::Off;
 }
 }  // namespace
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -34,13 +34,13 @@
 #define TILEDB_S3_H
 
 #ifdef HAVE_S3
+#include "tiledb/common/logger.h"
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/s3_thread_pool_executor.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/logger.h"
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/uri.h"
 #include "tiledb/sm/stats/stats.h"
 
@@ -73,6 +73,8 @@
 #include <mutex>
 #include <string>
 #include <vector>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.cc
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.cc
@@ -34,8 +34,10 @@
 
 #include <cassert>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filesystem/s3_thread_pool_executor.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.h
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.h
@@ -40,7 +40,9 @@
 #include <mutex>
 #include <unordered_set>
 
-#include "tiledb/sm/misc/thread_pool.h"
+#include "tiledb/common/thread_pool.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -31,11 +31,11 @@
  */
 
 #include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/filesystem.h"
 #include "tiledb/sm/enums/vfs_mode.h"
 #include "tiledb/sm/filesystem/hdfs_filesystem.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/stats.h"
@@ -44,6 +44,8 @@
 #include <list>
 #include <sstream>
 #include <unordered_map>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -39,14 +39,14 @@
 #include <string>
 #include <vector>
 
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/cache/lru_cache.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/filelock.h"
 #include "tiledb/sm/misc/cancelable_tasks.h"
 #include "tiledb/sm/misc/macros.h"
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/uri.h"
 
 #ifdef _WIN32
@@ -70,6 +70,8 @@
 #ifdef HAVE_HDFS
 #include "tiledb/sm/filesystem/hdfs_filesystem.h"
 #endif
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/vfs_file_handle.cc
+++ b/tiledb/sm/filesystem/vfs_file_handle.cc
@@ -31,11 +31,13 @@
  */
 
 #include "tiledb/sm/filesystem/vfs_file_handle.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/vfs_mode.h"
 #include "tiledb/sm/filesystem/vfs.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {
@@ -59,7 +61,7 @@ Status VFSFileHandle::close() {
   if (!is_open_) {
     std::stringstream msg;
     msg << "Cannot close file '" << uri_.to_string() << "'; File is not open";
-    auto st = tiledb::sm::Status::VFSFileHandleError(msg.str());
+    auto st = Status::VFSFileHandleError(msg.str());
     return LOG_STATUS(st);
   }
 
@@ -92,7 +94,7 @@ Status VFSFileHandle::read(uint64_t offset, void* buffer, uint64_t nbytes) {
     std::stringstream msg;
     msg << "Cannot read from file '" << uri_.to_string()
         << "'; File is not open";
-    auto st = tiledb::sm::Status::VFSFileHandleError(msg.str());
+    auto st = Status::VFSFileHandleError(msg.str());
     return LOG_STATUS(st);
   }
 
@@ -103,7 +105,7 @@ Status VFSFileHandle::sync() {
   if (!is_open_) {
     std::stringstream msg;
     msg << "Cannot sync file '" << uri_.to_string() << "'; File is not open";
-    auto st = tiledb::sm::Status::VFSFileHandleError(msg.str());
+    auto st = Status::VFSFileHandleError(msg.str());
     return LOG_STATUS(st);
   }
 
@@ -119,7 +121,7 @@ Status VFSFileHandle::write(const void* buffer, uint64_t nbytes) {
     std::stringstream msg;
     msg << "Cannot write to file '" << uri_.to_string()
         << "'; File is not open";
-    auto st = tiledb::sm::Status::VFSFileHandleError(msg.str());
+    auto st = Status::VFSFileHandleError(msg.str());
     return LOG_STATUS(st);
   }
 

--- a/tiledb/sm/filesystem/vfs_file_handle.h
+++ b/tiledb/sm/filesystem/vfs_file_handle.h
@@ -35,8 +35,10 @@
 
 #include <atomic>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/uri.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -32,8 +32,8 @@
 #ifdef _WIN32
 
 #include "tiledb/sm/filesystem/win.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <Shlwapi.h>
@@ -43,6 +43,8 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -39,12 +39,14 @@
 #include <string>
 #include <vector>
 
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/filelock.h"
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/uri.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/filter/bit_width_reduction_filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/filter_option.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/bit_width_reduction_filter.h
+++ b/tiledb/sm/filter/bit_width_reduction_filter.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_BIT_WIDTH_REDUCTION_FILTER_H
 #define TILEDB_BIT_WIDTH_REDUCTION_FILTER_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/bitshuffle_filter.cc
+++ b/tiledb/sm/filter/bitshuffle_filter.cc
@@ -31,12 +31,14 @@
  */
 
 #include "tiledb/sm/filter/bitshuffle_filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/filter_type.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/tile/tile.h"
 
 #include "bitshuffle_core.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/bitshuffle_filter.h
+++ b/tiledb/sm/filter/bitshuffle_filter.h
@@ -35,9 +35,11 @@
 
 #include <vector>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/filter/filter.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/byteshuffle_filter.cc
+++ b/tiledb/sm/filter/byteshuffle_filter.cc
@@ -31,12 +31,14 @@
  */
 
 #include "tiledb/sm/filter/byteshuffle_filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/filter_type.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/tile/tile.h"
 
 #include "blosc/shuffle.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/byteshuffle_filter.h
+++ b/tiledb/sm/filter/byteshuffle_filter.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_BYTESHUFFLE_FILTER_H
 #define TILEDB_BYTESHUFFLE_FILTER_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/checksum_md5_filter.cc
+++ b/tiledb/sm/filter/checksum_md5_filter.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/filter/checksum_md5_filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/crypto/crypto.h"
 #include "tiledb/sm/enums/filter_type.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/tile/tile.h"
 
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/checksum_md5_filter.h
+++ b/tiledb/sm/filter/checksum_md5_filter.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_CHECKSUM_MD5_FILTER_H
 #define TILEDB_CHECKSUM_MD5_FILTER_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/checksum_sha256_filter.cc
+++ b/tiledb/sm/filter/checksum_sha256_filter.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/filter/checksum_sha256_filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/crypto/crypto.h"
 #include "tiledb/sm/enums/filter_type.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/tile/tile.h"
 
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/checksum_sha256_filter.h
+++ b/tiledb/sm/filter/checksum_sha256_filter.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_CHECKSUM_SHA256_FILTER_H
 #define TILEDB_CHECKSUM_SHA256_FILTER_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/filter/compression_filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/compressors/bzip_compressor.h"
 #include "tiledb/sm/compressors/dd_compressor.h"
@@ -42,9 +43,10 @@
 #include "tiledb/sm/enums/filter_option.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_COMPRESSION_FILTER_H
 #define TILEDB_COMPRESSION_FILTER_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.cc
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/filter/encryption_aes256gcm_filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/preallocated_buffer.h"
 #include "tiledb/sm/crypto/crypto.h"
 #include "tiledb/sm/crypto/encryption_key.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/enums/filter_type.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.h
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_ENCRYPTION_AES256GCM_FILTER_H
 #define TILEDB_ENCRYPTION_AES256GCM_FILTER_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/filter.cc
+++ b/tiledb/sm/filter/filter.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/filter/filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/bit_width_reduction_filter.h"
@@ -42,7 +43,8 @@
 #include "tiledb/sm/filter/encryption_aes256gcm_filter.h"
 #include "tiledb/sm/filter/noop_filter.h"
 #include "tiledb/sm/filter/positive_delta_filter.h"
-#include "tiledb/sm/misc/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_FILTER_H
 #define TILEDB_FILTER_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/config/config.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/filter_buffer.cc
+++ b/tiledb/sm/filter/filter_buffer.cc
@@ -31,8 +31,10 @@
  */
 
 #include "tiledb/sm/filter/filter_buffer.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/filter/filter_storage.h"
-#include "tiledb/sm/misc/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/filter_buffer.h
+++ b/tiledb/sm/filter/filter_buffer.h
@@ -37,9 +37,11 @@
 #include <memory>
 #include <vector>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/filter/filter_pipeline.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/crypto/encryption_key.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/enums/filter_type.h"
@@ -39,10 +40,11 @@
 #include "tiledb/sm/filter/filter.h"
 #include "tiledb/sm/filter/filter_storage.h"
 #include "tiledb/sm/filter/noop_filter.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -37,11 +37,13 @@
 #include <utility>
 #include <vector>
 
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/filter/filter.h"
 #include "tiledb/sm/filter/filter_buffer.h"
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/tile/chunked_buffer.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/filter_storage.cc
+++ b/tiledb/sm/filter/filter_storage.cc
@@ -33,6 +33,8 @@
 #include "tiledb/sm/filter/filter_storage.h"
 #include "tiledb/sm/buffer/buffer.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/filter/filter_storage.h
+++ b/tiledb/sm/filter/filter_storage.h
@@ -37,7 +37,9 @@
 #include <memory>
 #include <unordered_map>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/noop_filter.cc
+++ b/tiledb/sm/filter/noop_filter.cc
@@ -31,9 +31,11 @@
  */
 
 #include "tiledb/sm/filter/noop_filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_buffer.h"
-#include "tiledb/sm/misc/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/noop_filter.h
+++ b/tiledb/sm/filter/noop_filter.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_NOOP_FILTER_H
 #define TILEDB_NOOP_FILTER_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/filter/positive_delta_filter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/filter_option.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/filter/positive_delta_filter.h
+++ b/tiledb/sm/filter/positive_delta_filter.h
@@ -33,8 +33,10 @@
 #ifndef TILEDB_POSITIVE_DELTA_FILTER_H
 #define TILEDB_POSITIVE_DELTA_FILTER_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/filter/filter.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -39,6 +39,8 @@
 
 #include <vector>
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -32,6 +32,7 @@
  */
 
 #include "tiledb/sm/fragment/fragment_metadata.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -39,7 +40,6 @@
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
@@ -48,6 +48,8 @@
 
 #include <cassert>
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -38,10 +38,12 @@
 #include <unordered_map>
 #include <vector>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/misc/uri.h"
 #include "tiledb/sm/rtree/rtree.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/fragment/written_fragment_info.h
+++ b/tiledb/sm/fragment/written_fragment_info.h
@@ -37,6 +37,8 @@
 
 #include "tiledb/sm/misc/uri.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/global_state/global_state.cc
+++ b/tiledb/sm/global_state/global_state.cc
@@ -39,12 +39,14 @@
 #include "tiledb/sm/misc/constants.h"
 
 #ifdef __linux__
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/filesystem/posix.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/utils.h"
 #endif
 
 #include <cassert>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/global_state.h
+++ b/tiledb/sm/global_state/global_state.h
@@ -37,8 +37,10 @@
 #include <set>
 #include <string>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/config/config.h"
-#include "tiledb/sm/misc/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/libcurl_state.cc
+++ b/tiledb/sm/global_state/libcurl_state.cc
@@ -31,11 +31,13 @@
  */
 
 #include "tiledb/sm/global_state/libcurl_state.h"
-#include "tiledb/sm/misc/logger.h"
+#include "tiledb/common/logger.h"
 
 #ifdef TILEDB_SERIALIZATION
 #include <curl/curl.h>
 #endif
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/libcurl_state.h
+++ b/tiledb/sm/global_state/libcurl_state.h
@@ -33,7 +33,9 @@
 #ifndef TILEDB_LIBCURL_STATE_H
 #define TILEDB_LIBCURL_STATE_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/openssl_state.cc
+++ b/tiledb/sm/global_state/openssl_state.cc
@@ -34,6 +34,8 @@
 
 #ifdef _WIN32
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 namespace global_state {
@@ -53,6 +55,8 @@ Status init_openssl() {
 #include <memory>
 #include <mutex>
 #include <vector>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/openssl_state.h
+++ b/tiledb/sm/global_state/openssl_state.h
@@ -33,7 +33,9 @@
 #ifndef TILEDB_OPENSSL_STATE_H
 #define TILEDB_OPENSSL_STATE_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/signal_handlers.cc
+++ b/tiledb/sm/global_state/signal_handlers.cc
@@ -43,8 +43,10 @@
 #include <unistd.h>
 #endif
 
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/global_state/signal_handlers.h"
-#include "tiledb/sm/misc/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/signal_handlers.h
+++ b/tiledb/sm/global_state/signal_handlers.h
@@ -35,7 +35,9 @@
 
 #include <cinttypes>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/tbb_state.cc
+++ b/tiledb/sm/global_state/tbb_state.cc
@@ -42,6 +42,8 @@
 #include <memory>
 #include <sstream>
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 namespace global_state {

--- a/tiledb/sm/global_state/tbb_state.h
+++ b/tiledb/sm/global_state/tbb_state.h
@@ -34,7 +34,9 @@
 #ifndef TILEDB_TBB_STATE_H
 #define TILEDB_TBB_STATE_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/unit_test_config.h
+++ b/tiledb/sm/global_state/unit_test_config.h
@@ -37,6 +37,8 @@
 
 #include "tiledb/sm/misc/macros.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/global_state/watchdog.cc
+++ b/tiledb/sm/global_state/watchdog.cc
@@ -1,9 +1,43 @@
+/**
+ * @file   watchdog.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file defines the Watchdog thread class.
+ */
+
 #include "tiledb/sm/global_state/watchdog.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/global_state/global_state.h"
 #include "tiledb/sm/global_state/signal_handlers.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/global_state/watchdog.h
+++ b/tiledb/sm/global_state/watchdog.h
@@ -37,7 +37,9 @@
 #include <mutex>
 #include <thread>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -31,15 +31,17 @@
  */
 
 #include "tiledb/sm/metadata/metadata.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/enums/datatype.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/misc/uuid.h"
 
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -38,8 +38,10 @@
 #include <mutex>
 #include <vector>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/uri.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/cancelable_tasks.cc
+++ b/tiledb/sm/misc/cancelable_tasks.cc
@@ -31,7 +31,9 @@
  */
 
 #include "tiledb/sm/misc/cancelable_tasks.h"
-#include "tiledb/sm/misc/thread_pool.h"
+#include "tiledb/common/thread_pool.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/cancelable_tasks.h
+++ b/tiledb/sm/misc/cancelable_tasks.h
@@ -37,8 +37,10 @@
 #include <functional>
 #include <mutex>
 
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -42,6 +42,8 @@
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/query/result_coords.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/misc/parallel_functions.h
+++ b/tiledb/sm/misc/parallel_functions.h
@@ -33,8 +33,8 @@
 #ifndef TILEDB_PARALLEL_FUNCTIONS_H
 #define TILEDB_PARALLEL_FUNCTIONS_H
 
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/global_state/global_state.h"
-#include "tiledb/sm/misc/thread_pool.h"
 
 #include <algorithm>
 #include <cassert>
@@ -45,6 +45,8 @@
 #include <tbb/parallel_for_each.h>
 #include <tbb/parallel_sort.h>
 #endif
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/tile_overlap.h
+++ b/tiledb/sm/misc/tile_overlap.h
@@ -36,6 +36,8 @@
 #include <cinttypes>
 #include <vector>
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -37,7 +37,9 @@
 #include <cstring>
 #include <vector>
 
-#include "tiledb/sm/misc/logger.h"
+#include "tiledb/common/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/uri.cc
+++ b/tiledb/sm/misc/uri.cc
@@ -31,8 +31,8 @@
  */
 
 #include "tiledb/sm/misc/uri.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/filesystem/vfs.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #ifdef _WIN32
@@ -40,6 +40,8 @@
 #endif
 
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/uri.h
+++ b/tiledb/sm/misc/uri.h
@@ -35,7 +35,9 @@
 
 #include <string>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -32,10 +32,10 @@
  */
 
 #include "tiledb/sm/misc/utils.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/uri.h"
 
 #include <iostream>
@@ -52,6 +52,8 @@
 #ifdef __linux__
 #include "tiledb/sm/filesystem/posix.h"
 #endif
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -39,8 +39,10 @@
 #include <type_traits>
 #include <vector>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/misc/types.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/uuid.cc
+++ b/tiledb/sm/misc/uuid.cc
@@ -43,6 +43,8 @@
 #include <cstdio>
 #endif
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 namespace uuid {

--- a/tiledb/sm/misc/uuid.h
+++ b/tiledb/sm/misc/uuid.h
@@ -33,7 +33,9 @@
 #ifndef TILEDB_UUID_H
 #define TILEDB_UUID_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -31,16 +31,18 @@
  */
 
 #include "tiledb/sm/query/query.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/enums/query_type.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
 #include <cassert>
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -38,14 +38,16 @@
 #include <utility>
 #include <vector>
 
+#include "tiledb/common/logger.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
-#include "tiledb/sm/misc/logger.h"
-#include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/reader.h"
 #include "tiledb/sm/query/writer.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/query_macros.h
+++ b/tiledb/sm/query/query_macros.h
@@ -33,6 +33,8 @@
 #ifndef TILEDB_QUERY_MACROS_H
 #define TILEDB_QUERY_MACROS_H
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/read_cell_slab_iter.cc
+++ b/tiledb/sm/query/read_cell_slab_iter.cc
@@ -31,14 +31,16 @@
  */
 
 #include "tiledb/sm/query/read_cell_slab_iter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/enums/layout.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <cassert>
 #include <iostream>
 #include <list>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/read_cell_slab_iter.h
+++ b/tiledb/sm/query/read_cell_slab_iter.h
@@ -40,6 +40,8 @@
 #include "tiledb/sm/query/result_space_tile.h"
 #include "tiledb/sm/subarray/cell_slab_iter.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/query/reader.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -38,7 +39,6 @@
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/global_state/global_state.h"
 #include "tiledb/sm/misc/comparators.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/query_macros.h"
@@ -51,6 +51,8 @@
 
 #include <iostream>
 #include <unordered_set>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -40,8 +40,8 @@
 #include <queue>
 #include <vector>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/tile_domain.h"
-#include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/misc/uri.h"
 #include "tiledb/sm/query/result_cell_slab.h"
@@ -49,6 +49,8 @@
 #include "tiledb/sm/query/result_space_tile.h"
 #include "tiledb/sm/query/write_cell_slab_iter.h"
 #include "tiledb/sm/subarray/subarray_partitioner.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/result_cell_slab.h
+++ b/tiledb/sm/query/result_cell_slab.h
@@ -38,6 +38,8 @@
 
 #include "tiledb/sm/query/result_tile.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -38,6 +38,8 @@
 
 #include "tiledb/sm/query/result_tile.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/result_space_tile.h
+++ b/tiledb/sm/query/result_space_tile.h
@@ -42,6 +42,8 @@
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/query/result_tile.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -40,6 +40,8 @@
 #include <iostream>
 #include <list>
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -42,6 +42,8 @@
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/tile/tile.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/write_cell_slab_iter.cc
+++ b/tiledb/sm/query/write_cell_slab_iter.cc
@@ -31,13 +31,15 @@
  */
 
 #include "tiledb/sm/query/write_cell_slab_iter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/enums/layout.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <cassert>
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/write_cell_slab_iter.h
+++ b/tiledb/sm/query/write_cell_slab_iter.h
@@ -35,7 +35,9 @@
 
 #include <vector>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -31,13 +31,13 @@
  */
 
 #include "tiledb/sm/query/writer.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/comparators.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/misc/uuid.h"
@@ -48,6 +48,8 @@
 
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -37,12 +37,14 @@
 #include <set>
 #include <unordered_map>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/fragment/written_fragment_info.h"
-#include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/query/write_cell_slab_iter.h"
 #include "tiledb/sm/subarray/subarray.h"
 #include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -31,8 +31,8 @@
  */
 
 #include "tiledb/sm/rest/curl.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/global_state/global_state.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <cstring>
@@ -40,6 +40,8 @@
 
 // TODO: replace this with config option
 #define CURL_MAX_RETRIES 3
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -47,6 +47,8 @@
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/enums/serialization_type.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -32,10 +32,10 @@
 
 #include <cassert>
 
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/enums/query_type.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/rest/rest_client.h"
@@ -47,6 +47,8 @@
 #include "tiledb/sm/rest/curl.h"
 #include "tiledb/sm/serialization/tiledb-rest.capnp.h"
 #endif
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -36,9 +36,11 @@
 #include <string>
 #include <unordered_map>
 
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/serialization/query.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -31,16 +31,18 @@
  */
 
 #include "tiledb/sm/rtree/rtree.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 #include "tiledb/sm/enums/datatype.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <cassert>
 #include <iostream>
 #include <list>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/rtree/rtree.h
+++ b/tiledb/sm/rtree/rtree.h
@@ -35,9 +35,11 @@
 
 #include <vector>
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/domain.h"
-#include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/misc/tile_overlap.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/serialization/array_schema.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -43,7 +44,6 @@
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/serialization/capnp_utils.h"
 
 #include <set>
@@ -52,6 +52,8 @@
 #include <capnp/compat/json.h>
 #include <capnp/serialize.h>
 #endif
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/serialization/array_schema.h
+++ b/tiledb/sm/serialization/array_schema.h
@@ -35,7 +35,9 @@
 
 #include <unordered_map>
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -32,6 +32,7 @@
  */
 
 #include "tiledb/sm/serialization/query.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/buffer/buffer_list.h"
 #include "tiledb/sm/config/config.h"
@@ -39,7 +40,6 @@
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/enums/query_type.h"
 #include "tiledb/sm/enums/serialization_type.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/query/reader.h"
@@ -53,6 +53,8 @@
 #include <capnp/message.h>
 #include <capnp/serialize.h>
 #endif
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -35,8 +35,10 @@
 
 #include <unordered_map>
 
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -31,13 +31,13 @@
  */
 
 #include "tiledb/sm/storage_manager/consolidator.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/enums/query_type.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/fragment/fragment_info.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/misc/uuid.h"
@@ -49,6 +49,8 @@
 
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -33,13 +33,15 @@
 #ifndef TILEDB_CONSOLIDATOR_H
 #define TILEDB_CONSOLIDATOR_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/filesystem/filelock.h"
-#include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/storage_manager/open_array.h"
 
 #include <vector>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -31,7 +31,9 @@
  */
 
 #include "tiledb/sm/storage_manager/context.h"
-#include "tiledb/sm/misc/logger.h"
+#include "tiledb/common/logger.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -33,10 +33,12 @@
 #ifndef TILEDB_CONTEXT_H
 #define TILEDB_CONTEXT_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
 #include <mutex>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -38,6 +38,8 @@
 
 #include <cassert>
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/storage_manager/open_array.h
+++ b/tiledb/sm/storage_manager/open_array.h
@@ -45,6 +45,8 @@
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/uri.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/cache/buffer_lru_cache.h"
@@ -44,7 +45,6 @@
 #include "tiledb/sm/enums/query_type.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/global_state/global_state.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/misc/uuid.h"
@@ -60,6 +60,8 @@
 #include <algorithm>
 #include <iostream>
 #include <sstream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -48,14 +48,16 @@
 #include <tbb/task_scheduler_init.h>
 #endif
 
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/enums/walk_order.h"
 #include "tiledb/sm/filesystem/filelock.h"
 #include "tiledb/sm/fragment/fragment_info.h"
 #include "tiledb/sm/misc/cancelable_tasks.h"
-#include "tiledb/sm/misc/status.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/uri.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/subarray/cell_slab_iter.cc
+++ b/tiledb/sm/subarray/cell_slab_iter.cc
@@ -31,16 +31,18 @@
  */
 
 #include "tiledb/sm/subarray/cell_slab_iter.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/enums/layout.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/types.h"
 
 #include <cassert>
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/subarray/cell_slab_iter.h
+++ b/tiledb/sm/subarray/cell_slab_iter.h
@@ -36,6 +36,8 @@
 #include "tiledb/sm/subarray/cell_slab.h"
 #include "tiledb/sm/subarray/subarray.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -48,6 +48,8 @@
 #include <sstream>
 #include <unordered_set>
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -33,10 +33,10 @@
 #ifndef TILEDB_SUBARRAY_H
 #define TILEDB_SUBARRAY_H
 
+#include "tiledb/common/logger.h"
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/datatype.h"
-#include "tiledb/sm/misc/logger.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/misc/tile_overlap.h"
 #include "tiledb/sm/misc/types.h"
 
@@ -47,6 +47,8 @@
 #include <mutex>
 #include <set>
 #include <vector>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -49,6 +49,8 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -36,9 +36,11 @@
 #include <list>
 
 #include <unordered_map>
+#include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/thread_pool.h"
 #include "tiledb/sm/subarray/subarray.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/tile/chunked_buffer.cc
+++ b/tiledb/sm/tile/chunked_buffer.cc
@@ -36,6 +36,8 @@
 #include <cstdlib>
 #include <iostream>
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/tile/chunked_buffer.h
+++ b/tiledb/sm/tile/chunked_buffer.h
@@ -70,11 +70,13 @@
 #ifndef TILEDB_chunked_buffer_H
 #define TILEDB_chunked_buffer_H
 
-#include "tiledb/sm/misc/logger.h"
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/common/status.h"
 
 #include <cinttypes>
 #include <vector>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -31,14 +31,16 @@
  */
 
 #include "tiledb/sm/tile/generic_tile_io.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/crypto/encryption_key.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/filter/compression_filter.h"
 #include "tiledb/sm/filter/encryption_aes256gcm_filter.h"
-#include "tiledb/sm/misc/logger.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/tile/generic_tile_io.h
+++ b/tiledb/sm/tile/generic_tile_io.h
@@ -38,6 +38,8 @@
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/uri.h"
 
+using namespace tiledb::common;
+
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -31,10 +31,12 @@
  */
 
 #include "tiledb/sm/tile/tile.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
-#include "tiledb/sm/misc/logger.h"
 
 #include <iostream>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -33,13 +33,15 @@
 #ifndef TILEDB_TILE_H
 #define TILEDB_TILE_H
 
+#include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/const_buffer.h"
-#include "tiledb/sm/misc/status.h"
 #include "tiledb/sm/tile/chunked_buffer.h"
 
 #include <cinttypes>
+
+using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {


### PR DESCRIPTION
Moved `Status`, `ThreadPool` and `Logger` from the `sm` folder to a new `common` folder. This is necessary as we are adding a new executor module that uses these common classes. 