### PR TITLE
Fix C++ API consolidate_metadata incorrect config

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -62,6 +62,7 @@
 * Fixed bug in setting a fill value for var-sized attributes.
 * Fixed a bug where the cpp headers would always produce compile-time warnings about using the deprecated c-api "tiledb_coords()" [#1765](https://github.com/TileDB-Inc/TileDB/pull/1765)
 * Only serialize the Array URI in the array schema client side. [#1806](https://github.com/TileDB-Inc/TileDB/pull/1806)
+* Fix C++ api `consolidate_metadata` function uses incorrect config [#1841](https://github.com/TileDB-Inc/TileDB/pull/1841) [#1844](https://github.com/TileDB-Inc/TileDB/pull/1844)
 
 ## API additions
 

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -1258,7 +1258,7 @@ class Array {
       config_aux = &local_cfg;
     }
 
-    (*config)["sm.consolidation.mode"] = "array_meta";
+    (*config_aux)["sm.consolidation.mode"] = "array_meta";
     consolidate(
         ctx, uri, encryption_type, encryption_key, key_length, config_aux);
   }
@@ -1294,7 +1294,7 @@ class Array {
       config_aux = &local_cfg;
     }
 
-    (*config)["sm.consolidation.mode"] = "array_meta";
+    (*config_aux)["sm.consolidation.mode"] = "array_meta";
     consolidate(
         ctx,
         uri,


### PR DESCRIPTION
@mikejiang pointed out in [#1841](https://github.com/TileDB-Inc/TileDB/pull/1841) we are incorrectly setting the wrong config for the metadata consolidation parameter.