### PR TITLE
Revert "Target haswell or AVX2 for prebuilt libraries"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -44,7 +44,6 @@
 * Read-ahead cache for cloud-storage backends [#1785](https://github.com/TileDB-Inc/TileDB/pull/1785)
 * Allow multiple empty values at the end of a variable-length write [#1805](https://github.com/TileDB-Inc/TileDB/pull/1805)
 * Build system will raise overridable error if important paths contain regex character [#1808](https://github.com/TileDB-Inc/TileDB/pull/1808)
-* Prebuilt artifacts for release now target `haswell` for minimum architecture for linux/macos and `AVX2` for msvcc [#1809](https://github.com/TileDB-Inc/TileDB/pull/1809)
 * Lazily create AWS ClientConfiguration to avoid slow context creations for non S3 usage after the AWS SDK version bump [#1821](https://github.com/TileDB-Inc/TileDB/pull/1821)
 * Moved `Status`, `ThreadPool`, and `Logger` classes from folder `tiledb/sm` to `tiledb/common` [#1843](https://github.com/TileDB-Inc/TileDB/pull/1843)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,8 +97,6 @@ stages:
       TILEDB_SERIALIZATION: ON
       TILEDB_FORCE_BUILD_DEPS: ON
       MACOSX_DEPLOYMENT_TARGET: 10.13
-      CFLAGS: "-march=haswell"
-      CXXFLAGS: "-march=haswell"
     jobs:
      - job:
        strategy:
@@ -133,7 +131,6 @@ stages:
              TILEDB_FORCE_BUILD_DEPS: ON
              ARTIFACT_OS: 'windows'
              ARTIFACT_EXTRAS: 'full'
-             CL: "/arch:AVX2"
        pool:
          vmImage: $(imageName)
        steps:


### PR DESCRIPTION
This reverts commit 06a5591eecf6035ae1a187f1039e1441ef8e8d8e.

The haswell arch was too new for rhub osx build machine. We've reverted this for now until we can figure out what r-hub (and CRAN)'s architectures are to avoid illegal instruction errors.