### PR TITLE
Add UT for 0-capacity LRU cache

### DIFF
--- a/test/src/unit-lru_cache.cc
+++ b/test/src/unit-lru_cache.cc
@@ -228,32 +228,34 @@ TEST_CASE_METHOD(
 
 TEST_CASE("BufferLRUCache of 0 capacity", "[lru_cache]") {
   // Create 0 size cache
-  BufferLRUCache* lru_cache_ = new BufferLRUCache(CACHE_ZERO_SIZE);
-  auto it = lru_cache_->item_iter_begin();
-  auto it_end = lru_cache_->item_iter_end();
+  BufferLRUCache* lru_cache = new BufferLRUCache(CACHE_ZERO_SIZE);
+  auto it = lru_cache->item_iter_begin();
+  auto it_end = lru_cache->item_iter_end();
   CHECK(it == it_end);
 
   // Test insert
   Buffer v;
   CHECK(v.realloc(CACHE_ZERO_SIZE + 1).ok());
-  Status st = lru_cache_->insert("key", std::move(v));
+  Status st = lru_cache->insert("key", std::move(v));
   CHECK(st.ok());
 
   // Test read
   Buffer v_buf;
   bool success;
-  st = lru_cache_->read("key", &v_buf, 0, sizeof(int), &success);
+  st = lru_cache->read("key", &v_buf, 0, sizeof(int), &success);
   CHECK(st.ok());
   CHECK(!success);
 
   // Test invalidate
-  st = lru_cache_->invalidate("key", &success);
+  st = lru_cache->invalidate("key", &success);
   CHECK(st.ok());
   CHECK(!success);
 
   // Test clear
-  lru_cache_->clear();
-  it = lru_cache_->item_iter_begin();
-  it_end = lru_cache_->item_iter_end();
+  lru_cache->clear();
+  it = lru_cache->item_iter_begin();
+  it_end = lru_cache->item_iter_end();
   CHECK(it == it_end);
+
+  delete lru_cache;
 }


### PR DESCRIPTION
Add a simple unit test to ensure an LRUCache with 0 capacity can be created and accessed by public APIs without errors.
