### PR TITLE
Ensure non-zero estimates can contain at least one cell

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,8 @@
 
 ## Bug fixes
 
+* The result size estimatation routines will no longer return non-zero sizes that can not contain a single value. [#1849](https://github.com/TileDB-Inc/TileDB/pull/1849)
+
 ## API additions
 
 # TileDB v2.1.0 Release Notes

--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -1818,34 +1818,44 @@ TEST_CASE_METHOD(
       rc = tiledb_query_get_est_result_size_wrapper(
           ctx_, query, TILEDB_COORDS, &size);
       CHECK(rc == TILEDB_OK);
-      auto coords_size = (uint64_t)ceil(
-          (1.0 / 2) * (1.0 / 4) * 4 * sizeof(uint64_t) +
-          1.0 * (2.0 / 7) * 4 * sizeof(uint64_t));
+      auto coords_size = std::max<uint64_t>(
+          (uint64_t)ceil(
+              (1.0 / 2) * (1.0 / 4) * 4 * sizeof(uint64_t) +
+              1.0 * (2.0 / 7) * 4 * sizeof(uint64_t)),
+          2 * sizeof(uint64_t));
       CHECK(size == coords_size);
       rc = tiledb_query_get_est_result_size_wrapper(ctx_, query, "d1", &size);
       CHECK(rc == TILEDB_OK);
-      auto d1_size = (uint64_t)ceil(
-          (1.0 / 2) * (1.0 / 4) * 2 * sizeof(uint64_t) +
-          1.0 * (2.0 / 7) * 2 * sizeof(uint64_t));
+      auto d1_size = std::max<uint64_t>(
+          (uint64_t)ceil(
+              (1.0 / 2) * (1.0 / 4) * 2 * sizeof(uint64_t) +
+              1.0 * (2.0 / 7) * 2 * sizeof(uint64_t)),
+          sizeof(uint64_t));
       CHECK(size == d1_size);
       rc = tiledb_query_get_est_result_size_wrapper(ctx_, query, "d2", &size);
       CHECK(rc == TILEDB_OK);
-      auto d2_size = (uint64_t)ceil(
-          (1.0 / 2) * (1.0 / 4) * 2 * sizeof(uint64_t) +
-          1.0 * (2.0 / 7) * 2 * sizeof(uint64_t));
+      auto d2_size = std::max<uint64_t>(
+          (uint64_t)ceil(
+              (1.0 / 2) * (1.0 / 4) * 2 * sizeof(uint64_t) +
+              1.0 * (2.0 / 7) * 2 * sizeof(uint64_t)),
+          sizeof(uint64_t));
       CHECK(size == d2_size);
       rc = tiledb_query_get_est_result_size_wrapper(ctx_, query, "a", &size);
       CHECK(rc == TILEDB_OK);
-      auto a_size = (uint64_t)ceil(
-          (1.0 / 2) * (1.0 / 4) * 2 * sizeof(int) +
-          1.0 * (2.0 / 7) * 2 * sizeof(int));
+      auto a_size = std::max<uint64_t>(
+          (uint64_t)ceil(
+              (1.0 / 2) * (1.0 / 4) * 2 * sizeof(int) +
+              1.0 * (2.0 / 7) * 2 * sizeof(int)),
+          sizeof(int));
       CHECK(size == a_size);
       rc = tiledb_query_get_est_result_size_var_wrapper(
           ctx_, query, "b", &size_off, &size_val);
       CHECK(rc == TILEDB_OK);
-      auto b_off_size = (uint64_t)ceil(
-          (1.0 / 2) * (1.0 / 4) * 2 * sizeof(uint64_t) +
-          1.0 * (2.0 / 7) * 2 * sizeof(uint64_t));
+      auto b_off_size = std::max<uint64_t>(
+          (uint64_t)ceil(
+              (1.0 / 2) * (1.0 / 4) * 2 * sizeof(uint64_t) +
+              1.0 * (2.0 / 7) * 2 * sizeof(uint64_t)),
+          sizeof(uint64_t));
       CHECK(size_off == b_off_size);
       auto b_val_size = (uint64_t)ceil(
           (1.0 / 2) * (1.0 / 4) * 3 * sizeof(int) +
@@ -2014,26 +2024,36 @@ TEST_CASE_METHOD(
       rc = tiledb_query_get_est_result_size_wrapper(
           ctx_, query, TILEDB_COORDS, &size);
       CHECK(rc == TILEDB_OK);
-      auto coords_size = (uint64_t)ceil(1.0 * (1.0 / 3) * 4 * sizeof(uint64_t));
+      auto coords_size = std::max<uint64_t>(
+          (uint64_t)ceil(1.0 * (1.0 / 3) * 4 * sizeof(uint64_t)),
+          2 * sizeof(uint64_t));
       CHECK(size == coords_size);
       rc = tiledb_query_get_est_result_size_wrapper(ctx_, query, "d1", &size);
       CHECK(rc == TILEDB_OK);
-      auto d1_size = (uint64_t)ceil(1.0 * (1.0 / 3) * 2 * sizeof(uint64_t));
+      auto d1_size = std::max<uint64_t>(
+          (uint64_t)ceil(1.0 * (1.0 / 3) * 2 * sizeof(uint64_t)),
+          sizeof(uint64_t));
       CHECK(size == d1_size);
       rc = tiledb_query_get_est_result_size_wrapper(ctx_, query, "d2", &size);
       CHECK(rc == TILEDB_OK);
-      auto d2_size = (uint64_t)ceil(1.0 * (1.0 / 3) * 2 * sizeof(uint64_t));
+      auto d2_size = std::max<uint64_t>(
+          (uint64_t)ceil(1.0 * (1.0 / 3) * 2 * sizeof(uint64_t)),
+          sizeof(uint64_t));
       CHECK(size == d2_size);
       rc = tiledb_query_get_est_result_size_wrapper(ctx_, query, "a", &size);
       CHECK(rc == TILEDB_OK);
-      auto a_size = (uint64_t)ceil(1.0 * (1.0 / 3) * 2 * sizeof(int));
+      auto a_size = std::max<uint64_t>(
+          (uint64_t)ceil(1.0 * (1.0 / 3) * 2 * sizeof(int)), sizeof(int));
       CHECK(size == a_size);
       rc = tiledb_query_get_est_result_size_var_wrapper(
           ctx_, query, "b", &size_off, &size_val);
       CHECK(rc == TILEDB_OK);
-      auto b_off_size = (uint64_t)ceil(1.0 * (1.0 / 3) * 2 * sizeof(uint64_t));
+      auto b_off_size = std::max<uint64_t>(
+          (uint64_t)ceil(1.0 * (1.0 / 3) * 2 * sizeof(uint64_t)),
+          sizeof(uint64_t));
       CHECK(size_off == b_off_size);
-      auto b_val_size = (uint64_t)ceil(1.0 * (1.0 / 3) * 5 * sizeof(int));
+      auto b_val_size = std::max<uint64_t>(
+          (uint64_t)ceil(1.0 * (1.0 / 3) * 5 * sizeof(int)), sizeof(int));
       CHECK(size_val == b_val_size);
     }
 

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -73,7 +73,7 @@ TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
     query.add_range(1, range[0], range[1]);
 
     auto est_size = query.est_result_size("a");
-    REQUIRE(est_size == 1);
+    REQUIRE(est_size == 4);
 
     std::vector<int> data(est_size);
     query.set_layout(TILEDB_ROW_MAJOR).set_buffer("a", data);


### PR DESCRIPTION
For fixed-size values, we clamp the lower bound for non-zero size estimates to
the cell size.

For var-size values, we clamp the lower bound to the datatype size.