### PR TITLE
Set the AWS SDK HttpOptions::installSigPipeHandler.

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -150,6 +150,16 @@ Status S3::init(const Config& config, ThreadPool* const thread_pool) {
 
   options_.loggingOptions.logLevel = aws_log_name_to_level(logging_level);
 
+  // By default, curl sets the signal handler for SIGPIPE to SIG_IGN while
+  // executing. When curl is done executing, it restores the previous signal
+  // handler. This is not thread safe, so the AWS SDK disables this behavior
+  // in curl using the `CURLOPT_NOSIGNAL` option.
+  // Here, we set the `installSigPipeHandler` AWS SDK option to `true` to allow
+  // the AWS SDK to set its own signal handler to ignore SIGPIPE signals. A
+  // SIGPIPE may be raised from the socket library when the peer disconnects
+  // unexpectedly.
+  options_.httpOptions.installSigPipeHandler = true;
+
   // Initialize the library once per process.
   std::call_once(aws_lib_initialized, [this]() { Aws::InitAPI(options_); });
 


### PR DESCRIPTION
By default, curl sets the signal handler for SIGPIPE to SIG_IGN while
executing. When curl is done executing, it restores the previous signal
handler. This is not thread safe, so the AWS SDK disables this behavior
in curl using the `CURLOPT_NOSIGNAL` option.
Here, we set the `installSigPipeHandler` AWS SDK option to `true` to allow
the AWS SDK to set its own signal handler to ignore SIGPIPE signals. A
SIGPIPE may be raised from the socket library when the peer disconnects
unexpectedly.

Here's an example of an unhandled SIGPIPE that crashed TileDB when making a
GetObject request:
```
Thread 27 "tiledbvcf" received signal SIGPIPE, Broken pipe.
[Switching to Thread 0x7ffff1541700 (LWP 32635)]
0x00007ffff6a2c459 in write () from /lib64/libpthread.so.0
Missing separate debuginfos, use: debuginfo-install bzip2-libs-1.0.6-13.amzn2.0.2.x86_64 libgcc-7.3.1-9.amzn2.x86_64 libstdc++-7.3.1-9.amzn2.x86_64 xz-libs-5.2.2-1.amzn2.0.2.x86_64 zlib-1.2.7-18.amzn2.x86_64
(gdb) bt
write () from /lib64/libpthread.so.0
sock_write () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
BIO_write () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
ssl3_write_pending () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
do_ssl3_write () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
ssl3_dispatch_alert () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
ssl3_shutdown () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
SSL_shutdown () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
ossl_close.isra () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
Curl_ossl_close () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
Curl_disconnect () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
Curl_connect () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
multi_runsingle () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
curl_multi_perform () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
curl_easy_perform () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
Aws::Http::CurlHttpClient::MakeRequest(std::shared_ptr<Aws::Http::HttpRequest> const&, Aws::Utils::RateLimits::RateLimiterInterface*, Aws::Utils::RateLimits::RateLimiterInterface*) const ()
   from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
Aws::Client::AWSClient::AttemptOneRequest(std::shared_ptr<Aws::Http::HttpRequest> const&, Aws::AmazonWebServiceRequest const&, char const*, char const*) const () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
Aws::Client::AWSClient::AttemptExhaustively(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*, char const*) const () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
Aws::Client::AWSClient::MakeRequestWithUnparsedResponse(Aws::Http::URI const&, Aws::AmazonWebServiceRequest const&, Aws::Http::HttpMethod, char const*, char const*) const ()
   from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
Aws::S3::S3Client::GetObject(Aws::S3::Model::GetObjectRequest const&) const () from /home/ec2-user/TileDB/dist/lib64/libtiledb.so.2.1
...
```