### PR TITLE
Pin CI Python to v3.8.

### DIFF
--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -12,7 +12,7 @@ steps:
 # Need this for virtualenv and arrow tests if enabled
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.x'
+    versionSpec: '3.8'
 
 - bash: |
     set -e pipefail

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -3,7 +3,7 @@ steps:
 # Need this for virtualenv
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.x'
+    versionSpec: '3.8'
 
 - bash: |
     set -e pipefail


### PR DESCRIPTION
Currently we spec for any v3. Azure updated to Python3.9 which does not support
PyArrow. This patch pins the version to 3.8 to allow CI to pass.