### PR TITLE
Fix assert in ThreadPool::wait_or_work

### DIFF
--- a/tiledb/common/thread_pool.cc
+++ b/tiledb/common/thread_pool.cc
@@ -273,7 +273,7 @@ Status ThreadPool::wait_or_work(Task&& task) {
       tp->task_stack_mutex_.unlock();
 
       // Execute the inner task.
-      assert(task.valid());
+      assert(inner_task.valid());
       inner_task();
     } else {
       // The task stack is now empty, retry.


### PR DESCRIPTION
Before executing `inner_task`, we intend to assert that it is valid. However,
we are incorrectly asserting that the outer `task` is valid.