### PR TITLE
Adjust fill in value support for issue with REST

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,8 @@
 
 ## Bug fixes
 
+* Fix ArraySchema not write protecting fill values for only schema version 6 or newer [#1868](https://github.com/TileDB-Inc/TileDB/pull/1868)
+
 ## API additions
 
 # TileDB v2.1.1 Release Notes

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -372,7 +372,7 @@ Status ArraySchema::serialize(Buffer* buff) const {
   auto attribute_num = (uint32_t)attributes_.size();
   RETURN_NOT_OK(buff->write(&attribute_num, sizeof(uint32_t)));
   for (auto& attr : attributes_)
-    RETURN_NOT_OK(attr->serialize(buff));
+    RETURN_NOT_OK(attr->serialize(buff, version_));
 
   return Status::Ok();
 }

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -152,7 +152,7 @@ const std::string& Attribute::name() const {
 // type (uint8_t)
 // cell_val_num (uint32_t)
 // filter_pipeline (see FilterPipeline::serialize)
-Status Attribute::serialize(Buffer* buff) {
+Status Attribute::serialize(Buffer* buff, uint32_t version) {
   // Write attribute name
   auto attribute_name_size = (uint32_t)name_.size();
   RETURN_NOT_OK(buff->write(&attribute_name_size, sizeof(uint32_t)));
@@ -169,10 +169,12 @@ Status Attribute::serialize(Buffer* buff) {
   RETURN_NOT_OK(filters_.serialize(buff));
 
   // Write fill value
-  auto fill_value_size = (uint64_t)fill_value_.size();
-  assert(fill_value_size != 0);
-  RETURN_NOT_OK(buff->write(&fill_value_size, sizeof(uint64_t)));
-  RETURN_NOT_OK(buff->write(&fill_value_[0], fill_value_.size()));
+  if (version >= 6) {
+    auto fill_value_size = (uint64_t)fill_value_.size();
+    assert(fill_value_size != 0);
+    RETURN_NOT_OK(buff->write(&fill_value_size, sizeof(uint64_t)));
+    RETURN_NOT_OK(buff->write(&fill_value_[0], fill_value_.size()));
+  }
 
   return Status::Ok();
 }

--- a/tiledb/sm/array_schema/attribute.h
+++ b/tiledb/sm/array_schema/attribute.h
@@ -112,9 +112,10 @@ class Attribute {
    * Serializes the object members into a binary buffer.
    *
    * @param buff The buffer to serialize the data into.
+   * @param version The format spec version.
    * @return Status
    */
-  Status serialize(Buffer* buff);
+  Status serialize(Buffer* buff, uint32_t version);
 
   /**
    * Sets the attribute number of values per cell. Note that if the attribute


### PR DESCRIPTION
The fill in value is only serialized to disk if the array schema version is`>= 6`. Previously if the schema was created from de-serializing from Cap'n Proto and it was a version 5 or older then the fill in values were incorrectly serialized on disk causing a corrupt array schema that could not be read.