### PR TITLE
LRUCache::insert() bugs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@
 ## Bug fixes
 
 * Fix ArraySchema not write protecting fill values for only schema version 6 or newer [#1868](https://github.com/TileDB-Inc/TileDB/pull/1868)
+* Fix segfault that may occur in the VFS read-ahead cache [#1871](https://github.com/TileDB-Inc/TileDB/pull/1871)
 
 ## API additions
 

--- a/tiledb/sm/cache/lru_cache.h
+++ b/tiledb/sm/cache/lru_cache.h
@@ -153,29 +153,37 @@ class LRUCache {
     if (size > max_size_)
       return Status::Ok();
 
-    const auto item_it = item_map_.find(key);
-    const bool exists = item_it != item_map_.end();
-
+    const bool exists = item_map_.count(key) == 1;
     if (exists && !overwrite)
       return Status::Ok();
 
-    // Evict if necessary
+    // Evict objects until there is room for `object`. Note that this
+    // invalidates the state in `exists`.
     while (size_ + size > max_size_)
       evict();
 
-    // Key exists
-    if (exists) {
+    // If an object associated with `key` still exists in the cache, replace it.
+    // Otherwise, add a new entry in the cache.
+    auto item_it = item_map_.find(key);
+    if (item_it != item_map_.end()) {
       // Replace cache item
       auto& node = item_it->second;
       auto& item = *node;
+
+      // Replace the object in the cache item.
       item.object_ = std::move(object);
+
+      // Subtract the old size from `size_`.
+      size_ -= item.size_;
+
+      // Replace the object size in the cache item.
       item.size_ = size;
 
       // Move cache item node to the end of the list
       if (std::next(node) != item_ll_.end()) {
         item_ll_.splice(item_ll_.end(), item_ll_, node, std::next(node));
       }
-    } else {  // Key does not exist
+    } else {
       // Create new node in linked list
       item_ll_.emplace_back(key, std::move(object), size);
 


### PR DESCRIPTION
This fixes two long-standing bugs our LRU implementation, which is shared between
the tile cache and the new VFS read-ahead cache.

1. When inserting an element, we evict at least one object in the cache to
make room for the new object. If we evict an object with the same key as the
object being inserted, the `item_it` iterator is invalidated and segfaults
when used.

2. The `LRUCache::size_` corrupts every time that an object is inserted that
shares a key with an existing object.