### PR TITLE
Disable Arrow unit tests in the Windows CI job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ stages:
           VS2017:
             imageName: 'vs2017-win2016'
             TILEDB_S3: ON
-            TILEDB_TESTS_ENABLE_ARROW: ON
+            TILEDB_TESTS_ENABLE_ARROW: OFF
       pool:
         vmImage: $(imageName)
       steps:


### PR DESCRIPTION
This disables the arrow unit tests in the Windows CI job until we have time to
debug the versioning issue causing failures.