### PR TITLE
[DRAFT] Nullable Attributes

### DIFF
--- a/format_spec/FORMAT_SPEC.md
+++ b/format_spec/FORMAT_SPEC.md
@@ -2,7 +2,7 @@
 
 
 :information_source: **Notes:**  
-- The current TileDB format version number is **5** (`uint32_t`).
+- The current TileDB format version number is **7** (`uint32_t`).
 - All data written by TileDB and referenced in this document is **little-endian**. 
 
 ## Table of Contents

--- a/format_spec/array_schema.md
+++ b/format_spec/array_schema.md
@@ -1,4 +1,4 @@
-# Array Schema File
+#Array Schema File
 
 The array schema file has name `__array_schema.tdb` and is located here:
 
@@ -69,4 +69,4 @@ The attribute has internal format:
 | Filters | [Filter Pipeline](./filter_pipeline.md) | The filter pipeline used on attribute value tiles |
 | Fill value size | `uint64_t` | The size in bytes of the fill value |
 | Fill value | `uint8_t[]` | The fill value |
-
+| Nullable | `bool` | Whether or not the attribute can be null |

--- a/format_spec/fragment.md
+++ b/format_spec/fragment.md
@@ -27,7 +27,7 @@ my_array                              # array folder
 
 There can be any number of fragments in an array. The fragment folder contains:
 * A single [fragment metadata file](#fragment-metadata-file) named `__fragment_metadata.tdb`. 
-* Any number of [data files](#data-file). For each fixed-sized attribute `a1` (or dimension `d1`), there is a single data file `a1.tdb` (`d1.tdb`) containing the values along this attribute (dimension). For every var-sized attribute `a2` (or dimensions `d2`), there are two data files; `a2_var.tdb` (`d2_var.tdb`) containing the var-sized values of the attribute (dimension) and `a2.tdb` (`d2.tdb`) containing the starting offsets of each value in `a2_var.tdb` (`d2_var.rdb`).
+* Any number of [data files](#data-file). For each fixed-sized attribute `a1` (or dimension `d1`), there is a single data file `a1.tdb` (`d1.tdb`) containing the values along this attribute (dimension). For every var-sized attribute `a2` (or dimensions `d2`), there are two data files; `a2_var.tdb` (`d2_var.tdb`) containing the var-sized values of the attribute (dimension) and `a2.tdb` (`d2.tdb`) containing the starting offsets of each value in `a2_var.tdb` (`d2_var.rdb`). Both fixed-sized and var-sized attributes can be nullable. A nullable attribute, `a3`, will have an additional file `a3_validity.tdb` that contains its validity vector.
 
 ## Fragment Metadata File 
 
@@ -127,6 +127,7 @@ The footer is a simple blob \(i.e., _not a generic tile_\) with the following in
 | Last tile cell num | `uint64_t` | For sparse arrays, the number of cells in the last tile in the fragment |
 | File sizes | `uint64_t[]` | The size in bytes of each attribute/dimension file in the fragment. For var-length attributes/dimensions, this is the size of the offsets file. |
 | File var sizes | `uint64_t[]` | The size in bytes of each var-length attribute/dimension file in the fragment. |
+| File validity sizes | `uint64_t[]` | The size in bytes of each attribute/dimension validity vector file in the fragment. |
 | R-Tree offset | `uint64_t` | The offset to the generic tile storing the R-Tree in the metadata file. |
 | Tile offset for attribute/dimension 1 | `uint64_t` | The offset to the generic tile storing the tile offsets for attribute/dimension 1. |
 | … | … | … |
@@ -137,6 +138,9 @@ The footer is a simple blob \(i.e., _not a generic tile_\) with the following in
 | Tile var sizes offset for attribute/dimension 1 | `uint64_t` | The offset to the generic tile storing the variable tile sizes for attribute/dimension 1. |
 | … | … | … |
 | Tile var sizes offset for attribute/dimension N | `uint64_t` | The offset to the generic tile storing the variable tile sizes for attribute/dimension N. |
+| Tile validity offset for attribute/dimension 1 | `uint64_t` | The offset to the generic tile storing the tile validity offsets for attribute/dimension 1. |
+| … | … | … |
+| Tile validity offset for attribute/dimension N | `uint64_t` | The offset to the generic tile storing the tile validity offsets for attribute/dimension N |
 | Footer length | `uint64_t` | Sum of bytes of the above fields. Only present when there is at least one var-sized dimension. |
 
 ## Data File 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,9 +93,9 @@ set(TILEDB_TEST_SOURCES
   src/unit-buffer.cc
   src/unit-bufferlist.cc
   src/unit-capi-any.cc
+  src/unit-capi-array.cc
   src/unit-capi-array_schema.cc
   src/unit-capi-async.cc
-  src/unit-capi-array.cc
   src/unit-capi-buffer.cc
   src/unit-capi-config.cc
   src/unit-capi-consolidation.cc
@@ -103,15 +103,15 @@ set(TILEDB_TEST_SOURCES
   src/unit-capi-dense_array_2.cc
   src/unit-capi-dense_neg.cc
   src/unit-capi-dense_vector.cc
-  src/unit-duplicates.cc
   src/unit-capi-empty-var-length.cc
   src/unit-capi-enum_values.cc
   src/unit-capi-error.cc
   src/unit-capi-fill_values.cc
   src/unit-capi-filter.cc
-  src/unit-capi-incomplete.cc
   src/unit-capi-incomplete-2.cc
+  src/unit-capi-incomplete.cc
   src/unit-capi-metadata.cc
+  src/unit-capi-nullable.cc
   src/unit-capi-object_mgmt.cc
   src/unit-capi-query.cc
   src/unit-capi-query_2.cc
@@ -120,12 +120,13 @@ set(TILEDB_TEST_SOURCES
   src/unit-capi-sparse_neg.cc
   src/unit-capi-sparse_neg_2.cc
   src/unit-capi-sparse_real.cc
-  src/unit-capi-string_dims.cc
   src/unit-capi-sparse_real_2.cc
   src/unit-capi-string.cc
+  src/unit-capi-string_dims.cc
   src/unit-capi-uri.cc
   src/unit-capi-version.cc
   src/unit-capi-vfs.cc
+  src/unit-duplicates.cc
   src/unit-CellSlabIter.cc
   src/unit-compression-dd.cc
   src/unit-compression-rle.cc
@@ -153,6 +154,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-TileDomain.cc
   src/unit-uri.cc
   src/unit-uuid.cc
+  src/unit-ValidityVector.cc
   src/unit-vfs.cc
   src/unit-win-filesystem.cc
   src/unit.cc
@@ -163,12 +165,13 @@ if (TILEDB_CPP_API)
     src/unit-cppapi-array.cc
     src/unit-cppapi-checksum.cc
     src/unit-cppapi-config.cc
-    src/unit-cppapi-consolidation.cc
     src/unit-cppapi-consolidation-sparse.cc
+    src/unit-cppapi-consolidation.cc
     src/unit-cppapi-datetimes.cc
     src/unit-cppapi-fill_values.cc
     src/unit-cppapi-filter.cc
     src/unit-cppapi-metadata.cc
+    src/unit-cppapi-nullable.cc
     src/unit-cppapi-query.cc
     src/unit-cppapi-schema.cc
     src/unit-cppapi-subarray.cc

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -445,9 +445,9 @@ TEST_CASE_METHOD(
               .ok());
   Tile tile_2_0(
       Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_2_0, false);
-  auto tile_pair = result_tile_2_0.tile_pair("d");
-  REQUIRE(tile_pair != nullptr);
-  tile_pair->first = tile_2_0;
+  auto tile_tuple = result_tile_2_0.tile_tuple("d");
+  REQUIRE(tile_tuple != nullptr);
+  std::get<0>(*tile_tuple) = tile_2_0;
 
   std::vector<uint64_t> vec_3_0 = {1000, 1000, 8, 9};
   Buffer buff_3_0(&vec_3_0[0], vec_3_0.size() * sizeof(uint64_t));
@@ -457,9 +457,9 @@ TEST_CASE_METHOD(
               .ok());
   Tile tile_3_0(
       Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_0, false);
-  tile_pair = result_tile_3_0.tile_pair("d");
-  REQUIRE(tile_pair != nullptr);
-  tile_pair->first = tile_3_0;
+  tile_tuple = result_tile_3_0.tile_tuple("d");
+  REQUIRE(tile_tuple != nullptr);
+  std::get<0>(*tile_tuple) = tile_3_0;
 
   std::vector<uint64_t> vec_3_1 = {1000, 12, 19, 1000};
   Buffer buff_3_1(&vec_3_1[0], vec_3_1.size() * sizeof(uint64_t));
@@ -469,9 +469,9 @@ TEST_CASE_METHOD(
               .ok());
   Tile tile_3_1(
       Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_1, false);
-  tile_pair = result_tile_3_1.tile_pair("d");
-  REQUIRE(tile_pair != nullptr);
-  tile_pair->first = tile_3_1;
+  tile_tuple = result_tile_3_1.tile_tuple("d");
+  REQUIRE(tile_tuple != nullptr);
+  std::get<0>(*tile_tuple) = tile_3_1;
 
   result_coords.emplace_back(&result_tile_2_0, 1);
   result_coords.emplace_back(&result_tile_2_0, 3);
@@ -1271,9 +1271,9 @@ TEST_CASE_METHOD(
               .ok());
   Tile tile_3_0_d1(
       Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_0_d1, false);
-  auto tile_pair = result_tile_3_0.tile_pair("d1");
-  REQUIRE(tile_pair != nullptr);
-  tile_pair->first = tile_3_0_d1;
+  auto tile_tuple = result_tile_3_0.tile_tuple("d1");
+  REQUIRE(tile_tuple != nullptr);
+  std::get<0>(*tile_tuple) = tile_3_0_d1;
 
   std::vector<uint64_t> vec_3_0_d2 = {1000, 3, 1000, 1000};
   Buffer buff_3_0_d2(&vec_3_0_d2[0], vec_3_0_d2.size() * sizeof(uint64_t));
@@ -1283,9 +1283,9 @@ TEST_CASE_METHOD(
               .ok());
   Tile tile_3_0_d2(
       Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_0_d2, false);
-  tile_pair = result_tile_3_0.tile_pair("d2");
-  REQUIRE(tile_pair != nullptr);
-  tile_pair->first = tile_3_0_d2;
+  tile_tuple = result_tile_3_0.tile_tuple("d2");
+  REQUIRE(tile_tuple != nullptr);
+  std::get<0>(*tile_tuple) = tile_3_0_d2;
 
   std::vector<uint64_t> vec_3_1_d1 = {5, 1000, 5, 1000};
   Buffer buff_3_1_d1(&vec_3_1_d1[0], vec_3_1_d1.size() * sizeof(uint64_t));
@@ -1295,9 +1295,9 @@ TEST_CASE_METHOD(
               .ok());
   Tile tile_3_1_d1(
       Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_1_d1, false);
-  tile_pair = result_tile_3_1.tile_pair("d1");
-  REQUIRE(tile_pair != nullptr);
-  tile_pair->first = tile_3_1_d1;
+  tile_tuple = result_tile_3_1.tile_tuple("d1");
+  REQUIRE(tile_tuple != nullptr);
+  std::get<0>(*tile_tuple) = tile_3_1_d1;
 
   std::vector<uint64_t> vec_3_1_d2 = {5, 1000, 6, 1000};
   Buffer buff_3_1_d2(&vec_3_1_d2[0], vec_3_1_d2.size() * sizeof(uint64_t));
@@ -1307,9 +1307,9 @@ TEST_CASE_METHOD(
               .ok());
   Tile tile_3_1_d2(
       Datatype::UINT64, sizeof(uint64_t), 0, &chunked_buffer_3_1_d2, false);
-  tile_pair = result_tile_3_1.tile_pair("d2");
-  REQUIRE(tile_pair != nullptr);
-  tile_pair->first = tile_3_1_d2;
+  tile_tuple = result_tile_3_1.tile_tuple("d2");
+  REQUIRE(tile_tuple != nullptr);
+  std::get<0>(*tile_tuple) = tile_3_1_d2;
 
   result_coords.emplace_back(&result_tile_3_0, 1);
   result_coords.emplace_back(&result_tile_3_1, 0);

--- a/test/src/unit-ValidityVector.cc
+++ b/test/src/unit-ValidityVector.cc
@@ -1,0 +1,103 @@
+/**
+ * @file unit-ValidityVector.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `ValidityVector` class.
+ */
+
+#include "tiledb/sm/query/validity_vector.h"
+
+#include <catch.hpp>
+#include <iostream>
+
+using namespace std;
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "ValidityVector: Test default constructor",
+    "[ValidityVector][default_constructor]") {
+  ValidityVector validity_vector;
+  REQUIRE(validity_vector.bytemap() == nullptr);
+  REQUIRE(validity_vector.bytemap_size() == nullptr);
+  REQUIRE(validity_vector.buffer() == nullptr);
+  REQUIRE(validity_vector.buffer_size() == nullptr);
+}
+
+TEST_CASE(
+    "ValidityVector: Test move constructor",
+    "[ValidityVector][move_constructor]") {
+  uint8_t bytemap[10];
+  uint64_t bytemap_size = sizeof(bytemap);
+  for (uint64_t i = 0; i < bytemap_size; ++i)
+    bytemap[i] = i % 2;
+
+  ValidityVector validity_vector1;
+  validity_vector1.init_bytemap(bytemap, &bytemap_size);
+
+  ValidityVector validity_vector2(std::move(validity_vector1));
+
+  REQUIRE(validity_vector2.bytemap() == bytemap);
+  REQUIRE(validity_vector2.bytemap_size() == &bytemap_size);
+  REQUIRE(validity_vector2.buffer() == bytemap);
+  REQUIRE(validity_vector2.buffer_size() == &bytemap_size);
+}
+
+TEST_CASE(
+    "ValidityVector: Test move-assignment",
+    "[ValidityVector][move_assignment]") {
+  uint8_t bytemap[10];
+  uint64_t bytemap_size = sizeof(bytemap);
+  for (uint64_t i = 0; i < bytemap_size; ++i)
+    bytemap[i] = i % 2;
+
+  ValidityVector validity_vector1;
+  validity_vector1.init_bytemap(bytemap, &bytemap_size);
+
+  ValidityVector validity_vector2 = std::move(validity_vector1);
+
+  REQUIRE(validity_vector2.bytemap() == bytemap);
+  REQUIRE(validity_vector2.bytemap_size() == &bytemap_size);
+  REQUIRE(validity_vector2.buffer() == bytemap);
+  REQUIRE(validity_vector2.buffer_size() == &bytemap_size);
+}
+
+TEST_CASE(
+    "ValidityVector: Test init_bytemap", "[ValidityVector][init_bytemap]") {
+  uint8_t bytemap[10];
+  uint64_t bytemap_size = sizeof(bytemap);
+  for (uint64_t i = 0; i < bytemap_size; ++i)
+    bytemap[i] = i % 2;
+
+  ValidityVector validity_vector;
+  validity_vector.init_bytemap(bytemap, &bytemap_size);
+
+  REQUIRE(validity_vector.bytemap() == bytemap);
+  REQUIRE(validity_vector.bytemap_size() == &bytemap_size);
+  REQUIRE(validity_vector.buffer() == bytemap);
+  REQUIRE(validity_vector.buffer_size() == &bytemap_size);
+}

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -990,7 +990,7 @@ void ArraySchemaFx::load_and_check_array_schema(const std::string& path) {
       "  > BZIP2: COMPRESSION_LEVEL=5\n" +
       "  > BitWidthReduction: BIT_WIDTH_MAX_WINDOW=1000\n\n" +
       "### Attribute ###\n" + "- Name: " + ATTR_NAME + "\n" +
-      "- Type: " + ATTR_TYPE_STR + "\n" +
+      "- Type: " + ATTR_TYPE_STR + "\n" + "- Nullable: false\n" +
       "- Cell val num: " + CELL_VAL_NUM_STR + "\n" + "- Filters: 2\n" +
       "  > BZIP2: COMPRESSION_LEVEL=5\n" +
       "  > BitWidthReduction: BIT_WIDTH_MAX_WINDOW=1000\n" +

--- a/test/src/unit-capi-fill_values.cc
+++ b/test/src/unit-capi-fill_values.cc
@@ -93,8 +93,9 @@ TEST_CASE(
 
   // Check dump
   std::string dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-                     "- Type: INT32\n" + "- Cell val num: 1\n" +
-                     "- Filters: 0\n" + "- Fill value: -2147483648\n";
+                     "- Type: INT32\n" + "- Nullable: false\n" +
+                     "- Cell val num: 1\n" + "- Filters: 0\n" +
+                     "- Fill value: -2147483648\n\n";
   check_dump(ctx, a, dump);
 
   // Correct setter
@@ -109,8 +110,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: 1\n" + "- Filters: 0\n" +
-         "- Fill value: 5\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: 1\n" +
+         "- Filters: 0\n" + "- Fill value: 5\n";
   check_dump(ctx, a, dump);
 
   // Setting the cell val num, also sets the fill value to a new default
@@ -124,8 +125,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: 2\n" + "- Filters: 0\n" +
-         "- Fill value: -2147483648, -2147483648\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: 2\n" +
+         "- Filters: 0\n" + "- Fill value: -2147483648\n, -2147483648\n\n";
   check_dump(ctx, a, dump);
 
   // Set a fill value that is comprised of two integers
@@ -142,8 +143,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: 2\n" + "- Filters: 0\n" +
-         "- Fill value: 1, 2\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: 2\n" +
+         "- Filters: 0\n" + "- Fill value: 1, 2\n";
   check_dump(ctx, a, dump);
 
   // Make the attribute var-sized
@@ -152,8 +153,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: var\n" + "- Filters: 0\n" +
-         "- Fill value: -2147483648\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: var\n" +
+         "- Filters: 0\n" + "- Fill value: -2147483648\n\n";
   check_dump(ctx, a, dump);
 
   // Get the default var-sized fill value
@@ -177,8 +178,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: var\n" + "- Filters: 0\n" +
-         "- Fill value: 1, 2, 3\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: var\n" +
+         "- Filters: 0\n" + "- Fill value: 1, 2, 3\n";
   check_dump(ctx, a, dump);
 
   // Clean up

--- a/test/src/unit-capi-nullable.cc
+++ b/test/src/unit-capi-nullable.cc
@@ -1,0 +1,847 @@
+/**
+ * @file unit-capi-nullable.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests arrays with nullable attributes.
+ */
+
+#include "catch.hpp"
+#include "test/src/helpers.h"
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/misc/utils.h"
+
+#include <iostream>
+#include <vector>
+
+using namespace std;
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+struct test_dim_t {
+  test_dim_t(
+      const string& name,
+      const tiledb_datatype_t type,
+      const void* const domain,
+      const uint64_t tile_extent)
+      : name_(name)
+      , type_(type)
+      , domain_(domain)
+      , tile_extent_(tile_extent) {
+  }
+
+  string name_;
+  tiledb_datatype_t type_;
+  const void* domain_;
+  uint64_t tile_extent_;
+};
+
+struct test_attr_t {
+  test_attr_t(
+      const string& name,
+      const tiledb_datatype_t type,
+      const uint32_t cell_val_num,
+      const bool nullable)
+      : name_(name)
+      , type_(type)
+      , cell_val_num_(cell_val_num)
+      , nullable_(nullable) {
+  }
+
+  string name_;
+  tiledb_datatype_t type_;
+  uint32_t cell_val_num_;
+  bool nullable_;
+};
+
+struct test_query_buffer_t {
+  test_query_buffer_t(
+      const string& name,
+      void* const buffer,
+      uint64_t* const buffer_size,
+      void* const buffer_var,
+      uint64_t* const buffer_var_size,
+      uint8_t* const buffer_validity,
+      uint64_t* const buffer_validity_size)
+      : name_(name)
+      , buffer_(buffer)
+      , buffer_size_(buffer_size)
+      , buffer_var_(buffer_var)
+      , buffer_var_size_(buffer_var_size)
+      , buffer_validity_(buffer_validity)
+      , buffer_validity_size_(buffer_validity_size) {
+  }
+
+  string name_;
+  void* buffer_;
+  uint64_t* buffer_size_;
+  void* buffer_var_;
+  uint64_t* buffer_var_size_;
+  uint8_t* buffer_validity_;
+  uint64_t* buffer_validity_size_;
+};
+
+class NullableArrayFx {
+ public:
+#ifdef _WIN32
+  const string FILE_URI_PREFIX = "";
+  const string FILE_TEMP_DIR =
+      tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
+#else
+  const string FILE_URI_PREFIX = "file://";
+  const string FILE_TEMP_DIR =
+      tiledb::sm::Posix::current_dir() + "/tiledb_test/";
+#endif
+
+  /** Constructor. */
+  NullableArrayFx();
+
+  /** Destructor. */
+  ~NullableArrayFx();
+
+  /**
+   * Creates, writes, and reads nullable attributes.
+   *
+   * @param test_attrs The nullable attributes to test.
+   * @param array_type The type of the array (dense/sparse).
+   * @param cell_order The cell order of the array.
+   * @param tile_order The tile order of the array.
+   * @param write_order The write layout.
+   */
+  void do_2d_nullable_test(
+      const vector<test_attr_t>& test_attrs,
+      tiledb_array_type_t array_type,
+      tiledb_layout_t cell_order,
+      tiledb_layout_t tile_order,
+      tiledb_layout_t write_order);
+
+ private:
+  /** The C-API context object. */
+  tiledb_ctx_t* ctx_;
+
+  /** The C-API VFS object. */
+  tiledb_vfs_t* vfs_;
+
+  /**
+   * Creates a directory using `vfs_`.
+   *
+   * @param path The directory path.
+   */
+  void create_dir(const string& path);
+
+  /**
+   * Removes a directory using `vfs_`.
+   *
+   * @param path The directory path.
+   */
+  void remove_dir(const string& path);
+
+  /**
+   * Creates a TileDB array.
+   *
+   * @param array_name The name of the array.
+   * @param array_type The type of the array (dense/sparse).
+   * @param test_dims The dimensions in the array.
+   * @param test_attrs The attributes in the array.
+   * @param cell_order The cell order of the array.
+   * @param tile_order The tile order of the array.
+   */
+  void create_array(
+      const string& array_name,
+      tiledb_array_type_t array_type,
+      const vector<test_dim_t>& test_dims,
+      const vector<test_attr_t>& test_attrs,
+      tiledb_layout_t cell_order,
+      tiledb_layout_t tile_order);
+
+  /**
+   * Creates and executes a single write query.
+   *
+   * @param array_name The name of the array.
+   * @param test_query_buffers The query buffers to write.
+   * @param layout The write layout.
+   */
+  void write(
+      const string& array_name,
+      const vector<test_query_buffer_t>& test_query_buffers,
+      tiledb_layout_t layout);
+
+  /**
+   * Creates and executes a single read query.
+   *
+   * @param array_name The name of the array.
+   * @param test_query_buffers The query buffers to read.
+   * @param subarray The subarray to read.
+   */
+  void read(
+      const string& array_name,
+      const vector<test_query_buffer_t>& test_query_buffers,
+      const void* subarray);
+};
+
+NullableArrayFx::NullableArrayFx() {
+  // Create a config.
+  tiledb_config_t* config = nullptr;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  // Create the context.
+  REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  // Create the VFS.
+  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+
+  tiledb_config_free(&config);
+}
+
+NullableArrayFx::~NullableArrayFx() {
+  remove_dir(FILE_TEMP_DIR);
+}
+
+void NullableArrayFx::create_dir(const string& path) {
+  REQUIRE(tiledb_vfs_create_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
+}
+
+void NullableArrayFx::remove_dir(const string& path) {
+  int is_dir = 0;
+  REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
+  if (is_dir)
+    REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
+}
+
+void NullableArrayFx::create_array(
+    const string& array_name,
+    const tiledb_array_type_t array_type,
+    const vector<test_dim_t>& test_dims,
+    const vector<test_attr_t>& test_attrs,
+    const tiledb_layout_t cell_order,
+    const tiledb_layout_t tile_order) {
+  remove_dir(FILE_TEMP_DIR);
+  create_dir(FILE_TEMP_DIR);
+
+  // Create the dimensions.
+  vector<tiledb_dimension_t*> dims;
+  dims.reserve(test_dims.size());
+  for (const auto& test_dim : test_dims) {
+    tiledb_dimension_t* dim;
+    const int rc = tiledb_dimension_alloc(
+        ctx_,
+        test_dim.name_.c_str(),
+        test_dim.type_,
+        test_dim.domain_,
+        &test_dim.tile_extent_,
+        &dim);
+    REQUIRE(rc == TILEDB_OK);
+
+    dims.emplace_back(dim);
+  }
+
+  // Create the domain.
+  tiledb_domain_t* domain;
+  int rc = tiledb_domain_alloc(ctx_, &domain);
+  REQUIRE(rc == TILEDB_OK);
+  for (const auto& dim : dims) {
+    rc = tiledb_domain_add_dimension(ctx_, domain, dim);
+    REQUIRE(rc == TILEDB_OK);
+  }
+
+  // Create attributes
+  vector<tiledb_attribute_t*> attrs;
+  attrs.reserve(test_attrs.size());
+  for (const auto& test_attr : test_attrs) {
+    tiledb_attribute_t* attr;
+    rc = tiledb_attribute_alloc(
+        ctx_, test_attr.name_.c_str(), test_attr.type_, &attr);
+    REQUIRE(rc == TILEDB_OK);
+
+    rc = tiledb_attribute_set_cell_val_num(ctx_, attr, test_attr.cell_val_num_);
+    REQUIRE(rc == TILEDB_OK);
+
+    if (test_attr.nullable_) {
+      rc = tiledb_attribute_set_nullable(ctx_, attr, 1);
+      REQUIRE(rc == TILEDB_OK);
+    }
+
+    attrs.emplace_back(attr);
+  }
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  rc = tiledb_array_schema_alloc(ctx_, array_type, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, cell_order);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_tile_order(ctx_, array_schema, tile_order);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_domain(ctx_, array_schema, domain);
+  REQUIRE(rc == TILEDB_OK);
+  for (const auto& attr : attrs) {
+    rc = tiledb_array_schema_add_attribute(ctx_, array_schema, attr);
+    REQUIRE(rc == TILEDB_OK);
+  }
+
+  // Check array schema
+  rc = tiledb_array_schema_check(ctx_, array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create array
+  rc = tiledb_array_create(
+      ctx_, (FILE_TEMP_DIR + array_name).c_str(), array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Free attributes.
+  for (auto& attr : attrs) {
+    tiledb_attribute_free(&attr);
+  }
+
+  // Free dimensions.
+  for (auto& dim : dims) {
+    tiledb_dimension_free(&dim);
+  }
+
+  // Free the domain.
+  tiledb_domain_free(&domain);
+
+  // Free the array schema.
+  tiledb_array_schema_free(&array_schema);
+}
+
+void NullableArrayFx::write(
+    const string& array_name,
+    const vector<test_query_buffer_t>& test_query_buffers,
+    const tiledb_layout_t layout) {
+  // Open the array for writing.
+  tiledb_array_t* array;
+  int rc =
+      tiledb_array_alloc(ctx_, (FILE_TEMP_DIR + array_name).c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create the write query.
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set the query layout.
+  rc = tiledb_query_set_layout(ctx_, query, layout);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set the query buffers.
+  for (const auto& test_query_buffer : test_query_buffers) {
+    if (test_query_buffer.buffer_validity_size_ == nullptr) {
+      if (test_query_buffer.buffer_var_ == nullptr) {
+        rc = tiledb_query_set_buffer(
+            ctx_,
+            query,
+            test_query_buffer.name_.c_str(),
+            test_query_buffer.buffer_,
+            test_query_buffer.buffer_size_);
+        REQUIRE(rc == TILEDB_OK);
+      } else {
+        rc = tiledb_query_set_buffer_var(
+            ctx_,
+            query,
+            test_query_buffer.name_.c_str(),
+            static_cast<uint64_t*>(test_query_buffer.buffer_),
+            test_query_buffer.buffer_size_,
+            test_query_buffer.buffer_var_,
+            test_query_buffer.buffer_var_size_);
+        REQUIRE(rc == TILEDB_OK);
+      }
+    } else {
+      if (test_query_buffer.buffer_var_ == nullptr) {
+        rc = tiledb_query_set_buffer_nullable(
+            ctx_,
+            query,
+            test_query_buffer.name_.c_str(),
+            test_query_buffer.buffer_,
+            test_query_buffer.buffer_size_,
+            test_query_buffer.buffer_validity_,
+            test_query_buffer.buffer_validity_size_);
+        REQUIRE(rc == TILEDB_OK);
+      } else {
+        rc = tiledb_query_set_buffer_var_nullable(
+            ctx_,
+            query,
+            test_query_buffer.name_.c_str(),
+            static_cast<uint64_t*>(test_query_buffer.buffer_),
+            test_query_buffer.buffer_size_,
+            test_query_buffer.buffer_var_,
+            test_query_buffer.buffer_var_size_,
+            test_query_buffer.buffer_validity_,
+            test_query_buffer.buffer_validity_size_);
+        REQUIRE(rc == TILEDB_OK);
+      }
+    }
+  }
+
+  // Submit the query.
+  rc = tiledb_query_submit(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Finalize the query, a no-op for non-global writes.
+  rc = tiledb_query_finalize(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+void NullableArrayFx::read(
+    const string& array_name,
+    const vector<test_query_buffer_t>& test_query_buffers,
+    const void* const subarray) {
+  // Open the array for reading.
+  tiledb_array_t* array;
+  int rc =
+      tiledb_array_alloc(ctx_, (FILE_TEMP_DIR + array_name).c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create the read query.
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set the query buffers.
+  for (size_t i = 0; i < test_query_buffers.size(); ++i) {
+    const test_query_buffer_t& test_query_buffer = test_query_buffers[i];
+    if (test_query_buffer.buffer_validity_size_ == nullptr) {
+      if (test_query_buffer.buffer_var_ == nullptr) {
+        rc = tiledb_query_set_buffer(
+            ctx_,
+            query,
+            test_query_buffer.name_.c_str(),
+            test_query_buffer.buffer_,
+            test_query_buffer.buffer_size_);
+        REQUIRE(rc == TILEDB_OK);
+      } else {
+        rc = tiledb_query_set_buffer_var(
+            ctx_,
+            query,
+            test_query_buffer.name_.c_str(),
+            static_cast<uint64_t*>(test_query_buffer.buffer_),
+            test_query_buffer.buffer_size_,
+            test_query_buffer.buffer_var_,
+            test_query_buffer.buffer_var_size_);
+        REQUIRE(rc == TILEDB_OK);
+      }
+    } else {
+      if (test_query_buffer.buffer_var_ == nullptr) {
+        rc = tiledb_query_set_buffer_nullable(
+            ctx_,
+            query,
+            test_query_buffer.name_.c_str(),
+            test_query_buffer.buffer_,
+            test_query_buffer.buffer_size_,
+            test_query_buffer.buffer_validity_,
+            test_query_buffer.buffer_validity_size_);
+        REQUIRE(rc == TILEDB_OK);
+      } else {
+        rc = tiledb_query_set_buffer_var_nullable(
+            ctx_,
+            query,
+            test_query_buffer.name_.c_str(),
+            static_cast<uint64_t*>(test_query_buffer.buffer_),
+            test_query_buffer.buffer_size_,
+            test_query_buffer.buffer_var_,
+            test_query_buffer.buffer_var_size_,
+            test_query_buffer.buffer_validity_,
+            test_query_buffer.buffer_validity_size_);
+        REQUIRE(rc == TILEDB_OK);
+      }
+    }
+  }
+
+  // Set the subarray to read.
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Submit the query.
+  rc = tiledb_query_submit(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Finalize the query, a no-op for non-global writes.
+  rc = tiledb_query_finalize(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+void NullableArrayFx::do_2d_nullable_test(
+    const vector<test_attr_t>& test_attrs,
+    const tiledb_array_type_t array_type,
+    const tiledb_layout_t cell_order,
+    const tiledb_layout_t tile_order,
+    const tiledb_layout_t write_order) {
+  const string array_name = "2d_nullable_array";
+
+  // Skip row-major and col-major writes for sparse arrays.
+  if (array_type == TILEDB_SPARSE &&
+      (write_order == TILEDB_ROW_MAJOR || write_order == TILEDB_COL_MAJOR)) {
+    return;
+  }
+
+  // Define the dimensions.
+  vector<test_dim_t> test_dims;
+  const uint64_t d1_domain[] = {1, 4};
+  const uint64_t d1_tile_extent = 2;
+  test_dims.emplace_back("d1", TILEDB_UINT64, d1_domain, d1_tile_extent);
+  const uint64_t d2_domain[] = {1, 4};
+  const uint64_t d2_tile_extent = 2;
+  test_dims.emplace_back("d2", TILEDB_UINT64, d2_domain, d2_tile_extent);
+
+  // Create the array.
+  create_array(
+      array_name, array_type, test_dims, test_attrs, cell_order, tile_order);
+
+  // Define the write query buffers for "a1".
+  vector<test_query_buffer_t> write_query_buffers;
+  int a1_write_buffer[16];
+  for (int i = 0; i < 16; ++i)
+    a1_write_buffer[i] = i;
+  uint64_t a1_write_buffer_size = sizeof(a1_write_buffer);
+  uint8_t a1_write_buffer_validity[16];
+  for (int i = 0; i < 16; ++i)
+    a1_write_buffer_validity[i] = rand() % 2;
+  uint64_t a1_write_buffer_validity_size = sizeof(a1_write_buffer_validity);
+  write_query_buffers.emplace_back(
+      "a1",
+      a1_write_buffer,
+      &a1_write_buffer_size,
+      nullptr,
+      nullptr,
+      a1_write_buffer_validity,
+      &a1_write_buffer_validity_size);
+
+  // Define the write query buffers for "a2".
+  int a2_write_buffer[16];
+  for (int i = 0; i < 16; ++i)
+    a2_write_buffer[i] = a1_write_buffer[16 - 1 - i];
+  uint64_t a2_write_buffer_size = sizeof(a2_write_buffer);
+  uint8_t a2_write_buffer_validity[16];
+  for (uint64_t i = 0; i < 16; ++i)
+    a2_write_buffer_validity[i] = a1_write_buffer_validity[16 - 1 - i];
+  uint64_t a2_write_buffer_validity_size = sizeof(a2_write_buffer_validity);
+  if (test_attrs.size() >= 2) {
+    write_query_buffers.emplace_back(
+        "a2",
+        a2_write_buffer,
+        &a2_write_buffer_size,
+        nullptr,
+        nullptr,
+        a2_write_buffer_validity,
+        &a2_write_buffer_validity_size);
+  }
+
+  // Define the write query buffers for "a3".
+  uint64_t a3_write_buffer[16];
+  for (uint64_t i = 0; i < 16; ++i)
+    a3_write_buffer[i] = i * sizeof(int) * 2;
+  uint64_t a3_write_buffer_size = sizeof(a3_write_buffer);
+  int a3_write_buffer_var[32];
+  for (int i = 0; i < 32; ++i)
+    a3_write_buffer_var[i] = i;
+  uint64_t a3_write_buffer_var_size = sizeof(a3_write_buffer_var);
+  uint8_t a3_write_buffer_validity[32];
+  for (int i = 0; i < 32; ++i)
+    a3_write_buffer_validity[i] = rand() % 2;
+  uint64_t a3_write_buffer_validity_size = sizeof(a3_write_buffer_validity);
+  if (test_attrs.size() >= 3) {
+    write_query_buffers.emplace_back(
+        "a3",
+        a3_write_buffer,
+        &a3_write_buffer_size,
+        a3_write_buffer_var,
+        &a3_write_buffer_var_size,
+        a3_write_buffer_validity,
+        &a3_write_buffer_validity_size);
+  }
+
+  // Define dimension query buffers for either sparse arrays or dense arrays
+  // with an unordered write order.
+  uint64_t d1_write_buffer[16];
+  uint64_t d2_write_buffer[16];
+  uint64_t d1_write_buffer_size;
+  uint64_t d2_write_buffer_size;
+  if (array_type == TILEDB_SPARSE || write_order == TILEDB_UNORDERED) {
+    vector<uint64_t> d1_write_vec;
+    vector<uint64_t> d2_write_vec;
+
+    // Coordinates for sparse arrays written in global order have unique
+    // ordering when either/both cell and tile ordering is col-major.
+    if (array_type == TILEDB_SPARSE && write_order == TILEDB_GLOBAL_ORDER &&
+        (cell_order == TILEDB_COL_MAJOR || tile_order == TILEDB_COL_MAJOR)) {
+      if (cell_order == TILEDB_ROW_MAJOR && tile_order == TILEDB_COL_MAJOR) {
+        d1_write_vec = {1, 1, 2, 2, 3, 3, 4, 4, 1, 1, 2, 2, 3, 3, 4, 4};
+        d2_write_vec = {1, 2, 1, 2, 1, 2, 1, 2, 3, 4, 3, 4, 3, 4, 3, 4};
+      } else if (
+          cell_order == TILEDB_COL_MAJOR && tile_order == TILEDB_ROW_MAJOR) {
+        d1_write_vec = {1, 2, 1, 2, 1, 2, 1, 2, 3, 4, 3, 4, 3, 4, 3, 4};
+        d2_write_vec = {1, 1, 2, 2, 3, 3, 4, 4, 1, 1, 2, 2, 3, 3, 4, 4};
+      } else {
+        REQUIRE(cell_order == TILEDB_COL_MAJOR);
+        REQUIRE(tile_order == TILEDB_COL_MAJOR);
+        d1_write_vec = {1, 2, 1, 2, 3, 4, 3, 4, 1, 2, 1, 2, 3, 4, 3, 4};
+        d2_write_vec = {1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 4, 4};
+      }
+    } else {
+      d1_write_vec = {1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 4, 4};
+      d2_write_vec = {1, 2, 1, 2, 3, 4, 3, 4, 1, 2, 1, 2, 3, 4, 3, 4};
+    }
+
+    REQUIRE(d1_write_vec.size() == 16);
+    for (size_t i = 0; i < 16; ++i)
+      d1_write_buffer[i] = d1_write_vec[i];
+    d1_write_buffer_size = sizeof(d1_write_buffer);
+    write_query_buffers.emplace_back(
+        "d1",
+        d1_write_buffer,
+        &d1_write_buffer_size,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr);
+
+    REQUIRE(d2_write_vec.size() == 16);
+    for (size_t i = 0; i < 16; ++i)
+      d2_write_buffer[i] = d2_write_vec[i];
+    d2_write_buffer_size = sizeof(d2_write_buffer);
+    write_query_buffers.emplace_back(
+        "d2",
+        d2_write_buffer,
+        &d2_write_buffer_size,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr);
+  }
+
+  // Execute the write query.
+  write(array_name, write_query_buffers, write_order);
+
+  // Define the read query buffers for "a1".
+  vector<test_query_buffer_t> read_query_buffers;
+  int a1_read_buffer[16] = {0};
+  uint64_t a1_read_buffer_size = sizeof(a1_read_buffer);
+  uint8_t a1_read_buffer_validity[16] = {0};
+  uint64_t a1_read_buffer_validity_size = sizeof(a1_read_buffer_validity);
+  read_query_buffers.emplace_back(
+      "a1",
+      a1_read_buffer,
+      &a1_read_buffer_size,
+      nullptr,
+      nullptr,
+      a1_read_buffer_validity,
+      &a1_read_buffer_validity_size);
+
+  // Define the read query buffers for "a2".
+  int a2_read_buffer[16] = {0};
+  uint64_t a2_read_buffer_size = sizeof(a2_read_buffer);
+  uint8_t a2_read_buffer_validity[16] = {0};
+  uint64_t a2_read_buffer_validity_size = sizeof(a2_read_buffer_validity);
+  if (test_attrs.size() >= 2) {
+    read_query_buffers.emplace_back(
+        "a2",
+        a2_read_buffer,
+        &a2_read_buffer_size,
+        nullptr,
+        nullptr,
+        a2_read_buffer_validity,
+        &a2_read_buffer_validity_size);
+  }
+
+  // Define the read query buffers for "a3".
+  uint64_t a3_read_buffer[16] = {0};
+  uint64_t a3_read_buffer_size = sizeof(a3_read_buffer);
+  int a3_read_buffer_var[32] = {0};
+  uint64_t a3_read_buffer_var_size = sizeof(a3_read_buffer);
+  uint8_t a3_read_buffer_validity[32] = {0};
+  uint64_t a3_read_buffer_validity_size = sizeof(a3_read_buffer_validity);
+  if (test_attrs.size() >= 3) {
+    read_query_buffers.emplace_back(
+        "a3",
+        a3_read_buffer,
+        &a3_read_buffer_size,
+        a3_read_buffer_var,
+        &a3_read_buffer_var_size,
+        a3_read_buffer_validity,
+        &a3_read_buffer_validity_size);
+  }
+
+  // Execute a read query over the entire domain.
+  const uint64_t subarray_full[] = {1, 4, 1, 4};
+  read(array_name, read_query_buffers, subarray_full);
+
+  // Each value in `a1_read_buffer` corresponds to its index in
+  // the original `a1_write_buffer`. Check that the ordering of
+  // the validity buffer matches the ordering in the value buffer.
+  REQUIRE(a1_read_buffer_size == a1_write_buffer_size);
+  REQUIRE(a1_read_buffer_validity_size == a1_write_buffer_validity_size);
+  uint8_t expected_a1_read_buffer_validity[16];
+  for (int i = 0; i < 16; ++i) {
+    const uint64_t idx = a1_read_buffer[i];
+    expected_a1_read_buffer_validity[i] = a1_write_buffer_validity[idx];
+  }
+  REQUIRE(!memcmp(
+      a1_read_buffer_validity,
+      expected_a1_read_buffer_validity,
+      a1_read_buffer_validity_size));
+
+  // Each value in `a2_read_buffer` corresponds to its reversed index in
+  // the original `a2_write_buffer`. Check that the ordering of
+  // the validity buffer matches the ordering in the value buffer.
+  if (test_attrs.size() >= 2) {
+    REQUIRE(a2_read_buffer_size == a2_write_buffer_size);
+    REQUIRE(a2_read_buffer_validity_size == a2_write_buffer_validity_size);
+    uint8_t expected_a2_read_buffer_validity[16];
+    for (int i = 0; i < 16; ++i) {
+      const uint64_t idx = a2_read_buffer[16 - 1 - i];
+      expected_a2_read_buffer_validity[i] = a2_write_buffer_validity[idx];
+    }
+    REQUIRE(!memcmp(
+        a2_read_buffer_validity,
+        expected_a2_read_buffer_validity,
+        a2_read_buffer_validity_size));
+  }
+
+  // Each value in `a3_read_buffer_var` corresponds to its index in
+  // the original `a3_write_buffer_var`. Check that the ordering of
+  // the validity buffer matches the ordering in the value buffer.
+  if (test_attrs.size() >= 3) {
+    REQUIRE(a3_read_buffer_size == a3_write_buffer_size);
+    REQUIRE(a3_read_buffer_var_size == a3_write_buffer_var_size);
+    REQUIRE(a3_read_buffer_validity_size == a3_write_buffer_validity_size);
+    uint8_t expected_a3_read_buffer_validity[32];
+    for (int i = 0; i < 32; ++i) {
+      const uint64_t idx = a3_read_buffer_var[i];
+      expected_a3_read_buffer_validity[i] = a3_write_buffer_validity[idx];
+    }
+    REQUIRE(!memcmp(
+        a3_read_buffer_validity,
+        expected_a3_read_buffer_validity,
+        a3_read_buffer_validity_size));
+  }
+
+  // Execute a read query over a partial domain.
+  const uint64_t subarray_partial[] = {2, 3, 2, 3};
+  read(array_name, read_query_buffers, subarray_partial);
+
+  // Each value in `a1_read_buffer` corresponds to its index in
+  // the original `a1_write_buffer`. Check that the ordering of
+  // the validity buffer matches the ordering in the value buffer.
+  REQUIRE(a1_read_buffer_size == a1_write_buffer_size / 4);
+  REQUIRE(a1_read_buffer_validity_size == a1_write_buffer_validity_size / 4);
+  for (int i = 0; i < 4; ++i) {
+    const uint64_t idx = a1_read_buffer[i];
+    expected_a1_read_buffer_validity[i] = a1_write_buffer_validity[idx];
+  }
+  REQUIRE(!memcmp(
+      a1_read_buffer_validity,
+      expected_a1_read_buffer_validity,
+      a1_read_buffer_validity_size));
+
+  // Each value in `a2_read_buffer` corresponds to its reversed index in
+  // the original `a2_write_buffer`. Check that the ordering of
+  // the validity buffer matches the ordering in the value buffer.
+  if (test_attrs.size() >= 2) {
+    REQUIRE(a2_read_buffer_size == a2_write_buffer_size / 4);
+    REQUIRE(a2_read_buffer_validity_size == a2_write_buffer_validity_size / 4);
+    uint8_t expected_a2_read_buffer_validity[4];
+    for (int i = 0; i < 4; ++i) {
+      const uint64_t idx = a2_read_buffer[4 - 1 - i];
+      expected_a2_read_buffer_validity[i] = a2_write_buffer_validity[idx];
+    }
+    REQUIRE(!memcmp(
+        a2_read_buffer_validity,
+        expected_a2_read_buffer_validity,
+        a2_read_buffer_validity_size));
+  }
+
+  // Each value in `a3_read_buffer_var` corresponds to its index in
+  // the original `a3_write_buffer_var`. Check that the ordering of
+  // the validity buffer matches the ordering in the value buffer.
+  if (test_attrs.size() >= 3) {
+    REQUIRE(a3_read_buffer_size == a3_write_buffer_size / 4);
+    REQUIRE(a3_read_buffer_var_size == a3_write_buffer_var_size / 4);
+    REQUIRE(a3_read_buffer_validity_size == a3_write_buffer_validity_size / 4);
+    uint8_t expected_a3_read_buffer_validity[32];
+    for (int i = 0; i < 8; ++i) {
+      const uint64_t idx = a3_read_buffer_var[i];
+      expected_a3_read_buffer_validity[i] = a3_write_buffer_validity[idx];
+    }
+    REQUIRE(!memcmp(
+        a3_read_buffer_validity,
+        expected_a3_read_buffer_validity,
+        a3_read_buffer_validity_size));
+  }
+}
+
+TEST_CASE_METHOD(
+    NullableArrayFx,
+    "C API: Test 2D array with nullable attributes",
+    "[capi][2d][nullable]") {
+  vector<test_attr_t> attrs;
+  attrs.emplace_back("a1", TILEDB_INT32, 1, true);
+  attrs.emplace_back("a2", TILEDB_INT32, 1, true);
+  attrs.emplace_back("a3", TILEDB_INT32, TILEDB_VAR_NUM, true);
+
+  for (auto attr_iter = attrs.begin(); attr_iter != attrs.end(); ++attr_iter) {
+    vector<test_attr_t> test_attrs(attrs.begin(), attr_iter + 1);
+    for (const tiledb_array_type_t array_type : {TILEDB_DENSE, TILEDB_SPARSE}) {
+      for (const tiledb_layout_t cell_order :
+           {TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR}) {
+        for (const tiledb_layout_t tile_order :
+             {TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR}) {
+          for (const tiledb_layout_t write_order : {TILEDB_ROW_MAJOR,
+                                                    TILEDB_COL_MAJOR,
+                                                    TILEDB_UNORDERED,
+                                                    TILEDB_GLOBAL_ORDER}) {
+            do_2d_nullable_test(
+                test_attrs, array_type, cell_order, tile_order, write_order);
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/src/unit-cppapi-fill_values.cc
+++ b/test/src/unit-cppapi-fill_values.cc
@@ -247,8 +247,9 @@ TEST_CASE(
 
   // Check dump
   std::string dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-                     "- Type: INT32\n" + "- Cell val num: 1\n" +
-                     "- Filters: 0\n" + "- Fill value: -2147483648\n";
+                     "- Type: INT32\n" + "- Nullable: false\n" +
+                     "- Cell val num: 1\n" + "- Filters: 0\n" +
+                     "- Fill value: -2147483648\n";
   check_dump(a, dump);
 
   // Correct setter
@@ -261,8 +262,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: 1\n" + "- Filters: 0\n" +
-         "- Fill value: 5\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: 1\n" +
+         "- Filters: 0\n" + "- Fill value: 5\n";
   check_dump(a, dump);
 
   // Setting the cell val num, also sets the fill value to a new default
@@ -274,8 +275,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: 2\n" + "- Filters: 0\n" +
-         "- Fill value: -2147483648, -2147483648\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: 2\n" +
+         "- Filters: 0\n" + "- Fill value: -2147483648, -2147483648\n";
   check_dump(a, dump);
 
   // Set a fill value that is comprised of two integers
@@ -290,8 +291,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: 2\n" + "- Filters: 0\n" +
-         "- Fill value: 1, 2\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: 2\n" +
+         "- Filters: 0\n" + "- Fill value: 1, 2\n";
   check_dump(a, dump);
 
   // Make the attribute var-sized
@@ -299,8 +300,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: var\n" + "- Filters: 0\n" +
-         "- Fill value: -2147483648\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: var\n" +
+         "- Filters: 0\n" + "- Fill value: -2147483648\n";
   check_dump(a, dump);
 
   // Get the default var-sized fill value
@@ -321,8 +322,8 @@ TEST_CASE(
 
   // Check dump
   dump = std::string("### Attribute ###\n") + "- Name: a\n" +
-         "- Type: INT32\n" + "- Cell val num: var\n" + "- Filters: 0\n" +
-         "- Fill value: 1, 2, 3\n";
+         "- Type: INT32\n" + "- Nullable: false\n" + "- Cell val num: var\n" +
+         "- Filters: 0\n" + "- Fill value: 1, 2, 3\n";
   check_dump(a, dump);
 }
 

--- a/test/src/unit-cppapi-nullable.cc
+++ b/test/src/unit-cppapi-nullable.cc
@@ -1,0 +1,564 @@
+/**
+ * @file unit-cppapi-nullable.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests arrays with nullable attributes.
+ */
+
+#include "catch.hpp"
+#include "test/src/helpers.h"
+#include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/misc/utils.h"
+
+#include <iostream>
+#include <vector>
+
+using namespace std;
+using namespace tiledb;
+using namespace tiledb::test;
+
+template <typename T>
+struct test_dim_t {
+  test_dim_t(
+      const string& name, const array<T, 2>& domain, const uint64_t tile_extent)
+      : name_(name)
+      , domain_(domain)
+      , tile_extent_(tile_extent) {
+  }
+
+  string name_;
+  array<T, 2> domain_;
+  uint64_t tile_extent_;
+};
+
+template <typename T>
+struct test_attr_t {
+  test_attr_t(const string& name, const bool var, const bool nullable)
+      : name_(name)
+      , var_(var)
+      , nullable_(nullable) {
+  }
+
+  string name_;
+  bool var_;
+  bool nullable_;
+};
+
+template <typename T>
+struct test_query_buffer_t {
+  test_query_buffer_t(const string& name, vector<T>* const data)
+      : name_(name)
+      , offsets_(nullptr)
+      , data_(data)
+      , validity_bytemap_(nullptr) {
+  }
+
+  test_query_buffer_t(
+      const string& name,
+      vector<T>* const data,
+      vector<uint8_t>* const validity_bytemap)
+      : name_(name)
+      , offsets_(nullptr)
+      , data_(data)
+      , validity_bytemap_(std::move(validity_bytemap)) {
+  }
+
+  test_query_buffer_t(
+      const string& name,
+      vector<uint64_t>* const offsets,
+      vector<T>* const data,
+      vector<uint8_t>* const validity_bytemap)
+      : name_(name)
+      , offsets_(offsets)
+      , data_(data)
+      , validity_bytemap_(validity_bytemap) {
+  }
+
+  string name_;
+  vector<uint64_t>* offsets_;
+  vector<T>* data_;
+  vector<uint8_t>* validity_bytemap_;
+};
+
+class NullableArrayCppFx {
+ public:
+  /** Constructor. */
+  NullableArrayCppFx();
+
+  /** Destructor. */
+  ~NullableArrayCppFx();
+
+  /**
+   * Creates, writes, and reads nullable attributes.
+   *
+   * @param test_attrs The nullable attributes to test.
+   * @param array_type The type of the array (dense/sparse).
+   * @param cell_order The cell order of the array.
+   * @param tile_order The tile order of the array.
+   * @param write_order The write layout.
+   */
+  template <typename ATTR_T>
+  void do_2d_nullable_test(
+      const vector<test_attr_t<ATTR_T>>& test_attrs,
+      tiledb_array_type_t array_type,
+      tiledb_layout_t cell_order,
+      tiledb_layout_t tile_order,
+      tiledb_layout_t write_order);
+
+ private:
+  /** The C++ API context object. */
+  Context ctx_;
+
+  /** The C++ API VFS object. */
+  VFS vfs_;
+
+  /**
+   * Removes a directory using `vfs_`.
+   *
+   * @param path The directory path.
+   */
+  void remove_dir(const string& path);
+
+  /**
+   * Creates a TileDB array.
+   *
+   * @param array_name The name of the array.
+   * @param array_type The type of the array (dense/sparse).
+   * @param test_dims The dimensions in the array.
+   * @param test_attrs The attributes in the array.
+   * @param cell_order The cell order of the array.
+   * @param tile_order The tile order of the array.
+   */
+  template <typename DIM_T, typename ATTR_T>
+  void create_array(
+      const string& array_name,
+      tiledb_array_type_t array_type,
+      const vector<test_dim_t<DIM_T>>& test_dims,
+      const vector<test_attr_t<ATTR_T>>& test_attrs,
+      tiledb_layout_t cell_order,
+      tiledb_layout_t tile_order);
+
+  /**
+   * Creates and executes a single write query.
+   *
+   * @param array_name The name of the array.
+   * @param test_query_buffers The query buffers to write.
+   * @param layout The write layout.
+   */
+  template <typename ATTR_T>
+  void write(
+      const string& array_name,
+      const vector<test_query_buffer_t<ATTR_T>>& test_query_buffers,
+      tiledb_layout_t layout);
+
+  /**
+   * Creates and executes a single read query.
+   *
+   * @param array_name The name of the array.
+   * @param test_query_buffers The query buffers to read.
+   * @param subarray The subarray to read.
+   */
+  template <typename ATTR_T>
+  void read(
+      const string& array_name,
+      const vector<test_query_buffer_t<ATTR_T>>& test_query_buffers,
+      const vector<uint64_t>& subarray);
+};
+
+NullableArrayCppFx::NullableArrayCppFx()
+    : vfs_(ctx_) {
+}
+
+NullableArrayCppFx::~NullableArrayCppFx() {
+}
+
+void NullableArrayCppFx::remove_dir(const string& path) {
+  if (vfs_.is_dir(path))
+    vfs_.remove_dir(path);
+}
+
+template <typename DIM_T, typename ATTR_T>
+void NullableArrayCppFx::create_array(
+    const string& array_name,
+    const tiledb_array_type_t array_type,
+    const vector<test_dim_t<DIM_T>>& test_dims,
+    const vector<test_attr_t<ATTR_T>>& test_attrs,
+    const tiledb_layout_t cell_order,
+    const tiledb_layout_t tile_order) {
+  remove_dir(array_name);
+
+  // Create the domain.
+  Domain domain(ctx_);
+
+  // Create the dimensions.
+  for (const auto& test_dim : test_dims) {
+    domain.add_dimension(Dimension::create<DIM_T>(
+        ctx_, test_dim.name_, test_dim.domain_, test_dim.tile_extent_));
+  }
+
+  // Create the array schema.
+  ArraySchema schema(ctx_, array_type);
+  schema.set_domain(domain);
+  schema.set_cell_order(cell_order);
+  schema.set_tile_order(tile_order);
+
+  // Create the attributes.
+  for (const auto& test_attr : test_attrs) {
+    Attribute attr =
+        test_attr.var_ ?
+            Attribute::create<vector<ATTR_T>>(ctx_, test_attr.name_) :
+            Attribute::create<ATTR_T>(ctx_, test_attr.name_);
+    attr.set_nullable(test_attr.nullable_);
+    schema.add_attribute(attr);
+  }
+
+  // Check the array schema.
+  schema.check();
+
+  // Create the array.
+  Array::create(array_name, schema);
+}
+
+template <typename ATTR_T>
+void NullableArrayCppFx::write(
+    const string& array_name,
+    const vector<test_query_buffer_t<ATTR_T>>& test_query_buffers,
+    const tiledb_layout_t layout) {
+  // Open the array for writing.
+  Array array(ctx_, array_name, TILEDB_WRITE);
+  REQUIRE(array.is_open());
+
+  // Create the write query.
+  Query query(ctx_, array, TILEDB_WRITE);
+
+  // Set the query layout.
+  query.set_layout(layout);
+
+  // Set the query buffers.
+  for (const auto& test_query_buffer : test_query_buffers) {
+    if (!test_query_buffer.validity_bytemap_) {
+      if (!test_query_buffer.offsets_) {
+        query.set_buffer(test_query_buffer.name_, *test_query_buffer.data_);
+      } else {
+        query.set_buffer(
+            test_query_buffer.name_,
+            *test_query_buffer.offsets_,
+            *test_query_buffer.data_);
+      }
+    } else {
+      if (!test_query_buffer.offsets_) {
+        query.set_buffer_nullable(
+            test_query_buffer.name_,
+            *test_query_buffer.data_,
+            *test_query_buffer.validity_bytemap_);
+      } else {
+        query.set_buffer_nullable(
+            test_query_buffer.name_,
+            *test_query_buffer.offsets_,
+            *test_query_buffer.data_,
+            *test_query_buffer.validity_bytemap_);
+      }
+    }
+  }
+
+  // Submit the query.
+  REQUIRE(query.submit() == Query::Status::COMPLETE);
+
+  // Finalize the query, a no-op for non-global writes.
+  query.finalize();
+
+  // Clean up
+  array.close();
+}
+
+template <typename ATTR_T>
+void NullableArrayCppFx::read(
+    const string& array_name,
+    const vector<test_query_buffer_t<ATTR_T>>& test_query_buffers,
+    const vector<uint64_t>& subarray) {
+  // Open the array for reading.
+  Array array(ctx_, array_name, TILEDB_READ);
+  REQUIRE(array.is_open());
+
+  // Create the read query.
+  Query query(ctx_, array, TILEDB_READ);
+
+  // Set the query buffers.
+  for (const auto& test_query_buffer : test_query_buffers) {
+    if (!test_query_buffer.validity_bytemap_) {
+      if (!test_query_buffer.offsets_) {
+        query.set_buffer(test_query_buffer.name_, *test_query_buffer.data_);
+      } else {
+        query.set_buffer(
+            test_query_buffer.name_,
+            *test_query_buffer.offsets_,
+            *test_query_buffer.data_);
+      }
+    } else {
+      if (!test_query_buffer.offsets_) {
+        query.set_buffer_nullable(
+            test_query_buffer.name_,
+            *test_query_buffer.data_,
+            *test_query_buffer.validity_bytemap_);
+      } else {
+        query.set_buffer_nullable(
+            test_query_buffer.name_,
+            *test_query_buffer.offsets_,
+            *test_query_buffer.data_,
+            *test_query_buffer.validity_bytemap_);
+      }
+    }
+  }
+
+  // Set the subarray to read.
+  query.set_subarray(subarray);
+
+  // Submit the query.
+  REQUIRE(query.submit() == Query::Status::COMPLETE);
+
+  // Finalize the query, a no-op for non-global reads.
+  query.finalize();
+
+  // Clean up
+  array.close();
+}
+
+template <typename ATTR_T>
+void NullableArrayCppFx::do_2d_nullable_test(
+    const vector<test_attr_t<ATTR_T>>& test_attrs,
+    const tiledb_array_type_t array_type,
+    const tiledb_layout_t cell_order,
+    const tiledb_layout_t tile_order,
+    const tiledb_layout_t write_order) {
+  const string array_name = "cpp_2d_nullable_array";
+
+  // Skip row-major and col-major writes for sparse arrays.
+  if (array_type == TILEDB_SPARSE &&
+      (write_order == TILEDB_ROW_MAJOR || write_order == TILEDB_COL_MAJOR)) {
+    return;
+  }
+
+  // Define the dimensions.
+  vector<test_dim_t<uint64_t>> test_dims;
+  const array<uint64_t, 2> d1_domain = {1, 4};
+  const uint64_t d1_tile_extent = 2;
+  test_dims.emplace_back("d1", d1_domain, d1_tile_extent);
+  const array<uint64_t, 2> d2_domain = {1, 4};
+  const uint64_t d2_tile_extent = 2;
+  test_dims.emplace_back("d2", d2_domain, d2_tile_extent);
+
+  // Create the array.
+  create_array(
+      array_name, array_type, test_dims, test_attrs, cell_order, tile_order);
+
+  // Define the write query buffers for "a1".
+  vector<test_query_buffer_t<ATTR_T>> write_query_buffers;
+  vector<ATTR_T> a1_write_buffer;
+  for (int i = 0; i < 16; ++i)
+    a1_write_buffer.emplace_back(i);
+  vector<uint8_t> a1_write_buffer_validity;
+  for (int i = 0; i < 16; ++i)
+    a1_write_buffer_validity.emplace_back(rand() % 2);
+  write_query_buffers.emplace_back(
+      "a1", &a1_write_buffer, &a1_write_buffer_validity);
+
+  // Define the write query buffers for "a2".
+  vector<ATTR_T> a2_write_buffer(a1_write_buffer.size());
+  for (size_t i = 0; i < a1_write_buffer.size(); ++i)
+    a2_write_buffer[i] = a1_write_buffer[a1_write_buffer.size() - 1 - i];
+  vector<uint8_t> a2_write_buffer_validity(a1_write_buffer_validity.size());
+  for (size_t i = 0; i < a1_write_buffer_validity.size(); ++i)
+    a2_write_buffer_validity[i] =
+        a1_write_buffer_validity[a1_write_buffer_validity.size() - 1 - i];
+  if (test_attrs.size() >= 2) {
+    write_query_buffers.emplace_back(
+        "a2", &a2_write_buffer, &a2_write_buffer_validity);
+  }
+
+  // Define the write query buffers for "a3".
+  vector<uint64_t> a3_write_buffer;
+  for (uint64_t i = 0; i < 16; ++i)
+    a3_write_buffer.emplace_back(i * sizeof(int) * 2);
+  vector<ATTR_T> a3_write_buffer_var;
+  for (int i = 0; i < 32; ++i)
+    a3_write_buffer_var.emplace_back(i);
+  vector<uint8_t> a3_write_buffer_validity;
+  for (int i = 0; i < 32; ++i)
+    a3_write_buffer_validity.emplace_back(rand() % 2);
+  if (test_attrs.size() >= 3) {
+    write_query_buffers.emplace_back(
+        "a3",
+        &a3_write_buffer,
+        &a3_write_buffer_var,
+        &a3_write_buffer_validity);
+  }
+
+  // Define dimension query buffers for either sparse arrays or dense arrays
+  // with an unordered write order.
+  vector<uint64_t> d1_write_buffer;
+  vector<uint64_t> d2_write_buffer;
+  if (array_type == TILEDB_SPARSE || write_order == TILEDB_UNORDERED) {
+    // Coordinates for sparse arrays written in global order have unique
+    // ordering when either/both cell and tile ordering is col-major.
+    if (array_type == TILEDB_SPARSE && write_order == TILEDB_GLOBAL_ORDER &&
+        (cell_order == TILEDB_COL_MAJOR || tile_order == TILEDB_COL_MAJOR)) {
+      if (cell_order == TILEDB_ROW_MAJOR && tile_order == TILEDB_COL_MAJOR) {
+        d1_write_buffer = {1, 1, 2, 2, 3, 3, 4, 4, 1, 1, 2, 2, 3, 3, 4, 4};
+        d2_write_buffer = {1, 2, 1, 2, 1, 2, 1, 2, 3, 4, 3, 4, 3, 4, 3, 4};
+      } else if (
+          cell_order == TILEDB_COL_MAJOR && tile_order == TILEDB_ROW_MAJOR) {
+        d1_write_buffer = {1, 2, 1, 2, 1, 2, 1, 2, 3, 4, 3, 4, 3, 4, 3, 4};
+        d2_write_buffer = {1, 1, 2, 2, 3, 3, 4, 4, 1, 1, 2, 2, 3, 3, 4, 4};
+      } else {
+        REQUIRE(cell_order == TILEDB_COL_MAJOR);
+        REQUIRE(tile_order == TILEDB_COL_MAJOR);
+        d1_write_buffer = {1, 2, 1, 2, 3, 4, 3, 4, 1, 2, 1, 2, 3, 4, 3, 4};
+        d2_write_buffer = {1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 4, 4};
+      }
+    } else {
+      d1_write_buffer = {1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 4, 4};
+      d2_write_buffer = {1, 2, 1, 2, 3, 4, 3, 4, 1, 2, 1, 2, 3, 4, 3, 4};
+    }
+
+    write_query_buffers.emplace_back("d1", &d1_write_buffer);
+    write_query_buffers.emplace_back("d2", &d2_write_buffer);
+  }
+
+  // Execute the write query.
+  write(array_name, write_query_buffers, write_order);
+
+  // Define the read query buffers for "a1".
+  vector<test_query_buffer_t<uint64_t>> read_query_buffers;
+  vector<ATTR_T> a1_read_buffer(16);
+  vector<uint8_t> a1_read_buffer_validity(16);
+  read_query_buffers.emplace_back(
+      "a1", &a1_read_buffer, &a1_read_buffer_validity);
+
+  // Define the read query buffers for "a2".
+  vector<ATTR_T> a2_read_buffer(16);
+  vector<uint8_t> a2_read_buffer_validity(16);
+  if (test_attrs.size() >= 2) {
+    read_query_buffers.emplace_back(
+        "a2", &a2_read_buffer, &a2_read_buffer_validity);
+  }
+
+  // Define the read query buffers for "a3".
+  vector<uint64_t> a3_read_buffer(16);
+  vector<ATTR_T> a3_read_buffer_var(32);
+  vector<uint8_t> a3_read_buffer_validity(32);
+  if (test_attrs.size() >= 3) {
+    read_query_buffers.emplace_back(
+        "a3", &a3_read_buffer, &a3_read_buffer_var, &a3_read_buffer_validity);
+  }
+
+  // Execute a read query over the entire domain.
+  const vector<uint64_t> subarray_full = {1, 4, 1, 4};
+  read(array_name, read_query_buffers, subarray_full);
+
+  // Each value in `a1_read_buffer` corresponds to its index in
+  // the original `a1_write_buffer`. Check that the ordering of
+  // the validity buffer matches the ordering in the value buffer.
+  REQUIRE(a1_read_buffer.size() == a1_write_buffer.size());
+  REQUIRE(a1_read_buffer_validity.size() == a1_write_buffer_validity.size());
+  vector<uint8_t> expected_a1_read_buffer_validity(16);
+  for (int i = 0; i < 16; ++i) {
+    const uint64_t idx = a1_read_buffer[i];
+    expected_a1_read_buffer_validity[i] = a1_write_buffer_validity[idx];
+  }
+  REQUIRE(!memcmp(
+      a1_read_buffer_validity.data(),
+      expected_a1_read_buffer_validity.data(),
+      a1_read_buffer_validity.size()));
+
+  // Each value in `a2_read_buffer` corresponds to its reversed index in
+  // the original `a2_write_buffer`. Check that the ordering of
+  // the validity buffer matches the ordering in the value buffer.
+  if (test_attrs.size() >= 2) {
+    REQUIRE(a2_read_buffer.size() == a2_write_buffer.size());
+    REQUIRE(a2_read_buffer_validity.size() == a2_write_buffer_validity.size());
+    vector<uint8_t> expected_a2_read_buffer_validity(16);
+    for (int i = 0; i < 16; ++i) {
+      const uint64_t idx = a2_read_buffer[16 - 1 - i];
+      expected_a2_read_buffer_validity[i] = a2_write_buffer_validity[idx];
+    }
+    REQUIRE(!memcmp(
+        a2_read_buffer_validity.data(),
+        expected_a2_read_buffer_validity.data(),
+        a2_read_buffer_validity.size()));
+  }
+
+  // Each value in `a3_read_buffer_var` corresponds to its index in
+  // the original `a3_write_buffer_var`. Check that the ordering of
+  // the validity buffer matches the ordering in the value buffer.
+  if (test_attrs.size() >= 3) {
+    REQUIRE(a3_read_buffer.size() == a3_write_buffer.size());
+    REQUIRE(a3_read_buffer_var.size() == a3_write_buffer_var.size());
+    REQUIRE(a3_read_buffer_validity.size() == a3_write_buffer_validity.size());
+    vector<uint8_t> expected_a3_read_buffer_validity(32);
+    for (int i = 0; i < 32; ++i) {
+      const uint64_t idx = a3_read_buffer_var[i];
+      expected_a3_read_buffer_validity[i] = a3_write_buffer_validity[idx];
+    }
+    REQUIRE(!memcmp(
+        a3_read_buffer_validity.data(),
+        expected_a3_read_buffer_validity.data(),
+        a3_read_buffer_validity.size()));
+  }
+
+  // TODO JOE add scoped executor
+  remove_dir(array_name);
+}
+
+TEST_CASE_METHOD(
+    NullableArrayCppFx,
+    "C++ API: Test 2D array with nullable attributes",
+    "[cppapi][2d][nullable]") {
+  vector<test_attr_t<uint64_t>> attrs;
+  attrs.emplace_back("a1", false /* var */, true /* nullable */);
+  attrs.emplace_back("a2", false /* var */, true /* nullable */);
+  attrs.emplace_back("a3", true /* var */, true /* nullable */);
+
+  for (auto attr_iter = attrs.begin(); attr_iter != attrs.end(); ++attr_iter) {
+    vector<test_attr_t<uint64_t>> test_attrs(attrs.begin(), attr_iter + 1);
+    for (const tiledb_array_type_t array_type : {TILEDB_DENSE, TILEDB_SPARSE}) {
+      for (const tiledb_layout_t cell_order :
+           {TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR}) {
+        for (const tiledb_layout_t tile_order :
+             {TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR}) {
+          for (const tiledb_layout_t write_order : {TILEDB_ROW_MAJOR,
+                                                    TILEDB_COL_MAJOR,
+                                                    TILEDB_UNORDERED,
+                                                    TILEDB_GLOBAL_ORDER}) {
+            do_2d_nullable_test(
+                test_attrs, array_type, cell_order, tile_order, write_order);
+          }
+        }
+      }
+    }
+  }
+}

--- a/tiledb/common/status.cc
+++ b/tiledb/common/status.cc
@@ -135,6 +135,9 @@ std::string Status::code_to_string() const {
     case StatusCode::Query:
       type = "[TileDB::Query] Error";
       break;
+    case StatusCode::ValidityVector:
+      type = "[TileDB::ValidityVector] Error";
+      break;
     case StatusCode::VFS:
       type = "[TileDB::VFS] Error";
       break;

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -91,6 +91,7 @@ enum class StatusCode : char {
   ChunkedBuffer,
   Buffer,
   Query,
+  ValidityVector,
   VFS,
   ConstBuffer,
   Dimension,
@@ -231,6 +232,11 @@ class Status {
   /** Return a QueryError error class Status with a given message **/
   static Status QueryError(const std::string& msg) {
     return Status(StatusCode::Query, msg, -1);
+  }
+
+  /** Return a ValidityVectorError error class Status with a given message **/
+  static Status ValidityVectorError(const std::string& msg) {
+    return Status(StatusCode::ValidityVector, msg, -1);
   }
 
   /** Return a VFSError error class Status with a given message **/

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -327,6 +327,13 @@ bool ArraySchema::is_dim(const std::string& name) const {
   return this->dimension(name) != nullptr;
 }
 
+bool ArraySchema::is_nullable(const std::string& name) const {
+  const Attribute* const attr = this->attribute(name);
+  if (attr == nullptr)
+    return false;
+  return attr->nullable();
+}
+
 // ===== FORMAT =====
 // version (uint32_t)
 // allow_dups (bool)

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -190,6 +190,9 @@ class ArraySchema {
   /** Returns true if the input name is a dimension. */
   bool is_dim(const std::string& name) const;
 
+  /** Returns true if the input name is nullable. */
+  bool is_nullable(const std::string& name) const;
+
   /**
    * Serializes the array schema object into a buffer.
    *

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -53,13 +53,16 @@ namespace sm {
 /* ********************************* */
 
 Attribute::Attribute()
-    : Attribute("", Datatype::CHAR) {
+    : Attribute("", Datatype::CHAR, false) {
 }
 
-Attribute::Attribute(const std::string& name, Datatype type) {
+Attribute::Attribute(
+    const std::string& name, const Datatype type, const bool nullable) {
   name_ = name;
   type_ = type;
+  nullable_ = nullable;
   cell_val_num_ = (type == Datatype::ANY) ? constants::var_num : 1;
+  nullable_ = false;
   set_default_fill_value();
 }
 
@@ -68,6 +71,7 @@ Attribute::Attribute(const Attribute* attr) {
   name_ = attr->name();
   type_ = attr->type();
   cell_val_num_ = attr->cell_val_num();
+  nullable_ = attr->nullable();
   filters_ = attr->filters_;
   fill_value_ = attr->fill_value_;
 }
@@ -89,7 +93,7 @@ unsigned int Attribute::cell_val_num() const {
   return cell_val_num_;
 }
 
-Status Attribute::deserialize(ConstBuffer* buff, uint32_t version) {
+Status Attribute::deserialize(ConstBuffer* buff, const uint32_t version) {
   // Load attribute name
   uint32_t attribute_name_size;
   RETURN_NOT_OK(buff->read(&attribute_name_size, sizeof(uint32_t)));
@@ -119,6 +123,10 @@ Status Attribute::deserialize(ConstBuffer* buff, uint32_t version) {
     set_default_fill_value();
   }
 
+  // Load nullable flag
+  if (version >= 7)
+    RETURN_NOT_OK(buff->read(&nullable_, sizeof(bool)));
+
   return Status::Ok();
 }
 
@@ -129,6 +137,7 @@ void Attribute::dump(FILE* out) const {
   fprintf(out, "### Attribute ###\n");
   fprintf(out, "- Name: %s\n", name_.c_str());
   fprintf(out, "- Type: %s\n", datatype_str(type_).c_str());
+  fprintf(out, "- Nullable: %s\n", (nullable_ ? "true" : "false"));
   if (!var_size())
     fprintf(out, "- Cell val num: %u\n", cell_val_num_);
   else
@@ -154,7 +163,8 @@ const std::string& Attribute::name() const {
 // type (uint8_t)
 // cell_val_num (uint32_t)
 // filter_pipeline (see FilterPipeline::serialize)
-Status Attribute::serialize(Buffer* buff, uint32_t version) {
+// nullable (bool)
+Status Attribute::serialize(Buffer* buff, const uint32_t version) {
   // Write attribute name
   auto attribute_name_size = (uint32_t)name_.size();
   RETURN_NOT_OK(buff->write(&attribute_name_size, sizeof(uint32_t)));
@@ -178,6 +188,10 @@ Status Attribute::serialize(Buffer* buff, uint32_t version) {
     RETURN_NOT_OK(buff->write(&fill_value_[0], fill_value_.size()));
   }
 
+  // Write nullable
+  if (version >= 7)
+    RETURN_NOT_OK(buff->write(&nullable_, sizeof(bool)));
+
   return Status::Ok();
 }
 
@@ -190,6 +204,11 @@ Status Attribute::set_cell_val_num(unsigned int cell_val_num) {
   cell_val_num_ = cell_val_num;
   set_default_fill_value();
 
+  return Status::Ok();
+}
+
+Status Attribute::set_nullable(const bool nullable) {
+  nullable_ = nullable;
   return Status::Ok();
 }
 
@@ -262,6 +281,10 @@ Datatype Attribute::type() const {
 
 bool Attribute::var_size() const {
   return cell_val_num_ == constants::var_num;
+}
+
+bool Attribute::nullable() const {
+  return nullable_;
 }
 
 /* ********************************* */

--- a/tiledb/sm/array_schema/attribute.h
+++ b/tiledb/sm/array_schema/attribute.h
@@ -67,7 +67,7 @@ class Attribute {
    * @note The default number of values per cell is 1 for all datatypes except
    *     `ANY`, which is always variable-sized.
    */
-  Attribute(const std::string& name, Datatype type);
+  Attribute(const std::string& name, Datatype type, bool nullable = false);
 
   /**
    * Constructor. It clones the input attribute.
@@ -128,6 +128,13 @@ class Attribute {
    */
   Status set_cell_val_num(unsigned int cell_val_num);
 
+  /**
+   * Sets the nullability for this attribute.
+   *
+   * @return Status
+   */
+  Status set_nullable(bool nullable);
+
   /** Sets the filter pipeline for this attribute. */
   Status set_filter_pipeline(const FilterPipeline* pipeline);
 
@@ -158,6 +165,12 @@ class Attribute {
    */
   bool var_size() const;
 
+  /**
+   * Returns *true* if this is a nullable attribute, and *false*
+   * otherwise.
+   */
+  bool nullable() const;
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -165,6 +178,9 @@ class Attribute {
 
   /** The attribute number of values per cell. */
   unsigned cell_val_num_;
+
+  /** True if this attribute may be null. */
+  bool nullable_;
 
   /** The attribute filter pipeline. */
   FilterPipeline filters_;

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -39,6 +39,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/common/status.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/result_coords.h"
 
 #include <vector>

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1455,6 +1455,18 @@ void tiledb_attribute_free(tiledb_attribute_t** attr) {
   }
 }
 
+int32_t tiledb_attribute_set_nullable(
+    tiledb_ctx_t* ctx, tiledb_attribute_t* attr, uint8_t nullable) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, attr) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx, attr->attr_->set_nullable(static_cast<bool>(nullable))))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_attribute_set_filter_list(
     tiledb_ctx_t* ctx,
     tiledb_attribute_t* attr,
@@ -2595,6 +2607,70 @@ int32_t tiledb_query_set_buffer_var(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_set_buffer_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void* buffer,
+    uint64_t* buffer_size,
+    uint8_t* buffer_validity_bytemap,
+    uint64_t* buffer_validity_bytemap_size) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Set attribute buffer
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          query->query_->set_buffer_vbytemap(
+              name,
+              buffer,
+              buffer_size,
+              buffer_validity_bytemap,
+              buffer_validity_bytemap_size)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_set_buffer_var_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t* buffer_off,
+    uint64_t* buffer_off_size,
+    void* buffer_val,
+    uint64_t* buffer_val_size,
+    uint8_t* buffer_validity_bytemap,
+    uint64_t* buffer_validity_bytemap_size) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // On writes, check the provided offsets for validity.
+  if (query->query_->type() == tiledb::sm::QueryType::WRITE &&
+      save_error(
+          ctx,
+          tiledb::sm::Query::check_var_attr_offsets(
+              buffer_off, buffer_off_size, buffer_val_size)))
+    return TILEDB_ERR;
+
+  // Set attribute buffers
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          query->query_->set_buffer_vbytemap(
+              name,
+              buffer_off,
+              buffer_off_size,
+              buffer_val,
+              buffer_val_size,
+              buffer_validity_bytemap,
+              buffer_validity_bytemap_size)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_get_buffer(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
@@ -2630,6 +2706,62 @@ int32_t tiledb_query_get_buffer_var(
           ctx,
           query->query_->get_buffer(
               name, buffer_off, buffer_off_size, buffer_val, buffer_val_size)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_get_buffer_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void** buffer,
+    uint64_t** buffer_size,
+    uint8_t** buffer_validity_bytemap,
+    uint64_t** buffer_validity_bytemap_size) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Set attribute buffer
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          query->query_->get_buffer_vbytemap(
+              name,
+              buffer,
+              buffer_size,
+              buffer_validity_bytemap,
+              buffer_validity_bytemap_size)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_get_buffer_var_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t** buffer_off,
+    uint64_t** buffer_off_size,
+    void** buffer_val,
+    uint64_t** buffer_val_size,
+    uint8_t** buffer_validity_bytemap,
+    uint64_t** buffer_validity_bytemap_size) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Get attribute buffers
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          query->query_->get_buffer_vbytemap(
+              name,
+              buffer_off,
+              buffer_off_size,
+              buffer_val,
+              buffer_val_size,
+              buffer_validity_bytemap,
+              buffer_validity_bytemap_size)))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1875,6 +1875,23 @@ TILEDB_EXPORT int32_t tiledb_attribute_alloc(
 TILEDB_EXPORT void tiledb_attribute_free(tiledb_attribute_t** attr);
 
 /**
+ * Sets the nullability of an attribute.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_attribute_set_nullable(ctx, attr, 1);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param attr The target attribute.
+ * @param nullable Non-zero if the attribute is nullable.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_attribute_set_nullable(
+    tiledb_ctx_t* ctx, tiledb_attribute_t* attr, uint8_t nullable);
+
+/**
  * Sets the filter list for an attribute.
  *
  * **Example:**
@@ -3232,7 +3249,109 @@ TILEDB_EXPORT int32_t tiledb_query_set_buffer_var(
     uint64_t* buffer_val_size);
 
 /**
- * Gets the buffer of a fixed-sized attribute from a query. If the
+ * Sets the buffer for a fixed-sized, nullable attribute to a query, which will
+ * either hold the values to be written (if it is a write query), or will hold
+ * the results from a read query. The validity buffer is a byte map, where each
+ * non-zero byte represents a valid (i.e. "non-null") attribute value.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * int32_t a1[100];
+ * uint64_t a1_size = sizeof(a1);
+ * uint8_t a1_validity[100];
+ * uint64_t a1_validity_size = sizeof(a1_validity);
+ * tiledb_query_set_buffer_nullable(
+ *   ctx, query, "a1", a1, &a1_size, a1_validity, &a1_validity_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param name The attribute/dimension to set the buffer for. Note that
+ *     zipped coordinates have special name `TILEDB_COORDS`.
+ * @param buffer The buffer that either have the input data to be written,
+ *     or will hold the data to be read.
+ * @param buffer_size In the case of writes, this is the size of `buffer`
+ *     in bytes. In the case of reads, this initially contains the allocated
+ *     size of `buffer`, but after the termination of the query
+ *     it will contain the size of the useful (read) data in `buffer`.
+ * @param buffer_validity_bytemap The validity byte map that has exactly
+ *     one value for each value in `buffer`.
+ * @param buffer_validity_bytemap_size In the case of writes, this is the
+ *     size of `buffer_validity_bytemap` in bytes. In the case of reads,
+ *     this initially contains the allocated size of `buffer_validity_bytemap`,
+ *     but after the termination of the query it will contain the size of the
+ *     useful (read) data in `buffer_validity_bytemap`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_set_buffer_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void* buffer,
+    uint64_t* buffer_size,
+    uint8_t* buffer_validity_bytemap,
+    uint64_t* buffer_validity_bytemap_size);
+
+/**
+ * Sets the buffer for a var-sized, nullable attribute to a query, which will
+ * either hold the values to be written (if it is a write query), or will hold
+ * the results from a read query.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint64_t a2_off[10];
+ * uint64_t a2_off_size = sizeof(a2_off);
+ * char a2_val[100];
+ * uint64_t a2_val_size = sizeof(a2_val);
+ * uint8_t a2_validity[100];
+ * uint64_t a2_validity_size = sizeof(a2_validity);
+ * tiledb_query_set_buffer_var(
+ *     ctx, query, "a2", a2_off, &a2_off_size, a2_val, &a2_val_size,
+ *     a2_validity, &a2_validity_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param name The attribute/dimension to set the buffer for.
+ * @param buffer_off The buffer that either have the input data to be written,
+ *     or will hold the data to be read. This buffer holds the starting offsets
+ *     of each cell value in `buffer_val`.
+ * @param buffer_off_size In the case of writes, it is the size of `buffer_off`
+ *     in bytes. In the case of reads, this initially contains the allocated
+ *     size of `buffer_off`, but after the *end of the query*
+ *     (`tiledb_query_submit`) it will contain the size of the useful (read)
+ *     data in `buffer_off`.
+ * @param buffer_val The buffer that either have the input data to be written,
+ *     or will hold the data to be read. This buffer holds the actual var-sized
+ *     cell values.
+ * @param buffer_val_size In the case of writes, it is the size of `buffer_val`
+ *     in bytes. In the case of reads, this initially contains the allocated
+ *     size of `buffer_val`, but after the termination of the function
+ *     it will contain the size of the useful (read) data in `buffer_val`.
+ * @param buffer_validity_bytemap The validity byte map that has exactly
+ *     one value for each value in `buffer`.
+ * @param buffer_validity_bytemap_size In the case of writes, this is the
+ *     size of `buffer_validity_bytemap` in bytes. In the case of reads,
+ *     this initially contains the allocated size of `buffer_validity_bytemap`,
+ *     but after the termination of the query it will contain the size of the
+ *     useful (read) data in `buffer_validity_bytemap`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_set_buffer_var_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t* buffer_off,
+    uint64_t* buffer_off_size,
+    void* buffer_val,
+    uint64_t* buffer_val_size,
+    uint8_t* buffer_validity_bytemap,
+    uint64_t* buffer_validity_bytemap_size);
+
+/**
+ * Gets the buffer of a fixed-sized attribute/dimension from a query. If the
  * buffer has not been set, then `buffer` is set to `nullptr`.
  *
  * **Example:**
@@ -3297,6 +3416,92 @@ TILEDB_EXPORT int32_t tiledb_query_get_buffer_var(
     uint64_t** buffer_off_size,
     void** buffer_val,
     uint64_t** buffer_val_size);
+
+/**
+ * Gets the buffer of a fixed-sized, nullable attribute from a query. If the
+ * buffer has not been set, then `buffer` and `buffer_validity_bytemap` are
+ * set to `nullptr`.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * int* a1;
+ * uint64_t* a1_size;
+ * uint8_t* a1_validity;
+ * uint64_t* a1_validity_size;
+ * tiledb_query_get_buffer(
+ *   ctx, query, "a1", &a1, &a1_size, &a1_validity, &a1_validity_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param name The attribute/dimension to get the buffer for. Note that the
+ *     zipped coordinates have special name `TILEDB_COORDS`.
+ * @param buffer The buffer to retrieve.
+ * @param buffer_size A pointer to the size of the buffer. Note that this is
+ *     a double pointer and returns the original variable address from
+ *     `set_buffer`.
+ * @param buffer_validity_bytemap The validity bytemap buffer to retrieve.
+ * @param buffer_validity_bytemap_size A pointer to the size of the validity
+ *     bytemap buffer. Note that this is a double pointer and returns the
+ * origina variable address from `set_buffer_nullable`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_buffer_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void** buffer,
+    uint64_t** buffer_size,
+    uint8_t** buffer_validity_bytemap,
+    uint64_t** buffer_validity_bytemap_size);
+
+/**
+ * Gets the values and offsets buffers for a var-sized, nullable attribute
+ * to a query. If the buffers have not been set, then `buffer_off`,
+ * `buffer_val`, and `buffer_validity_bytemap` are set to `nullptr`.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint64_t* a2_off;
+ * uint64_t* a2_off_size;
+ * char* a2_val;
+ * uint64_t* a2_val_size;
+ * uint8_t* a2_validity;
+ * uint64_t* a2_validity_size;
+ * tiledb_query_get_buffer_var(
+ *     ctx, query, "a2", &a2_off, &a2_off_size, &a2_val, &a2_val_size,
+ *     &a2_validity, &a2_validity_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param name The attribute/dimension to set the buffer for.
+ * @param buffer_off The offsets buffer to be retrieved.
+ * @param buffer_off_size A pointer to the size of the offsets buffer. Note that
+ *     this is a `uint_64**` pointer and returns the original variable address
+ * from `set_buffer`.
+ * @param buffer_val The values buffer to be retrieved.
+ * @param buffer_val_size A pointer to the size of the values buffer. Note that
+ *     this is a `uint_64**` pointer and returns the original variable address
+ * from `set_buffer`.
+ * @param buffer_validity_bytemap The validity bytemap buffer to retrieve.
+ * @param buffer_validity_bytemap_size A pointer to the size of the validity
+ *     bytemap buffer. Note that this is a double pointer and returns the
+ * origina variable address from `set_buffer_var_nullable`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_buffer_var_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t** buffer_off,
+    uint64_t** buffer_off_size,
+    void** buffer_val,
+    uint64_t** buffer_val_size,
+    uint8_t** buffer_validity_bytemap,
+    uint64_t** buffer_validity_bytemap_size);
 
 /**
  * Sets the layout of the cells to be written or read.

--- a/tiledb/sm/c_api/tiledb_struct_def.h
+++ b/tiledb/sm/c_api/tiledb_struct_def.h
@@ -43,6 +43,7 @@
 #include "tiledb/sm/filter/compression_filter.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/query/query.h"
+#include "tiledb/sm/query/validity_vector.h"
 #include "tiledb/sm/storage_manager/context.h"
 #include "tiledb/sm/subarray/subarray.h"
 #include "tiledb/sm/subarray/subarray_partitioner.h"

--- a/tiledb/sm/cpp_api/attribute.h
+++ b/tiledb/sm/cpp_api/attribute.h
@@ -337,6 +337,25 @@ class Attribute {
     return *this;
   }
 
+  /**
+   * Sets the nullability of an attribute.
+   *
+   * **Example:**
+   * @code{.cpp}
+   * auto a1 = Attribute::create<int>(...);
+   * a1.set_nullable(true);
+   * @endcode
+   *
+   * @param nullable Whether the attribute is nullable.
+   * @return Reference to this Attribute
+   */
+  Attribute& set_nullable(bool nullable) {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_attribute_set_nullable(
+        ctx.ptr().get(), attr_.get(), static_cast<uint8_t>(nullable)));
+    return *this;
+  }
+
   /** Returns the C TileDB attribute object pointer. */
   std::shared_ptr<tiledb_attribute_t> ptr() const {
     return attr_;

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -139,6 +139,17 @@ void FragmentMetadata::set_tile_var_size(
   tile_var_sizes_[idx][tid] = size;
 }
 
+void FragmentMetadata::set_tile_validity_offset(
+    const std::string& name, uint64_t tid, uint64_t step) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  tid += tile_index_base_;
+  assert(tid < tile_validity_offsets_[idx].size());
+  tile_validity_offsets_[idx][tid] = file_validity_sizes_[idx];
+  file_validity_sizes_[idx] += step;
+}
+
 uint64_t FragmentMetadata::cell_num(uint64_t tile_pos) const {
   if (dense_)
     return array_schema_->domain()->cell_num_per_tile();
@@ -328,6 +339,8 @@ Status FragmentMetadata::fragment_size(uint64_t* size) const {
     *size += file_size;
   for (const auto& file_var_size : file_var_sizes_)
     *size += file_var_size;
+  for (const auto& file_validity_size : file_validity_sizes_)
+    *size += file_validity_size;
 
   // Add fragment metadata file size
   assert(meta_file_size_ != 0);  // The file size should be loaded
@@ -395,6 +408,12 @@ Status FragmentMetadata::init(const NDRange& non_empty_domain) {
 
   // Initialize variable tile sizes
   tile_var_sizes_.resize(num);
+
+  // Initialize validity tile offsets
+  tile_validity_offsets_.resize(num);
+  file_validity_sizes_.resize(num);
+  for (unsigned int i = 0; i < num; ++i)
+    file_validity_sizes_[i] = 0;
 
   return Status::Ok();
 }
@@ -478,6 +497,17 @@ Status FragmentMetadata::store(const EncryptionKey& encryption_key) {
     offset += nbytes;
   }
 
+  // Store validity tile offsets
+  if (version_ >= 7) {
+    gt_offsets_.tile_validity_offsets_.resize(num);
+    for (unsigned int i = 0; i < num; ++i) {
+      gt_offsets_.tile_validity_offsets_[i] = offset;
+      RETURN_NOT_OK_ELSE(
+          store_tile_validity_offsets(i, encryption_key, &nbytes), clean_up());
+      offset += nbytes;
+    }
+  }
+
   // Store footer
   RETURN_NOT_OK_ELSE(store_footer(encryption_key), clean_up());
 
@@ -499,6 +529,7 @@ Status FragmentMetadata::set_num_tiles(uint64_t num_tiles) {
     tile_offsets_[i].resize(num_tiles, 0);
     tile_var_offsets_[i].resize(num_tiles, 0);
     tile_var_sizes_[i].resize(num_tiles, 0);
+    tile_validity_offsets_[i].resize(num_tiles, 0);
   }
 
   if (!dense_) {
@@ -532,6 +563,10 @@ URI FragmentMetadata::var_uri(const std::string& name) const {
   return fragment_uri_.join_path(name + "_var" + constants::file_suffix);
 }
 
+URI FragmentMetadata::validity_uri(const std::string& name) const {
+  return fragment_uri_.join_path(name + "_validity" + constants::file_suffix);
+}
+
 Status FragmentMetadata::load_tile_offsets(
     const EncryptionKey& encryption_key, std::vector<std::string>&& names) {
   // Sort 'names' in ascending order of their index. The
@@ -557,6 +592,12 @@ Status FragmentMetadata::load_tile_offsets(
   for (const auto& name : names) {
     if (array_schema_->var_size(name))
       RETURN_NOT_OK(load_tile_var_offsets(encryption_key, idx_map_[name]));
+  }
+
+  // Load all of the var offsets.
+  for (const auto& name : names) {
+    if (array_schema_->is_nullable(name))
+      RETURN_NOT_OK(load_tile_validity_offsets(encryption_key, idx_map_[name]));
   }
 
   return Status::Ok();
@@ -585,6 +626,19 @@ Status FragmentMetadata::file_var_offset(
   auto idx = it->second;
   RETURN_NOT_OK(load_tile_var_offsets(encryption_key, idx));
   *offset = tile_var_offsets_[idx][tile_idx];
+  return Status::Ok();
+}
+
+Status FragmentMetadata::file_validity_offset(
+    const EncryptionKey& encryption_key,
+    const std::string& name,
+    uint64_t tile_idx,
+    uint64_t* offset) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  RETURN_NOT_OK(load_tile_validity_offsets(encryption_key, idx));
+  *offset = tile_validity_offsets_[idx][tile_idx];
   return Status::Ok();
 }
 
@@ -625,6 +679,7 @@ Status FragmentMetadata::persisted_tile_var_size(
   assert(it != idx_map_.end());
   auto idx = it->second;
   RETURN_NOT_OK(load_tile_var_offsets(encryption_key, idx));
+
   auto tile_num = this->tile_num();
 
   *tile_size = (tile_idx != tile_num - 1) ?
@@ -634,6 +689,29 @@ Status FragmentMetadata::persisted_tile_var_size(
 
   return Status::Ok();
 }
+
+Status FragmentMetadata::persisted_tile_validity_size(
+    const EncryptionKey& encryption_key,
+    const std::string& name,
+    uint64_t tile_idx,
+    uint64_t* tile_size) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  RETURN_NOT_OK(load_tile_validity_offsets(encryption_key, idx));
+
+  auto tile_num = this->tile_num();
+
+  *tile_size =
+      (tile_idx != tile_num - 1) ?
+          tile_validity_offsets_[idx][tile_idx + 1] -
+              tile_validity_offsets_[idx][tile_idx] :
+          file_validity_sizes_[idx] - tile_validity_offsets_[idx][tile_idx];
+
+  return Status::Ok();
+}
+
+// TODO validity persisted size?
 
 uint64_t FragmentMetadata::tile_size(
     const std::string& name, uint64_t tile_idx) const {
@@ -679,6 +757,7 @@ Status FragmentMetadata::write_footer(Buffer* buff) const {
   RETURN_NOT_OK(write_last_tile_cell_num(buff));
   RETURN_NOT_OK(write_file_sizes(buff));
   RETURN_NOT_OK(write_file_var_sizes(buff));
+  RETURN_NOT_OK(write_file_validity_sizes(buff));
   RETURN_NOT_OK(write_generic_tile_offsets(buff));
 
   return Status::Ok();
@@ -724,7 +803,13 @@ Status FragmentMetadata::load_tile_var_sizes(
 
 Status FragmentMetadata::get_footer_size(
     uint32_t version, uint64_t* size) const {
-  *size = (version < 3) ? footer_size_v3_v4() : footer_size_v5_or_higher();
+  if (version < 3) {
+    *size = footer_size_v3_v4();
+  } else if (version < 4) {
+    *size = footer_size_v5_v6();
+  } else {
+    *size = footer_size_v7_or_higher();
+  }
 
   return Status::Ok();
 }
@@ -778,7 +863,7 @@ uint64_t FragmentMetadata::footer_size_v3_v4() const {
   return size;
 }
 
-uint64_t FragmentMetadata::footer_size_v5_or_higher() const {
+uint64_t FragmentMetadata::footer_size_v5_v6() const {
   auto dim_num = array_schema_->dim_num();
   auto num = array_schema_->attribute_num() + dim_num + 1;
   uint64_t domain_size = 0;
@@ -814,6 +899,48 @@ uint64_t FragmentMetadata::footer_size_v5_or_higher() const {
   size += num * sizeof(uint64_t);  // tile offsets
   size += num * sizeof(uint64_t);  // tile var offsets
   size += num * sizeof(uint64_t);  // tile var sizes
+
+  return size;
+}
+
+uint64_t FragmentMetadata::footer_size_v7_or_higher() const {
+  auto dim_num = array_schema_->dim_num();
+  auto num = array_schema_->attribute_num() + dim_num + 1;
+  uint64_t domain_size = 0;
+
+  if (non_empty_domain_.empty()) {
+    // For var-sized dimensions, this function would be called only upon
+    // writing the footer to storage, in which case the non-empty domain
+    // would not be empty. For reading the footer from storage, the footer
+    // size is explicitly stored to and retrieved from storage, so this
+    // function is not called then.
+    assert(array_schema_->domain()->all_dims_fixed());
+    for (unsigned d = 0; d < dim_num; ++d)
+      domain_size += 2 * array_schema_->domain()->dimension(d)->coord_size();
+  } else {
+    for (unsigned d = 0; d < dim_num; ++d) {
+      domain_size += non_empty_domain_[d].size();
+      if (array_schema_->dimension(d)->var_size())
+        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized
+    }
+  }
+
+  // Get footer size
+  uint64_t size = 0;
+  size += sizeof(uint32_t);        // version
+  size += sizeof(char);            // dense
+  size += sizeof(char);            // null non-empty domain
+  size += domain_size;             // non-empty domain
+  size += sizeof(uint64_t);        // sparse tile num
+  size += sizeof(uint64_t);        // last tile cell num
+  size += num * sizeof(uint64_t);  // file sizes
+  size += num * sizeof(uint64_t);  // file var sizes
+  size += num * sizeof(uint64_t);  // file validity sizes
+  size += sizeof(uint64_t);        // R-Tree offset
+  size += num * sizeof(uint64_t);  // tile offsets
+  size += num * sizeof(uint64_t);  // tile var offsets
+  size += num * sizeof(uint64_t);  // tile var sizes
+  size += num * sizeof(uint64_t);  // tile validity sizes
 
   return size;
 }
@@ -1035,6 +1162,32 @@ Status FragmentMetadata::load_tile_var_sizes(
   return Status::Ok();
 }
 
+Status FragmentMetadata::load_tile_validity_offsets(
+    const EncryptionKey& encryption_key, unsigned idx) {
+  if (version_ <= 6)
+    return Status::Ok();
+
+  std::lock_guard<std::mutex> lock(mtx_);
+
+  if (loaded_metadata_.tile_validity_offsets_[idx])
+    return Status::Ok();
+
+  Buffer buff;
+  RETURN_NOT_OK(read_generic_tile_from_file(
+      encryption_key, gt_offsets_.tile_validity_offsets_[idx], &buff));
+
+  // TODO JOE
+  // STATS_ADD_COUNTER(
+  //    stats::Stats::CounterType::READ_TILE_OFFSETS_SIZE, buff.size());
+
+  ConstBuffer cbuff(&buff);
+  RETURN_NOT_OK(load_tile_validity_offsets(idx, &cbuff));
+
+  loaded_metadata_.tile_validity_offsets_[idx] = true;
+
+  return Status::Ok();
+}
+
 // ===== FORMAT =====
 //  bounding_coords_num (uint64_t)
 //  bounding_coords_#1 (void*) bounding_coords_#2 (void*) ...
@@ -1063,6 +1216,8 @@ Status FragmentMetadata::load_file_sizes(ConstBuffer* buff, uint32_t version) {
   else
     return load_file_sizes_v5_or_higher(buff);
 }
+
+// TODO JOE load file validity sizes?
 
 // ===== FORMAT =====
 // file_sizes#0 (uint64_t)
@@ -1132,6 +1287,23 @@ Status FragmentMetadata::load_file_var_sizes_v5_or_higher(ConstBuffer* buff) {
   auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
   file_var_sizes_.resize(num);
   Status st = buff->read(&file_var_sizes_[0], num * sizeof(uint64_t));
+
+  if (!st.ok()) {
+    return LOG_STATUS(Status::FragmentMetadataError(
+        "Cannot load fragment metadata; Reading tile offsets failed"));
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_file_validity_sizes(
+    ConstBuffer* buff, uint32_t version) {
+  if (version <= 6)
+    return Status::Ok();
+
+  auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
+  file_validity_sizes_.resize(num);
+  Status st = buff->read(&file_validity_sizes_[0], num * sizeof(uint64_t));
 
   if (!st.ok()) {
     return LOG_STATUS(Status::FragmentMetadataError(
@@ -1510,6 +1682,37 @@ Status FragmentMetadata::load_tile_var_sizes(unsigned idx, ConstBuffer* buff) {
   return Status::Ok();
 }
 
+Status FragmentMetadata::load_tile_validity_offsets(
+    unsigned idx, ConstBuffer* buff) {
+  Status st;
+  uint64_t tile_validity_offsets_num = 0;
+
+  // Get number of tile offsets
+  st = buff->read(&tile_validity_offsets_num, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status::FragmentMetadataError("Cannot load fragment metadata; Reading "
+                                      "number of validity tile offsets "
+                                      "failed"));
+  }
+
+  // Get tile offsets
+  if (tile_validity_offsets_num != 0) {
+    tile_validity_offsets_[idx].resize(tile_validity_offsets_num);
+    st = buff->read(
+        &tile_validity_offsets_[idx][0],
+        tile_validity_offsets_num * sizeof(uint64_t));
+
+    if (!st.ok()) {
+      return LOG_STATUS(Status::FragmentMetadataError(
+          "Cannot load fragment metadata; Reading validity tile offsets "
+          "failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
 Status FragmentMetadata::load_version(ConstBuffer* buff) {
   RETURN_NOT_OK(buff->read(&version_, sizeof(uint32_t)));
   return Status::Ok();
@@ -1529,8 +1732,10 @@ Status FragmentMetadata::load_generic_tile_offsets(
     ConstBuffer* buff, uint32_t version) {
   if (version == 3 || version == 4)
     return load_generic_tile_offsets_v3_v4(buff);
-  else if (version > 4)
-    return load_generic_tile_offsets_v5_or_higher(buff);
+  else if (version >= 5 && version < 7)
+    return load_generic_tile_offsets_v5_v6(buff);
+  else if (version >= 7)
+    return load_generic_tile_offsets_v7_or_higher(buff);
 
   assert(false);
   return Status::Ok();
@@ -1564,7 +1769,35 @@ Status FragmentMetadata::load_generic_tile_offsets_v3_v4(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-Status FragmentMetadata::load_generic_tile_offsets_v5_or_higher(
+Status FragmentMetadata::load_generic_tile_offsets_v5_v6(ConstBuffer* buff) {
+  // Load R-Tree offset
+  RETURN_NOT_OK(buff->read(&gt_offsets_.rtree_, sizeof(uint64_t)));
+
+  // Load offsets for tile offsets
+  auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
+  gt_offsets_.tile_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(buff->read(&gt_offsets_.tile_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile var offsets
+  gt_offsets_.tile_var_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_var_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile var sizes
+  gt_offsets_.tile_var_sizes_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_var_sizes_[i], sizeof(uint64_t)));
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_generic_tile_offsets_v7_or_higher(
     ConstBuffer* buff) {
   // Load R-Tree offset
   RETURN_NOT_OK(buff->read(&gt_offsets_.rtree_, sizeof(uint64_t)));
@@ -1588,6 +1821,15 @@ Status FragmentMetadata::load_generic_tile_offsets_v5_or_higher(
   for (unsigned i = 0; i < num; ++i) {
     RETURN_NOT_OK(
         buff->read(&gt_offsets_.tile_var_sizes_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile validity offsets
+  if (version_ >= 7) {
+    gt_offsets_.tile_validity_offsets_.resize(num);
+    for (unsigned i = 0; i < num; ++i) {
+      RETURN_NOT_OK(
+          buff->read(&gt_offsets_.tile_validity_offsets_[i], sizeof(uint64_t)));
+    }
   }
 
   return Status::Ok();
@@ -1625,6 +1867,7 @@ Status FragmentMetadata::load_v1_v2(const EncryptionKey& encryption_key) {
   RETURN_NOT_OK(load_last_tile_cell_num(&cbuff));
   RETURN_NOT_OK(load_file_sizes(&cbuff, version_));
   RETURN_NOT_OK(load_file_var_sizes(&cbuff, version_));
+  RETURN_NOT_OK(load_file_validity_sizes(&cbuff, version_));
 
   return Status::Ok();
 }
@@ -1668,6 +1911,7 @@ Status FragmentMetadata::load_footer(
   RETURN_NOT_OK(load_last_tile_cell_num(cbuff.get()));
   RETURN_NOT_OK(load_file_sizes(cbuff.get(), version));
   RETURN_NOT_OK(load_file_var_sizes(cbuff.get(), version));
+  RETURN_NOT_OK(load_file_validity_sizes(cbuff.get(), version));
 
   unsigned num = array_schema_->attribute_num() + 1;
   num += (version >= 5) ? array_schema_->dim_num() : 0;
@@ -1675,10 +1919,12 @@ Status FragmentMetadata::load_footer(
   tile_offsets_.resize(num);
   tile_var_offsets_.resize(num);
   tile_var_sizes_.resize(num);
+  tile_validity_offsets_.resize(num);
 
   loaded_metadata_.tile_offsets_.resize(num, false);
   loaded_metadata_.tile_var_offsets_.resize(num, false);
   loaded_metadata_.tile_var_sizes_.resize(num, false);
+  loaded_metadata_.tile_validity_offsets_.resize(num, false);
 
   RETURN_NOT_OK(load_generic_tile_offsets(cbuff.get(), version));
 
@@ -1709,6 +1955,24 @@ Status FragmentMetadata::write_file_sizes(Buffer* buff) const {
 Status FragmentMetadata::write_file_var_sizes(Buffer* buff) const {
   auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
   Status st = buff->write(&file_var_sizes_[0], num * sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(Status::FragmentMetadataError(
+        "Cannot serialize fragment metadata; Writing file sizes failed"));
+  }
+
+  return Status::Ok();
+}
+
+// ===== FORMAT =====
+// file_validity_sizes#0 (uint64_t)
+// ...
+// file_validity_sizes#{attribute_num+dim_num} (uint64_t)
+Status FragmentMetadata::write_file_validity_sizes(Buffer* buff) const {
+  if (version_ <= 6)
+    return Status::Ok();
+
+  auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
+  Status st = buff->write(&file_validity_sizes_[0], num * sizeof(uint64_t));
   if (!st.ok()) {
     return LOG_STATUS(Status::FragmentMetadataError(
         "Cannot serialize fragment metadata; Writing file sizes failed"));
@@ -1763,6 +2027,18 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
     if (!st.ok()) {
       return LOG_STATUS(Status::FragmentMetadataError(
           "Cannot serialize fragment metadata; Writing tile var sizes failed"));
+    }
+  }
+
+  // Write tile validity offsets
+  if (version_ >= 7) {
+    for (unsigned i = 0; i < num; ++i) {
+      st =
+          buff->write(&gt_offsets_.tile_validity_offsets_[i], sizeof(uint64_t));
+      if (!st.ok()) {
+        return LOG_STATUS(Status::FragmentMetadataError(
+            "Cannot serialize fragment metadata; Writing tile offsets failed"));
+      }
     }
   }
 
@@ -2041,6 +2317,48 @@ Status FragmentMetadata::write_tile_var_sizes(unsigned idx, Buffer* buff) {
                                         "Writing variable tile sizes failed"));
     }
   }
+  return Status::Ok();
+}
+
+Status FragmentMetadata::store_tile_validity_offsets(
+    unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
+  Buffer buff;
+  RETURN_NOT_OK(write_tile_validity_offsets(idx, &buff));
+  RETURN_NOT_OK(
+      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+
+  // TODO JOE
+  // STATS_ADD_COUNTER(
+  //    stats::Stats::CounterType::WRITE_TILE_OFFSETS_SIZE, *nbytes);
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::write_tile_validity_offsets(
+    unsigned idx, Buffer* buff) {
+  Status st;
+
+  // Write number of tile offsets
+  uint64_t tile_validity_offsets_num = tile_validity_offsets_[idx].size();
+  st = buff->write(&tile_validity_offsets_num, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status::FragmentMetadataError("Cannot serialize fragment metadata; "
+                                      "Writing number of validity tile offsets "
+                                      "failed"));
+  }
+
+  // Write tile offsets
+  if (tile_validity_offsets_num != 0) {
+    st = buff->write(
+        &tile_validity_offsets_[idx][0],
+        tile_validity_offsets_num * sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(Status::FragmentMetadataError(
+          "Cannot serialize fragment metadata; Writing tile offsets failed"));
+    }
+  }
+
   return Status::Ok();
 }
 

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -86,6 +86,12 @@ const uint64_t cell_var_offset_size = sizeof(uint64_t);
 /** The type of a variable cell offset. */
 const Datatype cell_var_offset_type = Datatype::UINT64;
 
+/** The size of a validity cell. */
+const uint64_t cell_validity_size = sizeof(uint8_t);
+
+/** The type of a validity cell. */
+const Datatype cell_validity_type = Datatype::UINT8;
+
 /** A special value indicating variable size. */
 const uint64_t var_size = std::numeric_limits<uint64_t>::max();
 
@@ -449,7 +455,7 @@ const int32_t library_version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
 /** The TileDB serialization format version number. */
-const uint32_t format_version = 6;
+const uint32_t format_version = 7;
 
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
 const uint64_t max_tile_chunk_size = 64 * 1024;

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -71,11 +71,17 @@ extern const std::string array_metadata_folder_name;
 /** The default tile capacity. */
 extern const uint64_t capacity;
 
-/** The size of a variable cell offset. */
+/** The size of a variable offset cell. */
 extern const uint64_t cell_var_offset_size;
 
-/** The type of a variable cell offset. */
+/** The type of a variable offset cell. */
 extern const Datatype cell_var_offset_type;
+
+/** The size of a validity cell. */
+extern const uint64_t cell_validity_size;
+
+/** The type of a validity cell. */
+extern const Datatype cell_validity_type;
 
 /** A special value indicating varibale size. */
 extern const uint64_t var_size;

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -237,65 +237,6 @@ typedef std::vector<uint8_t> ByteVecValue;
 /** A byte vector. */
 typedef std::vector<uint8_t> ByteVec;
 
-/** Contains the buffer(s) and buffer size(s) for some attribute/dimension. */
-struct QueryBuffer {
-  /**
-   * The attribute/dimension buffer. In case the attribute/dimension is
-   * var-sized, this is the offsets buffer.
-   */
-  void* buffer_;
-  /**
-   * For a var-sized attribute/dimension, this is the data buffer. It is
-   * `nullptr` for fixed-sized attributes/dimensions.
-   */
-  void* buffer_var_;
-  /**
-   * The size (in bytes) of `buffer_`. Note that this size may be altered by
-   * a read query to reflect the useful data written in the buffer.
-   */
-  uint64_t* buffer_size_;
-  /**
-   * The size (in bytes) of `buffer_var_`. Note that this size may be altered
-   * by a read query to reflect the useful data written in the buffer.
-   */
-  uint64_t* buffer_var_size_;
-  /**
-   * This is the original size (in bytes) of `buffer_` (before
-   * potentially altered by the query).
-   */
-  uint64_t original_buffer_size_;
-  /**
-   * This is the original size (in bytes) of `buffer_var_` (before
-   * potentially altered by the query).
-   */
-  uint64_t original_buffer_var_size_;
-
-  /** Constructor. */
-  QueryBuffer() {
-    buffer_ = nullptr;
-    buffer_var_ = nullptr;
-    buffer_size_ = nullptr;
-    buffer_var_size_ = nullptr;
-    original_buffer_size_ = 0;
-    original_buffer_var_size_ = 0;
-  }
-
-  /** Constructor. */
-  QueryBuffer(
-      void* buffer,
-      void* buffer_var,
-      uint64_t* buffer_size,
-      uint64_t* buffer_var_size)
-      : buffer_(buffer)
-      , buffer_var_(buffer_var)
-      , buffer_size_(buffer_size)
-      , buffer_var_size_(buffer_var_size) {
-    original_buffer_size_ = *buffer_size;
-    original_buffer_var_size_ =
-        (buffer_var_size_ != nullptr) ? *buffer_var_size : 0;
-  }
-};
-
 }  // namespace sm
 
 }  // namespace tiledb

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -268,10 +268,18 @@ Status get_timestamp_range(
 }
 
 Status get_fragment_name_version(const std::string& name, uint32_t* version) {
-  // First check if it is in version 3, which has 5 '_' in the name
+  // First check if it is version 3 or greater, which has 5 '_'
+  // characters in the name.
   size_t n = std::count(name.begin(), name.end(), '_');
   if (n == 5) {
-    *version = 3;
+    // Fetch the fragment version from the fragment name. If the fragment
+    // version is greater than or equal to 7, we have a footer version of 4.
+    // Otherwise, it is version 3.
+    const int frag_version = std::stoi(name.substr(name.find_last_of('_') + 1));
+    if (frag_version >= 7)
+      *version = 4;
+    else
+      *version = 3;
     return Status::Ok();
   }
 

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -334,12 +334,6 @@ std::vector<std::string> Query::buffer_names() const {
   return reader_.buffer_names();
 }
 
-QueryBuffer Query::buffer(const std::string& name) const {
-  if (type_ == QueryType::WRITE)
-    return writer_.buffer(name);
-  return reader_.buffer(name);
-}
-
 Status Query::finalize() {
   if (status_ == QueryStatus::UNINITIALIZED)
     return Status::Ok();
@@ -406,6 +400,101 @@ Status Query::get_buffer(
         name, buffer_off, buffer_off_size, buffer_val, buffer_val_size);
   return reader_.get_buffer(
       name, buffer_off, buffer_off_size, buffer_val, buffer_val_size);
+}
+
+Status Query::get_buffer_vbytemap(
+    const char* name,
+    uint64_t** buffer_off,
+    uint64_t** buffer_off_size,
+    void** buffer_val,
+    uint64_t** buffer_val_size,
+    uint8_t** buffer_validity_bytemap,
+    uint64_t** buffer_validity_bytemap_size) const {
+  const ValidityVector* vv;
+  RETURN_NOT_OK(get_buffer(
+      name, buffer_off, buffer_off_size, buffer_val, buffer_val_size, &vv));
+
+  *buffer_validity_bytemap = vv->bytemap();
+  *buffer_validity_bytemap_size = vv->bytemap_size();
+
+  return Status::Ok();
+}
+
+Status Query::get_buffer_vbytemap(
+    const char* name,
+    void** buffer,
+    uint64_t** buffer_size,
+    uint8_t** buffer_validity_bytemap,
+    uint64_t** buffer_validity_bytemap_size) const {
+  const ValidityVector* vv;
+  RETURN_NOT_OK(get_buffer(name, buffer, buffer_size, &vv));
+
+  *buffer_validity_bytemap = vv->bytemap();
+  *buffer_validity_bytemap_size = vv->bytemap_size();
+
+  return Status::Ok();
+}
+
+Status Query::get_buffer(
+    const char* name,
+    void** buffer,
+    uint64_t** buffer_size,
+    const ValidityVector** validity_vector) const {
+  // Check nullable attribute
+  auto array_schema = this->array_schema();
+  if (array_schema->attribute(name) == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot get buffer; Invalid attribute name '") + name +
+        "'"));
+  if (array_schema->var_size(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot get buffer; '") + name + "' is var-sized"));
+  if (!array_schema->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot get buffer; '") + name + "' is non-nullable"));
+
+  if (type_ == QueryType::WRITE)
+    return writer_.get_buffer_nullable(
+        name, buffer, buffer_size, validity_vector);
+  return reader_.get_buffer_nullable(
+      name, buffer, buffer_size, validity_vector);
+}
+
+Status Query::get_buffer(
+    const char* name,
+    uint64_t** buffer_off,
+    uint64_t** buffer_off_size,
+    void** buffer_val,
+    uint64_t** buffer_val_size,
+    const ValidityVector** validity_vector) const {
+  // Check attribute
+  auto array_schema = this->array_schema();
+  if (array_schema->attribute(name) == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot get buffer; Invalid attribute name '") + name +
+        "'"));
+  if (!array_schema->var_size(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
+  if (!array_schema->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot get buffer; '") + name + "' is non-nullable"));
+
+  if (type_ == QueryType::WRITE)
+    return writer_.get_buffer_nullable(
+        name,
+        buffer_off,
+        buffer_off_size,
+        buffer_val,
+        buffer_val_size,
+        validity_vector);
+  return reader_.get_buffer_nullable(
+      name,
+      buffer_off,
+      buffer_off_size,
+      buffer_val,
+      buffer_val_size,
+      validity_vector);
 }
 
 Status Query::get_attr_serialization_state(
@@ -567,11 +656,7 @@ Writer* Query::writer() {
   return &writer_;
 }
 
-Status Query::set_buffer(
-    const std::string& name,
-    void* buffer,
-    uint64_t* buffer_size,
-    bool check_null_buffers) {
+Status Query::check_set_fixed_buffer(const std::string& name) {
   if (name == constants::coords &&
       !array_->array_schema()->domain()->all_dims_same_type())
     return LOG_STATUS(Status::QueryError(
@@ -584,6 +669,16 @@ Status Query::set_buffer(
         "Cannot set buffer; Setting a buffer for zipped coordinates is not "
         "applicable to domains with variable-sized dimensions"));
 
+  return Status::Ok();
+}
+
+Status Query::set_buffer(
+    const std::string& name,
+    void* const buffer,
+    uint64_t* const buffer_size,
+    const bool check_null_buffers) {
+  RETURN_NOT_OK(check_set_fixed_buffer(name));
+
   if (type_ == QueryType::WRITE)
     return writer_.set_buffer(name, buffer, buffer_size);
   return reader_.set_buffer(name, buffer, buffer_size, check_null_buffers);
@@ -591,11 +686,11 @@ Status Query::set_buffer(
 
 Status Query::set_buffer(
     const std::string& name,
-    uint64_t* buffer_off,
-    uint64_t* buffer_off_size,
-    void* buffer_val,
-    uint64_t* buffer_val_size,
-    bool check_null_buffers) {
+    uint64_t* const buffer_off,
+    uint64_t* const buffer_off_size,
+    void* const buffer_val,
+    uint64_t* const buffer_val_size,
+    const bool check_null_buffers) {
   if (type_ == QueryType::WRITE)
     return writer_.set_buffer(
         name, buffer_off, buffer_off_size, buffer_val, buffer_val_size);
@@ -605,6 +700,91 @@ Status Query::set_buffer(
       buffer_off_size,
       buffer_val,
       buffer_val_size,
+      check_null_buffers);
+}
+
+Status Query::set_buffer_vbytemap(
+    const std::string& name,
+    void* const buffer,
+    uint64_t* const buffer_size,
+    uint8_t* const buffer_validity_bytemap,
+    uint64_t* const buffer_validity_bytemap_size,
+    const bool check_null_buffers) {
+  // Convert the bytemap into a ValidityVector.
+  ValidityVector vv;
+  RETURN_NOT_OK(
+      vv.init_bytemap(buffer_validity_bytemap, buffer_validity_bytemap_size));
+
+  return set_buffer(
+      name, buffer, buffer_size, std::move(vv), check_null_buffers);
+}
+
+Status Query::set_buffer_vbytemap(
+    const std::string& name,
+    uint64_t* const buffer_off,
+    uint64_t* const buffer_off_size,
+    void* const buffer_val,
+    uint64_t* const buffer_val_size,
+    uint8_t* const buffer_validity_bytemap,
+    uint64_t* const buffer_validity_bytemap_size,
+    const bool check_null_buffers) {
+  // Convert the bytemap into a ValidityVector.
+  ValidityVector vv;
+  RETURN_NOT_OK(
+      vv.init_bytemap(buffer_validity_bytemap, buffer_validity_bytemap_size));
+
+  return set_buffer(
+      name,
+      buffer_off,
+      buffer_off_size,
+      buffer_val,
+      buffer_val_size,
+      std::move(vv),
+      check_null_buffers);
+}
+
+Status Query::set_buffer(
+    const std::string& name,
+    void* const buffer,
+    uint64_t* const buffer_size,
+    ValidityVector&& validity_vector,
+    const bool check_null_buffers) {
+  RETURN_NOT_OK(check_set_fixed_buffer(name));
+
+  if (type_ == QueryType::WRITE)
+    return writer_.set_buffer(
+        name, buffer, buffer_size, std::move(validity_vector));
+  return reader_.set_buffer(
+      name,
+      buffer,
+      buffer_size,
+      std::move(validity_vector),
+      check_null_buffers);
+}
+
+Status Query::set_buffer(
+    const std::string& name,
+    uint64_t* const buffer_off,
+    uint64_t* const buffer_off_size,
+    void* const buffer_val,
+    uint64_t* const buffer_val_size,
+    ValidityVector&& validity_vector,
+    const bool check_null_buffers) {
+  if (type_ == QueryType::WRITE)
+    return writer_.set_buffer(
+        name,
+        buffer_off,
+        buffer_off_size,
+        buffer_val,
+        buffer_val_size,
+        std::move(validity_vector));
+  return reader_.set_buffer(
+      name,
+      buffer_off,
+      buffer_off_size,
+      buffer_val,
+      buffer_val_size,
+      std::move(validity_vector),
       check_null_buffers);
 }
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -45,6 +45,7 @@
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/reader.h"
+#include "tiledb/sm/query/validity_vector.h"
 #include "tiledb/sm/query/writer.h"
 
 using namespace tiledb::common;
@@ -222,12 +223,6 @@ class Query {
   std::vector<std::string> buffer_names() const;
 
   /**
-   * Gets the query buffer for the input attribute/dimension.
-   * An empty string means the special default attribute.
-   */
-  QueryBuffer buffer(const std::string& name) const;
-
-  /**
    * Marks a query that has not yet been started as failed. This should not be
    * called asynchronously to cancel an in-progress query; for that use the
    * parent StorageManager's cancellation mechanism.
@@ -285,6 +280,47 @@ class Query {
       uint64_t** buffer_off_size,
       void** buffer_val,
       uint64_t** buffer_val_size) const;
+
+  /**
+   * Retrieves the buffer and validity bytemap of a fixed-sized, nullable
+   * attribute.
+   *
+   * @param name The buffer attribute name. An empty string means
+   *     the special default attribute.
+   * @param buffer The buffer to be retrieved.
+   * @param buffer_size A pointer to the buffer size to be retrieved.
+   * @param buffer The buffer to be retrieved.
+   * @param buffer_size A pointer to the buffer size to be retrieved.
+   * @return Status
+   */
+  Status get_buffer_vbytemap(
+      const char* name,
+      void** buffer,
+      uint64_t** buffer_size,
+      uint8_t** buffer_validity_bytemap,
+      uint64_t** buffer_validity_bytemap_size) const;
+
+  /**
+   * Retrieves the offsets, values, and validity bytemap buffers of
+   * a var-sized, nullable attribute.
+   *
+   * @param name The attribute name. An empty string means
+   *     the special default attribute.
+   * @param buffer_off The offsets buffer to be retrieved.
+   * @param buffer_off_size A pointer to the offsets buffer size to be
+   * retrieved.
+   * @param buffer_val The values buffer to be retrieved.
+   * @param buffer_val_size A pointer to the values buffer size to be retrieved.
+   * @return Status
+   */
+  Status get_buffer_vbytemap(
+      const char* name,
+      uint64_t** buffer_off,
+      uint64_t** buffer_off_size,
+      void** buffer_val,
+      uint64_t** buffer_val_size,
+      uint8_t** buffer_validity_bytemap,
+      uint64_t** buffer_validity_bytemap_size) const;
 
   /**
    * Returns the serialization state associated with the given attribute.
@@ -390,6 +426,78 @@ class Query {
       uint64_t* buffer_off_size,
       void* buffer_val,
       uint64_t* buffer_val_size,
+      bool check_null_buffers = true);
+
+  /**
+   * Sets the buffer for a fixed-sized, nullable attribute with a validity
+   * bytemap.
+   *
+   * @param name The attribute to set the buffer for.
+   * @param buffer The buffer that either have the input data to be written,
+   *     or will hold the data to be read.
+   * @param buffer_size In the case of writes, this is the size of `buffer`
+   *     in bytes. In the case of reads, this initially contains the allocated
+   *     size of `buffer`, but after the termination of the query
+   *     it will contain the size of the useful (read) data in `buffer`.
+   * @param buffer_validity_bytemap The buffer that either have the validity
+   * bytemap associated with the input data to be written, or will hold the
+   * validity bytemap to be read.
+   * @param buffer_validity_bytemap_size In the case of writes, this is the size
+   * of `buffer_validity_bytemap` in bytes. In the case of reads, this initially
+   *     contains the allocated size of `buffer_validity_bytemap`, but after the
+   *     termination of the query it will contain the size of the useful (read)
+   * data in `buffer_validity_bytemap`.
+   * @param check_null_buffers If true (default), null buffers are not allowed.
+   * @return Status
+   */
+  Status set_buffer_vbytemap(
+      const std::string& name,
+      void* buffer,
+      uint64_t* buffer_size,
+      uint8_t* buffer_validity_bytemap,
+      uint64_t* buffer_validity_bytemap_size,
+      bool check_null_buffers = true);
+
+  /**
+   * Sets the buffer for a var-sized, nullable attribute with a validity
+   * bytemap.
+   *
+   * @param name The attribute to set the buffer for.
+   * @param buffer_off The buffer that either have the input data to be written,
+   *     or will hold the data to be read. This buffer holds the starting
+   *     offsets of each cell value in `buffer_val`.
+   * @param buffer_off_size In the case of writes, it is the size of
+   *     `buffer_off` in bytes. In the case of reads, this initially contains
+   *     the allocated size of `buffer_off`, but after the termination of the
+   *     function it will contain the size of the useful (read) data in
+   *     `buffer_off`.
+   * @param buffer_val The buffer that either have the input data to be written,
+   *     or will hold the data to be read. This buffer holds the actual
+   *     var-sized cell values.
+   * @param buffer_val_size In the case of writes, it is the size of
+   *     `buffer_val` in bytes. In the case of reads, this initially contains
+   *     the allocated size of `buffer_val`, but after the termination of the
+   *     query it will contain the size of the useful (read) data in
+   *     `buffer_val`.
+   * @param buffer_validity_bytemap The buffer that either have the validity
+   * bytemap associated with the input data to be written, or will hold the
+   * validity bytemap to be read.
+   * @param buffer_validity_bytemap_size In the case of writes, this is the size
+   * of `buffer_validity_bytemap` in bytes. In the case of reads, this initially
+   *     contains the allocated size of `buffer_validity_bytemap`, but after the
+   *     termination of the query it will contain the size of the useful (read)
+   * data in `buffer_validity_bytemap`.
+   * @param check_null_buffers If true (default), null buffers are not allowed.
+   * @return Status
+   */
+  Status set_buffer_vbytemap(
+      const std::string& name,
+      uint64_t* buffer_off,
+      uint64_t* buffer_off_size,
+      void* buffer_val,
+      uint64_t* buffer_val_size,
+      uint8_t* buffer_validity_bytemap,
+      uint64_t* buffer_validity_bytemap_size,
       bool check_null_buffers = true);
 
   /**
@@ -501,6 +609,54 @@ class Query {
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
+
+  Status check_set_fixed_buffer(const std::string& name);
+
+  /**
+   * Internal routine for setting fixed-sized, nullable attribute buffers with
+   * a ValidityVector.
+   */
+  Status set_buffer(
+      const std::string& name,
+      void* buffer,
+      uint64_t* buffer_size,
+      ValidityVector&& validity_vector,
+      bool check_null_buffers = true);
+
+  /**
+   * Internal routine for setting var-sized, nullable attribute buffers with
+   * a ValidityVector.
+   */
+  Status set_buffer(
+      const std::string& name,
+      uint64_t* buffer_off,
+      uint64_t* buffer_off_size,
+      void* buffer_val,
+      uint64_t* buffer_val_size,
+      ValidityVector&& validity_vector,
+      bool check_null_buffers = true);
+
+  /**
+   * Internal routine for getting fixed-sized, nullable attribute buffers with
+   * a ValidityVector.
+   */
+  Status get_buffer(
+      const char* name,
+      void** buffer,
+      uint64_t** buffer_size,
+      const ValidityVector** validity_vector) const;
+
+  /**
+   * Internal routine for getting fixed-sized, nullable attribute buffers with
+   * a ValidityVector.
+   */
+  Status get_buffer(
+      const char* name,
+      uint64_t** buffer_off,
+      uint64_t** buffer_off_size,
+      void** buffer_val,
+      uint64_t** buffer_val_size,
+      const ValidityVector** validity_vector) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/query_buffer.h
+++ b/tiledb/sm/query/query_buffer.h
@@ -1,0 +1,165 @@
+/**
+ * @file   query_buffer.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class ValidityVector.
+ */
+
+#ifndef TILEDB_QUERY_BUFFER_H
+#define TILEDB_QUERY_BUFFER_H
+
+#include "tiledb/sm/misc/logger.h"
+#include "tiledb/sm/misc/macros.h"
+#include "tiledb/sm/misc/status.h"
+#include "tiledb/sm/query/validity_vector.h"
+
+namespace tiledb {
+namespace sm {
+
+/** Contains the buffer(s) and buffer size(s) for some attribute/dimension. */
+class QueryBuffer {
+ public:
+  /**
+   * The attribute/dimension buffer. In case the attribute/dimension is
+   * var-sized, this is the offsets buffer.
+   */
+  void* buffer_;
+
+  /**
+   * For a var-sized attribute/dimension, this is the data buffer. It is
+   * `nullptr` for fixed-sized attributes/dimensions.
+   */
+  void* buffer_var_;
+
+  /**
+   * The size (in bytes) of `buffer_`. Note that this size may be altered by
+   * a read query to reflect the useful data written in the buffer.
+   */
+  uint64_t* buffer_size_;
+
+  /**
+   * The size (in bytes) of `buffer_var_`. Note that this size may be altered
+   * by a read query to reflect the useful data written in the buffer.
+   */
+  uint64_t* buffer_var_size_;
+
+  /**
+   * The validity vector, which wraps a uint8_t* bytemap buffer and a
+   * uint64_t* bytemap buffer size. These will be null for non-nullable
+   * attributes.
+   */
+  ValidityVector validity_vector_;
+
+  /**
+   * This is the original size (in bytes) of `buffer_` (before
+   * potentially altered by the query).
+   */
+  uint64_t original_buffer_size_;
+
+  /**
+   * This is the original size (in bytes) of `buffer_var_` (before
+   * potentially altered by the query).
+   */
+  uint64_t original_buffer_var_size_;
+
+  /**
+   * This is the original size (in bytes) of `validity_vector_.buffer()` (before
+   * potentially altered by the query).
+   */
+  uint64_t original_validity_vector_size_;
+
+  /** Default constructor. */
+  QueryBuffer()
+      : buffer_(nullptr)
+      , buffer_var_(nullptr)
+      , buffer_size_(nullptr)
+      , buffer_var_size_(nullptr)
+      , original_buffer_size_(0)
+      , original_buffer_var_size_(0)
+      , original_validity_vector_size_(0) {
+  }
+
+  /** Value Constructor. */
+  QueryBuffer(
+      void* const buffer,
+      void* const buffer_var,
+      uint64_t* const buffer_size,
+      uint64_t* const buffer_var_size)
+      : buffer_(buffer)
+      , buffer_var_(buffer_var)
+      , buffer_size_(buffer_size)
+      , buffer_var_size_(buffer_var_size) {
+    original_buffer_size_ = *buffer_size;
+    original_buffer_var_size_ =
+        (buffer_var_size_ != nullptr) ? *buffer_var_size_ : 0;
+    original_validity_vector_size_ = 0;
+  }
+
+  /** Value Constructor. */
+  QueryBuffer(
+      void* const buffer,
+      void* const buffer_var,
+      uint64_t* const buffer_size,
+      uint64_t* const buffer_var_size,
+      ValidityVector&& validity_vector)
+      : buffer_(buffer)
+      , buffer_var_(buffer_var)
+      , buffer_size_(buffer_size)
+      , buffer_var_size_(buffer_var_size)
+      , validity_vector_(std::move(validity_vector)) {
+    original_buffer_size_ = *buffer_size;
+    original_buffer_var_size_ =
+        (buffer_var_size_ != nullptr) ? *buffer_var_size_ : 0;
+    original_validity_vector_size_ =
+        (validity_vector_.buffer_size() != nullptr) ?
+            *validity_vector_.buffer_size() :
+            0;
+  }
+
+  QueryBuffer& operator=(QueryBuffer&& rhs) {
+    if (&rhs == this)
+      return *this;
+
+    std::swap(buffer_, rhs.buffer_);
+    std::swap(buffer_var_, rhs.buffer_var_);
+    std::swap(buffer_size_, rhs.buffer_size_);
+    std::swap(buffer_var_size_, rhs.buffer_var_size_);
+    std::swap(original_buffer_size_, rhs.original_buffer_size_);
+    std::swap(original_buffer_var_size_, rhs.original_buffer_var_size_);
+    std::swap(
+        original_validity_vector_size_, rhs.original_validity_vector_size_);
+    validity_vector_ = std::move(rhs.validity_vector_);
+
+    return *this;
+  }
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_QUERY_BUFFER_H

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -44,9 +44,11 @@
 #include "tiledb/sm/array_schema/tile_domain.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/misc/uri.h"
+#include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/result_cell_slab.h"
 #include "tiledb/sm/query/result_coords.h"
 #include "tiledb/sm/query/result_space_tile.h"
+#include "tiledb/sm/query/validity_vector.h"
 #include "tiledb/sm/query/write_cell_slab_iter.h"
 #include "tiledb/sm/subarray/subarray_partitioner.h"
 
@@ -212,9 +214,6 @@ class Reader {
   /** Returns the names of the buffers set by the user for the read query. */
   std::vector<std::string> buffer_names() const;
 
-  /** Fetch QueryBuffer for the input attribute/dimension. */
-  QueryBuffer buffer(const std::string& name) const;
-
   /**
    * Returns `true` if the query was incomplete, i.e., if all subarray
    * partitions in the read state have not been processed or there
@@ -251,6 +250,42 @@ class Reader {
       uint64_t** buffer_off_size,
       void** buffer_val,
       uint64_t** buffer_val_size) const;
+
+  /**
+   * Retrieves the buffer of a fixed-sized, nullable attribute.
+   *
+   * @param name The attribute name.
+   * @param buffer The buffer to be retrieved.
+   * @param buffer_size A pointer to the buffer size to be retrieved.
+   * @param ValidityVector The validity vector to be retrieved.
+   * @return Status
+   */
+  Status get_buffer_nullable(
+      const std::string& name,
+      void** buffer,
+      uint64_t** buffer_size,
+      const ValidityVector** validity_vector) const;
+
+  /**
+   * Retrieves the offsets, values, and validity buffers of a var-sized,
+   * nullable attribute.
+   *
+   * @param name The attribute/dimension name.
+   * @param buffer_off The offsets buffer to be retrieved.
+   * @param buffer_off_size A pointer to the offsets buffer size to be
+   *     retrieved.
+   * @param buffer_val The values buffer to be retrieved.
+   * @param buffer_val_size A pointer to the values buffer size to be retrieved.
+   * @param ValidityVector The validity vector to be retrieved.
+   * @return Status
+   */
+  Status get_buffer_nullable(
+      const std::string& name,
+      uint64_t** buffer_off,
+      uint64_t** buffer_off_size,
+      void** buffer_val,
+      uint64_t** buffer_val_size,
+      const ValidityVector** validity_vector) const;
 
   /** Returns the first fragment uri. */
   URI first_fragment_uri() const;
@@ -328,6 +363,57 @@ class Reader {
       uint64_t* buffer_off_size,
       void* buffer_val,
       uint64_t* buffer_val_size,
+      bool check_null_buffers = true);
+
+  /**
+   * Sets the buffer for a fixed-sized, nullable attribute.
+   *
+   * @param name The attribute to set the buffer for.
+   * @param buffer The buffer that will hold the data to be read.
+   * @param buffer_size This initially contains the allocated
+   *     size of `buffer`, but after the termination of the function
+   *     it will contain the size of the useful (read) data in `buffer`.
+   * @param check_null_buffers If true (default), null buffers are not allowed.
+   * @param validity_vector The validity vector associated with values in
+   * `buffer`.
+   * @return Status
+   */
+  Status set_buffer(
+      const std::string& name,
+      void* buffer,
+      uint64_t* buffer_size,
+      ValidityVector&& validity_vector,
+      bool check_null_buffers = true);
+
+  /**
+   * Sets the buffer for a var-sized, nullable attribute.
+   *
+   * @param name The name to set the buffer for.
+   * @param buffer_off The buffer that will hold the data to be read.
+   *     This buffer holds the starting offsets of each cell value in
+   *     `buffer_val`.
+   * @param buffer_off_size This initially contains
+   *     the allocated size of `buffer_off`, but after the termination of the
+   *     function it will contain the size of the useful (read) data in
+   *     `buffer_off`.
+   * @param buffer_val The buffer that will hold the data to be read.
+   *     This buffer holds the actual var-sized cell values.
+   * @param buffer_val_size This initially contains
+   *     the allocated size of `buffer_val`, but after the termination of the
+   *     function it will contain the size of the useful (read) data in
+   *     `buffer_val`.
+   * @param validity_vector The validity vector associated with values in
+   * `buffer_val`.
+   * @param check_null_buffers If true (default), null buffers are not allowed.
+   * @return Status
+   */
+  Status set_buffer(
+      const std::string& name,
+      uint64_t* buffer_off,
+      uint64_t* buffer_off_size,
+      void* buffer_val,
+      uint64_t* buffer_val_size,
+      ValidityVector&& validity_vector,
       bool check_null_buffers = true);
 
   /** Sets the fragment metadata. */
@@ -1092,7 +1178,8 @@ class Reader {
       std::vector<uint64_t>* offset_offsets_per_cs,
       std::vector<uint64_t>* var_offsets_per_cs,
       uint64_t* total_offset_size,
-      uint64_t* total_var_size) const;
+      uint64_t* total_var_size,
+      uint64_t* total_validity_size) const;
 
   /**
    * Copies the cells for the input **var-sized** attribute/dimension and result
@@ -1338,6 +1425,46 @@ class Reader {
       const;
 
   /**
+   * Runs the input fixed-sized tile for the input nullable attribute
+   * through the filter pipeline. The tile buffer is modified to contain the
+   * output of the pipeline.
+   *
+   * @param name The attribute/dimension the tile belong to.
+   * @param tile The tile to be unfiltered.
+   * @param tile_validity The validity tile to be unfiltered.
+   * @param result_cell_slab_ranges Result cell slab ranges sorted in ascending
+   *    order.
+   * @return Status
+   */
+  Status unfilter_tile_nullable(
+      const std::string& name,
+      Tile* tile,
+      Tile* tile_validity,
+      const std::vector<std::pair<uint64_t, uint64_t>>* result_cell_slab_ranges)
+      const;
+
+  /**
+   * Runs the input var-sized tile for the input nullable attribute through
+   * the filter pipeline. The tile buffer is modified to contain the output of
+   * the pipeline.
+   *
+   * @param name The attribute/dimension the tile belong to.
+   * @param tile The offsets tile to be unfiltered.
+   * @param tile_var The value tile to be unfiltered.
+   * @param tile_validity The validity tile to be unfiltered.
+   * @param result_cell_slab_ranges Result cell slab ranges sorted in ascending
+   *    order.
+   * @return Status
+   */
+  Status unfilter_tile_nullable(
+      const std::string& name,
+      Tile* tile,
+      Tile* tile_var,
+      Tile* tile_validity,
+      const std::vector<std::pair<uint64_t, uint64_t>>* result_cell_slab_ranges)
+      const;
+
+  /**
    * Gets all the result coordinates of the input tile into `result_coords`.
    *
    * @param result_tile The result tile to read the coordinates from.
@@ -1384,6 +1511,38 @@ class Reader {
       const std::string& name,
       Tile* tile,
       Tile* tile_var) const;
+
+  /**
+   * Initializes a fixed-sized tile.
+   *
+   * @param format_version The format version of the tile.
+   * @param name The attribute/dimension the tile belongs to.
+   * @param tile The tile to be initialized.
+   * @param tile_validity The validity tile to be initialized.
+   * @return Status
+   */
+  Status init_tile_nullable(
+      uint32_t format_version,
+      const std::string& name,
+      Tile* tile,
+      Tile* tile_validity) const;
+
+  /**
+   * Initializes a var-sized tile.
+   *
+   * @param format_version The format version of the tile.
+   * @param name The attribute/dimension the tile belongs to.
+   * @param tile The offsets tile to be initialized.
+   * @param tile_var The var-sized data tile to be initialized.
+   * @param tile_validity The validity tile to be initialized.
+   * @return Status
+   */
+  Status init_tile_nullable(
+      uint32_t format_version,
+      const std::string& name,
+      Tile* tile,
+      Tile* tile_var,
+      Tile* tile_validity) const;
 
   /**
    * Loads tile offsets for each attribute/dimension name into

--- a/tiledb/sm/query/validity_vector.h
+++ b/tiledb/sm/query/validity_vector.h
@@ -1,0 +1,160 @@
+/**
+ * @file   validity_vector.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class ValidityVector.
+ */
+
+#ifndef TILEDB_VALIDITY_VECTOR_H
+#define TILEDB_VALIDITY_VECTOR_H
+
+#include <vector>
+
+#include "tiledb/sm/misc/logger.h"
+#include "tiledb/sm/misc/macros.h"
+#include "tiledb/sm/misc/status.h"
+
+namespace tiledb {
+namespace sm {
+
+class ValidityVector {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Default constructor. */
+  ValidityVector()
+      : buffer_(nullptr)
+      , buffer_size_(0) {
+  }
+
+  /** Move constructor. */
+  ValidityVector(ValidityVector&& rhs) {
+    std::swap(buffer_, rhs.buffer_);
+    std::swap(buffer_size_, rhs.buffer_size_);
+  }
+
+  /** Destructor. */
+  ~ValidityVector() = default;
+
+  DISABLE_COPY(ValidityVector);
+
+  /* ********************************* */
+  /*             OPERATORS             */
+  /* ********************************* */
+
+  /** Move-assignment operator. */
+  ValidityVector& operator=(ValidityVector&& rhs) {
+    if (&rhs == this)
+      return *this;
+
+    std::swap(buffer_, rhs.buffer_);
+    std::swap(buffer_size_, rhs.buffer_size_);
+
+    return *this;
+  }
+
+  DISABLE_COPY_ASSIGN(ValidityVector);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Initializes the validity vector with a bytemap. This does
+   * not take ownership of the bytemap. Each non-zero byte represents
+   * a valid attribute value.
+   *
+   * @param bytemap The byte map.
+   * @param bytemap_size The byte size of `bytemap`.
+   * @return Status
+   */
+  Status init_bytemap(uint8_t* const bytemap, uint64_t* bytemap_size) {
+    if (buffer_ != nullptr)
+      return Status::ValidityVectorError(
+          "ValidityVector instance already initialized");
+
+    buffer_ = bytemap;
+    buffer_size_ = bytemap_size;
+
+    return Status::Ok();
+  }
+
+  /** Returns the bytemap that this instance was initialized with. */
+  uint8_t* bytemap() const {
+    return buffer_;
+  }
+
+  /**
+   * Returns the size of the bytemap that this instance was initialized
+   * with.
+   */
+  uint64_t* bytemap_size() const {
+    return buffer_size_;
+  }
+
+  /**
+   * Returns the internal buffer. This is currently a byte map, but
+   * will change to a bitmap in the future.
+   *
+   * @return a pointer to the internal buffer.
+   */
+  uint8_t* buffer() const {
+    return buffer_;
+  }
+
+  /**
+   * Returns the size of the internal buffer.
+   *
+   * @return a pointer to the internal buffer size.
+   */
+  uint64_t* buffer_size() const {
+    return buffer_size_;
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /**
+   * Contains a byte-map, where each non-zero byte represents
+   * a valid (non-null) attribute value and a zero byte represents
+   * a null (non-valid) attribute value.
+   */
+  uint8_t* buffer_;
+
+  /** The size of `buffer_size_`. */
+  uint64_t* buffer_size_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_VALIDITY_VECTOR_H

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -143,20 +143,6 @@ std::vector<std::string> Writer::buffer_names() const {
   return ret;
 }
 
-QueryBuffer Writer::buffer(const std::string& name) const {
-  // Special zipped coordinates
-  if (name == constants::coords)
-    return QueryBuffer(coords_buffer_, nullptr, coords_buffer_size_, nullptr);
-
-  // Attribute or dimension
-  auto buf = buffers_.find(name);
-  if (buf != buffers_.end())
-    return buf->second;
-
-  // Named buffer does not exist
-  return QueryBuffer{};
-}
-
 Status Writer::finalize() {
   STATS_START_TIMER(stats::Stats::TimerType::WRITE_FINALIZE)
 
@@ -212,6 +198,56 @@ Status Writer::get_buffer(
   *buffer_off_size = nullptr;
   *buffer_val = nullptr;
   *buffer_val_size = nullptr;
+
+  return Status::Ok();
+}
+
+Status Writer::get_buffer_nullable(
+    const std::string& name,
+    void** buffer,
+    uint64_t** buffer_size,
+    const ValidityVector** validity_vector) const {
+  // Attribute or dimension
+  auto it = buffers_.find(name);
+  if (it != buffers_.end()) {
+    *buffer = it->second.buffer_;
+    *buffer_size = it->second.buffer_size_;
+    *validity_vector = &it->second.validity_vector_;
+    return Status::Ok();
+  }
+
+  // Named buffer does not exist
+  *buffer = nullptr;
+  *buffer_size = nullptr;
+  *validity_vector = nullptr;
+
+  return Status::Ok();
+}
+
+Status Writer::get_buffer_nullable(
+    const std::string& name,
+    uint64_t** buffer_off,
+    uint64_t** buffer_off_size,
+    void** buffer_val,
+    uint64_t** buffer_val_size,
+    const ValidityVector** validity_vector) const {
+  // Attribute or dimension
+  auto it = buffers_.find(name);
+  if (it != buffers_.end()) {
+    *buffer_off = (uint64_t*)it->second.buffer_;
+    *buffer_off_size = it->second.buffer_size_;
+    *buffer_val = it->second.buffer_var_;
+    *buffer_val_size = it->second.buffer_var_size_;
+    *validity_vector = &it->second.validity_vector_;
+    return Status::Ok();
+  }
+
+  // Named buffer does not exist
+  *buffer_off = nullptr;
+  *buffer_off_size = nullptr;
+  *buffer_val = nullptr;
+  *buffer_val_size = nullptr;
+  *validity_vector = nullptr;
 
   return Status::Ok();
 }
@@ -297,7 +333,7 @@ void Writer::set_array_schema(const ArraySchema* array_schema) {
 }
 
 Status Writer::set_buffer(
-    const std::string& name, void* buffer, uint64_t* buffer_size) {
+    const std::string& name, void* const buffer, uint64_t* const buffer_size) {
   // Check buffer
   if (buffer == nullptr || buffer_size == nullptr)
     return LOG_STATUS(Status::WriterError(
@@ -313,8 +349,8 @@ Status Writer::set_buffer(
     return set_coords_buffer(buffer, buffer_size);
 
   // For easy reference
-  bool is_dim = array_schema_->is_dim(name);
-  bool is_attr = array_schema_->is_attr(name);
+  const bool is_dim = array_schema_->is_dim(name);
+  const bool is_attr = array_schema_->is_attr(name);
 
   // Neither a dimension nor an attribute
   if (!is_dim && !is_attr)
@@ -322,9 +358,14 @@ Status Writer::set_buffer(
         std::string("Cannot set buffer; Invalid buffer name '") + name +
         "' (it should be an attribute or dimension)"));
 
+  // Must not be nullable
+  if (array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer; Input attribute/dimension '") + name +
+        "' is nullable"));
+
   // Error if it is var-sized
-  bool var_size = (array_schema_->var_size(name));
-  if (var_size)
+  if (array_schema_->var_size(name))
     return LOG_STATUS(Status::WriterError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is var-sized"));
@@ -365,10 +406,10 @@ Status Writer::set_buffer(
 
 Status Writer::set_buffer(
     const std::string& name,
-    uint64_t* buffer_off,
-    uint64_t* buffer_off_size,
-    void* buffer_val,
-    uint64_t* buffer_val_size) {
+    uint64_t* const buffer_off,
+    uint64_t* const buffer_off_size,
+    void* const buffer_val,
+    uint64_t* const buffer_val_size) {
   // Check buffer
   if (buffer_off == nullptr || buffer_off_size == nullptr ||
       buffer_val == nullptr || buffer_val_size == nullptr)
@@ -381,8 +422,8 @@ Status Writer::set_buffer(
         Status::WriterError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
-  bool is_dim = array_schema_->is_dim(name);
-  bool is_attr = array_schema_->is_attr(name);
+  const bool is_dim = array_schema_->is_dim(name);
+  const bool is_attr = array_schema_->is_attr(name);
 
   // Neither a dimension nor an attribute
   if (!is_dim && !is_attr)
@@ -390,9 +431,14 @@ Status Writer::set_buffer(
         std::string("Cannot set buffer; Invalid buffer name '") + name +
         "' (it should be an attribute or dimension)"));
 
+  // Must not be nullable
+  if (array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer; Input attribute/dimension '") + name +
+        "' is nullable"));
+
   // Error if it is fixed-sized
-  bool var_size = (array_schema_->var_size(name));
-  if (!var_size)
+  if (!array_schema_->var_size(name))
     return LOG_STATUS(Status::WriterError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is fixed-sized"));
@@ -422,6 +468,107 @@ Status Writer::set_buffer(
   // Set attribute/dimension buffer
   buffers_[name] =
       QueryBuffer(buffer_off, buffer_val, buffer_off_size, buffer_val_size);
+
+  return Status::Ok();
+}
+
+Status Writer::set_buffer(
+    const std::string& name,
+    void* const buffer,
+    uint64_t* const buffer_size,
+    ValidityVector&& validity_vector) {
+  // Check buffer
+  if (buffer == nullptr || buffer_size == nullptr)
+    return LOG_STATUS(Status::WriterError(
+        "Cannot set buffer; Buffer or buffer size is null"));
+
+  // Array schema must exist
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(
+        Status::WriterError("Cannot set buffer; Array schema not set"));
+
+  // Must be an attribute
+  if (!array_schema_->is_attr(name))
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer; Buffer name '") + name +
+        "' is not an attribute"));
+
+  // Must be fixed-size
+  if (array_schema_->var_size(name))
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer; Input attribute '") + name +
+        "' is var-sized"));
+
+  // Must be nullable
+  if (!array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer; Input attribute '") + name +
+        "' is not nullable"));
+
+  // Error if setting a new attribute after initialization
+  const bool exists = buffers_.find(name) != buffers_.end();
+  if (initialized_ && !exists)
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer for new attribute '") + name +
+        "' after initialization"));
+
+  // Set attribute/dimension buffer
+  buffers_[name] = QueryBuffer(
+      buffer, nullptr, buffer_size, nullptr, std::move(validity_vector));
+
+  return Status::Ok();
+}
+
+Status Writer::set_buffer(
+    const std::string& name,
+    uint64_t* const buffer_off,
+    uint64_t* const buffer_off_size,
+    void* const buffer_val,
+    uint64_t* const buffer_val_size,
+    ValidityVector&& validity_vector) {
+  // Check buffer
+  if (buffer_off == nullptr || buffer_off_size == nullptr ||
+      buffer_val == nullptr || buffer_val_size == nullptr)
+    return LOG_STATUS(Status::WriterError(
+        "Cannot set buffer; Buffer or buffer size is null"));
+
+  // Array schema must exist
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(
+        Status::WriterError("Cannot set buffer; Array schema not set"));
+
+  // Must be an attribute
+  if (!array_schema_->is_attr(name))
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer; Buffer name '") + name +
+        "' is not an attribute"));
+
+  // Must be var-size
+  if (!array_schema_->var_size(name))
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer; Input attribute '") + name +
+        "' is fixed-sized"));
+
+  // Must be nullable
+  if (!array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer; Input attribute '") + name +
+        "' is not nullable"));
+
+  // Error if setting a new attribute after initialization
+  const bool exists = buffers_.find(name) != buffers_.end();
+  if (initialized_ && !exists)
+    return LOG_STATUS(Status::WriterError(
+        std::string("Cannot set buffer for new attribute '") + name +
+        "' after initialization"));
+
+  // Set attribute/dimension buffer
+  buffers_[name] = QueryBuffer(
+      buffer_off,
+      buffer_val,
+      buffer_off_size,
+      buffer_val_size,
+      std::move(validity_vector));
 
   return Status::Ok();
 }
@@ -551,8 +698,8 @@ Status Writer::check_buffer_sizes() const {
   uint64_t expected_cell_num = 0;
   for (const auto& it : buffers_) {
     const auto& attr = it.first;
-    bool is_var = array_schema_->var_size(attr);
-    auto buffer_size = *it.second.buffer_size_;
+    const bool is_var = array_schema_->var_size(attr);
+    const uint64_t buffer_size = *it.second.buffer_size_;
     if (is_var) {
       expected_cell_num = buffer_size / constants::cell_var_offset_size;
     } else {
@@ -566,9 +713,28 @@ Status Writer::check_buffer_sizes() const {
       ss << " (" << expected_cell_num << " != " << cell_num << ")";
       return LOG_STATUS(Status::WriterError(ss.str()));
     }
+
+#if 0
+    if (array_schema_->is_nullable(attr)) {
+      const uint64_t buffer_validity_size = *it.second.validity_vector_.buffer_size();
+      const uint64_t cell_validity_num =
+          buffer_validity_size / constants::cell_validity_size;
+
+      if (expected_cell_num != cell_validity_num) {
+        std::stringstream ss;
+        ss << "Buffer sizes check failed; Invalid number of validity cells "
+              "given for ";
+        ss << "attribute '" << attr << "'";
+        ss << " (" << expected_cell_num << " != " << cell_validity_num << ")";
+        return LOG_STATUS(Status::WriterError(ss.str()));
+      }
+    }
+#endif
   }
   return Status::Ok();
 }
+
+// TODO JOE: check_buffer_validity_sizes() ?
 
 Status Writer::check_coord_dups(const std::vector<uint64_t>& cell_pos) const {
   STATS_START_TIMER(stats::Stats::TimerType::WRITE_CHECK_COORD_DUPS)
@@ -888,6 +1054,8 @@ Status Writer::close_files(FragmentMetadata* meta) const {
     RETURN_NOT_OK(storage_manager_->close_file(meta->uri(name)));
     if (array_schema_->var_size(name))
       RETURN_NOT_OK(storage_manager_->close_file(meta->var_uri(name)));
+    if (array_schema_->is_nullable(name))
+      RETURN_NOT_OK(storage_manager_->close_file(meta->validity_uri(name)));
   }
 
   return Status::Ok();
@@ -1087,13 +1255,14 @@ Status Writer::compute_coords_metadata(
   // Compute number of tiles. Assumes all attributes and
   // and dimensions have the same number of tiles
   auto it = tiles.begin();
-  auto tile_num = array_schema_->var_size(it->first) ? it->second.size() / 2 :
-                                                       it->second.size();
+  const uint64_t t = 1 + (array_schema_->var_size(it->first) ? 1 : 0) +
+                     (array_schema_->is_nullable(it->first) ? 1 : 0);
+  auto tile_num = it->second.size() / t;
   auto dim_num = array_schema_->dim_num();
 
   // Compute MBRs
   auto statuses = parallel_for(
-      storage_manager_->compute_tp(), 0, tile_num, [&](uint64_t t) {
+      storage_manager_->compute_tp(), 0, tile_num, [&](uint64_t i) {
         NDRange mbr(dim_num);
         std::vector<const void*> data(dim_num);
         for (unsigned d = 0; d < dim_num; ++d) {
@@ -1102,13 +1271,13 @@ Status Writer::compute_coords_metadata(
           auto tiles_it = tiles.find(dim_name);
           assert(tiles_it != tiles.end());
           if (!dim->var_size())
-            dim->compute_mbr(tiles_it->second[t], &mbr[d]);
+            dim->compute_mbr(tiles_it->second[i], &mbr[d]);
           else
             dim->compute_mbr_var(
-                tiles_it->second[2 * t], tiles_it->second[2 * t + 1], &mbr[d]);
+                tiles_it->second[2 * i], tiles_it->second[2 * i + 1], &mbr[d]);
         }
 
-        meta->set_mbr(t, mbr);
+        meta->set_mbr(i, mbr);
         return Status::Ok();
       });
 
@@ -1233,13 +1402,22 @@ Status Writer::filter_tiles(
 
 Status Writer::filter_tiles(
     const std::string& name, std::vector<Tile>* tiles) const {
-  bool var_size = array_schema_->var_size(name);
+  const bool var_size = array_schema_->var_size(name);
+  const bool nullable = array_schema_->is_nullable(name);
+
   // Filter all tiles
   auto tile_num = tiles->size();
   for (size_t i = 0; i < tile_num; ++i) {
     RETURN_NOT_OK(filter_tile(name, &(*tiles)[i], var_size));
+
     if (var_size) {
       ++i;
+      RETURN_NOT_OK(filter_tile(name, &(*tiles)[i], false));
+    }
+
+    if (nullable) {
+      ++i;
+
       RETURN_NOT_OK(filter_tile(name, &(*tiles)[i], false));
     }
   }
@@ -1430,7 +1608,7 @@ Status Writer::global_write_handle_last_tile() {
 Status Writer::filter_last_tiles(
     std::unordered_map<std::string, std::vector<Tile>>* tiles) const {
   // Initialize attribute and coordinate tiles
-  for (auto it : buffers_)
+  for (const auto& it : buffers_)
     (*tiles)[it.first] = std::vector<Tile>();
 
   // Prepare the tiles first
@@ -1441,8 +1619,11 @@ Status Writer::filter_last_tiles(
         std::advance(buff_it, i);
         const auto& name = &(buff_it->first);
 
-        auto& last_tile = global_write_state_->last_tiles_[*name].first;
-        auto& last_tile_var = global_write_state_->last_tiles_[*name].second;
+        auto& last_tile = std::get<0>(global_write_state_->last_tiles_[*name]);
+        auto& last_tile_var =
+            std::get<1>(global_write_state_->last_tiles_[*name]);
+        auto& last_tile_validity =
+            std::get<2>(global_write_state_->last_tiles_[*name]);
 
         if (!last_tile.empty()) {
           std::vector<Tile>& tiles_ref = (*tiles)[*name];
@@ -1451,6 +1632,8 @@ Status Writer::filter_last_tiles(
           tiles_ref.push_back(last_tile.clone(false));
           if (!last_tile_var.empty())
             tiles_ref.push_back(last_tile_var.clone(false));
+          if (!last_tile_validity.empty())
+            tiles_ref.push_back(last_tile_validity.clone(false));
         }
         return Status::Ok();
       });
@@ -1479,7 +1662,7 @@ bool Writer::all_last_tiles_empty() const {
   // See if any last attribute/coordinate tiles are nonempty
   for (const auto& it : buffers_) {
     const auto& name = it.first;
-    auto& last_tile = global_write_state_->last_tiles_[name].first;
+    auto& last_tile = std::get<0>(global_write_state_->last_tiles_[name]);
     if (!last_tile.empty())
       return false;
   }
@@ -1504,18 +1687,33 @@ Status Writer::init_global_write_state() {
   for (const auto& it : buffers_) {
     // Initialize last tiles
     const auto& name = it.first;
-    auto last_tile_pair = std::pair<std::string, std::pair<Tile, Tile>>(
-        name, std::pair<Tile, Tile>(Tile(), Tile()));
-    auto it_ret = global_write_state_->last_tiles_.emplace(last_tile_pair);
+    auto last_tile_tuple = std::pair<std::string, std::tuple<Tile, Tile, Tile>>(
+        name, std::tuple<Tile, Tile, Tile>(Tile(), Tile(), Tile()));
+    auto it_ret = global_write_state_->last_tiles_.emplace(last_tile_tuple);
 
     if (!array_schema_->var_size(name)) {
-      auto& last_tile = it_ret.first->second.first;
-      RETURN_NOT_OK_ELSE(init_tile(name, &last_tile), clean_up(uri));
+      auto& last_tile = std::get<0>(it_ret.first->second);
+      if (!array_schema_->is_nullable(name)) {
+        RETURN_NOT_OK_ELSE(init_tile(name, &last_tile), clean_up(uri));
+      } else {
+        auto& last_tile_validity = std::get<2>(it_ret.first->second);
+        RETURN_NOT_OK_ELSE(
+            init_tile_nullable(name, &last_tile, &last_tile_validity),
+            clean_up(uri));
+      }
     } else {
-      auto& last_tile = it_ret.first->second.first;
-      auto& last_tile_var = it_ret.first->second.second;
-      RETURN_NOT_OK_ELSE(
-          init_tile(name, &last_tile, &last_tile_var), clean_up(uri));
+      auto& last_tile = std::get<0>(it_ret.first->second);
+      auto& last_tile_var = std::get<1>(it_ret.first->second);
+      if (!array_schema_->is_nullable(name)) {
+        RETURN_NOT_OK_ELSE(
+            init_tile(name, &last_tile, &last_tile_var), clean_up(uri));
+      } else {
+        auto& last_tile_validity = std::get<2>(it_ret.first->second);
+        RETURN_NOT_OK_ELSE(
+            init_tile_nullable(
+                name, &last_tile, &last_tile_var, &last_tile_validity),
+            clean_up(uri));
+      }
     }
 
     // Initialize cells written
@@ -1559,6 +1757,60 @@ Status Writer::init_tile(
       0));
   RETURN_NOT_OK(tile_var->init_unfiltered(
       constants::format_version, type, tile_size, datatype_size(type), 0));
+  return Status::Ok();
+}
+
+Status Writer::init_tile_nullable(
+    const std::string& name, Tile* tile, Tile* tile_validity) const {
+  // For easy reference
+  auto cell_size = array_schema_->cell_size(name);
+  auto type = array_schema_->type(name);
+  auto domain = array_schema_->domain();
+  auto capacity = array_schema_->capacity();
+  auto cell_num_per_tile = has_coords_ ? capacity : domain->cell_num_per_tile();
+  auto tile_size = cell_num_per_tile * cell_size;
+
+  // Initialize
+  RETURN_NOT_OK(tile->init_unfiltered(
+      constants::format_version, type, tile_size, cell_size, 0));
+  RETURN_NOT_OK(tile_validity->init_unfiltered(
+      constants::format_version,
+      constants::cell_validity_type,
+      tile_size,
+      constants::cell_validity_size,
+      0));
+
+  return Status::Ok();
+}
+
+Status Writer::init_tile_nullable(
+    const std::string& name,
+    Tile* tile,
+    Tile* tile_var,
+    Tile* tile_validity) const {
+  // For easy reference
+  auto type = array_schema_->type(name);
+  auto domain = array_schema_->domain();
+  auto capacity = array_schema_->capacity();
+  auto cell_num_per_tile = has_coords_ ? capacity : domain->cell_num_per_tile();
+  auto tile_size = cell_num_per_tile * constants::cell_var_offset_size;
+
+  // Initialize
+  RETURN_NOT_OK(tile->init_unfiltered(
+      constants::format_version,
+      constants::cell_var_offset_type,
+      tile_size,
+      constants::cell_var_offset_size,
+      0));
+  RETURN_NOT_OK(tile_var->init_unfiltered(
+      constants::format_version, type, tile_size, datatype_size(type), 0));
+  RETURN_NOT_OK(tile_validity->init_unfiltered(
+      constants::format_version,
+      constants::cell_validity_type,
+      tile_size,
+      constants::cell_validity_size,
+      0));
+
   return Status::Ok();
 }
 
@@ -1628,14 +1880,25 @@ Status Writer::init_tiles(
     uint64_t tile_num,
     std::vector<Tile>* tiles) const {
   // Initialize tiles
-  bool var_size = array_schema_->var_size(name);
-  auto tiles_len = (var_size) ? 2 * tile_num : tile_num;
+  const bool var_size = array_schema_->var_size(name);
+  const bool nullable = array_schema_->is_nullable(name);
+  const size_t t =
+      1 + static_cast<size_t>(var_size) + static_cast<size_t>(nullable);
+  const size_t tiles_len = t * tile_num;
   tiles->resize(tiles_len);
-  for (size_t i = 0; i < tiles_len; i += (1 + var_size)) {
+  for (size_t i = 0; i < tiles_len; i += t) {
     if (!var_size) {
-      RETURN_NOT_OK(init_tile(name, &((*tiles)[i])));
+      if (nullable)
+        RETURN_NOT_OK(
+            init_tile_nullable(name, &((*tiles)[i]), &((*tiles)[i + 1])));
+      else
+        RETURN_NOT_OK(init_tile(name, &((*tiles)[i])));
     } else {
-      RETURN_NOT_OK(init_tile(name, &((*tiles)[i]), &((*tiles)[i + 1])));
+      if (nullable)
+        RETURN_NOT_OK(init_tile_nullable(
+            name, &((*tiles)[i]), &((*tiles)[i + 1]), &((*tiles)[i + 2])));
+      else
+        RETURN_NOT_OK(init_tile(name, &((*tiles)[i]), &((*tiles)[i + 1])));
     }
   }
 
@@ -1789,22 +2052,6 @@ Status Writer::prepare_and_filter_attr_tiles(
         const auto& attr = buff_it->first;
         auto& tiles = (*attr_tiles)[attr];
         RETURN_CANCEL_OR_ERROR(prepare_tiles(attr, write_cell_ranges, &tiles));
-
-        /*
-            if (i == 0) {
-              // Gather stats
-              const uint64_t tile_num = write_cell_ranges.size();
-              uint64_t cell_num = 0;
-              auto var_size = array_schema_->var_size(attr);
-              for (size_t t = 0; t < tile_num; ++t)
-                cell_num += var_size ? tiles[2 * t].cell_num() :
-           tiles[t].cell_num();
-              STATS_ADD_COUNTER(stats::Stats::CounterType::WRITE_CELL_NUM,
-           cell_num);
-           STATS_ADD_COUNTER(stats::Stats::CounterType::WRITE_TILE_NUM,
-           tile_num);
-            }
-        */
         RETURN_CANCEL_OR_ERROR(filter_tiles(attr, &tiles));
         return Status::Ok();
       });
@@ -1861,8 +2108,10 @@ Status Writer::prepare_full_tiles_fixed(
     const std::set<uint64_t>& coord_dups,
     std::vector<Tile>* tiles) const {
   // For easy reference
+  auto nullable = array_schema_->is_nullable(name);
   auto it = buffers_.find(name);
   auto buffer = (unsigned char*)it->second.buffer_;
+  auto buffer_validity = (unsigned char*)it->second.validity_vector_.buffer();
   auto buffer_size = it->second.buffer_size_;
   auto cell_size = array_schema_->cell_size(name);
   auto capacity = array_schema_->capacity();
@@ -1875,13 +2124,20 @@ Status Writer::prepare_full_tiles_fixed(
     return Status::Ok();
 
   // First fill the last tile
-  auto& last_tile = global_write_state_->last_tiles_[name].first;
+  auto& last_tile = std::get<0>(global_write_state_->last_tiles_[name]);
+  auto& last_tile_validity =
+      std::get<2>(global_write_state_->last_tiles_[name]);
   uint64_t cell_idx = 0;
   if (!last_tile.empty()) {
     if (coord_dups.empty()) {
       do {
         RETURN_NOT_OK(
             last_tile.write(buffer + cell_idx * cell_size, cell_size));
+        if (nullable) {
+          RETURN_NOT_OK(last_tile_validity.write(
+              buffer_validity + cell_idx * constants::cell_validity_size,
+              constants::cell_validity_size));
+        }
         ++cell_idx;
       } while (!last_tile.full() && cell_idx != cell_num);
     } else {
@@ -1889,6 +2145,11 @@ Status Writer::prepare_full_tiles_fixed(
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
           RETURN_NOT_OK(
               last_tile.write(buffer + cell_idx * cell_size, cell_size));
+          if (nullable) {
+            RETURN_NOT_OK(last_tile_validity.write(
+                buffer_validity + cell_idx * constants::cell_validity_size,
+                constants::cell_validity_size));
+          }
         }
         ++cell_idx;
       } while (!last_tile.full() && cell_idx != cell_num);
@@ -1902,26 +2163,46 @@ Status Writer::prepare_full_tiles_fixed(
       (full_tile_num - last_tile.full()) * cell_num_per_tile;
 
   if (full_tile_num > 0) {
-    tiles->resize(full_tile_num);
-    for (auto& tile : (*tiles))
-      RETURN_NOT_OK(init_tile(name, &tile));
+    const uint64_t t = 1 + (nullable ? 1 : 0);
+    tiles->resize(t * full_tile_num);
+
+    for (uint64_t i = 0; i < tiles->size(); i += t)
+      if (!nullable)
+        RETURN_NOT_OK(init_tile(name, &((*tiles)[i])));
+      else
+        RETURN_NOT_OK(
+            init_tile_nullable(name, &((*tiles)[i]), &((*tiles)[i + 1])));
 
     // Handle last tile (it must be either full or empty)
     if (last_tile.full()) {
       (*tiles)[0] = last_tile;
       last_tile.reset();
+      if (nullable) {
+        (*tiles)[1] = last_tile_validity;
+        last_tile_validity.reset();
+      }
     } else {
       assert(last_tile.empty());
+      if (nullable) {
+        assert(last_tile_validity.empty());
+      }
     }
 
     // Write all remaining cells one by one
     if (coord_dups.empty()) {
       for (uint64_t tile_idx = 0, i = 0; i < cell_num_to_write;) {
         if ((*tiles)[tile_idx].full())
-          ++tile_idx;
+          tile_idx += t;
 
         RETURN_NOT_OK((*tiles)[tile_idx].write(
             buffer + cell_idx * cell_size, cell_size * cell_num_per_tile));
+
+        if (nullable) {
+          RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
+              buffer_validity + cell_idx * constants::cell_validity_size,
+              constants::cell_validity_size * cell_num_per_tile));
+        }
+
         cell_idx += cell_num_per_tile;
         i += cell_num_per_tile;
       }
@@ -1930,10 +2211,16 @@ Status Writer::prepare_full_tiles_fixed(
            ++cell_idx, ++i) {
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
           if ((*tiles)[tile_idx].full())
-            ++tile_idx;
+            tile_idx += t;
 
           RETURN_NOT_OK((*tiles)[tile_idx].write(
               buffer + cell_idx * cell_size, cell_size));
+
+          if (nullable) {
+            RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
+                buffer_validity + cell_idx * constants::cell_validity_size,
+                constants::cell_validity_size));
+          }
         }
       }
     }
@@ -1944,12 +2231,22 @@ Status Writer::prepare_full_tiles_fixed(
   if (coord_dups.empty()) {
     for (; cell_idx < cell_num; ++cell_idx) {
       RETURN_NOT_OK(last_tile.write(buffer + cell_idx * cell_size, cell_size));
+      if (nullable) {
+        RETURN_NOT_OK(last_tile_validity.write(
+            buffer_validity + cell_idx * constants::cell_validity_size,
+            constants::cell_validity_size));
+      }
     }
   } else {
     for (; cell_idx < cell_num; ++cell_idx) {
       if (coord_dups.find(cell_idx) == coord_dups.end())
         RETURN_NOT_OK(
             last_tile.write(buffer + cell_idx * cell_size, cell_size));
+      if (nullable) {
+        RETURN_NOT_OK(last_tile_validity.write(
+            buffer_validity + cell_idx * constants::cell_validity_size,
+            constants::cell_validity_size));
+      }
     }
   }
 
@@ -1964,8 +2261,10 @@ Status Writer::prepare_full_tiles_var(
     std::vector<Tile>* tiles) const {
   // For easy reference
   auto it = buffers_.find(name);
+  auto nullable = array_schema_->is_nullable(name);
   auto buffer = (uint64_t*)it->second.buffer_;
   auto buffer_var = (unsigned char*)it->second.buffer_var_;
+  auto buffer_validity = (unsigned char*)it->second.validity_vector_.buffer();
   auto buffer_size = it->second.buffer_size_;
   auto buffer_var_size = it->second.buffer_var_size_;
   auto capacity = array_schema_->capacity();
@@ -1979,40 +2278,62 @@ Status Writer::prepare_full_tiles_var(
     return Status::Ok();
 
   // First fill the last tile
-  auto& last_tile_pair = global_write_state_->last_tiles_[name];
-  auto& last_tile = last_tile_pair.first;
-  auto& last_tile_var = last_tile_pair.second;
+  auto& last_tile_tuple = global_write_state_->last_tiles_[name];
+  auto& last_tile = std::get<0>(last_tile_tuple);
+  auto& last_tile_var = std::get<1>(last_tile_tuple);
+  auto& last_tile_validity = std::get<2>(last_tile_tuple);
+
+  (void)last_tile_validity;
+  (void)nullable;
+  (void)buffer_validity;
 
   uint64_t cell_idx = 0;
   if (!last_tile.empty()) {
     if (coord_dups.empty()) {
       do {
-        // Write offset
+        // Write offset.
         offset = last_tile_var.size();
         RETURN_NOT_OK(last_tile.write(&offset, sizeof(offset)));
 
-        // Write var-sized value
+        // Write var-sized value(s).
         var_size = (cell_idx == cell_num - 1) ?
                        *buffer_var_size - buffer[cell_idx] :
                        buffer[cell_idx + 1] - buffer[cell_idx];
         RETURN_NOT_OK(
-            last_tile_var.write(&buffer_var[buffer[cell_idx]], var_size));
+            last_tile_var.write(buffer_var + buffer[cell_idx], var_size));
+
+        // Write validity value(s).
+        if (nullable)
+          RETURN_NOT_OK(last_tile_validity.write(
+              buffer_validity + (buffer[cell_idx] / last_tile_var.cell_size() *
+                                 constants::cell_validity_size),
+              var_size / last_tile_var.cell_size() *
+                  constants::cell_validity_size));
 
         ++cell_idx;
       } while (!last_tile.full() && cell_idx != cell_num);
     } else {
       do {
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
-          // Write offset
+          // Write offset.
           offset = last_tile_var.size();
           RETURN_NOT_OK(last_tile.write(&offset, sizeof(offset)));
 
-          // Write var-sized value
+          // Write var-sized value(s).
           var_size = (cell_idx == cell_num - 1) ?
                          *buffer_var_size - buffer[cell_idx] :
                          buffer[cell_idx + 1] - buffer[cell_idx];
           RETURN_NOT_OK(
-              last_tile_var.write(&buffer_var[buffer[cell_idx]], var_size));
+              last_tile_var.write(buffer_var + buffer[cell_idx], var_size));
+
+          // Write validity value(s).
+          if (nullable)
+            RETURN_NOT_OK(last_tile_validity.write(
+                buffer_validity +
+                    (buffer[cell_idx] / last_tile_var.cell_size() *
+                     constants::cell_validity_size),
+                var_size / last_tile_var.cell_size() *
+                    constants::cell_validity_size));
         }
 
         ++cell_idx;
@@ -2027,10 +2348,15 @@ Status Writer::prepare_full_tiles_var(
       (full_tile_num - last_tile.full()) * cell_num_per_tile;
 
   if (full_tile_num > 0) {
-    tiles->resize(2 * full_tile_num);
+    const uint64_t t = 2 + (nullable ? 1 : 0);
+    tiles->resize(t * full_tile_num);
     auto tiles_len = tiles->size();
-    for (uint64_t i = 0; i < tiles_len; i += 2)
-      RETURN_NOT_OK(init_tile(name, &((*tiles)[i]), &((*tiles)[i + 1])));
+    for (uint64_t i = 0; i < tiles_len; i += t)
+      if (!nullable)
+        RETURN_NOT_OK(init_tile(name, &((*tiles)[i]), &((*tiles)[i + 1])));
+      else
+        RETURN_NOT_OK(init_tile_nullable(
+            name, &((*tiles)[i]), &((*tiles)[i + 1]), &((*tiles)[i + 2])));
 
     // Handle last tile (it must be either full or empty)
     if (last_tile.full()) {
@@ -2038,9 +2364,15 @@ Status Writer::prepare_full_tiles_var(
       last_tile.reset();
       (*tiles)[1] = last_tile_var;
       last_tile_var.reset();
+      if (nullable) {
+        (*tiles)[2] = last_tile_validity;
+        last_tile_validity.reset();
+      }
     } else {
       assert(last_tile.empty());
       assert(last_tile_var.empty());
+      if (nullable)
+        assert(last_tile_validity.empty());
     }
 
     // Write all remaining cells one by one
@@ -2048,36 +2380,53 @@ Status Writer::prepare_full_tiles_var(
       for (uint64_t tile_idx = 0, i = 0; i < cell_num_to_write;
            ++cell_idx, ++i) {
         if ((*tiles)[tile_idx].full())
-          tile_idx += 2;
+          tile_idx += t;
 
-        // Write offset
+        // Write offset.
         offset = (*tiles)[tile_idx + 1].size();
         RETURN_NOT_OK((*tiles)[tile_idx].write(&offset, sizeof(offset)));
 
-        // Write var-sized value
+        // Write var-sized value(s).
         var_size = (cell_idx == cell_num - 1) ?
                        *buffer_var_size - buffer[cell_idx] :
                        buffer[cell_idx + 1] - buffer[cell_idx];
         RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
-            &buffer_var[buffer[cell_idx]], var_size));
+            buffer_var + buffer[cell_idx], var_size));
+
+        // Write validity value(s).
+        if (nullable)
+          RETURN_NOT_OK((*tiles)[tile_idx + 2].write(
+              buffer_validity + (buffer[cell_idx] / last_tile_var.cell_size() *
+                                 constants::cell_validity_size),
+              var_size / last_tile_var.cell_size() *
+                  constants::cell_validity_size));
       }
     } else {
       for (uint64_t tile_idx = 0, i = 0; i < cell_num_to_write;
            ++cell_idx, ++i) {
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
           if ((*tiles)[tile_idx].full())
-            tile_idx += 2;
+            tile_idx += t;
 
-          // Write offset
+          // Write offset.
           offset = (*tiles)[tile_idx + 1].size();
           RETURN_NOT_OK((*tiles)[tile_idx].write(&offset, sizeof(offset)));
 
-          // Write var-sized value
+          // Write var-sized value(s).
           var_size = (cell_idx == cell_num - 1) ?
                          *buffer_var_size - buffer[cell_idx] :
                          buffer[cell_idx + 1] - buffer[cell_idx];
           RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
-              &buffer_var[buffer[cell_idx]], var_size));
+              buffer_var + buffer[cell_idx], var_size));
+
+          // Write validity value(s).
+          if (nullable)
+            RETURN_NOT_OK((*tiles)[tile_idx + 2].write(
+                buffer_validity +
+                    (buffer[cell_idx] / last_tile_var.cell_size() *
+                     constants::cell_validity_size),
+                var_size / last_tile_var.cell_size() *
+                    constants::cell_validity_size));
         }
       }
     }
@@ -2087,30 +2436,46 @@ Status Writer::prepare_full_tiles_var(
   assert(cell_num - cell_idx < cell_num_per_tile - last_tile.cell_num());
   if (coord_dups.empty()) {
     for (; cell_idx < cell_num; ++cell_idx) {
-      // Write offset
+      // Write offset.
       offset = last_tile_var.size();
       RETURN_NOT_OK(last_tile.write(&offset, sizeof(offset)));
 
-      // Write var-sized value
+      // Write var-sized value(s).
       var_size = (cell_idx == cell_num - 1) ?
                      *buffer_var_size - buffer[cell_idx] :
                      buffer[cell_idx + 1] - buffer[cell_idx];
       RETURN_NOT_OK(
-          last_tile_var.write(&buffer_var[buffer[cell_idx]], var_size));
+          last_tile_var.write(buffer_var + buffer[cell_idx], var_size));
+
+      // Write validity value(s).
+      if (nullable)
+        RETURN_NOT_OK(last_tile_validity.write(
+            buffer_validity + (buffer[cell_idx] / last_tile_var.cell_size() *
+                               constants::cell_validity_size),
+            var_size / last_tile_var.cell_size() *
+                constants::cell_validity_size));
     }
   } else {
     for (; cell_idx < cell_num; ++cell_idx) {
       if (coord_dups.find(cell_idx) == coord_dups.end()) {
-        // Write offset
+        // Write offset.
         offset = last_tile_var.size();
         RETURN_NOT_OK(last_tile.write(&offset, sizeof(offset)));
 
-        // Write var-sized value
+        // Write var-sized value(s).
         var_size = (cell_idx == cell_num - 1) ?
                        *buffer_var_size - buffer[cell_idx] :
                        buffer[cell_idx + 1] - buffer[cell_idx];
         RETURN_NOT_OK(
-            last_tile_var.write(&buffer_var[buffer[cell_idx]], var_size));
+            last_tile_var.write(buffer_var + buffer[cell_idx], var_size));
+
+        // Write validity value(s).
+        if (nullable)
+          RETURN_NOT_OK(last_tile_validity.write(
+              buffer_validity + (buffer[cell_idx] / last_tile_var.cell_size() *
+                                 constants::cell_validity_size),
+              var_size / last_tile_var.cell_size() *
+                  constants::cell_validity_size));
       }
     }
   }
@@ -2130,12 +2495,15 @@ Status Writer::prepare_tiles(
     return Status::Ok();
 
   // For easy reference
+  auto nullable = array_schema_->is_nullable(attribute);
   auto var_size = array_schema_->var_size(attribute);
   auto it = buffers_.find(attribute);
   auto buffer = (uint64_t*)it->second.buffer_;
   auto buffer_var = (uint64_t*)it->second.buffer_var_;
+  auto buffer_validity = (uint64_t*)it->second.validity_vector_.buffer();
   auto buffer_size = it->second.buffer_size_;
   auto buffer_var_size = it->second.buffer_var_size_;
+  auto buffer_validity_size = it->second.validity_vector_.buffer_size();
   auto cell_val_num = array_schema_->cell_val_num(attribute);
 
   // Initialize tiles and buffer
@@ -2144,47 +2512,101 @@ Status Writer::prepare_tiles(
   auto buff_var =
       (!var_size) ? nullptr :
                     std::make_shared<ConstBuffer>(buffer_var, *buffer_var_size);
+  auto buff_validity =
+      (!nullable) ?
+          nullptr :
+          std::make_shared<ConstBuffer>(buffer_validity, *buffer_validity_size);
 
   // Populate each tile with the write cell ranges
-  uint64_t end_pos = array_schema_->domain()->cell_num_per_tile() - 1;
-  for (size_t i = 0, t = 0; i < tile_num; ++i, t += (var_size) ? 2 : 1) {
+  const uint64_t end_pos = array_schema_->domain()->cell_num_per_tile() - 1;
+  const uint64_t t_inc = 1 + (var_size ? 1 : 0) + (nullable ? 1 : 0);
+  for (size_t i = 0, t = 0; i < tile_num; ++i, t += t_inc) {
     uint64_t pos = 0;
     for (const auto& wcr : write_cell_ranges[i]) {
       // Write empty range
       if (wcr.pos_ > pos) {
-        if (var_size)
-          RETURN_NOT_OK(write_empty_cell_range_to_tile_var(
-              wcr.pos_ - pos, &(*tiles)[t], &(*tiles)[t + 1]));
-        else
-          RETURN_NOT_OK(write_empty_cell_range_to_tile(
-              (wcr.pos_ - pos) * cell_val_num, &(*tiles)[t]));
+        if (var_size) {
+          if (nullable)
+            RETURN_NOT_OK(write_empty_cell_range_to_tile_var_nullable(
+                wcr.pos_ - pos,
+                &(*tiles)[t],
+                &(*tiles)[t + 1],
+                &(*tiles)[t + 2]));
+          else
+            RETURN_NOT_OK(write_empty_cell_range_to_tile_var(
+                wcr.pos_ - pos, &(*tiles)[t], &(*tiles)[t + 1]));
+        } else {
+          if (nullable)
+            RETURN_NOT_OK(write_empty_cell_range_to_tile_nullable(
+                (wcr.pos_ - pos) * cell_val_num,
+                &(*tiles)[t],
+                &(*tiles)[t + 1]));
+          else
+            RETURN_NOT_OK(write_empty_cell_range_to_tile(
+                (wcr.pos_ - pos) * cell_val_num, &(*tiles)[t]));
+        }
         pos = wcr.pos_;
       }
 
       // Write (non-empty) range
-      if (var_size)
-        RETURN_NOT_OK(write_cell_range_to_tile_var(
-            buff.get(),
-            buff_var.get(),
-            wcr.start_,
-            wcr.end_,
-            &(*tiles)[t],
-            &(*tiles)[t + 1]));
-      else
-        RETURN_NOT_OK(write_cell_range_to_tile(
-            buff.get(), wcr.start_, wcr.end_, &(*tiles)[t]));
+      if (var_size) {
+        if (nullable) {
+          RETURN_NOT_OK(write_cell_range_to_tile_var_nullable(
+              buff.get(),
+              buff_var.get(),
+              buff_validity.get(),
+              wcr.start_,
+              wcr.end_,
+              &(*tiles)[t],
+              &(*tiles)[t + 1],
+              &(*tiles)[t + 2]));
+        } else
+          RETURN_NOT_OK(write_cell_range_to_tile_var(
+              buff.get(),
+              buff_var.get(),
+              wcr.start_,
+              wcr.end_,
+              &(*tiles)[t],
+              &(*tiles)[t + 1]));
+      } else {
+        if (nullable)
+          RETURN_NOT_OK(write_cell_range_to_tile_nullable(
+              buff.get(),
+              buff_validity.get(),
+              wcr.start_,
+              wcr.end_,
+              &(*tiles)[t],
+              &(*tiles)[t + 1]));
+        else
+          RETURN_NOT_OK(write_cell_range_to_tile(
+              buff.get(), wcr.start_, wcr.end_, &(*tiles)[t]));
+      }
 
       pos += wcr.end_ - wcr.start_ + 1;
     }
 
     // Write empty range
     if (pos <= end_pos) {
-      if (var_size)
-        RETURN_NOT_OK(write_empty_cell_range_to_tile_var(
-            end_pos - pos + 1, &(*tiles)[t], &(*tiles)[t + 1]));
-      else
-        RETURN_NOT_OK(write_empty_cell_range_to_tile(
-            (end_pos - pos + 1) * cell_val_num, &(*tiles)[t]));
+      if (var_size) {
+        if (nullable) {
+          RETURN_NOT_OK(write_empty_cell_range_to_tile_var_nullable(
+              end_pos - pos + 1,
+              &(*tiles)[t],
+              &(*tiles)[t + 1],
+              &(*tiles)[t + 2]));
+        } else
+          RETURN_NOT_OK(write_empty_cell_range_to_tile_var(
+              end_pos - pos + 1, &(*tiles)[t], &(*tiles)[t + 1]));
+      } else {
+        if (nullable)
+          RETURN_NOT_OK(write_empty_cell_range_to_tile_nullable(
+              (end_pos - pos + 1) * cell_val_num,
+              &(*tiles)[t],
+              &(*tiles)[t + 1]));
+        else
+          RETURN_NOT_OK(write_empty_cell_range_to_tile(
+              (end_pos - pos + 1) * cell_val_num, &(*tiles)[t]));
+      }
     }
   }
 
@@ -2243,7 +2665,10 @@ Status Writer::prepare_tiles_fixed(
     return Status::Ok();
 
   // For easy reference
+  auto nullable = array_schema_->is_nullable(name);
   auto buffer = (unsigned char*)buffers_.find(name)->second.buffer_;
+  auto buffer_validity =
+      (unsigned char*)buffers_.find(name)->second.validity_vector_.buffer();
   auto cell_size = array_schema_->cell_size(name);
   auto cell_num = (uint64_t)cell_pos.size();
   auto capacity = array_schema_->capacity();
@@ -2251,9 +2676,15 @@ Status Writer::prepare_tiles_fixed(
   auto tile_num = utils::math::ceil(cell_num - dups_num, capacity);
 
   // Initialize tiles
-  tiles->resize(tile_num);
-  for (auto& tile : (*tiles))
-    RETURN_NOT_OK(init_tile(name, &tile));
+  const uint64_t t = 1 + (nullable ? 1 : 0);
+  tiles->resize(t * tile_num);
+  for (uint64_t i = 0; i < tiles->size(); i += t) {
+    if (!nullable)
+      RETURN_NOT_OK(init_tile(name, &((*tiles)[i])));
+    else
+      RETURN_NOT_OK(
+          init_tile_nullable(name, &((*tiles)[i]), &((*tiles)[i + 1])));
+  }
 
   // Write all cells one by one
   if (dups_num == 0) {
@@ -2263,6 +2694,10 @@ Status Writer::prepare_tiles_fixed(
 
       RETURN_NOT_OK((*tiles)[tile_idx].write(
           buffer + cell_pos[i] * cell_size, cell_size));
+      if (nullable)
+        RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
+            buffer_validity + cell_pos[i] * constants::cell_validity_size,
+            constants::cell_validity_size));
     }
   } else {
     for (uint64_t i = 0, tile_idx = 0; i < cell_num; ++i) {
@@ -2274,6 +2709,10 @@ Status Writer::prepare_tiles_fixed(
 
       RETURN_NOT_OK((*tiles)[tile_idx].write(
           buffer + cell_pos[i] * cell_size, cell_size));
+      if (nullable)
+        RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
+            buffer_validity + cell_pos[i] * constants::cell_validity_size,
+            constants::cell_validity_size));
     }
   }
 
@@ -2287,8 +2726,10 @@ Status Writer::prepare_tiles_var(
     std::vector<Tile>* tiles) const {
   // For easy reference
   auto it = buffers_.find(name);
+  auto nullable = array_schema_->is_nullable(name);
   auto buffer = (uint64_t*)it->second.buffer_;
   auto buffer_var = (unsigned char*)it->second.buffer_var_;
+  auto buffer_validity = (unsigned char*)it->second.validity_vector_.buffer();
   auto buffer_var_size = it->second.buffer_var_size_;
   auto cell_num = (uint64_t)cell_pos.size();
   auto capacity = array_schema_->capacity();
@@ -2298,27 +2739,42 @@ Status Writer::prepare_tiles_var(
   uint64_t var_size;
 
   // Initialize tiles
-  tiles->resize(2 * tile_num);
+  const uint64_t t = 2 + (nullable ? 1 : 0);
+  tiles->resize(t * tile_num);
   auto tiles_len = tiles->size();
-  for (uint64_t i = 0; i < tiles_len; i += 2)
-    RETURN_NOT_OK(init_tile(name, &((*tiles)[i]), &((*tiles)[i + 1])));
+  for (uint64_t i = 0; i < tiles_len; i += t) {
+    if (!nullable)
+      RETURN_NOT_OK(init_tile(name, &((*tiles)[i]), &((*tiles)[i + 1])));
+    else
+      RETURN_NOT_OK(init_tile_nullable(
+          name, &((*tiles)[i]), &((*tiles)[i + 1]), &((*tiles)[i + 2])));
+  }
 
   // Write all cells one by one
   if (dups_num == 0) {
     for (uint64_t i = 0, tile_idx = 0; i < cell_num; ++i) {
       if ((*tiles)[tile_idx].full())
-        tile_idx += 2;
+        tile_idx += t;
 
-      // Write offset
+      // Write offset.
       offset = (*tiles)[tile_idx + 1].size();
       RETURN_NOT_OK((*tiles)[tile_idx].write(&offset, sizeof(offset)));
 
-      // Write var-sized value
+      // Write var-sized value(s).
       var_size = (cell_pos[i] == cell_num - 1) ?
                      *buffer_var_size - buffer[cell_pos[i]] :
                      buffer[cell_pos[i] + 1] - buffer[cell_pos[i]];
       RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
-          &buffer_var[buffer[cell_pos[i]]], var_size));
+          buffer_var + buffer[cell_pos[i]], var_size));
+
+      // Write validity value(s).
+      if (nullable) {
+        const uint64_t tile_var_cell_size = (*tiles)[tile_idx + 1].cell_size();
+        RETURN_NOT_OK((*tiles)[tile_idx + 2].write(
+            buffer_validity + (buffer[cell_pos[i]] / tile_var_cell_size *
+                               constants::cell_validity_size),
+            var_size / tile_var_cell_size * constants::cell_validity_size));
+      }
     }
   } else {
     for (uint64_t i = 0, tile_idx = 0; i < cell_num; ++i) {
@@ -2326,18 +2782,27 @@ Status Writer::prepare_tiles_var(
         continue;
 
       if ((*tiles)[tile_idx].full())
-        tile_idx += 2;
+        tile_idx += t;
 
-      // Write offset
+      // Write offset.
       offset = (*tiles)[tile_idx + 1].size();
       RETURN_NOT_OK((*tiles)[tile_idx].write(&offset, sizeof(offset)));
 
-      // Write var-sized value
+      // Write var-sized value(s).
       var_size = (cell_pos[i] == cell_num - 1) ?
                      *buffer_var_size - buffer[cell_pos[i]] :
                      buffer[cell_pos[i] + 1] - buffer[cell_pos[i]];
       RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
-          &buffer_var[buffer[cell_pos[i]]], var_size));
+          buffer_var + buffer[cell_pos[i]], var_size));
+
+      // Write validity value(s).
+      if (nullable) {
+        const uint64_t tile_var_cell_size = (*tiles)[tile_idx + 1].cell_size();
+        RETURN_NOT_OK((*tiles)[tile_idx + 2].write(
+            buffer_validity + (buffer[cell_pos[i]] / tile_var_cell_size *
+                               constants::cell_validity_size),
+            var_size / tile_var_cell_size * constants::cell_validity_size));
+      }
     }
   }
 
@@ -2409,7 +2874,7 @@ Status Writer::split_coords_buffer() {
     if (buff.buffer_ == nullptr)
       RETURN_NOT_OK(Status::WriterError(
           "Cannot split coordinate buffers; memory allocation failed"));
-    buffers_[dim_name] = buff;
+    buffers_[dim_name] = std::move(buff);
   }
 
   // Split coordinates
@@ -2465,8 +2930,10 @@ Status Writer::unordered_write() {
 
   // Set the number of tiles in the metadata
   auto it = tiles.begin();
-  auto tile_num = array_schema_->var_size(it->first) ? it->second.size() / 2 :
-                                                       it->second.size();
+  const uint64_t tile_num_divisor =
+      1 + (array_schema_->var_size(it->first) ? 1 : 0) +
+      (array_schema_->is_nullable(it->first) ? 1 : 0);
+  auto tile_num = it->second.size() / tile_num_divisor;
   frag_meta->set_num_tiles(tile_num);
 
   STATS_ADD_COUNTER(stats::Stats::CounterType::WRITE_TILE_NUM, tile_num);
@@ -2510,6 +2977,24 @@ Status Writer::write_empty_cell_range_to_tile(uint64_t num, Tile* tile) const {
   return Status::Ok();
 }
 
+Status Writer::write_empty_cell_range_to_tile_nullable(
+    uint64_t num, Tile* tile, Tile* tile_validity) const {
+  auto type = tile->type();
+  auto fill_size = datatype_size(type);
+  auto fill_value = constants::fill_value(type);
+  assert(fill_value != nullptr);
+
+  for (uint64_t i = 0; i < num; ++i) {
+    RETURN_NOT_OK(tile->write(fill_value, fill_size));
+
+    // Write validity empty value
+    uint8_t empty_validity_value = 0;
+    RETURN_NOT_OK(tile_validity->write(&empty_validity_value, sizeof(uint8_t)));
+  }
+
+  return Status::Ok();
+}
+
 Status Writer::write_empty_cell_range_to_tile_var(
     uint64_t num, Tile* tile, Tile* tile_var) const {
   auto type = tile_var->type();
@@ -2529,11 +3014,53 @@ Status Writer::write_empty_cell_range_to_tile_var(
   return Status::Ok();
 }
 
+Status Writer::write_empty_cell_range_to_tile_var_nullable(
+    uint64_t num, Tile* tile, Tile* tile_var, Tile* tile_validity) const {
+  auto type = tile_var->type();
+  auto fill_size = datatype_size(type);
+  auto fill_value = constants::fill_value(type);
+  assert(fill_value != nullptr);
+
+  for (uint64_t i = 0; i < num; ++i) {
+    // Write next offset
+    const uint64_t next_offset = tile_var->size();
+    RETURN_NOT_OK(tile->write(&next_offset, sizeof(uint64_t)));
+
+    // Write variable-sized empty value
+    RETURN_NOT_OK(tile_var->write(fill_value, fill_size));
+
+    // Write validity empty value
+    uint8_t empty_validity_value = 0;
+    RETURN_NOT_OK(tile_validity->write(&empty_validity_value, sizeof(uint8_t)));
+  }
+
+  return Status::Ok();
+}
+
 Status Writer::write_cell_range_to_tile(
     ConstBuffer* buff, uint64_t start, uint64_t end, Tile* tile) const {
-  auto cell_size = tile->cell_size();
-  buff->set_offset(start * cell_size);
-  return tile->write(buff, (end - start + 1) * cell_size);
+  auto fixed_cell_size = tile->cell_size();
+  buff->set_offset(start * fixed_cell_size);
+  return tile->write(buff, (end - start + 1) * fixed_cell_size);
+}
+
+Status Writer::write_cell_range_to_tile_nullable(
+    ConstBuffer* buff,
+    ConstBuffer* buff_validity,
+    uint64_t start,
+    uint64_t end,
+    Tile* tile,
+    Tile* tile_validity) const {
+  auto fixed_cell_size = tile->cell_size();
+  buff->set_offset(start * fixed_cell_size);
+  RETURN_NOT_OK(tile->write(buff, (end - start + 1) * fixed_cell_size));
+
+  auto validity_cell_size = constants::cell_validity_size;
+  buff_validity->set_offset(start * validity_cell_size);
+  RETURN_NOT_OK(tile_validity->write(
+      buff_validity, (end - start + 1) * validity_cell_size));
+
+  return Status::Ok();
 }
 
 Status Writer::write_cell_range_to_tile_var(
@@ -2559,6 +3086,41 @@ Status Writer::write_cell_range_to_tile_var(
     auto cell_var_size = end_offset - start_offset;
     buff_var->set_offset(start_offset);
     RETURN_NOT_OK(tile_var->write(buff_var, cell_var_size));
+  }
+
+  return Status::Ok();
+}
+
+Status Writer::write_cell_range_to_tile_var_nullable(
+    ConstBuffer* buff,
+    ConstBuffer* buff_var,
+    ConstBuffer* buff_validity,
+    uint64_t start,
+    uint64_t end,
+    Tile* tile,
+    Tile* tile_var,
+    Tile* tile_validity) const {
+  auto buff_cell_num = buff->size() / sizeof(uint64_t);
+
+  for (auto i = start; i <= end; ++i) {
+    // Write next offset.
+    uint64_t next_offset = tile_var->size();
+    RETURN_NOT_OK(tile->write(&next_offset, sizeof(uint64_t)));
+
+    // Write variable-sized value(s).
+    auto last_cell = (i == buff_cell_num - 1);
+    auto start_offset = buff->value<uint64_t>(i * sizeof(uint64_t));
+    auto end_offset = last_cell ?
+                          buff_var->size() :
+                          buff->value<uint64_t>((i + 1) * sizeof(uint64_t));
+    auto cell_var_size = end_offset - start_offset;
+    buff_var->set_offset(start_offset);
+    RETURN_NOT_OK(tile_var->write(buff_var, cell_var_size));
+
+    // Write the validity value(s).
+    buff_validity->set_offset(start_offset / tile_var->cell_size());
+    RETURN_NOT_OK(tile_validity->write(
+        buff_validity, cell_var_size / tile_var->cell_size()));
   }
 
   return Status::Ok();
@@ -2598,9 +3160,11 @@ Status Writer::write_tiles(
     return Status::Ok();
 
   // For easy reference
-  bool var_size = array_schema_->var_size(name);
+  const bool var_size = array_schema_->var_size(name);
+  const bool nullable = array_schema_->is_nullable(name);
   const auto& uri = frag_meta->uri(name);
   const auto& var_uri = var_size ? frag_meta->var_uri(name) : URI("");
+  const auto& validity_uri = nullable ? frag_meta->validity_uri(name) : URI("");
 
   // Write tiles
   auto tile_num = tiles->size();
@@ -2618,6 +3182,16 @@ Status Writer::write_tiles(
           name, tile_id, tile->filtered_buffer()->size());
       frag_meta->set_tile_var_size(name, tile_id, tile->pre_filtered_size());
     }
+
+    if (nullable) {
+      ++i;
+
+      tile = &(*tiles)[i];
+      RETURN_NOT_OK(
+          storage_manager_->write(validity_uri, tile->filtered_buffer()));
+      frag_meta->set_tile_validity_offset(
+          name, tile_id, tile->filtered_buffer()->size());
+    }
   }
 
   // Close files, except in the case of global order
@@ -2625,6 +3199,9 @@ Status Writer::write_tiles(
     RETURN_NOT_OK(storage_manager_->close_file(frag_meta->uri(name)));
     if (var_size)
       RETURN_NOT_OK(storage_manager_->close_file(frag_meta->var_uri(name)));
+    if (nullable)
+      RETURN_NOT_OK(
+          storage_manager_->close_file(frag_meta->validity_uri(name)));
   }
 
   return Status::Ok();
@@ -2638,8 +3215,7 @@ std::string Writer::coords_to_str(uint64_t i) const {
   for (unsigned d = 0; d < dim_num; ++d) {
     auto dim = array_schema_->dimension(d);
     const auto& dim_name = dim->name();
-    auto buff = buffers_.find(dim_name)->second;
-    ss << dim->coord_to_str(buff, i);
+    ss << dim->coord_to_str(buffers_.find(dim_name)->second, i);
     if (d < dim_num - 1)
       ss << ", ";
   }
@@ -2668,6 +3244,7 @@ Status Writer::set_coords_buffer(void* buffer, uint64_t* buffer_size) {
 }
 
 void Writer::get_dim_attr_stats() const {
+  // TODO JOE
   for (const auto& it : buffers_) {
     const auto& name = it.first;
     auto var_size = array_schema_->var_size(name);

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -40,6 +40,8 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/fragment/written_fragment_info.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/query/query_buffer.h"
+#include "tiledb/sm/query/validity_vector.h"
 #include "tiledb/sm/query/write_cell_slab_iter.h"
 #include "tiledb/sm/subarray/subarray.h"
 #include "tiledb/sm/tile/tile.h"
@@ -70,9 +72,10 @@ class Writer {
      * Stores the last tile of each attribute/dimension for each write
      * operation. For fixed-sized attributes/dimensions, the second tile is
      * ignored. For var-sized attributes/dimensions, the first tile is the
-     * offsets tile, whereas the second tile is the values tile.
+     * offsets tile, whereas the second tile is the values tile. In both cases,
+     * the third tile stores a validity tile for nullable attributes.
      */
-    std::unordered_map<std::string, std::pair<Tile, Tile>> last_tiles_;
+    std::unordered_map<std::string, std::tuple<Tile, Tile, Tile>> last_tiles_;
 
     /**
      * Stores the number of cells written for each attribute/dimension across
@@ -150,12 +153,6 @@ class Writer {
   /** Returns the names of the buffers set by the user for the write query. */
   std::vector<std::string> buffer_names() const;
 
-  /**
-   * Returns the query buffer for the given attribute/dimension name.
-   * The name can be TILEDB_COORDS.
-   */
-  QueryBuffer buffer(const std::string& name) const;
-
   /** Finalizes the reader. */
   Status finalize();
 
@@ -188,6 +185,42 @@ class Writer {
       uint64_t** buffer_off_size,
       void** buffer_val,
       uint64_t** buffer_val_size) const;
+
+  /**
+   * Retrieves the buffer of a fixed-sized, nullable attribute.
+   *
+   * @param name The buffer name.
+   * @param buffer The buffer to be retrieved.
+   * @param buffer_size A pointer to the buffer size to be retrieved.
+   * @param validity_vector A pointer to the validity vector to be retrieved.
+   * @return Status
+   */
+  Status get_buffer_nullable(
+      const std::string& name,
+      void** buffer,
+      uint64_t** buffer_size,
+      const ValidityVector** validity_vector) const;
+
+  /**
+   * Retrieves the offsets and values buffers of a var-sized,
+   * nullable attribute.
+   *
+   * @param name The buffer attribute/dimension.
+   * @param buffer_off The offsets buffer to be retrieved.
+   * @param buffer_off_size A pointer to the offsets buffer size to be
+   * retrieved.
+   * @param buffer_val The values buffer to be retrieved.
+   * @param buffer_val_size A pointer to the values buffer size to be retrieved.
+   * @param validity_vector A pointer to the validity vector to be retrieved.
+   * @return Status
+   */
+  Status get_buffer_nullable(
+      const std::string& name,
+      uint64_t** buffer_off,
+      uint64_t** buffer_off_size,
+      void** buffer_val,
+      uint64_t** buffer_val_size,
+      const ValidityVector** validity_vector) const;
 
   /** Returns current setting of check_coord_dups_ */
   bool get_check_coord_dups() const;
@@ -243,6 +276,45 @@ class Writer {
       uint64_t* buffer_off_size,
       void* buffer_val,
       uint64_t* buffer_val_size);
+
+  /**
+   * Sets the buffer for a fixed-sized, nullable attribute.
+   *
+   * @param name The attribute to set the buffer for.
+   * @param buffer The buffer that has the input data to be written.
+   * @param buffer_size The size of `buffer` in bytes.
+   * @param validity_vector The validity vector associated with values in
+   * `buffer`.
+   * @return Status
+   */
+  Status set_buffer(
+      const std::string& name,
+      void* buffer,
+      uint64_t* buffer_size,
+      ValidityVector&& validity_vector);
+
+  /**
+   * Sets the buffer for a var-sized, nullable attribute.
+   *
+   * @param name The attribute to set the buffer for.
+   * @param buffer_off The buffer that has the input data to be written,
+   *     This buffer holds the starting offsets of each cell value in
+   *     `buffer_val`.
+   * @param buffer_off_size The size of `buffer_off` in bytes.
+   * @param buffer_val The buffer that has the input data to be written.
+   *     This buffer holds the actual var-sized cell values.
+   * @param buffer_val_size The size of `buffer_val` in bytes.
+   * @param validity_vector The validity vector associated with values in
+   * `buffer_val`.
+   * @return Status
+   */
+  Status set_buffer(
+      const std::string& name,
+      uint64_t* buffer_off,
+      uint64_t* buffer_off_size,
+      void* buffer_val,
+      uint64_t* buffer_val_size,
+      ValidityVector&& validity_vector);
 
   /** Sets current setting of check_coord_dups_ */
   void set_check_coord_dups(bool b);
@@ -595,6 +667,32 @@ class Writer {
   Status init_tile(const std::string& name, Tile* tile, Tile* tile_var) const;
 
   /**
+   * Initializes a fixed-sized, nullable tile.
+   *
+   * @param name The attribute the tile belongs to.
+   * @param tile The tile to be initialized.
+   * @param tile_validity The validity tile to be initialized.
+   * @return Status
+   */
+  Status init_tile_nullable(
+      const std::string& name, Tile* tile, Tile* tile_validity) const;
+
+  /**
+   * Initializes a var-sized, nullable tile.
+   *
+   * @param name The attribute the tile belongs to.
+   * @param tile The offsets tile to be initialized.
+   * @param tile_var The var-sized data tile to be initialized.
+   * @param tile_validity The validity tile to be initialized.
+   * @return Status
+   */
+  Status init_tile_nullable(
+      const std::string& name,
+      Tile* tile,
+      Tile* tile_var,
+      Tile* tile_validity) const;
+
+  /**
    * Initializes dense cell range iterators for the subarray to be writte,
    * one per overlapping tile.
    *
@@ -878,6 +976,18 @@ class Writer {
 
   /**
    * Writes an empty cell range to the input tile.
+   * Applicable to **fixed-sized** attributes.
+   *
+   * @param num Number of empty values to write.
+   * @param tile The tile to write to.
+   * @param tile_validity The tile with the validity cells to write to.
+   * @return Status
+   */
+  Status write_empty_cell_range_to_tile_nullable(
+      uint64_t num, Tile* tile, Tile* tile_validity) const;
+
+  /**
+   * Writes an empty cell range to the input tile.
    * Applicable to **variable-sized** attributes.
    *
    * @param num Number of empty values to write.
@@ -887,6 +997,19 @@ class Writer {
    */
   Status write_empty_cell_range_to_tile_var(
       uint64_t num, Tile* tile, Tile* tile_var) const;
+
+  /**
+   * Writes an empty cell range to the input tile.
+   * Applicable to **variable-sized** attributes.
+   *
+   * @param num Number of empty values to write.
+   * @param tile The tile offsets to write to.
+   * @param tile_var The tile with the var-sized cells to write to.
+   * @param tile_validity The tile with the validity cells to write to.
+   * @return Status
+   */
+  Status write_empty_cell_range_to_tile_var_nullable(
+      uint64_t num, Tile* tile, Tile* tile_var, Tile* tile_validity) const;
 
   /**
    * Writes the input cell range to the input tile, for a particular
@@ -900,6 +1023,27 @@ class Writer {
    */
   Status write_cell_range_to_tile(
       ConstBuffer* buff, uint64_t start, uint64_t end, Tile* tile) const;
+
+  /**
+   * Writes the input cell range to the input tile, for a particular
+   * buffer. Applicable to **fixed-sized** attributes.
+   *
+   * @param buff The write buffer where the cells will be copied from.
+   * @param buff_validity The write buffer where the validity cell values will
+   * be copied from.
+   * @param start The start element in the write buffer.
+   * @param end The end element in the write buffer.
+   * @param tile The tile to write to.
+   * @param tile_validity The validity tile to be initialized.
+   * @return Status
+   */
+  Status write_cell_range_to_tile_nullable(
+      ConstBuffer* buff,
+      ConstBuffer* buff_validity,
+      uint64_t start,
+      uint64_t end,
+      Tile* tile,
+      Tile* tile_validity) const;
 
   /**
    * Writes the input cell range to the input tile, for a particular
@@ -920,6 +1064,31 @@ class Writer {
       uint64_t end,
       Tile* tile,
       Tile* tile_var) const;
+
+  /**
+   * Writes the input cell range to the input tile, for a particular
+   * buffer. Applicable to **variable-sized**, nullable attributes.
+   *
+   * @param buff The write buffer where the cell offsets will be copied from.
+   * @param buff_var The write buffer where the cell values will be copied from.
+   * @param buff_validity The write buffer where the validity cell values will
+   * be copied from.
+   * @param start The start element in the write buffer.
+   * @param end The end element in the write buffer.
+   * @param tile The tile offsets to write to.
+   * @param tile_var The tile with the var-sized cells to write to.
+   * @param tile_validity The validity tile to be initialized.
+   * @return Status
+   */
+  Status write_cell_range_to_tile_var_nullable(
+      ConstBuffer* buff,
+      ConstBuffer* buff_var,
+      ConstBuffer* buff_validity,
+      uint64_t start,
+      uint64_t end,
+      Tile* tile,
+      Tile* tile_var,
+      Tile* tile_validity) const;
 
   /**
    * Writes all the input tiles to storage.


### PR DESCRIPTION
While this is a work-in-progress, both the C and C++ API are sufficiently
complete to run end-to-end read/write queries.

This patch has many remaining TODO items:
- Complete the unsafe and string-specific `set_buffer_nullable` C++ API routines.
- A fixed compressor specific to validity tiles.
- Selective decompression on validity tiles.
- Add the `get_buffer_nullable` C API routines.
- Misc style issues (incomplete comments, in-code documentation)