### PR TITLE
Hilbert order, improvements and bug fixes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,11 +6,18 @@
 
 ## Breaking behavior
 
+* The tile extent can now be set to null, in which case internally TileDB sets the extent to the dimension domain range. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
+
 ## New features
 
 * Support for AWS S3 "AssumeRole" temporary credentials [#1882](https://github.com/TileDB-Inc/TileDB/pull/1882)
+* Added support for Hilbert order sorting for sparse arrays. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 
 ## Improvements
+
+* Prevented unnecessary sorting when (1) there is a single fragment and (i) either the query layout is global order, or (ii) the number of dimensions is 1, and (2) when there is a single range for which the result coordinates have already been sorted. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
+* Added extra stats for consolidation. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
+* Disabled checking if cells are written in global order when consolidating, as it was redundant (the cells are already being read in global order during consolidation). [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880) 
 
 ## Deprecations
 
@@ -18,8 +25,16 @@
 
 * Fix ArraySchema not write protecting fill values for only schema version 6 or newer [#1868](https://github.com/TileDB-Inc/TileDB/pull/1868)
 * Fix segfault that may occur in the VFS read-ahead cache [#1871](https://github.com/TileDB-Inc/TileDB/pull/1871)
+* The result size estimation routines will no longer return non-zero sizes that can not contain a single value. [#1849](https://github.com/TileDB-Inc/TileDB/pull/1849)
+* Fixed issue with string dimensions and non-set subarray (which implies spanning the whole domain). There was an assertion being triggered. Now it works properly.
+* Fixed bug when checking the dimension domain for infinity or NaN values. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
+* Fixed bug with string dimension partitioning. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 
 ## API additions
+
+### C++ API
+
+* Added function `Dimension::create` that allows not setting a space tile extent. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 
 # TileDB v2.1.0 Release Notes
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -129,12 +129,14 @@ set(TILEDB_TEST_SOURCES
   src/unit-CellSlabIter.cc
   src/unit-compression-dd.cc
   src/unit-compression-rle.cc
-  src/unit-ctx.cc
   src/unit-crypto.cc
+  src/unit-ctx.cc
+  src/unit-dimension.cc
   src/unit-filter-buffer.cc
   src/unit-filter-pipeline.cc
   src/unit-gcs.cc
   src/unit-hdfs-filesystem.cc
+  src/unit-hilbert.cc
   src/unit-lru_cache.cc
   src/unit-Reader.cc
   src/unit-ReadCellSlabIter.cc
@@ -152,6 +154,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-Tile.cc
   src/unit-TileDomain.cc
   src/unit-uri.cc
+  src/unit-utils.cc
   src/unit-uuid.cc
   src/unit-vfs.cc
   src/unit-win-filesystem.cc
@@ -168,6 +171,7 @@ if (TILEDB_CPP_API)
     src/unit-cppapi-datetimes.cc
     src/unit-cppapi-fill_values.cc
     src/unit-cppapi-filter.cc
+    src/unit-cppapi-hilbert.cc
     src/unit-cppapi-metadata.cc
     src/unit-cppapi-query.cc
     src/unit-cppapi-schema.cc

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -2332,7 +2332,7 @@ TEST_CASE_METHOD(
   partition.get_range(0, 0, &range);
   CHECK(range != nullptr);
   CHECK(range->start_str() == std::string("a", 1));
-  CHECK(range->end_str() == std::string("a", 1));
+  CHECK(range->end_str() == std::string("a\x7F", 2));
   CHECK(partitioner_split.next(&unsplittable).ok());
   CHECK(!unsplittable);
   partition = partitioner_split.current();
@@ -2385,7 +2385,7 @@ TEST_CASE_METHOD(
   partition.get_range(0, 0, &range);
   CHECK(range != nullptr);
   CHECK(range->start_str() == std::string("bb", 2));
-  CHECK(range->end_str() == std::string("bb", 2));
+  CHECK(range->end_str() == std::string("b\x7F", 2));
   CHECK(partitioner_split_2.next(&unsplittable).ok());
   CHECK(!unsplittable);
   partition = partitioner_split_2.current();

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -1167,7 +1167,7 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     ArraySchemaFx,
     "C API: Test array schema with invalid dimension domain and tile extent",
-    "[capi], [array-schema]") {
+    "[capi][array-schema]") {
   // Domain range exceeds type range - error
   tiledb_dimension_t* d0;
   uint64_t dim_domain[] = {0, UINT64_MAX};
@@ -1175,12 +1175,16 @@ TEST_CASE_METHOD(
       ctx_, "d0", TILEDB_UINT64, dim_domain, nullptr, &d0);
   CHECK(rc == TILEDB_ERR);
 
-  // Create dimension with huge range and no tile extent - not ok
+  // Create dimension with huge range and no tile extent - this should be ok
   tiledb_dimension_t* d1;
   dim_domain[1] = UINT64_MAX - 1;
   rc = tiledb_dimension_alloc(
       ctx_, "d1", TILEDB_UINT64, dim_domain, nullptr, &d1);
-  CHECK(rc == TILEDB_ERR);
+  CHECK(rc == TILEDB_OK);
+  const void* extent;
+  rc = tiledb_dimension_get_tile_extent(ctx_, d1, &extent);
+  CHECK(rc == TILEDB_OK);
+  CHECK(extent == nullptr);
 
   // Create dimension with huge range and tile extent - error
   tiledb_dimension_t* d2;
@@ -1224,7 +1228,7 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     ArraySchemaFx,
     "C API: Test NAN and INF in dimensions",
-    "[capi][array-schema][array-schema-nan-inf]") {
+    "[capi][array-schema][nan-inf]") {
   // Create dimension with INF
   tiledb_dimension_t* d;
   float dim_domain[] = {0, std::numeric_limits<float>::infinity()};
@@ -1241,8 +1245,69 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     ArraySchemaFx,
+    "C API: Test setting null extent to domain range",
+    "[capi][array-schema][null-extent-default]") {
+  // Create dimensions
+  tiledb_dimension_t* d1;
+  int32_t d1_dom[] = {1, 100};
+  int rc =
+      tiledb_dimension_alloc(ctx_, "d1", TILEDB_INT32, d1_dom, nullptr, &d1);
+  CHECK(rc == TILEDB_OK);
+  tiledb_dimension_t* d2;
+  float d2_dom[] = {1.1f, 1.3f};
+  rc = tiledb_dimension_alloc(ctx_, "d2", TILEDB_FLOAT32, d2_dom, nullptr, &d2);
+  CHECK(rc == TILEDB_OK);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  rc = tiledb_array_schema_alloc(ctx_, TILEDB_SPARSE, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set domain
+  tiledb_domain_t* domain;
+  rc = tiledb_domain_alloc(ctx_, &domain);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, d1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, d2);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_domain(ctx_, array_schema, domain);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Get extents
+  tiledb_domain_t* r_domain;
+  rc = tiledb_array_schema_get_domain(ctx_, array_schema, &r_domain);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_dimension_t* r_d1;
+  rc = tiledb_domain_get_dimension_from_index(ctx_, r_domain, 0, &r_d1);
+  REQUIRE(rc == TILEDB_OK);
+  const void* extent = NULL;
+  rc = tiledb_dimension_get_tile_extent(ctx_, r_d1, &extent);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(extent != NULL);
+  CHECK(*(const int32_t*)extent == 100);
+  tiledb_dimension_t* r_d2;
+  rc = tiledb_domain_get_dimension_from_index(ctx_, r_domain, 1, &r_d2);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_dimension_get_tile_extent(ctx_, r_d2, &extent);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(extent != NULL);
+  CHECK(*(const float*)extent == d2_dom[1] - d2_dom[0]);
+
+  // Clean up
+  tiledb_dimension_free(&d1);
+  tiledb_dimension_free(&d2);
+  tiledb_dimension_free(&r_d1);
+  tiledb_dimension_free(&r_d2);
+  tiledb_domain_free(&domain);
+  tiledb_domain_free(&r_domain);
+  tiledb_array_schema_free(&array_schema);
+}
+
+TEST_CASE_METHOD(
+    ArraySchemaFx,
     "C API: Test array schema offsets/coords filter lists",
-    "[capi], [array-schema], [filter]") {
+    "[capi][array-schema][filter]") {
   SECTION("- No serialization") {
     serialize_array_schema_ = false;
   }

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -1873,10 +1873,10 @@ TEST_CASE_METHOD(
   read_array_1d(
       ctx_, array, layout, "aa", "cc", &r_d_off, &r_d_val, &r_a, &status);
   CHECK(status == TILEDB_INCOMPLETE);
-  CHECK(r_d_val == "aa");
-  c_d_off = {0};
+  CHECK(r_d_val == "aabb");
+  c_d_off = {0, 2};
   CHECK(r_d_off == c_d_off);
-  c_a = {1};
+  c_a = {1, 2};
   CHECK(r_a == c_a);
 
   // Read [aa, cc] - INCOMPLETE, no result

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -1,0 +1,2176 @@
+/**
+ * @file   unit-cppapi-hilbert.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2020 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C++ API for array related functions.
+ */
+
+#include "catch.hpp"
+#include "tiledb/sm/cpp_api/tiledb"
+
+using namespace tiledb;
+
+void create_int32_array(const std::string& array_name) {
+  Context ctx;
+  Domain domain(ctx);
+  auto d1 = Dimension::create<int32_t>(ctx, "d1", {{0, 100}});
+  auto d2 = Dimension::create<int32_t>(ctx, "d2", {{0, 200}});
+  domain.add_dimensions(d1, d2);
+  auto a = Attribute::create<int32_t>(ctx, "a");
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain);
+  schema.add_attribute(a);
+  schema.set_cell_order(TILEDB_HILBERT);
+  schema.set_capacity(2);
+  CHECK_NOTHROW(schema.check());
+  Array::create(array_name, schema);
+}
+
+void create_int32_array_negative_domain(const std::string& array_name) {
+  Context ctx;
+  Domain domain(ctx);
+  auto d1 = Dimension::create<int32_t>(ctx, "d1", {{-50, 50}});
+  auto d2 = Dimension::create<int32_t>(ctx, "d2", {{-100, 100}});
+  domain.add_dimensions(d1, d2);
+  auto a = Attribute::create<int32_t>(ctx, "a");
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain);
+  schema.add_attribute(a);
+  schema.set_cell_order(TILEDB_HILBERT);
+  schema.set_capacity(2);
+  CHECK_NOTHROW(schema.check());
+  Array::create(array_name, schema);
+}
+
+void create_float32_array(const std::string& array_name) {
+  Context ctx;
+  Domain domain(ctx);
+  auto d1 = Dimension::create<float>(ctx, "d1", {{0.0, 1.0}});
+  auto d2 = Dimension::create<float>(ctx, "d2", {{0.0, 2.0}});
+  domain.add_dimensions(d1, d2);
+  auto a = Attribute::create<int32_t>(ctx, "a");
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain);
+  schema.add_attribute(a);
+  schema.set_cell_order(TILEDB_HILBERT);
+  schema.set_capacity(2);
+  CHECK_NOTHROW(schema.check());
+  Array::create(array_name, schema);
+}
+
+void create_string_array(const std::string& array_name) {
+  Context ctx;
+  Domain domain(ctx);
+  auto d1 = Dimension::create(ctx, "d1", TILEDB_STRING_ASCII, nullptr, nullptr);
+  auto d2 = Dimension::create(ctx, "d2", TILEDB_STRING_ASCII, nullptr, nullptr);
+  domain.add_dimensions(d1, d2);
+  auto a = Attribute::create<int32_t>(ctx, "a");
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain);
+  schema.add_attribute(a);
+  schema.set_cell_order(TILEDB_HILBERT);
+  schema.set_capacity(2);
+  CHECK_NOTHROW(schema.check());
+  Array::create(array_name, schema);
+}
+
+template <class T1, class T2>
+void write_2d_array(
+    const std::string& array_name,
+    std::vector<T1>& buff_d1,
+    std::vector<T2>& buff_d2,
+    std::vector<int32_t>& buff_a,
+    tiledb_layout_t layout) {
+  Context ctx;
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w, TILEDB_WRITE);
+  query_w.set_buffer("a", buff_a);
+  query_w.set_buffer("d1", buff_d1);
+  query_w.set_buffer("d2", buff_d2);
+  query_w.set_layout(layout);
+  CHECK_NOTHROW(query_w.submit());
+  array_w.close();
+}
+
+void write_2d_array(
+    const std::string& array_name,
+    std::vector<uint64_t>& off_d1,
+    std::string& buff_d1,
+    std::vector<uint64_t>& off_d2,
+    std::string& buff_d2,
+    std::vector<int32_t>& buff_a,
+    tiledb_layout_t layout) {
+  Context ctx;
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w, TILEDB_WRITE);
+  query_w.set_buffer("a", buff_a);
+  query_w.set_buffer("d1", off_d1, buff_d1);
+  query_w.set_buffer("d2", off_d2, buff_d2);
+  query_w.set_layout(layout);
+  CHECK_NOTHROW(query_w.submit());
+  array_w.close();
+}
+
+TEST_CASE("C++ API: Test Hilbert, errors", "[cppapi][hilbert][error]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Hilbert not applicable to dense
+  {
+    Domain domain(ctx);
+    auto d1 = Dimension::create<int32_t>(ctx, "d1", {{0, 100}});
+    auto d2 = Dimension::create<int32_t>(ctx, "d2", {{0, 200}}, 10);
+    domain.add_dimensions(d1, d2);
+    auto a = Attribute::create<int32_t>(ctx, "a");
+    ArraySchema schema(ctx, TILEDB_DENSE);
+    schema.set_domain(domain);
+    schema.add_attribute(a);
+    CHECK_THROWS(schema.set_cell_order(TILEDB_HILBERT));
+
+    // Hilbert order only applicable to cells
+    CHECK_THROWS(schema.set_tile_order(TILEDB_HILBERT));
+  }
+
+  // Check maximum dimensions
+  {
+    Domain domain(ctx);
+    auto d1 = Dimension::create<int32_t>(ctx, "d1", {{0, 100}});
+    auto d2 = Dimension::create<int32_t>(ctx, "d2", {{0, 200}});
+    auto d3 = Dimension::create<int32_t>(ctx, "d3", {{0, 200}});
+    auto d4 = Dimension::create<int32_t>(ctx, "d4", {{0, 200}});
+    auto d5 = Dimension::create<int32_t>(ctx, "d5", {{0, 200}});
+    auto d6 = Dimension::create<int32_t>(ctx, "d6", {{0, 200}});
+    auto d7 = Dimension::create<int32_t>(ctx, "d7", {{0, 200}});
+    auto d8 = Dimension::create<int32_t>(ctx, "d8", {{0, 200}});
+    auto d9 = Dimension::create<int32_t>(ctx, "d9", {{0, 200}});
+    auto d10 = Dimension::create<int32_t>(ctx, "d10", {{0, 200}});
+    auto d11 = Dimension::create<int32_t>(ctx, "d11", {{0, 200}});
+    auto d12 = Dimension::create<int32_t>(ctx, "d12", {{0, 200}});
+    auto d13 = Dimension::create<int32_t>(ctx, "d13", {{0, 200}});
+    auto d14 = Dimension::create<int32_t>(ctx, "d14", {{0, 200}});
+    auto d15 = Dimension::create<int32_t>(ctx, "d15", {{0, 200}});
+    auto d16 = Dimension::create<int32_t>(ctx, "d16", {{0, 200}});
+    auto d17 = Dimension::create<int32_t>(ctx, "d17", {{0, 200}});
+    domain.add_dimensions(
+        d1,
+        d2,
+        d3,
+        d4,
+        d5,
+        d6,
+        d7,
+        d8,
+        d9,
+        d10,
+        d11,
+        d12,
+        d13,
+        d14,
+        d15,
+        d16,
+        d17);
+    auto a = Attribute::create<int32_t>(ctx, "a");
+    ArraySchema schema(ctx, TILEDB_SPARSE);
+    schema.set_domain(domain);
+    schema.add_attribute(a);
+    CHECK_NOTHROW(schema.set_cell_order(TILEDB_HILBERT));
+    CHECK_THROWS(schema.check());
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array(array_name);
+
+  // Hilbert order not applicable to write queries
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  std::vector<int32_t> buff_a = {3, 2, 1, 4};
+  std::vector<int32_t> buff_d1 = {1, 1, 4, 5};
+  std::vector<int32_t> buff_d2 = {1, 3, 2, 4};
+  Query query_w(ctx, array_w, TILEDB_WRITE);
+  query_w.set_buffer("a", buff_a);
+  query_w.set_buffer("d1", buff_d1);
+  query_w.set_buffer("d2", buff_d2);
+  CHECK_THROWS(query_w.set_layout(TILEDB_HILBERT));
+  array_w.close();
+
+  // Hilbert order not applicable to read queries
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(4);
+  std::vector<int32_t> r_buff_d1(4);
+  std::vector<int32_t> r_buff_d2(4);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1);
+  query_r.set_buffer("d2", r_buff_d2);
+  CHECK_THROWS(query_r.set_layout(TILEDB_HILBERT));
+  array_r.close();
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, test 2D, int32, write unordered, read global",
+    "[cppapi][hilbert][2d][int32]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_a = {3, 2, 1, 4};
+  std::vector<int32_t> buff_d1 = {1, 1, 4, 5};
+  std::vector<int32_t> buff_d2 = {1, 3, 2, 4};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Read
+  SECTION("- Global order") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(4);
+    std::vector<int32_t> r_buff_d1(4);
+    std::vector<int32_t> r_buff_d2(4);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {2, 3, 4, 1};
+    std::vector<int32_t> c_buff_d1 = {1, 1, 5, 4};
+    std::vector<int32_t> c_buff_d2 = {3, 1, 4, 2};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  SECTION("- Row-major") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(4);
+    std::vector<int32_t> r_buff_d1(4);
+    std::vector<int32_t> r_buff_d2(4);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_ROW_MAJOR);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {3, 2, 1, 4};
+    std::vector<int32_t> c_buff_d1 = {1, 1, 4, 5};
+    std::vector<int32_t> c_buff_d2 = {1, 3, 2, 4};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  SECTION("- Col-major") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(4);
+    std::vector<int32_t> r_buff_d1(4);
+    std::vector<int32_t> r_buff_d2(4);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_COL_MAJOR);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {3, 1, 2, 4};
+    std::vector<int32_t> c_buff_d1 = {1, 4, 1, 5};
+    std::vector<int32_t> c_buff_d2 = {1, 2, 3, 4};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  // Read
+  SECTION("- Unordered") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(4);
+    std::vector<int32_t> r_buff_d1(4);
+    std::vector<int32_t> r_buff_d2(4);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_UNORDERED);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {2, 3, 4, 1};
+    std::vector<int32_t> c_buff_d1 = {1, 1, 5, 4};
+    std::vector<int32_t> c_buff_d2 = {3, 1, 4, 2};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, int32, 2D, partitioner",
+    "[cppapi][hilbert][2d][int32][partitioner]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_d1 = {1, 1, 4, 5};
+  std::vector<int32_t> buff_d2 = {1, 3, 2, 4};
+  std::vector<int32_t> buff_a = {3, 2, 1, 4};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  SECTION("- entire domain") {
+    // Read array
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(2);
+    std::vector<int32_t> r_buff_d1(2);
+    std::vector<int32_t> r_buff_d2(2);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    std::vector<int32_t> c_buff_a = {2, 3};
+    std::vector<int32_t> c_buff_d1 = {1, 1};
+    std::vector<int32_t> c_buff_d2 = {3, 1};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results again
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    c_buff_a = {4, 1};
+    c_buff_d1 = {5, 4};
+    c_buff_d2 = {4, 2};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    // Read until complete
+    CHECK_NOTHROW(query_r.submit());
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 0);
+
+    array_r.close();
+  }
+
+  SECTION("- subarray") {
+    // Read array
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(2);
+    std::vector<int32_t> r_buff_d1(2);
+    std::vector<int32_t> r_buff_d2(2);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    query_r.set_subarray({1, 5, 1, 7});
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    std::vector<int32_t> c_buff_a = {2, 3};
+    std::vector<int32_t> c_buff_d1 = {1, 1};
+    std::vector<int32_t> c_buff_d2 = {3, 1};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results again
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    c_buff_a = {4, 1};
+    c_buff_d1 = {5, 4};
+    c_buff_d2 = {4, 2};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    array_r.close();
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, test writing in global order",
+    "[cppapi][hilbert][write][global-order]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_a = {3, 2, 1, 4};
+  std::vector<int32_t> buff_d1 = {1, 1, 4, 5};
+  std::vector<int32_t> buff_d2 = {1, 3, 2, 4};
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w, TILEDB_WRITE);
+  query_w.set_buffer("a", buff_a);
+  query_w.set_buffer("d1", buff_d1);
+  query_w.set_buffer("d2", buff_d2);
+  query_w.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_THROWS(query_w.submit());
+
+  // Write correctly
+  buff_a = {2, 3, 4, 1};
+  buff_d1 = {1, 1, 5, 4};
+  buff_d2 = {3, 1, 4, 2};
+  CHECK_NOTHROW(query_w.submit());
+  query_w.finalize();
+  array_w.close();
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, slicing", "[cppapi][hilbert][read][slicing]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_a = {3, 2, 4, 1};
+  std::vector<int32_t> buff_d1 = {1, 1, 5, 4};
+  std::vector<int32_t> buff_d2 = {1, 3, 4, 2};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  SECTION("- Row-major") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(3);
+    std::vector<int32_t> r_buff_d1(3);
+    std::vector<int32_t> r_buff_d2(3);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_subarray({1, 4, 1, 4});
+    query_r.set_layout(TILEDB_ROW_MAJOR);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {3, 2, 1};
+    std::vector<int32_t> c_buff_d1 = {1, 1, 4};
+    std::vector<int32_t> c_buff_d2 = {1, 3, 2};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  SECTION("- Global order") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(3);
+    std::vector<int32_t> r_buff_d1(3);
+    std::vector<int32_t> r_buff_d2(3);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_subarray({1, 4, 1, 4});
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {2, 3, 1};
+    std::vector<int32_t> c_buff_d1 = {1, 1, 4};
+    std::vector<int32_t> c_buff_d2 = {3, 1, 2};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, multiple fragments, read in global order",
+    "[cppapi][hilbert][read][multiple-fragments][global-order]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {3, 2, 4, 1};
+  std::vector<int32_t> buff_d1 = {1, 1, 5, 4};
+  std::vector<int32_t> buff_d2 = {1, 3, 4, 2};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Write second fragment
+  buff_a = {5, 6, 7, 8};
+  buff_d1 = {2, 2, 3, 7};
+  buff_d2 = {1, 2, 7, 7};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  std::vector<int32_t> r_buff_d1(8);
+  std::vector<int32_t> r_buff_d2(8);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1);
+  query_r.set_buffer("d2", r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  array_r.close();
+
+  // Check results. Here is the hilbert value order:
+  // (1, 3) ->   673842753890680
+  // (1, 1) ->   972199115346920
+  // (2, 1) ->  1282508796834212
+  // (2, 2) ->  2094006769413898
+  // (3, 7) ->  8953635051284643
+  // (5, 4) -> 14306049248121919
+  // (4, 2) -> 15960063827832505
+  // (7, 7) -> 34415049034468853
+  std::vector<int32_t> c_buff_a = {2, 3, 5, 6, 7, 4, 1, 8};
+  std::vector<int32_t> c_buff_d1 = {1, 1, 2, 2, 3, 5, 4, 7};
+  std::vector<int32_t> c_buff_d2 = {3, 1, 1, 2, 7, 4, 2, 7};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, int32, unsplittable",
+    "[cppapi][hilbert][read][2d][int32][unsplittable]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {3, 2, 4, 1};
+  std::vector<int32_t> buff_d1 = {1, 1, 5, 4};
+  std::vector<int32_t> buff_d2 = {1, 3, 4, 2};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  int32_t r_buff_d1[2];
+  int32_t r_buff_d2[2];
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1, 0);
+  query_r.set_buffer("d2", r_buff_d2, 0);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+  CHECK(query_r.result_buffer_elements()["a"].second == 0);
+  array_r.close();
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, consolidation",
+    "[cppapi][hilbert][consolidation]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {3, 2, 4, 1};
+  std::vector<int32_t> buff_d1 = {1, 1, 5, 4};
+  std::vector<int32_t> buff_d2 = {1, 3, 4, 2};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Write second fragment
+  buff_a = {5, 6, 7, 8};
+  buff_d1 = {2, 2, 3, 7};
+  buff_d2 = {1, 2, 7, 7};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Consolidate and vacuum
+  Config config;
+  config["sm.consolidation.mode"] = "fragments";
+  config["sm.vacuum.mode"] = "fragments";
+  CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
+  CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
+  auto contents = vfs.ls(array_name);
+  CHECK(contents.size() == 5);
+
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  std::vector<int32_t> r_buff_d1(8);
+  std::vector<int32_t> r_buff_d2(8);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1);
+  query_r.set_buffer("d2", r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  array_r.close();
+
+  // Check results. Here is the hilbert value order:
+  // (1, 3) ->   673842753890680
+  // (1, 1) ->   972199115346920
+  // (2, 1) ->  1282508796834212
+  // (2, 2) ->  2094006769413898
+  // (3, 7) ->  8953635051284643
+  // (5, 4) -> 14306049248121919
+  // (4, 2) -> 15960063827832505
+  // (7, 7) -> 34415049034468853
+  std::vector<int32_t> c_buff_a = {2, 3, 5, 6, 7, 4, 1, 8};
+  std::vector<int32_t> c_buff_d1 = {1, 1, 2, 2, 3, 5, 4, 7};
+  std::vector<int32_t> c_buff_d2 = {3, 1, 1, 2, 7, 4, 2, 7};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2D, int32, negative, read/write in global order",
+    "[cppapi][hilbert][int32][negative][write][read][global-order]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array_negative_domain(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_a = {3, 2, 1, 4};
+  std::vector<int32_t> buff_d1 = {-49, -49, -46, -45};
+  std::vector<int32_t> buff_d2 = {-99, -97, -98, -96};
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w, TILEDB_WRITE);
+  query_w.set_buffer("a", buff_a);
+  query_w.set_buffer("d1", buff_d1);
+  query_w.set_buffer("d2", buff_d2);
+  query_w.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_THROWS(query_w.submit());
+
+  // Write correctly
+  buff_a = {2, 3, 4, 1};
+  buff_d1 = {-49, -49, -45, -46};
+  buff_d2 = {-97, -99, -96, -98};
+  CHECK_NOTHROW(query_w.submit());
+  query_w.finalize();
+  array_w.close();
+
+  // Read
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(4);
+  std::vector<int32_t> r_buff_d1(4);
+  std::vector<int32_t> r_buff_d2(4);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1);
+  query_r.set_buffer("d2", r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+
+  // Check results
+  CHECK(query_r.query_status() == Query::Status::COMPLETE);
+  CHECK(query_r.result_buffer_elements()["a"].second == 4);
+  std::vector<int32_t> c_buff_a = {2, 3, 4, 1};
+  std::vector<int32_t> c_buff_d1 = {-49, -49, -45, -46};
+  std::vector<int32_t> c_buff_d2 = {-97, -99, -96, -98};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+  array_r.close();
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, int32, negative, 2D, partitioner",
+    "[cppapi][hilbert][2d][int32][negative][partitioner]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array_negative_domain(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_d1 = {-49, -49, -46, -45};
+  std::vector<int32_t> buff_d2 = {-99, -97, -98, -96};
+  std::vector<int32_t> buff_a = {3, 2, 1, 4};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  SECTION("- entire domain") {
+    // Read array
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(2);
+    std::vector<int32_t> r_buff_d1(2);
+    std::vector<int32_t> r_buff_d2(2);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    std::vector<int32_t> c_buff_a = {2, 3};
+    std::vector<int32_t> c_buff_d1 = {-49, -49};
+    std::vector<int32_t> c_buff_d2 = {-97, -99};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results again
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    c_buff_a = {4, 1};
+    c_buff_d1 = {-45, -46};
+    c_buff_d2 = {-96, -98};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    // Read until complete
+    CHECK_NOTHROW(query_r.submit());
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 0);
+
+    array_r.close();
+  }
+
+  SECTION("- subarray") {
+    // Read array
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(2);
+    std::vector<int32_t> r_buff_d1(2);
+    std::vector<int32_t> r_buff_d2(2);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    query_r.set_subarray({-49, -45, -99, -93});
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    std::vector<int32_t> c_buff_a = {2, 3};
+    std::vector<int32_t> c_buff_d1 = {-49, -49};
+    std::vector<int32_t> c_buff_d2 = {-97, -99};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results again
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    c_buff_a = {4, 1};
+    c_buff_d1 = {-45, -46};
+    c_buff_d2 = {-96, -98};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    array_r.close();
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, int32, negative, slicing",
+    "[cppapi][hilbert][2d][int32][negative][read][slicing]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array_negative_domain(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_a = {3, 2, 4, 1};
+  std::vector<int32_t> buff_d1 = {-49, -49, -45, -46};
+  std::vector<int32_t> buff_d2 = {-99, -97, -96, -98};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  SECTION("- Row-major") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(3);
+    std::vector<int32_t> r_buff_d1(3);
+    std::vector<int32_t> r_buff_d2(3);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_subarray({-49, -46, -99, -96});
+    query_r.set_layout(TILEDB_ROW_MAJOR);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {3, 2, 1};
+    std::vector<int32_t> c_buff_d1 = {-49, -49, -46};
+    std::vector<int32_t> c_buff_d2 = {-99, -97, -98};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  SECTION("- Global order") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(3);
+    std::vector<int32_t> r_buff_d1(3);
+    std::vector<int32_t> r_buff_d2(3);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_subarray({-49, -46, -99, -96});
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {2, 3, 1};
+    std::vector<int32_t> c_buff_d1 = {-49, -49, -46};
+    std::vector<int32_t> c_buff_d2 = {-97, -99, -98};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, int32, negative, multiple fragments, read in "
+    "global order",
+    "[cppapi][hilbert][2d][int32][negative][read][multiple-fragments][global-"
+    "order]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array_negative_domain(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {3, 2, 4, 1};
+  std::vector<int32_t> buff_d1 = {-49, -49, -45, -46};
+  std::vector<int32_t> buff_d2 = {-99, -97, -96, -98};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Write second fragment
+  buff_a = {5, 6, 7, 8};
+  buff_d1 = {-48, -48, -47, -43};
+  buff_d2 = {-99, -98, -93, -93};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  std::vector<int32_t> r_buff_d1(8);
+  std::vector<int32_t> r_buff_d2(8);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1);
+  query_r.set_buffer("d2", r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  array_r.close();
+
+  // Check results. Here is the hilbert value order:
+  std::vector<int32_t> c_buff_a = {2, 3, 5, 6, 7, 4, 1, 8};
+  std::vector<int32_t> c_buff_d1 = {-49, -49, -48, -48, -47, -45, -46, -43};
+  std::vector<int32_t> c_buff_d2 = {-97, -99, -99, -98, -93, -96, -98, -93};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, int32, negative, consolidation",
+    "[cppapi][hilbert][2d][int32][negative][consolidation]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array_negative_domain(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {3, 2, 4, 1};
+  std::vector<int32_t> buff_d1 = {-49, -49, -45, -46};
+  std::vector<int32_t> buff_d2 = {-99, -97, -96, -98};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Write second fragment
+  buff_a = {5, 6, 7, 8};
+  buff_d1 = {-48, -48, -47, -43};
+  buff_d2 = {-99, -98, -93, -93};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Consolidate and vacuum
+  Config config;
+  config["sm.consolidation.mode"] = "fragments";
+  config["sm.vacuum.mode"] = "fragments";
+  CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
+  CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
+  auto contents = vfs.ls(array_name);
+  CHECK(contents.size() == 5);
+
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  std::vector<int32_t> r_buff_d1(8);
+  std::vector<int32_t> r_buff_d2(8);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1);
+  query_r.set_buffer("d2", r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  array_r.close();
+
+  // Check results. Here is the hilbert value order:
+  std::vector<int32_t> c_buff_a = {2, 3, 5, 6, 7, 4, 1, 8};
+  std::vector<int32_t> c_buff_d1 = {-49, -49, -48, -48, -47, -45, -46, -43};
+  std::vector<int32_t> c_buff_d2 = {-97, -99, -99, -98, -93, -96, -98, -93};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, int32, negative, unsplittable",
+    "[cppapi][hilbert][read][2d][int32][negative][unsplittable]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_int32_array_negative_domain(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {3, 2, 4, 1};
+  std::vector<int32_t> buff_d1 = {-49, -49, -45, -46};
+  std::vector<int32_t> buff_d2 = {-99, -97, -96, -98};
+  write_2d_array<int32_t, int32_t>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  int32_t r_buff_d1[2];
+  int32_t r_buff_d2[2];
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1, 0);
+  query_r.set_buffer("d2", r_buff_d2, 0);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+  CHECK(query_r.result_buffer_elements()["a"].second == 0);
+  array_r.close();
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2D, float32, read/write in global order",
+    "[cppapi][hilbert][float32][write][read][global-order]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_float32_array(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  std::vector<float> buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
+  std::vector<float> buff_d2 = {0.3f, 0.1f, 0.2f, 0.4f};
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w, TILEDB_WRITE);
+  query_w.set_buffer("a", buff_a);
+  query_w.set_buffer("d1", buff_d1);
+  query_w.set_buffer("d2", buff_d2);
+  query_w.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_THROWS(query_w.submit());
+
+  // Write correctly
+  buff_a = {3, 2, 1, 4};
+  buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
+  buff_d2 = {0.1f, 0.3f, 0.2f, 0.4f};
+  CHECK_NOTHROW(query_w.submit());
+  query_w.finalize();
+  array_w.close();
+
+  // Read
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(4);
+  std::vector<float> r_buff_d1(4);
+  std::vector<float> r_buff_d2(4);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1);
+  query_r.set_buffer("d2", r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+
+  // Check results
+  // Hilbert values:
+  // (0.1f, 0.1f) ->  31040194354799722
+  // (0.1f, 0.3f) -> 141289400074368426
+  // (0.4f, 0.2f) -> 429519776226080170
+  // (0.5f, 0.4f) -> 474732384249878186
+  CHECK(query_r.query_status() == Query::Status::COMPLETE);
+  CHECK(query_r.result_buffer_elements()["a"].second == 4);
+  std::vector<int32_t> c_buff_a = {3, 2, 1, 4};
+  std::vector<float> c_buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
+  std::vector<float> c_buff_d2 = {0.1f, 0.3f, 0.2f, 0.4f};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+  array_r.close();
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, float32, 2D, partitioner",
+    "[cppapi][hilbert][2d][float32][partitioner]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_float32_array(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  std::vector<float> buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
+  std::vector<float> buff_d2 = {0.3f, 0.1f, 0.2f, 0.4f};
+  write_2d_array<float, float>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  SECTION("- entire domain") {
+    // Read array
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(2);
+    std::vector<float> r_buff_d1(2);
+    std::vector<float> r_buff_d2(2);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 1);
+    std::vector<int32_t> c_buff_a = {3};
+    std::vector<float> c_buff_d1 = {0.1f};
+    std::vector<float> c_buff_d2 = {0.1f};
+    CHECK(r_buff_a[0] == c_buff_a[0]);
+    CHECK(r_buff_d1[0] == c_buff_d1[0]);
+    CHECK(r_buff_d2[0] == c_buff_d2[0]);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results again
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 1);
+    c_buff_a = {2};
+    c_buff_d1 = {0.1f};
+    c_buff_d2 = {0.3f};
+    CHECK(r_buff_a[0] == c_buff_a[0]);
+    CHECK(r_buff_d1[0] == c_buff_d1[0]);
+    CHECK(r_buff_d2[0] == c_buff_d2[0]);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results again
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    c_buff_a = {1, 4};
+    c_buff_d1 = {0.4f, 0.5f};
+    c_buff_d2 = {0.2f, 0.4f};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    // Read until complete
+    CHECK_NOTHROW(query_r.submit());
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 0);
+
+    array_r.close();
+  }
+
+  SECTION("- subarray") {
+    // Read array
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(2);
+    std::vector<float> r_buff_d1(2);
+    std::vector<float> r_buff_d2(2);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    query_r.set_subarray({0.1f, 0.6f, 0.1f, 0.7f});
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 1);
+    std::vector<int32_t> c_buff_a = {3};
+    std::vector<float> c_buff_d1 = {0.1f};
+    std::vector<float> c_buff_d2 = {0.1f};
+    CHECK(r_buff_a[0] == c_buff_a[0]);
+    CHECK(r_buff_d1[0] == c_buff_d1[0]);
+    CHECK(r_buff_d2[0] == c_buff_d2[0]);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results again
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 1);
+    c_buff_a = {2};
+    c_buff_d1 = {0.1f};
+    c_buff_d2 = {0.3f};
+    CHECK(r_buff_a[0] == c_buff_a[0]);
+    CHECK(r_buff_d1[0] == c_buff_d1[0]);
+    CHECK(r_buff_d2[0] == c_buff_d2[0]);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results again
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    c_buff_a = {1, 4};
+    c_buff_d1 = {0.4f, 0.5f};
+    c_buff_d2 = {0.2f, 0.4f};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+
+    // Read until complete
+    CHECK_NOTHROW(query_r.submit());
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 0);
+
+    array_r.close();
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, float32, slicing",
+    "[cppapi][hilbert][2d][float32][read][slicing]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_float32_array(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  std::vector<float> buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
+  std::vector<float> buff_d2 = {0.3f, 0.1f, 0.2f, 0.4f};
+  write_2d_array<float, float>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  SECTION("- Col-major") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(3);
+    std::vector<float> r_buff_d1(3);
+    std::vector<float> r_buff_d2(3);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_subarray({0.1f, 0.4f, 0.1f, 0.6f});
+    query_r.set_layout(TILEDB_COL_MAJOR);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {3, 1, 2};
+    std::vector<float> c_buff_d1 = {0.1f, 0.4f, 0.1f};
+    std::vector<float> c_buff_d2 = {0.1f, 0.2f, 0.3f};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  SECTION("- Global order") {
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(3);
+    std::vector<float> r_buff_d1(3);
+    std::vector<float> r_buff_d2(3);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_buff_d1);
+    query_r.set_buffer("d2", r_buff_d2);
+    query_r.set_subarray({0.1f, 0.4f, 0.1f, 0.6f});
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    CHECK_NOTHROW(query_r.submit());
+    array_r.close();
+
+    // Check results
+    std::vector<int32_t> c_buff_a = {3, 2, 1};
+    std::vector<float> c_buff_d1 = {0.1f, 0.1f, 0.4f};
+    std::vector<float> c_buff_d2 = {0.1f, 0.3f, 0.2f};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, floa32, multiple fragments, read in "
+    "global order",
+    "[cppapi][hilbert][2d][float32][read][multiple-fragments][global-"
+    "order]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_float32_array(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  std::vector<float> buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
+  std::vector<float> buff_d2 = {0.3f, 0.1f, 0.2f, 0.4f};
+  write_2d_array<float, float>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Write second fragment
+  buff_a = {5, 6, 7, 8};
+  buff_d1 = {0.2f, 0.2f, 0.3f, 0.7f};
+  buff_d2 = {0.2f, 0.1f, 0.7f, 0.7f};
+  write_2d_array<float, float>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  std::vector<float> r_buff_d1(8);
+  std::vector<float> r_buff_d2(8);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1);
+  query_r.set_buffer("d2", r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  array_r.close();
+
+  // Check results. Here is the hilbert value order:
+  // (0.1f, 0.1f) ->   31040194354799722
+  // (0.1f, 0.3f) ->  141289400074368426
+  // (0.2f, 0.2f) ->  230584300921369344
+  // (0.2f, 0.1f) ->  276927224145762282
+  // (0.4f, 0.2f) ->  429519776226080170
+  // (0.5f, 0.4f) ->  474732384249878186
+  // (0.3f, 0.7f) ->  607500946658220714
+  // (0.7f, 0.7f) -> 4004185071769213610
+  std::vector<int32_t> c_buff_a = {3, 2, 5, 6, 1, 4, 7, 8};
+  std::vector<float> c_buff_d1 = {
+      0.1f, 0.1f, 0.2f, 0.2f, 0.4f, 0.5f, 0.3f, 0.7f};
+  std::vector<float> c_buff_d2 = {
+      0.1f, 0.3f, 0.2f, 0.1f, 0.2f, 0.4f, 0.7f, 0.7f};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, float32, consolidation",
+    "[cppapi][hilbert][2d][float32][consolidation]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_float32_array(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  std::vector<float> buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
+  std::vector<float> buff_d2 = {0.3f, 0.1f, 0.2f, 0.4f};
+  write_2d_array<float, float>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Write second fragment
+  buff_a = {5, 6, 7, 8};
+  buff_d1 = {0.2f, 0.2f, 0.3f, 0.7f};
+  buff_d2 = {0.2f, 0.1f, 0.7f, 0.7f};
+  write_2d_array<float, float>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Consolidate and vacuum
+  Config config;
+  config["sm.consolidation.mode"] = "fragments";
+  config["sm.vacuum.mode"] = "fragments";
+  CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
+  CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
+  auto contents = vfs.ls(array_name);
+  CHECK(contents.size() == 5);
+
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  std::vector<float> r_buff_d1(8);
+  std::vector<float> r_buff_d2(8);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1);
+  query_r.set_buffer("d2", r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  array_r.close();
+
+  // Check results. Here is the hilbert value order:
+  // (0.1f, 0.1f) ->   31040194354799722
+  // (0.1f, 0.3f) ->  141289400074368426
+  // (0.2f, 0.2f) ->  230584300921369344
+  // (0.2f, 0.1f) ->  276927224145762282
+  // (0.4f, 0.2f) ->  429519776226080170
+  // (0.5f, 0.4f) ->  474732384249878186
+  // (0.3f, 0.7f) ->  607500946658220714
+  // (0.7f, 0.7f) -> 4004185071769213610
+  std::vector<int32_t> c_buff_a = {3, 2, 5, 6, 1, 4, 7, 8};
+  std::vector<float> c_buff_d1 = {
+      0.1f, 0.1f, 0.2f, 0.2f, 0.4f, 0.5f, 0.3f, 0.7f};
+  std::vector<float> c_buff_d2 = {
+      0.1f, 0.3f, 0.2f, 0.1f, 0.2f, 0.4f, 0.7f, 0.7f};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, float32, unsplittable",
+    "[cppapi][hilbert][read][2d][float32][unsplittable]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_float32_array(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  std::vector<float> buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
+  std::vector<float> buff_d2 = {0.3f, 0.1f, 0.2f, 0.4f};
+  write_2d_array<float, float>(
+      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  float r_buff_d1[2];
+  float r_buff_d2[2];
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_buff_d1, 0);
+  query_r.set_buffer("d2", r_buff_d2, 0);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+  CHECK(query_r.result_buffer_elements()["a"].second == 0);
+  array_r.close();
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2D, string, read/write in global order",
+    "[cppapi][hilbert][string][write][read][global-order]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_string_array(array_name);
+
+  // Write array
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  std::string buff_d1("1adogcamel33");
+  std::vector<uint64_t> off_d1 = {0, 2, 5, 10};
+  std::string buff_d2("catstopstockt1");
+  std::vector<uint64_t> off_d2 = {0, 3, 7, 12};
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w, TILEDB_WRITE);
+  query_w.set_buffer("a", buff_a);
+  query_w.set_buffer("d1", off_d1, buff_d1);
+  query_w.set_buffer("d2", off_d2, buff_d2);
+  query_w.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_THROWS(query_w.submit());
+
+  // Write correctly
+  buff_d1 = std::string("dogcamel331a");
+  off_d1 = {0, 3, 8, 10};
+  buff_d2 = std::string("stopstockt1cat");
+  off_d2 = {0, 4, 9, 11};
+  query_w.set_buffer("d1", off_d1, buff_d1);
+  query_w.set_buffer("d2", off_d2, buff_d2);
+  CHECK_NOTHROW(query_w.submit());
+  query_w.finalize();
+  array_w.close();
+
+  // Read
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(4);
+  std::string r_buff_d1;
+  r_buff_d1.resize(20);
+  std::vector<uint64_t> r_off_d1(4);
+  std::string r_buff_d2;
+  r_buff_d2.resize(20);
+  std::vector<uint64_t> r_off_d2(4);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_off_d1, r_buff_d1);
+  query_r.set_buffer("d2", r_off_d2, r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+
+  // Check results. Hilbert values:
+  // (dog, stop)    ->     785843883856635242
+  // (camel, stock) ->     785914162406170797
+  // (33, t1)       ->     877430626372812800
+  // (1a, cat)      ->     919167533801450154
+  CHECK(query_r.query_status() == Query::Status::COMPLETE);
+  CHECK(query_r.result_buffer_elements()["a"].second == 4);
+  r_buff_d1.resize(query_r.result_buffer_elements()["d1"].second);
+  r_buff_d2.resize(query_r.result_buffer_elements()["d2"].second);
+  std::vector<int32_t> c_buff_a = {2, 3, 1, 4};
+  std::string c_buff_d1("dogcamel331a");
+  std::vector<uint64_t> c_off_d1 = {0, 3, 8, 10};
+  std::string c_buff_d2("stopstockt1cat");
+  std::vector<uint64_t> c_off_d2 = {0, 4, 9, 11};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_off_d1 == c_off_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+  CHECK(r_off_d2 == c_off_d2);
+  array_r.close();
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, string, multiple fragments, read in "
+    "global order",
+    "[cppapi][hilbert][2d][string][read][multiple-fragments][global-"
+    "order]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_string_array(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  auto buff_d1 = std::string("cameldog331a");
+  std::vector<uint64_t> off_d1 = {0, 5, 8, 10};
+  auto buff_d2 = std::string("stockstopt1cat");
+  std::vector<uint64_t> off_d2 = {0, 5, 9, 11};
+  write_2d_array(
+      array_name, off_d1, buff_d1, off_d2, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Write second fragment
+  buff_a = {5, 6, 7, 8};
+  buff_d1 = std::string("blueazstarurn");
+  off_d1 = {0, 4, 6, 10};
+  buff_d2 = std::string("aceyellowredgrey");
+  off_d2 = {0, 3, 9, 12};
+  write_2d_array(
+      array_name, off_d1, buff_d1, off_d2, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Read
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  std::string r_buff_d1;
+  r_buff_d1.resize(100);
+  std::vector<uint64_t> r_off_d1(8);
+  std::string r_buff_d2;
+  r_buff_d2.resize(100);
+  std::vector<uint64_t> r_off_d2(8);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_off_d1, r_buff_d1);
+  query_r.set_buffer("d2", r_off_d2, r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  array_r.close();
+
+  // Check results. Hilbert values:
+  // (blue, ace)    ->     721526731798250756
+  // (urn, grey)    ->     741275904800572752
+  // (star, red)    ->     757250025264009195
+  // (dog, stop)    ->     785843883856635242
+  // (camel, stock) ->     785914162406170797
+  // (az, yellow)   ->     788282729955763606
+  // (33, t1)       ->     877430626372812800
+  // (1a, cat)      ->     919167533801450154
+  CHECK(query_r.query_status() == Query::Status::COMPLETE);
+  CHECK(query_r.result_buffer_elements()["a"].second == 8);
+  r_buff_d1.resize(query_r.result_buffer_elements()["d1"].second);
+  r_buff_d2.resize(query_r.result_buffer_elements()["d2"].second);
+  std::vector<int32_t> c_buff_a = {5, 8, 7, 3, 2, 6, 1, 4};
+  std::string c_buff_d1("blueurnstardogcamelaz331a");
+  std::vector<uint64_t> c_off_d1 = {0, 4, 7, 11, 14, 19, 21, 23};
+  std::string c_buff_d2("acegreyredstopstockyellowt1cat");
+  std::vector<uint64_t> c_off_d2 = {0, 3, 7, 10, 14, 19, 25, 27};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_off_d1 == c_off_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+  CHECK(r_off_d2 == c_off_d2);
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, string, consolidation",
+    "[cppapi][hilbert][2d][string][consolidation]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_string_array(array_name);
+
+  // Write first fragment
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  auto buff_d1 = std::string("cameldog331a");
+  std::vector<uint64_t> off_d1 = {0, 5, 8, 10};
+  auto buff_d2 = std::string("stockstopt1cat");
+  std::vector<uint64_t> off_d2 = {0, 5, 9, 11};
+  write_2d_array(
+      array_name, off_d1, buff_d1, off_d2, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Write second fragment
+  buff_a = {5, 6, 7, 8};
+  buff_d1 = std::string("blueazstarurn");
+  off_d1 = {0, 4, 6, 10};
+  buff_d2 = std::string("aceyellowredgrey");
+  off_d2 = {0, 3, 9, 12};
+  write_2d_array(
+      array_name, off_d1, buff_d1, off_d2, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Consolidate and vacuum
+  Config config;
+  config["sm.consolidation.mode"] = "fragments";
+  config["sm.vacuum.mode"] = "fragments";
+  CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
+  CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
+  auto contents = vfs.ls(array_name);
+  CHECK(contents.size() == 5);
+
+  // Read
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(8);
+  std::string r_buff_d1;
+  r_buff_d1.resize(100);
+  std::vector<uint64_t> r_off_d1(8);
+  std::string r_buff_d2;
+  r_buff_d2.resize(100);
+  std::vector<uint64_t> r_off_d2(8);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_off_d1, r_buff_d1);
+  query_r.set_buffer("d2", r_off_d2, r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  array_r.close();
+
+  // Check results. Hilbert values:
+  // (blue, ace)    ->     721526731798250756
+  // (urn, grey)    ->     741275904800572752
+  // (star, red)    ->     757250025264009195
+  // (dog, stop)    ->     785843883856635242
+  // (camel, stock) ->     785914162406170797
+  // (az, yellow)   ->     788282729955763606
+  // (33, t1)       ->     877430626372812800
+  // (1a, cat)      ->     919167533801450154
+  CHECK(query_r.query_status() == Query::Status::COMPLETE);
+  CHECK(query_r.result_buffer_elements()["a"].second == 8);
+  r_buff_d1.resize(query_r.result_buffer_elements()["d1"].second);
+  r_buff_d2.resize(query_r.result_buffer_elements()["d2"].second);
+  std::vector<int32_t> c_buff_a = {5, 8, 7, 3, 2, 6, 1, 4};
+  std::string c_buff_d1("blueurnstardogcamelaz331a");
+  std::vector<uint64_t> c_off_d1 = {0, 4, 7, 11, 14, 19, 21, 23};
+  std::string c_buff_d2("acegreyredstopstockyellowt1cat");
+  std::vector<uint64_t> c_off_d2 = {0, 3, 7, 10, 14, 19, 25, 27};
+  CHECK(r_buff_a == c_buff_a);
+  CHECK(r_buff_d1 == c_buff_d1);
+  CHECK(r_off_d1 == c_off_d1);
+  CHECK(r_buff_d2 == c_buff_d2);
+  CHECK(r_off_d2 == c_off_d2);
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, string, slicing",
+    "[cppapi][hilbert][2d][string][read][slicing]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_string_array(array_name);
+
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  auto buff_d1 = std::string("cameldog331a");
+  std::vector<uint64_t> off_d1 = {0, 5, 8, 10};
+  auto buff_d2 = std::string("stockstopt1cat");
+  std::vector<uint64_t> off_d2 = {0, 5, 9, 11};
+  write_2d_array(
+      array_name, off_d1, buff_d1, off_d2, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  SECTION("- Row-major") {
+    // Read
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(4);
+    std::string r_buff_d1;
+    r_buff_d1.resize(20);
+    std::vector<uint64_t> r_off_d1(4);
+    std::string r_buff_d2;
+    r_buff_d2.resize(20);
+    std::vector<uint64_t> r_off_d2(4);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_off_d1, r_buff_d1);
+    query_r.set_buffer("d2", r_off_d2, r_buff_d2);
+    query_r.set_layout(TILEDB_ROW_MAJOR);
+    query_r.add_range(0, std::string("3"), std::string("z"));
+    query_r.add_range(1, std::string("a"), std::string("vase"));
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 3);
+    r_buff_d1.resize(query_r.result_buffer_elements()["d1"].second);
+    r_buff_d2.resize(query_r.result_buffer_elements()["d2"].second);
+    r_off_d1.resize(query_r.result_buffer_elements()["d1"].first);
+    r_off_d2.resize(query_r.result_buffer_elements()["d2"].first);
+    r_buff_a.resize(query_r.result_buffer_elements()["a"].second);
+    std::vector<int32_t> c_buff_a = {1, 2, 3};
+    std::string c_buff_d1("33cameldog");
+    std::vector<uint64_t> c_off_d1 = {0, 2, 7};
+    std::string c_buff_d2("t1stockstop");
+    std::vector<uint64_t> c_off_d2 = {0, 2, 7};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_off_d1 == c_off_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+    CHECK(r_off_d2 == c_off_d2);
+  }
+
+  SECTION("- Global order") {
+    // Read
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(4);
+    std::string r_buff_d1;
+    r_buff_d1.resize(20);
+    std::vector<uint64_t> r_off_d1(4);
+    std::string r_buff_d2;
+    r_buff_d2.resize(20);
+    std::vector<uint64_t> r_off_d2(4);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_off_d1, r_buff_d1);
+    query_r.set_buffer("d2", r_off_d2, r_buff_d2);
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    query_r.add_range(0, std::string("3"), std::string("z"));
+    query_r.add_range(1, std::string("a"), std::string("vase"));
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results. Hilbert values:
+    // (dog, stop)    ->     785843883856635242
+    // (camel, stock) ->     785914162406170797
+    // (33, t1)       ->     877430626372812800
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 3);
+    r_buff_d1.resize(query_r.result_buffer_elements()["d1"].second);
+    r_buff_d2.resize(query_r.result_buffer_elements()["d2"].second);
+    r_off_d1.resize(query_r.result_buffer_elements()["d1"].first);
+    r_off_d2.resize(query_r.result_buffer_elements()["d2"].first);
+    r_buff_a.resize(query_r.result_buffer_elements()["a"].second);
+    std::vector<int32_t> c_buff_a = {3, 2, 1};
+    std::string c_buff_d1("dogcamel33");
+    std::vector<uint64_t> c_off_d1 = {0, 3, 8};
+    std::string c_buff_d2("stopstockt1");
+    std::vector<uint64_t> c_off_d2 = {0, 4, 9};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_off_d1 == c_off_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+    CHECK(r_off_d2 == c_off_d2);
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, string, 2D, partitioner",
+    "[cppapi][hilbert][2d][string][partitioner]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_string_array(array_name);
+
+  // Write
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  auto buff_d1 = std::string("cameldog331a");
+  std::vector<uint64_t> off_d1 = {0, 5, 8, 10};
+  auto buff_d2 = std::string("stockstopt1cat");
+  std::vector<uint64_t> off_d2 = {0, 5, 9, 11};
+  write_2d_array(
+      array_name, off_d1, buff_d1, off_d2, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  SECTION("- entire domain") {
+    // Read array
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(4);
+    std::string r_buff_d1;
+    r_buff_d1.resize(13);
+    std::vector<uint64_t> r_off_d1(4);
+    std::string r_buff_d2;
+    r_buff_d2.resize(13);
+    std::vector<uint64_t> r_off_d2(4);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_off_d1, r_buff_d1);
+    query_r.set_buffer("d2", r_off_d2, r_buff_d2);
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    // (dog, stop)    ->     785843883856635242
+    // (camel, stock) ->     785914162406170797
+    // (33, t1)       ->     877430626372812800
+    // (1a, cat)      ->     919167533801450154
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    r_buff_d1.resize(query_r.result_buffer_elements()["d1"].second);
+    r_buff_d2.resize(query_r.result_buffer_elements()["d2"].second);
+    r_off_d1.resize(query_r.result_buffer_elements()["d1"].first);
+    r_off_d2.resize(query_r.result_buffer_elements()["d2"].first);
+    r_buff_a.resize(query_r.result_buffer_elements()["a"].second);
+    std::vector<int32_t> c_buff_a = {3, 2};
+    std::string c_buff_d1("dogcamel");
+    std::vector<uint64_t> c_off_d1 = {0, 3};
+    std::string c_buff_d2("stopstock");
+    std::vector<uint64_t> c_off_d2 = {0, 4};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_off_d1 == c_off_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+    CHECK(r_off_d2 == c_off_d2);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    // (dog, stop)    ->     785843883856635242
+    // (camel, stock) ->     785914162406170797
+    // (33, t1)       ->     877430626372812800
+    // (1a, cat)      ->     919167533801450154
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    r_buff_d1.resize(query_r.result_buffer_elements()["d1"].second);
+    r_buff_d2.resize(query_r.result_buffer_elements()["d2"].second);
+    r_off_d1.resize(query_r.result_buffer_elements()["d1"].first);
+    r_off_d2.resize(query_r.result_buffer_elements()["d2"].first);
+    r_buff_a.resize(query_r.result_buffer_elements()["a"].second);
+    c_buff_a = {1, 4};
+    c_buff_d1 = std::string("331a");
+    c_off_d1 = {0, 2};
+    c_buff_d2 = std::string("t1cat");
+    c_off_d2 = {0, 2};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_off_d1 == c_off_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+    CHECK(r_off_d2 == c_off_d2);
+
+    array_r.close();
+  }
+
+  SECTION("- subarray") {
+    // Read array
+    Array array_r(ctx, array_name, TILEDB_READ);
+    Query query_r(ctx, array_r, TILEDB_READ);
+    std::vector<int32_t> r_buff_a(4);
+    std::string r_buff_d1;
+    r_buff_d1.resize(13);
+    std::vector<uint64_t> r_off_d1(4);
+    std::string r_buff_d2;
+    r_buff_d2.resize(13);
+    std::vector<uint64_t> r_off_d2(4);
+    query_r.set_buffer("a", r_buff_a);
+    query_r.set_buffer("d1", r_off_d1, r_buff_d1);
+    query_r.set_buffer("d2", r_off_d2, r_buff_d2);
+    query_r.add_range(0, std::string("1a", 2), std::string("w", 1));
+    query_r.add_range(1, std::string("ca", 2), std::string("t1", 2));
+    query_r.set_layout(TILEDB_GLOBAL_ORDER);
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    // (dog, stop)    ->     785843883856635242
+    // (camel, stock) ->     785914162406170797
+    // (33, t1)       ->     877430626372812800
+    // (1a, cat)      ->     919167533801450154
+    CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    r_buff_d1.resize(query_r.result_buffer_elements()["d1"].second);
+    r_buff_d2.resize(query_r.result_buffer_elements()["d2"].second);
+    r_off_d1.resize(query_r.result_buffer_elements()["d1"].first);
+    r_off_d2.resize(query_r.result_buffer_elements()["d2"].first);
+    r_buff_a.resize(query_r.result_buffer_elements()["a"].second);
+    std::vector<int32_t> c_buff_a = {3, 2};
+    std::string c_buff_d1("dogcamel");
+    std::vector<uint64_t> c_off_d1 = {0, 3};
+    std::string c_buff_d2("stopstock");
+    std::vector<uint64_t> c_off_d2 = {0, 4};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_off_d1 == c_off_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+    CHECK(r_off_d2 == c_off_d2);
+
+    // Read again
+    CHECK_NOTHROW(query_r.submit());
+
+    // Check results
+    // (dog, stop)    ->     785843883856635242
+    // (camel, stock) ->     785914162406170797
+    // (33, t1)       ->     877430626372812800
+    // (1a, cat)      ->     919167533801450154
+    CHECK(query_r.query_status() == Query::Status::COMPLETE);
+    CHECK(query_r.result_buffer_elements()["a"].second == 2);
+    r_buff_d1.resize(query_r.result_buffer_elements()["d1"].second);
+    r_buff_d2.resize(query_r.result_buffer_elements()["d2"].second);
+    r_off_d1.resize(query_r.result_buffer_elements()["d1"].first);
+    r_off_d2.resize(query_r.result_buffer_elements()["d2"].first);
+    r_buff_a.resize(query_r.result_buffer_elements()["a"].second);
+    c_buff_a = {1, 4};
+    c_buff_d1 = std::string("331a");
+    c_off_d1 = {0, 2};
+    c_buff_d2 = std::string("t1cat");
+    c_off_d2 = {0, 2};
+    CHECK(r_buff_a == c_buff_a);
+    CHECK(r_buff_d1 == c_buff_d1);
+    CHECK(r_off_d1 == c_off_d1);
+    CHECK(r_buff_d2 == c_buff_d2);
+    CHECK(r_off_d2 == c_off_d2);
+
+    array_r.close();
+  }
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}
+
+TEST_CASE(
+    "C++ API: Test Hilbert, 2d, string, unsplittable",
+    "[cppapi][hilbert][read][2d][string][unsplittable]") {
+  Context ctx;
+  VFS vfs(ctx);
+  std::string array_name = "hilbert_array";
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+
+  // Create array
+  create_string_array(array_name);
+
+  // Write
+  std::vector<int32_t> buff_a = {2, 3, 1, 4};
+  auto buff_d1 = std::string("cameldog331a");
+  std::vector<uint64_t> off_d1 = {0, 5, 8, 10};
+  auto buff_d2 = std::string("stockstopt1cat");
+  std::vector<uint64_t> off_d2 = {0, 5, 9, 11};
+  write_2d_array(
+      array_name, off_d1, buff_d1, off_d2, buff_d2, buff_a, TILEDB_UNORDERED);
+
+  // Read
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r, TILEDB_READ);
+  std::vector<int32_t> r_buff_a(1);
+  std::string r_buff_d1;
+  r_buff_d1.resize(1);
+  std::vector<uint64_t> r_off_d1(1);
+  std::string r_buff_d2;
+  r_buff_d2.resize(1);
+  std::vector<uint64_t> r_off_d2(1);
+  query_r.set_buffer("a", r_buff_a);
+  query_r.set_buffer("d1", r_off_d1, r_buff_d1);
+  query_r.set_buffer("d2", r_off_d2, r_buff_d2);
+  query_r.set_layout(TILEDB_GLOBAL_ORDER);
+  CHECK_NOTHROW(query_r.submit());
+  CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
+  CHECK(query_r.result_buffer_elements()["a"].second == 0);
+  array_r.close();
+
+  // Remove array
+  if (vfs.is_dir(array_name))
+    CHECK_NOTHROW(vfs.remove_dir(array_name));
+}

--- a/test/src/unit-dimension.cc
+++ b/test/src/unit-dimension.cc
@@ -1,0 +1,611 @@
+/**
+ * @file unit-dimension.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `Dimension` class.
+ */
+
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/misc/hilbert.h"
+
+#include <catch.hpp>
+#include <iostream>
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "Dimension: Test map_to_uint64, integers",
+    "[dimension][map_to_uint64][int]") {
+  // Create dimensions
+  Dimension d1("d1", Datatype::INT32);
+  int32_t dom1[] = {0, 100};
+  d1.set_domain(dom1);
+  Dimension d2("d2", Datatype::INT32);
+  int32_t dom2[] = {0, 200};
+  d2.set_domain(dom2);
+
+  // Create 2D hilbert curve (auxiliary here)
+  Hilbert h(2);
+  auto bits = h.bits();
+  uint64_t coords[2];
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+
+  // Map (1, 1)
+  int32_t dv = 1;
+  auto v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 21262214);
+  coords[0] = v;
+  dv = 1;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 10683998);
+  coords[1] = v;
+  auto hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 972199115346920);
+
+  // Map (1, 3)
+  dv = 1;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 21262214);
+  coords[0] = v;
+  dv = 3;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 32051994);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 673842753890680);
+
+  // Map (4, 2)
+  dv = 4;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 85048857);
+  coords[0] = v;
+  dv = 2;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 21367996);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 15960063827832505);
+
+  // Map (5, 4)
+  dv = 5;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 106311071);
+  coords[0] = v;
+  dv = 4;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 42735992);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 14306049248121919);
+
+  // Map (2, 1)
+  dv = 2;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 42524428);
+  coords[0] = v;
+  dv = 1;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 10683998);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 1282508796834212);
+
+  // Map (2, 2)
+  dv = 2;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 42524428);
+  coords[0] = v;
+  dv = 2;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 21367996);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 2094006769413898);
+
+  // Map (3, 7)
+  dv = 3;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 63786642);
+  coords[0] = v;
+  dv = 7;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 74787987);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 8953635051284643);
+
+  // Map (7, 7)
+  dv = 7;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 148835500);
+  coords[0] = v;
+  dv = 7;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 74787987);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 34415049034468853);
+}
+
+TEST_CASE(
+    "Dimension: Test map_to_uint64, int32, negative",
+    "[dimension][map_to_uint64][int32][negative]") {
+  // Create dimensions
+  Dimension d1("d1", Datatype::INT32);
+  int32_t dom1[] = {-50, 50};
+  d1.set_domain(dom1);
+  Dimension d2("d2", Datatype::INT32);
+  int32_t dom2[] = {-100, 100};
+  d2.set_domain(dom2);
+
+  // Create 2D hilbert curve (auxiliary here)
+  Hilbert h(2);
+  auto bits = h.bits();
+  uint64_t coords[2];
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+
+  // Map (-49, -99)
+  int32_t dv = -49;
+  auto v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 21262214);
+  coords[0] = v;
+  dv = -99;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 10683998);
+  coords[1] = v;
+  auto hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 972199115346920);
+
+  // Map (-49, -97)
+  dv = -49;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 21262214);
+  coords[0] = v;
+  dv = -97;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 32051994);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 673842753890680);
+
+  // Map (-46, -98)
+  dv = -46;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 85048857);
+  coords[0] = v;
+  dv = -98;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 21367996);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 15960063827832505);
+
+  // Map (-45, -96)
+  dv = -45;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 106311071);
+  coords[0] = v;
+  dv = -96;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 42735992);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 14306049248121919);
+
+  // Map (-48, -99)
+  dv = -48;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 42524428);
+  coords[0] = v;
+  dv = -99;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 10683998);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 1282508796834212);
+
+  // Map (-48, -98)
+  dv = -48;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 42524428);
+  coords[0] = v;
+  dv = -98;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 21367996);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 2094006769413898);
+
+  // Map (-47, -93)
+  dv = -47;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 63786642);
+  coords[0] = v;
+  dv = -93;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 74787987);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 8953635051284643);
+
+  // Map (-43, -93)
+  dv = -43;
+  v = d1.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 148835500);
+  coords[0] = v;
+  dv = -93;
+  v = d2.map_to_uint64(&dv, sizeof(int32_t), bits, bucket_num);
+  CHECK(v == 74787987);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 34415049034468853);
+}
+
+TEST_CASE(
+    "Dimension: Test map_to_uint64, float32",
+    "[dimension][map_to_uint64][float32") {
+  // Create dimensions
+  Dimension d1("d1", Datatype::FLOAT32);
+  float dom1[] = {0.0f, 1.0f};
+  d1.set_domain(dom1);
+  Dimension d2("d2", Datatype::FLOAT32);
+  float dom2[] = {0.0f, 2.0f};
+  d2.set_domain(dom2);
+
+  // Create 2D hilbert curve (auxiliary here)
+  Hilbert h(2);
+  auto bits = h.bits();
+  uint64_t coords[2];
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+
+  // Map (0.1f, 0.3f)
+  float dv = 0.1f;
+  auto v = d1.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 214748367);
+  coords[0] = v;
+  dv = 0.3f;
+  v = d2.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 322122559);
+  coords[1] = v;
+  auto hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 141289400074368426);
+
+  // Map (0.1f, 0.1f)
+  dv = 0.1f;
+  v = d1.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 214748367);
+  coords[0] = v;
+  dv = 0.1f;
+  v = d2.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 107374183);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 31040194354799722);
+
+  // Map (0.5f, 0.4f)
+  dv = 0.5f;
+  v = d1.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 1073741823);
+  coords[0] = v;
+  dv = 0.4f;
+  v = d2.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 429496735);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 474732384249878186);
+
+  // Map (0.4f, 0.2f)
+  dv = 0.4f;
+  v = d1.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 858993471);
+  coords[0] = v;
+  dv = 0.2f;
+  v = d2.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 214748367);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 429519776226080170);
+
+  // Map (0.2f, 0.1f)
+  dv = 0.2f;
+  v = d1.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 429496735);
+  coords[0] = v;
+  dv = 0.1f;
+  v = d2.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 107374183);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 276927224145762282);
+
+  // Map (0.2f, 0.2f)
+  dv = 0.2f;
+  v = d1.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 429496735);
+  coords[0] = v;
+  dv = 0.2f;
+  v = d2.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 214748367);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 230584300921369344);
+
+  // Map (0.3f, 0.7f)
+  dv = 0.3f;
+  v = d1.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 644245119);
+  coords[0] = v;
+  dv = 0.7f;
+  v = d2.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 751619263);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 607500946658220714);
+
+  // Map (0.7f, 0.7f)
+  dv = 0.7f;
+  v = d1.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 1503238527);
+  coords[0] = v;
+  dv = 0.7f;
+  v = d2.map_to_uint64(&dv, sizeof(float), bits, bucket_num);
+  CHECK(v == 751619263);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 4004185071769213610);
+
+  // (0.1f, 0.1f) ->   31040194354799722
+  // (0.1f, 0.3f) ->  141289400074368426
+  // (0.2f, 0.2f) ->  230584300921369344
+  // (0.2f, 0.1f) ->  276927224145762282
+  // (0.4f, 0.2f) ->  429519776226080170
+  // (0.5f, 0.4f) ->  474732384249878186
+  // (0.3f, 0.7f) ->  607500946658220714
+  // (0.7f, 0.7f) -> 4004185071769213610
+}
+
+TEST_CASE(
+    "Dimension: Test map_to_uint64, string",
+    "[dimension][map_to_uint64][string]") {
+  // Create dimensions
+  Dimension d1("d1", Datatype::STRING_ASCII);
+  Dimension d2("d2", Datatype::STRING_ASCII);
+
+  // Create 2D hilbert curve (auxiliary here)
+  Hilbert h(2);
+  auto bits = h.bits();
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+  uint64_t coords[2];
+
+  // Map (1a, cat)
+  std::string dv = "1a";
+  auto v = d1.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 414220288);
+  coords[0] = v;
+  dv = "cat";
+  v = d2.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 833665536);
+  coords[1] = v;
+  auto hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 919167533801450154);
+
+  // Map (dog, stop)
+  dv = "dog";
+  v = d1.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 842511232);
+  coords[0] = v;
+  dv = "stop";
+  v = d2.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 968505272);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 785843883856635242);
+
+  // Map (camel, stock)
+  dv = "camel";
+  v = d1.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 833664690);
+  coords[0] = v;
+  dv = "stock";
+  v = d2.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 968505265);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 785914162406170797);
+
+  // Map (33, t1)
+  dv = "33";
+  v = d1.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 429490176);
+  coords[0] = v;
+  dv = "t1";
+  v = d2.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 974684160);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 877430626372812800);
+
+  // Map (blue, ac3)
+  dv = "blue";
+  v = d1.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 825637554);
+  coords[0] = v;
+  dv = "ace";
+  v = d2.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 816951936);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 721526731798250756);
+
+  // Map (az, yellow)
+  dv = "az";
+  v = d1.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 817692672);
+  coords[0] = v;
+  dv = "yellow";
+  v = d2.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 1018345014);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 788282729955763606);
+
+  // Map (star, red)
+  dv = "star";
+  v = d1.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 968503481);
+  coords[0] = v;
+  dv = "red";
+  v = d2.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 959623680);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 757250025264009195);
+
+  // Map (urn, grey)
+  dv = "urn";
+  v = d1.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 985216768);
+  coords[0] = v;
+  dv = "grey";
+  v = d2.map_to_uint64(dv.data(), dv.size(), bits, bucket_num);
+  CHECK(v == 867775164);
+  coords[1] = v;
+  hv = h.coords_to_hilbert(coords);
+  CHECK(hv == 741275904800572752);
+
+  // (blue, ace)    ->     721526731798250756
+  // (urn, grey)    ->     741275904800572752
+  // (star, red)    ->     757250025264009195
+  // (dog, stop)    ->     785843883856635242
+  // (camel, stock) ->     785914162406170797
+  // (az, yellow)   ->     788282729955763606
+  // (33, t1)       ->     877430626372812800
+  // (1a, cat)      ->     919167533801450154
+}
+
+TEST_CASE(
+    "Dimension: Test map_from_uint64, int32",
+    "[dimension][map_from_uint64][int32]") {
+  // Create dimensions
+  Dimension d1("d1", Datatype::INT32);
+  int32_t dom1[] = {0, 100};
+  d1.set_domain(dom1);
+
+  // Set number of buckets
+  Hilbert h(2);
+  auto bits = h.bits();
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+
+  // Test - they are off by 1 as compared to the previous test
+  // due to rounding. That does not affect correctness of the
+  // partitioning algorith (where map_from_uint64 is used).
+  auto val = d1.map_from_uint64(63786642, bits, bucket_num);
+  auto val_int32 = *(const int32_t*)(&val[0]);
+  CHECK(val_int32 == 2);
+  val = d1.map_from_uint64(42524428, bits, bucket_num);
+  val_int32 = *(const int32_t*)(&val[0]);
+  CHECK(val_int32 == 1);
+}
+
+TEST_CASE(
+    "Dimension: Test map_from_uint64, int32, negative",
+    "[dimension][map_from_uint64][int32][negative]") {
+  // Create dimensions
+  Dimension d1("d1", Datatype::INT32);
+  int32_t dom1[] = {-50, 50};
+  d1.set_domain(dom1);
+
+  // Set number of buckets
+  Hilbert h(2);
+  auto bits = h.bits();
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+
+  // Test - they are off by 1 as compared to the previous test
+  // due to rounding. That does not affect correctness of the
+  // partitioning algorith (where map_from_uint64 is used).
+  auto val = d1.map_from_uint64(63786642, bits, bucket_num);
+  auto val_int32 = *(const int32_t*)(&val[0]);
+  CHECK(val_int32 == -48);
+  val = d1.map_from_uint64(42524428, bits, bucket_num);
+  val_int32 = *(const int32_t*)(&val[0]);
+  CHECK(val_int32 == -49);
+}
+
+TEST_CASE(
+    "Dimension: Test map_from_uint64, float32",
+    "[dimension][map_from_uint64][float32]") {
+  // Create dimensions
+  Dimension d1("d1", Datatype::FLOAT32);
+  float dom1[] = {0.0f, 1.0f};
+  d1.set_domain(dom1);
+
+  // Set number of buckets
+  Hilbert h(2);
+  auto bits = h.bits();
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+
+  auto val = d1.map_from_uint64(1503238527, bits, bucket_num);
+  auto val_int32 = *(const float*)(&val[0]);
+  CHECK(val_int32 == 0.7f);
+  val = d1.map_from_uint64(429496735, bits, bucket_num);
+  val_int32 = *(const float*)(&val[0]);
+  CHECK(val_int32 == 0.2f);
+}
+
+TEST_CASE(
+    "Dimension: Test map_from_uint64, string",
+    "[dimension][map_from_uint64][string]") {
+  // Create dimensions
+  Dimension d1("d1", Datatype::STRING_ASCII);
+
+  // Set number of buckets
+  Hilbert h(2);
+  auto bits = h.bits();
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+
+  std::string v_str = std::string("star\0\0\0\0", 8);
+  auto v = d1.map_to_uint64(v_str.data(), v_str.size(), bits, bucket_num);
+  auto val = d1.map_from_uint64(v, bits, bucket_num);
+  auto val_str = std::string((const char*)(&val[0]), 8);
+  CHECK(val_str == v_str);
+
+  v_str = std::string("blue\0\0\0\0", 8);
+  v = d1.map_to_uint64(v_str.data(), v_str.size(), bits, bucket_num);
+  val = d1.map_from_uint64(v, bits, bucket_num);
+  val_str = std::string((const char*)(&val[0]), 4);
+  CHECK(val_str == std::string("blud", 4));
+
+  v_str = std::string("yellow\0\0", 8);
+  v = d1.map_to_uint64(v_str.data(), v_str.size(), bits, bucket_num);
+  val = d1.map_from_uint64(v, bits, bucket_num);
+  val_str = std::string((const char*)(&val[0]), 4);
+  CHECK(val_str == std::string("yell", 4));
+}

--- a/test/src/unit-hilbert.cc
+++ b/test/src/unit-hilbert.cc
@@ -1,0 +1,92 @@
+/**
+ * @file   unit-hilbert.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests class Hilbert.
+ */
+
+#include "catch.hpp"
+#include "tiledb/sm/misc/hilbert.h"
+
+using namespace tiledb::sm;
+
+TEST_CASE("Hilbert: Test 2D", "[hilbert][2D]") {
+  Hilbert h(4, 2);
+  CHECK(h.bits() == 4);
+  CHECK(h.dim_num() == 2);
+
+  std::vector<uint64_t> coords = {2, 3};
+  auto v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 9);
+
+  coords = {0, 0};
+  v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 0);
+
+  coords = {0, 3};
+  v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 5);
+
+  coords = {3, 0};
+  v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 15);
+
+  coords = {5, 4};
+  v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 35);
+
+  coords = {4, 2};
+  v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 30);
+}
+
+TEST_CASE("Hilbert: Test 3D", "[hilbert][3D]") {
+  Hilbert h(4, 3);
+
+  std::vector<uint64_t> coords = {0, 0, 0};
+  auto v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 0);
+
+  coords = {0, 0, 1};
+  v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 1);
+
+  coords = {0, 1, 0};
+  v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 3);
+
+  coords = {1, 0, 0};
+  v = h.coords_to_hilbert(&coords[0]);
+  CHECK(v == 7);
+}
+
+TEST_CASE("Hilbert: Test default bits, getter", "[hilbert][bits][getter]") {
+  Hilbert h(3);
+  CHECK(h.bits() == 21);
+  CHECK(h.dim_num() == 3);
+}

--- a/test/src/unit-utils.cc
+++ b/test/src/unit-utils.cc
@@ -1,0 +1,79 @@
+/**
+ * @file   unit-utils.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the various utility functions.
+ */
+
+#include <catch.hpp>
+#include "tiledb/sm/misc/utils.h"
+
+using namespace tiledb::sm::utils;
+
+TEST_CASE("Utils: Test left_p2_m1", "[utils][left_p2_m1]") {
+  CHECK(math::left_p2_m1(0) == 0);
+  CHECK(math::left_p2_m1(1) == 1);
+  CHECK(math::left_p2_m1(2) == 1);
+  CHECK(math::left_p2_m1(3) == 3);
+  CHECK(math::left_p2_m1(4) == 3);
+  CHECK(math::left_p2_m1(5) == 3);
+  CHECK(math::left_p2_m1(6) == 3);
+  CHECK(math::left_p2_m1(7) == 7);
+  CHECK(math::left_p2_m1(8) == 7);
+  CHECK(math::left_p2_m1(9) == 7);
+  CHECK(math::left_p2_m1(10) == 7);
+  CHECK(math::left_p2_m1(11) == 7);
+  CHECK(math::left_p2_m1(12) == 7);
+  CHECK(math::left_p2_m1(13) == 7);
+  CHECK(math::left_p2_m1(14) == 7);
+  CHECK(math::left_p2_m1(15) == 15);
+  CHECK(math::left_p2_m1(UINT64_MAX) == UINT64_MAX);
+  CHECK(math::left_p2_m1(UINT64_MAX - 1) == (UINT64_MAX >> 1));
+}
+
+TEST_CASE("Utils: Test right_p2_m1", "[utils][right_p2_m1]") {
+  CHECK(math::right_p2_m1(0) == 0);
+  CHECK(math::right_p2_m1(1) == 1);
+  CHECK(math::right_p2_m1(2) == 3);
+  CHECK(math::right_p2_m1(3) == 3);
+  CHECK(math::right_p2_m1(4) == 7);
+  CHECK(math::right_p2_m1(5) == 7);
+  CHECK(math::right_p2_m1(6) == 7);
+  CHECK(math::right_p2_m1(7) == 7);
+  CHECK(math::right_p2_m1(8) == 15);
+  CHECK(math::right_p2_m1(9) == 15);
+  CHECK(math::right_p2_m1(10) == 15);
+  CHECK(math::right_p2_m1(11) == 15);
+  CHECK(math::right_p2_m1(12) == 15);
+  CHECK(math::right_p2_m1(13) == 15);
+  CHECK(math::right_p2_m1(14) == 15);
+  CHECK(math::right_p2_m1(15) == 15);
+  CHECK(math::right_p2_m1(16) == 31);
+  CHECK(math::right_p2_m1(UINT64_MAX) == UINT64_MAX);
+  CHECK(math::right_p2_m1(UINT64_MAX - 1) == UINT64_MAX);
+}

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -264,7 +264,7 @@ class ArraySchema {
   void set_capacity(uint64_t capacity);
 
   /** Sets the cell order. */
-  void set_cell_order(Layout cell_order);
+  Status set_cell_order(Layout cell_order);
 
   /**
    * Sets the domain. The function returns an error if the array has been
@@ -273,7 +273,7 @@ class ArraySchema {
   Status set_domain(Domain* domain);
 
   /** Sets the tile order. */
-  void set_tile_order(Layout tile_order);
+  Status set_tile_order(Layout tile_order);
 
   /** Set version of schema, only used for serialization */
   void set_version(uint32_t version);

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -33,12 +33,17 @@
 #ifndef TILEDB_DIMENSION_H
 #define TILEDB_DIMENSION_H
 
+#include <bitset>
+#include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <string>
 
 #include "tiledb/common/logger.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/query/result_coords.h"
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;
@@ -425,6 +430,105 @@ class Dimension {
   bool value_in_range(const std::string& value, const Range& range) const;
 
   /**
+   * Maps the c-th cell in the input query buffer to a uint64 value,
+   * based on discretizing the domain into `bucket_num` buckets.
+   * This value is used to compute a Hilbert value.
+   */
+  uint64_t map_to_uint64(
+      const QueryBuffer* buff,
+      uint64_t c,
+      uint64_t coords_num,
+      int bits,
+      uint64_t bucket_num) const;
+
+  /**
+   * Maps the c-th cell in the input query buffer to a uint64 value,
+   * based on discretizing the domain into `bucket_num` buckets.
+   * This value is used to compute a Hilbert value.
+   */
+  template <class T>
+  static uint64_t map_to_uint64(
+      const Dimension* dim,
+      const QueryBuffer* buff,
+      uint64_t c,
+      uint64_t coords_num,
+      int bits,
+      uint64_t bucket_num);
+
+  /**
+   * Maps the input coordinate to a uint64 value,
+   * based on discretizing the domain into `bucket_num` buckets.
+   * This value is used to compute a Hilbert value.
+   */
+  uint64_t map_to_uint64(
+      const void* coord,
+      uint64_t coord_size,
+      int bits,
+      uint64_t bucket_num) const;
+
+  /**
+   * Maps the input coordinate to a uint64 value,
+   * based on discretizing the domain into `bucket_num` buckets.
+   * This value is used to compute a Hilbert value.
+   */
+  template <class T>
+  static uint64_t map_to_uint64_2(
+      const Dimension* dim,
+      const void* coord,
+      uint64_t coord_size,
+      int bits,
+      uint64_t bucket_num);
+
+  /**
+   * Maps the input result coordinate to a uint64 value,
+   * based on discretizing the domain into `bucket_num` buckets.
+   * This value is used to compute a Hilbert value.
+   */
+  uint64_t map_to_uint64(
+      const ResultCoords& coord,
+      uint32_t dim_idx,
+      int bits,
+      uint64_t bucket_num) const;
+
+  /**
+   * Maps the input result coordinate to a uint64 value,
+   * based on discretizing the domain into `bucket_num` buckets.
+   * This value is used to compute a Hilbert value.
+   */
+  template <class T>
+  static uint64_t map_to_uint64_3(
+      const Dimension* dim,
+      const ResultCoords& coord,
+      uint32_t dim_idx,
+      int bits,
+      uint64_t bucket_num);
+
+  /**
+   * Maps a uint64 value (produced by `map_to_uint64`) to its corresponding
+   * value in the original dimension domain. `bucket_num` is the number
+   * of buckets used to discretize the original value.
+   */
+  ByteVecValue map_from_uint64(
+      uint64_t value, int bits, uint64_t bucket_num) const;
+
+  /**
+   * Maps a uint64 value (produced by `map_to_uint64`) to its corresponding
+   * value in the original dimension domain. `bucket_num` is the number
+   * of buckets used to discretize the original value.
+   */
+  template <class T>
+  static ByteVecValue map_from_uint64(
+      const Dimension* dim, uint64_t value, int bits, uint64_t bucket_num);
+
+  /** Returns `true` if `value` is smaller than the start of `range`. */
+  bool smaller_than(const ByteVecValue& value, const Range& range) const;
+
+  /** Returns `true` if `value` is smaller than the start of `range`. */
+  template <class T>
+  static bool smaller_than(
+      const Dimension* dim, const ByteVecValue& value, const Range& range);
+
+  /**
    * Serializes the object members into a binary buffer.
    *
    * @param buff The buffer to serialize the data into.
@@ -613,6 +717,44 @@ class Dimension {
    */
   std::function<bool(const void*, const Range&)> value_in_range_func_;
 
+  /**
+   * Stores the appropriate templated map_to_uint64() function based on
+   * the dimension datatype.
+   */
+  std::function<uint64_t(
+      const Dimension*, const QueryBuffer*, uint64_t, uint64_t, int, uint64_t)>
+      map_to_uint64_func_;
+
+  /**
+   * Stores the appropriate templated map_to_uint64_2() function based on
+   * the dimension datatype.
+   */
+  std::function<uint64_t(
+      const Dimension*, const void*, uint64_t, int, uint64_t)>
+      map_to_uint64_2_func_;
+
+  /**
+   * Stores the appropriate templated map_to_uint64_3() function based on
+   * the dimension datatype.
+   */
+  std::function<uint64_t(
+      const Dimension*, const ResultCoords&, uint32_t, int, uint64_t)>
+      map_to_uint64_3_func_;
+
+  /**
+   * Stores the appropriate templated map_from_uint64() function based on
+   * the dimension datatype.
+   */
+  std::function<ByteVecValue(const Dimension*, uint64_t, int, uint64_t)>
+      map_from_uint64_func_;
+
+  /**
+   * Stores the appropriate templated smaller_than() function based on
+   * the dimension datatype.
+   */
+  std::function<bool(const Dimension*, const ByteVecValue&, const Range&)>
+      smaller_than_func_;
+
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
@@ -660,14 +802,12 @@ class Dimension {
     auto domain = (const T*)domain_.data();
 
     // Check for NAN and INF
-    if (std::is_integral<T>::value) {
-      if (std::isinf(domain[0]) || std::isinf(domain[1]))
-        return LOG_STATUS(
-            Status::DimensionError("Domain check failed; domain contains NaN"));
-      if (std::isnan(domain[0]) || std::isnan(domain[1]))
-        return LOG_STATUS(
-            Status::DimensionError("Domain check failed; domain contains NaN"));
-    }
+    if (std::isinf(domain[0]) || std::isinf(domain[1]))
+      return LOG_STATUS(
+          Status::DimensionError("Domain check failed; domain contains NaN"));
+    if (std::isnan(domain[0]) || std::isnan(domain[1]))
+      return LOG_STATUS(
+          Status::DimensionError("Domain check failed; domain contains NaN"));
 
     // Upper bound should not be smaller than lower
     if (domain[1] < domain[0])
@@ -756,6 +896,21 @@ class Dimension {
 
   /** Sets the templated value_in_range() function. */
   void set_value_in_range_func();
+
+  /** Sets the templated map_to_uint64() function. */
+  void set_map_to_uint64_func();
+
+  /** Sets the templated map_to_uint64_2() function. */
+  void set_map_to_uint64_2_func();
+
+  /** Sets the templated map_to_uint64_3() function. */
+  void set_map_to_uint64_3_func();
+
+  /** Sets the templated map_from_uint64() function. */
+  void set_map_from_uint64_func();
+
+  /** Sets the templated smaller_than() function. */
+  void set_smaller_than_func();
 };
 
 }  // namespace sm

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2065,8 +2065,11 @@ int32_t tiledb_array_schema_set_cell_order(
   if (sanity_check(ctx) == TILEDB_ERR ||
       sanity_check(ctx, array_schema) == TILEDB_ERR)
     return TILEDB_ERR;
-  array_schema->array_schema_->set_cell_order(
-      static_cast<tiledb::sm::Layout>(cell_order));
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          array_schema->array_schema_->set_cell_order(
+              static_cast<tiledb::sm::Layout>(cell_order))))
+    return TILEDB_ERR;
   return TILEDB_OK;
 }
 
@@ -2077,8 +2080,11 @@ int32_t tiledb_array_schema_set_tile_order(
   if (sanity_check(ctx) == TILEDB_ERR ||
       sanity_check(ctx, array_schema) == TILEDB_ERR)
     return TILEDB_ERR;
-  array_schema->array_schema_->set_tile_order(
-      static_cast<tiledb::sm::Layout>(tile_order));
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          array_schema->array_schema_->set_tile_order(
+              static_cast<tiledb::sm::Layout>(tile_order))))
+    return TILEDB_ERR;
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/c_api/tiledb_enum.h
+++ b/tiledb/sm/c_api/tiledb_enum.h
@@ -135,6 +135,8 @@
     TILEDB_LAYOUT_ENUM(GLOBAL_ORDER) = 2,
     /** Unordered layout */
     TILEDB_LAYOUT_ENUM(UNORDERED) = 3,
+    /** Hilbert layout */
+    TILEDB_LAYOUT_ENUM(HILBERT) = 4,
 #endif
 
 #ifdef TILEDB_FILTER_TYPE_ENUM

--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -592,6 +592,8 @@ class ArraySchema : public Schema {
         return "COL-MAJOR";
       case TILEDB_UNORDERED:
         return "UNORDERED";
+      case TILEDB_HILBERT:
+        return "HILBERT";
     }
     return "";
   }

--- a/tiledb/sm/cpp_api/dimension.h
+++ b/tiledb/sm/cpp_api/dimension.h
@@ -396,6 +396,36 @@ class Dimension {
   }
 
   /**
+   * Factory function for creating a new dimension with datatype T and
+   * without specifying a tile extent.
+   *
+   * **Example:**
+   * @code{.cpp}
+   * tiledb::Context ctx;
+   * // Create a dimension with inclusive domain [0,1000] and no tile extent.
+   * auto dim = Dimension::create<int32_t>(ctx, "d", {{0, 1000}});
+   * @endcode
+   *
+   * @tparam T int, char, etc...
+   * @param ctx The TileDB context.
+   * @param name The dimension name.
+   * @param domain The dimension domain. A pair [lower,upper] of inclusive
+   * bounds.
+   * @return A new `Dimension` object.
+   */
+  template <typename T>
+  static Dimension create(
+      const Context& ctx,
+      const std::string& name,
+      const std::array<T, 2>& domain) {
+    using DataT = impl::TypeHandler<T>;
+    static_assert(
+        DataT::tiledb_num == 1,
+        "Dimension types cannot be compound, use arithmetic type.");
+    return create_impl(ctx, name, DataT::tiledb_type, &domain, nullptr);
+  }
+
+  /**
    * Factory function for creating a new dimension (non typechecked).
    *
    * @param ctx The TileDB context.

--- a/tiledb/sm/enums/layout.h
+++ b/tiledb/sm/enums/layout.h
@@ -62,6 +62,8 @@ inline const std::string& layout_str(Layout layout) {
       return constants::global_order_str;
     case Layout::UNORDERED:
       return constants::unordered_str;
+    case Layout::HILBERT:
+      return constants::hilbert_str;
     default:
       return constants::empty_str;
   }
@@ -77,6 +79,8 @@ inline Status layout_enum(const std::string& layout_str, Layout* layout) {
     *layout = Layout::GLOBAL_ORDER;
   else if (layout_str == constants::unordered_str)
     *layout = Layout::UNORDERED;
+  else if (layout_str == constants::hilbert_str)
+    *layout = Layout::HILBERT;
   else {
     return Status::Error("Invalid Layout " + layout_str);
   }

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -405,6 +405,9 @@ const std::string global_order_str = "global-order";
 /** The string representation for the unordered layout. */
 const std::string unordered_str = "unordered";
 
+/** The string representation for the Hilbert layout. */
+const std::string hilbert_str = "hilbert";
+
 /** The string representation of null. */
 const std::string null_str = "null";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -393,6 +393,9 @@ extern const std::string global_order_str;
 /** The string representation for the unordered layout. */
 extern const std::string unordered_str;
 
+/** The string representation for the Hilbert layout. */
+extern const std::string hilbert_str;
+
 /** The string representation of null. */
 extern const std::string null_str;
 

--- a/tiledb/sm/misc/hilbert.h
+++ b/tiledb/sm/misc/hilbert.h
@@ -1,0 +1,351 @@
+/**
+ * @file   hilbert.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class Hilbert. This class utilizes two functions from
+ * John Skilling, "Programming the Hilbert Curve". In AIP, 2004.
+ */
+
+#ifndef TILEDB_HILBERT_H
+#define TILEDB_HILBERT_H
+
+#include <sys/types.h>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+
+namespace tiledb {
+namespace sm {
+
+/* ********************************* */
+/*             CONSTANTS             */
+/* ********************************* */
+
+/**
+ * The Hilbert curve fills a multi-dimensional space in a particular manner
+ * with a 1D line. The typical operations of this class is converting a
+ * multi-dimensional tuple of coordinates into a 1D Hilbert value, and
+ * vice versa.
+ *
+ * For the 2D case, the Hilbert curve looks as follows:
+ *
+ \verbatim
+         |
+      15 |    @---@   @---@   @---@   @---@   @---@   @---@   @---@   @---@
+         |    |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+         |    @   @---@   @   @   @---@   @   @   @---@   @   @   @---@   @
+         |    |           |   |           |   |           |   |           |
+         |    @---@   @---@   @---@   @---@   @---@   @---@   @---@   @---@
+         |        |   |           |   |           |   |           |   |
+         |    @---@   @---@---@---@   @---@   @---@   @---@---@---@   @---@
+         |    |                           |   |                           |
+         |    @   @---@---@   @---@---@   @   @   @---@---@   @---@---@   @
+         |    |   |       |   |       |   |   |   |       |   |       |   |
+   Dim[1]|    @---@   @---@   @---@   @---@   @---@   @---@   @---@   @---@
+         |            |           |                   |           |
+         |    @---@   @---@   @---@   @---@   @---@   @---@   @---@   @---@
+         |    |   |       |   |       |   |   |   |       |   |       |   |
+         |    @   @---@---@   @---@---@   @---@   @---@---@   @---@---@   @
+         |    |                                                           |
+         |    @---@   @---@---@   @---@---@   @---@---@   @---@---@   @---@
+         |        |   |       |   |       |   |       |   |       |   |
+         |    @---@   @---@   @---@   @---@   @---@   @---@   @---@   @---@
+         |    |           |           |           |           |           |
+         |    @   @---@   @   @---@   @---@   @---@   @---@   @   @---@   @
+         |    |   |   |   |   |   |       |   |       |   |   |   |   |   |
+         |    @---@   @---@   @   @---@---@   @---@---@   @   @---@   @---@
+         |                    |                           |
+       3 |    5---6   9---@   @   @---@---@   @---@---@   @   @---@   @---@
+         |    |   |   |   |   |   |       |   |       |   |   |   |   |   |
+       2 |    4   7---8   @  30---@   @---@   @---@   @---@   @   @---@   @
+         |    |           |           |           |           |           |
+       1 |    3---2   @---@   @---@   @---@   @---@   @---@   @---@   @---@
+         |        |   |       |   |       |   |       |   |       |   |
+       0 |    0---1   @---@---@   @--20---@   @---@---@   @---@---@   @--255
+         |
+          -------------------------------------------------------------------
+              0   1   2   3               Dim[0]                          15
+
+ \endverbatim
+ *
+ * The Hilbert value of (2,3) is 9, whereas the coordinates corresponding to
+ * Hilbert value 2 are (1,1).
+ *
+ * The class utilizes two functions from John Skilling's work published in:
+ * John Skilling, "Programming the Hilbert Curve". In AIP, 2004
+ */
+class Hilbert {
+ public:
+  /* ********************************* */
+  /*             CONSTANTS             */
+  /* ********************************* */
+
+  /**
+   * Maximum number of dimensions for defining the Hilbert curve. Although the
+   * Hilbert curve can be defined over arbitrary dimensionality, we limit the
+   * number of dimensions because they affect the number of bits used to
+   * represent a Hilbert value; in our class, a Hilbert value is a int64_t
+   * number and, thus, it cannot exceed 64 bits.
+   */
+  static const int HC_MAX_DIM = 16;
+
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * Constructor.
+   *
+   * @param bits Number of bits used for coordinate values across each dimension
+   * @param dim_num Number of dimensions
+   */
+  Hilbert(int bits, int dim_num)
+      : bits_(bits)
+      , dim_num_(dim_num) {
+    assert(dim_num >= 0 && dim_num < HC_MAX_DIM);
+    assert(bits * dim_num <= int(sizeof(uint64_t) * 8 - 1));
+  }
+
+  /**
+   * Constructor. The number of bits will be calculated based
+   * on the number of dimensions.
+   *
+   * @param dim_num Number of dimensions
+   */
+  Hilbert(int dim_num)
+      : dim_num_(dim_num) {
+    assert(dim_num >= 0 && dim_num < HC_MAX_DIM);
+    bits_ = (sizeof(uint64_t) * 8 - 1) / dim_num_;
+  }
+
+  /** Destructor. */
+  ~Hilbert() = default;
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Returns the number of bits. */
+  int bits() const {
+    return bits_;
+  }
+
+  /** Returns the number of dimensions. */
+  int dim_num() const {
+    return dim_num_;
+  }
+
+  /**
+   * Converts a set of coordinates to a Hilbert value.
+   *
+   * @param coords The coordinates to be converted.
+   * @return The output Hilbert value.
+   */
+  uint64_t coords_to_hilbert(uint64_t* coords) {
+    assert(coords != nullptr);
+    uint64_t ret = 0;
+
+    // Convert coords to the transpose form of the hilbert value
+    axes_to_transpose(coords, bits_, dim_num_);
+
+    // Convert the hilbert transpose form into an int64_t hilbert value
+    uint64_t c = 1;  // This is a bit shifted from right to left over coords[i]
+    uint64_t h = 1;  // This is a bit shifted from right to left over hilbert
+    for (int j = 0; j < bits_; ++j, c <<= 1) {
+      for (int i = dim_num_ - 1; i >= 0; --i, h <<= 1) {
+        if (coords[i] & c)
+          ret |= h;
+      }
+    }
+
+    return ret;
+  }
+
+  /**
+   * Converts a Hilbert value into a set of coordinates.
+   *
+   * @param hilbert The Hilbert value to be converted.
+   * @param coords The output coordinates.
+   * @return void
+   */
+  void hilbert_to_coords(uint64_t hilbert, uint64_t* coords) {
+    assert(coords != nullptr);
+
+    // Initialization
+    for (int i = 0; i < dim_num_; ++i)
+      coords[i] = 0;
+
+    // Convert the int64_t hilbert value to its transpose form
+    uint64_t c = 1;  // This is a bit shifted from right to left over coords[i]
+    uint64_t h = 1;  // This is a bit shifted from right to left over hilbert
+    for (int j = 0; j < bits_; ++j, c <<= 1) {
+      for (int i = dim_num_ - 1; i >= 0; --i, h <<= 1) {
+        if (hilbert & h)
+          coords[i] |= c;
+      }
+    }
+
+    // Convert coords to the transpose form of the hilbert value
+    transpose_to_axes(coords, bits_, dim_num_);
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** Number of bits for representing a coordinate per dimension. */
+  int bits_;
+  /** Number of dimensions. */
+  int dim_num_;
+
+  /* ********************************* */
+  /*           PRIVATE METHODS         */
+  /* ********************************* */
+
+  /**
+   * From John Skilling's work. It converts the input coordinates
+   * to what is called the transpose of the Hilbert value. This is done
+   * in place.
+   *
+   * **Example**
+   *
+   * Let b=5 and n=3. Let the 15-bit Hilbert value of the input coordinates
+   * be A B C D E a b c d e 1 2 3 4 5. The function places this number into
+   * parameter X as follows:
+   *
+   \verbatim
+             X[0] = A D b e 3                  X[1]|
+             X[1] = B E c 1 4    <------->         |  /X[2]
+             X[2] = C a d 2 5                axes  | /
+                    high  low                      |/______
+
+                                                         X[0]
+   \endverbatim
+   *
+   * The X value after the function terminates is called the transpose form
+   * of the Hilbert value.
+   *
+   * @param X Input coordinates, and output transpose (the conversion is
+   *     done in place).
+   * @param b Number of bits for representing a coordinate per dimension
+   *     (it should be equal to bits_).
+   * @param n Number of dimensions (it should be equal to dim_num_).
+   * @return void
+   */
+  void axes_to_transpose(uint64_t* X, int b, int n) {
+    uint64_t P, Q, t;
+    int i;
+
+    // Inverse undo
+    for (Q = (uint64_t)1 << (b - 1); Q > 1; Q >>= 1) {
+      P = Q - 1;
+      if (X[0] & Q)  // invert
+        X[0] ^= P;
+      for (i = 1; i < n; i++)
+        if (X[i] & Q)  // invert
+          X[0] ^= P;
+        else {  // exchange
+          t = (X[0] ^ X[i]) & P;
+          X[0] ^= t;
+          X[i] ^= t;
+        }
+    }
+
+    // Gray encode (inverse of decode)
+    for (i = 1; i < n; i++)
+      X[i] ^= X[i - 1];
+    t = X[n - 1];
+    for (i = 1; i < b; i <<= 1)
+      X[n - 1] ^= X[n - 1] >> i;
+    t ^= X[n - 1];
+    for (i = n - 2; i >= 0; i--)
+      X[i] ^= t;
+  }
+
+  /**
+   * From John Skilling's work. It converts the transpose of a
+   * Hilbert value into the corresponding coordinates. This is done in place.
+   *
+   * **Example**
+   *
+   * Let b=5 and n=3. Let the 15-bit Hilbert value of the output coordinates
+   * be A B C D E a b c d e 1 2 3 4 5. The function takes as input the tranpose
+   * form of the Hilbert value, which is stored in X as follows:
+   *
+   \verbatim
+             X[0] = A D b e 3                  X[1]|
+             X[1] = B E c 1 4    <------->         |  /X[2]
+             X[2] = C a d 2 5                axes  | /
+                    high  low                      |/______
+
+                                                         X[0]
+   \endverbatim
+   *
+   * The X value after the function terminates will contain the coordinates
+   * corresponding to the Hilbert value.
+   *
+   * @param X Input transpose, and output coordinates (the conversion is
+   *     done in place).
+   * @param b Number of bits for representing a coordinate per dimension
+   *     (it should be equal to bits_).
+   * @param n Number of dimensions (it should be equal to dim_num_).
+   * @return void
+   */
+  void transpose_to_axes(uint64_t* X, int b, int n) {
+    uint64_t M, P, Q, t;
+    int i;
+
+    // Gray decode by H ^ (H/2)
+    t = X[n - 1] >> 1;
+    for (i = n - 1; i; i--)
+      X[i] ^= X[i - 1];
+    X[0] ^= t;
+
+    // Undo excess work
+    M = 2 << (b - 1);
+    for (Q = 2; Q != M; Q <<= 1) {
+      P = Q - 1;
+      for (i = n - 1; i; i--)
+        if (X[i] & Q)  // invert
+          X[0] ^= P;
+        else {  // exchange
+          t = (X[0] ^ X[i]) & P;
+          X[0] ^= t;
+          X[i] ^= t;
+        }
+      if (X[0] & Q)  // invert
+        X[0] ^= P;
+    }
+  }
+};
+
+}  // namespace sm
+}  // end namespace tiledb
+
+#endif  // TILEDB_HILBERT_H

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -210,7 +210,11 @@ class Range {
 
   /** Returns true if the range start is the same as its end. */
   bool unary() const {
-    assert(!range_.empty());
+    // If the range is empty, then it corresponds to strings
+    // covering the whole domain (so it is not unary)
+    if (range_.empty())
+      return false;
+
     bool same_size =
         range_start_size_ == 0 || 2 * range_start_size_ == range_.size();
     return same_size &&

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -675,6 +675,32 @@ T safe_mul(T a, T b) {
   return prod;
 }
 
+uint64_t left_p2_m1(uint64_t value) {
+  // Edge case
+  if (value == UINT64_MAX)
+    return value;
+
+  uint64_t ret = 0;  // Min power of 2 minus 1
+  while (ret <= value) {
+    ret = (ret << 1) | 1;  // Next larger power of 2 minus 1
+  }
+
+  return ret >> 1;
+}
+
+uint64_t right_p2_m1(uint64_t value) {
+  // Edge case
+  if (value == 0)
+    return value;
+
+  uint64_t ret = UINT64_MAX;  // Max power of 2 minus 1
+  while (ret >= value) {
+    ret >>= 1;  // Next smaller power of 2 minus 1
+  }
+
+  return (ret << 1) | 1;
+}
+
 }  // namespace math
 
 // Explicit template instantiations

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -315,6 +315,18 @@ double log(double b, double x);
 template <class T>
 T safe_mul(T a, T b);
 
+/**
+ * Returns the maximum power of 2 minus one that is smaller than
+ * or equal to `value`.
+ */
+uint64_t left_p2_m1(uint64_t value);
+
+/**
+ * Returns the minimum power of 2 minus one that is larger than
+ * or equal to `value`.
+ */
+uint64_t right_p2_m1(uint64_t value);
+
 }  // namespace math
 
 /* ********************************* */

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -567,6 +567,15 @@ Writer* Query::writer() {
   return &writer_;
 }
 
+Status Query::disable_check_global_order() {
+  if (type_ == QueryType::READ)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot disable checking global order; Applicable only to writes"));
+
+  writer_.disable_check_global_order();
+  return Status::Ok();
+}
+
 Status Query::set_buffer(
     const std::string& name,
     void* buffer,
@@ -619,6 +628,10 @@ Status Query::set_est_result_size(
 }
 
 Status Query::set_layout(Layout layout) {
+  if (layout == Layout::HILBERT)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set layout; Hilbert order is not applicable to queries"));
+
   layout_ = layout;
   return Status::Ok();
 }

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -343,6 +343,12 @@ class Query {
   Writer* writer();
 
   /**
+   * Disables checking the global order. Applicable only to writes.
+   * This option will supercede the config.
+   */
+  Status disable_check_global_order();
+
+  /**
    * Sets the buffer for a fixed-sized attribute/dimension.
    *
    * @param name The attribute/dimension to set the buffer for.

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -39,6 +39,7 @@
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/global_state/global_state.h"
 #include "tiledb/sm/misc/comparators.h"
+#include "tiledb/sm/misc/hilbert.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/query_macros.h"
@@ -52,6 +53,7 @@
 #include <iostream>
 #include <unordered_set>
 
+using namespace tiledb;
 using namespace tiledb::common;
 
 namespace tiledb {
@@ -678,10 +680,7 @@ Status Reader::compute_range_result_coords(
   auto range_num = subarray->range_num();
   range_result_coords->resize(range_num);
   auto cell_order = array_schema_->cell_order();
-  Layout layout =
-      (layout_ == Layout::GLOBAL_ORDER || layout_ == Layout::UNORDERED) ?
-          cell_order :
-          layout_;
+  Layout layout = (layout_ == Layout::UNORDERED) ? cell_order : layout_;
   auto allows_dups = array_schema_->allows_dups();
 
   auto statuses = parallel_for(
@@ -700,6 +699,7 @@ Status Reader::compute_range_result_coords(
           RETURN_CANCEL_OR_ERROR(sort_result_coords(
               ((*range_result_coords)[r]).begin(),
               ((*range_result_coords)[r]).end(),
+              ((*range_result_coords)[r]).size(),
               layout));
           RETURN_CANCEL_OR_ERROR(
               dedup_result_coords(&((*range_result_coords)[r])));
@@ -823,14 +823,30 @@ Status Reader::compute_subarray_coords(
   if (layout_ == Layout::UNORDERED)
     return Status::Ok();
 
-  // Sort
-  auto cell_order = array_schema_->cell_order();
-  Layout layout = (layout_ == Layout ::UNORDERED) ? cell_order : layout_;
+  // We should not sort if:
+  // - there is a single fragment and global order
+  // - there is a single fragment and one dimension
+  // - there are multiple fragments and a single range and dups are not allowed
+  //   (therefore, the coords in that range have already been sorted)
+  auto dim_num = array_schema_->dim_num();
+  bool must_sort = true;
+  auto allows_dups = array_schema_->allows_dups();
+  auto single_range = (range_result_coords->size() == 1);
+  if (layout_ == Layout::GLOBAL_ORDER || dim_num == 1) {
+    must_sort = !belong_to_single_fragment(
+        result_coords->begin() + result_coords_size, result_coords->end());
+  } else if (single_range && !allows_dups) {
+    must_sort = belong_to_single_fragment(
+        result_coords->begin() + result_coords_size, result_coords->end());
+  }
 
-  RETURN_NOT_OK(sort_result_coords(
-      result_coords->begin() + result_coords_size,
-      result_coords->end(),
-      layout));
+  if (must_sort) {
+    RETURN_NOT_OK(sort_result_coords(
+        result_coords->begin() + result_coords_size,
+        result_coords->end(),
+        result_coords->size() - result_coords_size,
+        layout_));
+  }
 
   return Status::Ok();
 }
@@ -2445,10 +2461,8 @@ void Reader::reset_buffer_sizes() {
 Status Reader::sort_result_coords(
     std::vector<ResultCoords>::iterator iter_begin,
     std::vector<ResultCoords>::iterator iter_end,
+    size_t coords_num,
     Layout layout) const {
-  // TODO: do not sort if it is single fragment and
-  // (i) it is single dimension, or (ii) it is global order
-
   auto domain = array_schema_->domain();
 
   if (layout == Layout::ROW_MAJOR) {
@@ -2458,11 +2472,22 @@ Status Reader::sort_result_coords(
     parallel_sort(
         storage_manager_->compute_tp(), iter_begin, iter_end, ColCmp(domain));
   } else if (layout == Layout::GLOBAL_ORDER) {
-    parallel_sort(
-        storage_manager_->compute_tp(),
-        iter_begin,
-        iter_end,
-        GlobalCmp(domain));
+    if (array_schema_->cell_order() == Layout::HILBERT) {
+      std::vector<std::pair<uint64_t, uint64_t>> hilbert_values(coords_num);
+      RETURN_NOT_OK(calculate_hilbert_values(iter_begin, &hilbert_values));
+      parallel_sort(
+          storage_manager_->compute_tp(),
+          hilbert_values.begin(),
+          hilbert_values.end(),
+          HilbertCmp(domain, iter_begin));
+      RETURN_NOT_OK(reorganize_result_coords(iter_begin, &hilbert_values));
+    } else {
+      parallel_sort(
+          storage_manager_->compute_tp(),
+          iter_begin,
+          iter_end,
+          GlobalCmp(domain));
+    }
   } else {
     assert(false);
   }
@@ -2476,6 +2501,7 @@ Status Reader::sparse_read() {
   // sparse fragments
   std::vector<ResultCoords> result_coords;
   std::vector<ResultTile> sparse_result_tiles;
+
   RETURN_NOT_OK(compute_result_coords(&sparse_result_tiles, &result_coords));
   std::vector<ResultTile*> result_tiles;
   for (auto& srt : sparse_result_tiles)
@@ -2764,6 +2790,82 @@ bool Reader::est_result_size_computed() {
 std::unordered_map<std::string, Subarray::MemorySize>
 Reader::get_max_mem_size_map() {
   return subarray_.get_max_mem_size_map(storage_manager_->compute_tp());
+}
+
+Status Reader::calculate_hilbert_values(
+    std::vector<ResultCoords>::iterator iter_begin,
+    std::vector<std::pair<uint64_t, uint64_t>>* hilbert_values) const {
+  auto dim_num = array_schema_->dim_num();
+  Hilbert h(dim_num);
+  auto bits = h.bits();
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+  auto coords_num = (uint64_t)hilbert_values->size();
+
+  // Calculate Hilbert values in parallel
+  auto statuses = parallel_for(
+      storage_manager_->compute_tp(), 0, coords_num, [&](uint64_t c) {
+        std::vector<uint64_t> coords(dim_num);
+        for (uint32_t d = 0; d < dim_num; ++d) {
+          auto dim = array_schema_->dimension(d);
+          coords[d] =
+              dim->map_to_uint64(*(iter_begin + c), d, bits, bucket_num);
+        }
+        (*hilbert_values)[c] =
+            std::pair<uint64_t, uint64_t>(h.coords_to_hilbert(&coords[0]), c);
+        return Status::Ok();
+      });
+
+  // Check all statuses
+  for (auto& st : statuses)
+    RETURN_NOT_OK_ELSE(st, LOG_STATUS(st));
+
+  return Status::Ok();
+}
+
+Status Reader::reorganize_result_coords(
+    std::vector<ResultCoords>::iterator iter_begin,
+    std::vector<std::pair<uint64_t, uint64_t>>* hilbert_values) const {
+  auto coords_num = hilbert_values->size();
+  size_t i_src, i_dst;
+  ResultCoords pending;
+  for (size_t i_dst_first = 0; i_dst_first < coords_num; ++i_dst_first) {
+    // Check if this element needs to be permuted
+    i_src = (*hilbert_values)[i_dst_first].second;
+    if (i_src == i_dst_first)
+      continue;
+
+    i_dst = i_dst_first;
+    pending = std::move(*(iter_begin + i_dst));
+
+    // Follow the permutation cycle
+    do {
+      *(iter_begin + i_dst) = std::move(*(iter_begin + i_src));
+      (*hilbert_values)[i_dst].second = i_dst;
+
+      i_dst = i_src;
+      i_src = (*hilbert_values)[i_src].second;
+    } while (i_src != i_dst_first);
+
+    *(iter_begin + i_dst) = std::move(pending);
+    (*hilbert_values)[i_dst].second = i_dst;
+  }
+
+  return Status::Ok();
+}
+
+bool Reader::belong_to_single_fragment(
+    std::vector<ResultCoords>::iterator iter_begin,
+    std::vector<ResultCoords>::iterator iter_end) const {
+  if (iter_begin == iter_end)
+    return true;
+
+  uint32_t last_frag_idx = iter_begin->tile_->frag_idx();
+  for (auto it = iter_begin + 1; it != iter_end; ++it) {
+    if (it->tile_->frag_idx() != last_frag_idx)
+      return false;
+  }
+
+  return true;
 }
 
 }  // namespace sm

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -1477,12 +1477,14 @@ class Reader {
    *
    * @param iter_begin The start position of the coordinates to sort.
    * @param iter_end The end position of the coordinates to sort.
+   * @param coords_num The number of coordinates to be sorted.
    * @param layout The layout to sort into.
    * @return Status
    */
   Status sort_result_coords(
       std::vector<ResultCoords>::iterator iter_begin,
       std::vector<ResultCoords>::iterator iter_end,
+      size_t coords_num,
       Layout layout) const;
 
   /** Performs a read on a sparse array. */
@@ -1533,6 +1535,40 @@ class Reader {
   /** Gets statistics about the result tiles. */
   void get_result_tile_stats(
       const std::vector<ResultTile*>& result_tiles) const;
+
+  /**
+   * Calculates the hilbert values of the result coordinates between
+   * `iter_begin` and `iter_begin + hilbert_values.size()`.
+   * The hilbert values are stored
+   * in `hilbert_values`, where the first pair value is the hilbert value
+   * and the second is the position of the result coords after the
+   * input iterator.
+   */
+  Status calculate_hilbert_values(
+      std::vector<ResultCoords>::iterator iter_begin,
+      std::vector<std::pair<uint64_t, uint64_t>>* hilbert_values) const;
+
+  /**
+   * It reorganizes the result coords given the iterator offsets in
+   * `hilbert_values` (second values in the pair). This essentially
+   * sorts the result coordinates starting at `iter_begin` based
+   * on the already sorted hilbert values.
+   *
+   * The algorithm is in-place, operates with O(1) memory and
+   * in O(coords_num) time, but modifies the offsets/positions in
+   * `hilbert_values`.
+   */
+  Status reorganize_result_coords(
+      std::vector<ResultCoords>::iterator iter_begin,
+      std::vector<std::pair<uint64_t, uint64_t>>* hilbert_values) const;
+
+  /**
+   * Returns true if the result coordinates between the two iterators
+   * belong to the same fragment.
+   */
+  bool belong_to_single_fragment(
+      std::vector<ResultCoords>::iterator iter_begin,
+      std::vector<ResultCoords>::iterator iter_end) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -62,6 +62,13 @@ struct ResultCoords {
   bool valid_;
 
   /** Constructor. */
+  ResultCoords()
+      : tile_(nullptr)
+      , pos_(0)
+      , valid_(false) {
+  }
+
+  /** Constructor. */
   ResultCoords(ResultTile* tile, uint64_t pos)
       : tile_(tile)
       , pos_(pos)

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -124,6 +124,12 @@ class Writer {
   /** Adds a range to the subarray on the input dimension. */
   Status add_range(unsigned dim_idx, const Range& range);
 
+  /**
+   * Disables checking the global order. Applicable only to writes.
+   * This option will supercede the config.
+   */
+  void disable_check_global_order();
+
   /** Retrieves the number of ranges of the subarray for the given dimension. */
   Status get_range_num(unsigned dim_idx, uint64_t* range_num) const;
 
@@ -315,6 +321,12 @@ class Writer {
   uint64_t coords_num_;
 
   /**
+   * If `true`, it will not check if the written coordinates are
+   * in the global order. This supercedes the config.
+   */
+  bool disable_check_global_order_;
+
+  /**
    * True if either zipped coordinates buffer or separate coordinate
    * buffers are set.
    */
@@ -434,6 +446,14 @@ class Writer {
    * @return Status
    */
   Status check_global_order() const;
+
+  /**
+   * Throws an error if there are coordinates that do not obey the
+   * global order. Applicable only to Hilbert order.
+   *
+   * @return Status
+   */
+  Status check_global_order_hilbert() const;
 
   /** Correctness checks for `subarray_`. */
   Status check_subarray() const;
@@ -976,6 +996,11 @@ class Writer {
 
   /** Gets statistics about dimensions and attributes written. */
   void get_dim_attr_stats() const;
+
+  /** Calculates the hilbert values of the input coordinate buffers. */
+  Status calculate_hilbert_values(
+      const std::vector<const QueryBuffer*>& buffs,
+      std::vector<uint64_t>* hilbert_values) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -662,12 +662,24 @@ std::string Stats::dump_read() const {
 }
 
 std::string Stats::dump_consolidate() const {
+  auto consolidate_steps =
+      counter_stats_.find(CounterType::CONSOLIDATE_STEP_NUM)->second;
   auto consolidate_frags =
       timer_stats_.find(TimerType::CONSOLIDATE_FRAGS)->second;
+  auto consolidate_main =
+      timer_stats_.find(TimerType::CONSOLIDATE_MAIN)->second;
+  auto consolidate_compute_next =
+      timer_stats_.find(TimerType::CONSOLIDATE_COMPUTE_NEXT)->second;
   auto consolidate_array_meta =
       timer_stats_.find(TimerType::CONSOLIDATE_ARRAY_META)->second;
   auto consolidate_frag_meta =
       timer_stats_.find(TimerType::CONSOLIDATE_FRAG_META)->second;
+  auto consolidate_create_buffers =
+      timer_stats_.find(TimerType::CONSOLIDATE_CREATE_BUFFERS)->second;
+  auto consolidate_create_queries =
+      timer_stats_.find(TimerType::CONSOLIDATE_CREATE_QUERIES)->second;
+  auto consolidate_copy_array =
+      timer_stats_.find(TimerType::CONSOLIDATE_COPY_ARRAY)->second;
   std::stringstream ss;
 
   auto consolidate =
@@ -675,7 +687,16 @@ std::string Stats::dump_consolidate() const {
   if (consolidate != 0) {
     ss << "==== CONSOLIDATION ====\n\n";
     write(&ss, "- Consolidation time: ", consolidate);
+    write(&ss, "  * Number of consolidation steps: ", consolidate_steps);
     write(&ss, "  * Time to consolidate fragments: ", consolidate_frags);
+    write(
+        &ss,
+        "    > Time to compute next to consolidate: ",
+        consolidate_compute_next);
+    write(&ss, "    > Time for main consolidation: ", consolidate_main);
+    write(&ss, "      # Time to create buffers: ", consolidate_create_buffers);
+    write(&ss, "      # Time to create queries: ", consolidate_create_queries);
+    write(&ss, "      # Time to copy the array: ", consolidate_copy_array);
     write(
         &ss,
         "  * Time to consolidate array metadata: ",

--- a/tiledb/sm/stats/stats.h
+++ b/tiledb/sm/stats/stats.h
@@ -82,7 +82,12 @@ class Stats {
   /** Enumerates the stat timer types. */
   DEFINE_TILEDB_STATS(
       TimerType,
+      CONSOLIDATE_CREATE_BUFFERS,
+      CONSOLIDATE_CREATE_QUERIES,
+      CONSOLIDATE_COPY_ARRAY,
       CONSOLIDATE_FRAGS,
+      CONSOLIDATE_MAIN,
+      CONSOLIDATE_COMPUTE_NEXT,
       CONSOLIDATE_ARRAY_META,
       CONSOLIDATE_FRAG_META,
       READ_ARRAY_OPEN,
@@ -179,6 +184,7 @@ class Stats {
       WRITE_CELL_NUM,
       WRITE_ARRAY_META_SIZE,
       WRITE_OPS_NUM,
+      CONSOLIDATE_STEP_NUM,
       VFS_S3_SLOW_DOWN_RETRIES);
 
   /* ****************************** */

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -694,8 +694,8 @@ std::vector<uint64_t> Subarray::get_range_coords(uint64_t range_idx) const {
     }
     std::reverse(ret.begin(), ret.end());
   } else {
-    // Global order - single range
-    assert(layout == Layout::GLOBAL_ORDER);
+    // Global order or Hilbert - single range
+    assert(layout == Layout::GLOBAL_ORDER || layout == Layout::HILBERT);
     assert(range_num() == 1);
     for (unsigned i = 0; i < dim_num; ++i)
       ret.push_back(0);
@@ -1279,8 +1279,8 @@ void Subarray::compute_range_offsets() {
     }
     std::reverse(range_offsets_.begin(), range_offsets_.end());
   } else {
-    // Global order - single range
-    assert(layout == Layout::GLOBAL_ORDER);
+    // Global order or Hilbert - single range
+    assert(layout == Layout::GLOBAL_ORDER || layout == Layout::HILBERT);
     assert(range_num() == 1);
     range_offsets_.push_back(1);
     if (dim_num > 1) {

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -37,6 +37,8 @@
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/enums/layout.h"
+#include "tiledb/sm/misc/hilbert.h"
+#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/stats.h"
 
 #include <iomanip>
@@ -49,10 +51,9 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
+using namespace tiledb;
 using namespace tiledb::common;
-
-namespace tiledb {
-namespace sm {
+using namespace tiledb::sm;
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -428,6 +429,7 @@ void SubarrayPartitioner::calibrate_current_start_end(bool* must_split_slab) {
 
   auto layout = subarray_.layout();
   auto cell_order = subarray_.array()->array_schema()->cell_order();
+  cell_order = (cell_order == Layout::HILBERT) ? Layout::ROW_MAJOR : cell_order;
   layout = (layout == Layout::UNORDERED) ? cell_order : layout;
   assert(layout == Layout::ROW_MAJOR || layout == Layout::COL_MAJOR);
 
@@ -582,6 +584,10 @@ void SubarrayPartitioner::compute_splitting_value_on_tiles(
   assert(range.layout() == Layout::GLOBAL_ORDER);
   *unsplittable = true;
 
+  // Inapplicable to Hilbert cell order
+  if (subarray_.array()->array_schema()->cell_order() == Layout::HILBERT)
+    return;
+
   // For easy reference
   auto array_schema = subarray_.array()->array_schema();
   auto dim_num = subarray_.array()->array_schema()->dim_num();
@@ -619,7 +625,10 @@ void SubarrayPartitioner::compute_splitting_value_single_range(
     const Subarray& range,
     unsigned* splitting_dim,
     ByteVecValue* splitting_value,
+    bool* normal_order,
     bool* unsplittable) {
+  *normal_order = true;
+
   // Special case for global order
   if (subarray_.layout() == Layout::GLOBAL_ORDER) {
     compute_splitting_value_on_tiles(
@@ -643,6 +652,16 @@ void SubarrayPartitioner::compute_splitting_value_single_range(
                cell_order :
                layout;
   *splitting_dim = UINT32_MAX;
+
+  // Special case for Hilbert cell order
+  if (cell_order == Layout::HILBERT) {
+    compute_splitting_value_single_range_hilbert(
+        range, splitting_dim, splitting_value, normal_order, unsplittable);
+    return;
+  }
+
+  // Cell order is either row- or col-major
+  assert(cell_order == Layout::ROW_MAJOR || cell_order == Layout::COL_MAJOR);
 
   std::vector<unsigned> dims;
   if (layout == Layout::ROW_MAJOR) {
@@ -673,17 +692,69 @@ void SubarrayPartitioner::compute_splitting_value_single_range(
   assert(*splitting_dim != UINT32_MAX);
 }
 
+void SubarrayPartitioner::compute_splitting_value_single_range_hilbert(
+    const Subarray& range,
+    unsigned* splitting_dim,
+    ByteVecValue* splitting_value,
+    bool* normal_order,
+    bool* unsplittable) {
+  // For easy reference
+  auto array_schema = subarray_.array()->array_schema();
+  auto dim_num = array_schema->dim_num();
+  Hilbert h(dim_num);
+
+  // Compute the uint64 mapping of the range (bits properly shifted)
+  std::vector<std::array<uint64_t, 2>> range_uint64;
+  compute_range_uint64(range, &range_uint64, unsplittable);
+
+  // Check if unsplittable (range_uint64 is unary)
+  if (*unsplittable)
+    return;
+
+  // Compute the splitting dimension
+  compute_splitting_dim_hilbert(range_uint64, splitting_dim);
+
+  // Compute splitting value
+  compute_splitting_value_hilbert(
+      range_uint64[*splitting_dim], *splitting_dim, splitting_value);
+
+  // Check for unsplittable again
+  auto dim = array_schema->dimension(*splitting_dim);
+  const Range* r;
+  range.get_range(*splitting_dim, 0, &r);
+  if (dim->smaller_than(*splitting_value, *r)) {
+    *unsplittable = true;
+    return;
+  }
+
+  // Set normal order
+  std::vector<uint64_t> hilbert_coords(dim_num);
+  for (uint32_t d = 0; d < dim_num; ++d)
+    hilbert_coords[d] = range_uint64[d][0];
+  auto hilbert_left = h.coords_to_hilbert(&hilbert_coords[0]);
+  for (uint32_t d = 0; d < dim_num; ++d) {
+    if (d == *splitting_dim)
+      hilbert_coords[d] = range_uint64[d][1];
+    else
+      hilbert_coords[d] = range_uint64[d][0];
+  }
+  auto hilbert_right = h.coords_to_hilbert(&hilbert_coords[0]);
+  *normal_order = (hilbert_left < hilbert_right);
+}
+
 void SubarrayPartitioner::compute_splitting_value_multi_range(
     unsigned* splitting_dim,
     uint64_t* splitting_range,
     ByteVecValue* splitting_value,
+    bool* normal_order,
     bool* unsplittable) {
   const auto& partition = state_.multi_range_.front();
+  *normal_order = true;
 
   // Single-range partittion
   if (partition.range_num() == 1) {
     compute_splitting_value_single_range(
-        partition, splitting_dim, splitting_value, unsplittable);
+        partition, splitting_dim, splitting_value, normal_order, unsplittable);
     return;
   }
 
@@ -811,7 +882,6 @@ Status SubarrayPartitioner::next_from_single_range(bool* unsplittable) {
     do {
       auto& partition = state_.single_range_.front();
       must_split = this->must_split(&partition);
-
       if (must_split)
         RETURN_NOT_OK(split_top_single_range(unsplittable));
     } while (must_split && !*unsplittable);
@@ -840,8 +910,9 @@ Status SubarrayPartitioner::split_top_single_range(bool* unsplittable) {
   // Finding splitting value
   ByteVecValue splitting_value;
   unsigned splitting_dim;
+  bool normal_order;
   compute_splitting_value_single_range(
-      range, &splitting_dim, &splitting_value, unsplittable);
+      range, &splitting_dim, &splitting_value, &normal_order, unsplittable);
 
   if (*unsplittable)
     return Status::Ok();
@@ -852,8 +923,13 @@ Status SubarrayPartitioner::split_top_single_range(bool* unsplittable) {
 
   // Update list
   state_.single_range_.pop_front();
-  state_.single_range_.push_front(std::move(r2));
-  state_.single_range_.push_front(std::move(r1));
+  if (normal_order) {
+    state_.single_range_.push_front(std::move(r2));
+    state_.single_range_.push_front(std::move(r1));
+  } else {
+    state_.single_range_.push_front(std::move(r1));
+    state_.single_range_.push_front(std::move(r2));
+  }
 
   return Status::Ok();
 }
@@ -872,8 +948,13 @@ Status SubarrayPartitioner::split_top_multi_range(bool* unsplittable) {
   unsigned splitting_dim;
   uint64_t splitting_range = UINT64_MAX;
   ByteVecValue splitting_value;
+  bool normal_order;
   compute_splitting_value_multi_range(
-      &splitting_dim, &splitting_range, &splitting_value, unsplittable);
+      &splitting_dim,
+      &splitting_range,
+      &splitting_value,
+      &normal_order,
+      unsplittable);
 
   if (*unsplittable)
     return Status::Ok();
@@ -886,8 +967,13 @@ Status SubarrayPartitioner::split_top_multi_range(bool* unsplittable) {
 
   // Update list
   state_.multi_range_.pop_front();
-  state_.multi_range_.push_front(std::move(p2));
-  state_.multi_range_.push_front(std::move(p1));
+  if (normal_order) {
+    state_.multi_range_.push_front(std::move(p2));
+    state_.multi_range_.push_front(std::move(p1));
+  } else {
+    state_.multi_range_.push_front(std::move(p1));
+    state_.multi_range_.push_front(std::move(p2));
+  }
 
   return Status::Ok();
 }
@@ -902,5 +988,164 @@ void SubarrayPartitioner::swap(SubarrayPartitioner& partitioner) {
   std::swap(compute_tp_, partitioner.compute_tp_);
 }
 
-}  // namespace sm
-}  // namespace tiledb
+void SubarrayPartitioner::compute_range_uint64(
+    const Subarray& range,
+    std::vector<std::array<uint64_t, 2>>* range_uint64,
+    bool* unsplittable) const {
+  // Initializations
+  auto array_schema = subarray_.array()->array_schema();
+  auto dim_num = array_schema->dim_num();
+  const Range* r;
+  *unsplittable = true;
+  range_uint64->resize(dim_num);
+  Hilbert h(dim_num);
+  auto bits = h.bits();
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+
+  // Default values for empty range start/end
+  auto max_string = std::string("\x7F\x7F\x7F\x7F\x7F\x7F\x7F\x7F", 8);
+
+  // Calculate mapped range
+  bool empty_start, empty_end;
+  for (uint32_t d = 0; d < dim_num; ++d) {
+    auto dim = array_schema->dimension(d);
+    auto var = dim->var_size();
+    range.get_range(d, 0, &r);
+    empty_start = var ? (r->start_size() == 0) : r->empty();
+    empty_end = var ? (r->end_size() == 0) : r->empty();
+    auto max_default =
+        var ? dim->map_to_uint64(
+                  max_string.data(), max_string.size(), bits, bucket_num) :
+              (UINT64_MAX >> (64 - bits));
+
+    (*range_uint64)[d][0] =
+        empty_start ? 0 :  // min default
+            dim->map_to_uint64(r->start(), r->start_size(), bits, bucket_num);
+    (*range_uint64)[d][1] =
+        empty_end ?
+            max_default :
+            dim->map_to_uint64(r->end(), r->end_size(), bits, bucket_num);
+
+    assert((*range_uint64)[d][0] <= (*range_uint64)[d][1]);
+
+    if ((*range_uint64)[d][0] != (*range_uint64)[d][1])
+      *unsplittable = false;
+  }
+}
+
+void SubarrayPartitioner::compute_splitting_dim_hilbert(
+    const std::vector<std::array<uint64_t, 2>>& range_uint64,
+    uint32_t* splitting_dim) const {
+  // For easy reference
+  auto array_schema = subarray_.array()->array_schema();
+  auto dim_num = array_schema->dim_num();
+
+  // Prepare candidate splitting dimensions
+  std::set<uint32_t> splitting_dims;
+  for (uint32_t d = 0; d < dim_num; ++d) {
+    if (range_uint64[d][0] != range_uint64[d][1])  // If not unary
+      splitting_dims.insert(d);
+  }
+
+  // This vector stores the coordinates of the range grid
+  // defined over the potential split of a range across all
+  // the dimensions. If there are dim_num dimensions, this
+  // will contain 2^{dim_num} elements. The coordinates will be
+  // (1,1,..., 1), (1,1,...,1), (2,1,...,1), (2,1,....,2), ...,
+  // Each such coordinate is also associated with a hilbert value.
+  std::vector<std::pair<uint64_t, std::vector<uint64_t>>> range_grid;
+
+  // Auxiliary grid size in order to exclude unary ranges. For instance,
+  // for 2D, if the range on the second dimension is unary, only
+  // coordinates (1,1) and (2,1) will appear, with coordinates
+  // (1,2) and (2,2) being excluded.
+  std::vector<uint64_t> grid_size(dim_num);
+  bool unary;
+  for (uint32_t d = 0; d < dim_num; ++d) {
+    unary = (range_uint64[d][0] == range_uint64[d][1]);
+    grid_size[d] = 1 + (int32_t)!unary;
+  }
+
+  // Prepare the grid
+  std::vector<uint64_t> grid_coords(dim_num, 1);
+  std::vector<uint64_t> hilbert_coords(dim_num);
+  uint64_t hilbert_value;
+  Hilbert h(dim_num);
+  while (grid_coords[0] < grid_size[0] + 1) {
+    // Map hilbert values of range_uint64 endpoints to range grid
+    for (uint32_t d = 0; d < dim_num; ++d)
+      hilbert_coords[d] = range_uint64[d][grid_coords[d] - 1];
+    hilbert_value = h.coords_to_hilbert(&hilbert_coords[0]);
+    range_grid.push_back(std::make_pair(hilbert_value, grid_coords));
+
+    // Advance coordinates
+    auto d = (int32_t)dim_num - 1;
+    ++grid_coords[d];
+    while (d > 0 && grid_coords[d] == grid_size[d] + 1) {
+      grid_coords[d--] = 1;
+      ++grid_coords[d];
+    }
+  }
+
+  // Choose splitting dimension
+  std::sort(range_grid.begin(), range_grid.end());
+  auto next_coords = range_grid[0].second;
+  size_t c = 1;
+  while (splitting_dims.size() != 1) {
+    assert(c < range_grid.size());
+    for (uint32_t d = 0; d < dim_num; ++d) {
+      if (range_grid[c].second[d] != next_coords[d]) {  // Exclude dimension
+        splitting_dims.erase(d);
+        break;
+      }
+    }
+    ++c;
+  }
+
+  // The remaining dimension is the splitting dimension
+  assert(splitting_dims.size() == 1);
+  *splitting_dim = *(splitting_dims.begin());
+}
+
+void SubarrayPartitioner::compute_splitting_value_hilbert(
+    const std::array<uint64_t, 2>& range_uint64,
+    uint32_t splitting_dim,
+    ByteVecValue* splitting_value) const {
+  auto array_schema = subarray_.array()->array_schema();
+  auto dim_num = array_schema->dim_num();
+  uint64_t splitting_value_uint64;   // Splitting value
+  uint64_t left_p2_m1, right_p2_m1;  // Left/right powers of 2 minus 1
+
+  // Compute left and right (2^i-1) enclosing the uint64 range
+  left_p2_m1 = utils::math::left_p2_m1(range_uint64[0]);
+  right_p2_m1 = utils::math::right_p2_m1(range_uint64[1]);
+  assert(left_p2_m1 != right_p2_m1);  // Cannot be unary
+
+  // Compute splitting value
+  uint64_t splitting_offset = 0;
+  auto range_uint64_start = range_uint64[0];
+  auto range_uint64_end = range_uint64[1];
+  while (true) {
+    if (((left_p2_m1 << 1) + 1) != right_p2_m1) {
+      // More than one power of 2 apart, split at largest power of 2 in between
+      splitting_value_uint64 = splitting_offset + (right_p2_m1 >> 1);
+      break;
+    } else {  // One power apart - need to normalize and repeat
+      range_uint64_start -= (left_p2_m1 + 1);
+      range_uint64_end -= (left_p2_m1 + 1);
+      left_p2_m1 = utils::math::left_p2_m1(range_uint64_start);
+      right_p2_m1 = utils::math::right_p2_m1(range_uint64_end);
+      assert(left_p2_m1 != right_p2_m1);  // Cannot be unary
+      splitting_offset += left_p2_m1 + 1;
+    }
+  }
+
+  // Set real splitting value
+  Hilbert h(dim_num);
+  auto bits = h.bits();
+  auto bucket_num = ((uint64_t)1 << bits) - 1;
+
+  *splitting_value =
+      array_schema->dimension(splitting_dim)
+          ->map_from_uint64(splitting_value_uint64, bits, bucket_num);
+}

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -359,24 +359,45 @@ class SubarrayPartitioner {
   /**
    * Computes the splitting value and dimension for the input range.
    * In case of real domains, if this function may not be able to find a
-   * splitting value and set ``unsplittable`` to ``true``.
+   * splitting value and set ``unsplittable`` to ``true``. Value
+   * `normal_order` is `true` if after the split, the first range
+   * precedes the second in the query layout. Otherwise, it is
+   * the reverse order (this is used in global order reads when
+   * the cell order is Hilbert).
    */
   void compute_splitting_value_single_range(
       const Subarray& range,
       unsigned* splitting_dim,
       ByteVecValue* splitting_value,
+      bool* normal_order,
+      bool* unsplittable);
+
+  /**
+   * Same as `compute_splitting_value_single_range` but this is applicable
+   * only to global order reads when the cell order is Hilbert.
+   */
+  void compute_splitting_value_single_range_hilbert(
+      const Subarray& range,
+      unsigned* splitting_dim,
+      ByteVecValue* splitting_value,
+      bool* normal_order,
       bool* unsplittable);
 
   /**
    * Computes the splitting value and dimension for
    * ``state_.multi_range_.front()``. In case of real domains, if this
    * function may not be able to find a splitting value and set
-   * ``unsplittable`` to ``true``.
+   * ``unsplittable`` to ``true``. Value
+   * `normal_order` is `true` if after the split, the first range
+   * precedes the second in the query layout. Otherwise, it is
+   * the reverse order (this is used in global order reads when
+   * the cell order is Hilbert).
    */
   void compute_splitting_value_multi_range(
       unsigned* splitting_dim,
       uint64_t* splitting_range,
       ByteVecValue* splitting_value,
+      bool* normal_order,
       bool* unsplittable);
 
   /** Returns ``true`` if the input partition must be split. */
@@ -416,6 +437,42 @@ class SubarrayPartitioner {
    * the given partitioner.
    */
   void swap(SubarrayPartitioner& partitioner);
+
+  /**
+   * Maps the input `range` to `range_uint64` that uses only
+   * uint64 values, with the number of bits calculated by
+   * the Hilbert order on the array dimensions. These values
+   * will be used as coordinates to calculate Hilbert values.
+   *
+   * @param range The input ND range.
+   * @param range_uint64 The mapped ND range to be calculated.
+   * @param unsplittable Set to `true` if the mapped ND `range_uint64`
+   *     is unary and `false` otherwise.
+   * @return void
+   */
+  void compute_range_uint64(
+      const Subarray& range,
+      std::vector<std::array<uint64_t, 2>>* range_uint64,
+      bool* unsplittable) const;
+
+  /**
+   * Calculates the splitting dimension for Hilbert cell order,
+   * based on the mapped uint64 range.
+   */
+  void compute_splitting_dim_hilbert(
+      const std::vector<std::array<uint64_t, 2>>& range_uint64,
+      uint32_t* splitting_dim) const;
+
+  /**
+   * Given the input mapped `range_uint64` on the splitting
+   * dimension, it calcuates the real spliting value
+   * for the original range (i.e., in the original dimension domain,
+   * not the mapped uint64 domain).
+   */
+  void compute_splitting_value_hilbert(
+      const std::array<uint64_t, 2>& range_uint64,
+      uint32_t splitting_dim,
+      ByteVecValue* splitting_value) const;
 };
 
 }  // namespace sm


### PR DESCRIPTION
This PR adds [Hilbert](https://en.wikipedia.org/wiki/Hilbert_curve) ordering to sparse array cells. This preserves better the spatial locality of cells across multiple dimensions, and eliminates the need to define space tiling which was very tedious and difficult to tune for sparse arrays. In addition, it makes a few improvements and fixes some important bugs.

**Improvements:**
1. The tile extent can now be set to null, in which case internally TileDB sets the extent to the dimension domain range.
2.  Prevented unnecessary sorting when (1) there is a single fragment and (i) either the query layout is global order, or (ii) the number of dimensions is 1, and (2) when there is a single range for which the result coordinates have already been sorted.
3. Added extra stats for consolidation
4. Disabled checking if cells are written in global order when consolidating, as it was redundant (the cells are already being read in global order during consolidation). 

**Bug fixes:**
1. Fixed bug when checking the dimension domain for infinity or NaN values.
2. Fixed issue with string dimensions and non-set subarray (which implies spanning the whole domain). There was an assertion being triggered. Now it works properly.
3. Fixed bug with string dimension partitioning.