### PR TITLE
Prevent segfault due to out-of-range GZip level

### DIFF
--- a/tiledb/sm/compressors/gzip_compressor.cc
+++ b/tiledb/sm/compressors/gzip_compressor.cc
@@ -51,6 +51,10 @@ Status GZip::compress(
     return LOG_STATUS(Status::CompressionError(
         "Failed compressing with GZip; invalid buffer format"));
 
+  if (level > GZip::maximum_level())
+    return LOG_STATUS(Status::CompressionError(
+        "Failed compressing with GZip; invalid compression level."));
+
   int ret;
   z_stream strm;
 

--- a/tiledb/sm/compressors/gzip_compressor.h
+++ b/tiledb/sm/compressors/gzip_compressor.h
@@ -73,6 +73,11 @@ class GZip {
   /** Returns the compression overhead for the given input. */
   static uint64_t overhead(uint64_t buffer_size);
 
+  /** Returns the maximum compression level. */
+  static int maximum_level() {
+    return 9;
+  }
+
   /** Returns the default compression level. */
   static int default_level() {
     return -1;


### PR DESCRIPTION
We should check values in the constructor, but this will prevent the crash in #1876.