### PR TITLE
Enable Arrow unit tests on Windows CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ stages:
           VS2017:
             imageName: 'vs2017-win2016'
             TILEDB_S3: ON
-            TILEDB_TESTS_ENABLE_ARROW: OFF
+            TILEDB_TESTS_ENABLE_ARROW: ON
       pool:
         vmImage: $(imageName)
       steps:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,7 +44,7 @@ if (NOT DEFINED $CACHE{TILEDB_TESTS_ENABLE_ARROW})
 endif()
 
 if (${TILEDB_TESTS_ENABLE_ARROW})
-  find_package(Python COMPONENTS Interpreter Development REQUIRED)
+  find_package(Python 3.8 EXACT COMPONENTS Interpreter Development REQUIRED)
   find_package(pybind11)
 
   # If we can't find the pybind11 cmake config (not available in pypi yet)


### PR DESCRIPTION
This forces cmake `find_package` to use v3.8 of python to allow the arrow
unit tests to run on the Windows CI.