### PR TITLE
Fix -Wrange-loop-analysis build errors under AppleClang 12

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,8 +41,9 @@ stages:
             TILEDB_TESTS_ENABLE_ARROW: ON
             CXX: clang++
           macOS_azure:
-            imageName: 'macOS-10.14'
+            imageName: 'macOS-10.15'
             TILEDB_AZURE: ON
+            TILEDB_SERIALIZATION: ON
             CXX: clang++
           macOS_gcs:
             imageName: 'macOS-10.14'

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -32,8 +32,8 @@ steps:
     set -e pipefail
     open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
     sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -allowUntrusted -target /
-  condition: eq(variables['Agent.OS'], 'Darwin')
-  displayName: 'Install system headers (OSX only)'
+  condition: and(eq(variables['Agent.OS'], 'Darwin'), eq(variables['imageName'], 'macOS-10.14'))
+  displayName: 'Install system headers (OSX 10.14 only)'
 
 - bash: |
     set -e pipefail

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -124,7 +124,7 @@ Status filter_pipeline_from_capnp(
     return Status::Ok();
 
   auto filter_list_reader = filter_pipeline_reader.getFilters();
-  for (const auto& filter_reader : filter_list_reader) {
+  for (auto filter_reader : filter_list_reader) {
     FilterType type = FilterType::FILTER_NONE;
     RETURN_NOT_OK(filter_type_enum(filter_reader.getType().cStr(), &type));
     std::unique_ptr<Filter> filter(Filter::create(type));
@@ -388,7 +388,7 @@ Status domain_from_capnp(
   domain->reset(new Domain());
 
   auto dimensions = domain_reader.getDimensions();
-  for (const auto& dimension : dimensions) {
+  for (auto dimension : dimensions) {
     std::unique_ptr<Dimension> dim;
     RETURN_NOT_OK(dimension_from_capnp(dimension, &dim));
     RETURN_NOT_OK((*domain)->add_dimension(dim.get()));
@@ -498,7 +498,7 @@ Status array_schema_from_capnp(
 
   // Set attributes
   auto attributes_reader = schema_reader.getAttributes();
-  for (const auto& attr_reader : attributes_reader) {
+  for (auto attr_reader : attributes_reader) {
     std::unique_ptr<Attribute> attribute;
     RETURN_NOT_OK(attribute_from_capnp(attr_reader, &attribute));
     RETURN_NOT_OK((*array_schema)->add_attribute(attribute.get(), false));

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -439,7 +439,7 @@ bool Subarray::is_default(uint32_t dim_index) const {
 }
 
 bool Subarray::is_set() const {
-  for (const auto& d : is_default_)
+  for (auto d : is_default_)
     if (d == false)
       return true;
   return false;


### PR DESCRIPTION
Fixes some build errors I saw in TileDB-Py under the macOS 10.15 AZP image. We didn't have a target on that image, so moved the `macOS_azure` entry to 10.15, and enabled serialization (that's where 3/4 errors were located).

```
/Users/runner/work/1/s/tiledb/sm/serialization/array_schema.cc:127:20: error: loop variable 'filter_reader' is always a copy because the range of type 'capnp::List<tiledb::sm::serialization::capnp::Filter, capnp::Kind::STRUCT>::Reader' does not return a reference [-Werror,-Wrange-loop-analysis]
  for (const auto& filter_reader : filter_list_reader) {
                   ^
/Users/runner/work/1/s/tiledb/sm/serialization/array_schema.cc:127:8: note: use non-reference type 'tiledb::sm::serialization::capnp::Filter::Reader'
  for (const auto& filter_reader : filter_list_reader) {
```