### PR TITLE
Always serialize ArraySchema with the current format version

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -342,8 +342,11 @@ bool ArraySchema::is_dim(const std::string& name) const {
 //   attribute #2
 //   ...
 Status ArraySchema::serialize(Buffer* buff) const {
-  // Write version
-  RETURN_NOT_OK(buff->write(&version_, sizeof(uint32_t)));
+  // Write version, which is always the current version. Despite
+  // the in-memory `version_`, we will serialize every array schema
+  // as the latest version.
+  const uint32_t version = constants::format_version;
+  RETURN_NOT_OK(buff->write(&version, sizeof(uint32_t)));
 
   // Write allows_dups
   RETURN_NOT_OK(buff->write(&allows_dups_, sizeof(bool)));
@@ -368,13 +371,13 @@ Status ArraySchema::serialize(Buffer* buff) const {
   RETURN_NOT_OK(cell_var_offsets_filters_.serialize(buff));
 
   // Write domain
-  RETURN_NOT_OK(domain_->serialize(buff, version_));
+  RETURN_NOT_OK(domain_->serialize(buff, version));
 
   // Write attributes
   auto attribute_num = (uint32_t)attributes_.size();
   RETURN_NOT_OK(buff->write(&attribute_num, sizeof(uint32_t)));
   for (auto& attr : attributes_)
-    RETURN_NOT_OK(attr->serialize(buff, version_));
+    RETURN_NOT_OK(attr->serialize(buff, version));
 
   return Status::Ok();
 }


### PR DESCRIPTION
This fixes a bug in the following scenario:
1. Read an array with an older format version
2. Write an a new array, using the array schema from the previous step.
3. Read the new array.

Note that our serialization path does not check the version. We do not support
writing array schemas as if they were being written from an earlier version
of the core.

In step #2, we serialize the array schema as if it was the latest version but
set the "version" attribute to an older version.
In step #3, we read the "version" attribute and deserialize that format. The
format is a newer format, so the deserialization fails.

---

There are a few options to fix the bug:
1. Always write the "version" as the latest version. This ensures future reads
can correctly deserialize the on-disk format.

2. Treat all deserialized objects (e.g. in-memory ArraySchema objects) as if
they were the latest version.

3. Modify the serialization path for backwards compatibility.

Solution 3 is a lot of work, and I'm not sure if we even need/want to support
that use-case. Solution 2 is my preferred fix, but there may be a future use-case
where we want to know that version of an ArraySchema after it has been deserialized.
This patch implements solution 1.