### PR TITLE
Replace `float_t` with `float` in unit tests.

### DIFF
--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -278,8 +278,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
 
   rc = tiledb_array_get_metadata(ctx_, array, "foo", &v_type, &v_num, &v_r);
   CHECK(rc == TILEDB_OK);
@@ -301,8 +301,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
   CHECK(key_len == strlen("bb"));
   CHECK(!strncmp(key, "bb", strlen("bb")));
 
@@ -442,8 +442,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
 
   rc = tiledb_array_get_metadata(ctx_, array, "foo", &v_type, &v_num, &v_r);
   CHECK(rc == TILEDB_OK);
@@ -461,8 +461,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
   CHECK(key_len == strlen("bb"));
   CHECK(!strncmp(key, "bb", strlen("bb")));
 
@@ -531,8 +531,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
 
   rc = tiledb_array_get_metadata(ctx_, array, "cccc", &v_type, &v_num, &v_r);
   CHECK(rc == TILEDB_OK);
@@ -552,8 +552,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
   CHECK(key_len == strlen("bb"));
   CHECK(!strncmp(key, "bb", strlen("bb")));
 
@@ -904,8 +904,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
 
   rc = tiledb_array_get_metadata(ctx_, array, "cccc", &v_type, &v_num, &v_r);
   CHECK(rc == TILEDB_OK);
@@ -925,8 +925,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
   CHECK(key_len == strlen("bb"));
   CHECK(!strncmp(key, "bb", strlen("bb")));
 

--- a/test/src/unit-cppapi-metadata.cc
+++ b/test/src/unit-cppapi-metadata.cc
@@ -228,8 +228,8 @@ TEST_CASE_METHOD(
   array.get_metadata("bb", &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
 
   array.get_metadata("zero_val", &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_FLOAT32);
@@ -248,8 +248,8 @@ TEST_CASE_METHOD(
   array.get_metadata_from_index(1, &key, &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
   CHECK(key.size() == strlen("bb"));
   CHECK(!strncmp(key.data(), "bb", strlen("bb")));
 
@@ -352,8 +352,8 @@ TEST_CASE_METHOD(
   array.get_metadata("bb", &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
 
   array.get_metadata("foo", &v_type, &v_num, &v_r);
   CHECK(v_r == nullptr);
@@ -365,8 +365,8 @@ TEST_CASE_METHOD(
   array.get_metadata_from_index(0, &key, &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
   CHECK(key.size() == strlen("bb"));
   CHECK(!strncmp(key.data(), "bb", strlen("bb")));
 
@@ -417,8 +417,8 @@ TEST_CASE_METHOD(
   array.get_metadata("bb", &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
 
   array.get_metadata("cccc", &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_INT32);
@@ -432,8 +432,8 @@ TEST_CASE_METHOD(
   array.get_metadata_from_index(0, &key, &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
   CHECK(key.size() == strlen("bb"));
   CHECK(!strncmp(key.data(), "bb", strlen("bb")));
 
@@ -632,8 +632,8 @@ TEST_CASE_METHOD(
   array.get_metadata("bb", &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
 
   array.get_metadata("cccc", &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_INT32);
@@ -647,8 +647,8 @@ TEST_CASE_METHOD(
   array.get_metadata_from_index(0, &key, &v_type, &v_num, &v_r);
   CHECK(v_type == TILEDB_FLOAT32);
   CHECK(v_num == 2);
-  CHECK(((const float_t*)v_r)[0] == 1.1f);
-  CHECK(((const float_t*)v_r)[1] == 1.2f);
+  CHECK(((const float*)v_r)[0] == 1.1f);
+  CHECK(((const float*)v_r)[1] == 1.2f);
   CHECK(key.size() == strlen("bb"));
   CHECK(!strncmp(key.data(), "bb", strlen("bb")));
 


### PR DESCRIPTION
This fixes issue #1891 

Internally, we represent `TILEDB_FLOAT32` as a `float`.
The size of a `float_t` may be different from a `float`, so we must cast with
a `float` in our unit tests to match TileDB's internal representation of a
`TILEDB_FLOAT32`.