### PR TITLE
Support converting offsets from bytes to elements for Arrow

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 * Support for Hilbert order sorting for sparse arrays. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 * Support for AWS S3 "AssumeRole" temporary credentials [#1882](https://github.com/TileDB-Inc/TileDB/pull/1882)
 * Experimental support for an in-memory backend used with bootstrap option "--enable-memfs" [#1873](https://github.com/TileDB-Inc/TileDB/pull/1873)
+* Support for element offsets for var-sized attributes. [#1897] (https://github.com/TileDB-Inc/TileDB/pull/1897)
 
 ## Improvements
 

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -232,6 +232,7 @@ void check_save_to_file() {
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.num_tbb_threads -1\n";
+  ss << "sm.offsets_format bytes\n";
   ss << "sm.skip_checksum_validation false\n";
   ss << "sm.sub_partitioner_memory_budget 0\n";
   ss << "sm.tile_cache_size 10000000\n";
@@ -441,6 +442,9 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   rc = tiledb_config_set(config, "vfs.hdfs.username", "stavros", &error);
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
+  rc = tiledb_config_set(config, "sm.offsets_format", "elements", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
 
   // Prepare maps
   std::map<std::string, std::string> all_param_values;
@@ -473,6 +477,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.consolidation.step_size_ratio"] = "0.0";
   all_param_values["sm.consolidation.mode"] = "fragments";
   all_param_values["sm.vacuum.mode"] = "fragments";
+  all_param_values["sm.offsets_format"] = "elements";
 
   all_param_values["vfs.min_batch_gap"] = "512000";
   all_param_values["vfs.min_batch_size"] = "20971520";

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1309,7 +1309,7 @@ TEST_CASE("C++ API: Test element offsets", "[cppapi][sparse][element-offset]") {
 
   array.close();
 
-  // 1. READ when offset format is bytes (default case)
+  // 1. Read when offset format is bytes (default case)
   Config config = ctx.config();
   CHECK((std::string)config["sm.offsets_format"] == "bytes");
 
@@ -1328,7 +1328,7 @@ TEST_CASE("C++ API: Test element offsets", "[cppapi][sparse][element-offset]") {
 
   array.close();
 
-  // 2. READ again using element offsets
+  // 2. Read again using element offsets
 
   Config config2;
   // Change config of offsets format from bytes to elements
@@ -1336,9 +1336,6 @@ TEST_CASE("C++ API: Test element offsets", "[cppapi][sparse][element-offset]") {
   Context ctx2(config2);
 
   array.open(TILEDB_READ);
-
-  // TODO: Add +1 when the final version is ready
-  b_off.resize(data_offsets.size());
 
   Query query3(ctx2, array, TILEDB_READ);
   query3.set_buffer("attr", b_off, b_val);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1268,3 +1268,90 @@ TEST_CASE(
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 }
+
+TEST_CASE("C++ API: Test element offsets", "[cppapi][sparse][element-offset]") {
+  Context ctx;
+  VFS vfs(ctx);
+
+  // Create the array
+  std::string array_name = "test_element_offset";
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  Domain dom(ctx);
+  dom.add_dimension(Dimension::create<int64_t>(ctx, "d1", {{1, 4}}, 4))
+      .add_dimension(Dimension::create<int64_t>(ctx, "d2", {{1, 4}}, 4));
+
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  Attribute attr(ctx, "attr", TILEDB_INT32);
+  attr.set_cell_val_num(TILEDB_VAR_NUM);
+  schema.add_attribute(attr);
+  schema.set_tile_order(TILEDB_ROW_MAJOR);
+  schema.set_cell_order(TILEDB_ROW_MAJOR);
+  schema.set_domain(dom);
+
+  Array::create(array_name, schema);
+
+  // Write some variable-sized data in the array
+  std::vector<int64_t> d1 = {1, 2, 3, 4};
+  std::vector<int64_t> d2 = {2, 1, 3, 4};
+
+  std::vector<int32_t> data = {1, 1, 2, 3, 3, 3, 4};
+  std::vector<uint64_t> data_offsets = {0, 8, 12, 24};
+
+  Array array(ctx, array_name, TILEDB_WRITE);
+  Query query(ctx, array, TILEDB_WRITE);
+  query.set_layout(TILEDB_UNORDERED)
+      .set_buffer("d1", d1)
+      .set_buffer("d2", d2)
+      .set_buffer("attr", data_offsets, data);
+  CHECK_NOTHROW(query.submit());
+
+  array.close();
+
+  // 1. READ when offset format is bytes (default case)
+  Config config = ctx.config();
+  CHECK((std::string)config["sm.offsets_format"] == "bytes");
+
+  array.open(TILEDB_READ);
+  Query query2(ctx, array, TILEDB_READ);
+
+  std::vector<int32_t> b_val(data.size());
+  std::vector<uint64_t> b_off(data_offsets.size());
+  query2.set_buffer("attr", b_off, b_val);
+
+  CHECK_NOTHROW(query2.submit());
+
+  // Check that bytes offsets are properly returned
+  CHECK(b_val == data);
+  CHECK(b_off == data_offsets);
+
+  array.close();
+
+  // 2. READ again using element offsets
+
+  Config config2;
+  // Change config of offsets format from bytes to elements
+  config2["sm.offsets_format"] = "elements";
+  Context ctx2(config2);
+
+  array.open(TILEDB_READ);
+
+  // TODO: Add +1 when the final version is ready
+  b_off.resize(data_offsets.size());
+
+  Query query3(ctx2, array, TILEDB_READ);
+  query3.set_buffer("attr", b_off, b_val);
+  CHECK_NOTHROW(query3.submit());
+
+  // Check the element offsets are properly returned
+  std::vector<uint64_t> data_off_elements = {0, 2, 3, 6};
+  CHECK(b_val == data);
+  CHECK(b_off == data_off_elements);
+
+  array.close();
+
+  // Clean up
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+}

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -975,6 +975,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The memory budget for tiles of var-sized attributes
  *    to be fetched during reads.<br>
  *    **Default**: 10GB
+ * - `sm.offsets_format` <br>
+ *    The offsets format (`bytes` or `elements`) to be used for
+ *    var-sized attributes.<br>
+ *    **Default**: bytes
  * - `vfs.num_threads` <br>
  *    The number of threads allocated for VFS operations (any backend), per VFS
  *    instance. <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -82,6 +82,7 @@ const std::string Config::SM_CONSOLIDATION_STEP_MAX_FRAGS = "4294967295";
 const std::string Config::SM_CONSOLIDATION_STEP_SIZE_RATIO = "0.0";
 const std::string Config::SM_CONSOLIDATION_MODE = "fragments";
 const std::string Config::SM_VACUUM_MODE = "fragments";
+const std::string Config::SM_OFFSETS_FORMAT = "bytes";
 const std::string Config::VFS_MIN_PARALLEL_SIZE = "10485760";
 const std::string Config::VFS_MIN_BATCH_GAP = "512000";
 const std::string Config::VFS_MIN_BATCH_SIZE = "20971520";
@@ -197,6 +198,7 @@ Config::Config() {
   param_values_["sm.consolidation.steps"] = SM_CONSOLIDATION_STEPS;
   param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
   param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
+  param_values_["sm.offsets_format"] = SM_OFFSETS_FORMAT;
   param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
@@ -434,6 +436,8 @@ Status Config::unset(const std::string& param) {
     param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
   } else if (param == "sm.vacuum.mode") {
     param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
+  } else if (param == "sm.offsets_format") {
+    param_values_["sm.offsets_format"] = SM_OFFSETS_FORMAT;
   } else if (param == "vfs.min_parallel_size") {
     param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   } else if (param == "vfs.min_batch_gap") {

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -632,6 +632,10 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &v32));
   } else if (param == "sm.consolidation.step_size_ratio") {
     RETURN_NOT_OK(utils::parse::convert(value, &vf));
+  } else if (param == "sm.offsets_format") {
+    if (value != "bytes" && value != "elements")
+      return LOG_STATUS(
+          Status::ConfigError("Invalid offsets format parameter value"));
   } else if (param == "vfs.min_parallel_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_batch_gap") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -179,6 +179,13 @@ class Config {
    */
   static const std::string SM_VACUUM_MODE;
 
+  /** The offset format to be used for variable-sized attributes. It can be one
+   * of:
+   *    - "bytes": express offsets in bytes
+   *    - "elements": express offsets in number of elements
+   */
+  static const std::string SM_OFFSETS_FORMAT;
+
   /** The default minimum number of bytes in a parallel VFS operation. */
   static const std::string VFS_MIN_PARALLEL_SIZE;
 

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -179,7 +179,8 @@ class Config {
    */
   static const std::string SM_VACUUM_MODE;
 
-  /** The offset format to be used for variable-sized attributes. It can be one
+  /**
+   * The offset format to be used for variable-sized attributes. It can be one
    * of:
    *    - "bytes": express offsets in bytes
    *    - "elements": express offsets in number of elements

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -322,6 +322,10 @@ class Config {
    *    The memory budget for tiles of var-sized attributes
    *    to be fetched during reads.<br>
    *    **Default**: 10GB
+   * - `sm.offsets_format` <br>
+   *    The offsets format (`bytes` or `elements`) to be used for
+   *    var-sized attributes.<br>
+   *    **Default**: bytes
    * - `vfs.num_threads` <br>
    *    The number of threads allocated for VFS operations (any backend), per
    *    VFS instance. <br>

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -2503,12 +2503,12 @@ Status Reader::init_read_state() {
       config.get<uint64_t>("sm.memory_budget_var", &memory_budget_var, &found));
   assert(found);
   offsets_format_ = config.get("sm.offsets_format", &found);
+  assert(found);
   if (offsets_format_ != "bytes" && offsets_format_ != "elements") {
     return LOG_STATUS(
         Status::ReaderError("Cannot initialize reader; Unsupported offsets "
                             "format in configuration"));
   }
-  assert(found);
 
   // Consider the validity memory budget to be identical to `sm.memory_budget`
   // because the validity vector is currently a bytemap. When converted to a

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -913,6 +913,9 @@ class Reader {
   /** The query subarray (initially the whole domain by default). */
   Subarray subarray_;
 
+  /** The offset format used for variable-sized attributes. */
+  std::string offsets_format_;
+
   /** Protects result tiles. */
   mutable std::mutex result_tiles_mutex_;
 


### PR DESCRIPTION
Apache arrow uses `element count` instead of `bytes` for offsets. In order to facilitate zero copy buffers with arrow we add support for internally converting on read from bytes to elements for offsets. 

For the time being we set the offset format to either bytes (default) or elements via a Config parameter.

