### PR TITLE
Bump Hadoop dot-release in `install-hadoop.sh`

### DIFF
--- a/scripts/install-hadoop.sh
+++ b/scripts/install-hadoop.sh
@@ -27,7 +27,7 @@
 # Installs and configures HDFS.
 set -x
 
-HADOOP_VERSION="3.1.3"
+HADOOP_VERSION="3.1.4"
 
 die() {
   echo "$@" 1>&2 ; popd 2>/dev/null; exit 1


### PR DESCRIPTION
The HDFS CI is failing because v3.1.3 of hadoop has been removed from the
closest mirror. This patch moves the version from v3.1.3 to v3.1.4