### PR TITLE
Remove usage of PRIu64

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -298,12 +298,16 @@ unsigned int ArraySchema::dim_num() const {
 void ArraySchema::dump(FILE* out) const {
   if (out == nullptr)
     out = stdout;
-  fprintf(out, "- Array type: %s\n", array_type_str(array_type_).c_str());
-  fprintf(out, "- Cell order: %s\n", layout_str(cell_order_).c_str());
-  fprintf(out, "- Tile order: %s\n", layout_str(tile_order_).c_str());
-  fprintf(out, "- Capacity: %" PRIu64 "\n", capacity_);
-  fprintf(out, "- Allows duplicates: %s\n", (allows_dups_ ? "true" : "false"));
-  fprintf(out, "- Coordinates filters: %u", (unsigned)coords_filters_.size());
+
+  std::stringstream ss;
+  ss << "- Array type: " << array_type_str(array_type_) << "\n";
+  ss << "- Cell order: " << layout_str(cell_order_) << "\n";
+  ss << "- Tile order: " << layout_str(tile_order_) << "\n";
+  ss << "- Capacity: " << capacity_ << "\n";
+  ss << "- Allows duplicates: " << (allows_dups_ ? "true" : "false") << "\n";
+  ss << "- Coordinates filters: " << coords_filters_.size();
+  fprintf(out, "%s", ss.str().c_str());
+
   coords_filters_.dump(out);
   fprintf(
       out,

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -34,8 +34,6 @@
 #ifndef TILEDB_ARRAY_METADATA_H
 #define TILEDB_ARRAY_METADATA_H
 
-#define __STDC_FORMAT_MACROS
-
 #include <unordered_map>
 
 #include "tiledb/common/status.h"

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -790,13 +790,10 @@ void Stats::report_ratio(
     const char* unit,
     uint64_t numerator,
     uint64_t denominator) const {
-  fprintf(
-      out,
-      "%s: %" PRIu64 " / %" PRIu64 " %s",
-      msg,
-      numerator,
-      denominator,
-      unit);
+  std::stringstream ss;
+  ss << msg << ": " << numerator << " / " << denominator << " " << unit;
+  fprintf(out, "%s", ss.str().c_str());
+
   if (denominator > 0) {
     fprintf(out, " (%.1fx)", double(numerator) / double(denominator));
   }
@@ -809,13 +806,10 @@ void Stats::report_ratio_pct(
     const char* unit,
     uint64_t numerator,
     uint64_t denominator) const {
-  fprintf(
-      out,
-      "%s: %" PRIu64 " / %" PRIu64 " %s",
-      msg,
-      numerator,
-      denominator,
-      unit);
+  std::stringstream ss;
+  ss << msg << ": " << numerator << " / " << denominator << " " << unit;
+  fprintf(out, "%s", ss.str().c_str());
+
   if (denominator > 0) {
     fprintf(out, " (%.1f%%)", 100.0 * double(numerator) / double(denominator));
   }

--- a/tiledb/sm/stats/stats.h
+++ b/tiledb/sm/stats/stats.h
@@ -33,8 +33,6 @@
 #ifndef TILEDB_STATS_H
 #define TILEDB_STATS_H
 
-#define __STDC_FORMAT_MACROS
-
 #include <inttypes.h>
 #include <atomic>
 #include <chrono>


### PR DESCRIPTION
To avoid windows-specific issues with PRIu64, we can avoid it by using C++ IO
streams instead of fprintf() to build strings that need uint64_t formatting.