### PR TITLE
Bump AWS SDK dot-release (#1899)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,8 @@
 
 ## Bug fixes
 
+* Updated the AWS SDK to v1.8.84 to fix an uncaught exception when using S3 [#1899](https://github.com/TileDB-Inc/TileDB/pull/1899)[TileDB-Py #409](https://github.com/TileDB-Inc/TileDB-Py/issues/409)
+
 ## API additions
 
 # TileDB v2.1.2 Release Notes

--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -96,8 +96,8 @@ if (NOT AWSSDK_FOUND)
 
     ExternalProject_Add(ep_awssdk
       PREFIX "externals"
-      URL "https://github.com/aws/aws-sdk-cpp/archive/1.8.6.zip"
-      URL_HASH SHA1=5f4f58adabe2c7a241d49cb3ab2c96962fed1466
+      URL "https://github.com/aws/aws-sdk-cpp/archive/1.8.84.zip"
+      URL_HASH SHA1=e32a53a01c75ca7fdfe9feed9c5bbcedd98708e3
       CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${AWS_CMAKE_BUILD_TYPE}
         -DENABLE_TESTING=OFF


### PR DESCRIPTION
This bumps the AWSSDK to the latest dot-release of 1.8 to fix:
https://github.com/TileDB-Inc/TileDB-Py/issues/409

Co-authored-by: Joe Maley <joe@tiledb.com>