### PR TITLE
Fix narrowing conversion in Dimension::split_range and Dimension::ceil_to_tile

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,7 @@
 * Fixed bug when checking the dimension domain for infinity or NaN values. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 * Fixed bug with string dimension partitioning. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 * Updated the AWS SDK to v1.8.84 to fix an uncaught exception when using S3 [#1899](https://github.com/TileDB-Inc/TileDB/pull/1899)[TileDB-Py #409](https://github.com/TileDB-Inc/TileDB-Py/issues/409)
+* Fixed bug where a read on a sparse array may return duplicate values. [#1905](https://github.com/TileDB-Inc/TileDB/pull/1905)
 
 ## API additions
 

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -345,7 +345,8 @@ void Dimension::ceil_to_tile(
   auto floored_mid = (T)div * tile_extent + dim_dom[0];
   T sp = (std::numeric_limits<T>::is_integer) ?
              floored_mid - 1 :
-             std::nextafter(floored_mid, std::numeric_limits<T>::lowest());
+             static_cast<T>(
+                 std::nextafter(floored_mid, std::numeric_limits<T>::lowest()));
   std::memcpy(&(*v)[0], &sp, sizeof(T));
 }
 
@@ -811,7 +812,7 @@ void Dimension::split_range(
   ret[0] = r_t[0];
   ret[1] = v_t;
   r1->set_range(ret, sizeof(ret));
-  ret[0] = (int_domain) ? (v_t + 1) : std::nextafter(v_t, max);
+  ret[0] = int_domain ? (v_t + 1) : static_cast<T>(std::nextafter(v_t, max));
   ret[1] = r_t[1];
   r2->set_range(ret, sizeof(ret));
 }


### PR DESCRIPTION
The ternary operator infers the its type from the two return values. When
`std::nextafter` is returned, the type is inferred as a floating point. When
the other return value is a large int, its lower values may be truncated because
they cannot be represented as a floating point.