### PR TITLE
Rename offsets config variable

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -232,11 +232,11 @@ void check_save_to_file() {
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.num_tbb_threads -1\n";
-  ss << "sm.offsets_format bytes\n";
   ss << "sm.skip_checksum_validation false\n";
   ss << "sm.sub_partitioner_memory_budget 0\n";
   ss << "sm.tile_cache_size 10000000\n";
   ss << "sm.vacuum.mode fragments\n";
+  ss << "sm.var_offsets.mode bytes\n";
   ss << "vfs.azure.block_list_block_size 5242880\n";
   ss << "vfs.azure.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
@@ -442,7 +442,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   rc = tiledb_config_set(config, "vfs.hdfs.username", "stavros", &error);
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
-  rc = tiledb_config_set(config, "sm.offsets_format", "elements", &error);
+  rc = tiledb_config_set(config, "sm.var_offsets.mode", "elements", &error);
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
 
@@ -477,7 +477,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.consolidation.step_size_ratio"] = "0.0";
   all_param_values["sm.consolidation.mode"] = "fragments";
   all_param_values["sm.vacuum.mode"] = "fragments";
-  all_param_values["sm.offsets_format"] = "elements";
+  all_param_values["sm.var_offsets.mode"] = "elements";
 
   all_param_values["vfs.min_batch_gap"] = "512000";
   all_param_values["vfs.min_batch_size"] = "20971520";

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1311,7 +1311,7 @@ TEST_CASE("C++ API: Test element offsets", "[cppapi][sparse][element-offset]") {
 
   // 1. Read when offset format is bytes (default case)
   Config config = ctx.config();
-  CHECK((std::string)config["sm.offsets_format"] == "bytes");
+  CHECK((std::string)config["sm.var_offsets.mode"] == "bytes");
 
   array.open(TILEDB_READ);
   Query query2(ctx, array, TILEDB_READ);
@@ -1332,7 +1332,7 @@ TEST_CASE("C++ API: Test element offsets", "[cppapi][sparse][element-offset]") {
 
   Config config2;
   // Change config of offsets format from bytes to elements
-  config2["sm.offsets_format"] = "elements";
+  config2["sm.var_offsets.mode"] = "elements";
   Context ctx2(config2);
 
   array.open(TILEDB_READ);

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -983,7 +983,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The memory budget for tiles of var-sized attributes
  *    to be fetched during reads.<br>
  *    **Default**: 10GB
- * - `sm.offsets_format` <br>
+ * - `sm.var_offsets.mode` <br>
  *    The offsets format (`bytes` or `elements`) to be used for
  *    var-sized attributes.<br>
  *    **Default**: bytes

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -82,7 +82,7 @@ const std::string Config::SM_CONSOLIDATION_STEP_MAX_FRAGS = "4294967295";
 const std::string Config::SM_CONSOLIDATION_STEP_SIZE_RATIO = "0.0";
 const std::string Config::SM_CONSOLIDATION_MODE = "fragments";
 const std::string Config::SM_VACUUM_MODE = "fragments";
-const std::string Config::SM_OFFSETS_FORMAT = "bytes";
+const std::string Config::SM_OFFSETS_FORMAT_MODE = "bytes";
 const std::string Config::VFS_MIN_PARALLEL_SIZE = "10485760";
 const std::string Config::VFS_MIN_BATCH_GAP = "512000";
 const std::string Config::VFS_MIN_BATCH_SIZE = "20971520";
@@ -198,7 +198,7 @@ Config::Config() {
   param_values_["sm.consolidation.steps"] = SM_CONSOLIDATION_STEPS;
   param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
   param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
-  param_values_["sm.offsets_format"] = SM_OFFSETS_FORMAT;
+  param_values_["sm.var_offsets.mode"] = SM_OFFSETS_FORMAT_MODE;
   param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
@@ -436,8 +436,8 @@ Status Config::unset(const std::string& param) {
     param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
   } else if (param == "sm.vacuum.mode") {
     param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
-  } else if (param == "sm.offsets_format") {
-    param_values_["sm.offsets_format"] = SM_OFFSETS_FORMAT;
+  } else if (param == "sm.var_offsets.mode") {
+    param_values_["sm.var_offsets.mode"] = SM_OFFSETS_FORMAT_MODE;
   } else if (param == "vfs.min_parallel_size") {
     param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   } else if (param == "vfs.min_batch_gap") {
@@ -632,7 +632,7 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &v32));
   } else if (param == "sm.consolidation.step_size_ratio") {
     RETURN_NOT_OK(utils::parse::convert(value, &vf));
-  } else if (param == "sm.offsets_format") {
+  } else if (param == "sm.var_offsets.mode") {
     if (value != "bytes" && value != "elements")
       return LOG_STATUS(
           Status::ConfigError("Invalid offsets format parameter value"));

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -180,12 +180,12 @@ class Config {
   static const std::string SM_VACUUM_MODE;
 
   /**
-   * The offset format to be used for variable-sized attributes. It can be one
-   * of:
+   * The offset format mode to be used for variable-sized attributes. It can
+   * be one of:
    *    - "bytes": express offsets in bytes
    *    - "elements": express offsets in number of elements
    */
-  static const std::string SM_OFFSETS_FORMAT;
+  static const std::string SM_OFFSETS_FORMAT_MODE;
 
   /** The default minimum number of bytes in a parallel VFS operation. */
   static const std::string VFS_MIN_PARALLEL_SIZE;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -327,7 +327,7 @@ class Config {
    *    The memory budget for tiles of var-sized attributes
    *    to be fetched during reads.<br>
    *    **Default**: 10GB
-   * - `sm.offsets_format` <br>
+   * - `sm.var_offsets.mode` <br>
    *    The offsets format (`bytes` or `elements`) to be used for
    *    var-sized attributes.<br>
    *    **Default**: bytes

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -1494,7 +1494,7 @@ Status Reader::copy_partitioned_var_cells(
       auto var_dest = buffer_var + var_offset;
       auto validity_dest = buffer_validity + (var_offset / attr_datatype_size);
 
-      if (offsets_format_ == "elements") {
+      if (offsets_format_mode_ == "elements") {
         var_offset = var_offset / attr_datatype_size;
       }
       // Copy offset
@@ -2502,9 +2502,9 @@ Status Reader::init_read_state() {
   RETURN_NOT_OK(
       config.get<uint64_t>("sm.memory_budget_var", &memory_budget_var, &found));
   assert(found);
-  offsets_format_ = config.get("sm.offsets_format", &found);
+  offsets_format_mode_ = config.get("sm.var_offsets.mode", &found);
   assert(found);
-  if (offsets_format_ != "bytes" && offsets_format_ != "elements") {
+  if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
     return LOG_STATUS(
         Status::ReaderError("Cannot initialize reader; Unsupported offsets "
                             "format in configuration"));

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -914,7 +914,7 @@ class Reader {
   Subarray subarray_;
 
   /** The offset format used for variable-sized attributes. */
-  std::string offsets_format_;
+  std::string offsets_format_mode_;
 
   /** Protects result tiles. */
   mutable std::mutex result_tiles_mutex_;


### PR DESCRIPTION
We have decided to use the following three config options for Arrow support:

```
sm.var_offsets.mode ("bytes", "elements")
sm.var_offsets.bitsize ("32", "64")
sm.var_offsets.extra_element ("true", "false")
```

We already have `sm.offsets_format`, so we need to rename it to  `sm.var_offsets.mode` before we ship a release. This hasn't shipped so there's no reason to have any sort of backwards-compatibility with the existing config name.