### PR TITLE
Add `tiledb_query_{get,set}_range_from_name` C/C++ APIs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -43,11 +43,13 @@
 ### C++ API
 
 * Added functions for getting fragment information. [#1900](https://github.com/TileDB-Inc/TileDB/pull/1900)
+* Added APIs for getting and setting ranges of queries using a dimension name. [#1920](https://github.com/TileDB-Inc/TileDB/pull/1920)
 
 ### C++ API
 
 * Added class `FragmentInfo` and functions for getting fragment information. [#1900](https://github.com/TileDB-Inc/TileDB/pull/1900)
 * Added function `Dimension::create` that allows not setting a space tile extent. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
+* Added APIs for getting and setting ranges of queries using a dimension name. [#1920](https://github.com/TileDB-Inc/TileDB/pull/1920)
 
 # TileDB v2.1.0 Release Notes
 

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -432,11 +432,27 @@ Query
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_add_range
     :project: TileDB-C
+.. doxygenfunction:: tiledb_query_add_range_by_name
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_query_get_range
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_query_get_range_from_name
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_add_range_var
     :project: TileDB-C
+.. doxygenfunction:: tiledb_query_add_range_var_by_name
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_query_get_range_var
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_query_get_range_var_from_name
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_query_get_range_var_size
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_query_get_range_var_size_from_name
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_query_get_range_num
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_query_get_range_num_from_name
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_get_est_result_size
     :project: TileDB-C

--- a/examples/c_api/nullable_attribute.c
+++ b/examples/c_api/nullable_attribute.c
@@ -168,7 +168,7 @@ void read_array() {
   tiledb_array_alloc(ctx, array_name, &array);
   tiledb_array_open(ctx, array, TILEDB_READ);
 
-  // Slice only rows 1, 2 and cols 2, 3, 4
+  // Read the full array
   int subarray_full[] = {1, 2, 1, 2};
 
   // Set maximum buffer sizes

--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -232,7 +232,7 @@ void Query2Fx::create_dense_array(const std::string& array_name, bool anon) {
   rc = tiledb_attribute_set_cell_val_num(ctx_, b, TILEDB_VAR_NUM);
   CHECK(rc == TILEDB_OK);
 
-  // Create array schmea
+  // Create array schema
   tiledb_array_schema_t* array_schema;
   rc = tiledb_array_schema_alloc(ctx_, TILEDB_DENSE, &array_schema);
   CHECK(rc == TILEDB_OK);
@@ -2886,6 +2886,108 @@ TEST_CASE_METHOD(
   // Clean up
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+
+  remove_array(array_name);
+}
+
+TEST_CASE_METHOD(
+    Query2Fx,
+    "C API: Test range by name APIs",
+    "[capi][query_2][range][string-dims]") {
+  std::string array_name = "query_ranges";
+  remove_array(array_name);
+
+  // Create array
+  uint64_t dom[] = {1, 10};
+  uint64_t extent = 5;
+  create_array(
+      ctx_,
+      array_name,
+      TILEDB_SPARSE,
+      {"d1", "d2"},
+      {TILEDB_STRING_ASCII, TILEDB_UINT64},
+      {nullptr, dom},
+      {nullptr, &extent},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      2,
+      false,
+      false);
+
+  // Open array
+  tiledb_array_t* array = nullptr;
+  int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query
+  tiledb_query_t* query = nullptr;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  CHECK(rc == TILEDB_OK);
+
+  // set dimensions
+  char d1_data[] = "abbccdddd";
+  uint64_t d1_data_size = sizeof(d1_data) - 1;  // Ignore '\0'
+  uint64_t d1_off[] = {0, 1, 3, 5};
+  uint64_t d1_off_size = sizeof(d1_off);
+  rc = tiledb_query_set_buffer_var(
+      ctx_, query, "d1", d1_off, &d1_off_size, d1_data, &d1_data_size);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Add 1 range per dimension
+  char s1[] = "a";
+  char s2[] = "cc";
+  // Variable-sized range
+  rc = tiledb_query_add_range_var_by_name(ctx_, query, "d1", s1, 1, s2, 2);
+  CHECK(rc == TILEDB_OK);
+  // fixed-sized range
+  uint64_t r[] = {1, 2};
+  rc = tiledb_query_add_range_by_name(ctx_, query, "d2", &r[0], &r[1], nullptr);
+  CHECK(rc == TILEDB_OK);
+
+  // Check number of ranges on each dimension
+  uint64_t range_num;
+  rc = tiledb_query_get_range_num_from_name(ctx_, query, "d1", &range_num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(range_num == 1);
+  rc = tiledb_query_get_range_num_from_name(ctx_, query, "d2", &range_num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(range_num == 1);
+
+  // Check ranges
+  const void *start, *end, *stride;
+  rc = tiledb_query_get_range_from_name(
+      ctx_, query, "d2", 0, &start, &end, &stride);
+  CHECK(rc == TILEDB_OK);
+  CHECK(*(const uint64_t*)start == 1);
+  CHECK(*(const uint64_t*)end == 2);
+
+  uint64_t start_size = 0, end_size = 0;
+  rc = tiledb_query_get_range_var_size_from_name(
+      ctx_, query, "d1", 0, &start_size, &end_size);
+  CHECK(rc == TILEDB_OK);
+  CHECK(start_size == 1);
+  CHECK(end_size == 2);
+  std::vector<char> start_data(start_size);
+  std::vector<char> end_data(end_size);
+  rc = tiledb_query_get_range_var_from_name(
+      ctx_, query, "d1", 0, start_data.data(), end_data.data());
+  CHECK(rc == TILEDB_OK);
+  CHECK(std::string(start_data.data()) == "a");
+  CHECK(std::string(end_data.data()) == "cc");
+
+  // Clean-up
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  CHECK(array == nullptr);
+  tiledb_query_free(&query);
+  CHECK(query == nullptr);
 
   remove_array(array_name);
 }

--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -2978,8 +2978,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_get_range_var_from_name(
       ctx_, query, "d1", 0, start_data.data(), end_data.data());
   CHECK(rc == TILEDB_OK);
-  CHECK(std::string(start_data.data()) == "a");
-  CHECK(std::string(end_data.data()) == "cc");
+  CHECK(std::string(start_data.begin(), start_data.end()) == "a");
+  CHECK(std::string(end_data.begin(), end_data.end()) == "cc");
 
   // Clean-up
   rc = tiledb_array_close(ctx_, array);

--- a/test/src/unit-cppapi-query.cc
+++ b/test/src/unit-cppapi-query.cc
@@ -279,10 +279,10 @@ TEST_CASE(
   std::array<std::string, 2> range1 = query.range("d1", 0);
   CHECK(range1[0] == s1);
   CHECK(range1[1] == s2);
-  auto range2 = query.range<int>("d2", 0);
+  std::array<int, 3> range2 = query.range<int>("d2", 0);
   CHECK(range2[0] == 1);
   CHECK(range2[1] == 2);
-  CHECK(range[2] == 0);
+  CHECK(range2[2] == 0);
 
   // Close array
   array.close();

--- a/test/src/unit-cppapi-query.cc
+++ b/test/src/unit-cppapi-query.cc
@@ -229,3 +229,64 @@ TEST_CASE(
   array1.close();
   array2.close();
 }
+
+TEST_CASE(
+    "C++ API: Test add and get ranges by name",
+    "[cppapi][query][range][string-dims]") {
+  const std::string array_name = "test_ranges";
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  // Create array with string and fixed dimensions
+  auto d1 = Dimension::create(ctx, "d1", TILEDB_STRING_ASCII, nullptr, nullptr);
+  auto d2 = Dimension::create<int>(ctx, "d2", {{1, 10}}, 5);
+
+  Domain dom(ctx);
+  dom.add_dimension(d1);
+  dom.add_dimension(d2);
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  auto a = Attribute::create<int32_t>(ctx, "a");
+  schema.add_attribute(a);
+  schema.set_domain(dom);
+  Array::create(array_name, schema);
+
+  // set dimensions
+  Array array(ctx, array_name, TILEDB_READ);
+  std::string d1_data("abbccdddd");
+  uint64_t d1_off[] = {0, 1, 3, 5};
+  uint64_t d1_off_size = 4;
+  Query query(ctx, array, TILEDB_READ);
+  CHECK_NOTHROW(query.set_buffer(
+      "d1", d1_off, d1_off_size, (void*)d1_data.c_str(), d1_data.size()));
+
+  // Add 1 range per dimension
+  std::string s1("a", 1);
+  std::string s2("cc", 2);
+  CHECK_NOTHROW(query.add_range("d1", s1, s2));
+  int range[] = {1, 2};
+  CHECK_NOTHROW(query.add_range("d2", range[0], range[1]));
+
+  // Check number of ranges on each dimension
+  int range_num = query.range_num("d1");
+  CHECK(range_num == 1);
+  range_num = query.range_num("d2");
+  CHECK(range_num == 1);
+
+  // Check ranges
+  std::array<std::string, 2> range1 = query.range("d1", 0);
+  CHECK(range1[0] == s1);
+  CHECK(range1[1] == s2);
+  auto range2 = query.range<int>("d2", 0);
+  CHECK(range2[0] == 1);
+  CHECK(range2[1] == 2);
+  CHECK(range[2] == 0);
+
+  // Close array
+  array.close();
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+}

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -536,6 +536,19 @@ Status Domain::has_dimension(const std::string& name, bool* has_dim) const {
   return Status::Ok();
 }
 
+Status Domain::get_dimension_index(
+    const std::string& name, unsigned* dim_idx) const {
+  for (unsigned d = 0; d < dim_num_; ++d) {
+    if (dimensions_[d]->name() == name) {
+      *dim_idx = d;
+      return Status::Ok();
+    }
+  }
+
+  return Status::DomainError(
+      "Cannot get dimension index; Invalid dimension name");
+}
+
 Status Domain::init(Layout cell_order, Layout tile_order) {
   // Set cell and tile order
   cell_order_ = cell_order;

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -416,6 +416,15 @@ class Domain {
   Status has_dimension(const std::string& name, bool* has_dim) const;
 
   /**
+   * Gets the index in the domain of a given dimension name
+   *
+   * @param name Name of dimension to check for
+   * @param dim_idx The index of this dimension in the domain
+   * @return Status
+   */
+  Status get_dimension_index(const std::string& name, unsigned* dim_idx) const;
+
+  /**
    * Initializes the domain.
    *
    * @param cell_order The cell order of the array the domain belongs to.

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2954,6 +2954,23 @@ int32_t tiledb_query_add_range(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_add_range_by_name(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* dim_name,
+    const void* start,
+    const void* end,
+    const void* stride) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx, query->query_->add_range_by_name(dim_name, start, end, stride)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_add_range_var(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
@@ -2974,6 +2991,26 @@ int32_t tiledb_query_add_range_var(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_add_range_var_by_name(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* dim_name,
+    const void* start,
+    uint64_t start_size,
+    const void* end,
+    uint64_t end_size) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          query->query_->add_range_var_by_name(
+              dim_name, start, start_size, end, end_size)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_get_range_num(
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
@@ -2983,6 +3020,21 @@ int32_t tiledb_query_get_range_num(
     return TILEDB_ERR;
 
   if (SAVE_ERROR_CATCH(ctx, query->query_->get_range_num(dim_idx, range_num)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_get_range_num_from_name(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    const char* dim_name,
+    uint64_t* range_num) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx, query->query_->get_range_num_from_name(dim_name, range_num)))
     return TILEDB_ERR;
 
   return TILEDB_OK;
@@ -3007,6 +3059,26 @@ int32_t tiledb_query_get_range(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_get_range_from_name(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    const char* dim_name,
+    uint64_t range_idx,
+    const void** start,
+    const void** end,
+    const void** stride) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          query->query_->get_range_from_name(
+              dim_name, range_idx, start, end, stride)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_get_range_var_size(
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
@@ -3026,6 +3098,25 @@ int32_t tiledb_query_get_range_var_size(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_get_range_var_size_from_name(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    const char* dim_name,
+    uint64_t range_idx,
+    uint64_t* start_size,
+    uint64_t* end_size) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          query->query_->get_range_var_size_from_name(
+              dim_name, range_idx, start_size, end_size)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_get_range_var(
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
@@ -3038,6 +3129,25 @@ int32_t tiledb_query_get_range_var(
 
   if (SAVE_ERROR_CATCH(
           ctx, query->query_->get_range_var(dim_idx, range_idx, start, end)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_get_range_var_from_name(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    const char* dim_name,
+    uint64_t range_idx,
+    void* start,
+    void* end) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          query->query_->get_range_var_from_name(
+              dim_name, range_idx, start, end)))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3818,7 +3818,7 @@ TILEDB_EXPORT int32_t tiledb_query_get_layout(
 TILEDB_EXPORT int32_t tiledb_query_get_array(
     tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** array);
 /**
- * Adds a 1D range along a subarray dimension, which is in the form
+ * Adds a 1D range along a subarray dimension index, which is in the form
  * (start, end, stride). The datatype of the range components
  * must be the same as the type of the domain of the array in the query.
  *
@@ -3851,8 +3851,41 @@ TILEDB_EXPORT int32_t tiledb_query_add_range(
     const void* stride);
 
 /**
- * Adds a 1D variable-sized range along a subarray dimension, which is in the
- * form (start, end). Applicable only to variable-sized dimensions.
+ * Adds a 1D range along a subarray dimension name, which is in the form
+ * (start, end, stride). The datatype of the range components
+ * must be the same as the type of the domain of the array in the query.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint32_t dim_name = "rows";
+ * int64_t start = 10;
+ * int64_t end = 20;
+ * tiledb_query_add_range_by_name(ctx, query, dim_name, &start, &end, nullptr);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The query to add the range to.
+ * @param dim_name The name of the dimension to add the range to.
+ * @param start The range start.
+ * @param end The range end.
+ * @param stride The range stride.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note The stride is currently unsupported. Use `nullptr` as the
+ *     stride argument.
+ */
+int32_t tiledb_query_add_range_by_name(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* dim_name,
+    const void* start,
+    const void* end,
+    const void* stride);
+
+/**
+ * Adds a 1D variable-sized range along a subarray dimension index, which is in
+ * the form (start, end). Applicable only to variable-sized dimensions.
  *
  * **Example:**
  *
@@ -3882,7 +3915,39 @@ TILEDB_EXPORT int32_t tiledb_query_add_range_var(
     uint64_t end_size);
 
 /**
- * Retrieves the number of ranges of the query subarray along a given dimension.
+ * Adds a 1D variable-sized range along a subarray dimension name, which is in
+ * the form (start, end). Applicable only to variable-sized dimensions.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint32_t dim_name = "rows";
+ * char start[] = "a";
+ * char end[] = "bb";
+ * tiledb_query_add_range_var_by_name(ctx, query, dim_name, start, 1, end, 2);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The query to add the range to.
+ * @param dim_name The name of the dimension to add the range to.
+ * @param start The range start.
+ * @param start_size The size of the range start in bytes.
+ * @param end The range end.
+ * @param end_size The size of the range end in bytes.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_add_range_var_by_name(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* dim_name,
+    const void* start,
+    uint64_t start_size,
+    const void* end,
+    uint64_t end_size);
+
+/**
+ * Retrieves the number of ranges of the query subarray along a given dimension
+ * index.
  *
  * **Example:**
  *
@@ -3904,7 +3969,31 @@ TILEDB_EXPORT int32_t tiledb_query_get_range_num(
     uint64_t* range_num);
 
 /**
- * Retrieves a specific range of the query subarray along a given dimension.
+ * Retrieves the number of ranges of the query subarray along a given dimension
+ * name.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint64_t range_num;
+ * tiledb_query_get_range_num_from_name(ctx, query, dim_name, &range_num);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param query The query.
+ * @param dim_name The name of the dimension whose range number to retrieve.
+ * @param range_num The number of ranges to retrieve.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_range_num_from_name(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    const char* dim_name,
+    uint64_t* range_num);
+
+/**
+ * Retrieves a specific range of the query subarray along a given dimension
+ * index.
  *
  * **Example:**
  *
@@ -3935,8 +4024,40 @@ TILEDB_EXPORT int32_t tiledb_query_get_range(
     const void** stride);
 
 /**
+ * Retrieves a specific range of the query subarray along a given dimension
+ * name.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * const void* start;
+ * const void* end;
+ * const void* stride;
+ * tiledb_query_get_range_from_name(
+ *     ctx, query, dim_name, range_idx, &start, &end, &stride);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param query The query.
+ * @param dim_name The name of the dimension to retrieve the range from.
+ * @param range_idx The index of the range to retrieve.
+ * @param start The range start to retrieve.
+ * @param end The range end to retrieve.
+ * @param stride The range stride to retrieve.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_range_from_name(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    const char* dim_name,
+    uint64_t range_idx,
+    const void** start,
+    const void** end,
+    const void** stride);
+
+/**
  * Retrieves a range's start and end size for a given variable-length
- * dimensions at a given range index.
+ * dimension index at a given range index.
  *
  * **Example:**
  *
@@ -3964,15 +4085,44 @@ TILEDB_EXPORT int32_t tiledb_query_get_range_var_size(
     uint64_t* end_size);
 
 /**
+ * Retrieves a range's start and end size for a given variable-length
+ * dimension name at a given range index.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint64_t start_size;
+ * uint64_t end_size;
+ * tiledb_query_get_range_var_size_from_name(
+ *     ctx, query, dim_name, range_idx, &start_size, &end_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param query The query.
+ * @param dim_name The name of the dimension to retrieve the range from.
+ * @param range_idx The index of the range to retrieve.
+ * @param start_size range start size in bytes
+ * @param end_size range end size in bytes
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_range_var_size_from_name(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    const char* dim_name,
+    uint64_t range_idx,
+    uint64_t* start_size,
+    uint64_t* end_size);
+
+/**
  * Retrieves a specific range of the query subarray along a given
- * variable-length dimension.
+ * variable-length dimension index.
  *
  * **Example:**
  *
  * @code{.c}
  * const void* start;
  * const void* end;
- * tiledb_query_get_range(
+ * tiledb_query_get_range_var(
  *     ctx, query, dim_idx, range_idx, &start, &end);
  * @endcode
  *
@@ -3988,6 +4138,35 @@ TILEDB_EXPORT int32_t tiledb_query_get_range_var(
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint32_t dim_idx,
+    uint64_t range_idx,
+    void* start,
+    void* end);
+
+/**
+ * Retrieves a specific range of the query subarray along a given
+ * variable-length dimension name.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * const void* start;
+ * const void* end;
+ * tiledb_query_get_range_var_from_name(
+ *     ctx, query, dim_name, range_idx, &start, &end);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param query The query.
+ * @param dim_name The name of the dimension to retrieve the range from.
+ * @param range_idx The index of the range to retrieve.
+ * @param start The range start to retrieve.
+ * @param end The range end to retrieve.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_range_var_from_name(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    const char* dim_name,
     uint64_t range_idx,
     void* start,
     void* end);

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -199,6 +199,77 @@ Status Query::get_range_var(
   return Status::Ok();
 }
 
+Status Query::add_range_by_name(
+    const std::string& dim_name,
+    const void* start,
+    const void* end,
+    const void* stride) {
+  unsigned dim_idx;
+  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
+      dim_name, &dim_idx));
+
+  return add_range(dim_idx, start, end, stride);
+}
+
+Status Query::add_range_var_by_name(
+    const std::string& dim_name,
+    const void* start,
+    uint64_t start_size,
+    const void* end,
+    uint64_t end_size) {
+  unsigned dim_idx;
+  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
+      dim_name, &dim_idx));
+
+  return add_range_var(dim_idx, start, start_size, end, end_size);
+}
+
+Status Query::get_range_num_from_name(
+    const std::string& dim_name, uint64_t* range_num) const {
+  unsigned dim_idx;
+  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
+      dim_name, &dim_idx));
+
+  return get_range_num(dim_idx, range_num);
+}
+
+Status Query::get_range_from_name(
+    const std::string& dim_name,
+    uint64_t range_idx,
+    const void** start,
+    const void** end,
+    const void** stride) const {
+  unsigned dim_idx;
+  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
+      dim_name, &dim_idx));
+
+  return get_range(dim_idx, range_idx, start, end, stride);
+}
+
+Status Query::get_range_var_size_from_name(
+    const std::string& dim_name,
+    uint64_t range_idx,
+    uint64_t* start_size,
+    uint64_t* end_size) const {
+  unsigned dim_idx;
+  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
+      dim_name, &dim_idx));
+
+  return get_range_var_size(dim_idx, range_idx, start_size, end_size);
+}
+
+Status Query::get_range_var_from_name(
+    const std::string& dim_name,
+    uint64_t range_idx,
+    void* start,
+    void* end) const {
+  unsigned dim_idx;
+  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
+      dim_name, &dim_idx));
+
+  return get_range_var(dim_idx, range_idx, start, end);
+}
+
 Status Query::get_est_result_size(const char* name, uint64_t* size) {
   if (type_ == QueryType::WRITE)
     return LOG_STATUS(Status::QueryError(

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -117,7 +117,7 @@ class Query {
   /* ********************************* */
 
   /**
-   * Adds a range to the (read/write) query on the input dimension,
+   * Adds a range to the (read/write) query on the input dimension by index,
    * in the form of (start, end, stride).
    * The range components must be of the same type as the domain type of the
    * underlying array.
@@ -127,7 +127,7 @@ class Query {
 
   /**
    * Adds a variable-sized range to the (read/write) query on the input
-   * dimension, in the form of (start, end).
+   * dimension by index, in the form of (start, end).
    */
   Status add_range_var(
       unsigned dim_idx,
@@ -136,11 +136,12 @@ class Query {
       const void* end,
       uint64_t end_size);
 
-  /** Retrieves the number of ranges of the subarray for the given dimension. */
+  /** Retrieves the number of ranges of the subarray for the given dimension
+   * index. */
   Status get_range_num(unsigned dim_idx, uint64_t* range_num) const;
 
   /**
-   * Retrieves a range from a dimension in the form (start, end, stride).
+   * Retrieves a range from a dimension index in the form (start, end, stride).
    *
    * @param dim_idx The dimension to retrieve the range from.
    * @param range_idx The id of the range to retrieve.
@@ -157,7 +158,7 @@ class Query {
       const void** stride) const;
 
   /**
-   * Retrieves a range's sizes for a variable-length dimension
+   * Retrieves a range's sizes for a variable-length dimension index
    *
    * @param dim_idx The dimension to retrieve the range from.
    * @param range_idx The id of the range to retrieve.
@@ -172,8 +173,8 @@ class Query {
       uint64_t* end_size) const;
 
   /**
-   * Retrieves a range from a variable-length dimension in the form (start,
-   * end).
+   * Retrieves a range from a variable-length dimension index in the form
+   * (start, end).
    *
    * @param dim_idx The dimension to retrieve the range from.
    * @param range_idx The id of the range to retrieve.
@@ -183,6 +184,83 @@ class Query {
    */
   Status get_range_var(
       unsigned dim_idx, uint64_t range_idx, void* start, void* end) const;
+
+  /**
+   * Adds a range to the (read/write) query on the input dimension by name,
+   * in the form of (start, end, stride).
+   * The range components must be of the same type as the domain type of the
+   * underlying array.
+   */
+
+  Status add_range_by_name(
+      const std::string& dim_name,
+      const void* start,
+      const void* end,
+      const void* stride);
+
+  /**
+   * Adds a variable-sized range to the (read/write) query on the input
+   * dimension by name, in the form of (start, end).
+   */
+  Status add_range_var_by_name(
+      const std::string& dim_name,
+      const void* start,
+      uint64_t start_size,
+      const void* end,
+      uint64_t end_size);
+
+  /** Retrieves the number of ranges of the subarray for the given dimension
+   * name. */
+  Status get_range_num_from_name(
+      const std::string& dim_name, uint64_t* range_num) const;
+
+  /**
+   * Retrieves a range from a dimension name in the form (start, end, stride).
+   *
+   * @param dim_name The dimension to retrieve the range from.
+   * @param range_idx The id of the range to retrieve.
+   * @param start The range start to retrieve.
+   * @param end The range end to retrieve.
+   * @param stride The range stride to retrieve.
+   * @return Status
+   */
+  Status get_range_from_name(
+      const std::string& dim_name,
+      uint64_t range_idx,
+      const void** start,
+      const void** end,
+      const void** stride) const;
+
+  /**
+   * Retrieves a range's sizes for a variable-length dimension name
+   *
+   * @param dim_name The dimension name to retrieve the range from.
+   * @param range_idx The id of the range to retrieve.
+   * @param start_size range start size in bytes
+   * @param end_size range end size in bytes
+   * @return Status
+   */
+  Status get_range_var_size_from_name(
+      const std::string& dim_name,
+      uint64_t range_idx,
+      uint64_t* start_size,
+      uint64_t* end_size) const;
+
+  /**
+   * Retrieves a range from a variable-length dimension name in the form (start,
+   * end).
+   *
+   * @param dim_name The dimension name to retrieve the range from.
+   * @param range_idx The id of the range to retrieve.
+   * @param start The range start to retrieve.
+   * @param end The range end to retrieve.
+   * @return Status
+   */
+  Status get_range_var_from_name(
+      const std::string& dim_name,
+      uint64_t range_idx,
+      void* start,
+      void* end) const;
 
   /**
    * Gets the estimated result size (in bytes) for the input fixed-sized


### PR DESCRIPTION
This patch is adding setters and getters of query ranges using dimension names.
So far the available APIs are only allowing those operations using dimension indexes.

```
build % make -C tiledb tiledb_unit && ./tiledb/test/tiledb_unit "[range]"
[ 49%] Built target TILEDB_CORE_OBJECTS
Scanning dependencies of target tiledb_unit
[ 49%] Building CXX object test/CMakeFiles/tiledb_unit.dir/src/unit-cppapi-query.cc.o
[ 49%] Linking CXX executable tiledb_unit
[100%] Built target tiledb_unit
Filters: [range]
===============================================================================
All tests passed (54 assertions in 2 test cases)

```