### PR TITLE
Fix tools and add string to mbrs and CI

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,7 @@
 * Prevented unnecessary sorting when (1) there is a single fragment and (i) either the query layout is global order, or (ii) the number of dimensions is 1, and (2) when there is a single range for which the result coordinates have already been sorted. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 * Added extra stats for consolidation. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 * Disabled checking if cells are written in global order when consolidating, as it was redundant (the cells are already being read in global order during consolidation). [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880) 
+* Add support for printing MBRs with string dimensions in TileDB Tools [#1926](https://github.com/TileDB-Inc/TileDB/pull/1926)
 
 ## Deprecations
 
@@ -37,6 +38,7 @@
 * Updated the AWS SDK to v1.8.84 to fix an uncaught exception when using S3 [#1899](https://github.com/TileDB-Inc/TileDB/pull/1899)[TileDB-Py #409](https://github.com/TileDB-Inc/TileDB-Py/issues/409)
 * Fixed bug where a read on a sparse array may return duplicate values. [#1905](https://github.com/TileDB-Inc/TileDB/pull/1905)
 * Fixed bug where an array could not be opened if created with an array schema from an older version [#1889](https://github.com/TileDB-Inc/TileDB/pull/1889)
+* Fix compilation of TileDB Tools [#1926](https://github.com/TileDB-Inc/TileDB/pull/1926)
 
 ## API additions
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ stages:
             imageName: 'ubuntu-16.04'
             TILEDB_S3: ON
             TILEDB_STATIC: OFF
+            TILEDB_TOOLS: ON
             CXX: g++
           linux_hdfs:
             imageName: 'ubuntu-16.04'

--- a/tools/src/misc/common.h
+++ b/tools/src/misc/common.h
@@ -33,7 +33,7 @@
 #ifndef TILEDB_CLI_COMMON_H
 #define TILEDB_CLI_COMMON_H
 
-#include "tiledb/sm/misc/status.h"
+#include "tiledb/common/status.h"
 
 namespace tiledb {
 namespace cli {
@@ -41,7 +41,7 @@ namespace cli {
 /** Throws an exception if the given Status is not ok. */
 #define THROW_NOT_OK(s)                                          \
   do {                                                           \
-    tiledb::sm::Status _s = (s);                                 \
+    tiledb::common::Status _s = (s);                             \
     if (!_s.ok())                                                \
       throw std::runtime_error("TileDB Error: " + _s.message()); \
   } while (0)


### PR DESCRIPTION
This fixes the compilation of TileDB Tools, along with adding support for String MBRs and enabled CI for linux to make sure the tools always build going forward.

~@joe-maley This can be backported as tools are broken in 2.1 also. It doesn't need to be in the 2.1.3 release.~