### PR TITLE
Using our OpenSSL from superbuild requires pkg-config

### DIFF
--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -98,6 +98,10 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
   else()
     set(DEPENDS)
     if (TARGET ep_openssl)
+      # This branch specifically intends that curl will find our OpenSSL
+      # via pkg-config. Ensure it exists to avoid confusing errors.
+      find_package(PkgConfig REQUIRED)
+
       list(APPEND DEPENDS ep_openssl)
       set(WITH_SSL "--with-ssl")
       set(SSL_PKG_CONFIG_PATH "${TILEDB_EP_INSTALL_PREFIX}/lib/pkgconfig:${TILEDB_EP_INSTALL_PREFIX}/lib64/pkgconfig")


### PR DESCRIPTION
When we build OpenSSL from source, we tell the Curl build to use OpenSSL's
pkg-config files to find OpenSSL. If pkg-config is not available, the
curl configure fails because the test programs won't build. This is
buried inside of Curl's config.log and the problem is not directly
obvious. The Curl configure fails with a very unhelpful error, and
the underlying reason is the test programs try to link default
lib/include paths rather than our 'externals/install/lib'.
At best the top level build will fail with a confusing error,
at worst we might link a system SSL we don't want in superbuild
mode.

---
[ch3958]