### PR TITLE
Handle `must_split_slab` in SubarrayPartitioner::split_current()

### DIFF
--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -578,17 +578,28 @@ Status SubarrayPartitioner::split_current(bool* unsplittable) {
         range_num * (1 - constants::multi_range_reduction_in_split);
     current_.end_ = current_.start_ + (uint64_t)new_range_num - 1;
 
-    // Calibrating `current_` will never increase the size. If the
-    // `must_split_slab` returns `true`, we know that `current_` needed
-    // to be split, both before and after calibrating its `start` and
-    // `end`. For now, we will ignore the return value of `must_split_slab`.
     bool must_split_slab;
     calibrate_current_start_end(&must_split_slab);
-    (void)must_split_slab;
+
+    // If the range between `current_.start_` and `current_.end_`
+    // will not fit within the memory contraints, `must_split_slab`
+    // will be true. We must split the current partition.
+    //
+    // This is a difficult path to reach, but this has been manually
+    // tested. This path was reached by re-assigning the query
+    // buffers with smaller buffers after an incomplete read.
+    if (must_split_slab) {
+      if (state_.multi_range_.empty())
+        state_.start_ = current_.start_;
+      state_.multi_range_.push_front(current_.partition_);
+      split_top_multi_range(unsplittable);
+      return next_from_multi_range(unsplittable);
+    }
 
     current_.partition_ =
         subarray_.get_subarray(current_.start_, current_.end_);
     state_.start_ = current_.end_ + 1;
+
     return Status::Ok();
   }
 


### PR DESCRIPTION
After calibrating `current_` in `SubarrayPartitioner::split_current()`, the
`must_split_slab` may be true. In this scenario, the reader will get stuck
in an infinite loop because it can not make progress on the current partition.

This change handles `must_split_slab == true` to split the current partition.
I verified the fix in a repro scenario that was previously hanging. It now
completes with the expected number of records.