### PR TITLE
Nullable fill values

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,7 +10,7 @@
 
 ## New features
 
-* Support for nullable attributes. [#1895](https://github.com/TileDB-Inc/TileDB/pull/1895)
+* Support for nullable attributes. [#1895](https://github.com/TileDB-Inc/TileDB/pull/1895) [#1938](https://github.com/TileDB-Inc/TileDB/pull/1938)
 * Support for Hilbert order sorting for sparse arrays. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 * Support for AWS S3 "AssumeRole" temporary credentials [#1882](https://github.com/TileDB-Inc/TileDB/pull/1882)
 * Experimental support for an in-memory backend used with bootstrap option "--enable-memfs" [#1873](https://github.com/TileDB-Inc/TileDB/pull/1873)

--- a/format_spec/array_schema.md
+++ b/format_spec/array_schema.md
@@ -71,3 +71,4 @@ The attribute has internal format:
 | Fill value size | `uint64_t` | The size in bytes of the fill value |
 | Fill value | `uint8_t[]` | The fill value |
 | Nullable | `bool` | Whether or not the attribute can be null |
+| Fill value validity | `uint8_t` | The validity fill value |

--- a/tiledb/sm/array_schema/attribute.h
+++ b/tiledb/sm/array_schema/attribute.h
@@ -171,8 +171,24 @@ class Attribute {
    */
   Status get_fill_value(const void** value, uint64_t* size) const;
 
+  /**
+   * Sets the fill value for the nullable attribute. Applicable to
+   * both fixed-sized and var-sized attributes.
+   */
+  Status set_fill_value(const void* value, uint64_t size, uint8_t valid);
+
+  /**
+   * Gets the fill value for the nullable attribute. Applicable to
+   * fixed-sized and var-sized attributes.
+   */
+  Status get_fill_value(
+      const void** value, uint64_t* size, uint8_t* valid) const;
+
   /** Returns the fill value. */
   const ByteVecValue& fill_value() const;
+
+  /** Returns the fill value validity. */
+  uint8_t fill_value_validity() const;
 
   /** Returns the attribute type. */
   Datatype type() const;
@@ -211,6 +227,9 @@ class Attribute {
 
   /** The fill value. */
   ByteVecValue fill_value_;
+
+  /** The fill value validity, applicable only to nullable attributes. */
+  uint8_t fill_value_validity_;
 
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1634,6 +1634,36 @@ int32_t tiledb_attribute_get_fill_value(
   return TILEDB_OK;
 }
 
+int32_t tiledb_attribute_set_fill_value_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_attribute_t* attr,
+    const void* value,
+    uint64_t size,
+    uint8_t valid) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, attr) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(ctx, attr->attr_->set_fill_value(value, size, valid)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_attribute_get_fill_value_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_attribute_t* attr,
+    const void** value,
+    uint64_t* size,
+    uint8_t* valid) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, attr) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(ctx, attr->attr_->get_fill_value(value, size, valid)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 /* ********************************* */
 /*              DOMAIN               */
 /* ********************************* */

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -2151,7 +2151,7 @@ TILEDB_EXPORT int32_t tiledb_attribute_dump(
  * tiledb_attribute_set_fill_value(ctx, attr, &value, size);
  *
  * // Assumming a var char attribute
- * const char* value = "null";
+ * const char* value = "foo";
  * uint64_t size = strlen(value);
  * tiledb_attribute_set_fill_value(ctx, attr, value, size);
  * @endcode
@@ -2210,6 +2210,93 @@ TILEDB_EXPORT int32_t tiledb_attribute_get_fill_value(
     tiledb_attribute_t* attr,
     const void** value,
     uint64_t* size);
+
+/**
+ * Sets the default fill value for the input, nullable attribute. This value
+ * will be used for the input attribute whenever querying (1) an empty cell in
+ * a dense array, or (2) a non-empty cell (in either dense or sparse array)
+ * when values on the input attribute are missing (e.g., if the user writes
+ * a subset of the attributes in a write operation).
+ *
+ * Applicable to var-sized attributes.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * // Assumming a int32 attribute
+ * int32_t value = 0;
+ * uint64_t size = sizeof(value);
+ * uint8_t valid = 0;
+ * tiledb_attribute_set_fill_value_nullable(ctx, attr, &value, size, valid);
+ *
+ * // Assumming a var char attribute
+ * const char* value = "foo";
+ * uint64_t size = strlen(value);
+ * uint8_t valid = 1;
+ * tiledb_attribute_set_fill_value(ctx, attr, value, size, valid);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param attr The target attribute.
+ * @param value The fill value to set.
+ * @param size The fill value size in bytes.
+ * @param valid The validity fill value, zero for a null value and
+ *     non-zero for a valid attribute.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note A call to `tiledb_attribute_cell_val_num` sets the fill value
+ *     of the attribute to its default. Therefore, make sure you invoke
+ *     `tiledb_attribute_set_fill_value_nullable` after deciding on the
+ *     number of values this attribute will hold in each cell.
+ *
+ * @note For fixed-sized attributes, the input `size` should be equal
+ *     to the cell size.
+ */
+TILEDB_EXPORT int32_t tiledb_attribute_set_fill_value_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_attribute_t* attr,
+    const void* value,
+    uint64_t size,
+    uint8_t validity);
+
+/**
+ * Gets the default fill value for the input, nullable attribute. This value
+ * will be used for the input attribute whenever querying (1) an empty cell in
+ * a dense array, or (2) a non-empty cell (in either dense or sparse array)
+ * when values on the input attribute are missing (e.g., if the user writes
+ * a subset of the attributes in a write operation).
+ *
+ * Applicable to both fixed-sized and var-sized attributes.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * // Assuming a int32 attribute
+ * const int32_t* value;
+ * uint64_t size;
+ * uint8_t valid;
+ * tiledb_attribute_get_fill_value(ctx, attr, &value, &size, &valid);
+ *
+ * // Assuming a var char attribute
+ * const char* value;
+ * uint64_t size;
+ * uint8_t valid;
+ * tiledb_attribute_get_fill_value(ctx, attr, &value, &size, &valid);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param attr The target attribute.
+ * @param value A pointer to the fill value to get.
+ * @param size The size of the fill value to get.
+ * @param valid The fill value validity to get.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_attribute_get_fill_value_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_attribute_t* attr,
+    const void** value,
+    uint64_t* size,
+    uint8_t* valid);
 
 /* ********************************* */
 /*               DOMAIN              */

--- a/tiledb/sm/cpp_api/attribute.h
+++ b/tiledb/sm/cpp_api/attribute.h
@@ -303,6 +303,95 @@ class Attribute {
         ctx.ptr().get(), attr_.get(), value, size));
   }
 
+  /**
+   * Sets the default fill value for the input, nullable attribute. This value
+   * will be used for the input attribute whenever querying (1) an empty cell in
+   * a dense array, or (2) a non-empty cell (in either dense or sparse array)
+   * when values on the input attribute are missing (e.g., if the user writes
+   * a subset of the attributes in a write operation).
+   *
+   * Applicable to var-sized attributes.
+   *
+   * **Example:**
+   *
+   * @code{.c}
+   * tiledb::Context ctx;
+   *
+   * // Fixed-sized attribute
+   * auto a1 = tiledb::Attribute::create<int>(ctx, "a1");
+   * a1.set_nullable(true);
+   * int32_t value = 0;
+   * uint64_t size = sizeof(value);
+   * uint8_t valid = 0;
+   * a1.set_fill_value(&value, size, valid);
+   *
+   * // Var-sized attribute
+   * auto a2 = tiledb::Attribute::create<std::string>(ctx, "a2");
+   * a2.set_nullable(true);
+   * std::string value("null");
+   * uint8_t valid = 0;
+   * a2.set_fill_value(value.c_str(), value.size(), valid);
+   * @endcode
+   *
+   * @param value The fill value to set.
+   * @param size The fill value size in bytes.
+   * @param valid The validity fill value, zero for a null value and
+   *     non-zero for a valid attribute.
+   *
+   * @note A call to `cell_val_num` sets the fill value
+   *     of the attribute to its default. Therefore, make sure you invoke
+   *     `set_fill_value` after deciding on the number
+   *     of values this attribute will hold in each cell.
+   *
+   * @note For fixed-sized attributes, the input `size` should be equal
+   *     to the cell size.
+   */
+  Attribute& set_fill_value(const void* value, uint64_t size, uint8_t valid) {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_attribute_set_fill_value_nullable(
+        ctx.ptr().get(), attr_.get(), value, size, valid));
+    return *this;
+  }
+
+  /**
+   * Gets the default fill value for the input attribute. This value will
+   * be used for the input attribute whenever querying (1) an empty cell in
+   * a dense array, or (2) a non-empty cell (in either dense or sparse array)
+   * when values on the input attribute are missing (e.g., if the user writes
+   * a subset of the attributes in a write operation).
+   *
+   * Applicable to both fixed-sized and var-sized attributes.
+   *
+   * **Example:**
+   *
+   * @code{.c}
+   * // Fixed-sized attribute
+   * auto a1 = tiledb::Attribute::create<int>(ctx, "a1");
+   * a1.set_nullable(true);
+   * const int32_t* value;
+   * uint64_t size;
+   * uint8_t valid;
+   * a1.get_fill_value(&value, &size, &valid);
+   *
+   * // Var-sized attribute
+   * auto a2 = tiledb::Attribute::create<std::string>(ctx, "a2");
+   * a2.set_nullable(true);
+   * const char* value;
+   * uint64_t size;
+   * uint8_t valid;
+   * a2.get_fill_value(&value, &size, &valid);
+   * @endcode
+   *
+   * @param value A pointer to the fill value to get.
+   * @param size The size of the fill value to get.
+   * @param valid The fill value validity to get.
+   */
+  void get_fill_value(const void** value, uint64_t* size, uint8_t* valid) {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_attribute_get_fill_value_nullable(
+        ctx.ptr().get(), attr_.get(), value, size, valid));
+  }
+
   /** Check if attribute is variable sized. **/
   bool variable_sized() const {
     return cell_val_num() == TILEDB_VAR_NUM;


### PR DESCRIPTION
This adds support for setting fill-values for nullable attributes. This
introduces new routine to the C-API and C++-API. By default, fill values will
be null.

Note that this changes the on-disk format, but we have no released version 7
so I did not bump the version.