### PR TITLE
Incorrect fragment metadata consolidation

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -399,6 +399,8 @@ class FragmentMetadata {
    */
   Status get_footer_size(uint32_t version, uint64_t* size) const;
 
+  uint64_t footer_size() const;
+
   /** Returns the MBR of the input tile. */
   const NDRange& mbr(uint64_t tile_idx) const;
 
@@ -595,6 +597,12 @@ class FragmentMetadata {
 
   /** Stores the size of each validity attribute file. */
   std::vector<uint64_t> file_validity_sizes_;
+
+  /** Size of the fragment metadata footer. */
+  uint64_t footer_size_;
+
+  /** Offset of the fragment metadata footer. */
+  uint64_t footer_offset_;
 
   /** The uri of the fragment the metadata belongs to. */
   URI fragment_uri_;
@@ -1047,7 +1055,8 @@ class FragmentMetadata {
    * Reads the fragment metadata file footer (which contains the generic tile
    * offsets) into the input buffer.
    */
-  Status read_file_footer(Buffer* buff) const;
+  Status read_file_footer(
+      Buffer* buff, uint64_t* footer_offset, uint64_t* footer_size) const;
 
   /**
    * Writes the contents of the input buffer as a separate

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -496,7 +496,6 @@ Status Consolidator::consolidate_fragment_meta(
   RETURN_NOT_OK(utils::parse::get_fragment_version(meta_name, &meta_version));
 
   // Serialize all fragment names and footer offsets into a single buffer
-  uint64_t footer_size = 0;
   for (auto m : meta) {
     // Write name size and name
     auto name = m->fragment_uri().to_string();
@@ -504,8 +503,8 @@ Status Consolidator::consolidate_fragment_meta(
     RETURN_NOT_OK(buff.write(&name_size, sizeof(uint64_t)));
     RETURN_NOT_OK(buff.write(name.c_str(), name_size));
     RETURN_NOT_OK(buff.write(&offset, sizeof(uint64_t)));
-    RETURN_NOT_OK(m->get_footer_size(meta_version, &footer_size));
-    offset += footer_size;
+
+    offset += m->footer_size();
   }
 
   // Serialize all fragment metadata footers in parallel


### PR DESCRIPTION
This adds unit tests and fixes an an issue with consolidating fragment metadata with string dimensions. Previously when we were writing out the new consolidated fragment metadata file, we incorrectly were computing the size of the fragment metadata. Instead of relying on the fixed size of a fragment metadata, we need to account for string dimensions where we write the size of the metadata at the end of the footer.