### PR TITLE
Remove trailing ; to silence -pedantic; set C++ mode

### DIFF
--- a/tiledb/sm/cpp_api/arrow_io_impl.h
+++ b/tiledb/sm/cpp_api/arrow_io_impl.h
@@ -829,8 +829,8 @@ void query_set_buffer_arrow_array(
   importer.import_(name, arw_array, arw_schema);
 }
 
-};  // end namespace arrow
-};  // end namespace tiledb
+}  // end namespace arrow
+}  // end namespace tiledb
 
 /* End TileDB Arrow IO public API implementation */
 /* ************************************************************************ */

--- a/tiledb/sm/cpp_api/arrowio
+++ b/tiledb/sm/cpp_api/arrowio
@@ -1,4 +1,4 @@
-/**
+/**      -*-C++-*-
  * vim: set ft=cpp:
  * @file   arrowio
  *
@@ -86,7 +86,7 @@ private:
   ArrowExporter* exporter_;
 };
 
-};  // end namespace arrow
-};  // end namespace tiledb
+}  // end namespace arrow
+}  // end namespace tiledb
 
 #include "arrow_io_impl.h"


### PR DESCRIPTION
This PR removes two pairs of semicolons that `g++ -pedantic` complains about, and sets the Emacs mode for `arrowio`.  

The mode can also be set at the [bottom via file-mode variable](https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html#Specifying-File-Variables) if that is preferred; or in the slightly longer form `-*- mode: C++; -*-`.  Either way it is a little nice to see semantic highlighting enabled even when customary extension is missing.  The header also has a vim mode set.  

No actual functionality added or removed. 