### PR TITLE
Fix tiledb_dimension_alloc returning non-null pointer after error

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,7 @@
 
 ## Bug fixes
 
+* Fix tiledb_dimension_alloc returning a non-null pointer after error [#1959]((https://github.com/TileDB-Inc/TileDB/pull/1859)
 * Fix ArraySchema not write protecting fill values for only schema version 6 or newer [#1868](https://github.com/TileDB-Inc/TileDB/pull/1868)
 * Fix segfault that may occur in the VFS read-ahead cache [#1871](https://github.com/TileDB-Inc/TileDB/pull/1871)
 * The result size estimation routines will no longer return non-zero sizes that can not contain a single value. [#1849](https://github.com/TileDB-Inc/TileDB/pull/1849)

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -569,6 +569,7 @@ void ArraySchemaFx::create_array(const std::string& path) {
       &tile_extent,
       &d3);
   REQUIRE(rc == TILEDB_ERR);
+  REQUIRE(d3 == nullptr);
 
   // Set up filters
   tiledb_filter_t* filter;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1784,6 +1784,7 @@ int32_t tiledb_dimension_alloc(
       tiledb::sm::Dimension(name, static_cast<tiledb::sm::Datatype>(type));
   if ((*dim)->dim_ == nullptr) {
     delete *dim;
+    *dim = nullptr;
     auto st = Status::Error("Failed to allocate TileDB dimension object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -1794,6 +1795,7 @@ int32_t tiledb_dimension_alloc(
   if (SAVE_ERROR_CATCH(ctx, (*dim)->dim_->set_domain(dim_domain))) {
     delete (*dim)->dim_;
     delete *dim;
+    *dim = nullptr;
     return TILEDB_ERR;
   }
 
@@ -1801,6 +1803,7 @@ int32_t tiledb_dimension_alloc(
   if (SAVE_ERROR_CATCH(ctx, (*dim)->dim_->set_tile_extent(tile_extent))) {
     delete (*dim)->dim_;
     delete *dim;
+    *dim = nullptr;
     return TILEDB_ERR;
   }
 


### PR DESCRIPTION
Avoids segfault in the following circumstance:
  - client calls dimension_alloc which returns error condition
  - client observes non-null pointer and calls tiledb_dimension_free
    before raising error

This matches behavior in other allocation functions.