### PR TITLE
Support 32bit offsets in writer

### DIFF
--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -2125,7 +2125,7 @@ void SparseArrayFx::check_invalid_offsets(const std::string& array_name) {
       &a2_buffer_offset_size,
       buffers[1],
       &a2_buffer_size);
-  CHECK(rc == TILEDB_ERR);
+  CHECK(tiledb_query_submit(ctx_, query) == TILEDB_ERR);
 
   // Check non-ascending offsets error
   buffer_a2[0] = 0;
@@ -2139,7 +2139,7 @@ void SparseArrayFx::check_invalid_offsets(const std::string& array_name) {
       &buffer_sizes[0],
       buffers[1],
       &buffer_sizes[1]);
-  CHECK(rc == TILEDB_ERR);
+  CHECK(tiledb_query_submit(ctx_, query) == TILEDB_ERR);
 
   // Check out-of-bounds offsets error
   buffer_a2[0] = 0;
@@ -2153,7 +2153,7 @@ void SparseArrayFx::check_invalid_offsets(const std::string& array_name) {
       &buffer_sizes[0],
       buffers[1],
       &buffer_sizes[1]);
-  CHECK(rc == TILEDB_ERR);
+  CHECK(tiledb_query_submit(ctx_, query) == TILEDB_ERR);
 
   // Close array
   rc = tiledb_array_close(ctx_, array);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -395,7 +395,8 @@ TEST_CASE(
     Query q(ctx, array, TILEDB_WRITE);
     q.set_layout(TILEDB_GLOBAL_ORDER);
     q.set_coordinates(coord);
-    REQUIRE_THROWS(q.set_buffer("a", a_offset, a));
+    q.set_buffer("a", a_offset, a);
+    REQUIRE_THROWS(q.submit());
   }
 
   // Test case of non-ascending offsets
@@ -405,7 +406,8 @@ TEST_CASE(
     Query q(ctx, array, TILEDB_WRITE);
     q.set_layout(TILEDB_GLOBAL_ORDER);
     q.set_coordinates(coord);
-    REQUIRE_THROWS(q.set_buffer("a", a_offset, a));
+    q.set_buffer("a", a_offset, a);
+    REQUIRE_THROWS(q.submit());
   }
 
   array.close();

--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -931,17 +931,17 @@ TEST_CASE(
     SECTION("Unordered write") {
       write_dense_array(
           ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
-      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
+      read_and_check_dense_array(ctx, array_name, data, data_offsets_exp);
     }
     SECTION("Ordered write") {
       write_dense_array(
           ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
-      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
+      read_and_check_dense_array(ctx, array_name, data, data_offsets_exp);
     }
     SECTION("Global order write") {
       write_dense_array(
           ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
-      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
+      read_and_check_dense_array(ctx, array_name, data, data_offsets_exp);
     }
   }
 

--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -70,8 +70,38 @@ void write_sparse_array(
 
   Array array(ctx, array_name, TILEDB_WRITE);
   Query query(ctx, array, TILEDB_WRITE);
-  query.set_layout(layout).set_buffer("d1", d1).set_buffer("d2", d2).set_buffer(
-      "attr", data_offsets, data);
+  query.set_layout(layout);
+  query.set_buffer("d1", d1);
+  query.set_buffer("d2", d2);
+  query.set_buffer("attr", data_offsets, data);
+  CHECK_NOTHROW(query.submit());
+
+  // Finalize is necessary in global writes, otherwise a no-op
+  query.finalize();
+
+  array.close();
+}
+
+void write_sparse_array(
+    Context ctx,
+    const std::string& array_name,
+    std::vector<int32_t>& data,
+    std::vector<uint32_t>& data_offsets,
+    tiledb_layout_t layout) {
+  std::vector<int64_t> d1 = {1, 2, 3, 4};
+  std::vector<int64_t> d2 = {2, 1, 3, 4};
+
+  Array array(ctx, array_name, TILEDB_WRITE);
+  Query query(ctx, array, TILEDB_WRITE);
+  query.set_layout(layout);
+  query.set_buffer("d1", d1);
+  query.set_buffer("d2", d2);
+  query.set_buffer(
+      "attr",
+      reinterpret_cast<uint64_t*>(data_offsets.data()),
+      data_offsets.size(),
+      data.data(),
+      data.size());
   CHECK_NOTHROW(query.submit());
 
   // Finalize is necessary in global writes, otherwise a no-op
@@ -91,6 +121,34 @@ void read_and_check_sparse_array(
   std::vector<int32_t> attr_val(expected_data.size());
   std::vector<uint64_t> attr_off(expected_offsets.size());
   query.set_buffer("attr", attr_off, attr_val);
+
+  CHECK_NOTHROW(query.submit());
+
+  // Check the element offsets are properly returned
+  CHECK(attr_val == expected_data);
+  CHECK(attr_off == expected_offsets);
+
+  array.close();
+}
+
+void read_and_check_sparse_array(
+    Context ctx,
+    const std::string& array_name,
+    std::vector<int32_t>& expected_data,
+    std::vector<uint32_t>& expected_offsets) {
+  Array array(ctx, array_name, TILEDB_READ);
+  Query query(ctx, array, TILEDB_READ);
+
+  std::vector<int32_t> attr_val(expected_data.size());
+  std::vector<uint32_t> attr_off(expected_offsets.size());
+  // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
+  // accepts it
+  query.set_buffer(
+      "attr",
+      reinterpret_cast<uint64_t*>(attr_off.data()),
+      attr_off.size(),
+      attr_val.data(),
+      attr_val.size());
   CHECK_NOTHROW(query.submit());
 
   // Check the element offsets are properly returned
@@ -138,7 +196,6 @@ void write_dense_array(
   query.set_layout(layout);
   if (layout == TILEDB_UNORDERED) {
     // sparse write to dense array
-
     query.set_buffer("d1", d1);
     query.set_buffer("d2", d2);
   } else {
@@ -147,6 +204,42 @@ void write_dense_array(
 
   CHECK_NOTHROW(query.submit());
 
+  // Finalize is necessary in global writes, otherwise a no-op
+  query.finalize();
+
+  array.close();
+}
+
+void write_dense_array(
+    Context ctx,
+    const std::string& array_name,
+    std::vector<int32_t>& data,
+    std::vector<uint32_t>& data_offsets,
+    tiledb_layout_t layout) {
+  std::vector<int64_t> d1 = {1, 1, 2, 2};
+  std::vector<int64_t> d2 = {1, 2, 1, 2};
+
+  Array array(ctx, array_name, TILEDB_WRITE);
+  Query query(ctx, array, TILEDB_WRITE);
+
+  // Write using a 32-bit vector, but cast it to 64-bit pointer so that the API
+  // accepts it
+  query.set_buffer(
+      "attr",
+      reinterpret_cast<uint64_t*>(data_offsets.data()),
+      data_offsets.size(),
+      data.data(),
+      data.size());
+  query.set_layout(layout);
+  if (layout == TILEDB_UNORDERED) {
+    // sparse write to dense array
+    query.set_buffer("d1", d1);
+    query.set_buffer("d2", d2);
+  } else {
+    query.set_subarray<int64_t>({1, 2, 1, 2});
+  }
+
+  CHECK_NOTHROW(query.submit());
   // Finalize is necessary in global writes, otherwise a no-op
   query.finalize();
 
@@ -165,6 +258,34 @@ void read_and_check_dense_array(
   std::vector<uint64_t> attr_off(expected_offsets.size());
   query.set_subarray<int64_t>({1, 2, 1, 2});
   query.set_buffer("attr", attr_off, attr_val);
+  CHECK_NOTHROW(query.submit());
+
+  // Check the element offsets are properly returned
+  CHECK(attr_val == expected_data);
+  CHECK(attr_off == expected_offsets);
+
+  array.close();
+}
+
+void read_and_check_dense_array(
+    Context ctx,
+    const std::string& array_name,
+    std::vector<int32_t>& expected_data,
+    std::vector<uint32_t>& expected_offsets) {
+  Array array(ctx, array_name, TILEDB_READ);
+  Query query(ctx, array, TILEDB_READ);
+
+  std::vector<int32_t> attr_val(expected_data.size());
+  std::vector<uint32_t> attr_off(expected_offsets.size());
+  query.set_subarray<int64_t>({1, 2, 1, 2});
+  // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
+  // accepts it
+  query.set_buffer(
+      "attr",
+      reinterpret_cast<uint64_t*>(attr_off.data()),
+      attr_off.size(),
+      attr_val.data(),
+      attr_val.size());
   CHECK_NOTHROW(query.submit());
 
   // Check the element offsets are properly returned
@@ -666,39 +787,27 @@ TEST_CASE(
   create_sparse_array(array_name);
 
   std::vector<int32_t> data = {1, 2, 3, 4, 5, 6};
-  // TODO: use a 32-bit offset vector when it's supported on the write path
-  std::vector<uint64_t> data_offsets = {0, 4, 12, 20};
-  Context ctx;
-  write_sparse_array(ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
+  // Create 32 bit byte offsets buffer to use
+  std::vector<uint32_t> data_byte_offsets = {0, 4, 12, 20};
 
   Config config;
   // Change config of offsets bitsize from 64 to 32
   config["sm.var_offsets.bitsize"] = 32;
-
-  std::vector<int32_t> attr_val(data.size());
-  std::vector<uint32_t> attr_off(data_offsets.size());
+  Context ctx(config);
 
   SECTION("Byte offsets (default case)") {
     CHECK((std::string)config["sm.var_offsets.mode"] == "bytes");
-    Context ctx(config);
 
-    Array array(ctx, array_name, TILEDB_READ);
-    Query query(ctx, array, TILEDB_READ);
-
-    // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
-    // accepts it
-    query.set_buffer(
-        "attr",
-        reinterpret_cast<uint64_t*>(attr_off.data()),
-        attr_off.size(),
-        attr_val.data(),
-        attr_val.size());
-    CHECK_NOTHROW(query.submit());
-
-    // Check that byte offsets are properly returned
-    std::vector<uint32_t> data_offsets_exp = {0, 4, 12, 20};
-    CHECK(attr_val == data);
-    CHECK(attr_off == data_offsets_exp);
+    SECTION("Unordered write") {
+      write_sparse_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
+      read_and_check_sparse_array(ctx, array_name, data, data_byte_offsets);
+    }
+    SECTION("Global order write") {
+      write_sparse_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_sparse_array(ctx, array_name, data, data_byte_offsets);
+    }
   }
 
   SECTION("Element offsets") {
@@ -706,52 +815,39 @@ TEST_CASE(
     config["sm.var_offsets.mode"] = "elements";
     Context ctx(config);
 
-    Array array(ctx, array_name, TILEDB_READ);
-    Query query(ctx, array, TILEDB_READ);
+    // Create 32 bit element offsets buffer to use
+    std::vector<uint32_t> data_element_offsets = {0, 1, 3, 5};
 
-    // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
-    // accepts it
-    query.set_buffer(
-        "attr",
-        reinterpret_cast<uint64_t*>(attr_off.data()),
-        attr_off.size(),
-        attr_val.data(),
-        attr_val.size());
-    CHECK_NOTHROW(query.submit());
-
-    // Check that element offsets are properly returned
-    std::vector<uint32_t> data_offsets_exp = {0, 1, 3, 5};
-    CHECK(attr_val == data);
-    CHECK(attr_off == data_offsets_exp);
-
-    array.close();
+    SECTION("Unordered write") {
+      write_sparse_array(
+          ctx, array_name, data, data_element_offsets, TILEDB_UNORDERED);
+      read_and_check_sparse_array(ctx, array_name, data, data_element_offsets);
+    }
+    SECTION("Global order write") {
+      write_sparse_array(
+          ctx, array_name, data, data_element_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_sparse_array(ctx, array_name, data, data_element_offsets);
+    }
   }
 
   SECTION("Extra element") {
     config["sm.var_offsets.extra_element"] = "true";
     Context ctx(config);
 
-    // Extend offsets buffer to accomodate for the extra element
-    attr_off.resize(attr_off.size() + 1);
-
-    Array array(ctx, array_name, TILEDB_READ);
-    Query query(ctx, array, TILEDB_READ);
-
-    // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
-    // accepts it
-    query.set_buffer(
-        "attr",
-        reinterpret_cast<uint64_t*>(attr_off.data()),
-        attr_off.size(),
-        attr_val.data(),
-        attr_val.size());
-    CHECK_NOTHROW(query.submit());
-
     // Check the extra element is included in the offsets
     uint32_t data_size = static_cast<uint32_t>(sizeof(data[0]) * data.size());
     std::vector<uint32_t> data_offsets_exp = {0, 4, 12, 20, data_size};
-    CHECK(attr_val == data);
-    CHECK(attr_off == data_offsets_exp);
+
+    SECTION("Unordered write") {
+      write_sparse_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
+      read_and_check_sparse_array(ctx, array_name, data, data_offsets_exp);
+    }
+    SECTION("Global order write") {
+      write_sparse_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_sparse_array(ctx, array_name, data, data_offsets_exp);
+    }
   }
 
   // Clean up
@@ -770,41 +866,33 @@ TEST_CASE(
   std::string array_name = "test_32bit_offset";
   create_dense_array(array_name);
 
-  Config config;
-  Context ctx;
   std::vector<int32_t> data = {1, 2, 3, 4, 5, 6};
-  // TODO: use a 32-bit offset vector when it's supported on the write path
-  std::vector<uint64_t> data_offsets = {0, 4, 12, 20};
-  write_dense_array(ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
+  // Create 32 bit offsets byte buffer to use
+  std::vector<uint32_t> data_byte_offsets = {0, 4, 12, 20};
 
+  Config config;
   // Change config of offsets bitsize from 64 to 32
   config["sm.var_offsets.bitsize"] = 32;
-
-  std::vector<int32_t> attr_val(data.size());
-  std::vector<uint32_t> attr_off(data_offsets.size());
+  Context ctx(config);
 
   SECTION("Byte offsets (default case)") {
     CHECK((std::string)config["sm.var_offsets.mode"] == "bytes");
-    Context ctx(config);
 
-    Array array(ctx, array_name, TILEDB_READ);
-    Query query(ctx, array, TILEDB_READ);
-
-    // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
-    // accepts it
-    query.set_buffer(
-        "attr",
-        reinterpret_cast<uint64_t*>(attr_off.data()),
-        attr_off.size(),
-        attr_val.data(),
-        attr_val.size());
-    query.set_subarray<int64_t>({1, 2, 1, 2});
-    CHECK_NOTHROW(query.submit());
-
-    // Check that byte offsets are properly returned
-    std::vector<uint32_t> data_offsets_exp = {0, 4, 12, 20};
-    CHECK(attr_val == data);
-    CHECK(attr_off == data_offsets_exp);
+    SECTION("Unordered write") {
+      write_dense_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
+    }
+    SECTION("Ordered write") {
+      write_dense_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
+    }
+    SECTION("Global order write") {
+      write_dense_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
+    }
   }
 
   SECTION("Element offsets") {
@@ -812,54 +900,49 @@ TEST_CASE(
     config["sm.var_offsets.mode"] = "elements";
     Context ctx(config);
 
-    Array array(ctx, array_name, TILEDB_READ);
-    Query query(ctx, array, TILEDB_READ);
+    // Create 32 bit element offsets buffer to use
+    std::vector<uint32_t> data_element_offsets = {0, 1, 3, 5};
 
-    // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
-    // accepts it
-    query.set_buffer(
-        "attr",
-        reinterpret_cast<uint64_t*>(attr_off.data()),
-        attr_off.size(),
-        attr_val.data(),
-        attr_val.size());
-    query.set_subarray<int64_t>({1, 2, 1, 2});
-    CHECK_NOTHROW(query.submit());
-
-    // Check that element offsets are properly returned
-    std::vector<uint32_t> data_offsets_exp = {0, 1, 3, 5};
-    CHECK(attr_val == data);
-    CHECK(attr_off == data_offsets_exp);
-
-    array.close();
+    SECTION("Unordered write") {
+      write_dense_array(
+          ctx, array_name, data, data_element_offsets, TILEDB_UNORDERED);
+      read_and_check_dense_array(ctx, array_name, data, data_element_offsets);
+    }
+    SECTION("Ordered write") {
+      write_dense_array(
+          ctx, array_name, data, data_element_offsets, TILEDB_ROW_MAJOR);
+      read_and_check_dense_array(ctx, array_name, data, data_element_offsets);
+    }
+    SECTION("Global order write") {
+      write_dense_array(
+          ctx, array_name, data, data_element_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_dense_array(ctx, array_name, data, data_element_offsets);
+    }
   }
 
   SECTION("Extra element") {
     config["sm.var_offsets.extra_element"] = "true";
     Context ctx(config);
 
-    // Extend offsets buffer to accomodate for the extra element
-    attr_off.resize(attr_off.size() + 1);
-
-    Array array(ctx, array_name, TILEDB_READ);
-    Query query(ctx, array, TILEDB_READ);
-
-    // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
-    // accepts it
-    query.set_buffer(
-        "attr",
-        reinterpret_cast<uint64_t*>(attr_off.data()),
-        attr_off.size(),
-        attr_val.data(),
-        attr_val.size());
-    query.set_subarray<int64_t>({1, 2, 1, 2});
-    CHECK_NOTHROW(query.submit());
-
     // Check the extra element is included in the offsets
     uint32_t data_size = static_cast<uint32_t>(sizeof(data[0]) * data.size());
     std::vector<uint32_t> data_offsets_exp = {0, 4, 12, 20, data_size};
-    CHECK(attr_val == data);
-    CHECK(attr_off == data_offsets_exp);
+
+    SECTION("Unordered write") {
+      write_dense_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
+    }
+    SECTION("Ordered write") {
+      write_dense_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
+    }
+    SECTION("Global order write") {
+      write_dense_array(
+          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
+    }
   }
 
   // Clean up

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2668,14 +2668,6 @@ int32_t tiledb_query_set_buffer_var(
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  // On writes, check the provided offsets for validity.
-  if (query->query_->type() == tiledb::sm::QueryType::WRITE &&
-      save_error(
-          ctx,
-          tiledb::sm::Query::check_var_attr_offsets(
-              buffer_off, buffer_off_size, buffer_val_size)))
-    return TILEDB_ERR;
-
   // Set attribute buffers
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -2724,14 +2716,6 @@ int32_t tiledb_query_set_buffer_var_nullable(
     uint64_t* buffer_validity_bytemap_size) {
   // Sanity check
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
-    return TILEDB_ERR;
-
-  // On writes, check the provided offsets for validity.
-  if (query->query_->type() == tiledb::sm::QueryType::WRITE &&
-      save_error(
-          ctx,
-          tiledb::sm::Query::check_var_attr_offsets(
-              buffer_off, buffer_off_size, buffer_val_size)))
     return TILEDB_ERR;
 
   // Set attribute buffers

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -727,50 +727,6 @@ Status Query::cancel() {
   return Status::Ok();
 }
 
-Status Query::check_var_attr_offsets(
-    const uint64_t* buffer_off,
-    const uint64_t* buffer_off_size,
-    const uint64_t* buffer_val_size) {
-  if (buffer_off == nullptr || buffer_off_size == nullptr ||
-      buffer_val_size == nullptr)
-    return LOG_STATUS(Status::QueryError("Cannot use null offset buffers."));
-
-  auto num_offsets = *buffer_off_size / sizeof(uint64_t);
-  if (num_offsets == 0)
-    return Status::Ok();
-
-  uint64_t prev_offset = buffer_off[0];
-  // Allow the initial offset to be equal to the size, this indicates
-  // the first and only value in the buffer is to be empty
-  if (prev_offset > *buffer_val_size)
-    return LOG_STATUS(Status::QueryError(
-        "Invalid offsets; offset " + std::to_string(prev_offset) +
-        " specified for buffer of size " + std::to_string(*buffer_val_size)));
-  else if (prev_offset == *buffer_val_size)
-    return LOG_STATUS(Status::QueryError(
-        "Invalid offsets; zero length single cell writes are not supported"));
-
-  for (uint64_t i = 1; i < num_offsets; i++) {
-    if (buffer_off[i] < prev_offset)
-      return LOG_STATUS(
-          Status::QueryError("Invalid offsets; offsets must be given in "
-                             "strictly ascending order."));
-
-    // Allow the last offset(s) to be equal to the size, this indicates the last
-    // value(s) are to be empty
-    if (buffer_off[i] > *buffer_val_size ||
-        (buffer_off[i] == *buffer_val_size &&
-         buffer_off[(i < num_offsets - 1 ? i + 1 : i)] != *buffer_val_size))
-      return LOG_STATUS(Status::QueryError(
-          "Invalid offsets; offset " + std::to_string(buffer_off[i]) +
-          " specified for buffer of size " + std::to_string(*buffer_val_size)));
-
-    prev_offset = buffer_off[i];
-  }
-
-  return Status::Ok();
-}
-
 Status Query::process() {
   if (status_ == QueryStatus::UNINITIALIZED)
     return LOG_STATUS(

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -341,19 +341,6 @@ class Query {
   Status cancel();
 
   /**
-   * Check the validity of the provided buffer offsets for a variable attribute.
-   *
-   * @param buffer_off Offset buffer
-   * @param buffer_off_size Pointer to size of offset buffer
-   * @param buffer_val_size Pointer to size of data buffer
-   * @return Status
-   */
-  static Status check_var_attr_offsets(
-      const uint64_t* buffer_off,
-      const uint64_t* buffer_off_size,
-      const uint64_t* buffer_val_size);
-
-  /**
    * Finalizes the query, flushing all internal state. Applicable only to global
    * layout writes. It has no effect for any other query type.
    */

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -567,6 +567,13 @@ class Writer {
   Status check_subarray() const;
 
   /**
+   * Check the validity of the provided buffer offsets for a variable attribute.
+   *
+   * @return Status
+   */
+  Status check_var_attr_offsets() const;
+
+  /**
    * Cleans up the coordinate buffers. Applicable only if the coordinate
    * buffers were allocated by TileDB (not the user)
    */
@@ -821,11 +828,18 @@ class Writer {
   Status ordered_write();
 
   /**
-   * Process a buffer offset according to the configured options for
+   * Return an element of the offsets buffer at a certain position
+   * taking into account the configured bitsize
+   */
+  uint64_t get_offset_buffer_element(
+      const void* buffer, const uint64_t pos) const;
+
+  /**
+   * Return a buffer offset according to the configured options for
    * variable-sized attributes (e.g. transform a byte offset to element offset)
    */
   uint64_t prepare_buffer_offset(
-      const uint64_t offset, const uint64_t datasize) const;
+      const void* buffer, const uint64_t pos, const uint64_t datasize) const;
 
   /**
    * Applicable only to write in global order. It prepares only full


### PR DESCRIPTION
In the same spirit as https://github.com/TileDB-Inc/TileDB/pull/1950/files we modify the write path to accept uint32_t offsets.
The changes are done on the fly and do not change the on-disk format.