### PR TITLE
Fix GCS read-ahead

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -495,7 +495,10 @@ void create_subarray(
 }
 
 void get_supported_fs(
-    bool* s3_supported, bool* hdfs_supported, bool* azure_supported) {
+    bool* s3_supported,
+    bool* hdfs_supported,
+    bool* azure_supported,
+    bool* gcs_supported) {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
@@ -509,35 +512,49 @@ void get_supported_fs(
   rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_AZURE, &is_supported);
   REQUIRE(rc == TILEDB_OK);
   *azure_supported = (bool)is_supported;
+  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_GCS, &is_supported);
+  REQUIRE(rc == TILEDB_OK);
+  *gcs_supported = (bool)is_supported;
 
   // Override VFS support if the user used the '--vfs' command line argument.
   if (!g_vfs.empty()) {
     REQUIRE(
         (g_vfs == "native" || g_vfs == "s3" || g_vfs == "hdfs" ||
-         g_vfs == "azure"));
+         g_vfs == "azure" || g_vfs == "gcs"));
 
     if (g_vfs == "native") {
       *s3_supported = false;
       *hdfs_supported = false;
       *azure_supported = false;
+      *gcs_supported = false;
     }
 
     if (g_vfs == "s3") {
       *s3_supported = true;
       *hdfs_supported = false;
       *azure_supported = false;
+      *gcs_supported = false;
     }
 
     if (g_vfs == "hdfs") {
       *s3_supported = false;
       *hdfs_supported = true;
       *azure_supported = false;
+      *gcs_supported = false;
     }
 
     if (g_vfs == "azure") {
       *s3_supported = false;
       *hdfs_supported = false;
       *azure_supported = true;
+      *gcs_supported = false;
+    }
+
+    if (g_vfs == "gcs") {
+      *s3_supported = false;
+      *hdfs_supported = false;
+      *azure_supported = false;
+      *gcs_supported = true;
     }
   }
 

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -303,9 +303,13 @@ void create_ctx_and_vfs(
  * @param s3_supported Set to `true` if S3 is supported.
  * @param hdfs_supported Set to `true` if HDFS is supported.
  * @param azure_supported Set to `true` if Azure is supported.
+ * @param gcs_supported Set to `true` if GCS is supported.
  */
 void get_supported_fs(
-    bool* s3_supported, bool* hdfs_supported, bool* azure_supported);
+    bool* s3_supported,
+    bool* hdfs_supported,
+    bool* azure_supported,
+    bool* gcs_supported);
 
 /**
  * Helper function to check if in-memory filesystem is supported

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -110,7 +110,9 @@ void VFSFx::set_supported_fs() {
   tiledb_ctx_t* ctx = nullptr;
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
-  get_supported_fs(&supports_s3_, &supports_hdfs_, &supports_azure_);
+  bool supports_gcs;  // unused
+  get_supported_fs(
+      &supports_s3_, &supports_hdfs_, &supports_azure_, &supports_gcs);
   get_supported_memfs(&supports_memfs_);
 
   tiledb_ctx_free(&ctx);

--- a/test/src/unit-gcs.cc
+++ b/test/src/unit-gcs.cc
@@ -76,6 +76,8 @@ GCSFx::~GCSFx() {
 }
 
 void GCSFx::init_gcs(Config&& config) {
+  REQUIRE(config.set("vfs.gcs.project_id", "TODO").ok());
+
   REQUIRE(thread_pool_.init(2).ok());
   REQUIRE(gcs_.init(config, &thread_pool_).ok());
 

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -312,8 +312,9 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
   bool s3_supported = false;
   bool hdfs_supported = false;
   bool azure_supported = false;
+  bool gcs_supported = false;
   tiledb::test::get_supported_fs(
-      &s3_supported, &hdfs_supported, &azure_supported);
+      &s3_supported, &hdfs_supported, &azure_supported, &gcs_supported);
 
   std::vector<std::pair<URI, Config>> root_pairs;
   if (s3_supported) {

--- a/test/src/vfs_helpers.cc
+++ b/test/src/vfs_helpers.cc
@@ -39,31 +39,38 @@ namespace test {
 
 std::vector<std::unique_ptr<SupportedFs>> vfs_test_get_fs_vec() {
   std::vector<std::unique_ptr<SupportedFs>> fs_vec;
-  bool supports_s3_ = false;
-  bool supports_hdfs_ = false;
-  bool supports_azure_ = false;
-  bool supports_memfs_ = false;
-  get_supported_fs(&supports_s3_, &supports_hdfs_, &supports_azure_);
-  if (supports_s3_) {
+  bool supports_s3 = false;
+  bool supports_hdfs = false;
+  bool supports_azure = false;
+  bool supports_memfs = false;
+  bool supports_gcs = false;
+  get_supported_fs(
+      &supports_s3, &supports_hdfs, &supports_azure, &supports_gcs);
+  if (supports_s3) {
     SupportedFsS3* s3_fs = new SupportedFsS3();
     fs_vec.emplace_back(s3_fs);
   }
 
-  if (supports_hdfs_) {
+  if (supports_hdfs) {
     SupportedFsHDFS* hdfs_fs = new SupportedFsHDFS();
     fs_vec.emplace_back(hdfs_fs);
   }
 
-  if (supports_azure_) {
+  if (supports_azure) {
     SupportedFsAzure* azure_fs = new SupportedFsAzure();
     fs_vec.emplace_back(azure_fs);
+  }
+
+  if (supports_gcs) {
+    SupportedFsGCS* gcs_fs = new SupportedFsGCS();
+    fs_vec.emplace_back(gcs_fs);
   }
 
   SupportedFsLocal* local_fs = new SupportedFsLocal();
   fs_vec.emplace_back(local_fs);
 
-  get_supported_memfs(&supports_memfs_);
-  if (supports_memfs_) {
+  get_supported_memfs(&supports_memfs);
+  if (supports_memfs) {
     SupportedFsMem* mem_fs = new SupportedFsMem();
     fs_vec.emplace_back(mem_fs);
   }
@@ -230,10 +237,10 @@ Status SupportedFsAzure::prepare_config(
 
 Status SupportedFsAzure::init(tiledb_ctx_t* ctx, tiledb_vfs_t* vfs) {
   int is_container = 0;
-  int rc = tiledb_vfs_is_bucket(ctx, vfs, container.c_str(), &is_container);
+  int rc = tiledb_vfs_is_bucket(ctx, vfs, container_.c_str(), &is_container);
   REQUIRE(rc == TILEDB_OK);
   if (!is_container) {
-    rc = tiledb_vfs_create_bucket(ctx, vfs, container.c_str());
+    rc = tiledb_vfs_create_bucket(ctx, vfs, container_.c_str());
     REQUIRE(rc == TILEDB_OK);
   }
 
@@ -242,16 +249,52 @@ Status SupportedFsAzure::init(tiledb_ctx_t* ctx, tiledb_vfs_t* vfs) {
 
 Status SupportedFsAzure::close(tiledb_ctx_t* ctx, tiledb_vfs_t* vfs) {
   int is_container = 0;
-  int rc = tiledb_vfs_is_bucket(ctx, vfs, container.c_str(), &is_container);
+  int rc = tiledb_vfs_is_bucket(ctx, vfs, container_.c_str(), &is_container);
   CHECK(rc == TILEDB_OK);
   if (is_container) {
-    CHECK(tiledb_vfs_remove_bucket(ctx, vfs, container.c_str()) == TILEDB_OK);
+    CHECK(tiledb_vfs_remove_bucket(ctx, vfs, container_.c_str()) == TILEDB_OK);
   }
 
   return Status::Ok();
 }
 
 std::string SupportedFsAzure::temp_dir() {
+  return temp_dir_;
+}
+
+Status SupportedFsGCS::prepare_config(
+    tiledb_config_t* config, tiledb_error_t* error) {
+  REQUIRE(
+      tiledb_config_set(config, "vfs.gcs.project_id", "TODO", &error) ==
+      TILEDB_OK);
+
+  return Status::Ok();
+}
+
+Status SupportedFsGCS::init(tiledb_ctx_t* ctx, tiledb_vfs_t* vfs) {
+  int is_bucket = 0;
+  int rc = tiledb_vfs_is_bucket(ctx, vfs, bucket_.c_str(), &is_bucket);
+  REQUIRE(rc == TILEDB_OK);
+  if (!is_bucket) {
+    rc = tiledb_vfs_create_bucket(ctx, vfs, bucket_.c_str());
+    REQUIRE(rc == TILEDB_OK);
+  }
+
+  return Status::Ok();
+}
+
+Status SupportedFsGCS::close(tiledb_ctx_t* ctx, tiledb_vfs_t* vfs) {
+  int is_bucket = 0;
+  int rc = tiledb_vfs_is_bucket(ctx, vfs, bucket_.c_str(), &is_bucket);
+  CHECK(rc == TILEDB_OK);
+  if (is_bucket) {
+    CHECK(tiledb_vfs_remove_bucket(ctx, vfs, bucket_.c_str()) == TILEDB_OK);
+  }
+
+  return Status::Ok();
+}
+
+std::string SupportedFsGCS::temp_dir() {
   return temp_dir_;
 }
 

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -1080,11 +1080,6 @@ Status GCS::read(
   stream.read(static_cast<char*>(buffer), length + read_ahead_length);
   *length_returned = stream.gcount();
 
-  if (!stream) {
-    return LOG_STATUS(Status::GCSError(
-        std::string("Read object failed on: " + uri.to_string())));
-  }
-
   stream.Close();
 
   if (*length_returned < length) {


### PR DESCRIPTION
This fixes the following issue reported in TileDB-Py:
https://github.com/TileDB-Inc/TileDB-Py/issues/443
"TileDBError: [TileDB::?] Error:: Read object failed on: gcs://tiledb/test/__array_schema.tdb"

The issue is that if the `stream` in GCS::read is read beyond the length of
the stream, the `operator!` will return true. I'm not sure whether this is a
bug GCS client library or not. I would only expect the stream to reach the EOF
rather than a failed state.

Either way, we do our own error-checking later in this path by comparing
`if (*length_returned < length)`. This patch removes the check on `!stream`.

---

With our recent VFS refactor in the test path, I was easily able to connect test
GCS before-and-after this patch. Without this patch, many unit tests fail.
With the patch, all of the unit tests pass. This is important to note because
GCS is not under test in the CI -- if it was, we would have caught this regression
much earlier.

Since I've already written the SupportedFsGCS class for testing purposes, I've
included in this patch as well. Note that I've configured the GCS project id
to "TODO", which will be changed when we include the GCS emulator in CI. For
my testing purposes, I had replaced "TODO" with the project-id on the real GCS.