### PR TITLE
Backport 1969 to release 2.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,12 @@
 
 ## API additions
 
+# TileDB v2.1.5 Release Notes
+
+## Bug fixes
+
+* Fix segfault in optimized `compute_results_sparse<char>` [#1969](https://github.com/TileDB-Inc/TileDB/pull/1969)
+
 # TileDB v2.1.4 Release Notes
 
 ## Improvements
@@ -33,6 +39,7 @@ Optimize `ResultTile::compute_results_sparse<char>` resulting in significant per
 * Updated the AWS SDK to v1.8.84 to fix an uncaught exception when using S3 [#1899](https://github.com/TileDB-Inc/TileDB/pull/1899)[TileDB-Py #409](https://github.com/TileDB-Inc/TileDB-Py/issues/409)
 * Fixed bug where a read on a sparse array may return duplicate values. [#1905](https://github.com/TileDB-Inc/TileDB/pull/1905)
 * Fixed bug where an array could not be opened if created with an array schema from an older version [#1889](https://github.com/TileDB-Inc/TileDB/pull/1889)
+* Fix compilation of TileDB Tools [#1926](https://github.com/TileDB-Inc/TileDB/pull/1926)
 
 # TileDB v2.1.2 Release Notes
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -527,17 +527,17 @@ void ResultTile::compute_results_sparse<char>(
   // `r_bitmap` for each corresponding coordinate. If they do
   // not match, we must compare each coordinate in the partition.
   static const uint64_t c_partition_num = 6;
+  // We calculate the size of each partition by dividing the total
+  // number of coordinates by the number of partitions. If this
+  // does not evenly divide, we will append the remaining coordinates
+  // onto the last partition.
+  const uint64_t c_partition_size_div = coords_num / c_partition_num;
+  const uint64_t c_partition_size_rem = coords_num % c_partition_num;
   const bool is_sorted_dim =
       ((cell_order == Layout::ROW_MAJOR && dim_idx == 0) ||
        (cell_order == Layout::COL_MAJOR && dim_idx == dim_num - 1));
-  if (is_sorted_dim && coords_num > c_partition_num) {
-    // We calculate the size of each partition by dividing the total
-    // number of coordinates by the number of partitions. If this
-    // does not evenly divide, we will append the remaining coordinates
-    // onto the last partition.
-    const uint64_t c_partition_size_div = coords_num / c_partition_num;
-    const uint64_t c_partition_size_rem = coords_num % c_partition_num;
-
+  if (is_sorted_dim && c_partition_size_div > 1 &&
+      coords_num > c_partition_num) {
     // Loop over each coordinate partition.
     for (uint64_t p = 0; p < c_partition_num; ++p) {
       // Calculate the size of this partition.
@@ -549,6 +549,7 @@ void ResultTile::compute_results_sparse<char>(
       // in this partition.
       const uint64_t first_c_pos = p * c_partition_size_div;
       const uint64_t last_c_pos = first_c_pos + c_partition_size - 1;
+      assert(first_c_pos < last_c_pos);
 
       // The coordinate values are determined by their offset and size
       // within `buff_str`. Calculate the offset and size for the


### PR DESCRIPTION
Backport 1969 to release 2.1 to fix the segfault that can occur in the new optimized code path.