### PR TITLE
Backport 1966 to release 2.1: Fix GCS read-ahead

### DIFF
--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -1078,11 +1078,6 @@ Status GCS::read(
   stream.read(static_cast<char*>(buffer), length + read_ahead_length);
   *length_returned = stream.gcount();
 
-  if (!stream) {
-    return LOG_STATUS(Status::GCSError(
-        std::string("Read object failed on: " + uri.to_string())));
-  }
-
   stream.Close();
 
   if (*length_returned < length) {


### PR DESCRIPTION
This fixes the following issue reported in TileDB-Py:
TileDB-Inc/TileDB-Py#443
"TileDBError: [TileDB::?] Error:: Read object failed on: gcs://tiledb/test/__array_schema.tdb"

The issue is that if the stream in GCS::read is read beyond the length of
the stream, the operator! will return true. I'm not sure whether this is a
bug GCS client library or not. I would only expect the stream to reach the EOF
rather than a failed state.

Either way, we do our own error-checking later in this path by comparing
if (*length_returned < length). This patch removes the check on !stream.