### PR TITLE
Optimize consolidated fragment metadata loading

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@
 * Added extra stats for consolidation. [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880)
 * Disabled checking if cells are written in global order when consolidating, as it was redundant (the cells are already being read in global order during consolidation). [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880) 
 * Add support for printing MBRs with string dimensions in TileDB Tools [#1926](https://github.com/TileDB-Inc/TileDB/pull/1926)
+* Optimize consolidated fragment metadata loading [#1975](https://github.com/TileDB-Inc/TileDB/pull/1975)
 
 ## Deprecations
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -355,9 +355,21 @@ Status FragmentMetadata::fragment_size(uint64_t* size) const {
   for (const auto& file_validity_size : file_validity_sizes_)
     *size += file_validity_size;
 
+  // The fragment metadata file size can be empty when we've loaded consolidated
+  // metadata
+  uint64_t meta_file_size = meta_file_size_;
+  if (meta_file_size == 0) {
+    auto meta_uri = fragment_uri_.join_path(
+        std::string(constants::fragment_metadata_filename));
+    RETURN_NOT_OK(
+        storage_manager_->vfs()->file_size(meta_uri, &meta_file_size));
+  }
+  // Validate that the meta_file_size is not zero, either preloaded or fetched
+  // above
+  assert(meta_file_size != 0);
+
   // Add fragment metadata file size
-  assert(meta_file_size_ != 0);  // The file size should be loaded
-  *size += meta_file_size_;
+  *size += meta_file_size;
 
   return Status::Ok();
 }
@@ -446,7 +458,11 @@ Status FragmentMetadata::load(
     uint32_t meta_version) {
   auto meta_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
-  RETURN_NOT_OK(storage_manager_->vfs()->file_size(meta_uri, &meta_file_size_));
+  // Load the metadata file size when we are not reading from consolidated
+  // buffer
+  if (f_buff == nullptr)
+    RETURN_NOT_OK(
+        storage_manager_->vfs()->file_size(meta_uri, &meta_file_size_));
 
   // Get fragment name version
   uint32_t f_version;


### PR DESCRIPTION
This is part one of two changes for optimizing consolidated fragment metadata loading. This changes removes using VFS to always fetch the metadata file size. Instead we select the file size only if not reading from a consolidated file buffer. We also adjust the `fragment_size` function, used by consolidation, to fetch the fragment metadata file size on request. The fetching of the size on-demand for consolidation will yield the same performance degredation we see in open array, however this is acceptable for patch one and will be addressed in the next series with a format change.