### PR TITLE
Optimize Reader::load_tile_offsets for only relevant fragments

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,7 @@
 * Disabled checking if cells are written in global order when consolidating, as it was redundant (the cells are already being read in global order during consolidation). [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880) 
 * Add support for printing MBRs with string dimensions in TileDB Tools [#1926](https://github.com/TileDB-Inc/TileDB/pull/1926)
 * Optimize consolidated fragment metadata loading [#1975](https://github.com/TileDB-Inc/TileDB/pull/1975)
+* Optimize `Reader::load_tile_offsets` for loading only relevant fragments [#1976](https://github.com/TileDB-Inc/TileDB/pull/1976)
 
 ## Deprecations
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -2217,6 +2217,10 @@ Status Subarray::load_relevant_fragment_tile_var_sizes(
   return Status::Ok();
 }
 
+std::vector<unsigned> Subarray::relevant_fragments() const {
+  return relevant_fragments_;
+}
+
 // Explicit instantiations
 template Status Subarray::compute_tile_coords<int8_t>();
 template Status Subarray::compute_tile_coords<uint8_t>();

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -638,6 +638,11 @@ class Subarray {
   std::unordered_map<std::string, MemorySize> get_max_mem_size_map(
       ThreadPool* compute_tp);
 
+  /**
+   * Return relevant fragments as computed
+   */
+  std::vector<unsigned> relevant_fragments() const;
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */


### PR DESCRIPTION
This optimization is to adjust the `Reader::load_tile_offsets` class to only loop over the relevant fragments as computed by the subarray class based on intersection. This is a performance optimization for arrays which have a large number of fragments and which we are incorrectly fetching a large amount of unneeded data.