### PR TITLE
Backport 1979 to release 2.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,7 @@
 
 * Optimize consolidated fragment metadata loading [#1975](https://github.com/TileDB-Inc/TileDB/pull/1975)
 * Optimize `Reader::load_tile_offsets` for loading only relevant fragments [#1976](https://github.com/TileDB-Inc/TileDB/pull/1976)
+* Optimize locking in `FragmentMetadata::load_tile_offsets` and `FragmentMetadata::load_tile_var_offsets` [#1979](https://github.com/TileDB-Inc/TileDB/pull/1979)
 
 ## Bug fixes
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -393,12 +393,14 @@ Status FragmentMetadata::init(const NDRange& non_empty_domain) {
 
   // Initialize tile offsets
   tile_offsets_.resize(num);
+  tile_offsets_mtx_.resize(num);
   file_sizes_.resize(num);
   for (unsigned int i = 0; i < num; ++i)
     file_sizes_[i] = 0;
 
   // Initialize variable tile offsets
   tile_var_offsets_.resize(num);
+  tile_var_offsets_mtx_.resize(num);
   file_var_sizes_.resize(num);
   for (unsigned int i = 0; i < num; ++i)
     file_var_sizes_[i] = 0;
@@ -983,7 +985,7 @@ Status FragmentMetadata::load_tile_offsets(
   if (loaded_metadata_.tile_offsets_[idx])
     return Status::Ok();
 
-  std::lock_guard<std::mutex> lock(mtx_);
+  std::lock_guard<std::mutex> lock(tile_offsets_mtx_[idx]);
 
   if (loaded_metadata_.tile_offsets_[idx])
     return Status::Ok();
@@ -1012,7 +1014,7 @@ Status FragmentMetadata::load_tile_var_offsets(
   if (loaded_metadata_.tile_var_offsets_[idx])
     return Status::Ok();
 
-  std::lock_guard<std::mutex> lock(mtx_);
+  std::lock_guard<std::mutex> lock(tile_var_offsets_mtx_[idx]);
 
   if (loaded_metadata_.tile_var_offsets_[idx])
     return Status::Ok();
@@ -1332,6 +1334,7 @@ Status FragmentMetadata::load_tile_offsets(ConstBuffer* buff) {
 
   // Allocate tile offsets
   tile_offsets_.resize(attribute_num + 1);
+  tile_offsets_mtx_.resize(attribute_num + 1);
 
   // For all attributes, get the tile offsets
   for (unsigned int i = 0; i < attribute_num + 1; ++i) {
@@ -1402,6 +1405,7 @@ Status FragmentMetadata::load_tile_var_offsets(ConstBuffer* buff) {
 
   // Allocate tile offsets
   tile_var_offsets_.resize(attribute_num);
+  tile_var_offsets_mtx_.resize(attribute_num);
 
   // For all attributes, get the variable tile offsets
   for (unsigned int i = 0; i < attribute_num; ++i) {
@@ -1695,7 +1699,9 @@ Status FragmentMetadata::load_footer(
   num += (version >= 5) ? array_schema_->dim_num() : 0;
 
   tile_offsets_.resize(num);
+  tile_offsets_mtx_.resize(num);
   tile_var_offsets_.resize(num);
+  tile_var_offsets_mtx_.resize(num);
   tile_var_sizes_.resize(num);
 
   loaded_metadata_.tile_offsets_.resize(num, false);

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -979,6 +979,10 @@ Status FragmentMetadata::load_tile_offsets(
   if (version_ <= 2)
     return Status::Ok();
 
+  // If the tile offset is already loaded, exit early to avoid the lock
+  if (loaded_metadata_.tile_offsets_[idx])
+    return Status::Ok();
+
   std::lock_guard<std::mutex> lock(mtx_);
 
   if (loaded_metadata_.tile_offsets_[idx])
@@ -1002,6 +1006,10 @@ Status FragmentMetadata::load_tile_offsets(
 Status FragmentMetadata::load_tile_var_offsets(
     const EncryptionKey& encryption_key, unsigned idx) {
   if (version_ <= 2)
+    return Status::Ok();
+
+  // If the tile var offset is already loaded, exit early to avoid the lock
+  if (loaded_metadata_.tile_var_offsets_[idx])
     return Status::Ok();
 
   std::lock_guard<std::mutex> lock(mtx_);

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -544,6 +544,12 @@ class FragmentMetadata {
   /** Local mutex for thread-safety. */
   std::mutex mtx_;
 
+  /** Mutex per tile offset loading. */
+  std::deque<std::mutex> tile_offsets_mtx_;
+
+  /** Mutex per tile var offset loading. */
+  std::deque<std::mutex> tile_var_offsets_mtx_;
+
   /** The non-empty domain of the fragment. */
   NDRange non_empty_domain_;
 


### PR DESCRIPTION
This is a backport of `Optimize FragmentMetadata::load_tile_offsets and FragmentMetadata::load_tile_var_offsets` (#1979) to the release-2.1 branch.