### PR TITLE
Fix segfault in ResultTile::str_coord_intersects

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -47,6 +47,7 @@
 * Fixed bug where an array could not be opened if created with an array schema from an older version [#1889](https://github.com/TileDB-Inc/TileDB/pull/1889)
 * Fix compilation of TileDB Tools [#1926](https://github.com/TileDB-Inc/TileDB/pull/1926)
 * Fix segfault in optimized compute_results_sparse [#1969](https://github.com/TileDB-Inc/TileDB/pull/1969)
+* Fix segfault in `ResultTile::str_coords_intersects` [#1981](https://github.com/TileDB-Inc/TileDB/pull/1981)
 
 ## API additions
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -646,7 +646,7 @@ void ResultTile::compute_results_sparse<char>(
   // Often, a memory comparison for one byte is as quick as comparing
   // 4 or 8 bytes. We will only get a benefit if we successfully
   // find a `memcmp` on a much larger range.
-  static const uint64_t zeroed_size = coords_num < 256 ? coords_num : 256;
+  const uint64_t zeroed_size = coords_num < 256 ? coords_num : 256;
   for (uint64_t i = 0; i < coords_num; i += zeroed_size) {
     const uint64_t partition_size =
         (i < coords_num - zeroed_size) ? zeroed_size : coords_num - i;


### PR DESCRIPTION
The issue is caused by zeroed_size being set to static and thus it does to get changed after first setting. This causes a segfault if the `coords_num` is less than 256.