### PR TITLE
Backport fix segfault in ResultTile::str_coord_intersects to release-2.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,7 @@
 
 * Fix segfault in optimized `compute_results_sparse<char>` [#1969](https://github.com/TileDB-Inc/TileDB/pull/1969)
 * Fix GCS "Error:: Read object failed"[#1966](https://github.com/TileDB-Inc/TileDB/pull/1966)
+* Fix segfault in `ResultTile::str_coords_intersects` [#1981](https://github.com/TileDB-Inc/TileDB/pull/1981)
 
 # TileDB v2.1.4 Release Notes
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -605,7 +605,7 @@ void ResultTile::compute_results_sparse<char>(
   // Often, a memory comparison for one byte is as quick as comparing
   // 4 or 8 bytes. We will only get a benefit if we successfully
   // find a `memcmp` on a much larger range.
-  static const uint64_t zeroed_size = coords_num < 256 ? coords_num : 256;
+  const uint64_t zeroed_size = coords_num < 256 ? coords_num : 256;
   for (uint64_t i = 0; i < coords_num; i += zeroed_size) {
     const uint64_t partition_size =
         (i < coords_num - zeroed_size) ? zeroed_size : coords_num - i;


### PR DESCRIPTION
This is a backport of #1981 .

The issue is caused by zeroed_size being set to static and thus it does to get changed after first setting. This causes a segfault if the `coords_num` is less than 256.