### PR TITLE
use SubarrayPartitioner->current() for load_tile_offsets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,7 +28,7 @@
 * Disabled checking if cells are written in global order when consolidating, as it was redundant (the cells are already being read in global order during consolidation). [#1880](https://github.com/TileDB-Inc/TileDB/pull/1880) 
 * Add support for printing MBRs with string dimensions in TileDB Tools [#1926](https://github.com/TileDB-Inc/TileDB/pull/1926)
 * Optimize consolidated fragment metadata loading [#1975](https://github.com/TileDB-Inc/TileDB/pull/1975)
-* Optimize `Reader::load_tile_offsets` for loading only relevant fragments [#1976](https://github.com/TileDB-Inc/TileDB/pull/1976)
+* Optimize `Reader::load_tile_offsets` for loading only relevant fragments [#1976](https://github.com/TileDB-Inc/TileDB/pull/1976) [#1983](https://github.com/TileDB-Inc/TileDB/pull/1983)
 * Optimize locking in `FragmentMetadata::load_tile_offsets` and `FragmentMetadata::load_tile_var_offsets` [#1979](https://github.com/TileDB-Inc/TileDB/pull/1979)
 * Exit early in `Reader::copy_coordinates`/`Reader::copy_attribute_values` when no results [#1984](https://github.com/TileDB-Inc/TileDB/pull/1984)
 

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -2795,15 +2795,8 @@ Status Reader::load_tile_offsets(const std::vector<std::string>& names) {
 
   // Fetch relevant fragments so we load tile offsets only from intersecting
   // fragments
-  auto relevant_fragments = subarray_.relevant_fragments();
-  // If there are no relevant fragments let's make sure the overlap was computed
-  // ideally we'd guarantee this before entering this function but this is a
-  // safety fallback. Worst case we'll compute an empty overlap a second time.
-  if (relevant_fragments.empty()) {
-    RETURN_NOT_OK(
-        subarray_.compute_tile_overlap(storage_manager_->compute_tp()));
-    relevant_fragments = subarray_.relevant_fragments();
-  }
+  const auto relevant_fragments =
+      read_state_.partitioner_.current().relevant_fragments();
 
   const auto statuses = parallel_for(
       storage_manager_->compute_tp(),


### PR DESCRIPTION
The subarray for load_tile_offsets should be the current subarray from the SubarrayPartitioner not the `subarray_` class member.