### PR TITLE
Exit early in copy_attribute_values when empty res

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,6 +30,7 @@
 * Optimize consolidated fragment metadata loading [#1975](https://github.com/TileDB-Inc/TileDB/pull/1975)
 * Optimize `Reader::load_tile_offsets` for loading only relevant fragments [#1976](https://github.com/TileDB-Inc/TileDB/pull/1976)
 * Optimize locking in `FragmentMetadata::load_tile_offsets` and `FragmentMetadata::load_tile_var_offsets` [#1979](https://github.com/TileDB-Inc/TileDB/pull/1979)
+* Exit early in `Reader::copy_coordinates`/`Reader::copy_attribute_values` when no results [#1984](https://github.com/TileDB-Inc/TileDB/pull/1984)
 
 ## Deprecations
 

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -2858,6 +2858,10 @@ Status Reader::read_coordinate_tiles(
 Status Reader::read_tiles(
     const std::vector<std::string>& names,
     const std::vector<ResultTile*>& result_tiles) const {
+  // Shortcut for empty tile vec
+  if (result_tiles.empty())
+    return Status::Ok();
+
   // Reading tiles are thread safe. However, we will perform
   // them on this thread if there is only one read to perform.
   if (names.size() == 1) {
@@ -3158,6 +3162,11 @@ Status Reader::copy_coordinates(
     const std::vector<ResultCellSlab>& result_cell_slabs) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_COPY_COORDS);
 
+  if (result_cell_slabs.empty() && result_tiles.empty()) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
   const uint64_t stride = UINT64_MAX;
 
   // Build a lists of coordinate names to copy, separating them by
@@ -3211,6 +3220,11 @@ Status Reader::copy_attribute_values(
     const std::vector<ResultTile*>& result_tiles,
     const std::vector<ResultCellSlab>& result_cell_slabs) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_COPY_ATTR_VALUES);
+
+  if (result_cell_slabs.empty() && result_tiles.empty()) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
 
   // Build an association from the result tile to the cell slab ranges
   // that it contains.


### PR DESCRIPTION
In `Reader::copy_attribute_values` we do not exit early when there is no results, so we end up calling `Reader::load_tile_offsets` et al unnecessarily. This change can improve performance of the no-results case and avoid unnecessary VFS reads.