### PR TITLE
Limit CI runs of backwards compatibility checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,8 @@ pr:
 stages:
   - stage: CI
     condition: and(not(startsWith(variables['Build.SourceBranch'], 'refs/tags')), not(startsWith(variables['Build.SourceBranchName'], 'build-')))
+    variables:
+      BACKWARDS_COMPATIBILITY_ARRAYS: OFF
     jobs:
     - job:
       strategy:
@@ -62,6 +64,7 @@ stages:
             TILEDB_SERIALIZATION: ON
             TILEDB_S3: ON
             CXX: g++
+            BACKWARDS_COMPATIBILITY_ARRAYS: ON
 
       pool:
         vmImage: $(imageName)

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -62,7 +62,9 @@ steps:
     git config --global user.name 'Azure Pipeline'
     git config --global user.email 'no-reply@tiledb.io'
 
-    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-3 test/inputs/arrays/read_compatibility_test
+    if [[ "$BACKWARDS_COMPATIBILITY_ARRAYS" == "ON" ]]; then
+      git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-3 test/inputs/arrays/read_compatibility_test
+    fi
     #   displayName: 'Clone Unit-Test-Arrays'
 
     # - bash: |

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -58,7 +58,9 @@ steps:
     $env:AWS_SECRET_ACCESS_KEY = "miniosecretkey"
 
     # Clone backwards compatibility test arrays
-    git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-3 $env:BUILD_SOURCESDIRECTORY/test/inputs/arrays/read_compatibility_test
+    if ($env:BACKWARDS_COMPATIBILITY_ARRAYS -eq "ON") {
+      git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.0.0-3 $env:BUILD_SOURCESDIRECTORY/test/inputs/arrays/read_compatibility_test
+    }
 
     if ($env:TILEDB_S3 -eq "ON") {
       # update CMake to disable S3 for the test configuration, see minio note above


### PR DESCRIPTION
The backwards compatibility arrays add 5-15 minutes to the CI jobs depending on the environment. There is no need to run these tests for all jobs, so instead lets only run it for linux serialization job which is one of the faster jobs in the matrix.