### PR TITLE
Patch capnp libkj to fix build with GCC 9

### DIFF
--- a/cmake/Modules/FindCapnp_EP.cmake
+++ b/cmake/Modules/FindCapnp_EP.cmake
@@ -156,10 +156,13 @@ if (NOT CAPNP_FOUND)
           "-DCMAKE_CXX_FLAGS=${CXXFLAGS_DEF}"
           ${TILEDB_EP_BASE}/src/ep_capnp/c++
         UPDATE_COMMAND ""
+        PATCH_COMMAND
+          patch -d ${TILEDB_EP_BASE}/src/ep_capnp/ -N -p1 -i ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_capnp/libkj-invokable-const.patch
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE
         LOG_INSTALL TRUE
+        LOG_PATCH TRUE
         LOG_OUTPUT_ON_FAILURE ${TILEDB_LOG_OUTPUT_ON_FAILURE}
       )
     endif()

--- a/cmake/inputs/patches/ep_capnp/libkj-invokable-const.patch
+++ b/cmake/inputs/patches/ep_capnp/libkj-invokable-const.patch
@@ -1,0 +1,35 @@
+diff --git a/c++/src/kj/main.c++ b/c++/src/kj/main.c++
+index 4d84294a..d25369f4 100644
+--- a/c++/src/kj/main.c++
++++ b/c++/src/kj/main.c++
+@@ -631,7 +631,7 @@ void MainBuilder::MainImpl::usageError(StringPtr programName, StringPtr message)
+
+ class MainBuilder::Impl::OptionDisplayOrder {
+ public:
+-  bool operator()(const Option* a, const Option* b) {
++  bool operator()(const Option* a, const Option* b) const {
+     if (a == b) return false;
+
+     char aShort = '\0';
+diff --git a/c++/src/kj/time.c++ b/c++/src/kj/time.c++
+index 5b3b4334..ead7e4c1 100644
+--- a/c++/src/kj/time.c++
++++ b/c++/src/kj/time.c++
+@@ -41,7 +41,7 @@ Clock& nullClock() {
+
+ struct TimerImpl::Impl {
+   struct TimerBefore {
+-    bool operator()(TimerPromiseAdapter* lhs, TimerPromiseAdapter* rhs);
++    bool operator()(TimerPromiseAdapter* lhs, TimerPromiseAdapter* rhs) const;
+   };
+   using Timers = std::multiset<TimerPromiseAdapter*, TimerBefore>;
+   Timers timers;
+@@ -75,7 +75,7 @@ private:
+ };
+
+ inline bool TimerImpl::Impl::TimerBefore::operator()(
+-    TimerPromiseAdapter* lhs, TimerPromiseAdapter* rhs) {
++    TimerPromiseAdapter* lhs, TimerPromiseAdapter* rhs) const {
+   return lhs->time < rhs->time;
+ }
+


### PR DESCRIPTION
Fixes errors like this:

```
.../ep_capnp/c++/src/kj/main.c++:690:38:   required from here
.../x86_64-conda-linux-gnu/include/c++/9.3.0/bits/stl_tree.h:780:8: error: static assertion failed: comparison object must be invocable as const
  780 |        is_invocable_v<const _Compare&, const _Key&, const _Key&>,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[5]: *** [src/kj/CMakeFiles/kj.dir/main.c++.o] Error 1
make[4]: *** [src/kj/CMakeFiles/kj.dir/all] Error 2
```