### PR TITLE
Set download names for ExternalProjects

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -96,6 +96,8 @@ if (NOT AWSSDK_FOUND)
 
     ExternalProject_Add(ep_awssdk
       PREFIX "externals"
+      # Set download name to avoid collisions with only the version number in the filename
+      DOWNLOAD_NAME ep_awssdk.zip
       URL "https://github.com/aws/aws-sdk-cpp/archive/1.8.84.zip"
       URL_HASH SHA1=e32a53a01c75ca7fdfe9feed9c5bbcedd98708e3
       CMAKE_ARGS

--- a/cmake/Modules/FindAzureSDK_EP.cmake
+++ b/cmake/Modules/FindAzureSDK_EP.cmake
@@ -92,6 +92,8 @@ if (NOT AZURESDK_FOUND)
 
     ExternalProject_Add(ep_azuresdk
       PREFIX "externals"
+      # Set download name to avoid collisions with only the version number in the filename
+      DOWNLOAD_NAME ep_azuresdk.zip
       URL "https://github.com/Azure/azure-storage-cpplite/archive/v0.2.0.zip"
       URL_HASH SHA1=058975ccac9b60b522c9f7fd044a3d2aaec9f893
       CMAKE_ARGS

--- a/cmake/Modules/FindCapnp_EP.cmake
+++ b/cmake/Modules/FindCapnp_EP.cmake
@@ -144,6 +144,8 @@ if (NOT CAPNP_FOUND)
     else()
       ExternalProject_Add(ep_capnp
         PREFIX "externals"
+        # Set download name to avoid collisions with only the version number in the filename
+        DOWNLOAD_NAME ep_capnp.tar.gz
         URL "https://github.com/capnproto/capnproto/archive/v0.6.1.tar.gz"
         URL_HASH SHA1=2aec1f83cc4851ae58e1419c87f11f8aa63a9392
         CONFIGURE_COMMAND

--- a/cmake/Modules/FindCatch_EP.cmake
+++ b/cmake/Modules/FindCatch_EP.cmake
@@ -52,6 +52,8 @@ if (NOT CATCH2_FOUND AND TILEDB_SUPERBUILD)
   message(STATUS "Adding Catch as an external project")
   ExternalProject_Add(ep_catch
     PREFIX "externals"
+    # Set download name to avoid collisions with only the version number in the filename
+    DOWNLOAD_NAME ep_catch.zip
     URL "https://github.com/catchorg/Catch2/archive/v2.11.1.zip"
     URL_HASH SHA1=758c33d983c8e3bd0b2e5f9d20153104578edb81
     CONFIGURE_COMMAND ""

--- a/cmake/Modules/FindClipp_EP.cmake
+++ b/cmake/Modules/FindClipp_EP.cmake
@@ -53,6 +53,8 @@ if (NOT CLIPP_FOUND)
     message(STATUS "Adding Clipp as an external project")
     ExternalProject_Add(ep_clipp
       PREFIX "externals"
+      # Set download name to avoid collisions with only the version number in the filename
+      DOWNLOAD_NAME ep_clipp.zip
       URL "https://github.com/muellan/clipp/archive/v1.1.0.zip"
       URL_HASH SHA1=df30cf97426fead8c34899065181adea747981e2
       UPDATE_COMMAND ""

--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -74,6 +74,8 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
     set(WITH_SSL "-DCMAKE_USE_WINSSL=ON")
     ExternalProject_Add(ep_curl
       PREFIX "externals"
+      # Set download name to avoid collisions with only the version number in the filename
+      DOWNLOAD_NAME ep_curl.tar.gz
       URL "https://curl.haxx.se/download/curl-7.71.1.tar.gz"
       URL_HASH SHA1=9c032e134c7684f34f98afaf9974f048da893930
       CMAKE_ARGS

--- a/cmake/Modules/FindGCSSDK_EP.cmake
+++ b/cmake/Modules/FindGCSSDK_EP.cmake
@@ -72,6 +72,8 @@ if (NOT GCSSDK_FOUND)
 
     ExternalProject_Add(ep_gcssdk
       PREFIX "externals"
+      # Set download name to avoid collisions with only the version number in the filename
+      DOWNLOAD_NAME ep_gcssdk.zip
       URL "https://github.com/googleapis/google-cloud-cpp/archive/v1.16.0.zip"
       URL_HASH SHA1=562ae055ebd6304b7fdf58a7b18c867b870bac95
       BUILD_IN_SOURCE 1

--- a/cmake/Modules/FindLZ4_EP.cmake
+++ b/cmake/Modules/FindLZ4_EP.cmake
@@ -83,6 +83,8 @@ if (NOT LZ4_FOUND)
     set(LZ4_CMAKE_DIR "${TILEDB_EP_SOURCE_DIR}/ep_lz4/contrib/cmake_unofficial")
     ExternalProject_Add(ep_lz4
       PREFIX "externals"
+      # Set download name to avoid collisions with only the version number in the filename
+      DOWNLOAD_NAME ep_lz4.zip
       URL "https://github.com/lz4/lz4/archive/v1.8.2.zip"
       URL_HASH SHA1=ebf6c227965318ecd73820ade8f5dbd83d48b3e8
       CONFIGURE_COMMAND

--- a/cmake/Modules/FindSpdlog_EP.cmake
+++ b/cmake/Modules/FindSpdlog_EP.cmake
@@ -50,6 +50,8 @@ if (NOT SPDLOG_FOUND AND TILEDB_SUPERBUILD)
   message(STATUS "Adding Spdlog as an external project")
   ExternalProject_Add(ep_spdlog
     PREFIX "externals"
+    # Set download name to avoid collisions with only the version number in the filename
+    DOWNLOAD_NAME ep_spdlog.zip
     URL "https://github.com/gabime/spdlog/archive/v0.16.3.zip"
     URL_HASH SHA1=00a732da1449c15b787491a924d63590c1649710
     CONFIGURE_COMMAND ""

--- a/cmake/Modules/FindTBB_EP.cmake
+++ b/cmake/Modules/FindTBB_EP.cmake
@@ -232,6 +232,8 @@ else()
       # On Windows we download pre-built binaries.
       ExternalProject_Add(ep_tbb
         PREFIX "externals"
+        # Set download name to avoid collisions with only the version number in the filename
+        DOWNLOAD_NAME ep_tbb.zip
         URL "https://github.com/intel/tbb/releases/download/v2020.1/tbb-2020.1-win.zip"
         URL_HASH SHA1=fdcdba2026f4c11f1cb3cbc36ff45d828219e580
         CONFIGURE_COMMAND ""
@@ -247,6 +249,8 @@ else()
     else()
       ExternalProject_Add(ep_tbb
         PREFIX "externals"
+        # Set download name to avoid collisions with only the version number in the filename
+        DOWNLOAD_NAME ep_tbb.tar.gz
         URL "https://github.com/intel/tbb/archive/v2020.1.tar.gz"
         URL_HASH SHA1=c42a33b5fc42aedeba75c204a5367593e28a6977
         CONFIGURE_COMMAND ""

--- a/cmake/Modules/FindZstd_EP.cmake
+++ b/cmake/Modules/FindZstd_EP.cmake
@@ -87,6 +87,8 @@ if (NOT ZSTD_FOUND)
 
     ExternalProject_Add(ep_zstd
       PREFIX "externals"
+      # Set download name to avoid collisions with only the version number in the filename
+      DOWNLOAD_NAME ep_zstd.zip
       URL "https://github.com/facebook/zstd/archive/v1.3.4.zip"
       URL_HASH SHA1=2f33cb8af3c964124be67ff4a50824a85b5e1907
       CONFIGURE_COMMAND


### PR DESCRIPTION
Many external projects download their source from github and end up with a file name that is just a semantic version, i.e. `v1.8.2.zip`. This can cause collisions if we randomly set two libraries to the same name, like what I did when I updated spdlog. To fix this we should set the `DOWNLOAD_NAME` in the cmake external_project.