### PR TITLE
Add support for s3 requester pays

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -269,6 +269,7 @@ void check_save_to_file() {
   ss << "vfs.s3.proxy_scheme http\n";
   ss << "vfs.s3.region us-east-1\n";
   ss << "vfs.s3.request_timeout_ms 3000\n";
+  ss << "vfs.s3.requester_pays false\n";
   ss << "vfs.s3.scheme https\n";
   ss << "vfs.s3.use_multipart_upload true\n";
   ss << "vfs.s3.use_virtual_addressing true\n";
@@ -535,6 +536,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.s3.connect_scale_factor"] = "25";
   all_param_values["vfs.s3.logging_level"] = "Off";
   all_param_values["vfs.s3.request_timeout_ms"] = "3000";
+  all_param_values["vfs.s3.requester_pays"] = "false";
   all_param_values["vfs.s3.proxy_host"] = "";
   all_param_values["vfs.s3.proxy_password"] = "";
   all_param_values["vfs.s3.proxy_port"] = "0";
@@ -591,6 +593,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.connect_scale_factor"] = "25";
   vfs_param_values["s3.logging_level"] = "Off";
   vfs_param_values["s3.request_timeout_ms"] = "3000";
+  vfs_param_values["s3.requester_pays"] = "false";
   vfs_param_values["s3.proxy_host"] = "";
   vfs_param_values["s3.proxy_password"] = "";
   vfs_param_values["s3.proxy_port"] = "0";
@@ -641,6 +644,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["connect_scale_factor"] = "25";
   s3_param_values["logging_level"] = "Off";
   s3_param_values["request_timeout_ms"] = "3000";
+  s3_param_values["requester_pays"] = "false";
   s3_param_values["proxy_host"] = "";
   s3_param_values["proxy_password"] = "";
   s3_param_values["proxy_port"] = "0";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -60,7 +60,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 50);
+  CHECK(names.size() == 51);
 }
 
 TEST_CASE(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1152,6 +1152,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.s3.request_timeout_ms` <br>
  *    The request timeout in ms. Any `long` value is acceptable. <br>
  *    **Default**: 3000
+ * - `vfs.s3.requester_pays` <br>
+ *    The requester pays for the S3 access charges. <br>
+ *    **Default**: false
  * - `vfs.s3.proxy_host` <br>
  *    The S3 proxy host. <br>
  *    **Default**: ""

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -129,6 +129,7 @@ const std::string Config::VFS_S3_CONNECT_TIMEOUT_MS = "3000";
 const std::string Config::VFS_S3_CONNECT_MAX_TRIES = "5";
 const std::string Config::VFS_S3_CONNECT_SCALE_FACTOR = "25";
 const std::string Config::VFS_S3_REQUEST_TIMEOUT_MS = "3000";
+const std::string Config::VFS_S3_REQUESTER_PAYS = "false";
 const std::string Config::VFS_S3_PROXY_SCHEME = "http";
 const std::string Config::VFS_S3_PROXY_HOST = "";
 const std::string Config::VFS_S3_PROXY_PORT = "0";
@@ -251,6 +252,7 @@ Config::Config() {
   param_values_["vfs.s3.connect_max_tries"] = VFS_S3_CONNECT_MAX_TRIES;
   param_values_["vfs.s3.connect_scale_factor"] = VFS_S3_CONNECT_SCALE_FACTOR;
   param_values_["vfs.s3.request_timeout_ms"] = VFS_S3_REQUEST_TIMEOUT_MS;
+  param_values_["vfs.s3.requester_pays"] = VFS_S3_REQUESTER_PAYS;
   param_values_["vfs.s3.proxy_scheme"] = VFS_S3_PROXY_SCHEME;
   param_values_["vfs.s3.proxy_host"] = VFS_S3_PROXY_HOST;
   param_values_["vfs.s3.proxy_port"] = VFS_S3_PROXY_PORT;
@@ -537,6 +539,8 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.s3.connect_scale_factor"] = VFS_S3_CONNECT_SCALE_FACTOR;
   } else if (param == "vfs.s3.request_timeout_ms") {
     param_values_["vfs.s3.request_timeout_ms"] = VFS_S3_REQUEST_TIMEOUT_MS;
+  } else if (param == "vfs.s3.requester_pays") {
+    param_values_["vfs.s3.requester_pays"] = VFS_S3_REQUESTER_PAYS;
   } else if (param == "vfs.s3.proxy_scheme") {
     param_values_["vfs.s3.proxy_scheme"] = VFS_S3_PROXY_SCHEME;
   } else if (param == "vfs.s3.proxy_host") {
@@ -686,6 +690,8 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &vint64));
   } else if (param == "vfs.s3.request_timeout_ms") {
     RETURN_NOT_OK(utils::parse::convert(value, &vint64));
+  } else if (param == "vfs.s3.requester_pays") {
+    RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "vfs.s3.proxy_port") {
     RETURN_NOT_OK(utils::parse::convert(value, &vint64));
   } else if (param == "vfs.s3.verify_ssl") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -321,6 +321,9 @@ class Config {
   /** Request timeout in milliseconds. */
   static const std::string VFS_S3_REQUEST_TIMEOUT_MS;
 
+  /** Requester pays for the S3 access charges. */
+  static const std::string VFS_S3_REQUESTER_PAYS;
+
   /** S3 proxy scheme. */
   static const std::string VFS_S3_PROXY_SCHEME;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -493,6 +493,9 @@ class Config {
    * - `vfs.s3.request_timeout_ms` <br>
    *    The request timeout in ms. Any `long` value is acceptable. <br>
    *    **Default**: 3000
+   * - `vfs.s3.requester_pays` <br>
+   *    The requester pays for the S3 access charges. <br>
+   *    **Default**: false
    * - `vfs.s3.proxy_host` <br>
    *    The proxy host. <br>
    *    **Default**: ""

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -539,6 +539,9 @@ class S3 {
   /** Config stored from init for lazy client_init. */
   Config config_;
 
+  /** Set the request payer for a s3 request. */
+  Aws::S3::Model::RequestPayer request_payer_;
+
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */


### PR DESCRIPTION
If an AWS bucket has the requester pays option enabled a separate parameter is needed by the client to signal to AWS that the user accepts responsibility for the s3 access charges. This change adds a new boolean config option `aws.s3.requester_pays` to allow the user to set this behavior.