### PR TITLE
Fix thread-pool deadlock

### DIFF
--- a/test/src/unit-threadpool.cc
+++ b/test/src/unit-threadpool.cc
@@ -59,8 +59,8 @@ TEST_CASE("ThreadPool: Test single thread", "[threadpool]") {
     REQUIRE(task.valid());
     results.emplace_back(std::move(task));
   }
-  CHECK(pool.wait_all(results).ok());
-  CHECK(result == 100);
+  REQUIRE(pool.wait_all(results).ok());
+  REQUIRE(result == 100);
 }
 
 TEST_CASE("ThreadPool: Test multiple threads", "[threadpool]") {
@@ -74,8 +74,8 @@ TEST_CASE("ThreadPool: Test multiple threads", "[threadpool]") {
       return Status::Ok();
     }));
   }
-  CHECK(pool.wait_all(results).ok());
-  CHECK(result == 100);
+  REQUIRE(pool.wait_all(results).ok());
+  REQUIRE(result == 100);
 }
 
 TEST_CASE("ThreadPool: Test wait status", "[threadpool]") {
@@ -89,8 +89,8 @@ TEST_CASE("ThreadPool: Test wait status", "[threadpool]") {
       return i == 50 ? Status::Error("Generic error") : Status::Ok();
     }));
   }
-  CHECK(!pool.wait_all(results).ok());
-  CHECK(result == 100);
+  REQUIRE(!pool.wait_all(results).ok());
+  REQUIRE(result == 100);
 }
 
 TEST_CASE("ThreadPool: Test no wait", "[threadpool]") {
@@ -104,7 +104,7 @@ TEST_CASE("ThreadPool: Test no wait", "[threadpool]") {
         std::this_thread::sleep_for(std::chrono::seconds(1));
         return Status::Ok();
       });
-      CHECK(task.valid());
+      REQUIRE(task.valid());
     }
     // There may be an error logged when the pool is destroyed if there are
     // outstanding tasks, but everything should still complete.
@@ -140,7 +140,7 @@ TEST_CASE(
       num_ok += st.ok() ? 1 : 0;
     }
 
-    CHECK(result == num_ok);
+    REQUIRE(result == num_ok);
   }
 
   SECTION("- With cancellation callback") {
@@ -173,8 +173,8 @@ TEST_CASE(
       num_ok += st.ok() ? 1 : 0;
     }
 
-    CHECK(result == num_ok);
-    CHECK(num_cancelled == (tasks.size() - num_ok));
+    REQUIRE(result == num_ok);
+    REQUIRE(num_cancelled == (tasks.size() - num_ok));
   }
 }
 
@@ -186,8 +186,8 @@ TEST_CASE("ThreadPool: Test execute with empty pool", "[threadpool]") {
     return Status::Ok();
   });
 
-  CHECK(!task.valid());
-  CHECK(result == 0);
+  REQUIRE(!task.valid());
+  REQUIRE(result == 0);
 }
 
 TEST_CASE("ThreadPool: Test recursion", "[threadpool]") {
@@ -226,11 +226,11 @@ TEST_CASE("ThreadPool: Test recursion", "[threadpool]") {
       return Status::Ok();
     });
 
-    CHECK(task.valid());
+    REQUIRE(task.valid());
     tasks.emplace_back(std::move(task));
   }
-  CHECK(pool.wait_all(tasks).ok());
-  CHECK(result == (num_tasks * num_nested_tasks));
+  REQUIRE(pool.wait_all(tasks).ok());
+  REQUIRE(result == (num_tasks * num_nested_tasks));
 
   // Test a top-level execute-and-wait with async-style inner tasks.
   std::condition_variable cv;
@@ -251,11 +251,11 @@ TEST_CASE("ThreadPool: Test recursion", "[threadpool]") {
       return Status::Ok();
     });
 
-    CHECK(task.valid());
+    REQUIRE(task.valid());
     tasks.emplace_back(std::move(task));
   }
 
-  CHECK(pool.wait_all(tasks).ok());
+  REQUIRE(pool.wait_all(tasks).ok());
 
   // Wait all inner tasks to complete.
   std::unique_lock<std::mutex> ul(cv_mutex);
@@ -279,87 +279,96 @@ TEST_CASE("ThreadPool: Test recursion, two pools", "[threadpool]") {
 
   SECTION("- Ten threads") {
     REQUIRE(pool_a.init(10).ok());
-    REQUIRE(pool_b.init(2).ok());
+    REQUIRE(pool_b.init(10).ok());
   }
 
-  // Test recursive execute-and-wait.
-  std::atomic<int> result(0);
-  const size_t num_tasks_a = 10;
-  const size_t num_tasks_b = 10;
-  const size_t num_tasks_c = 10;
-  std::vector<ThreadPool::Task> tasks_a;
-  for (size_t i = 0; i < num_tasks_a; ++i) {
-    auto task_a = pool_a.execute([&]() {
-      std::vector<ThreadPool::Task> tasks_b;
-      for (size_t j = 0; j < num_tasks_b; ++j) {
-        auto task_b = pool_b.execute([&]() {
-          std::vector<ThreadPool::Task> tasks_c;
-          for (size_t k = 0; k < num_tasks_b; ++k) {
-            auto task_c = pool_a.execute([&result]() {
-              ++result;
-              return Status::Ok();
-            });
-
-            tasks_c.emplace_back(std::move(task_c));
-          }
-
-          pool_a.wait_all(tasks_c);
-          return Status::Ok();
-        });
-
-        tasks_b.emplace_back(std::move(task_b));
-      }
-
-      pool_b.wait_all(tasks_b).ok();
-      return Status::Ok();
-    });
-
-    CHECK(task_a.valid());
-    tasks_a.emplace_back(std::move(task_a));
+  SECTION("- Twenty threads") {
+    REQUIRE(pool_a.init(20).ok());
+    REQUIRE(pool_b.init(20).ok());
   }
-  CHECK(pool_a.wait_all(tasks_a).ok());
-  CHECK(result == (num_tasks_a * num_tasks_b * num_tasks_c));
 
-  // Test a top-level execute-and-wait with async-style inner tasks.
-  std::condition_variable cv;
-  std::mutex cv_mutex;
-  tasks_a.clear();
-  for (size_t i = 0; i < num_tasks_a; ++i) {
-    auto task_a = pool_a.execute([&]() {
-      std::vector<ThreadPool::Task> tasks_b;
-      for (size_t j = 0; j < num_tasks_b; ++j) {
-        auto task_b = pool_b.execute([&]() {
-          std::vector<ThreadPool::Task> tasks_c;
-          for (size_t k = 0; k < num_tasks_b; ++k) {
-            auto task_c = pool_a.execute([&]() {
-              if (--result == 0) {
-                std::unique_lock<std::mutex> ul(cv_mutex);
-                cv.notify_all();
-              }
-              return Status::Ok();
-            });
+  // This test logic is relatively inexpensive, run it 50 times
+  // to increase the chance of encountering race conditions.
+  for (int t = 0; t < 50; ++t) {
+    // Test recursive execute-and-wait.
+    std::atomic<int> result(0);
+    const size_t num_tasks_a = 10;
+    const size_t num_tasks_b = 10;
+    const size_t num_tasks_c = 10;
+    std::vector<ThreadPool::Task> tasks_a;
+    for (size_t i = 0; i < num_tasks_a; ++i) {
+      auto task_a = pool_a.execute([&]() {
+        std::vector<ThreadPool::Task> tasks_b;
+        for (size_t j = 0; j < num_tasks_c; ++j) {
+          auto task_b = pool_b.execute([&]() {
+            std::vector<ThreadPool::Task> tasks_c;
+            for (size_t k = 0; k < num_tasks_b; ++k) {
+              auto task_c = pool_a.execute([&result]() {
+                ++result;
+                return Status::Ok();
+              });
 
-            tasks_c.emplace_back(std::move(task_c));
-          }
+              tasks_c.emplace_back(std::move(task_c));
+            }
 
-          pool_a.wait_all(tasks_c);
-          return Status::Ok();
-        });
+            pool_a.wait_all(tasks_c);
+            return Status::Ok();
+          });
 
-        tasks_b.emplace_back(std::move(task_b));
-      }
+          tasks_b.emplace_back(std::move(task_b));
+        }
 
-      pool_b.wait_all(tasks_b).ok();
-      return Status::Ok();
-    });
+        pool_b.wait_all(tasks_b).ok();
+        return Status::Ok();
+      });
 
-    CHECK(task_a.valid());
-    tasks_a.emplace_back(std::move(task_a));
+      REQUIRE(task_a.valid());
+      tasks_a.emplace_back(std::move(task_a));
+    }
+    REQUIRE(pool_a.wait_all(tasks_a).ok());
+    REQUIRE(result == (num_tasks_a * num_tasks_b * num_tasks_c));
+
+    // Test a top-level execute-and-wait with async-style inner tasks.
+    std::condition_variable cv;
+    std::mutex cv_mutex;
+    tasks_a.clear();
+    for (size_t i = 0; i < num_tasks_a; ++i) {
+      auto task_a = pool_a.execute([&]() {
+        std::vector<ThreadPool::Task> tasks_b;
+        for (size_t j = 0; j < num_tasks_b; ++j) {
+          auto task_b = pool_b.execute([&]() {
+            std::vector<ThreadPool::Task> tasks_c;
+            for (size_t k = 0; k < num_tasks_c; ++k) {
+              auto task_c = pool_a.execute([&]() {
+                if (--result == 0) {
+                  std::unique_lock<std::mutex> ul(cv_mutex);
+                  cv.notify_all();
+                }
+                return Status::Ok();
+              });
+
+              tasks_c.emplace_back(std::move(task_c));
+            }
+
+            pool_a.wait_all(tasks_c);
+            return Status::Ok();
+          });
+
+          tasks_b.emplace_back(std::move(task_b));
+        }
+
+        pool_b.wait_all(tasks_b).ok();
+        return Status::Ok();
+      });
+
+      REQUIRE(task_a.valid());
+      tasks_a.emplace_back(std::move(task_a));
+    }
+    REQUIRE(pool_a.wait_all(tasks_a).ok());
+
+    // Wait all inner tasks to complete.
+    std::unique_lock<std::mutex> ul(cv_mutex);
+    while (result > 0)
+      cv.wait(ul);
   }
-  CHECK(pool_a.wait_all(tasks_a).ok());
-
-  // Wait all inner tasks to complete.
-  std::unique_lock<std::mutex> ul(cv_mutex);
-  while (result > 0)
-    cv.wait(ul);
 }

--- a/tiledb/common/thread_pool.cc
+++ b/tiledb/common/thread_pool.cc
@@ -41,9 +41,13 @@ namespace common {
 // Define the static ThreadPool member variables.
 std::unordered_map<std::thread::id, ThreadPool*> ThreadPool::tp_index_;
 std::mutex ThreadPool::tp_index_lock_;
+std::unordered_map<std::thread::id, std::shared_ptr<ThreadPool::PackagedTask>>
+    ThreadPool::task_index_;
+std::mutex ThreadPool::task_index_lock_;
 
 ThreadPool::ThreadPool()
     : concurrency_level_(0)
+    , task_stack_clock_(0)
     , idle_threads_(0)
     , should_terminate_(false) {
 }
@@ -85,8 +89,11 @@ Status ThreadPool::init(const uint64_t concurrency_level) {
   // Save the concurrency level.
   concurrency_level_ = concurrency_level;
 
-  // Index this ThreadPool instance from all of its thread ids.
+  // Add indexes from this ThreadPool instance from all of its thread ids.
   add_tp_index();
+
+  // Add task indexes for each thread in this thread pool.
+  add_task_index();
 
   return st;
 }
@@ -112,8 +119,16 @@ ThreadPool::Task ThreadPool::execute(std::function<Status()>&& function) {
     return invalid_future;
   }
 
-  PackagedTask task(std::move(function));
-  ThreadPool::Task future = task.get_future();
+  // Locate the currently executing task, which may be null.
+  const std::thread::id tid = std::this_thread::get_id();
+  std::shared_ptr<PackagedTask> parent_task = lookup_task(tid);
+
+  // Create the packaged task.
+  std::shared_ptr<PackagedTask> task = std::make_shared<PackagedTask>(
+      std::move(function), std::move(parent_task));
+
+  // Fetch the future from the packaged task.
+  ThreadPool::Task future = task->get_future();
 
   // When we have a concurrency level > 1, we will have at least
   // one thread available to pick up the task. For a concurrency
@@ -122,26 +137,31 @@ ThreadPool::Task ThreadPool::execute(std::function<Status()>&& function) {
   // thread.
   if (concurrency_level_ == 1) {
     ul.unlock();
-    task();
+    exec_packaged_task(task);
   } else {
     // Lookup the thread pool that this thread belongs to. If it
     // does not belong to a thread pool, `lookup_tp` will return
     // `nullptr`.
-    ThreadPool* const tp = lookup_tp();
+    ThreadPool* const tp = lookup_tp(tid);
 
     // As both an optimization and a means of breaking deadlock,
     // execute the task if this thread belongs to `this`. Otherwise,
     // queue it for a worker thread.
     if (tp == this && idle_threads_ == 0) {
       ul.unlock();
-      task();
+      exec_packaged_task(task);
     } else {
       // Add `task` to the stack of pending tasks.
-      task_stack_.push(std::move(task));
+      task_stack_.emplace_back(std::move(task));
       task_stack_cv_.notify_one();
 
-      // The `ul` protects both `task_stack_` and `idle_threads_`,
-      // save a copy of `idle_threads_` before releasing the lock.
+      // Increment the logical clock to indicate that the
+      // `task_stack_` has been modified.
+      ++task_stack_clock_;
+
+      // The `ul` protects `task_stack_`, `task_stack_clock_`, and
+      // `idle_threads_`. Save a copy of `idle_threads_` before releasing
+      // the lock.
       const uint64_t idle_threads_cp = idle_threads_;
       ul.unlock();
 
@@ -206,43 +226,46 @@ std::vector<Status> ThreadPool::wait_all_status(std::vector<Task>& tasks) {
 }
 
 Status ThreadPool::wait_or_work(Task&& task) {
+  // Records the last read value from `task_stack_clock_`.
+  uint64_t last_task_stack_clock = 0;
+
   do {
     if (task.done())
       break;
 
-    // Lookup the thread pool that this thread belongs to. If it
-    // does not belong to a thread pool, `lookup_tp` will return
-    // `nullptr`.
-    ThreadPool* tp = lookup_tp();
+    // Lock the `task_stack_` to receive the next task to work on.
+    task_stack_mutex_.lock();
 
-    // If the calling thread exists outside of a thread pool, it may
-    // service pending tasks from this thread pool.
-    if (tp == nullptr) {
-      tp = this;
-    }
+    // Determine if `task_stack_` has been modified since our
+    // last loop. This is always true for the first iteration
+    // in this loop. Note that `task_stack_clock_` may overflow,
+    // producing a false-positive. In that scenario, we will
+    // perform one spurious loop but will not affect the
+    // correctness of this routine.
+    const bool task_stack_modified = last_task_stack_clock == 0 ||
+                                     last_task_stack_clock != task_stack_clock_;
 
-    // Lock the `tp->task_stack_` to receive the next task to work on.
-    tp->task_stack_mutex_.lock();
-
-    // If there are no pending tasks, we will wait for `task` to complete.
-    if (tp->task_stack_.empty()) {
-      tp->task_stack_mutex_.unlock();
+    // If there are no pending tasks or the stack of pending tasks has
+    // not changed since our last inspection, we will wait for `task`
+    // to complete.
+    if (task_stack_.empty() || !task_stack_modified) {
+      task_stack_mutex_.unlock();
 
       // Add `task` to `blocked_tasks_` so that the `execute()` path can
       // signal it when a new pending task is available.
-      tp->blocked_tasks_mutex_.lock();
-      tp->blocked_tasks_.insert(task.task_state_);
-      tp->blocked_tasks_mutex_.unlock();
+      blocked_tasks_mutex_.lock();
+      blocked_tasks_.insert(task.task_state_);
+      blocked_tasks_mutex_.unlock();
 
       // Block until the task is signaled. It will be signaled when it
       // has completed or when there is new work to execute on `task_stack_`.
       task.wait();
 
       // Remove `task` from `blocked_tasks_`.
-      tp->blocked_tasks_mutex_.lock();
-      if (tp->blocked_tasks_.count(task.task_state_) > 0)
-        tp->blocked_tasks_.erase(task.task_state_);
-      tp->blocked_tasks_mutex_.unlock();
+      blocked_tasks_mutex_.lock();
+      if (blocked_tasks_.count(task.task_state_) > 0)
+        blocked_tasks_.erase(task.task_state_);
+      blocked_tasks_mutex_.unlock();
 
       // After the task has been woken up, check to see if it has completed.
       if (task.done()) {
@@ -258,26 +281,67 @@ Status ThreadPool::wait_or_work(Task&& task) {
       }
 
       // Lock the `task_stack_` again before checking for the next pending task.
-      tp->task_stack_mutex_.lock();
+      task_stack_mutex_.lock();
     }
 
     // We may have released and re-aquired the `task_stack_mutex_`. We must
     // check if it is still non-empty.
-    if (!tp->task_stack_.empty()) {
+    if (!task_stack_.empty()) {
       // Pull the next task off of the task stack. We specifically use a LIFO
-      // ordering to prevent overflowing the call stack.
-      PackagedTask inner_task = std::move(tp->task_stack_.top());
-      tp->task_stack_.pop();
+      // ordering to prevent overflowing the call stack. We will skip tasks
+      // that are not descendents of the task we are currently executing in.
+      const std::thread::id tid = std::this_thread::get_id();
+      std::shared_ptr<PackagedTask> current_task = lookup_task(tid);
+      std::shared_ptr<PackagedTask> descendent_task = nullptr;
+      if (current_task == nullptr) {
+        // We are not executing in the context of a threadpool task, we do
+        // not have any restriction on which task we can execute. Select
+        // the next one.
+        descendent_task = task_stack_.back();
+        task_stack_.pop_back();
+      } else {
+        // Find the next pending task that is a descendent of `current_task`.
+        for (auto riter = task_stack_.rbegin(); riter != task_stack_.rend();
+             ++riter) {
+          // Determine if the task pointed to by `riter` is a descendent
+          // of `current_task`.
+          const PackagedTask* tmp_task = riter->get();
+          while (tmp_task != nullptr) {
+            const PackagedTask* const tmp_task_parent = tmp_task->get_parent();
+            if (tmp_task_parent == current_task.get()) {
+              descendent_task = *riter;
+              break;
+            }
+            tmp_task = tmp_task_parent;
+          }
 
-      // We're done mutating `tp->task_stack_`.
-      tp->task_stack_mutex_.unlock();
+          // If we found a descendent task, erase it from the task stack
+          // and break.
+          if (descendent_task != nullptr) {
+            task_stack_.erase(std::next(riter).base());
+            break;
+          }
+        }
+      }
 
-      // Execute the inner task.
-      assert(inner_task.valid());
-      inner_task();
+      // Save the current state of `task_stack_clock_`. We may mutate it below.
+      last_task_stack_clock = task_stack_clock_;
+
+      // If `descendent_task` is non-null, we must have removed it from
+      // the `task_stack_`. In this scenario, increment the logical clock
+      // to indicate that the `task_stack_` has been modified.
+      if (descendent_task != nullptr)
+        ++task_stack_clock_;
+
+      // We're done mutating `task_stack_` and `task_stack_clock_`.
+      task_stack_mutex_.unlock();
+
+      // Execute the descendent task if we found one.
+      if (descendent_task != nullptr)
+        exec_packaged_task(descendent_task);
     } else {
       // The task stack is now empty, retry.
-      tp->task_stack_mutex_.unlock();
+      task_stack_mutex_.unlock();
     }
   } while (true);
 
@@ -299,12 +363,14 @@ void ThreadPool::terminate() {
     t.join();
   }
 
+  remove_task_index();
+
   threads_.clear();
 }
 
 void ThreadPool::worker(ThreadPool& pool) {
   while (true) {
-    PackagedTask task;
+    std::shared_ptr<PackagedTask> task = nullptr;
 
     {
       // Wait until there's work to do.
@@ -315,20 +381,17 @@ void ThreadPool::worker(ThreadPool& pool) {
       });
 
       if (!pool.task_stack_.empty()) {
-        task = std::move(pool.task_stack_.top());
-        pool.task_stack_.pop();
+        task = std::move(pool.task_stack_.back());
+        pool.task_stack_.pop_back();
         --pool.idle_threads_;
       } else {
         // The task stack was empty, ensure `task` is invalid.
-        if (task.valid()) {
-          task.reset();
-          assert(!task.valid());
-        }
+        task = nullptr;
       }
     }
 
-    if (task.valid())
-      task();
+    if (task != nullptr)
+      exec_packaged_task(task);
 
     if (pool.should_terminate_)
       break;
@@ -347,12 +410,56 @@ void ThreadPool::remove_tp_index() {
     tp_index_.erase(thread.get_id());
 }
 
-ThreadPool* ThreadPool::lookup_tp() {
-  const std::thread::id tid = std::this_thread::get_id();
+ThreadPool* ThreadPool::lookup_tp(const std::thread::id tid) {
   std::lock_guard<std::mutex> lock(tp_index_lock_);
   if (tp_index_.count(tid) == 1)
     return tp_index_[tid];
   return nullptr;
+}
+
+void ThreadPool::add_task_index() {
+  std::lock_guard<std::mutex> lock(task_index_lock_);
+  for (const auto& thread : threads_)
+    task_index_[thread.get_id()] = nullptr;
+}
+
+void ThreadPool::remove_task_index() {
+  std::lock_guard<std::mutex> lock(task_index_lock_);
+  for (const auto& thread : threads_)
+    task_index_.erase(thread.get_id());
+}
+
+std::shared_ptr<ThreadPool::PackagedTask> ThreadPool::lookup_task(
+    const std::thread::id tid) {
+  std::lock_guard<std::mutex> lock(task_index_lock_);
+  if (task_index_.count(tid) == 1)
+    return task_index_[tid];
+  return nullptr;
+}
+
+void ThreadPool::exec_packaged_task(std::shared_ptr<PackagedTask> const task) {
+  const std::thread::id tid = std::this_thread::get_id();
+
+  // Before we execute `task`, we must update `task_index_` to map
+  // this thread-id to the executing task. Note that we only lock
+  // `task_index_` to protect the container itself. The elements
+  // on the map are only ever accessed by the thread that the
+  // element is keyed on, making it implicitly safe.
+  std::shared_ptr<PackagedTask> tmp_task = nullptr;
+  std::unique_lock<std::mutex> ul(task_index_lock_);
+  if (task_index_.count(tid) == 1)
+    tmp_task = task_index_[tid];
+  task_index_[tid] = task;
+  ul.unlock();
+
+  // Execute `task`.
+  (*task)();
+
+  // Restore `task_index_` to the task that it was previously
+  // executing, which may be null.
+  ul.lock();
+  task_index_[tid] = tmp_task;
+  ul.unlock();
 }
 
 }  // namespace common


### PR DESCRIPTION
The majority of the changes in this patch modify the `PackagedTask` class. This class is only internally visible to the `ThreadPool` class. Instances of `PackagedTask` act as pending tasks that are executed by worker threads. Pending tasks are enqueued on a `std::stack`.

As part of our ThreadPool contract, it is valid to recursively execute tasks on the same thread pool. For example:
```
ThreadPool tp;

auto fn_b = []() {
  std::cout << “B” << std::endl;
};

auto fn_a = []() {
  std::cout << “A” << std::endl;
  auto child_task = tp.execute(fn_b);
  tp.wait_all({child_task});
};

auto parent_task = tp.execute(fn_a);
tp.wait_all({parent_task});
```

Logically, this forms an acyclic graph where `child_task` is a descendent of `parent_task`. Note that we do not currently store any in-code state for this graph, this is entirely logical right now.

When an arbitrary thread executes `ThreadPool::wait_all()`, this routine will silently act as a worker thread until the task that it is waiting on becomes available. We must impose a limitation that this only services pending jobs are descendent of the task being waited on. Otherwise, we encounter dead-lock.

Consider the following scenario:
```
ThreadPool tp;

std::mutex mtx;

auto fn_b = []() {
  std::cout << “B” << std::endl;
};

auto fn_a = [&mtx]() {
  mtx.lock();
  std::cout << “A” << std::endl;
  std::vector<ThreadPool::task> child_tasks;
  for (int i = 0; i < 100; ++i) {
    ThreadPool::task child_task = tp.execute(fn_b);
    child_tasks.emplace_back(child_task);
  }
  tp.wait_all(child_tasks);
  mtx.unlock();
};

ThreadPool::task parent_task_1 = tp.execute(fn_a);
ThreadPool::task parent_task_2 = tp.execute(fn_a);
tp.wait_all({parent_task_1, parent_task_2});
```

If the line `tp.wait_all(child_tasks);` executes within `parent_task_1`, it might try to execute `parent_task_2`, which will deadlock on `mtx.lock();`. It is only valid for it to execute any the child tasks. Note the we could continue this example with grand-child tasks, but the property still holds: we can execute any descendent tasks (not just immediate children).

This patch adds the state and logic necessary within the `ThreadPool::wait_all` to only execute tasks that are descendents of the task being waited on.

- The `PackagedTask` class now has a pointer to its parent task.
- Modified all instances of `PackagedTask` to instances of `shared_ptr<PackagedTask>`. The motivation is that the lifetime of these instances must persist after they have been serviced by a worker thread. This prevents parent-pointers from going stale.
    - The move-constructor and move-assignment operator are no longer needed, so they have been disabled.
    - The valid() and reset() routines are no longer needed, we can leverage the interfaces of `shared_ptr` instead.
- Added an `unordered_map` within `ThreadPool` that maps each thread id to the `PackagedTask` it is currently executing. This allows the `ThreadPool::execute()` path to determine the parent task.
- Modified the `ThreadPool::wait_or_work` routine to only execute tasks that are descendents of the task that invoked this routine.
- Prior to this patch, the loop over the pending tasks on `task_stack_` within `ThreadPool::wait_or_work` would have work for as long as the `task_stack_` was non-empty. This is no longer true, because it may be non-empty but only contain non-descendent tasks. I have introduced a logical clock to determine if the `task_task_` has changed since the last iteration.
- Within `ThreadPool::wait_or_work`, it would service tasks from the threadpool that the executing thread belongs to. This is not required. Instead, it will service tasks on the threadpool that the tasks it is waiting on belong to.