### PR TITLE
Per-cell validity values

### DIFF
--- a/test/src/unit-capi-nullable.cc
+++ b/test/src/unit-capi-nullable.cc
@@ -583,8 +583,8 @@ void NullableArrayFx::do_2d_nullable_test(
   for (int i = 0; i < 32; ++i)
     a3_write_buffer_var[i] = i;
   uint64_t a3_write_buffer_var_size = sizeof(a3_write_buffer_var);
-  uint8_t a3_write_buffer_validity[32];
-  for (int i = 0; i < 32; ++i)
+  uint8_t a3_write_buffer_validity[16];
+  for (int i = 0; i < 16; ++i)
     a3_write_buffer_validity[i] = rand() % 2;
   uint64_t a3_write_buffer_validity_size = sizeof(a3_write_buffer_validity);
   if (test_attrs.size() >= 3) {
@@ -696,7 +696,7 @@ void NullableArrayFx::do_2d_nullable_test(
   uint64_t a3_read_buffer_size = sizeof(a3_read_buffer);
   int a3_read_buffer_var[32] = {0};
   uint64_t a3_read_buffer_var_size = sizeof(a3_read_buffer);
-  uint8_t a3_read_buffer_validity[32] = {0};
+  uint8_t a3_read_buffer_validity[16] = {0};
   uint64_t a3_read_buffer_validity_size = sizeof(a3_read_buffer_validity);
   if (test_attrs.size() >= 3) {
     read_query_buffers.emplace_back(
@@ -723,6 +723,7 @@ void NullableArrayFx::do_2d_nullable_test(
     const uint64_t idx = a1_read_buffer[i];
     expected_a1_read_buffer_validity[i] = a1_write_buffer_validity[idx];
   }
+
   REQUIRE(!memcmp(
       a1_read_buffer_validity,
       expected_a1_read_buffer_validity,
@@ -752,9 +753,9 @@ void NullableArrayFx::do_2d_nullable_test(
     REQUIRE(a3_read_buffer_size == a3_write_buffer_size);
     REQUIRE(a3_read_buffer_var_size == a3_write_buffer_var_size);
     REQUIRE(a3_read_buffer_validity_size == a3_write_buffer_validity_size);
-    uint8_t expected_a3_read_buffer_validity[32];
-    for (int i = 0; i < 32; ++i) {
-      const uint64_t idx = a3_read_buffer_var[i];
+    uint8_t expected_a3_read_buffer_validity[16];
+    for (int i = 0; i < 16; ++i) {
+      const uint64_t idx = a3_read_buffer_var[i * 2] / 2;
       expected_a3_read_buffer_validity[i] = a3_write_buffer_validity[idx];
     }
     REQUIRE(!memcmp(
@@ -805,11 +806,12 @@ void NullableArrayFx::do_2d_nullable_test(
     REQUIRE(a3_read_buffer_size == a3_write_buffer_size / 4);
     REQUIRE(a3_read_buffer_var_size == a3_write_buffer_var_size / 4);
     REQUIRE(a3_read_buffer_validity_size == a3_write_buffer_validity_size / 4);
-    uint8_t expected_a3_read_buffer_validity[32];
-    for (int i = 0; i < 8; ++i) {
-      const uint64_t idx = a3_read_buffer_var[i];
+    uint8_t expected_a3_read_buffer_validity[4];
+    for (int i = 0; i < 4; ++i) {
+      const uint64_t idx = a3_read_buffer_var[i * 2] / 2;
       expected_a3_read_buffer_validity[i] = a3_write_buffer_validity[idx];
     }
+
     REQUIRE(!memcmp(
         a3_read_buffer_validity,
         expected_a3_read_buffer_validity,

--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -90,7 +90,6 @@ struct SerializationFx {
     for (unsigned i = 0; i < ncells; i++) {
       a1.push_back(i);
       a2.push_back(i);
-      a2_nullable.push_back(a2.back() % 5 == 0 ? 0 : 1);
       a2.push_back(2 * i);
       a2_nullable.push_back(a2.back() % 5 == 0 ? 0 : 1);
 
@@ -132,7 +131,6 @@ struct SerializationFx {
     for (unsigned i = 0; i < ncells; i++) {
       a1.push_back(i);
       a2.push_back(i);
-      a2_nullable.push_back(a2.back() % 5 == 0 ? 0 : 1);
       a2.push_back(2 * i);
       a2_nullable.push_back(a2.back() % 5 == 0 ? 0 : 1);
 
@@ -175,7 +173,6 @@ struct SerializationFx {
     for (unsigned i = 0; i < ncells; i++) {
       a1.push_back(i);
       a2.push_back(i);
-      a2_nullable.push_back(a2.back() % 5 == 0 ? 0 : 1);
       a2.push_back(2 * i);
       a2_nullable.push_back(a2.back() % 5 == 0 ? 0 : 1);
 
@@ -220,7 +217,6 @@ struct SerializationFx {
     for (unsigned i = 0; i < ncells; i++) {
       a1.push_back(i);
       a2.push_back(i);
-      a2_nullable.push_back(a2.back() % 5 == 0 ? 0 : 1);
       a2.push_back(2 * i);
       a2_nullable.push_back(a2.back() % 5 == 0 ? 0 : 1);
 
@@ -438,7 +434,7 @@ TEST_CASE_METHOD(
     Query query(ctx, array);
     std::vector<uint32_t> a1(1000);
     std::vector<uint32_t> a2(1000);
-    std::vector<uint8_t> a2_nullable(1000);
+    std::vector<uint8_t> a2_nullable(500);
     std::vector<char> a3_data(1000 * 100);
     std::vector<uint64_t> a3_offsets(1000);
     std::vector<int32_t> subarray = {1, 10, 1, 10};
@@ -469,7 +465,7 @@ TEST_CASE_METHOD(
     auto result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 100);
     REQUIRE(std::get<1>(result_el["a2"]) == 200);
-    REQUIRE(std::get<2>(result_el["a2"]) == 200);
+    REQUIRE(std::get<2>(result_el["a2"]) == 100);
     REQUIRE(std::get<0>(result_el["a3"]) == 100);
     REQUIRE(std::get<1>(result_el["a3"]) == 5050);
 
@@ -481,7 +477,7 @@ TEST_CASE_METHOD(
     Array array(ctx, array_uri, TILEDB_READ);
     Query query(ctx, array);
     std::vector<uint32_t> a1(1000);
-    std::vector<uint32_t> a2(1000);
+    std::vector<uint32_t> a2(500);
     std::vector<uint8_t> a2_nullable(1000);
     std::vector<char> a3_data(1000 * 100);
     std::vector<uint64_t> a3_offsets(1000);
@@ -513,7 +509,7 @@ TEST_CASE_METHOD(
     auto result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 4);
     REQUIRE(std::get<1>(result_el["a2"]) == 8);
-    REQUIRE(std::get<2>(result_el["a2"]) == 8);
+    REQUIRE(std::get<2>(result_el["a2"]) == 4);
     REQUIRE(std::get<0>(result_el["a3"]) == 4);
     REQUIRE(std::get<1>(result_el["a3"]) == 114);
 
@@ -568,7 +564,7 @@ TEST_CASE_METHOD(
     auto result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 2);
     REQUIRE(std::get<1>(result_el["a2"]) == 4);
-    REQUIRE(std::get<2>(result_el["a2"]) == 4);
+    REQUIRE(std::get<2>(result_el["a2"]) == 2);
     REQUIRE(std::get<0>(result_el["a3"]) == 2);
     REQUIRE(std::get<1>(result_el["a3"]) == 47);
 
@@ -580,7 +576,7 @@ TEST_CASE_METHOD(
     result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 1);
     REQUIRE(std::get<1>(result_el["a2"]) == 2);
-    REQUIRE(std::get<2>(result_el["a2"]) == 2);
+    REQUIRE(std::get<2>(result_el["a2"]) == 1);
     REQUIRE(std::get<0>(result_el["a3"]) == 1);
     REQUIRE(std::get<1>(result_el["a3"]) == 33);
 
@@ -592,7 +588,7 @@ TEST_CASE_METHOD(
     result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 1);
     REQUIRE(std::get<1>(result_el["a2"]) == 2);
-    REQUIRE(std::get<2>(result_el["a2"]) == 2);
+    REQUIRE(std::get<2>(result_el["a2"]) == 1);
     REQUIRE(std::get<0>(result_el["a3"]) == 1);
     REQUIRE(std::get<1>(result_el["a3"]) == 34);
   }
@@ -639,7 +635,7 @@ TEST_CASE_METHOD(
     auto result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 10);
     REQUIRE(std::get<1>(result_el["a2"]) == 20);
-    REQUIRE(std::get<2>(result_el["a2"]) == 20);
+    REQUIRE(std::get<2>(result_el["a2"]) == 10);
     REQUIRE(std::get<0>(result_el["a3"]) == 10);
     REQUIRE(std::get<1>(result_el["a3"]) == 55);
 
@@ -690,7 +686,7 @@ TEST_CASE_METHOD(
     REQUIRE(std::get<1>(result_el[TILEDB_COORDS]) == 20);
     REQUIRE(std::get<1>(result_el["a1"]) == 10);
     REQUIRE(std::get<1>(result_el["a2"]) == 20);
-    REQUIRE(std::get<2>(result_el["a2"]) == 20);
+    REQUIRE(std::get<2>(result_el["a2"]) == 10);
     REQUIRE(std::get<0>(result_el["a3"]) == 10);
     REQUIRE(std::get<1>(result_el["a3"]) == 55);
 
@@ -743,7 +739,7 @@ TEST_CASE_METHOD(
     auto result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 100);
     REQUIRE(std::get<1>(result_el["a2"]) == 200);
-    REQUIRE(std::get<2>(result_el["a2"]) == 200);
+    REQUIRE(std::get<2>(result_el["a2"]) == 100);
     REQUIRE(std::get<0>(result_el["a3"]) == 100);
     REQUIRE(std::get<1>(result_el["a3"]) == 5050);
 
@@ -788,7 +784,7 @@ TEST_CASE_METHOD(
     auto result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 4);
     REQUIRE(std::get<1>(result_el["a2"]) == 8);
-    REQUIRE(std::get<2>(result_el["a2"]) == 8);
+    REQUIRE(std::get<2>(result_el["a2"]) == 4);
     REQUIRE(std::get<0>(result_el["a3"]) == 4);
     REQUIRE(std::get<1>(result_el["a3"]) == 114);
 
@@ -844,7 +840,7 @@ TEST_CASE_METHOD(
     auto result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 2);
     REQUIRE(std::get<1>(result_el["a2"]) == 4);
-    REQUIRE(std::get<2>(result_el["a2"]) == 4);
+    REQUIRE(std::get<2>(result_el["a2"]) == 2);
     REQUIRE(std::get<0>(result_el["a3"]) == 2);
     REQUIRE(std::get<1>(result_el["a3"]) == 47);
 
@@ -856,7 +852,7 @@ TEST_CASE_METHOD(
     result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 1);
     REQUIRE(std::get<1>(result_el["a2"]) == 2);
-    REQUIRE(std::get<2>(result_el["a2"]) == 2);
+    REQUIRE(std::get<2>(result_el["a2"]) == 1);
     REQUIRE(std::get<0>(result_el["a3"]) == 1);
     REQUIRE(std::get<1>(result_el["a3"]) == 33);
 
@@ -868,7 +864,7 @@ TEST_CASE_METHOD(
     result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 1);
     REQUIRE(std::get<1>(result_el["a2"]) == 2);
-    REQUIRE(std::get<2>(result_el["a2"]) == 2);
+    REQUIRE(std::get<2>(result_el["a2"]) == 1);
     REQUIRE(std::get<0>(result_el["a3"]) == 1);
     REQUIRE(std::get<1>(result_el["a3"]) == 34);
   }

--- a/test/src/unit-cppapi-fill_values.cc
+++ b/test/src/unit-cppapi-fill_values.cc
@@ -109,9 +109,9 @@ void write_array_1d_partial(
   std::vector<uint8_t> a1_validity = {1, 0};
   std::vector<char> a2_val = {'3', '3', '4', '4', '4'};
   std::vector<uint64_t> a2_off = {0, 2};
-  std::vector<uint8_t> a2_validity = {1, 0, 0, 0, 1};
+  std::vector<uint8_t> a2_validity = {1, 0};
   std::vector<double> a3 = {3.1, 3.2, 4.1, 4.2};
-  std::vector<uint8_t> a3_validity = {1, 0, 1, 0};
+  std::vector<uint8_t> a3_validity = {0, 1};
 
   Array array(ctx, array_name, TILEDB_WRITE);
   Query query(ctx, array, TILEDB_WRITE);
@@ -144,9 +144,9 @@ void read_array_1d_partial(
   std::vector<uint8_t> a1_validity(10);
   std::vector<char> a2_val(100);
   std::vector<uint64_t> a2_off(20);
-  std::vector<uint8_t> a2_validity(100);
+  std::vector<uint8_t> a2_validity(20);
   std::vector<double> a3(20);
-  std::vector<uint8_t> a3_validity(20);
+  std::vector<uint8_t> a3_validity(10);
 
   Array array(ctx, array_name, TILEDB_READ);
   Query query(ctx, array, TILEDB_READ);
@@ -170,9 +170,12 @@ void read_array_1d_partial(
   REQUIRE(std::get<1>(res["a3"]) == 20);
   if (nullable_attributes) {
     REQUIRE(std::get<2>(res["a1"]) == 10);
-    REQUIRE(std::get<2>(res["a2"]) == 5 + 8 * fill_char.size());
-    REQUIRE(std::get<2>(res["a3"]) == 20);
+    REQUIRE(std::get<2>(res["a2"]) == 10);
+    REQUIRE(std::get<2>(res["a3"]) == 10);
   }
+
+  const uint8_t fill_null = 0;
+  const uint8_t fill_valid = 1;
 
   uint64_t off = 0;
   for (size_t i = 0; i < 2; ++i) {
@@ -184,7 +187,14 @@ void read_array_1d_partial(
     }
     CHECK(!std::memcmp(&a3[2 * i], &fill_double[0], sizeof(double)));
     CHECK(!std::memcmp(&a3[2 * i + 1], &fill_double[1], sizeof(double)));
+
+    if (nullable_attributes) {
+      CHECK(!std::memcmp(&a1_validity[i], &fill_valid, sizeof(uint8_t)));
+      CHECK(!std::memcmp(&a2_validity[i], &fill_null, sizeof(uint8_t)));
+      CHECK(!std::memcmp(&a3_validity[i], &fill_valid, sizeof(uint8_t)));
+    }
   }
+
   CHECK(a1[2] == 3);
   if (nullable_attributes)
     CHECK(a1_validity[2] == 1);
@@ -195,29 +205,22 @@ void read_array_1d_partial(
   CHECK(a2_val[off] == '3');
   CHECK(a2_val[off + 1] == '3');
   if (nullable_attributes) {
-    CHECK(a2_validity[off] == 1);
-    CHECK(a2_validity[off + 1] == 0);
+    CHECK(a2_validity[2] == 1);
+    CHECK(a2_validity[3] == 0);
   }
   off += 2;
   CHECK(a2_off[3] == off);
   CHECK(a2_val[off] == '4');
   CHECK(a2_val[off + 1] == '4');
   CHECK(a2_val[off + 2] == '4');
-  if (nullable_attributes) {
-    CHECK(a2_validity[off] == 0);
-    CHECK(a2_validity[off + 1] == 0);
-    CHECK(a2_validity[off + 2] == 1);
-  }
   off += 3;
   CHECK(a3[4] == 3.1);
   CHECK(a3[5] == 3.2);
   CHECK(a3[6] == 4.1);
   CHECK(a3[7] == 4.2);
   if (nullable_attributes) {
-    CHECK(a3_validity[4] == 0);
-    CHECK(a3_validity[5] == 0);
-    CHECK(a3_validity[6] == 0);
-    CHECK(a3_validity[7] == 0);
+    CHECK(a3_validity[2] == 0);
+    CHECK(a3_validity[3] == 1);
   }
   for (size_t i = 4; i < 10; ++i) {
     CHECK(a1[i] == fill_int32);
@@ -227,16 +230,15 @@ void read_array_1d_partial(
     CHECK(a2_off[i] == off);
     for (size_t c = 0; c < fill_char.size(); ++c) {
       CHECK(a2_val[off] == fill_char[c]);
-      if (nullable_attributes) {
-        CHECK(a2_validity[off] == 0);
-      }
       ++off;
     }
     CHECK(!std::memcmp(&a3[2 * i], &fill_double[0], sizeof(double)));
     CHECK(!std::memcmp(&a3[2 * i + 1], &fill_double[1], sizeof(double)));
+
     if (nullable_attributes) {
-      CHECK(a3_validity[2 * i] == 1);
-      CHECK(a3_validity[2 * i + 1] == 1);
+      CHECK(!std::memcmp(&a1_validity[i], &fill_valid, sizeof(uint8_t)));
+      CHECK(!std::memcmp(&a2_validity[i], &fill_null, sizeof(uint8_t)));
+      CHECK(!std::memcmp(&a3_validity[i], &fill_valid, sizeof(uint8_t)));
     }
   }
 

--- a/test/src/unit-cppapi-nullable.cc
+++ b/test/src/unit-cppapi-nullable.cc
@@ -403,12 +403,12 @@ void NullableArrayCppFx::do_2d_nullable_test(
   // Define the write query buffers for "a3".
   vector<uint64_t> a3_write_buffer;
   for (uint64_t i = 0; i < 16; ++i)
-    a3_write_buffer.emplace_back(i * sizeof(int) * 2);
+    a3_write_buffer.emplace_back(i * sizeof(ATTR_T) * 2);
   vector<ATTR_T> a3_write_buffer_var;
   for (int i = 0; i < 32; ++i)
     a3_write_buffer_var.emplace_back(i);
   vector<uint8_t> a3_write_buffer_validity;
-  for (int i = 0; i < 32; ++i)
+  for (int i = 0; i < 16; ++i)
     a3_write_buffer_validity.emplace_back(rand() % 2);
   if (test_attrs.size() >= 3) {
     write_query_buffers.emplace_back(
@@ -470,7 +470,7 @@ void NullableArrayCppFx::do_2d_nullable_test(
   // Define the read query buffers for "a3".
   vector<uint64_t> a3_read_buffer(16);
   vector<ATTR_T> a3_read_buffer_var(32);
-  vector<uint8_t> a3_read_buffer_validity(32);
+  vector<uint8_t> a3_read_buffer_validity(16);
   if (test_attrs.size() >= 3) {
     read_query_buffers.emplace_back(
         "a3", &a3_read_buffer, &a3_read_buffer_var, &a3_read_buffer_validity);
@@ -519,11 +519,12 @@ void NullableArrayCppFx::do_2d_nullable_test(
     REQUIRE(a3_read_buffer.size() == a3_write_buffer.size());
     REQUIRE(a3_read_buffer_var.size() == a3_write_buffer_var.size());
     REQUIRE(a3_read_buffer_validity.size() == a3_write_buffer_validity.size());
-    vector<uint8_t> expected_a3_read_buffer_validity(32);
-    for (int i = 0; i < 32; ++i) {
-      const uint64_t idx = a3_read_buffer_var[i];
+    vector<uint8_t> expected_a3_read_buffer_validity(16);
+    for (int i = 0; i < 16; ++i) {
+      const uint64_t idx = a3_read_buffer_var[i * 2] / 2;
       expected_a3_read_buffer_validity[i] = a3_write_buffer_validity[idx];
     }
+
     REQUIRE(!memcmp(
         a3_read_buffer_validity.data(),
         expected_a3_read_buffer_validity.data(),

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -1053,23 +1053,29 @@ class Writer {
    * Writes an empty cell range to the input tile.
    * Applicable to **fixed-sized** attributes.
    *
-   * @param num Number of empty values to write.
+   * @param cell_num Number of empty cells to write.
+   * @param cell_val_num Number of values per cell.
    * @param tile The tile to write to.
    * @return Status
    */
-  Status write_empty_cell_range_to_tile(uint64_t num, Tile* tile) const;
+  Status write_empty_cell_range_to_tile(
+      uint64_t num, uint32_t cell_val_num, Tile* tile) const;
 
   /**
    * Writes an empty cell range to the input tile.
    * Applicable to **fixed-sized** attributes.
    *
-   * @param num Number of empty values to write.
+   * @param cell_num Number of empty cells to write.
+   * @param cell_val_num Number of values per cell.
    * @param tile The tile to write to.
    * @param tile_validity The tile with the validity cells to write to.
    * @return Status
    */
   Status write_empty_cell_range_to_tile_nullable(
-      uint64_t num, Tile* tile, Tile* tile_validity) const;
+      uint64_t num,
+      uint32_t cell_val_num,
+      Tile* tile,
+      Tile* tile_validity) const;
 
   /**
    * Writes an empty cell range to the input tile.


### PR DESCRIPTION
This makes the necessary changes to read/write validity values per-cell instead
of per-value. This is applicable to both fixed and var-sized attributes.