### PR TITLE
Document raw stats as JSON formatted in the C/C++ APIs

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -6211,7 +6211,7 @@ TILEDB_EXPORT int32_t tiledb_stats_dump_str(char** out);
 
 /**
  * Dump all raw internal statistics counters to some output (e.g.,
- * file or stdout).
+ * file or stdout) as a JSON.
  *
  * @param out The output.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
@@ -6219,8 +6219,8 @@ TILEDB_EXPORT int32_t tiledb_stats_dump_str(char** out);
 TILEDB_EXPORT int32_t tiledb_stats_raw_dump(FILE* out);
 
 /**
- * Dump all raw internal statistics counters to an output string. The caller is
- * responsible for freeing the resulting string.
+ * Dump all raw internal statistics counters to a JSON-formatted output string.
+ * The caller is responsible for freeing the resulting string.
  *
  * **Example:**
  *

--- a/tiledb/sm/cpp_api/stats.h
+++ b/tiledb/sm/cpp_api/stats.h
@@ -91,7 +91,8 @@ class Stats {
   }
 
   /**
-   * Dump all raw statistics counters to some output (e.g., file or stdout).
+   * Dump all raw statistics counters to some output (e.g., file or stdout)
+   * as a JSON.
    *
    * @param out The output.
    */


### PR DESCRIPTION
The `raw_dump` API has been a JSON since day-0, but has not been annotated
as such in the C/C++ APIs.