### PR TITLE
Fix concurrent timer stats

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -165,6 +165,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/array_schema.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/stats.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/timer_stat.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/context.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/consolidator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/open_array.cc

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -54,18 +54,29 @@ Stats::Stats() {
 /*              API               */
 /* ****************************** */
 
-void Stats::add_counter(CounterType stat, uint64_t count) {
+void Stats::add_counter(const CounterType stat, uint64_t count) {
   std::unique_lock<std::mutex> lck(mtx_);
   auto it = counter_stats_.find(stat);
   assert(it != counter_stats_.end());
   it->second += count;
 }
 
-void Stats::add_timer(TimerType stat, double count) {
+void Stats::start_timer(const TimerType stat) {
+  const std::thread::id tid = std::this_thread::get_id();
+
   std::unique_lock<std::mutex> lck(mtx_);
   auto it = timer_stats_.find(stat);
   assert(it != timer_stats_.end());
-  it->second += count;
+  it->second.start_timer(tid);
+}
+
+void Stats::end_timer(const TimerType stat) {
+  const std::thread::id tid = std::this_thread::get_id();
+
+  std::unique_lock<std::mutex> lck(mtx_);
+  auto it = timer_stats_.find(stat);
+  assert(it != timer_stats_.end());
+  it->second.end_timer(tid);
 }
 
 bool Stats::enabled() const {
@@ -77,7 +88,7 @@ void Stats::reset() {
 
   timer_stats_.clear();
   for (uint64_t i = 0; i != static_cast<uint64_t>(TimerType::__SIZE); ++i)
-    timer_stats_[static_cast<TimerType>(i)] = 0;
+    timer_stats_[static_cast<TimerType>(i)].reset();
 
   counter_stats_.clear();
   for (uint64_t i = 0; i != static_cast<uint64_t>(CounterType::__SIZE); ++i)
@@ -103,7 +114,7 @@ void Stats::dump(std::string* out) const {
   ss << "\n";
   ss << dump_vfs();
 
-  auto dbg_secs = timer_stats_.find(TimerType::DBG)->second;
+  auto dbg_secs = timer_stats_.at(TimerType::DBG).duration();
   if (dbg_secs != 0)
     ss << "\nDebugging time: " << dbg_secs << " secs\n";
 
@@ -132,10 +143,10 @@ void Stats::raw_dump(std::string* out) const {
     // to the end of the previous stat.
     if (i == 0) {
       ss << "  \"" << timer_names[i]
-         << "\": " << timer_stats_.find(static_cast<TimerType>(i))->second;
+         << "\": " << timer_stats_.at(static_cast<TimerType>(i)).duration();
     } else {
       ss << ",\n  \"" << timer_names[i]
-         << "\": " << timer_stats_.find(static_cast<TimerType>(i))->second;
+         << "\": " << timer_stats_.at(static_cast<TimerType>(i)).duration();
     }
   }
 
@@ -178,37 +189,41 @@ void Stats::set_enabled(bool enabled) {
 /* ****************************** */
 
 std::string Stats::dump_write() const {
-  auto write_time = timer_stats_.find(TimerType::WRITE)->second;
+  auto write_time = timer_stats_.find(TimerType::WRITE)->second.duration();
   auto write_split_coords_buff =
-      timer_stats_.find(TimerType::WRITE_SPLIT_COORDS_BUFF)->second;
+      timer_stats_.find(TimerType::WRITE_SPLIT_COORDS_BUFF)->second.duration();
   auto write_check_coord_oob =
-      timer_stats_.find(TimerType::WRITE_CHECK_COORD_OOB)->second;
+      timer_stats_.find(TimerType::WRITE_CHECK_COORD_OOB)->second.duration();
   auto write_sort_coords =
-      timer_stats_.find(TimerType::WRITE_SORT_COORDS)->second;
+      timer_stats_.find(TimerType::WRITE_SORT_COORDS)->second.duration();
   auto write_check_coord_dups =
-      timer_stats_.find(TimerType::WRITE_CHECK_COORD_DUPS)->second;
+      timer_stats_.find(TimerType::WRITE_CHECK_COORD_DUPS)->second.duration();
   auto write_compute_coord_dups =
-      timer_stats_.find(TimerType::WRITE_COMPUTE_COORD_DUPS)->second;
+      timer_stats_.find(TimerType::WRITE_COMPUTE_COORD_DUPS)->second.duration();
   auto write_prepare_tiles =
-      timer_stats_.find(TimerType::WRITE_PREPARE_TILES)->second;
+      timer_stats_.find(TimerType::WRITE_PREPARE_TILES)->second.duration();
   auto write_compute_coord_meta =
-      timer_stats_.find(TimerType::WRITE_COMPUTE_COORD_META)->second;
+      timer_stats_.find(TimerType::WRITE_COMPUTE_COORD_META)->second.duration();
   auto write_filter_tiles =
-      timer_stats_.find(TimerType::WRITE_FILTER_TILES)->second;
-  auto write_tiles = timer_stats_.find(TimerType::WRITE_TILES)->second;
+      timer_stats_.find(TimerType::WRITE_FILTER_TILES)->second.duration();
+  auto write_tiles =
+      timer_stats_.find(TimerType::WRITE_TILES)->second.duration();
   auto write_store_frag_meta =
-      timer_stats_.find(TimerType::WRITE_STORE_FRAG_META)->second;
-  auto write_finalize = timer_stats_.find(TimerType::WRITE_FINALIZE)->second;
+      timer_stats_.find(TimerType::WRITE_STORE_FRAG_META)->second.duration();
+  auto write_finalize =
+      timer_stats_.find(TimerType::WRITE_FINALIZE)->second.duration();
   auto write_check_global_order =
-      timer_stats_.find(TimerType::WRITE_CHECK_GLOBAL_ORDER)->second;
+      timer_stats_.find(TimerType::WRITE_CHECK_GLOBAL_ORDER)->second.duration();
   auto write_init_tile_its =
-      timer_stats_.find(TimerType::WRITE_INIT_TILE_ITS)->second;
+      timer_stats_.find(TimerType::WRITE_INIT_TILE_ITS)->second.duration();
   auto write_compute_cell_ranges =
-      timer_stats_.find(TimerType::WRITE_COMPUTE_CELL_RANGES)->second;
+      timer_stats_.find(TimerType::WRITE_COMPUTE_CELL_RANGES)
+          ->second.duration();
   auto write_prepare_and_filter_tiles =
-      timer_stats_.find(TimerType::WRITE_PREPARE_AND_FILTER_TILES)->second;
+      timer_stats_.find(TimerType::WRITE_PREPARE_AND_FILTER_TILES)
+          ->second.duration();
   auto write_array_meta =
-      timer_stats_.find(TimerType::WRITE_ARRAY_META)->second;
+      timer_stats_.find(TimerType::WRITE_ARRAY_META)->second.duration();
   auto write_num = counter_stats_.find(CounterType::WRITE_NUM)->second;
   auto write_attr_num =
       counter_stats_.find(CounterType::WRITE_ATTR_NUM)->second;
@@ -369,68 +384,84 @@ std::string Stats::dump_write() const {
 }
 
 std::string Stats::dump_read() const {
-  auto read_time = timer_stats_.find(TimerType::READ)->second;
+  auto read_time = timer_stats_.find(TimerType::READ)->second.duration();
   auto read_fill_dense_coords =
-      timer_stats_.find(TimerType::READ_FILL_DENSE_COORDS)->second;
-  auto read_array_open = timer_stats_.find(TimerType::READ_ARRAY_OPEN)->second;
+      timer_stats_.find(TimerType::READ_FILL_DENSE_COORDS)->second.duration();
+  auto read_array_open =
+      timer_stats_.find(TimerType::READ_ARRAY_OPEN)->second.duration();
   auto read_load_array_schema =
-      timer_stats_.find(TimerType::READ_LOAD_ARRAY_SCHEMA)->second;
+      timer_stats_.find(TimerType::READ_LOAD_ARRAY_SCHEMA)->second.duration();
   auto read_load_array_meta =
-      timer_stats_.find(TimerType::READ_LOAD_ARRAY_META)->second;
+      timer_stats_.find(TimerType::READ_LOAD_ARRAY_META)->second.duration();
   auto read_load_frag_meta =
-      timer_stats_.find(TimerType::READ_LOAD_FRAG_META)->second;
+      timer_stats_.find(TimerType::READ_LOAD_FRAG_META)->second.duration();
   auto read_load_consolidated_frag_meta =
-      timer_stats_.find(TimerType::READ_LOAD_CONSOLIDATED_FRAG_META)->second;
-  auto read_init_state = timer_stats_.find(TimerType::READ_INIT_STATE)->second;
+      timer_stats_.find(TimerType::READ_LOAD_CONSOLIDATED_FRAG_META)
+          ->second.duration();
+  auto read_init_state =
+      timer_stats_.find(TimerType::READ_INIT_STATE)->second.duration();
   auto total_read_time = read_time + read_init_state;
   auto read_compute_est_result_size =
-      timer_stats_.find(TimerType::READ_COMPUTE_EST_RESULT_SIZE)->second;
+      timer_stats_.find(TimerType::READ_COMPUTE_EST_RESULT_SIZE)
+          ->second.duration();
   auto read_compute_tile_overlap =
-      timer_stats_.find(TimerType::READ_COMPUTE_TILE_OVERLAP)->second;
+      timer_stats_.find(TimerType::READ_COMPUTE_TILE_OVERLAP)
+          ->second.duration();
   auto read_compute_tile_coords =
-      timer_stats_.find(TimerType::READ_COMPUTE_TILE_COORDS)->second;
+      timer_stats_.find(TimerType::READ_COMPUTE_TILE_COORDS)->second.duration();
   auto read_compute_next_partition =
-      timer_stats_.find(TimerType::READ_NEXT_PARTITION)->second;
+      timer_stats_.find(TimerType::READ_NEXT_PARTITION)->second.duration();
   auto read_split_current_partition =
-      timer_stats_.find(TimerType::READ_SPLIT_CURRENT_PARTITION)->second;
+      timer_stats_.find(TimerType::READ_SPLIT_CURRENT_PARTITION)
+          ->second.duration();
   auto read_compute_result_coords =
-      timer_stats_.find(TimerType::READ_COMPUTE_RESULT_COORDS)->second;
+      timer_stats_.find(TimerType::READ_COMPUTE_RESULT_COORDS)
+          ->second.duration();
   auto read_compute_range_coords =
-      timer_stats_.find(TimerType::READ_COMPUTE_RANGE_RESULT_COORDS)->second;
+      timer_stats_.find(TimerType::READ_COMPUTE_RANGE_RESULT_COORDS)
+          ->second.duration();
   auto read_compute_sparse_result_tiles =
-      timer_stats_.find(TimerType::READ_COMPUTE_SPARSE_RESULT_TILES)->second;
+      timer_stats_.find(TimerType::READ_COMPUTE_SPARSE_RESULT_TILES)
+          ->second.duration();
   auto read_compute_sparse_result_cell_slabs_sparse =
       timer_stats_
           .find(TimerType::READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_SPARSE)
-          ->second;
+          ->second.duration();
   auto read_compute_sparse_result_cell_slabs_dense =
       timer_stats_.find(TimerType::READ_COMPUTE_SPARSE_RESULT_CELL_SLABS_DENSE)
-          ->second;
+          ->second.duration();
   auto read_copy_attr_values =
-      timer_stats_.find(TimerType::READ_COPY_ATTR_VALUES)->second;
+      timer_stats_.find(TimerType::READ_COPY_ATTR_VALUES)->second.duration();
   auto read_copy_coords =
-      timer_stats_.find(TimerType::READ_COPY_COORDS)->second;
+      timer_stats_.find(TimerType::READ_COPY_COORDS)->second.duration();
   auto read_copy_fixed_attr_values =
-      timer_stats_.find(TimerType::READ_COPY_FIXED_ATTR_VALUES)->second;
+      timer_stats_.find(TimerType::READ_COPY_FIXED_ATTR_VALUES)
+          ->second.duration();
   auto read_copy_fixed_coords =
-      timer_stats_.find(TimerType::READ_COPY_FIXED_COORDS)->second;
+      timer_stats_.find(TimerType::READ_COPY_FIXED_COORDS)->second.duration();
   auto read_copy_var_attr_values =
-      timer_stats_.find(TimerType::READ_COPY_VAR_ATTR_VALUES)->second;
+      timer_stats_.find(TimerType::READ_COPY_VAR_ATTR_VALUES)
+          ->second.duration();
   auto read_copy_var_coords =
-      timer_stats_.find(TimerType::READ_COPY_VAR_COORDS)->second;
-  auto read_attr_tiles = timer_stats_.find(TimerType::READ_ATTR_TILES)->second;
+      timer_stats_.find(TimerType::READ_COPY_VAR_COORDS)->second.duration();
+  auto read_attr_tiles =
+      timer_stats_.find(TimerType::READ_ATTR_TILES)->second.duration();
   auto read_coord_tiles =
-      timer_stats_.find(TimerType::READ_COORD_TILES)->second;
+      timer_stats_.find(TimerType::READ_COORD_TILES)->second.duration();
   auto read_unfilter_attr_tiles =
-      timer_stats_.find(TimerType::READ_UNFILTER_ATTR_TILES)->second;
+      timer_stats_.find(TimerType::READ_UNFILTER_ATTR_TILES)->second.duration();
   auto read_unfilter_coord_tiles =
-      timer_stats_.find(TimerType::READ_UNFILTER_COORD_TILES)->second;
+      timer_stats_.find(TimerType::READ_UNFILTER_COORD_TILES)
+          ->second.duration();
   auto read_compute_relevant_tile_overlap =
-      timer_stats_.find(TimerType::READ_COMPUTE_RELEVANT_TILE_OVERLAP)->second;
+      timer_stats_.find(TimerType::READ_COMPUTE_RELEVANT_TILE_OVERLAP)
+          ->second.duration();
   auto read_load_relevant_rtrees =
-      timer_stats_.find(TimerType::READ_LOAD_RELEVANT_RTREES)->second;
+      timer_stats_.find(TimerType::READ_LOAD_RELEVANT_RTREES)
+          ->second.duration();
   auto read_compute_relevant_frags =
-      timer_stats_.find(TimerType::READ_COMPUTE_RELEVANT_FRAGS)->second;
+      timer_stats_.find(TimerType::READ_COMPUTE_RELEVANT_FRAGS)
+          ->second.duration();
 
   auto array_schema_size =
       counter_stats_.find(CounterType::READ_ARRAY_SCHEMA_SIZE)->second;
@@ -688,21 +719,23 @@ std::string Stats::dump_consolidate() const {
   auto consolidate_steps =
       counter_stats_.find(CounterType::CONSOLIDATE_STEP_NUM)->second;
   auto consolidate_frags =
-      timer_stats_.find(TimerType::CONSOLIDATE_FRAGS)->second;
+      timer_stats_.find(TimerType::CONSOLIDATE_FRAGS)->second.duration();
   auto consolidate_main =
-      timer_stats_.find(TimerType::CONSOLIDATE_MAIN)->second;
+      timer_stats_.find(TimerType::CONSOLIDATE_MAIN)->second.duration();
   auto consolidate_compute_next =
-      timer_stats_.find(TimerType::CONSOLIDATE_COMPUTE_NEXT)->second;
+      timer_stats_.find(TimerType::CONSOLIDATE_COMPUTE_NEXT)->second.duration();
   auto consolidate_array_meta =
-      timer_stats_.find(TimerType::CONSOLIDATE_ARRAY_META)->second;
+      timer_stats_.find(TimerType::CONSOLIDATE_ARRAY_META)->second.duration();
   auto consolidate_frag_meta =
-      timer_stats_.find(TimerType::CONSOLIDATE_FRAG_META)->second;
+      timer_stats_.find(TimerType::CONSOLIDATE_FRAG_META)->second.duration();
   auto consolidate_create_buffers =
-      timer_stats_.find(TimerType::CONSOLIDATE_CREATE_BUFFERS)->second;
+      timer_stats_.find(TimerType::CONSOLIDATE_CREATE_BUFFERS)
+          ->second.duration();
   auto consolidate_create_queries =
-      timer_stats_.find(TimerType::CONSOLIDATE_CREATE_QUERIES)->second;
+      timer_stats_.find(TimerType::CONSOLIDATE_CREATE_QUERIES)
+          ->second.duration();
   auto consolidate_copy_array =
-      timer_stats_.find(TimerType::CONSOLIDATE_COPY_ARRAY)->second;
+      timer_stats_.find(TimerType::CONSOLIDATE_COPY_ARRAY)->second.duration();
   std::stringstream ss;
 
   auto consolidate =

--- a/tiledb/sm/stats/timer_stat.cc
+++ b/tiledb/sm/stats/timer_stat.cc
@@ -1,0 +1,120 @@
+/**
+ * @file   timer_stat.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains the TimerStat implementation.
+ */
+
+#include <assert.h>
+
+#include "tiledb/sm/stats/timer_stat.h"
+
+namespace tiledb {
+namespace sm {
+namespace stats {
+
+// Static member variable definitions.
+std::unordered_map<
+    std::thread::id,
+    std::chrono::high_resolution_clock::time_point>
+    TimerStat::start_times_;
+
+/* ****************************** */
+/*   CONSTRUCTORS & DESTRUCTORS   */
+/* ****************************** */
+
+TimerStat::TimerStat()
+    : duration_(0.0f) {
+}
+
+/* ****************************** */
+/*              API               */
+/* ****************************** */
+
+void TimerStat::start_timer(const std::thread::id tid) {
+  start_times_[tid] = std::chrono::high_resolution_clock::now();
+}
+
+void TimerStat::end_timer(const std::thread::id tid) {
+  std::chrono::high_resolution_clock::time_point* const start_time =
+      &start_times_[tid];
+
+  // Check for intersections with pending timers on other
+  // threads.
+  std::chrono::high_resolution_clock::time_point end_time;
+  for (const auto& start_times_kv : start_times_) {
+    const std::thread::id other_tid = start_times_kv.first;
+    const std::chrono::high_resolution_clock::time_point* const
+        other_start_time = &start_times_kv.second;
+
+    // Do not compare this state with itself.
+    if (other_tid == tid)
+      continue;
+
+    // Check if the other state has a pending timer.
+    if (other_start_time->time_since_epoch().count() > 0) {
+      // If the other thread's timer started at an earlier or identical
+      // time than this thread's timer, the other thread will capture
+      // the entire duration of this timer.
+      if (*other_start_time <= *start_time) {
+        // Discard this entire duration.
+        *start_time = std::chrono::high_resolution_clock::time_point();
+        return;
+      }
+
+      // If the other thread's timer started at a later time than this
+      // thread's timer, only record this thread's timer to an end time
+      // equal to the other thread's timer.
+      assert(*other_start_time > *start_time);
+      end_time = *other_start_time;
+    }
+  }
+
+  // If we did not set `end_time`, set it as the current time.
+  if (end_time.time_since_epoch().count() == 0)
+    end_time = std::chrono::high_resolution_clock::now();
+
+  // Calculate and record the duration.
+  const std::chrono::duration<double> duration = end_time - *start_time;
+  duration_ += duration.count();
+
+  // Reset the start time.
+  *start_time = std::chrono::high_resolution_clock::time_point();
+}
+
+void TimerStat::reset() {
+  duration_ = 0.0f;
+}
+
+double TimerStat::duration() const {
+  return duration_;
+}
+
+}  // namespace stats
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/stats/timer_stat.h
+++ b/tiledb/sm/stats/timer_stat.h
@@ -1,0 +1,105 @@
+/**
+ * @file   timer_stat.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains the TimerStat definition.
+ *
+ * This allows starting and stopping concurrent timers on different threads,
+ * but does not count overlapping time periods toward the recorded duration.
+ *
+ * Thread-safety: none.
+ */
+
+#ifndef TILEDB_TIMER_STAT_H
+#define TILEDB_TIMER_STAT_H
+
+#include <thread>
+#include <unordered_map>
+
+namespace tiledb {
+namespace sm {
+namespace stats {
+
+class TimerStat {
+ public:
+  /* ****************************** */
+  /*   CONSTRUCTORS & DESTRUCTORS   */
+  /* ****************************** */
+
+  /** Constructor. */
+  TimerStat();
+
+  /** Destructor. */
+  ~TimerStat() = default;
+
+  /* ****************************** */
+  /*              API               */
+  /* ****************************** */
+
+  /**
+   * Starts a timer for `tid`. This may not be called again
+   * until a subsequent call to `end_timer`.
+   */
+  void start_timer(std::thread::id tid);
+
+  /**
+   * Ends a timer for `tid`. This may not be called again
+   * until a subsequent call to `start_timer`.
+   */
+  void end_timer(std::thread::id tid);
+
+  /**
+   * Resets the total recorded durations.
+   */
+  void reset();
+
+  /**
+   * Returns the sum of all recorded durations among threads.
+   */
+  double duration() const;
+
+ private:
+  /* ****************************** */
+  /*       PRIVATE ATTRIBUTES       */
+  /* ****************************** */
+
+  /** The total duration of all recorded timers. */
+  double duration_;
+
+  /** The start time for all pending timers. */
+  static std::unordered_map<
+      std::thread::id,
+      std::chrono::high_resolution_clock::time_point>
+      start_times_;
+};
+
+}  // namespace stats
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_TIMER_STAT_H


### PR DESCRIPTION
Consider the following scenario where two threads start timers for the same
timer type:
0s: Thread-1 starts timer
2s: Thread-2 starts timer
10s: Thread-1 ends timer
12s: Thread-2 ends timer

The total real time spent in this path is 12s. Currently, this stat would
record a total duration of 20s.

This patch modifies the timer stats to ignore concurrent, intersecting periods
of time.

When a timer, T0, starts, it maps the thread-id to the start time. When the timer
ends, there are three scenarios:

- If the entire period of T0 captured by another timer, T1, we will discard T0.
- If the period of T0 has overlap with another timer, T1, we will record only
  period that does not intersect with T1.
- If the entire period of T0 does not intersect with any other pending timers,
  the entire period of T0 is recorded.

As a sanity check, here are some read stats captured with this patch:
```
- Time to compute estimated result size: 0.0491438 secs
  * Time to compute tile overlap: 3.93101 secs
    > Time to compute relevant fragments: 0.00273819 secs
    > Time to load relevant fragment R-trees: 0.243354 secs
    > Time to compute relevant fragment tile overlap: 3.67877 secs

- Time to open array: 0.903539 secs
  * Time to load array schema: 0.367741 secs
  * Time to load consolidated fragment metadata: 9.48e-07 secs
  * Time to load fragment metadata: 0.376818 secs

- Total metadata read: 14630297 bytes (0.0136255 GB)
  * Array schema: 820 bytes (7.63685e-07 GB)
  * Fragment metadata: 1268 bytes (1.18092e-06 GB)
  * R-tree: 4129649 bytes (0.00384604 GB)
  * Fixed-sized tile offsets: 4619344 bytes (0.0043021 GB)
  * Var-sized tile offsets: 2939600 bytes (0.00273772 GB)
  * Var-sized tile sizes: 2939616 bytes (0.00273773 GB)

- Time to load array metadata: 0.159307 secs
  * Array metadata size: 131 bytes (1.22003e-07 GB)

- Time to initialize the read state: 3.89744 secs

- Read time: 276.338 secs
  * Time to compute next partition: 7.18336 secs
  * Time to split current partition: 0.036456 secs
  * Time to compute result coordinates: 75.526 secs
    > Time to compute sparse result tiles: 0.144924 secs
    > Time to read coordinate tiles: 47.2449 secs
    > Time to unfilter coordinate tiles: 6.34937 secs
    > Time to compute range result coordinates: 21.1172 secs
  * Time to compute sparse result cell slabs: 0.282873 secs
  * Time to copy result attribute values: 189.016 secs
    > Time to read attribute tiles: 153.389 secs
    > Time to unfilter attribute tiles: 15.9935 secs
    > Time to copy fixed-sized attribute values: 0.923105 secs
    > Time to copy var-sized attribute values: 6.2675 secs
  * Time to copy result coordinates: 4.22086 secs
    > Time to copy fixed-sized coordinates: 0.283924 secs
    > Time to copy var-sized coordinates: 2.28946 secs
```