### PR TITLE
Add support for REST header for credential name

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@
 ## Improvements
 
 * Add additional timer statistics for openning array for reads [#2027](https://github.com/TileDB-Inc/TileDB/pull/2027)
+* Add `rest.creation_access_credentials_name` configuration parameter [#2025](https://github.com/TileDB-Inc/TileDB/pull/2025)
 
 ## Deprecations
 

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1215,6 +1215,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `rest.ignore_ssl_validation` <br>
  *    Have curl ignore ssl peer and host validation for REST server. <br>
  *    **Default**: false
+ * - `rest.creation_access_credentials_name` <br>
+ *    The name of the registered access key to use for creation of the REST
+ *    server. <br>
+ *    **Default**: no default set
  *
  * **Example:**
  *

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -556,6 +556,10 @@ class Config {
    * - `rest.ignore_ssl_validation` <br>
    *    Have curl ignore ssl peer and host validation for REST server. <br>
    *    **Default**: false
+   * - `rest.creation_access_credentials_name` <br>
+   *    The name of the registered access key to use for creation of the REST
+   *    server. <br>
+   *    **Default**: no default set
    */
   Config& set(const std::string& param, const std::string& value) {
     tiledb_error_t* err;

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -131,6 +131,14 @@ Status RestClient::post_array_schema_to_rest(
   BufferList serialized;
   RETURN_NOT_OK(serialized.add_buffer(std::move(buff)));
 
+  bool found = false;
+  const std::string creation_access_credentials_name =
+      config_->get("rest.creation_access_credentials_name", &found);
+  if (found)
+    RETURN_NOT_OK(set_header(
+        "X-TILEDB-CLOUD-ACCESS-CREDENTIALS-NAME",
+        creation_access_credentials_name));
+
   // Init curl and form the URL
   Curl curlc;
   std::string array_ns, array_uri;


### PR DESCRIPTION
When creating a new array, a user might wish to specify the pre-registered aws credentials to use when creating a TileDB Cloud array. This adds a new config option `"rest.creation_access_credentials_name"` that can be set. No default value is given for this, as its a completely optional parameter ignored if the user does not set it.


Example usage (python):
```
>>> import tiledb
>>> domain = tiledb.Domain(*[tiledb.Dim(name='rows', domain=(1, 4), tile=4, dtype='int32'), tiledb.Dim(name='cols', domain=(1, 4), tile=4, dtype='int32'),])
>>> attrs = [tiledb.Attr(name='a', dtype='int32', var=False)]
>>> config = tiledb.Config()
>>> config["rest.token"] = "mytoken"
>>> config["rest.creation_access_credentials_name"] = "test"
>>> ctx = tiledb.Ctx(config)
>>> schema = tiledb.ArraySchema(domain=domain, sparse=True, attrs=attrs, cell_order="row-major", tile_order="col-major", ctx=ctx)
>>> tiledb.SparseArray.create("tiledb://example/s3://mybucket/myexample", schema)

```