### PR TITLE
Add tiledb_query_set_config / Query::set_config API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,8 +22,10 @@
 ## API additions
 
 ### C API
+* Add `tiledb_query_set_config` to apply a `tiledb_config_t` to query-level parameters [#2030](https://github.com/TileDB-Inc/TileDB/pull/2030)
 
 ### C++ API
+* Added `Query::set_config` to apply a `tiledb::Config` to query-level parameters [#2030](https://github.com/TileDB-Inc/TileDB/pull/2030)
 
 # TileDB v2.2.1 Release Notes
 

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -412,6 +412,8 @@ Query
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_get_buffer_var_nullable
     :project: TileDB-C
+.. doxygenfunction:: tiledb_query_set_config
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_query_set_layout
     :project: TileDB-C
 .. doxygenfunction:: tiledb_query_free

--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -2991,3 +2991,132 @@ TEST_CASE_METHOD(
 
   remove_array(array_name);
 }
+
+TEST_CASE_METHOD(
+    Query2Fx, "C API: Test query set config", "[capi][config][query]") {
+  std::string array_name = "query_set_config";
+  remove_array(array_name);
+
+  // Create array
+  int32_t dom[] = {1, 6};
+  int32_t extent = 2;
+  create_array(
+      ctx_,
+      array_name,
+      TILEDB_DENSE,
+      {"d1"},
+      {TILEDB_INT32},
+      {dom},
+      {&extent},
+      {"a"},
+      {TILEDB_INT32},
+      {TILEDB_VAR_NUM},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      2,
+      false,
+      false);
+
+  // Open array
+  tiledb_array_t* array = nullptr;
+  int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query
+  tiledb_query_t* query = nullptr;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
+  CHECK(rc == TILEDB_OK);
+
+  // Create config
+  tiledb_error_t* err;
+  tiledb_config_t* config = nullptr;
+  rc = tiledb_config_alloc(&config, &err);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_config_set(config, "sm.var_offsets.bitsize", "32", &err);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_config_set(config, "sm.var_offsets.extra_element", "true", &err);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_config_set(config, "sm.var_offsets.mode", "elements", &err);
+  CHECK(rc == TILEDB_OK);
+
+  // Test setting config
+  rc = tiledb_query_set_config(ctx_, query, config);
+  CHECK(rc == TILEDB_OK);
+
+  // Test modified behavior
+  std::vector<uint32_t> offsets = {0, 1, 2, 4, 7, 9, 10};
+  // even in elements mode, we need to pass offsets size as if uint64
+  uint64_t offsets_size = offsets.size() * sizeof(uint64_t);
+  std::vector<int32_t> data = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  uint64_t data_size = data.size() * sizeof(int32_t);
+
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query,
+      "a",
+      (uint64_t*)offsets.data(),
+      &offsets_size,
+      data.data(),
+      &data_size);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_query_submit(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_query_finalize(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_query_free(&query);
+
+  // Create read query
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  tiledb_query_t* query2 = nullptr;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query2);
+  CHECK(rc == TILEDB_OK);
+
+  // Set override config
+  rc = tiledb_query_set_config(ctx_, query2, config);
+  CHECK(rc == TILEDB_OK);
+
+  std::vector<int32_t> data2;
+  std::vector<uint32_t> offsets2;
+  data2.resize(data.size());
+  offsets2.resize(offsets.size());
+
+  rc = tiledb_query_set_buffer_var(
+      ctx_,
+      query2,
+      "a",
+      (uint64_t*)offsets2.data(),
+      &offsets_size,
+      data2.data(),
+      &data_size);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_query_set_subarray(ctx_, query2, &dom);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_query_submit(ctx_, query2);
+  CHECK(rc == TILEDB_OK);
+
+  CHECK(data == data2);
+  CHECK(offsets == offsets2);
+
+  // Clean up
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_query_free(&query2);
+  CHECK(query2 == nullptr);
+  tiledb_array_free(&array);
+  CHECK(array == nullptr);
+
+  remove_array(array_name);
+}

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -396,6 +396,17 @@ inline int32_t sanity_check(tiledb_config_t* config, tiledb_error_t** error) {
   return TILEDB_OK;
 }
 
+inline int32_t sanity_check(tiledb_ctx_t* ctx, tiledb_config_t* config) {
+  if (config == nullptr || config->config_ == nullptr) {
+    auto st = Status::Error("Cannot set config; Invalid config object");
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
+
+  return TILEDB_OK;
+}
+
 inline int32_t sanity_check(
     tiledb_config_iter_t* config_iter, tiledb_error_t** error) {
   if (config_iter == nullptr || config_iter->config_iter_ == nullptr) {
@@ -2630,7 +2641,8 @@ int32_t tiledb_query_set_config(
     tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_config_t* config) {
   // Sanity check
   if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, query) == TILEDB_ERR || config->config_ == nullptr)
+      sanity_check(ctx, query) == TILEDB_ERR ||
+      sanity_check(ctx, config) == TILEDB_ERR)
     return TILEDB_ERR;
 
   if (SAVE_ERROR_CATCH(ctx, query->query_->set_config(*(config->config_))))

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1122,6 +1122,7 @@ int32_t tiledb_ctx_get_config(tiledb_ctx_t* ctx, tiledb_config_t** config) {
     return TILEDB_OOM;
   }
 
+  // this assignment is a copy
   *((*config)->config_) = ctx->ctx_->storage_manager()->config();
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2626,6 +2626,19 @@ int32_t tiledb_query_alloc(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_set_config(
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_config_t* config) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR ||
+      sanity_check(ctx, query) == TILEDB_ERR || config->config_ == nullptr)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(ctx, query->query_->set_config(*(config->config_))))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_set_subarray(
     tiledb_ctx_t* ctx, tiledb_query_t* query, const void* subarray) {
   // Sanity check

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1543,7 +1543,10 @@ tiledb_ctx_alloc(tiledb_config_t* config, tiledb_ctx_t** ctx);
 TILEDB_EXPORT void tiledb_ctx_free(tiledb_ctx_t** ctx);
 
 /**
- * Retrieves the config from a TileDB context.
+ * Retrieves a copy of the config from a TileDB context.
+ * Modifying this config will not affect the initialized
+ * context configuration.
+ *
  *
  * **Example:**
  *

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3316,6 +3316,27 @@ TILEDB_EXPORT int32_t tiledb_query_alloc(
     tiledb_query_t** query);
 
 /**
+ * Set the query config
+ *
+ * Setting the configuration with this function overrides the following
+ * Query-level parameters only:
+ *
+ * - `sm.memory_budget`
+ * - `sm.memory_budget_var`
+ * - `sm.sub_partitioner_memory_budget`
+ * - `sm.var_offsets.mode`
+ * - `sm.var_offsets.extra_element`
+ * - `sm.var_offsets.bitsize`
+ * - `sm.check_coord_dups`
+ * - `sm.check_coord_oob`
+ * - `sm.check_global_order`
+ * - `sm.dedup_coords`
+ */
+
+TILEDB_EXPORT int32_t tiledb_query_set_config(
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_config_t* config);
+
+/**
  * Indicates that the query will write or read a subarray, and provides
  * the appropriate information.
  *

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1077,6 +1077,32 @@ class Query {
   }
 
   /**
+   * Set the query config.
+   *
+   * Setting configuration with this function overrides the following
+   * Query-level parameters only:
+   *
+   * - `sm.memory_budget`
+   * - `sm.memory_budget_var`
+   * - `sm.sub_partitioner_memory_budget`
+   * - `sm.var_offsets.mode`
+   * - `sm.var_offsets.extra_element`
+   * - `sm.var_offsets.bitsize`
+   * - `sm.check_coord_dups`
+   * - `sm.check_coord_oob`
+   * - `sm.check_global_order`
+   * - `sm.dedup_coords`
+   */
+  Query& set_config(const Config& config) {
+    auto ctx = ctx_.get();
+
+    ctx.handle_error(tiledb_query_set_config(
+        ctx.ptr().get(), query_.get(), config.ptr().get()));
+
+    return *this;
+  }
+
+  /**
    * Set the coordinate buffer.
    *
    * The coordinate buffer has been deprecated. Set the coordinates for

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -802,6 +802,15 @@ Status Query::check_set_fixed_buffer(const std::string& name) {
   return Status::Ok();
 }
 
+Status Query::set_config(const Config& config) {
+  if (type_ == QueryType::READ)
+    reader_.set_config(config);
+  else
+    writer_.set_config(config);
+
+  return Status::Ok();
+}
+
 Status Query::set_buffer(
     const std::string& name,
     void* const buffer,

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -482,6 +482,18 @@ class Query {
   Status disable_check_global_order();
 
   /**
+   * Sets the config for the Query
+   *
+   * This function overrides the config for Query-level parameters only.
+   * Semantically, the initial query config is copied from the context
+   * config upon initialization. Note that The context config is immutable
+   * at the C API level because tiledb_ctx_get_config always returns a copy.
+   *
+   * Config parameters set here will *only* be applied within the Query.
+   */
+  Status set_config(const Config& config);
+
+  /**
    * Sets the buffer for a fixed-sized attribute/dimension.
    *
    * @param name The attribute/dimension to set the buffer for.

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -440,6 +440,9 @@ class Reader {
   void set_fragment_metadata(
       const std::vector<FragmentMetadata*>& fragment_metadata);
 
+  /** Sets config for query-level parameters only. */
+  Status set_config(const Config& config);
+
   /**
    * Sets the cell layout of the query. The function will return an error
    * if the queried array is a key-value store (because it has its default
@@ -918,6 +921,9 @@ class Reader {
 
   /** The array schema. */
   const ArraySchema* array_schema_;
+
+  /** The config for query-level parameters only. */
+  Config config_;
 
   /**
    * Maps attribute/dimension names to their buffers.

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -337,6 +337,9 @@ class Writer {
       uint64_t* buffer_val_size,
       ValidityVector&& validity_vector);
 
+  /** Sets config for query-level parameters only. */
+  Status set_config(const Config& config);
+
   /** Sets current setting of check_coord_dups_ */
   void set_check_coord_dups(bool b);
 
@@ -393,6 +396,9 @@ class Writer {
 
   /** The array schema. */
   const ArraySchema* array_schema_;
+
+  /** The config for query-level parameters only. */
+  Config config_;
 
   /** Maps attribute/dimensions names to their buffers. */
   std::unordered_map<std::string, QueryBuffer> buffers_;


### PR DESCRIPTION
This API sets a config object on a tiledb Query which applies only to
Query-level parameters (see tiledb.h description). Allows these parameters
to vary on a per-Query basis, without changes to the immutability
of context-level configuration.

(also slightly modifies some of the var-offsets test harnesses to accept
an optional config object in order to test the C++ API)