### PR TITLE
Update TileDB dependencies

### DIFF
--- a/cmake/Modules/FindCatch_EP.cmake
+++ b/cmake/Modules/FindCatch_EP.cmake
@@ -54,8 +54,8 @@ if (NOT CATCH2_FOUND AND TILEDB_SUPERBUILD)
     PREFIX "externals"
     # Set download name to avoid collisions with only the version number in the filename
     DOWNLOAD_NAME ep_catch.zip
-    URL "https://github.com/catchorg/Catch2/archive/v2.11.1.zip"
-    URL_HASH SHA1=758c33d983c8e3bd0b2e5f9d20153104578edb81
+    URL "https://github.com/catchorg/Catch2/archive/v2.13.4.zip"
+    URL_HASH SHA1=344f5803a12e7f0bafc6572b62c6c463244ee602
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/cmake/Modules/FindClipp_EP.cmake
+++ b/cmake/Modules/FindClipp_EP.cmake
@@ -55,8 +55,8 @@ if (NOT CLIPP_FOUND)
       PREFIX "externals"
       # Set download name to avoid collisions with only the version number in the filename
       DOWNLOAD_NAME ep_clipp.zip
-      URL "https://github.com/muellan/clipp/archive/v1.1.0.zip"
-      URL_HASH SHA1=df30cf97426fead8c34899065181adea747981e2
+      URL "https://github.com/muellan/clipp/archive/v1.2.3.zip"
+      URL_HASH SHA1=5cb4255d29e1b47b5d5abf7481befe659ffc3ee1
       UPDATE_COMMAND ""
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""

--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -76,8 +76,8 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
       PREFIX "externals"
       # Set download name to avoid collisions with only the version number in the filename
       DOWNLOAD_NAME ep_curl.tar.gz
-      URL "https://curl.haxx.se/download/curl-7.71.1.tar.gz"
-      URL_HASH SHA1=9c032e134c7684f34f98afaf9974f048da893930
+      URL "https://curl.se/download/curl-7.74.0.tar.gz"
+      URL_HASH SHA1=cd7239cf9223b39ade86a14eb37fe68f5656eae9
       CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         -DCMAKE_BUILD_TYPE=Release
@@ -130,8 +130,8 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
 
     ExternalProject_Add(ep_curl
       PREFIX "externals"
-      URL "https://curl.haxx.se/download/curl-7.71.1.tar.gz"
-      URL_HASH SHA1=9c032e134c7684f34f98afaf9974f048da893930
+      URL "https://curl.se/download/curl-7.74.0.tar.gz"
+      URL_HASH SHA1=cd7239cf9223b39ade86a14eb37fe68f5656eae9
       CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -E env PKG_CONFIG_PATH=${SSL_PKG_CONFIG_PATH} ${TILEDB_EP_BASE}/src/ep_curl/configure
           --prefix=${TILEDB_EP_INSTALL_PREFIX}

--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -71,7 +71,7 @@ endif()
 if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
   message(STATUS "Adding Curl as an external project")
   if (WIN32)
-    set(WITH_SSL "-DCMAKE_USE_WINSSL=ON")
+    set(WITH_SSL "-DCMAKE_USE_SCHANNEL=ON")
     ExternalProject_Add(ep_curl
       PREFIX "externals"
       # Set download name to avoid collisions with only the version number in the filename

--- a/cmake/Modules/FindLZ4_EP.cmake
+++ b/cmake/Modules/FindLZ4_EP.cmake
@@ -80,13 +80,13 @@ if (NOT LZ4_FOUND)
     if (WIN32)
       set(ARCH_SPEC -A X64)
     endif()
-    set(LZ4_CMAKE_DIR "${TILEDB_EP_SOURCE_DIR}/ep_lz4/contrib/cmake_unofficial")
+    set(LZ4_CMAKE_DIR "${TILEDB_EP_SOURCE_DIR}/ep_lz4/build/cmake/")
     ExternalProject_Add(ep_lz4
       PREFIX "externals"
       # Set download name to avoid collisions with only the version number in the filename
       DOWNLOAD_NAME ep_lz4.zip
-      URL "https://github.com/lz4/lz4/archive/v1.8.2.zip"
-      URL_HASH SHA1=ebf6c227965318ecd73820ade8f5dbd83d48b3e8
+      URL "https://github.com/lz4/lz4/archive/v1.9.3.zip"
+      URL_HASH SHA1=3e28f6691ee45c468b5aba3943bf26528b030a55
       CONFIGURE_COMMAND
         ${CMAKE_COMMAND}
           ${ARCH_SPEC}
@@ -112,6 +112,8 @@ if (NOT LZ4_FOUND)
     message(FATAL_ERROR "Unable to find LZ4")
   endif()
 endif()
+
+set(ignoreUnusedWarning "${TILEDB_LZ4_EP_BUILT}")
 
 if (LZ4_FOUND AND NOT TARGET LZ4::LZ4)
   add_library(LZ4::LZ4 UNKNOWN IMPORTED)

--- a/cmake/Modules/FindOpenSSL_EP.cmake
+++ b/cmake/Modules/FindOpenSSL_EP.cmake
@@ -91,8 +91,8 @@ if (NOT OPENSSL_FOUND AND TILEDB_SUPERBUILD)
 
   ExternalProject_Add(ep_openssl
     PREFIX "externals"
-    URL "https://github.com/openssl/openssl/archive/OpenSSL_1_1_0h.zip"
-    URL_HASH SHA1=7558a4444480047759041df1424071041b91d065
+    URL "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1i.zip"
+    URL_HASH SHA1=627938302f681dfac186a9225b65368516b4f484
     CONFIGURE_COMMAND
       ${TILEDB_EP_BASE}/src/ep_openssl/config
         --prefix=${TILEDB_EP_INSTALL_PREFIX}

--- a/cmake/Modules/FindZstd_EP.cmake
+++ b/cmake/Modules/FindZstd_EP.cmake
@@ -89,8 +89,8 @@ if (NOT ZSTD_FOUND)
       PREFIX "externals"
       # Set download name to avoid collisions with only the version number in the filename
       DOWNLOAD_NAME ep_zstd.zip
-      URL "https://github.com/facebook/zstd/archive/v1.3.4.zip"
-      URL_HASH SHA1=2f33cb8af3c964124be67ff4a50824a85b5e1907
+      URL "https://github.com/facebook/zstd/archive/v1.4.8.zip"
+      URL_HASH SHA1=8323c212a779ada25f5d587349326e84b047b536
       CONFIGURE_COMMAND
         ${CMAKE_COMMAND}
         ${ARCH_SPEC}

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -120,9 +120,11 @@ TEST_CASE("C++ API: Config Equality", "[cppapi], [cppapi-config]") {
   config1["foo"] = "bar";
   tiledb::Config config2;
   config2["foo"] = "bar";
-  CHECK(config1 == config2);
+  bool config_equal = config1 == config2;
+  CHECK(config_equal);
 
   // Check for inequality
   config2["foo"] = "bar2";
-  CHECK(config1 != config2);
+  bool config_not_equal = config1 != config2;
+  CHECK(config_not_equal);
 }

--- a/test/src/unit-cppapi-metadata.cc
+++ b/test/src/unit-cppapi-metadata.cc
@@ -264,7 +264,7 @@ TEST_CASE_METHOD(
   v_type = (tiledb_datatype_t)std::numeric_limits<int32_t>::max();
   has_key = array.has_metadata("non-existent-key", &v_type);
   CHECK(has_key == false);
-  CHECK(v_type == std::numeric_limits<int32_t>::max());
+  CHECK(v_type == (tiledb_datatype_t)std::numeric_limits<int32_t>::max());
 
   // Close array
   array.close();

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -1716,7 +1716,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter]") {
       uint64_t elt = 0;
       CHECK(chunked_buffer.read(&elt, sizeof(uint64_t), (i * sizeof(uint64_t)))
                 .ok());
-      CHECK(elt == rng(gen_copy));
+      CHECK((int64_t)elt == rng(gen_copy));
     }
   }
 

--- a/test/src/unit-hdfs-filesystem.cc
+++ b/test/src/unit-hdfs-filesystem.cc
@@ -81,9 +81,9 @@ TEST_CASE("Test HDFS filesystem", "[hdfs]") {
   st = hdfs.touch(URI("hdfs:///tiledb_test/tiledb_test_file"));
   CHECK(st.ok());
 
-  tSize buffer_size = 100000;
+  uint64_t buffer_size = 100000;
   auto write_buffer = new char[buffer_size];
-  for (int i = 0; i < buffer_size; i++) {
+  for (uint64_t i = 0; i < buffer_size; i++) {
     write_buffer[i] = 'a' + (i % 26);
   }
   st = hdfs.write(

--- a/test/src/unit-threadpool.cc
+++ b/test/src/unit-threadpool.cc
@@ -174,7 +174,7 @@ TEST_CASE(
     }
 
     REQUIRE(result == num_ok);
-    REQUIRE(num_cancelled == (tasks.size() - num_ok));
+    REQUIRE(num_cancelled == ((int64_t)tasks.size() - num_ok));
   }
 }
 


### PR DESCRIPTION
This ticket is updating `Clipp, Curl, LZ4, OpenSSL, Zstd` and `Catch` to the latest stable versions.
For `bzip2` and `zlib` there are no newer versions.

The following dependencies are out of the scope of this ticket: `clang-tools (tidy, format), capnp, AWS, Azure, GCS, spdlog, TBB`