### PR TITLE
Heap Profiler

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -88,6 +88,7 @@ endif()
 
 # List of all core source files
 set(TILEDB_CORE_SOURCES
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/heap_profiler.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/logger.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/status.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/thread_pool.cc

--- a/tiledb/common/heap_profiler.cc
+++ b/tiledb/common/heap_profiler.cc
@@ -1,0 +1,336 @@
+/**
+ * @file   heap_profiler.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains definitions of statistics-related code.
+ */
+
+#include <fstream>
+#include <iostream>
+
+#include "tiledb/common/heap_profiler.h"
+
+namespace tiledb {
+namespace common {
+
+HeapProfiler heap_profiler;
+
+// A callback to dump stats and terminate when the C++
+// allocation APIs fail (e.g. ::operator new).
+void failed_cpp_alloc_cb() {
+  heap_profiler.dump_and_terminate_internal();
+}
+
+/* ****************************** */
+/*   CONSTRUCTORS & DESTRUCTORS   */
+/* ****************************** */
+
+HeapProfiler::HeapProfiler()
+    : dump_interval_ms_(0)
+    , dump_interval_bytes_(0)
+    , reserved_memory_(nullptr)
+    , num_allocs_(0)
+    , num_deallocs_(0)
+    , num_alloc_bytes_(0)
+    , num_dealloc_bytes_(0)
+    , last_interval_dump_alloc_bytes_(0) {
+}
+
+HeapProfiler::~HeapProfiler() {
+  if (periodic_dump_thread_ != nullptr) {
+    // Set `dump_interval_ms_` to 0 to signal `periodic_dump_thread_`
+    // to stop. We intentionally leave `dump_interval_ms_` unprotected
+    // because we only mutate it one time (here) after initialization.
+    dump_interval_ms_ = 0;
+    periodic_dump_thread_->join();
+  }
+
+  // TODO free all labels
+}
+
+/* ****************************** */
+/*              API               */
+/* ****************************** */
+
+void HeapProfiler::enable(
+    const std::string& file_name_prefix,
+    const uint64_t dump_interval_ms,
+    const uint64_t dump_interval_bytes,
+    const uint64_t dump_threshold_bytes) {
+  std::unique_lock<std::mutex> ul(mutex_);
+
+  if (enabled()) {
+    std::cerr << "TileDB: HeapProfiler can not be reinitialized" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  dump_interval_ms_ = dump_interval_ms;
+  dump_interval_bytes_ = dump_interval_bytes;
+  dump_threshold_bytes_ = dump_threshold_bytes;
+
+  // Reserve 50MiB to free when we encounter an out-of-memory
+  // scenario. This attempts to ensure there is enough memory
+  // available to dump stats.
+  reserved_memory_ = std::malloc(50 * 1024 * 1024);
+
+  if (!file_name_prefix.empty())
+    file_name_ = create_dump_file(file_name_prefix);
+
+  if (dump_interval_ms_ > 0)
+    start_periodic_dump();
+
+  // Attach a callback for when the C++ allocation APIs fail.
+  std::set_new_handler(failed_cpp_alloc_cb);
+}
+
+void HeapProfiler::record_alloc(
+    void* const p, const size_t size, const std::string& label) {
+  std::unique_lock<std::mutex> ul(mutex_);
+
+  try {
+    const uint64_t addr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p));
+    assert(addr_to_alloc_.count(addr) > 1);
+    if (addr_to_alloc_.count(addr) > 1) {
+      std::cerr << "TileDB:: duplicate alloc on " << std::hex << addr
+                << std::endl;
+      return;
+    }
+
+    // Increment the total number of allocation operations.
+    ++num_allocs_;
+
+    // Record a mapping from `addr` to the bytes allocated and the user-provided
+    // string label (if provided). Note that labels are cached/deduped on
+    // `labels_cache_`.
+    addr_to_alloc_[addr] = std::make_pair(size, fetch_label_ptr(label));
+
+    // Increase the total number of allocated bytes.
+    num_alloc_bytes_ += size;
+
+    // Perform an interval dump if necessary.
+    try_interval_dump();
+  } catch (const std::bad_alloc&) {
+    dump_and_terminate_internal();
+  }
+}
+
+void HeapProfiler::record_dealloc(void* const p) {
+  std::unique_lock<std::mutex> ul(mutex_);
+
+  try {
+    const uint64_t addr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(p));
+    assert(addr_to_alloc_.count(addr) == 0);
+    if (addr_to_alloc_.count(addr) == 0) {
+      std::cerr << "TileDB:: unmatched dealloc on " << std::hex << addr
+                << std::endl;
+      return;
+    }
+
+    // Increment the total number of deallocation operations.
+    ++num_deallocs_;
+
+    // Increase the total number of allocated bytes.
+    num_dealloc_bytes_ += addr_to_alloc_[addr].first;
+
+    // Release the label to the `label_cache_`.
+    release_label_ptr(addr_to_alloc_[addr].second);
+    addr_to_alloc_.erase(addr);
+    ++num_deallocs_;
+  } catch (const std::bad_alloc&) {
+    dump_and_terminate_internal();
+  }
+}
+
+void HeapProfiler::dump_and_terminate() {
+  std::unique_lock<std::mutex> ul(mutex_);
+  dump_and_terminate_internal();
+}
+
+void HeapProfiler::dump() {
+  std::unique_lock<std::mutex> ul(mutex_);
+  dump_internal();
+}
+
+/* ****************************** */
+/*       PRIVATE FUNCTIONS        */
+/* ****************************** */
+
+void HeapProfiler::start_periodic_dump() {
+  // Spawn a thread to dump every `dump_interval_ms_` milliseconds.
+  periodic_dump_thread_ =
+      std::unique_ptr<std::thread>(new std::thread([this]() {
+        // Loop until `dump_interval_ms_` is set to `0` in the
+        // HeapProfiler destructor.
+        while (dump_interval_ms_ > 0) {
+          std::this_thread::sleep_for(
+              std::chrono::milliseconds(dump_interval_ms_));
+          dump();
+        }
+      }));
+}
+
+void HeapProfiler::try_interval_dump() {
+  if (dump_interval_bytes_ == 0)
+    return;
+
+  // If the total allocation bytes have increased by more than
+  // `dump_interval_bytes_` since the last interval dump, perform
+  // a dump.
+  if (num_alloc_bytes_ - last_interval_dump_alloc_bytes_ >=
+      dump_interval_bytes_) {
+    dump_internal();
+    last_interval_dump_alloc_bytes_ = num_alloc_bytes_;
+  }
+}
+
+std::string HeapProfiler::create_dump_file(
+    const std::string& file_name_prefix) {
+  const uint64_t epoch_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count();
+  const std::string file_name =
+      file_name_prefix + "__" + std::to_string(epoch_ms);
+
+  std::ofstream file_stream;
+  file_stream.open(file_name, std::ofstream::out);
+  if (!file_stream) {
+    std::cerr << "TileDB:: failed to create dump file " << file_name
+              << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  file_stream.close();
+
+  return file_name;
+}
+
+const std::string* HeapProfiler::fetch_label_ptr(const std::string& label) {
+  if (label.empty())
+    return nullptr;
+
+  // If we have an entry in `labels_cache_` with a value matching
+  // `label`, return a pointer to the cached string. Note that pointers
+  // and references to elements on `labels_cache_` are not invalidated
+  // in the event of an internal rehash.
+  auto iter = labels_cache_.find(label);
+  if (iter != labels_cache_.end()) {
+    ++iter->second;
+    return &iter->first;
+  }
+
+  std::pair<std::unordered_map<std::string, uint64_t>::iterator, bool> ret =
+      labels_cache_.emplace(label, 1);
+  assert(ret.second);
+
+  return &ret.first->first;
+}
+
+void HeapProfiler::release_label_ptr(const std::string* label) {
+  if (!label)
+    return;
+
+  // Fetch the cache entry.
+  assert(!label->empty());
+  auto iter = labels_cache_.find(*label);
+  assert(iter != labels_cache_.end());
+
+  // Decrement the reference counter. If the referene count
+  // reaches 0, free the label and delete its entry in the
+  // cache.
+  if (--iter->second == 0)
+    labels_cache_.erase(iter);
+}
+
+void HeapProfiler::dump_and_terminate_internal() {
+  // Free our reserved heap memory in an attempt to
+  // ensure there is enough memory to dump the stats.
+  free(reserved_memory_);
+
+  std::cerr << "TileDB: HeapProfiler terminating" << std::endl;
+
+  // Dump the stats and exit the process.
+  dump_internal();
+  exit(EXIT_FAILURE);
+}
+
+void HeapProfiler::dump_internal() {
+  std::ofstream file_stream;
+  if (!file_name_.empty()) {
+    file_stream.open(file_name_, std::ofstream::out | std::ofstream::app);
+    if (!file_stream) {
+      std::cerr << "TileDB:: failed to open dump file " << file_name_
+                << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+
+  std::ostream* const out_stream =
+      (file_name_.empty() ? &std::cout : &file_stream);
+
+  *out_stream << "TileDB: HeapProfiler dump" << std::endl;
+  *out_stream << "  num_allocs_ " << num_allocs_ << std::endl;
+  *out_stream << "  num_deallocs_ " << num_deallocs_ << std::endl;
+  *out_stream << "  num_alloc_bytes_ " << num_alloc_bytes_ << std::endl;
+  *out_stream << "  num_dealloc_bytes_ " << num_dealloc_bytes_ << std::endl;
+
+  // Build a map between labels and their total number of outstanding bytes.
+  std::unordered_map<const std::string*, uint64_t> label_to_alloc;
+  for (const auto& kv : addr_to_alloc_) {
+    const uint64_t bytes = kv.second.first;
+    const std::string* const label = kv.second.second;
+    if (labels_cache_[*label] == 1) {
+      // If this label is only used once, we immediately know that
+      // there are no other elements in `addr_to_alloc_` to sum.
+      // Print this now to avoid consuming more memory within
+      // `label_to_alloc`.
+      if (dump_threshold_bytes_ == 0 || bytes >= dump_threshold_bytes_)
+        *out_stream << "[" << *label << "]"
+                    << " " << bytes << std::endl;
+    } else {
+      if (label_to_alloc.count(label) == 0)
+        label_to_alloc[label] = bytes;
+      else
+        label_to_alloc[label] += bytes;
+    }
+  }
+
+  for (const auto& kv : label_to_alloc) {
+    const std::string* const label = kv.first;
+    const uint64_t bytes = kv.second;
+    if (dump_threshold_bytes_ == 0 || bytes >= dump_threshold_bytes_)
+      *out_stream << "[" << *label << "]"
+                  << " " << bytes << std::endl;
+  }
+
+  if (!file_name_.empty())
+    file_stream.close();
+}
+
+}  // namespace common
+}  // namespace tiledb

--- a/tiledb/common/heap_profiler.h
+++ b/tiledb/common/heap_profiler.h
@@ -1,0 +1,255 @@
+/**
+ * @file   heap_profiler.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the HeapProfiler.
+ */
+
+#ifndef TILEDB_HEAP_PROFILER_H
+#define TILEDB_HEAP_PROFILER_H
+
+#include <cassert>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "tiledb/common/macros.h"
+
+namespace tiledb {
+namespace common {
+
+class HeapProfiler {
+ public:
+  /* ****************************** */
+  /*   CONSTRUCTORS & DESTRUCTORS   */
+  /* ****************************** */
+
+  /** Constructor. */
+  HeapProfiler();
+
+  /** Destructor. */
+  ~HeapProfiler();
+
+  DISABLE_COPY(HeapProfiler);
+
+  DISABLE_MOVE(HeapProfiler);
+
+  /* ********************************* */
+  /*             OPERATORS             */
+  /* ********************************* */
+
+  DISABLE_COPY_ASSIGN(HeapProfiler);
+
+  DISABLE_MOVE_ASSIGN(HeapProfiler);
+
+  /* ****************************** */
+  /*              API               */
+  /* ****************************** */
+
+  /** Returns true if the heap profiler is enabled. */
+  inline bool enabled() const {
+    // We know that this instance has been initalized
+    // if `reserved_memory_` has been set.
+    return reserved_memory_ != nullptr;
+  }
+
+  /**
+   * Initialize and start the profiler.
+   *
+   * @param file_name_prefix If empty, stats are dumped to stdout.
+   *   If non-empty, this specifies the file_name prefix to
+   *   write to. For example, value "tiledb_mem_stats" will write
+   *   to "tiledb_mem_stats__1611170501", where the postfix is
+   *   determined by the current epoch.
+   * @param dump_interval_ms If non-zero, this spawns a dedicated
+   *   thread to dump on this time interval.
+   * @param dump_interval_bytes If non-zero, a dump will occur when
+   *   the total number of lifetime allocated bytes is increased by
+   *   more than this amount.
+   * @param dump_threshold_bytes If non-zero, labeled allocations with
+   *   a number of bytes lower than this threshold will not be reported
+   *   in the dump.
+   */
+  void enable(
+      const std::string& file_name_prefix,
+      uint64_t dump_interval_ms,
+      uint64_t dump_interval_bytes,
+      uint64_t dump_threshold_bytes);
+
+  /**
+   * Records a successful allocation.
+   *
+   * @param p The pointer to the allocated memory.
+   * @param size The allocation byte size of `p`.
+   * @param label An optional label to associate with this
+   *   allocation.
+   */
+  void record_alloc(void* p, size_t size, const std::string& label = "");
+
+  /**
+   * Records a deallocation, where `p` has been recorded
+   * in `record_alloc()`.
+   *
+   * @param p The pointer to the deallocated memory.
+   */
+  void record_dealloc(void* p);
+
+  /** Dumps the current stats and terminates the process. */
+  void dump_and_terminate();
+
+  /** Dumps the current stats. */
+  void dump();
+
+  /* ****************************** */
+  /*       PRIVATE ATTRIBUTES       */
+  /* ****************************** */
+
+  /**
+   * When non-empty, stats are dumped to this file instead of
+   * stdout.
+   */
+  std::string file_name_;
+
+  /**
+   * When non-zero, stats are asynchronously dumped on
+   * this time interval.
+   */
+  uint64_t dump_interval_ms_;
+
+  /**
+   * When non-zero, stats are synchronously dumped at the
+   * time of an allocation that increases the total number
+   * of allocated bytes to the next interval defiend by
+   * this value.
+   */
+  uint64_t dump_interval_bytes_;
+
+  /**
+   * When non-zero, the dump will not report labeled allocations
+   * with a byte count lower than this number.
+   */
+  uint64_t dump_threshold_bytes_;
+
+  /**
+   * When `dump_interval_ms_` is non-zero, this thread is
+   * responsible for periodically dumping the stats.
+   */
+  std::unique_ptr<std::thread> periodic_dump_thread_;
+
+  /** Protects all below member variables. */
+  std::mutex mutex_;
+
+  /**
+   * Reserve a fixed size of memory at initialization. When we
+   * are out of memory, we will free this reserved memory to
+   * in an attempt to ensure that the final
+   */
+  void* reserved_memory_;
+
+  /**
+   * Maps an address to a pair, where the pair contains the current
+   * number of allocated bytes and a pointer to a label. The
+   * labels also exist on `labels_cache_` as a way to de-duplicate
+   * identical labels.
+   */
+  std::unordered_map<uint64_t, std::pair<size_t, const std::string*>>
+      addr_to_alloc_;
+
+  /**
+   * The `record_alloc` routine allows an optional, free-form string
+   * label to associate with the allocation. For example, this could be
+   * an attribute name, a file name, a line number, etc. This map is
+   * used to deduplicate identical strings among separate
+   * allocations.
+   *
+   * The key is a shared, heap-allocated string. The associated value
+   * is a reference counter. When the reference counter reaches zero,
+   * the label is removed from this cache.
+   */
+  std::unordered_map<std::string, uint64_t> labels_cache_;
+
+  /** The total number of allocation operations. */
+  uint64_t num_allocs_;
+
+  /** The total number of deallocation operations. */
+  uint64_t num_deallocs_;
+
+  /** The total number of allocated bytes. */
+  uint64_t num_alloc_bytes_;
+
+  /** The total number of deallocated bytes. */
+  uint64_t num_dealloc_bytes_;
+
+  /**
+   * This is not a stat, but to track the allocation size
+   * of the last dump triggered by `dump_interval_bytes_`.
+   */
+  uint64_t last_interval_dump_alloc_bytes_;
+
+  /* ****************************** */
+  /*       PRIVATE FUNCTIONS        */
+  /* ****************************** */
+
+  /** Initializes and starts `periodic_dump_thread_`. */
+  void start_periodic_dump();
+
+  /** Performs an interval dump if necessary. */
+  void try_interval_dump();
+
+  /** Creates a dump file and returns the file name. */
+  std::string create_dump_file(const std::string& file_name_prefix);
+
+  /** Fetches the cached string matching the value of `label`. */
+  const std::string* fetch_label_ptr(const std::string& label);
+
+  /** Returns the cache string fetched from `fetch_label_ptr`. */
+  void release_label_ptr(const std::string* label);
+
+  /**
+   * Dumps the current stats and terminates the process without
+   * locking on `mutex_`.
+   */
+  void dump_and_terminate_internal();
+
+  /* Dumps the current stats without locking on `mutex_`. */
+  void dump_internal();
+};
+
+/* ********************************* */
+/*               GLOBAL              */
+/* ********************************* */
+
+/** The singleton instance holding all heap stats. */
+extern HeapProfiler heap_profiler;
+
+}  // namespace common
+}  // namespace tiledb
+
+#endif  // TILEDB_HEAP_PROFILER_H

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -32,6 +32,7 @@
  */
 
 #include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/common/heap_profiler.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
@@ -4757,6 +4758,23 @@ int32_t tiledb_stats_free_str(char** out) {
     std::free(*out);
     *out = nullptr;
   }
+  return TILEDB_OK;
+}
+
+/* ****************************** */
+/*          Heap Profiler         */
+/* ****************************** */
+
+int32_t tiledb_heap_profiler_enable(
+    const char* const file_name_prefix,
+    const uint64_t dump_interval_ms,
+    const uint64_t dump_interval_bytes,
+    const uint64_t dump_threshold_bytes) {
+  tiledb::common::heap_profiler.enable(
+      file_name_prefix ? std::string(file_name_prefix) : "",
+      dump_interval_ms,
+      dump_interval_bytes,
+      dump_threshold_bytes);
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -6274,6 +6274,34 @@ TILEDB_EXPORT int32_t tiledb_stats_raw_dump_str(char** out);
 TILEDB_EXPORT int32_t tiledb_stats_free_str(char** out);
 
 /* ****************************** */
+/*          Heap Profiler         */
+/* ****************************** */
+
+/**
+ * Enable heap profiling.
+ *
+ * @param file_name_prefix If empty or null, stats are dumped
+ *   to stdout. If non-empty, this specifies the file_name prefix to
+ *   write to. For example, value "tiledb_mem_stats" will write
+ *   to "tiledb_mem_stats__1611170501", where the postfix is
+ *   determined by the current epoch.
+ * @param dump_interval_ms If non-zero, this spawns a dedicated
+ *   thread to dump on this time interval.
+ * @param dump_interval_bytes If non-zero, a dump will occur when
+ *   the total number of lifetime allocated bytes is increased by
+ *   more than this amount.
+ * @param dump_threshold_bytes If non-zero, labeled allocations with
+ *   a number of bytes lower than this threshold will not be reported
+ *   in the dump.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_heap_profiler_enable(
+    const char* file_name_prefix,
+    uint64_t dump_interval_ms,
+    uint64_t dump_interval_bytes,
+    uint64_t dump_threshold_bytes);
+
+/* ****************************** */
 /*          FRAGMENT INFO         */
 /* ****************************** */
 


### PR DESCRIPTION
This introduces a new C API:
```
TILEDB_EXPORT int32_t tiledb_heap_profiler_enable(
    const char* file_name_prefix,
    uint64_t dump_interval_ms,
    uint64_t dump_interval_bytes,
    uint64_t dump_threshold_bytes);
```

Executing the API does the following:
- The singleton HeapProfiler is enabled, which may only be done once in the
lifetime of the process.
- On an uncaught `std::bad_alloc` (anywhere in the process) we will perform
a stat dump and kill the process.
- If `dump_interval_ms` is non-zero, a thread is started which will dump
the heap stats periodically.
- If `dump_interval_bytes` is non-zero, the next allocation that increases
the lifetime total allocation byte size by this amount will perform a dump.
- If `dump_threshold_bytes` non-zero, labeled allocations with a total
alloc size less than this amount will be ignored. This is used to reduce
verbosity of the dump for trivial allocations.

This is dead code at the moment. The idea is that all dynamic memory allocations
in our source code will be accompanied by a call HeapProfiler::record_alloc().
When called, this save stats. Additionally, failed dynamic memory allocations
may invoke HeapProfiler::dump_and_terminate(). Similarly for dellocations.

The HeapProfiler is responsible for:
- Setting up the uncaught `std::bad_alloc` hook.
- Setting up a periodic dump thread.
- Reserving memory at initialization. This is an opaque block of dynamic memory
  that is freed when entering dump_and_terminate(). The intention is to release
  memory after a fail allocation to provide enough memory for the dump to be
  successful.
- Keeps a "labels cache" which is basically an object pool of strings to prevent
  duplication of string labels. For example, a caller may do:
```
tiledb::common::heap_profiler.record_alloc(p1, size1, "reader.cc::1923");
tiledb::common::heap_profiler.record_alloc(p2, size2, "reader.cc::1923");
tiledb::common::heap_profiler.record_alloc(p3, size3, "reader.cc::1923");
```
  * Where "reader.cc::1923" could be generated by compilers macros, e.g. `std::string(__FILE__ + "::" + __LINE__)`.
  In this scenario, we don't want to haev 3x "reader.cc::1923" strings allocated.
  We share them in the HeapProfiler.

The next step is to refactor our code base to find-and-replace all dynamic
memory APIs with a macro/typedef that will record alloc/dealloc stats as they
are used.