### PR TITLE
C API heap profiling

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,6 +26,7 @@
 
 ### C API
 * Add `tiledb_query_set_config` to apply a `tiledb_config_t` to query-level parameters [#2030](https://github.com/TileDB-Inc/TileDB/pull/2030)
+* Add `tiledb_heap_profiler_enable` to enable heap memory profiling [#2035](https://github.com/TileDB-Inc/TileDB/pull/2035)
 
 ### C++ API
 * Added `Query::set_config` to apply a `tiledb::Config` to query-level parameters [#2030](https://github.com/TileDB-Inc/TileDB/pull/2030)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -88,6 +88,7 @@ endif()
 
 # List of all core source files
 set(TILEDB_CORE_SOURCES
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/heap_memory.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/heap_profiler.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/logger.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/status.cc

--- a/tiledb/common/heap_memory.cc
+++ b/tiledb/common/heap_memory.cc
@@ -1,0 +1,112 @@
+/**
+ * @file   heap_memory.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Implements TileDB-variants of dynamic (heap) memory allocation routines.
+ */
+
+#include <cstdlib>
+
+#include "tiledb/common/heap_memory.h"
+#include "tiledb/common/heap_profiler.h"
+
+namespace tiledb {
+namespace common {
+
+// Protects against races between memory management APIs
+// and the HeapProfiler API.
+static std::mutex heap_mem_lock;
+
+void* tiledb_malloc(const size_t size, const std::string& label) {
+  if (!heap_profiler.enabled()) {
+    return malloc(size);
+  }
+
+  std::unique_lock<std::mutex> ul(heap_mem_lock);
+
+  void* const p = malloc(size);
+
+  if (!p)
+    heap_profiler.dump_and_terminate();
+
+  heap_profiler.record_alloc(p, size, label);
+
+  return p;
+}
+
+void* tiledb_calloc(
+    const size_t num, const size_t size, const std::string& label) {
+  if (!heap_profiler.enabled()) {
+    return calloc(num, size);
+  }
+
+  std::unique_lock<std::mutex> ul(heap_mem_lock);
+
+  void* const p = calloc(num, size);
+
+  if (!p)
+    heap_profiler.dump_and_terminate();
+
+  heap_profiler.record_alloc(p, num * size, label);
+
+  return p;
+}
+
+void* tiledb_realloc(
+    void* const p, const size_t size, const std::string& label) {
+  if (!heap_profiler.enabled()) {
+    return realloc(p, size);
+  }
+
+  std::unique_lock<std::mutex> ul(heap_mem_lock);
+
+  void* const p_realloc = realloc(p, size);
+
+  if (!p_realloc)
+    heap_profiler.dump_and_terminate();
+
+  heap_profiler.record_dealloc(p);
+  heap_profiler.record_alloc(p_realloc, size, label);
+
+  return p_realloc;
+}
+
+void tiledb_free(void* const p) {
+  if (!heap_profiler.enabled()) {
+    free(p);
+    return;
+  }
+
+  std::unique_lock<std::mutex> ul(heap_mem_lock);
+
+  free(p);
+  heap_profiler.record_dealloc(p);
+}
+
+}  // namespace common
+}  // namespace tiledb

--- a/tiledb/common/heap_memory.h
+++ b/tiledb/common/heap_memory.h
@@ -1,0 +1,72 @@
+/**
+ * @file   heap_memory.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Defines TileDB-variants of dynamic (heap) memory allocation routines. When
+ * the global `heap_profiler` is enabled, these routines will record memory
+ * stats. Should allocation fail, stats will print and exit the program.
+ */
+
+#ifndef TILEDB_HEAP_MEMORY_H
+#define TILEDB_HEAP_MEMORY_H
+
+#include <string>
+
+namespace tiledb {
+namespace common {
+
+/** TileDB variant of `malloc`. */
+void* tiledb_malloc(size_t size, const std::string& label);
+
+/** TileDB variant of `calloc`. */
+void* tiledb_calloc(size_t num, size_t size, const std::string& label);
+
+/** TileDB variant of `realloc`. */
+void* tiledb_realloc(void* p, size_t size, const std::string& label);
+
+/** TileDB variant of `free`. */
+void tiledb_free(void* p);
+
+}  // namespace common
+}  // namespace tiledb
+
+#define TILEDB_HEAP_MEM_LABEL \
+  std::string(__FILE__) + std::string(":") + std::to_string(__LINE__)
+
+#define tdb_malloc(size) \
+  tiledb::common::tiledb_malloc(size, TILEDB_HEAP_MEM_LABEL)
+
+#define tdb_calloc(num, size) \
+  tiledb::common::tiledb_calloc(num, size, TILEDB_HEAP_MEM_LABEL)
+
+#define tdb_realloc(p, size) \
+  tiledb::common::tiledb_realloc(p, size, TILEDB_HEAP_MEM_LABEL)
+
+#define tdb_free(p) tiledb::common::tiledb_free(p)
+
+#endif  // TILEDB_HEAP_MEMORY_H

--- a/tiledb/sm/buffer/buffer.cc
+++ b/tiledb/sm/buffer/buffer.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/const_buffer.h"
 
@@ -74,7 +75,7 @@ Buffer::Buffer(const Buffer& buff) {
     if (buff.data_ == nullptr) {
       data_ = nullptr;
     } else {
-      data_ = std::malloc(alloced_size_);
+      data_ = tdb_malloc(alloced_size_);
       assert(data_);
       std::memcpy(data_, buff.data_, buff.alloced_size_);
     }
@@ -111,7 +112,7 @@ uint64_t Buffer::alloced_size() const {
 
 void Buffer::clear() {
   if (data_ != nullptr && owns_data_)
-    std::free(data_);
+    tdb_free(data_);
 
   data_ = nullptr;
   offset_ = 0;
@@ -169,14 +170,14 @@ Status Buffer::realloc(const uint64_t nbytes) {
   }
 
   if (data_ == nullptr) {
-    data_ = std::malloc(nbytes);
+    data_ = tdb_malloc(nbytes);
     if (data_ == nullptr) {
       return LOG_STATUS(Status::BufferError(
           "Cannot allocate buffer; Memory allocation failed"));
     }
     alloced_size_ = nbytes;
   } else if (nbytes > alloced_size_) {
-    auto new_data = std::realloc(data_, nbytes);
+    auto new_data = tdb_realloc(data_, nbytes);
     if (new_data == nullptr) {
       return LOG_STATUS(Status::BufferError(
           "Cannot reallocate buffer; Memory allocation failed"));

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -34,6 +34,7 @@
 #include <sstream>
 #include <unordered_set>
 
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/filesystem/mem_filesystem.h"
 #include "tiledb/sm/misc/utils.h"
@@ -129,7 +130,7 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
   /** Destructor. */
   ~File() {
     if (data_) {
-      free(data_);
+      tdb_free(data_);
     }
   }
 
@@ -206,7 +207,7 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
     }
 
     if (data_ == nullptr) {
-      data_ = malloc(nbytes);
+      data_ = tdb_malloc(nbytes);
       if (data_ == nullptr) {
         return LOG_STATUS(Status::MemFSError(
             std::string("Out of memory, cannot write to file")));
@@ -215,7 +216,7 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
       size_ = nbytes;
     } else {
       void* new_data;
-      new_data = realloc(data_, size_ + nbytes);
+      new_data = tdb_realloc(data_, size_ + nbytes);
 
       if (new_data == nullptr) {
         return LOG_STATUS(Status::MemFSError(

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -32,6 +32,7 @@
 #ifdef _WIN32
 
 #include "tiledb/sm/filesystem/win.h"
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/utils.h"
@@ -129,13 +130,13 @@ Status Win::touch(const std::string& filename) const {
 std::string Win::current_dir() {
   std::string dir;
   unsigned long length = GetCurrentDirectory(0, nullptr);
-  char* path = (char*)std::malloc(length * sizeof(char));
+  char* path = (char*)tdb_malloc(length * sizeof(char));
   if (path == nullptr || GetCurrentDirectory(length, path) == 0) {
     LOG_STATUS(
         Status::IOError(std::string("Failed to get current directory.")));
   }
   dir = path;
-  std::free(path);
+  tdb_free(path);
   return dir;
 }
 

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/filter/filter_pipeline.h"
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/crypto/encryption_key.h"
 #include "tiledb/sm/enums/encryption_type.h"
@@ -295,9 +296,9 @@ Status FilterPipeline::filter_chunks_reverse(
   // We will perform lazy allocation for discrete chunk buffers. For contiguous
   // chunk buffers, we will allocate the buffer now.
   if (buffer_addressing == ChunkedBuffer::BufferAddressing::CONTIGUOUS) {
-    void* buffer = malloc(total_size);
+    void* buffer = tdb_malloc(total_size);
     if (buffer == nullptr) {
-      return LOG_STATUS(Status::FilterError("malloc() failed"));
+      return LOG_STATUS(Status::FilterError("tdb_malloc() failed"));
     }
     output->set_contiguous(buffer);
   }

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/query/writer.h"
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
@@ -1301,7 +1302,7 @@ void Writer::clear_coord_buffers() {
   // Applicable only if the coordinate buffers have been allocated by
   // TileDB, which happens only when the zipped coordinates buffer is set
   for (auto b : to_clean_)
-    std::free(b);
+    tdb_free(b);
   to_clean_.clear();
   coord_buffer_sizes_.clear();
 }
@@ -3184,7 +3185,7 @@ Status Writer::split_coords_buffer() {
     auto it = coord_buffer_sizes_.emplace(dim_name, coord_buffer_size);
     QueryBuffer buff;
     buff.buffer_size_ = &(it.first->second);
-    buff.buffer_ = std::malloc(coord_buffer_size);
+    buff.buffer_ = tdb_malloc(coord_buffer_size);
     to_clean_.push_back(buff.buffer_);
     if (buff.buffer_ == nullptr)
       RETURN_NOT_OK(Status::WriterError(

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/serialization/array_schema.h"
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/attribute.h"
@@ -758,7 +759,7 @@ Status nonempty_domain_deserialize(
           RETURN_NOT_OK(utils::deserialize_coords(
               reader.getNonEmptyDomain(), dimension, &subarray));
           std::memcpy(nonempty_domain, subarray, 2 * dimension->coord_size());
-          std::free(subarray);
+          tdb_free(subarray);
         }
 
         break;
@@ -778,7 +779,7 @@ Status nonempty_domain_deserialize(
           RETURN_NOT_OK(utils::deserialize_coords(
               reader.getNonEmptyDomain(), dimension, &subarray));
           std::memcpy(nonempty_domain, subarray, 2 * dimension->coord_size());
-          std::free(subarray);
+          tdb_free(subarray);
         }
 
         break;
@@ -909,7 +910,7 @@ Status nonempty_domain_deserialize(
               nonempty_domain,
               subarray,
               2 * schema->dimension(0)->coord_size());
-          std::free(subarray);
+          tdb_free(subarray);
         }
 
         break;
@@ -932,7 +933,7 @@ Status nonempty_domain_deserialize(
               nonempty_domain,
               subarray,
               2 * schema->dimension(0)->coord_size());
-          std::free(subarray);
+          tdb_free(subarray);
         }
 
         break;

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -35,6 +35,7 @@
 
 #ifdef TILEDB_SERIALIZATION
 
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/buffer/buffer.h"
@@ -489,7 +490,7 @@ Status deserialize_subarray(
   if (subarray_buff.size() == 0) {
     *subarray = nullptr;
   } else {
-    *subarray = std::malloc(subarray_size);
+    *subarray = tdb_malloc(subarray_size);
     std::memcpy(*subarray, subarray_buff.data(), subarray_size);
   }
 
@@ -537,7 +538,7 @@ Status deserialize_coords(
   if (subarray_buff.size() == 0) {
     *subarray = nullptr;
   } else {
-    *subarray = std::malloc(subarray_size);
+    *subarray = tdb_malloc(subarray_size);
     std::memcpy(*subarray, subarray_buff.data(), subarray_size);
   }
 

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -32,6 +32,7 @@
  */
 
 #include "tiledb/sm/serialization/query.h"
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/buffer/buffer_list.h"
@@ -976,8 +977,8 @@ Status query_from_capnp(
         void* subarray = nullptr;
         RETURN_NOT_OK(
             utils::deserialize_subarray(subarray_reader, schema, &subarray));
-        RETURN_NOT_OK_ELSE(query->set_subarray(subarray), std::free(subarray));
-        std::free(subarray);
+        RETURN_NOT_OK_ELSE(query->set_subarray(subarray), tdb_free(subarray));
+        tdb_free(subarray);
       }
 
       // Subarray

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/tile/tile.h"
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
 
@@ -421,7 +422,7 @@ Status Tile::zip_coordinates() {
   char* const tile_c = static_cast<char*>(buffer);
 
   // Create a tile clone
-  char* const tile_tmp = static_cast<char*>(std::malloc(tile_size));
+  char* const tile_tmp = static_cast<char*>(tdb_malloc(tile_size));
   assert(tile_tmp);
   std::memcpy(tile_tmp, tile_c, tile_size);
 
@@ -437,7 +438,7 @@ Status Tile::zip_coordinates() {
   }
 
   // Clean up
-  std::free((void*)tile_tmp);
+  tdb_free((void*)tile_tmp);
 
   return Status::Ok();
 }


### PR DESCRIPTION
This adds tiledb-variants of the dynamic heap memory allocation C APIs:
malloc, calloc, realloc, free

This updates all uses of these routines in the tiledb/ directory, skipping
everything in the c_api and cpp_api folders.