### PR TITLE
Parallelize closing of files on write

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
 
 ## Improvements
 
+* Parallelize across attributes when closing a write [#2048](https://github.com/TileDB-Inc/TileDB/pull/2048)
+
 ## Deprecations
 
 ## Bug fixes


### PR DESCRIPTION
This change parallelizes the closing of files on writes. This solves a performance problem when the user was using S3 or other object store where we buffer the multi-part writes. If the user's data was below the buffer size, then no io would have occurred until the closing when we flush buffers. This causes a large performance penalty relative to expected because up to three files per field had to be uploaded serially.