### PR TITLE
Release s3 multipart lock early in flush_object

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
 
 ## Improvements
 
+* Unlock s3 multipart mutex early on flush [#2049](https://github.com/TileDB-Inc/TileDB/pull/2049)
+
 ## Deprecations
 
 ## Bug fixes

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -351,6 +351,7 @@ Status S3::flush_object(const URI& uri) {
     RETURN_NOT_OK(flush_st);
     return Status::Ok();
   }
+  multipart_lck.unlock();
 
   const MultiPartUploadState& state = state_iter->second;
 
@@ -366,7 +367,6 @@ Status S3::flush_object(const URI& uri) {
 
     auto bucket = state.bucket;
     auto key = state.key;
-    multipart_lck.unlock();
 
     wait_for_object_to_propagate(move(bucket), move(key));
 


### PR DESCRIPTION
For S3 with mutipart uploads, the last step is to flush the object. We grab an exclusive lock to get the shared state, but don't unlock it until after we complete the upload. There is no need to hold the lock after we get the shared state. Unlocking early will yield better
parallelism and performance.