### PR TITLE
Remove is_dir from `FragmentMetadata::store`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 
 * Parallelize across attributes when closing a write [#2048](https://github.com/TileDB-Inc/TileDB/pull/2048)
 * Support for dimension/attribute names that contain commonly reserved filesystem characters [#2047](https://github.com/TileDB-Inc/TileDB/pull/2047)
+* Remove unnecessary `is_dir` in `FragmentMetadata::store`, this can increase performance for s3 writes [#2050](https://github.com/TileDB-Inc/TileDB/pull/2050)
 
 ## Deprecations
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -493,13 +493,6 @@ Status FragmentMetadata::store(const EncryptionKey& encryption_key) {
   auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
   uint64_t offset = 0, nbytes;
 
-  // Do nothing if fragment directory does not exist. The fragment directory
-  // is created only when some attribute file is written
-  bool is_dir = false;
-  RETURN_NOT_OK(storage_manager_->is_dir(fragment_uri_, &is_dir));
-  if (!is_dir)
-    return Status::Ok();
-
   // Store R-Tree
   gt_offsets_.rtree_ = offset;
   RETURN_NOT_OK_ELSE(store_rtree(encryption_key, &nbytes), clean_up());


### PR DESCRIPTION
The checking for if the fragment folder exists is not needed. I've traced the path to `FragmentMetadata::store` and if the tiles are empty we exit early. There is no need to check the directory exists, and we can save what can be costly listing operation on s3.