### PR TITLE
Parallelize var/nullable/data tile writes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 * Support for dimension/attribute names that contain commonly reserved filesystem characters [#2047](https://github.com/TileDB-Inc/TileDB/pull/2047)
 * Remove unnecessary `is_dir` in `FragmentMetadata::store`, this can increase performance for s3 writes [#2050](https://github.com/TileDB-Inc/TileDB/pull/2050)
 * Improve S3 multipart locking [#2055](https://github.com/TileDB-Inc/TileDB/pull/2055)
+* Parallelize across var/nullable/data in `writer::write_tiles` [#2051](https://github.com/TileDB-Inc/TileDB/pull/2051)
 
 ## Deprecations
 


### PR DESCRIPTION
For ordered/unordered writes the write_all_tiles parallelizes across attributes but still wrote the var/nullable/data tiles serially. This
adjusts that to additionally parallelize this.