### PR TITLE
Fix race in timer stats

### DIFF
--- a/tiledb/sm/stats/timer_stat.cc
+++ b/tiledb/sm/stats/timer_stat.cc
@@ -38,12 +38,6 @@ namespace tiledb {
 namespace sm {
 namespace stats {
 
-// Static member variable definitions.
-std::unordered_map<
-    std::thread::id,
-    std::chrono::high_resolution_clock::time_point>
-    TimerStat::start_times_;
-
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
@@ -62,7 +56,7 @@ void TimerStat::start_timer(const std::thread::id tid) {
 
 void TimerStat::end_timer(const std::thread::id tid) {
   std::chrono::high_resolution_clock::time_point* const start_time =
-      &start_times_[tid];
+      &start_times_.at(tid);
 
   // Check for intersections with pending timers on other
   // threads.

--- a/tiledb/sm/stats/timer_stat.h
+++ b/tiledb/sm/stats/timer_stat.h
@@ -92,7 +92,7 @@ class TimerStat {
   double duration_;
 
   /** The start time for all pending timers. */
-  static std::unordered_map<
+  std::unordered_map<
       std::thread::id,
       std::chrono::high_resolution_clock::time_point>
       start_times_;


### PR DESCRIPTION
At an earlier point in the design of the thread-aware time stats, I had chosen
to use a static map. This was not needed in the final design and now causes
problems. Currently, stat start/stop times may cross timer types resulting
in corrupt timings.

In my test scenario,
```
// before
- Write time: 469902 secs
```

```
// after
- Write time: 0.081757 secs
```