### PR TITLE
Improve S3 multipart locking scenarios

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@
 * Parallelize across attributes when closing a write [#2048](https://github.com/TileDB-Inc/TileDB/pull/2048)
 * Support for dimension/attribute names that contain commonly reserved filesystem characters [#2047](https://github.com/TileDB-Inc/TileDB/pull/2047)
 * Remove unnecessary `is_dir` in `FragmentMetadata::store`, this can increase performance for s3 writes [#2050](https://github.com/TileDB-Inc/TileDB/pull/2050)
+* Improve S3 multipart locking [#2055](https://github.com/TileDB-Inc/TileDB/pull/2055)
 
 ## Deprecations
 

--- a/tiledb/common/rwlock.h
+++ b/tiledb/common/rwlock.h
@@ -1,0 +1,93 @@
+/**
+ * @file   rwlock.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a rwlock implementation.
+ */
+
+#include <condition_variable>
+#include <mutex>
+
+class RWLock {
+ public:
+  RWLock()
+      : writer_(false)
+      , waiting_writers_(0)
+      , readers_(0) {
+  }
+
+  ~RWLock() = default;
+
+  void read_lock() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    while (waiting_writers_ > 0 || writer_)
+      cv_.wait(ul);
+    ++readers_;
+  }
+
+  void read_unlock() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    if (--readers_ == 0)
+      cv_.notify_all();
+  }
+
+  void write_lock() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    ++waiting_writers_;
+    while (writer_ || readers_ > 0)
+      cv_.wait(ul);
+    --waiting_writers_;
+    writer_ = true;
+  }
+
+  void write_unlock() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    writer_ = false;
+    cv_.notify_all();
+  }
+
+  void write_downgrade() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    ++readers_;
+    writer_ = false;
+    cv_.notify_all();
+  }
+
+ private:
+  bool writer_;
+
+  uint64_t waiting_writers_;
+
+  uint64_t readers_;
+
+  /** Mutex */
+  std::mutex mutex_;
+
+  /** Conditional variable for tracking changes in read/write lock counts */
+  std::condition_variable cv_;
+};

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -641,6 +641,9 @@ class S3 {
   /** Set the request payer for a s3 request. */
   Aws::S3::Model::RequestPayer request_payer_;
 
+  /** Protects file_buffers map */
+  std::mutex file_buffers_mtx_;
+
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -446,130 +446,54 @@ class S3 {
         Aws::String&& in_key,
         Aws::String&& in_upload_id,
         std::map<int, Aws::S3::Model::CompletedPart>&& in_completed_parts)
-        : part_number_(in_part_number)
-        , bucket_(std::move(in_bucket))
-        , key_(std::move(in_key))
-        , upload_id_(std::move(in_upload_id))
-        , completed_parts_(std::move(in_completed_parts))
-        , st_(Status::Ok())
-        , mtx_(){};
+        : part_number(in_part_number)
+        , bucket(std::move(in_bucket))
+        , key(std::move(in_key))
+        , upload_id(std::move(in_upload_id))
+        , completed_parts(std::move(in_completed_parts))
+        , st(Status::Ok())
+        , mtx(){};
 
-    MultiPartUploadState(MultiPartUploadState&& other) {
-      std::lock_guard<std::mutex> lck(other.mtx_);
-      this->part_number_ = other.part_number_;
-      this->bucket_ = std::move(other.bucket_);
-      this->key_ = std::move(other.key_);
-      this->upload_id_ = std::move(other.upload_id_);
-      this->completed_parts_ = std::move(other.completed_parts_);
-      this->st_ = other.st_;
+    MultiPartUploadState(MultiPartUploadState&& other) noexcept {
+      std::lock_guard<std::mutex> lck(other.mtx);
+      this->part_number = other.part_number;
+      this->bucket = std::move(other.bucket);
+      this->key = std::move(other.key);
+      this->upload_id = std::move(other.upload_id);
+      this->completed_parts = std::move(other.completed_parts);
+      this->st = other.st;
     }
 
     // Copy initialization
     MultiPartUploadState(const MultiPartUploadState& other) {
-      this->part_number_ = other.part_number_;
-      this->bucket_ = other.bucket_;
-      this->key_ = other.key_;
-      this->upload_id_ = other.upload_id_;
-      this->completed_parts_ = other.completed_parts_;
-      this->st_ = other.st_;
+      this->part_number = other.part_number;
+      this->bucket = other.bucket;
+      this->key = other.key;
+      this->upload_id = other.upload_id;
+      this->completed_parts = other.completed_parts;
+      this->st = other.st;
     }
 
     /** The current part number. */
-    uint64_t part_number_;
+    uint64_t part_number;
 
     /** The AWS bucket. */
-    Aws::String bucket_;
+    Aws::String bucket;
 
     /** The AWS key. */
-    Aws::String key_;
+    Aws::String key;
 
     /** The AWS upload id. */
-    Aws::String upload_id_;
+    Aws::String upload_id;
 
     /** Maps each part number to its completed part state. */
-    std::map<int, Aws::S3::Model::CompletedPart> completed_parts_;
+    std::map<int, Aws::S3::Model::CompletedPart> completed_parts;
 
     /** The overall status of the multipart request. */
-    Status st_;
+    Status st;
 
     /** Mutex for thread safety */
-    mutable std::mutex mtx_;
-
-    /**
-     * Get part number thead safe
-     * @return part_number
-     */
-    uint64_t part_number() const;
-
-    /**
-     * Set part number thread safet
-     * @param part_number to set
-     */
-    void part_number(const uint64_t& part_number);
-
-    /**
-     * Get bucket name thread safe
-     * @return bucket name
-     */
-    Aws::String bucket() const;
-
-    /**
-     * Set the bucket name thead safe
-     * @param bucket name
-     */
-    void bucket(const Aws::String& bucket);
-
-    /**
-     * Get key prefix thread safet
-     * @return key prefix
-     */
-    Aws::String key() const;
-
-    /**
-     * Set key prefix thread safe
-     * @param key
-     */
-    void key(const Aws::String& key);
-
-    /**
-     * Get upload id thread safet
-     * @return upload id
-     */
-    Aws::String upload_id() const;
-
-    /**
-     * Set upload id thread safet
-     *
-     * @param upload_id
-     */
-    void upload_id(const Aws::String& upload_id);
-
-    /**
-     * Get a copy of the completed parts map, thread safe
-     * @return copy of completed_parts map
-     */
-    std::map<int, Aws::S3::Model::CompletedPart> completed_parts() const;
-
-    /**
-     * Emplace a part onto the completed parts map thead safe
-     * @param part_num
-     * @param part
-     * @return
-     */
-    void completed_parts_emplace(
-        const int& part_num, const Aws::S3::Model::CompletedPart& part);
-
-    /**
-     * Get status thread safet
-     * @return
-     */
-    Status st() const;
-
-    /**
-     * Set status thread safe
-     * @param st
-     */
-    void st(const Status& st);
+    mutable std::mutex mtx;
   };
 
   /* ********************************* */


### PR DESCRIPTION
This PR has 3 parts, separated into three commits. The first commit adds getters/setters for the `MultiPartUploadState` class, and adds thread-safety locking to this class. This allows us to move a lot of locking from the S3 class to a per file locking in the `MultiPartUploadState` class itself.

The second commit reworks the `multipart_upload_mtx_` locking to allow us to release early and reduce the duration and places where we hold S3 class level locking. The main changes involve switching from iterators of `multipart_upload_states_` to fetching references to the specific `MultiPartUploadState` and rely on the locking introduced to that class.

The third change, parallelizes the disconnect and the marking of completion or failure of any outstanding multi-part requests.