### PR TITLE
(#4934) add missing std::nothrow to 'new' request so can return error…

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4197,7 +4197,7 @@ int32_t tiledb_vfs_alloc(
   }
 
   // Create VFS object
-  (*vfs)->vfs_ = new tiledb::sm::VFS();
+  (*vfs)->vfs_ = new (std::nothrow) tiledb::sm::VFS();
   if ((*vfs)->vfs_ == nullptr) {
     auto st =
         Status::Error("Failed to allocate TileDB virtual filesystem object");


### PR DESCRIPTION
… to tiledb_vfs_alloc() clients as intended.