### PR TITLE
Add support for REST http requests to retry

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,8 @@
 
 ## New features
 
+* Add support for retrying REST requests that fail with certain http status code such as 503 [#2060](https://github.com/TileDB-Inc/TileDB/pull/2060)
+
 ## Improvements
 
 * Parallelize across attributes when closing a write [#2048](https://github.com/TileDB-Inc/TileDB/pull/2048)

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -211,6 +211,10 @@ void check_save_to_file() {
   std::stringstream ss;
   ss << "config.env_var_prefix TILEDB_\n";
   ss << "rest.http_compressor any\n";
+  ss << "rest.retry_count 3\n";
+  ss << "rest.retry_delay_factor 1.25\n";
+  ss << "rest.retry_http_codes 503\n";
+  ss << "rest.retry_initial_delay_ms 500\n";
   ss << "rest.server_address https://api.tiledb.com\n";
   ss << "rest.server_serialization_format CAPNP\n";
   ss << "sm.check_coord_dups true\n";
@@ -462,6 +466,10 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["rest.server_address"] = "https://api.tiledb.com";
   all_param_values["rest.server_serialization_format"] = "CAPNP";
   all_param_values["rest.http_compressor"] = "any";
+  all_param_values["rest.retry_count"] = "3";
+  all_param_values["rest.retry_delay_factor"] = "1.25";
+  all_param_values["rest.retry_initial_delay_ms"] = "500";
+  all_param_values["rest.retry_http_codes"] = "503";
   all_param_values["sm.dedup_coords"] = "false";
   all_param_values["sm.check_coord_dups"] = "true";
   all_param_values["sm.check_coord_oob"] = "true";

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1219,6 +1219,20 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The name of the registered access key to use for creation of the REST
  *    server. <br>
  *    **Default**: no default set
+ * -  `rest.retry_http_codes` <br>
+ *     CSV list of http status codes to automatically retry a REST request for
+ * <br>
+ *     **Default**: "503"
+ * -  `rest.retry_count` <br>
+ *     Number of times to retry failed REST requests <br>
+ *     **Default**: 3
+ * -  `rest.retry_initial_delay_ms` <br>
+ *     Initial delay in milliseconds to wait until retrying a REST request <br>
+ *     **Default**: 500
+ * -  `rest.retry_delay_factor` <br>
+ *     The delay factor to exponentially wait until further retries of a failed
+ * REST request <br>
+ *     **Default**: 1.25
  *
  * **Example:**
  *

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -49,11 +49,15 @@ namespace sm {
 /*        CONFIG DEFAULTS         */
 /* ****************************** */
 
+const std::string Config::CONFIG_ENVIRONMENT_VARIABLE_PREFIX = "TILEDB_";
 const std::string Config::REST_SERVER_DEFAULT_ADDRESS =
     "https://api.tiledb.com";
 const std::string Config::REST_SERIALIZATION_DEFAULT_FORMAT = "CAPNP";
 const std::string Config::REST_SERVER_DEFAULT_HTTP_COMPRESSOR = "any";
-const std::string Config::CONFIG_ENVIRONMENT_VARIABLE_PREFIX = "TILEDB_";
+const std::string Config::REST_RETRY_HTTP_CODES = "503";
+const std::string Config::REST_RETRY_COUNT = "3";
+const std::string Config::REST_RETRY_INITIAL_DELAY_MS = "500";
+const std::string Config::REST_RETRY_DELAY_FACTOR = "1.25";
 const std::string Config::SM_DEDUP_COORDS = "false";
 const std::string Config::SM_CHECK_COORD_DUPS = "true";
 const std::string Config::SM_CHECK_COORD_OOB = "true";
@@ -174,6 +178,10 @@ Config::Config() {
   param_values_["rest.server_serialization_format"] =
       REST_SERIALIZATION_DEFAULT_FORMAT;
   param_values_["rest.http_compressor"] = REST_SERVER_DEFAULT_HTTP_COMPRESSOR;
+  param_values_["rest.retry_http_codes"] = REST_RETRY_HTTP_CODES;
+  param_values_["rest.retry_count"] = REST_RETRY_COUNT;
+  param_values_["rest.retry_initial_delay_ms"] = REST_RETRY_INITIAL_DELAY_MS;
+  param_values_["rest.retry_delay_factor"] = REST_RETRY_DELAY_FACTOR;
   param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
   param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
   param_values_["sm.check_coord_dups"] = SM_CHECK_COORD_DUPS;
@@ -393,6 +401,14 @@ Status Config::unset(const std::string& param) {
         REST_SERIALIZATION_DEFAULT_FORMAT;
   } else if (param == "rest.http_compressor") {
     param_values_["rest.http_compressor"] = REST_SERVER_DEFAULT_HTTP_COMPRESSOR;
+  } else if (param == "rest.retry_http_codes") {
+    param_values_["rest.retry_http_codes"] = REST_RETRY_HTTP_CODES;
+  } else if (param == "rest.retry_count") {
+    param_values_["rest.retry_count"] = REST_RETRY_COUNT;
+  } else if (param == "rest.retry_initial_delay_ms") {
+    param_values_["rest.retry_initial_delay_ms"] = REST_RETRY_INITIAL_DELAY_MS;
+  } else if (param == "rest.retry_delay_factor") {
+    param_values_["rest.retry_delay_factor"] = REST_RETRY_DELAY_FACTOR;
   } else if (param == "config.env_var_prefix") {
     param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
   } else if (param == "sm.dedup_coords") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -38,10 +38,12 @@
 #endif
 
 #include "tiledb/common/status.h"
+#include "tiledb/sm/misc/utils.h"
 
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 using namespace tiledb::common;
 
@@ -67,6 +69,18 @@ class Config {
 
   /** The default compressor for http requests with the rest server. */
   static const std::string REST_SERVER_DEFAULT_HTTP_COMPRESSOR;
+
+  /** The default http codes to automatically retry requests on. */
+  static const std::string REST_RETRY_HTTP_CODES;
+
+  /** The default number of attempts to retry a http request. */
+  static const std::string REST_RETRY_COUNT;
+
+  /** The default initial delay for retrying a http request in milliseconds. */
+  static const std::string REST_RETRY_INITIAL_DELAY_MS;
+
+  /** The default exponential delay factor for retrying a http request. */
+  static const std::string REST_RETRY_DELAY_FACTOR;
 
   /** The prefix to use for checking for parameter environmental variables. */
   static const std::string CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
@@ -396,6 +410,22 @@ class Config {
    */
   template <class T>
   Status get(const std::string& param, T* value, bool* found) const;
+
+  /**
+   * Retrieves the value of the given parameter in the templated type.
+   * Sets `found` to `true` if found and `false` otherwise.
+   */
+  template <class T>
+  Status get_vector(
+      const std::string& param, std::vector<T>* value, bool* found) const {
+    // Check if parameter exists
+    const char* val = get_from_config_or_env(param, found);
+    if (!*found)
+      return Status::Ok();
+
+    // Parameter found, retrieve value
+    return utils::parse::convert<T>(val, value);
+  }
 
   /** Returns the param -> value map. */
   const std::map<std::string, std::string>& param_values() const;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -560,6 +560,21 @@ class Config {
    *    The name of the registered access key to use for creation of the REST
    *    server. <br>
    *    **Default**: no default set
+   * -  `rest.retry_http_codes` <br>
+   *     CSV list of http status codes to automatically retry a REST request for
+   * <br>
+   *     **Default**: "503"
+   * -  `rest.retry_count` <br>
+   *     Number of times to retry failed REST requests <br>
+   *     **Default**: 3
+   * -  `rest.retry_initial_delay_ms` <br>
+   *     Initial delay in milliseconds to wait until retrying a REST request
+   * <br>
+   *     **Default**: 500
+   * -  `rest.retry_delay_factor` <br>
+   *     The delay factor to exponentially wait until further retries of a
+   * failed REST request <br>
+   *     **Default**: 1.25
    */
   Config& set(const std::string& param, const std::string& value) {
     tiledb_error_t* err;

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -576,6 +576,8 @@ const std::array<std::string, 6> cert_files_linux = {
     "/etc/ssl/cert.pem"                                   // Alpine Linux
 };
 #endif
+
+const std::string config_delimiter = ",";
 }  // namespace constants
 
 }  // namespace sm

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -503,6 +503,9 @@ extern const std::string redirection_header_key;
 /** List of possible certificates files for libcurl */
 extern const std::array<std::string, 6> cert_files_linux;
 #endif
+
+/** Delimiter for lists passed as config parameter */
+extern const std::string config_delimiter;
 }  // namespace constants
 
 }  // namespace sm

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -232,6 +232,18 @@ class Curl {
   /** Response headers attached to each response. */
   HeaderCbData headerData;
 
+  /** Number of times to attempt retry. */
+  uint64_t retry_count_;
+
+  /** Retry backoff factor. */
+  double retry_delay_factor_;
+
+  /** Initial delay in milliseconds before attempting retry. */
+  uint64_t retry_initial_delay_ms_;
+
+  /** List of http status codes to retry. */
+  std::vector<uint32_t> retry_http_codes_;
+
   /**
    * Populates the curl slist with authorization (token or username+password),
    * and any extra headers.
@@ -312,6 +324,14 @@ class Curl {
    * @return Possibly empty error message string
    */
   std::string get_curl_errstr(CURLcode curl_code) const;
+
+  /**
+   * Checks the curl http status code to see if it matches a list of http
+   * requests to retry
+   * @param retry true if the http code matches the retry list
+   * @return Status
+   */
+  Status should_retry(bool* retry) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -509,6 +509,13 @@ std::string Stats::dump_read() const {
   auto read_cell_num = counter_stats_.find(CounterType::READ_CELL_NUM)->second;
   auto read_ops_num = counter_stats_.find(CounterType::READ_OPS_NUM)->second;
 
+  auto rest_http_retries =
+      counter_stats_.find(CounterType::REST_HTTP_RETRIES)->second;
+  // Treat this count as a double since we record the retry time in
+  // milliseconds. Divide by 1000 to get seconds
+  double rest_http_retry_time =
+      counter_stats_.find(CounterType::REST_HTTP_RETRY_TIME)->second / 1000.0f;
+
   // Derived counters.
   auto read_dim_num =
       read_dim_var_num + read_dim_fixed_num + read_dim_zipped_num;
@@ -583,6 +590,11 @@ std::string Stats::dump_read() const {
         read_unfiltered_byte_num,
         read_byte_num);
     ss << "\n";
+
+    if (rest_http_retries > 0) {
+      write(&ss, "- Number of REST HTTP retries: ", rest_http_retries);
+      write(&ss, "- Time spend in REST HTTP retries: ", rest_http_retry_time);
+    }
 
     if (read_compute_est_result_size != 0) {
       write(

--- a/tiledb/sm/stats/stats.h
+++ b/tiledb/sm/stats/stats.h
@@ -191,7 +191,9 @@ class Stats {
       WRITE_ARRAY_META_SIZE,
       WRITE_OPS_NUM,
       CONSOLIDATE_STEP_NUM,
-      VFS_S3_SLOW_DOWN_RETRIES);
+      VFS_S3_SLOW_DOWN_RETRIES,
+      REST_HTTP_RETRIES,
+      REST_HTTP_RETRY_TIME);
 
   /* ****************************** */
   /*   CONSTRUCTORS & DESTRUCTORS   */


### PR DESCRIPTION
If certain http status codes are returned from the REST server we should retry the request. This add support for retrying the curl request. Four new configuration options are added to support adjusting the retry limit, and the time between retries. The retry works with an exponential backoff.

| Parameter | Default Value |
| ------------------ | --- |
| `rest.retry_count` | `3` |
| `rest.retry_delay_factor` | `1.25` |
| `rest.retry_http_codes` | `503` |
| `rest.retry_initial_delay_ms` | `500` |