### PR TITLE
Load ArraySchema in parallel to listing fragments

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 * Support for dimension/attribute names that contain commonly reserved filesystem characters [#2047](https://github.com/TileDB-Inc/TileDB/pull/2047)
 * Remove unnecessary `is_dir` in `FragmentMetadata::store`, this can increase performance for s3 writes [#2050](https://github.com/TileDB-Inc/TileDB/pull/2050)
 * Improve S3 multipart locking [#2055](https://github.com/TileDB-Inc/TileDB/pull/2055)
+* Parallize loading fragments and array schema [#2061](https://github.com/TileDB-Inc/TileDB/pull/2061)
 
 ## Deprecations
 


### PR DESCRIPTION
For `array_open_for_reads` we can list the fragments in parallel to loading the array schema. Listing the fragments and loading the fragment metadata does not require the array schema. Loading everything in parallel can save 100-300 milliseconds in the open time for S3 based arrays.