### PR TITLE
RAII read-write lock

### DIFF
--- a/tiledb/common/rwlock.h
+++ b/tiledb/common/rwlock.h
@@ -27,22 +27,44 @@
  *
  * @section DESCRIPTION
  *
- * This file defines a rwlock implementation.
+ * This file defines and implements a write-preferring read-write lock.
  */
+
+#ifndef TILEDB_RWLOCK_H
+#define TILEDB_RWLOCK_H
 
 #include <condition_variable>
 #include <mutex>
 
+#include "tiledb/common/macros.h"
+
+namespace tiledb {
+namespace common {
+
 class RWLock {
  public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Default constructor. */
   RWLock()
       : writer_(false)
       , waiting_writers_(0)
       , readers_(0) {
   }
 
+  /** Default destructor. */
   ~RWLock() = default;
 
+  DISABLE_COPY_AND_COPY_ASSIGN(RWLock);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(RWLock);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Blocks until acquiring a read lock. */
   void read_lock() {
     std::unique_lock<std::mutex> ul(mutex_);
     while (waiting_writers_ > 0 || writer_)
@@ -50,12 +72,17 @@ class RWLock {
     ++readers_;
   }
 
+  /**
+   * Releases a read lock, must be called after
+   * `read_lock`.
+   */
   void read_unlock() {
     std::unique_lock<std::mutex> ul(mutex_);
     if (--readers_ == 0)
       cv_.notify_all();
   }
 
+  /** Blocks until acquiring a write lock. */
   void write_lock() {
     std::unique_lock<std::mutex> ul(mutex_);
     ++waiting_writers_;
@@ -65,12 +92,17 @@ class RWLock {
     writer_ = true;
   }
 
+  /**
+   * Releases a write lock, must be called after
+   * `write_lock`.
+   */
   void write_unlock() {
     std::unique_lock<std::mutex> ul(mutex_);
     writer_ = false;
     cv_.notify_all();
   }
 
+  /** Synchronously downgrades a write lock to a read lock. */
   void write_downgrade() {
     std::unique_lock<std::mutex> ul(mutex_);
     ++readers_;
@@ -79,15 +111,27 @@ class RWLock {
   }
 
  private:
-  bool writer_;
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
 
-  uint64_t waiting_writers_;
-
-  uint64_t readers_;
-
-  /** Mutex */
+  /** Protects all member variables. */
   std::mutex mutex_;
 
-  /** Conditional variable for tracking changes in read/write lock counts */
+  /** Conditional variable to signal lock activity. */
   std::condition_variable cv_;
+
+  /** True if a write lock is held. */
+  bool writer_;
+
+  /** The number of writers waiting in `write_lock`. */
+  uint64_t waiting_writers_;
+
+  /** The number of outstanding read locks. */
+  uint64_t readers_;
 };
+
+}  // namespace common
+}  // namespace tiledb
+
+#endif  // TILEDB_RWLOCK_H

--- a/tiledb/common/unique_rwlock.h
+++ b/tiledb/common/unique_rwlock.h
@@ -1,0 +1,122 @@
+/**
+ * @file   unique_rwlock.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines and implements the UniqueRWLock<R> class and
+ * type-defintions for UniqueReadLock and UniqueWriteLock.
+ */
+
+#ifndef TILEDB_UNIQUE_RWLOCK_H
+#define TILEDB_UNIQUE_RWLOCK_H
+
+#include "tiledb/common/macros.h"
+#include "tiledb/common/rwlock.h"
+
+namespace tiledb {
+namespace common {
+
+template <bool R>
+class UniqueRWLock final {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /*
+   * Value constructor. Locks `rwlock` and releases
+   * it in the destructor. If template-type `R` is
+   * true, this class performs read-locking. Otherwise,
+   * this performs write-locking.
+   *
+   * @param rwlock the read-write lock.
+   */
+  explicit UniqueRWLock(RWLock* const rwlock)
+      : rwlock_(rwlock)
+      , locked_(false) {
+    assert(rwlock_);
+
+    lock();
+  }
+
+  /** Destructor. Releases the read-write lock. */
+  ~UniqueRWLock() {
+    if (locked_)
+      unlock();
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(UniqueRWLock);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(UniqueRWLock);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Acquires the read-write lock. */
+  void lock() {
+    assert(!locked_);
+
+    if (R)
+      rwlock_->read_lock();
+    else
+      rwlock_->write_lock();
+
+    locked_ = true;
+  }
+
+  /** Releases the read-write lock. */
+  void unlock() {
+    assert(locked_);
+
+    if (R)
+      rwlock_->read_unlock();
+    else
+      rwlock_->write_unlock();
+
+    locked_ = false;
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The read-write lock. */
+  RWLock* const rwlock_;
+
+  /** True if holding a lock on `rwlock_`. */
+  bool locked_;
+};
+
+// Type-define UniqueReadLock and UniqueWriteLock.
+using UniqueReadLock = UniqueRWLock<true>;
+using UniqueWriteLock = UniqueRWLock<false>;
+
+}  // namespace common
+}  // namespace tiledb
+
+#endif  // TILEDB_UNIQUE_RWLOCK_H


### PR DESCRIPTION
This introduces `UniqueReadLock` and `UniqueWriteLock` for scoped locking on
`tiledb::common::RWLock`.