### PR TITLE
Fix nullable attributes

### DIFF
--- a/examples/c_api/nullable_attribute.c
+++ b/examples/c_api/nullable_attribute.c
@@ -37,7 +37,7 @@
 #include <tiledb/tiledb.h>
 
 // Name of array.
-const char* array_name = "nullable_attribute_array";
+const char* array_name = "nullable_attributes_array";
 
 void create_array() {
   // Create TileDB context
@@ -123,7 +123,7 @@ void write_array() {
   // Specify the validity buffer for each attribute
   uint8_t a1_validity_buf[] = {1, 0, 0, 1};
   uint64_t a1_validity_buf_size = sizeof(a1_validity_buf);
-  uint8_t a2_validity_buf[] = {0, 1, 1, 1, 0, 0, 1, 1};
+  uint8_t a2_validity_buf[] = {0, 1, 1, 0};
   uint64_t a2_validity_buf_size = sizeof(a2_validity_buf);
 
   // Set the query buffers specifying the validity for each data
@@ -173,11 +173,11 @@ void read_array() {
 
   // Set maximum buffer sizes
   uint64_t a1_data_size = 16;
-  uint64_t a1_validity_buf_size = a1_data_size;
+  uint64_t a1_validity_buf_size = 4;
 
   uint64_t a2_data_size = 32;
   uint64_t a2_off_size = 32;
-  uint64_t a2_validity_buf_size = a2_data_size;
+  uint64_t a2_validity_buf_size = 4;
 
   // Prepare the vector that will hold the result
   int* a1_data = (int*)malloc(a1_data_size);
@@ -229,8 +229,16 @@ void read_array() {
   printf("\n");
 
   printf("a2: \n");
-  for (i = 0; i < 8; ++i) {
-    (a2_validity_buf[i] > 0) ? printf("%d ", a2_data[i]) : printf("NULL ");
+  for (i = 0; i < 4; ++i) {
+    if (a2_validity_buf[i] > 0) {
+      printf("{ ");
+      printf("%d", a2_data[i * 2]);
+      printf(", ");
+      printf("%d", a2_data[i * 2 + 1]);
+      printf(" }");
+    } else {
+      printf("{ NULL }");
+    }
   }
   printf("\n");
 

--- a/examples/cpp_api/nullable_attribute.cc
+++ b/examples/cpp_api/nullable_attribute.cc
@@ -38,7 +38,7 @@
 using namespace tiledb;
 
 // Name of array.
-std::string array_name("nullable_atrributes_array");
+std::string array_name("nullable_attributes_array");
 
 void create_array() {
   // Create a TileDB context
@@ -87,7 +87,7 @@ void write_array() {
 
   // Specify the validity buffer for each attribute
   std::vector<uint8_t> a1_validity_buf = {1, 0, 0, 1};
-  std::vector<uint8_t> a2_validity_buf = {0, 1, 1, 1, 0, 0, 1, 1};
+  std::vector<uint8_t> a2_validity_buf = {0, 1, 1, 0};
 
   // Set the query buffers specifying the validity for each data
   query.set_buffer_nullable("a1", a1_data, a1_validity_buf)
@@ -110,7 +110,7 @@ void read_array() {
 
   std::vector<int> a2_data(8);
   std::vector<uint64_t> a2_off(4);
-  std::vector<uint8_t> a2_validity_buf(a2_data.size());
+  std::vector<uint8_t> a2_validity_buf(a2_off.size());
 
   // Prepare and submit the query, and close the array
   Query query(ctx, array);
@@ -136,8 +136,16 @@ void read_array() {
   std::cout << std::endl;
 
   std::cout << "a2: " << std::endl;
-  for (i = 0; i < 8; ++i) {
-    std::cout << (a2_validity_buf[i] > 0 ? std::to_string(a2_data[i]) : "NULL");
+  for (i = 0; i < 4; ++i) {
+    if (a2_validity_buf[i] > 0) {
+      std::cout << "{ ";
+      std::cout << std::to_string(a2_data[i * 2]);
+      std::cout << ", ";
+      std::cout << std::to_string(a2_data[i * 2 + 1]);
+      std::cout << " }";
+    } else {
+      std::cout << "{ NULL }";
+    }
     std::cout << " ";
   }
   std::cout << std::endl;


### PR DESCRIPTION
Currently, the nullable examples are per-value instead of per-cell. This
modifies the examples to use per-cell validity values.