### PR TITLE
static_cast to bool to fix build on Apple Clang 11

### DIFF
--- a/tiledb/common/heap_memory.h
+++ b/tiledb/common/heap_memory.h
@@ -197,7 +197,7 @@ class tiledb_shared_ptr {
   }
 
   explicit operator bool() const noexcept {
-    return sp_;
+    return sp_ ? true : false;
   }
 
   long int use_count() const noexcept {


### PR DESCRIPTION
Fixes the following build error on Apple Clang 11 (CI is on Apple Clang 12):
```
TileDB/tiledb/../tiledb/common/heap_memory.h:200:12: error: no viable conversion from returned value of type
      'const std::shared_ptr<blob_client>' to function return type 'bool'
    return sp_;
           ^~~
/Users/inorton/work/git/TileDB/tiledb/sm/filesystem/azure.cc:173:3: note: in instantiation of member function
      'tiledb::common::tiledb_shared_ptr<azure::storage_lite::blob_client>::operator bool' requested here
  assert(client_);
```