### PR TITLE
Use debug instead of release on macOS CI

### DIFF
--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -159,7 +159,7 @@ steps:
     if [[ "$AGENT_OS" == "Darwin" ]]; then
       # We want to be able to print a stack trace when a core dump occurs
       sudo chmod 1777 /cores
-      bootstrap_args="${bootstrap_args} --enable-release-symbols";
+      bootstrap_args="${bootstrap_args} --enable-debug";
     fi
 
     # displayName: 'Install dependencies'


### PR DESCRIPTION
It seems that we need to use debug - even temporarily - to be able to dig deeper into the frequent macOS failures now that we have access to the stack trace of the crash, since optimisations are kicking in making investigation hard

For example:
https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=9402&view=logs&j=a61baa00-dda3-5af5-052d-d606a187faa9&t=d33ba111-1ddb-5d82-c878-738d39b7c42a
