### PR TITLE
Add c++ api Config constructors from STL maps

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,8 @@
 
 ### C++ API
 
+* Add new Config constructors for converting from STL map types [#2081](https://github.com/TileDB-Inc/TileDB/pull/2081)
+
 # TileDB v2.2.3 Release Notes
 
 ## New features

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -38,8 +38,10 @@
 #include "tiledb.h"
 #include "utils.h"
 
+#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace tiledb {
 
@@ -194,6 +196,31 @@ class Config {
     if (config) {
       config_ = std::shared_ptr<tiledb_config_t>(*config, Config::free);
       *config = nullptr;
+    }
+  }
+
+  /**
+   * Constructor that takes as input a STL map that stores the config parameters
+   *
+   * @param config
+   */
+  explicit Config(const std::map<std::string, std::string>& config) {
+    create_config();
+    for (const auto& kv : config) {
+      set(kv.first, kv.second);
+    }
+  }
+
+  /**
+   * Constructor that takes as input a STL unordered_map that stores the config
+   * parameters
+   *
+   * @param config
+   */
+  explicit Config(const std::unordered_map<std::string, std::string>& config) {
+    create_config();
+    for (const auto& kv : config) {
+      set(kv.first, kv.second);
     }
   }
 


### PR DESCRIPTION
This adds two new constructors to the c++ api that lets a user create a configuration object from a `map` or `unordered_map`.