### PR TITLE
Run tiledb_unit with -d to get test names and durations

### DIFF
--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -198,7 +198,7 @@ steps:
     else
       # run directly the executable, cmake catches the segfault and blocks
       # the core dump
-      ./tiledb/test/tiledb_unit
+      ./tiledb/test/tiledb_unit -d yes
     fi
 
     # Kill the running Minio server, OSX only because Linux runs it within


### PR DESCRIPTION
Switching to direct invocation of `tiledb_unit` disabled the test name/duration output. Re-enable by running with `tiledb_unit -d yes` (because that output can sometimes be useful for debugging).