### PR TITLE
Adjust GCS multipart locking to be URI based

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
 
 ## Improvements
 
+* Improve GCS multipart locking [#2087](https://github.com/TileDB-Inc/TileDB/pull/2087)
+
 ## Deprecations
 
 ## Bug fixes

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -41,6 +41,7 @@
 #include <unordered_set>
 
 #include "tiledb/common/logger.h"
+#include "tiledb/common/unique_rwlock.h"
 #include "tiledb/sm/filesystem/gcs.h"
 #include "tiledb/sm/global_state/global_state.h"
 #include "tiledb/sm/misc/utils.h"
@@ -790,37 +791,56 @@ Status GCS::write_parts(
   std::string object_path;
   RETURN_NOT_OK(parse_gcs_uri(uri, &bucket_name, &object_path));
 
-  // Protect 'multi_part_upload_states_' from concurrent read and writes.
-  std::unique_lock<std::mutex> states_lock(multi_part_upload_states_lock_);
+  MultiPartUploadState* state;
+  std::unique_lock<std::mutex> state_lck;
+
+  // Take a lock protecting the shared multipart data structures
+  // Read lock to see if it exists
+  UniqueReadLock unique_rl(&multipart_upload_rwlock_);
 
   auto state_iter = multi_part_upload_states_.find(uri.to_string());
   if (state_iter == multi_part_upload_states_.end()) {
-    // Delete file if it exists (overwrite).
-    bool exists;
-    RETURN_NOT_OK(is_object(uri, &exists));
-    if (exists) {
-      RETURN_NOT_OK(remove_object(uri));
+    // If the state is new, we must grab write lock, so unlock from read and
+    // grab write
+    unique_rl.unlock();
+    UniqueWriteLock unique_wl(&multipart_upload_rwlock_);
+    // Since we switched locks we need to once again check to make sure another
+    // thread didn't create the state
+    state_iter = multi_part_upload_states_.find(uri.to_string());
+    if (state_iter == multi_part_upload_states_.end()) {
+      // Instantiate the new state.
+      MultiPartUploadState new_state(object_path);
+
+      // Store the new state.
+      multi_part_upload_states_.emplace(uri.to_string(), std::move(new_state));
+      state = &multi_part_upload_states_.at(uri.to_string());
+      state_lck = std::unique_lock<std::mutex>(state->mtx_);
+
+      // Downgrade to read lock, expected below outside the create
+      unique_wl.unlock();
+
+      // Delete file if it exists (overwrite).
+      bool exists;
+      RETURN_NOT_OK(is_object(uri, &exists));
+      if (exists) {
+        RETURN_NOT_OK(remove_object(uri));
+      }
+    } else {
+      // If another thread switched state, switch back to a read lock
+      state = &multi_part_upload_states_.at(uri.to_string());
+
+      // Lock multipart state
+      state_lck = std::unique_lock<std::mutex>(state->mtx_);
     }
+  } else {
+    state = &multi_part_upload_states_.at(uri.to_string());
 
-    // Instantiate the new state.
-    MultiPartUploadState state(object_path);
+    // Lock multipart state
+    state_lck = std::unique_lock<std::mutex>(state->mtx_);
 
-    // Store the new state.
-    const std::pair<
-        std::unordered_map<std::string, MultiPartUploadState>::iterator,
-        bool>
-        emplaced = multi_part_upload_states_.emplace(
-            uri.to_string(), std::move(state));
-    assert(emplaced.second);
-    state_iter = emplaced.first;
+    // Unlock, as make_upload_part_req will reaquire as necessary.
+    unique_rl.unlock();
   }
-
-  MultiPartUploadState* const state = &state_iter->second;
-
-  // We're done reading and writing from 'multi_part_upload_states_'. Mutating
-  // the 'state' element does not affect the thread-safety of
-  // 'multi_part_upload_states_'.
-  states_lock.unlock();
 
   if (num_ops == 1) {
     const std::string object_part_path = state->next_part_path();
@@ -828,6 +848,7 @@ Status GCS::write_parts(
     const Status st =
         upload_part(bucket_name, object_part_path, buffer, length);
     state->update_st(st);
+    state_lck.unlock();
     return st;
   } else {
     std::vector<ThreadPool::Task> tasks;
@@ -854,6 +875,7 @@ Status GCS::write_parts(
 
     const Status st = thread_pool_->wait_all(tasks);
     state->update_st(st);
+    state_lck.unlock();
     return st;
   }
 
@@ -900,7 +922,8 @@ Status GCS::flush_object(const URI& uri) {
   const Status flush_write_cache_st =
       flush_write_cache(uri, write_cache_buffer, true);
 
-  std::unique_lock<std::mutex> states_lock(multi_part_upload_states_lock_);
+  // Take a lock protecting 'multipart_upload_states_'.
+  UniqueReadLock unique_rl(&multipart_upload_rwlock_);
 
   if (multi_part_upload_states_.count(uri.to_string()) == 0) {
     return flush_write_cache_st;
@@ -909,7 +932,9 @@ Status GCS::flush_object(const URI& uri) {
   MultiPartUploadState* const state =
       &multi_part_upload_states_.at(uri.to_string());
 
-  states_lock.unlock();
+  // Lock multipart state
+  std::unique_lock<std::mutex> state_lck(state->mtx_);
+  unique_rl.unlock();
 
   const std::vector<std::string> part_paths = state->get_part_paths();
 
@@ -922,8 +947,9 @@ Status GCS::flush_object(const URI& uri) {
   std::string last_part_path = part_paths.back();
   const Status st = wait_for_object_to_propagate(bucket_name, last_part_path);
   state->update_st(st);
+  state_lck.unlock();
 
-  if (!state->st().ok()) {
+  if (!st.ok()) {
     // Delete all outstanding part objects.
     delete_parts(bucket_name, part_paths);
 
@@ -1010,9 +1036,9 @@ Status GCS::delete_part(
 
 void GCS::finish_multi_part_upload(const URI& uri) {
   // Protect 'multi_part_upload_states_' from multiple writers.
-  std::unique_lock<std::mutex> states_lock(multi_part_upload_states_lock_);
+  UniqueWriteLock unique_wl(&multipart_upload_rwlock_);
   multi_part_upload_states_.erase(uri.to_string());
-  states_lock.unlock();
+  unique_wl.unlock();
 
   // Protect 'write_cache_map_' from multiple writers.
   std::unique_lock<std::mutex> cache_lock(write_cache_map_lock_);

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -37,6 +37,7 @@
 
 #include <google/cloud/storage/client.h>
 
+#include "tiledb/common/rwlock.h"
 #include "tiledb/common/status.h"
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
@@ -299,6 +300,29 @@ class GCS {
         , st_(Status::Ok()) {
     }
 
+    MultiPartUploadState(MultiPartUploadState&& other) noexcept {
+      this->object_path_ = std::move(other.object_path_);
+      this->next_part_id_ = other.next_part_id_;
+      this->part_paths_ = std::move(other.part_paths_);
+      this->st_ = other.st_;
+    }
+
+    // Copy initialization
+    MultiPartUploadState(const MultiPartUploadState& other) {
+      this->object_path_ = other.object_path_;
+      this->next_part_id_ = other.next_part_id_;
+      this->part_paths_ = other.part_paths_;
+      this->st_ = other.st_;
+    }
+
+    MultiPartUploadState& operator=(const MultiPartUploadState& other) {
+      this->object_path_ = other.object_path_;
+      this->next_part_id_ = other.next_part_id_;
+      this->part_paths_ = other.part_paths_;
+      this->st_ = other.st_;
+      return *this;
+    }
+
     /* Generates the next part path. */
     std::string next_part_path() {
       const uint64_t part_id = next_part_id_++;
@@ -324,6 +348,9 @@ class GCS {
         st_ = st;
       }
     }
+
+    /** Mutex for thread safety */
+    mutable std::mutex mtx_;
 
    private:
     // The object path for the final composed object.
@@ -383,8 +410,8 @@ class GCS {
   std::unordered_map<std::string, MultiPartUploadState>
       multi_part_upload_states_;
 
-  /** Protects 'multi_part_upload_states_'. */
-  std::mutex multi_part_upload_states_lock_;
+  /** Protects 'multipart_upload_states_'. */
+  RWLock multipart_upload_rwlock_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -1376,7 +1376,7 @@ Status S3::write_multipart(
 
     // Since we switched locks we need to once again check to make sure another
     // thread didn't create the state
-    auto state_iter = multipart_upload_states_.find(uri_path);
+    state_iter = multipart_upload_states_.find(uri_path);
     if (state_iter == multipart_upload_states_.end()) {
       auto& path = aws_uri.GetPath();
       std::string path_str = path.c_str();


### PR DESCRIPTION
Previously GCS used class level locking around multipart uploads. This switches so that each multipart state uses its own locking. The class level map for in-progress multipart uploads is switched to use a read/write lock.

These same changes were made to the S3 class and saved several seconds in the example where there was a large number of attributes and only a few MB of data.