### PR TITLE
Limit range splits on string dimensions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@
 ## Deprecations
 
 ## Bug fixes
+* Fix an edge-case where a read query may hang on array with string dimensions [#2089](https://github.com/TileDB-Inc/TileDB/pull/2089)
 * Fix mutex locking bugs on Windows due to unlocking on different thread and missing task join [#2077](https://github.com/TileDB-Inc/TileDB/pull/2077)
 
 ## API additions

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -191,6 +191,7 @@ if (TILEDB_CPP_API)
     src/unit-cppapi-nullable.cc
     src/unit-cppapi-query.cc
     src/unit-cppapi-schema.cc
+    src/unit-cppapi-string-dims.cc
     src/unit-cppapi-subarray.cc
     src/unit-cppapi-type.cc
     src/unit-cppapi-updates.cc

--- a/test/src/unit-cppapi-string-dims.cc
+++ b/test/src/unit-cppapi-string-dims.cc
@@ -1,0 +1,110 @@
+/**
+ * @file   unit-cppapi-string-dims.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C++ API with string dimensions.
+ */
+
+#include "catch.hpp"
+#include "tiledb/sm/cpp_api/tiledb"
+
+using namespace tiledb;
+
+TEST_CASE(
+    "C++ API: Test infinite string splits",
+    "[cppapi][string-dim][infinite-split]") {
+  const std::string array_name = "cpp_unit_array";
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  // Define a sparse, 2D array where the first dimension is a string. We will
+  // test a read query that would cause an infinite loop splitting string
+  // dimensions if not for our fixed limit
+  // `constants::max_string_dim_split_depth`.
+  Domain domain(ctx);
+  domain
+      .add_dimension(
+          Dimension::create(ctx, "dim1", TILEDB_STRING_ASCII, nullptr, nullptr))
+      .add_dimension(Dimension::create<int32_t>(ctx, "dim2", {{0, 9}}, 10));
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  schema.add_attribute(Attribute::create<int32_t>(ctx, "a1"));
+  Array::create(array_name, schema);
+
+  // Write data to the array.
+  std::vector<char> dim1 = {'a', 'b', 'b', 'c', 'a', 'b', 'b', 'c'};
+  std::vector<uint64_t> dim1_offsets = {0, 1, 3, 4, 5, 7};
+  std::vector<int32_t> dim2 = {1, 1, 1, 2, 2, 2};
+  std::vector<int32_t> a1_data = {1, 2, 3, 4, 5, 6};
+  Array array_write(ctx, array_name, TILEDB_WRITE);
+  Query query_write(ctx, array_write, TILEDB_WRITE);
+  query_write.set_layout(TILEDB_UNORDERED)
+      .set_buffer("a1", a1_data)
+      .set_buffer("dim1", dim1_offsets, dim1)
+      .set_buffer("dim2", dim2);
+
+  // Perform the write and close the array.
+  query_write.submit();
+  array_write.close();
+
+  // Prepare a read query.
+  Array array_read(ctx, array_name, TILEDB_READ);
+  Query query_read(ctx, array_read, TILEDB_READ);
+  auto dim1_non_empty_domain = array_read.non_empty_domain_var(0);
+  auto dim2_non_empty_domain = array_read.non_empty_domain<int32_t>(1);
+  query_read.add_range(
+      0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
+  query_read.add_range<int32_t>(
+      1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
+
+  // Prepare buffers with small enough sizes to ensure the string dimension
+  // must split.
+  a1_data = std::vector<int32_t>(2);
+  dim1 = std::vector<char>(8);
+  dim1_offsets = std::vector<uint64_t>(1);
+  dim2 = std::vector<int32_t>(1);
+
+  query_read.set_layout(TILEDB_ROW_MAJOR)
+      .set_buffer("a1", a1_data)
+      .set_buffer("dim1", dim1_offsets, dim1)
+      .set_buffer("dim2", dim2);
+
+  // Submit the query and ensure it does not hang on an infinite loop.
+  tiledb::Query::Status status = tiledb::Query::Status::UNINITIALIZED;
+  do {
+    status = query_read.submit();
+  } while (status == tiledb::Query::Status::INCOMPLETE);
+
+  array_read.close();
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+}

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -472,6 +472,12 @@ const uint32_t format_version = 8;
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
 const uint64_t max_tile_chunk_size = 64 * 1024;
 
+/**
+ * Maximum splitting depth on a string dimension. For a maximum depth
+ * of D, the maximum number of splits is 2^D.
+ */
+const uint64_t max_string_dim_split_depth = 7;
+
 /** Maximum number of attempts to wait for an S3 response. */
 const unsigned int s3_max_attempts = 100;
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -459,6 +459,12 @@ extern const uint32_t format_version;
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
 extern const uint64_t max_tile_chunk_size;
 
+/**
+ * Maximum splitting depth on a string dimension. For a maximum depth
+ * of D, the maximum number of splits is 2^D.
+ */
+extern const uint64_t max_string_dim_split_depth;
+
 /** Maximum number of attempts to wait for an S3 response. */
 extern const unsigned int s3_max_attempts;
 

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -59,7 +59,8 @@ class Range {
  public:
   /** Default constructor. */
   Range()
-      : range_start_size_(0) {
+      : range_start_size_(0)
+      , partition_depth_(0) {
   }
 
   /** Constructor setting a range. */
@@ -227,14 +228,32 @@ class Range {
     return range_start_size_ != 0;
   }
 
+  /** Sets the partition depth. */
+  void set_partition_depth(uint64_t partition_depth) {
+    partition_depth_ = partition_depth;
+  }
+
+  /** Returns the partition depth. */
+  uint64_t partition_depth() const {
+    return partition_depth_;
+  }
+
  private:
   /** The range as a flat byte vector.*/
   std::vector<uint8_t> range_;
+
   /**
    * Non-zero only for var-sized ranges. It is the size of the
    * start of `range_`.
    */
   uint64_t range_start_size_;
+
+  /**
+   * The ranges in a query's initial subarray have a depth of 0.
+   * When a range is split, the depth on the split ranges are
+   * set to +1 the depth of the original range.
+   */
+  uint64_t partition_depth_;
 };
 
 /** An N-dimensional range, consisting of a vector of 1D ranges. */


### PR DESCRIPTION
This patch introduces a "depth" attribute on a `Range` type. Consider the
scenario where the partitioner splits an int range {1, 4} as far as it can:
```
depth 0: {1, 4}
depth 1: {1, 2}, {3, 4}
depth 2: {1, 1}, {2, 2}, {3, 3}, {4, 4}
```

The partitioner can not split the ranges at depth 2 any further. Unlike integer
ranges, string ranges can be split indefinitely. Consider the scenario where
the partitioner splits a string range { { 97 }, { 98 } } (ascii range {"a",
"b"}) as far as it can:
```
depth 0: {{97}, {99}}
depth 1: {{97}, {98 127}}, {{99}, {99}}
depth 2: {{97}, {97 127}}, {{98}, {98 127}}, ...
depth 3: {{97}, {97 63 127}}, {{97 64}, {97 127}}, ...
...
depth 21: {{97 1 1}, {97 1 1 3 127}}, {{97 1 1 4}, {97 1 1 7 127}}, ...
```

In the partitioner, it may split a string dimension to find estimated results
that fit the budget. There is a scenario where estimated results will never
fit the budget, regardless of many times the string dimension split. This causes
an infinite loop. To fix this scenario, this patch introduces a constant to
define the maximum split depth of a string dimension.

A depth of D will limit the total number of splits to `2^D - 1`. It is set to `7`
to split a string dimension no more than `127` times.

---

TYPE: BUG
DESC: Fix an edge-case where a read query may hang on array with string dimensions