### PR TITLE
Add breakdown of read_state init times

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 ## New features
 
 ## Improvements
+* Add additional stats printing to breakdown read state initialization timings [#2095](https://github.com/TileDB-Inc/TileDB/pull/2095)
 * Places the in-memory filesystem under unit test [#1961](https://github.com/TileDB-Inc/TileDB/pull/1961)
 * Adds a Github Action to automate the HISTORY.md [#2075](https://github.com/TileDB-Inc/TileDB/pull/2075)
 

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -659,6 +659,19 @@ std::string Stats::dump_read() const {
     }
 
     write(&ss, "- Time to initialize the read state: ", read_init_state);
+    write(&ss, "  * Time to compute tile overlap: ", read_compute_tile_overlap);
+    write(
+        &ss,
+        "    > Time to compute relevant fragments: ",
+        read_compute_relevant_frags);
+    write(
+        &ss,
+        "    > Time to load relevant fragment R-trees: ",
+        read_load_relevant_rtrees);
+    write(
+        &ss,
+        "    > Time to compute relevant fragment tile overlap: ",
+        read_compute_relevant_tile_overlap);
     ss << "\n";
 
     write(&ss, "- Read time: ", read_time);


### PR DESCRIPTION
The computing of tile overlap, relevant fragments and r-tree happens in the read state init but the stats were previously were only exposed if the user ran an est result size function. Now they will be exposed as a under normal reads too.


TYPE: IMPROVEMENT
DESC: Add additional stats printing to breakdown read state initialization timings