### PR TITLE
[Backport release-2.2] Add breakdown of read_state init times (#2095)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 
 ## Improvements
 
+* Add additional stats printing to breakdown read state initialization timings [#2095](https://github.com/TileDB-Inc/TileDB/pull/2095)
 * Improve GCS multipart locking [#2087](https://github.com/TileDB-Inc/TileDB/pull/2087)
 
 ## Deprecations

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -618,6 +618,19 @@ std::string Stats::dump_read() const {
     }
 
     write(&ss, "- Time to initialize the read state: ", read_init_state);
+    write(&ss, "  * Time to compute tile overlap: ", read_compute_tile_overlap);
+    write(
+        &ss,
+        "    > Time to compute relevant fragments: ",
+        read_compute_relevant_frags);
+    write(
+        &ss,
+        "    > Time to load relevant fragment R-trees: ",
+        read_load_relevant_rtrees);
+    write(
+        &ss,
+        "    > Time to compute relevant fragment tile overlap: ",
+        read_compute_relevant_tile_overlap);
     ss << "\n";
 
     write(&ss, "- Read time: ", read_time);


### PR DESCRIPTION
Backport dc9782b from #2095 