### PR TITLE
Config: unset non-default parameter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,7 @@
 ## API additions
 
 ### C API
+* Remove non-default parameter in tiledb_config_unset. [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)
 
 ### C++ API
 * Add support for a string-typed, variable-sized, nullable attribute in the C++ API. [#2090](https://github.com/TileDB-Inc/TileDB/pull/2090)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,10 +25,10 @@
 ## API additions
 
 ### C API
-* Removes non-default parameter in . [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)
+* Removes non-default parameter in tiledb_config_unset. [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)
 
 ### C++ API
-* Removes non-default parameter in . [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)
+* Removes non-default parameter in Config::unset. [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)
 * Add support for a string-typed, variable-sized, nullable attribute in the C++ API. [#2090](https://github.com/TileDB-Inc/TileDB/pull/2090)
 
 * Add new Config constructors for converting from STL map types [#2081](https://github.com/TileDB-Inc/TileDB/pull/2081)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,9 +25,10 @@
 ## API additions
 
 ### C API
-* Remove non-default parameter in tiledb_config_unset. [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)
+* Removes non-default parameter in . [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)
 
 ### C++ API
+* Removes non-default parameter in . [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)
 * Add support for a string-typed, variable-sized, nullable attribute in the C++ API. [#2090](https://github.com/TileDB-Inc/TileDB/pull/2090)
 
 * Add new Config constructors for converting from STL map types [#2081](https://github.com/TileDB-Inc/TileDB/pull/2081)

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -399,6 +399,42 @@ TEST_CASE("C API: Test config", "[capi], [config]") {
   CHECK(error == nullptr);
   CHECK(!strcmp(value, "10000000"));
 
+  // Set valid, defaulting parameter
+  rc = tiledb_config_set(config, "vfs.s3.region", "pluto", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  rc = tiledb_config_get(config, "vfs.s3.region", &value, &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  CHECK(!strcmp(value, "pluto"));
+
+  // Unset valid, defaulting parameter
+  rc = tiledb_config_unset(config, "vfs.s3.region", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  rc = tiledb_config_get(config, "vfs.s3.region", &value, &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  CHECK(!strcmp(value, "us-east-1"));
+
+  // Set valid, non-defaulting parameter
+  rc = tiledb_config_set(config, "foo", "123", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  rc = tiledb_config_get(config, "foo", &value, &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  CHECK(!strcmp(value, "123"));
+
+  // Unset valid, non-defaulting parameter
+  rc = tiledb_config_unset(config, "foo", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  rc = tiledb_config_get(config, "foo", &value, &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  CHECK(value == nullptr);
+
   // Check out of range argument for correct parameter
   rc = tiledb_config_set(
       config, "sm.tile_cache_size", "100000000000000000000", &error);

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -584,10 +584,9 @@ Status Config::unset(const std::string& param) {
   } else if (param == "vfs.hdfs.kerb_ticket_cache_path") {
     param_values_["vfs.hdfs.kerb_ticket_cache_path"] =
         VFS_HDFS_KERB_TICKET_CACHE_PATH;
+  } else {
+    param_values_.erase(param);
   }
-
-  // Remove from the set parameters
-  set_params_.erase(param);
 
   return Status::Ok();
 }


### PR DESCRIPTION
This patch ensures that `Config::unset` is properly removing a non-defaulting parameter. 2 basic tests have also been added to display the unsetting of a defaulting and non-defaulting parameter in `unit-capi-config.cc`

TYPE: C_API
DESC: Removes non-default parameter in "tiledb_config_unset".

TYPE: CPP_API
DESC: Removes non-default parameter in "Config::unset".