### PR TITLE
Pin python package breathe to 4.26.1

### DIFF
--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx==3.1.*
-breathe>=4.19.2
+breathe==4.26.1
 sphinxcontrib-contentui==0.2.5
 sphinx_rtd_theme==0.5.0
 cmake==3.18.0


### PR DESCRIPTION
The CI is broken building the docs, this is the last known version of the
breathe package that was known to work.

---

TYPE: NO_HISTORY
DESC: N/A