### PR TITLE
Set non_empty_domain_computed_ for remote arrays

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 * Smoke Test, remove nullable structs from global namespace. [#2078](https://github.com/TileDB-Inc/TileDB/pull/2078)
 
 ## Improvements
+* Cache non_empty_domain for REST arrays like all other arrays [#2105](https://github.com/TileDB-Inc/TileDB/pull/2105)
 * Add additional stats printing to breakdown read state initialization timings [#2095](https://github.com/TileDB-Inc/TileDB/pull/2095)
 * Places the in-memory filesystem under unit test [#1961](https://github.com/TileDB-Inc/TileDB/pull/1961)
 * Adds a Github Action to automate the HISTORY.md [#2075](https://github.com/TileDB-Inc/TileDB/pull/2075)

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -849,6 +849,7 @@ Status Array::load_remote_non_empty_domain() {
       return LOG_STATUS(Status::ArrayError(
           "Cannot load metadata; remote array with no REST client."));
     RETURN_NOT_OK(rest_client->get_array_non_empty_domain(this, timestamp_));
+    non_empty_domain_computed_ = true;
   }
   return Status::Ok();
 }


### PR DESCRIPTION
REST arrays should set `non_empty_domain_computed_=true` like all others to avoid refetching the non_empty_domain for each user request to get it.

TYPE: IMPROVEMENT
DESC: Cache non_empty_domain for REST arrays like all other arrays