### PR TITLE
Relational Attribute Operators

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 ## Breaking behavior
 
 ## New features
+* Adds support for filtering query results with relational operators [#2109](https://github.com/TileDB-Inc/TileDB/pull/2109)
 * Name attribute/dimension files by index. This is fragment-specific and updates the format version to version 9. [#2107](https://github.com/TileDB-Inc/TileDB/pull/2107)
 * Smoke Test, remove nullable structs from global namespace. [#2078](https://github.com/TileDB-Inc/TileDB/pull/2078)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,13 +138,14 @@ set(TILEDB_TEST_SOURCES
   src/unit-capi-uri.cc
   src/unit-capi-version.cc
   src/unit-capi-vfs.cc
-  src/unit-duplicates.cc
   src/unit-CellSlabIter.cc
+  src/unit-ChunkedBuffer.cc
   src/unit-compression-dd.cc
   src/unit-compression-rle.cc
   src/unit-crypto.cc
   src/unit-ctx.cc
   src/unit-dimension.cc
+  src/unit-duplicates.cc
   src/unit-empty-var-length.cc
   src/unit-filter-buffer.cc
   src/unit-filter-pipeline.cc
@@ -152,13 +153,13 @@ set(TILEDB_TEST_SOURCES
   src/unit-hdfs-filesystem.cc
   src/unit-hilbert.cc
   src/unit-lru_cache.cc
-  src/unit-Reader.cc
+  src/unit-QueryCondition.cc
   src/unit-ReadCellSlabIter.cc
+  src/unit-Reader.cc
   src/unit-rtree.cc
-  src/unit-s3.cc
   src/unit-s3-no-multipart.cc
+  src/unit-s3.cc
   src/unit-status.cc
-  src/unit-ChunkedBuffer.cc
   src/unit-Subarray.cc
   src/unit-SubarrayPartitioner-dense.cc
   src/unit-SubarrayPartitioner-error.cc

--- a/test/src/unit-QueryCondition.cc
+++ b/test/src/unit-QueryCondition.cc
@@ -1,0 +1,615 @@
+/**
+ * @file unit-QueryCondition.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `QueryCondition` class.
+ */
+
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/array_schema/domain.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/query_condition_combination_op.h"
+#include "tiledb/sm/enums/query_condition_op.h"
+#include "tiledb/sm/query/query_condition.h"
+
+#include <catch.hpp>
+#include <iostream>
+
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "QueryCondition: Test default constructor",
+    "[QueryCondition][default_constructor]") {
+  QueryCondition query_condition;
+  REQUIRE(query_condition.empty());
+  REQUIRE(query_condition.field_names().empty());
+}
+
+TEST_CASE(
+    "QueryCondition: Test value constructor",
+    "[QueryCondition][value_constructor]") {
+  std::string field_name = "foo";
+  int value = 5;
+
+  QueryCondition query_condition(
+      std::string(field_name), &value, sizeof(value), QueryConditionOp::LT);
+  REQUIRE(!query_condition.empty());
+  REQUIRE(!query_condition.field_names().empty());
+  REQUIRE(query_condition.field_names().count(field_name) == 1);
+}
+
+TEST_CASE(
+    "QueryCondition: Test copy constructor",
+    "[QueryCondition][copy_constructor]") {
+  std::string field_name = "foo";
+  int value = 5;
+
+  QueryCondition query_condition1(
+      std::string(field_name), &value, sizeof(value), QueryConditionOp::LT);
+  QueryCondition query_condition2(query_condition1);
+  REQUIRE(!query_condition2.empty());
+  REQUIRE(!query_condition2.field_names().empty());
+  REQUIRE(query_condition2.field_names().count(field_name) == 1);
+}
+
+TEST_CASE(
+    "QueryCondition: Test move constructor",
+    "[QueryCondition][move_constructor]") {
+  std::string field_name = "foo";
+  int value = 5;
+
+  QueryCondition query_condition1(
+      std::string(field_name), &value, sizeof(value), QueryConditionOp::LT);
+  QueryCondition query_condition2(std::move(query_condition1));
+  REQUIRE(!query_condition2.empty());
+  REQUIRE(!query_condition2.field_names().empty());
+  REQUIRE(query_condition2.field_names().count(field_name) == 1);
+}
+
+TEST_CASE(
+    "QueryCondition: Test assignment operator",
+    "[QueryCondition][assignment_operator]") {
+  std::string field_name = "foo";
+  int value = 5;
+
+  QueryCondition query_condition1(
+      std::string(field_name), &value, sizeof(value), QueryConditionOp::LT);
+  QueryCondition query_condition2;
+  query_condition2 = query_condition1;
+  REQUIRE(!query_condition2.empty());
+  REQUIRE(!query_condition2.field_names().empty());
+  REQUIRE(query_condition2.field_names().count(field_name) == 1);
+}
+
+TEST_CASE(
+    "QueryCondition: Test move-assignment operator",
+    "[QueryCondition][move_assignment_operator]") {
+  std::string field_name = "foo";
+  int value = 5;
+
+  QueryCondition query_condition1(
+      std::string(field_name), &value, sizeof(value), QueryConditionOp::LT);
+  QueryCondition query_condition2;
+  query_condition2 = std::move(query_condition1);
+  REQUIRE(!query_condition2.empty());
+  REQUIRE(!query_condition2.field_names().empty());
+  REQUIRE(query_condition2.field_names().count(field_name) == 1);
+}
+
+/**
+ * Tests a comparison operator on all cells in a tile.
+ *
+ * @param op The relational query condition operator.
+ * @param field_name The attribute name in the tile.
+ * @param cells The number of cells in the tile.
+ * @param result_tile The result tile.
+ * @param values The values written to the tile.
+ */
+template <typename T>
+void test_cmp_cells(
+    const QueryConditionOp op,
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values);
+
+/**
+ * C-string template-specialization for `test_cmp_cells`.
+ */
+template <>
+void test_cmp_cells<char*>(
+    const QueryConditionOp op,
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values) {
+  const char* const cmp_value = "ae";
+  const QueryCondition query_condition(
+      std::string(field_name), cmp_value, 2 * sizeof(char), op);
+
+  bool cmp;
+  for (uint64_t i = 0; i < cells; ++i) {
+    REQUIRE(query_condition.cmp_cell(array_schema, result_tile, i, &cmp).ok());
+
+    switch (op) {
+      case QueryConditionOp::LT:
+        REQUIRE(
+            cmp == (std::string(&static_cast<char*>(values)[2 * i], 2) <
+                    std::string(cmp_value, 2)));
+        break;
+      case QueryConditionOp::LE:
+        REQUIRE(
+            cmp == (std::string(&static_cast<char*>(values)[2 * i], 2) <=
+                    std::string(cmp_value, 2)));
+        break;
+      case QueryConditionOp::GT:
+        REQUIRE(
+            cmp == (std::string(&static_cast<char*>(values)[2 * i], 2) >
+                    std::string(cmp_value, 2)));
+        break;
+      case QueryConditionOp::GE:
+        REQUIRE(
+            cmp == (std::string(&static_cast<char*>(values)[2 * i], 2) >=
+                    std::string(cmp_value, 2)));
+        break;
+      case QueryConditionOp::EQ:
+        REQUIRE(
+            cmp == (std::string(&static_cast<char*>(values)[2 * i], 2) ==
+                    std::string(cmp_value, 2)));
+        break;
+      case QueryConditionOp::NE:
+        REQUIRE(
+            cmp == (std::string(&static_cast<char*>(values)[2 * i], 2) !=
+                    std::string(cmp_value, 2)));
+        break;
+      default:
+        REQUIRE(false);
+    }
+  }
+
+  // Compare against the fill value.
+  const void* fill_value;
+  uint64_t fill_value_size;
+  array_schema->attribute(field_name)
+      ->get_fill_value(&fill_value, &fill_value_size);
+  REQUIRE(fill_value_size == 2 * sizeof(char));
+  REQUIRE(query_condition.cmp_cell_fill_value(array_schema, &cmp).ok());
+  switch (op) {
+    case QueryConditionOp::LT:
+      REQUIRE(
+          cmp == (std::string(static_cast<const char*>(fill_value), 2) <
+                  std::string(cmp_value, 2)));
+      break;
+    case QueryConditionOp::LE:
+      REQUIRE(
+          cmp == (std::string(static_cast<const char*>(fill_value), 2) <=
+                  std::string(cmp_value, 2)));
+      break;
+    case QueryConditionOp::GT:
+      REQUIRE(
+          cmp == (std::string(static_cast<const char*>(fill_value), 2) >
+                  std::string(cmp_value, 2)));
+      break;
+    case QueryConditionOp::GE:
+      REQUIRE(
+          cmp == (std::string(static_cast<const char*>(fill_value), 2) >=
+                  std::string(cmp_value, 2)));
+      break;
+    case QueryConditionOp::EQ:
+      REQUIRE(
+          cmp == (std::string(static_cast<const char*>(fill_value), 2) ==
+                  std::string(cmp_value, 2)));
+      break;
+    case QueryConditionOp::NE:
+      REQUIRE(
+          cmp == (std::string(static_cast<const char*>(fill_value), 2) !=
+                  std::string(cmp_value, 2)));
+      break;
+    default:
+      REQUIRE(false);
+  }
+}
+
+/**
+ * Non-specialized template type for `test_cmp_cells`.
+ */
+template <typename T>
+void test_cmp_cells(
+    const QueryConditionOp op,
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values) {
+  const T cmp_value = 5;
+  const QueryCondition query_condition(
+      std::string(field_name), &cmp_value, sizeof(T), op);
+
+  bool cmp;
+  for (uint64_t i = 0; i < cells; ++i) {
+    // Compare against the cell value.
+    REQUIRE(query_condition.cmp_cell(array_schema, result_tile, i, &cmp).ok());
+    switch (op) {
+      case QueryConditionOp::LT:
+        REQUIRE(cmp == (static_cast<T*>(values)[i] < cmp_value));
+        break;
+      case QueryConditionOp::LE:
+        REQUIRE(cmp == (static_cast<T*>(values)[i] <= cmp_value));
+        break;
+      case QueryConditionOp::GT:
+        REQUIRE(cmp == (static_cast<T*>(values)[i] > cmp_value));
+        break;
+      case QueryConditionOp::GE:
+        REQUIRE(cmp == (static_cast<T*>(values)[i] >= cmp_value));
+        break;
+      case QueryConditionOp::EQ:
+        REQUIRE(cmp == (static_cast<T*>(values)[i] == cmp_value));
+        break;
+      case QueryConditionOp::NE:
+        REQUIRE(cmp == (static_cast<T*>(values)[i] != cmp_value));
+        break;
+      default:
+        REQUIRE(false);
+    }
+  }
+
+  // Compare against the fill value.
+  const void* fill_value;
+  uint64_t fill_value_size;
+  array_schema->attribute(field_name)
+      ->get_fill_value(&fill_value, &fill_value_size);
+  REQUIRE(fill_value_size == sizeof(T));
+  REQUIRE(query_condition.cmp_cell_fill_value(array_schema, &cmp).ok());
+  switch (op) {
+    case QueryConditionOp::LT:
+      REQUIRE(cmp == (*static_cast<const T*>(fill_value) < cmp_value));
+      break;
+    case QueryConditionOp::LE:
+      REQUIRE(cmp == (*static_cast<const T*>(fill_value) <= cmp_value));
+      break;
+    case QueryConditionOp::GT:
+      REQUIRE(cmp == (*static_cast<const T*>(fill_value) > cmp_value));
+      break;
+    case QueryConditionOp::GE:
+      REQUIRE(cmp == (*static_cast<const T*>(fill_value) >= cmp_value));
+      break;
+    case QueryConditionOp::EQ:
+      REQUIRE(cmp == (*static_cast<const T*>(fill_value) == cmp_value));
+      break;
+    case QueryConditionOp::NE:
+      REQUIRE(cmp == (*static_cast<const T*>(fill_value) != cmp_value));
+      break;
+    default:
+      REQUIRE(false);
+  }
+}
+
+/**
+ * Tests each comparison operator on all cells in a tile.
+ *
+ * @param field_name The attribute name in the tile.
+ * @param cells The number of cells in the tile.
+ * @param result_tile The result tile.
+ * @param values The values written to the tile.
+ */
+template <typename T>
+void test_cmp_operators(
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values) {
+  test_cmp_cells<T>(
+      QueryConditionOp::LT,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_cmp_cells<T>(
+      QueryConditionOp::LE,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_cmp_cells<T>(
+      QueryConditionOp::GT,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_cmp_cells<T>(
+      QueryConditionOp::GE,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_cmp_cells<T>(
+      QueryConditionOp::EQ,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_cmp_cells<T>(
+      QueryConditionOp::NE,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+}
+
+/**
+ * Populates a tile and tests query condition comparisons against
+ * each cell.
+ *
+ * @param field_name The attribute name in the tile.
+ * @param cells The number of cells in the tile.
+ * @param type The TILEDB data type of the attribute.
+ * @param array_schema The array schema.
+ * @param result_tile The result tile.
+ */
+template <typename T>
+void test_cmp_tile(
+    const std::string& field_name,
+    uint64_t cells,
+    Datatype type,
+    ArraySchema* array_schema,
+    ResultTile* result_tile);
+
+/**
+ * C-string template-specialization for `test_cmp_tile`.
+ */
+template <>
+void test_cmp_tile<char*>(
+    const std::string& field_name,
+    const uint64_t cells,
+    const Datatype type,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile) {
+  ResultTile::TileTuple* const tile_tuple = result_tile->tile_tuple(field_name);
+  Tile* const tile = &std::get<0>(*tile_tuple);
+
+  REQUIRE(tile->init_unfiltered(
+                  constants::format_version,
+                  type,
+                  2 * cells * sizeof(char),
+                  2 * sizeof(char),
+                  0)
+              .ok());
+  char values[2 * cells];
+  for (uint64_t i = 0; i < cells; ++i) {
+    values[i * 2] = 'a';
+    values[(i * 2) + 1] = 'a' + static_cast<char>(i);
+  }
+  REQUIRE(tile->write(values, 2 * cells * sizeof(char)).ok());
+
+  test_cmp_operators<char*>(
+      field_name, cells, array_schema, result_tile, values);
+}
+
+/**
+ * Non-specialized template type for `test_cmp_tile`.
+ */
+template <typename T>
+void test_cmp_tile(
+    const std::string& field_name,
+    const uint64_t cells,
+    const Datatype type,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile) {
+  ResultTile::TileTuple* const tile_tuple = result_tile->tile_tuple(field_name);
+  Tile* const tile = &std::get<0>(*tile_tuple);
+
+  REQUIRE(
+      tile->init_unfiltered(
+              constants::format_version, type, cells * sizeof(T), sizeof(T), 0)
+          .ok());
+  T values[cells];
+  for (uint64_t i = 0; i < cells; ++i) {
+    values[i] = static_cast<T>(i);
+  }
+  REQUIRE(tile->write(&values, cells * sizeof(T)).ok());
+
+  test_cmp_operators<T>(field_name, cells, array_schema, result_tile, values);
+}
+
+/**
+ * Constructs a tile and tests query condition comparisons against
+ * each cell.
+ *
+ * @param type The TILEDB data type of the attribute.
+ */
+template <typename T>
+void test_cmp(const Datatype type);
+
+/**
+ * C-string template-specialization for `test_cmp`.
+ */
+template <>
+void test_cmp<char*>(const Datatype type) {
+  REQUIRE(type == Datatype::STRING_ASCII);
+
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const char* fill_value = "ac";
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(attr.set_cell_val_num(2).ok());
+  REQUIRE(attr.set_fill_value(fill_value, 2 * sizeof(char)).ok());
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &domain);
+  result_tile.init_attr_tile(field_name);
+
+  test_cmp_tile<char*>(field_name, cells, type, &array_schema, &result_tile);
+}
+
+/**
+ * Non-specialized template type for `test_cmp`.
+ */
+template <typename T>
+void test_cmp(const Datatype type) {
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const T fill_value = 3;
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(attr.set_cell_val_num(1).ok());
+  REQUIRE(attr.set_fill_value(&fill_value, sizeof(T)).ok());
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &domain);
+  result_tile.init_attr_tile(field_name);
+
+  test_cmp_tile<T>(field_name, cells, type, &array_schema, &result_tile);
+}
+
+TEST_CASE("QueryCondition: Test comparisons", "[QueryCondition][comparisons]") {
+  test_cmp<int8_t>(Datatype::INT8);
+  test_cmp<uint8_t>(Datatype::UINT8);
+  test_cmp<int16_t>(Datatype::INT16);
+  test_cmp<uint16_t>(Datatype::UINT16);
+  test_cmp<int32_t>(Datatype::INT32);
+  test_cmp<uint32_t>(Datatype::UINT32);
+  test_cmp<int64_t>(Datatype::INT64);
+  test_cmp<uint64_t>(Datatype::UINT64);
+  test_cmp<float>(Datatype::FLOAT32);
+  test_cmp<double>(Datatype::FLOAT64);
+  test_cmp<char>(Datatype::CHAR);
+  test_cmp<int64_t>(Datatype::DATETIME_YEAR);
+  test_cmp<int64_t>(Datatype::DATETIME_MONTH);
+  test_cmp<int64_t>(Datatype::DATETIME_WEEK);
+  test_cmp<int64_t>(Datatype::DATETIME_DAY);
+  test_cmp<int64_t>(Datatype::DATETIME_HR);
+  test_cmp<int64_t>(Datatype::DATETIME_MIN);
+  test_cmp<int64_t>(Datatype::DATETIME_SEC);
+  test_cmp<int64_t>(Datatype::DATETIME_MS);
+  test_cmp<int64_t>(Datatype::DATETIME_US);
+  test_cmp<int64_t>(Datatype::DATETIME_NS);
+  test_cmp<int64_t>(Datatype::DATETIME_PS);
+  test_cmp<int64_t>(Datatype::DATETIME_FS);
+  test_cmp<int64_t>(Datatype::DATETIME_AS);
+  test_cmp<char*>(Datatype::STRING_ASCII);
+}
+
+TEST_CASE(
+    "QueryCondition: Test combinations", "[QueryCondition][combinations]") {
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const Datatype type = Datatype::UINT64;
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &domain);
+  result_tile.init_attr_tile(field_name);
+  ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
+  Tile* const tile = &std::get<0>(*tile_tuple);
+
+  // Initialize and populate the data tile.
+  REQUIRE(tile->init_unfiltered(
+                  constants::format_version,
+                  type,
+                  cells * sizeof(uint64_t),
+                  sizeof(uint64_t),
+                  0)
+              .ok());
+  uint64_t values[cells];
+  for (uint64_t i = 0; i < cells; ++i) {
+    values[i] = i;
+  }
+  REQUIRE(tile->write(&values, cells * sizeof(uint64_t)).ok());
+
+  // Build a combined query for `> 3 AND <= 7`.
+  uint64_t cmp_value_1 = 3;
+  const QueryCondition query_condition_1(
+      std::string(field_name),
+      &cmp_value_1,
+      sizeof(uint64_t),
+      QueryConditionOp::GT);
+  uint64_t cmp_value_2 = 7;
+  const QueryCondition query_condition_2(
+      std::string(field_name),
+      &cmp_value_2,
+      sizeof(uint64_t),
+      QueryConditionOp::LE);
+  QueryCondition query_condition_3;
+  REQUIRE(query_condition_1
+              .combine(
+                  query_condition_2,
+                  QueryConditionCombinationOp::AND,
+                  &query_condition_3)
+              .ok());
+
+  // Test the combined query condition on the cells.
+  for (uint64_t i = 0; i < cells; ++i) {
+    bool cmp;
+    REQUIRE(
+        query_condition_3.cmp_cell(&array_schema, &result_tile, i, &cmp).ok());
+    REQUIRE(cmp == (i > 3 && i <= 7));
+  }
+}

--- a/test/src/unit-capi-smoke-test.cc
+++ b/test/src/unit-capi-smoke-test.cc
@@ -62,7 +62,11 @@ class SmokeTestFx {
       tiledb::sm::Posix::current_dir() + "/tiledb_test/";
 #endif
 
+  /**
+   * Wraps data to build a dimension with the C-API.
+   */
   struct test_dim_t {
+    /** Value constructor. */
     test_dim_t(
         const string& name,
         const tiledb_datatype_t type,
@@ -74,13 +78,24 @@ class SmokeTestFx {
         , tile_extent_(tile_extent) {
     }
 
+    /** Dimension name. */
     string name_;
+
+    /** Dimension data type. */
     tiledb_datatype_t type_;
+
+    /** Dimension domain range. */
     const void* domain_;
+
+    /** Tile extent size. */
     uint64_t tile_extent_;
   };
 
+  /**
+   * Wraps data to build an attribute with the C-API.
+   */
   struct test_attr_t {
+    /** Value constructor. */
     test_attr_t(
         const string& name,
         const tiledb_datatype_t type,
@@ -90,12 +105,155 @@ class SmokeTestFx {
         , cell_val_num_(cell_val_num) {
     }
 
+    /** Attribute name. */
     string name_;
+
+    /** Attribute data type. */
     tiledb_datatype_t type_;
+
+    /** Values per cell. */
     uint32_t cell_val_num_;
   };
 
+  /**
+   * Wraps data to build a query condition with the C-API.
+   */
+  struct test_query_condition_t {
+    /** Value constructor. */
+    test_query_condition_t(
+        const string& name, const tiledb_query_condition_op_t op)
+        : name_(name)
+        , op_(op) {
+    }
+
+    /** Destructor. */
+    virtual ~test_query_condition_t() = default;
+
+    /** Returns the value to compare against. */
+    virtual const void* value() const = 0;
+
+    /** Returns the byte size of the value to compare against. */
+    virtual uint64_t value_size() const = 0;
+
+    /** Returns true if (`lhs` `op_` `value_`). */
+    virtual bool cmp(const void* lhs) const = 0;
+
+    /** The name of the attribute to compare against. */
+    const string name_;
+
+    /** The relational operator. */
+    const tiledb_query_condition_op_t op_;
+  };
+
+  /** Returns a shared_ptr for the template-typed query condition. */
+  template <typename T>
+  shared_ptr<test_query_condition_t> make_condition(
+      const string& name, const tiledb_query_condition_op_t op, const T value) {
+    return shared_ptr<test_query_condition_t>(
+        new test_query_condition_t_impl<T>(name, op, value));
+  }
+
+  /** The template-typed test_query_condition_t implementation. */
+  template <typename T>
+  struct test_query_condition_t_impl;
+
+  /** The string template-typed test_query_condition_t implementation. */
+  template <>
+  struct test_query_condition_t_impl<const char*>
+      : public test_query_condition_t {
+    test_query_condition_t_impl(
+        const string& name,
+        const tiledb_query_condition_op_t op,
+        const char* value)
+        : test_query_condition_t(name, op)
+        , value_(value)
+        , value_size_(strlen(value_)) {
+    }
+
+    const void* value() const {
+      return value_;
+    }
+
+    uint64_t value_size() const {
+      return value_size_;
+    }
+
+    bool cmp(const void* lhs) const {
+      switch (op_) {
+        case TILEDB_LT:
+          return string(static_cast<const char*>(lhs), value_size_) <
+                 string(value_, value_size_);
+        case TILEDB_LE:
+          return string(static_cast<const char*>(lhs), value_size_) <=
+                 string(value_, value_size_);
+        case TILEDB_GT:
+          return string(static_cast<const char*>(lhs), value_size_) >
+                 string(value_, value_size_);
+        case TILEDB_GE:
+          return string(static_cast<const char*>(lhs), value_size_) >=
+                 string(value_, value_size_);
+        case TILEDB_EQ:
+          return string(static_cast<const char*>(lhs), value_size_) ==
+                 string(value_, value_size_);
+        case TILEDB_NE:
+          return string(static_cast<const char*>(lhs), value_size_) !=
+                 string(value_, value_size_);
+        default:
+          break;
+      }
+
+      REQUIRE(false);
+      return false;
+    }
+
+    const char* const value_;
+    const uint64_t value_size_;
+  };
+
+  /** The generic template-typed test_query_condition_t implementation. */
+  template <typename T>
+  struct test_query_condition_t_impl : public test_query_condition_t {
+    test_query_condition_t_impl(
+        const string& name, const tiledb_query_condition_op_t op, const T value)
+        : test_query_condition_t(name, op)
+        , value_(value) {
+    }
+
+    const void* value() const {
+      return static_cast<const void*>(&value_);
+    }
+
+    uint64_t value_size() const {
+      return static_cast<uint64_t>(sizeof(T));
+    }
+
+    bool cmp(const void* lhs) const {
+      switch (op_) {
+        case TILEDB_LT:
+          return *static_cast<const T*>(lhs) < value_;
+        case TILEDB_LE:
+          return *static_cast<const T*>(lhs) <= value_;
+        case TILEDB_GT:
+          return *static_cast<const T*>(lhs) > value_;
+        case TILEDB_GE:
+          return *static_cast<const T*>(lhs) >= value_;
+        case TILEDB_EQ:
+          return *static_cast<const T*>(lhs) == value_;
+        case TILEDB_NE:
+          return *static_cast<const T*>(lhs) != value_;
+        default:
+          break;
+      }
+
+      REQUIRE(false);
+      return false;
+    }
+
+    const T value_;
+  };
+
   struct test_query_buffer_t {
+    /** Value constructor. */
     test_query_buffer_t(
         const string& name,
         void* const buffer,
@@ -126,6 +284,7 @@ class SmokeTestFx {
    * Create, write and read attributes to an array.
    *
    * @param test_attrs The attributes to test.
+   * @param test_query_conditions The attribute conditions to filter on.
    * @param test_dims The dimensions to test.
    * @param array_type The type of the array (dense/sparse).
    * @param cell_order The cell order of the array.
@@ -135,6 +294,7 @@ class SmokeTestFx {
    */
   void smoke_test(
       const vector<test_attr_t>& test_attrs,
+      const vector<shared_ptr<test_query_condition_t>>& test_query_conditions,
       const vector<test_dim_t>& test_dims,
       tiledb_array_type_t array_type,
       tiledb_layout_t cell_order,
@@ -202,12 +362,14 @@ class SmokeTestFx {
    * Creates and executes a single read query.
    *
    * @param array_name The name of the array.
+   * @param test_query_conditions The attribute conditions to filter on.
    * @param test_query_buffers The query buffers to read.
    * @param subarray The subarray to read.
    * @param encryption_type The encryption type of the array.
    */
   void read(
       const string& array_name,
+      const vector<shared_ptr<test_query_condition_t>>& test_query_conditions,
       const vector<test_query_buffer_t>& test_query_buffers,
       const void* subarray,
       tiledb_encryption_type_t encryption_type);
@@ -428,6 +590,7 @@ void SmokeTestFx::write(
 
 void SmokeTestFx::read(
     const string& array_name,
+    const vector<shared_ptr<test_query_condition_t>>& test_query_conditions,
     const vector<test_query_buffer_t>& test_query_buffers,
     const void* subarray,
     tiledb_encryption_type_t encryption_type) {
@@ -483,6 +646,42 @@ void SmokeTestFx::read(
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
   REQUIRE(rc == TILEDB_OK);
 
+  // Create the attribute condition objects.
+  tiledb_query_condition_t* combined_query_condition = nullptr;
+  for (size_t i = 0; i < test_query_conditions.size(); ++i) {
+    tiledb_query_condition_t* query_condition;
+    rc = tiledb_query_condition_alloc(
+        ctx_,
+        test_query_conditions[i]->name_.c_str(),
+        test_query_conditions[i]->value(),
+        test_query_conditions[i]->value_size(),
+        test_query_conditions[i]->op_,
+        &query_condition);
+    REQUIRE(rc == TILEDB_OK);
+
+    if (i == 0) {
+      combined_query_condition = query_condition;
+    } else {
+      tiledb_query_condition_t* tmp_query_condition;
+      rc = tiledb_query_condition_combine(
+          ctx_,
+          combined_query_condition,
+          query_condition,
+          TILEDB_AND,
+          &tmp_query_condition);
+      REQUIRE(rc == TILEDB_OK);
+      tiledb_query_condition_free(&combined_query_condition);
+      tiledb_query_condition_free(&query_condition);
+      combined_query_condition = tmp_query_condition;
+    }
+  }
+
+  // Set the query condition.
+  if (combined_query_condition != nullptr) {
+    rc = tiledb_query_set_condition(ctx_, query, combined_query_condition);
+    REQUIRE(rc == TILEDB_OK);
+  }
+
   // Submit the query.
   rc = tiledb_query_submit(ctx_, query);
   REQUIRE(rc == TILEDB_OK);
@@ -500,12 +699,14 @@ void SmokeTestFx::read(
   // Clean up
   rc = tiledb_array_close(ctx_, array);
   REQUIRE(rc == TILEDB_OK);
+  tiledb_query_condition_free(&combined_query_condition);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
 
 void SmokeTestFx::smoke_test(
     const vector<test_attr_t>& test_attrs,
+    const vector<shared_ptr<test_query_condition_t>>& test_query_conditions,
     const vector<test_dim_t>& test_dims,
     tiledb_array_type_t array_type,
     tiledb_layout_t cell_order,
@@ -532,6 +733,22 @@ void SmokeTestFx::smoke_test(
     }
   }
 
+  // If a query condition filters on an attribute name that does not
+  // exist, skip this permutation of the smoke test.
+  for (const auto& test_query_condition : test_query_conditions) {
+    bool attr_exists_for_cond = false;
+    for (const auto& test_attr : test_attrs) {
+      if (test_attr.name_ == test_query_condition->name_) {
+        attr_exists_for_cond = true;
+        break;
+      }
+    }
+
+    if (!attr_exists_for_cond) {
+      return;
+    }
+  }
+
   // Create the array.
   create_array(
       array_name,
@@ -544,11 +761,13 @@ void SmokeTestFx::smoke_test(
 
   // Calculate the total cells in the array.
   uint64_t total_cells = 1;
+  vector<uint64_t> dim_ranges;
   for (const auto& test_dim : test_dims) {
     const uint64_t max_range = ((uint64_t*)(test_dim.domain_))[1];
     const uint64_t min_range = ((uint64_t*)(test_dim.domain_))[0];
-    const uint64_t full_range = max_range - min_range + 1;
-    total_cells *= full_range;
+    const uint64_t range = max_range - min_range + 1;
+    total_cells *= range;
+    dim_ranges.emplace_back(range);
   }
 
   vector<test_query_buffer_t> write_query_buffers;
@@ -597,43 +816,68 @@ void SmokeTestFx::smoke_test(
         &b_write_buffer_offset_size);
   }
 
+  // Create the write buffer for attribute "c".
+  uint64_t c_write_buffer_size = 0;
+  char* c_write_buffer = nullptr;
+  if (test_attrs.size() >= 3) {
+    REQUIRE(test_attrs[2].name_ == "c");
+    const uint64_t cell_len = test_attrs[2].cell_val_num_;
+    const uint64_t type_size = tiledb_datatype_size(test_attrs[2].type_);
+    c_write_buffer_size = cell_len * total_cells * type_size;
+    c_write_buffer = (char*)malloc(c_write_buffer_size);
+
+    REQUIRE(cell_len == 2);
+    REQUIRE(type_size == 1);
+    for (uint64_t i = 0; i < total_cells; i++) {
+      c_write_buffer[(i * 2)] = 'a';
+      c_write_buffer[(i * 2) + 1] = 'a' + (i % 10);
+    }
+
+    write_query_buffers.emplace_back(
+        test_attrs[2].name_,
+        c_write_buffer,
+        &c_write_buffer_size,
+        nullptr,
+        nullptr);
+  }
+
   // Define dimension query write vectors for either sparse arrays
   // or dense arrays with an unordered write order.
-  vector<uint64_t*> d_write_buffers;
+  vector<pair<uint64_t*, uint64_t>> d_write_buffers;
+  d_write_buffers.reserve(test_dims.size());
   if (array_type == TILEDB_SPARSE || write_order == TILEDB_UNORDERED) {
-    // Calculate the write buffer lengths using the ranges of the dimensions.
-    vector<uint64_t> dimension_ranges;
-    uint64_t dim_buffer_len = 0;
-    for (auto dims_iter = test_dims.begin(); dims_iter != test_dims.end();
-         ++dims_iter) {
-      const uint64_t max_range = ((uint64_t*)(dims_iter->domain_))[1];
-      const uint64_t min_range = ((uint64_t*)(dims_iter->domain_))[0];
-      dim_buffer_len = (max_range - min_range) + 1;
-      dimension_ranges.emplace_back(dim_buffer_len);
-    }
+    vector<uint64_t> ranges;
+    for (const auto& test_dim : test_dims) {
+      const uint64_t max_range =
+          static_cast<const uint64_t*>(test_dim.domain_)[1];
+      const uint64_t min_range =
+          static_cast<const uint64_t*>(test_dim.domain_)[0];
+      const uint64_t range = (max_range - min_range) + 1;
 
-    // Create the dimension write buffers.
-    for (const uint64_t range : dimension_ranges) {
-      d_write_buffers.emplace_back(
-          (uint64_t*)malloc(range * sizeof(uint64_t*)));
-    }
+      REQUIRE(tiledb_datatype_size(test_dim.type_) == sizeof(uint64_t));
+      const uint64_t d_write_buffer_size = total_cells * sizeof(uint64_t);
+      uint64_t* const d_write_buffer =
+          static_cast<uint64_t*>(malloc(d_write_buffer_size));
 
-    // Fill the write buffers with values.
-    auto dims_iter = test_dims.begin();
-    for (uint64_t* const d_write_buffer : d_write_buffers) {
-      for (uint64_t i = 0; i < dimension_ranges[i]; i++) {
-        d_write_buffer[i] = i;
+      for (uint64_t i = 0; i < total_cells; ++i) {
+        uint64_t j = 1;
+        for (const auto& range : ranges) {
+          j *= range;
+        }
+
+        d_write_buffer[i] = ((i / j) % range) + 1;
       }
-      uint64_t write_buffer_size =
-          dim_buffer_len * tiledb_datatype_size(dims_iter->type_);
+
+      d_write_buffers.emplace_back(d_write_buffer, d_write_buffer_size);
 
       write_query_buffers.emplace_back(
-          dims_iter->name_,
-          d_write_buffer,
-          &(write_buffer_size),
+          test_dim.name_,
+          d_write_buffers.back().first,
+          &d_write_buffers.back().second,
           nullptr,
           nullptr);
-      dims_iter = std::next(dims_iter, 1);
+
+      ranges.emplace_back(range);
     }
   }
 
@@ -683,6 +927,27 @@ void SmokeTestFx::smoke_test(
         &b_read_buffer_offset_size);
   }
 
+  // Create the read buffers for attribute "c".
+  uint64_t c_read_buffer_size = 0;
+  char* c_read_buffer = nullptr;
+  if (test_attrs.size() >= 3) {
+    const uint64_t cell_len = test_attrs[2].cell_val_num_;
+    const uint64_t type_size = tiledb_datatype_size(test_attrs[2].type_);
+    c_read_buffer_size = total_cells * cell_len * type_size;
+    c_read_buffer = (char*)malloc(c_read_buffer_size);
+    for (uint64_t i = 0; i < total_cells; i++) {
+      c_read_buffer[(i * 2)] = 0;
+      c_read_buffer[(i * 2) + 1] = 0;
+    }
+
+    read_query_buffers.emplace_back(
+        test_attrs[2].name_,
+        c_read_buffer,
+        &c_read_buffer_size,
+        nullptr,
+        nullptr);
+  }
+
   // This logic assumes that all dimensions are of type TILEDB_UINT64.
   uint64_t subarray_size = 2 * test_dims.size() * sizeof(uint64_t);
   uint64_t* subarray_full = (uint64_t*)malloc(subarray_size);
@@ -693,31 +958,105 @@ void SmokeTestFx::smoke_test(
     subarray_full[(i * 2) + 1] = max_range;
   }
 
-  read(array_name, read_query_buffers, subarray_full, encryption_type);
+  // Read from the array.
+  read(
+      array_name,
+      test_query_conditions,
+      read_query_buffers,
+      subarray_full,
+      encryption_type);
 
-  // Check the read on "a"
-  assert(a_read_buffer_size == a_write_buffer_size);
-  const uint64_t buffer_len =
+  // Map each cell value to a bool that indicates whether or
+  // not we expect it in the read results.
+  unordered_map<int32_t, bool> expected_a_values_read;
+  unordered_map<string, bool> expected_c_values_read;
+  for (uint64_t i = 0; i < total_cells; ++i) {
+    expected_a_values_read[i] = true;
+    if (test_attrs.size() >= 3) {
+      expected_c_values_read[string(&c_write_buffer[i * 2], 2)] = true;
+    }
+  }
+
+  // Populate the expected values maps. We only filter on attributes
+  // "a" and "c".
+  for (const auto& test_query_condition : test_query_conditions) {
+    if (test_query_condition->name_ == "a") {
+      for (uint64_t i = 0; i < total_cells; ++i) {
+        const bool expected = test_query_condition->cmp(&a_write_buffer[i]);
+        if (!expected) {
+          expected_a_values_read[i] = false;
+        }
+      }
+    } else {
+      REQUIRE(test_query_condition->name_ == "c");
+      for (uint64_t i = 0; i < total_cells; ++i) {
+        const bool expected =
+            test_query_condition->cmp(&c_write_buffer[(i * 2)]);
+        if (!expected) {
+          expected_c_values_read[string(&c_write_buffer[i * 2], 2)] = false;
+        }
+      }
+    }
+  }
+
+  // Calculate the number of cells read from the "a" read buffer.
+  const uint64_t cells_read =
       a_read_buffer_size / tiledb_datatype_size(test_attrs[0].type_);
-  for (size_t i = 0; i < buffer_len; ++i) {
-    assert(((int32_t*)a_read_buffer)[i] == ((int32_t*)a_write_buffer)[i]);
+
+  // When we check the values on "a", store a vector of the cell indexes
+  // from the write-buffer. We can use this to ensure that the values
+  // in the other attributes are similarly ordered.
+  vector<uint64_t> cell_idx_vec;
+
+  // Check the read values on "a".
+  for (uint64_t i = 0; i < cells_read; ++i) {
+    const int32_t cell_value = ((int32_t*)a_read_buffer)[i];
+    REQUIRE(expected_a_values_read[cell_value]);
+
+    // We expect to read a unique cell value exactly once.
+    expected_a_values_read[cell_value] = false;
+
+    // The cell value is the cell index in the write buffers.
+    cell_idx_vec.emplace_back(cell_value);
   }
 
   // Check the read on "b".
   if (test_attrs.size() >= 2) {
-    assert(b_read_buffer_size == b_write_buffer_size);
-    const uint64_t buffer_len =
-        b_read_buffer_size / tiledb_datatype_size(test_attrs[1].type_);
-    for (size_t i = 0; i < buffer_len; ++i) {
-      assert(((int32_t*)b_read_buffer)[i] == ((int32_t*)b_write_buffer)[i]);
+    const uint64_t type_size = tiledb_datatype_size(test_attrs[1].type_);
+    REQUIRE(b_read_buffer_size == 2 * cells_read * type_size);
+    for (uint64_t i = 0; i < cells_read; ++i) {
+      const uint64_t write_i = cell_idx_vec[i];
+      REQUIRE(
+          ((int32_t*)b_read_buffer)[(i * 2)] ==
+          ((int32_t*)b_write_buffer)[(write_i * 2)]);
+      REQUIRE(
+          ((int32_t*)b_read_buffer)[(i * 2) + 1] ==
+          ((int32_t*)b_write_buffer)[(write_i * 2) + 1]);
     }
+  }
 
-    assert(b_read_buffer_offset_size == b_write_buffer_offset_size);
-    const uint64_t buffer_offset_len =
-        b_read_buffer_offset_size / sizeof(uint64_t);
-    for (size_t i = 0; i < buffer_offset_len; ++i) {
-      assert(b_read_buffer_offset[i] == b_write_buffer_offset[i]);
+  // Check the read on "c"
+  if (test_attrs.size() >= 3) {
+    const uint64_t cell_len = test_attrs[2].cell_val_num_;
+    const uint64_t type_size = tiledb_datatype_size(test_attrs[2].type_);
+    REQUIRE(c_read_buffer_size == cell_len * cells_read * type_size);
+
+    for (uint64_t i = 0; i < cells_read; ++i) {
+      REQUIRE(expected_c_values_read[string(
+          &c_read_buffer[(i * cell_len)], cell_len)]);
+
+      const uint64_t write_i = cell_idx_vec[i];
+      for (uint64_t j = 0; j < cell_len; ++j) {
+        REQUIRE(
+            c_read_buffer[(i * cell_len) + j] ==
+            c_write_buffer[(write_i * cell_len) + j]);
+      }
     }
+  }
+
+  // Free the dimension write buffers.
+  for (const auto& kv : d_write_buffers) {
+    free(kv.first);
   }
 
   // Free the write buffers.
@@ -742,45 +1081,80 @@ void SmokeTestFx::smoke_test(
 
 TEST_CASE_METHOD(
     SmokeTestFx, "C API: Test a dynamic range of arrays", "[capi][smoke]") {
+  // Build a vector of attributes.
   vector<test_attr_t> attrs;
   attrs.emplace_back("a", TILEDB_INT32, 1);
   attrs.emplace_back("b", TILEDB_INT32, TILEDB_VAR_NUM);
+  attrs.emplace_back("c", TILEDB_STRING_ASCII, 2);
 
+  // Build a vector of query conditions.
+  vector<vector<shared_ptr<test_query_condition_t>>> query_conditions_vec;
+  query_conditions_vec.push_back({});
+  query_conditions_vec.push_back({make_condition<int32_t>("a", TILEDB_LT, 4)});
+  query_conditions_vec.push_back({make_condition<int32_t>("a", TILEDB_GT, 3)});
+  query_conditions_vec.push_back({make_condition<int32_t>("a", TILEDB_LE, 20)});
+  query_conditions_vec.push_back({make_condition<int32_t>("a", TILEDB_GE, 3)});
+  query_conditions_vec.push_back({make_condition<int32_t>("a", TILEDB_EQ, 7)});
+  query_conditions_vec.push_back({make_condition<int32_t>("a", TILEDB_NE, 10)});
+  query_conditions_vec.push_back({
+      make_condition<int32_t>("a", TILEDB_GT, 6),
+      make_condition<int32_t>("a", TILEDB_LE, 20),
+  });
+  query_conditions_vec.push_back({
+      make_condition<int32_t>("a", TILEDB_LT, 30),
+      make_condition<int32_t>("a", TILEDB_GE, 7),
+      make_condition<int32_t>("a", TILEDB_NE, 9),
+  });
+  query_conditions_vec.push_back(
+      {make_condition<const char*>("c", TILEDB_LT, "ae")});
+  query_conditions_vec.push_back(
+      {make_condition<const char*>("c", TILEDB_GE, "ad")});
+  query_conditions_vec.push_back(
+      {make_condition<const char*>("c", TILEDB_EQ, "ab")});
+  query_conditions_vec.push_back(
+      {make_condition<int32_t>("a", TILEDB_LT, 30),
+       make_condition<const char*>("c", TILEDB_GE, "ad")});
+
+  // Build a vector of dimensions.
   vector<test_dim_t> dims;
-  const uint64_t d1_domain[] = {1, 10};
-  const uint64_t d1_tile_extent = 1;
+  const uint64_t d1_domain[] = {1, 9};
+  const uint64_t d1_tile_extent = 3;
   dims.emplace_back("d1", TILEDB_UINT64, d1_domain, d1_tile_extent);
-  const uint64_t d2_domain[] = {1, 20};
+  const uint64_t d2_domain[] = {1, 10};
   const uint64_t d2_tile_extent = 5;
   dims.emplace_back("d2", TILEDB_UINT64, d2_domain, d2_tile_extent);
-  const uint64_t d3_domain[] = {1, 30};
-  const uint64_t d3_tile_extent = 10;
+  const uint64_t d3_domain[] = {1, 15};
+  const uint64_t d3_tile_extent = 5;
   dims.emplace_back("d3", TILEDB_UINT64, d3_domain, d3_tile_extent);
-
-  const tiledb_layout_t write_order = TILEDB_ROW_MAJOR;
 
   for (auto attr_iter = attrs.begin(); attr_iter != attrs.end(); ++attr_iter) {
     vector<test_attr_t> test_attrs(attrs.begin(), attr_iter + 1);
-
-    for (const tiledb_array_type_t array_type : {TILEDB_DENSE, TILEDB_SPARSE}) {
-      for (const tiledb_layout_t cell_order :
-           {TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR}) {
-        for (const tiledb_layout_t tile_order :
+    for (const auto& query_conditions : query_conditions_vec) {
+      for (const tiledb_array_type_t array_type :
+           {TILEDB_DENSE, TILEDB_SPARSE}) {
+        for (const tiledb_layout_t cell_order :
              {TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR}) {
-          for (const tiledb_encryption_type_t encryption_type :
-               {TILEDB_NO_ENCRYPTION, TILEDB_AES_256_GCM}) {
-            vector<test_dim_t> test_dims;
-            for (const test_dim_t& dim : dims) {
-              test_dims.emplace_back(dim);
+          for (const tiledb_layout_t tile_order :
+               {TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR}) {
+            for (const tiledb_encryption_type_t encryption_type :
+                 {TILEDB_NO_ENCRYPTION, TILEDB_AES_256_GCM}) {
+              for (const tiledb_layout_t write_order :
+                   {TILEDB_ROW_MAJOR, TILEDB_UNORDERED}) {
+                vector<test_dim_t> test_dims;
+                for (const test_dim_t& dim : dims) {
+                  test_dims.emplace_back(dim);
 
-              smoke_test(
-                  test_attrs,
-                  test_dims,
-                  array_type,
-                  cell_order,
-                  tile_order,
-                  write_order,
-                  encryption_type);
+                  smoke_test(
+                      test_attrs,
+                      query_conditions,
+                      test_dims,
+                      array_type,
+                      cell_order,
+                      tile_order,
+                      write_order,
+                      encryption_type);
+                }
+              }
             }
           }
         }

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -157,6 +157,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/win_constants.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/work_arounds.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query_condition.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/reader.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/result_tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/read_cell_slab_iter.cc

--- a/tiledb/common/status.cc
+++ b/tiledb/common/status.cc
@@ -231,6 +231,9 @@ std::string Status::code_to_string() const {
     case StatusCode::FragmentInfoError:
       type = "[TileDB::FragmentInfo] Error";
       break;
+    case StatusCode::QueryCondition:
+      type = "[TileDB::QueryCondition] Error";
+      break;
     default:
       type = "[TileDB::?] Error:";
   }

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -128,7 +128,8 @@ enum class StatusCode : char {
   SerializationError,
   ChecksumError,
   ThreadPoolError,
-  FragmentInfoError
+  FragmentInfoError,
+  QueryCondition
 };
 
 class Status {
@@ -414,6 +415,11 @@ class Status {
   /** Return a FragmentInfoError error class Status with a given message **/
   static Status FragmentInfoError(const std::string& msg) {
     return Status(StatusCode::FragmentInfoError, msg, -1);
+  }
+
+  /** Return a QueryConditionError error class Status with a given message **/
+  static Status QueryConditionError(const std::string& msg) {
+    return Status(StatusCode::QueryCondition, msg, -1);
   }
 
   /** Returns true iff the status indicates success **/

--- a/tiledb/sm/c_api/tiledb_enum.h
+++ b/tiledb/sm/c_api/tiledb_enum.h
@@ -200,6 +200,30 @@
     TILEDB_QUERY_STATUS_ENUM(UNINITIALIZED) = 4,
 #endif
 
+#ifdef TILEDB_QUERY_CONDITION_OP_ENUM
+    /** Less-than operator */
+    TILEDB_QUERY_CONDITION_OP_ENUM(LT) = 0,
+    /** Less-than-or-equal operator */
+    TILEDB_QUERY_CONDITION_OP_ENUM(LE) = 1,
+    /** Greater-than operator */
+    TILEDB_QUERY_CONDITION_OP_ENUM(GT) = 2,
+    /** Greater-than-or-equal operator */
+    TILEDB_QUERY_CONDITION_OP_ENUM(GE) = 3,
+    /** Equal operator */
+    TILEDB_QUERY_CONDITION_OP_ENUM(EQ) = 4,
+    /** Not-equal operator */
+    TILEDB_QUERY_CONDITION_OP_ENUM(NE) = 5,
+#endif
+
+#ifdef TILEDB_QUERY_CONDITION_COMBINATION_OP_ENUM
+    /**'And' operator */
+    TILEDB_QUERY_CONDITION_COMBINATION_OP_ENUM(AND) = 0,
+    /** 'Or' operator */
+    TILEDB_QUERY_CONDITION_COMBINATION_OP_ENUM(OR) = 1,
+    /** 'Not' operator */
+    TILEDB_QUERY_CONDITION_COMBINATION_OP_ENUM(NOT) = 2,
+#endif
+
 #ifdef TILEDB_SERIALIZATION_TYPE_ENUM
     /** Serialize to json */
     TILEDB_SERIALIZATION_TYPE_ENUM(JSON),

--- a/tiledb/sm/c_api/tiledb_struct_def.h
+++ b/tiledb/sm/c_api/tiledb_struct_def.h
@@ -44,6 +44,7 @@
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/fragment/fragment_info.h"
 #include "tiledb/sm/query/query.h"
+#include "tiledb/sm/query/query_condition.h"
 #include "tiledb/sm/storage_manager/context.h"
 #include "tiledb/sm/subarray/subarray.h"
 #include "tiledb/sm/subarray/subarray_partitioner.h"
@@ -103,6 +104,10 @@ struct tiledb_filter_list_t {
 
 struct tiledb_query_t {
   tiledb::sm::Query* query_ = nullptr;
+};
+
+struct tiledb_query_condition_t {
+  tiledb::sm::QueryCondition* query_condition_ = nullptr;
 };
 
 struct tiledb_vfs_t {

--- a/tiledb/sm/enums/query_condition_combination_op.h
+++ b/tiledb/sm/enums/query_condition_combination_op.h
@@ -1,0 +1,98 @@
+/**
+ * @file query_condition_condition_op.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This defines the tiledb QueryConditionCombinationOp enum that maps to
+ * tiledb_query_condition_combination_op_t C-api enum.
+ */
+
+#ifndef TILEDB_QUERY_CONDITION_COMBINATION_OP_H
+#define TILEDB_QUERY_CONDITION_COMBINATION_OP_H
+
+#include <cassert>
+
+#include "tiledb/common/status.h"
+#include "tiledb/sm/misc/constants.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/** Defines the query condition ops. */
+enum class QueryConditionCombinationOp : uint8_t {
+#define TILEDB_QUERY_CONDITION_COMBINATION_OP_ENUM(id) id
+#include "tiledb/sm/c_api/tiledb_enum.h"
+#undef TILEDB_QUERY_CONDITION_COMBINATION_OP_ENUM
+};
+
+/**
+ * Returns the string representation of the input QueryConditionCombinationOp
+ * type.
+ */
+inline const std::string& query_condition_combination_op_str(
+    QueryConditionCombinationOp query_condition_combination_op) {
+  switch (query_condition_combination_op) {
+    case QueryConditionCombinationOp::AND:
+      return constants::query_condition_combination_op_and_str;
+    case QueryConditionCombinationOp::OR:
+      return constants::query_condition_combination_op_or_str;
+    case QueryConditionCombinationOp::NOT:
+      return constants::query_condition_combination_op_not_str;
+    default:
+      return constants::empty_str;
+  }
+}
+
+/** Returns the query condition_op given a string representation. */
+inline Status query_condition_combination_op_enum(
+    const std::string& query_condition_combination_op_str,
+    QueryConditionCombinationOp* query_condition_combination_op) {
+  if (query_condition_combination_op_str ==
+      constants::query_condition_combination_op_and_str)
+    *query_condition_combination_op = QueryConditionCombinationOp::AND;
+  else if (
+      query_condition_combination_op_str ==
+      constants::query_condition_combination_op_or_str)
+    *query_condition_combination_op = QueryConditionCombinationOp::OR;
+  else if (
+      query_condition_combination_op_str ==
+      constants::query_condition_combination_op_not_str)
+    *query_condition_combination_op = QueryConditionCombinationOp::NOT;
+  else {
+    return Status::Error(
+        "Invalid QueryConditionCombinationOp " +
+        query_condition_combination_op_str);
+  }
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_QUERY_CONDITION_COMBINATION_OP_H

--- a/tiledb/sm/enums/query_condition_op.h
+++ b/tiledb/sm/enums/query_condition_op.h
@@ -1,0 +1,100 @@
+/**
+ * @file query_condition_op.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This defines the tiledb QueryConditionOp enum that maps to
+ * tiledb_query_condition_op_t C-api enum.
+ */
+
+#ifndef TILEDB_QUERY_CONDITION_OP_H
+#define TILEDB_QUERY_CONDITION_OP_H
+
+#include <cassert>
+
+#include "tiledb/common/status.h"
+#include "tiledb/sm/misc/constants.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/** Defines the query condition ops. */
+enum class QueryConditionOp : uint8_t {
+#define TILEDB_QUERY_CONDITION_OP_ENUM(id) id
+#include "tiledb/sm/c_api/tiledb_enum.h"
+#undef TILEDB_QUERY_CONDITION_OP_ENUM
+};
+
+/** Returns the string representation of the input QueryConditionOp type. */
+inline const std::string& query_condition_op_str(
+    QueryConditionOp query_condition_op) {
+  switch (query_condition_op) {
+    case QueryConditionOp::LT:
+      return constants::query_condition_op_lt_str;
+    case QueryConditionOp::LE:
+      return constants::query_condition_op_le_str;
+    case QueryConditionOp::GT:
+      return constants::query_condition_op_gt_str;
+    case QueryConditionOp::GE:
+      return constants::query_condition_op_ge_str;
+    case QueryConditionOp::EQ:
+      return constants::query_condition_op_eq_str;
+    case QueryConditionOp::NE:
+      return constants::query_condition_op_ne_str;
+    default:
+      return constants::empty_str;
+  }
+}
+
+/** Returns the query condition_op given a string representation. */
+inline Status query_condition_op_enum(
+    const std::string& query_condition_op_str,
+    QueryConditionOp* query_condition_op) {
+  if (query_condition_op_str == constants::query_condition_op_lt_str)
+    *query_condition_op = QueryConditionOp::LT;
+  else if (query_condition_op_str == constants::query_condition_op_le_str)
+    *query_condition_op = QueryConditionOp::LE;
+  else if (query_condition_op_str == constants::query_condition_op_gt_str)
+    *query_condition_op = QueryConditionOp::GT;
+  else if (query_condition_op_str == constants::query_condition_op_ge_str)
+    *query_condition_op = QueryConditionOp::GE;
+  else if (query_condition_op_str == constants::query_condition_op_eq_str)
+    *query_condition_op = QueryConditionOp::EQ;
+  else if (query_condition_op_str == constants::query_condition_op_ne_str)
+    *query_condition_op = QueryConditionOp::NE;
+  else {
+    return Status::Error("Invalid QueryConditionOp " + query_condition_op_str);
+  }
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_QUERY_CONDITION_OP_H

--- a/tiledb/sm/enums/query_status.h
+++ b/tiledb/sm/enums/query_status.h
@@ -42,7 +42,7 @@
 namespace tiledb {
 namespace sm {
 
-/** Defines the query states (used in asynchronous queries). */
+/** Defines the query statuses. */
 enum class QueryStatus : uint8_t {
 #define TILEDB_QUERY_STATUS_ENUM(id) id
 #include "tiledb/sm/c_api/tiledb_enum.h"

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -225,6 +225,7 @@ const std::string query_type_read_str = "READ";
 
 /** TILEDB_WRITE Query String **/
 const std::string query_type_write_str = "WRITE";
+
 /** TILEDB_FAILED Query String **/
 const std::string query_status_failed_str = "FAILED";
 
@@ -239,6 +240,33 @@ const std::string query_status_incomplete_str = "INCOMPLETE";
 
 /** TILEDB_UNINITIALIZED Query String **/
 const std::string query_status_uninitialized_str = "UNINITIALIZED";
+
+/** TILEDB_LT Query Condition Op String **/
+const std::string query_condition_op_lt_str = "LT";
+
+/** TILEDB_LE Query Condition Op String **/
+const std::string query_condition_op_le_str = "LE";
+
+/** TILEDB_GT Query Condition Op String **/
+const std::string query_condition_op_gt_str = "GT";
+
+/** TILEDB_GE Query Condition Op String **/
+const std::string query_condition_op_ge_str = "GE";
+
+/** TILEDB_EQ Query Condition Op String **/
+const std::string query_condition_op_eq_str = "EQ";
+
+/** TILEDB_NE Query Condition Op String **/
+const std::string query_condition_op_ne_str = "NE";
+
+/** TILEDB_AND Query Condition Combination Op String **/
+const std::string query_condition_combination_op_and_str = "AND";
+
+/** TILEDB_OR Query Condition Combination Op String **/
+const std::string query_condition_combination_op_or_str = "OR";
+
+/** TILEDB_NOT Query Condition Combination Op String **/
+const std::string query_condition_combination_op_not_str = "NOT";
 
 /** TILEDB_COMPRESSION Filter type string */
 const std::string filter_type_compression_str = "COMPRESSION";

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -230,6 +230,33 @@ extern const std::string query_status_incomplete_str;
 /** TILEDB_UNINITIALIZED Query String **/
 extern const std::string query_status_uninitialized_str;
 
+/** TILEDB_LT Query Condition Op String **/
+extern const std::string query_condition_op_lt_str;
+
+/** TILEDB_LE Query Condition Op String **/
+extern const std::string query_condition_op_le_str;
+
+/** TILEDB_GT Query Condition Op String **/
+extern const std::string query_condition_op_gt_str;
+
+/** TILEDB_GE Query Condition Op String **/
+extern const std::string query_condition_op_ge_str;
+
+/** TILEDB_EQ Query Condition Op String **/
+extern const std::string query_condition_op_eq_str;
+
+/** TILEDB_NE Query Condition Op String **/
+extern const std::string query_condition_op_ne_str;
+
+/** TILEDB_AND Query Condition Combination Op String **/
+extern const std::string query_condition_combination_op_and_str;
+
+/** TILEDB_OR Query Condition Combination Op String **/
+extern const std::string query_condition_combination_op_or_str;
+
+/** TILEDB_NOT Query Condition Combination Op String **/
+extern const std::string query_condition_combination_op_not_str;
+
 /** TILEDB_COMPRESSION Filter type string */
 extern const std::string filter_type_compression_str;
 

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -36,6 +36,7 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/query/query_condition.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
@@ -945,6 +946,14 @@ Status Query::set_layout(Layout layout) {
 
   layout_ = layout;
   return Status::Ok();
+}
+
+Status Query::set_condition(const QueryCondition& condition) {
+  if (type_ == QueryType::WRITE)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set query condition; Operation only applicable "
+        "to read queries"));
+  return reader_.set_condition(condition);
 }
 
 Status Query::set_sparse_mode(bool sparse_mode) {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -44,6 +44,7 @@
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/query/query_condition.h"
 #include "tiledb/sm/query/reader.h"
 #include "tiledb/sm/query/validity_vector.h"
 #include "tiledb/sm/query/writer.h"
@@ -632,6 +633,14 @@ class Query {
    * layout for both reads and writes.
    */
   Status set_layout(Layout layout);
+
+  /**
+   * Sets the condition for filtering results in a read query.
+   *
+   * @param condition The condition object.
+   * @return Status
+   */
+  Status set_condition(const QueryCondition& condition);
 
   /**
    * This is applicable only to dense arrays (errors out for sparse arrays),

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1,0 +1,468 @@
+/**
+ * @file query_condition.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Implements the QueryCondition class.
+ */
+
+#include "tiledb/sm/query/query_condition.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/query_condition_combination_op.h"
+#include "tiledb/sm/enums/query_condition_op.h"
+#include "tiledb/sm/misc/utils.h"
+
+#include <iostream>
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+QueryCondition::QueryCondition() {
+}
+
+QueryCondition::QueryCondition(
+    std::string&& field_name,
+    const void* const condition_value,
+    const uint64_t condition_value_size,
+    const QueryConditionOp op) {
+  clauses_.emplace_back(
+      std::move(field_name), condition_value, condition_value_size, op);
+}
+
+QueryCondition::QueryCondition(const QueryCondition& rhs)
+    : clauses_(rhs.clauses_)
+    , combination_ops_(rhs.combination_ops_) {
+}
+
+QueryCondition::QueryCondition(QueryCondition&& rhs)
+    : clauses_(std::move(rhs.clauses_))
+    , combination_ops_(std::move(rhs.combination_ops_)) {
+}
+
+QueryCondition::~QueryCondition() {
+}
+
+QueryCondition& QueryCondition::operator=(const QueryCondition& rhs) {
+  clauses_ = rhs.clauses_;
+  combination_ops_ = rhs.combination_ops_;
+
+  return *this;
+}
+
+QueryCondition& QueryCondition::operator=(QueryCondition&& rhs) {
+  clauses_ = std::move(rhs.clauses_);
+  combination_ops_ = std::move(rhs.combination_ops_);
+
+  return *this;
+}
+
+Status QueryCondition::check(const ArraySchema* const array_schema) const {
+  for (const auto& clause : clauses_) {
+    const std::string field_name = clause.field_name_;
+    const uint64_t condition_value_size = clause.condition_value_size_;
+
+    const Attribute* const attribute = array_schema->attribute(field_name);
+    if (!attribute) {
+      return Status::QueryConditionError(
+          "Clause field name is not an attribute " + field_name);
+    }
+
+    if (attribute->var_size()) {
+      return Status::QueryConditionError(
+          "Clause attribute may not be var-sized: " + field_name);
+    }
+
+    if (attribute->nullable()) {
+      return Status::QueryConditionError(
+          "Clause attribute may not be nullable: " + field_name);
+    }
+
+    if (attribute->cell_val_num() != 1 &&
+        attribute->type() != Datatype::STRING_ASCII) {
+      return Status::QueryConditionError(
+          "Clause attribute must have one value per cell for non-string "
+          "attributes: " +
+          field_name);
+    }
+
+    if (attribute->cell_size() != condition_value_size) {
+      return Status::QueryConditionError(
+          "Clause condition value size mismatch: " +
+          std::to_string(attribute->cell_size()) +
+          " != " + std::to_string(condition_value_size));
+    }
+
+    switch (attribute->type()) {
+      case Datatype::ANY:
+        return Status::QueryConditionError(
+            "Clause attribute type may not be of type 'ANY': " + field_name);
+      case Datatype::STRING_UTF8:
+      case Datatype::STRING_UTF16:
+      case Datatype::STRING_UTF32:
+      case Datatype::STRING_UCS2:
+      case Datatype::STRING_UCS4:
+        return Status::QueryConditionError(
+            "Clause attribute type may not be a UTF/UCS string: " + field_name);
+      default:
+        break;
+    }
+  }
+
+  return Status::Ok();
+}
+
+Status QueryCondition::combine(
+    const QueryCondition& rhs,
+    const QueryConditionCombinationOp combination_op,
+    QueryCondition* const combined_cond) const {
+  assert(combination_op == QueryConditionCombinationOp::AND);
+  if (combination_op != QueryConditionCombinationOp::AND) {
+    return Status::QueryConditionError(
+        "Cannot combine query conditions; Only the 'AND' "
+        "comination op is supported");
+  }
+
+  combined_cond->clauses_ = clauses_;
+  combined_cond->clauses_.insert(
+      combined_cond->clauses_.end(), rhs.clauses_.begin(), rhs.clauses_.end());
+
+  combined_cond->combination_ops_ = combination_ops_;
+  combined_cond->combination_ops_.emplace_back(combination_op);
+  combined_cond->combination_ops_.insert(
+      combined_cond->combination_ops_.end(),
+      rhs.combination_ops_.begin(),
+      rhs.combination_ops_.end());
+
+  return Status::Ok();
+}
+
+bool QueryCondition::empty() const {
+  return clauses_.empty();
+}
+
+std::unordered_set<std::string> QueryCondition::field_names() const {
+  std::unordered_set<std::string> field_names_set;
+  for (const auto& clause : clauses_) {
+    field_names_set.insert(clause.field_name_);
+  }
+
+  return field_names_set;
+}
+
+template <class T>
+bool QueryCondition::cmp_clause(
+    void* const cell_value, const Clause& clause) const {
+  switch (clause.op_) {
+    case QueryConditionOp::LT:
+      return *static_cast<const T*>(cell_value) <
+             *static_cast<const T*>(clause.condition_value_);
+    case QueryConditionOp::LE:
+      return *static_cast<const T*>(cell_value) <=
+             *static_cast<const T*>(clause.condition_value_);
+    case QueryConditionOp::GT:
+      return *static_cast<const T*>(cell_value) >
+             *static_cast<const T*>(clause.condition_value_);
+    case QueryConditionOp::GE:
+      return *static_cast<const T*>(cell_value) >=
+             *static_cast<const T*>(clause.condition_value_);
+    case QueryConditionOp::EQ:
+      return *static_cast<const T*>(cell_value) ==
+             *static_cast<const T*>(clause.condition_value_);
+    case QueryConditionOp::NE:
+      return *static_cast<const T*>(cell_value) !=
+             *static_cast<const T*>(clause.condition_value_);
+    default:
+      LOG_FATAL("Unknown query condition op");
+  }
+
+  return false;
+}
+
+bool QueryCondition::cmp_clause_str(
+    void* const cell_value,
+    const uint64_t cell_value_size,
+    const Clause& clause) const {
+  std::string cell_value_str(
+      static_cast<const char*>(cell_value), cell_value_size);
+  std::string condition_value_str(
+      static_cast<const char*>(clause.condition_value_),
+      clause.condition_value_size_);
+
+  switch (clause.op_) {
+    case QueryConditionOp::LT:
+      return cell_value_str < condition_value_str;
+    case QueryConditionOp::LE:
+      return cell_value_str <= condition_value_str;
+    case QueryConditionOp::GT:
+      return cell_value_str > condition_value_str;
+    case QueryConditionOp::GE:
+      return cell_value_str >= condition_value_str;
+    case QueryConditionOp::EQ:
+      return cell_value_str == condition_value_str;
+    case QueryConditionOp::NE:
+      return cell_value_str != condition_value_str;
+    default:
+      LOG_FATAL("Unknown query condition op");
+  }
+
+  return false;
+}
+
+template <class T>
+Status QueryCondition::cmp_clause(
+    ResultTile* const result_tile,
+    const uint64_t cell_idx,
+    const Clause& clause,
+    bool* const cmp) const {
+  T cell_value;
+  RETURN_NOT_OK(
+      result_tile->read(clause.field_name_, &cell_value, 0, cell_idx, 1));
+  *cmp = cmp_clause<T>(&cell_value, clause);
+  return Status::Ok();
+}
+
+Status QueryCondition::cmp_clause_str(
+    ResultTile* const result_tile,
+    const uint64_t cell_idx,
+    const Clause& clause,
+    bool* const cmp) const {
+  const Tile& tile = std::get<0>(*result_tile->tile_tuple(clause.field_name_));
+  const uint64_t cell_size = tile.cell_size();
+
+  char* const cell_value = static_cast<char*>(tdb_malloc(cell_size));
+
+  const Status st =
+      result_tile->read(clause.field_name_, cell_value, 0, cell_idx, 1);
+  if (!st.ok()) {
+    tdb_free(cell_value);
+    return st;
+  }
+
+  *cmp = cmp_clause_str(cell_value, cell_size, clause);
+
+  tdb_free(cell_value);
+
+  return Status::Ok();
+}
+
+Status QueryCondition::cmp_cell(
+    const ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    const uint64_t cell_idx,
+    bool* const cmp) const {
+  if (clauses_.empty() || result_tile->cell_num() == 0) {
+    *cmp = true;
+    return Status::Ok();
+  }
+
+  // We have a combination op between each clause, where each
+  // combination op is an 'AND'.
+  assert(clauses_.size() - 1 == combination_ops_.size());
+
+  for (const auto& clause : clauses_) {
+    const Attribute* const attribute =
+        array_schema->attribute(clause.field_name_);
+    if (!attribute) {
+      return LOG_STATUS(Status::QueryConditionError(
+          "Unknown attribute " + clause.field_name_));
+    }
+
+    const Datatype type = attribute->type();
+    switch (type) {
+      case Datatype::INT8:
+        RETURN_NOT_OK(cmp_clause<int8_t>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::UINT8:
+        RETURN_NOT_OK(cmp_clause<uint8_t>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::INT16:
+        RETURN_NOT_OK(cmp_clause<int16_t>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::UINT16:
+        RETURN_NOT_OK(cmp_clause<uint16_t>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::INT32:
+        RETURN_NOT_OK(cmp_clause<int32_t>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::UINT32:
+        RETURN_NOT_OK(cmp_clause<uint32_t>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::INT64:
+        RETURN_NOT_OK(cmp_clause<int64_t>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::UINT64:
+        RETURN_NOT_OK(cmp_clause<uint64_t>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::FLOAT32:
+        RETURN_NOT_OK(cmp_clause<float>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::FLOAT64:
+        RETURN_NOT_OK(cmp_clause<double>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::STRING_ASCII:
+        RETURN_NOT_OK(cmp_clause_str(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::CHAR:
+        RETURN_NOT_OK(cmp_clause<char>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::DATETIME_YEAR:
+      case Datatype::DATETIME_MONTH:
+      case Datatype::DATETIME_WEEK:
+      case Datatype::DATETIME_DAY:
+      case Datatype::DATETIME_HR:
+      case Datatype::DATETIME_MIN:
+      case Datatype::DATETIME_SEC:
+      case Datatype::DATETIME_MS:
+      case Datatype::DATETIME_US:
+      case Datatype::DATETIME_NS:
+      case Datatype::DATETIME_PS:
+      case Datatype::DATETIME_FS:
+      case Datatype::DATETIME_AS:
+        RETURN_NOT_OK(cmp_clause<int64_t>(result_tile, cell_idx, clause, cmp));
+        break;
+      case Datatype::ANY:
+      case Datatype::STRING_UTF8:
+      case Datatype::STRING_UTF16:
+      case Datatype::STRING_UTF32:
+      case Datatype::STRING_UCS2:
+      case Datatype::STRING_UCS4:
+      default:
+        return LOG_STATUS(Status::ReaderError(
+            "Cannot perform query comparison; Unsupported query "
+            "conditional type on " +
+            clause.field_name_));
+    }
+
+    if (!*cmp) {
+      return Status::Ok();
+    }
+  }
+
+  *cmp = true;
+  return Status::Ok();
+}
+
+Status QueryCondition::cmp_cell_fill_value(
+    const ArraySchema* const array_schema, bool* const cmp) const {
+  if (clauses_.empty()) {
+    *cmp = true;
+    return Status::Ok();
+  }
+
+  // We have a combination op between each clause, where each
+  // combination op is an 'AND'.
+  assert(clauses_.size() - 1 == combination_ops_.size());
+
+  for (const auto& clause : clauses_) {
+    const Attribute* const attribute =
+        array_schema->attribute(clause.field_name_);
+    if (!attribute) {
+      return LOG_STATUS(Status::QueryConditionError(
+          "Unknown attribute " + clause.field_name_));
+    }
+
+    const Datatype type = attribute->type();
+    ByteVecValue fill_value = attribute->fill_value();
+    switch (type) {
+      case Datatype::INT8:
+        *cmp = cmp_clause<int8_t>(fill_value.data(), clause);
+        break;
+      case Datatype::UINT8:
+        *cmp = cmp_clause<uint8_t>(fill_value.data(), clause);
+        break;
+      case Datatype::INT16:
+        *cmp = cmp_clause<int16_t>(fill_value.data(), clause);
+        break;
+      case Datatype::UINT16:
+        *cmp = cmp_clause<uint16_t>(fill_value.data(), clause);
+        break;
+      case Datatype::INT32:
+        *cmp = cmp_clause<int32_t>(fill_value.data(), clause);
+        break;
+      case Datatype::UINT32:
+        *cmp = cmp_clause<uint32_t>(fill_value.data(), clause);
+        break;
+      case Datatype::INT64:
+        *cmp = cmp_clause<int64_t>(fill_value.data(), clause);
+        break;
+      case Datatype::UINT64:
+        *cmp = cmp_clause<uint64_t>(fill_value.data(), clause);
+        break;
+      case Datatype::FLOAT32:
+        *cmp = cmp_clause<float>(fill_value.data(), clause);
+        break;
+      case Datatype::FLOAT64:
+        *cmp = cmp_clause<double>(fill_value.data(), clause);
+        break;
+      case Datatype::STRING_ASCII:
+        *cmp = cmp_clause_str(fill_value.data(), fill_value.size(), clause);
+        break;
+      case Datatype::CHAR:
+        *cmp = cmp_clause<char>(fill_value.data(), clause);
+        break;
+      case Datatype::DATETIME_YEAR:
+      case Datatype::DATETIME_MONTH:
+      case Datatype::DATETIME_WEEK:
+      case Datatype::DATETIME_DAY:
+      case Datatype::DATETIME_HR:
+      case Datatype::DATETIME_MIN:
+      case Datatype::DATETIME_SEC:
+      case Datatype::DATETIME_MS:
+      case Datatype::DATETIME_US:
+      case Datatype::DATETIME_NS:
+      case Datatype::DATETIME_PS:
+      case Datatype::DATETIME_FS:
+      case Datatype::DATETIME_AS:
+        *cmp = cmp_clause<int64_t>(fill_value.data(), clause);
+        break;
+      case Datatype::ANY:
+      case Datatype::STRING_UTF8:
+      case Datatype::STRING_UTF16:
+      case Datatype::STRING_UTF32:
+      case Datatype::STRING_UCS2:
+      case Datatype::STRING_UCS4:
+      default:
+        return LOG_STATUS(Status::ReaderError(
+            "Cannot perform query comparison; Unsupported query "
+            "conditional type on " +
+            clause.field_name_));
+    }
+
+    if (!*cmp) {
+      return Status::Ok();
+    }
+  }
+
+  *cmp = true;
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -1,0 +1,311 @@
+/**
+ * @file query_condition.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Defines the QueryCondition class.
+ */
+
+#ifndef TILEDB_QUERY_CONDITION_H
+#define TILEDB_QUERY_CONDITION_H
+
+#include <unordered_set>
+
+#include "tiledb/common/logger.h"
+#include "tiledb/common/status.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/query/result_tile.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+enum class QueryConditionOp : uint8_t;
+enum class QueryConditionCombinationOp : uint8_t;
+
+class QueryCondition {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Default constructor. */
+  QueryCondition();
+
+  /** Value constructor.
+   *
+   * @param field_name The name of the field this operation applies to.
+   * @param condition_value The value to compare to.
+   * @param condition_value_size The byte size of condition_value.
+   * @param op The relational operation between the value of the field
+   *     and `condition_value`.
+   */
+  QueryCondition(
+      std::string&& field_name,
+      const void* condition_value,
+      uint64_t condition_value_size,
+      QueryConditionOp op);
+
+  /** Copy constructor. */
+  QueryCondition(const QueryCondition& rhs);
+
+  /** Move constructor. */
+  QueryCondition(QueryCondition&& rhs);
+
+  /** Destructor. */
+  ~QueryCondition();
+
+  /* ********************************* */
+  /*             OPERATORS             */
+  /* ********************************* */
+
+  /** Copy-assignment operator. */
+  QueryCondition& operator=(const QueryCondition& rhs);
+
+  /** Move-assignment operator. */
+  QueryCondition& operator=(QueryCondition&& rhs);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Verifies that the current state contains supported comparison
+   * operations. Currently, we support the following:
+   *   - Fixed-size, single-value, non-nullable attributes.
+   *   - The QueryConditionCombinationOp::AND operator.
+   *
+   * @param array_schema The current array schena.
+   * @return Status
+   */
+  Status check(const ArraySchema* array_schema) const;
+
+  /**
+   * Combines this instance with the right-hand-side instance by
+   * the given operator.
+   *
+   * @param rhs The condition instance to combine with.
+   * @param combination_op The operation to combine them.
+   * @param combined_cond The output condition to mutate. This is
+   *    expected to be allocated by the caller.
+   * @return Status
+   */
+  Status combine(
+      const QueryCondition& rhs,
+      QueryConditionCombinationOp combination_op,
+      QueryCondition* combined_cond) const;
+
+  /**
+   * Returns true if this condition does not have any conditional clauses.
+   */
+  bool empty() const;
+
+  /**
+   * Returns a set of all unique field names among the conditional clauses.
+   */
+  std::unordered_set<std::string> field_names() const;
+
+  /**
+   * Compares the cell in `result_tile` at `cell_idx` against all of
+   * the conditional clauses. The output, `cmp` determines whether
+   * the cell should be extracted or filtered.
+   *
+   * @param array_schema The array schema.
+   * @param result_tile The tile containing the cell value.
+   * @param cell_idx The index of the cell within `result_tile`.
+   * @param cmp Mutates to true if the cell should be extracted.
+   *   Otherwise, this mutates to false to indicate that the cell
+   *   should be filtered out from the results.
+   * @return Status
+   */
+  Status cmp_cell(
+      const ArraySchema* array_schema,
+      ResultTile* result_tile,
+      uint64_t cell_idx,
+      bool* cmp) const;
+
+  /**
+   * Compares the against fill values for the attributes in the conditional
+   * clauses.
+   *
+   * @param array_schema The array schema.
+   * @param cmp Mutates to true if the cell should be extracted.
+   *   Otherwise, this mutates to false to indicate that the cell
+   *   should be filtered out from the results.
+   * @return Status
+   */
+  Status cmp_cell_fill_value(const ArraySchema* array_schema, bool* cmp) const;
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE DATATYPES         */
+  /* ********************************* */
+
+  /** Represents a single, conditional clause. */
+  struct Clause {
+    /** Value constructor. */
+    Clause(
+        std::string&& field_name,
+        const void* const condition_value,
+        const uint64_t condition_value_size,
+        const QueryConditionOp op)
+        : field_name_(std::move(field_name))
+        , condition_value_(condition_value)
+        , condition_value_size_(condition_value_size)
+        , op_(op){};
+
+    /** Copy constructor. */
+    Clause(const Clause& rhs)
+        : field_name_(rhs.field_name_)
+        , condition_value_(rhs.condition_value_)
+        , condition_value_size_(rhs.condition_value_size_)
+        , op_(rhs.op_){};
+
+    /** Move constructor. */
+    Clause(Clause&& rhs)
+        : field_name_(std::move(rhs.field_name_))
+        , condition_value_(rhs.condition_value_)
+        , condition_value_size_(rhs.condition_value_size_)
+        , op_(rhs.op_){};
+
+    /** Assignment operator. */
+    Clause& operator=(const Clause& rhs) {
+      field_name_ = rhs.field_name_;
+      condition_value_ = rhs.condition_value_;
+      condition_value_size_ = rhs.condition_value_size_;
+      op_ = rhs.op_;
+
+      return *this;
+    }
+
+    /** Move-assignment operator. */
+    Clause& operator=(Clause&& rhs) {
+      field_name_ = std::move(rhs.field_name_);
+      condition_value_ = rhs.condition_value_;
+      condition_value_size_ = rhs.condition_value_size_;
+      op_ = rhs.op_;
+
+      return *this;
+    }
+
+    /** The attribute name. */
+    std::string field_name_;
+
+    /** The value to compare against. */
+    const void* condition_value_;
+
+    /** The byte size of `condition_value_`. */
+    uint64_t condition_value_size_;
+
+    /** The comparison operator. */
+    QueryConditionOp op_;
+  };
+
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /**
+   * All clauses in this condition. Clauses `clauses_[i]` and
+   * `clauses_[i + 1]` are combined by the `combination_ops_[i]`
+   * operator.
+   */
+  std::vector<Clause> clauses_;
+
+  /** Logical operators to combine clauses stored in `clauses_`. */
+  std::vector<QueryConditionCombinationOp> combination_ops_;
+
+  /* ********************************* */
+  /*          PRIVATE METHODS          */
+  /* ********************************* */
+
+  /**
+   * Compares a value against an individual conditional clause.
+   *
+   * @tparam T the primtive cell type.
+   * @param cell_value The cell value, assumed to be of size T.
+   * @param clause The clause to compare against.
+   * @return true if the cell should be extracted.
+   *   Otherwise, this mutates to false to indicate that the cell
+   *   should be filtered out from the results.
+   */
+  template <class T>
+  bool cmp_clause(void* cell_value, const Clause& clause) const;
+
+  /**
+   * Compares a string value against an individual conditional clause.
+   *
+   * @tparam T the primtive cell type.
+   * @param cell_value The string value, assumed to be of size T.
+   * @param clause The clause to compare against.
+   * @return true if the cell should be extracted.
+   *   Otherwise, this mutates to false to indicate that the cell
+   *   should be filtered out from the results.
+   */
+  bool cmp_clause_str(
+      void* cell_value, uint64_t cell_value_size, const Clause& clause) const;
+
+  /**
+   * Compares a cell against an individual conditional clause.
+   *
+   * @tparam T the primtive cell type.
+   * @param result_tile The tile containing the cell value.
+   * @param cell_idx The index of the cell within `result_tile`.
+   * @param clause The clause to compare against.
+   * @param cmp Mutates to true if the cell should be extracted.
+   *   Otherwise, this mutates to false to indicate that the cell
+   *   should be filtered out from the results.
+   */
+  template <class T>
+  Status cmp_clause(
+      ResultTile* result_tile,
+      uint64_t cell_idx,
+      const Clause& clause,
+      bool* cmp) const;
+
+  /**
+   * Compares a string cell against an individual conditional clause.
+   *
+   * @param result_tile The tile containing the cell value.
+   * @param cell_idx The index of the cell within `result_tile`.
+   * @param clause The clause to compare against.
+   * @param cmp Mutates to true if the cell should be extracted.
+   *   Otherwise, this mutates to false to indicate that the cell
+   *   should be filtered out from the results.
+   */
+  Status cmp_clause_str(
+      ResultTile* result_tile,
+      uint64_t cell_idx,
+      const Clause& clause,
+      bool* cmp) const;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_QUERY_CONDITION_H

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -45,6 +45,7 @@
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/misc/uri.h"
 #include "tiledb/sm/query/query_buffer.h"
+#include "tiledb/sm/query/query_condition.h"
 #include "tiledb/sm/query/result_cell_slab.h"
 #include "tiledb/sm/query/result_coords.h"
 #include "tiledb/sm/query/result_space_tile.h"
@@ -451,6 +452,14 @@ class Reader {
   Status set_layout(Layout layout);
 
   /**
+   * Sets the condition for filtering results.
+   *
+   * @param condition The condition object.
+   * @return Status
+   */
+  Status set_condition(const QueryCondition& condition);
+
+  /**
    * This is applicable only to dense arrays (errors out for sparse arrays),
    * and only in the case where the array is opened in a way that all its
    * fragments are sparse. If the input is `true`, then the dense array
@@ -625,6 +634,12 @@ class Reader {
   /* ********************************* */
   /*         PRIVATE DATATYPES         */
   /* ********************************* */
+
+  /** Bitflags for individual dimension/attributes in `process_tiles()`. */
+  typedef uint8_t ProcessTileFlags;
+
+  /** Bitflag values applicable to `ProcessTileFlags`. */
+  enum ProcessTileFlag { READ = 1, COPY = 2 };
 
   class CopyFixedCellsContextCache {
    public:
@@ -936,6 +951,9 @@ class Reader {
 
   /** The layout of the cells in the result of the subarray. */
   Layout layout_;
+
+  /** The query condition. */
+  QueryCondition condition_;
 
   /** Read state. */
   ReadState read_state_;
@@ -1699,6 +1717,66 @@ class Reader {
 
   /** Performs a read on a sparse array. */
   Status sparse_read();
+
+  /**
+   * Applies the query condition, `condition_`, to filter cell indexes
+   * within `result_cell_slabs`. This mutates `result_cell_slabs`.
+   *
+   * @param result_cell_slabs The unfiltered cell slabs.
+   * @param result_tiles The result tiles that must contain values for
+   *   attributes within `condition_`.
+   * @param stride The stride between cells, defaulting to UINT64_MAX
+   *   for contiguous cells.
+   * @return Status
+   */
+  Status apply_query_condition(
+      std::vector<ResultCellSlab>* result_cell_slabs,
+      const std::vector<ResultTile*>& result_tiles,
+      uint64_t stride = UINT64_MAX);
+
+  /**
+   * The work routine for `apply_query_condition` that operates on
+   * a partition of the `result_cell_slabs`.
+   *
+   * @param rcs_partition The partition to populate.
+   * @param partition_start The inclusive starting position of the
+   *   partition within `result_cell_slabs`.
+   * @param partition_end The exclusive starting position of the
+   *   partition within `result_cell_slabs`.
+   * @param result_cell_slabs The unfiltered cell slabs.
+   * @param stride The stride between cells.
+   * @return Status
+   */
+  Status apply_query_condition_partition(
+      std::vector<ResultCellSlab>* rcs_partition,
+      size_t partition_start,
+      size_t partition_end,
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      uint64_t stride);
+
+  /**
+   * For each dimension/attribute in `names`, performs the actions
+   * defined in the `ProcessTileFlags`.
+   *
+   * @param names The dimension/attribute names to process.
+   * @param result_tiles The retrieved tiles will be stored inside the
+   *   `ResultTile` instances in this vector.
+   * @param result_cell_slabs The cell slabs to process.
+   * @param stride The stride between cells, UINT64_MAX for contiguous.
+   */
+  Status process_tiles(
+      const std::unordered_map<std::string, ProcessTileFlags>& names,
+      const std::vector<ResultTile*>& result_tiles,
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      uint64_t stride);
+
+  /**
+   * Builds and returns an association from each tile in `result_cell_slabs`
+   * to the cell slabs it contains.
+   */
+  std::unordered_map<ResultTile*, std::vector<std::pair<uint64_t, uint64_t>>>
+  compute_rcs_ranges(
+      const std::vector<ResultCellSlab>& result_cell_slabs) const;
 
   /**
    * Copies the result coordinates to the user buffers.

--- a/tiledb/sm/tile/chunked_buffer.h
+++ b/tiledb/sm/tile/chunked_buffer.h
@@ -67,8 +67,8 @@
  * It is up to the caller to free the instance before destruction.
  */
 
-#ifndef TILEDB_chunked_buffer_H
-#define TILEDB_chunked_buffer_H
+#ifndef TILEDB_CHUNKED_BUFFER_H
+#define TILEDB_CHUNKED_BUFFER_H
 
 #include "tiledb/common/logger.h"
 #include "tiledb/common/status.h"
@@ -399,4 +399,4 @@ class ChunkedBuffer {
 }  // namespace sm
 }  // namespace tiledb
 
-#endif  // TILEDB_chunked_buffer_H
+#endif  // TILEDB_CHUNKED_BUFFER_H


### PR DESCRIPTION
This exposes a C API for applying relational operators on attribute values.

Within the read path, attributes in the conditional clauses are read early but
not copied back to the user buffers. Each cell value is scanned to determine if
it should be returned to the user. If a cell does not meet the criteria for
extraction, the result cell slabs are split to contain ranges that omit the
filtered cells.

Known limitations:
- Applicable only to fixed-sized, non-nullable attributes.
- Single-value cells only, with the exception of string types.
- Does not support UTF/UCS strings.

Future improvements:
- Performance profiling and improvements. Each cell is currently copied from
  the tiles before compared. We will need to use the lower-level APIs to access
  the tile buffers without using the Tile::read() interface.
- Serialization support
- CPP API support

---

TYPE: FEATURE
DESC: Adds support for filtering query results with relational operators