### PR TITLE
Remove 'empty_string3' dir

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 * Smoke Test, remove nullable structs from global namespace. [#2078](https://github.com/TileDB-Inc/TileDB/pull/2078)
 
 ## Improvements
+* The latest version of  was leaving behind a . This ensures that the directory is removed when  is run. [#2113](https://github.com/TileDB-Inc/TileDB/pull/2113)
 * Migrating AZP CI to GA [#2111](https://github.com/TileDB-Inc/TileDB/pull/2111)
 * Cache non_empty_domain for REST arrays like all other arrays [#2105](https://github.com/TileDB-Inc/TileDB/pull/2105)
 * Add additional stats printing to breakdown read state initialization timings [#2095](https://github.com/TileDB-Inc/TileDB/pull/2095)

--- a/test/src/unit-empty-var-length.cc
+++ b/test/src/unit-empty-var-length.cc
@@ -695,10 +695,10 @@ TEST_CASE_METHOD(
     std::vector<uint64_t> q2_result_offsets = {0, 0, 0, 0};
     REQUIRE(r_offsets == q2_result_offsets);
     REQUIRE(r_data[0] == StringEmptyFx3::data[0]);
+  }
 
-    VFS vfs(ctx);
-    if (vfs.is_dir(array_name)) {
-      vfs.remove_dir(array_name);
-    }
+  Context ctx;
+  if (Object::object(ctx, array_name).type() == Object::Type::Array) {
+    Object::remove(ctx, array_name);
   }
 }

--- a/test/src/unit-empty-var-length.cc
+++ b/test/src/unit-empty-var-length.cc
@@ -695,5 +695,10 @@ TEST_CASE_METHOD(
     std::vector<uint64_t> q2_result_offsets = {0, 0, 0, 0};
     REQUIRE(r_offsets == q2_result_offsets);
     REQUIRE(r_data[0] == StringEmptyFx3::data[0]);
+
+    VFS vfs(ctx);
+    if (vfs.is_dir(array_name)) {
+      vfs.remove_dir(array_name);
+    }
   }
 }


### PR DESCRIPTION
TYPE: IMPROVEMENT

DESC: The latest version of `dev` was leaving behind a `test/empty_string3/`. This ensures that the directory is removed when `make check` is run. 