### PR TITLE
Set non_empty_domain_computed_ for remote arrays (#2105)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
 
 ## Improvements
 
+* Cache non_empty_domain for REST arrays like all other arrays [#2105](https://github.com/TileDB-Inc/TileDB/pull/2105)
+
 ## Deprecations
 
 ## Bug fixes

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -849,6 +849,7 @@ Status Array::load_remote_non_empty_domain() {
       return LOG_STATUS(Status::ArrayError(
           "Cannot load metadata; remote array with no REST client."));
     RETURN_NOT_OK(rest_client->get_array_non_empty_domain(this, timestamp_));
+    non_empty_domain_computed_ = true;
   }
   return Status::Ok();
 }


### PR DESCRIPTION
* Set non_empty_domain_computed_ for remote arrays

REST arrays should set `non_empty_domain_computed_=true` like all others
to avoid refetching the non_empty_domain for each user request to get
it.

* Update HISTORY.md for #2105

Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>