### PR TITLE
Misc GHA cleanup

### DIFF
--- a/.github/workflows/automate-history.yml
+++ b/.github/workflows/automate-history.yml
@@ -5,7 +5,7 @@ on:
     types: [edited, opened, synchronize, reopened]
 
 jobs:
-  my_job_1:
+  add_history_commit:
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/build-macOS10.14-GCS.yml
+++ b/.github/workflows/build-macOS10.14-GCS.yml
@@ -1,10 +1,10 @@
 name: build-macos-10.14-GCS
 on:
   push:
-#    branches:
-#      - dev
-#      - release-*
-#      - refs/tags/*
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string

--- a/.github/workflows/build-macOS10.14-S3.yml
+++ b/.github/workflows/build-macOS10.14-S3.yml
@@ -1,10 +1,10 @@
 name: build-macos-10.14-S3
 on:
   push:
-#    branches:
-#      - dev
-#      - release-*
-#      - refs/tags/*
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string

--- a/.github/workflows/build-ubuntu16.04-AZURE.yml
+++ b/.github/workflows/build-ubuntu16.04-AZURE.yml
@@ -1,10 +1,10 @@
 name: build-ubuntu-16.04-AZURE
 on:
   push:
-#    branches:
-#      - dev
-#      - release-*
-#      - refs/tags/*
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string

--- a/.github/workflows/build-ubuntu16.04-GCS.yml
+++ b/.github/workflows/build-ubuntu16.04-GCS.yml
@@ -1,10 +1,10 @@
 name: build-ubuntu-16.04-GCS
 on:
   push:
-#    branches:
-#      - dev
-#      - release-*
-#      - refs/tags/*
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string

--- a/.github/workflows/build-ubuntu16.04-HDFS.yml
+++ b/.github/workflows/build-ubuntu16.04-HDFS.yml
@@ -1,10 +1,10 @@
 name: build-ubuntu-16.04-HDFS
 on:
   push:
-#    branches:
-#      - dev
-#      - release-*
-#      - refs/tags/*
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string

--- a/.github/workflows/build-ubuntu16.04-S3.yml
+++ b/.github/workflows/build-ubuntu16.04-S3.yml
@@ -1,10 +1,10 @@
 name: build-ubuntu-16.04-S3
 on:
   push:
-#    branches:
-#      - dev
-#      - release-*
-#      - refs/tags/*
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string

--- a/.github/workflows/build-ubuntu16.04-SERIALIZATION.yml
+++ b/.github/workflows/build-ubuntu16.04-SERIALIZATION.yml
@@ -1,10 +1,10 @@
 name: build-ubuntu-16.04-SERIALIZATION
 on:
   push:
-#    branches:
-#      - dev
-#      - release-*
-#      - refs/tags/*
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string


### PR DESCRIPTION
- This restricts the CI build jobs to not run on every push, and
- Renames the job in `automate-history` to something more appropriate

---

NO_HISTORY