### PR TITLE
Share `tile_overlap_` with partitioned `Subarray` instances.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 * Smoke Test, remove nullable structs from global namespace. [#2078](https://github.com/TileDB-Inc/TileDB/pull/2078)
 
 ## Improvements
+* Reduced memory consumption in the read path for multi-range reads. [#2118](https://github.com/TileDB-Inc/TileDB/pull/2118)
 * The latest version of  was leaving behind a . This ensures that the directory is removed when  is run. [#2113](https://github.com/TileDB-Inc/TileDB/pull/2113)
 * Migrating AZP CI to GA [#2111](https://github.com/TileDB-Inc/TileDB/pull/2111)
 * Cache non_empty_domain for REST arrays like all other arrays [#2105](https://github.com/TileDB-Inc/TileDB/pull/2105)

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -1009,10 +1009,16 @@ Status Reader::compute_range_result_coords(
   if (fragment_metadata_[fragment_idx]->dense())
     return Status::Ok();
 
-  auto tr = overlap[fragment_idx][range_idx].tile_ranges_.begin();
-  auto tr_end = overlap[fragment_idx][range_idx].tile_ranges_.end();
-  auto t = overlap[fragment_idx][range_idx].tiles_.begin();
-  auto t_end = overlap[fragment_idx][range_idx].tiles_.end();
+  const uint64_t overlap_range_offset =
+      read_state_.partitioner_.current_partition_info()->start_;
+  auto tr = overlap[fragment_idx][range_idx + overlap_range_offset]
+                .tile_ranges_.begin();
+  auto tr_end = overlap[fragment_idx][range_idx + overlap_range_offset]
+                    .tile_ranges_.end();
+  auto t =
+      overlap[fragment_idx][range_idx + overlap_range_offset].tiles_.begin();
+  auto t_end =
+      overlap[fragment_idx][range_idx + overlap_range_offset].tiles_.end();
 
   while (tr != tr_end || t != t_end) {
     // Handle tile range
@@ -1139,8 +1145,11 @@ Status Reader::compute_sparse_result_tiles(
 
   // For easy reference
   auto domain = array_schema_->domain();
-  const auto& subarray = read_state_.partitioner_.current();
+  auto& partitioner = read_state_.partitioner_;
+  const auto& subarray = partitioner.current();
   const auto& overlap = subarray.tile_overlap();
+  const uint64_t overlap_range_offset =
+      partitioner.current_partition_info()->start_;
   auto range_num = subarray.range_num();
   auto fragment_num = fragment_metadata_.size();
   std::vector<unsigned> first_fragment;
@@ -1160,7 +1169,8 @@ Status Reader::compute_sparse_result_tiles(
 
     for (uint64_t r = 0; r < range_num; ++r) {
       // Handle range of tiles (full overlap)
-      const auto& tile_ranges = overlap[f][r].tile_ranges_;
+      const auto& tile_ranges =
+          overlap[f][r + overlap_range_offset].tile_ranges_;
       for (const auto& tr : tile_ranges) {
         for (uint64_t t = tr.first; t <= tr.second; ++t) {
           auto pair = std::pair<unsigned, uint64_t>(f, t);
@@ -1178,7 +1188,7 @@ Status Reader::compute_sparse_result_tiles(
       }
 
       // Handle single tiles
-      const auto& o_tiles = overlap[f][r].tiles_;
+      const auto& o_tiles = overlap[f][r + overlap_range_offset].tiles_;
       for (const auto& o_tile : o_tiles) {
         auto t = o_tile.first;
         auto pair = std::pair<unsigned, uint64_t>(f, t);

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -579,7 +579,19 @@ class Subarray {
   const T* tile_coords_ptr(
       const std::vector<T>& tile_coords, std::vector<uint8_t>* aux) const;
 
-  /** Returns the tile overlap of the subarray. */
+  /**
+   * Returns the tile overlap of the subarray.
+   *
+   * The outer vector is indexed by fragment ids and the inner vector is
+   * indexed by range indexes.
+   *
+   * As an optimization, the underlying data structure is shared between
+   * `Subarray` instances and their partitioned `Subarray` instances created
+   * by the `SubarrayPartitioner`. The indexes in the inner vector are
+   * indexed by the ranges in the original/parent `Subarray` instance. For
+   * the partitioned/child `Subarray` instances, the caller must access the
+   * ranges by their index in the parent.
+   */
   const std::vector<std::vector<TileOverlap>>& tile_overlap() const;
 
   /**
@@ -699,14 +711,11 @@ class Subarray {
    * of all array fragments. Each element is a vector corresponding
    * to a single range of the subarray. These vectors/ranges are sorted
    * according to ``layout_``.
+   *
+   * This is shared between a `Subarray` and all of its `Subarray` partitions
+   * created by the `SubarrayPartitioner`.
    */
-  std::vector<std::vector<TileOverlap>> tile_overlap_;
-
-  /**
-   * ``True`` if the tile overlap for the ranges of the subarray has
-   *  been computed.
-   */
-  bool tile_overlap_computed_;
+  tdb_shared_ptr<std::vector<std::vector<TileOverlap>>> tile_overlap_;
 
   /**
    * ``True`` if ranges should attempt to be coalesced as they are added.


### PR DESCRIPTION
Currently, a partitioned Subarray makes a copy of all relevant `tile_overlap_`
elements in the parent. This data structure may be large. This patch shares
the data structure to deduplicate memory and save on copy time.

This changes the contract to `Subarray::tile_overlap`. The caller is now
responsible for indexing the ranges in the return value as if they were the
range indexes in the parent.

Additionally, I've removed `Subarray:tile_overlap_computed_` because we can
derive the same information by checking if `Subarray:tile_overlap_` is a nullptr.

---

TYPE: IMPROVEMENT
DESC: Reduced memory consumption in the read path for multi-range reads.