### PR TITLE
Unsplittable serialized queries need to recompute tile_overlap

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,7 @@
 ## Deprecations
 
 ## Bug fixes
+* Fix segfault in serialized queries when partition is unsplittable [#2120](https://github.com/TileDB-Inc/TileDB/pull/2120)
 * Always use original buffer size in serialized read queries serverside. [#2115](https://github.com/TileDB-Inc/TileDB/pull/2115)
 * Fix an edge-case where a read query may hang on array with string dimensions [#2089](https://github.com/TileDB-Inc/TileDB/pull/2089)
 * Fix mutex locking bugs on Windows due to unlocking on different thread and missing task join [#2077](https://github.com/TileDB-Inc/TileDB/pull/2077)


### PR DESCRIPTION
If a query is unsplittable then when it is resubmitted the query does not move to the next partition and instead attempts to run the current one again. Serialization of queries does not ship the tile overlap since it can be large. As such when deserializing if the read_state_ is unsplittable we need to make sure we recompute the tile_overlap for the current subarray so it is available for the read.

TYPE: BUG

DESC: Fix segfault in serialized queries when partition is unsplittable