### PR TITLE
Unsplittable serialized queries need to recompute tile_overlap (backport #2120)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,7 @@
 ## Bug fixes
 
 * Always use original buffer size in serialized read queries serverside. [#2115](https://github.com/TileDB-Inc/TileDB/pull/2115)
+* Fix segfault in serialized queries when partition is unsplittable [#2120](https://github.com/TileDB-Inc/TileDB/pull/2120)
 
 ## API additions
 

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -244,7 +244,8 @@ Status subarray_partitioner_from_capnp(
     const Array* array,
     const capnp::SubarrayPartitioner::Reader& reader,
     SubarrayPartitioner* partitioner,
-    ThreadPool* compute_tp) {
+    ThreadPool* compute_tp,
+    const bool& compute_current_tile_overlap) {
   // Get memory budget
   uint64_t memory_budget = 0;
   RETURN_NOT_OK(tiledb::sm::utils::parse::convert(
@@ -318,6 +319,10 @@ Status subarray_partitioner_from_capnp(
     partition_info->partition_ = Subarray(array, layout, false);
     RETURN_NOT_OK(subarray_from_capnp(
         partition_info_reader.getSubarray(), &partition_info->partition_));
+
+    if (compute_current_tile_overlap) {
+      partition_info->partition_.compute_tile_overlap(compute_tp);
+    }
   }
 
   // Partitioner state
@@ -387,7 +392,11 @@ Status read_state_from_capnp(
         array,
         read_state_reader.getSubarrayPartitioner(),
         &read_state->partitioner_,
-        compute_tp));
+        compute_tp,
+        // If the current partition is unsplittable, this means we need to make
+        // sure the tile_overlap for the current is computed because we won't go
+        // to the next partition
+        read_state->unsplittable_));
   }
 
   return Status::Ok();


### PR DESCRIPTION
If a query is unsplittable then when it is resubmitted the query does not move to the next partition and instead attempts to run the current one again. Serialization of queries does not ship the tile overlap since it can be large. As such when deserializing if the read_state_ is unsplittable we need to make sure we recompute the tile_overlap for the current subarray so it is available for the read.