### PR TITLE
Fix bug in `ResultTile::compute_results_sparse<char>`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,7 @@
 ## Deprecations
 
 ## Bug fixes
+* Corrected a bug where sparse cells may be incorrectly returned using string dimensions. [#2125](https://github.com/TileDB-Inc/TileDB/pull/2125)
 * Fix segfault in serialized queries when partition is unsplittable [#2120](https://github.com/TileDB-Inc/TileDB/pull/2120)
 * Always use original buffer size in serialized read queries serverside. [#2115](https://github.com/TileDB-Inc/TileDB/pull/2115)
 * Fix an edge-case where a read query may hang on array with string dimensions [#2089](https://github.com/TileDB-Inc/TileDB/pull/2089)

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -620,7 +620,7 @@ void ResultTile::compute_results_sparse<char>(
         uint64_t c_offset = 0, c_size = 0;
         for (uint64_t pos = first_c_pos; pos <= last_c_pos; ++pos) {
           c_offset = buff_off[pos];
-          c_size = (pos < last_c_pos) ? buff_off[pos + 1] - c_offset :
+          c_size = (pos < coords_num) ? buff_off[pos + 1] - c_offset :
                                         buff_str_size - c_offset;
           r_bitmap[pos] = str_coord_intersects(
               c_offset, c_size, buff_str, range_start, range_end);


### PR DESCRIPTION
The compute_results_sparse partitions in the input coordinates into ranges.
The size of the last coordinate is incorrectly calculated, which may corrupt
the corresponding entry in `result_bitmap` for this coordinate.

To calculate the size of a coordinate, we take the difference between two
contiguous offsets. We do not have a trailing offset for the last coordinate,
so we must leverage the total buffer size. Currently, we incorrectly do this
for the last coordinate in _every_ partition. We need to do this for the last
coordinate in the _last_ partition.

---

TYPE: BUG
DESC: Corrected a bug where sparse cells may be incorrectly returned using string dimensions.
