### PR TITLE
Consolidation/vacuum should use ctx if config null

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,8 +20,8 @@
 * Add additional stats printing to breakdown read state initialization timings [#2095](https://github.com/TileDB-Inc/TileDB/pull/2095)
 * Places the in-memory filesystem under unit test [#1961](https://github.com/TileDB-Inc/TileDB/pull/1961)
 * Adds a Github Action to automate the HISTORY.md [#2075](https://github.com/TileDB-Inc/TileDB/pull/2075)
-
 * Improve GCS multipart locking [#2087](https://github.com/TileDB-Inc/TileDB/pull/2087)
+* Consolidation functions now use the ctx's config if not config is passed [#2126](https://github.com/TileDB-Inc/TileDB/pull/2126)
 
 ## Deprecations
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3655,7 +3655,8 @@ int32_t tiledb_array_consolidate_with_key(
               static_cast<tiledb::sm::EncryptionType>(encryption_type),
               encryption_key,
               key_length,
-              (config == nullptr) ? nullptr : config->config_)))
+              (config == nullptr) ? &ctx->ctx_->storage_manager()->config() :
+                                    config->config_)))
     return TILEDB_ERR;
 
   return TILEDB_OK;
@@ -3670,7 +3671,9 @@ int32_t tiledb_array_vacuum(
   if (SAVE_ERROR_CATCH(
           ctx,
           ctx->ctx_->storage_manager()->array_vacuum(
-              array_uri, (config == nullptr) ? nullptr : config->config_)))
+              array_uri,
+              (config == nullptr) ? &ctx->ctx_->storage_manager()->config() :
+                                    config->config_)))
     return TILEDB_ERR;
 
   return TILEDB_OK;
@@ -4029,7 +4032,8 @@ int32_t tiledb_array_consolidate_metadata(
               static_cast<tiledb::sm::EncryptionType>(TILEDB_NO_ENCRYPTION),
               nullptr,
               0,
-              (config == nullptr) ? nullptr : config->config_)))
+              (config == nullptr) ? &ctx->ctx_->storage_manager()->config() :
+                                    config->config_)))
     return TILEDB_ERR;
 
   return TILEDB_OK;
@@ -4053,7 +4057,8 @@ int32_t tiledb_array_consolidate_metadata_with_key(
               static_cast<tiledb::sm::EncryptionType>(encryption_type),
               encryption_key,
               key_length,
-              (config == nullptr) ? nullptr : config->config_)))
+              (config == nullptr) ? &ctx->ctx_->storage_manager()->config() :
+                                    config->config_)))
     return TILEDB_ERR;
 
   return TILEDB_OK;


### PR DESCRIPTION
If the user only passes a ctx and not a config we should use the config from the ctx object for the consolidation and vacuum functions.

<!--
Thank you for your contribution. Please add a summary of the change and fill in the TYPE an DESC for automatic addition to HISTORY.md
-->

<!-- Automatic history file management:
  Set the type to one of FORMAT, BREAKING_API, BREAKING_BEHAVIOR, FEATURE, IMPROVEMENT, DEPRECATION, BUG, C_API, CPP_API or NO_HISTORY.
  NO_HISTORY should be used rarely. It is mostly associated with repo level changes (README/CI/etc) that do not need to be logged in
  the HISTORY.md file for version updates.
  Set the DESC to a one line summary of the change
-->
TYPE: BUG

DESC: Consolidate and vacuum will now correctly use the ctx's config if no config is passed directly.
