### PR TITLE
Print read stats when array is opened

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 * Smoke Test, remove nullable structs from global namespace. [#2078](https://github.com/TileDB-Inc/TileDB/pull/2078)
 
 ## Improvements
+* Allow open array stats to be printed without read query [#2131](https://github.com/TileDB-Inc/TileDB/pull/2131)
 * Cleanup the GHA CI scripts - put common code into external shell scripts. [#2124](https://github.com/TileDB-Inc/TileDB/pull/2124)
 * Reduced memory consumption in the read path for multi-range reads. [#2118](https://github.com/TileDB-Inc/TileDB/pull/2118)
 * The latest version of  was leaving behind a . This ensures that the directory is removed when  is run. [#2113](https://github.com/TileDB-Inc/TileDB/pull/2113)

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -529,7 +529,7 @@ std::string Stats::dump_read() const {
       read_overlap_tile_num * read_attr_nullable_num;
 
   std::stringstream ss;
-  if (read_num != 0) {
+  if (read_num != 0 || read_array_open > 0) {
     ss << "==== READ ====\n\n";
     write(&ss, "- Number of read queries: ", read_num);
     write(&ss, "- Number of attempts until results are found: ", read_loop_num);


### PR DESCRIPTION
This allows the open array stats to be shown without having to run a query


TYPE: IMPROVEMENT

DESC: Allow open array stats to be printed without read query
