### PR TITLE
[Backport release-2.2] Print read stats when array is opened (#2131)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 
 * Cache non_empty_domain for REST arrays like all other arrays [#2105](https://github.com/TileDB-Inc/TileDB/pull/2105)
 * Add additional timer statistics for openning array for reads [#2027](https://github.com/TileDB-Inc/TileDB/pull/2027)
+* Allow open array stats to be printed without read query [#2131](https://github.com/TileDB-Inc/TileDB/pull/2131)
 
 ## Deprecations
 

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -497,7 +497,7 @@ std::string Stats::dump_read() const {
       read_overlap_tile_num * read_attr_nullable_num;
 
   std::stringstream ss;
-  if (read_num != 0) {
+  if (read_num != 0 || read_array_open > 0) {
     ss << "==== READ ====\n\n";
     write(&ss, "- Number of read queries: ", read_num);
     write(&ss, "- Number of attempts until results are found: ", read_loop_num);


### PR DESCRIPTION
This allows the open array stats to be shown without having to run a query