### PR TITLE
[Backport release-2.2] Share `tile_overlap_` with partitioned `Subarray` instances. (#2118)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,6 +24,7 @@
 
 ## Improvements
 
+* Reduced memory consumption in the read path for multi-range reads. [#2118](https://github.com/TileDB-Inc/TileDB/pull/2118)
 * Cache non_empty_domain for REST arrays like all other arrays [#2105](https://github.com/TileDB-Inc/TileDB/pull/2105)
 * Add additional timer statistics for openning array for reads [#2027](https://github.com/TileDB-Inc/TileDB/pull/2027)
 * Allow open array stats to be printed without read query [#2131](https://github.com/TileDB-Inc/TileDB/pull/2131)

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -1009,10 +1009,16 @@ Status Reader::compute_range_result_coords(
   if (fragment_metadata_[fragment_idx]->dense())
     return Status::Ok();
 
-  auto tr = overlap[fragment_idx][range_idx].tile_ranges_.begin();
-  auto tr_end = overlap[fragment_idx][range_idx].tile_ranges_.end();
-  auto t = overlap[fragment_idx][range_idx].tiles_.begin();
-  auto t_end = overlap[fragment_idx][range_idx].tiles_.end();
+  const uint64_t overlap_range_offset =
+      read_state_.partitioner_.current_partition_info()->start_;
+  auto tr = overlap[fragment_idx][range_idx + overlap_range_offset]
+                .tile_ranges_.begin();
+  auto tr_end = overlap[fragment_idx][range_idx + overlap_range_offset]
+                    .tile_ranges_.end();
+  auto t =
+      overlap[fragment_idx][range_idx + overlap_range_offset].tiles_.begin();
+  auto t_end =
+      overlap[fragment_idx][range_idx + overlap_range_offset].tiles_.end();
 
   while (tr != tr_end || t != t_end) {
     // Handle tile range
@@ -1139,8 +1145,11 @@ Status Reader::compute_sparse_result_tiles(
 
   // For easy reference
   auto domain = array_schema_->domain();
-  const auto& subarray = read_state_.partitioner_.current();
+  auto& partitioner = read_state_.partitioner_;
+  const auto& subarray = partitioner.current();
   const auto& overlap = subarray.tile_overlap();
+  const uint64_t overlap_range_offset =
+      partitioner.current_partition_info()->start_;
   auto range_num = subarray.range_num();
   auto fragment_num = fragment_metadata_.size();
   std::vector<unsigned> first_fragment;
@@ -1160,7 +1169,8 @@ Status Reader::compute_sparse_result_tiles(
 
     for (uint64_t r = 0; r < range_num; ++r) {
       // Handle range of tiles (full overlap)
-      const auto& tile_ranges = overlap[f][r].tile_ranges_;
+      const auto& tile_ranges =
+          overlap[f][r + overlap_range_offset].tile_ranges_;
       for (const auto& tr : tile_ranges) {
         for (uint64_t t = tr.first; t <= tr.second; ++t) {
           auto pair = std::pair<unsigned, uint64_t>(f, t);
@@ -1178,7 +1188,7 @@ Status Reader::compute_sparse_result_tiles(
       }
 
       // Handle single tiles
-      const auto& o_tiles = overlap[f][r].tiles_;
+      const auto& o_tiles = overlap[f][r + overlap_range_offset].tiles_;
       for (const auto& o_tile : o_tiles) {
         auto t = o_tile.first;
         auto pair = std::pair<unsigned, uint64_t>(f, t);

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1905,7 +1905,7 @@ Status Subarray::compute_tile_overlap(ThreadPool* const compute_tp) {
   compute_range_offsets();
 
   // Initialization
-  tile_overlap_ = tdb_make_shared(std::vector<std::vector<TileOverlap>>);
+  tile_overlap_ = std::make_shared<std::vector<std::vector<TileOverlap>>>();
   auto meta = array_->fragment_metadata();
   auto fragment_num = meta.size();
   tile_overlap_->resize(fragment_num);

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -715,7 +715,7 @@ class Subarray {
    * This is shared between a `Subarray` and all of its `Subarray` partitions
    * created by the `SubarrayPartitioner`.
    */
-  tdb_shared_ptr<std::vector<std::vector<TileOverlap>>> tile_overlap_;
+  std::shared_ptr<std::vector<std::vector<TileOverlap>>> tile_overlap_;
 
   /**
    * ``True`` if ranges should attempt to be coalesced as they are added.

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -579,7 +579,19 @@ class Subarray {
   const T* tile_coords_ptr(
       const std::vector<T>& tile_coords, std::vector<uint8_t>* aux) const;
 
-  /** Returns the tile overlap of the subarray. */
+  /**
+   * Returns the tile overlap of the subarray.
+   *
+   * The outer vector is indexed by fragment ids and the inner vector is
+   * indexed by range indexes.
+   *
+   * As an optimization, the underlying data structure is shared between
+   * `Subarray` instances and their partitioned `Subarray` instances created
+   * by the `SubarrayPartitioner`. The indexes in the inner vector are
+   * indexed by the ranges in the original/parent `Subarray` instance. For
+   * the partitioned/child `Subarray` instances, the caller must access the
+   * ranges by their index in the parent.
+   */
   const std::vector<std::vector<TileOverlap>>& tile_overlap() const;
 
   /**
@@ -699,14 +711,11 @@ class Subarray {
    * of all array fragments. Each element is a vector corresponding
    * to a single range of the subarray. These vectors/ranges are sorted
    * according to ``layout_``.
+   *
+   * This is shared between a `Subarray` and all of its `Subarray` partitions
+   * created by the `SubarrayPartitioner`.
    */
-  std::vector<std::vector<TileOverlap>> tile_overlap_;
-
-  /**
-   * ``True`` if the tile overlap for the ranges of the subarray has
-   *  been computed.
-   */
-  bool tile_overlap_computed_;
+  tdb_shared_ptr<std::vector<std::vector<TileOverlap>>> tile_overlap_;
 
   /**
    * ``True`` if ranges should attempt to be coalesced as they are added.


### PR DESCRIPTION
* Share `tile_overlap_` with partitioned `Subarray` instances.

Currently, a partitioned Subarray makes a copy of all relevant `tile_overlap_`
elements in the parent. This data structure may be large. This patch shares
the data structure to deduplicate memory and save on copy time.

This changes the contract to `Subarray::tile_overlap`. The caller is now
responsible for indexing the ranges in the return value as if they were the
range indexes in the parent.

Additionally, I've removed `Subarray:tile_overlap_computed_` because we can
derive the same information by checking if `Subarray:tile_overlap_` is a nullptr.

---

TYPE: IMPROVEMENT
DESC: Reduced memory consumption in the read path for multi-range reads.

