### PR TITLE
[Backport] S3 Server-Side Encryption (#2130)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,10 @@
 
 # TileDB v2.2.5 Release Notes
 
+## New features
+
+* Config option vfs.s3.sse for S3 server-side encryption support [#2130](https://github.com/TileDB-Inc/TileDB/pull/2130)
+
 ## Improvements
 
 * Cache non_empty_domain for REST arrays like all other arrays [#2105](https://github.com/TileDB-Inc/TileDB/pull/2105)

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -542,6 +542,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.s3.connect_timeout_ms"] = "3000";
   all_param_values["vfs.s3.connect_max_tries"] = "5";
   all_param_values["vfs.s3.connect_scale_factor"] = "25";
+  all_param_values["vfs.s3.sse"] = "";
+  all_param_values["vfs.s3.sse_kms_key_id"] = "";
   all_param_values["vfs.s3.logging_level"] = "Off";
   all_param_values["vfs.s3.request_timeout_ms"] = "3000";
   all_param_values["vfs.s3.requester_pays"] = "false";
@@ -599,6 +601,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.connect_timeout_ms"] = "3000";
   vfs_param_values["s3.connect_max_tries"] = "5";
   vfs_param_values["s3.connect_scale_factor"] = "25";
+  vfs_param_values["s3.sse"] = "";
+  vfs_param_values["s3.sse_kms_key_id"] = "";
   vfs_param_values["s3.logging_level"] = "Off";
   vfs_param_values["s3.request_timeout_ms"] = "3000";
   vfs_param_values["s3.requester_pays"] = "false";
@@ -650,6 +654,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["connect_timeout_ms"] = "3000";
   s3_param_values["connect_max_tries"] = "5";
   s3_param_values["connect_scale_factor"] = "25";
+  s3_param_values["sse"] = "";
+  s3_param_values["sse_kms_key_id"] = "";
   s3_param_values["logging_level"] = "Off";
   s3_param_values["request_timeout_ms"] = "3000";
   s3_param_values["requester_pays"] = "false";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -60,7 +60,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 51);
+  CHECK(names.size() == 53);
 }
 
 TEST_CASE(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1175,6 +1175,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.s3.verify_ssl` <br>
  *    Enable HTTPS certificate verification. <br>
  *    **Default**: true""
+ * - `vfs.s3.sse` <br>
+ *    The server-side encryption algorithm to use. Supported non-empty
+ *    values are "aes256" and "kms" (AWS key management service). <br>
+ *    **Default**: ""
  * - `vfs.hdfs.name_node_uri"` <br>
  *    Name node for HDFS. <br>
  *    **Default**: ""

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -132,6 +132,8 @@ const std::string Config::VFS_S3_CA_PATH = "";
 const std::string Config::VFS_S3_CONNECT_TIMEOUT_MS = "3000";
 const std::string Config::VFS_S3_CONNECT_MAX_TRIES = "5";
 const std::string Config::VFS_S3_CONNECT_SCALE_FACTOR = "25";
+const std::string Config::VFS_S3_SSE = "";
+const std::string Config::VFS_S3_SSE_KMS_KEY_ID = "";
 const std::string Config::VFS_S3_REQUEST_TIMEOUT_MS = "3000";
 const std::string Config::VFS_S3_REQUESTER_PAYS = "false";
 const std::string Config::VFS_S3_PROXY_SCHEME = "http";
@@ -259,6 +261,8 @@ Config::Config() {
   param_values_["vfs.s3.connect_timeout_ms"] = VFS_S3_CONNECT_TIMEOUT_MS;
   param_values_["vfs.s3.connect_max_tries"] = VFS_S3_CONNECT_MAX_TRIES;
   param_values_["vfs.s3.connect_scale_factor"] = VFS_S3_CONNECT_SCALE_FACTOR;
+  param_values_["vfs.s3.sse"] = VFS_S3_SSE;
+  param_values_["vfs.s3.sse_kms_key_id"] = VFS_S3_SSE_KMS_KEY_ID;
   param_values_["vfs.s3.request_timeout_ms"] = VFS_S3_REQUEST_TIMEOUT_MS;
   param_values_["vfs.s3.requester_pays"] = VFS_S3_REQUESTER_PAYS;
   param_values_["vfs.s3.proxy_scheme"] = VFS_S3_PROXY_SCHEME;
@@ -553,6 +557,10 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.s3.connect_max_tries"] = VFS_S3_CONNECT_MAX_TRIES;
   } else if (param == "vfs.s3.connect_scale_factor") {
     param_values_["vfs.s3.connect_scale_factor"] = VFS_S3_CONNECT_SCALE_FACTOR;
+  } else if (param == "vfs.s3.sse") {
+    param_values_["vfs.s3.sse"] = VFS_S3_SSE;
+  } else if (param == "vfs.s3.sse_kms_key_id") {
+    param_values_["vfs.s3.sse_kms_key_id"] = VFS_S3_SSE_KMS_KEY_ID;
   } else if (param == "vfs.s3.request_timeout_ms") {
     param_values_["vfs.s3.request_timeout_ms"] = VFS_S3_REQUEST_TIMEOUT_MS;
   } else if (param == "vfs.s3.requester_pays") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -332,6 +332,12 @@ class Config {
   /** Connect scale factor for exponential backoff. */
   static const std::string VFS_S3_CONNECT_SCALE_FACTOR;
 
+  /** S3 server-side encryption algorithm. */
+  static const std::string VFS_S3_SSE;
+
+  /** The S3 KMS key id for KMS server-side-encryption. */
+  static const std::string VFS_S3_SSE_KMS_KEY_ID;
+
   /** Request timeout in milliseconds. */
   static const std::string VFS_S3_REQUEST_TIMEOUT_MS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -515,7 +515,11 @@ class Config {
    *    **Default**: ""
    * - `vfs.s3.verify_ssl` <br>
    *    Enable HTTPS certificate verification. <br>
-   *    **Default**: true""
+   *    **Default**: true
+   * - `vfs.s3.sse` <br>
+   *    The server-side encryption algorithm to use. Supported non-empty
+   *    values are "aes256" and "kms" (AWS key management service). <br>
+   *    **Default**: ""
    * - `vfs.hdfs.name_node_uri"` <br>
    *    Name node for HDFS. <br>
    *    **Default**: ""

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -122,7 +122,8 @@ S3::S3()
     , vfs_thread_pool_(nullptr)
     , use_virtual_addressing_(false)
     , use_multipart_upload_(true)
-    , request_payer_(Aws::S3::Model::RequestPayer::NOT_SET) {
+    , request_payer_(Aws::S3::Model::RequestPayer::NOT_SET)
+    , sse_(Aws::S3::Model::ServerSideEncryption::NOT_SET) {
 }
 
 S3::~S3() {
@@ -196,6 +197,38 @@ Status S3::init(const Config& config, ThreadPool* const thread_pool) {
 
   if (request_payer)
     request_payer_ = Aws::S3::Model::RequestPayer::requester;
+
+  auto sse = config.get("vfs.s3.sse", &found);
+  assert(found);
+
+  auto sse_kms_key_id = config.get("vfs.s3.sse_kms_key_id", &found);
+  assert(found);
+
+  if (!sse.empty()) {
+    if (sse == "aes256") {
+      sse_ = Aws::S3::Model::ServerSideEncryption::AES256;
+    } else if (sse == "kms") {
+      sse_ = Aws::S3::Model::ServerSideEncryption::aws_kms;
+      sse_kms_key_id_ = sse_kms_key_id;
+      if (sse_kms_key_id_.empty()) {
+        return Status::S3Error(
+            "Config parameter 'vfs.s3.sse_kms_key_id' must be set "
+            "for kms server-side encryption.");
+      }
+    } else {
+      return Status::S3Error(
+          "Unknown 'vfs.s3.sse' config value " + sse +
+          "; supported values are 'aes256' and 'kms'.");
+    }
+  }
+
+  // Ensure `sse_kms_key_id` was only set for kms encryption.
+  if (!sse_kms_key_id.empty() &&
+      sse_ != Aws::S3::Model::ServerSideEncryption::aws_kms) {
+    return Status::S3Error(
+        "Config parameter 'vfs.s3.sse_kms_key_id' may only be "
+        "set for 'vfs.s3.sse' == 'kms'.");
+  }
 
   config_ = config;
 
@@ -816,6 +849,10 @@ Status S3::touch(const URI& uri) const {
   put_object_request.SetBody(request_stream);
   if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET)
     put_object_request.SetRequestPayer(request_payer_);
+  if (sse_ != Aws::S3::Model::ServerSideEncryption::NOT_SET)
+    put_object_request.SetServerSideEncryption(sse_);
+  if (!sse_kms_key_id_.empty())
+    put_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
 
   auto put_object_outcome = client_->PutObject(put_object_request);
   if (!put_object_outcome.IsSuccess()) {
@@ -1104,6 +1141,10 @@ Status S3::copy_object(const URI& old_uri, const URI& new_uri) {
   copy_object_request.SetKey(dst_uri.GetPath());
   if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET)
     copy_object_request.SetRequestPayer(request_payer_);
+  if (sse_ != Aws::S3::Model::ServerSideEncryption::NOT_SET)
+    copy_object_request.SetServerSideEncryption(sse_);
+  if (!sse_kms_key_id_.empty())
+    copy_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
 
   auto copy_object_outcome = client_->CopyObject(copy_object_request);
   if (!copy_object_outcome.IsSuccess()) {
@@ -1189,6 +1230,11 @@ Status S3::initiate_multipart_request(
   multipart_upload_request.SetContentType("application/octet-stream");
   if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET)
     multipart_upload_request.SetRequestPayer(request_payer_);
+  if (sse_ != Aws::S3::Model::ServerSideEncryption::NOT_SET)
+    multipart_upload_request.SetServerSideEncryption(sse_);
+  if (!sse_kms_key_id_.empty())
+    multipart_upload_request.SetSSEKMSKeyId(
+        Aws::String(sse_kms_key_id_.c_str()));
 
   auto multipart_upload_outcome =
       client_->CreateMultipartUpload(multipart_upload_request);
@@ -1313,6 +1359,10 @@ Status S3::flush_direct(const URI& uri) {
   put_object_request.SetKey(aws_uri.GetPath());
   if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET)
     put_object_request.SetRequestPayer(request_payer_);
+  if (sse_ != Aws::S3::Model::ServerSideEncryption::NOT_SET)
+    put_object_request.SetServerSideEncryption(sse_);
+  if (!sse_kms_key_id_.empty())
+    put_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
 
   auto put_object_outcome = client_->PutObject(put_object_request);
   if (!put_object_outcome.IsSuccess()) {

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -577,6 +577,12 @@ class S3 {
   /** Set the request payer for a s3 request. */
   Aws::S3::Model::RequestPayer request_payer_;
 
+  /** The server-side encryption algorithm. */
+  Aws::S3::Model::ServerSideEncryption sse_;
+
+  /** The server-side encryption kms key. */
+  std::string sse_kms_key_id_;
+
   /** Protects file_buffers map */
   std::mutex file_buffers_mtx_;
 


### PR DESCRIPTION
* S3 Server-Side Encryption

Introduces config option "vfs.s3.sse". Valid non-empty values are "aes256" and
"kms". These are the two supported SSE types in the AWS SDK.

If non-empty, the S3 class will use SSE on all of the requests we use that
support SSE.

This was manually tested by creating an array with "aes256" and using the
S3 web portal to verify SSE is enabled on the objects.