### PR TITLE
Fix consolidated fragment metadata parsing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -28,6 +28,7 @@
 ## Deprecations
 
 ## Bug fixes
+* Fixes a potential crash when opening an array with consolidated fragment metadata [#2135](https://github.com/TileDB-Inc/TileDB/pull/2135)
 * Corrected a bug where sparse cells may be incorrectly returned using string dimensions. [#2125](https://github.com/TileDB-Inc/TileDB/pull/2125)
 * Fix segfault in serialized queries when partition is unsplittable [#2120](https://github.com/TileDB-Inc/TileDB/pull/2120)
 * Always use original buffer size in serialized read queries serverside. [#2115](https://github.com/TileDB-Inc/TileDB/pull/2115)

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -230,14 +230,10 @@ class FragmentMetadata {
 
   /**
    * Loads the basic metadata from storage or `f_buff` for later
-   * versions if it is not `nullptr`. `meta_version` is the
-   * version of the consolidated metadata file.
+   * versions if it is not `nullptr`.
    */
   Status load(
-      const EncryptionKey& encryption_key,
-      Buffer* f_buff,
-      uint64_t offset,
-      uint32_t meta_version);
+      const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset);
 
   /** Stores all the metadata to storage. */
   Status store(const EncryptionKey& encryption_key);
@@ -761,7 +757,7 @@ class FragmentMetadata {
       const EncryptionKey& encryption_key, unsigned idx);
 
   /** Loads the generic tile offsets from the buffer. */
-  Status load_generic_tile_offsets(ConstBuffer* buff, uint32_t version);
+  Status load_generic_tile_offsets(ConstBuffer* buff);
 
   /**
    * Loads the generic tile offsets from the buffer. Applicable to
@@ -790,7 +786,7 @@ class FragmentMetadata {
   Status load_bounding_coords(ConstBuffer* buff);
 
   /** Loads the sizes of each attribute or dimension file from the buffer. */
-  Status load_file_sizes(ConstBuffer* buff, uint32_t version);
+  Status load_file_sizes(ConstBuffer* buff);
 
   /**
    * Loads the sizes of each attribute or dimension file from the buffer.
@@ -808,7 +804,7 @@ class FragmentMetadata {
    * Loads the sizes of each variable attribute or dimension file from the
    * buffer.
    */
-  Status load_file_var_sizes(ConstBuffer* buff, uint32_t version);
+  Status load_file_var_sizes(ConstBuffer* buff);
 
   /**
    * Loads the sizes of each variable attribute or dimension file from the
@@ -823,7 +819,7 @@ class FragmentMetadata {
   Status load_file_var_sizes_v5_or_higher(ConstBuffer* buff);
 
   /** Loads the sizes of each attribute validity file from the buffer. */
-  Status load_file_validity_sizes(ConstBuffer* buff, uint32_t version);
+  Status load_file_validity_sizes(ConstBuffer* buff);
 
   /**
    * Loads the cell number of the last tile from the fragment metadata buffer.
@@ -842,7 +838,7 @@ class FragmentMetadata {
   Status load_mbrs(ConstBuffer* buff);
 
   /** Loads the non-empty domain from the input buffer. */
-  Status load_non_empty_domain(ConstBuffer* buff, uint32_t version);
+  Status load_non_empty_domain(ConstBuffer* buff);
 
   /**
    * Loads the non-empty domain from the input buffer,
@@ -918,10 +914,7 @@ class FragmentMetadata {
    * it is not `nullptr` (version 3 or after).
    */
   Status load_v3_or_higher(
-      const EncryptionKey& encryption_key,
-      Buffer* f_buff,
-      uint64_t offset,
-      uint32_t meta_version);
+      const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset);
 
   /**
    * Loads the footer of the metadata file, which contains
@@ -930,10 +923,7 @@ class FragmentMetadata {
    * will be loaded from `f_buff`.
    */
   Status load_footer(
-      const EncryptionKey& encryption_key,
-      Buffer* f_buff,
-      uint64_t offset,
-      uint32_t meta_version);
+      const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset);
 
   /** Writes the sizes of each attribute file to the buffer. */
   Status write_file_sizes(Buffer* buff) const;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -212,7 +212,6 @@ Status StorageManager::array_open_for_reads(
   URI meta_uri;
   Buffer f_buff;
   std::unordered_map<std::string, uint64_t> offsets;
-  uint32_t meta_version = 0;
 
   // Fetch array fragments async
   std::vector<ThreadPool::Task> load_array_fragments_task;
@@ -222,7 +221,6 @@ Status StorageManager::array_open_for_reads(
                                                           &fragments_to_load,
                                                           &fragment_uris,
                                                           &meta_uri,
-                                                          &meta_version,
                                                           &offsets,
                                                           &timestamp,
                                                           this]() {
@@ -231,8 +229,8 @@ Status StorageManager::array_open_for_reads(
     RETURN_NOT_OK(
         get_sorted_uris(fragment_uris, timestamp, &fragments_to_load));
     // Get the consolidated fragment metadata
-    RETURN_NOT_OK(load_consolidated_fragment_meta(
-        meta_uri, enc_key, &f_buff, &offsets, &meta_version));
+    RETURN_NOT_OK(
+        load_consolidated_fragment_meta(meta_uri, enc_key, &f_buff, &offsets));
     return Status::Ok();
   }));
 
@@ -265,7 +263,6 @@ Status StorageManager::array_open_for_reads(
       fragments_to_load,
       &f_buff,
       offsets,
-      meta_version,
       fragment_metadata);
 
   if (!st.ok()) {
@@ -305,25 +302,18 @@ Status StorageManager::array_open_for_reads(
   std::vector<URI> uris;
   Buffer f_buff;
   std::unordered_map<std::string, uint64_t> offsets;
-  uint32_t meta_version = 0;
 
   std::vector<ThreadPool::Task> load_array_fragments_task;
-  load_array_fragments_task.emplace_back(io_tp_->execute([array_uri,
-                                                          &enc_key,
-                                                          &f_buff,
-                                                          &meta_uri,
-                                                          &meta_version,
-                                                          &offsets,
-                                                          &uris,
-                                                          this]() {
-    RETURN_NOT_OK(this->vfs_->ls(array_uri.add_trailing_slash(), &uris));
-    // Get the consolidated fragment metadata URI
-    RETURN_NOT_OK(get_consolidated_fragment_meta_uri(uris, &meta_uri));
-    // Get the consolidated fragment metadata
-    RETURN_NOT_OK(load_consolidated_fragment_meta(
-        meta_uri, enc_key, &f_buff, &offsets, &meta_version));
-    return Status::Ok();
-  }));
+  load_array_fragments_task.emplace_back(io_tp_->execute(
+      [array_uri, &enc_key, &f_buff, &meta_uri, &offsets, &uris, this]() {
+        RETURN_NOT_OK(this->vfs_->ls(array_uri.add_trailing_slash(), &uris));
+        // Get the consolidated fragment metadata URI
+        RETURN_NOT_OK(get_consolidated_fragment_meta_uri(uris, &meta_uri));
+        // Get the consolidated fragment metadata
+        RETURN_NOT_OK(load_consolidated_fragment_meta(
+            meta_uri, enc_key, &f_buff, &offsets));
+        return Status::Ok();
+      }));
 
   auto open_array = (OpenArray*)nullptr;
   Status st = array_open_without_fragments(array_uri, enc_key, &open_array);
@@ -352,7 +342,6 @@ Status StorageManager::array_open_for_reads(
       fragments_to_load,
       &f_buff,
       offsets,
-      meta_version,
       fragment_metadata);
 
   if (!st.ok()) {
@@ -483,9 +472,8 @@ Status StorageManager::array_reopen(
   // Get the consolidated fragment metadata
   Buffer f_buff;
   std::unordered_map<std::string, uint64_t> offsets;
-  uint32_t meta_version = 0;
-  RETURN_NOT_OK(load_consolidated_fragment_meta(
-      meta_uri, enc_key, &f_buff, &offsets, &meta_version));
+  RETURN_NOT_OK(
+      load_consolidated_fragment_meta(meta_uri, enc_key, &f_buff, &offsets));
 
   // Get fragment metadata in the case of reads, if not fetched already
   auto st = load_fragment_metadata(
@@ -494,7 +482,6 @@ Status StorageManager::array_reopen(
       fragments_to_load,
       &f_buff,
       offsets,
-      meta_version,
       fragment_metadata);
   if (!st.ok()) {
     open_array->mtx_unlock();
@@ -1374,7 +1361,7 @@ Status StorageManager::get_fragment_info(
   // Get fragment non-empty domain
   FragmentMetadata meta(
       this, array_schema, fragment_uri, timestamp_range, !sparse);
-  RETURN_NOT_OK(meta.load(encryption_key, nullptr, 0, 0));
+  RETURN_NOT_OK(meta.load(encryption_key, nullptr, 0));
 
   // This is important for format version > 2
   sparse = !meta.dense();
@@ -2202,14 +2189,12 @@ Status StorageManager::load_fragment_metadata(
     const std::vector<TimestampedURI>& fragments_to_load,
     Buffer* meta_buff,
     const std::unordered_map<std::string, uint64_t>& offsets,
-    uint32_t meta_version,
     std::vector<FragmentMetadata*>* fragment_metadata) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_LOAD_FRAG_META)
 
   // Load the metadata for each fragment, only if they are not already loaded
   auto fragment_num = fragments_to_load.size();
   fragment_metadata->resize(fragment_num);
-  uint32_t f_version;
   auto statuses = parallel_for(compute_tp_, 0, fragment_num, [&](size_t f) {
     const auto& sf = fragments_to_load[f];
     auto array_schema = open_array->array_schema();
@@ -2219,6 +2204,7 @@ Status StorageManager::load_fragment_metadata(
           sf.uri_.join_path(constants::coords + constants::file_suffix);
 
       auto name = sf.uri_.remove_trailing_slash().last_path_part();
+      uint32_t f_version;
       RETURN_NOT_OK(utils::parse::get_fragment_name_version(name, &f_version));
 
       // Note that the fragment metadata version is >= the array schema
@@ -2251,8 +2237,7 @@ Status StorageManager::load_fragment_metadata(
 
       // Load fragment metadata
       RETURN_NOT_OK_ELSE(
-          metadata->load(encryption_key, f_buff, offset, meta_version),
-          tdb_delete(metadata));
+          metadata->load(encryption_key, f_buff, offset), tdb_delete(metadata));
       open_array->insert_fragment_metadata(metadata);
     }
     (*fragment_metadata)[f] = metadata;
@@ -2270,11 +2255,8 @@ Status StorageManager::load_consolidated_fragment_meta(
     const URI& uri,
     const EncryptionKey& enc_key,
     Buffer* f_buff,
-    std::unordered_map<std::string, uint64_t>* offsets,
-    uint32_t* meta_version) {
+    std::unordered_map<std::string, uint64_t>* offsets) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_LOAD_CONSOLIDATED_FRAG_META)
-
-  *meta_version = 0;
 
   // No consolidated fragment metadata file
   if (uri.to_string().empty())
@@ -2308,12 +2290,6 @@ Status StorageManager::load_consolidated_fragment_meta(
     f_buff->read(&offset, sizeof(uint64_t));
     (*offsets)[name] = offset;
   }
-
-  // Get the consolidated fragment metadata version
-  auto meta_name = uri.remove_trailing_slash().last_path_part();
-  auto pos = meta_name.find_last_of('.');
-  meta_name = (pos == std::string::npos) ? meta_name : meta_name.substr(0, pos);
-  RETURN_NOT_OK(utils::parse::get_fragment_version(meta_name, meta_version));
 
   return Status::Ok();
 

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -1087,7 +1087,6 @@ class StorageManager {
    *     where the basic metadata can be found. If the offset cannot be
    *     found, then the metadata of that fragment will be loaded from
    *     storage instead.
-   * @param meta_version The version of the consolidated fragment metadata.
    * @param fragment_metadata The fragment metadata retrieved in a
    *     vector.
    * @return Status
@@ -1098,7 +1097,6 @@ class StorageManager {
       const std::vector<TimestampedURI>& fragments_to_load,
       Buffer* meta_buff,
       const std::unordered_map<std::string, uint64_t>& offsets,
-      uint32_t meta_version,
       std::vector<FragmentMetadata*>* fragment_metadata);
 
   /**
@@ -1109,15 +1107,13 @@ class StorageManager {
    * @param f_buff The buffer to hold the consolidated fragment metadata.
    * @param offsets A map from the fragment name to the offset in `f_buff` where
    *     the basic fragment metadata starts.
-   * @param meta_version The version of the consolidated metadata file.
    * @return Status
    */
   Status load_consolidated_fragment_meta(
       const URI& uri,
       const EncryptionKey& enc_key,
       Buffer* f_buff,
-      std::unordered_map<std::string, uint64_t>* offsets,
-      uint32_t* meta_version);
+      std::unordered_map<std::string, uint64_t>* offsets);
 
   /**
    * Retrieves the URI of the latest consolidated fragment metadata,


### PR DESCRIPTION
Currently, all footers in consolidated metadata files are parsed with the format
version of the consolidated metadata file. This patch ensures that footers are
parsed with the version stored in the footer.

In practice, this can fix one potential error when opening an array:
TileDBError: [TileDB::ConstBuffer] Error: Read buffer overflow

---
TYPE: BUG
DESC: Fixes a potential crash when opening an array with consolidated fragment metadata