### PR TITLE
Fix consolidated fragment metadata parsing (#2135)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -34,7 +34,7 @@
 * Allow open array stats to be printed without read query [#2131](https://github.com/TileDB-Inc/TileDB/pull/2131)
 
 ## Bug fixes
-
+* Fixes a potential crash when opening an array with consolidated fragment metadata [#2135](https://github.com/TileDB-Inc/TileDB/pull/2135)
 * Corrected a bug where sparse cells may be incorrectly returned using string dimensions. [#2125](https://github.com/TileDB-Inc/TileDB/pull/2125)
 * Always use original buffer size in serialized read queries serverside. [#2115](https://github.com/TileDB-Inc/TileDB/pull/2115)
 * Fix segfault in serialized queries when partition is unsplittable [#2120](https://github.com/TileDB-Inc/TileDB/pull/2120)

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -454,10 +454,7 @@ uint64_t FragmentMetadata::last_tile_cell_num() const {
 }
 
 Status FragmentMetadata::load(
-    const EncryptionKey& encryption_key,
-    Buffer* f_buff,
-    uint64_t offset,
-    uint32_t meta_version) {
+    const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset) {
   auto meta_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
   // Load the metadata file size when we are not reading from consolidated
@@ -481,7 +478,7 @@ Status FragmentMetadata::load(
   //    * __t1_t2_uuid_version
   if (f_version == 1)
     return load_v1_v2(encryption_key);
-  return load_v3_or_higher(encryption_key, f_buff, offset, meta_version);
+  return load_v3_or_higher(encryption_key, f_buff, offset);
 }
 
 Status FragmentMetadata::store(const EncryptionKey& encryption_key) {
@@ -1292,8 +1289,8 @@ Status FragmentMetadata::load_bounding_coords(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-Status FragmentMetadata::load_file_sizes(ConstBuffer* buff, uint32_t version) {
-  if (version < 5)
+Status FragmentMetadata::load_file_sizes(ConstBuffer* buff) {
+  if (version_ < 5)
     return load_file_sizes_v1_v4(buff);
   else
     return load_file_sizes_v5_or_higher(buff);
@@ -1334,9 +1331,8 @@ Status FragmentMetadata::load_file_sizes_v5_or_higher(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-Status FragmentMetadata::load_file_var_sizes(
-    ConstBuffer* buff, uint32_t version) {
-  if (version < 5)
+Status FragmentMetadata::load_file_var_sizes(ConstBuffer* buff) {
+  if (version_ < 5)
     return load_file_var_sizes_v1_v4(buff);
   else
     return load_file_var_sizes_v5_or_higher(buff);
@@ -1376,9 +1372,8 @@ Status FragmentMetadata::load_file_var_sizes_v5_or_higher(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-Status FragmentMetadata::load_file_validity_sizes(
-    ConstBuffer* buff, uint32_t version) {
-  if (version <= 6)
+Status FragmentMetadata::load_file_validity_sizes(ConstBuffer* buff) {
+  if (version_ <= 6)
     return Status::Ok();
 
   auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
@@ -1440,11 +1435,10 @@ Status FragmentMetadata::load_mbrs(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-Status FragmentMetadata::load_non_empty_domain(
-    ConstBuffer* buff, uint32_t version) {
-  if (version <= 2)
+Status FragmentMetadata::load_non_empty_domain(ConstBuffer* buff) {
+  if (version_ <= 2)
     return load_non_empty_domain_v1_v2(buff);
-  else if (version == 3 || version == 4)
+  else if (version_ == 3 || version_ == 4)
     return load_non_empty_domain_v3_v4(buff);
   return load_non_empty_domain_v5_or_higher(buff);
 }
@@ -1810,13 +1804,12 @@ Status FragmentMetadata::load_sparse_tile_num(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-Status FragmentMetadata::load_generic_tile_offsets(
-    ConstBuffer* buff, uint32_t version) {
-  if (version == 3 || version == 4)
+Status FragmentMetadata::load_generic_tile_offsets(ConstBuffer* buff) {
+  if (version_ == 3 || version_ == 4)
     return load_generic_tile_offsets_v3_v4(buff);
-  else if (version >= 5 && version < 7)
+  else if (version_ >= 5 && version_ < 7)
     return load_generic_tile_offsets_v5_v6(buff);
-  else if (version >= 7)
+  else if (version_ >= 7)
     return load_generic_tile_offsets_v7_or_higher(buff);
 
   assert(false);
@@ -1940,34 +1933,28 @@ Status FragmentMetadata::load_v1_v2(const EncryptionKey& encryption_key) {
   // Deserialize
   ConstBuffer cbuff(&buff);
   RETURN_NOT_OK(load_version(&cbuff));
-  RETURN_NOT_OK(load_non_empty_domain(&cbuff, version_));
+  RETURN_NOT_OK(load_non_empty_domain(&cbuff));
   RETURN_NOT_OK(load_mbrs(&cbuff));
   RETURN_NOT_OK(load_bounding_coords(&cbuff));
   RETURN_NOT_OK(load_tile_offsets(&cbuff));
   RETURN_NOT_OK(load_tile_var_offsets(&cbuff));
   RETURN_NOT_OK(load_tile_var_sizes(&cbuff));
   RETURN_NOT_OK(load_last_tile_cell_num(&cbuff));
-  RETURN_NOT_OK(load_file_sizes(&cbuff, version_));
-  RETURN_NOT_OK(load_file_var_sizes(&cbuff, version_));
-  RETURN_NOT_OK(load_file_validity_sizes(&cbuff, version_));
+  RETURN_NOT_OK(load_file_sizes(&cbuff));
+  RETURN_NOT_OK(load_file_var_sizes(&cbuff));
+  RETURN_NOT_OK(load_file_validity_sizes(&cbuff));
 
   return Status::Ok();
 }
 
 Status FragmentMetadata::load_v3_or_higher(
-    const EncryptionKey& encryption_key,
-    Buffer* f_buff,
-    uint64_t offset,
-    uint32_t meta_version) {
-  RETURN_NOT_OK(load_footer(encryption_key, f_buff, offset, meta_version));
+    const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset) {
+  RETURN_NOT_OK(load_footer(encryption_key, f_buff, offset));
   return Status::Ok();
 }
 
 Status FragmentMetadata::load_footer(
-    const EncryptionKey& encryption_key,
-    Buffer* f_buff,
-    uint64_t offset,
-    uint32_t meta_version) {
+    const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset) {
   (void)encryption_key;  // Not used for now, perhaps in the future
   std::lock_guard<std::mutex> lock(mtx_);
 
@@ -1989,18 +1976,16 @@ Status FragmentMetadata::load_footer(
   }
 
   RETURN_NOT_OK(load_version(cbuff.get()));
-  uint32_t version = (f_buff == nullptr) ? version_ : meta_version;
-
   RETURN_NOT_OK(load_dense(cbuff.get()));
-  RETURN_NOT_OK(load_non_empty_domain(cbuff.get(), version));
+  RETURN_NOT_OK(load_non_empty_domain(cbuff.get()));
   RETURN_NOT_OK(load_sparse_tile_num(cbuff.get()));
   RETURN_NOT_OK(load_last_tile_cell_num(cbuff.get()));
-  RETURN_NOT_OK(load_file_sizes(cbuff.get(), version));
-  RETURN_NOT_OK(load_file_var_sizes(cbuff.get(), version));
-  RETURN_NOT_OK(load_file_validity_sizes(cbuff.get(), version));
+  RETURN_NOT_OK(load_file_sizes(cbuff.get()));
+  RETURN_NOT_OK(load_file_var_sizes(cbuff.get()));
+  RETURN_NOT_OK(load_file_validity_sizes(cbuff.get()));
 
   unsigned num = array_schema_->attribute_num() + 1;
-  num += (version >= 5) ? array_schema_->dim_num() : 0;
+  num += (version_ >= 5) ? array_schema_->dim_num() : 0;
 
   tile_offsets_.resize(num);
   tile_offsets_mtx_.resize(num);
@@ -2014,7 +1999,7 @@ Status FragmentMetadata::load_footer(
   loaded_metadata_.tile_var_sizes_.resize(num, false);
   loaded_metadata_.tile_validity_offsets_.resize(num, false);
 
-  RETURN_NOT_OK(load_generic_tile_offsets(cbuff.get(), version));
+  RETURN_NOT_OK(load_generic_tile_offsets(cbuff.get()));
 
   loaded_metadata_.footer_ = true;
 

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -230,14 +230,10 @@ class FragmentMetadata {
 
   /**
    * Loads the basic metadata from storage or `f_buff` for later
-   * versions if it is not `nullptr`. `meta_version` is the
-   * version of the consolidated metadata file.
+   * versions if it is not `nullptr`.
    */
   Status load(
-      const EncryptionKey& encryption_key,
-      Buffer* f_buff,
-      uint64_t offset,
-      uint32_t meta_version);
+      const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset);
 
   /** Stores all the metadata to storage. */
   Status store(const EncryptionKey& encryption_key);
@@ -761,7 +757,7 @@ class FragmentMetadata {
       const EncryptionKey& encryption_key, unsigned idx);
 
   /** Loads the generic tile offsets from the buffer. */
-  Status load_generic_tile_offsets(ConstBuffer* buff, uint32_t version);
+  Status load_generic_tile_offsets(ConstBuffer* buff);
 
   /**
    * Loads the generic tile offsets from the buffer. Applicable to
@@ -790,7 +786,7 @@ class FragmentMetadata {
   Status load_bounding_coords(ConstBuffer* buff);
 
   /** Loads the sizes of each attribute or dimension file from the buffer. */
-  Status load_file_sizes(ConstBuffer* buff, uint32_t version);
+  Status load_file_sizes(ConstBuffer* buff);
 
   /**
    * Loads the sizes of each attribute or dimension file from the buffer.
@@ -808,7 +804,7 @@ class FragmentMetadata {
    * Loads the sizes of each variable attribute or dimension file from the
    * buffer.
    */
-  Status load_file_var_sizes(ConstBuffer* buff, uint32_t version);
+  Status load_file_var_sizes(ConstBuffer* buff);
 
   /**
    * Loads the sizes of each variable attribute or dimension file from the
@@ -823,7 +819,7 @@ class FragmentMetadata {
   Status load_file_var_sizes_v5_or_higher(ConstBuffer* buff);
 
   /** Loads the sizes of each attribute validity file from the buffer. */
-  Status load_file_validity_sizes(ConstBuffer* buff, uint32_t version);
+  Status load_file_validity_sizes(ConstBuffer* buff);
 
   /**
    * Loads the cell number of the last tile from the fragment metadata buffer.
@@ -842,7 +838,7 @@ class FragmentMetadata {
   Status load_mbrs(ConstBuffer* buff);
 
   /** Loads the non-empty domain from the input buffer. */
-  Status load_non_empty_domain(ConstBuffer* buff, uint32_t version);
+  Status load_non_empty_domain(ConstBuffer* buff);
 
   /**
    * Loads the non-empty domain from the input buffer,
@@ -918,10 +914,7 @@ class FragmentMetadata {
    * it is not `nullptr` (version 3 or after).
    */
   Status load_v3_or_higher(
-      const EncryptionKey& encryption_key,
-      Buffer* f_buff,
-      uint64_t offset,
-      uint32_t meta_version);
+      const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset);
 
   /**
    * Loads the footer of the metadata file, which contains
@@ -930,10 +923,7 @@ class FragmentMetadata {
    * will be loaded from `f_buff`.
    */
   Status load_footer(
-      const EncryptionKey& encryption_key,
-      Buffer* f_buff,
-      uint64_t offset,
-      uint32_t meta_version);
+      const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset);
 
   /** Writes the sizes of each attribute file to the buffer. */
   Status write_file_sizes(Buffer* buff) const;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -211,7 +211,6 @@ Status StorageManager::array_open_for_reads(
   URI meta_uri;
   Buffer f_buff;
   std::unordered_map<std::string, uint64_t> offsets;
-  uint32_t meta_version = 0;
 
   // Fetch array fragments async
   std::vector<ThreadPool::Task> load_array_fragments_task;
@@ -221,7 +220,6 @@ Status StorageManager::array_open_for_reads(
                                                           &fragments_to_load,
                                                           &fragment_uris,
                                                           &meta_uri,
-                                                          &meta_version,
                                                           &offsets,
                                                           &timestamp,
                                                           this]() {
@@ -230,8 +228,8 @@ Status StorageManager::array_open_for_reads(
     RETURN_NOT_OK(
         get_sorted_uris(fragment_uris, timestamp, &fragments_to_load));
     // Get the consolidated fragment metadata
-    RETURN_NOT_OK(load_consolidated_fragment_meta(
-        meta_uri, enc_key, &f_buff, &offsets, &meta_version));
+    RETURN_NOT_OK(
+        load_consolidated_fragment_meta(meta_uri, enc_key, &f_buff, &offsets));
     return Status::Ok();
   }));
 
@@ -264,7 +262,6 @@ Status StorageManager::array_open_for_reads(
       fragments_to_load,
       &f_buff,
       offsets,
-      meta_version,
       fragment_metadata);
 
   if (!st.ok()) {
@@ -304,25 +301,18 @@ Status StorageManager::array_open_for_reads(
   std::vector<URI> uris;
   Buffer f_buff;
   std::unordered_map<std::string, uint64_t> offsets;
-  uint32_t meta_version = 0;
 
   std::vector<ThreadPool::Task> load_array_fragments_task;
-  load_array_fragments_task.emplace_back(io_tp_->execute([array_uri,
-                                                          &enc_key,
-                                                          &f_buff,
-                                                          &meta_uri,
-                                                          &meta_version,
-                                                          &offsets,
-                                                          &uris,
-                                                          this]() {
-    RETURN_NOT_OK(this->vfs_->ls(array_uri.add_trailing_slash(), &uris));
-    // Get the consolidated fragment metadata URI
-    RETURN_NOT_OK(get_consolidated_fragment_meta_uri(uris, &meta_uri));
-    // Get the consolidated fragment metadata
-    RETURN_NOT_OK(load_consolidated_fragment_meta(
-        meta_uri, enc_key, &f_buff, &offsets, &meta_version));
-    return Status::Ok();
-  }));
+  load_array_fragments_task.emplace_back(io_tp_->execute(
+      [array_uri, &enc_key, &f_buff, &meta_uri, &offsets, &uris, this]() {
+        RETURN_NOT_OK(this->vfs_->ls(array_uri.add_trailing_slash(), &uris));
+        // Get the consolidated fragment metadata URI
+        RETURN_NOT_OK(get_consolidated_fragment_meta_uri(uris, &meta_uri));
+        // Get the consolidated fragment metadata
+        RETURN_NOT_OK(load_consolidated_fragment_meta(
+            meta_uri, enc_key, &f_buff, &offsets));
+        return Status::Ok();
+      }));
 
   auto open_array = (OpenArray*)nullptr;
   Status st = array_open_without_fragments(array_uri, enc_key, &open_array);
@@ -351,7 +341,6 @@ Status StorageManager::array_open_for_reads(
       fragments_to_load,
       &f_buff,
       offsets,
-      meta_version,
       fragment_metadata);
 
   if (!st.ok()) {
@@ -481,9 +470,8 @@ Status StorageManager::array_reopen(
   // Get the consolidated fragment metadata
   Buffer f_buff;
   std::unordered_map<std::string, uint64_t> offsets;
-  uint32_t meta_version = 0;
-  RETURN_NOT_OK(load_consolidated_fragment_meta(
-      meta_uri, enc_key, &f_buff, &offsets, &meta_version));
+  RETURN_NOT_OK(
+      load_consolidated_fragment_meta(meta_uri, enc_key, &f_buff, &offsets));
 
   // Get fragment metadata in the case of reads, if not fetched already
   auto st = load_fragment_metadata(
@@ -492,7 +480,6 @@ Status StorageManager::array_reopen(
       fragments_to_load,
       &f_buff,
       offsets,
-      meta_version,
       fragment_metadata);
   if (!st.ok()) {
     open_array->mtx_unlock();
@@ -1372,7 +1359,7 @@ Status StorageManager::get_fragment_info(
   // Get fragment non-empty domain
   FragmentMetadata meta(
       this, array_schema, fragment_uri, timestamp_range, !sparse);
-  RETURN_NOT_OK(meta.load(encryption_key, nullptr, 0, 0));
+  RETURN_NOT_OK(meta.load(encryption_key, nullptr, 0));
 
   // This is important for format version > 2
   sparse = !meta.dense();
@@ -2188,14 +2175,12 @@ Status StorageManager::load_fragment_metadata(
     const std::vector<TimestampedURI>& fragments_to_load,
     Buffer* meta_buff,
     const std::unordered_map<std::string, uint64_t>& offsets,
-    uint32_t meta_version,
     std::vector<FragmentMetadata*>* fragment_metadata) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_LOAD_FRAG_META)
 
   // Load the metadata for each fragment, only if they are not already loaded
   auto fragment_num = fragments_to_load.size();
   fragment_metadata->resize(fragment_num);
-  uint32_t f_version;
   auto statuses = parallel_for(compute_tp_, 0, fragment_num, [&](size_t f) {
     const auto& sf = fragments_to_load[f];
     auto array_schema = open_array->array_schema();
@@ -2205,6 +2190,7 @@ Status StorageManager::load_fragment_metadata(
           sf.uri_.join_path(constants::coords + constants::file_suffix);
 
       auto name = sf.uri_.remove_trailing_slash().last_path_part();
+      uint32_t f_version;
       RETURN_NOT_OK(utils::parse::get_fragment_name_version(name, &f_version));
 
       // Note that the fragment metadata version is >= the array schema
@@ -2232,8 +2218,7 @@ Status StorageManager::load_fragment_metadata(
 
       // Load fragment metadata
       RETURN_NOT_OK_ELSE(
-          metadata->load(encryption_key, f_buff, offset, meta_version),
-          delete metadata);
+          metadata->load(encryption_key, f_buff, offset), delete metadata);
       open_array->insert_fragment_metadata(metadata);
     }
     (*fragment_metadata)[f] = metadata;
@@ -2251,11 +2236,8 @@ Status StorageManager::load_consolidated_fragment_meta(
     const URI& uri,
     const EncryptionKey& enc_key,
     Buffer* f_buff,
-    std::unordered_map<std::string, uint64_t>* offsets,
-    uint32_t* meta_version) {
+    std::unordered_map<std::string, uint64_t>* offsets) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_LOAD_CONSOLIDATED_FRAG_META)
-
-  *meta_version = 0;
 
   // No consolidated fragment metadata file
   if (uri.to_string().empty())
@@ -2288,12 +2270,6 @@ Status StorageManager::load_consolidated_fragment_meta(
     f_buff->read(&offset, sizeof(uint64_t));
     (*offsets)[name] = offset;
   }
-
-  // Get the consolidated fragment metadata version
-  auto meta_name = uri.remove_trailing_slash().last_path_part();
-  auto pos = meta_name.find_last_of('.');
-  meta_name = (pos == std::string::npos) ? meta_name : meta_name.substr(0, pos);
-  RETURN_NOT_OK(utils::parse::get_fragment_version(meta_name, meta_version));
 
   return Status::Ok();
 

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -1086,7 +1086,6 @@ class StorageManager {
    *     where the basic metadata can be found. If the offset cannot be
    *     found, then the metadata of that fragment will be loaded from
    *     storage instead.
-   * @param meta_version The version of the consolidated fragment metadata.
    * @param fragment_metadata The fragment metadata retrieved in a
    *     vector.
    * @return Status
@@ -1097,7 +1096,6 @@ class StorageManager {
       const std::vector<TimestampedURI>& fragments_to_load,
       Buffer* meta_buff,
       const std::unordered_map<std::string, uint64_t>& offsets,
-      uint32_t meta_version,
       std::vector<FragmentMetadata*>* fragment_metadata);
 
   /**
@@ -1108,15 +1106,13 @@ class StorageManager {
    * @param f_buff The buffer to hold the consolidated fragment metadata.
    * @param offsets A map from the fragment name to the offset in `f_buff` where
    *     the basic fragment metadata starts.
-   * @param meta_version The version of the consolidated metadata file.
    * @return Status
    */
   Status load_consolidated_fragment_meta(
       const URI& uri,
       const EncryptionKey& enc_key,
       Buffer* f_buff,
-      std::unordered_map<std::string, uint64_t>* offsets,
-      uint32_t* meta_version);
+      std::unordered_map<std::string, uint64_t>* offsets);
 
   /**
    * Retrieves the URI of the latest consolidated fragment metadata,


### PR DESCRIPTION
* Fix consolidated fragment metadata parsing

Currently, all footers in consolidated metadata files are parsed with the format
version of the consolidated metadata file. This patch ensures that footers are
parsed with the version stored in the footer.

In practice, this can fix one potential error when opening an array:
TileDBError: [TileDB::ConstBuffer] Error: Read buffer overflow

---
TYPE: BUG
DESC: Fixes a potential crash when opening an array with consolidated fragment metadata
