### PR TITLE
Apply 'var_offsets.extra_element' mode to string dimension offsets too

### DIFF
--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -3331,7 +3331,7 @@ Status Reader::copy_attribute_values(
 Status Reader::add_extra_offset() {
   for (const auto& it : buffers_) {
     const auto& name = it.first;
-    if (!array_schema_->is_attr(name) || !array_schema_->var_size(name))
+    if (!array_schema_->var_size(name))
       continue;
 
     auto buffer = static_cast<unsigned char*>(it.second.buffer_);


### PR DESCRIPTION
closes ch6101

<!--
Thank you for your contribution. Please add a summary of the change and fill in the TYPE an DESC for automatic addition to HISTORY.md
-->

<!-- Automatic history file management:
  Set the type to one of FORMAT, BREAKING_API, BREAKING_BEHAVIOR, FEATURE, IMPROVEMENT, DEPRECATION, BUG, C_API, CPP_API or NO_HISTORY.
  NO_HISTORY should be used rarely. It is mostly associated with repo level changes (README/CI/etc) that do not need to be logged in
  the HISTORY.md file for version updates.
  Set the DESC to a one line summary of the change
-->

TYPE: BUG

DESC: Apply 'var_offsets.extra_element' mode to string dimension offsets too