### PR TITLE
[Backport release-2.2] Parallelize file_size lookup in get_fragment_info (#2143)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
 
 ## Improvements
 
+* Improve fragment info loading by parallelizing fragment_size requests [#2143](https://github.com/TileDB-Inc/TileDB/pull/2143)
+
 ## Deprecations
 
 ## Bug fixes

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1220,15 +1220,30 @@ Status StorageManager::get_fragment_info(
   if (fragment_metadata.empty())
     return array_close_for_reads(array_uri);
 
-  for (auto meta : fragment_metadata) {
+  std::vector<uint64_t> sizes(fragment_metadata.size());
+
+  auto statuses = parallel_for(
+      this->compute_tp_,
+      0,
+      fragment_metadata.size(),
+      [&fragment_metadata, &sizes](uint64_t i) {
+        const auto meta = fragment_metadata[i];
+
+        // Get fragment size
+        uint64_t size;
+        RETURN_NOT_OK(meta->fragment_size(&size));
+        sizes[i] = size;
+
+        return Status::Ok();
+      });
+
+  for (const auto& st : statuses)
+    RETURN_NOT_OK_ELSE(st, array_close_for_reads(array_uri));
+
+  for (uint64_t i = 0; i < fragment_metadata.size(); i++) {
+    const auto meta = fragment_metadata[i];
     const auto& uri = meta->fragment_uri();
     bool sparse = !meta->dense();
-
-    // Get fragment size
-    uint64_t size;
-    RETURN_NOT_OK_ELSE(
-        meta->fragment_size(&size), array_close_for_reads(array_uri));
-
     // Get non-empty domain, and compute expanded non-empty domain
     // (only for dense fragments)
     const auto& non_empty_domain = meta->non_empty_domain();
@@ -1243,7 +1258,7 @@ Status StorageManager::get_fragment_info(
         sparse,
         meta->timestamp_range(),
         meta->cell_num(),
-        size,
+        sizes[i],
         meta->has_consolidated_footer(),
         non_empty_domain,
         expanded_non_empty_domain));


### PR DESCRIPTION
The call to `fragment_size` is expensive, it is also safe to do in parallel. This shifts to calling fragment_size inside a parallel_for to speed up this operation. In testing on an array with 2600 fragments, this drops the loading of fragment metadata from 96s to 11s.