### PR TITLE
Update pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,5 @@
-<!--
-Thank you for your contribution. Please add a summary of the change and fill in the TYPE an DESC for automatic addition to HISTORY.md
--->
+<long description>
 
-<!-- Automatic history file management:
-  Set the type to one of FORMAT, BREAKING_API, BREAKING_BEHAVIOR, FEATURE, IMPROVEMENT, DEPRECATION, BUG, C_API, CPP_API or NO_HISTORY.
-  NO_HISTORY should be used rarely. It is mostly associated with repo level changes (README/CI/etc) that do not need to be logged in
-  the HISTORY.md file for version updates.
-  Set the DESC to a one line summary of the change
--->
-TYPE:
-
-DESC:
+---
+TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
+DESC: <short description>


### PR DESCRIPTION
The history bot is not aware of block comments. This updates the template
to remove them.

---

TYPE: NO_HISTORY