### PR TITLE
[Backport] Improve GCS retries (#2148)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 
 ## Improvements
 
+* Added config option vfs.gcs.request_timeout_ms [#2148](https://github.com/TileDB-Inc/TileDB/pull/2148)
 * Improve fragment info loading by parallelizing fragment_size requests [#2143](https://github.com/TileDB-Inc/TileDB/pull/2143)
 
 ## Deprecations

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -256,6 +256,7 @@ void check_save_to_file() {
   ss << "vfs.gcs.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
   ss << "vfs.gcs.multi_part_size 5242880\n";
+  ss << "vfs.gcs.request_timeout_ms 3000\n";
   ss << "vfs.gcs.use_multi_part_upload true\n";
   ss << "vfs.min_batch_gap 512000\n";
   ss << "vfs.min_batch_size 20971520\n";
@@ -509,6 +510,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       std::to_string(std::thread::hardware_concurrency());
   all_param_values["vfs.gcs.multi_part_size"] = "5242880";
   all_param_values["vfs.gcs.use_multi_part_upload"] = "true";
+  all_param_values["vfs.gcs.request_timeout_ms"] = "3000";
   all_param_values["vfs.azure.storage_account_name"] = "";
   all_param_values["vfs.azure.storage_account_key"] = "";
   all_param_values["vfs.azure.blob_endpoint"] = "";
@@ -568,6 +570,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       std::to_string(std::thread::hardware_concurrency());
   vfs_param_values["gcs.multi_part_size"] = "5242880";
   vfs_param_values["gcs.use_multi_part_upload"] = "true";
+  vfs_param_values["gcs.request_timeout_ms"] = "3000";
   vfs_param_values["azure.storage_account_name"] = "";
   vfs_param_values["azure.storage_account_key"] = "";
   vfs_param_values["azure.blob_endpoint"] = "";
@@ -622,6 +625,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       std::to_string(std::thread::hardware_concurrency());
   gcs_param_values["multi_part_size"] = "5242880";
   gcs_param_values["use_multi_part_upload"] = "true";
+  gcs_param_values["request_timeout_ms"] = "3000";
 
   std::map<std::string, std::string> azure_param_values;
   azure_param_values["storage_account_name"] = "";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -60,7 +60,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 53);
+  CHECK(names.size() == 54);
 }
 
 TEST_CASE(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1072,6 +1072,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.gcs.use_multi_part_upload` <br>
  *    Determines if the GCS backend can use chunked part uploads. <br>
  *    **Default**: "true"
+ * - `vfs.gcs.request_timeout_ms` <br>
+ *    The maximum amount of time to retry network requests to GCS. <br>
+ *    **Default**: "3000"
  * - `vfs.s3.region` <br>
  *    The S3 region, if S3 is enabled. <br>
  *    **Default**: us-east-1

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -112,6 +112,7 @@ const std::string Config::VFS_GCS_MAX_PARALLEL_OPS =
     Config::SM_IO_CONCURRENCY_LEVEL;
 const std::string Config::VFS_GCS_MULTI_PART_SIZE = "5242880";
 const std::string Config::VFS_GCS_USE_MULTI_PART_UPLOAD = "true";
+const std::string Config::VFS_GCS_REQUEST_TIMEOUT_MS = "3000";
 const std::string Config::VFS_S3_REGION = "us-east-1";
 const std::string Config::VFS_S3_AWS_ACCESS_KEY_ID = "";
 const std::string Config::VFS_S3_AWS_SECRET_ACCESS_KEY = "";
@@ -241,6 +242,7 @@ Config::Config() {
   param_values_["vfs.gcs.multi_part_size"] = VFS_GCS_MULTI_PART_SIZE;
   param_values_["vfs.gcs.use_multi_part_upload"] =
       VFS_GCS_USE_MULTI_PART_UPLOAD;
+  param_values_["vfs.gcs.request_timeout_ms"] = VFS_GCS_REQUEST_TIMEOUT_MS;
   param_values_["vfs.s3.region"] = VFS_S3_REGION;
   param_values_["vfs.s3.aws_access_key_id"] = VFS_S3_AWS_ACCESS_KEY_ID;
   param_values_["vfs.s3.aws_secret_access_key"] = VFS_S3_AWS_SECRET_ACCESS_KEY;
@@ -515,6 +517,8 @@ Status Config::unset(const std::string& param) {
   } else if (param == "vfs.gcs.use_multi_part_upload") {
     param_values_["vfs.gcs.use_multi_part_upload"] =
         VFS_GCS_USE_MULTI_PART_UPLOAD;
+  } else if (param == "vfs.gcs.request_timeout_ms") {
+    param_values_["vfs.gcs.request_timeout_ms"] = VFS_GCS_REQUEST_TIMEOUT_MS;
   } else if (param == "vfs.s3.region") {
     param_values_["vfs.s3.region"] = VFS_S3_REGION;
   } else if (param == "vfs.s3.aws_access_key_id") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -275,6 +275,9 @@ class Config {
   /** GCS use multi part upload. */
   static const std::string VFS_GCS_USE_MULTI_PART_UPLOAD;
 
+  /** GCS request timeout in milliseconds. */
+  static const std::string VFS_GCS_REQUEST_TIMEOUT_MS;
+
   /** S3 region. */
   static const std::string VFS_S3_REGION;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -413,6 +413,9 @@ class Config {
    * - `vfs.gcs.use_multi_part_upload` <br>
    *    Determines if the GCS backend can use chunked part uploads. <br>
    *    **Default**: "true"
+   * - `vfs.gcs.request_timeout_ms` <br>
+   *    The maximum amount of time to retry network requests to GCS. <br>
+   *    **Default**: "3000"
    * - `vfs.s3.region` <br>
    *    The S3 region, if S3 is enabled. <br>
    *    **Default**: us-east-1

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -59,7 +59,8 @@ GCS::GCS()
     , write_cache_max_size_(0)
     , max_parallel_ops_(1)
     , multi_part_part_size_(0)
-    , use_multi_part_upload_(true) {
+    , use_multi_part_upload_(true)
+    , request_timeout_ms_(0) {
 }
 
 GCS::~GCS() {
@@ -90,6 +91,9 @@ Status GCS::init(const Config& config, ThreadPool* const thread_pool) {
   assert(found);
   RETURN_NOT_OK(config.get<uint64_t>(
       "vfs.gcs.multi_part_size", &multi_part_part_size_, &found));
+  assert(found);
+  RETURN_NOT_OK(config.get<uint64_t>(
+      "vfs.gcs.request_timeout_ms", &request_timeout_ms_, &found));
   assert(found);
 
   write_cache_max_size_ = max_parallel_ops_ * multi_part_part_size_;
@@ -143,7 +147,9 @@ Status GCS::init_client() const {
     google::cloud::storage::ClientOptions client_options(
         *creds, channel_options);
     auto client = google::cloud::storage::Client(
-        client_options, google::cloud::storage::StrictIdempotencyPolicy());
+        client_options,
+        google::cloud::storage::LimitedTimeRetryPolicy(
+            std::chrono::milliseconds(request_timeout_ms_)));
     client_ = google::cloud::StatusOr<google::cloud::storage::Client>(client);
     if (!client_) {
       return LOG_STATUS(Status::GCSError(

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -406,6 +406,9 @@ class GCS {
   /** Whether or not to use part list upload. */
   bool use_multi_part_upload_;
 
+  /** The timeout for network requests. */
+  uint64_t request_timeout_ms_;
+
   /** Maps a object URI to its part list upload state. */
   std::unordered_map<std::string, MultiPartUploadState>
       multi_part_upload_states_;


### PR DESCRIPTION
* Improve GCS retries

1. Removes the strict-idempotent retry policy. Previously, the GCS client would
only retry idempotent requests. With this patch, the GCS client will retry
all requests.

2. The GCS client will now retry requests up to a configurable deadline. A new
config option "vfs.gcs.request_timeout_ms" has been added, which defaults to
3000ms.

---

TYPE: IMPROVEMENT
DESC: Added config option "vfs.gcs.request_timeout_ms"