### PR TITLE
do not upload (never used) artifacts from msys builds

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -32,8 +32,8 @@ jobs:
           MINGW_INSTALLS: ${{ matrix.msystem }}
           PKGEXT: ".pkg.tar.xz"
         shell: msys2 {0}
-      - name: "Upload binaries"
-        uses: actions/upload-artifact@v2
-        with:
-          name: mingw-w64-${{ matrix.arch }}-tiledb
-          path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*
+      #- name: "Upload binaries"
+      #  uses: actions/upload-artifact@v2
+      #  with:
+      #    name: mingw-w64-${{ matrix.arch }}-tiledb
+      #    path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -32,8 +32,3 @@ jobs:
           MINGW_INSTALLS: ${{ matrix.msystem }}
           PKGEXT: ".pkg.tar.xz"
         shell: msys2 {0}
-      #- name: "Upload binaries"
-      #  uses: actions/upload-artifact@v2
-      #  with:
-      #    name: mingw-w64-${{ matrix.arch }}-tiledb
-      #    path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 * Smoke Test, remove nullable structs from global namespace. [#2078](https://github.com/TileDB-Inc/TileDB/pull/2078)
 
 ## Improvements
+* Windows msys2 build artifacts are no longer uploaded [#2159](https://github.com/TileDB-Inc/TileDB/pull/2159)
 * Parallelize Writer::filter_tiles [#2156](https://github.com/TileDB-Inc/TileDB/pull/2156)
 * Added config option vfs.gcs.request_timeout_ms [#2148](https://github.com/TileDB-Inc/TileDB/pull/2148)
 * Improve fragment info loading by parallelizing fragment_size requests [#2143](https://github.com/TileDB-Inc/TileDB/pull/2143)


### PR DESCRIPTION
Continuous integration for TileDB currently tests two flavors under Windows for use with R. One corresponds to the actual toolchain use and produces artifacts we later deploy ("rtools4") as it matches the toolchain at CRAN.  The other is more aspirational and forward looking and help detects possible changes under a possible future toolchain ("msys2").  No artifacts from the second build are used.  It is confusing between the two artifact sets, so this PR suggests to no longer upload the ones from the second build.  Thanks to @jeroen for making that suggestion.

No functional changes as both continuous integration test sets will continue to run unaltered.

---
TYPE: IMPROVEMENT 
DESC: Windows msys2 build artifacts are no longer uploaded
