### PR TITLE
 Add config option to bound read ranges to domain

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@
 * Smoke Test, remove nullable structs from global namespace. [#2078](https://github.com/TileDB-Inc/TileDB/pull/2078)
 
 ## Improvements
+* Add config option `sm.read_range_oob` to toggle bounding read ranges to domain or erroring [#2162](https://github.com/TileDB-Inc/TileDB/pull/2162)
 * Windows msys2 build artifacts are no longer uploaded [#2159](https://github.com/TileDB-Inc/TileDB/pull/2159)
 * Add internal log functions to log at different log levels [#2161](https://github.com/TileDB-Inc/TileDB/pull/2161)
 * Parallelize Writer::filter_tiles [#2156](https://github.com/TileDB-Inc/TileDB/pull/2156)

--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -487,7 +487,8 @@ void create_subarray(
   for (unsigned d = 0; d < dim_num; ++d) {
     auto dim_range_num = ranges[d].size() / 2;
     for (size_t j = 0; j < dim_range_num; ++j) {
-      ret.add_range(d, sm::Range(&ranges[d][2 * j], 2 * sizeof(T)));
+      sm::Range range(&ranges[d][2 * j], 2 * sizeof(T));
+      ret.add_range(d, std::move(range), true);
     }
   }
 

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -2253,7 +2253,7 @@ TEST_CASE_METHOD(
   tiledb::sm::Subarray subarray(array->array_, layout);
   tiledb::sm::Range r;
   r.set_str_range("bb", "bb");
-  subarray.add_range(0, r);
+  subarray.add_range(0, std::move(r), true);
   ThreadPool tp;
   CHECK(tp.init(4).ok());
   SubarrayPartitioner partitioner(
@@ -2282,7 +2282,7 @@ TEST_CASE_METHOD(
   // Check full
   tiledb::sm::Subarray subarray_full(array->array_, layout);
   r.set_str_range("a", "bb");
-  subarray_full.add_range(0, r);
+  subarray_full.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_full(
       subarray_full, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_full.set_result_budget("d", 16, 4);
@@ -2302,7 +2302,7 @@ TEST_CASE_METHOD(
   // Check split
   tiledb::sm::Subarray subarray_split(array->array_, layout);
   r.set_str_range("a", "bb");
-  subarray_split.add_range(0, r);
+  subarray_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split(
       subarray_split, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_split.set_result_budget("d", 10, 4);
@@ -2332,7 +2332,7 @@ TEST_CASE_METHOD(
   // Check no split 2 MBRs
   tiledb::sm::Subarray subarray_no_split(array->array_, layout);
   r.set_str_range("bb", "cc");
-  subarray_no_split.add_range(0, r);
+  subarray_no_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_no_split(
       subarray_no_split, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_no_split.set_result_budget("d", 16, 10);
@@ -2354,7 +2354,7 @@ TEST_CASE_METHOD(
   // Check split 2 MBRs
   tiledb::sm::Subarray subarray_split_2(array->array_, layout);
   r.set_str_range("bb", "cc");
-  subarray_split_2.add_range(0, r);
+  subarray_split_2.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split_2(
       subarray_split_2, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_split_2.set_result_budget("d", 8, 10);
@@ -2482,7 +2482,7 @@ TEST_CASE_METHOD(
   tiledb::sm::Subarray subarray(array->array_, layout);
   tiledb::sm::Range r;
   r.set_str_range("cc", "ccd");
-  subarray.add_range(0, r);
+  subarray.add_range(0, std::move(r), true);
   ThreadPool tp;
   CHECK(tp.init(4).ok());
   SubarrayPartitioner partitioner(

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -241,6 +241,7 @@ void check_save_to_file() {
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.num_tbb_threads -1\n";
+  ss << "sm.read_range_oob error\n";
   ss << "sm.skip_checksum_validation false\n";
   ss << "sm.sub_partitioner_memory_budget 0\n";
   ss << "sm.tile_cache_size 10000000\n";
@@ -540,6 +541,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.consolidation.buffer_size"] = "50000000";
   all_param_values["sm.consolidation.step_size_ratio"] = "0.0";
   all_param_values["sm.consolidation.mode"] = "fragments";
+  all_param_values["sm.read_range_oob"] = "error";
   all_param_values["sm.vacuum.mode"] = "fragments";
   all_param_values["sm.var_offsets.bitsize"] = "32";
   all_param_values["sm.var_offsets.extra_element"] = "true";

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -162,8 +162,17 @@ class Dimension {
    *     - if the lower range bound is larger than the upper
    *     - if the range falls outside the dimension domain
    *     - for real domains, if any range bound is NaN
+   *
    */
   Status check_range(const Range& range) const;
+
+  /**
+   * Adjust a range so that the upper/lower bounds are within the dimension's
+   * domain.
+   * @param range Query range object that might be mutated
+   * @return status if error
+   */
+  Status adjust_range_oob(Range* range) const;
 
   /**
    * Performs correctness checks on the input range. Returns `true`
@@ -239,10 +248,91 @@ class Dimension {
          << domain[0] << ", " << domain[1] << "] on dimension '" << dim->name()
          << "'";
       *err_msg = ss.str();
+
       return false;
     }
 
     return true;
+  }
+
+  /**
+   * Takes a range from a query and might mutate it so the lower/upper values
+   * are within the domain of the dimension. If mutation occurs a warning is
+   * logged
+   *
+   * @tparam T datatype
+   * @param dim dimension object to get domain from
+   * @param range Query range objects to mutate
+   */
+  template <
+      typename T,
+      typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  static void adjust_range_oob(const Dimension* dim, const Range* range) {
+    auto domain = (const T*)dim->domain().data();
+    auto r = (T*)range->data();
+
+    // Check out-of-bounds
+    if (r[0] < domain[0]) {
+      std::stringstream ss;
+      ss << "Range lower bound " << r[0] << " is out of domain bounds ["
+         << domain[0] << ", " << domain[1]
+         << "]. Adjusting range lower bound to be " << domain[0]
+         << " on dimension '" << dim->name() << "'";
+      global_logger().warn(ss.str().c_str());
+
+      r[0] = domain[0];
+    }
+
+    if (r[1] > domain[1]) {
+      std::stringstream ss;
+      ss << "Range upper bound " << r[1] << " is out of domain bounds ["
+         << domain[0] << ", " << domain[1]
+         << "]. Adjusting range upper bound to be " << domain[1]
+         << " on dimension '" << dim->name() << "'";
+      global_logger().warn(ss.str().c_str());
+
+      r[1] = domain[1];
+    }
+  }
+
+  /**
+   * Takes a range from a query and might mutate it so the lower/upper values
+   * are within the domain of the dimension. If mutation occurs a warning is
+   * logged
+   *
+   * @tparam T datatype
+   * @param dim dimension object to get domain from
+   * @param range Query range objects to mutate
+   */
+  template <
+      typename T,
+      typename std::enable_if<!std::is_integral<T>::value>::type* = nullptr>
+  static void adjust_range_oob(const Dimension* dim, const Range* range) {
+    auto domain = (const T*)dim->domain().data();
+    auto r = (T*)range->data();
+
+    // Check out-of-bounds
+    if (r[0] < domain[0]) {
+      std::stringstream ss;
+      ss << "Range lower bound " << r[0] << " is out of domain bounds ["
+         << domain[0] << ", " << domain[1]
+         << "]. Adjusting range lower bound to be " << domain[0]
+         << " on dimension '" << dim->name() << "'";
+      global_logger().warn(ss.str().c_str());
+
+      r[0] = domain[0];
+    }
+
+    if (r[1] > domain[1]) {
+      std::stringstream ss;
+      ss << "Range upper bound " << r[1] << " is out of domain bounds ["
+         << domain[0] << ", " << domain[1]
+         << "]. Adjusting range upper bound to be " << domain[1]
+         << " on dimension '" << dim->name() << "'";
+      global_logger().warn(ss.str().c_str());
+
+      r[1] = domain[1];
+    }
   }
 
   /** Returns true if the input range coincides with tile boundaries. */
@@ -619,6 +709,12 @@ class Dimension {
       check_range_func_;
 
   /**
+   * Stores the appropriate templated check_range() function based on the
+   * dimension datatype.
+   */
+  std::function<void(const Dimension*, const Range*)> adjust_range_oob_func_;
+
+  /**
    * Stores the appropriate templated coincides_with_tiles() function based on
    * the dimension datatype.
    */
@@ -852,6 +948,9 @@ class Dimension {
 
   /** Sets the templated check_range() function. */
   void set_check_range_func();
+
+  /** Set the templated adjust_range_oob_func() function. */
+  void set_adjust_range_oob_func();
 
   /** Sets the templated coincides_with_tiles() function. */
   void set_coincides_with_tiles_func();

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -915,6 +915,11 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    If `true`, an error will be thrown if there are cells with coordinates
  *    lying outside the domain during sparse fragment writes.  <br>
  *    **Default**: true
+ *    `sm.read_range_oob` <br>
+ *    If `error`, this will check ranges for read with out-of-bounds on the
+ *    dimension domain's. If `warn`, the ranges will be capped at the
+ *    dimension's domain and a warning logged. <br>
+ *    **Default**: true
  * - `sm.check_global_order` <br>
  *    Checks if the coordinates obey the global array order. Applicable only
  *    to sparse writes in global order.

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -66,6 +66,7 @@ const std::string Config::REST_RETRY_DELAY_FACTOR = "1.25";
 const std::string Config::SM_DEDUP_COORDS = "false";
 const std::string Config::SM_CHECK_COORD_DUPS = "true";
 const std::string Config::SM_CHECK_COORD_OOB = "true";
+const std::string Config::SM_READ_RANGE_OOB = "error";
 const std::string Config::SM_CHECK_GLOBAL_ORDER = "true";
 const std::string Config::SM_TILE_CACHE_SIZE = "10000000";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
@@ -195,6 +196,7 @@ Config::Config() {
   param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
   param_values_["sm.check_coord_dups"] = SM_CHECK_COORD_DUPS;
   param_values_["sm.check_coord_oob"] = SM_CHECK_COORD_OOB;
+  param_values_["sm.read_range_oob"] = SM_READ_RANGE_OOB;
   param_values_["sm.check_global_order"] = SM_CHECK_GLOBAL_ORDER;
   param_values_["sm.tile_cache_size"] = SM_TILE_CACHE_SIZE;
   param_values_["sm.memory_budget"] = SM_MEMORY_BUDGET;
@@ -431,6 +433,8 @@ Status Config::unset(const std::string& param) {
     param_values_["sm.check_coord_dups"] = SM_CHECK_COORD_DUPS;
   } else if (param == "sm.check_coord_oob") {
     param_values_["sm.check_coord_oob"] = SM_CHECK_COORD_OOB;
+  } else if (param == "sm.read_range_oob") {
+    param_values_["sm.read_range_oob"] = SM_READ_RANGE_OOB;
   } else if (param == "sm.check_global_order") {
     param_values_["sm.check_global_order"] = SM_CHECK_GLOBAL_ORDER;
   } else if (param == "sm.tile_cache_size") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -107,6 +107,13 @@ class Config {
   static const std::string SM_CHECK_COORD_OOB;
 
   /**
+   * If `true`, this will check ranges for read with out-of-bounds on the
+   * dimension domain's. If `false`, the ranges will be capped at the
+   * dimension's domain and a warning logged
+   */
+  static const std::string SM_READ_RANGE_OOB;
+
+  /**
    * If `true`, this will check if the cells upon writes in global order
    * are indeed provided in global order.
    */

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -277,6 +277,11 @@ class Config {
    *    If `true`, an error will be thrown if there are cells with coordinates
    *    falling outside the array domain during sparse fragment writes. <br>
    *    **Default**: true
+   *    `sm.read_range_oob` <br>
+   *    If `error`, this will check ranges for read with out-of-bounds on the
+   *    dimension domain's and error. If `warn`, the ranges will be capped at
+   * the dimension's domain and a warning logged. <br>
+   *    **Default**: true
    * - `sm.check_global_order` <br>
    *    Checks if the coordinates obey the global array order. Applicable only
    *    to sparse writes in global order.

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -113,9 +113,10 @@ Status Query::add_range(
   std::memcpy(&range[coord_size], end, coord_size);
 
   // Add range
+  Range r(&range[0], 2 * coord_size);
   if (type_ == QueryType::WRITE)
-    return writer_.add_range(dim_idx, Range(&range[0], 2 * coord_size));
-  return reader_.add_range(dim_idx, Range(&range[0], 2 * coord_size));
+    return writer_.add_range(dim_idx, std::move(r));
+  return reader_.add_range(dim_idx, std::move(r));
 }
 
 Status Query::add_range_var(
@@ -146,7 +147,7 @@ Status Query::add_range_var(
   // Add range
   Range r;
   r.set_range_var(start, start_size, end, end_size);
-  return reader_.add_range(dim_idx, r);
+  return reader_.add_range(dim_idx, std::move(r));
 }
 
 Status Query::get_range_num(unsigned dim_idx, uint64_t* range_num) const {
@@ -976,9 +977,21 @@ Status Query::set_subarray(const void* subarray) {
     auto dim_num = array_->array_schema()->dim_num();
     auto s_ptr = (const unsigned char*)subarray;
     uint64_t offset = 0;
+
+    // Get read_range_oob config setting
+    bool found = false;
+    std::string read_range_oob = config().get("sm.read_range_oob", &found);
+    assert(found);
+    if (read_range_oob != "error" && read_range_oob != "warn")
+      return LOG_STATUS(Status::QueryError(
+          "Invalid value " + read_range_oob +
+          " for sm.read_range_obb. Acceptable values are 'error' or 'warn'."));
+
     for (unsigned d = 0; d < dim_num; ++d) {
       auto r_size = 2 * array_->array_schema()->dimension(d)->coord_size();
-      RETURN_NOT_OK(sub.add_range(d, Range(&s_ptr[offset], r_size)));
+      Range range(&s_ptr[offset], r_size);
+      RETURN_NOT_OK(
+          sub.add_range(d, std::move(range), read_range_oob == "error"));
       offset += r_size;
     }
   }

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -494,8 +494,9 @@ class Query {
   Status set_config(const Config& config);
 
   /**
-   * Get the config of the query
-   * @return
+   * Get the config of the query.
+   *
+   * @return Config from query
    */
   const Config& config() const;
 

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -131,7 +131,7 @@ class Reader {
   const Array* array() const;
 
   /** Adds a range to the subarray on the input dimension. */
-  Status add_range(unsigned dim_idx, const Range& range);
+  Status add_range(unsigned dim_idx, Range&& range);
 
   /** Retrieves the number of ranges of the subarray for the given dimension. */
   Status get_range_num(unsigned dim_idx, uint64_t* range_num) const;

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -89,7 +89,7 @@ const Array* Writer::array() const {
   return array_;
 }
 
-Status Writer::add_range(unsigned dim_idx, const Range& range) {
+Status Writer::add_range(unsigned dim_idx, Range&& range) {
   if (!array_schema_->dense())
     return LOG_STATUS(
         Status::WriterError("Adding a subarray range to a write query is not "
@@ -100,7 +100,7 @@ Status Writer::add_range(unsigned dim_idx, const Range& range) {
         Status::WriterError("Cannot add range; Multi-range dense writes "
                             "are not supported"));
 
-  return subarray_.add_range(dim_idx, range);
+  return subarray_.add_range(dim_idx, std::move(range), true);
 }
 
 Status Writer::get_range_num(unsigned dim_idx, uint64_t* range_num) const {

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -125,7 +125,7 @@ class Writer {
   const Array* array() const;
 
   /** Adds a range to the subarray on the input dimension. */
-  Status add_range(unsigned dim_idx, const Range& range);
+  Status add_range(unsigned dim_idx, Range&& range);
 
   /**
    * Disables checking the global order. Applicable only to writes.

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -115,7 +115,8 @@ Subarray& Subarray::operator=(Subarray&& subarray) noexcept {
 /*               API              */
 /* ****************************** */
 
-Status Subarray::add_range(uint32_t dim_idx, const Range& range) {
+Status Subarray::add_range(
+    uint32_t dim_idx, Range&& range, const bool& read_range_oob_error) {
   auto dim_num = array_->array_schema()->dim_num();
   if (dim_idx >= dim_num)
     return LOG_STATUS(Status::SubarrayError(
@@ -134,6 +135,8 @@ Status Subarray::add_range(uint32_t dim_idx, const Range& range) {
 
   // Correctness checks
   auto dim = array_->array_schema()->dimension(dim_idx);
+  if (!read_range_oob_error)
+    RETURN_NOT_OK(dim->adjust_range_oob(&range));
   RETURN_NOT_OK(dim->check_range(range));
 
   // Add the range

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -209,7 +209,8 @@ class Subarray {
   /* ********************************* */
 
   /** Adds a range along the dimension with the given index. */
-  Status add_range(uint32_t dim_idx, const Range& range);
+  Status add_range(
+      uint32_t dim_idx, Range&& range, const bool& read_range_oob_error);
 
   /**
    * Adds a range along the dimension with the given index, without


### PR DESCRIPTION
This adds a new option `sm.read_range_oob_error` which defaults to true, in order to keep existing behavior. When set to true any range that is out of bounds for the domain of an array will cause an error to be returned and the range to not be set.

If the option is instead set to false, the behavior changes and we print a warning about the out of bounds but instead mutate the range so the lower/upper bound is equal to the domain. This improves the user experience greatly by allowing a user who does not know the domain to issue a broad range and get results returned.

Example of warning messages if the user log level is set to warning:
```
[2021-03-26 15:45:09.651] [tiledb] [Process: 29587] [Thread: 29587] [warning] Range upper bound 4 is out of domain bounds [0, 3]. Adjusting range upper bound to be 3 on dimension 'rows'
[2021-03-26 15:45:09.651] [tiledb] [Process: 29587] [Thread: 29587] [warning] Range lower bound -1 is out of domain bounds [0, 3]. Adjusting range lower bound to be 0 on dimension 'cols'
```

Example usage:

```
// Array has 2 dimensions, both with domains of [0, 3]
Array array(ctx, array_name, TILEDB_READ);
Query query(ctx, array);
Config cfg;
cfg.set("sm.read_range_oob", "error");

query.set_config(cfg);
// The range of [1, 4] will get converted to `[1, 3]`
query.add_range(0, 1, 4);
// The range of [-1, 3] will get converted to `[0, 3]`
query.add_range(1, -1, 3);

query.submit();
```


I'd like to keep existing behavior and backport this to 2.2. In 2.3 I'd suggest we add another PR to change the default, making it breaking behavior, in order improve the experience and default to the warnings that are available in 2.3 to inform the user of the OOB that is adjusted.

---
TYPE: IMPROVEMENT
DESC:  Add config option \`sm.read_range_oob\` to toggle bounding read ranges to domain or erroring
