### PR TITLE
Fix check for null pointer in query deserialization

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -725,7 +725,7 @@ Status query_from_capnp(
 
           if (existing_offset_buffer_size_ptr != nullptr)
             existing_offset_buffer_size = *existing_offset_buffer_size_ptr;
-          if (existing_offset_buffer_size_ptr != nullptr)
+          if (existing_buffer_size_ptr != nullptr)
             existing_buffer_size = *existing_buffer_size_ptr;
         } else {
           RETURN_NOT_OK(query->get_buffer_vbytemap(


### PR DESCRIPTION
In function 'query_from_capnp' in file 'sm/serialization/query.cc', the pointer 'existing_offset_buffer_size_ptr' is checked for a null value instead of 'existing_buffer_size_ptr' before dereferencing the latter.

---
TYPE: BUG
DESC: Fix check for null pointer in query deserialization
