### PR TITLE
Add support for config serialization

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@
 ## Breaking behavior
 
 ## New features
+* Add support for serialization of config objects [#2164](https://github.com/TileDB-Inc/TileDB/pull/2164)
 * Add C and C++ examples to the  directory for the  APIs. [#2160](https://github.com/TileDB-Inc/TileDB/pull/2160)
 * supporting serialization (using capnproto) build on windows [#2100](https://github.com/TileDB-Inc/TileDB/pull/2100)
 * Config option vfs.s3.sse for S3 server-side encryption support [#2130](https://github.com/TileDB-Inc/TileDB/pull/2130)
@@ -33,6 +34,7 @@
 ## API additions
 
 ### C API
+* Added `tiledb_serialize_config` and `tiledb_deserialize_config` [#2164](https://github.com/TileDB-Inc/TileDB/pull/2164)
 * Add new api,  to get a query's config. [#2167](https://github.com/TileDB-Inc/TileDB/pull/2167)
 * Removes non-default parameter in tiledb_config_unset. [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)
 

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -33,6 +33,7 @@
 #include <thread>
 
 #include "catch.hpp"
+#include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/cpp_api/tiledb"
 
 int setenv_local(const char* __name, const char* __value) {
@@ -128,3 +129,43 @@ TEST_CASE("C++ API: Config Equality", "[cppapi], [cppapi-config]") {
   bool config_not_equal = config1 != config2;
   CHECK(config_not_equal);
 }
+
+#ifdef TILEDB_SERIALIZATION
+TEST_CASE(
+    "C++ API: Config Serialization",
+    "[cppapi], [cppapi-config], [serialization]") {
+  tiledb_serialization_type_t format;
+  SECTION("- json") {
+    format = tiledb_serialization_type_t::TILEDB_JSON;
+  }
+
+  SECTION("- capnp") {
+    format = tiledb_serialization_type_t::TILEDB_CAPNP;
+  }
+  // Check for equality
+  tiledb::Config config1;
+  config1["foo"] = "bar";
+
+  tiledb::Context ctx;
+
+  // Serialize the query (client-side).
+  tiledb_buffer_t* buff1;
+  int32_t rc = tiledb_serialize_config(
+      ctx.ptr().get(), config1.ptr().get(), format, 1, &buff1);
+  CHECK(rc == TILEDB_OK);
+
+  tiledb_config_t* config2_ptr;
+  rc = tiledb_deserialize_config(
+      ctx.ptr().get(), buff1, format, 0, &config2_ptr);
+  CHECK(rc == TILEDB_OK);
+  tiledb::Config config2(&config2_ptr);
+
+  bool config_equal = config1 == config2;
+  CHECK(config_equal);
+
+  // Check for inequality
+  CHECK(config2.get("foo") == std::string("bar"));
+
+  tiledb_buffer_free(&buff1);
+}
+#endif  // TILEDB_SERIALIZATION

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -165,6 +165,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/rest/rest_client.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/rtree/rtree.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/array_schema.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/config.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/stats.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/timer_stat.cc

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -59,6 +59,7 @@
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/serialization/array_schema.h"
+#include "tiledb/sm/serialization/config.h"
 #include "tiledb/sm/serialization/query.h"
 #include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/storage_manager/context.h"
@@ -398,6 +399,17 @@ inline int32_t sanity_check(tiledb_config_t* config, tiledb_error_t** error) {
 }
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, tiledb_config_t* config) {
+  if (config == nullptr || config->config_ == nullptr) {
+    auto st = Status::Error("Cannot set config; Invalid config object");
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
+
+  return TILEDB_OK;
+}
+
+inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_config_t* config) {
   if (config == nullptr || config->config_ == nullptr) {
     auto st = Status::Error("Cannot set config; Invalid config object");
     LOG_STATUS(st);
@@ -4832,8 +4844,10 @@ int32_t tiledb_serialize_array_schema(
               array_schema->array_schema_,
               (tiledb::sm::SerializationType)serialize_type,
               (*buffer)->buffer_,
-              client_side)))
+              client_side))) {
+    tiledb_buffer_free(buffer);
     return TILEDB_ERR;
+  }
 
   return TILEDB_OK;
 }
@@ -4895,8 +4909,10 @@ int32_t tiledb_serialize_query(
               query->query_,
               (tiledb::sm::SerializationType)serialize_type,
               client_side == 1,
-              (*buffer_list)->buffer_list_)))
+              (*buffer_list)->buffer_list_))) {
+    tiledb_buffer_list_free(buffer_list);
     return TILEDB_ERR;
+  }
 
   return TILEDB_OK;
 }
@@ -4954,8 +4970,10 @@ int32_t tiledb_serialize_array_nonempty_domain(
               nonempty_domain,
               is_empty,
               (tiledb::sm::SerializationType)serialize_type,
-              (*buffer)->buffer_)))
+              (*buffer)->buffer_))) {
+    tiledb_buffer_free(buffer);
     return TILEDB_ERR;
+  }
 
   return TILEDB_OK;
 }
@@ -5016,8 +5034,10 @@ int32_t tiledb_serialize_array_non_empty_domain_all_dimensions(
           tiledb::sm::serialization::nonempty_domain_serialize(
               array->array_,
               (tiledb::sm::SerializationType)serialize_type,
-              (*buffer)->buffer_)))
+              (*buffer)->buffer_))) {
+    tiledb_buffer_free(buffer);
     return TILEDB_ERR;
+  }
 
   return TILEDB_OK;
 }
@@ -5151,8 +5171,10 @@ int32_t tiledb_serialize_query_est_result_sizes(
               query->query_,
               (tiledb::sm::SerializationType)serialize_type,
               client_side == 1,
-              (*buffer)->buffer_)))
+              (*buffer)->buffer_))) {
+    tiledb_buffer_free(buffer);
     return TILEDB_ERR;
+  }
 
   return TILEDB_OK;
 }
@@ -5177,6 +5199,72 @@ int32_t tiledb_deserialize_query_est_result_sizes(
               client_side == 1,
               *buffer->buffer_)))
     return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_serialize_config(
+    tiledb_ctx_t* ctx,
+    const tiledb_config_t* config,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    tiledb_buffer_t** buffer) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR ||
+      sanity_check(ctx, config) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Create buffer
+  if (tiledb_buffer_alloc(ctx, buffer) != TILEDB_OK ||
+      sanity_check(ctx, *buffer) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          tiledb::sm::serialization::config_serialize(
+              config->config_,
+              (tiledb::sm::SerializationType)serialize_type,
+              (*buffer)->buffer_,
+              client_side))) {
+    tiledb_buffer_free(buffer);
+    return TILEDB_ERR;
+  }
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_deserialize_config(
+    tiledb_ctx_t* ctx,
+    const tiledb_buffer_t* buffer,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    tiledb_config_t** config) {
+  // Currently unused:
+  (void)client_side;
+
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR ||
+      sanity_check(ctx, buffer) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Create array schema struct
+  *config = new (std::nothrow) tiledb_config_t;
+  if (*config == nullptr) {
+    auto st = Status::Error("Failed to allocate TileDB config object");
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_OOM;
+  }
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          tiledb::sm::serialization::config_deserialize(
+              &((*config)->config_),
+              (tiledb::sm::SerializationType)serialize_type,
+              *buffer->buffer_))) {
+    delete *config;
+    return TILEDB_ERR;
+  }
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -335,6 +335,45 @@ TILEDB_EXPORT int32_t tiledb_deserialize_query_est_result_sizes(
     int32_t client_side,
     const tiledb_buffer_t* buffer);
 
+/**
+ * Serializes the given config.
+ *
+ * @note The caller must free the returned `tiledb_buffer_t`.
+ *
+ * @param ctx The TileDB context.
+ * @param config The config to serialize.
+ * @param serialization_type Type of serialization to use
+ * @param client_side If set to 1, serialize from "client-side" perspective.
+ *    Else, "server-side.". Currently unused for config
+ * @param buffer Will be set to a newly allocated buffer containing the
+ *      serialized max buffer sizes.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_serialize_config(
+    tiledb_ctx_t* ctx,
+    const tiledb_config_t* config,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    tiledb_buffer_t** buffer);
+
+/**
+ * Deserializes a new config from the given buffer.
+ *
+ * @param ctx The TileDB context.
+ * @param buffer Buffer to deserialize from
+ * @param serialization_type Type of serialization to use
+ * @param client_side If set to 1, deserialize from "client-side" perspective.
+ *    Else, "server-side.". Currently unused for config
+ * @param config Will be set to a newly allocated config.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_deserialize_config(
+    tiledb_ctx_t* ctx,
+    const tiledb_buffer_t* buffer,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    tiledb_config_t** config);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -38,6 +38,7 @@
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/serialization/tiledb-rest.capnp.h"
@@ -46,6 +47,7 @@ using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {
+class Dimension;
 namespace serialization {
 namespace utils {
 

--- a/tiledb/sm/serialization/config.cc
+++ b/tiledb/sm/serialization/config.cc
@@ -1,0 +1,222 @@
+/**
+ * @file   config.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines serialization functions for Config.
+ */
+
+#include "tiledb/sm/serialization/config.h"
+#include "tiledb/common/heap_memory.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/config/config.h"
+#include "tiledb/sm/enums/array_type.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/filter_option.h"
+#include "tiledb/sm/enums/filter_type.h"
+#include "tiledb/sm/enums/layout.h"
+#include "tiledb/sm/enums/serialization_type.h"
+#include "tiledb/sm/misc/constants.h"
+
+#ifdef _WIN32
+#include "tiledb/sm/serialization/meet-capnproto-win32-include-expectations.h"
+#endif
+
+#include "tiledb/sm/serialization/capnp_utils.h"
+
+#include <set>
+
+#ifdef TILEDB_SERIALIZATION
+#include <capnp/compat/json.h>
+#include <capnp/serialize.h>
+#endif
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+namespace serialization {
+
+#ifdef TILEDB_SERIALIZATION
+
+Status config_to_capnp(
+    const Config* config,
+    capnp::Config::Builder* config_builder,
+    const bool client_side) {
+  if (config == nullptr)
+    return LOG_STATUS(Status::SerializationError(
+        "Error serializing config; config is null."));
+
+  auto entries = config_builder->initEntries(config->param_values().size());
+  uint64_t i = 0;
+  for (const auto& kv : config->param_values()) {
+    entries[i].setKey(kv.first);
+    entries[i].setValue(kv.second);
+    ++i;
+  }
+
+  return Status::Ok();
+}
+
+Status config_from_capnp(
+    const capnp::Config::Reader& config_reader,
+    tdb_unique_ptr<Config>* config) {
+  config->reset(tdb_new(Config));
+
+  if (config_reader.hasEntries()) {
+    auto entries = config_reader.getEntries();
+    for (const auto kv : entries) {
+      RETURN_NOT_OK((*config)->set(kv.getKey().cStr(), kv.getValue().cStr()));
+    }
+  }
+  return Status::Ok();
+}
+
+Status config_serialize(
+    Config* config,
+    SerializationType serialize_type,
+    Buffer* serialized_buffer,
+    const bool client_side) {
+  try {
+    ::capnp::MallocMessageBuilder message;
+    capnp::Config::Builder configBuilder = message.initRoot<capnp::Config>();
+    RETURN_NOT_OK(config_to_capnp(config, &configBuilder, client_side));
+
+    serialized_buffer->reset_size();
+    serialized_buffer->reset_offset();
+
+    switch (serialize_type) {
+      case SerializationType::JSON: {
+        ::capnp::JsonCodec json;
+        kj::String capnp_json = json.encode(configBuilder);
+        const auto json_len = capnp_json.size();
+        const char nul = '\0';
+        // size does not include needed null terminator, so add +1
+        RETURN_NOT_OK(serialized_buffer->realloc(json_len + 1));
+        RETURN_NOT_OK(serialized_buffer->write(capnp_json.cStr(), json_len));
+        RETURN_NOT_OK(serialized_buffer->write(&nul, 1));
+        break;
+      }
+      case SerializationType::CAPNP: {
+        kj::Array<::capnp::word> protomessage = messageToFlatArray(message);
+        kj::ArrayPtr<const char> message_chars = protomessage.asChars();
+        const auto nbytes = message_chars.size();
+        RETURN_NOT_OK(serialized_buffer->realloc(nbytes));
+        RETURN_NOT_OK(serialized_buffer->write(message_chars.begin(), nbytes));
+        break;
+      }
+      default: {
+        return LOG_STATUS(Status::SerializationError(
+            "Error serializing config; Unknown serialization type "
+            "passed"));
+      }
+    }
+
+  } catch (kj::Exception& e) {
+    return LOG_STATUS(Status::SerializationError(
+        "Error serializing config; kj::Exception: " +
+        std::string(e.getDescription().cStr())));
+  } catch (std::exception& e) {
+    return LOG_STATUS(Status::SerializationError(
+        "Error serializing config; exception " + std::string(e.what())));
+  }
+
+  return Status::Ok();
+}
+
+Status config_deserialize(
+    Config** config,
+    SerializationType serialize_type,
+    const Buffer& serialized_buffer) {
+  try {
+    tdb_unique_ptr<Config> decoded_config = nullptr;
+
+    switch (serialize_type) {
+      case SerializationType::JSON: {
+        ::capnp::JsonCodec json;
+        ::capnp::MallocMessageBuilder message_builder;
+        capnp::Config::Builder config_builder =
+            message_builder.initRoot<capnp::Config>();
+        json.decode(
+            kj::StringPtr(static_cast<const char*>(serialized_buffer.data())),
+            config_builder);
+        capnp::Config::Reader config_reader = config_builder.asReader();
+        RETURN_NOT_OK(config_from_capnp(config_reader, &decoded_config));
+        break;
+      }
+      case SerializationType::CAPNP: {
+        const auto mBytes =
+            reinterpret_cast<const kj::byte*>(serialized_buffer.data());
+        ::capnp::FlatArrayMessageReader reader(kj::arrayPtr(
+            reinterpret_cast<const ::capnp::word*>(mBytes),
+            serialized_buffer.size() / sizeof(::capnp::word)));
+        capnp::Config::Reader config_reader = reader.getRoot<capnp::Config>();
+        RETURN_NOT_OK(config_from_capnp(config_reader, &decoded_config));
+        break;
+      }
+      default: {
+        return LOG_STATUS(Status::SerializationError(
+            "Error deserializing config; Unknown serialization type "
+            "passed"));
+      }
+    }
+
+    if (decoded_config == nullptr)
+      return LOG_STATUS(Status::SerializationError(
+          "Error serializing config; deserialized config is null"));
+
+    *config = decoded_config.release();
+  } catch (kj::Exception& e) {
+    return LOG_STATUS(Status::SerializationError(
+        "Error deserializing config; kj::Exception: " +
+        std::string(e.getDescription().cStr())));
+  } catch (std::exception& e) {
+    return LOG_STATUS(Status::SerializationError(
+        "Error deserializing config; exception " + std::string(e.what())));
+  }
+
+  return Status::Ok();
+}
+
+#else
+
+Status config_serialize(Config*, SerializationType, Buffer*, const bool) {
+  return LOG_STATUS(Status::SerializationError(
+      "Cannot serialize; serialization not enabled."));
+}
+
+Status config_deserialize(Config**, SerializationType, const Buffer&) {
+  return LOG_STATUS(Status::SerializationError(
+      "Cannot serialize; serialization not enabled."));
+}
+
+#endif  // TILEDB_SERIALIZATION
+
+}  // namespace serialization
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/serialization/config.h
+++ b/tiledb/sm/serialization/config.h
@@ -1,0 +1,83 @@
+/**
+ * @file   config.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares serialization functions for Config.
+ */
+
+#ifndef TILEDB_SERIALIZATION_CONFIG_H
+#define TILEDB_SERIALIZATION_CONFIG_H
+
+#include <unordered_map>
+
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class Config;
+class Buffer;
+enum class SerializationType : uint8_t;
+
+namespace serialization {
+
+/**
+ * Serialize a config via Cap'n Prto
+ *
+ * @param Config config object to serialize
+ * @param serialize_type format to serialize into Cap'n Proto or JSON
+ * @param serialized_buffer buffer to store serialized bytes in
+ * @param client_side indicate if client or server side. If server side we won't
+ * serialize the array URI
+ * @return
+ */
+Status config_serialize(
+    Config* config,
+    SerializationType serialize_type,
+    Buffer* serialized_buffer,
+    const bool client_side);
+
+/**
+ * Deserialize a config via Cap'n proto
+ *
+ * @param config to deserialize into
+ * @param serialize_type format the data is serialized in Cap'n Proto of JSON
+ * @param serialized_buffer buffer to read serialized bytes from
+ * @return Status
+ */
+Status config_deserialize(
+    Config** config,
+    SerializationType serialize_type,
+    const Buffer& serialized_buffer);
+}  // namespace serialization
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_SERIALIZATION_CONFIG_H

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -16,6 +16,17 @@ struct DomainArray {
   float64 @9 :List(Float64);
 }
 
+struct KV {
+  key @0 :Text;
+  value @1 :Text;
+}
+
+struct Config {
+# Represents a config object
+  entries @0 :List(KV);
+  # list of key-value settings
+}
+
 struct Array {
   timestamp @0 :UInt64;
   # timestamp array was opened


### PR DESCRIPTION
This adds a new c-api for config serialization. This allows a user to serialization the configuration into JSON or cap'n proto format. This will eventually be used by the query and array to include the config when those objects are serialized.

---
TYPE: FEATURE
DESC: Add support for serialization of config objects

TYPE: C_API
DESC: Added \`tiledb_serialize_config\` and \`tiledb_deserialize_config\`