### PR TITLE
[Backport release-2.2] Add c/c++ api for getting config from query

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,7 +18,11 @@
 
 ### C API
 
+* Add new api,`tiledb_query_get_config` to get a query's config. [#2167](https://github.com/TileDB-Inc/TileDB/pull/2167)
+
 ### C++ API
+
+* Add new api, `Query.config()`  to get a query's config. [#2167](https://github.com/TileDB-Inc/TileDB/pull/2167)
 
 # TileDB v2.2.7 Release Notes
 

--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -3046,6 +3046,16 @@ TEST_CASE_METHOD(
   rc = tiledb_query_set_config(ctx_, query, config);
   CHECK(rc == TILEDB_OK);
 
+  // Test getting config, it should be identical
+  tiledb_config_t* config2;
+  rc = tiledb_query_get_config(ctx_, query, &config2);
+  CHECK(rc == TILEDB_OK);
+
+  uint8_t equal;
+  rc = tiledb_config_compare(config, config2, &equal);
+  CHECK(rc == TILEDB_OK);
+  CHECK(equal == 1);
+
   // Test modified behavior
   std::vector<uint32_t> offsets = {0, 1, 2, 4, 7, 9, 10};
   // even in elements mode, we need to pass offsets size as if uint64

--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -236,6 +236,11 @@ void write_dense_array(
 
   if (config != nullptr) {
     query.set_config(*config);
+
+    // Validate we can retrieve set config
+    Config config2 = query.config();
+    bool same = *config == config2;
+    CHECK(same == true);
   }
 
   query.set_buffer("attr", data_offsets, data);
@@ -271,6 +276,11 @@ void write_dense_array(
 
   if (config != nullptr) {
     query.set_config(*config);
+
+    // Validate we can retrieve set config
+    Config config2 = query.config();
+    bool same = *config == config2;
+    CHECK(same == true);
   }
 
   // Write using a 32-bit vector, but cast it to 64-bit pointer so that the API
@@ -308,6 +318,11 @@ void read_and_check_dense_array(
 
   if (config != nullptr) {
     query.set_config(*config);
+
+    // Validate we can retrieve set config
+    Config config2 = query.config();
+    bool same = *config == config2;
+    CHECK(same == true);
   }
 
   std::vector<int32_t> attr_val(expected_data.size());
@@ -334,6 +349,11 @@ void read_and_check_dense_array(
 
   if (config != nullptr) {
     query.set_config(*config);
+
+    // Validate we can retrieve set config
+    Config config2 = query.config();
+    bool same = *config == config2;
+    CHECK(same == true);
   }
 
   std::vector<int32_t> attr_val(expected_data.size());

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2651,6 +2651,29 @@ int32_t tiledb_query_set_config(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_get_config(
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_config_t** config) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Create a new config struct
+  *config = new (std::nothrow) tiledb_config_t;
+  if (*config == nullptr)
+    return TILEDB_OOM;
+
+  // Create storage manager
+  (*config)->config_ = new (std::nothrow) tiledb::sm::Config();
+  if ((*config)->config_ == nullptr) {
+    delete (*config);
+    return TILEDB_OOM;
+  }
+
+  *((*config)->config_) = query->query_->config();
+
+  // Success
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_set_subarray(
     tiledb_ctx_t* ctx, tiledb_query_t* query, const void* subarray) {
   // Sanity check

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3358,6 +3358,24 @@ TILEDB_EXPORT int32_t tiledb_query_set_config(
     tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_config_t* config);
 
 /**
+ * Retrieves the config from a Query.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_config_t* config;
+ * tiledb_query_get_config(ctx, vfs, &config);
+ * // Make sure to free the retrieved config
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The query object.
+ * @param config The config to be retrieved.
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_config(
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_config_t** config);
+/**
  * Indicates that the query will write or read a subarray, and provides
  * the appropriate information.
  *

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1103,6 +1103,17 @@ class Query {
   }
 
   /**
+   * Get the config
+   * @return Config
+   */
+  Config config() const {
+    tiledb_config_t* config;
+    tiledb_query_get_config(ctx_.get().ptr().get(), query_.get(), &config);
+
+    return Config(&config);
+  }
+
+  /**
    * Set the coordinate buffer.
    *
    * The coordinate buffer has been deprecated. Set the coordinates for

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1058,6 +1058,13 @@ QueryType Query::type() const {
   return type_;
 }
 
+const Config& Query::config() const {
+  if (type_ == QueryType::READ)
+    return reader_.config();
+  else
+    return writer_.config();
+}
+
 /* ****************************** */
 /*          PRIVATE METHODS       */
 /* ****************************** */

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -494,6 +494,12 @@ class Query {
   Status set_config(const Config& config);
 
   /**
+   * Get the config of the query
+   * @return
+   */
+  const Config& config() const;
+
+  /**
    * Sets the buffer for a fixed-sized attribute/dimension.
    *
    * @param name The attribute/dimension to set the buffer for.

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -3544,5 +3544,9 @@ bool Reader::belong_to_single_fragment(
   return true;
 }
 
+const Config& Reader::config() const {
+  return config_;
+}
+
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -444,6 +444,12 @@ class Reader {
   Status set_config(const Config& config);
 
   /**
+   * Get the config of the writer
+   * @return Config
+   */
+  const Config& config() const;
+
+  /**
    * Sets the cell layout of the query. The function will return an error
    * if the queried array is a key-value store (because it has its default
    * layout for both reads and writes.

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -3650,5 +3650,8 @@ Status Writer::calculate_hilbert_values(
   return Status::Ok();
 }
 
+const Config& Writer::config() const {
+  return config_;
+}
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -340,6 +340,12 @@ class Writer {
   /** Sets config for query-level parameters only. */
   Status set_config(const Config& config);
 
+  /**
+   * Get the config of the writer
+   * @return Config
+   */
+  const Config& config() const;
+
   /** Sets current setting of check_coord_dups_ */
   void set_check_coord_dups(bool b);
 


### PR DESCRIPTION
This introduces a new c api `tiledb_query_get_config` and a new C++ api `Query.config()` which fetches the config that is set on the query. This can either be a config from `set_config` or the ctx's config if the user never set one on the query explicitly.
