### PR TITLE
[backport release-2.2] Add config option to bound read ranges to domain

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@
 
 ## Improvements
 
+* Add config option `sm.read_range_oob` to toggle bounding read ranges to domain or erroring [#2162](https://github.com/TileDB-Inc/TileDB/pull/2162)
+
 ## Deprecations
 
 ## Bug fixes

--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -487,7 +487,8 @@ void create_subarray(
   for (unsigned d = 0; d < dim_num; ++d) {
     auto dim_range_num = ranges[d].size() / 2;
     for (size_t j = 0; j < dim_range_num; ++j) {
-      ret.add_range(d, sm::Range(&ranges[d][2 * j], 2 * sizeof(T)));
+      sm::Range range(&ranges[d][2 * j], 2 * sizeof(T));
+      ret.add_range(d, std::move(range), true);
     }
   }
 

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -2253,7 +2253,7 @@ TEST_CASE_METHOD(
   tiledb::sm::Subarray subarray(array->array_, layout);
   tiledb::sm::Range r;
   r.set_str_range("bb", "bb");
-  subarray.add_range(0, r);
+  subarray.add_range(0, std::move(r), true);
   ThreadPool tp;
   CHECK(tp.init(4).ok());
   SubarrayPartitioner partitioner(
@@ -2282,7 +2282,7 @@ TEST_CASE_METHOD(
   // Check full
   tiledb::sm::Subarray subarray_full(array->array_, layout);
   r.set_str_range("a", "bb");
-  subarray_full.add_range(0, r);
+  subarray_full.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_full(
       subarray_full, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_full.set_result_budget("d", 16, 4);
@@ -2302,7 +2302,7 @@ TEST_CASE_METHOD(
   // Check split
   tiledb::sm::Subarray subarray_split(array->array_, layout);
   r.set_str_range("a", "bb");
-  subarray_split.add_range(0, r);
+  subarray_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split(
       subarray_split, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_split.set_result_budget("d", 10, 4);
@@ -2332,7 +2332,7 @@ TEST_CASE_METHOD(
   // Check no split 2 MBRs
   tiledb::sm::Subarray subarray_no_split(array->array_, layout);
   r.set_str_range("bb", "cc");
-  subarray_no_split.add_range(0, r);
+  subarray_no_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_no_split(
       subarray_no_split, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_no_split.set_result_budget("d", 16, 10);
@@ -2354,7 +2354,7 @@ TEST_CASE_METHOD(
   // Check split 2 MBRs
   tiledb::sm::Subarray subarray_split_2(array->array_, layout);
   r.set_str_range("bb", "cc");
-  subarray_split_2.add_range(0, r);
+  subarray_split_2.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split_2(
       subarray_split_2, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_split_2.set_result_budget("d", 8, 10);
@@ -2482,7 +2482,7 @@ TEST_CASE_METHOD(
   tiledb::sm::Subarray subarray(array->array_, layout);
   tiledb::sm::Range r;
   r.set_str_range("cc", "ccd");
-  subarray.add_range(0, r);
+  subarray.add_range(0, std::move(r), true);
   ThreadPool tp;
   CHECK(tp.init(4).ok());
   SubarrayPartitioner partitioner(

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -236,6 +236,7 @@ void check_save_to_file() {
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.num_tbb_threads -1\n";
+  ss << "sm.read_range_oob error\n";
   ss << "sm.skip_checksum_validation false\n";
   ss << "sm.sub_partitioner_memory_budget 0\n";
   ss << "sm.tile_cache_size 10000000\n";
@@ -495,6 +496,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.consolidation.buffer_size"] = "50000000";
   all_param_values["sm.consolidation.step_size_ratio"] = "0.0";
   all_param_values["sm.consolidation.mode"] = "fragments";
+  all_param_values["sm.read_range_oob"] = "error";
   all_param_values["sm.vacuum.mode"] = "fragments";
   all_param_values["sm.var_offsets.bitsize"] = "32";
   all_param_values["sm.var_offsets.extra_element"] = "true";

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -915,6 +915,11 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    If `true`, an error will be thrown if there are cells with coordinates
  *    lying outside the domain during sparse fragment writes.  <br>
  *    **Default**: true
+ *    `sm.read_range_oob` <br>
+ *    If `error`, this will check ranges for read with out-of-bounds on the
+ *    dimension domain's. If `warn`, the ranges will be capped at the
+ *    dimension's domain and a warning logged. <br>
+ *    **Default**: true
  * - `sm.check_global_order` <br>
  *    Checks if the coordinates obey the global array order. Applicable only
  *    to sparse writes in global order.

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -61,6 +61,7 @@ const std::string Config::REST_RETRY_DELAY_FACTOR = "1.25";
 const std::string Config::SM_DEDUP_COORDS = "false";
 const std::string Config::SM_CHECK_COORD_DUPS = "true";
 const std::string Config::SM_CHECK_COORD_OOB = "true";
+const std::string Config::SM_READ_RANGE_OOB = "error";
 const std::string Config::SM_CHECK_GLOBAL_ORDER = "true";
 const std::string Config::SM_TILE_CACHE_SIZE = "10000000";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
@@ -189,6 +190,7 @@ Config::Config() {
   param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
   param_values_["sm.check_coord_dups"] = SM_CHECK_COORD_DUPS;
   param_values_["sm.check_coord_oob"] = SM_CHECK_COORD_OOB;
+  param_values_["sm.read_range_oob"] = SM_READ_RANGE_OOB;
   param_values_["sm.check_global_order"] = SM_CHECK_GLOBAL_ORDER;
   param_values_["sm.tile_cache_size"] = SM_TILE_CACHE_SIZE;
   param_values_["sm.memory_budget"] = SM_MEMORY_BUDGET;
@@ -423,6 +425,8 @@ Status Config::unset(const std::string& param) {
     param_values_["sm.check_coord_dups"] = SM_CHECK_COORD_DUPS;
   } else if (param == "sm.check_coord_oob") {
     param_values_["sm.check_coord_oob"] = SM_CHECK_COORD_OOB;
+  } else if (param == "sm.read_range_oob") {
+    param_values_["sm.read_range_oob"] = SM_READ_RANGE_OOB;
   } else if (param == "sm.check_global_order") {
     param_values_["sm.check_global_order"] = SM_CHECK_GLOBAL_ORDER;
   } else if (param == "sm.tile_cache_size") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -101,6 +101,13 @@ class Config {
   static const std::string SM_CHECK_COORD_OOB;
 
   /**
+   * If `true`, this will check ranges for read with out-of-bounds on the
+   * dimension domain's. If `false`, the ranges will be capped at the
+   * dimension's domain and a warning logged
+   */
+  static const std::string SM_READ_RANGE_OOB;
+
+  /**
    * If `true`, this will check if the cells upon writes in global order
    * are indeed provided in global order.
    */

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -250,6 +250,11 @@ class Config {
    *    If `true`, an error will be thrown if there are cells with coordinates
    *    falling outside the array domain during sparse fragment writes. <br>
    *    **Default**: true
+   *    `sm.read_range_oob` <br>
+   *    If `error`, this will check ranges for read with out-of-bounds on the
+   *    dimension domain's and error. If `warn`, the ranges will be capped at
+   * the dimension's domain and a warning logged. <br>
+   *    **Default**: true
    * - `sm.check_global_order` <br>
    *    Checks if the coordinates obey the global array order. Applicable only
    *    to sparse writes in global order.

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -494,8 +494,9 @@ class Query {
   Status set_config(const Config& config);
 
   /**
-   * Get the config of the query
-   * @return
+   * Get the config of the query.
+   *
+   * @return Config from query
    */
   const Config& config() const;
 

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -131,7 +131,7 @@ class Reader {
   const Array* array() const;
 
   /** Adds a range to the subarray on the input dimension. */
-  Status add_range(unsigned dim_idx, const Range& range);
+  Status add_range(unsigned dim_idx, Range&& range);
 
   /** Retrieves the number of ranges of the subarray for the given dimension. */
   Status get_range_num(unsigned dim_idx, uint64_t* range_num) const;

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -88,7 +88,7 @@ const Array* Writer::array() const {
   return array_;
 }
 
-Status Writer::add_range(unsigned dim_idx, const Range& range) {
+Status Writer::add_range(unsigned dim_idx, Range&& range) {
   if (!array_schema_->dense())
     return LOG_STATUS(
         Status::WriterError("Adding a subarray range to a write query is not "
@@ -99,7 +99,7 @@ Status Writer::add_range(unsigned dim_idx, const Range& range) {
         Status::WriterError("Cannot add range; Multi-range dense writes "
                             "are not supported"));
 
-  return subarray_.add_range(dim_idx, range);
+  return subarray_.add_range(dim_idx, std::move(range), true);
 }
 
 Status Writer::get_range_num(unsigned dim_idx, uint64_t* range_num) const {

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -125,7 +125,7 @@ class Writer {
   const Array* array() const;
 
   /** Adds a range to the subarray on the input dimension. */
-  Status add_range(unsigned dim_idx, const Range& range);
+  Status add_range(unsigned dim_idx, Range&& range);
 
   /**
    * Disables checking the global order. Applicable only to writes.

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -115,7 +115,8 @@ Subarray& Subarray::operator=(Subarray&& subarray) noexcept {
 /*               API              */
 /* ****************************** */
 
-Status Subarray::add_range(uint32_t dim_idx, const Range& range) {
+Status Subarray::add_range(
+    uint32_t dim_idx, Range&& range, const bool& read_range_oob_error) {
   auto dim_num = array_->array_schema()->dim_num();
   if (dim_idx >= dim_num)
     return LOG_STATUS(Status::SubarrayError(
@@ -134,6 +135,8 @@ Status Subarray::add_range(uint32_t dim_idx, const Range& range) {
 
   // Correctness checks
   auto dim = array_->array_schema()->dimension(dim_idx);
+  if (!read_range_oob_error)
+    RETURN_NOT_OK(dim->adjust_range_oob(&range));
   RETURN_NOT_OK(dim->check_range(range));
 
   // Add the range

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -209,7 +209,8 @@ class Subarray {
   /* ********************************* */
 
   /** Adds a range along the dimension with the given index. */
-  Status add_range(uint32_t dim_idx, const Range& range);
+  Status add_range(
+      uint32_t dim_idx, Range&& range, const bool& read_range_oob_error);
 
   /**
    * Adds a range along the dimension with the given index, without


### PR DESCRIPTION
This adds a new option `sm.read_range_oob` which defaults to "error". When set to true any range that is out of bounds for the domain of an array will cause an error to be returned and the range to not be set. This is the existing TileDB behavior.

If the option is instead set to "warn", the behavior changes and we print a warning about the out of bounds but instead mutate the range so the lower/upper bound is equal to the domain. This improves the user experience greatly by allowing a user who does not know the domain to issue a broad range and get results returned.

NOTE: For the backport this logs at an error level since we don't have 'warn' and runtime log levels in 2.2. It does not return an error, only the spdlog level for the message is error.