### PR TITLE
[backport release-2.2] Add support for config serialization

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,8 @@
 
 ## New features
 
+* Add support for serialization of config objects [#2164](https://github.com/TileDB-Inc/TileDB/pull/2164)
+
 ## Improvements
 
 ## Deprecations
@@ -19,6 +21,7 @@
 ### C API
 
 * Add new api,`tiledb_query_get_config` to get a query's config. [#2167](https://github.com/TileDB-Inc/TileDB/pull/2167)
+* Added `tiledb_serialize_config` and `tiledb_deserialize_config` [#2164](https://github.com/TileDB-Inc/TileDB/pull/2164)
 
 ### C++ API
 

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -33,6 +33,7 @@
 #include <thread>
 
 #include "catch.hpp"
+#include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/cpp_api/tiledb"
 
 int setenv_local(const char* __name, const char* __value) {
@@ -126,3 +127,43 @@ TEST_CASE("C++ API: Config Equality", "[cppapi], [cppapi-config]") {
   config2["foo"] = "bar2";
   CHECK(config1 != config2);
 }
+
+#ifdef TILEDB_SERIALIZATION
+TEST_CASE(
+    "C++ API: Config Serialization",
+    "[cppapi], [cppapi-config], [serialization]") {
+  tiledb_serialization_type_t format;
+  SECTION("- json") {
+    format = tiledb_serialization_type_t::TILEDB_JSON;
+  }
+
+  SECTION("- capnp") {
+    format = tiledb_serialization_type_t::TILEDB_CAPNP;
+  }
+  // Check for equality
+  tiledb::Config config1;
+  config1["foo"] = "bar";
+
+  tiledb::Context ctx;
+
+  // Serialize the query (client-side).
+  tiledb_buffer_t* buff1;
+  int32_t rc = tiledb_serialize_config(
+      ctx.ptr().get(), config1.ptr().get(), format, 1, &buff1);
+  CHECK(rc == TILEDB_OK);
+
+  tiledb_config_t* config2_ptr;
+  rc = tiledb_deserialize_config(
+      ctx.ptr().get(), buff1, format, 0, &config2_ptr);
+  CHECK(rc == TILEDB_OK);
+  tiledb::Config config2(&config2_ptr);
+
+  bool config_equal = config1 == config2;
+  CHECK(config_equal);
+
+  // Check for inequality
+  CHECK(config2.get("foo") == std::string("bar"));
+
+  tiledb_buffer_free(&buff1);
+}
+#endif  // TILEDB_SERIALIZATION

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -163,6 +163,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/rest/rest_client.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/rtree/rtree.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/array_schema.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/config.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/stats.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/context.cc

--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -335,6 +335,45 @@ TILEDB_EXPORT int32_t tiledb_deserialize_query_est_result_sizes(
     int32_t client_side,
     const tiledb_buffer_t* buffer);
 
+/**
+ * Serializes the given config.
+ *
+ * @note The caller must free the returned `tiledb_buffer_t`.
+ *
+ * @param ctx The TileDB context.
+ * @param config The config to serialize.
+ * @param serialization_type Type of serialization to use
+ * @param client_side If set to 1, serialize from "client-side" perspective.
+ *    Else, "server-side.". Currently unused for config
+ * @param buffer Will be set to a newly allocated buffer containing the
+ *      serialized max buffer sizes.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_serialize_config(
+    tiledb_ctx_t* ctx,
+    const tiledb_config_t* config,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    tiledb_buffer_t** buffer);
+
+/**
+ * Deserializes a new config from the given buffer.
+ *
+ * @param ctx The TileDB context.
+ * @param buffer Buffer to deserialize from
+ * @param serialization_type Type of serialization to use
+ * @param client_side If set to 1, deserialize from "client-side" perspective.
+ *    Else, "server-side.". Currently unused for config
+ * @param config Will be set to a newly allocated config.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_deserialize_config(
+    tiledb_ctx_t* ctx,
+    const tiledb_buffer_t* buffer,
+    tiledb_serialization_type_t serialize_type,
+    int32_t client_side,
+    tiledb_config_t** config);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -37,6 +37,7 @@
 
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/serialization/tiledb-rest.capnp.h"
@@ -45,6 +46,7 @@ using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {
+class Dimension;
 namespace serialization {
 namespace utils {
 

--- a/tiledb/sm/serialization/config.cc
+++ b/tiledb/sm/serialization/config.cc
@@ -1,0 +1,217 @@
+/**
+ * @file   config.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines serialization functions for Config.
+ */
+
+#include "tiledb/sm/serialization/config.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/config/config.h"
+#include "tiledb/sm/enums/array_type.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/filter_option.h"
+#include "tiledb/sm/enums/filter_type.h"
+#include "tiledb/sm/enums/layout.h"
+#include "tiledb/sm/enums/serialization_type.h"
+#include "tiledb/sm/misc/constants.h"
+
+#include "tiledb/sm/serialization/capnp_utils.h"
+
+#include <set>
+
+#ifdef TILEDB_SERIALIZATION
+#include <capnp/compat/json.h>
+#include <capnp/serialize.h>
+#endif
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+namespace serialization {
+
+#ifdef TILEDB_SERIALIZATION
+
+Status config_to_capnp(
+    const Config* config,
+    capnp::Config::Builder* config_builder,
+    const bool client_side) {
+  if (config == nullptr)
+    return LOG_STATUS(Status::SerializationError(
+        "Error serializing config; config is null."));
+
+  auto entries = config_builder->initEntries(config->param_values().size());
+  uint64_t i = 0;
+  for (const auto& kv : config->param_values()) {
+    entries[i].setKey(kv.first);
+    entries[i].setValue(kv.second);
+    ++i;
+  }
+
+  return Status::Ok();
+}
+
+Status config_from_capnp(
+    const capnp::Config::Reader& config_reader,
+    std::unique_ptr<Config>* config) {
+  config->reset(new Config);
+
+  if (config_reader.hasEntries()) {
+    auto entries = config_reader.getEntries();
+    for (const auto kv : entries) {
+      RETURN_NOT_OK((*config)->set(kv.getKey().cStr(), kv.getValue().cStr()));
+    }
+  }
+  return Status::Ok();
+}
+
+Status config_serialize(
+    Config* config,
+    SerializationType serialize_type,
+    Buffer* serialized_buffer,
+    const bool client_side) {
+  try {
+    ::capnp::MallocMessageBuilder message;
+    capnp::Config::Builder configBuilder = message.initRoot<capnp::Config>();
+    RETURN_NOT_OK(config_to_capnp(config, &configBuilder, client_side));
+
+    serialized_buffer->reset_size();
+    serialized_buffer->reset_offset();
+
+    switch (serialize_type) {
+      case SerializationType::JSON: {
+        ::capnp::JsonCodec json;
+        kj::String capnp_json = json.encode(configBuilder);
+        const auto json_len = capnp_json.size();
+        const char nul = '\0';
+        // size does not include needed null terminator, so add +1
+        RETURN_NOT_OK(serialized_buffer->realloc(json_len + 1));
+        RETURN_NOT_OK(serialized_buffer->write(capnp_json.cStr(), json_len));
+        RETURN_NOT_OK(serialized_buffer->write(&nul, 1));
+        break;
+      }
+      case SerializationType::CAPNP: {
+        kj::Array<::capnp::word> protomessage = messageToFlatArray(message);
+        kj::ArrayPtr<const char> message_chars = protomessage.asChars();
+        const auto nbytes = message_chars.size();
+        RETURN_NOT_OK(serialized_buffer->realloc(nbytes));
+        RETURN_NOT_OK(serialized_buffer->write(message_chars.begin(), nbytes));
+        break;
+      }
+      default: {
+        return LOG_STATUS(Status::SerializationError(
+            "Error serializing config; Unknown serialization type "
+            "passed"));
+      }
+    }
+
+  } catch (kj::Exception& e) {
+    return LOG_STATUS(Status::SerializationError(
+        "Error serializing config; kj::Exception: " +
+        std::string(e.getDescription().cStr())));
+  } catch (std::exception& e) {
+    return LOG_STATUS(Status::SerializationError(
+        "Error serializing config; exception " + std::string(e.what())));
+  }
+
+  return Status::Ok();
+}
+
+Status config_deserialize(
+    Config** config,
+    SerializationType serialize_type,
+    const Buffer& serialized_buffer) {
+  try {
+    std::unique_ptr<Config> decoded_config = nullptr;
+
+    switch (serialize_type) {
+      case SerializationType::JSON: {
+        ::capnp::JsonCodec json;
+        ::capnp::MallocMessageBuilder message_builder;
+        capnp::Config::Builder config_builder =
+            message_builder.initRoot<capnp::Config>();
+        json.decode(
+            kj::StringPtr(static_cast<const char*>(serialized_buffer.data())),
+            config_builder);
+        capnp::Config::Reader config_reader = config_builder.asReader();
+        RETURN_NOT_OK(config_from_capnp(config_reader, &decoded_config));
+        break;
+      }
+      case SerializationType::CAPNP: {
+        const auto mBytes =
+            reinterpret_cast<const kj::byte*>(serialized_buffer.data());
+        ::capnp::FlatArrayMessageReader reader(kj::arrayPtr(
+            reinterpret_cast<const ::capnp::word*>(mBytes),
+            serialized_buffer.size() / sizeof(::capnp::word)));
+        capnp::Config::Reader config_reader = reader.getRoot<capnp::Config>();
+        RETURN_NOT_OK(config_from_capnp(config_reader, &decoded_config));
+        break;
+      }
+      default: {
+        return LOG_STATUS(Status::SerializationError(
+            "Error deserializing config; Unknown serialization type "
+            "passed"));
+      }
+    }
+
+    if (decoded_config == nullptr)
+      return LOG_STATUS(Status::SerializationError(
+          "Error serializing config; deserialized config is null"));
+
+    *config = decoded_config.release();
+  } catch (kj::Exception& e) {
+    return LOG_STATUS(Status::SerializationError(
+        "Error deserializing config; kj::Exception: " +
+        std::string(e.getDescription().cStr())));
+  } catch (std::exception& e) {
+    return LOG_STATUS(Status::SerializationError(
+        "Error deserializing config; exception " + std::string(e.what())));
+  }
+
+  return Status::Ok();
+}
+
+#else
+
+Status config_serialize(Config*, SerializationType, Buffer*, const bool) {
+  return LOG_STATUS(Status::SerializationError(
+      "Cannot serialize; serialization not enabled."));
+}
+
+Status config_deserialize(Config**, SerializationType, const Buffer&) {
+  return LOG_STATUS(Status::SerializationError(
+      "Cannot serialize; serialization not enabled."));
+}
+
+#endif  // TILEDB_SERIALIZATION
+
+}  // namespace serialization
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/serialization/config.h
+++ b/tiledb/sm/serialization/config.h
@@ -1,0 +1,83 @@
+/**
+ * @file   config.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares serialization functions for Config.
+ */
+
+#ifndef TILEDB_SERIALIZATION_CONFIG_H
+#define TILEDB_SERIALIZATION_CONFIG_H
+
+#include <unordered_map>
+
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class Config;
+class Buffer;
+enum class SerializationType : uint8_t;
+
+namespace serialization {
+
+/**
+ * Serialize a config via Cap'n Prto
+ *
+ * @param Config config object to serialize
+ * @param serialize_type format to serialize into Cap'n Proto or JSON
+ * @param serialized_buffer buffer to store serialized bytes in
+ * @param client_side indicate if client or server side. If server side we won't
+ * serialize the array URI
+ * @return
+ */
+Status config_serialize(
+    Config* config,
+    SerializationType serialize_type,
+    Buffer* serialized_buffer,
+    const bool client_side);
+
+/**
+ * Deserialize a config via Cap'n proto
+ *
+ * @param config to deserialize into
+ * @param serialize_type format the data is serialized in Cap'n Proto of JSON
+ * @param serialized_buffer buffer to read serialized bytes from
+ * @return Status
+ */
+Status config_deserialize(
+    Config** config,
+    SerializationType serialize_type,
+    const Buffer& serialized_buffer);
+}  // namespace serialization
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_SERIALIZATION_CONFIG_H

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -16,6 +16,17 @@ struct DomainArray {
   float64 @9 :List(Float64);
 }
 
+struct KV {
+  key @0 :Text;
+  value @1 :Text;
+}
+
+struct Config {
+# Represents a config object
+  entries @0 :List(KV);
+  # list of key-value settings
+}
+
 struct Array {
   timestamp @0 :UInt64;
   # timestamp array was opened

--- a/tiledb/sm/serialization/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/tiledb-rest.capnp.c++
@@ -224,6 +224,115 @@ const ::capnp::_::RawSchema s_ce5904e6f9410cec = {
   0, 10, i_ce5904e6f9410cec, nullptr, nullptr, { &s_ce5904e6f9410cec, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<47> b_e3dadf2bf211bc97 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    151, 188,  17, 242,  43, 223, 218, 227,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0, 170,   0,   0,   0,
+     29,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     25,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  75,  86,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  34,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0,  50,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     40,   0,   0,   0,   3,   0,   1,   0,
+     52,   0,   0,   0,   2,   0,   1,   0,
+    107, 101, 121,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    118,  97, 108, 117, 101,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_e3dadf2bf211bc97 = b_e3dadf2bf211bc97.words;
+#if !CAPNP_LITE
+static const uint16_t m_e3dadf2bf211bc97[] = {0, 1};
+static const uint16_t i_e3dadf2bf211bc97[] = {0, 1};
+const ::capnp::_::RawSchema s_e3dadf2bf211bc97 = {
+  0xe3dadf2bf211bc97, b_e3dadf2bf211bc97.words, 47, nullptr, m_e3dadf2bf211bc97,
+  0, 2, i_e3dadf2bf211bc97, nullptr, nullptr, { &s_e3dadf2bf211bc97, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<37> b_b6c95b4b8111ad36 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+     54, 173,  17, 129,  75,  91, 201, 182,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0, 202,   0,   0,   0,
+     33,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     29,   0,   0,   0,  63,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  67, 111, 110, 102, 105, 103,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     13,   0,   0,   0,  66,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   1,   0,
+     36,   0,   0,   0,   2,   0,   1,   0,
+    101, 110, 116, 114, 105, 101, 115,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   3,   0,   1,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    151, 188,  17, 242,  43, 223, 218, 227,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_b6c95b4b8111ad36 = b_b6c95b4b8111ad36.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_b6c95b4b8111ad36[] = {
+  &s_e3dadf2bf211bc97,
+};
+static const uint16_t m_b6c95b4b8111ad36[] = {0};
+static const uint16_t i_b6c95b4b8111ad36[] = {0};
+const ::capnp::_::RawSchema s_b6c95b4b8111ad36 = {
+  0xb6c95b4b8111ad36, b_b6c95b4b8111ad36.words, 37, d_b6c95b4b8111ad36, m_b6c95b4b8111ad36,
+  1, 1, i_b6c95b4b8111ad36, nullptr, nullptr, { &s_b6c95b4b8111ad36, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<64> b_a45730f57e0460b4 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     180,  96,   4, 126, 245,  48,  87, 164,
@@ -3773,6 +3882,22 @@ constexpr uint16_t DomainArray::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind DomainArray::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* DomainArray::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// KV
+constexpr uint16_t KV::_capnpPrivate::dataWordSize;
+constexpr uint16_t KV::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind KV::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* KV::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// Config
+constexpr uint16_t Config::_capnpPrivate::dataWordSize;
+constexpr uint16_t Config::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind Config::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* Config::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 // Array

--- a/tiledb/sm/serialization/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/tiledb-rest.capnp.h
@@ -15,6 +15,8 @@ namespace capnp {
 namespace schemas {
 
 CAPNP_DECLARE_SCHEMA(ce5904e6f9410cec);
+CAPNP_DECLARE_SCHEMA(e3dadf2bf211bc97);
+CAPNP_DECLARE_SCHEMA(b6c95b4b8111ad36);
 CAPNP_DECLARE_SCHEMA(a45730f57e0460b4);
 CAPNP_DECLARE_SCHEMA(d71de32f98e296fe);
 CAPNP_DECLARE_SCHEMA(92ad78f56de3d76a);
@@ -68,6 +70,40 @@ struct DomainArray {
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(ce5904e6f9410cec, 0, 10)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct KV {
+  KV() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(e3dadf2bf211bc97, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct Config {
+  Config() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(b6c95b4b8111ad36, 0, 1)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -901,6 +937,217 @@ class DomainArray::Builder {
 class DomainArray::Pipeline {
  public:
   typedef DomainArray Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class KV::Reader {
+ public:
+  typedef KV Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasKey() const;
+  inline ::capnp::Text::Reader getKey() const;
+
+  inline bool hasValue() const;
+  inline ::capnp::Text::Reader getValue() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class KV::Builder {
+ public:
+  typedef KV Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasKey();
+  inline ::capnp::Text::Builder getKey();
+  inline void setKey(::capnp::Text::Reader value);
+  inline ::capnp::Text::Builder initKey(unsigned int size);
+  inline void adoptKey(::capnp::Orphan<::capnp::Text>&& value);
+  inline ::capnp::Orphan<::capnp::Text> disownKey();
+
+  inline bool hasValue();
+  inline ::capnp::Text::Builder getValue();
+  inline void setValue(::capnp::Text::Reader value);
+  inline ::capnp::Text::Builder initValue(unsigned int size);
+  inline void adoptValue(::capnp::Orphan<::capnp::Text>&& value);
+  inline ::capnp::Orphan<::capnp::Text> disownValue();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class KV::Pipeline {
+ public:
+  typedef KV Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class Config::Reader {
+ public:
+  typedef Config Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasEntries() const;
+  inline ::capnp::List<::tiledb::sm::serialization::capnp::KV>::Reader
+  getEntries() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class Config::Builder {
+ public:
+  typedef Config Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasEntries();
+  inline ::capnp::List<::tiledb::sm::serialization::capnp::KV>::Builder
+  getEntries();
+  inline void setEntries(
+      ::capnp::List<::tiledb::sm::serialization::capnp::KV>::Reader value);
+  inline ::capnp::List<::tiledb::sm::serialization::capnp::KV>::Builder
+  initEntries(unsigned int size);
+  inline void adoptEntries(
+      ::capnp::Orphan<::capnp::List<::tiledb::sm::serialization::capnp::KV>>&&
+          value);
+  inline ::capnp::Orphan<::capnp::List<::tiledb::sm::serialization::capnp::KV>>
+  disownEntries();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class Config::Pipeline {
+ public:
+  typedef Config Pipelines;
 
   inline Pipeline(decltype(nullptr))
       : _typeless(nullptr) {
@@ -5995,6 +6242,130 @@ inline ::capnp::Orphan<::capnp::List<double>>
 DomainArray::Builder::disownFloat64() {
   return ::capnp::_::PointerHelpers<::capnp::List<double>>::disown(
       _builder.getPointerField(::capnp::bounded<9>() * ::capnp::POINTERS));
+}
+
+inline bool KV::Reader::hasKey() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool KV::Builder::hasKey() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::Text::Reader KV::Reader::getKey() const {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::capnp::Text::Builder KV::Builder::getKey() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void KV::Builder::setKey(::capnp::Text::Reader value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::set(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      value);
+}
+inline ::capnp::Text::Builder KV::Builder::initKey(unsigned int size) {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::init(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      size);
+}
+inline void KV::Builder::adoptKey(::capnp::Orphan<::capnp::Text>&& value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::adopt(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::Text> KV::Builder::disownKey() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::disown(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool KV::Reader::hasValue() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool KV::Builder::hasValue() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::Text::Reader KV::Reader::getValue() const {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::capnp::Text::Builder KV::Builder::getValue() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void KV::Builder::setValue(::capnp::Text::Reader value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::set(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      value);
+}
+inline ::capnp::Text::Builder KV::Builder::initValue(unsigned int size) {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::init(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      size);
+}
+inline void KV::Builder::adoptValue(::capnp::Orphan<::capnp::Text>&& value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::adopt(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::Text> KV::Builder::disownValue() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::disown(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+
+inline bool Config::Reader::hasEntries() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool Config::Builder::hasEntries() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::List<::tiledb::sm::serialization::capnp::KV>::Reader
+Config::Reader::getEntries() const {
+  return ::capnp::_::PointerHelpers<
+      ::capnp::List<::tiledb::sm::serialization::capnp::KV>>::
+      get(_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::capnp::List<::tiledb::sm::serialization::capnp::KV>::Builder
+Config::Builder::getEntries() {
+  return ::capnp::_::PointerHelpers<
+      ::capnp::List<::tiledb::sm::serialization::capnp::KV>>::
+      get(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void Config::Builder::setEntries(
+    ::capnp::List<::tiledb::sm::serialization::capnp::KV>::Reader value) {
+  ::capnp::_::PointerHelpers<
+      ::capnp::List<::tiledb::sm::serialization::capnp::KV>>::
+      set(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          value);
+}
+inline ::capnp::List<::tiledb::sm::serialization::capnp::KV>::Builder
+Config::Builder::initEntries(unsigned int size) {
+  return ::capnp::_::PointerHelpers<
+      ::capnp::List<::tiledb::sm::serialization::capnp::KV>>::
+      init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          size);
+}
+inline void Config::Builder::adoptEntries(
+    ::capnp::Orphan<::capnp::List<::tiledb::sm::serialization::capnp::KV>>&&
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::capnp::List<::tiledb::sm::serialization::capnp::KV>>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::List<::tiledb::sm::serialization::capnp::KV>>
+Config::Builder::disownEntries() {
+  return ::capnp::_::PointerHelpers<
+      ::capnp::List<::tiledb::sm::serialization::capnp::KV>>::
+      disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 inline ::uint64_t Array::Reader::getTimestamp() const {


### PR DESCRIPTION
This adds a new c-api for config serialization. This allows a user to serialization the configuration into JSON or cap'n proto format.