### PR TITLE
[backport release-2.2] Fix warnings caused in Unit Tests

### DIFF
--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -120,9 +120,11 @@ TEST_CASE("C++ API: Config Equality", "[cppapi], [cppapi-config]") {
   config1["foo"] = "bar";
   tiledb::Config config2;
   config2["foo"] = "bar";
-  CHECK(config1 == config2);
+  bool config_equal = config1 == config2;
+  CHECK(config_equal);
 
   // Check for inequality
   config2["foo"] = "bar2";
-  CHECK(config1 != config2);
+  bool config_not_equal = config1 != config2;
+  CHECK(config_not_equal);
 }

--- a/test/src/unit-cppapi-metadata.cc
+++ b/test/src/unit-cppapi-metadata.cc
@@ -264,7 +264,7 @@ TEST_CASE_METHOD(
   v_type = (tiledb_datatype_t)std::numeric_limits<int32_t>::max();
   has_key = array.has_metadata("non-existent-key", &v_type);
   CHECK(has_key == false);
-  CHECK(v_type == std::numeric_limits<int32_t>::max());
+  CHECK(v_type == (tiledb_datatype_t)std::numeric_limits<int32_t>::max());
 
   // Close array
   array.close();

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -1716,7 +1716,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter]") {
       uint64_t elt = 0;
       CHECK(chunked_buffer.read(&elt, sizeof(uint64_t), (i * sizeof(uint64_t)))
                 .ok());
-      CHECK(elt == rng(gen_copy));
+      CHECK((int64_t)elt == rng(gen_copy));
     }
   }
 

--- a/test/src/unit-hdfs-filesystem.cc
+++ b/test/src/unit-hdfs-filesystem.cc
@@ -81,9 +81,9 @@ TEST_CASE("Test HDFS filesystem", "[hdfs]") {
   st = hdfs.touch(URI("hdfs:///tiledb_test/tiledb_test_file"));
   CHECK(st.ok());
 
-  tSize buffer_size = 100000;
+  uint64_t buffer_size = 100000;
   auto write_buffer = new char[buffer_size];
-  for (int i = 0; i < buffer_size; i++) {
+  for (uint64_t i = 0; i < buffer_size; i++) {
     write_buffer[i] = 'a' + (i % 26);
   }
   st = hdfs.write(

--- a/test/src/unit-threadpool.cc
+++ b/test/src/unit-threadpool.cc
@@ -174,7 +174,7 @@ TEST_CASE(
     }
 
     REQUIRE(result == num_ok);
-    REQUIRE(num_cancelled == (tasks.size() - num_ok));
+    REQUIRE(num_cancelled == ((int64_t)tasks.size() - num_ok));
   }
 }
 


### PR DESCRIPTION
These were originally caught by @ypatia in upgrading Catch2 library for 2.3. These are needed for backporting to work with GCC 10.2.