### PR TITLE
Add config to query serialization

### DIFF
--- a/tiledb/sm/serialization/config.cc
+++ b/tiledb/sm/serialization/config.cc
@@ -65,9 +65,7 @@ namespace serialization {
 #ifdef TILEDB_SERIALIZATION
 
 Status config_to_capnp(
-    const Config* config,
-    capnp::Config::Builder* config_builder,
-    const bool client_side) {
+    const Config* config, capnp::Config::Builder* config_builder) {
   if (config == nullptr)
     return LOG_STATUS(Status::SerializationError(
         "Error serializing config; config is null."));
@@ -105,7 +103,7 @@ Status config_serialize(
   try {
     ::capnp::MallocMessageBuilder message;
     capnp::Config::Builder configBuilder = message.initRoot<capnp::Config>();
-    RETURN_NOT_OK(config_to_capnp(config, &configBuilder, client_side));
+    RETURN_NOT_OK(config_to_capnp(config, &configBuilder));
 
     serialized_buffer->reset_size();
     serialized_buffer->reset_offset();
@@ -212,7 +210,7 @@ Status config_serialize(Config*, SerializationType, Buffer*, const bool) {
 
 Status config_deserialize(Config**, SerializationType, const Buffer&) {
   return LOG_STATUS(Status::SerializationError(
-      "Cannot serialize; serialization not enabled."));
+      "Cannot deserialize; serialization not enabled."));
 }
 
 #endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/serialization/config.h
+++ b/tiledb/sm/serialization/config.h
@@ -37,6 +37,12 @@
 
 #include "tiledb/common/status.h"
 
+#ifdef TILEDB_SERIALIZATION
+#include <capnp/compat/json.h>
+#include <capnp/serialize.h>
+#include "tiledb/sm/serialization/tiledb-rest.capnp.h"
+#endif
+
 using namespace tiledb::common;
 
 namespace tiledb {
@@ -47,6 +53,26 @@ class Buffer;
 enum class SerializationType : uint8_t;
 
 namespace serialization {
+
+#ifdef TILEDB_SERIALIZATION
+/**
+ * Serialize a config into a cap'n proto class
+ * @param config config to serialize
+ * @param config_builder cap'n proto message class
+ * @return Status
+ */
+Status config_to_capnp(
+    const Config* config, capnp::Config::Builder* config_builder);
+
+/**
+ * Create a config object from a cap'n proto class
+ * @param config_reader cap'n proto message class
+ * @param config config to deserialize into
+ * @return Status
+ */
+Status config_from_capnp(
+    const capnp::Config::Reader& config_reader, tdb_unique_ptr<Config>* config);
+#endif
 
 /**
  * Serialize a config via Cap'n Prto

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -45,6 +45,7 @@
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/query/reader.h"
 #include "tiledb/sm/query/writer.h"
+#include "tiledb/sm/serialization/config.h"
 
 #ifdef _WIN32
 #include "tiledb/sm/serialization/meet-capnproto-win32-include-expectations.h"
@@ -605,6 +606,11 @@ Status query_to_capnp(
     RETURN_NOT_OK(writer_to_capnp(*writer, &builder));
   }
 
+  // Serialize Config
+  const Config* config = query.config();
+  auto config_builder = query_builder->initConfig();
+  RETURN_NOT_OK(config_to_capnp(config, &config_builder));
+
   return Status::Ok();
 }
 
@@ -649,6 +655,16 @@ Status query_from_capnp(
 
   // Deserialize array instance.
   RETURN_NOT_OK(array_from_capnp(query_reader.getArray(), array));
+
+  // Deserialize Config
+  if (query_reader.hasConfig()) {
+    tdb_unique_ptr<Config> decoded_config = nullptr;
+    auto config_reader = query_reader.getConfig();
+    RETURN_NOT_OK(config_from_capnp(config_reader, &decoded_config));
+    if (decoded_config != nullptr) {
+      RETURN_NOT_OK(query->set_config(*decoded_config));
+    }
+  }
 
   // Deserialize and set attribute buffers.
   if (!query_reader.hasAttributeBufferHeaders())

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -371,13 +371,16 @@ struct Query {
     # Total number of bytes in validity buffers
 
     varOffsetsMode @10 :Text;
-    # The offsets format (`bytes` or `elements`) to be used
+    # This field is not longer used, it is replaced by the config
 
     varOffsetsAddExtraElement @11 :Bool;
-    # `True` if an extra element is to be added to the end of the offsets buffer
+    # This field is not longer used, it is replaced by the config
 
     varOffsetsBitsize @12 :Int32;
-    # The offsets bitsize (`32` or `64`) to be used
+    # This field is not longer used, it is replaced by the config
+
+    config @13 :Config;
+    # Config set on query
 }
 
 struct NonEmptyDomain {


### PR DESCRIPTION
The query class holds a local config for adjustment of query settings. This class local config is now included in the serialized object so any settings are persisted across serialization.

---
TYPE: IMPROVEMENT
DESC: Add config to query serialization.
