### PR TITLE
C-API error path leak in tiledb_config_alloc

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,7 @@
 ## Deprecations
 
 ## Bug fixes
+* Fix memory leak of `tiledb_config_t` in error path of `tiledb_config_alloc`. [#2178](https://github.com/TileDB-Inc/TileDB/pull/2178)
 
 ## API additions
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -876,6 +876,8 @@ int32_t tiledb_config_alloc(tiledb_config_t** config, tiledb_error_t** error) {
         Status::Error("Cannot create config object; Memory allocation failed");
     LOG_STATUS(st);
     create_error(error, st);
+    if (*config != nullptr)
+      delete *config;
     return TILEDB_OOM;
   }
 


### PR DESCRIPTION
This fixes a memory leak of tiledb_config_t in the error path of tiledb_config_alloc.

---
TYPE: BUG
DESC: Fix memory leak of \`tiledb_config_t\` in error path of \`tiledb_config_alloc\`.
