### PR TITLE
Fix various memory leaks in unit tests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@
 * Smoke Test, remove nullable structs from global namespace. [#2078](https://github.com/TileDB-Inc/TileDB/pull/2078)
 
 ## Improvements
+* Adjust unit tests to reduce memory leaks inside the tests. [#2179](https://github.com/TileDB-Inc/TileDB/pull/2179)
 * Reduces memory usage in multi-range range reads [#2165](https://github.com/TileDB-Inc/TileDB/pull/2165)
 * Add config option `sm.read_range_oob` to toggle bounding read ranges to domain or erroring [#2162](https://github.com/TileDB-Inc/TileDB/pull/2162)
 * Windows msys2 build artifacts are no longer uploaded [#2159](https://github.com/TileDB-Inc/TileDB/pull/2159)

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -2226,6 +2226,7 @@ TEST_CASE_METHOD(
   // Close array
   rc = tiledb_array_close(ctx_, array);
   CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
 
   // #### PARTITIONER ####
 
@@ -2453,6 +2454,9 @@ TEST_CASE_METHOD(
   // Close array
   rc = tiledb_array_close(ctx_, array);
   CHECK(rc == TILEDB_OK);
+
+  // Free array
+  tiledb_array_free(&array);
 
   // #### PARTITIONER ####
 

--- a/test/src/unit-bufferlist.cc
+++ b/test/src/unit-bufferlist.cc
@@ -122,6 +122,8 @@ TEST_CASE("BufferList: Test read", "[buffer][bufferlist]") {
   buffer_list.reset_offset();
   REQUIRE(buffer_list.read_at_most(data, 0, &num_read).ok());
   REQUIRE(num_read == 0);
+
+  std::free(data);
 }
 
 TEST_CASE("C API: Test empty BufferList", "[capi][buffer][bufferlist]") {

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -159,6 +159,7 @@ void ArrayFx::create_sparse_vector(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 }
 
@@ -211,6 +212,7 @@ void ArrayFx::create_sparse_array(const std::string& path) {
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim_1);
   tiledb_dimension_free(&dim_2);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 }
 
@@ -266,6 +268,7 @@ void ArrayFx::create_dense_vector(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 }
 
@@ -318,6 +321,7 @@ void ArrayFx::create_dense_array(const std::string& path) {
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim_1);
   tiledb_dimension_free(&dim_2);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 }
 

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -1026,6 +1026,7 @@ TEST_CASE_METHOD(
   rc = tiledb_dimension_get_tile_extent(ctx_, d1, &extent);
   CHECK(rc == TILEDB_OK);
   CHECK(extent == nullptr);
+  tiledb_dimension_free(&d1);
 
   // Create dimension with huge range and tile extent - error
   tiledb_dimension_t* d2;
@@ -1229,6 +1230,8 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
 
   // Clean up
+  tiledb_filter_free(&filter);
+  tiledb_filter_list_free(&filter_list);
   tiledb_attribute_free(&attr1);
   tiledb_dimension_free(&d1);
   tiledb_domain_free(&domain);
@@ -1370,6 +1373,7 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_vfs_close(ctx_, fh);
   REQUIRE(rc == TILEDB_OK);
+  tiledb_vfs_fh_free(&fh);
 
   // Check for failure opening the array.
   tiledb_array_t* array;
@@ -1856,11 +1860,13 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
 
   // Clean up
+  tiledb_attribute_free(&a);
   tiledb_dimension_free(&d1);
   tiledb_dimension_free(&d2);
   tiledb_dimension_free(&r_d1);
   tiledb_dimension_free(&r_d2);
   tiledb_domain_free(&domain);
+  tiledb_domain_free(&read_dom);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_array_schema_free(&array_schema);

--- a/test/src/unit-capi-async.cc
+++ b/test/src/unit-capi-async.cc
@@ -644,6 +644,10 @@ void AsyncFx::read_dense_async() {
   // Clean up
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  free(buffer_a1);
+  free(buffer_a2_off);
+  free(buffer_a2_val);
+  free(buffer_a3);
 }
 
 void AsyncFx::read_sparse_async() {

--- a/test/src/unit-capi-attributes.cc
+++ b/test/src/unit-capi-attributes.cc
@@ -147,6 +147,7 @@ void Attributesfx::create_dense_vector(
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 }
 

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -295,6 +295,8 @@ void check_save_to_file() {
 
   CHECK(ss.str() == ss_file.str());
   remove_file("test_config.txt");
+
+  tiledb_config_free(&config);
 }
 
 TEST_CASE("C API: Test config", "[capi], [config]") {
@@ -932,6 +934,7 @@ TEST_CASE("C API: Test VFS config inheritance", "[capi][config][vfs-inherit]") {
 
   tiledb_config_free(&config);
   tiledb_config_free(&vfs_config);
+  tiledb_config_free(&vfs_config_get);
   tiledb_vfs_free(&vfs);
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-capi-dense_neg.cc
+++ b/test/src/unit-capi-dense_neg.cc
@@ -147,6 +147,7 @@ void DenseNegFx::create_dense_vector(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 }
 

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -153,6 +153,7 @@ void DenseVectorFx::create_dense_vector(
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 
   const char* attributes[] = {ATTR_NAME.c_str()};
@@ -511,6 +512,7 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 
   // --- Zero write ----

--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -649,6 +649,7 @@ TEST_CASE_METHOD(
   rc = tiledb_array_consolidate(ctx_, array_name_.c_str(), config);
   CHECK(rc == TILEDB_OK);
   tiledb_config_free(&config);
+  tiledb_array_free(&array);
 
   // Open the array in read mode
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
@@ -947,6 +948,7 @@ TEST_CASE_METHOD(
       ctx_, array_name_.c_str(), enc_type_, key_, key_len_, config);
   CHECK(rc == TILEDB_OK);
   tiledb_config_free(&config);
+  tiledb_array_free(&array);
 
   // Open the array in read mode
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
@@ -994,6 +996,7 @@ TEST_CASE_METHOD(
       ctx_, array_name_.c_str(), enc_type_, key_, key_len_, config);
   CHECK(rc == TILEDB_OK);
   tiledb_config_free(&config);
+  tiledb_array_free(&array);
 
   // Open the array in read mode
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
@@ -1062,6 +1065,7 @@ TEST_CASE_METHOD(
   CHECK(*((int32_t*)vback_ptr) == 10);
   rc = tiledb_array_close(ctx_, array);
   CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
 
   // Prevent array metadata filename/timestamp conflicts
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -1087,6 +1091,8 @@ TEST_CASE_METHOD(
   CHECK(*((int32_t*)vback_ptr) == 20);
   rc = tiledb_array_close(ctx_, array);
   CHECK(rc == TILEDB_OK);
+
+  tiledb_array_free(&array);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-capi-nullable.cc
+++ b/test/src/unit-capi-nullable.cc
@@ -227,6 +227,8 @@ NullableArrayFx::NullableArrayFx() {
 
 NullableArrayFx::~NullableArrayFx() {
   remove_dir(FILE_TEMP_DIR);
+  tiledb_ctx_free(&ctx_);
+  tiledb_vfs_free(&vfs_);
 }
 
 void NullableArrayFx::create_dir(const string& path) {

--- a/test/src/unit-capi-object_mgmt.cc
+++ b/test/src/unit-capi-object_mgmt.cc
@@ -130,7 +130,12 @@ void ObjectMgmtFx::create_array(const std::string& path) {
 
   // Create array
   REQUIRE(tiledb_array_create(ctx_, path.c_str(), array_schema) == TILEDB_OK);
+
+  // Free objects
+  tiledb_attribute_free(&a1);
   tiledb_dimension_free(&d1);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
 }
 
 void ObjectMgmtFx::check_object_type(const std::string& path) {

--- a/test/src/unit-capi-query.cc
+++ b/test/src/unit-capi-query.cc
@@ -530,7 +530,10 @@ TEST_CASE_METHOD(
   rc = tiledb_array_close(ctx_, array);
   REQUIRE(rc == TILEDB_OK);
 
+  tiledb_array_schema_free(&rschema);
   tiledb_query_free(&query);
   tiledb_array_free(&array);
+  // TODO: this cause a segfault
+  //  tiledb_array_free(&rarray);
   remove_temp_dir(temp_dir);
 }

--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -3055,6 +3055,7 @@ TEST_CASE_METHOD(
   rc = tiledb_config_compare(config, config2, &equal);
   CHECK(rc == TILEDB_OK);
   CHECK(equal == 1);
+  tiledb_config_free(&config2);
 
   // Test modified behavior
   std::vector<uint32_t> offsets = {0, 1, 2, 4, 7, 9, 10};
@@ -3127,6 +3128,8 @@ TEST_CASE_METHOD(
   CHECK(query2 == nullptr);
   tiledb_array_free(&array);
   CHECK(array == nullptr);
+
+  tiledb_config_free(&config);
 
   remove_array(array_name);
 }

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -338,6 +338,8 @@ void SparseArrayFx::create_sparse_array_2D(
   REQUIRE(rc == TILEDB_OK);
 
   // Clean up
+  tiledb_filter_free(&filter);
+  tiledb_filter_list_free(&list);
   tiledb_attribute_free(&a);
   tiledb_dimension_free(&d1);
   tiledb_dimension_free(&d2);
@@ -2226,6 +2228,7 @@ void SparseArrayFx::check_sparse_array_no_results(
   // Clean up
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  delete[] buffer;
 }
 
 void SparseArrayFx::write_partial_sparse_array(const std::string& array_name) {
@@ -2802,6 +2805,8 @@ TEST_CASE_METHOD(
   free(a2_off);
   free(a2);
   free(a3);
+  free(coords_dim1);
+  free(coords_dim2);
   tiledb_query_free(&empty_query);
 
   // ---- Second READ query (non-empty)
@@ -2872,6 +2877,8 @@ TEST_CASE_METHOD(
   free(a2_off);
   free(a2);
   free(a3);
+  free(coords_dim1);
+  free(coords_dim2);
   tiledb_query_free(&query);
 
   // Clean up

--- a/test/src/unit-capi-sparse_neg.cc
+++ b/test/src/unit-capi-sparse_neg.cc
@@ -145,6 +145,7 @@ void SparseNegFx::create_sparse_vector(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 }
 
@@ -207,6 +208,8 @@ void SparseNegFx::create_sparse_array(const std::string& path) {
   CHECK(rc == TILEDB_OK);
 
   // Clean up
+  tiledb_filter_free(&filter);
+  tiledb_filter_list_free(&list);
   tiledb_attribute_free(&a);
   tiledb_dimension_free(&d1);
   tiledb_dimension_free(&d2);

--- a/test/src/unit-capi-sparse_neg_2.cc
+++ b/test/src/unit-capi-sparse_neg_2.cc
@@ -144,6 +144,7 @@ void SparseNegFx2::create_sparse_vector(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   tiledb_attribute_free(&attr);
   tiledb_dimension_free(&dim);
+  tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
 }
 
@@ -206,6 +207,8 @@ void SparseNegFx2::create_sparse_array(const std::string& path) {
   CHECK(rc == TILEDB_OK);
 
   // Clean up
+  tiledb_filter_free(&filter);
+  tiledb_filter_list_free(&list);
   tiledb_attribute_free(&a);
   tiledb_dimension_free(&d1);
   tiledb_dimension_free(&d2);

--- a/test/src/unit-capi-sparse_real.cc
+++ b/test/src/unit-capi-sparse_real.cc
@@ -160,6 +160,8 @@ void SparseRealFx::create_sparse_array(const std::string& path) {
   CHECK(rc == TILEDB_OK);
 
   // Clean up
+  tiledb_filter_free(&filter);
+  tiledb_filter_list_free(&list);
   tiledb_attribute_free(&a);
   tiledb_dimension_free(&d1);
   tiledb_dimension_free(&d2);
@@ -400,6 +402,8 @@ void SparseRealFx::create_sparse_array_double(const std::string& path) {
   CHECK(rc == TILEDB_OK);
 
   // Clean up
+  tiledb_filter_free(&filter);
+  tiledb_filter_list_free(&list);
   tiledb_attribute_free(&a);
   tiledb_dimension_free(&d1);
   tiledb_dimension_free(&d2);

--- a/test/src/unit-capi-sparse_real_2.cc
+++ b/test/src/unit-capi-sparse_real_2.cc
@@ -159,6 +159,8 @@ void SparseRealFx2::create_sparse_array(const std::string& path) {
   CHECK(rc == TILEDB_OK);
 
   // Clean up
+  tiledb_filter_free(&filter);
+  tiledb_filter_list_free(&list);
   tiledb_attribute_free(&a);
   tiledb_dimension_free(&d1);
   tiledb_dimension_free(&d2);

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -1918,6 +1918,9 @@ TEST_CASE_METHOD(
   CHECK(start == "a");
   CHECK(end == "ee");
 
+  // Free array
+  tiledb_array_free(&array);
+
   // Open array
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
@@ -2336,6 +2339,7 @@ TEST_CASE_METHOD(
   // Consolidate fragment metadata
   rc = tiledb_array_consolidate(ctx_, array_name.c_str(), config);
   CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
 
   // Open array
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
@@ -2373,6 +2377,7 @@ TEST_CASE_METHOD(
   // Close array
   rc = tiledb_array_close(ctx_, array);
   CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
 
   // Consolidate
   rc = tiledb_array_consolidate(ctx_, array_name.c_str(), nullptr);

--- a/test/src/unit-empty-var-length.cc
+++ b/test/src/unit-empty-var-length.cc
@@ -145,6 +145,7 @@ void StringEmptyFx::create_array(const std::string& array_name) {
   // Clean up
   tiledb_attribute_free(&a1);
   tiledb_attribute_free(&a2);
+  tiledb_attribute_free(&a3);
   tiledb_attribute_free(&a4);
   tiledb_dimension_free(&d1);
   tiledb_domain_free(&domain);

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -1471,10 +1471,12 @@ TEST_CASE("Filter: Test random pipeline", "[filter]") {
         auto idx = (unsigned)rng_constructors_first(gen);
         Filter* filter = constructors_first[idx]();
         CHECK(pipeline.add_filter(*filter).ok());
+        delete filter;
       } else {
         auto idx = (unsigned)rng_constructors(gen);
         Filter* filter = constructors[idx]();
         CHECK(pipeline.add_filter(*filter).ok());
+        delete filter;
       }
     }
 

--- a/test/src/vfs_helpers.cc
+++ b/test/src/vfs_helpers.cc
@@ -93,7 +93,7 @@ Status vfs_test_init(
 
   REQUIRE(tiledb_ctx_alloc(config_tmp, ctx) == TILEDB_OK);
   REQUIRE(tiledb_vfs_alloc(*ctx, config_tmp, vfs) == TILEDB_OK);
-  if (config_tmp == nullptr) {
+  if (config == nullptr) {
     tiledb_config_free(&config_tmp);
   }
 


### PR DESCRIPTION
There were a number of places where we were not freeing allocated objects or malloced memory. This address those and reduces the ASAN leak detection from the unit tests to the core library.

---
TYPE: IMPROVEMENT
DESC: Adjust unit tests to reduce memory leaks inside the tests.