### PR TITLE
Heap profiling failure

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -39,8 +39,8 @@
 ## Bug fixes
 * Fixes a potential memory leak in the filter pipeline [#2185](https://github.com/TileDB-Inc/TileDB/pull/2185)
 * Fixes misc memory leaks in the unit tests [#2183](https://github.com/TileDB-Inc/TileDB/pull/2183)
-* Fix memory leak of `tiledb_config_t` in error path of `tiledb_config_alloc`. [#2178](https://github.com/TileDB-Inc/TileDB/pull/2178)
 * Change mutex from basic to recursive [#2180](https://github.com/TileDB-Inc/TileDB/pull/2180)
+* Fix memory leak of `tiledb_config_t` in error path of `tiledb_config_alloc`. [#2178](https://github.com/TileDB-Inc/TileDB/pull/2178)
 
 ## API additions
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,6 +40,7 @@
 * Fixes a potential memory leak in the filter pipeline [#2185](https://github.com/TileDB-Inc/TileDB/pull/2185)
 * Fixes misc memory leaks in the unit tests [#2183](https://github.com/TileDB-Inc/TileDB/pull/2183)
 * Fix memory leak of `tiledb_config_t` in error path of `tiledb_config_alloc`. [#2178](https://github.com/TileDB-Inc/TileDB/pull/2178)
+* Change mutex from basic to recursive [#2180](https://github.com/TileDB-Inc/TileDB/pull/2180)
 
 ## API additions
 

--- a/tiledb/common/heap_memory.cc
+++ b/tiledb/common/heap_memory.cc
@@ -40,14 +40,14 @@ namespace common {
 
 // Protects against races between memory management APIs
 // and the HeapProfiler API.
-std::mutex __tdb_heap_mem_lock;
+std::recursive_mutex __tdb_heap_mem_lock;
 
 void* tiledb_malloc(const size_t size, const std::string& label) {
   if (!heap_profiler.enabled()) {
     return std::malloc(size);
   }
 
-  std::unique_lock<std::mutex> ul(__tdb_heap_mem_lock);
+  std::unique_lock<std::recursive_mutex> ul(__tdb_heap_mem_lock);
 
   void* const p = std::malloc(size);
 
@@ -65,7 +65,7 @@ void* tiledb_calloc(
     return std::calloc(num, size);
   }
 
-  std::unique_lock<std::mutex> ul(__tdb_heap_mem_lock);
+  std::unique_lock<std::recursive_mutex> ul(__tdb_heap_mem_lock);
 
   void* const p = std::calloc(num, size);
 
@@ -83,7 +83,7 @@ void* tiledb_realloc(
     return std::realloc(p, size);
   }
 
-  std::unique_lock<std::mutex> ul(__tdb_heap_mem_lock);
+  std::unique_lock<std::recursive_mutex> ul(__tdb_heap_mem_lock);
 
   void* const p_realloc = std::realloc(p, size);
 
@@ -102,7 +102,7 @@ void tiledb_free(void* const p) {
     return;
   }
 
-  std::unique_lock<std::mutex> ul(__tdb_heap_mem_lock);
+  std::unique_lock<std::recursive_mutex> ul(__tdb_heap_mem_lock);
 
   free(p);
   heap_profiler.record_dealloc(p);

--- a/tiledb/common/heap_memory.h
+++ b/tiledb/common/heap_memory.h
@@ -44,7 +44,7 @@
 namespace tiledb {
 namespace common {
 
-extern std::mutex __tdb_heap_mem_lock;
+extern std::recursive_mutex __tdb_heap_mem_lock;
 
 /** TileDB variant of `malloc`. */
 void* tiledb_malloc(size_t size, const std::string& label);
@@ -65,7 +65,7 @@ T* tiledb_new(const std::string& label, Args&&... args) {
     return new T(std::forward<Args>(args)...);
   }
 
-  std::unique_lock<std::mutex> ul(__tdb_heap_mem_lock);
+  std::unique_lock<std::recursive_mutex> ul(__tdb_heap_mem_lock);
 
   T* const p = new T(std::forward<Args>(args)...);
 
@@ -85,7 +85,7 @@ void tiledb_delete(T* const p) {
     return;
   }
 
-  std::unique_lock<std::mutex> ul(__tdb_heap_mem_lock);
+  std::unique_lock<std::recursive_mutex> ul(__tdb_heap_mem_lock);
 
   delete p;
   heap_profiler.record_dealloc(p);
@@ -98,7 +98,7 @@ T* tiledb_new_array(const std::size_t size, const std::string& label) {
     return new T[size];
   }
 
-  std::unique_lock<std::mutex> ul(__tdb_heap_mem_lock);
+  std::unique_lock<std::recursive_mutex> ul(__tdb_heap_mem_lock);
 
   T* const p = new T[size];
 
@@ -118,7 +118,7 @@ void tiledb_delete_array(T* const p) {
     return;
   }
 
-  std::unique_lock<std::mutex> ul(__tdb_heap_mem_lock);
+  std::unique_lock<std::recursive_mutex> ul(__tdb_heap_mem_lock);
 
   delete[] p;
   heap_profiler.record_dealloc(p);


### PR DESCRIPTION
Change type of __tdb_heap_mem_lock from std::mutex to std::recursive_mutex to avoid failures when heap profiling functions recurse.
---
TYPE: BUG
DESC: Change mutex from basic to recursive
