### PR TITLE
Deep-copy return value from tiledb_query_get_array

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -37,6 +37,7 @@
 ## API additions
 
 ### C API
+* tiledb_query_get_array now returns a deep-copy [#2184](https://github.com/TileDB-Inc/TileDB/pull/2184)
 * Added `tiledb_serialize_config` and `tiledb_deserialize_config` [#2164](https://github.com/TileDB-Inc/TileDB/pull/2164)
 * Add new api,  to get a query's config. [#2167](https://github.com/TileDB-Inc/TileDB/pull/2167)
 * Removes non-default parameter in tiledb_config_unset. [#2099](https://github.com/TileDB-Inc/TileDB/pull/2099)

--- a/test/src/unit-capi-query.cc
+++ b/test/src/unit-capi-query.cc
@@ -506,7 +506,7 @@ TEST_CASE_METHOD(
   tiledb_array_t* rarray;
   rc = tiledb_query_get_array(ctx_, query, &rarray);
   REQUIRE(rc == TILEDB_OK);
-  CHECK(rarray->array_ == array->array_);
+  CHECK(rarray->array_ != array->array_);
 
   tiledb_array_schema_t* rschema;
   rc = tiledb_array_get_schema(ctx_, rarray, &rschema);
@@ -533,7 +533,6 @@ TEST_CASE_METHOD(
   tiledb_array_schema_free(&rschema);
   tiledb_query_free(&query);
   tiledb_array_free(&array);
-  // TODO: this cause a segfault
-  //  tiledb_array_free(&rarray);
+  tiledb_array_free(&rarray);
   remove_temp_dir(temp_dir);
 }

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -65,6 +65,9 @@ class Array {
   /** Constructor. */
   Array(const URI& array_uri, StorageManager* storage_manager);
 
+  /** Copy constructor. */
+  Array(const Array& rhs);
+
   /** Destructor. */
   ~Array() = default;
 
@@ -332,7 +335,7 @@ class Array {
    * should be stored. Wherever a key is needed, a pointer to this memory region
    * should be passed instead of a copy of the bytes.
    */
-  EncryptionKey encryption_key_;
+  tdb_shared_ptr<EncryptionKey> encryption_key_;
 
   /** The metadata of the fragments the array was opened with. */
   std::vector<FragmentMetadata*> fragment_metadata_;

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -55,6 +55,15 @@ Metadata::Metadata() {
   timestamp_range_ = std::make_pair(t, t);
 }
 
+Metadata::Metadata(const Metadata& rhs)
+    : metadata_map_(rhs.metadata_map_)
+    , timestamp_range_(rhs.timestamp_range_)
+    , loaded_metadata_uris_(rhs.loaded_metadata_uris_)
+    , uri_(rhs.uri_) {
+  if (!rhs.metadata_index_.empty())
+    build_metadata_index();
+}
+
 Metadata::~Metadata() = default;
 
 /* ********************************* */
@@ -131,7 +140,7 @@ Status Metadata::deserialize(
     }
   }
 
-  RETURN_NOT_OK(build_metadata_index());
+  build_metadata_index();
   // Note: `metadata_map_` and `metadata_index_` are immutable after this point
 
   return Status::Ok();
@@ -241,7 +250,7 @@ Status Metadata::get(
     uint32_t* value_num,
     const void** value) {
   if (metadata_index_.empty())
-    RETURN_NOT_OK(build_metadata_index());
+    build_metadata_index();
 
   if (index >= metadata_index_.size())
     return LOG_STATUS(
@@ -332,14 +341,12 @@ Metadata::iterator Metadata::end() const {
 /*          PRIVATE METHODS          */
 /* ********************************* */
 
-Status Metadata::build_metadata_index() {
+void Metadata::build_metadata_index() {
   // Create metadata index for fast lookups from index
   metadata_index_.resize(metadata_map_.size());
   size_t i = 0;
   for (auto& m : metadata_map_)
     metadata_index_[i++] = std::make_pair(&(m.first), &(m.second));
-
-  return Status::Ok();
 }
 
 }  // namespace sm

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -89,6 +89,9 @@ class Metadata {
   /** Constructor. */
   Metadata();
 
+  /** Copy constructor. */
+  Metadata(const Metadata& rhs);
+
   /** Destructor. */
   ~Metadata();
 
@@ -262,9 +265,8 @@ class Metadata {
 
   /**
    * Build the metadata index vector from the metadata map
-   * @return Status
    */
-  Status build_metadata_index();
+  void build_metadata_index();
 };
 
 }  // namespace sm


### PR DESCRIPTION
Currently, the tiledb_query_get_array returns a newly-allocated C structure
that contains a pointer to the internal array. This is problematic because
we cannot free the C structure with tiledb_array_free. This change makes the
API return a deep copy.

---

TYPE: C_API
DESC: tiledb_query_get_array now returns a deep-copy