### PR TITLE
[BACKPORT] Deep-copy return value from tiledb_query_get_array

### DIFF
--- a/test/src/unit-capi-query.cc
+++ b/test/src/unit-capi-query.cc
@@ -506,7 +506,7 @@ TEST_CASE_METHOD(
   tiledb_array_t* rarray;
   rc = tiledb_query_get_array(ctx_, query, &rarray);
   REQUIRE(rc == TILEDB_OK);
-  CHECK(rarray->array_ == array->array_);
+  CHECK(rarray->array_ != array->array_);
 
   tiledb_array_schema_t* rschema;
   rc = tiledb_array_get_schema(ctx_, rarray, &rschema);
@@ -532,5 +532,6 @@ TEST_CASE_METHOD(
 
   tiledb_query_free(&query);
   tiledb_array_free(&array);
+  tiledb_array_free(&rarray);
   remove_temp_dir(temp_dir);
 }

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -60,6 +60,7 @@ namespace sm {
 
 Array::Array(const URI& array_uri, StorageManager* storage_manager)
     : array_uri_(array_uri)
+    , encryption_key_(new EncryptionKey())
     , storage_manager_(storage_manager) {
   is_open_ = false;
   array_schema_ = nullptr;
@@ -68,6 +69,23 @@ Array::Array(const URI& array_uri, StorageManager* storage_manager)
   metadata_loaded_ = false;
   non_empty_domain_computed_ = false;
 };
+
+Array::Array(const Array& rhs)
+    : array_schema_(rhs.array_schema_)
+    , array_uri_(rhs.array_uri_)
+    , encryption_key_(rhs.encryption_key_)
+    , fragment_metadata_(rhs.fragment_metadata_)
+    , is_open_(rhs.is_open_.load())
+    , query_type_(rhs.query_type_)
+    , timestamp_(rhs.timestamp_)
+    , storage_manager_(rhs.storage_manager_)
+    , last_max_buffer_sizes_(rhs.last_max_buffer_sizes_)
+    , remote_(rhs.remote_)
+    , metadata_(rhs.metadata_)
+    , metadata_loaded_(rhs.metadata_loaded_)
+    , non_empty_domain_computed_(rhs.non_empty_domain_computed_)
+    , non_empty_domain_(rhs.non_empty_domain_) {
+}
 
 /* ********************************* */
 /*                API                */
@@ -84,7 +102,7 @@ const URI& Array::array_uri() const {
 }
 
 const EncryptionKey* Array::encryption_key() const {
-  return &encryption_key_;
+  return encryption_key_.get();
 }
 
 Status Array::open(
@@ -105,7 +123,7 @@ Status Array::open(
 
   // Copy the key bytes.
   RETURN_NOT_OK(
-      encryption_key_.set_key(encryption_type, encryption_key, key_length));
+      encryption_key_->set_key(encryption_type, encryption_key, key_length));
 
   timestamp_ = timestamp;
   metadata_.clear();
@@ -124,12 +142,12 @@ Status Array::open(
     RETURN_NOT_OK(storage_manager_->array_open_for_reads(
         array_uri_,
         timestamp_,
-        encryption_key_,
+        *encryption_key_,
         &array_schema_,
         &fragment_metadata_));
   } else {
     RETURN_NOT_OK(storage_manager_->array_open_for_writes(
-        array_uri_, encryption_key_, &array_schema_));
+        array_uri_, *encryption_key_, &array_schema_));
     metadata_.reset(timestamp_);
   }
 
@@ -162,7 +180,7 @@ Status Array::open(
 
   // Copy the key bytes.
   RETURN_NOT_OK(
-      encryption_key_.set_key(encryption_type, encryption_key, key_length));
+      encryption_key_->set_key(encryption_type, encryption_key, key_length));
 
   timestamp_ = utils::time::timestamp_now_ms();
   metadata_.clear();
@@ -182,7 +200,7 @@ Status Array::open(
     RETURN_NOT_OK(storage_manager_->array_open_for_reads(
         array_uri_,
         fragment_info,
-        encryption_key_,
+        *encryption_key_,
         &array_schema_,
         &fragment_metadata_));
   }
@@ -209,7 +227,7 @@ Status Array::open(
 
   // Copy the key bytes.
   RETURN_NOT_OK(
-      encryption_key_.set_key(encryption_type, encryption_key, key_length));
+      encryption_key_->set_key(encryption_type, encryption_key, key_length));
 
   timestamp_ =
       (query_type == QueryType::READ) ? utils::time::timestamp_now_ms() : 0;
@@ -228,12 +246,12 @@ Status Array::open(
     RETURN_NOT_OK(storage_manager_->array_open_for_reads(
         array_uri_,
         timestamp_,
-        encryption_key_,
+        *encryption_key_,
         &array_schema_,
         &fragment_metadata_));
   } else {
     RETURN_NOT_OK(storage_manager_->array_open_for_writes(
-        array_uri_, encryption_key_, &array_schema_));
+        array_uri_, *encryption_key_, &array_schema_));
     metadata_.reset(timestamp_);
   }
 
@@ -278,7 +296,7 @@ Status Array::close() {
       RETURN_NOT_OK(storage_manager_->array_close_for_reads(array_uri_));
     } else {
       RETURN_NOT_OK(storage_manager_->array_close_for_writes(
-          array_uri_, encryption_key_, &metadata_));
+          array_uri_, *encryption_key_, &metadata_));
     }
   }
 
@@ -449,7 +467,7 @@ Status Array::get_max_buffer_size(
 
 const EncryptionKey& Array::get_encryption_key() const {
   std::unique_lock<std::mutex> lck(mtx_);
-  return encryption_key_;
+  return *encryption_key_;
 }
 
 Status Array::reopen() {
@@ -480,15 +498,15 @@ Status Array::reopen(uint64_t timestamp) {
   if (remote_) {
     return open(
         query_type_,
-        encryption_key_.encryption_type(),
-        encryption_key_.key().data(),
-        encryption_key_.key().size());
+        encryption_key_->encryption_type(),
+        encryption_key_->key().data(),
+        encryption_key_->key().size());
   }
 
   RETURN_NOT_OK(storage_manager_->array_reopen(
       array_uri_,
       timestamp_,
-      encryption_key_,
+      *encryption_key_,
       &array_schema_,
       &fragment_metadata_));
 
@@ -770,7 +788,7 @@ Status Array::compute_max_buffer_sizes(
   // non-empty regions of the subarray.
   for (auto& meta : fragment_metadata_)
     RETURN_NOT_OK(
-        meta->add_max_buffer_sizes(encryption_key_, subarray, buffer_sizes));
+        meta->add_max_buffer_sizes(*encryption_key_, subarray, buffer_sizes));
 
   // Prepare an NDRange for the subarray
   auto dim_num = array_schema_->dim_num();
@@ -836,7 +854,7 @@ Status Array::load_metadata() {
         array_uri_, timestamp_, this));
   } else {
     RETURN_NOT_OK(storage_manager_->load_array_metadata(
-        array_uri_, encryption_key_, timestamp_, &metadata_));
+        array_uri_, *encryption_key_, timestamp_, &metadata_));
   }
   metadata_loaded_ = true;
   return Status::Ok();

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -65,6 +65,9 @@ class Array {
   /** Constructor. */
   Array(const URI& array_uri, StorageManager* storage_manager);
 
+  /** Copy constructor. */
+  Array(const Array& rhs);
+
   /** Destructor. */
   ~Array() = default;
 
@@ -332,7 +335,7 @@ class Array {
    * should be stored. Wherever a key is needed, a pointer to this memory region
    * should be passed instead of a copy of the bytes.
    */
-  EncryptionKey encryption_key_;
+  std::shared_ptr<EncryptionKey> encryption_key_;
 
   /** The metadata of the fragments the array was opened with. */
   std::vector<FragmentMetadata*> fragment_metadata_;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3011,12 +3011,31 @@ int32_t tiledb_query_get_array(
 
   // Create array datatype
   *array = new (std::nothrow) tiledb_array_t;
+  if (*array == nullptr) {
+    auto st = Status::Error(
+        "Failed to create TileDB array object; Memory allocation error");
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_OOM;
+  }
 
-  // Get array
-  (*array)->array_ = query->query_->array();
+  // Allocate an array object, copied from the query's array.
+  (*array)->array_ =
+      new (std::nothrow) tiledb::sm::Array(*query->query_->array());
+  if ((*array)->array_ == nullptr) {
+    delete *array;
+    *array = nullptr;
+    auto st = Status::Error(
+        "Failed to create TileDB array object; Memory allocation "
+        "error");
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_OOM;
+  }
 
   return TILEDB_OK;
 }
+
 int32_t tiledb_query_add_range(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
@@ -4310,7 +4329,7 @@ int32_t tiledb_vfs_get_config(
   if (*config == nullptr)
     return TILEDB_OOM;
 
-  // Create storage manager
+  // Create a new config
   (*config)->config_ = new (std::nothrow) tiledb::sm::Config();
   if ((*config)->config_ == nullptr) {
     delete (*config);

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -55,6 +55,15 @@ Metadata::Metadata() {
   timestamp_range_ = std::make_pair(t, t);
 }
 
+Metadata::Metadata(const Metadata& rhs)
+    : metadata_map_(rhs.metadata_map_)
+    , timestamp_range_(rhs.timestamp_range_)
+    , loaded_metadata_uris_(rhs.loaded_metadata_uris_)
+    , uri_(rhs.uri_) {
+  if (!rhs.metadata_index_.empty())
+    build_metadata_index();
+}
+
 Metadata::~Metadata() = default;
 
 /* ********************************* */
@@ -131,7 +140,7 @@ Status Metadata::deserialize(
     }
   }
 
-  RETURN_NOT_OK(build_metadata_index());
+  build_metadata_index();
   // Note: `metadata_map_` and `metadata_index_` are immutable after this point
 
   return Status::Ok();
@@ -241,7 +250,7 @@ Status Metadata::get(
     uint32_t* value_num,
     const void** value) {
   if (metadata_index_.empty())
-    RETURN_NOT_OK(build_metadata_index());
+    build_metadata_index();
 
   if (index >= metadata_index_.size())
     return LOG_STATUS(
@@ -332,14 +341,12 @@ Metadata::iterator Metadata::end() const {
 /*          PRIVATE METHODS          */
 /* ********************************* */
 
-Status Metadata::build_metadata_index() {
+void Metadata::build_metadata_index() {
   // Create metadata index for fast lookups from index
   metadata_index_.resize(metadata_map_.size());
   size_t i = 0;
   for (auto& m : metadata_map_)
     metadata_index_[i++] = std::make_pair(&(m.first), &(m.second));
-
-  return Status::Ok();
 }
 
 }  // namespace sm

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -88,6 +88,9 @@ class Metadata {
   /** Constructor. */
   Metadata();
 
+  /** Copy constructor. */
+  Metadata(const Metadata& rhs);
+
   /** Destructor. */
   ~Metadata();
 
@@ -262,9 +265,8 @@ class Metadata {
 
   /**
    * Build the metadata index vector from the metadata map
-   * @return Status
    */
-  Status build_metadata_index();
+  void build_metadata_index();
 };
 
 }  // namespace sm


### PR DESCRIPTION
Currently, the `tiledb_query_get_array` returns a newly-allocated C structure
that contains a pointer to the internal array. This is problematic because
we cannot free the C structure with `tiledb_array_free`. This change makes the
API return a deep copy.`

---

TYPE: C_API
DESC: tiledb_query_get_array now returns a deep-copy
