### PR TITLE
Fix leak in S3 VFS read

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -753,13 +753,16 @@ Status S3::read(
       ("bytes=" + std::to_string(offset) + "-" +
        std::to_string(offset + length + read_ahead_length - 1))
           .c_str());
-  get_object_request.SetResponseStreamFactory(
-      [buffer, length, read_ahead_length]() {
-        auto streamBuf = new boost::interprocess::bufferbuf(
-            (char*)buffer, length + read_ahead_length);
-        return Aws::New<Aws::IOStream>(
-            constants::s3_allocation_tag.c_str(), streamBuf);
-      });
+  // Create a unique_ptr so that this will be freed at the end of the function
+  // call This only needs to live long enough for the request itself
+  auto streamBuf = tdb_unique_ptr<boost::interprocess::bufferbuf>(tdb_new(
+      boost::interprocess::bufferbuf,
+      (char*)buffer,
+      length + read_ahead_length));
+  get_object_request.SetResponseStreamFactory([&streamBuf]() {
+    return Aws::New<Aws::IOStream>(
+        constants::s3_allocation_tag.c_str(), streamBuf.get());
+  });
   if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET)
     get_object_request.SetRequestPayer(request_payer_);
 


### PR DESCRIPTION
This fix a leak in the S3 read code path where we allocated a `boost::interprocess::bufferbuf` but did not free it. This changes from a raw pointer to a `std::unique_ptr`.

Fixes #2168 

---
TYPE: BUG
DESC: Fixes a memory leak in the S3 read path
