### PR TITLE
Backward compatibility writes

### DIFF
--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -229,6 +229,10 @@ Array
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_create_with_key
     :project: TileDB-C
+.. doxygenfunction:: tiledb_array_update_version
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_update_version_with_key
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_array_consolidate
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_consolidate_with_key
@@ -301,6 +305,8 @@ Array Schema
 .. doxygenfunction:: tiledb_array_schema_get_domain
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_schema_get_tile_order
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_array_schema_get_version
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_schema_get_attribute_num
     :project: TileDB-C

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -684,6 +684,12 @@ void ArraySchemaFx::load_and_check_array_schema(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   CHECK(tile_order == TILE_ORDER);
 
+  // Check version
+  uint32_t format_version;
+  rc = tiledb_array_schema_get_version(ctx_, array_schema, &format_version);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(format_version == tiledb::sm::constants::format_version);
+
   // Check array_schema type
   tiledb_array_type_t type;
   rc = tiledb_array_schema_get_array_type(ctx_, array_schema, &type);
@@ -846,7 +852,9 @@ void ArraySchemaFx::load_and_check_array_schema(const std::string& path) {
 
   // Check dump
   std::string dump_str =
-      std::string("- Array type: ") + ARRAY_TYPE_STR + "\n" +
+      std::string("- Array version: ") +
+      std::to_string(tiledb::sm::constants::format_version) + "\n" +
+      "- Array type: " + ARRAY_TYPE_STR + "\n" +
       "- Cell order: " + CELL_ORDER_STR + "\n" +
       "- Tile order: " + TILE_ORDER_STR + "\n" + "- Capacity: " + CAPACITY_STR +
       "\n"

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -206,7 +206,7 @@ class ArraySchema {
    * @param buff The buffer the array schema is serialized into.
    * @return Status
    */
-  Status serialize(Buffer* buff) const;
+  Status serialize(Buffer* buff);
 
   /** Returns the tile order. */
   Layout tile_order() const;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2448,6 +2448,17 @@ int32_t tiledb_array_schema_get_tile_order(
   return TILEDB_OK;
 }
 
+int32_t tiledb_array_schema_get_version(
+    tiledb_ctx_t* ctx,
+    const tiledb_array_schema_t* array_schema,
+    uint32_t* version) {
+  if (sanity_check(ctx) == TILEDB_ERR ||
+      sanity_check(ctx, array_schema) == TILEDB_ERR)
+    return TILEDB_ERR;
+  *version = array_schema->array_schema_->version();
+  return TILEDB_OK;
+}
+
 int32_t tiledb_array_schema_get_attribute_num(
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
@@ -3684,6 +3695,33 @@ int32_t tiledb_array_create_with_key(
                 uri, array_schema->array_schema_, key)))
       return TILEDB_ERR;
   }
+  return TILEDB_OK;
+}
+
+int32_t tiledb_array_update_version(tiledb_ctx_t* ctx, const char* array_uri) {
+  return tiledb_array_update_version_with_key(
+      ctx, array_uri, TILEDB_NO_ENCRYPTION, nullptr, 0);
+}
+
+int32_t tiledb_array_update_version_with_key(
+    tiledb_ctx_t* ctx,
+    const char* array_uri,
+    tiledb_encryption_type_t encryption_type,
+    const void* encryption_key,
+    uint32_t key_length) {
+  // Sanity checks
+  if (sanity_check(ctx) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          ctx->ctx_->storage_manager()->array_update_version(
+              array_uri,
+              static_cast<tiledb::sm::EncryptionType>(encryption_type),
+              encryption_key,
+              key_length)))
+    return TILEDB_ERR;
+
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3192,6 +3192,26 @@ TILEDB_EXPORT int32_t tiledb_array_schema_get_tile_order(
     tiledb_layout_t* tile_order);
 
 /**
+ * Retrieves the array format version.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint32_t version;
+ * tiledb_array_schema_get_version(ctx, array_schema, &version);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_schema The array schema.
+ * @param version The version to be retrieved.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_schema_get_version(
+    tiledb_ctx_t* ctx,
+    const tiledb_array_schema_t* array_schema,
+    uint32_t* version);
+
+/**
  * Retrieves the number of array attributes.
  *
  * **Example:**
@@ -4898,6 +4918,51 @@ TILEDB_EXPORT int32_t tiledb_array_create_with_key(
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const tiledb_array_schema_t* array_schema,
+    tiledb_encryption_type_t encryption_type,
+    const void* encryption_key,
+    uint32_t key_length);
+
+/**
+ * Updates the array format version to the latest one.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_update_version(
+ *     ctx, "hdfs:///tiledb_arrays/my_array");
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_uri The name of the TileDB array to update.
+ *
+ * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
+ */
+TILEDB_EXPORT int32_t
+tiledb_array_update_version(tiledb_ctx_t* ctx, const char* array_uri);
+
+/**
+ * Updates the array format version to the latest one.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint8_t key[32] = ...;
+ * tiledb_array_update_version_with_key(
+ *     ctx, "hdfs:///tiledb_arrays/my_array",
+ *     TILEDB_AES_256_GCM, key, sizeof(key));
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_uri The name of the TileDB array to update.
+ * @param encryption_type The encryption type to use.
+ * @param encryption_key The encryption key to use.
+ * @param key_length Length in bytes of the encryption key.
+ *
+ * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_update_version_with_key(
+    tiledb_ctx_t* ctx,
+    const char* array_uri,
     tiledb_encryption_type_t encryption_type,
     const void* encryption_key,
     uint32_t key_length);

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -613,6 +613,56 @@ class Array {
   }
 
   /**
+   * @brief Updates the array format version to the latest one.
+   *
+   * **Example:**
+   * @code{.cpp}
+   * tiledb::Array::update_version(ctx, "s3://bucket-name/array-name");
+   * @endcode
+   *
+   * @param ctx TileDB context
+   * @param array_uri The URI of the TileDB array to update.
+   */
+  static void update_version(const Context& ctx, const std::string& uri) {
+    update_version(ctx, uri, TILEDB_NO_ENCRYPTION, nullptr, 0);
+  }
+
+  /**
+   * @brief Updates the array format version to the latest one.
+   *
+   * **Example:**
+   * @code{.cpp}
+   * // Load AES-256 key from disk, environment variable, etc.
+   * uint8_t key[32] = ...;
+   * tiledb::Array::update_version(
+   *     ctx,
+   *     "s3://bucket-name/array-name",
+   *     TILEDB_AES_256_GCM,
+   *     key,
+   *     sizeof(key));
+   * @endcode
+   *
+   * @param ctx TileDB context
+   * @param array_uri The URI of the TileDB array to be consolidated.
+   * @param encryption_type The encryption type to use.
+   * @param encryption_key The encryption key to use.
+   * @param key_length Length in bytes of the encryption key.
+   */
+  static void update_version(
+      const Context& ctx,
+      const std::string& uri,
+      tiledb_encryption_type_t encryption_type,
+      const void* encryption_key,
+      uint32_t key_length) {
+    ctx.handle_error(tiledb_array_update_version_with_key(
+        ctx.ptr().get(),
+        uri.c_str(),
+        encryption_type,
+        encryption_key,
+        key_length));
+  }
+
+  /**
    * @brief Consolidates the fragments of an array into a single fragment.
    *
    * You must first finalize all queries to the array before consolidation can

--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -286,6 +286,15 @@ class ArraySchema : public Schema {
     return layout;
   }
 
+  /** Returns the format version. */
+  uint32_t version() const {
+    auto& ctx = ctx_.get();
+    uint32_t version;
+    ctx.handle_error(tiledb_array_schema_get_version(
+        ctx.ptr().get(), schema_.get(), &version));
+    return version;
+  }
+
   /**
    * Sets the tile order.
    *

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -74,7 +74,7 @@ FragmentMetadata::FragmentMetadata(
   has_consolidated_footer_ = false;
   rtree_ = RTree(array_schema_->domain(), constants::rtree_fanout);
   meta_file_size_ = 0;
-  version_ = constants::format_version;
+  version_ = array_schema_->version();
   tile_index_base_ = 0;
   sparse_tile_num_ = 0;
   footer_size_ = 0;

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -469,6 +469,9 @@ const int32_t library_version[3] = {
 /** The TileDB serialization format version number. */
 const uint32_t format_version = 9;
 
+/** The lowest version supported for back compat writes. */
+const uint32_t back_compat_writes_min_format_version = 7;
+
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
 const uint64_t max_tile_chunk_size = 64 * 1024;
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -456,6 +456,9 @@ extern const int32_t library_version[3];
 /** The TileDB serialization format version number. */
 extern const uint32_t format_version;
 
+/** The lowest version supported for back compat writes. */
+extern const uint32_t back_compat_writes_min_format_version;
+
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
 extern const uint64_t max_tile_chunk_size;
 

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -857,6 +857,15 @@ const Subarray* Writer::subarray_ranges() const {
 Status Writer::write() {
   get_dim_attr_stats();
 
+  // If we can't write in the array format version, update the array
+  // metadata to the current version
+  const uint32_t version = array_schema_->version();
+  if (version != constants::format_version &&
+      version < constants::back_compat_writes_min_format_version) {
+    RETURN_NOT_OK(storage_manager_->store_array_schema(
+        const_cast<ArraySchema*>(array_schema_), array_->get_encryption_key()));
+  }
+
   STATS_START_TIMER(stats::GlobalStats::TimerType::WRITE)
   STATS_ADD_COUNTER(stats::GlobalStats::CounterType::WRITE_NUM, 1)
 
@@ -1576,7 +1585,8 @@ Status Writer::create_fragment(
     uri = fragment_uri_;
   } else {
     std::string new_fragment_str;
-    RETURN_NOT_OK(new_fragment_name(timestamp, &new_fragment_str));
+    RETURN_NOT_OK(new_fragment_name(
+        timestamp, array_->array_schema()->version(), &new_fragment_str));
     uri = array_schema_->array_uri().join_path(new_fragment_str);
   }
   auto timestamp_range = std::pair<uint64_t, uint64_t>(timestamp, timestamp);
@@ -1970,7 +1980,7 @@ Status Writer::init_tile(const std::string& name, Tile* tile) const {
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version, type, tile_size, cell_size, 0));
+      array_schema_->version(), type, tile_size, cell_size, 0));
 
   return Status::Ok();
 }
@@ -1986,13 +1996,13 @@ Status Writer::init_tile(
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version,
+      array_schema_->version(),
       constants::cell_var_offset_type,
       tile_size,
       constants::cell_var_offset_size,
       0));
   RETURN_NOT_OK(tile_var->init_unfiltered(
-      constants::format_version, type, tile_size, datatype_size(type), 0));
+      array_schema_->version(), type, tile_size, datatype_size(type), 0));
   return Status::Ok();
 }
 
@@ -2008,9 +2018,9 @@ Status Writer::init_tile_nullable(
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version, type, tile_size, cell_size, 0));
+      array_schema_->version(), type, tile_size, cell_size, 0));
   RETURN_NOT_OK(tile_validity->init_unfiltered(
-      constants::format_version,
+      array_schema_->version(),
       constants::cell_validity_type,
       tile_size,
       constants::cell_validity_size,
@@ -2033,15 +2043,15 @@ Status Writer::init_tile_nullable(
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version,
+      array_schema_->version(),
       constants::cell_var_offset_type,
       tile_size,
       constants::cell_var_offset_size,
       0));
   RETURN_NOT_OK(tile_var->init_unfiltered(
-      constants::format_version, type, tile_size, datatype_size(type), 0));
+      array_schema_->version(), type, tile_size, datatype_size(type), 0));
   RETURN_NOT_OK(tile_validity->init_unfiltered(
-      constants::format_version,
+      array_schema_->version(),
       constants::cell_validity_type,
       tile_size,
       constants::cell_validity_size,
@@ -2081,7 +2091,7 @@ Status Writer::init_tiles(
 }
 
 Status Writer::new_fragment_name(
-    uint64_t timestamp, std::string* frag_uri) const {
+    uint64_t timestamp, uint32_t format_version, std::string* frag_uri) const {
   timestamp = (timestamp != 0) ? timestamp : utils::time::timestamp_now_ms();
 
   if (frag_uri == nullptr)
@@ -2091,7 +2101,7 @@ Status Writer::new_fragment_name(
   RETURN_NOT_OK(uuid::generate_uuid(&uuid, false));
   std::stringstream ss;
   ss << "/__" << timestamp << "_" << timestamp << "_" << uuid << "_"
-     << constants::format_version;
+     << format_version;
 
   *frag_uri = ss.str();
   return Status::Ok();

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -767,7 +767,8 @@ class Writer {
    * @param frag_uri Will store the new special fragment name
    * @return Status
    */
-  Status new_fragment_name(uint64_t timestamp, std::string* frag_uri) const;
+  Status new_fragment_name(
+      uint64_t timestamp, uint32_t format_version, std::string* frag_uri) const;
 
   /**
    * This deletes the global write state and deletes the potentially

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -377,7 +377,10 @@ class Consolidator {
    * as `__<first_URI_timestamp>_<last_URI_timestamp>_<uuid>`.
    */
   Status compute_new_fragment_uri(
-      const URI& first, const URI& last, URI* new_uri) const;
+      const URI& first,
+      const URI& last,
+      uint32_t format_version,
+      URI* new_uri) const;
 
   /** Checks and sets the input configuration parameters. */
   Status set_config(const Config* config);

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -219,6 +219,22 @@ class StorageManager {
       std::vector<FragmentMetadata*>* fragment_metadata);
 
   /**
+   * Updates the array version to the latest one.
+   *
+   * @param array_name The name of the array to update.
+   * @param encryption_type The encryption type of the array
+   * @param encryption_key If the array is encrypted, the private encryption
+   *    key. For unencrypted arrays, pass `nullptr`.
+   * @param key_length The length in bytes of the encryption key.
+   * @return Status
+   */
+  Status array_update_version(
+      const char* array_name,
+      EncryptionType encryption_type,
+      const void* encryption_key,
+      uint32_t key_length);
+
+  /**
    * Consolidates the fragments of an array into a single one.
    *
    * @param array_name The name of the array to be consolidated.


### PR DESCRIPTION
When a client with a higher version tries to write to an older array
with version greater or equal to 7, we now write in that version. If
the array has a version lesser than 7, we update the array schema
metadata to the current version before the write.

Also added an api to allow the user to migrate an array to the current
version and get the current version from the array schema metadata.

---
TYPE: IMPROVEMENT
DESC: Support backward compat writes
