### PR TITLE
Continued stats refactor + subarray stats

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -481,7 +481,7 @@ void create_subarray(
     tiledb::sm::Layout layout,
     tiledb::sm::Subarray* subarray,
     bool coalesce_ranges) {
-  tiledb::sm::Subarray ret(array, layout, coalesce_ranges);
+  tiledb::sm::Subarray ret(array, layout, &g_helper_stats, coalesce_ranges);
 
   auto dim_num = (unsigned)ranges.size();
   for (unsigned d = 0; d < dim_num; ++d) {

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -37,6 +37,7 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/enums/serialization_type.h"
+#include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/subarray/subarray.h"
 #include "tiledb_serialization.h"
 
@@ -69,6 +70,11 @@ class SubarrayPartitioner;
 }
 
 namespace test {
+
+// A dummy `Stats` instance. This is useful for constructing
+// objects that require a parent `Stats` object. These stats are
+// never used.
+static tiledb::sm::stats::Stats g_helper_stats("test");
 
 // For easy reference
 typedef std::pair<tiledb_filter_type_t, int> Compressor;

--- a/test/src/unit-DenseTiler.cc
+++ b/test/src/unit-DenseTiler.cc
@@ -30,6 +30,7 @@
  * Tests the `DenseTiler` class.
  */
 
+#include "test/src/helpers.h"
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/tiledb"
@@ -202,11 +203,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler1.tile_num() == 2);
@@ -219,11 +220,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {6, 9};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler2.tile_num() == 1);
@@ -261,11 +262,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -293,11 +294,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {7, 8};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan2 = tiler2.copy_plan(0);
@@ -313,11 +314,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub3[] = {7, 8};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3}, sizeof(sub3), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan3 = tiler3.copy_plan(0);
@@ -358,11 +359,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0;
@@ -383,11 +384,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {7, 10};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile2;
@@ -399,11 +400,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub3[] = {7, 10};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3}, sizeof(sub3), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile3;
@@ -440,11 +441,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0;
@@ -490,11 +491,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {-2, 1};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0;
@@ -544,11 +545,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler1.tile_num() == 4);
@@ -562,11 +563,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {7, 9};
   int32_t sub2_1[] = {23, 27};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler2.tile_num() == 1);
@@ -580,11 +581,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler3.tile_num() == 4);
@@ -598,11 +599,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {7, 10};
   int32_t sub4_1[] = {23, 27};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler4.tile_num() == 1);
@@ -644,11 +645,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler1.tile_num() == 4);
@@ -662,11 +663,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {7, 9};
   int32_t sub2_1[] = {23, 27};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler2.tile_num() == 1);
@@ -680,11 +681,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler3.tile_num() == 4);
@@ -698,11 +699,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {7, 10};
   int32_t sub4_1[] = {23, 27};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test correctness of initialization
   CHECK(tiler4.tile_num() == 1);
@@ -744,11 +745,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -799,11 +800,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan2_0 = tiler2.copy_plan(0);
@@ -821,11 +822,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan3_0 = tiler3.copy_plan(0);
@@ -880,11 +881,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan4_0 = tiler4.copy_plan(0);
@@ -931,11 +932,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -990,11 +991,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan2_0 = tiler2.copy_plan(0);
@@ -1013,11 +1014,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan3_0 = tiler3.copy_plan(0);
@@ -1068,11 +1069,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan4_0 = tiler4.copy_plan(0);
@@ -1118,11 +1119,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 9};
   int32_t sub1_1[] = {11, 20};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -1179,11 +1180,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {1, 5};
   int32_t sub1_1[] = {8, 12};
-  Subarray subarray1(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray1(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -1241,11 +1242,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0;
@@ -1304,14 +1305,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
   buff_a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile2_0;
@@ -1338,14 +1339,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
   buff_a = {1, 6, 11, 2, 7, 12, 3, 8, 13, 4, 9, 14, 5, 10, 15};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile3_0;
@@ -1404,14 +1405,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
   buff_a = {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile4_0;
@@ -1467,11 +1468,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0;
@@ -1541,14 +1542,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
   buff_a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile2_0;
@@ -1593,14 +1594,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
   buff_a = {1, 6, 11, 2, 7, 12, 3, 8, 13, 4, 9, 14, 5, 10, 15};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile3_0;
@@ -1670,14 +1671,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
   buff_a = {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile4_0;
@@ -1754,11 +1755,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 9};
   int32_t sub1_1[] = {11, 20};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0;
@@ -1815,11 +1816,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {1, 5};
   int32_t sub1_1[] = {8, 12};
-  Subarray subarray1(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray1(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0;
@@ -1870,11 +1871,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0;
@@ -1902,11 +1903,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {7, 10};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile2;
@@ -1919,11 +1920,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub3[] = {7, 10};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3}, sizeof(sub3), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile3;
@@ -1964,11 +1965,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0_a1;
@@ -2000,11 +2001,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {7, 10};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile2_a1;
@@ -2020,11 +2021,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub3[] = {7, 10};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3}, sizeof(sub3), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile3_a1;
@@ -2077,11 +2078,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0;
@@ -2143,7 +2144,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -2157,7 +2158,7 @@ TEST_CASE_METHOD(
       &buff_a_size,
       nullptr,
       ValidityVector(&buff_a_n[0], &buff_a_n_size));
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile2_0;
@@ -2196,7 +2197,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
@@ -2210,7 +2211,7 @@ TEST_CASE_METHOD(
       &buff_a_size,
       nullptr,
       ValidityVector(&buff_a_n[0], &buff_a_n_size));
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile3_0;
@@ -2272,7 +2273,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
@@ -2286,7 +2287,7 @@ TEST_CASE_METHOD(
       &buff_a_size,
       nullptr,
       ValidityVector(&buff_a_n[0], &buff_a_n_size));
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile4_0;
@@ -2360,11 +2361,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -2496,7 +2497,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -2508,7 +2509,7 @@ TEST_CASE_METHOD(
   buff_a_val_size = buff_a_val.size();
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;
@@ -2656,11 +2657,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -2792,7 +2793,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -2823,7 +2824,7 @@ TEST_CASE_METHOD(
   buff_a_val_size = buff_a_val.size() * sizeof(int32_t);
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;
@@ -2972,11 +2973,12 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, "bytes", 64, true);
+  DenseTiler<int32_t> tiler1(
+      &buffers, &subarray1, &test::g_helper_stats, "bytes", 64, true);
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -3108,7 +3110,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -3140,7 +3142,8 @@ TEST_CASE_METHOD(
   buff_a_val_size = buff_a_val.size() * sizeof(int32_t);
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, "bytes", 64, true);
+  DenseTiler<int32_t> tiler2(
+      &buffers, &subarray2, &test::g_helper_stats, "bytes", 64, true);
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;
@@ -3275,11 +3278,12 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, "elements", 64, false);
+  DenseTiler<int32_t> tiler1(
+      &buffers, &subarray1, &test::g_helper_stats, "elements", 64, false);
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -3411,7 +3415,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -3426,7 +3430,8 @@ TEST_CASE_METHOD(
   buff_a_val_size = buff_a_val.size() * sizeof(int32_t);
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, "elements", 64, false);
+  DenseTiler<int32_t> tiler2(
+      &buffers, &subarray2, &test::g_helper_stats, "elements", 64, false);
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;
@@ -3561,11 +3566,12 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, "elements", 32, false);
+  DenseTiler<int32_t> tiler1(
+      &buffers, &subarray1, &test::g_helper_stats, "elements", 32, false);
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -3697,7 +3703,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -3712,7 +3718,8 @@ TEST_CASE_METHOD(
   buff_a_val_size = buff_a_val.size() * sizeof(int32_t);
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, "elements", 32, false);
+  DenseTiler<int32_t> tiler2(
+      &buffers, &subarray2, &test::g_helper_stats, "elements", 32, false);
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;

--- a/test/src/unit-SubarrayPartitioner-dense.cc
+++ b/test/src/unit-SubarrayPartitioner-dense.cc
@@ -255,7 +255,13 @@ void SubarrayPartitionerDenseFx::test_subarray_partitioner(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner subarray_partitioner(
-      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), budget);
   CHECK(st.ok());
 
@@ -277,7 +283,13 @@ void SubarrayPartitionerDenseFx::test_subarray_partitioner(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner subarray_partitioner(
-      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
 
   // Note: this is necessary, otherwise the subarray partitioner does
   // not check if the memory budget is exceeded for attributes whose
@@ -552,7 +564,13 @@ TEST_CASE_METHOD(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner subarray_partitioner(
-      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   auto st = subarray_partitioner.set_result_budget("a", 100 * sizeof(int));
   CHECK(st.ok());
   st = subarray_partitioner.set_result_budget("b", 1, 1);

--- a/test/src/unit-SubarrayPartitioner-error.cc
+++ b/test/src/unit-SubarrayPartitioner-error.cc
@@ -133,7 +133,13 @@ TEST_CASE_METHOD(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner subarray_partitioner(
-      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   uint64_t budget, budget_off, budget_val;
 
   auto st = subarray_partitioner.get_result_budget("a", &budget);

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -346,7 +346,13 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner subarray_partitioner(
-      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), budget);
   CHECK(st.ok());
 
@@ -370,7 +376,13 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner subarray_partitioner(
-      &config, subarray, memory_budget, memory_budget_var, 0, &tp);
+      &config,
+      subarray,
+      memory_budget,
+      memory_budget_var,
+      0,
+      &tp,
+      &g_helper_stats);
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), result_budget);
   CHECK(st.ok());
 
@@ -392,7 +404,13 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner subarray_partitioner(
-      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
 
   // Note: this is necessary, otherwise the subarray partitioner does
   // not check if the memory budget is exceeded for attributes whose
@@ -667,7 +685,13 @@ TEST_CASE_METHOD(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner subarray_partitioner(
-      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   auto st = subarray_partitioner.set_result_budget("a", 100);
   CHECK(st.ok());
   st = subarray_partitioner.set_result_budget("b", 1, 1);
@@ -2255,7 +2279,7 @@ TEST_CASE_METHOD(
   }
 
   // Check unsplittable
-  tiledb::sm::Subarray subarray(array->array_, layout);
+  tiledb::sm::Subarray subarray(array->array_, layout, &g_helper_stats);
   tiledb::sm::Range r;
   r.set_str_range("bb", "bb");
   subarray.add_range(0, std::move(r), true);
@@ -2263,7 +2287,13 @@ TEST_CASE_METHOD(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner partitioner(
-      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   auto st = partitioner.set_result_budget("d", 10);
   CHECK(!st.ok());
   uint64_t budget = 0;
@@ -2286,11 +2316,17 @@ TEST_CASE_METHOD(
   CHECK(range->end_str() == std::string("bb", 2));
 
   // Check full
-  tiledb::sm::Subarray subarray_full(array->array_, layout);
+  tiledb::sm::Subarray subarray_full(array->array_, layout, &g_helper_stats);
   r.set_str_range("a", "bb");
   subarray_full.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_full(
-      &config, subarray_full, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray_full,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   st = partitioner_full.set_result_budget("d", 16, 4);
   CHECK(st.ok());
   CHECK(partitioner_full.get_result_budget("d", &budget_off, &budget_val).ok());
@@ -2306,11 +2342,17 @@ TEST_CASE_METHOD(
   CHECK(range->end_str() == std::string("bb", 2));
 
   // Check split
-  tiledb::sm::Subarray subarray_split(array->array_, layout);
+  tiledb::sm::Subarray subarray_split(array->array_, layout, &g_helper_stats);
   r.set_str_range("a", "bb");
   subarray_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split(
-      &config, subarray_split, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray_split,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   st = partitioner_split.set_result_budget("d", 10, 4);
   CHECK(st.ok());
   CHECK(
@@ -2336,11 +2378,18 @@ TEST_CASE_METHOD(
   CHECK(partitioner_split.done());
 
   // Check no split 2 MBRs
-  tiledb::sm::Subarray subarray_no_split(array->array_, layout);
+  tiledb::sm::Subarray subarray_no_split(
+      array->array_, layout, &g_helper_stats);
   r.set_str_range("bb", "cc");
   subarray_no_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_no_split(
-      &config, subarray_no_split, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray_no_split,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   st = partitioner_no_split.set_result_budget("d", 16, 10);
   CHECK(st.ok());
   CHECK(partitioner_no_split.get_result_budget("d", &budget_off, &budget_val)
@@ -2358,11 +2407,17 @@ TEST_CASE_METHOD(
   CHECK(range->end_str() == std::string("cc", 2));
 
   // Check split 2 MBRs
-  tiledb::sm::Subarray subarray_split_2(array->array_, layout);
+  tiledb::sm::Subarray subarray_split_2(array->array_, layout, &g_helper_stats);
   r.set_str_range("bb", "cc");
   subarray_split_2.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split_2(
-      &config, subarray_split_2, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray_split_2,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   st = partitioner_split_2.set_result_budget("d", 8, 10);
   CHECK(st.ok());
   CHECK(partitioner_split_2.get_result_budget("d", &budget_off, &budget_val)
@@ -2488,7 +2543,7 @@ TEST_CASE_METHOD(
     layout = Layout::UNORDERED;
   }
 
-  tiledb::sm::Subarray subarray(array->array_, layout);
+  tiledb::sm::Subarray subarray(array->array_, layout, &g_helper_stats);
   tiledb::sm::Range r;
   r.set_str_range("cc", "ccd");
   subarray.add_range(0, std::move(r), true);
@@ -2496,7 +2551,13 @@ TEST_CASE_METHOD(
   CHECK(tp.init(4).ok());
   Config config;
   SubarrayPartitioner partitioner(
-      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config,
+      subarray,
+      memory_budget_,
+      memory_budget_var_,
+      0,
+      &tp,
+      &g_helper_stats);
   auto st = partitioner.set_result_budget("d", 10, 4);
   CHECK(st.ok());
   CHECK(partitioner.get_result_budget("d", &budget_off, &budget_val).ok());

--- a/tiledb/common/scoped_executor.h
+++ b/tiledb/common/scoped_executor.h
@@ -1,0 +1,89 @@
+/**
+ * @file   scoped_executor.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines and implements the `ScopedExecutor` class.
+ */
+
+#ifndef TILEDB_SCOPED_EXECUTOR_H
+#define TILEDB_SCOPED_EXECUTOR_H
+
+#include <functional>
+
+#include "tiledb/common/macros.h"
+
+namespace tiledb {
+namespace common {
+
+class ScopedExecutor final {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Default constructor. */
+  ScopedExecutor() = default;
+
+  /**
+   * Value constructor. Executes `fn` when this instance is
+   * destructed.
+   *
+   * @param fn The function to execute on destruction.
+   */
+  explicit ScopedExecutor(std::function<void()>&& fn)
+      : fn_(std::move(fn)) {
+  }
+
+  /** Move constructor. */
+  ScopedExecutor(ScopedExecutor&& rhs) {
+    fn_.swap(rhs.fn_);
+  }
+
+  /** Destructor. Executes `fn_`. */
+  ~ScopedExecutor() {
+    if (fn_) {
+      fn_();
+    }
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(ScopedExecutor);
+  DISABLE_MOVE_ASSIGN(ScopedExecutor);
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The wrapped function to execute on destruction. */
+  std::function<void()> fn_;
+};
+
+}  // namespace common
+}  // namespace tiledb
+
+#endif  // TILEDB_SCOPED_EXECUTOR_H

--- a/tiledb/sm/query/dense_tiler.h
+++ b/tiledb/sm/query/dense_tiler.h
@@ -145,6 +145,7 @@ class DenseTiler {
   DenseTiler(
       const std::unordered_map<std::string, QueryBuffer>* buffers,
       const Subarray* subarray,
+      stats::Stats* const parent_stats,
       const std::string& offsets_format_mode = "bytes",
       uint64_t offsets_bitsize = 64,
       bool offsets_extra_element = false);
@@ -231,13 +232,13 @@ class DenseTiler {
   /** Returns the coordinates of the first tile intersecting the subarray. */
   const std::vector<uint64_t>& first_sub_tile_coords() const;
 
-  /** Returns the dense tiler stats. */
-  const stats::Stats& stats() const;
-
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /** The stats for the dense tiler. */
+  stats::Stats* stats_;
 
   /** The array schema. */
   const ArraySchema* array_schema_;
@@ -289,9 +290,6 @@ class DenseTiler {
    * will be added in the end of the offsets buffer of var-sized attributes
    */
   bool offsets_extra_element_;
-
-  /** The stats for the dense tiler. */
-  stats::Stats stats_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -44,6 +44,7 @@
 #include <sstream>
 
 using namespace tiledb::common;
+using namespace tiledb::sm::stats;
 
 namespace tiledb {
 namespace sm {
@@ -971,8 +972,14 @@ Status Query::set_subarray(const void* subarray) {
         Status::QueryError("Cannot set subarray; Function not applicable to "
                            "domains with variable-sized dimensions"));
 
+  // To construct the `Subarray` object, it needs the stats of
+  // the parent. Depending the type, the parent stats will either
+  // be from the `reader_` or `writer_`.
+  Stats* const parent_stats =
+      (type_ == QueryType::WRITE) ? writer_.stats() : reader_.stats();
+
   // Prepare a subarray object
-  Subarray sub(array_, layout_);
+  Subarray sub(array_, layout_, parent_stats);
   if (subarray != nullptr) {
     auto dim_num = array_->array_schema()->dim_num();
     auto s_ptr = (const unsigned char*)subarray;
@@ -1008,8 +1015,14 @@ Status Query::set_subarray(const void* subarray) {
 }
 
 Status Query::set_subarray_unsafe(const NDRange& subarray) {
+  // To construct the `Subarray` object, it needs the stats of
+  // the parent. Depending the type, the parent stats will either
+  // be from the `reader_` or `writer_`.
+  Stats* const parent_stats =
+      (type_ == QueryType::WRITE) ? writer_.stats() : reader_.stats();
+
   // Prepare a subarray object
-  Subarray sub(array_, layout_);
+  Subarray sub(array_, layout_, parent_stats);
   if (!subarray.empty()) {
     auto dim_num = array_->array_schema()->dim_num();
     for (unsigned d = 0; d < dim_num; ++d)

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -76,13 +76,16 @@ class Reader {
      * the user buffers.
      */
     bool overflowed_ = false;
+
     /** The subarray partitioner. */
     SubarrayPartitioner partitioner_;
+
     /**
      * ``true`` if the next partition cannot be retrieved from the
      * partitioner, because it reaches a partition that is unsplittable.
      */
     bool unsplittable_ = false;
+
     /** True if the reader has been initialized. */
     bool initialized_ = false;
 
@@ -497,6 +500,9 @@ class Reader {
 
   /** Sets the bitsize of offsets */
   Status set_offsets_bitsize(const uint32_t bitsize);
+
+  /** Returns `stats_`. */
+  stats::Stats* stats();
 
   /* ********************************* */
   /*          STATIC FUNCTIONS         */
@@ -916,6 +922,9 @@ class Reader {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /** The class stats. */
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The array. */
   const Array* array_;

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -48,7 +48,6 @@
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;
-using namespace tiledb::sm::stats;
 
 namespace tiledb {
 namespace sm {
@@ -368,6 +367,9 @@ class Writer {
   /** Returns the query subarray object. */
   const Subarray* subarray_ranges() const;
 
+  /** Returns `stats_`. */
+  stats::Stats* stats();
+
   /** Performs a write query using its set members. */
   Status write();
 
@@ -378,6 +380,9 @@ class Writer {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /** The class stats. */
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The array. */
   const Array* array_;
@@ -501,9 +506,6 @@ class Writer {
 
   /** The offset bitsize used for variable-sized attributes. */
   uint32_t offsets_bitsize_;
-
-  /** The stats for the writer. */
-  Stats stats_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -61,6 +61,7 @@
 #endif
 
 using namespace tiledb::common;
+using namespace tiledb::sm::stats;
 
 namespace tiledb {
 namespace sm {
@@ -247,6 +248,7 @@ Status subarray_partitioner_to_capnp(
 }
 
 Status subarray_partitioner_from_capnp(
+    Stats* reader_stats,
     const Config* config,
     const Array* array,
     const capnp::SubarrayPartitioner::Reader& reader,
@@ -268,7 +270,7 @@ Status subarray_partitioner_from_capnp(
   RETURN_NOT_OK(layout_enum(subarray_reader.getLayout(), &layout));
 
   // Subarray, which is used to initialize the partitioner.
-  Subarray subarray(array, layout, false);
+  Subarray subarray(array, layout, reader_stats, false);
   RETURN_NOT_OK(subarray_from_capnp(reader.getSubarray(), &subarray));
   *partitioner = SubarrayPartitioner(
       config,
@@ -276,7 +278,8 @@ Status subarray_partitioner_from_capnp(
       memory_budget,
       memory_budget_var,
       memory_budget_validity,
-      compute_tp);
+      compute_tp,
+      reader_stats);
 
   // Per-attr mem budgets
   if (reader.hasBudget()) {
@@ -324,7 +327,7 @@ Status subarray_partitioner_from_capnp(
     partition_info->end_ = partition_info_reader.getEnd();
     partition_info->split_multi_range_ =
         partition_info_reader.getSplitMultiRange();
-    partition_info->partition_ = Subarray(array, layout, false);
+    partition_info->partition_ = Subarray(array, layout, reader_stats, false);
     RETURN_NOT_OK(subarray_from_capnp(
         partition_info_reader.getSubarray(), &partition_info->partition_));
 
@@ -347,7 +350,7 @@ Status subarray_partitioner_from_capnp(
   const unsigned num_sr = sr_reader.size();
   for (unsigned i = 0; i < num_sr; i++) {
     auto subarray_reader_ = sr_reader[i];
-    state->single_range_.emplace_back(array, layout, false);
+    state->single_range_.emplace_back(array, layout, reader_stats, false);
     Subarray& subarray_ = state->single_range_.back();
     RETURN_NOT_OK(subarray_from_capnp(subarray_reader_, &subarray_));
   }
@@ -355,7 +358,7 @@ Status subarray_partitioner_from_capnp(
   const unsigned num_m = m_reader.size();
   for (unsigned i = 0; i < num_m; i++) {
     auto subarray_reader_ = m_reader[i];
-    state->multi_range_.emplace_back(array, layout, false);
+    state->multi_range_.emplace_back(array, layout, reader_stats, false);
     Subarray& subarray_ = state->multi_range_.back();
     RETURN_NOT_OK(subarray_from_capnp(subarray_reader_, &subarray_));
   }
@@ -402,6 +405,7 @@ Status read_state_from_capnp(
   // Subarray partitioner
   if (read_state_reader.hasSubarrayPartitioner()) {
     RETURN_NOT_OK(subarray_partitioner_from_capnp(
+        reader->stats(),
         reader->config(),
         array,
         read_state_reader.getSubarrayPartitioner(),
@@ -447,7 +451,7 @@ Status reader_from_capnp(
   RETURN_NOT_OK(reader->set_layout(layout));
 
   // Subarray
-  Subarray subarray(array, layout, false);
+  Subarray subarray(array, layout, reader->stats(), false);
   auto subarray_reader = reader_reader.getSubarray();
   RETURN_NOT_OK(subarray_from_capnp(subarray_reader, &subarray));
   RETURN_NOT_OK(reader->set_subarray(subarray));
@@ -1110,7 +1114,7 @@ Status query_from_capnp(
 
       // Subarray
       if (writer_reader.hasSubarrayRanges()) {
-        Subarray subarray(array, layout, false);
+        Subarray subarray(array, layout, query->writer()->stats(), false);
         auto subarray_reader = writer_reader.getSubarrayRanges();
         RETURN_NOT_OK(subarray_from_capnp(subarray_reader, &subarray));
         RETURN_NOT_OK(query->writer()->set_subarray(subarray));

--- a/tiledb/sm/stats/global_stats.h
+++ b/tiledb/sm/stats/global_stats.h
@@ -38,12 +38,14 @@
 #include <chrono>
 #include <iomanip>
 #include <iostream>
+#include <list>
 #include <mutex>
 #include <sstream>
 #include <thread>
 #include <unordered_map>
 #include <vector>
 
+#include "tiledb/common/heap_memory.h"
 #include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/stats/timer_stat.h"
 
@@ -222,8 +224,12 @@ class GlobalStats {
   /** Enable or disable statistics gathering. */
   void set_enabled(bool enabled);
 
-  /** Sets the new stats. */
-  void set_stats(const Stats& stats);
+  /**
+   * Registers a `Stats` instance. Stats in this instance
+   * will be aggregated and dumped with the other registered
+   * stats.
+   */
+  void register_stats(const tdb_shared_ptr<Stats>& stats);
 
   /** Reset all counters to zero. */
   void reset();
@@ -269,12 +275,8 @@ class GlobalStats {
   /** Mutex to protext in multi-threading scenarios. */
   std::mutex mtx_;
 
-  /**
-   * The new stats.
-   *
-   * @note This will be refactored soon.
-   */
-  Stats stats_;
+  /** The aggregated stats. */
+  std::list<tdb_shared_ptr<stats::Stats>> registered_stats_;
 
   /* ****************************** */
   /*       PRIVATE FUNCTIONS        */
@@ -291,6 +293,9 @@ class GlobalStats {
 
   /** Dump the current vfs stats. */
   std::string dump_vfs() const;
+
+  /** Dump the current registered stats. */
+  std::string dump_registered_stats() const;
 
   /** Parse a comma-separated string of enum names. */
   std::vector<std::string> parse_enum_names(

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -151,10 +151,6 @@ class Consolidator {
       const void* encryption_key,
       uint32_t key_length);
 
-  /* ********************************* */
-  /*          STATIC FUNCTIONS         */
-  /* ********************************* */
-
  private:
   /* ********************************* */
   /*        PRIVATE ATTRIBUTES         */

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -40,6 +40,7 @@
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/tile_overlap.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/subarray/subarray_tile_overlap.h"
 
 #include <cmath>
@@ -171,7 +172,10 @@ class Subarray {
    * @param coalesce_ranges When enabled, ranges will attempt to coalesce
    *     with existing ranges as they are added.
    */
-  Subarray(const Array* array, bool coalesce_ranges = true);
+  Subarray(
+      const Array* array,
+      stats::Stats* parent_stats,
+      bool coalesce_ranges = true);
 
   /**
    * Constructor.
@@ -183,7 +187,11 @@ class Subarray {
    * @param coalesce_ranges When enabled, ranges will attempt to coalesce
    *     with existing ranges as they are added.
    */
-  Subarray(const Array* array, Layout layout, bool coalesce_ranges = true);
+  Subarray(
+      const Array* array,
+      Layout layout,
+      stats::Stats* parent_stats,
+      bool coalesce_ranges = true);
 
   /**
    * Copy constructor. This performs a deep copy (including memcpy of
@@ -744,6 +752,9 @@ class Subarray {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /** The class stats. */
+  stats::Stats* stats_;
 
   /** The array the subarray object is associated with. */
   const Array* array_;

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -54,6 +54,7 @@
 using namespace tiledb;
 using namespace tiledb::common;
 using namespace tiledb::sm;
+using namespace tiledb::sm::stats;
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -64,11 +65,13 @@ SubarrayPartitioner::SubarrayPartitioner() = default;
 SubarrayPartitioner::SubarrayPartitioner(
     const Config* const config,
     const Subarray& subarray,
-    uint64_t memory_budget,
-    uint64_t memory_budget_var,
-    uint64_t memory_budget_validity,
-    ThreadPool* const compute_tp)
-    : config_(config)
+    const uint64_t memory_budget,
+    const uint64_t memory_budget_var,
+    const uint64_t memory_budget_validity,
+    ThreadPool* const compute_tp,
+    Stats* const parent_stats)
+    : stats_(parent_stats->create_child("SubarrayPartitioner"))
+    , config_(config)
     , subarray_(subarray)
     , memory_budget_(memory_budget)
     , memory_budget_var_(memory_budget_var)
@@ -728,6 +731,7 @@ void SubarrayPartitioner::calibrate_current_start_end(bool* must_split_slab) {
 
 SubarrayPartitioner SubarrayPartitioner::clone() const {
   SubarrayPartitioner clone;
+  clone.stats_ = stats_;
   clone.config_ = config_;
   clone.subarray_ = subarray_;
   clone.budget_ = budget_;
@@ -778,6 +782,7 @@ Status SubarrayPartitioner::compute_current_start_end(bool* found) {
       &memory_sizes,
       compute_tp_));
 
+  bool done = false;
   current_.start_ = tile_overlap->range_idx_start();
   for (current_.end_ = tile_overlap->range_idx_start();
        current_.end_ <= tile_overlap->range_idx_end();
@@ -799,23 +804,52 @@ Status SubarrayPartitioner::compute_current_start_end(bool* found) {
           mem_size.size_fixed_ > memory_budget_ ||
           mem_size.size_var_ > memory_budget_var_ ||
           mem_size.size_validity_ > memory_budget_validity_) {
-        // Cannot find range that fits in the buffer
-        if (current_.end_ == current_.start_) {
-          *found = false;
-          return Status::Ok();
+        if (cur_size.size_fixed_ > budget.size_fixed_) {
+          stats_->add_counter(
+              "compute_current_start_end.fixed_result_size_overflow", 1);
+        } else if (cur_size.size_var_ > budget.size_var_) {
+          stats_->add_counter(
+              "compute_current_start_end.var_result_size_overflow", 1);
+        } else if (cur_size.size_validity_ > budget.size_validity_) {
+          stats_->add_counter(
+              "compute_current_start_end.validity_result_size_overflow", 1);
+        } else if (mem_size.size_fixed_ > memory_budget_) {
+          stats_->add_counter(
+              "compute_current_start_end.fixed_tile_size_overflow", 1);
+        } else if (mem_size.size_var_ > memory_budget_var_) {
+          stats_->add_counter(
+              "compute_current_start_end.var_tile_size_overflow", 1);
+        } else if (mem_size.size_validity_ > memory_budget_validity_) {
+          stats_->add_counter(
+              "compute_current_start_end.validity_tile_size_overflow", 1);
         }
 
-        // Range found, make it inclusive
-        current_.end_--;
-        *found = true;
-        return Status::Ok();
+        done = true;
+        break;
       }
+    }
+
+    if (done) {
+      break;
     }
   }
 
-  // Range found, make it inclusive
-  current_.end_--;
-  *found = true;
+  *found = current_.end_ != current_.start_;
+  if (*found) {
+    // If the range was found, make it inclusive before returning.
+    current_.end_--;
+
+    stats_->add_counter("compute_current_start_end.found", 1);
+    stats_->add_counter(
+        "compute_current_start_end.ranges",
+        tile_overlap->range_idx_end() - tile_overlap->range_idx_start() + 1);
+    stats_->add_counter(
+        "compute_current_start_end.adjusted_ranges",
+        current_.end_ - current_.start_ + 1);
+
+  } else {
+    stats_->add_counter("compute_current_start_end.not_found", 1);
+  }
 
   return Status::Ok();
 }
@@ -1266,6 +1300,7 @@ Status SubarrayPartitioner::split_top_multi_range(bool* unsplittable) {
 }
 
 void SubarrayPartitioner::swap(SubarrayPartitioner& partitioner) {
+  std::swap(stats_, partitioner.stats_);
   std::swap(config_, partitioner.config_);
   std::swap(subarray_, partitioner.subarray_);
   std::swap(budget_, partitioner.budget_);

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -38,6 +38,7 @@
 #include <unordered_map>
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/subarray/subarray.h"
 
 using namespace tiledb::common;
@@ -167,7 +168,8 @@ class SubarrayPartitioner {
       uint64_t memory_budget,
       uint64_t memory_budget_var,
       uint64_t memory_budget_validity,
-      ThreadPool* compute_tp);
+      ThreadPool* compute_tp,
+      stats::Stats* parent_stats);
 
   /** Destructor. */
   ~SubarrayPartitioner();
@@ -328,6 +330,9 @@ class SubarrayPartitioner {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /** The class stats. */
+  stats::Stats* stats_;
 
   /** The config. */
   const Config* config_;


### PR DESCRIPTION
TYPE: IMPROVEMENT
DESC: Added additional stats for subarrays and subarray partitioners

---

This adds new stats to the Subarray and SubarrayPartitioner classes, using
the new-style `Stats` object.

This adds a number of usability improvements for the new-style stats:

- I had to remove the calls to `__func__` because they were resolving to
non-useful strings like "operator()" instead of the function name in some
scenarios.

- The `Stats::start_timer` now returns an object that ends the timer when it
goes out of scope. There are existing problems where a timer is started but
never ends because the routine returns before reaching the `Stats::end_timer`.

- Moves `Stats::end_timer` into the private scope.

- Introduces `ScopedExecutor` class, which generally executes a bound function
on destruction. This is a generically useful data structure but is used for
ending timers.

- `Stats` objects are now trees. The `Stats::dump()` API will now aggregate/flatten
all stats in itself and its children for the output. The motivation is to keep
stats separately so that there isn't contention on a lock. For example, if we had
`10` Subarray instances all attempting to increment the same counter on
different threads, we would impact performance.

- Removed the `Stats::append` because it no longer needed. Same with `Stats::reset`
and the copy/move implementations.

- The global states dumps each `Stats` instance individually. I wasn't sure
if we wanted to try to combine all of its `Stats` instances.

---

Finally, here's some example output:
```
--- Counters ---

Reader.SubarrayPartitioner.compute_current_start_end.var_tile_size_overflow: 1
Reader.SubarrayPartitioner.compute_current_start_end.ranges: 131072
Reader.SubarrayPartitioner.compute_current_start_end.found: 1
Reader.SubarrayPartitioner.compute_current_start_end.adjusted_ranges: 2831
Reader.Subarray.precompute_tile_overlap.tile_overlap_byte_size: 338813216
Reader.Subarray.precompute_tile_overlap.relevant_fragment_num: 16
Reader.Subarray.precompute_tile_overlap.ranges_requested: 244400
Reader.Subarray.precompute_tile_overlap.ranges_computed: 131072
Reader.Subarray.precompute_tile_overlap.fragment_num: 48
Reader.Subarray.precompute_tile_overlap.count: 1
```
