### PR TITLE
check_pr_body workflow: handle single/double/back quotes

### DIFF
--- a/.github/workflows/check-pr-body.yml
+++ b/.github/workflows/check-pr-body.yml
@@ -11,4 +11,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2
       - name: Run PR body checker
-        run: python ./scripts/parse_pr.py "${{ github.event.pull_request.body }}"
+        run: |
+          cat <<'EOF' | scripts/parse_pr.py
+          ${{ github.event.pull_request.body }}
+          EOF

--- a/scripts/parse_pr.py
+++ b/scripts/parse_pr.py
@@ -1,4 +1,5 @@
-import argparse
+#!/usr/bin/env python3
+
 import itertools as it
 import sys
 from operator import itemgetter
@@ -47,16 +48,17 @@ def parse_pr_body(
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Check PR description")
-    parser.add_argument("body", help="The PR text description body")
-    args = parser.parse_args()
+    if len(sys.argv) > 1:
+        body = sys.argv[1]
+    else:
+        body = sys.stdin.read()
 
     # If the reserved keyword "NO_HISTORY" is included anywhere in the PR body,
     # do not check it for validity or modify the history
-    if "NO_HISTORY" in args.body:
+    if "NO_HISTORY" in body:
         return
 
-    header_descriptions = parse_pr_body(args.body)
+    header_descriptions = parse_pr_body(body)
     if not header_descriptions:
         raise ValueError(f"Unable to locate history annotation in PR body")
 

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import logging
 import re


### PR DESCRIPTION
- Fix `check_pr_body` to handle embedded quotes in the PR description (e.g. https://github.com/TileDB-Inc/TileDB/runs/2309130505?check_suite_focus=true)
- Make `parse_pr.py` and `prepare_release.py` scripts executable

---
TYPE: NO_HISTORY
