### PR TITLE
Config param to skip splitting on estimated result sizes

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -243,6 +243,7 @@ void check_save_to_file() {
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.read_range_oob error\n";
   ss << "sm.skip_checksum_validation false\n";
+  ss << "sm.skip_est_size_partitioning false\n";
   ss << "sm.sub_partitioner_memory_budget 0\n";
   ss << "sm.tile_cache_size 10000000\n";
   ss << "sm.vacuum.mode fragments\n";
@@ -524,6 +525,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.check_coord_oob"] = "true";
   all_param_values["sm.check_global_order"] = "true";
   all_param_values["sm.tile_cache_size"] = "100";
+  all_param_values["sm.skip_est_size_partitioning"] = "false";
   all_param_values["sm.memory_budget"] = "5368709120";
   all_param_values["sm.memory_budget_var"] = "10737418240";
   all_param_values["sm.sub_partitioner_memory_budget"] = "0";

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -69,6 +69,7 @@ const std::string Config::SM_CHECK_COORD_OOB = "true";
 const std::string Config::SM_READ_RANGE_OOB = "error";
 const std::string Config::SM_CHECK_GLOBAL_ORDER = "true";
 const std::string Config::SM_TILE_CACHE_SIZE = "10000000";
+const std::string Config::SM_SKIP_EST_SIZE_PARTITIONING = "false";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
 const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
 const std::string Config::SM_SUB_PARTITIONER_MEMORY_BUDGET = "0";
@@ -194,6 +195,8 @@ Config::Config() {
   param_values_["sm.read_range_oob"] = SM_READ_RANGE_OOB;
   param_values_["sm.check_global_order"] = SM_CHECK_GLOBAL_ORDER;
   param_values_["sm.tile_cache_size"] = SM_TILE_CACHE_SIZE;
+  param_values_["sm.skip_est_size_partitioning"] =
+      SM_SKIP_EST_SIZE_PARTITIONING;
   param_values_["sm.memory_budget"] = SM_MEMORY_BUDGET;
   param_values_["sm.memory_budget_var"] = SM_MEMORY_BUDGET_VAR;
   param_values_["sm.sub_partitioner_memory_budget"] =

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -118,6 +118,9 @@ class Config {
   /** The tile cache size. */
   static const std::string SM_TILE_CACHE_SIZE;
 
+  /** If `true`, bypass partitioning on estimated result sizes. */
+  static const std::string SM_SKIP_EST_SIZE_PARTITIONING;
+
   /**
    * The maximum memory budget for producing the result (in bytes)
    * for a fixed-sized attribute or the offsets of a var-sized attribute.

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -356,6 +356,12 @@ class SubarrayPartitioner {
   /** The memory budget for the validity vectors. */
   uint64_t memory_budget_validity_;
 
+  /**
+   * If true, do not consider estimated result sizes when
+   * determining if a partition should be split.
+   */
+  bool skip_split_on_est_size_;
+
   /** The thread pool for compute-bound tasks. */
   ThreadPool* compute_tp_;
 


### PR DESCRIPTION
This introduces a new, advanced config parameter "sm.skip_est_size_partitioning".
This is intentionally undocumented in the c/cpp-api headers because it is an
advanced tuning parameter. This is useful for reads where the result size
estimate is too large and causes unnecessary partition splits.

---

TYPE: IMPROVEMENT
DESC: Introduces config parameter "sm.skip_est_size_partitioning"