### PR TITLE
AWS S3: adding option to skip Aws::InitAPI

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -283,6 +283,7 @@ void check_save_to_file() {
   ss << "vfs.s3.request_timeout_ms 3000\n";
   ss << "vfs.s3.requester_pays false\n";
   ss << "vfs.s3.scheme https\n";
+  ss << "vfs.s3.skip_init false\n";
   ss << "vfs.s3.use_multipart_upload true\n";
   ss << "vfs.s3.use_virtual_addressing true\n";
   ss << "vfs.s3.verify_ssl true\n";
@@ -584,6 +585,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.s3.aws_session_name"] = "";
   all_param_values["vfs.s3.endpoint_override"] = "";
   all_param_values["vfs.s3.use_virtual_addressing"] = "true";
+  all_param_values["vfs.s3.skip_init"] = "false";
   all_param_values["vfs.s3.use_multipart_upload"] = "true";
   all_param_values["vfs.s3.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -644,6 +646,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.aws_session_name"] = "";
   vfs_param_values["s3.endpoint_override"] = "";
   vfs_param_values["s3.use_virtual_addressing"] = "true";
+  vfs_param_values["s3.skip_init"] = "false";
   vfs_param_values["s3.use_multipart_upload"] = "true";
   vfs_param_values["s3.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -698,6 +701,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["aws_session_name"] = "";
   s3_param_values["endpoint_override"] = "";
   s3_param_values["use_virtual_addressing"] = "true";
+  s3_param_values["skip_init"] = "false";
   s3_param_values["use_multipart_upload"] = "true";
   s3_param_values["max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -879,11 +883,19 @@ TEST_CASE(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_config_set(config, "vfs.s3.use_virtual_addressing", "True", &err);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_config_set(config, "vfs.s3.skip_init", "FALSE", &err);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_config_set(config, "vfs.s3.skip_init", "False", &err);
+  CHECK(rc == TILEDB_OK);
   rc =
       tiledb_config_set(config, "vfs.s3.use_virtual_addressing", "FALSE", &err);
   CHECK(rc == TILEDB_OK);
   rc =
       tiledb_config_set(config, "vfs.s3.use_virtual_addressing", "False", &err);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_config_set(config, "vfs.s3.skit_init", "TRUE", &err);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_config_set(config, "vfs.s3.skip_init", "True", &err);
   CHECK(rc == TILEDB_OK);
 
   rc = tiledb_config_set(config, "vfs.s3.use_multipart_upload", "TRUE", &err);

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -61,7 +61,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 54);
+  CHECK(names.size() == 55);
 }
 
 TEST_CASE(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1112,6 +1112,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The S3 use of virtual addressing (`true` or `false`), if S3 is
  *    enabled. <br>
  *    **Default**: true
+ * - `vfs.s3.skip_init` <br>
+ *    Skip Aws::InitAPI for the S3 layer (`true` or `false`) <br>
+ *    **Default**: false
  * - `vfs.s3.use_multipart_upload` <br>
  *    The S3 use of multi-part upload requests (`true` or `false`), if S3 is
  *    enabled. <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -126,6 +126,7 @@ const std::string Config::VFS_S3_AWS_SESSION_NAME = "";
 const std::string Config::VFS_S3_SCHEME = "https";
 const std::string Config::VFS_S3_ENDPOINT_OVERRIDE = "";
 const std::string Config::VFS_S3_USE_VIRTUAL_ADDRESSING = "true";
+const std::string Config::VFS_S3_SKIP_INIT = "false";
 const std::string Config::VFS_S3_USE_MULTIPART_UPLOAD = "true";
 const std::string Config::VFS_S3_MAX_PARALLEL_OPS =
     Config::SM_IO_CONCURRENCY_LEVEL;
@@ -261,6 +262,7 @@ Config::Config() {
   param_values_["vfs.s3.endpoint_override"] = VFS_S3_ENDPOINT_OVERRIDE;
   param_values_["vfs.s3.use_virtual_addressing"] =
       VFS_S3_USE_VIRTUAL_ADDRESSING;
+  param_values_["vfs.s3.skip_init"] = VFS_S3_SKIP_INIT;
   param_values_["vfs.s3.use_multipart_upload"] = VFS_S3_USE_MULTIPART_UPLOAD;
   param_values_["vfs.s3.max_parallel_ops"] = VFS_S3_MAX_PARALLEL_OPS;
   param_values_["vfs.s3.multipart_part_size"] = VFS_S3_MULTIPART_PART_SIZE;
@@ -555,6 +557,8 @@ Status Config::unset(const std::string& param) {
   } else if (param == "vfs.s3.use_virtual_addressing") {
     param_values_["vfs.s3.use_virtual_addressing"] =
         VFS_S3_USE_VIRTUAL_ADDRESSING;
+  } else if (param == "vfs.s3.skip_init") {
+    param_values_["vfs.s3.skip_init"] = VFS_S3_SKIP_INIT;
   } else if (param == "vfs.s3.use_multipart_upload") {
     param_values_["vfs.s3.use_multipart_upload"] = VFS_S3_USE_MULTIPART_UPLOAD;
   } else if (param == "vfs.s3.max_parallel_ops") {
@@ -711,6 +715,8 @@ Status Config::sanity_check(
       return LOG_STATUS(
           Status::ConfigError("Invalid S3 scheme parameter value"));
   } else if (param == "vfs.s3.use_virtual_addressing") {
+    RETURN_NOT_OK(utils::parse::convert(value, &v));
+  } else if (param == "vfs.s3.skit_init") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "vfs.s3.use_multipart_upload") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -325,6 +325,9 @@ class Config {
   /** Use virtual addressing (false for minio, true for AWS S3). */
   static const std::string VFS_S3_USE_VIRTUAL_ADDRESSING;
 
+  /** S3 skip init. */
+  static const std::string VFS_S3_SKIP_INIT;
+
   /** Use virtual addressing (true). */
   static const std::string VFS_S3_USE_MULTIPART_UPLOAD;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -480,6 +480,9 @@ class Config {
    *    The S3 use of virtual addressing (`true` or `false`), if S3 is
    *    enabled. <br>
    *    **Default**: true
+   * - `vfs.s3.skip_init` <br>
+   *    Skip Aws::InitAPI for the S3 layer (`true` or `false`) <br>
+   *    **Default**: false
    * - `vfs.s3.use_multipart_upload` <br>
    *    The S3 use of multi-part upload requests (`true` or `false`), if S3 is
    *    enabled. <br>

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -164,8 +164,13 @@ Status S3::init(const Config& config, ThreadPool* const thread_pool) {
   // unexpectedly.
   options_.httpOptions.installSigPipeHandler = true;
 
+  bool skip_init;
+  RETURN_NOT_OK(config.get<bool>("vfs.s3.skip_init", &skip_init, &found));
+  assert(found);
+
   // Initialize the library once per process.
-  std::call_once(aws_lib_initialized, [this]() { Aws::InitAPI(options_); });
+  if (!skip_init)
+    std::call_once(aws_lib_initialized, [this]() { Aws::InitAPI(options_); });
 
   if (options_.loggingOptions.logLevel != Aws::Utils::Logging::LogLevel::Off) {
     Aws::Utils::Logging::InitializeAWSLogging(


### PR DESCRIPTION
Some developers are initializing AWS S3 before entering tileDB. Giving
them the option to skip Aws::InitAPI in our configuration.

---
TYPE: IMPROVEMENT
DESC: AWS S3: adding option to skip Aws::InitAPI
