### PR TITLE
[Backport release-2.2] Limit `TileOverlap` instances while partitioning

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 
 ## Improvements
 
+* Reduces memory usage in multi-range range reads [#2165](https://github.com/TileDB-Inc/TileDB/pull/2165)
 * Add config option `sm.read_range_oob` to toggle bounding read ranges to domain or erroring [#2162](https://github.com/TileDB-Inc/TileDB/pull/2162)
 
 ## Deprecations

--- a/test/src/unit-SubarrayPartitioner-dense.cc
+++ b/test/src/unit-SubarrayPartitioner-dense.cc
@@ -253,8 +253,9 @@ void SubarrayPartitionerDenseFx::test_subarray_partitioner(
 
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), budget);
   CHECK(st.ok());
 
@@ -274,8 +275,9 @@ void SubarrayPartitionerDenseFx::test_subarray_partitioner(
 
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
 
   // Note: this is necessary, otherwise the subarray partitioner does
   // not check if the memory budget is exceeded for attributes whose
@@ -548,8 +550,9 @@ TEST_CASE_METHOD(
 
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
   auto st = subarray_partitioner.set_result_budget("a", 100 * sizeof(int));
   CHECK(st.ok());
   st = subarray_partitioner.set_result_budget("b", 1, 1);

--- a/test/src/unit-SubarrayPartitioner-error.cc
+++ b/test/src/unit-SubarrayPartitioner-error.cc
@@ -131,8 +131,9 @@ TEST_CASE_METHOD(
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
   uint64_t budget, budget_off, budget_val;
 
   auto st = subarray_partitioner.get_result_budget("a", &budget);

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -344,8 +344,9 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
 
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), budget);
   CHECK(st.ok());
 
@@ -367,8 +368,9 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
 
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget, memory_budget_var, 0, &tp);
+      &config, subarray, memory_budget, memory_budget_var, 0, &tp);
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), result_budget);
   CHECK(st.ok());
 
@@ -388,8 +390,9 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
 
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
 
   // Note: this is necessary, otherwise the subarray partitioner does
   // not check if the memory budget is exceeded for attributes whose
@@ -662,8 +665,9 @@ TEST_CASE_METHOD(
 
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner subarray_partitioner(
-      subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
   auto st = subarray_partitioner.set_result_budget("a", 100);
   CHECK(st.ok());
   st = subarray_partitioner.set_result_budget("b", 1, 1);
@@ -2256,8 +2260,9 @@ TEST_CASE_METHOD(
   subarray.add_range(0, std::move(r), true);
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner partitioner(
-      subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
   auto st = partitioner.set_result_budget("d", 10);
   CHECK(!st.ok());
   uint64_t budget = 0;
@@ -2284,7 +2289,7 @@ TEST_CASE_METHOD(
   r.set_str_range("a", "bb");
   subarray_full.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_full(
-      subarray_full, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray_full, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_full.set_result_budget("d", 16, 4);
   CHECK(st.ok());
   CHECK(partitioner_full.get_result_budget("d", &budget_off, &budget_val).ok());
@@ -2304,7 +2309,7 @@ TEST_CASE_METHOD(
   r.set_str_range("a", "bb");
   subarray_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split(
-      subarray_split, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray_split, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_split.set_result_budget("d", 10, 4);
   CHECK(st.ok());
   CHECK(
@@ -2334,7 +2339,7 @@ TEST_CASE_METHOD(
   r.set_str_range("bb", "cc");
   subarray_no_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_no_split(
-      subarray_no_split, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray_no_split, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_no_split.set_result_budget("d", 16, 10);
   CHECK(st.ok());
   CHECK(partitioner_no_split.get_result_budget("d", &budget_off, &budget_val)
@@ -2356,7 +2361,7 @@ TEST_CASE_METHOD(
   r.set_str_range("bb", "cc");
   subarray_split_2.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split_2(
-      subarray_split_2, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray_split_2, memory_budget_, memory_budget_var_, 0, &tp);
   st = partitioner_split_2.set_result_budget("d", 8, 10);
   CHECK(st.ok());
   CHECK(partitioner_split_2.get_result_budget("d", &budget_off, &budget_val)
@@ -2485,8 +2490,9 @@ TEST_CASE_METHOD(
   subarray.add_range(0, std::move(r), true);
   ThreadPool tp;
   CHECK(tp.init(4).ok());
+  Config config;
   SubarrayPartitioner partitioner(
-      subarray, memory_budget_, memory_budget_var_, 0, &tp);
+      &config, subarray, memory_budget_, memory_budget_var_, 0, &tp);
   auto st = partitioner.set_result_budget("d", 10, 4);
   CHECK(st.ok());
   CHECK(partitioner.get_result_budget("d", &budget_off, &budget_val).ok());

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -233,6 +233,7 @@ void check_save_to_file() {
   ss << "sm.enable_signal_handlers true\n";
   ss << "sm.io_concurrency_level " << std::thread::hardware_concurrency()
      << "\n";
+  ss << "sm.max_tile_overlap_size 314572800\n";
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.num_tbb_threads -1\n";
@@ -501,6 +502,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.var_offsets.bitsize"] = "32";
   all_param_values["sm.var_offsets.extra_element"] = "true";
   all_param_values["sm.var_offsets.mode"] = "elements";
+  all_param_values["sm.max_tile_overlap_size"] = "314572800";
 
   all_param_values["vfs.min_batch_gap"] = "512000";
   all_param_values["vfs.min_batch_size"] = "20971520";

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -173,6 +173,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/cell_slab_iter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray_partitioner.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray_tile_overlap.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/chunked_buffer.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/generic_tile_io.cc

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2682,7 +2682,7 @@ int32_t tiledb_query_get_config(
     return TILEDB_OOM;
   }
 
-  *((*config)->config_) = query->query_->config();
+  *((*config)->config_) = *query->query_->config();
 
   // Success
   return TILEDB_OK;

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -90,6 +90,7 @@ const std::string Config::SM_VACUUM_MODE = "fragments";
 const std::string Config::SM_OFFSETS_BITSIZE = "64";
 const std::string Config::SM_OFFSETS_EXTRA_ELEMENT = "false";
 const std::string Config::SM_OFFSETS_FORMAT_MODE = "bytes";
+const std::string Config::SM_MAX_TILE_OVERLAP_SIZE = "314572800";  // 300MiB
 const std::string Config::VFS_MIN_PARALLEL_SIZE = "10485760";
 const std::string Config::VFS_MIN_BATCH_GAP = "512000";
 const std::string Config::VFS_MIN_BATCH_SIZE = "20971520";
@@ -217,6 +218,7 @@ Config::Config() {
   param_values_["sm.var_offsets.bitsize"] = SM_OFFSETS_BITSIZE;
   param_values_["sm.var_offsets.extra_element"] = SM_OFFSETS_EXTRA_ELEMENT;
   param_values_["sm.var_offsets.mode"] = SM_OFFSETS_FORMAT_MODE;
+  param_values_["sm.max_tile_overlap_size"] = SM_MAX_TILE_OVERLAP_SIZE;
   param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
@@ -474,6 +476,8 @@ Status Config::unset(const std::string& param) {
     param_values_["sm.var_offsets.extra_element"] = SM_OFFSETS_EXTRA_ELEMENT;
   } else if (param == "sm.var_offsets.mode") {
     param_values_["sm.var_offsets.mode"] = SM_OFFSETS_FORMAT_MODE;
+  } else if (param == "sm.max_tile_overlap_size") {
+    param_values_["sm.max_tile_overlap_size"] = SM_MAX_TILE_OVERLAP_SIZE;
   } else if (param == "vfs.min_parallel_size") {
     param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
   } else if (param == "vfs.min_batch_gap") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -220,6 +220,11 @@ class Config {
    */
   static const std::string SM_OFFSETS_FORMAT_MODE;
 
+  /**
+   * The maximum estimated size of the internal tile overlap structure.
+   */
+  static const std::string SM_MAX_TILE_OVERLAP_SIZE;
+
   /** The default minimum number of bytes in a parallel VFS operation. */
   static const std::string VFS_MIN_PARALLEL_SIZE;
 

--- a/tiledb/sm/misc/tile_overlap.h
+++ b/tiledb/sm/misc/tile_overlap.h
@@ -34,9 +34,8 @@
 #define TILEDB_TILE_OVERLAP_H
 
 #include <cinttypes>
+#include <cstddef>
 #include <vector>
-
-using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {
@@ -53,8 +52,19 @@ struct TileOverlap {
    * indicates full overlap and 0.0 no overlap at all.
    */
   std::vector<std::pair<uint64_t, double>> tiles_;
+
   /** Ranges of tile ids that lie completely inside the subarray range. */
   std::vector<std::pair<uint64_t, uint64_t>> tile_ranges_;
+
+  /** Returns the current byte size of an instance. */
+  size_t byte_size() const {
+    static const uint64_t tiles_element_size =
+        sizeof(std::pair<uint64_t, double>);
+    static const uint64_t tile_ranges_element_size =
+        sizeof(std::pair<uint64_t, uint64_t>);
+    return sizeof(TileOverlap) + (tiles_.size() * tiles_element_size) +
+           (tile_ranges_.size() * tile_ranges_element_size);
+  }
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -979,7 +979,7 @@ Status Query::set_subarray(const void* subarray) {
 
     // Get read_range_oob config setting
     bool found = false;
-    std::string read_range_oob = config().get("sm.read_range_oob", &found);
+    std::string read_range_oob = config()->get("sm.read_range_oob", &found);
     assert(found);
     if (read_range_oob != "error" && read_range_oob != "warn")
       return LOG_STATUS(Status::QueryError(
@@ -1071,7 +1071,7 @@ QueryType Query::type() const {
   return type_;
 }
 
-const Config& Query::config() const {
+const Config* Query::config() const {
   if (type_ == QueryType::READ)
     return reader_.config();
   else

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -498,7 +498,7 @@ class Query {
    *
    * @return Config from query
    */
-  const Config& config() const;
+  const Config* config() const;
 
   /**
    * Sets the buffer for a fixed-sized attribute/dimension.

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -443,11 +443,8 @@ class Reader {
   /** Sets config for query-level parameters only. */
   Status set_config(const Config& config);
 
-  /**
-   * Get the config of the writer
-   * @return Config
-   */
-  const Config& config() const;
+  /** Returns the internal config. */
+  const Config* config() const;
 
   /**
    * Sets the cell layout of the query. The function will return an error

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -3650,8 +3650,8 @@ Status Writer::calculate_hilbert_values(
   return Status::Ok();
 }
 
-const Config& Writer::config() const {
-  return config_;
+const Config* Writer::config() const {
+  return &config_;
 }
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -344,7 +344,7 @@ class Writer {
    * Get the config of the writer
    * @return Config
    */
-  const Config& config() const;
+  const Config* config() const;
 
   /** Sets current setting of check_coord_dups_ */
   void set_check_coord_dups(bool b);

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -63,7 +63,6 @@ Subarray::Subarray() {
   cell_order_ = Layout::ROW_MAJOR;
   est_result_size_computed_ = false;
   coalesce_ranges_ = true;
-  tile_overlap_range_offset_ = 0;
 }
 
 Subarray::Subarray(const Array* array, bool coalesce_ranges)
@@ -74,7 +73,6 @@ Subarray::Subarray(const Array* array, Layout layout, bool coalesce_ranges)
     : array_(array)
     , layout_(layout)
     , coalesce_ranges_(coalesce_ranges) {
-  tile_overlap_range_offset_ = 0;
   est_result_size_computed_ = false;
   cell_order_ = array_->array_schema()->cell_order();
   add_default_ranges();
@@ -124,8 +122,7 @@ Status Subarray::add_range(
 
   // Must reset the result size and tile overlap
   est_result_size_computed_ = false;
-  tile_overlap_ = nullptr;
-  tile_overlap_range_offset_ = 0;
+  tile_overlap_.clear();
 
   // Remove the default range
   if (is_default_[dim_idx]) {
@@ -148,8 +145,7 @@ Status Subarray::add_range(
 Status Subarray::add_range_unsafe(uint32_t dim_idx, const Range& range) {
   // Must reset the result size and tile overlap
   est_result_size_computed_ = false;
-  tile_overlap_ = nullptr;
-  tile_overlap_range_offset_ = 0;
+  tile_overlap_.clear();
 
   // Remove the default range
   if (is_default_[dim_idx]) {
@@ -262,8 +258,7 @@ void Subarray::clear() {
   ranges_.clear();
   range_offsets_.clear();
   est_result_size_computed_ = false;
-  tile_overlap_ = nullptr;
-  tile_overlap_range_offset_ = 0;
+  tile_overlap_.clear();
   add_or_coalesce_range_func_.clear();
 }
 
@@ -424,11 +419,8 @@ Subarray Subarray::get_subarray(uint64_t start, uint64_t end) const {
     }
   }
 
-  // The `tile_overlap_` is a shared pointer that is shared between
-  // subarray and its partitions. This is an optimization to prevent
-  // duplicate memory among subarray instances.
   ret.tile_overlap_ = tile_overlap_;
-  ret.tile_overlap_range_offset_ = start;
+  ret.tile_overlap_.update_range(start, end);
 
   // Compute range offsets
   ret.compute_range_offsets();
@@ -503,7 +495,10 @@ Layout Subarray::layout() const {
 }
 
 Status Subarray::get_est_result_size(
-    const char* name, uint64_t* size, ThreadPool* const compute_tp) {
+    const char* name,
+    uint64_t* size,
+    const Config* const config,
+    ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
     return LOG_STATUS(
@@ -539,7 +534,7 @@ Status Subarray::get_est_result_size(
                               "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
-  RETURN_NOT_OK(compute_est_result_size(compute_tp));
+  RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
   *size = static_cast<uint64_t>(ceil(est_result_size_[name].size_fixed_));
 
   // If the size is non-zero, ensure it is large enough to
@@ -555,6 +550,7 @@ Status Subarray::get_est_result_size(
     const char* name,
     uint64_t* size_off,
     uint64_t* size_val,
+    const Config* const config,
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
@@ -591,7 +587,7 @@ Status Subarray::get_est_result_size(
                               "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
-  RETURN_NOT_OK(compute_est_result_size(compute_tp));
+  RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
   *size_off = static_cast<uint64_t>(ceil(est_result_size_[name].size_fixed_));
   *size_val = static_cast<uint64_t>(ceil(est_result_size_[name].size_var_));
 
@@ -617,6 +613,7 @@ Status Subarray::get_est_result_size_nullable(
     const char* name,
     uint64_t* size,
     uint64_t* size_validity,
+    const Config* const config,
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
@@ -652,7 +649,7 @@ Status Subarray::get_est_result_size_nullable(
                               "Attribute must be nullable"));
 
   // Compute tile overlap for each fragment
-  RETURN_NOT_OK(compute_est_result_size(compute_tp));
+  RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
   *size = static_cast<uint64_t>(ceil(est_result_size_[name].size_fixed_));
   *size_validity =
       static_cast<uint64_t>(ceil(est_result_size_[name].size_validity_));
@@ -673,6 +670,7 @@ Status Subarray::get_est_result_size_nullable(
     uint64_t* size_off,
     uint64_t* size_val,
     uint64_t* size_validity,
+    const Config* const config,
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
@@ -708,7 +706,7 @@ Status Subarray::get_est_result_size_nullable(
                               "Attribute must be nullable"));
 
   // Compute tile overlap for each fragment
-  RETURN_NOT_OK(compute_est_result_size(compute_tp));
+  RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
   *size_off = static_cast<uint64_t>(ceil(est_result_size_[name].size_fixed_));
   *size_val = static_cast<uint64_t>(ceil(est_result_size_[name].size_var_));
   *size_validity =
@@ -738,7 +736,10 @@ Status Subarray::get_est_result_size_nullable(
 }
 
 Status Subarray::get_max_memory_size(
-    const char* name, uint64_t* size, ThreadPool* const compute_tp) {
+    const char* name,
+    uint64_t* size,
+    const Config* const config,
+    ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
     return LOG_STATUS(Status::SubarrayError(
@@ -772,7 +773,7 @@ Status Subarray::get_max_memory_size(
                               "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
-  compute_est_result_size(compute_tp);
+  compute_est_result_size(config, compute_tp);
   *size = max_mem_size_[name].size_fixed_;
 
   return Status::Ok();
@@ -782,6 +783,7 @@ Status Subarray::get_max_memory_size(
     const char* name,
     uint64_t* size_off,
     uint64_t* size_val,
+    const Config* const config,
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
@@ -816,7 +818,7 @@ Status Subarray::get_max_memory_size(
                               "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
-  compute_est_result_size(compute_tp);
+  compute_est_result_size(config, compute_tp);
   *size_off = max_mem_size_[name].size_fixed_;
   *size_val = max_mem_size_[name].size_var_;
 
@@ -827,6 +829,7 @@ Status Subarray::get_max_memory_size_nullable(
     const char* name,
     uint64_t* size,
     uint64_t* size_validity,
+    const Config* const config,
     ThreadPool* const compute_tp) {
   // Check attribute name
   if (name == nullptr)
@@ -860,7 +863,7 @@ Status Subarray::get_max_memory_size_nullable(
                               "Attribute must be nullable"));
 
   // Compute tile overlap for each fragment
-  compute_est_result_size(compute_tp);
+  compute_est_result_size(config, compute_tp);
   *size = max_mem_size_[name].size_fixed_;
   *size_validity = max_mem_size_[name].size_validity_;
 
@@ -872,6 +875,7 @@ Status Subarray::get_max_memory_size_nullable(
     uint64_t* size_off,
     uint64_t* size_val,
     uint64_t* size_validity,
+    const Config* const config,
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
@@ -905,7 +909,7 @@ Status Subarray::get_max_memory_size_nullable(
                               "Attribute must be nullable"));
 
   // Compute tile overlap for each fragment
-  compute_est_result_size(compute_tp);
+  compute_est_result_size(config, compute_tp);
   *size_off = max_mem_size_[name].size_fixed_;
   *size_val = max_mem_size_[name].size_var_;
   *size_validity = max_mem_size_[name].size_validity_;
@@ -984,8 +988,9 @@ uint64_t Subarray::range_num() const {
     return 0;
 
   uint64_t ret = 1;
-  for (const auto& r : ranges_)
+  for (const auto& r : ranges_) {
     ret *= r.size();
+  }
 
   return ret;
 }
@@ -1134,16 +1139,6 @@ const std::vector<std::vector<uint8_t>>& Subarray::tile_coords() const {
   return tile_coords_;
 }
 
-const std::vector<std::vector<TileOverlap>>& Subarray::tile_overlap() const {
-  assert(tile_overlap_ != nullptr);
-  return *tile_overlap_;
-}
-
-uint64_t Subarray::overlap_range_offset() const {
-  assert(tile_overlap_ != nullptr);
-  return tile_overlap_range_offset_;
-}
-
 template <class T>
 Status Subarray::compute_tile_coords() {
   STATS_START_TIMER(stats::Stats::TimerType::READ_COMPUTE_TILE_COORDS)
@@ -1166,6 +1161,10 @@ const T* Subarray::tile_coords_ptr(
   if (it == tile_coords_map_.end())
     return nullptr;
   return (const T*)&(tile_coords_[it->second][0]);
+}
+
+const SubarrayTileOverlap* Subarray::subarray_tile_overlap() const {
+  return &tile_overlap_;
 }
 
 Status Subarray::compute_relevant_fragment_est_result_sizes(
@@ -1291,19 +1290,21 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
 }
 
 std::unordered_map<std::string, Subarray::ResultSize>
-Subarray::get_est_result_size_map(ThreadPool* const compute_tp) {
+Subarray::get_est_result_size_map(
+    const Config* const config, ThreadPool* const compute_tp) {
   // If the result sizes have not been computed, compute them first
   if (!est_result_size_computed_)
-    compute_est_result_size(compute_tp);
+    compute_est_result_size(config, compute_tp);
 
   return est_result_size_;
 }
 
 std::unordered_map<std::string, Subarray::MemorySize>
-Subarray::get_max_mem_size_map(ThreadPool* const compute_tp) {
+Subarray::get_max_mem_size_map(
+    const Config* const config, ThreadPool* const compute_tp) {
   // If the result sizes have not been computed, compute them first
   if (!est_result_size_computed_)
-    compute_est_result_size(compute_tp);
+    compute_est_result_size(config, compute_tp);
 
   return max_mem_size_;
 }
@@ -1549,13 +1550,18 @@ void Subarray::compute_range_offsets() {
   }
 }
 
-Status Subarray::compute_est_result_size(ThreadPool* const compute_tp) {
+Status Subarray::compute_est_result_size(
+    const Config* const config, ThreadPool* const compute_tp) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_COMPUTE_EST_RESULT_SIZE)
 
   if (est_result_size_computed_)
     return Status::Ok();
 
-  RETURN_NOT_OK(compute_tile_overlap(compute_tp));
+  // TODO: This routine is used in the path for the C APIs that estimate
+  // result sizes. We need to refactor this routine to handle the scenario
+  // where `tile_overlap_` may be truncated to fit the memory budget.
+  RETURN_NOT_OK(
+      precompute_tile_overlap(0, range_num() - 1, config, compute_tp, true));
 
   // Prepare estimated result size vector for all
   // attributes/dimension and zipped coords
@@ -1672,16 +1678,20 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
     std::set<std::pair<unsigned, uint64_t>>* frag_tiles) {
   result_sizes->resize(names.size(), {0.0, 0.0, 0.0});
 
+  const uint64_t translated_range_idx =
+      range_idx - tile_overlap_.range_idx_start();
+
   // Compute estimated result
   auto fragment_num = (unsigned)relevant_fragments_.size();
   for (unsigned i = 0; i < fragment_num; ++i) {
     auto f = relevant_fragments_[i];
-    const auto& overlap = (*tile_overlap_)[f][range_idx];
+    const TileOverlap* const overlap =
+        tile_overlap_.at(f, translated_range_idx);
     auto meta = fragment_meta[f];
 
     // Parse tile ranges
     uint64_t tile_size = 0, tile_var_size = 0;
-    for (const auto& tr : overlap.tile_ranges_) {
+    for (const auto& tr : overlap->tile_ranges_) {
       for (uint64_t tid = tr.first; tid <= tr.second; ++tid) {
         for (size_t n = 0; n < names.size(); ++n) {
           // Zipped coords applicable only in homogeneous domains
@@ -1712,7 +1722,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
     }
 
     // Parse individual tiles
-    for (const auto& t : overlap.tiles_) {
+    for (const auto& t : overlap->tiles_) {
       auto tid = t.first;
       auto ratio = t.second;
       for (size_t n = 0; n < names.size(); ++n) {
@@ -1909,34 +1919,77 @@ Status Subarray::compute_tile_coords_row() {
   return Status::Ok();
 }
 
-Status Subarray::compute_tile_overlap(ThreadPool* const compute_tp) {
+Status Subarray::precompute_tile_overlap(
+    const uint64_t start_range_idx,
+    const uint64_t end_range_idx,
+    const Config* config,
+    ThreadPool* const compute_tp,
+    const bool override_memory_constraint) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_COMPUTE_TILE_OVERLAP)
 
-  const bool tile_overlap_computed = tile_overlap_ != nullptr;
-  if (tile_overlap_computed)
+  // If the `tile_overlap_` has already been precomputed and contains
+  // the given range, re-use it with new range.
+  const bool tile_overlap_computed =
+      tile_overlap_.contains_range(start_range_idx, end_range_idx);
+  if (tile_overlap_computed) {
+    tile_overlap_.update_range(start_range_idx, end_range_idx);
     return Status::Ok();
+  }
 
   compute_range_offsets();
 
-  // Initialization
-  auto tile_overlap = std::make_shared<std::vector<std::vector<TileOverlap>>>();
   auto meta = array_->fragment_metadata();
   auto fragment_num = meta.size();
-  tile_overlap->resize(fragment_num);
-  auto range_num = this->range_num();
-  for (unsigned i = 0; i < fragment_num; ++i)
-    (*tile_overlap)[i].resize(range_num);
 
-  // Compute relevant fragments to the subarray
-  RETURN_NOT_OK(compute_relevant_fragments(compute_tp));
+  // Lookup the target maximum tile overlap size.
+  bool found = false;
+  uint64_t max_tile_overlap_size = 0;
+  RETURN_NOT_OK(config->get<uint64_t>(
+      "sm.max_tile_overlap_size", &max_tile_overlap_size, &found));
+  assert(found);
 
-  // Load the R-Trees and compute tile overlap only for relevant fragments
-  RETURN_NOT_OK(load_relevant_fragment_rtrees(compute_tp));
-  RETURN_NOT_OK(
-      compute_relevant_fragment_tile_overlap(compute_tp, tile_overlap.get()));
+  uint64_t tile_overlap_start = start_range_idx;
+  uint64_t tile_overlap_end = end_range_idx;
 
-  tile_overlap_ = std::move(tile_overlap);
-  tile_overlap_range_offset_ = 0;
+  // Currently, we allow the caller to override the memory constraint
+  // imposed by `constants::max_tile_overlap_size`. This is temporary
+  // until we refactor for all callers to become aware that `tile_overlap_`
+  // may be truncated.
+  uint64_t tmp_tile_overlap_end = tile_overlap_start;
+  if (override_memory_constraint || fragment_num == 0) {
+    tmp_tile_overlap_end = tile_overlap_end;
+  }
+
+  // Incrementally compute the tile overlap until either:
+  //   1). Tile overlap has been computed for all of the requested ranges.
+  //   2). The size of the current tile overlap has exceed our budget.
+  //
+  // Each loop is expensive, so we will double the range to compute for
+  // each successive loop. The intent is to minimize the number of loops
+  // at the risk of exceeding our target maximum memory usage for the
+  // tile overlap data.
+  ComputeRelevantFragmentsCtx relevant_fragment_ctx;
+  ComputeRelevantTileOverlapCtx tile_overlap_ctx;
+  SubarrayTileOverlap tile_overlap(
+      fragment_num, tile_overlap_start, tmp_tile_overlap_end);
+  do {
+    RETURN_NOT_OK(compute_relevant_fragments(
+        compute_tp, &tile_overlap, &relevant_fragment_ctx));
+    RETURN_NOT_OK(load_relevant_fragment_rtrees(compute_tp));
+    RETURN_NOT_OK(compute_relevant_fragment_tile_overlap(
+        compute_tp, &tile_overlap, &tile_overlap_ctx));
+
+    if (tmp_tile_overlap_end == tile_overlap_end ||
+        tile_overlap.byte_size() >= max_tile_overlap_size) {
+      tile_overlap_ = std::move(tile_overlap);
+      break;
+    }
+
+    // Double the range for the next loop.
+    tmp_tile_overlap_end = std::min<uint64_t>(
+        tile_overlap_end, tmp_tile_overlap_end + tile_overlap.range_num());
+    tile_overlap.expand(tmp_tile_overlap_end);
+  } while (true);
 
   return Status::Ok();
 
@@ -1952,7 +2005,6 @@ Subarray Subarray::clone() const {
   clone.is_default_ = is_default_;
   clone.range_offsets_ = range_offsets_;
   clone.tile_overlap_ = tile_overlap_;
-  clone.tile_overlap_range_offset_ = tile_overlap_range_offset_;
   clone.est_result_size_computed_ = est_result_size_computed_;
   clone.coalesce_ranges_ = coalesce_ranges_;
   clone.add_or_coalesce_range_func_ = add_or_coalesce_range_func_;
@@ -1963,30 +2015,31 @@ Subarray Subarray::clone() const {
   return clone;
 }
 
-TileOverlap Subarray::get_tile_overlap(uint64_t range_idx, unsigned fid) const {
+TileOverlap Subarray::compute_tile_overlap(
+    uint64_t range_idx, unsigned fid) const {
   assert(array_->array_schema()->dense());
   auto type = array_->array_schema()->dimension(0)->type();
   switch (type) {
     case Datatype::INT8:
-      return get_tile_overlap<int8_t>(range_idx, fid);
+      return compute_tile_overlap<int8_t>(range_idx, fid);
     case Datatype::UINT8:
-      return get_tile_overlap<uint8_t>(range_idx, fid);
+      return compute_tile_overlap<uint8_t>(range_idx, fid);
     case Datatype::INT16:
-      return get_tile_overlap<int16_t>(range_idx, fid);
+      return compute_tile_overlap<int16_t>(range_idx, fid);
     case Datatype::UINT16:
-      return get_tile_overlap<uint16_t>(range_idx, fid);
+      return compute_tile_overlap<uint16_t>(range_idx, fid);
     case Datatype::INT32:
-      return get_tile_overlap<int32_t>(range_idx, fid);
+      return compute_tile_overlap<int32_t>(range_idx, fid);
     case Datatype::UINT32:
-      return get_tile_overlap<uint32_t>(range_idx, fid);
+      return compute_tile_overlap<uint32_t>(range_idx, fid);
     case Datatype::INT64:
-      return get_tile_overlap<int64_t>(range_idx, fid);
+      return compute_tile_overlap<int64_t>(range_idx, fid);
     case Datatype::UINT64:
-      return get_tile_overlap<uint64_t>(range_idx, fid);
+      return compute_tile_overlap<uint64_t>(range_idx, fid);
     case Datatype::FLOAT32:
-      return get_tile_overlap<float>(range_idx, fid);
+      return compute_tile_overlap<float>(range_idx, fid);
     case Datatype::FLOAT64:
-      return get_tile_overlap<double>(range_idx, fid);
+      return compute_tile_overlap<double>(range_idx, fid);
     case Datatype::DATETIME_YEAR:
     case Datatype::DATETIME_MONTH:
     case Datatype::DATETIME_WEEK:
@@ -2000,7 +2053,7 @@ TileOverlap Subarray::get_tile_overlap(uint64_t range_idx, unsigned fid) const {
     case Datatype::DATETIME_PS:
     case Datatype::DATETIME_FS:
     case Datatype::DATETIME_AS:
-      return get_tile_overlap<int64_t>(range_idx, fid);
+      return compute_tile_overlap<int64_t>(range_idx, fid);
     default:
       assert(false);
   }
@@ -2008,7 +2061,8 @@ TileOverlap Subarray::get_tile_overlap(uint64_t range_idx, unsigned fid) const {
 }
 
 template <class T>
-TileOverlap Subarray::get_tile_overlap(uint64_t range_idx, unsigned fid) const {
+TileOverlap Subarray::compute_tile_overlap(
+    uint64_t range_idx, unsigned fid) const {
   assert(array_->array_schema()->dense());
   TileOverlap ret;
   auto ndrange = this->ndrange(range_idx);
@@ -2086,7 +2140,6 @@ void Subarray::swap(Subarray& subarray) {
   std::swap(is_default_, subarray.is_default_);
   std::swap(range_offsets_, subarray.range_offsets_);
   std::swap(tile_overlap_, subarray.tile_overlap_);
-  std::swap(tile_overlap_range_offset_, subarray.tile_overlap_range_offset_);
   std::swap(est_result_size_computed_, subarray.est_result_size_computed_);
   std::swap(coalesce_ranges_, subarray.coalesce_ranges_);
   std::swap(add_or_coalesce_range_func_, subarray.add_or_coalesce_range_func_);
@@ -2095,27 +2148,57 @@ void Subarray::swap(Subarray& subarray) {
   std::swap(relevant_fragments_, subarray.relevant_fragments_);
 }
 
-Status Subarray::compute_relevant_fragments(ThreadPool* const compute_tp) {
+Status Subarray::compute_relevant_fragments(
+    ThreadPool* const compute_tp,
+    const SubarrayTileOverlap* const tile_overlap,
+    ComputeRelevantFragmentsCtx* const fn_ctx) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_COMPUTE_RELEVANT_FRAGS)
 
   auto meta = array_->fragment_metadata();
   auto fragment_num = meta.size();
-  auto range_num = this->range_num();
-  std::vector<uint8_t> frag_bitmap(fragment_num, 0);
+  auto range_num = tile_overlap->range_num();
+
+  // Sanity check we have at least one fragment
+  // and one range to compute on.
+  if (fragment_num == 0 || range_num == 0) {
+    relevant_fragments_.clear();
+    relevant_fragments_.shrink_to_fit();
+    return Status::Ok();
+  }
+
+  // If this is the first time this routine is invoked,
+  // initialize `fn_ctx`. Otherwise, set `range_idx_start`
+  // to start from the end of the last range we calculated.
+  uint64_t range_idx_start = 0;
+  if (fn_ctx->frag_bytemap_.empty()) {
+    fn_ctx->frag_bytemap_.resize(fragment_num, 0);
+  } else {
+    assert(fn_ctx->frag_bytemap_.size() == fragment_num);
+    range_idx_start = fn_ctx->range_num_;
+  }
+
+  fn_ctx->range_num_ = range_num;
 
   // Compute the relevant fragments
   auto statuses = parallel_for_2d(
-      compute_tp, 0, fragment_num, 0, range_num, [&](unsigned f, uint64_t r) {
-        if (frag_bitmap[f] == 0 &&
-            meta[f]->overlaps_non_empty_domain(this->ndrange(r)))
-          frag_bitmap[f] = 1;
+      compute_tp,
+      0,
+      fragment_num,
+      range_idx_start,
+      fn_ctx->range_num_,
+      [&](unsigned f, uint64_t r) {
+        const uint64_t translated_r = r + tile_overlap->range_idx_start();
+        if (fn_ctx->frag_bytemap_[f] == 0 &&
+            meta[f]->overlaps_non_empty_domain(this->ndrange(translated_r)))
+          fn_ctx->frag_bytemap_[f] = 1;
         return Status::Ok();
       });
 
   // Copy to the result
+  relevant_fragments_.clear();
   relevant_fragments_.reserve(fragment_num);
   for (unsigned f = 0; f < fragment_num; ++f) {
-    if (frag_bitmap[f])
+    if (fn_ctx->frag_bytemap_[f])
       relevant_fragments_.emplace_back(f);
   }
   relevant_fragments_.shrink_to_fit();
@@ -2146,18 +2229,22 @@ Status Subarray::load_relevant_fragment_rtrees(
 
 Status Subarray::compute_relevant_fragment_tile_overlap(
     ThreadPool* const compute_tp,
-    std::vector<std::vector<TileOverlap>>* const tile_overlap) {
+    SubarrayTileOverlap* const tile_overlap,
+    ComputeRelevantTileOverlapCtx* const fn_ctx) {
   STATS_START_TIMER(stats::Stats::TimerType::READ_COMPUTE_RELEVANT_TILE_OVERLAP)
 
+  const auto range_num = tile_overlap->range_num();
+  fn_ctx->range_idx_offset_ = fn_ctx->range_idx_offset_ + fn_ctx->range_len_;
+  fn_ctx->range_len_ = range_num - fn_ctx->range_idx_offset_;
+
   const auto& meta = array_->fragment_metadata();
-  auto range_num = this->range_num();
 
   auto statuses =
       parallel_for(compute_tp, 0, relevant_fragments_.size(), [&](uint64_t i) {
-        auto f = relevant_fragments_[i];
-        auto dense = meta[f]->dense();
+        const auto f = relevant_fragments_[i];
+        const auto dense = meta[f]->dense();
         return compute_relevant_fragment_tile_overlap(
-            meta[f], f, dense, range_num, compute_tp, tile_overlap);
+            meta[f], f, dense, compute_tp, tile_overlap, fn_ctx);
       });
   for (const auto& st : statuses)
     RETURN_NOT_OK(st);
@@ -2171,26 +2258,35 @@ Status Subarray::compute_relevant_fragment_tile_overlap(
     FragmentMetadata* meta,
     unsigned frag_idx,
     bool dense,
-    uint64_t range_num,
     ThreadPool* const compute_tp,
-    std::vector<std::vector<TileOverlap>>* const tile_overlap) {
-  auto num_threads = compute_tp->concurrency_level();
-  auto ranges_per_thread = (uint64_t)ceil((double)range_num / num_threads);
-  auto statuses = parallel_for(compute_tp, 0, num_threads, [&](uint64_t t) {
-    auto r_start = t * ranges_per_thread;
-    auto r_end = std::min((t + 1) * ranges_per_thread - 1, range_num - 1);
-    for (uint64_t r = r_start; r <= r_end; ++r) {
-      if (dense) {  // Dense fragment
-        (*tile_overlap)[frag_idx][r] = get_tile_overlap(r, frag_idx);
-      } else {  // Sparse fragment
-        const auto& range = this->ndrange(r);
-        RETURN_NOT_OK(
-            meta->get_tile_overlap(range, &((*tile_overlap)[frag_idx][r])));
-      }
-    }
+    SubarrayTileOverlap* const tile_overlap,
+    ComputeRelevantTileOverlapCtx* const fn_ctx) {
+  const auto num_threads = compute_tp->concurrency_level();
+  const auto range_num = fn_ctx->range_len_;
 
-    return Status::Ok();
-  });
+  const auto ranges_per_thread =
+      (uint64_t)ceil((double)range_num / num_threads);
+  const auto statuses =
+      parallel_for(compute_tp, 0, num_threads, [&](uint64_t t) {
+        const auto r_start =
+            fn_ctx->range_idx_offset_ + (t * ranges_per_thread);
+        const auto r_end =
+            fn_ctx->range_idx_offset_ +
+            std::min((t + 1) * ranges_per_thread - 1, range_num - 1);
+        for (uint64_t r = r_start; r <= r_end; ++r) {
+          if (dense) {  // Dense fragment
+            *tile_overlap->at(frag_idx, r) = compute_tile_overlap(
+                r + tile_overlap->range_idx_start(), frag_idx);
+          } else {  // Sparse fragment
+            const auto& range =
+                this->ndrange(r + tile_overlap->range_idx_start());
+            RETURN_NOT_OK(
+                meta->get_tile_overlap(range, tile_overlap->at(frag_idx, r)));
+          }
+        }
+
+        return Status::Ok();
+      });
   for (const auto& st : statuses)
     RETURN_NOT_OK(st);
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -36,9 +36,11 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/sm/config/config.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/tile_overlap.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/subarray/subarray_tile_overlap.h"
 
 #include <cmath>
 #include <iostream>
@@ -110,7 +112,7 @@ enum class QueryType : uint8_t;
 class Subarray {
  public:
   /* ********************************* */
-  /*           TYPE DEFINITIONS        */
+  /*         PUBLIC DATA TYPES         */
   /* ********************************* */
 
   /**
@@ -246,10 +248,31 @@ class Subarray {
   void compute_range_offsets();
 
   /**
-   * Computes the tile overlap with all subarray ranges for
-   * all fragments.
+   * Precomputes the tile overlap with all subarray ranges for
+   * all fragments. The state is cached internally and accessible
+   * through the `get_subarray_tile_overlap` API.
+   *
+   * This routine may not compute tile overlap for the entire range.
+   * This only guarantees that:
+   *   1. Tile overlap will be computed for at least one range.
+   *   2. Tile overlap is computed starting from `start_range_idx`.
+   *
+   * The caller is responsible for checking the range indexes that
+   * were computed through the `get_subarray_tile_overlap` API.
+   *
+   * @param start_range_idx The start range index.
+   * @param end_range_idx The target end range index.
+   * @param config The config object.
+   * @param compute_tp The compute thread pool.
+   * @param override_memory_constraint When true, this forces the
+   *    routine to compute tile overlap for all ranges.
    */
-  Status compute_tile_overlap(ThreadPool* compute_tp);
+  Status precompute_tile_overlap(
+      uint64_t start_range_idx,
+      uint64_t end_range_idx,
+      const Config* config,
+      ThreadPool* compute_tp,
+      bool override_memory_constraint = false);
 
   /**
    * Computes the estimated result size (calibrated using the maximum size)
@@ -380,7 +403,10 @@ class Subarray {
    * attribute/dimension.
    */
   Status get_est_result_size(
-      const char* name, uint64_t* size, ThreadPool* compute_tp);
+      const char* name,
+      uint64_t* size,
+      const Config* config,
+      ThreadPool* compute_tp);
 
   /**
    * Gets the estimated result size (in bytes) for the input var-sized
@@ -390,6 +416,7 @@ class Subarray {
       const char* name,
       uint64_t* size_off,
       uint64_t* size_val,
+      const Config* config,
       ThreadPool* compute_tp);
 
   /**
@@ -400,6 +427,7 @@ class Subarray {
       const char* name,
       uint64_t* size,
       uint64_t* size_validity,
+      const Config* config,
       ThreadPool* compute_tp);
 
   /**
@@ -411,6 +439,7 @@ class Subarray {
       uint64_t* size_off,
       uint64_t* size_val,
       uint64_t* size_validity,
+      const Config* config,
       ThreadPool* compute_tp);
 
   /** returns whether the estimated result size has been computed or not */
@@ -421,7 +450,10 @@ class Subarray {
    * for the input fixed-sized attribute/dimensiom.
    */
   Status get_max_memory_size(
-      const char* name, uint64_t* size, ThreadPool* compute_tp);
+      const char* name,
+      uint64_t* size,
+      const Config* config,
+      ThreadPool* compute_tp);
 
   /**
    * Gets the maximum memory required to produce the result (in bytes)
@@ -431,6 +463,7 @@ class Subarray {
       const char* name,
       uint64_t* size_off,
       uint64_t* size_val,
+      const Config* config,
       ThreadPool* compute_tp);
 
   /*
@@ -441,6 +474,7 @@ class Subarray {
       const char* name,
       uint64_t* size,
       uint64_t* size_validity,
+      const Config* config,
       ThreadPool* compute_tp);
 
   /**
@@ -452,6 +486,7 @@ class Subarray {
       uint64_t* size_off,
       uint64_t* size_val,
       uint64_t* size_validity,
+      const Config* config,
       ThreadPool* compute_tp);
 
   /** Retrieves the query type of the subarray's array. */
@@ -581,27 +616,24 @@ class Subarray {
       const std::vector<T>& tile_coords, std::vector<uint8_t>* aux) const;
 
   /**
-   * Returns the tile overlap of the subarray.
+   * Returns the internal `TileOverlap` instance. The caller is responsible
+   * for ensuring that the input indexes are valid.
    *
-   * The outer vector is indexed by fragment ids and the inner vector is
-   * indexed by range indexes.
-   *
-   * As an optimization, the underlying data structure may be shared between
-   * `Subarray` instances and their partitioned `Subarray` instances created
-   * by the `SubarrayPartitioner`. The caller must use the
-   * `Subarray::overlap_range_offset` to determine the range index that points
-   * to the starting range of this `Subarray` instance.
+   * @param fragment_idx The fragment index.
+   * @param range_idx The range index.
    */
-  const std::vector<std::vector<TileOverlap>>& tile_overlap() const;
+  inline const TileOverlap* tile_overlap(
+      uint64_t fragment_idx, uint64_t range_idx) const {
+    return tile_overlap_.at(fragment_idx, range_idx);
+  }
 
   /**
-   * The `Subarray::tile_overlap` returns a data structure where the
-   * outter vector is indexed by fragment ids and the inner vector
-   * is indexed by range ids. This API returns the offset into the
-   * inner vector that points to the first range used by this
-   * `Subarray` instance.
+   * Returns the precomputed tile overlap. This may not contain
+   * tile overlap information for each range in this subarray. The
+   * caller is responsible for inspecting the returned object to
+   * determine the ranges it has information for.
    */
-  uint64_t overlap_range_offset() const;
+  const SubarrayTileOverlap* subarray_tile_overlap() const;
 
   /**
    * Compute `tile_coords_` and `tile_coords_map_`. The coordinates will
@@ -650,14 +682,14 @@ class Subarray {
    * @return
    */
   std::unordered_map<std::string, ResultSize> get_est_result_size_map(
-      ThreadPool* compute_tp);
+      const Config* config, ThreadPool* compute_tp);
 
   /**
    * Used by serialization to get the map of max mem sizes
    * @return
    */
   std::unordered_map<std::string, MemorySize> get_max_mem_size_map(
-      ThreadPool* compute_tp);
+      const Config* config, ThreadPool* compute_tp);
 
   /**
    * Return relevant fragments as computed
@@ -665,6 +697,50 @@ class Subarray {
   std::vector<unsigned> relevant_fragments() const;
 
  private:
+  /* ********************************* */
+  /*        PRIVATE DATA TYPES         */
+  /* ********************************* */
+
+  /**
+   * An opaque context to be used between successive calls
+   * to `compute_relevant_fragments`.
+   */
+  struct ComputeRelevantFragmentsCtx {
+    ComputeRelevantFragmentsCtx()
+        : range_num_(0) {
+    }
+
+    /** The bytemap, one byte per fragment. */
+    std::vector<uint8_t> frag_bytemap_;
+
+    /**
+     * The total number of ranges computed with in the
+     * last invocation of `compute_relevant_fragments`.
+     */
+    uint64_t range_num_;
+  };
+
+  /**
+   * An opaque context to be used between successive calls
+   * to `compute_relevant_fragment_tile_overlap`.
+   */
+  struct ComputeRelevantTileOverlapCtx {
+    ComputeRelevantTileOverlapCtx()
+        : range_idx_offset_(0)
+        , range_len_(0) {
+    }
+
+    /**
+     * The current range index offset. This points to the ending
+     * index from the last invocation of
+     * `compute_relevant_fragment_tile_overlap`.
+     */
+    uint64_t range_idx_offset_;
+
+    /** The number of ranges. */
+    uint64_t range_len_;
+  };
+
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
@@ -716,23 +792,10 @@ class Subarray {
   std::vector<unsigned> relevant_fragments_;
 
   /**
-   * Stores info about the overlap of the subarray with tiles
-   * of all array fragments. Each element is a vector corresponding
-   * to a single range of the subarray. These vectors/ranges are sorted
-   * according to ``layout_``.
-   *
-   * This is shared between a `Subarray` and all of its `Subarray` partitions
-   * created with the `Subarray::get_subarray` API.
+   * The precomputed tile overlap state. Is not guaranteed to be
+   * computed for all ranges in this subarray.
    */
-  std::shared_ptr<std::vector<std::vector<TileOverlap>>> tile_overlap_;
-
-  /**
-   * The first index in `tile_overlap_` corresponds to a fragment
-   * index. The second index corresponds to a range index. This
-   * variable stores the range index for the first range in
-   * this instance.
-   */
-  uint64_t tile_overlap_range_offset_;
+  SubarrayTileOverlap tile_overlap_;
 
   /**
    * ``True`` if ranges should attempt to be coalesced as they are added.
@@ -771,7 +834,7 @@ class Subarray {
   void add_default_ranges();
 
   /** Computes the estimated result size for all attributes/dimensions. */
-  Status compute_est_result_size(ThreadPool* compute_tp);
+  Status compute_est_result_size(const Config* config, ThreadPool* compute_tp);
 
   /**
    * Compute `tile_coords_` and `tile_coords_map_`. The coordinates will
@@ -804,7 +867,7 @@ class Subarray {
    * @param fid The id of the fragment to focus on.
    * @return The tile overlap.
    */
-  TileOverlap get_tile_overlap(uint64_t range_idx, unsigned fid) const;
+  TileOverlap compute_tile_overlap(uint64_t range_idx, unsigned fid) const;
 
   /**
    * Compute the tile overlap between ``range`` and the non-empty domain
@@ -816,7 +879,7 @@ class Subarray {
    * @return The tile overlap.
    */
   template <class T>
-  TileOverlap get_tile_overlap(uint64_t range_idx, unsigned fid) const;
+  TileOverlap compute_tile_overlap(uint64_t range_idx, unsigned fid) const;
 
   /**
    * Swaps the contents (all field values) of this subarray with the
@@ -828,16 +891,32 @@ class Subarray {
    * Computes the indexes of the fragments that are relevant to the query,
    * that is those whose non-empty domain intersects with at least one
    * range.
+   *
+   * @param compute_tp The thread pool for compute-bound tasks.
+   * @param tile_overlap Mutated to store the computed tile overlap.
+   * @param fn_ctx An opaque context object to be used between successive
+   * invocations.
    */
-  Status compute_relevant_fragments(ThreadPool* compute_tp);
+  Status compute_relevant_fragments(
+      ThreadPool* compute_tp,
+      const SubarrayTileOverlap* tile_overlap,
+      ComputeRelevantFragmentsCtx* fn_ctx);
 
   /** Loads the R-Trees of all relevant fragments in parallel. */
   Status load_relevant_fragment_rtrees(ThreadPool* compute_tp) const;
 
-  /** Computes the tile overlap for each range and relevant fragment. */
+  /**
+   * Computes the tile overlap for each range and relevant fragment.
+   *
+   * @param compute_tp The thread pool for compute-bound tasks.
+   * @param tile_overlap Mutated to store the computed tile overlap.
+   * @param fn_ctx An opaque context object to be used between successive
+   * invocations.
+   */
   Status compute_relevant_fragment_tile_overlap(
       ThreadPool* compute_tp,
-      std::vector<std::vector<TileOverlap>>* tile_overlap);
+      SubarrayTileOverlap* tile_overlap,
+      ComputeRelevantTileOverlapCtx* fn_ctx);
 
   /**
    * Computes the tile overlap for all ranges on the given relevant fragment.
@@ -845,18 +924,19 @@ class Subarray {
    * @param meta The fragment metadat to focus on.
    * @param frag_idx The fragment id.
    * @param dense Whether the fragment is dense or sparse.
-   * @param range_num The number of ranges.
    * @param compute_tp The thread pool for compute-bound tasks.
    * @param tile_overlap Mutated to store the computed tile overlap.
+   * @param fn_ctx An opaque context object to be used between successive
+   * invocations.
    * @return Status
    */
   Status compute_relevant_fragment_tile_overlap(
       FragmentMetadata* meta,
       unsigned frag_idx,
       bool dense,
-      uint64_t range_num,
       ThreadPool* compute_tp,
-      std::vector<std::vector<TileOverlap>>* tile_overlap);
+      SubarrayTileOverlap* tile_overlap,
+      ComputeRelevantTileOverlapCtx* fn_ctx);
 
   /**
    * Load the var-sized tile sizes for the input names and from the

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -62,17 +62,18 @@ using namespace tiledb::sm;
 SubarrayPartitioner::SubarrayPartitioner() = default;
 
 SubarrayPartitioner::SubarrayPartitioner(
+    const Config* const config,
     const Subarray& subarray,
     uint64_t memory_budget,
     uint64_t memory_budget_var,
     uint64_t memory_budget_validity,
     ThreadPool* const compute_tp)
-    : subarray_(subarray)
+    : config_(config)
+    , subarray_(subarray)
     , memory_budget_(memory_budget)
     , memory_budget_var_(memory_budget_var)
     , memory_budget_validity_(memory_budget_validity)
     , compute_tp_(compute_tp) {
-  subarray_.compute_tile_overlap(compute_tp_);
   state_.start_ = 0;
   auto range_num = subarray_.range_num();
   state_.end_ = (range_num > 0) ? range_num - 1 : 0;
@@ -727,6 +728,7 @@ void SubarrayPartitioner::calibrate_current_start_end(bool* must_split_slab) {
 
 SubarrayPartitioner SubarrayPartitioner::clone() const {
   SubarrayPartitioner clone;
+  clone.config_ = config_;
   clone.subarray_ = subarray_;
   clone.budget_ = budget_;
   clone.current_ = current_;
@@ -740,6 +742,15 @@ SubarrayPartitioner SubarrayPartitioner::clone() const {
 }
 
 Status SubarrayPartitioner::compute_current_start_end(bool* found) {
+  // Compute the tile overlap. Note that the ranges in `tile_overlap` may have
+  // been truncated the ending bound due to memory constraints.
+  RETURN_NOT_OK(subarray_.precompute_tile_overlap(
+      state_.start_, state_.end_, config_, compute_tp_));
+  const SubarrayTileOverlap* const tile_overlap =
+      subarray_.subarray_tile_overlap();
+  assert(tile_overlap->range_idx_start() == state_.start_);
+  assert(tile_overlap->range_idx_end() <= state_.end_);
+
   // Preparation
   auto array = subarray_.array();
   auto meta = array->fragment_metadata();
@@ -761,16 +772,17 @@ Status SubarrayPartitioner::compute_current_start_end(bool* found) {
   std::vector<std::vector<Subarray::MemorySize>> memory_sizes;
   RETURN_NOT_OK(subarray_.compute_relevant_fragment_est_result_sizes(
       names,
-      state_.start_,
-      state_.end_,
+      tile_overlap->range_idx_start(),
+      tile_overlap->range_idx_end(),
       &result_sizes,
       &memory_sizes,
       compute_tp_));
 
-  current_.start_ = state_.start_;
-  for (current_.end_ = state_.start_; current_.end_ <= state_.end_;
+  current_.start_ = tile_overlap->range_idx_start();
+  for (current_.end_ = tile_overlap->range_idx_start();
+       current_.end_ <= tile_overlap->range_idx_end();
        ++current_.end_) {
-    size_t r = current_.end_ - state_.start_;
+    size_t r = current_.end_ - tile_overlap->range_idx_start();
     for (size_t i = 0; i < names.size(); ++i) {
       auto& cur_size = cur_sizes[i];
       auto& mem_size = mem_sizes[i];
@@ -1060,34 +1072,44 @@ bool SubarrayPartitioner::must_split(Subarray* partition) {
     if (var_size) {
       if (!nullable) {
         partition->get_est_result_size(
-            b.first.c_str(), &size_fixed, &size_var, compute_tp_);
+            b.first.c_str(), &size_fixed, &size_var, config_, compute_tp_);
         partition->get_max_memory_size(
-            b.first.c_str(), &mem_size_fixed, &mem_size_var, compute_tp_);
+            b.first.c_str(),
+            &mem_size_fixed,
+            &mem_size_var,
+            config_,
+            compute_tp_);
       } else {
         partition->get_est_result_size_nullable(
             b.first.c_str(),
             &size_fixed,
             &size_var,
             &size_validity,
+            config_,
             compute_tp_);
         partition->get_max_memory_size_nullable(
             b.first.c_str(),
             &mem_size_fixed,
             &mem_size_var,
             &mem_size_validity,
+            config_,
             compute_tp_);
       }
     } else {
       if (!nullable) {
         partition->get_est_result_size(
-            b.first.c_str(), &size_fixed, compute_tp_);
+            b.first.c_str(), &size_fixed, config_, compute_tp_);
         partition->get_max_memory_size(
-            b.first.c_str(), &mem_size_fixed, compute_tp_);
+            b.first.c_str(), &mem_size_fixed, config_, compute_tp_);
       } else {
         partition->get_est_result_size_nullable(
-            b.first.c_str(), &size_fixed, &size_validity, compute_tp_);
+            b.first.c_str(), &size_fixed, &size_validity, config_, compute_tp_);
         partition->get_max_memory_size_nullable(
-            b.first.c_str(), &mem_size_fixed, &mem_size_validity, compute_tp_);
+            b.first.c_str(),
+            &mem_size_fixed,
+            &mem_size_validity,
+            config_,
+            compute_tp_);
       }
     }
 
@@ -1244,6 +1266,7 @@ Status SubarrayPartitioner::split_top_multi_range(bool* unsplittable) {
 }
 
 void SubarrayPartitioner::swap(SubarrayPartitioner& partitioner) {
+  std::swap(config_, partitioner.config_);
   std::swap(subarray_, partitioner.subarray_);
   std::swap(budget_, partitioner.budget_);
   std::swap(current_, partitioner.current_);

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -99,11 +99,14 @@ class SubarrayPartitioner {
      * current partition has been constructed from.
      */
     uint64_t start_;
+
     /**
      * The end range index from the original subarray that the
-     * current partition has been constructed from.
+     * current partition has been constructed from. This is an
+     * inclusive index.
      */
     uint64_t end_;
+
     /**
      * ``true`` if the partition came from splitting a multi-range
      * subarray that was put into ``state_.multi_range_``.
@@ -159,6 +162,7 @@ class SubarrayPartitioner {
 
   /** Constructor. */
   SubarrayPartitioner(
+      const Config* config,
       const Subarray& subarray,
       uint64_t memory_budget,
       uint64_t memory_budget_var,
@@ -324,6 +328,9 @@ class SubarrayPartitioner {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /** The config. */
+  const Config* config_;
 
   /** The subarray the partitioner will iterate on to produce partitions. */
   Subarray subarray_;

--- a/tiledb/sm/subarray/subarray_tile_overlap.cc
+++ b/tiledb/sm/subarray/subarray_tile_overlap.cc
@@ -1,0 +1,171 @@
+/**
+ * @file subarray_tile_overlap.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class SubarrayTileOverlap.
+ */
+
+#include "tiledb/sm/subarray/subarray_tile_overlap.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+SubarrayTileOverlap::SubarrayTileOverlap()
+    : range_idx_start_(0)
+    , range_idx_end_(0)
+    , range_idx_start_offset_(0)
+    , range_idx_end_offset_(0) {
+}
+
+SubarrayTileOverlap::SubarrayTileOverlap(const SubarrayTileOverlap& rhs)
+    : tile_overlap_idx_(rhs.tile_overlap_idx_)
+    , range_idx_start_(rhs.range_idx_start_)
+    , range_idx_end_(rhs.range_idx_end_)
+    , range_idx_start_offset_(rhs.range_idx_start_offset_)
+    , range_idx_end_offset_(rhs.range_idx_end_offset_) {
+}
+
+SubarrayTileOverlap::SubarrayTileOverlap(SubarrayTileOverlap&& rhs)
+    : tile_overlap_idx_(std::move(rhs.tile_overlap_idx_))
+    , range_idx_start_(rhs.range_idx_start_)
+    , range_idx_end_(rhs.range_idx_end_)
+    , range_idx_start_offset_(rhs.range_idx_start_offset_)
+    , range_idx_end_offset_(rhs.range_idx_end_offset_) {
+}
+
+SubarrayTileOverlap::SubarrayTileOverlap(
+    const uint64_t fragment_num,
+    const uint64_t range_idx_start,
+    const uint64_t range_idx_end)
+    : range_idx_start_(range_idx_start)
+    , range_idx_end_(range_idx_end)
+    , range_idx_start_offset_(0)
+    , range_idx_end_offset_(0) {
+  const uint64_t range_num = range_idx_end_ - range_idx_start_ + 1;
+  tile_overlap_idx_ = std::make_shared<TileOverlapIndex>();
+  tile_overlap_idx_->resize(fragment_num);
+  for (size_t i = 0; i < tile_overlap_idx_->size(); ++i)
+    (*tile_overlap_idx_)[i].resize(range_num);
+}
+
+SubarrayTileOverlap::~SubarrayTileOverlap() {
+}
+
+SubarrayTileOverlap& SubarrayTileOverlap::operator=(
+    const SubarrayTileOverlap& rhs) {
+  if (this != &rhs) {
+    tile_overlap_idx_ = rhs.tile_overlap_idx_;
+    range_idx_start_ = rhs.range_idx_start_;
+    range_idx_end_ = rhs.range_idx_end_;
+    range_idx_start_offset_ = rhs.range_idx_start_offset_;
+    range_idx_end_offset_ = rhs.range_idx_end_offset_;
+  }
+
+  return *this;
+}
+
+SubarrayTileOverlap& SubarrayTileOverlap::operator=(SubarrayTileOverlap&& rhs) {
+  if (this != &rhs) {
+    tile_overlap_idx_ = std::move(rhs.tile_overlap_idx_);
+    range_idx_start_ = rhs.range_idx_start_;
+    range_idx_end_ = rhs.range_idx_end_;
+    range_idx_start_offset_ = rhs.range_idx_start_offset_;
+    range_idx_end_offset_ = rhs.range_idx_end_offset_;
+  }
+
+  return *this;
+}
+
+uint64_t SubarrayTileOverlap::range_idx_start() const {
+  return range_idx_start_ + range_idx_start_offset_;
+}
+
+uint64_t SubarrayTileOverlap::range_idx_end() const {
+  return range_idx_end_ - range_idx_end_offset_;
+}
+
+uint64_t SubarrayTileOverlap::range_num() const {
+  return range_idx_end() - range_idx_start() + 1;
+}
+
+bool SubarrayTileOverlap::contains_range(
+    const uint64_t range_idx_start, const uint64_t range_idx_end) const {
+  if (!tile_overlap_idx_) {
+    return false;
+  }
+
+  if (range_idx_start < range_idx_start_ || range_idx_end > range_idx_end_) {
+    return false;
+  }
+
+  return true;
+}
+
+void SubarrayTileOverlap::update_range(
+    const uint64_t range_idx_start, const uint64_t range_idx_end) {
+  assert(contains_range(range_idx_start, range_idx_end));
+
+  range_idx_start_offset_ = range_idx_start - range_idx_start_;
+  range_idx_end_offset_ = range_idx_end_ - range_idx_end;
+}
+
+void SubarrayTileOverlap::expand(const uint64_t range_idx_end) {
+  if (range_idx_end <= range_idx_end_) {
+    return;
+  }
+
+  range_idx_end_ = range_idx_end;
+
+  const uint64_t range_num = range_idx_end_ - range_idx_start_ + 1;
+  for (size_t i = 0; i < tile_overlap_idx_->size(); ++i)
+    (*tile_overlap_idx_)[i].resize(range_num);
+}
+
+void SubarrayTileOverlap::clear() {
+  tile_overlap_idx_ = nullptr;
+  range_idx_start_ = 0;
+  range_idx_end_ = 0;
+  range_idx_start_offset_ = 0;
+  range_idx_end_offset_ = 0;
+}
+
+uint64_t SubarrayTileOverlap::byte_size() const {
+  uint64_t size = 0;
+  for (const auto& tile_overlaps : *tile_overlap_idx_) {
+    for (const auto& tile_overlap : tile_overlaps) {
+      size += tile_overlap.byte_size();
+    }
+  }
+
+  return size;
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/subarray/subarray_tile_overlap.h
+++ b/tiledb/sm/subarray/subarray_tile_overlap.h
@@ -1,0 +1,215 @@
+/**
+ * @file   subarray_tile_overlap.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the SubarrayTileOverlap class.
+ *
+ * The purpose of this class is to:
+ *   1. Provide abstract views of shared `TileOverlap` instances between
+ *      instances of `Subarray`.
+ *   2. Store partitioning indices that the `SubarrayPartitioner` can
+ *      use to determine the ranges that `TileOverlap` instances have
+ *      been computed for.
+ *
+ * Copies of this class share the same `TileOverlap` instances but have
+ * their own individual offsets that provide a logical view of the `TileOverlap`
+ * instances for their individual ranges.
+ *
+ * The range indices are unused by this class, but can be used by the caller
+ * (e.g. a `SubarrayPartitioner`) to determine which ranges in a `Subarray`
+ * the `TileOverlap` instances correspond to.
+ */
+
+#ifndef TILEDB_SUBARRAY_TILE_OVERLAP_H
+#define TILEDB_SUBARRAY_TILE_OVERLAP_H
+
+#include "tiledb/common/macros.h"
+#include "tiledb/sm/misc/tile_overlap.h"
+#include "tiledb/sm/misc/types.h"
+
+#include <iostream>
+
+namespace tiledb {
+namespace sm {
+
+class SubarrayTileOverlap final {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Default constructor. */
+  SubarrayTileOverlap();
+
+  /** Copy constructor. */
+  SubarrayTileOverlap(const SubarrayTileOverlap& rhs);
+
+  /** Move constructor. */
+  SubarrayTileOverlap(SubarrayTileOverlap&& rhs);
+
+  /**
+   * Value constructor.
+   *
+   * @param fragment_num The number of relevant fragments.
+   * @param range_idx_start The inclusive starting range index.
+   * @param range_idx_end The inclusive ending range index.
+   */
+  SubarrayTileOverlap(
+      uint64_t fragment_num, uint64_t range_idx_start, uint64_t range_idx_end);
+
+  /** Destructor. */
+  ~SubarrayTileOverlap();
+
+  /* ********************************* */
+  /*            OPERATORS              */
+  /* ********************************* */
+
+  /** Copy-assignment operator. */
+  SubarrayTileOverlap& operator=(const SubarrayTileOverlap&);
+
+  /** Move-assignment operator. */
+  SubarrayTileOverlap& operator=(SubarrayTileOverlap&&);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Returns a const-pointer to the internal `TileOverlap` instance. The
+   * caller is responsible for ensuring that a `TileOverlap` instance has
+   * been allocated for the input indexes.
+   *
+   * @param fragment_idx The fragment index.
+   * @param range_idx The range index, relative to `range_idx_start()`.
+   * @return The internal `TileOverlap` instance.
+   */
+  inline const TileOverlap* at(
+      uint64_t fragment_idx, uint64_t range_idx) const {
+    const uint64_t translated_range_idx = range_idx_start_offset_ + range_idx;
+    return &(*tile_overlap_idx_)[fragment_idx][translated_range_idx];
+  }
+
+  /**
+   * Returns a mutable-pointer to the internal `TileOverlap` instance. The
+   * caller is responsible for ensuring that a `TileOverlap` instance has
+   * been allocated for the input indexes.
+   *
+   * @param fragment_idx The fragment index.
+   * @param range_idx The range index, relative to `range_idx_start()`.
+   * @return The internal `TileOverlap` instance.
+   */
+  inline TileOverlap* at(uint64_t fragment_idx, uint64_t range_idx) {
+    const uint64_t translated_range_idx = range_idx_start_offset_ + range_idx;
+    return &(*tile_overlap_idx_)[fragment_idx][translated_range_idx];
+  }
+
+  /** The logical inclusive start range index in the subarray. */
+  uint64_t range_idx_start() const;
+
+  /** The logical inclusive end range index in the subarray. */
+  uint64_t range_idx_end() const;
+
+  /** The number of ranges in each fragment. */
+  uint64_t range_num() const;
+
+  /**
+   * Returns true if ranges have been allocated between the given
+   * input range.
+   *
+   * @param range_idx_start The inclusive starting range index.
+   * @param range_idx_end The inclusive ending range index.
+   * @return bool
+   */
+  bool contains_range(uint64_t range_idx_start, uint64_t range_idx_end) const;
+
+  /**
+   * Updates the logical range for this instance. The caller is responsible
+   * for ensuring that this instance contains this range. After calling
+   * this routine, the indexes in the `at()` routines will be relative to
+   * the `range_idx_start` parameter.
+   *
+   * @param range_idx_start The inclusive starting range index.
+   * @param range_idx_end The inclusive ending range index.
+   */
+  void update_range(uint64_t range_idx_start, uint64_t range_idx_end);
+
+  /**
+   * Expands the tile overlap by the end index, allocating empty
+   * TileOverlap objects for all the new ranges.
+   *
+   * @param range_idx_end The inclusive ending range index.
+   */
+  void expand(uint64_t range_idx_end);
+
+  /**
+   * Resets all state.
+   */
+  void clear();
+
+  /**
+   * Returns the total byte size of all stored `TileOverlap` instances.
+   */
+  uint64_t byte_size() const;
+
+ private:
+  /* ********************************* */
+  /*      PRIVATE DATA STRUCTURES      */
+  /* ********************************* */
+
+  /** Indexes instances of TileOverlap by a fragment-idx and range-idx. */
+  typedef std::vector<std::vector<TileOverlap>> TileOverlapIndex;
+
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /**
+   * The indexed TileOverlap instances. This is a shared pointer because
+   * it is shared between copies.
+   */
+  std::shared_ptr<TileOverlapIndex> tile_overlap_idx_;
+
+  /** The real inclusive start range index. */
+  uint64_t range_idx_start_;
+
+  /** The real inclusive end range index. */
+  uint64_t range_idx_end_;
+
+  /** Positive-offset from `range_idx_start_` to the logical inclusive start
+   * range index. */
+  uint64_t range_idx_start_offset_;
+
+  /** Negative-offset from `range_idx_end_` to the logical inclusive start range
+   * index. */
+  uint64_t range_idx_end_offset_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_SUBARRAY_TILE_OVERLAP_H


### PR DESCRIPTION
The memory consumption from the tile overlap state scales by the number of
fragments and number of ranges. This patch allows the subarray partitioner to
split subarrays that it estimates would consume too much memory. The motivation
is that the split subarrays will have a smaller number of ranges and therefore
have a smaller memory consumption from the tile overlap state.

The introduces a config option, `sm.max_tile_overlap_size` that the partitioner
uses to limit the range of the subarray it is operating on. This config option
is a target and not a hard limit.

The C APIs that estimate result sizes path through the
`Subarray::compute_est_result_size` routine. This routine is not yet aware
that the `tile_overlap_` may not be truncated due to the memory constraint. This
path forces the computation to override the memory constraint for now.

---
TYPE: NO_HISTORY
DESC: 
