### PR TITLE
Consolidated fragment md: use relative paths

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -2238,7 +2238,13 @@ Status StorageManager::load_fragment_metadata(
       // metadata buffer
       Buffer* f_buff = nullptr;
       uint64_t offset = 0;
-      auto it = offsets.find(sf.uri_.to_string());
+
+      auto it = offsets.end();
+      if (metadata->format_version() >= 9) {
+        it = offsets.find(name);
+      } else {
+        it = offsets.find(sf.uri_.to_string());
+      }
       if (it != offsets.end()) {
         f_buff = meta_buff;
         offset = it->second;


### PR DESCRIPTION
Now using relative paths in the consolidated fragment metadata so the
user can now move their arrays after consolidation

---
TYPE: IMPROVEMENT
DESC: Use relative paths in consolidated fragment metadata