### PR TITLE
Optimize `Subarray::compute_relevant_fragments`

### DIFF
--- a/test/src/unit-Subarray.cc
+++ b/test/src/unit-Subarray.cc
@@ -319,3 +319,609 @@ TEST_CASE_METHOD(
 
   close_array(ctx_, array_);
 }
+
+void verify_expanded_coordinates_2D(
+    Subarray* const subarray,
+    const uint64_t range_idx_start,
+    const uint64_t range_idx_end,
+    const uint64_t expected_range_idx_start,
+    const uint64_t expected_range_idx_end,
+    const std::vector<uint64_t>& expected_start_coords,
+    const std::vector<uint64_t>& expected_end_coords) {
+  std::vector<uint64_t> start_coords;
+  std::vector<uint64_t> end_coords;
+  subarray->get_expanded_coordinates(
+      range_idx_start, range_idx_end, &start_coords, &end_coords);
+  REQUIRE(start_coords == expected_start_coords);
+  REQUIRE(end_coords == expected_end_coords);
+  REQUIRE(subarray->range_idx(start_coords) == expected_range_idx_start);
+  REQUIRE(subarray->range_idx(end_coords) == expected_range_idx_end);
+
+  // Build a map from each inclusive range index between
+  // `range_idx_start` and `range_idx_end` that maps to a bool.
+  std::unordered_map<uint64_t, bool> range_idx_found;
+  for (uint64_t i = range_idx_start; i <= range_idx_end; ++i) {
+    range_idx_found[i] = false;
+  }
+
+  // Iterate through every coordinate between the start and end
+  // coordinate. If the flattened index is in `range_idx_found`,
+  // set the value to `true`.
+  for (uint64_t x = start_coords[0]; x <= end_coords[0]; ++x) {
+    for (uint64_t y = start_coords[1]; y <= end_coords[1]; ++y) {
+      const uint64_t range_idx = subarray->range_idx({x, y});
+      if (range_idx_found.count(range_idx) == 1) {
+        range_idx_found[range_idx] = true;
+      }
+    }
+  }
+
+  // Verify all flattened ranges are contained within the 2D
+  // space between `start_coords` and `end_coords`.
+  for (uint64_t i = range_idx_start; i <= range_idx_end; ++i) {
+    REQUIRE(range_idx_found[i] == true);
+  }
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, row-major, 2D",
+    "[Subarray][2d][row_major][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y"},
+      {TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain},
+      {&tile_extent_1, &tile_extent_2},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 2D subarray ranges as:
+   * 0  1  2  3
+   * 4  5  6  7
+   * 8  9  10 11
+   * 12 13 14 15
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges};
+  Layout subarray_layout = Layout::ROW_MAJOR;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [1, 2] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 1, 2, 1, 2, {0, 1}, {0, 2});
+
+  // The flattened, inclusive range [4, 6] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 4, 6, 4, 6, {1, 0}, {1, 2});
+
+  // The flattened, inclusive range [8, 8] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 8, 8, 8, 8, {2, 0}, {2, 0});
+
+  // The flattened, inclusive range [1, 7] must have
+  // a starting coordinate of (0, 0) and an ending coordinate
+  // of (1, 3) to contain ranges [0, 7].
+  verify_expanded_coordinates_2D(&subarray, 1, 7, 0, 7, {0, 0}, {1, 3});
+
+  // The flattened, inclusive range [5, 10] must have
+  // a starting coordinate of (1, 0) and an ending coordinate
+  // of (2, 3) to contain ranges [4, 11].
+  verify_expanded_coordinates_2D(&subarray, 5, 10, 4, 11, {1, 0}, {2, 3});
+
+  close_array(ctx_, array_);
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, col-major, 2D",
+    "[Subarray][2d][col_major][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y"},
+      {TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain},
+      {&tile_extent_1, &tile_extent_2},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 2D subarray ranges as:
+   * 0 4 8  12
+   * 1 5 9  13
+   * 2 6 10 14
+   * 3 7 11 15
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges};
+  Layout subarray_layout = Layout::COL_MAJOR;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [1, 2] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 1, 2, 1, 2, {1, 0}, {2, 0});
+
+  // The flattened, inclusive range [4, 6] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 4, 6, 4, 6, {0, 1}, {2, 1});
+
+  // The flattened, inclusive range [8, 8] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 8, 8, 8, 8, {0, 2}, {0, 2});
+
+  // The flattened, inclusive range [1, 7] must have
+  // a starting coordinate of (0, 0) and an ending coordinate
+  // of (3, 1) to contain ranges [0, 7].
+  verify_expanded_coordinates_2D(&subarray, 1, 7, 0, 7, {0, 0}, {3, 1});
+
+  // The flattened, inclusive range [5, 10] must have
+  // a starting coordinate of (0, 1) and an ending coordinate
+  // of (3, 2) to contain ranges [4, 11].
+  verify_expanded_coordinates_2D(&subarray, 5, 10, 4, 11, {0, 1}, {3, 2});
+
+  close_array(ctx_, array_);
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, unordered, 2D",
+    "[Subarray][2d][unordered][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y"},
+      {TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain},
+      {&tile_extent_1, &tile_extent_2},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 2D subarray ranges as:
+   * 0  1  2  3
+   * 4  5  6  7
+   * 8  9  10 11
+   * 12 13 14 15
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges};
+  Layout subarray_layout = Layout::UNORDERED;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [1, 2] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 1, 2, 1, 2, {0, 1}, {0, 2});
+
+  // The flattened, inclusive range [4, 6] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 4, 6, 4, 6, {1, 0}, {1, 2});
+
+  // The flattened, inclusive range [8, 8] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 8, 8, 8, 8, {2, 0}, {2, 0});
+
+  // The flattened, inclusive range [1, 7] must have
+  // a starting coordinate of (0, 0) and an ending coordinate
+  // of (1, 3) to contain ranges [0, 7].
+  verify_expanded_coordinates_2D(&subarray, 1, 7, 0, 7, {0, 0}, {1, 3});
+
+  // The flattened, inclusive range [5, 10] must have
+  // a starting coordinate of (1, 0) and an ending coordinate
+  // of (2, 3) to contain ranges [4, 11].
+  verify_expanded_coordinates_2D(&subarray, 5, 10, 4, 11, {1, 0}, {2, 3});
+
+  close_array(ctx_, array_);
+}
+
+void verify_expanded_coordinates_3D(
+    Subarray* const subarray,
+    const uint64_t range_idx_start,
+    const uint64_t range_idx_end,
+    const uint64_t expected_range_idx_start,
+    const uint64_t expected_range_idx_end,
+    const std::vector<uint64_t>& expected_start_coords,
+    const std::vector<uint64_t>& expected_end_coords) {
+  std::vector<uint64_t> start_coords;
+  std::vector<uint64_t> end_coords;
+  subarray->get_expanded_coordinates(
+      range_idx_start, range_idx_end, &start_coords, &end_coords);
+  REQUIRE(start_coords == expected_start_coords);
+  REQUIRE(end_coords == expected_end_coords);
+  REQUIRE(subarray->range_idx(start_coords) == expected_range_idx_start);
+  REQUIRE(subarray->range_idx(end_coords) == expected_range_idx_end);
+
+  // Build a map from each inclusive range index between
+  // `range_idx_start` and `range_idx_end` that maps to a bool.
+  std::unordered_map<uint64_t, bool> range_idx_found;
+  for (uint64_t i = range_idx_start; i <= range_idx_end; ++i) {
+    range_idx_found[i] = false;
+  }
+
+  // Iterate through every coordinate between the start and end
+  // coordinate. If the flattened index is in `range_idx_found`,
+  // set the value to `true`.
+  for (uint64_t x = start_coords[0]; x <= end_coords[0]; ++x) {
+    for (uint64_t y = start_coords[1]; y <= end_coords[1]; ++y) {
+      for (uint64_t z = start_coords[2]; z <= end_coords[2]; ++z) {
+        const uint64_t range_idx = subarray->range_idx({x, y, z});
+        if (range_idx_found.count(range_idx) == 1) {
+          range_idx_found[range_idx] = true;
+        }
+      }
+    }
+  }
+
+  // Verify all flattened ranges are contained within the 2D
+  // space between `start_coords` and `end_coords`.
+  for (uint64_t i = range_idx_start; i <= range_idx_end; ++i) {
+    REQUIRE(range_idx_found[i] == true);
+  }
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, row-major, 3D",
+    "[Subarray][3d][row_major][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  uint64_t tile_extent_3 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y", "z"},
+      {TILEDB_UINT64, TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain, domain},
+      {&tile_extent_1, &tile_extent_2, &tile_extent_3},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 3D subarray ranges as:
+   *
+   * z == 0
+   * 0  4  8  12
+   * 16 20 24 28
+   * 32 36 40 44
+   * 48 52 56 60
+   *
+   * z == 1
+   * 1  5  9  13
+   * 17 21 25 29
+   * 33 37 41 45
+   * 49 53 57 61
+   *
+   * z == 2
+   * 2  6  10 14
+   * 18 22 26 30
+   * 34 38 42 46
+   * 50 54 58 62
+   *
+   * z == 3
+   * 3  7  11 15
+   * 19 23 27 31
+   * 35 39 43 47
+   * 51 55 59 63
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  std::vector<uint64_t> d3_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges, d3_ranges};
+  Layout subarray_layout = Layout::ROW_MAJOR;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [0, 4] only expands
+  // on the last dimension.
+  verify_expanded_coordinates_3D(&subarray, 0, 4, 0, 7, {0, 0, 0}, {0, 1, 3});
+
+  // The flattened, inclusive range [56, 59] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 56, 59, 56, 59, {3, 2, 0}, {3, 2, 3});
+
+  // The flattened, inclusive range [16, 18] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 16, 18, 16, 18, {1, 0, 0}, {1, 0, 2});
+
+  // The flattened, inclusive range [37, 57] must have
+  // a starting coordinate of (2, 0, 0) and an ending coordinate
+  // of (3, 3, 3) to contain ranges [32, 63]. This ensures
+  // expansion along both the "y" and "z" dimension, leaving the
+  // "x" dimension untouched.
+  verify_expanded_coordinates_3D(
+      &subarray, 37, 57, 32, 63, {2, 0, 0}, {3, 3, 3});
+
+  close_array(ctx_, array_);
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, col-major, 3D",
+    "[Subarray][3d][col_major][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  uint64_t tile_extent_3 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y", "z"},
+      {TILEDB_UINT64, TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain, domain},
+      {&tile_extent_1, &tile_extent_2, &tile_extent_3},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 3D subarray ranges as:
+   *
+   * z == 0
+   * 0  16 32 48
+   * 4  20 36 52
+   * 8  24 40 56
+   * 12 28 44 60
+   *
+   * z == 1
+   * 1  17 33 49
+   * 5  21 37 53
+   * 9  25 41 57
+   * 13 29 45 61
+   *
+   * z == 2
+   * 2  18 34 50
+   * 6  22 38 54
+   * 10 26 42 58
+   * 14 30 46 62
+   *
+   * z == 3
+   * 3  19 35 51
+   * 7  23 39 55
+   * 11 27 43 59
+   * 15 31 47 63
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  std::vector<uint64_t> d3_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges, d3_ranges};
+  Layout subarray_layout = Layout::COL_MAJOR;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [0, 4] only expands
+  // on the last dimension.
+  verify_expanded_coordinates_3D(&subarray, 0, 4, 0, 7, {0, 0, 0}, {3, 1, 0});
+
+  // The flattened, inclusive range [56, 59] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 56, 59, 56, 59, {0, 2, 3}, {3, 2, 3});
+
+  // The flattened, inclusive range [16, 18] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 16, 18, 16, 18, {0, 0, 1}, {2, 0, 1});
+
+  // The flattened, inclusive range [37, 57] must have
+  // a starting coordinate of (0, 0, 2) and an ending coordinate
+  // of (3, 3, 3) to contain ranges [32, 63]. This ensures
+  // expansion along both the "x" and "y" dimension, leaving the
+  // "z" dimension untouched.
+  verify_expanded_coordinates_3D(
+      &subarray, 37, 57, 32, 63, {0, 0, 2}, {3, 3, 3});
+
+  close_array(ctx_, array_);
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, unordered, 3D",
+    "[Subarray][3d][unordered][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  uint64_t tile_extent_3 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y", "z"},
+      {TILEDB_UINT64, TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain, domain},
+      {&tile_extent_1, &tile_extent_2, &tile_extent_3},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 3D subarray ranges as:
+   *
+   * z == 0
+   * 0  4  8  12
+   * 16 20 24 28
+   * 32 36 40 44
+   * 48 52 56 60
+   *
+   * z == 1
+   * 1  5  9  13
+   * 17 21 25 29
+   * 33 37 41 45
+   * 49 53 57 61
+   *
+   * z == 2
+   * 2  6  10 14
+   * 18 22 26 30
+   * 34 38 42 46
+   * 50 54 58 62
+   *
+   * z == 3
+   * 3  7  11 15
+   * 19 23 27 31
+   * 35 39 43 47
+   * 51 55 59 63
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  std::vector<uint64_t> d3_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges, d3_ranges};
+  Layout subarray_layout = Layout::UNORDERED;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [56, 59] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 56, 59, 56, 59, {3, 2, 0}, {3, 2, 3});
+
+  // The flattened, inclusive range [16, 18] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 16, 18, 16, 18, {1, 0, 0}, {1, 0, 2});
+
+  // The flattened, inclusive range [37, 57] must have
+  // a starting coordinate of (2, 0, 0) and an ending coordinate
+  // of (3, 3, 3) to contain ranges [32, 63]. This ensures
+  // expansion along both the "y" and "z" dimension, leaving the
+  // "x" dimension untouched.
+  verify_expanded_coordinates_3D(
+      &subarray, 37, 57, 32, 63, {2, 0, 0}, {3, 3, 3});
+
+  close_array(ctx_, array_);
+}

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -2181,58 +2181,181 @@ Status Subarray::compute_relevant_fragments(
     ComputeRelevantFragmentsCtx* const fn_ctx) {
   STATS_START_TIMER(stats::GlobalStats::TimerType::READ_COMPUTE_RELEVANT_FRAGS)
 
-  auto meta = array_->fragment_metadata();
-  auto fragment_num = meta.size();
-  auto range_num = tile_overlap->range_num();
+  // Fetch the calibrated, multi-dimensional coordinates from the
+  // flattened (total order) range indexes. In this context,
+  // "calibration" implies that the coordinates contain the minimum
+  // n-dimensional space to encapsulate all ranges within `tile_overlap`.
+  std::vector<uint64_t> start_coords;
+  std::vector<uint64_t> end_coords;
+  get_expanded_coordinates(
+      tile_overlap->range_idx_start(),
+      tile_overlap->range_idx_end(),
+      &start_coords,
+      &end_coords);
 
-  // Sanity check we have at least one fragment
-  // and one range to compute on.
-  if (fragment_num == 0 || range_num == 0) {
-    relevant_fragments_.clear();
-    relevant_fragments_.shrink_to_fit();
+  // If the calibrated coordinates have not changed from
+  // the last call to this function, the computed relevant
+  // fragments will not change.
+  if (fn_ctx->initialized_ && start_coords == fn_ctx->last_start_coords_ &&
+      end_coords == fn_ctx->last_end_coords_) {
     return Status::Ok();
   }
 
-  // If this is the first time this routine is invoked,
-  // initialize `fn_ctx`. Otherwise, set `range_idx_start`
-  // to start from the end of the last range we calculated.
-  uint64_t range_idx_start = 0;
-  if (fn_ctx->frag_bytemap_.empty()) {
-    fn_ctx->frag_bytemap_.resize(fragment_num, 0);
-  } else {
-    assert(fn_ctx->frag_bytemap_.size() == fragment_num);
-    range_idx_start = fn_ctx->range_num_;
+  // Perform lazy-initialization the context cache for this routine.
+  const size_t fragment_num = array_->fragment_metadata().size();
+  const uint32_t dim_num = array_->array_schema()->dim_num();
+  if (!fn_ctx->initialized_) {
+    fn_ctx->initialized_ = true;
+
+    // Create a fragment bytemap for each dimension. Each
+    // non-zero byte represents an overlap between a fragment
+    // and at least one range in the corresponding dimension.
+    fn_ctx->frag_bytemaps_.resize(dim_num);
+    for (uint32_t d = 0; d < dim_num; ++d) {
+      fn_ctx->frag_bytemaps_[d].resize(fragment_num, 0);
+    }
   }
 
-  fn_ctx->range_num_ = range_num;
+  // Store the current calibrated coordinates.
+  fn_ctx->last_start_coords_ = start_coords;
+  fn_ctx->last_end_coords_ = end_coords;
 
-  // Compute the relevant fragments
-  auto status = parallel_for_2d(
-      compute_tp,
-      0,
-      fragment_num,
-      range_idx_start,
-      fn_ctx->range_num_,
-      [&](unsigned f, uint64_t r) {
-        const uint64_t translated_r = r + tile_overlap->range_idx_start();
-        if (fn_ctx->frag_bytemap_[f] == 0 &&
-            meta[f]->overlaps_non_empty_domain(this->ndrange(translated_r)))
-          fn_ctx->frag_bytemap_[f] = 1;
-        return Status::Ok();
-      });
+  // Populate the fragment bytemap for each dimension in parallel.
+  RETURN_NOT_OK(parallel_for(compute_tp, 0, dim_num, [&](const uint32_t d) {
+    return compute_relevant_fragments_for_dim(
+        compute_tp,
+        d,
+        fragment_num,
+        start_coords,
+        end_coords,
+        &fn_ctx->frag_bytemaps_[d]);
+  }));
 
-  // Copy to the result
+  // Recalculate relevant fragments.
   relevant_fragments_.clear();
   relevant_fragments_.reserve(fragment_num);
   for (unsigned f = 0; f < fragment_num; ++f) {
-    if (fn_ctx->frag_bytemap_[f])
+    bool relevant = true;
+    for (uint32_t d = 0; d < dim_num; ++d) {
+      if (fn_ctx->frag_bytemaps_[d][f] == 0) {
+        relevant = false;
+        break;
+      }
+    }
+
+    if (relevant) {
       relevant_fragments_.emplace_back(f);
+    }
   }
-  relevant_fragments_.shrink_to_fit();
 
   return Status::Ok();
 
   STATS_END_TIMER(stats::GlobalStats::TimerType::READ_COMPUTE_RELEVANT_FRAGS)
+}
+
+void Subarray::get_expanded_coordinates(
+    const uint64_t range_idx_start,
+    const uint64_t range_idx_end,
+    std::vector<uint64_t>* const start_coords,
+    std::vector<uint64_t>* const end_coords) const {
+  // Fetch the multi-dimensional coordinates from the
+  // flattened (total order) range indexes.
+  *start_coords = get_range_coords(range_idx_start);
+  *end_coords = get_range_coords(range_idx_end);
+
+  // This is only applicable to row-major, column-major, or unordered
+  // layouts. We will treat unordered layouts as the cell layout.
+  const Layout coords_layout =
+      (layout_ == Layout::UNORDERED) ? cell_order_ : layout_;
+  if (coords_layout == Layout::GLOBAL_ORDER ||
+      coords_layout == Layout::HILBERT) {
+    assert(*start_coords == *end_coords);
+    return;
+  }
+
+  assert(
+      coords_layout == Layout::ROW_MAJOR || coords_layout == Layout::COL_MAJOR);
+
+  const uint32_t dim_num = array_->array_schema()->dim_num();
+
+  // Locate the first dimension where the start/end coordinates deviate.
+  int64_t deviation_d;
+  if (coords_layout == Layout::ROW_MAJOR) {
+    deviation_d = 0;
+    while (deviation_d < dim_num - 1) {
+      if ((*start_coords)[deviation_d] != (*end_coords)[deviation_d])
+        break;
+      ++deviation_d;
+    }
+  } else {
+    assert(coords_layout == Layout::COL_MAJOR);
+    deviation_d = dim_num - 1;
+    while (deviation_d > 0) {
+      if ((*start_coords)[deviation_d] != (*end_coords)[deviation_d])
+        break;
+      --deviation_d;
+    }
+  }
+
+  // Calculate the first dimension to start the expansion. This is the
+  // the dimension that immediately follows the dimension where the
+  // coordinates deviate.
+  int64_t expand_d;
+  if (coords_layout == Layout::ROW_MAJOR) {
+    expand_d = deviation_d + 1;
+  } else {
+    assert(coords_layout == Layout::COL_MAJOR);
+    expand_d = deviation_d - 1;
+  }
+
+  // Expand each dimension at-and-after the expansion dimension so that
+  // the coordinates align with the first and last ranges.
+  if (coords_layout == Layout::ROW_MAJOR) {
+    for (int64_t d = expand_d; d < dim_num; ++d) {
+      (*start_coords)[d] = 0;
+      (*end_coords)[d] = ranges_[d].size() - 1;
+    }
+  } else {
+    assert(coords_layout == Layout::COL_MAJOR);
+    for (int64_t d = expand_d; d >= 0; --d) {
+      (*start_coords)[d] = 0;
+      (*end_coords)[d] = ranges_[d].size() - 1;
+    }
+  }
+}
+
+Status Subarray::compute_relevant_fragments_for_dim(
+    ThreadPool* const compute_tp,
+    const uint32_t dim_idx,
+    const uint64_t fragment_num,
+    const std::vector<uint64_t>& start_coords,
+    const std::vector<uint64_t>& end_coords,
+    std::vector<uint8_t>* const frag_bytemap) const {
+  const std::vector<FragmentMetadata*> meta = array_->fragment_metadata();
+  const Dimension* const dim = array_->array_schema()->dimension(dim_idx);
+
+  return parallel_for(compute_tp, 0, fragment_num, [&](const uint64_t f) {
+    // We're done when we have already determined fragment `f` to
+    // be relevant for this dimension.
+    if ((*frag_bytemap)[f] == 1) {
+      return Status::Ok();
+    }
+
+    // The fragment `f` is relevant to this dimension's fragment bytemap
+    // if it overlaps with any range between the start and end coordinates
+    // on this dimension.
+    const Range& frag_range = meta[f]->non_empty_domain()[dim_idx];
+    for (uint64_t r = start_coords[dim_idx]; r <= end_coords[dim_idx]; ++r) {
+      const Range& query_range = ranges_[dim_idx][r];
+
+      if (dim->overlap(frag_range, query_range)) {
+        (*frag_bytemap)[f] = 1;
+        break;
+      }
+    }
+
+    return Status::Ok();
+  });
 }
 
 Status Subarray::load_relevant_fragment_rtrees(


### PR DESCRIPTION
This patch refactors `Subarray::compute_relevant_fragments` to reduce the time
complexity at the expense of false-positive relevant fragments. The correctness
of the tile overlap computation is unaffected because it will not find overlap
within falsely relevant fragments.

Currently, this routine has a time complexity of:
`<# dimensions>[product]<# dimension ranges> * <# fragments>`

This patch modifies the routine to have a time complexity of:
`<# dimensions>[summation]<# dimension ranges> * <# fragments>`

Currently, a single relevant-fragment-bytemap is computed by checking overlap
on each fragment's ND-range against the ND-range for each flattened range
ids.

This patch maintains an individual relevant-fragment-bytemap for each
dimension, where the bytemap is computed by checking overlap on each fragment's
ND-range against each ND-range in subarray. The final relevant-fragment-bytemap
is computed by performing a logical AND among each dimension's individual
fragment bytemap.

The important consideration is that the input to this routine is a start/end
index on the flattened range ids. To reduce risk, this change does not modify
the interface to `Subarray::compute_relevant_fragments`. To compute in ND-space
instead of flattened-space, we must convert the input start/end indexes to
ND-coordinates. The ND space between the start/end coordinates is not guaranteed
to encapsulate all ranges in between the flattened ("total order") start/end
indexes. To handle this, we must expand the coordinates to sufficiently capture
all input ranges. This may add additional ranges, which may result in false
positive relevant fragments.

---
TYPE: IMPROVEMENT
DESC: Optimize `Subarray::compute_relevant_fragments`
