### PR TITLE
Query::Config() now returns a pointer

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -602,9 +602,9 @@ Status query_to_capnp(
   }
 
   // Serialize Config
-  const Config config = query.config();
+  const Config* config = query.config();
   auto config_builder = query_builder->initConfig();
-  RETURN_NOT_OK(config_to_capnp(&config, &config_builder));
+  RETURN_NOT_OK(config_to_capnp(config, &config_builder));
 
   return Status::Ok();
 }


### PR DESCRIPTION
This fixes serialization build on release-2.2 from the backport of PRs #2205/#2177. CI passed in the original backport but the swapping of the config return to a pointer caused a build failure on the release branch.

---
TYPE: NO_HISTORY
DESC: N/A
