### PR TITLE
[BACKPORT 2.2] Optimize `Subarray::compute_relevant_fragments`

### DIFF
--- a/test/src/unit-Subarray.cc
+++ b/test/src/unit-Subarray.cc
@@ -319,3 +319,609 @@ TEST_CASE_METHOD(
 
   close_array(ctx_, array_);
 }
+
+void verify_expanded_coordinates_2D(
+    Subarray* const subarray,
+    const uint64_t range_idx_start,
+    const uint64_t range_idx_end,
+    const uint64_t expected_range_idx_start,
+    const uint64_t expected_range_idx_end,
+    const std::vector<uint64_t>& expected_start_coords,
+    const std::vector<uint64_t>& expected_end_coords) {
+  std::vector<uint64_t> start_coords;
+  std::vector<uint64_t> end_coords;
+  subarray->get_expanded_coordinates(
+      range_idx_start, range_idx_end, &start_coords, &end_coords);
+  REQUIRE(start_coords == expected_start_coords);
+  REQUIRE(end_coords == expected_end_coords);
+  REQUIRE(subarray->range_idx(start_coords) == expected_range_idx_start);
+  REQUIRE(subarray->range_idx(end_coords) == expected_range_idx_end);
+
+  // Build a map from each inclusive range index between
+  // `range_idx_start` and `range_idx_end` that maps to a bool.
+  std::unordered_map<uint64_t, bool> range_idx_found;
+  for (uint64_t i = range_idx_start; i <= range_idx_end; ++i) {
+    range_idx_found[i] = false;
+  }
+
+  // Iterate through every coordinate between the start and end
+  // coordinate. If the flattened index is in `range_idx_found`,
+  // set the value to `true`.
+  for (uint64_t x = start_coords[0]; x <= end_coords[0]; ++x) {
+    for (uint64_t y = start_coords[1]; y <= end_coords[1]; ++y) {
+      const uint64_t range_idx = subarray->range_idx({x, y});
+      if (range_idx_found.count(range_idx) == 1) {
+        range_idx_found[range_idx] = true;
+      }
+    }
+  }
+
+  // Verify all flattened ranges are contained within the 2D
+  // space between `start_coords` and `end_coords`.
+  for (uint64_t i = range_idx_start; i <= range_idx_end; ++i) {
+    REQUIRE(range_idx_found[i] == true);
+  }
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, row-major, 2D",
+    "[Subarray][2d][row_major][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y"},
+      {TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain},
+      {&tile_extent_1, &tile_extent_2},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 2D subarray ranges as:
+   * 0  1  2  3
+   * 4  5  6  7
+   * 8  9  10 11
+   * 12 13 14 15
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges};
+  Layout subarray_layout = Layout::ROW_MAJOR;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [1, 2] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 1, 2, 1, 2, {0, 1}, {0, 2});
+
+  // The flattened, inclusive range [4, 6] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 4, 6, 4, 6, {1, 0}, {1, 2});
+
+  // The flattened, inclusive range [8, 8] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 8, 8, 8, 8, {2, 0}, {2, 0});
+
+  // The flattened, inclusive range [1, 7] must have
+  // a starting coordinate of (0, 0) and an ending coordinate
+  // of (1, 3) to contain ranges [0, 7].
+  verify_expanded_coordinates_2D(&subarray, 1, 7, 0, 7, {0, 0}, {1, 3});
+
+  // The flattened, inclusive range [5, 10] must have
+  // a starting coordinate of (1, 0) and an ending coordinate
+  // of (2, 3) to contain ranges [4, 11].
+  verify_expanded_coordinates_2D(&subarray, 5, 10, 4, 11, {1, 0}, {2, 3});
+
+  close_array(ctx_, array_);
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, col-major, 2D",
+    "[Subarray][2d][col_major][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y"},
+      {TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain},
+      {&tile_extent_1, &tile_extent_2},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 2D subarray ranges as:
+   * 0 4 8  12
+   * 1 5 9  13
+   * 2 6 10 14
+   * 3 7 11 15
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges};
+  Layout subarray_layout = Layout::COL_MAJOR;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [1, 2] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 1, 2, 1, 2, {1, 0}, {2, 0});
+
+  // The flattened, inclusive range [4, 6] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 4, 6, 4, 6, {0, 1}, {2, 1});
+
+  // The flattened, inclusive range [8, 8] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 8, 8, 8, 8, {0, 2}, {0, 2});
+
+  // The flattened, inclusive range [1, 7] must have
+  // a starting coordinate of (0, 0) and an ending coordinate
+  // of (3, 1) to contain ranges [0, 7].
+  verify_expanded_coordinates_2D(&subarray, 1, 7, 0, 7, {0, 0}, {3, 1});
+
+  // The flattened, inclusive range [5, 10] must have
+  // a starting coordinate of (0, 1) and an ending coordinate
+  // of (3, 2) to contain ranges [4, 11].
+  verify_expanded_coordinates_2D(&subarray, 5, 10, 4, 11, {0, 1}, {3, 2});
+
+  close_array(ctx_, array_);
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, unordered, 2D",
+    "[Subarray][2d][unordered][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y"},
+      {TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain},
+      {&tile_extent_1, &tile_extent_2},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 2D subarray ranges as:
+   * 0  1  2  3
+   * 4  5  6  7
+   * 8  9  10 11
+   * 12 13 14 15
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges};
+  Layout subarray_layout = Layout::UNORDERED;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [1, 2] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 1, 2, 1, 2, {0, 1}, {0, 2});
+
+  // The flattened, inclusive range [4, 6] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 4, 6, 4, 6, {1, 0}, {1, 2});
+
+  // The flattened, inclusive range [8, 8] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_2D(&subarray, 8, 8, 8, 8, {2, 0}, {2, 0});
+
+  // The flattened, inclusive range [1, 7] must have
+  // a starting coordinate of (0, 0) and an ending coordinate
+  // of (1, 3) to contain ranges [0, 7].
+  verify_expanded_coordinates_2D(&subarray, 1, 7, 0, 7, {0, 0}, {1, 3});
+
+  // The flattened, inclusive range [5, 10] must have
+  // a starting coordinate of (1, 0) and an ending coordinate
+  // of (2, 3) to contain ranges [4, 11].
+  verify_expanded_coordinates_2D(&subarray, 5, 10, 4, 11, {1, 0}, {2, 3});
+
+  close_array(ctx_, array_);
+}
+
+void verify_expanded_coordinates_3D(
+    Subarray* const subarray,
+    const uint64_t range_idx_start,
+    const uint64_t range_idx_end,
+    const uint64_t expected_range_idx_start,
+    const uint64_t expected_range_idx_end,
+    const std::vector<uint64_t>& expected_start_coords,
+    const std::vector<uint64_t>& expected_end_coords) {
+  std::vector<uint64_t> start_coords;
+  std::vector<uint64_t> end_coords;
+  subarray->get_expanded_coordinates(
+      range_idx_start, range_idx_end, &start_coords, &end_coords);
+  REQUIRE(start_coords == expected_start_coords);
+  REQUIRE(end_coords == expected_end_coords);
+  REQUIRE(subarray->range_idx(start_coords) == expected_range_idx_start);
+  REQUIRE(subarray->range_idx(end_coords) == expected_range_idx_end);
+
+  // Build a map from each inclusive range index between
+  // `range_idx_start` and `range_idx_end` that maps to a bool.
+  std::unordered_map<uint64_t, bool> range_idx_found;
+  for (uint64_t i = range_idx_start; i <= range_idx_end; ++i) {
+    range_idx_found[i] = false;
+  }
+
+  // Iterate through every coordinate between the start and end
+  // coordinate. If the flattened index is in `range_idx_found`,
+  // set the value to `true`.
+  for (uint64_t x = start_coords[0]; x <= end_coords[0]; ++x) {
+    for (uint64_t y = start_coords[1]; y <= end_coords[1]; ++y) {
+      for (uint64_t z = start_coords[2]; z <= end_coords[2]; ++z) {
+        const uint64_t range_idx = subarray->range_idx({x, y, z});
+        if (range_idx_found.count(range_idx) == 1) {
+          range_idx_found[range_idx] = true;
+        }
+      }
+    }
+  }
+
+  // Verify all flattened ranges are contained within the 2D
+  // space between `start_coords` and `end_coords`.
+  for (uint64_t i = range_idx_start; i <= range_idx_end; ++i) {
+    REQUIRE(range_idx_found[i] == true);
+  }
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, row-major, 3D",
+    "[Subarray][3d][row_major][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  uint64_t tile_extent_3 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y", "z"},
+      {TILEDB_UINT64, TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain, domain},
+      {&tile_extent_1, &tile_extent_2, &tile_extent_3},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 3D subarray ranges as:
+   *
+   * z == 0
+   * 0  4  8  12
+   * 16 20 24 28
+   * 32 36 40 44
+   * 48 52 56 60
+   *
+   * z == 1
+   * 1  5  9  13
+   * 17 21 25 29
+   * 33 37 41 45
+   * 49 53 57 61
+   *
+   * z == 2
+   * 2  6  10 14
+   * 18 22 26 30
+   * 34 38 42 46
+   * 50 54 58 62
+   *
+   * z == 3
+   * 3  7  11 15
+   * 19 23 27 31
+   * 35 39 43 47
+   * 51 55 59 63
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  std::vector<uint64_t> d3_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges, d3_ranges};
+  Layout subarray_layout = Layout::ROW_MAJOR;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [0, 4] only expands
+  // on the last dimension.
+  verify_expanded_coordinates_3D(&subarray, 0, 4, 0, 7, {0, 0, 0}, {0, 1, 3});
+
+  // The flattened, inclusive range [56, 59] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 56, 59, 56, 59, {3, 2, 0}, {3, 2, 3});
+
+  // The flattened, inclusive range [16, 18] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 16, 18, 16, 18, {1, 0, 0}, {1, 0, 2});
+
+  // The flattened, inclusive range [37, 57] must have
+  // a starting coordinate of (2, 0, 0) and an ending coordinate
+  // of (3, 3, 3) to contain ranges [32, 63]. This ensures
+  // expansion along both the "y" and "z" dimension, leaving the
+  // "x" dimension untouched.
+  verify_expanded_coordinates_3D(
+      &subarray, 37, 57, 32, 63, {2, 0, 0}, {3, 3, 3});
+
+  close_array(ctx_, array_);
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, col-major, 3D",
+    "[Subarray][3d][col_major][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  uint64_t tile_extent_3 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y", "z"},
+      {TILEDB_UINT64, TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain, domain},
+      {&tile_extent_1, &tile_extent_2, &tile_extent_3},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 3D subarray ranges as:
+   *
+   * z == 0
+   * 0  16 32 48
+   * 4  20 36 52
+   * 8  24 40 56
+   * 12 28 44 60
+   *
+   * z == 1
+   * 1  17 33 49
+   * 5  21 37 53
+   * 9  25 41 57
+   * 13 29 45 61
+   *
+   * z == 2
+   * 2  18 34 50
+   * 6  22 38 54
+   * 10 26 42 58
+   * 14 30 46 62
+   *
+   * z == 3
+   * 3  19 35 51
+   * 7  23 39 55
+   * 11 27 43 59
+   * 15 31 47 63
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  std::vector<uint64_t> d3_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges, d3_ranges};
+  Layout subarray_layout = Layout::COL_MAJOR;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [0, 4] only expands
+  // on the last dimension.
+  verify_expanded_coordinates_3D(&subarray, 0, 4, 0, 7, {0, 0, 0}, {3, 1, 0});
+
+  // The flattened, inclusive range [56, 59] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 56, 59, 56, 59, {0, 2, 3}, {3, 2, 3});
+
+  // The flattened, inclusive range [16, 18] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 16, 18, 16, 18, {0, 0, 1}, {2, 0, 1});
+
+  // The flattened, inclusive range [37, 57] must have
+  // a starting coordinate of (0, 0, 2) and an ending coordinate
+  // of (3, 3, 3) to contain ranges [32, 63]. This ensures
+  // expansion along both the "x" and "y" dimension, leaving the
+  // "z" dimension untouched.
+  verify_expanded_coordinates_3D(
+      &subarray, 37, 57, 32, 63, {0, 0, 2}, {3, 3, 3});
+
+  close_array(ctx_, array_);
+}
+
+TEST_CASE_METHOD(
+    SubarrayFx,
+    "Subarray: Test get_expanded_coordinates, unordered, 3D",
+    "[Subarray][3d][unordered][get_expanded_coordinates]") {
+  uint64_t domain[] = {1, 4};
+  uint64_t tile_extent_1 = 1;
+  uint64_t tile_extent_2 = 1;
+  uint64_t tile_extent_3 = 1;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"x", "y", "z"},
+      {TILEDB_UINT64, TILEDB_UINT64, TILEDB_UINT64},
+      {domain, domain, domain},
+      {&tile_extent_1, &tile_extent_2, &tile_extent_3},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_LZ4, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      1);
+
+  open_array(ctx_, array_, TILEDB_READ);
+
+  /**
+   * Populate the subarray with non-coalesced point ranges
+   * on each cell. This will populate the 3D subarray ranges as:
+   *
+   * z == 0
+   * 0  4  8  12
+   * 16 20 24 28
+   * 32 36 40 44
+   * 48 52 56 60
+   *
+   * z == 1
+   * 1  5  9  13
+   * 17 21 25 29
+   * 33 37 41 45
+   * 49 53 57 61
+   *
+   * z == 2
+   * 2  6  10 14
+   * 18 22 26 30
+   * 34 38 42 46
+   * 50 54 58 62
+   *
+   * z == 3
+   * 3  7  11 15
+   * 19 23 27 31
+   * 35 39 43 47
+   * 51 55 59 63
+   */
+  Subarray subarray;
+  std::vector<uint64_t> d1_ranges;
+  std::vector<uint64_t> d2_ranges;
+  std::vector<uint64_t> d3_ranges;
+  for (uint64_t i = domain[0]; i <= domain[1]; ++i) {
+    d1_ranges.emplace_back(i);
+    d1_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d2_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+    d3_ranges.emplace_back(i);
+  }
+  SubarrayRanges<uint64_t> ranges = {d1_ranges, d2_ranges, d3_ranges};
+  Layout subarray_layout = Layout::UNORDERED;
+  create_subarray(array_->array_, ranges, subarray_layout, &subarray, false);
+
+  // We must compute range offsets before invoking
+  // `get_expanded_coordinates`.
+  subarray.compute_range_offsets();
+
+  // The flattened, inclusive range [56, 59] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 56, 59, 56, 59, {3, 2, 0}, {3, 2, 3});
+
+  // The flattened, inclusive range [16, 18] does not expand
+  // the coordinates when calibrating.
+  verify_expanded_coordinates_3D(
+      &subarray, 16, 18, 16, 18, {1, 0, 0}, {1, 0, 2});
+
+  // The flattened, inclusive range [37, 57] must have
+  // a starting coordinate of (2, 0, 0) and an ending coordinate
+  // of (3, 3, 3) to contain ranges [32, 63]. This ensures
+  // expansion along both the "y" and "z" dimension, leaving the
+  // "x" dimension untouched.
+  verify_expanded_coordinates_3D(
+      &subarray, 37, 57, 32, 63, {2, 0, 0}, {3, 3, 3});
+
+  close_array(ctx_, array_);
+}

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -696,6 +696,22 @@ class Subarray {
    */
   std::vector<unsigned> relevant_fragments() const;
 
+  /**
+   * For flattened ("total order") start/end range indexes,
+   * return the starting and ending ND-range coordinates that
+   * contain the minimum space to contain all flattened ranges.
+   *
+   * @param range_idx_start flattened range starting index, inclusive.
+   * @param range_idx_end flattened range ending index, inclusive.
+   * @param start_coords mutated to contain the nd-range start coordinates.
+   * @param end_coords mutated to contain the nd-range end coordinates.
+   */
+  void get_expanded_coordinates(
+      uint64_t range_idx_start,
+      uint64_t range_idx_end,
+      std::vector<uint64_t>* start_coords,
+      std::vector<uint64_t>* end_coords) const;
+
  private:
   /* ********************************* */
   /*        PRIVATE DATA TYPES         */
@@ -707,17 +723,33 @@ class Subarray {
    */
   struct ComputeRelevantFragmentsCtx {
     ComputeRelevantFragmentsCtx()
-        : range_num_(0) {
+        : initialized_(false) {
     }
 
-    /** The bytemap, one byte per fragment. */
-    std::vector<uint8_t> frag_bytemap_;
+    /**
+     * This context cache is lazy initialized. This will be
+     * set to `true` when initialized in `compute_relevant_fragments()`.
+     */
+    bool initialized_;
 
     /**
-     * The total number of ranges computed with in the
-     * last invocation of `compute_relevant_fragments`.
+     * The last calibrated start coordinates.
      */
-    uint64_t range_num_;
+    std::vector<uint64_t> last_start_coords_;
+
+    /**
+     * The last calibrated end coordinates.
+     */
+    std::vector<uint64_t> last_end_coords_;
+
+    /**
+     * The fragment bytemaps for each dimension. The inner
+     * vector is the fragment bytemap that has a byte element
+     * for each fragment. Non-zero bytes represent relevant
+     * fragments for a specific dimension. Each dimension
+     * has its own fragment bytemap (the outer vector).
+     */
+    std::vector<std::vector<uint8_t>> frag_bytemaps_;
   };
 
   /**
@@ -901,6 +933,24 @@ class Subarray {
       ThreadPool* compute_tp,
       const SubarrayTileOverlap* tile_overlap,
       ComputeRelevantFragmentsCtx* fn_ctx);
+
+  /**
+   * Computes the relevant fragment bytemap for a specific dimension.
+   *
+   * @param compute_tp The thread pool for compute-bound tasks.
+   * @param dim_idx The index of the dimension to compute on.
+   * @param fragment_num The number of fragments to compute on.
+   * @param start_coords The starting range coordinates to compute between.
+   * @param end_coords The ending range coordinates to compute between.
+   * @param frag_bytemap The fragment bytemap to mutate.
+   */
+  Status compute_relevant_fragments_for_dim(
+      ThreadPool* compute_tp,
+      uint32_t dim_idx,
+      uint64_t fragment_num,
+      const std::vector<uint64_t>& start_coords,
+      const std::vector<uint64_t>& end_coords,
+      std::vector<uint8_t>* frag_bytemap) const;
 
   /** Loads the R-Trees of all relevant fragments in parallel. */
   Status load_relevant_fragment_rtrees(ThreadPool* compute_tp) const;


### PR DESCRIPTION
This patch refactors `Subarray::compute_relevant_fragments` to reduce the time
complexity at the expense of false-positive relevant fragments. The correctness
of the tile overlap computation is unaffected because it will not find overlap
within falsely relevant fragments.

Currently, this routine has a time complexity of:
`<# dimensions>[product]<# dimension ranges> * <# fragments>`

This patch modifies the routine to have a time complexity of:
`<# dimensions>[summation]<# dimension ranges> * <# fragments>`

Currently, a single relevant-fragment-bytemap is computed by checking overlap
on each fragment's ND-range against the ND-range for each flattened range
ids.

This patch maintains an individual relevant-fragment-bytemap for each
dimension, where the bytemap is computed by checking overlap on each fragment's
ND-range against each ND-range in subarray. The final relevant-fragment-bytemap
is computed by performing a logical AND among each dimension's individual
fragment bytemap.

The important consideration is that the input to this routine is a start/end
index on the flattened range ids. To reduce risk, this change does not modify
the interface to `Subarray::compute_relevant_fragments`. To compute in ND-space
instead of flattened-space, we must convert the input start/end indexes to
ND-coordinates. The ND space between the start/end coordinates is not guaranteed
to encapsulate all ranges in between the flattened ("total order") start/end
indexes. To handle this, we must expand the coordinates to sufficiently capture
all input ranges. This may add additional ranges, which may result in false
positive relevant fragments.

---
TYPE: IMPROVEMENT
DESC: Optimize `Subarray::compute_relevant_fragments`