### PR TITLE
Fix bootstrap_args in GHA

### DIFF
--- a/scripts/ci/build_libtiledb.sh
+++ b/scripts/ci/build_libtiledb.sh
@@ -27,9 +27,7 @@
 # Build and test libtiledb
 
 # Set up arguments for bootstrap.sh
-bootstrap_args="--enable=verbose";
-
-# name: 'Install dependencies'
+bootstrap_args="${boostrap_args} --enable=verbose";
 
 mkdir -p $GITHUB_WORKSPACE/build
 cd $GITHUB_WORKSPACE/build


### PR DESCRIPTION
The `bootstrap_args` set outside of the `build_libtiledb.sh` are overwritten
instead of appended-to.

---

TYPE: NO_HISTORY

