### PR TITLE
Add Ubuntu+ASAN to GHA job

### DIFF
--- a/.github/workflows/build-macOS10.14-GCS.yml
+++ b/.github/workflows/build-macOS10.14-GCS.yml
@@ -51,7 +51,7 @@ jobs:
           source scripts/install-gcs-emu.sh;
           source scripts/run-gcs-emu.sh;
 
-          bootstrap_args="${bootstrap_args} --enable-gcs";
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-gcs";
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
 
           # GCS unit tests are temporarily unsupported on CI for MacOS. Fake success with

--- a/.github/workflows/build-macOS10.14-S3.yml
+++ b/.github/workflows/build-macOS10.14-S3.yml
@@ -60,8 +60,8 @@ jobs:
           source scripts/install-minio.sh;
           source scripts/run-minio.sh;
 
-          bootstrap_args="${bootstrap_args} --enable-s3";
-          bootstrap_args="${bootstrap_args} --enable-tools";
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-s3";
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-tools";
           
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
 

--- a/.github/workflows/build-ubuntu16.04-ASAN.yml
+++ b/.github/workflows/build-ubuntu16.04-ASAN.yml
@@ -1,25 +1,14 @@
-name: build-ubuntu-16.04-SERIALIZATION
-on:
-  push:
-    branches:
-      - dev
-      - release-*
-      - refs/tags/*
-  pull_request:
-    branches:
-      - '*'  # must quote since "*" is a YAML reserved character; we want a string
+name: build-ubuntu-16.04-ASAN
+on: push
 env:
-  TILEDB_SERIALIZATION: ON
-  TILEDB_S3: ON
-  CXX: g++
-  BACKWARDS_COMPATIBILITY_ARRAYS: ON
+  CXX: g++-9
 
 jobs:
   build:
     runs-on: ubuntu-16.04
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
     timeout-minutes: 90
-    name: Build - ubuntu-16.04 - SERIALIZATION
+    name: Build - ubuntu-16.04 - ASAN
     steps:
       - uses: actions/checkout@v2
       - name: 'Print env'
@@ -37,6 +26,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
+
       - run: |
           set -e pipefail
           python -m pip install --upgrade pip virtualenv
@@ -60,19 +50,15 @@ jobs:
         id: test
         run: |
 
-          git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.2.0 test/inputs/arrays/read_compatibility_test
-
-          #   name: 'Clone Unit-Test-Arrays'
-
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-verbose";
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-sanitizer=address";
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-debug";
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-static-tiledb";
           BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-serialization";
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
 
-          # Bypass Catch2 Framework stdout interception with awk on test output
-          # make check | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
 
-
-          # - bash: |
           pushd $GITHUB_WORKSPACE/examples/cmake_project
           mkdir build && cd build
           cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dist .. && make
@@ -98,7 +84,6 @@ jobs:
           if [[ "${{ steps.test.outputs.TILEDB_CI_SUCCESS }}" -ne 1 ]]; then
             exit 1;
           fi
-      #
       - name: "Print log files (failed build only)"
         run: |
           source $GITHUB_WORKSPACE/scripts/ci/print_logs.sh

--- a/.github/workflows/build-ubuntu16.04-AZURE.yml
+++ b/.github/workflows/build-ubuntu16.04-AZURE.yml
@@ -80,7 +80,7 @@ jobs:
           source scripts/install-azurite.sh;
           source scripts/run-azurite.sh;
 
-          bootstrap_args="${bootstrap_args} --enable-azure";
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-azure";
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
           
           # Bypass Catch2 Framework stdout interception with awk on test output

--- a/.github/workflows/build-ubuntu16.04-GCS.yml
+++ b/.github/workflows/build-ubuntu16.04-GCS.yml
@@ -66,7 +66,7 @@ jobs:
           source scripts/install-gcs-emu.sh;
           source scripts/run-gcs-emu.sh;
 
-          bootstrap_args="${bootstrap_args} --enable-gcs";
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-gcs";
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
 
           # Bypass Catch2 Framework stdout interception with awk on test output

--- a/.github/workflows/build-ubuntu16.04-HDFS.yml
+++ b/.github/workflows/build-ubuntu16.04-HDFS.yml
@@ -68,7 +68,7 @@ jobs:
           source scripts/install-hadoop.sh
           source scripts/run-hadoop.sh
 
-          bootstrap_args="${bootstrap_args} --enable-hdfs";
+          BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-hdfs";
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
 
           # Bypass Catch2 Framework stdout interception with awk on test output

--- a/scripts/ci/build_libtiledb.sh
+++ b/scripts/ci/build_libtiledb.sh
@@ -26,15 +26,14 @@
 
 # Build and test libtiledb
 
-# Set up arguments for bootstrap.sh
-bootstrap_args="${boostrap_args} --enable=verbose";
+BOOTSTRAP_ARGS="${BOOTSTRAP_ARGS} --enable-verbose";
 
 mkdir -p $GITHUB_WORKSPACE/build
 cd $GITHUB_WORKSPACE/build
 
 # Configure and build TileDB
-echo "Bootstrapping with '$bootstrap_args'"
-$GITHUB_WORKSPACE/bootstrap $bootstrap_args
+echo "Bootstrapping with '$BOOTSTRAP_ARGS'"
+$GITHUB_WORKSPACE/bootstrap $BOOTSTRAP_ARGS
 
 make -j4
 make examples -j4


### PR DESCRIPTION
This introduces a new workflow for testing with ASAN address sanitization on
Ubuntu. This test knowingly fails. This is OK because its success is not tied
to our precheckin checks.

This mimics a similar job on the Azure Pipelines CI. That job has a false pass.
The job succeeds but ASAN issues are found. Let's add this to GHA so we're
aware of the problems. I will create a follow-up ticket for resolving the
address sanitization issues.

misc: Also renames `bootstrap_args` to `BOOTSTRAP_ARGS` since it is an env variable.

---

TYPE: NO_HISTORY
