### PR TITLE
Change example print statements

### DIFF
--- a/examples/c_api/fragment_info.c
+++ b/examples/c_api/fragment_info.c
@@ -158,14 +158,17 @@ void get_fragment_info() {
   uint64_t start;
   uint64_t end;
   tiledb_fragment_info_get_timestamp_range(ctx, fragment_info, 0, &start, &end);
-  printf("The fragment's timestamp range is {%u, %u}.\n", 
-    (uint32_t)start, (uint32_t)end);
+  printf(
+      "The fragment's timestamp range is {%u, %u}.\n",
+      (uint32_t)start,
+      (uint32_t)end);
 
   // Get the number of cells written to the fragment.
   uint64_t cell_num;
   tiledb_fragment_info_get_cell_num(ctx, fragment_info, 0, &cell_num);
-  printf("The number of cells written to the fragment is %u.\n", 
-    (uint32_t)cell_num);
+  printf(
+      "The number of cells written to the fragment is %u.\n",
+      (uint32_t)cell_num);
 
   // Get the format version of the fragment.
   uint32_t version;

--- a/examples/c_api/fragment_info.c
+++ b/examples/c_api/fragment_info.c
@@ -144,7 +144,7 @@ void get_fragment_info() {
   // Get fragment size
   uint64_t size;
   tiledb_fragment_info_get_fragment_size(ctx, fragment_info, 0, &size);
-  printf("The fragment size is %llu.\n", size);
+  printf("The fragment size is %lu.\n", size);
 
   // Check if the fragment is dense or sparse.
   int32_t dense;
@@ -158,12 +158,12 @@ void get_fragment_info() {
   uint64_t start;
   uint64_t end;
   tiledb_fragment_info_get_timestamp_range(ctx, fragment_info, 0, &start, &end);
-  printf("The fragment's timestamp range is {%llu, %llu}.\n", start, end);
+  printf("The fragment's timestamp range is {%lu, %lu}.\n", start, end);
 
   // Get the number of cells written to the fragment.
   uint64_t cell_num;
   tiledb_fragment_info_get_cell_num(ctx, fragment_info, 0, &cell_num);
-  printf("The number of cells written to the fragment is %llu.\n", cell_num);
+  printf("The number of cells written to the fragment is %lu.\n", cell_num);
 
   // Get the format version of the fragment.
   uint32_t version;

--- a/examples/c_api/fragment_info.c
+++ b/examples/c_api/fragment_info.c
@@ -144,7 +144,7 @@ void get_fragment_info() {
   // Get fragment size
   uint64_t size;
   tiledb_fragment_info_get_fragment_size(ctx, fragment_info, 0, &size);
-  printf("The fragment size is %lu.\n", size);
+  printf("The fragment size is %u.\n", (uint32_t)size);
 
   // Check if the fragment is dense or sparse.
   int32_t dense;
@@ -158,12 +158,14 @@ void get_fragment_info() {
   uint64_t start;
   uint64_t end;
   tiledb_fragment_info_get_timestamp_range(ctx, fragment_info, 0, &start, &end);
-  printf("The fragment's timestamp range is {%lu, %lu}.\n", start, end);
+  printf("The fragment's timestamp range is {%u, %u}.\n", 
+    (uint32_t)start, (uint32_t)end);
 
   // Get the number of cells written to the fragment.
   uint64_t cell_num;
   tiledb_fragment_info_get_cell_num(ctx, fragment_info, 0, &cell_num);
-  printf("The number of cells written to the fragment is %lu.\n", cell_num);
+  printf("The number of cells written to the fragment is %u.\n", 
+    (uint32_t)cell_num);
 
   // Get the format version of the fragment.
   uint32_t version;

--- a/examples/cpp_api/fragment_info.cc
+++ b/examples/cpp_api/fragment_info.cc
@@ -91,49 +91,52 @@ void get_fragment_info() {
 
   // Get number of written fragments.
   uint32_t num = fragment_info.fragment_num();
-  printf("The number of written fragments is %d.\n", num);
+  std::cout << "The number of written fragments is " << num << ".\n"
+            << std::endl;
 
   // Get fragment URI
   std::string uri = fragment_info.fragment_uri(0);
-  printf("The fragment URI is %s.\n", uri.c_str());
+  std::cout << "The fragment URI is " << uri.c_str() << ".\n" << std::endl;
 
   // Get fragment size
   uint64_t size = fragment_info.fragment_size(0);
-  printf("The fragment size is %llu.\n", size);
+  std::cout << "The fragment size is " << size << ".\n" << std::endl;
 
   // Check if the fragment is dense or sparse.
   bool dense = fragment_info.dense(0);
   if (dense == 1)
-    printf("The fragment is dense.\n");
+    std::cout << "The fragment is dense.\n" << std::endl;
   else
-    printf("The fragment is sparse.\n");
+    std::cout << "The fragment is sparse.\n" << std::endl;
 
   // Get the fragment timestamp range
   std::pair<uint64_t, uint64_t> timestamps = fragment_info.timestamp_range(0);
-  printf(
-      "The fragment's timestamp range is {%llu, %llu}.\n",
-      timestamps.first,
-      timestamps.second);
+  std::cout << "The fragment's timestamp range is {" << timestamps.first << " ,"
+            << timestamps.second << "}.\n"
+            << std::endl;
 
   // Get the number of cells written to the fragment.
   uint64_t cell_num = fragment_info.cell_num(0);
-  printf("The number of cells written to the fragment is %llu.\n", cell_num);
+  std::cout << "The number of cells written to the fragment is " << cell_num
+            << ".\n"
+            << std::endl;
 
   // Get the format version of the fragment.
   uint32_t version = fragment_info.version(0);
-  printf("The fragment's format version is %d.\n", version);
+  std::cout << "The fragment's format version is " << version << ".\n"
+            << std::endl;
 
   // Check if fragment has consolidated metadata.
   // If not, get the number of fragments with unconsolidated metadata
   //  in the fragment info object.
   bool consolidated = fragment_info.has_consolidated_metadata(0);
   if (consolidated != 0) {
-    printf("The fragment has consolidated metadata.\n");
+    std::cout << "The fragment has consolidated metadata.\n" << std::endl;
   } else {
     uint32_t unconsolidated = fragment_info.unconsolidated_metadata_num();
-    printf(
-        "The fragment has %d unconsolidated metadata fragments.\n",
-        unconsolidated);
+    std::cout << "The fragment has " << unconsolidated
+              << " unconsolidated metadata fragments.\n"
+              << std::endl;
   }
 
   // Get non-empty domain from index


### PR DESCRIPTION
TYPE:  FORMAT
DESC: Change printfs in C++ examples to cout, edit C print statements to fix format warnings
