### PR TITLE
Timestamp start/end for vacuuming/consolidation

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -236,6 +236,8 @@ void check_save_to_file() {
   ss << "sm.consolidation.step_min_frags 4294967295\n";
   ss << "sm.consolidation.step_size_ratio 0.0\n";
   ss << "sm.consolidation.steps 4294967295\n";
+  ss << "sm.consolidation.timestamp_end " << std::to_string(UINT64_MAX) << "\n";
+  ss << "sm.consolidation.timestamp_start 0\n";
   ss << "sm.dedup_coords false\n";
   ss << "sm.enable_signal_handlers true\n";
   ss << "sm.io_concurrency_level " << std::thread::hardware_concurrency()
@@ -249,6 +251,8 @@ void check_save_to_file() {
   ss << "sm.sub_partitioner_memory_budget 0\n";
   ss << "sm.tile_cache_size 10000000\n";
   ss << "sm.vacuum.mode fragments\n";
+  ss << "sm.vacuum.timestamp_end " << std::to_string(UINT64_MAX) << "\n";
+  ss << "sm.vacuum.timestamp_start 0\n";
   ss << "sm.var_offsets.bitsize 64\n";
   ss << "sm.var_offsets.extra_element false\n";
   ss << "sm.var_offsets.mode bytes\n";
@@ -542,6 +546,9 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.skip_checksum_validation"] = "false";
   all_param_values["sm.consolidation.amplification"] = "1.0";
   all_param_values["sm.consolidation.steps"] = "4294967295";
+  all_param_values["sm.consolidation.timestamp_start"] = "0";
+  all_param_values["sm.consolidation.timestamp_end"] =
+      std::to_string(UINT64_MAX);
   all_param_values["sm.consolidation.step_min_frags"] = "4294967295";
   all_param_values["sm.consolidation.step_max_frags"] = "4294967295";
   all_param_values["sm.consolidation.buffer_size"] = "50000000";
@@ -549,6 +556,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.consolidation.mode"] = "fragments";
   all_param_values["sm.read_range_oob"] = "warn";
   all_param_values["sm.vacuum.mode"] = "fragments";
+  all_param_values["sm.vacuum.timestamp_start"] = "0";
+  all_param_values["sm.vacuum.timestamp_end"] = std::to_string(UINT64_MAX);
   all_param_values["sm.var_offsets.bitsize"] = "32";
   all_param_values["sm.var_offsets.extra_element"] = "true";
   all_param_values["sm.var_offsets.mode"] = "elements";

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -78,6 +78,7 @@ struct ConsolidationFx {
   void write_dense_vector_del_1();
   void write_dense_vector_del_2();
   void write_dense_vector_del_3();
+  void write_dense_array_metadata();
   void write_dense_full();
   void write_dense_subarray();
   void write_dense_unordered();
@@ -87,6 +88,7 @@ struct ConsolidationFx {
   void write_sparse_heterogeneous_unordered();
   void write_sparse_string_full();
   void write_sparse_string_unordered();
+  void read_dense_array_metadata();
   void read_dense_vector(uint64_t timestamp = UINT64_MAX);
   void read_dense_vector_with_gaps();
   void read_dense_vector_mixed();
@@ -104,10 +106,18 @@ struct ConsolidationFx {
   void read_sparse_heterogeneous_unordered_full();
   void read_sparse_string_full_unordered();
   void read_sparse_string_unordered_full();
-  void consolidate_dense();
+  uint32_t get_num_fragments_to_vacuum_dense();
+  void consolidate_dense(
+      const std::string& mode = "fragments",
+      uint64_t start = 0,
+      uint64_t end = UINT64_MAX);
   void consolidate_sparse();
   void consolidate_sparse_heterogeneous();
   void consolidate_sparse_string();
+  void vacuum_dense(
+      const std::string& mode = "fragments",
+      uint64_t start = 0,
+      uint64_t end = UINT64_MAX);
   void remove_dense_vector();
   void remove_dense_array();
   void remove_sparse_array();
@@ -115,6 +125,8 @@ struct ConsolidationFx {
   void remove_sparse_string_array();
   void remove_array(const std::string& array_name);
   bool is_array(const std::string& array_name);
+  void get_array_meta_files_dense(std::vector<std::string>& files);
+  void get_array_meta_vac_files_dense(std::vector<std::string>& files);
 
   // Used to get the number of directories or files of another directory
   struct get_num_struct {
@@ -125,6 +137,8 @@ struct ConsolidationFx {
 
   static int get_dir_num(const char* path, void* data);
   static int get_meta_num(const char* path, void* data);
+  static int get_array_meta_files_callback(const char* path, void* data);
+  static int get_array_meta_vac_files_callback(const char* path, void* data);
 };
 
 ConsolidationFx::ConsolidationFx() {
@@ -1525,6 +1539,35 @@ void ConsolidationFx::write_dense_vector_del_3() {
   tiledb_array_free(&array);
 }
 
+void ConsolidationFx::write_dense_array_metadata() {
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  REQUIRE(rc == TILEDB_OK);
+  if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
+    rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  } else {
+    rc = tiledb_array_open_with_key(
+        ctx_,
+        array,
+        TILEDB_WRITE,
+        encryption_type_,
+        encryption_key_,
+        (uint32_t)strlen(encryption_key_));
+  }
+  REQUIRE(rc == TILEDB_OK);
+
+  // Write items
+  int32_t v = 5;
+  rc = tiledb_array_put_metadata(ctx_, array, "aaa", TILEDB_INT32, 1, &v);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+}
+
 void ConsolidationFx::write_dense_full() {
   // Set attributes
   const char* attributes[] = {"a1", "a2", "a3"};
@@ -2356,6 +2399,40 @@ void ConsolidationFx::write_sparse_string_unordered() {
   // Clean up
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+}
+
+void ConsolidationFx::read_dense_array_metadata() {
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, DENSE_ARRAY_NAME, &array);
+  REQUIRE(rc == TILEDB_OK);
+  if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
+    rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  } else {
+    rc = tiledb_array_open_with_key(
+        ctx_,
+        array,
+        TILEDB_WRITE,
+        encryption_type_,
+        encryption_key_,
+        (uint32_t)strlen(encryption_key_));
+  }
+  REQUIRE(rc == TILEDB_OK);
+
+  // Read
+  const void* v_r;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  rc = tiledb_array_get_metadata(ctx_, array, "aaa", &v_type, &v_num, &v_r);
+  CHECK(rc == TILEDB_OK);
+  CHECK(v_type == TILEDB_INT32);
+  CHECK(v_num == 1);
+  CHECK(*((const int32_t*)v_r) == 5);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_array_free(&array);
 }
 
 void ConsolidationFx::read_dense_vector(uint64_t timestamp) {
@@ -3831,10 +3908,52 @@ void ConsolidationFx::read_sparse_string_unordered_full() {
   free(buffer_coords_dim2_off);
 }
 
-void ConsolidationFx::consolidate_dense() {
+uint32_t ConsolidationFx::get_num_fragments_to_vacuum_dense() {
+  uint32_t to_vacuum_num = 0;
+
+  // Create fragment info object
+  tiledb_fragment_info_t* fragment_info = nullptr;
+  int rc = tiledb_fragment_info_alloc(ctx_, DENSE_ARRAY_NAME, &fragment_info);
+  CHECK(rc == TILEDB_OK);
+
+  // Load fragment info
+  rc = tiledb_fragment_info_load(ctx_, fragment_info);
+  CHECK(rc == TILEDB_OK);
+
+  // Get number of fragments to vacuum
+  rc = tiledb_fragment_info_get_to_vacuum_num(
+      ctx_, fragment_info, &to_vacuum_num);
+  CHECK(rc == TILEDB_OK);
+
+  tiledb_fragment_info_free(&fragment_info);
+
+  return to_vacuum_num;
+}
+
+void ConsolidationFx::consolidate_dense(
+    const std::string& mode, uint64_t start, uint64_t end) {
   int rc;
+  tiledb_config_t* cfg;
+  tiledb_error_t* err = nullptr;
+  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
+  REQUIRE(err == nullptr);
+  rc = tiledb_config_set(cfg, "sm.consolidation.mode", mode.c_str(), &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+  rc = tiledb_config_set(
+      cfg,
+      "sm.consolidation.timestamp_start",
+      std::to_string(start).c_str(),
+      &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+  rc = tiledb_config_set(
+      cfg, "sm.consolidation.timestamp_end", std::to_string(end).c_str(), &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+
   if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
-    rc = tiledb_array_consolidate(ctx_, DENSE_ARRAY_NAME, nullptr);
+    rc = tiledb_array_consolidate(ctx_, DENSE_ARRAY_NAME, cfg);
   } else {
     rc = tiledb_array_consolidate_with_key(
         ctx_,
@@ -3842,9 +3961,11 @@ void ConsolidationFx::consolidate_dense() {
         encryption_type_,
         encryption_key_,
         (uint32_t)strlen(encryption_key_),
-        nullptr);
+        cfg);
   }
   REQUIRE(rc == TILEDB_OK);
+
+  tiledb_config_free(&cfg);
 }
 
 void ConsolidationFx::consolidate_sparse() {
@@ -3894,6 +4015,31 @@ void ConsolidationFx::consolidate_sparse_string() {
         nullptr);
   }
   REQUIRE(rc == TILEDB_OK);
+}
+
+void ConsolidationFx::vacuum_dense(
+    const std::string& mode, uint64_t start, uint64_t end) {
+  int rc;
+  tiledb_config_t* cfg;
+  tiledb_error_t* err = nullptr;
+  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
+  REQUIRE(err == nullptr);
+  rc = tiledb_config_set(cfg, "sm.vacuum.mode", mode.c_str(), &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+  rc = tiledb_config_set(
+      cfg, "sm.vacuum.timestamp_start", std::to_string(start).c_str(), &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+  rc = tiledb_config_set(
+      cfg, "sm.vacuum.timestamp_end", std::to_string(end).c_str(), &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+
+  rc = tiledb_array_vacuum(ctx_, DENSE_ARRAY_NAME, cfg);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_config_free(&cfg);
 }
 
 void ConsolidationFx::remove_array(const std::string& array_name) {
@@ -4034,6 +4180,56 @@ int ConsolidationFx::get_meta_num(const char* path, void* data) {
     ++data_struct->num;
 
   return 1;
+}
+
+int ConsolidationFx::get_array_meta_files_callback(
+    const char* path, void* data) {
+  auto vec = static_cast<std::vector<std::string>*>(data);
+  if (!tiledb::sm::utils::parse::ends_with(
+          path, tiledb::sm::constants::vacuum_file_suffix))
+    vec->emplace_back(path);
+
+  return 1;
+}
+
+int ConsolidationFx::get_array_meta_vac_files_callback(
+    const char* path, void* data) {
+  auto vec = static_cast<std::vector<std::string>*>(data);
+  if (tiledb::sm::utils::parse::ends_with(
+          path, tiledb::sm::constants::vacuum_file_suffix))
+    vec->emplace_back(path);
+
+  return 1;
+}
+
+void ConsolidationFx::get_array_meta_files_dense(
+    std::vector<std::string>& files) {
+  files.clear();
+  tiledb::sm::URI dense_array_uri(DENSE_ARRAY_NAME);
+  int rc = tiledb_vfs_ls(
+      ctx_,
+      vfs_,
+      dense_array_uri.add_trailing_slash()
+          .join_path(tiledb::sm::constants::array_metadata_folder_name)
+          .c_str(),
+      &get_array_meta_files_callback,
+      &files);
+  CHECK(rc == TILEDB_OK);
+}
+
+void ConsolidationFx::get_array_meta_vac_files_dense(
+    std::vector<std::string>& files) {
+  files.clear();
+  tiledb::sm::URI dense_array_uri(DENSE_ARRAY_NAME);
+  int rc = tiledb_vfs_ls(
+      ctx_,
+      vfs_,
+      dense_array_uri.add_trailing_slash()
+          .join_path(tiledb::sm::constants::array_metadata_folder_name)
+          .c_str(),
+      &get_array_meta_vac_files_callback,
+      &files);
+  CHECK(rc == TILEDB_OK);
 }
 
 // Test valid configuration parameters
@@ -5639,4 +5835,142 @@ TEST_CASE_METHOD(
   tiledb_ctx_free(&ctx);
   tiledb_config_free(&config);
   remove_sparse_string_array();
+}
+
+TEST_CASE_METHOD(
+    ConsolidationFx,
+    "C API: Test consolidation and timestamps",
+    "[capi][consolidation][timestamps]") {
+  remove_dense_array();
+  create_dense_array();
+
+  SECTION("- consolidate fragments with timestamps") {
+    write_dense_subarray();
+    auto start = tiledb::sm::utils::time::timestamp_now_ms();
+    write_dense_unordered();
+    write_dense_full();
+    auto end = tiledb::sm::utils::time::timestamp_now_ms();
+    consolidate_dense("fragments", start, end);
+    read_dense_subarray_unordered_full();
+
+    CHECK(get_num_fragments_to_vacuum_dense() == 2);
+  }
+
+  SECTION("- consolidate array metadata with timestamps") {
+    write_dense_array_metadata();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    auto start = tiledb::sm::utils::time::timestamp_now_ms();
+    write_dense_array_metadata();
+    write_dense_array_metadata();
+    auto end = tiledb::sm::utils::time::timestamp_now_ms();
+    consolidate_dense("array_meta", start, end);
+    read_dense_array_metadata();
+
+    std::vector<std::string> array_meta_vac_files;
+    get_array_meta_vac_files_dense(array_meta_vac_files);
+    CHECK(array_meta_vac_files.size() == 1);
+
+    std::vector<std::string> array_meta_files;
+    get_array_meta_files_dense(array_meta_files);
+    CHECK(array_meta_files.size() == 4);
+
+    uint64_t file_size = 0;
+    int rc = tiledb_vfs_file_size(
+        ctx_, vfs_, array_meta_vac_files[0].c_str(), &file_size);
+    REQUIRE(rc == TILEDB_OK);
+
+    // Make sure we only have two files to vaccum
+    tiledb_vfs_fh_t* fh;
+    std::string vac_file;
+    vac_file.resize(file_size);
+    rc = tiledb_vfs_open(
+        ctx_, vfs_, array_meta_vac_files[0].c_str(), TILEDB_VFS_READ, &fh);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_vfs_read(ctx_, fh, 0, &vac_file[0], file_size);
+    REQUIRE(rc == TILEDB_OK);
+    CHECK(std::count(vac_file.begin(), vac_file.end(), '\n') == 2);
+    rc = tiledb_vfs_close(ctx_, fh);
+    REQUIRE(rc == TILEDB_OK);
+    tiledb_vfs_fh_free(&fh);
+    REQUIRE(rc == TILEDB_OK);
+  }
+
+  // Clean up
+  remove_dense_array();
+}
+
+TEST_CASE_METHOD(
+    ConsolidationFx,
+    "C API: Test vacuuming and timestamps",
+    "[capi][vacuuming][timestamps]") {
+  remove_dense_array();
+  create_dense_array();
+
+  SECTION("- vacuum fragments with timestamps") {
+    write_dense_subarray();
+
+    auto start1 = tiledb::sm::utils::time::timestamp_now_ms();
+    write_dense_unordered();
+    write_dense_full();
+    auto end1 = tiledb::sm::utils::time::timestamp_now_ms();
+    consolidate_dense("fragments", start1, end1);
+
+    auto start2 = tiledb::sm::utils::time::timestamp_now_ms();
+    write_dense_unordered();
+    write_dense_full();
+    auto end2 = tiledb::sm::utils::time::timestamp_now_ms();
+
+    consolidate_dense("fragments", start2, end2);
+    CHECK(get_num_fragments_to_vacuum_dense() == 4);
+
+    vacuum_dense("fragments", start1, end1);
+    CHECK(get_num_fragments_to_vacuum_dense() == 2);
+
+    read_dense_subarray_unordered_full();
+
+    vacuum_dense("fragments", start2, end2);
+    CHECK(get_num_fragments_to_vacuum_dense() == 0);
+  }
+
+  SECTION("- vacuum array metadata with timestamps") {
+    write_dense_array_metadata();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    auto start1 = tiledb::sm::utils::time::timestamp_now_ms();
+    write_dense_array_metadata();
+    write_dense_array_metadata();
+    auto end1 = tiledb::sm::utils::time::timestamp_now_ms();
+    consolidate_dense("array_meta", start1, end1);
+
+    auto start2 = tiledb::sm::utils::time::timestamp_now_ms();
+    write_dense_array_metadata();
+    write_dense_array_metadata();
+    auto end2 = tiledb::sm::utils::time::timestamp_now_ms();
+    consolidate_dense("array_meta", start2, end2);
+
+    std::vector<std::string> array_meta_vac_files;
+    get_array_meta_vac_files_dense(array_meta_vac_files);
+    CHECK(array_meta_vac_files.size() == 2);
+
+    std::vector<std::string> array_meta_files;
+    get_array_meta_files_dense(array_meta_files);
+    CHECK(array_meta_files.size() == 7);
+
+    vacuum_dense("array_meta", start1, end1);
+
+    get_array_meta_vac_files_dense(array_meta_vac_files);
+    CHECK(array_meta_vac_files.size() == 1);
+    get_array_meta_files_dense(array_meta_files);
+    CHECK(array_meta_files.size() == 5);
+
+    vacuum_dense("array_meta", start2, end2);
+
+    get_array_meta_vac_files_dense(array_meta_vac_files);
+    CHECK(array_meta_vac_files.size() == 0);
+    get_array_meta_files_dense(array_meta_files);
+    CHECK(array_meta_files.size() == 3);
+  }
+
+  // Clean up
+  remove_dense_array();
 }

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -123,11 +123,12 @@ class Array {
       uint32_t key_length);
 
   /**
-   * Opens the array for reading at a timestamp retrieved from the config.
+   * Opens the array for reading.
    *
    * @param query_type The query type. This should always be READ. It
    *    is here only for sanity check.
-   * @param timestamp The timestamp at which to open the array.
+   * @param timestamp_start The start timestamp at which to open the array.
+   * @param timestamp_end The end timestamp at which to open the array.
    * @param encryption_type The encryption type of the array
    * @param encryption_key If the array is encrypted, the private encryption
    *    key. For unencrypted arrays, pass `nullptr`.
@@ -138,7 +139,8 @@ class Array {
    */
   Status open(
       QueryType query_type,
-      uint64_t timestamp,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
       EncryptionType encryption_type,
       const void* encryption_key,
       uint32_t key_length);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3576,6 +3576,7 @@ int32_t tiledb_array_open_at(
           ctx,
           array->array_->open(
               static_cast<tiledb::sm::QueryType>(query_type),
+              0,
               timestamp,
               static_cast<tiledb::sm::EncryptionType>(TILEDB_NO_ENCRYPTION),
               nullptr,
@@ -3624,6 +3625,7 @@ int32_t tiledb_array_open_at_with_key(
           ctx,
           array->array_->open(
               static_cast<tiledb::sm::QueryType>(query_type),
+              0,
               timestamp,
               static_cast<tiledb::sm::EncryptionType>(encryption_type),
               encryption_key,

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -922,7 +922,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `sm.array.timestamp_start` <br>
  *    When set, an array will be opened between this value and
  *    `sm.array.timestamp_end` (inclusive) upon a read query. <br>
- *    **Default**: UINT64_MAX
+ *    **Default**: 0
  * - `sm.array.timestamp_end` <br>
  *    When set, an array will be opened between `sm.array.timestamp_start`
  *    and this value (inclusive) upon a read query. <br>
@@ -968,6 +968,16 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    `fragment_meta` (remove only consolidated fragment metadata), or
  *    `array_meta` (remove consolidated array metadata files). <br>
  *    **Default**: fragments
+ * - `sm.vacuum.timestamp_start` <br>
+ *    When set, an array will be vacuumed between this value and
+ *    `sm.vacuum.timestamp_end` (inclusive). <br>
+ *    Only for `fragments` and `array_meta` vacuum mode. <br>
+ *    **Default**: 0
+ * - `sm.vacuum.timestamp_end` <br>
+ *    When set, an array will be vacuumed between `sm.vacuum.timestamp_start`
+ *    and this value (inclusive). <br>
+ *    Only for `fragments` and `array_meta` vacuum mode. <br>
+ *    **Default**: UINT64_MAX
  * - `sm.consolidation_mode` <br>
  *    The consolidation mode, one of `fragments` (consolidate all fragments),
  *    `fragment_meta` (consolidate only fragment metadata footers to a single
@@ -1000,6 +1010,16 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The size ratio that two ("adjacent") fragments must satisfy to be
  *    considered for consolidation in a single step.<br>
  *    **Default**: 0.0
+ * - `sm.consolidation.timestamp_start` <br>
+ *    When set, an array will be consolidated between this value and
+ *    `sm.consolidation.timestamp_end` (inclusive). <br>
+ *    Only for `fragments` and `array_meta` consolidation mode. <br>
+ *    **Default**: 0
+ * - `sm.consolidation.timestamp_end` <br>
+ *    When set, an array will be consolidated between
+ *    `sm.consolidation.timestamp_start` and this value (inclusive). <br>
+ *    Only for `fragments` and `array_meta` consolidation mode. <br>
+ *    **Default**: UINT64_MAX
  * - `sm.memory_budget` <br>
  *    The memory budget for tiles of fixed-sized attributes (or offsets for
  *    var-sized attributes) to be fetched during reads.<br>
@@ -1227,10 +1247,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The logging level configured, possible values: "0": fatal, "1": error,
  *    "2": warn, "3": info "4": debug, "5": trace <br>
  *    **Default**: "1" if --enable-verbose bootstrap flag is provided,
- *    "0" otherwise
- *
- * <br>
- *
+ *    "0" otherwise <br>
  * - `rest.server_address` <br>
  *    URL for REST server to use for remote arrays. <br>
  *    **Default**: "https://api.tiledb.com"
@@ -1259,20 +1276,20 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The name of the registered access key to use for creation of the REST
  *    server. <br>
  *    **Default**: no default set
- * -  `rest.retry_http_codes` <br>
- *     CSV list of http status codes to automatically retry a REST request for
- * <br>
- *     **Default**: "503"
- * -  `rest.retry_count` <br>
- *     Number of times to retry failed REST requests <br>
- *     **Default**: 3
- * -  `rest.retry_initial_delay_ms` <br>
- *     Initial delay in milliseconds to wait until retrying a REST request <br>
- *     **Default**: 500
- * -  `rest.retry_delay_factor` <br>
- *     The delay factor to exponentially wait until further retries of a failed
- * REST request <br>
- *     **Default**: 1.25
+ * - `rest.retry_http_codes` <br>
+ *    CSV list of http status codes to automatically retry a REST request for
+ *    <br>
+ *    **Default**: "503"
+ * - `rest.retry_count` <br>
+ *    Number of times to retry failed REST requests <br>
+ *    **Default**: 3
+ * - `rest.retry_initial_delay_ms` <br>
+ *    Initial delay in milliseconds to wait until retrying a REST request <br>
+ *    **Default**: 500
+ * - `rest.retry_delay_factor` <br>
+ *    The delay factor to exponentially wait until further retries of a failed
+ *    REST request <br>
+ *    **Default**: 1.25
  *
  * **Example:**
  *

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -88,7 +88,12 @@ const std::string Config::SM_CONSOLIDATION_STEP_MIN_FRAGS = "4294967295";
 const std::string Config::SM_CONSOLIDATION_STEP_MAX_FRAGS = "4294967295";
 const std::string Config::SM_CONSOLIDATION_STEP_SIZE_RATIO = "0.0";
 const std::string Config::SM_CONSOLIDATION_MODE = "fragments";
+const std::string Config::SM_CONSOLIDATION_TIMESTAMP_START = "0";
+const std::string Config::SM_CONSOLIDATION_TIMESTAMP_END =
+    std::to_string(UINT64_MAX);
 const std::string Config::SM_VACUUM_MODE = "fragments";
+const std::string Config::SM_VACUUM_TIMESTAMP_START = "0";
+const std::string Config::SM_VACUUM_TIMESTAMP_END = std::to_string(UINT64_MAX);
 const std::string Config::SM_OFFSETS_BITSIZE = "64";
 const std::string Config::SM_OFFSETS_EXTRA_ELEMENT = "false";
 const std::string Config::SM_OFFSETS_FORMAT_MODE = "bytes";
@@ -221,7 +226,13 @@ Config::Config() {
       SM_CONSOLIDATION_STEP_SIZE_RATIO;
   param_values_["sm.consolidation.steps"] = SM_CONSOLIDATION_STEPS;
   param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
+  param_values_["sm.consolidation.timestamp_start"] =
+      SM_CONSOLIDATION_TIMESTAMP_START;
+  param_values_["sm.consolidation.timestamp_end"] =
+      SM_CONSOLIDATION_TIMESTAMP_END;
   param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
+  param_values_["sm.vacuum.timestamp_start"] = SM_VACUUM_TIMESTAMP_START;
+  param_values_["sm.vacuum.timestamp_end"] = SM_VACUUM_TIMESTAMP_END;
   param_values_["sm.var_offsets.bitsize"] = SM_OFFSETS_BITSIZE;
   param_values_["sm.var_offsets.extra_element"] = SM_OFFSETS_EXTRA_ELEMENT;
   param_values_["sm.var_offsets.mode"] = SM_OFFSETS_FORMAT_MODE;
@@ -480,8 +491,18 @@ Status Config::unset(const std::string& param) {
         SM_CONSOLIDATION_STEP_SIZE_RATIO;
   } else if (param == "sm.consolidation.mode") {
     param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
+  } else if (param == "sm.consolidation.timestamp_start") {
+    param_values_["sm.consolidation.timestamp_start"] =
+        SM_CONSOLIDATION_TIMESTAMP_START;
+  } else if (param == "sm.consolidation.timestamp_end") {
+    param_values_["sm.consolidation.timestamp_end"] =
+        SM_CONSOLIDATION_TIMESTAMP_END;
   } else if (param == "sm.vacuum.mode") {
     param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
+  } else if (param == "sm.vacuum.timestamp_start") {
+    param_values_["sm.vacuum.timestamp_start"] = SM_VACUUM_TIMESTAMP_START;
+  } else if (param == "sm.vacuum.timestamp_end") {
+    param_values_["sm.vacuum.timestamp_end"] = SM_VACUUM_TIMESTAMP_END;
   } else if (param == "sm.var_offsets.bitsize") {
     param_values_["sm.var_offsets.bitsize"] = SM_OFFSETS_BITSIZE;
   } else if (param == "sm.var_offsets.extra_element") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -208,12 +208,32 @@ class Config {
   static const std::string SM_CONSOLIDATION_MODE;
 
   /**
+   * An array will consolidate between this value and timestamp_end.
+   * */
+  static const std::string SM_CONSOLIDATION_TIMESTAMP_START;
+
+  /**
+   * An array will consolidate between timestamp_start and this value.
+   *  */
+  static const std::string SM_CONSOLIDATION_TIMESTAMP_END;
+
+  /**
    * The vacuum mode. It can be one of:
    *     - "fragments": only the fragments will be vacuumed
    *     - "fragment_meta": only the fragment metadata will be vacuumed
    *     - "array_meta": only the array metadata will be vacuumed
    */
   static const std::string SM_VACUUM_MODE;
+
+  /**
+   * An array will vacuum between this value and timestamp_end.
+   * */
+  static const std::string SM_VACUUM_TIMESTAMP_START;
+
+  /**
+   * An array will vacuum between timestamp_start and this value.
+   *  */
+  static const std::string SM_VACUUM_TIMESTAMP_END;
 
   /**
    * The size of offsets in bits to be used for offset buffers of var-sized

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -289,7 +289,7 @@ class Config {
    *    `sm.read_range_oob` <br>
    *    If `error`, this will check ranges for read with out-of-bounds on the
    *    dimension domain's and error. If `warn`, the ranges will be capped at
-   * the dimension's domain and a warning logged. <br>
+   *    the dimension's domain and a warning logged. <br>
    *    **Default**: warn
    * - `sm.check_global_order` <br>
    *    Checks if the coordinates obey the global array order. Applicable only
@@ -317,6 +317,16 @@ class Config {
    *    `fragment_meta` (remove only consolidated fragment metadata), or
    *    `array_meta` (remove consolidated array metadata files). <br>
    *    **Default**: fragments
+   * - `sm.vacuum.timestamp_start` <br>
+   *    When set, an array will be vacuumed between this value and
+   *    `sm.vacuum.timestamp_end` (inclusive). <br>
+   *    Only for `fragments` and `array_meta` vacuum mode. <br>
+   *    **Default**: 0
+   * - `sm.vacuum.timestamp_end` <br>
+   *    When set, an array will be vacuumed between `sm.vacuum.timestamp_start`
+   *    and this value (inclusive). <br>
+   *    Only for `fragments` and `array_meta` vacuum mode. <br>
+   *    **Default**: UINT64_MAX
    * - `sm.consolidation_mode` <br>
    *    The consolidation mode, one of `fragments` (consolidate all fragments),
    *    `fragment_meta` (consolidate only fragment metadata footers to a single
@@ -349,6 +359,16 @@ class Config {
    *    The size ratio that two ("adjacent") fragments must satisfy to be
    *    considered for consolidation in a single step.<br>
    *    **Default**: 0.0
+   * - `sm.consolidation.timestamp_start` <br>
+   *    When set, an array will be consolidated between this value and
+   *    `sm.consolidation.timestamp_end` (inclusive). <br>
+   *    Only for `fragments` and `array_meta` consolidation mode. <br>
+   *    **Default**: 0
+   * - `sm.consolidation.timestamp_end` <br>
+   *    When set, an array will be consolidated between
+   *    `sm.consolidation.timestamp_start` and this value (inclusive). <br>
+   *    Only for `fragments` and `array_meta` consolidation mode. <br>
+   *    **Default**: UINT64_MAX
    * - `sm.memory_budget` <br>
    *    The memory budget for tiles of fixed-sized attributes (or offsets for
    *    var-sized attributes) to be fetched during reads.<br>
@@ -379,7 +399,7 @@ class Config {
    *    **Default**: 102400
    * -  `vfs.read_ahead_cache_size` <br>
    *    The the total maximum size of the read-ahead cache, which is an LRU.
-   * <br>
+   *    <br>
    *    **Default**: 10485760
    * - `vfs.min_parallel_size` <br>
    *    The minimum number of bytes in a parallel VFS operation
@@ -577,10 +597,7 @@ class Config {
    *    The logging level configured, possible values: "0": fatal, "1": error,
    *    "2": warn, "3": info "4": debug, "5": trace <br>
    *    **Default**: "1" if --enable-verbose bootstrap flag is provided,
-   *    "0" otherwise
-   *
-   * <br>
-   *
+   *    "0" otherwise <br>
    * - `rest.server_address` <br>
    *    URL for REST server to use for remote arrays. <br>
    *    **Default**: "https://api.tiledb.com"
@@ -610,20 +627,20 @@ class Config {
    *    server. <br>
    *    **Default**: no default set
    * -  `rest.retry_http_codes` <br>
-   *     CSV list of http status codes to automatically retry a REST request for
-   * <br>
-   *     **Default**: "503"
-   * -  `rest.retry_count` <br>
-   *     Number of times to retry failed REST requests <br>
-   *     **Default**: 3
-   * -  `rest.retry_initial_delay_ms` <br>
-   *     Initial delay in milliseconds to wait until retrying a REST request
-   * <br>
-   *     **Default**: 500
-   * -  `rest.retry_delay_factor` <br>
-   *     The delay factor to exponentially wait until further retries of a
-   * failed REST request <br>
-   *     **Default**: 1.25
+   *    CSV list of http status codes to automatically retry a REST request for
+   *    <br>
+   *    **Default**: "503"
+   * - `rest.retry_count` <br>
+   *    Number of times to retry failed REST requests <br>
+   *    **Default**: 3
+   * - `rest.retry_initial_delay_ms` <br>
+   *    Initial delay in milliseconds to wait until retrying a REST request
+   *    <br>
+   *    **Default**: 500
+   * - `rest.retry_delay_factor` <br>
+   *    The delay factor to exponentially wait until further retries of a
+   *    failed REST request <br>
+   *    **Default**: 1.25
    */
   Config& set(const std::string& param, const std::string& value) {
     tiledb_error_t* err;

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -440,7 +440,7 @@ Status FragmentInfo::load(const EncryptionKey& encryption_key) {
 
   auto timestamp = utils::time::timestamp_now_ms();
   RETURN_NOT_OK(storage_manager_->get_fragment_info(
-      array_uri_, timestamp, encryption_key, this, true));
+      array_uri_, 0, timestamp, encryption_key, this, true));
 
   unconsolidated_metadata_num_ = 0;
   for (const auto& f : fragments_)

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -95,6 +95,10 @@ class Consolidator {
      *     - "array_meta": only the array metadata will be consolidated
      */
     std::string mode_;
+    /** Start time for consolidation. */
+    uint64_t timestamp_start_;
+    /** End time for consolidation. */
+    uint64_t timestamp_end_;
   };
 
   /* ********************************* */

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -264,9 +264,12 @@ class StorageManager {
    * information).
    *
    * @param array_name The name of the array to be vacuumed.
+   * @param timestamp_start The timestamp to start vacuuming at.
+   * @param timestamp_end The timestamp to end vacuuming at.
    * @return Status
    */
-  Status array_vacuum_fragments(const char* array_name);
+  Status array_vacuum_fragments(
+      const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end);
 
   /**
    * Cleans up consolidated fragment metadata (all except the last one).
@@ -280,9 +283,12 @@ class StorageManager {
    * Cleans up consolidated array metadata.
    *
    * @param array_name The name of the array to be consolidated.
+   * @param timestamp_start The timestamp to start vacuuming at.
+   * @param timestamp_end The timestamp to end vacuuming at.
    * @return Status
    */
-  Status array_vacuum_array_meta(const char* array_name);
+  Status array_vacuum_array_meta(
+      const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end);
 
   /**
    * Consolidates the metadata of an array into a single file.
@@ -502,7 +508,9 @@ class StorageManager {
    * timestamp.
    *
    * @param array_schema The array schema.
-   * @param timestamp The function will consider fragments created
+   * @param timestamp_start The function will consider fragments created
+   *     at or after this timestamp.
+   * @param timestamp_end The function will consider fragments created
    *     at or before this timestamp.
    * @param encryption_key The encryption key in case the array is encrypted.
    * @param fragment_info The fragment information to be retrieved.
@@ -513,7 +521,8 @@ class StorageManager {
    */
   Status get_fragment_info(
       const ArraySchema* array_schema,
-      uint64_t timestamp,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
       const EncryptionKey& encryption_key,
       FragmentInfo* fragment_info,
       bool get_to_vacuum = false);
@@ -523,7 +532,9 @@ class StorageManager {
    * timestamp.
    *
    * @param array_uri The array URI.
-   * @param timestamp The function will consider fragments created
+   * @param timestamp_start The function will consider fragments created
+   *     at or after this timestamp.
+   * @param timestamp_end The function will consider fragments created
    *     at or before this timestamp.
    * @param encryption_key The encryption key in case the array is encrypted.
    * @param fragment_info The fragment information to be retrieved.
@@ -534,7 +545,8 @@ class StorageManager {
    */
   Status get_fragment_info(
       const URI& array_uri,
-      uint64_t timestamp,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
       const EncryptionKey& encryption_key,
       FragmentInfo* fragment_info,
       bool get_to_vacuum = false);
@@ -673,12 +685,13 @@ class StorageManager {
 
   /**
    * Loads the array metadata from persistent storage that were created
-   * at or before `timestamp`.
+   * at or before `timestamp_end` and at or after `timestamp_start`.
    */
   Status load_array_metadata(
       const URI& array_uri,
       const EncryptionKey& encryption_key,
-      uint64_t timestamp,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
       Metadata* metadata);
 
   /** Removes a TileDB object (group, array). */
@@ -1144,13 +1157,15 @@ class StorageManager {
 
   /**
    * It computes the URIs `to_vacuum` from the input `uris`, considering
-   * only the URIs whose second timestamp is smaller than or equal to
-   * `timestamp`. The function also retrieves the `vac_uris` (files with
-   * `.vac` suffix) that were used to compute `to_vaccum`.
+   * only the URIs whose first timestamp is greater than or equal to
+   * `timestamp_start` or second timestamp is smaller than or equal to
+   * `timestamp_end`. The function also retrieves the `vac_uris` (files with
+   * `.vac` suffix) that were used to compute `to_vacuum`.
    */
   Status get_uris_to_vacuum(
       const std::vector<URI>& uris,
-      uint64_t timestamp,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
       std::vector<URI>* to_vacuum,
       std::vector<URI>* vac_uris) const;
 


### PR DESCRIPTION
Added configuration parameters to specify start and end times for
fragment and array metadata consolidation and vacuuming.

Also added more unit tests for opening an array at a starting timestamp.

---
TYPE: IMPROVEMENT
DESC: Timestamp start and end for vacuuming and consolidation
