### PR TITLE
Support TILEDB_DATETIME_{SEC,MS,US,NS} in arrow_io_impl.h

### DIFF
--- a/tiledb/sm/cpp_api/arrow_io_impl.h
+++ b/tiledb/sm/cpp_api/arrow_io_impl.h
@@ -209,13 +209,22 @@ ArrowInfo tiledb_buffer_arrow_fmt(BufferInfo bufferinfo, bool use_list = true) {
     case TILEDB_UINT64:
       return ArrowInfo("L");
 
-    // make sure this matches below
-    case TILEDB_DATETIME_NS:
-    case TILEDB_TIME_NS:
-      return ArrowInfo("tsn:");
-    case TILEDB_DATETIME_MS:
+    case TILEDB_TIME_SEC:
+      return ArrowInfo("tts");
     case TILEDB_TIME_MS:
-      return ArrowInfo("tdm");
+      return ArrowInfo("ttm");
+    case TILEDB_TIME_US:
+      return ArrowInfo("ttu");
+    case TILEDB_TIME_NS:
+      return ArrowInfo("ttn");
+    case TILEDB_DATETIME_SEC:
+      return ArrowInfo("tss:");
+    case TILEDB_DATETIME_MS:
+      return ArrowInfo("tsm:");
+    case TILEDB_DATETIME_US:
+      return ArrowInfo("tsu:");
+    case TILEDB_DATETIME_NS:
+      return ArrowInfo("tsn:");
 
     // TODO: these could potentially be rep'd w/ additional
     //       language-specific metadata
@@ -225,14 +234,10 @@ ArrowInfo tiledb_buffer_arrow_fmt(BufferInfo bufferinfo, bool use_list = true) {
     case TILEDB_DATETIME_DAY:
     case TILEDB_DATETIME_HR:
     case TILEDB_DATETIME_MIN:
-    case TILEDB_DATETIME_SEC:
-    case TILEDB_DATETIME_US:
     case TILEDB_DATETIME_PS:
     case TILEDB_DATETIME_FS:
     case TILEDB_DATETIME_AS:
     case TILEDB_TIME_MIN:
-    case TILEDB_TIME_SEC:
-    case TILEDB_TIME_US:
     case TILEDB_TIME_PS:
     case TILEDB_TIME_FS:
     case TILEDB_TIME_AS:


### PR DESCRIPTION
Support TileDB-Py's df indexer when using Arrow for datatypes `TILEDB_DATETIME_SEC`, `TILEDB_DATETIME_MS`,  `TILEDB_DATETIME_US`, and `TILEDB_DATETIME_NS`.

---
TYPE: FEATURE
DESC: Support TILEDB_DATETIME_{SEC,MS,US,NS} in arrow_io_impl.h