### PR TITLE
Backward compatibility writes

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -676,6 +676,12 @@ void ArraySchema::set_version(uint32_t version) {
   version_ = version;
 }
 
+uint32_t ArraySchema::write_version() const {
+  return version_ < constants::back_compat_writes_min_format_version ?
+             constants::format_version :
+             version_;
+}
+
 uint32_t ArraySchema::version() const {
   return version_;
 }

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -291,6 +291,9 @@ class ArraySchema {
   /** Set version of schema, only used for serialization */
   void set_version(uint32_t version);
 
+  /** Returns the version to write in. */
+  uint32_t write_version() const;
+
   /** Returns the array schema version. */
   uint32_t version() const;
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -74,7 +74,7 @@ FragmentMetadata::FragmentMetadata(
   has_consolidated_footer_ = false;
   rtree_ = RTree(array_schema_->domain(), constants::rtree_fanout);
   meta_file_size_ = 0;
-  version_ = constants::format_version;
+  version_ = array_schema_->write_version();
   tile_index_base_ = 0;
   sparse_tile_num_ = 0;
   footer_size_ = 0;

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -524,6 +524,9 @@ const int32_t library_version[3] = {
 /** The TileDB serialization format version number. */
 const uint32_t format_version = 9;
 
+/** The lowest version supported for back compat writes. */
+const uint32_t back_compat_writes_min_format_version = 7;
+
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
 const uint64_t max_tile_chunk_size = 64 * 1024;
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -510,6 +510,9 @@ extern const int32_t library_version[3];
 /** The TileDB serialization format version number. */
 extern const uint32_t format_version;
 
+/** The lowest version supported for back compat writes. */
+extern const uint32_t back_compat_writes_min_format_version;
+
 /** The maximum size of a tile chunk (unit of compression) in bytes. */
 extern const uint64_t max_tile_chunk_size;
 

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -1582,7 +1582,8 @@ Status Writer::create_fragment(
     uri = fragment_uri_;
   } else {
     std::string new_fragment_str;
-    RETURN_NOT_OK(new_fragment_name(timestamp, &new_fragment_str));
+    RETURN_NOT_OK(new_fragment_name(
+        timestamp, array_->array_schema()->write_version(), &new_fragment_str));
     uri = array_schema_->array_uri().join_path(new_fragment_str);
   }
   auto timestamp_range = std::pair<uint64_t, uint64_t>(timestamp, timestamp);
@@ -1975,7 +1976,7 @@ Status Writer::init_tile(const std::string& name, Tile* tile) const {
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version, type, tile_size, cell_size, 0));
+      array_schema_->write_version(), type, tile_size, cell_size, 0));
 
   return Status::Ok();
 }
@@ -1991,13 +1992,13 @@ Status Writer::init_tile(
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version,
+      array_schema_->write_version(),
       constants::cell_var_offset_type,
       tile_size,
       constants::cell_var_offset_size,
       0));
   RETURN_NOT_OK(tile_var->init_unfiltered(
-      constants::format_version, type, tile_size, datatype_size(type), 0));
+      array_schema_->write_version(), type, tile_size, datatype_size(type), 0));
   return Status::Ok();
 }
 
@@ -2013,9 +2014,9 @@ Status Writer::init_tile_nullable(
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version, type, tile_size, cell_size, 0));
+      array_schema_->write_version(), type, tile_size, cell_size, 0));
   RETURN_NOT_OK(tile_validity->init_unfiltered(
-      constants::format_version,
+      array_schema_->write_version(),
       constants::cell_validity_type,
       tile_size,
       constants::cell_validity_size,
@@ -2038,15 +2039,15 @@ Status Writer::init_tile_nullable(
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version,
+      array_schema_->write_version(),
       constants::cell_var_offset_type,
       tile_size,
       constants::cell_var_offset_size,
       0));
   RETURN_NOT_OK(tile_var->init_unfiltered(
-      constants::format_version, type, tile_size, datatype_size(type), 0));
+      array_schema_->write_version(), type, tile_size, datatype_size(type), 0));
   RETURN_NOT_OK(tile_validity->init_unfiltered(
-      constants::format_version,
+      array_schema_->write_version(),
       constants::cell_validity_type,
       tile_size,
       constants::cell_validity_size,
@@ -2086,7 +2087,7 @@ Status Writer::init_tiles(
 }
 
 Status Writer::new_fragment_name(
-    uint64_t timestamp, std::string* frag_uri) const {
+    uint64_t timestamp, uint32_t format_version, std::string* frag_uri) const {
   timestamp = (timestamp != 0) ? timestamp : utils::time::timestamp_now_ms();
 
   if (frag_uri == nullptr)
@@ -2096,7 +2097,7 @@ Status Writer::new_fragment_name(
   RETURN_NOT_OK(uuid::generate_uuid(&uuid, false));
   std::stringstream ss;
   ss << "/__" << timestamp << "_" << timestamp << "_" << uuid << "_"
-     << constants::format_version;
+     << format_version;
 
   *frag_uri = ss.str();
   return Status::Ok();

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -769,7 +769,8 @@ class Writer {
    * @param frag_uri Will store the new special fragment name
    * @return Status
    */
-  Status new_fragment_name(uint64_t timestamp, std::string* frag_uri) const;
+  Status new_fragment_name(
+      uint64_t timestamp, uint32_t format_version, std::string* frag_uri) const;
 
   /**
    * This deletes the global write state and deletes the potentially

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -478,7 +478,8 @@ Status Consolidator::consolidate_fragment_meta(
   URI uri;
   auto first = meta.front()->fragment_uri();
   auto last = meta.back()->fragment_uri();
-  RETURN_NOT_OK(compute_new_fragment_uri(first, last, &uri));
+  RETURN_NOT_OK(compute_new_fragment_uri(
+      first, last, array.array_schema()->write_version(), &uri));
   uri = URI(uri.to_string() + constants::meta_file_suffix);
 
   // Get the consolidated fragment metadata version
@@ -658,7 +659,12 @@ Status Consolidator::create_queries(
   // Get last fragment URI, which will be the URI of the consolidated fragment
   auto first = (*query_r)->first_fragment_uri();
   auto last = (*query_r)->last_fragment_uri();
-  RETURN_NOT_OK(compute_new_fragment_uri(first, last, new_fragment_uri));
+
+  RETURN_NOT_OK(compute_new_fragment_uri(
+      first,
+      last,
+      array_for_reads->array_schema()->write_version(),
+      new_fragment_uri));
 
   // Create write query
   *query_w =
@@ -790,7 +796,10 @@ Status Consolidator::compute_next_to_consolidate(
 }
 
 Status Consolidator::compute_new_fragment_uri(
-    const URI& first, const URI& last, URI* new_uri) const {
+    const URI& first,
+    const URI& last,
+    uint32_t format_version,
+    URI* new_uri) const {
   // Get uuid
   std::string uuid;
   RETURN_NOT_OK(uuid::generate_uuid(&uuid, false));
@@ -805,7 +814,7 @@ Status Consolidator::compute_new_fragment_uri(
   // Create new URI
   std::stringstream ss;
   ss << first.parent().to_string() << "/__" << t_first.first << "_"
-     << t_last.second << "_" << uuid << "_" << constants::format_version;
+     << t_last.second << "_" << uuid << "_" << format_version;
 
   *new_uri = URI(ss.str());
 

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -373,7 +373,10 @@ class Consolidator {
    * as `__<first_URI_timestamp>_<last_URI_timestamp>_<uuid>`.
    */
   Status compute_new_fragment_uri(
-      const URI& first, const URI& last, URI* new_uri) const;
+      const URI& first,
+      const URI& last,
+      uint32_t format_version,
+      URI* new_uri) const;
 
   /** Checks and sets the input configuration parameters. */
   Status set_config(const Config* config);


### PR DESCRIPTION
When a client with a higher version tries to write to an older array
with version greater or equal to 7, we now write in that version. If
the array has a version lesser than 7, we write the fragment in the
current format version.

---
TYPE: IMPROVEMENT
DESC: Support back compat writes