### PR TITLE
Refactor subarray_partitioner

### DIFF
--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -375,7 +375,7 @@ class SubarrayPartitioner {
    * and needs splitting along the splitting dimension (that depends on
    * the layout).
    */
-  void calibrate_current_start_end(bool* must_split_slab);
+  Status calibrate_current_start_end(bool* must_split_slab);
 
   /** Returns a deep copy of this SubarrayPartitioner. */
   SubarrayPartitioner clone() const;
@@ -438,7 +438,7 @@ class SubarrayPartitioner {
    * the reverse order (this is used in global order reads when
    * the cell order is Hilbert).
    */
-  void compute_splitting_value_multi_range(
+  Status compute_splitting_value_multi_range(
       unsigned* splitting_dim,
       uint64_t* splitting_range,
       ByteVecValue* splitting_value,


### PR DESCRIPTION
The subarray_partitioner makes multiple calls to Subarray::get_range_num without checking the return value. These calls are modified so that non-OK return values are propagated up the stack. 

---
TYPE: IMPROVEMENT
DESC: Make SubarrayPartitioner's member functions to return Status after calling Subarray::get_range_num. 
