### PR TITLE
Expand accepted windows URIs to support UNC paths

### DIFF
--- a/test/src/unit-uri.cc
+++ b/test/src/unit-uri.cc
@@ -75,15 +75,10 @@ TEST_CASE("URI: Test file URIs", "[uri]") {
   CHECK(URI::is_file(uri.to_string()));
   CHECK(uri.to_string() == "file:///path");
 #ifndef _WIN32
+  // note: "file://path" is an accepted URI form on windows for UNC
+  // level share viewing,but expected .is_invalid() on *nx.
   uri = URI("file://path");
   CHECK(uri.is_invalid());
-#else
-  // note: "file://path" is a valid URI form on windows tho' not a valid
-  // filesystem path. While it will pass on windows as a valid URI, attempts
-  // to create an array on such a path (attempted elsewhere in different unit
-  // test via  ArraySchemaFx::create_array(const std::string& path) )
-  // will fail with
-  //"Error: Cannot create directory '\\path': The specified path is invalid."
 #endif
   uri =
       URI("file:///path/is/quite/long/long/long/long/long/long/long/long/long/"

--- a/test/src/unit-uri.cc
+++ b/test/src/unit-uri.cc
@@ -74,8 +74,17 @@ TEST_CASE("URI: Test file URIs", "[uri]") {
   CHECK(!uri.is_invalid());
   CHECK(URI::is_file(uri.to_string()));
   CHECK(uri.to_string() == "file:///path");
+#ifndef _WIN32
   uri = URI("file://path");
   CHECK(uri.is_invalid());
+#else
+  // note: "file://path" is a valid URI form on windows tho' not a valid
+  // filesystem path. While it will pass on windows as a valid URI, attempts
+  // to create an array on such a path (attempted elsewhere in different unit
+  // test via  ArraySchemaFx::create_array(const std::string& path) )
+  // will fail with
+  //"Error: Cannot create directory '\\path': The specified path is invalid."
+#endif
   uri =
       URI("file:///path/is/quite/long/long/long/long/long/long/long/long/long/"
           "long/long/long/long/long/long/long/long/long/long/long/long/long/"

--- a/test/src/unit-uri.cc
+++ b/test/src/unit-uri.cc
@@ -76,7 +76,7 @@ TEST_CASE("URI: Test file URIs", "[uri]") {
   CHECK(uri.to_string() == "file:///path");
 #ifndef _WIN32
   // note: "file://path" is an accepted URI form on windows for UNC
-  // level share viewing,but expected .is_invalid() on *nx.
+  // level share viewing, but expected .is_invalid() on *nix.
   uri = URI("file://path");
   CHECK(uri.is_invalid());
 #endif

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -575,7 +575,13 @@ std::string Win::path_from_uri(const std::string& uri) {
   }
 
   std::string uri_with_scheme =
-      utils::parse::starts_with(uri, "file:///") ? uri : "file:///" + uri;
+      (utils::parse::starts_with(uri, "file://") ||
+       // also accept 'file:/x...'
+       (utils::parse::starts_with(uri, "file:/") && uri.substr(6, 1) != "/")) ?
+          uri
+          // else treat as file: item on 'localhost' (empty host name)
+          :
+          "file:///" + uri;
 
   unsigned long path_length = MAX_PATH;
   char path[MAX_PATH];

--- a/tiledb/sm/misc/uri.cc
+++ b/tiledb/sm/misc/uri.cc
@@ -110,12 +110,24 @@ bool URI::is_invalid() const {
 }
 
 bool URI::is_file(const std::string& path) {
+#ifdef _WIN32
+  return utils::parse::starts_with(path, "file://") ||
+         path.find("://") == std::string::npos;
+#else
   return utils::parse::starts_with(path, "file:///") ||
          path.find("://") == std::string::npos;
+#endif
 }
 
 bool URI::is_file() const {
+#ifdef _WIN32
+  return is_file(uri_);
+#else
+  // Observed: semantics here differ from sibling
+  // is_file(const std::string& path), here is missing
+  // additional check using "://".
   return utils::parse::starts_with(uri_, "file:///");
+#endif
 }
 
 bool URI::is_hdfs(const std::string& path) {


### PR DESCRIPTION
Expand accepted windows URIs to allow access to commonly used windows UNC paths.

(Changes made are conditionally specific to _WIN32 so *nix URI processing should not be affected.)

---
TYPE: BUG
DESC: Expand accepted windows URIs.
