### PR TITLE
Add Query::result_buffer_elements_nullable support for dims

### DIFF
--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -626,6 +626,12 @@ TEST_CASE(
         std::vector<uint64_t> data_off_exp1 = {0, 4, 12, 0};
         CHECK(attr_off == data_off_exp1);
 
+        // check returned data with nullable API
+        auto result_els = query_r.result_buffer_elements_nullable()["attr"];
+        CHECK(std::get<0>(result_els) == 3);
+        CHECK(std::get<1>(result_els) == 3);
+        CHECK(std::get<2>(result_els) == 0);
+
         // Second partial read
         reset_read_buffers(attr_val, attr_off);
         CHECK_NOTHROW(query_r.submit());

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -485,8 +485,12 @@ class Query {
     for (const auto& b_it : buff_sizes_) {
       auto attr_name = b_it.first;
       auto size_tuple = b_it.second;
-      auto var = schema_.has_attribute(attr_name) &&
-                 schema_.attribute(attr_name).cell_val_num() == TILEDB_VAR_NUM;
+      auto var =
+          (schema_.has_attribute(attr_name) &&
+           schema_.attribute(attr_name).cell_val_num() == TILEDB_VAR_NUM) ||
+          (schema_.domain().has_dimension(attr_name) &&
+           schema_.domain().dimension(attr_name).cell_val_num() ==
+               TILEDB_VAR_NUM);
       auto element_size = element_sizes_.find(attr_name)->second;
       elements[attr_name] = var ?
                                 std::tuple<uint64_t, uint64_t, uint64_t>(


### PR DESCRIPTION
TYPE: CPP_API
DESC: add Query::result_buffer_elements_nullable support for dims

---
[ch6969]