### PR TITLE
QueryCondition serialization support

### DIFF
--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -497,6 +497,57 @@ TEST_CASE_METHOD(
       std::free(b);
   }
 
+  SECTION("- Read all, with condition") {
+    Array array(ctx, array_uri, TILEDB_READ);
+    Query query(ctx, array);
+    std::vector<uint32_t> a1(1000);
+    std::vector<uint32_t> a2(1000);
+    std::vector<uint8_t> a2_nullable(500);
+    std::vector<char> a3_data(1000 * 100);
+    std::vector<uint64_t> a3_offsets(1000);
+    std::vector<int32_t> subarray = {1, 10, 1, 10};
+
+    query.set_subarray(subarray);
+    query.set_buffer("a1", a1);
+    query.set_buffer_nullable("a2", a2, a2_nullable);
+    query.set_buffer("a3", a3_offsets, a3_data);
+
+    uint32_t cmp_value = 5;
+    QueryCondition condition(
+        ctx, "a1", &cmp_value, sizeof(uint32_t), TILEDB_LT);
+    query.set_condition(condition);
+
+    // Serialize into a copy (client side).
+    std::vector<uint8_t> serialized;
+    serialize_query(ctx, query, &serialized, true);
+
+    // Deserialize into a new query and allocate buffers (server side).
+    Array array2(ctx, array_uri, TILEDB_READ);
+    Query query2(ctx, array2);
+    deserialize_query(ctx, serialized, &query2, false);
+    auto to_free = allocate_query_buffers(ctx, array2, &query2);
+
+    // Submit and serialize results (server side).
+    query2.submit();
+    serialize_query(ctx, query2, &serialized, false);
+
+    // Deserialize into original query (client side).
+    deserialize_query(ctx, serialized, &query, true);
+    REQUIRE(query.query_status() == Query::Status::COMPLETE);
+
+    // We expect all cells where `a1` >= `cmp_value` to be filtered
+    // out.
+    auto result_el = query.result_buffer_elements_nullable();
+    REQUIRE(std::get<1>(result_el["a1"]) == 5);
+    REQUIRE(std::get<1>(result_el["a2"]) == 10);
+    REQUIRE(std::get<2>(result_el["a2"]) == 5);
+    REQUIRE(std::get<0>(result_el["a3"]) == 5);
+    REQUIRE(std::get<1>(result_el["a3"]) == 15);
+
+    for (void* b : to_free)
+      std::free(b);
+  }
+
   SECTION("- Read subarray") {
     Array array(ctx, array_uri, TILEDB_READ);
     Query query(ctx, array);

--- a/tiledb/sm/enums/query_condition_combination_op.h
+++ b/tiledb/sm/enums/query_condition_combination_op.h
@@ -1,5 +1,5 @@
 /**
- * @file query_condition_condition_op.h
+ * @file query_condition_combination_op.h
  *
  * @section LICENSE
  *

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -726,6 +726,12 @@ Layout Query::layout() const {
   return layout_;
 }
 
+const QueryCondition* Query::condition() const {
+  if (type_ == QueryType::WRITE)
+    return nullptr;
+  return reader_.condition();
+}
+
 Status Query::cancel() {
   status_ = QueryStatus::FAILED;
   return Status::Ok();

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -461,6 +461,12 @@ class Query {
   /** Returns the cell layout. */
   Layout layout() const;
 
+  /**
+   * Returns the condition for filtering results in a read query.
+   * @return QueryCondition
+   */
+  const QueryCondition* condition() const;
+
   /** Processes a query. */
   Status process();
 

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -548,5 +548,23 @@ Status QueryCondition::apply(
   return Status::Ok();
 }
 
+void QueryCondition::set_clauses(std::vector<Clause>&& clauses) {
+  clauses_ = std::move(clauses);
+}
+
+void QueryCondition::set_combination_ops(
+    std::vector<QueryConditionCombinationOp>&& combination_ops) {
+  combination_ops_ = std::move(combination_ops);
+}
+
+std::vector<QueryCondition::Clause> QueryCondition::clauses() const {
+  return clauses_;
+}
+
+std::vector<QueryConditionCombinationOp> QueryCondition::combination_ops()
+    const {
+  return combination_ops_;
+}
+
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -322,7 +322,10 @@ class Reader {
   /** Returns the cell layout. */
   Layout layout() const;
 
-  /** Returns the conditions. */
+  /**
+   * Returns a const-pointer to the internal condition.
+   * @return QueryCondition
+   */
   const QueryCondition* condition() const;
 
   /** Returns `true` if no results were retrieved after a query. */

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -326,6 +326,29 @@ struct ReadState {
   # The subarray partitioner
 }
 
+struct ConditionClause {
+  # A clause within a condition
+
+  fieldName @0 :Text;
+  # The name of the field this clause applies to
+
+  value @1 :Data;
+  # The comparison value
+
+  op @2 :Text;
+  # The comparison operation
+}
+
+struct Condition {
+  # The query condition
+
+  clauses @0 :List(ConditionClause);
+  # All clauses in this condition
+
+  clauseCombinationOps @1 :List(Text);
+  # The operation that combines each condition
+}
+
 struct QueryReader {
   # Read struct (can't be called reader due to class name conflict)
 
@@ -337,6 +360,9 @@ struct QueryReader {
 
   readState @2 :ReadState;
   # Read state of reader
+
+  condition @3 :Condition;
+  # The query condition
 }
 
 struct Query {


### PR DESCRIPTION
This adds support for the serialization of the QueryCondition objects. These
are known the `Query` object, but only used within the `Reader`. I have modeled
the serialization schema to do the same thing: the capnp `Condition` struct
is owned by the capnp `Query` struct.

---

TYPE: IMPROVEMENT
DESC: Serialization support for query conditions