### PR TITLE
Fix unordered write with fixed+nullable attributes

### DIFF
--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -2756,7 +2756,7 @@ Status Writer::prepare_tiles_fixed(
   if (dups_num == 0) {
     for (uint64_t i = 0, tile_idx = 0; i < cell_num; ++i) {
       if ((*tiles)[tile_idx].full())
-        ++tile_idx;
+        tile_idx += t;
 
       RETURN_NOT_OK((*tiles)[tile_idx].write(
           buffer + cell_pos[i] * cell_size, cell_size));
@@ -2771,7 +2771,7 @@ Status Writer::prepare_tiles_fixed(
         continue;
 
       if ((*tiles)[tile_idx].full())
-        ++tile_idx;
+        tile_idx += t;
 
       RETURN_NOT_OK((*tiles)[tile_idx].write(
           buffer + cell_pos[i] * cell_size, cell_size));


### PR DESCRIPTION
For unordered writes on a fixed+nullable attribute, all tiles are not populated.
The write succeeds but reads will be incorrect and/or fail with:
"[TileDB::ChunkedBuffer] Error: Chunk read error; read out of bounds"

---

TYPE: BUG
DESC: Write fix for unordered writes on nullable, fixed attributes.
