### PR TITLE
Update some union initializers to use strict syntax

### DIFF
--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -248,7 +248,7 @@ Status Win::filelock_lock(
     return LOG_STATUS(Status::IOError(
         std::string("Failed to lock '" + filename + "'; CreateFile error")));
   }
-  OVERLAPPED overlapped = {0, 0, 0, 0, 0};
+  OVERLAPPED overlapped = {0, 0, {{0, 0}}, 0};
   if (LockFileEx(
           file_h,
           shared ? 0 : LOCKFILE_EXCLUSIVE_LOCK,
@@ -267,7 +267,7 @@ Status Win::filelock_lock(
 }
 
 Status Win::filelock_unlock(filelock_t fd) const {
-  OVERLAPPED overlapped = {0, 0, 0, 0, 0};
+  OVERLAPPED overlapped = {0, 0, {{0, 0}}, 0};
   if (UnlockFileEx(fd, 0, MAXDWORD, MAXDWORD, &overlapped) == 0) {
     CloseHandle(fd);
     return LOG_STATUS(
@@ -520,7 +520,7 @@ Status Win::write_at(
   while (buffer_size > constants::max_write_bytes) {
     LARGE_INTEGER offset;
     offset.QuadPart = file_offset;
-    OVERLAPPED ov = {0, 0, 0, 0, 0};
+    OVERLAPPED ov = {0, 0, {{0, 0}}, 0};
     ov.Offset = offset.LowPart;
     ov.OffsetHigh = offset.HighPart;
     if (WriteFile(
@@ -540,7 +540,7 @@ Status Win::write_at(
   }
   LARGE_INTEGER offset;
   offset.QuadPart = file_offset;
-  OVERLAPPED ov = {0, 0, 0, 0, 0};
+  OVERLAPPED ov = {0, 0, {{0, 0}}, 0};
   ov.Offset = offset.LowPart;
   ov.OffsetHigh = offset.HighPart;
   if (WriteFile(


### PR DESCRIPTION
Visual C++ is less string than clang about syntax. The `OVERLAPPED` structure contains a union. VC++ accepts a relaxed initializer syntax; clang does not. VC++ is does accept the strict syntax, thankfully.

---
TYPE: BUG
DESC: Update some union initializers to use strict syntax
