### PR TITLE
Consolidation: do not re-open array for each fragment

### DIFF
--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -99,14 +99,8 @@ class Array {
       uint32_t key_length);
 
   /**
-   * Opens the array for reading, loading only the input fragments.
-   * Note that the order of the input fragments matters; later
-   * fragments in the list may overwrite earlier ones.
+   * Opens the array for reading without fragments.
    *
-   * @param query_type The query type. This should always be READ. It
-   *    is here only for sanity check.
-   * @param fragment_info Information about the fragments to open the
-   *     array with.
    * @param encryption_type The encryption type of the array
    * @param encryption_key If the array is encrypted, the private encryption
    *    key. For unencrypted arrays, pass `nullptr`.
@@ -115,12 +109,18 @@ class Array {
    *
    * @note Applicable only to reads.
    */
-  Status open(
-      QueryType query_type,
-      const FragmentInfo& fragment_info,
+  Status open_without_fragments(
       EncryptionType encryption_type,
       const void* encryption_key,
       uint32_t key_length);
+
+  /**
+   * Reload the array with the specified fragments.
+   *
+   * @param fragment_info The list of fragments to load.
+   * @return Status
+   */
+  Status load_fragments(const FragmentInfo& fragment_info);
 
   /**
    * Opens the array for reading.

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -5562,18 +5562,13 @@ int32_t tiledb_fragment_info_load_with_key(
       sanity_check(ctx, fragment_info) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  // Create key
-  tiledb::sm::EncryptionKey key;
+  // Load fragment info
   if (SAVE_ERROR_CATCH(
           ctx,
-          key.set_key(
+          fragment_info->fragment_info_->load(
               static_cast<tiledb::sm::EncryptionType>(encryption_type),
               encryption_key,
               key_length)))
-    return TILEDB_ERR;
-
-  // Load fragment info
-  if (SAVE_ERROR_CATCH(ctx, fragment_info->fragment_info_->load(key)))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -171,7 +171,10 @@ class FragmentInfo {
    * Loads the fragment info from an array. The encryption key is used
    * only if the array is encrypted.
    */
-  Status load(const EncryptionKey& encryption_key);
+  Status load(
+      EncryptionType encryption_type,
+      const void* encryption_key,
+      uint32_t key_length);
 
   /** Set the dimension names and types to the object. */
   void set_dim_info(

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -222,26 +222,10 @@ class Consolidator {
       const NDRange& union_non_empty_domains) const;
 
   /**
-   * Consolidates the fragments of the input array.
-   *
-   * @param array_schema The schema of the array to consolidate.
-   * @param encryption_type The encryption type of the array
-   * @param encryption_key If the array is encrypted, the private encryption
-   *    key. For unencrypted arrays, pass `nullptr`.
-   * @param key_length The length in bytes of the encryption key.
-   * @return Status
-   */
-  Status consolidate(
-      const ArraySchema* array_schema,
-      EncryptionType encryption_type,
-      const void* encryption_key,
-      uint32_t key_length);
-
-  /**
    * Consolidates the input fragments of the input array. This function
    * implements a single consolidation step.
    *
-   * @param array_uri URI of array to consolidate.
+   * @param array_for_reads Array used for reads.
    * @param to_consolidate The fragments to consolidate in this consolidation
    *     step.
    * @param union_non_empty_domains The union of the non-empty domains of
@@ -256,12 +240,10 @@ class Consolidator {
    * @return Status
    */
   Status consolidate(
-      const URI& array_uri,
+      Array& array_for_reads,
+      Array& array_for_writes,
       const FragmentInfo& to_consolidate,
       const NDRange& union_non_empty_domains,
-      EncryptionType encryption_type,
-      const void* encryption_key,
-      uint32_t key_length,
       URI* new_fragment_uri);
 
   /**

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -169,24 +169,18 @@ class StorageManager {
       uint64_t timestamp_end);
 
   /**
-   * Opens an array for reads, focusing only on a given list of fragments.
-   * Only the metadata of the input fragments are retrieved.
+   * Opens an array for reads without fragments.
    *
    * @param array_uri The array URI.
-   * @param fragment_info Info about the fragments to open the array with.
    * @param enc_key The encryption key to use.
    * @param array_schema The array schema to be retrieved after the
    *     array is opened.
-   * @param fragment_metadata The fragment metadata to be retrieved
-   *     after the array is opened.
    * @return Status
    */
-  Status array_open_for_reads(
+  Status array_open_for_reads_without_fragments(
       const URI& array_uri,
-      const FragmentInfo& fragment_info,
       const EncryptionKey& enc_key,
-      ArraySchema** array_schema,
-      std::vector<FragmentMetadata*>* fragment_metadata);
+      ArraySchema** array_schema);
 
   /** Opens an array for writes.
    *
@@ -200,6 +194,22 @@ class StorageManager {
       const URI& array_uri,
       const EncryptionKey& enc_key,
       ArraySchema** array_schema);
+
+  /**
+   * Load fragments for an already open array.
+   *
+   * @param array_uri The array URI.
+   * @param enc_key The encryption key to use.
+   * @param fragment_metadata The fragment metadata to be retrieved
+   *     after the array is opened.
+   * @param fragment_info The list of fragment info.
+   * @return Status
+   */
+  Status array_load_fragments(
+      const URI& array_uri,
+      const EncryptionKey& enc_key,
+      std::vector<FragmentMetadata*>* fragment_metadata,
+      const FragmentInfo& fragment_info);
 
   /**
    * Reopens an already open array at a potentially new timestamp,
@@ -507,7 +517,7 @@ class StorageManager {
    * Gets the fragment information for a given array at a particular
    * timestamp.
    *
-   * @param array_schema The array schema.
+   * @param array The array.
    * @param timestamp_start The function will consider fragments created
    *     at or after this timestamp.
    * @param timestamp_end The function will consider fragments created
@@ -520,49 +530,22 @@ class StorageManager {
    * @return Status
    */
   Status get_fragment_info(
-      const ArraySchema* array_schema,
+      const Array& array,
       uint64_t timestamp_start,
       uint64_t timestamp_end,
-      const EncryptionKey& encryption_key,
-      FragmentInfo* fragment_info,
-      bool get_to_vacuum = false);
-
-  /**
-   * Gets the fragment information for a given array at a particular
-   * timestamp.
-   *
-   * @param array_uri The array URI.
-   * @param timestamp_start The function will consider fragments created
-   *     at or after this timestamp.
-   * @param timestamp_end The function will consider fragments created
-   *     at or before this timestamp.
-   * @param encryption_key The encryption key in case the array is encrypted.
-   * @param fragment_info The fragment information to be retrieved.
-   *     The fragments are sorted in chronological creation order.
-   * @param get_to_vacuum Whether or not to receive information about
-   *     fragments to vacuum.
-   * @return Status
-   */
-  Status get_fragment_info(
-      const URI& array_uri,
-      uint64_t timestamp_start,
-      uint64_t timestamp_end,
-      const EncryptionKey& encryption_key,
       FragmentInfo* fragment_info,
       bool get_to_vacuum = false);
 
   /**
    * Gets the fragment info for a single fragment URI.
    *
-   * @param array_schema The array schema.
-   * @param encryption_key The encryption key.
+   * @param array The array.
    * @param fragment_uri The fragment URI.
    * @param fragment_info The fragment info to retrieve.
    * @return Status
    */
   Status get_fragment_info(
-      const ArraySchema* array_schema,
-      const EncryptionKey& encryption_key,
+      const Array& array,
       const URI& fragment_uri,
       SingleFragmentInfo* fragment_info);
 


### PR DESCRIPTION
This change removes the need to open an array for read multiple times
during consolidation. It does so first by adding an api to open the
array without fragments and then retreive the list of fragment info
from the storage manager. Then when a fragment is to be consolidated,
we can use the already opened array and set which fragments should be
reloaded, which will only end up hitting the cached fragments.

---
TYPE: IMPROVEMENT
DESC: Consolidation: do not re-open array for each fragment
