### PR TITLE
Consolidate with timestamps, consider non empty domain before start time

### DIFF
--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -86,8 +86,14 @@ void FragmentInfo::append(const SingleFragmentInfo& fragment) {
   fragments_.emplace_back(fragment);
 }
 
+void FragmentInfo::expand_anterior_ndrange(
+    const Domain* domain, const NDRange& range) {
+  domain->expand_ndrange(range, &anterior_ndrange_);
+}
+
 void FragmentInfo::clear() {
   fragments_.clear();
+  anterior_ndrange_.clear();
 }
 
 void FragmentInfo::dump(FILE* out) const {
@@ -475,6 +481,10 @@ const std::vector<SingleFragmentInfo>& FragmentInfo::fragments() const {
   return fragments_;
 }
 
+const NDRange& FragmentInfo::anterior_ndrange() const {
+  return anterior_ndrange_;
+}
+
 uint32_t FragmentInfo::to_vacuum_num() const {
   return (uint32_t)to_vacuum_.size();
 }
@@ -496,6 +506,7 @@ FragmentInfo FragmentInfo::clone() const {
   clone.storage_manager_ = storage_manager_;
   clone.to_vacuum_ = to_vacuum_;
   clone.unconsolidated_metadata_num_ = unconsolidated_metadata_num_;
+  clone.anterior_ndrange_ = anterior_ndrange_;
 
   return clone;
 }
@@ -509,4 +520,5 @@ void FragmentInfo::swap(FragmentInfo& fragment_info) {
   std::swap(to_vacuum_, fragment_info.to_vacuum_);
   std::swap(
       unconsolidated_metadata_num_, fragment_info.unconsolidated_metadata_num_);
+  std::swap(anterior_ndrange_, fragment_info.anterior_ndrange_);
 }

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -34,6 +34,7 @@
 #define TILEDB_FRAGMENT_INFO_H
 
 #include "tiledb/common/status.h"
+#include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/crypto/encryption_key.h"
 #include "tiledb/sm/fragment/single_fragment_info.h"
 #include "tiledb/sm/misc/uri.h"
@@ -78,6 +79,9 @@ class FragmentInfo {
 
   /** Appends the info about a single fragment at the end of `fragments_`. */
   void append(const SingleFragmentInfo& fragment);
+
+  /** Expand the non empty domain before start with a new range */
+  void expand_anterior_ndrange(const Domain* domain, const NDRange& range);
 
   /** Clears the object. */
   void clear();
@@ -187,6 +191,9 @@ class FragmentInfo {
   /** Returns the vector with the info about individual fragments. */
   const std::vector<SingleFragmentInfo>& fragments() const;
 
+  /** Returns the non empty domain of the fragments before start time. */
+  const NDRange& anterior_ndrange() const;
+
   /** Returns the number of fragments to vacuum. */
   uint32_t to_vacuum_num() const;
 
@@ -218,6 +225,9 @@ class FragmentInfo {
 
   /** The number of fragments with unconsolidated metadata. */
   uint32_t unconsolidated_metadata_num_;
+
+  /** Non empty domain before the start time specified */
+  NDRange anterior_ndrange_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -302,6 +302,11 @@ bool Consolidator::are_consolidatable(
   if (all_sparse(fragment_info, start, end))
     return true;
 
+  auto anterior_ndrange = fragment_info.anterior_ndrange();
+  if (anterior_ndrange.size() != 0 &&
+      domain->overlap(union_non_empty_domains, anterior_ndrange))
+    return false;
+
   // Check overlap of union with earlier fragments
   const auto& fragments = fragment_info.fragments();
   for (size_t i = 0; i < start; ++i) {


### PR DESCRIPTION
This change makes sure that during consolidation, we make sure that
we will not have an invalid array by checking that a new dense
fragment will not overlap the non empty domain of fragments that are
coming before the starting timestamp.

---
TYPE: IMPROVEMENT
DESC: Consolidation: consider non empty domain before start timestamp