### PR TITLE
Consolidation: de-dupe FragmentInfo

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -149,9 +149,13 @@ Status Array::open_without_fragments(
   return Status::Ok();
 }
 
-Status Array::load_fragments(const FragmentInfo& fragment_info) {
+Status Array::load_fragments(
+    const std::vector<TimestampedURI>& fragments_to_load) {
   return storage_manager_->array_load_fragments(
-      array_uri_, *encryption_key_.get(), &fragment_metadata_, fragment_info);
+      array_uri_,
+      *encryption_key_.get(),
+      &fragment_metadata_,
+      fragments_to_load);
 }
 
 Status Array::open(

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -117,10 +117,10 @@ class Array {
   /**
    * Reload the array with the specified fragments.
    *
-   * @param fragment_info The list of fragments to load.
+   * @param fragments_to_load The list of fragments to load.
    * @return Status
    */
-  Status load_fragments(const FragmentInfo& fragment_info);
+  Status load_fragments(const std::vector<TimestampedURI>& fragments_to_load);
 
   /**
    * Opens the array for reading.

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -214,7 +214,8 @@ Status Consolidator::consolidate_fragments(
   }
 
   uint32_t step = 0;
-  FragmentInfo to_consolidate;
+  std::vector<TimestampedURI> to_consolidate;
+  bool all_sparse;
   do {
     // No need to consolidate if no more than 1 fragment exist
     if (fragment_info.fragment_num() <= 1)
@@ -226,6 +227,7 @@ Status Consolidator::consolidate_fragments(
         array_for_reads.array_schema(),
         fragment_info,
         &to_consolidate,
+        &all_sparse,
         &union_non_empty_domains);
     if (!st.ok()) {
       array_for_reads.close();
@@ -234,7 +236,7 @@ Status Consolidator::consolidate_fragments(
     }
 
     // Check if there is anything to consolidate
-    if (to_consolidate.fragment_num() <= 1)
+    if (to_consolidate.size() <= 1)
       break;
 
     // Consolidate the selected fragments
@@ -243,6 +245,7 @@ Status Consolidator::consolidate_fragments(
         array_for_reads,
         array_for_writes,
         to_consolidate,
+        all_sparse,
         union_non_empty_domains,
         &new_fragment_uri);
     if (!st.ok()) {
@@ -323,7 +326,8 @@ bool Consolidator::are_consolidatable(
 Status Consolidator::consolidate(
     Array& array_for_reads,
     Array& array_for_writes,
-    const FragmentInfo& to_consolidate,
+    const std::vector<TimestampedURI>& to_consolidate,
+    bool all_sparse,
     const NDRange& union_non_empty_domains,
     URI* new_fragment_uri) {
   STATS_START_TIMER(stats::GlobalStats::TimerType::CONSOLIDATE_MAIN)
@@ -336,11 +340,6 @@ Status Consolidator::consolidate(
 
   // Get schema
   auto array_schema = array_for_reads.array_schema();
-
-  // Compute if all fragments to consolidate are sparse
-  assert(to_consolidate.fragment_num() > 0);
-  bool all_sparse =
-      this->all_sparse(to_consolidate, 0, to_consolidate.fragment_num() - 1);
 
   // Prepare buffers
   std::vector<ByteVec> buffers;
@@ -644,11 +643,13 @@ Status Consolidator::create_queries(
 Status Consolidator::compute_next_to_consolidate(
     const ArraySchema* array_schema,
     const FragmentInfo& fragment_info,
-    FragmentInfo* to_consolidate,
+    std::vector<TimestampedURI>* to_consolidate,
+    bool* all_sparse,
     NDRange* union_non_empty_domains) const {
   STATS_START_TIMER(stats::GlobalStats::TimerType::CONSOLIDATE_COMPUTE_NEXT)
 
   // Preparation
+  *all_sparse = true;
   const auto& fragments = fragment_info.fragments();
   auto domain = array_schema->domain();
   to_consolidate->clear();
@@ -746,8 +747,11 @@ Status Consolidator::compute_next_to_consolidate(
       continue;
 
     // Results found
-    for (size_t f = min_col; f <= min_col + i; ++f)
-      to_consolidate->append(fragments[f]);
+    for (size_t f = min_col; f <= min_col + i; ++f) {
+      to_consolidate->emplace_back(
+          fragments[f].uri(), fragments[f].timestamp_range());
+      *all_sparse &= fragments[f].sparse();
+    }
     *union_non_empty_domains = m_union[i][min_col];
     break;
   }
@@ -854,19 +858,18 @@ Status Consolidator::set_query_buffers(
 }
 
 void Consolidator::update_fragment_info(
-    const FragmentInfo& to_consolidate,
+    const std::vector<TimestampedURI>& to_consolidate,
     const SingleFragmentInfo& new_fragment_info,
     FragmentInfo* fragment_info) const {
-  auto to_consolidate_it = to_consolidate.fragments().begin();
+  auto to_consolidate_it = to_consolidate.begin();
   auto fragment_it = fragment_info->fragments().begin();
   FragmentInfo updated_fragment_info;
   bool new_fragment_added = false;
 
   while (fragment_it != fragment_info->fragments().end()) {
     // No match - add the fragment info and advance `fragment_it`
-    if (to_consolidate_it == to_consolidate.fragments().end() ||
-        fragment_it->uri().to_string() !=
-            to_consolidate_it->uri().to_string()) {
+    if (to_consolidate_it == to_consolidate.end() ||
+        fragment_it->uri().to_string() != to_consolidate_it->uri_.to_string()) {
       updated_fragment_info.append(*fragment_it);
       ++fragment_it;
     } else {  // Match - add new fragment only once and advance both iterators
@@ -881,7 +884,7 @@ void Consolidator::update_fragment_info(
 
   assert(
       updated_fragment_info.fragment_num() ==
-      fragment_info->fragment_num() - to_consolidate.fragment_num() + 1);
+      fragment_info->fragment_num() - to_consolidate.size() + 1);
 
   *fragment_info = std::move(updated_fragment_info);
 }
@@ -946,13 +949,13 @@ Status Consolidator::set_config(const Config* config) {
 }
 
 Status Consolidator::write_vacuum_file(
-    const URI& new_uri, const FragmentInfo& to_consolidate) const {
+    const URI& new_uri,
+    const std::vector<TimestampedURI>& to_consolidate) const {
   URI vac_uri = URI(new_uri.to_string() + constants::vacuum_file_suffix);
 
   std::stringstream ss;
-  const auto& fragments = to_consolidate.fragments();
-  for (const auto& uri : fragments)
-    ss << uri.uri().to_string() << "\n";
+  for (const auto& timestampedURI : to_consolidate)
+    ss << timestampedURI.uri_.to_string() << "\n";
 
   auto data = ss.str();
   RETURN_NOT_OK(

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -226,15 +226,13 @@ class Consolidator {
    * implements a single consolidation step.
    *
    * @param array_for_reads Array used for reads.
+   * @param array_for_writes Array used for writes.
    * @param to_consolidate The fragments to consolidate in this consolidation
    *     step.
+   * @param all_sparse If all the fragments to consolidate are sparse.
    * @param union_non_empty_domains The union of the non-empty domains of
    *     the fragments in `to_consolidate`. Applicable only when those
    *     fragments are *not* all sparse.
-   * @param encryption_type The encryption type of the array
-   * @param encryption_key If the array is encrypted, the private encryption
-   *    key. For unencrypted arrays, pass `nullptr`.
-   * @param key_length The length in bytes of the encryption key.
    * @param new_fragment_uri The URI of the fragment created after
    *     consolidating the `to_consolidate` fragments.
    * @return Status
@@ -242,7 +240,8 @@ class Consolidator {
   Status consolidate(
       Array& array_for_reads,
       Array& array_for_writes,
-      const FragmentInfo& to_consolidate,
+      const std::vector<TimestampedURI>& to_consolidate,
+      bool all_sparse,
       const NDRange& union_non_empty_domains,
       URI* new_fragment_uri);
 
@@ -344,6 +343,8 @@ class Consolidator {
    * @param array_schema The array schema.
    * @param fragment_info Information about all the fragments.
    * @param to_consolidate The fragments to consolidate in the next step.
+   * @param all_sparse The function will return here if all fragments to
+   *     consolidate are all sparse.
    * @param union_non_empty_domains The function will return here the
    *     union of the non-empty domains of the fragments in `to_consolidate`.
    * @return Status
@@ -351,7 +352,8 @@ class Consolidator {
   Status compute_next_to_consolidate(
       const ArraySchema* array_schema,
       const FragmentInfo& fragment_info,
-      FragmentInfo* to_consolidate,
+      std::vector<TimestampedURI>* to_consolidate,
+      bool* all_sparse,
       NDRange* union_non_empty_domains) const;
 
   /**
@@ -399,14 +401,15 @@ class Consolidator {
    *     `fragment_info` of size >=0.
    */
   void update_fragment_info(
-      const FragmentInfo& to_consolidate,
+      const std::vector<TimestampedURI>& to_consolidate,
       const SingleFragmentInfo& new_fragment_info,
       FragmentInfo* fragment_info) const;
 
   /** Writes the vacuum file that contains the URIs of the consolidated
    * fragments. */
   Status write_vacuum_file(
-      const URI& new_uri, const FragmentInfo& to_consolidate) const;
+      const URI& new_uri,
+      const std::vector<TimestampedURI>& to_consolidate) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -386,7 +386,7 @@ Status StorageManager::array_load_fragments(
     const URI& array_uri,
     const EncryptionKey& enc_key,
     std::vector<FragmentMetadata*>* fragment_metadata,
-    const FragmentInfo& fragment_info) {
+    const std::vector<TimestampedURI>& fragments_to_load) {
   STATS_START_TIMER(stats::GlobalStats::TimerType::READ_ARRAY_OPEN)
 
   auto open_array = (OpenArray*)nullptr;
@@ -407,12 +407,6 @@ Status StorageManager::array_load_fragments(
     // Lock the array
     open_array->mtx_lock();
   }
-
-  // Determine which fragments to load
-  std::vector<TimestampedURI> fragments_to_load;
-  const auto& fragments = fragment_info.fragments();
-  for (const auto& fragment : fragments)
-    fragments_to_load.emplace_back(fragment.uri(), fragment.timestamp_range());
 
   std::unordered_map<std::string, uint64_t> offsets;
 

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -209,7 +209,7 @@ class StorageManager {
       const URI& array_uri,
       const EncryptionKey& enc_key,
       std::vector<FragmentMetadata*>* fragment_metadata,
-      const FragmentInfo& fragment_info);
+      const std::vector<TimestampedURI>& fragment_info);
 
   /**
    * Reopens an already open array at a potentially new timestamp,


### PR DESCRIPTION
This change optimizes consolidation by removing an unnecessary temporary
FragmentInfo structure to indicate which fragments to consolidate and
replaces it with a list of TimestampedURI that was already being created
in the storage manager.

---
TYPE: IMPROVEMENT
DESC: Consolidation: de-dupe FragmentInfo