### PR TITLE
For win32 builds with TILEDB_S3 active, add early check for build path length failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,12 +123,13 @@ option(TILEDB_SERIALIZATION "If true, enables building with support for query se
 option(TILEDB_CCACHE "If true, enables use of 'ccache' (if present)" OFF)
 option(TILEDB_ARROW_TESTS "If true, enables building the arrow adapter unit tests" OFF)
 option(TILEDB_LOG_OUTPUT_ON_FAILURE "If true, print error logs if dependency sub-project build fails" ON)
+option(TILEDB_SKIP_S3AWSSDK_DIR_LENGTH_CHECK "If true, skip check needed path length for awssdk (TILEDB_S3) dependent builds" OFF)
 
 set(TILEDB_INSTALL_LIBDIR "" CACHE STRING "If non-empty, install TileDB library to this directory instead of CMAKE_INSTALL_LIBDIR.")
 
 # early WIN32 audit of path length for aws sdk build where 
 # insufficient available path length causes sdk build failure.
-if (WIN32)
+if (WIN32 AND NOT TILEDB_SKIP_S3AWSSDK_DIR_LENGTH_CHECK)
   if (TILEDB_SUPERBUILD)
     if (TILEDB_S3)
       string(LENGTH ${CMAKE_CURRENT_BINARY_DIR} LENGTH_CMAKE_CURRENT_BINARY_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,20 @@ option(TILEDB_LOG_OUTPUT_ON_FAILURE "If true, print error logs if dependency sub
 
 set(TILEDB_INSTALL_LIBDIR "" CACHE STRING "If non-empty, install TileDB library to this directory instead of CMAKE_INSTALL_LIBDIR.")
 
+# early WIN32 audit of path length for aws sdk build where 
+# insufficient available path length causes sdk build failure.
+if (WIN32)
+  if (TILEDB_SUPERBUILD)
+    if (TILEDB_S3)
+      string(LENGTH ${CMAKE_CURRENT_BINARY_DIR} LENGTH_CMAKE_CURRENT_BINARY_DIR)
+      if ( NOT (LENGTH_CMAKE_CURRENT_BINARY_DIR LESS 61))
+        message(FATAL_ERROR " build directory path likely too long for building awssdk/dependencies!")
+      return()
+      endif()
+    endif()
+  endif()
+endif()
+
 ############################################################
 # Superbuild setup
 ############################################################


### PR DESCRIPTION
For win32 builds with TILEDB_S3 active, add early check for path lengths because of aws sdk build path length failures (to avoid waiting a while before failure occurs and then having to go find why)

---
TYPE: FEATURE
DESC: perform early audit for acceptable aws sdk windows path length