### PR TITLE
Check for minimum validity buffer size

### DIFF
--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -316,6 +316,11 @@ Status Reader::init(const Layout& layout) {
   // Initialize the read state
   RETURN_NOT_OK(init_read_state());
 
+  // Check the validity buffer sizes. This must be performed
+  // after `init_read_state` to ensure we have set the
+  // member state correctly from the config.
+  RETURN_NOT_OK(check_validity_buffer_sizes());
+
   return Status::Ok();
 }
 
@@ -873,6 +878,47 @@ Status Reader::check_subarray() const {
     return LOG_STATUS(Status::ReaderError(
         "Cannot initialize reader; Multi-range subarrays with "
         "global order layout are not supported"));
+
+  return Status::Ok();
+}
+
+Status Reader::check_validity_buffer_sizes() const {
+  // Verify that the validity buffer size for each
+  // nullable attribute is large enough to contain
+  // a validity value for each cell.
+  for (const auto& it : buffers_) {
+    const std::string& name = it.first;
+    if (array_schema_->is_nullable(name)) {
+      const uint64_t buffer_size = *it.second.buffer_size_;
+
+      uint64_t min_cell_num = 0;
+      if (array_schema_->var_size(name)) {
+        min_cell_num = buffer_size / constants::cell_var_offset_size;
+
+        // If the offsets buffer contains an extra element to mark
+        // the offset to the end of the data buffer, we do not need
+        // a validity value for that extra offset.
+        if (offsets_extra_element_)
+          min_cell_num = std::min<uint64_t>(0, min_cell_num - 1);
+      } else {
+        min_cell_num = buffer_size / array_schema_->cell_size(name);
+      }
+
+      const uint64_t buffer_validity_size =
+          *it.second.validity_vector_.buffer_size();
+      const uint64_t cell_validity_num =
+          buffer_validity_size / constants::cell_validity_size;
+
+      if (cell_validity_num < min_cell_num) {
+        std::stringstream ss;
+        ss << "Buffer sizes check failed; Invalid number of validity cells "
+              "given for ";
+        ss << "attribute '" << name << "'";
+        ss << " (" << cell_validity_num << " < " << min_cell_num << ")";
+        return LOG_STATUS(Status::ReaderError(ss.str()));
+      }
+    }
+  }
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -1014,6 +1014,9 @@ class Reader {
   /** Correctness checks for `subarray_`. */
   Status check_subarray() const;
 
+  /** Correctness checks validity buffer sizes in `buffers_`. */
+  Status check_validity_buffer_sizes() const;
+
   /**
    * Deletes the tiles on the input attribute/dimension from the result tiles.
    *


### PR DESCRIPTION
Currently, the read path assumes that the validity buffer size is large enough
to contain a validity value for each cell. When this is not true, the core will
overflow the user-set validity buffer.

This adds a runtime check that is invoked when a query is submitted. This ensures
that the validity buffer is large enough.

---

TYPE: IMPROVEMENT
DESC: Runtime check for minimum validity buffer size