### PR TITLE
Adjust Cap'n Proto cmake to better support system installs 

### DIFF
--- a/cmake/Modules/FindCapnp_EP.cmake
+++ b/cmake/Modules/FindCapnp_EP.cmake
@@ -99,7 +99,6 @@ if (NOT CAPNP_FOUND)
   endif()
 else()
   add_definitions(${CAPNP_DEFINITIONS})
-  set(TILEDB_CAPNPEXEC_PATH "${CAPNP_EXECUTABLE}")
 endif()
 
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -419,17 +419,6 @@ if (TILEDB_HDFS)
   endif()
 endif()
 
-# Serialization
-if (TILEDB_SERIALIZATION)
-  find_package(Capnp_EP REQUIRED)
-  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
-    INTERFACE
-      CapnProto::capnp
-      CapnProto::capnp-json
-      CapnProto::kj
-  )
-endif()
-
 # Sanitizer linker flags
 if (SANITIZER)
   target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
@@ -594,13 +583,26 @@ endif()
 # capnproto file generation
 ############################################################
 
+# Serialization
 if(TILEDB_SERIALIZATION)
-  find_package(CapnProto 0.8.0 REQUIRED
-      PATHS  ${TILEDB_EP_INSTALL_PREFIX} ${TILEDB_DEPS_NO_DEFAULT_PATH}
-    )
+  find_package(Capnp_EP REQUIRED)
+  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
+          INTERFACE
+          CapnProto::capnp
+          CapnProto::capnp-json
+          CapnProto::kj
+          )
+
+  # We only need to override the include path and PATH env for EP builds
+  if(TILEDB_CAPNP_EP_BUILT)
+    list(APPEND CAPNP_COMPILE_COMMAND ${CMAKE_COMMAND} -E env PATH=${TILEDB_EP_BASE}/install/bin ${CAPNP_EXECUTABLE} compile -I "${TILEDB_EP_BASE}/install/include" -oc++:"${CMAKE_CURRENT_BINARY_DIR}" ${CMAKE_CURRENT_SOURCE_DIR}/sm/serialization/tiledb-rest.capnp --src-prefix ${CMAKE_CURRENT_SOURCE_DIR})
+  else()
+    list(APPEND CAPNP_COMPILE_COMMAND ${CAPNP_EXECUTABLE} compile -oc++:"${CMAKE_CURRENT_BINARY_DIR}" ${CMAKE_CURRENT_SOURCE_DIR}/sm/serialization/tiledb-rest.capnp --src-prefix ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
 
   # note: run the compiler under `cmake -E env ...` because we need to run capnp executable
   #       the capnp driver needs to be able to find the plugin executables (eg capnpc-c++)
+  message(STATUS "CAPNP_COMPILE_COMMAND=${CAPNP_COMPILE_COMMAND}")
   add_custom_command(
 	    DEPENDS ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/tiledb-rest.capnp
       OUTPUT
@@ -609,7 +611,8 @@ if(TILEDB_SERIALIZATION)
       WORKING_DIRECTORY
         ${TILEDB_EP_BASE}/..
       COMMAND
-        cmake -E env PATH=${TILEDB_EP_BASE}/install/bin ${CAPNP_EXECUTABLE} compile -I "${TILEDB_EP_BASE}/install/include" -oc++:"${CMAKE_CURRENT_BINARY_DIR}" ${CMAKE_CURRENT_SOURCE_DIR}/sm/serialization/tiledb-rest.capnp --src-prefix ${CMAKE_CURRENT_SOURCE_DIR}
+        "${CAPNP_COMPILE_COMMAND}"
+      COMMAND_EXPAND_LISTS
       COMMENT "(re-)generate tiledb-rest.capnp.<h,c++>"
     )
 


### PR DESCRIPTION
Cap'n Proto cmake was adjusted in [#2100](#2100) and [#2210](#2210) to support windows and update to Cap'n Proto 0.8.0. This PR builds on those by making some minor adjustments to better support system installations of Cap'n Proto and to improve general compatibility. Changes include using `CMAKE_COMMAND` variable instead of hardcoding `cmake` as the command. We now conditionally change the Cap'n Proto compilation command based on if Cap'n Proto was built as part of the super build or not. Lastly we remove double importing Cap'n Proto.

---
TYPE: IMPROVEMENT
DESC: Improve Cap'n Proto cmake setup for system installations
