### PR TITLE
Fix to correctly apply to correctly apply patch create_symlink avoidance patch

### DIFF
--- a/cmake/Modules/FindCapnp_EP.cmake
+++ b/cmake/Modules/FindCapnp_EP.cmake
@@ -65,7 +65,7 @@ if (NOT CAPNP_FOUND)
 
     if (WIN32)
       find_package(Git REQUIRED)
-      set(CONDITIONAL_PATCH ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_capnp < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_capnp/capnp_CMakeLists.txt.patch)
+      set(CONDITIONAL_PATCH cd ${CMAKE_SOURCE_DIR} && ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_capnp < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_capnp/capnp_CMakeLists.txt.patch)
     else()
       set(CONDITIONAL_PATCH "")
     endif()


### PR DESCRIPTION
Add correct directory positioning for git apply to correctly apply create_symlink avoidance patch, corrects earlier regression.

---
TYPE: BUG
DESC: fix to correctly apply capnproto create_symlink avoidance patch