### PR TITLE
Fix nullable string example failure on gcc7

### DIFF
--- a/examples/cpp_api/nullable_attribute.cc
+++ b/examples/cpp_api/nullable_attribute.cc
@@ -176,28 +176,27 @@ void read_array() {
   std::cout << std::endl;
 
   std::cout << "a2: " << std::endl;
-  for(i = 0; i<4; ++i) {
-    if(a2_validity_buf[i]>0) {
+  for (i = 0; i < 4; ++i) {
+    if (a2_validity_buf[i] > 0) {
       std::cout << "{";
-      int start_idx = a2_off[i]/(sizeof(int));
+      int start_idx = a2_off[i] / (sizeof(int));
       int end_idx = 0;
-      if(i == (a2_off.size()-1)) {
+      if (i == (a2_off.size() - 1)) {
         end_idx = a2_off.size();
-      }
-      else {
-        end_idx = a2_off[i+1]/(sizeof(int));
+      } else {
+        end_idx = a2_off[i + 1] / (sizeof(int));
       }
       int count = 0;
-      for(int j=start_idx; j<end_idx; ++j) {
-        if(count>0) {
-          std::cout <<",";
+      for (int j = start_idx; j < end_idx; ++j) {
+        if (count > 0) {
+          std::cout << ",";
         }
         std::cout << a2_data[j];
         ++count;
       }
       std::cout << "}";
     } else {
-      std::cout <<"{ NULL }";
+      std::cout << "{ NULL }";
     }
     std::cout << " ";
   }

--- a/examples/cpp_api/nullable_attribute.cc
+++ b/examples/cpp_api/nullable_attribute.cc
@@ -178,7 +178,7 @@ void read_array() {
   std::cout << "a2: " << std::endl;
   for (i = 0; i < 4; ++i) {
     if (a2_validity_buf[i] > 0) {
-      std::cout << "{";
+      std::cout << "{ ";
       std::cout << std::to_string(a2_data[i * 2]);
       std::cout << ", ";
       std::cout << std::to_string(a2_data[i * 2 + 1]);

--- a/examples/cpp_api/nullable_attribute.cc
+++ b/examples/cpp_api/nullable_attribute.cc
@@ -176,15 +176,28 @@ void read_array() {
   std::cout << std::endl;
 
   std::cout << "a2: " << std::endl;
-  for (i = 0; i < 4; ++i) {
-    if (a2_validity_buf[i] > 0) {
-      std::cout << "{ ";
-      std::cout << std::to_string(a2_data[i * 2]);
-      std::cout << ", ";
-      std::cout << std::to_string(a2_data[i * 2 + 1]);
-      std::cout << " }";
+  for(i = 0; i<4; ++i) {
+    if(a2_validity_buf[i]>0) {
+      std::cout << "{";
+      int start_idx = a2_off[i]/(sizeof(int));
+      int end_idx = 0;
+      if(i == (a2_off.size()-1)) {
+        end_idx = a2_off.size();
+      }
+      else {
+        end_idx = a2_off[i+1]/(sizeof(int));
+      }
+      int count = 0;
+      for(int j=start_idx; j<end_idx; ++j) {
+        if(count>0) {
+          std::cout <<",";
+        }
+        std::cout << a2_data[j];
+        ++count;
+      }
+      std::cout << "}";
     } else {
-      std::cout << "{ NULL }";
+      std::cout <<"{ NULL }";
     }
     std::cout << " ";
   }

--- a/examples/cpp_api/nullable_attribute.cc
+++ b/examples/cpp_api/nullable_attribute.cc
@@ -179,22 +179,10 @@ void read_array() {
   for (i = 0; i < 4; ++i) {
     if (a2_validity_buf[i] > 0) {
       std::cout << "{";
-      int start_idx = a2_off[i] / (sizeof(int));
-      int end_idx = 0;
-      if (i == (a2_off.size() - 1)) {
-        end_idx = a2_off.size();
-      } else {
-        end_idx = a2_off[i + 1] / (sizeof(int));
-      }
-      int count = 0;
-      for (int j = start_idx; j < end_idx; ++j) {
-        if (count > 0) {
-          std::cout << ",";
-        }
-        std::cout << a2_data[j];
-        ++count;
-      }
-      std::cout << "}";
+      std::cout << std::to_string(a2_data[i * 2]);
+      std::cout << ", ";
+      std::cout << std::to_string(a2_data[i * 2 + 1]);
+      std::cout << " }";
     } else {
       std::cout << "{ NULL }";
     }

--- a/tiledb/sm/array_schema/tile_domain.h
+++ b/tiledb/sm/array_schema/tile_domain.h
@@ -100,16 +100,16 @@ class TileDomain {
   ~TileDomain() = default;
 
   /** Default copy constructor. */
-  TileDomain(const TileDomain& tile_domain) = default;
+  TileDomain(const TileDomain&) = default;
 
   /** Default move constructor. */
-  TileDomain(TileDomain&& tile_domain) = default;
+  TileDomain(TileDomain&&) = default;
 
   /** Default copy-assign operator. */
-  TileDomain& operator=(const TileDomain& tile_domain) = default;
+  TileDomain& operator=(const TileDomain&) = default;
 
   /** Default move-assign operator. */
-  TileDomain& operator=(TileDomain&& tile_domain) = default;
+  TileDomain& operator=(TileDomain&&) = default;
 
   /* ********************************* */
   /*                 API               */

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -76,19 +76,19 @@ class Range {
   }
 
   /** Copy constructor. */
-  Range(const Range& range) = default;
+  Range(const Range&) = default;
 
   /** Move constructor. */
-  Range(Range&& range) = default;
+  Range(Range&&) = default;
 
   /** Destructor. */
   ~Range() = default;
 
   /** Copy-assign operator.*/
-  Range& operator=(const Range& range) = default;
+  Range& operator=(const Range&) = default;
 
   /** Move-assign operator. */
-  Range& operator=(Range&& range) = default;
+  Range& operator=(Range&&) = default;
 
   /** Sets a fixed-sized range serialized in `r`. */
   void set_range(const void* r, uint64_t r_size) {

--- a/tiledb/sm/query/result_space_tile.h
+++ b/tiledb/sm/query/result_space_tile.h
@@ -62,17 +62,17 @@ class ResultSpaceTile {
   ~ResultSpaceTile() = default;
 
   /** Default copy constructor. */
-  ResultSpaceTile(const ResultSpaceTile& result_space_tile) = default;
+  ResultSpaceTile(const ResultSpaceTile&) = default;
 
   /** Default move constructor. */
-  ResultSpaceTile(ResultSpaceTile&& result_space_tile) = default;
+  ResultSpaceTile(ResultSpaceTile&&) = default;
 
   /** Default copy-assign operator. */
-  ResultSpaceTile& operator=(const ResultSpaceTile& result_space_tile) =
+  ResultSpaceTile& operator=(const ResultSpaceTile&) =
       default;
 
   /** Default move-assign operator. */
-  ResultSpaceTile& operator=(ResultSpaceTile&& result_space_tile) = default;
+  ResultSpaceTile& operator=(ResultSpaceTile&&) = default;
 
   /** Returns the fragment domains. */
   const std::vector<std::pair<unsigned, NDRange>>& frag_domains() const {

--- a/tiledb/sm/query/result_space_tile.h
+++ b/tiledb/sm/query/result_space_tile.h
@@ -68,8 +68,7 @@ class ResultSpaceTile {
   ResultSpaceTile(ResultSpaceTile&&) = default;
 
   /** Default copy-assign operator. */
-  ResultSpaceTile& operator=(const ResultSpaceTile&) =
-      default;
+  ResultSpaceTile& operator=(const ResultSpaceTile&) = default;
 
   /** Default move-assign operator. */
   ResultSpaceTile& operator=(ResultSpaceTile&&) = default;

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -84,20 +84,20 @@ class ResultTile {
   ~ResultTile() = default;
 
   /** Default copy constructor. */
-  ResultTile(const ResultTile& result_tile) = default;
+  ResultTile(const ResultTile&) = default;
 
   /** Default move constructor. */
-  ResultTile(ResultTile&& result_tile) = default;
+  ResultTile(ResultTile&&) = default;
 
   /* ********************************* */
   /*                API                */
   /* ********************************* */
 
   /** Default copy-assign operator. */
-  ResultTile& operator=(const ResultTile& result_tile) = default;
+  ResultTile& operator=(const ResultTile&) = default;
 
   /** Default move-assign operator. */
-  ResultTile& operator=(ResultTile&& result_tile) = default;
+  ResultTile& operator=(ResultTile&&) = default;
 
   /** Equality operator (mainly for debugging purposes). */
   bool operator==(const ResultTile& rt) const;

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -191,9 +191,9 @@ void Stats::add_counter(const std::string& stat, uint64_t count) {
   (void)stat;
   (void)count;
 }
-
-void Stats::start_timer(const std::string& stat) {
+ScopedExecutor Stats::start_timer(const std::string& stat) {
   (void)stat;
+  return ScopedExecutor();
 }
 
 void Stats::end_timer(const std::string& stat) {

--- a/tiledb/sm/subarray/cell_slab.h
+++ b/tiledb/sm/subarray/cell_slab.h
@@ -69,16 +69,16 @@ struct CellSlab {
   }
 
   /** Default copy constructor. */
-  CellSlab(const CellSlab& cell_slab) = default;
+  CellSlab(const CellSlab&) = default;
 
   /** Default move constructor. */
-  CellSlab(CellSlab&& cell_slab) = default;
+  CellSlab(CellSlab&&) = default;
 
   /** Default copy-assign operator. */
-  CellSlab& operator=(const CellSlab& cell_slab) = default;
+  CellSlab& operator=(const CellSlab&) = default;
 
   /** Default move-assign operator. */
-  CellSlab& operator=(CellSlab&& cell_slab) = default;
+  CellSlab& operator=(CellSlab&&) = default;
 
   /** Simple initializer. */
   void init(unsigned int dim_num) {

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1799,10 +1799,10 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
       } else {
         max_size_fixed =
             utils::math::safe_mul(cell_num, array_schema->cell_size(names[n]));
-        if (nullable[n])
-          max_size_validity =
-              utils::math::safe_mul(cell_num, constants::cell_validity_size);
       }
+      if (nullable[n])
+        max_size_validity =
+            utils::math::safe_mul(cell_num, constants::cell_validity_size);      
 
       (*result_sizes)[n].size_fixed_ =
           std::min<double>((*result_sizes)[n].size_fixed_, max_size_fixed);

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1802,7 +1802,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
       }
       if (nullable[n])
         max_size_validity =
-            utils::math::safe_mul(cell_num, constants::cell_validity_size);      
+            utils::math::safe_mul(cell_num, constants::cell_validity_size);
 
       (*result_sizes)[n].size_fixed_ =
           std::min<double>((*result_sizes)[n].size_fixed_, max_size_fixed);


### PR DESCRIPTION
The nullable string array example(nullable_attribute.cc) fails on CentOS7/gcc7.3 with an incomplete query. Finally I found that it is not a bug from gcc7. The bug for calculating max_size_validity caused that problem. When we add three attributes a1,a2,a3, the unordered_map buffer still keep in that order gcc4.8, clang, and vc2015. But in gcc 7, a2 becomes the first when we try to iterate. The incomplete query is not found when we use gcc4.8, clang or vc2015, since a1 is a fixed size attribute and a1 still shows to be the first in gcc4.8 and other compilers. If our example use more attributes, the incomplete query could also happen for gcc4.8, clang and vc2015. This incomplete query can also happen for other kinds of variable size attributes(such as vector<T>).  In this branch, I also fixed some warnings from gcc compiler when we provided unused parameters for default constructors and assign operators.

---
TYPE: BUG
DESC: The bug for calculating max_size_validity for var_size attribute caused incomplete query
