### PR TITLE
Subarray partitioner: fixes to hilbert partitioning

### DIFF
--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -1230,8 +1230,8 @@ TEST_CASE(
 
   // Write array
   std::vector<int32_t> buff_a = {2, 3, 1, 4};
-  std::vector<float> buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
-  std::vector<float> buff_d2 = {0.3f, 0.1f, 0.2f, 0.4f};
+  std::vector<float> buff_d1 = {0.1f, 0.1f, 0.41f, 0.4f};
+  std::vector<float> buff_d2 = {0.3f, 0.1f, 0.41f, 0.4f};
   write_2d_array<float, float>(
       array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
 
@@ -1278,8 +1278,8 @@ TEST_CASE(
     CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
     CHECK(query_r.result_buffer_elements()["a"].second == 2);
     c_buff_a = {1, 4};
-    c_buff_d1 = {0.4f, 0.5f};
-    c_buff_d2 = {0.2f, 0.4f};
+    c_buff_d1 = {0.41f, 0.4f};
+    c_buff_d2 = {0.41f, 0.4f};
     CHECK(r_buff_a == c_buff_a);
     CHECK(r_buff_d1 == c_buff_d1);
     CHECK(r_buff_d2 == c_buff_d2);
@@ -1336,8 +1336,8 @@ TEST_CASE(
     CHECK(query_r.query_status() == Query::Status::INCOMPLETE);
     CHECK(query_r.result_buffer_elements()["a"].second == 2);
     c_buff_a = {1, 4};
-    c_buff_d1 = {0.4f, 0.5f};
-    c_buff_d2 = {0.2f, 0.4f};
+    c_buff_d1 = {0.41f, 0.4f};
+    c_buff_d2 = {0.41f, 0.4f};
     CHECK(r_buff_a == c_buff_a);
     CHECK(r_buff_d1 == c_buff_d1);
     CHECK(r_buff_d2 == c_buff_d2);

--- a/test/src/unit-dimension.cc
+++ b/test/src/unit-dimension.cc
@@ -524,15 +524,12 @@ TEST_CASE(
   auto bits = h.bits();
   auto bucket_num = ((uint64_t)1 << bits) - 1;
 
-  // Test - they are off by 1 as compared to the previous test
-  // due to rounding. That does not affect correctness of the
-  // partitioning algorith (where map_from_uint64 is used).
   auto val = d1.map_from_uint64(63786642, bits, bucket_num);
   auto val_int32 = *(const int32_t*)(&val[0]);
-  CHECK(val_int32 == 2);
+  CHECK(val_int32 == 3);
   val = d1.map_from_uint64(42524428, bits, bucket_num);
   val_int32 = *(const int32_t*)(&val[0]);
-  CHECK(val_int32 == 1);
+  CHECK(val_int32 == 2);
 }
 
 TEST_CASE(
@@ -548,15 +545,12 @@ TEST_CASE(
   auto bits = h.bits();
   auto bucket_num = ((uint64_t)1 << bits) - 1;
 
-  // Test - they are off by 1 as compared to the previous test
-  // due to rounding. That does not affect correctness of the
-  // partitioning algorith (where map_from_uint64 is used).
   auto val = d1.map_from_uint64(63786642, bits, bucket_num);
   auto val_int32 = *(const int32_t*)(&val[0]);
-  CHECK(val_int32 == -48);
+  CHECK(val_int32 == -47);
   val = d1.map_from_uint64(42524428, bits, bucket_num);
   val_int32 = *(const int32_t*)(&val[0]);
-  CHECK(val_int32 == -49);
+  CHECK(val_int32 == -48);
 }
 
 TEST_CASE(
@@ -574,10 +568,10 @@ TEST_CASE(
 
   auto val = d1.map_from_uint64(1503238527, bits, bucket_num);
   auto val_int32 = *(const float*)(&val[0]);
-  CHECK(val_int32 == 0.7f);
+  CHECK(round(100 * val_int32) == 70);
   val = d1.map_from_uint64(429496735, bits, bucket_num);
   val_int32 = *(const float*)(&val[0]);
-  CHECK(val_int32 == 0.2f);
+  CHECK(round(100 * val_int32) == 20);
 }
 
 TEST_CASE(

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1248,13 +1248,15 @@ ByteVecValue Dimension::map_from_uint64(
   auto dom_end_T = *(const T*)dim->domain().end();
   double dom_range_T = dom_end_T - dom_start_T + std::is_integral<T>::value;
 
+  // Essentially take the largest value in the bucket
   if (std::is_integral<T>::value) {  // Integers
-    // Essentially take the largest value in the bucket
-    T norm_coord_T = ((value + 1) / (double)bucket_num) * dom_range_T - 1;
+    T norm_coord_T = ceil(((value + 1) / (double)bucket_num) * dom_range_T - 1);
     T coord_T = norm_coord_T + dom_start_T;
     std::memcpy(&ret[0], &coord_T, sizeof(T));
   } else {  // Floating point types
-    T norm_coord_T = (value / (double)bucket_num) * dom_range_T;
+    T norm_coord_T = ((value + 1) / (double)bucket_num) * dom_range_T;
+    norm_coord_T =
+        std::nextafter(norm_coord_T, std::numeric_limits<T>::lowest());
     T coord_T = norm_coord_T + dom_start_T;
     std::memcpy(&ret[0], &coord_T, sizeof(T));
   }

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -1449,30 +1449,36 @@ void SubarrayPartitioner::compute_splitting_value_hilbert(
     ByteVecValue* splitting_value) const {
   auto array_schema = subarray_.array()->array_schema();
   auto dim_num = array_schema->dim_num();
-  uint64_t splitting_value_uint64;   // Splitting value
-  uint64_t left_p2_m1, right_p2_m1;  // Left/right powers of 2 minus 1
+  uint64_t splitting_value_uint64 = range_uint64[0];  // Splitting value
+  if (range_uint64[0] + 1 != range_uint64[1]) {
+    uint64_t left_p2_m1, right_p2_m1;  // Left/right powers of 2 minus 1
 
-  // Compute left and right (2^i-1) enclosing the uint64 range
-  left_p2_m1 = utils::math::left_p2_m1(range_uint64[0]);
-  right_p2_m1 = utils::math::right_p2_m1(range_uint64[1]);
-  assert(left_p2_m1 != right_p2_m1);  // Cannot be unary
+    // Compute left and right (2^i-1) enclosing the uint64 range
+    left_p2_m1 = utils::math::left_p2_m1(range_uint64[0]);
+    right_p2_m1 = utils::math::right_p2_m1(range_uint64[1]);
+    assert(left_p2_m1 != right_p2_m1);  // Cannot be unary
 
-  // Compute splitting value
-  uint64_t splitting_offset = 0;
-  auto range_uint64_start = range_uint64[0];
-  auto range_uint64_end = range_uint64[1];
-  while (true) {
-    if (((left_p2_m1 << 1) + 1) != right_p2_m1) {
-      // More than one power of 2 apart, split at largest power of 2 in between
-      splitting_value_uint64 = splitting_offset + (right_p2_m1 >> 1);
-      break;
-    } else {  // One power apart - need to normalize and repeat
-      range_uint64_start -= (left_p2_m1 + 1);
-      range_uint64_end -= (left_p2_m1 + 1);
-      left_p2_m1 = utils::math::left_p2_m1(range_uint64_start);
-      right_p2_m1 = utils::math::right_p2_m1(range_uint64_end);
-      assert(left_p2_m1 != right_p2_m1);  // Cannot be unary
-      splitting_offset += left_p2_m1 + 1;
+    // Compute splitting value
+    uint64_t splitting_offset = 0;
+    auto range_uint64_start = range_uint64[0];
+    auto range_uint64_end = range_uint64[1];
+    while (true) {
+      if (((left_p2_m1 << 1) + 1) != right_p2_m1) {
+        // More than one power of 2 apart, split at largest power of 2 in
+        // between
+        splitting_value_uint64 = splitting_offset + (right_p2_m1 >> 1);
+        break;
+      } else if (left_p2_m1 == range_uint64_start) {
+        splitting_value_uint64 = splitting_offset + left_p2_m1;
+        break;
+      } else {  // One power apart - need to normalize and repeat
+        range_uint64_start -= (left_p2_m1 + 1);
+        range_uint64_end -= (left_p2_m1 + 1);
+        splitting_offset += (left_p2_m1 + 1);
+        left_p2_m1 = utils::math::left_p2_m1(range_uint64_start);
+        right_p2_m1 = utils::math::right_p2_m1(range_uint64_end);
+        assert(left_p2_m1 != right_p2_m1);  // Cannot be unary
+      }
     }
   }
 


### PR DESCRIPTION
This fixes a few issues in the Hilbert partitioning. First, when a range
includes only two Hilbert values, it splits on the left one. Second, it
fixes an int underflow when normalizing and the left range value
coincides with a power of two. Third, it fixes normalization to use the
proper splitting offset. Finally, when reverting from a Hilbert
coordinate value, it now returns the correct maximum possible value to
still fall into that bucket.

---
TYPE: IMPROVEMENT
DESC: Hilbert partitioning fixes
