### PR TITLE
Deprecate tiledb_array_get_timestamp + fix

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -818,7 +818,7 @@ TEST_CASE("C++ API: Open array at", "[cppapi][open-array-at]") {
 
   // Read from 0 timestamp
   Array array_r_at_0(ctx, array_name, TILEDB_READ, 0);
-  CHECK(array_r_at_0.timestamp_end() == 0);
+  CHECK(array_r_at_0.timestamp() == 0);
 
   SECTION("Testing Array::Array") {
     // Nothing to do - just for clarity
@@ -863,7 +863,7 @@ TEST_CASE("C++ API: Open array at", "[cppapi][open-array-at]") {
 
   // Reopen at first timestamp.
   array_r_at.reopen_at(first_timestamp);
-  CHECK(array_r_at.timestamp_end() == first_timestamp);
+  CHECK(array_r_at.timestamp() == first_timestamp);
   std::vector<int> a_r_reopen_at(4);
   Query query_r_reopen_at(ctx, array_r_at);
   query_r_reopen_at.set_subarray(subarray)

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -208,17 +208,16 @@ Status Array::open(
   metadata_loaded_ = false;
   non_empty_domain_computed_ = false;
 
-  if (query_type == QueryType::READ) {
-    timestamp_start_ = timestamp_start;
-    timestamp_end_ = timestamp_end;
-  } else {
-    assert(query_type == QueryType::WRITE);
-    if (timestamp_end == UINT64_MAX) {
-      timestamp_end_ = 0;
+  timestamp_start_ = timestamp_start;
+  timestamp_end_ = timestamp_end;
+
+  if (timestamp_end_ == UINT64_MAX) {
+    if (query_type == QueryType::READ) {
+      timestamp_end_ = utils::time::timestamp_now_ms();
     } else {
-      timestamp_end_ = timestamp_end;
+      assert(query_type == QueryType::WRITE);
+      timestamp_end_ = 0;
     }
-    timestamp_start_ = timestamp_start;
   }
 
   if (remote_) {
@@ -496,6 +495,10 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   metadata_loaded_ = false;
   non_empty_domain_.clear();
   non_empty_domain_computed_ = false;
+
+  if (timestamp_end_ == UINT64_MAX) {
+    timestamp_end_ = utils::time::timestamp_now_ms();
+  }
 
   if (remote_) {
     return open(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -4964,6 +4964,9 @@ TILEDB_EXPORT int32_t tiledb_array_reopen_at(
     tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t timestamp);
 
 /**
+ * This is a deprecated API. The start/end timestamps for opening an array
+ * are now set in the config.
+ *
  * Returns the timestamp, representing time in milliseconds ellapsed since
  * 1970-01-01 00:00:00 +0000 (UTC), at which the array was opened. See also the
  * documentation of `tiledb_array_open_at`.

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -620,7 +620,8 @@ class Array {
   }
 
   /** Returns the timestamp at which the array was opened. */
-  uint64_t timestamp_end() const {
+  TILEDB_DEPRECATED
+  uint64_t timestamp() const {
     auto& ctx = ctx_.get();
     uint64_t timestamp_end;
     ctx.handle_error(tiledb_array_get_timestamp(


### PR DESCRIPTION
The end timestamp for an array open is now interpretted as the current time.
I've deprecated the related `tiledb_array_get_timestamp` API because it is no
longer applicable to the start/end timestamp.

I also reverted the C++ API Array::timestamp_end to Array::timestamp. We haven't
shipped this change so it doesn't break anything.

---

TYPE: NO_HISTORY
DESC: Using `NO_HISTORY` since this is a bug in an unreleased feature