### PR TITLE
Change &foo[0] to foo.data() for a std::vector

### DIFF
--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1408,7 +1408,7 @@ class Query {
       impl::type_check<T>(schema_.domain().dimension(name).type());
 
     return set_buffer(
-        name, offsets.data(), offsets.size(), &data[0], data.size(), sizeof(T));
+        name, offsets.data(), offsets.size(), data.data(), data.size(), sizeof(T));
   }
 
   /**

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1408,7 +1408,12 @@ class Query {
       impl::type_check<T>(schema_.domain().dimension(name).type());
 
     return set_buffer(
-        name, offsets.data(), offsets.size(), data.data(), data.size(), sizeof(T));
+        name,
+        offsets.data(),
+        offsets.size(),
+        data.data(),
+        data.size(),
+        sizeof(T));
   }
 
   /**


### PR DESCRIPTION
The idiom `&foo[0]` is fine for an array; it's not the same for a vector. Accessing a non-existent element through `operator[]` is undefined behavior, triggered when `foo` is empty. It's compliant behavior for a library to throw an assertion failure in this case (that's how the defect came to light). The standard library provides `data()` to substitute for the old, C-style idiom.

---
TYPE: BUG
DESC: Treating `std::vector` like an array; accessing an element that's not present to get its address.
