### PR TITLE
Always run ASAN with matching compiler versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,9 +60,8 @@ stages:
             imageName: 'ubuntu-16.04'
             TILEDB_CI_ASAN: ON
             TILEDB_SERIALIZATION: ON
-            # Always run ASAN with matching compiler versions
             CXX: g++-9
-            CC: gcc-9
+            CC: gcc-9   # Always run ASAN with matching compiler versions
           linux_serialization:
             imageName: 'ubuntu-16.04'
             TILEDB_SERIALIZATION: ON

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,9 @@ stages:
             imageName: 'ubuntu-16.04'
             TILEDB_CI_ASAN: ON
             TILEDB_SERIALIZATION: ON
+            # Always run ASAN with matching compiler versions
             CXX: g++-9
+            CC: gcc-9
           linux_serialization:
             imageName: 'ubuntu-16.04'
             TILEDB_SERIALIZATION: ON


### PR DESCRIPTION
We had been running CI for the address sanitizer with gcc-9 for C++ but the default, which was gcc-5, for C. Adding some code with C linkage caused linking to fail on executables referencing the library. ASAN requires complete consistency in versions; it doesn't work otherwise.

---
TYPE: BUG
DESC: Always run ASAN with matching compiler versions
