### PR TITLE
Subarray partitioner: global order partition fix

### DIFF
--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -896,8 +896,11 @@ void SubarrayPartitioner::compute_splitting_value_on_tiles(
       *splitting_dim = d;
       dim->ceil_to_tile(
           *r, MAX(1, floor(tiles_apart / 2)) - 1, splitting_value);
-      *unsplittable = false;
-      break;
+
+      if (std::memcmp(splitting_value, r->end(), splitting_value->size())) {
+        *unsplittable = false;
+        break;
+      }
     }
   }
 }


### PR DESCRIPTION
This happens when the range boundaries are both at the end of a tile and
spaced one tile apart. This case should be considered unsplittable.

---
TYPE: BUG
DESC: Subarray partitioner: global order partition fix
