### PR TITLE
Fix some loop bounds that reference non-existent elements

### DIFF
--- a/test/src/unit-DenseTiler.cc
+++ b/test/src/unit-DenseTiler.cc
@@ -2488,7 +2488,7 @@ TEST_CASE_METHOD(
   c_data1_3_val[6] = 'o';
   c_data1_3_val[7] = 'o';
   c_data1_3_val[8] = 'o';
-  for (int i = 9; i <= 57; ++i)
+  for (int i = 9; i < 57; ++i)
     c_data1_3_val[i] = 0;
   CHECK(check_tile<uint8_t>(&tile1_3_val, c_data1_3_val));
 
@@ -3101,7 +3101,7 @@ TEST_CASE_METHOD(
   c_data1_3_val[6] = 15;
   c_data1_3_val[7] = 15;
   c_data1_3_val[8] = 15;
-  for (int i = 9; i <= 57; ++i)
+  for (int i = 9; i < 57; ++i)
     c_data1_3_val[i] = 0;
   CHECK(check_tile<int32_t>(&tile1_3_val, c_data1_3_val));
 
@@ -3406,7 +3406,7 @@ TEST_CASE_METHOD(
   c_data1_3_val[6] = 15;
   c_data1_3_val[7] = 15;
   c_data1_3_val[8] = 15;
-  for (int i = 9; i <= 57; ++i)
+  for (int i = 9; i < 57; ++i)
     c_data1_3_val[i] = 0;
   CHECK(check_tile<int32_t>(&tile1_3_val, c_data1_3_val));
 


### PR DESCRIPTION
unit-DenseTiler.cc has tests that use a number of fixed arrays. The loops that check them has a number of off-by-one bounds, in this case using <= for <.

---
TYPE: BUG
DESC: Fix some loop bounds that reference non-existent elements