### PR TITLE
[Backport] Refactor array open-timestamp APIs

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -781,16 +781,10 @@ void write_array(
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
-  tiledb_config_t* cfg;
-  tiledb_error_t* err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.array.timestamp_end", std::to_string(timestamp).c_str(), &err);
+
+  rc = tiledb_array_set_open_timestamp_end(ctx, array, timestamp);
   REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
+
   // Open array
   if (encryption_type == TILEDB_NO_ENCRYPTION)
     rc = tiledb_array_open(ctx, array, TILEDB_WRITE);
@@ -854,7 +848,6 @@ void write_array(
   // Clean up
   tiledb_array_free(&array);
   tiledb_query_free(&query);
-  tiledb_config_free(&cfg);
 }
 
 template <class T>

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -856,17 +856,10 @@ TEST_CASE_METHOD(
   CHECK(buffer_read_size == sizeof(buffer_read_c));
 
   // ---- READ AT ZERO TIMESTAMP ----
-  // Set array configuration
-  tiledb_config_t* cfg;
-  tiledb_error_t* err = nullptr;
+
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(cfg, "sm.array.timestamp_end", "0", &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, 0);
   REQUIRE(rc == TILEDB_OK);
 
   // Open array
@@ -884,15 +877,10 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   // Check timestamp
-  const char* timestamp_get = nullptr;
-  tiledb_config_t* config = nullptr;
-  rc = tiledb_array_get_config(ctx_, array, &config);
+  uint64_t timestamp_get;
+  rc = tiledb_array_get_open_timestamp_end(ctx_, array, &timestamp_get);
   CHECK(rc == TILEDB_OK);
-  rc =
-      tiledb_config_get(config, "sm.array.timestamp_end", &timestamp_get, &err);
-  CHECK(rc == TILEDB_OK);
-  CHECK(err == nullptr);
-  CHECK(!strcmp(timestamp_get, "0"));
+  CHECK(timestamp_get == 0);
 
   // Submit query
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
@@ -912,8 +900,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
-  tiledb_config_free(&cfg);
-  tiledb_config_free(&config);
 
   // Check correctness
   // Empty array still returns fill values
@@ -922,20 +908,9 @@ TEST_CASE_METHOD(
   // ---- READ AT TIMESTAMP BEFORE UPDATE ----
   buffer_read_size = sizeof(buffer_read);
 
-  // Set array configuration
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_end",
-      std::to_string(fragment_timestamps[0]).c_str(),
-      &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, fragment_timestamps[0]);
   REQUIRE(rc == TILEDB_OK);
 
   // Open array
@@ -970,7 +945,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
-  tiledb_config_free(&cfg);
 
   // Check correctness
   int buffer_read_at_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
@@ -981,17 +955,10 @@ TEST_CASE_METHOD(
   // Open array
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_end",
-      std::to_string(fragment_timestamps[1]).c_str(),
-      &err);
+
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, fragment_timestamps[1]);
   REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+
   REQUIRE(rc == TILEDB_OK);
   if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
     rc = tiledb_array_open(ctx_, array, TILEDB_READ);
@@ -1007,15 +974,9 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   // Check timestamp
-  timestamp_get = nullptr;
-  config = nullptr;
-  rc = tiledb_array_get_config(ctx_, array, &config);
+  rc = tiledb_array_get_open_timestamp_end(ctx_, array, &timestamp_get);
   CHECK(rc == TILEDB_OK);
-  rc =
-      tiledb_config_get(config, "sm.array.timestamp_end", &timestamp_get, &err);
-  CHECK(rc == TILEDB_OK);
-  CHECK(err == nullptr);
-  CHECK(!strcmp(timestamp_get, std::to_string(fragment_timestamps[1]).c_str()));
+  CHECK(timestamp_get == fragment_timestamps[1]);
 
   // Submit query
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
@@ -1040,20 +1001,10 @@ TEST_CASE_METHOD(
   // ---- REOPEN AT FIRST TIMESTAMP ----
   buffer_read_size = sizeof(buffer_read);
 
-  // Reopen array
-  tiledb_config_free(&cfg);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_end",
-      std::to_string(fragment_timestamps[1] - 1).c_str(),
-      &err);
+  rc = tiledb_array_set_open_timestamp_end(
+      ctx_, array, fragment_timestamps[1] - 1);
   REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
+
   rc = tiledb_array_reopen(ctx_, array);
   CHECK(rc == TILEDB_OK);
 
@@ -1083,22 +1034,10 @@ TEST_CASE_METHOD(
   buffer_read_size = sizeof(buffer_read);
 
   // Reopen array
-  tiledb_config_free(&cfg);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_start",
-      std::to_string(fragment_timestamps[0] + 1).c_str(),
-      &err);
+  rc = tiledb_array_set_open_timestamp_start(
+      ctx_, array, fragment_timestamps[0] + 1);
   REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.array.timestamp_end", std::to_string(UINT64_MAX).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, UINT64_MAX);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_reopen(ctx_, array);
   CHECK(rc == TILEDB_OK);
@@ -1121,8 +1060,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_query_free(&query);
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
-  tiledb_config_free(&config);
 
   // Check correctness
   int buffer_read_reopen_start_c[] = {INT_MIN,
@@ -1147,18 +1084,9 @@ TEST_CASE_METHOD(
   // Open array
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_start",
-      std::to_string(fragment_timestamps[1]).c_str(),
-      &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_set_open_timestamp_start(
+      ctx_, array, fragment_timestamps[1]);
+
   if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
     rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   } else {
@@ -1190,7 +1118,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_query_free(&query);
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
 
   // Check correctness
   // Check correctness
@@ -1214,18 +1141,10 @@ TEST_CASE_METHOD(
   // Open array
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_start",
-      std::to_string(fragment_timestamps[1] + 1).c_str(),
-      &err);
+  rc = tiledb_array_set_open_timestamp_start(
+      ctx_, array, fragment_timestamps[1] + 1);
   REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
+
   if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
     rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   } else {
@@ -1257,7 +1176,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_query_free(&query);
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
 
   // Check correctness
   // Check correctness
@@ -1310,20 +1228,11 @@ TEST_CASE_METHOD(
   // Some timestamp, it could be anything
   uint64_t timestamp = 1000;
 
-  // Set array configuration
-  tiledb_config_t* cfg;
-  tiledb_error_t* err = nullptr;
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.array.timestamp_end", std::to_string(timestamp).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp);
   REQUIRE(rc == TILEDB_OK);
 
   // Open array
@@ -1354,35 +1263,27 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   // Get written timestamp
-  const char* timestamp_get = nullptr;
-  rc = tiledb_config_get(cfg, "sm.array.timestamp_end", &timestamp_get, &err);
+  uint64_t timestamp_get;
+  rc = tiledb_array_get_open_timestamp_end(ctx_, array, &timestamp_get);
   CHECK(rc == TILEDB_OK);
-  CHECK(err == nullptr);
 
   uint64_t t1, t2;
   rc = tiledb_query_get_fragment_timestamp_range(ctx_, query, 0, &t1, &t2);
   CHECK(rc == TILEDB_OK);
-  CHECK(!strcmp(timestamp_get, std::to_string(t1).c_str()));
-  CHECK(!strcmp(timestamp_get, std::to_string(t2).c_str()));
+  CHECK(timestamp_get == t1);
+  CHECK(timestamp_get == t2);
 
   // Close array and clean up
   rc = tiledb_array_close(ctx_, array);
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
-  tiledb_config_free(&cfg);
 
   // ---- READ AT ZERO TIMESTAMP ----
-  // Set array configuration
+
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(cfg, "sm.array.timestamp_end", "0", &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, 0);
   REQUIRE(rc == TILEDB_OK);
 
   // Open array
@@ -1400,10 +1301,9 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   // Check timestamp
-  rc = tiledb_config_get(cfg, "sm.array.timestamp_end", &timestamp_get, &err);
+  rc = tiledb_array_get_open_timestamp_end(ctx_, array, &timestamp_get);
   CHECK(rc == TILEDB_OK);
-  CHECK(err == nullptr);
-  CHECK(!strcmp(timestamp_get, "0"));
+  CHECK(timestamp_get == 0);
 
   // Submit query
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
@@ -1426,7 +1326,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
-  tiledb_config_free(&cfg);
 
   // Check correctness
   // Empty array still returns fill values
@@ -1435,17 +1334,9 @@ TEST_CASE_METHOD(
   // ---- READ AT THE WRITTEN TIMESTAMP ----
   buffer_read_size = sizeof(buffer_read);
 
-  // Set array configuration
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   CHECK(rc == TILEDB_OK);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.array.timestamp_end", std::to_string(timestamp).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp);
   REQUIRE(rc == TILEDB_OK);
 
   // Open array
@@ -1480,7 +1371,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
-  tiledb_config_free(&cfg);
 
   // Check correctness
   int buffer_read_at_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -222,8 +222,6 @@ void check_save_to_file() {
   ss << "rest.retry_initial_delay_ms 500\n";
   ss << "rest.server_address https://api.tiledb.com\n";
   ss << "rest.server_serialization_format CAPNP\n";
-  ss << "sm.array.timestamp_end " << std::to_string(UINT64_MAX) << "\n";
-  ss << "sm.array.timestamp_start 0\n";
   ss << "sm.check_coord_dups true\n";
   ss << "sm.check_coord_oob true\n";
   ss << "sm.check_global_order true\n";
@@ -527,8 +525,6 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["rest.retry_delay_factor"] = "1.25";
   all_param_values["rest.retry_initial_delay_ms"] = "500";
   all_param_values["rest.retry_http_codes"] = "503";
-  all_param_values["sm.array.timestamp_start"] = "0";
-  all_param_values["sm.array.timestamp_end"] = std::to_string(UINT64_MAX);
   all_param_values["sm.dedup_coords"] = "false";
   all_param_values["sm.check_coord_dups"] = "true";
   all_param_values["sm.check_coord_oob"] = "true";

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -609,7 +609,6 @@ void ConsolidationFx::write_dense_vector_4_fragments(uint64_t timestamp) {
     a_4[i] = 310 + i;
   uint64_t a_4_size = sizeof(a_4);
 
-  // Set array configuration
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, DENSE_VECTOR_NAME, &array);
   CHECK(rc == TILEDB_OK);
@@ -617,15 +616,9 @@ void ConsolidationFx::write_dense_vector_4_fragments(uint64_t timestamp) {
   tiledb_error_t* err = nullptr;
   REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
   REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_end",
-      std::to_string(timestamp + 1).c_str(),
-      &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp + 1);
+  CHECK(rc == TILEDB_OK);
 
   // Open array
   if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
@@ -662,15 +655,8 @@ void ConsolidationFx::write_dense_vector_4_fragments(uint64_t timestamp) {
   err = nullptr;
   REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
   REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_end",
-      std::to_string(timestamp + 2).c_str(),
-      &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp + 2);
+  CHECK(rc == TILEDB_OK);
 
   if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
     rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
@@ -704,18 +690,9 @@ void ConsolidationFx::write_dense_vector_4_fragments(uint64_t timestamp) {
   rc = tiledb_array_close(ctx_, array);
   CHECK(rc == TILEDB_OK);
   tiledb_config_free(&cfg);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_end",
-      std::to_string(timestamp + 3).c_str(),
-      &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp + 3);
+  CHECK(rc == TILEDB_OK);
+
   if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
     rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
   } else {
@@ -747,18 +724,9 @@ void ConsolidationFx::write_dense_vector_4_fragments(uint64_t timestamp) {
   // Close and re-open at a new timestamp
   rc = tiledb_array_close(ctx_, array);
   CHECK(rc == TILEDB_OK);
-  tiledb_config_free(&cfg);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_end",
-      std::to_string(timestamp + 4).c_str(),
-      &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp + 4);
+  CHECK(rc == TILEDB_OK);
+
   REQUIRE(rc == TILEDB_OK);
   if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
     rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
@@ -2475,16 +2443,8 @@ void ConsolidationFx::read_dense_vector(uint64_t timestamp) {
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, DENSE_VECTOR_NAME, &array);
   CHECK(rc == TILEDB_OK);
-  tiledb_config_t* cfg;
-  tiledb_error_t* err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.array.timestamp_end", std::to_string(timestamp).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp);
+  CHECK(rc == TILEDB_OK);
 
   // Open array
   if (encryption_type_ == TILEDB_NO_ENCRYPTION) {
@@ -2534,7 +2494,6 @@ void ConsolidationFx::read_dense_vector(uint64_t timestamp) {
   // Clean up
   tiledb_array_free(&array);
   tiledb_query_free(&query);
-  tiledb_config_free(&cfg);
 }
 
 void ConsolidationFx::read_dense_vector_with_gaps() {
@@ -5497,15 +5456,9 @@ TEST_CASE_METHOD(
   tiledb_array_t* array;
   rc = tiledb_array_alloc(ctx_, DENSE_VECTOR_NAME, &array);
   CHECK(rc == TILEDB_OK);
-  tiledb_config_t* cfg;
-  tiledb_error_t* err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(cfg, "sm.array.timestamp_end", "1", &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, 1);
+  CHECK(rc == TILEDB_OK);
+
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
 
@@ -5541,7 +5494,6 @@ TEST_CASE_METHOD(
   // Clean up
   tiledb_array_free(&array);
   tiledb_query_free(&query);
-  tiledb_config_free(&cfg);
 
   // Clean up
   remove_dense_vector();

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -3493,10 +3493,6 @@ TEST_CASE_METHOD(
   std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
   create_temp_dir(temp_dir);
 
-  // Array configuration
-  tiledb_config_t* cfg;
-  tiledb_error_t* err;
-
   // Create and write dense array
   std::string array_name = temp_dir + "dense_reopen_array";
   create_dense_array(array_name);
@@ -3519,14 +3515,7 @@ TEST_CASE_METHOD(
   write_partial_dense_array(array_name);
 
   // Open array at a timestamp before the last fragment
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.array.timestamp_end", std::to_string(timestamp).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   CHECK(rc == TILEDB_OK);
@@ -3552,18 +3541,8 @@ TEST_CASE_METHOD(
   CHECK(a1_buffer[0] == 13);
 
   // Reopen the array to see the new fragment
-  tiledb_config_free(&cfg);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_end",
-      std::to_string(tiledb::sm::utils::time::timestamp_now_ms()).c_str(),
-      &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(
+      ctx_, array, tiledb::sm::utils::time::timestamp_now_ms());
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_reopen(ctx_, array);
   CHECK(rc == TILEDB_OK);
@@ -3598,12 +3577,6 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   // Re-opening arrays for writes should fail
-  tiledb_config_free(&cfg);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
-  REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_reopen(ctx_, array);
   CHECK(rc == TILEDB_ERR);
 
@@ -3613,7 +3586,6 @@ TEST_CASE_METHOD(
 
   // Clean up
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
 
   remove_temp_dir(temp_dir);
 }

--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -471,14 +471,7 @@ TEST_CASE_METHOD(
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
   REQUIRE(rc == TILEDB_OK);
-  tiledb_config_t* cfg;
-  tiledb_error_t* err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(cfg, "sm.array.timestamp_end", "1", &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, 1);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
@@ -495,18 +488,11 @@ TEST_CASE_METHOD(
   rc = tiledb_array_close(ctx_, array);
   REQUIRE(rc == TILEDB_OK);
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
 
   // Update
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
   REQUIRE(rc == TILEDB_OK);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(cfg, "sm.array.timestamp_end", "2", &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, 2);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
@@ -518,7 +504,6 @@ TEST_CASE_METHOD(
   rc = tiledb_array_close(ctx_, array);
   REQUIRE(rc == TILEDB_OK);
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
 
   // Open the array in read mode
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
@@ -596,13 +581,7 @@ TEST_CASE_METHOD(
   // Read at timestamp 1
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
   REQUIRE(rc == TILEDB_OK);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(cfg, "sm.array.timestamp_end", "1", &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, 1);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
@@ -614,7 +593,6 @@ TEST_CASE_METHOD(
   rc = tiledb_array_close(ctx_, array);
   REQUIRE(rc == TILEDB_OK);
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
 
   // Vacuum
   tiledb_config_t* config_v = nullptr;
@@ -751,15 +729,7 @@ TEST_CASE_METHOD(
   // Open the array in read mode at a timestamp
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
   REQUIRE(rc == TILEDB_OK);
-  tiledb_config_t* cfg;
-  tiledb_error_t* err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.array.timestamp_end", std::to_string(timestamp).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
@@ -783,7 +753,6 @@ TEST_CASE_METHOD(
   rc = tiledb_array_close(ctx_, array);
   REQUIRE(rc == TILEDB_OK);
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
 }
 
 TEST_CASE_METHOD(
@@ -829,15 +798,7 @@ TEST_CASE_METHOD(
   // Open the array in read mode at a timestamp
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
   REQUIRE(rc == TILEDB_OK);
-  tiledb_config_t* cfg;
-  tiledb_error_t* err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.array.timestamp_end", std::to_string(timestamp).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
@@ -858,18 +819,8 @@ TEST_CASE_METHOD(
   CHECK(num == 2);
 
   // Reopen
-  tiledb_config_free(&cfg);
-  err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_end",
-      std::to_string(tiledb::sm::utils::time::timestamp_now_ms()).c_str(),
-      &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(
+      ctx_, array, tiledb::sm::utils::time::timestamp_now_ms());
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_reopen(ctx_, array);
   CHECK(rc == TILEDB_OK);
@@ -888,7 +839,6 @@ TEST_CASE_METHOD(
   rc = tiledb_array_close(ctx_, array);
   REQUIRE(rc == TILEDB_OK);
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
 }
 
 TEST_CASE_METHOD(
@@ -1003,23 +953,9 @@ TEST_CASE_METHOD(
 
   // Open the array in read mode between timestamp1 and timestamp2
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  rc = tiledb_array_set_open_timestamp_start(ctx_, array, timestamp1);
   REQUIRE(rc == TILEDB_OK);
-  tiledb_config_t* cfg;
-  tiledb_error_t* err = nullptr;
-  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg,
-      "sm.array.timestamp_start",
-      std::to_string(timestamp1).c_str(),
-      &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.array.timestamp_end", std::to_string(timestamp2).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_array_set_config(ctx_, array, cfg);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp2);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
@@ -1044,7 +980,6 @@ TEST_CASE_METHOD(
   rc = tiledb_array_close(ctx_, array);
   REQUIRE(rc == TILEDB_OK);
   tiledb_array_free(&array);
-  tiledb_config_free(&cfg);
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -64,7 +64,8 @@ Array::Array(const URI& array_uri, StorageManager* storage_manager)
     , encryption_key_(tdb_make_shared(EncryptionKey))
     , is_open_(false)
     , timestamp_start_(0)
-    , timestamp_end_(0)
+    , timestamp_end_(UINT64_MAX)
+    , timestamp_end_opened_at_(UINT64_MAX)
     , storage_manager_(storage_manager)
     , config_(storage_manager_->config())
     , remote_(array_uri.is_tiledb())
@@ -80,6 +81,7 @@ Array::Array(const Array& rhs)
     , query_type_(rhs.query_type_)
     , timestamp_start_(rhs.timestamp_start_)
     , timestamp_end_(rhs.timestamp_end_)
+    , timestamp_end_opened_at_(rhs.timestamp_end_opened_at_)
     , storage_manager_(rhs.storage_manager_)
     , config_(rhs.config_)
     , last_max_buffer_sizes_(rhs.last_max_buffer_sizes_)
@@ -163,21 +165,10 @@ Status Array::open(
     EncryptionType encryption_type,
     const void* encryption_key,
     uint32_t key_length) {
-  bool found = false;
-  uint64_t timestamp_start = 0;
-  RETURN_NOT_OK(config_.get<uint64_t>(
-      "sm.array.timestamp_start", &timestamp_start, &found));
-  assert(found);
-
-  uint64_t timestamp_end = 0;
-  RETURN_NOT_OK(
-      config_.get<uint64_t>("sm.array.timestamp_end", &timestamp_end, &found));
-  assert(found);
-
   return Array::open(
       query_type,
-      timestamp_start,
-      timestamp_end,
+      timestamp_start_,
+      timestamp_end_,
       encryption_type,
       encryption_key,
       key_length);
@@ -209,14 +200,14 @@ Status Array::open(
   non_empty_domain_computed_ = false;
 
   timestamp_start_ = timestamp_start;
-  timestamp_end_ = timestamp_end;
 
-  if (timestamp_end_ == UINT64_MAX) {
+  timestamp_end_opened_at_ = timestamp_end;
+  if (timestamp_end_opened_at_ == UINT64_MAX) {
     if (query_type == QueryType::READ) {
-      timestamp_end_ = utils::time::timestamp_now_ms();
+      timestamp_end_opened_at_ = utils::time::timestamp_now_ms();
     } else {
       assert(query_type == QueryType::WRITE);
-      timestamp_end_ = 0;
+      timestamp_end_opened_at_ = 0;
     }
   }
 
@@ -234,11 +225,11 @@ Status Array::open(
         &array_schema_,
         &fragment_metadata_,
         timestamp_start_,
-        timestamp_end_));
+        timestamp_end_opened_at_));
   } else {
     RETURN_NOT_OK(storage_manager_->array_open_for_writes(
         array_uri_, *encryption_key_, &array_schema_));
-    metadata_.reset(timestamp_end_);
+    metadata_.reset(timestamp_end_opened_at_);
   }
 
   query_type_ = query_type;
@@ -457,21 +448,14 @@ const EncryptionKey& Array::get_encryption_key() const {
 }
 
 Status Array::reopen() {
-  bool found = false;
-  uint64_t timestamp_start = 0;
-  RETURN_NOT_OK(config_.get<uint64_t>(
-      "sm.array.timestamp_start", &timestamp_start, &found));
-  assert(found);
-
-  uint64_t timestamp_end = 0;
-  RETURN_NOT_OK(
-      config_.get<uint64_t>("sm.array.timestamp_end", &timestamp_end, &found));
-  assert(found);
-
-  timestamp_end_ = timestamp_end;
-  timestamp_start_ = timestamp_start;
-
-  return reopen(timestamp_start_, timestamp_end_);
+  if (timestamp_end_ == timestamp_end_opened_at_) {
+    // The user has not set `timestamp_end_` since it was last opened.
+    // In this scenario, re-open at the current timestamp.
+    return reopen(timestamp_start_, utils::time::timestamp_now_ms());
+  } else {
+    // The user has set `timestamp_end_`. Reopen at that time stamp.
+    return reopen(timestamp_start_, timestamp_end_);
+  }
 }
 
 Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
@@ -489,15 +473,15 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   clear_last_max_buffer_sizes();
 
   timestamp_start_ = timestamp_start;
-  timestamp_end_ = timestamp_end;
+  timestamp_end_opened_at_ = timestamp_end;
   fragment_metadata_.clear();
   metadata_.clear();
   metadata_loaded_ = false;
   non_empty_domain_.clear();
   non_empty_domain_computed_ = false;
 
-  if (timestamp_end_ == UINT64_MAX) {
-    timestamp_end_ = utils::time::timestamp_now_ms();
+  if (timestamp_end_opened_at_ == UINT64_MAX) {
+    timestamp_end_opened_at_ = utils::time::timestamp_now_ms();
   }
 
   if (remote_) {
@@ -514,8 +498,25 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
       &array_schema_,
       &fragment_metadata_,
       timestamp_start_,
-      timestamp_end_));
+      timestamp_end_opened_at_));
 
+  return Status::Ok();
+}
+
+Status Array::set_timestamp_start(const uint64_t timestamp_start) {
+  std::unique_lock<std::mutex> lck(mtx_);
+  timestamp_start_ = timestamp_start;
+  return Status::Ok();
+}
+
+uint64_t Array::timestamp_start() const {
+  std::unique_lock<std::mutex> lck(mtx_);
+  return timestamp_start_;
+}
+
+Status Array::set_timestamp_end(const uint64_t timestamp_end) {
+  std::unique_lock<std::mutex> lck(mtx_);
+  timestamp_end_ = timestamp_end;
   return Status::Ok();
 }
 
@@ -524,10 +525,9 @@ uint64_t Array::timestamp_end() const {
   return timestamp_end_;
 }
 
-Status Array::set_timestamp_end(uint64_t timestamp_end) {
+uint64_t Array::timestamp_end_opened_at() const {
   std::unique_lock<std::mutex> lck(mtx_);
-  timestamp_end_ = timestamp_end;
-  return Status::Ok();
+  return timestamp_end_opened_at_;
 }
 
 Status Array::set_config(Config config) {
@@ -866,13 +866,13 @@ Status Array::load_metadata() {
       return LOG_STATUS(Status::ArrayError(
           "Cannot load metadata; remote array with no REST client."));
     RETURN_NOT_OK(rest_client->get_array_metadata_from_rest(
-        array_uri_, timestamp_end_, this));
+        array_uri_, timestamp_end_opened_at_, this));
   } else {
     RETURN_NOT_OK(storage_manager_->load_array_metadata(
         array_uri_,
         *encryption_key_,
         timestamp_start_,
-        timestamp_end_,
+        timestamp_end_opened_at_,
         &metadata_));
   }
   metadata_loaded_ = true;
@@ -885,8 +885,8 @@ Status Array::load_remote_non_empty_domain() {
     if (rest_client == nullptr)
       return LOG_STATUS(Status::ArrayError(
           "Cannot load metadata; remote array with no REST client."));
-    RETURN_NOT_OK(
-        rest_client->get_array_non_empty_domain(this, timestamp_end_));
+    RETURN_NOT_OK(rest_client->get_array_non_empty_domain(
+        this, timestamp_end_opened_at_));
     non_empty_domain_computed_ = true;
   }
   return Status::Ok();

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -215,10 +215,19 @@ class Array {
    */
   Status reopen(uint64_t timestamp_start, uint64_t timestamp_end);
 
-  /** Returns the timestamp at which the array was opened. */
+  /** Returns the start timestamp. */
+  uint64_t timestamp_start() const;
+
+  /** Returns the end timestamp. */
   uint64_t timestamp_end() const;
 
-  /** Directly set the timestamp value. */
+  /** Returns the timestamp at which the array was opened. */
+  uint64_t timestamp_end_opened_at() const;
+
+  /** Directly set the timestamp start value. */
+  Status set_timestamp_start(uint64_t timestamp_start);
+
+  /** Directly set the timestamp end value. */
   Status set_timestamp_end(uint64_t timestamp_end);
 
   /** Directly set the array config. */
@@ -356,18 +365,28 @@ class Array {
   QueryType query_type_;
 
   /**
-   * The starting timestamp between which the `open_array_` got opened.
+   * The starting timestamp between to open `open_array_` at.
    * In TileDB, timestamps are in ms elapsed since
    * 1970-01-01 00:00:00 +0000 (UTC).
    */
   uint64_t timestamp_start_;
 
   /**
-   * The ending timestamp between  which the `open_array_` got opened.
+   * The ending timestamp between to open `open_array_` at.
    * In TileDB, timestamps are in ms elapsed since
-   * 1970-01-01 00:00:00 +0000 (UTC).
+   * 1970-01-01 00:00:00 +0000 (UTC). A value of UINT64_T
+   * will be interpretted as the current timestamp.
    */
   uint64_t timestamp_end_;
+
+  /**
+   * The ending timestamp that the array was last opened
+   * at. This is useful when `timestamp_end_` has been
+   * set to UINT64_T. In this scenario, this variable will
+   * store the timestamp for the time that the array was
+   * opened.
+   */
+  uint64_t timestamp_end_opened_at_;
 
   /** TileDB storage manager. */
   StorageManager* storage_manager_;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3565,6 +3565,49 @@ int32_t tiledb_array_alloc(
   return TILEDB_OK;
 }
 
+int32_t tiledb_array_set_open_timestamp_start(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t timestamp_start) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx, array->array_->set_timestamp_start(timestamp_start)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_array_set_open_timestamp_end(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t timestamp_end) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(ctx, array->array_->set_timestamp_end(timestamp_end)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_array_get_open_timestamp_start(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t* timestamp_start) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  *timestamp_start = array->array_->timestamp_start();
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_array_get_open_timestamp_end(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t* timestamp_end) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  *timestamp_end = array->array_->timestamp_end_opened_at();
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_array_open(
     tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t query_type) {
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
@@ -3693,7 +3736,7 @@ int32_t tiledb_array_get_timestamp(
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  *timestamp = array->array_->timestamp_end();
+  *timestamp = array->array_->timestamp_end_opened_at();
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -919,14 +919,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *
  * **Parameters**
  *
- * - `sm.array.timestamp_start` <br>
- *    When set, an array will be opened between this value and
- *    `sm.array.timestamp_end` (inclusive) upon a read query. <br>
- *    **Default**: 0
- * - `sm.array.timestamp_end` <br>
- *    When set, an array will be opened between `sm.array.timestamp_start`
- *    and this value (inclusive) upon a read query. <br>
- *    **Default**: UINT64_MAX
  * - `sm.dedup_coords` <br>
  *    If `true`, cells with duplicate coordinates will be removed during sparse
  *    fragment writes. Note that ties during deduplication are broken
@@ -4733,6 +4725,103 @@ TILEDB_EXPORT int32_t tiledb_query_condition_combine(
  */
 TILEDB_EXPORT int32_t tiledb_array_alloc(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_array_t** array);
+
+/**
+ * Sets the starting timestamp to use when opening (and reopening) the array.
+ * This is an inclusive bound. The default value is `0`.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "s3://tiledb_bucket/my_array", &array);
+ * tiledb_array_set_open_timestamp_start(ctx, array, 1234);
+ * tiledb_array_open(ctx, array, TILEDB_READ);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array The array to set the timestamp on.
+ * @param timestamp_start The epoch timestamp in milliseconds.
+ * @return `TILEDB_OK` for success or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_set_open_timestamp_start(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t timestamp_start);
+
+/**
+ * Sets the ending timestamp to use when opening (and reopening) the array.
+ * This is an inclusive bound. The UINT64_MAX timestamp is a reserved timestamp
+ * that will be interpretted as the current timestamp when an array is opened.
+ * The default value is `UINT64_MAX`.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "s3://tiledb_bucket/my_array", &array);
+ * tiledb_array_set_open_timestamp_end(ctx, array, 5678);
+ * tiledb_array_open(ctx, array, TILEDB_READ);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array The array to set the timestamp on.
+ * @param timestamp_end The epoch timestamp in milliseconds. Use UINT64_MAX for
+ *   the current timestamp.
+ * @return `TILEDB_OK` for success or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_set_open_timestamp_end(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t timestamp_end);
+
+/**
+ * Gets the starting timestamp used when opening (and reopening) the array.
+ * This is an inclusive bound.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "s3://tiledb_bucket/my_array", &array);
+ * tiledb_array_set_open_timestamp_start(ctx, array, 1234);
+ * tiledb_array_open(ctx, array, TILEDB_READ);
+ *
+ * uint64_t timestamp_start;
+ * tiledb_array_get_open_timestamp_start(ctx, array, &timestamp_start);
+ * assert(timestamp_start == 1234);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array The array to set the timestamp on.
+ * @param timestamp_start The output epoch timestamp in milliseconds.
+ * @return `TILEDB_OK` for success or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_get_open_timestamp_start(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t* timestamp_start);
+
+/**
+ * Gets the ending timestamp used when opening (and reopening) the array.
+ * This is an inclusive bound. If UINT64_MAX was set, this will return
+ * the timestamp at the time the array was opened. If the array has not
+ * yet been opened, it will return UINT64_MAX.`
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_t* array;
+ * tiledb_array_alloc(ctx, "s3://tiledb_bucket/my_array", &array);
+ * tiledb_array_set_open_timestamp_end(ctx, array, 5678);
+ * tiledb_array_open(ctx, array, TILEDB_READ);
+ *
+ * uint64_t timestamp_end;
+ * tiledb_array_get_open_timestamp_end(ctx, array, &timestamp_end);
+ * assert(timestamp_start == 5678);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array The array to set the timestamp on.
+ * @param timestamp_end The output epoch timestamp in milliseconds.
+ * @return `TILEDB_OK` for success or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_get_open_timestamp_end(
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t* timestamp_end);
 
 /**
  * Opens a TileDB array. The array is opened using a query type as input.

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -63,8 +63,6 @@ const std::string Config::REST_RETRY_HTTP_CODES = "503";
 const std::string Config::REST_RETRY_COUNT = "3";
 const std::string Config::REST_RETRY_INITIAL_DELAY_MS = "500";
 const std::string Config::REST_RETRY_DELAY_FACTOR = "1.25";
-const std::string Config::SM_ARRAY_TIMESTAMP_START = "0";
-const std::string Config::SM_ARRAY_TIMESTAMP_END = std::to_string(UINT64_MAX);
 const std::string Config::SM_DEDUP_COORDS = "false";
 const std::string Config::SM_CHECK_COORD_DUPS = "true";
 const std::string Config::SM_CHECK_COORD_OOB = "true";
@@ -197,8 +195,6 @@ Config::Config() {
   param_values_["rest.retry_delay_factor"] = REST_RETRY_DELAY_FACTOR;
   param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
   param_values_["config.logging_level"] = CONFIG_LOGGING_LEVEL;
-  param_values_["sm.array.timestamp_start"] = SM_ARRAY_TIMESTAMP_START;
-  param_values_["sm.array.timestamp_end"] = SM_ARRAY_TIMESTAMP_END;
   param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
   param_values_["sm.check_coord_dups"] = SM_CHECK_COORD_DUPS;
   param_values_["sm.check_coord_oob"] = SM_CHECK_COORD_OOB;
@@ -442,10 +438,6 @@ Status Config::unset(const std::string& param) {
     param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
   } else if (param == "config.logging_level") {
     param_values_["config.logging_level"] = CONFIG_LOGGING_LEVEL;
-  } else if (param == "sm.array.timestamp_start") {
-    param_values_["sm.array.timestamp_start"] = SM_ARRAY_TIMESTAMP_START;
-  } else if (param == "sm.array.timestamp_end") {
-    param_values_["sm.array.timestamp_end"] = SM_ARRAY_TIMESTAMP_END;
   } else if (param == "sm.dedup_coords") {
     param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
   } else if (param == "sm.check_coord_dups") {
@@ -679,10 +671,6 @@ Status Config::sanity_check(
     RETURN_NOT_OK(serialization_type_enum(value, &serialization_type));
   } else if (param == "config.logging_level") {
     RETURN_NOT_OK(utils::parse::convert(value, &v32));
-  } else if (param == "sm.array.timestamp_start") {
-    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
-  } else if (param == "sm.array.timestamp_end") {
-    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "sm.dedup_coords") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "sm.check_coord_dups") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -88,18 +88,6 @@ class Config {
    */
   static const std::string CONFIG_LOGGING_LEVEL;
 
-  /**
-   * An array will open between this value and timestamp_end upon a
-   * read query.
-   * */
-  static const std::string SM_ARRAY_TIMESTAMP_START;
-
-  /**
-   * An array will open between timestamp_start and this value upon a
-   * read query.
-   *  */
-  static const std::string SM_ARRAY_TIMESTAMP_END;
-
   /** If `true`, this will deduplicate coordinates upon sparse writes. */
   static const std::string SM_DEDUP_COORDS;
 

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -163,14 +163,14 @@ class Array {
 
   /**
    * @brief Constructor. This opens the array for the given query type at the
-   * given timestamp_end. The destructor calls the `close()` method.
+   * given timestamp. The destructor calls the `close()` method.
    *
    * This constructor takes as input a
-   * timestamp_end, representing time in milliseconds ellapsed since
+   * timestamp, representing time in milliseconds ellapsed since
    * 1970-01-01 00:00:00 +0000 (UTC). Opening the array at a
-   * timestamp_end provides a view of the array with all writes/updates that
-   * happened at or before `timestamp_end` (i.e., excluding those that
-   * occurred after `timestamp_end`). This is useful to ensure
+   * timestamp provides a view of the array with all writes/updates that
+   * happened at or before `timestamp` (i.e., excluding those that
+   * occurred after `timestamp`). This is useful to ensure
    * consistency at a potential distributed setting, where machines
    * need to operate on the same view of the array.
    *
@@ -179,22 +179,22 @@ class Array {
    * @code{.cpp}
    * // Open the array for reading
    * tiledb::Context ctx;
-   * // Get some `timestamp_end` here in milliseconds
+   * // Get some `timestamp` here in milliseconds
    * tiledb::Array array(
-   *     ctx, "s3://bucket-name/array-name", TILEDB_READ, timestamp_end);
+   *     ctx, "s3://bucket-name/array-name", TILEDB_READ, timestamp);
    * @endcode
    *
    * @param ctx TileDB context.
    * @param array_uri The array URI.
    * @param query_type Query type to open the array for.
-   * @param timestamp_end The timestamp_end to open the array at.
+   * @param timestamp The timestamp to open the array at.
    */
   TILEDB_DEPRECATED
   Array(
       const Context& ctx,
       const std::string& array_uri,
       tiledb_query_type_t query_type,
-      uint64_t timestamp_end)
+      uint64_t timestamp)
       : Array(
             ctx,
             array_uri,
@@ -202,7 +202,7 @@ class Array {
             TILEDB_NO_ENCRYPTION,
             nullptr,
             0,
-            timestamp_end) {
+            timestamp) {
   }
 
   // clang-format off
@@ -219,9 +219,9 @@ class Array {
    * tiledb::Context ctx;
    * // Load AES-256 key from disk, environment variable, etc.
    * uint8_t key[32] = ...;
-   * // Get some `timestamp_end` here in milliseconds
+   * // Get some `timestamp` here in milliseconds
    * tiledb::Array array(ctx, "s3://bucket-name/array-name", TILEDB_READ,
-   *    TILEDB_AES_256_GCM, key, sizeof(key), timestamp_end);
+   *    TILEDB_AES_256_GCM, key, sizeof(key), timestamp);
    * @endcode
    *
    * @param ctx TileDB context.
@@ -230,7 +230,7 @@ class Array {
    * @param encryption_type The encryption type to use.
    * @param encryption_key The encryption key to use.
    * @param key_length Length in bytes of the encryption key.
-   * @param timestamp_end The timestamp_end to open the array at.
+   * @param timestamp The timestamp to open the array at.
    */
   // clang-format on
   TILEDB_DEPRECATED
@@ -241,7 +241,7 @@ class Array {
       tiledb_encryption_type_t encryption_type,
       const void* encryption_key,
       uint32_t key_length,
-      uint64_t timestamp_end)
+      uint64_t timestamp)
       : ctx_(ctx)
       , schema_(ArraySchema(ctx, (tiledb_array_schema_t*)nullptr)) {
     tiledb_ctx_t* c_ctx = ctx.ptr().get();
@@ -256,7 +256,7 @@ class Array {
         encryption_type,
         encryption_key,
         key_length,
-        timestamp_end));
+        timestamp));
 
     tiledb_array_schema_t* array_schema;
     ctx.handle_error(tiledb_array_get_schema(c_ctx, array, &array_schema));
@@ -277,7 +277,7 @@ class Array {
       tiledb_query_type_t query_type,
       tiledb_encryption_type_t encryption_type,
       const std::string& encryption_key,
-      uint64_t timestamp_end)
+      uint64_t timestamp)
       : Array(
             ctx,
             array_uri,
@@ -285,7 +285,7 @@ class Array {
             encryption_type,
             encryption_key.data(),
             (uint32_t)encryption_key.size(),
-            timestamp_end) {
+            timestamp) {
   }
 
   /**
@@ -464,14 +464,14 @@ class Array {
   }
 
   /**
-   * @brief Opens the array for a query type, at the given timestamp_end.
+   * @brief Opens the array for a query type, at the given timestamp.
    *
    * This function takes as input a
-   * timestamp_end, representing time in milliseconds ellapsed since
+   * timestamp, representing time in milliseconds ellapsed since
    * 1970-01-01 00:00:00 +0000 (UTC). Opening the array at a
-   * timestamp_end provides a view of the array with all writes/updates that
-   * happened at or before `timestamp_end` (i.e., excluding those that
-   * occurred after `timestamp_end`). This is useful to ensure
+   * timestamp provides a view of the array with all writes/updates that
+   * happened at or before `timestamp` (i.e., excluding those that
+   * occurred after `timestamp`). This is useful to ensure
    * consistency at a potential distributed setting, where machines
    * need to operate on the same view of the array.
    *
@@ -481,17 +481,17 @@ class Array {
    * tiledb::Array array(ctx, "s3://bucket-name/array-name", TILEDB_WRITE);
    * // Close and open again for reading.
    * array.close();
-   * // Get some `timestamp_end` in milliseconds here
-   * array.open(TILEDB_READ, timestamp_end);
+   * // Get some `timestamp` in milliseconds here
+   * array.open(TILEDB_READ, timestamp);
    * @endcode
    *
    * @param query_type The type of queries the array object will be receiving.
-   * @param timestamp_end The timestamp_end to open the array at.
+   * @param timestamp The timestamp to open the array at.
    * @throws TileDBError if the array is already open or other error occurred.
    */
   TILEDB_DEPRECATED
-  void open(tiledb_query_type_t query_type, uint64_t timestamp_end) {
-    open(query_type, TILEDB_NO_ENCRYPTION, nullptr, 0, timestamp_end);
+  void open(tiledb_query_type_t query_type, uint64_t timestamp) {
+    open(query_type, TILEDB_NO_ENCRYPTION, nullptr, 0, timestamp);
   }
 
   /**
@@ -509,16 +509,16 @@ class Array {
    *    TILEDB_AES_256_GCM, key, sizeof(key));
    * // Close and open again for reading.
    * array.close();
-   * // Get some `timestamp_end` in milliseconds here
+   * // Get some `timestamp` in milliseconds here
    * array.open(TILEDB_READ, TILEDB_AES_256_GCM, key, sizeof(key),
-   * timestamp_end);
+   * timestamp);
    * @endcode
    *
    * @param query_type The type of queries the array object will be receiving.
    * @param encryption_type The encryption type to use.
    * @param encryption_key The encryption key to use.
    * @param key_length Length in bytes of the encryption key.
-   * @param timestamp_end The timestamp_end to open the array at.
+   * @param timestamp The timestamp to open the array at.
    */
   TILEDB_DEPRECATED
   void open(
@@ -526,7 +526,7 @@ class Array {
       tiledb_encryption_type_t encryption_type,
       const void* encryption_key,
       uint32_t key_length,
-      uint64_t timestamp_end) {
+      uint64_t timestamp) {
     auto& ctx = ctx_.get();
     tiledb_ctx_t* c_ctx = ctx.ptr().get();
     ctx.handle_error(tiledb_array_open_at_with_key(
@@ -536,7 +536,7 @@ class Array {
         encryption_type,
         encryption_key,
         key_length,
-        timestamp_end));
+        timestamp));
     tiledb_array_schema_t* array_schema;
     ctx.handle_error(
         tiledb_array_get_schema(c_ctx, array_.get(), &array_schema));
@@ -554,13 +554,13 @@ class Array {
       tiledb_query_type_t query_type,
       tiledb_encryption_type_t encryption_type,
       const std::string& encryption_key,
-      uint64_t timestamp_end) {
+      uint64_t timestamp) {
     open(
         query_type,
         encryption_type,
         encryption_key.data(),
         (uint32_t)encryption_key.size(),
-        timestamp_end);
+        timestamp);
   }
 
   /**
@@ -594,37 +594,72 @@ class Array {
   }
 
   /**
-   * Reopens the array at a specific timestamp_end.
+   * Reopens the array at a specific timestamp.
    *
    * **Example:**
    * @code{.cpp}
    * // Open the array for reading
    * tiledb::Array array(ctx, "s3://bucket-name/array-name", TILEDB_READ);
-   * uint64_t timestamp_end = tiledb_timestamp_now_ms();
-   * array.reopen_at(timestamp_end);
+   * uint64_t timestamp = tiledb_timestamp_now_ms();
+   * array.reopen_at(timestamp);
    * @endcode
    *
    * @throws TileDBError if the array was not already open or other error
    * occurred.
    */
   TILEDB_DEPRECATED
-  void reopen_at(uint64_t timestamp_end) {
+  void reopen_at(uint64_t timestamp) {
     auto& ctx = ctx_.get();
     tiledb_ctx_t* c_ctx = ctx.ptr().get();
-    ctx.handle_error(
-        tiledb_array_reopen_at(c_ctx, array_.get(), timestamp_end));
+    ctx.handle_error(tiledb_array_reopen_at(c_ctx, array_.get(), timestamp));
     tiledb_array_schema_t* array_schema;
     ctx.handle_error(
         tiledb_array_get_schema(c_ctx, array_.get(), &array_schema));
     schema_ = ArraySchema(ctx, array_schema);
   }
 
-  /** Returns the timestamp at which the array was opened. */
+  /**
+   * Returns the timestamp at which the array was opened.
+   *
+   * This has been deprecated, use `open_timestamp_end()` instead.
+   */
   TILEDB_DEPRECATED
   uint64_t timestamp() const {
     auto& ctx = ctx_.get();
+    uint64_t timestamp;
+    ctx.handle_error(
+        tiledb_array_get_timestamp(ctx.ptr().get(), array_.get(), &timestamp));
+    return timestamp;
+  }
+
+  /** Sets the inclusive starting timestamp when opening this array. */
+  void set_open_timestamp_start(uint64_t timestamp_start) const {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_array_set_open_timestamp_start(
+        ctx.ptr().get(), array_.get(), timestamp_start));
+  }
+
+  /** Sets the inclusive ending timestamp when opening this array. */
+  void set_open_timestamp_end(uint64_t timestamp_end) const {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_array_set_open_timestamp_end(
+        ctx.ptr().get(), array_.get(), timestamp_end));
+  }
+
+  /** Retrieves the inclusive starting timestamp. */
+  uint64_t open_timestamp_start() const {
+    auto& ctx = ctx_.get();
+    uint64_t timestamp_start;
+    ctx.handle_error(tiledb_array_get_open_timestamp_start(
+        ctx.ptr().get(), array_.get(), &timestamp_start));
+    return timestamp_start;
+  }
+
+  /** Retrieves the inclusive ending timestamp. */
+  uint64_t open_timestamp_end() const {
+    auto& ctx = ctx_.get();
     uint64_t timestamp_end;
-    ctx.handle_error(tiledb_array_get_timestamp(
+    ctx.handle_error(tiledb_array_get_open_timestamp_end(
         ctx.ptr().get(), array_.get(), &timestamp_end));
     return timestamp_end;
   }

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -262,15 +262,6 @@ class Config {
    *
    * **Parameters**
    *
-   * - `sm.array.timestamp_start` <br>
-   *    When set, an array will be opened between this value and
-   *    `sm.array.timestamp_end` (inclusive) upon a read query. <br>
-   *    **Default**: UINT64_MAX
-   * - `sm.array.timestamp_end` <br>
-   *    When set, an array will be opened between
-   *    `sm.array.timestamp_start` and this value (inclusive) upon a read
-   *    query. <br>
-   *    **Default**: UINT64_MAX
    * - `sm.dedup_coords` <br>
    *    If `true`, cells with duplicate coordinates will be removed during
    *    sparse fragment writes. Note that ties during deduplication are broken

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -1557,7 +1557,7 @@ Status Writer::compute_coords_metadata(
 Status Writer::create_fragment(
     bool dense, tdb_shared_ptr<FragmentMetadata>* frag_meta) const {
   URI uri;
-  uint64_t timestamp = array_->timestamp_end();
+  uint64_t timestamp = array_->timestamp_end_opened_at();
   if (!fragment_uri_.to_string().empty()) {
     uri = fragment_uri_;
   } else {


### PR DESCRIPTION
This patch refactors the API for start/end timestamps to use standard
getter/setter APIs instead of key-values in the config.

Does not include serialization/rest changes.

TYPE: C_API
DESC: Added tiledb_array_set_open_timestamp_start and tiledb_array_get_open_timestamp_start

TYPE: C_API
DESC: Added tiledb_array_set_open_timestamp_end and tiledb_array_get_open_timestamp_end

TYPE: CPP_API
DESC: Added Array::set_open_timestamp_start and Array::open_timestamp_start

TYPE: CPP_API
DESC: Added Array::set_open_timestamp_end and Array::open_timestamp_end