### PR TITLE
Fix buffer arguments in unit-curl.cc 

### DIFF
--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -46,8 +46,8 @@ TEST_CASE("CURL: Test curl's header parsing callback", "[curl]") {
   // RestClient
   char res_data[] =
       "Location: https://test.url.domain/v1/arrays/testns/test_arr";
-  size_t size = 50;
-  size_t count = 50;
+  size_t size = 1;
+  size_t count = sizeof(res_data);
 
   HeaderCbData userdata;
   std::string ns_array = "testns:test_arr";

--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -158,7 +158,7 @@ TEST_CASE_METHOD(WinFx, "Test Windows filesystem", "[windows]") {
 
   const unsigned buffer_size = 100000;
   auto write_buffer = new char[buffer_size];
-  for (int i = 0; i < buffer_size; i++) {
+  for (unsigned i = 0; i < buffer_size; i++) {
     write_buffer[i] = 'a' + (i % 26);
   }
   st = win_.write(test_file.to_path(), write_buffer, buffer_size);


### PR DESCRIPTION
Test "CURL: Test curl's header parsing callback" is passing invalid arguments to write_header_callback. Specifically, it declares that it has a buffer size that it hasn't allocated. This triggers an ASAN violation.

---
TYPE: BUG
DESC: Fix buffer arguments in unit-curl.cc 
