### PR TITLE
Fix Dimension::set_tile_extent for string+hilbert dimension

### DIFF
--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1445,6 +1445,13 @@ Status Dimension::set_tile_extent(const void* tile_extent) {
 }
 
 Status Dimension::set_tile_extent(const ByteVecValue& tile_extent) {
+  if (type_ == Datatype::STRING_ASCII) {
+    if (tile_extent.empty())
+      return Status::Ok();
+    return LOG_STATUS(Status::DimensionError(
+        std::string("Setting the tile extent to a dimension with type '") +
+        datatype_str(type_) + "' is not supported"));
+  }
   if (domain_.empty())
     return LOG_STATUS(Status::DimensionError(
         "Cannot set tile extent; Domain must be set first"));

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -549,7 +549,7 @@ Status Domain::init(Layout cell_order, Layout tile_order) {
   if (cell_order_ == Layout::HILBERT) {
     ByteVecValue be;
     for (auto& d : dimensions_) {
-      d->set_tile_extent(be);
+      RETURN_NOT_OK(d->set_tile_extent(be));
     }
   }
 


### PR DESCRIPTION
The Dimension::set_tile_extent() implementation errors out if the domain is
unset. We expect the domain to be unset for string dimensions. This patch
allows an empty tile extent to be set on string dimensions. This can be pathed
to by the following path with a hilbert cell-ordered array.
```
Dimension::set_tile_extent
Domain::init
ArraySchema::init
ArraySchema::deserialize
StorageManager::load_array_schema
```

---

TYPE: BUG
DESC: Fix false error message when opening an array with a string dimension and hilbert cell order