### PR TITLE
Add missing cast to fix range warning

### DIFF
--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -803,7 +803,7 @@ void Dimension::split_range<char>(
     assert(pos != 0);
     new_r2_start[pos] = 0;
     new_r2_start[--pos]++;
-  } while (pos >= 0 && (int)new_r2_start[pos] < 0);
+  } while (pos >= 0 && (int)(signed char)new_r2_start[pos] < 0);
   new_r2_start.resize(pos + 1);
 
   auto max_string = std::string("\x7F", 1);


### PR DESCRIPTION
Fixes the following warning/Werror on linux/aarch64; matches existing casts earlier in
function:
```
tiledb::sm::Range&, const ByteVecValue&, tiledb::sm::Range*, tiledb::sm::Range*) [with T = char; tiledb::sm::ByteVecValue = std::vector<unsigned char>]’:
/home/ubuntu/TileDB-Py/build/TileDB-2.2.9/tiledb/sm/array_schema/dimension.cc:797:47: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  797 |   } while (pos >= 0 && (int)new_r2_start[pos] < 0);
      |
```

---

TYPE: NO_HISTORY
DESC: Add missing cast to fix range warning
