### PR TITLE
Sn/fix missing response buffer in submit

### DIFF
--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -672,6 +672,7 @@ Status Curl::post_data(
     const std::string& url,
     const SerializationType serialization_type,
     const BufferList* data,
+    Buffer* const returned_data,
     PostResponseCb&& cb,
     const std::string& res_uri) {
   struct curl_slist* headers;
@@ -684,7 +685,7 @@ Status Curl::post_data(
   RETURN_NOT_OK(st);
 
   // Check for errors
-  RETURN_NOT_OK(check_curl_errors(ret, "POST"));
+  RETURN_NOT_OK(check_curl_errors(ret, "POST", returned_data));
 
   return Status::Ok();
 }

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -169,6 +169,7 @@ class Curl {
    * @param url URL to post to
    * @param serialization_type Serialization type to use
    * @param data Encoded data buffer for posting
+   * @param returned_data Buffer to store response data
    * @param write_cb Invoked as response body buffers are received.
    * @param res_ns_uri Array Namespace and URI
    * @return Status
@@ -178,6 +179,7 @@ class Curl {
       const std::string& url,
       SerializationType serialization_type,
       const BufferList* data,
+      Buffer* returned_data,
       PostResponseCb&& write_cb,
       const std::string& res_ns_uri);
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -379,6 +379,7 @@ Status RestClient::post_query_submit(
       url,
       serialization_type_,
       &serialized,
+      &scratch,
       std::move(write_cb),
       cache_key);
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -390,7 +390,7 @@ Status RestClient::post_query_submit(
         st.message()));
   }
 
-  return Status::Ok();
+  return st;
 }
 
 size_t RestClient::post_data_write_cb(


### PR DESCRIPTION
This PR passes the response buffer through  to allow for the reading of the response body from the query submit check. In addition it changes the return from an "automatic ok" to the actual status returned from the query itself to ensure we do not report okay if the body itself is empty.

We currently report an error without the actual response error body (just the code) like so:
```
tiledb.libtiledb.TileDBError: [TileDB::REST] Error: Error submitting query to REST; server returned no data. Curl error: Error in libcurl POST operation: libcurl error message 'CURLE_OK'; HTTP code 400; 
```

---
TYPE:  BUG
DESC: Fix for missing error response data when a query submit fails
