### PR TITLE
Rewrite `Dimension::overlap_ratio` to remove overflow, underflow, and divide by zero

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,6 +98,7 @@ list(APPEND TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/c_
 set(TILEDB_TEST_SOURCES
   src/helpers.h
   src/helpers.cc
+  src/helpers-dimension.h
   src/unit-azure.cc
   src/unit-backwards_compat.cc
   src/unit-buffer.cc

--- a/test/src/helpers-dimension.h
+++ b/test/src/helpers-dimension.h
@@ -1,0 +1,110 @@
+/**
+ * @file   helpers-dimension.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Helpers for tests involving dimensions.
+ */
+
+#include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/enums/datatype.h"
+
+#ifndef TILEDB_HELPERS_DIMENSION_H
+#define TILEDB_HELPERS_DIMENSION_H
+
+namespace tiledb {
+namespace test{
+
+/**
+ * A typed version of the standard range class. Constructs Range objects without
+ * requiring the caller to know anything about its data structures.
+ *
+ * @tparam T
+ */
+template <class T>
+class TypedRange :
+ public tiledb::sm::Range {
+ public:
+  /**
+   * Construct a Range from a single interval.
+   * @param low Lower bound of interval
+   * @param high Upper bound of interval
+   * @pre low <= high
+   */
+  TypedRange(T low, T high) {
+    T x[2] = {low,high};
+    set_range(&x[0], 2*sizeof(T));
+    /* Commentary: There's no way of initializing a Range without copying from
+     * existing memory. As a result any value-initializing constructor first
+     * needs to build an array and then copy it.
+     */
+  }
+};
+
+using Datatype = tiledb::sm::Datatype;
+
+template<class T>
+struct RangeTraits {
+  static Datatype datatype;
+};
+
+template<>
+struct RangeTraits<int32_t> {
+  static constexpr Datatype datatype = Datatype::INT32;
+};
+
+template<>
+struct RangeTraits<int64_t> {
+  static constexpr Datatype datatype = Datatype::INT64;
+};
+
+template<>
+struct RangeTraits<uint32_t> {
+  static constexpr Datatype datatype = Datatype::UINT32;
+};
+
+template<>
+struct RangeTraits<uint64_t> {
+  static constexpr Datatype datatype = Datatype::UINT64;
+};
+
+template<>
+struct RangeTraits<float> {
+  static constexpr Datatype datatype = Datatype::FLOAT32;
+};
+
+template<>
+struct RangeTraits<double> {
+  static constexpr Datatype datatype = Datatype::FLOAT64;
+};
+
+
+}
+}
+
+
+#endif //TILEDB_HELPERS_DIMENSION_H

--- a/test/src/helpers-dimension.h
+++ b/test/src/helpers-dimension.h
@@ -30,14 +30,14 @@
  * Helpers for tests involving dimensions.
  */
 
-#include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/misc/types.h"
 
 #ifndef TILEDB_HELPERS_DIMENSION_H
 #define TILEDB_HELPERS_DIMENSION_H
 
 namespace tiledb {
-namespace test{
+namespace test {
 
 /**
  * A typed version of the standard range class. Constructs Range objects without
@@ -46,8 +46,7 @@ namespace test{
  * @tparam T
  */
 template <class T>
-class TypedRange :
- public tiledb::sm::Range {
+class TypedRange : public tiledb::sm::Range {
  public:
   /**
    * Construct a Range from a single interval.
@@ -56,8 +55,8 @@ class TypedRange :
    * @pre low <= high
    */
   TypedRange(T low, T high) {
-    T x[2] = {low,high};
-    set_range(&x[0], 2*sizeof(T));
+    T x[2] = {low, high};
+    set_range(&x[0], 2 * sizeof(T));
     /* Commentary: There's no way of initializing a Range without copying from
      * existing memory. As a result any value-initializing constructor first
      * needs to build an array and then copy it.
@@ -67,44 +66,42 @@ class TypedRange :
 
 using Datatype = tiledb::sm::Datatype;
 
-template<class T>
+template <class T>
 struct RangeTraits {
   static Datatype datatype;
 };
 
-template<>
+template <>
 struct RangeTraits<int32_t> {
   static constexpr Datatype datatype = Datatype::INT32;
 };
 
-template<>
+template <>
 struct RangeTraits<int64_t> {
   static constexpr Datatype datatype = Datatype::INT64;
 };
 
-template<>
+template <>
 struct RangeTraits<uint32_t> {
   static constexpr Datatype datatype = Datatype::UINT32;
 };
 
-template<>
+template <>
 struct RangeTraits<uint64_t> {
   static constexpr Datatype datatype = Datatype::UINT64;
 };
 
-template<>
+template <>
 struct RangeTraits<float> {
   static constexpr Datatype datatype = Datatype::FLOAT32;
 };
 
-template<>
+template <>
 struct RangeTraits<double> {
   static constexpr Datatype datatype = Datatype::FLOAT64;
 };
 
+}  // namespace test
+}  // namespace tiledb
 
-}
-}
-
-
-#endif //TILEDB_HELPERS_DIMENSION_H
+#endif  // TILEDB_HELPERS_DIMENSION_H

--- a/test/src/unit-dimension.cc
+++ b/test/src/unit-dimension.cc
@@ -627,7 +627,7 @@ double basic_verify_overlap_ratio(T range1_low, T range1_high, T range2_low, T r
  */
 TEST_CASE(
     "Range<int32_t>.overlap_ratio: denominator overflow",
-    "[dimension][overlap_ratio]") {
+    "[dimension][overlap_ratio][signed][integral]") {
   typedef int32_t T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
@@ -639,7 +639,7 @@ TEST_CASE(
  */
 TEST_CASE(
         "Range<uint32_t>.overlap_ratio: denominator overflow",
-        "[dimension][overlap_ratio]") {
+        "[dimension][overlap_ratio][unsigned][integral]") {
   typedef uint32_t T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
@@ -651,7 +651,7 @@ TEST_CASE(
  */
 TEST_CASE(
         "Range<double>.overlap_ratio: denominator overflow",
-        "[dimension][overlap_ratio]") {
+        "[dimension][overlap_ratio][signed][floating]") {
   typedef double T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
@@ -660,7 +660,7 @@ TEST_CASE(
 
 TEST_CASE(
         "Range<uint32_t>.overlap_ratio: max base range",
-        "[dimension][overlap_ratio]") {
+        "[dimension][overlap_ratio][unsigned][integral]") {
   typedef uint32_t T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
@@ -669,7 +669,7 @@ TEST_CASE(
 
 TEST_CASE(
         "Range<uint32_t>.overlap_ratio: max both ranges",
-        "[dimension][overlap_ratio]") {
+        "[dimension][overlap_ratio][unsigned][integral]") {
   typedef uint32_t T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
@@ -678,7 +678,7 @@ TEST_CASE(
 
 TEST_CASE(
         "Range<int32_t>.overlap_ratio: over-by-1 legit-max base range",
-        "[dimension][overlap_ratio]") {
+        "[dimension][overlap_ratio][signed][integral]") {
   typedef int32_t T;
   auto max = std::numeric_limits<T>::max();
   basic_verify_overlap_ratio<T>(0, 1, -1, max);
@@ -687,7 +687,7 @@ TEST_CASE(
 
 TEST_CASE(
         "Range<int32_t>.overlap_ratio: legit-max base range",
-        "[dimension][overlap_ratio]") {
+        "[dimension][overlap_ratio][signed][integral]") {
   typedef int32_t T;
   auto max = std::numeric_limits<T>::max();
   basic_verify_overlap_ratio<T>(0, 1, -2, max-2);

--- a/test/src/unit-dimension.cc
+++ b/test/src/unit-dimension.cc
@@ -30,10 +30,10 @@
  * Tests the `Dimension` class.
  */
 
+#include "test/src/helpers-dimension.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/hilbert.h"
-#include "test/src/helpers-dimension.h"
 
 #include <catch.hpp>
 #include <iostream>
@@ -607,8 +607,8 @@ TEST_CASE(
 }
 
 template <class T>
-double basic_verify_overlap_ratio(T range1_low, T range1_high, T range2_low, T range2_high)
-{
+double basic_verify_overlap_ratio(
+    T range1_low, T range1_high, T range2_low, T range2_high) {
   auto r1 = TypedRange<T>(range1_low, range1_high);
   auto r2 = TypedRange<T>(range2_low, range2_high);
   Dimension d("foo", RangeTraits<T>::datatype);
@@ -631,15 +631,15 @@ TEST_CASE(
   typedef int32_t T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
-  basic_verify_overlap_ratio<T>(min/3, 1, min + 1, max);
+  basic_verify_overlap_ratio<T>(min / 3, 1, min + 1, max);
 }
 
 /**
  * Denominator overflow for an unsigned integral type.
  */
 TEST_CASE(
-        "Range<uint32_t>.overlap_ratio: denominator overflow",
-        "[dimension][overlap_ratio][unsigned][integral]") {
+    "Range<uint32_t>.overlap_ratio: denominator overflow",
+    "[dimension][overlap_ratio][unsigned][integral]") {
   typedef uint32_t T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
@@ -650,8 +650,8 @@ TEST_CASE(
  * Denominator overflow for double.
  */
 TEST_CASE(
-        "Range<double>.overlap_ratio: denominator overflow",
-        "[dimension][overlap_ratio][signed][floating]") {
+    "Range<double>.overlap_ratio: denominator overflow",
+    "[dimension][overlap_ratio][signed][floating]") {
   typedef double T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
@@ -659,17 +659,17 @@ TEST_CASE(
 }
 
 TEST_CASE(
-        "Range<uint32_t>.overlap_ratio: max base range",
-        "[dimension][overlap_ratio][unsigned][integral]") {
+    "Range<uint32_t>.overlap_ratio: max base range",
+    "[dimension][overlap_ratio][unsigned][integral]") {
   typedef uint32_t T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
-  basic_verify_overlap_ratio<T>(min, min+1, min, max);
+  basic_verify_overlap_ratio<T>(min, min + 1, min, max);
 }
 
 TEST_CASE(
-        "Range<uint32_t>.overlap_ratio: max both ranges",
-        "[dimension][overlap_ratio][unsigned][integral]") {
+    "Range<uint32_t>.overlap_ratio: max both ranges",
+    "[dimension][overlap_ratio][unsigned][integral]") {
   typedef uint32_t T;
   auto min = std::numeric_limits<T>::min();
   auto max = std::numeric_limits<T>::max();
@@ -677,20 +677,17 @@ TEST_CASE(
 }
 
 TEST_CASE(
-        "Range<int32_t>.overlap_ratio: over-by-1 legit-max base range",
-        "[dimension][overlap_ratio][signed][integral]") {
+    "Range<int32_t>.overlap_ratio: over-by-1 legit-max base range",
+    "[dimension][overlap_ratio][signed][integral]") {
   typedef int32_t T;
   auto max = std::numeric_limits<T>::max();
   basic_verify_overlap_ratio<T>(0, 1, -1, max);
 }
 
-
 TEST_CASE(
-        "Range<int32_t>.overlap_ratio: legit-max base range",
-        "[dimension][overlap_ratio][signed][integral]") {
+    "Range<int32_t>.overlap_ratio: legit-max base range",
+    "[dimension][overlap_ratio][signed][integral]") {
   typedef int32_t T;
   auto max = std::numeric_limits<T>::max();
-  basic_verify_overlap_ratio<T>(0, 1, -2, max-2);
+  basic_verify_overlap_ratio<T>(0, 1, -2, max - 2);
 }
-
-

--- a/test/src/unit-dimension.cc
+++ b/test/src/unit-dimension.cc
@@ -619,8 +619,6 @@ double basic_verify_overlap_ratio(
 }
 
 /**
- * Exercises the defect at the root cause of clubhouse#7192
- *
  * The denominator of the ratio is computed as range2_high - range2_low. For a
  * k-bit signed integer, the largest this value can take is 2^k-1, which is
  * larger than the maximum signed value of 2^(k-1)-1.

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -772,9 +772,9 @@ double Dimension::overlap_ratio(const Range& r1, const Range& r2) {
    * is zero. For signed types we need to check both.
    */
   const T safe_upper = std::nextafter(std::numeric_limits<T>::max() / 2, 0);
-  const T safe_lower = std::nextafter(std::numeric_limits<T>::min() / 2, 0);
   bool unsafe = safe_upper < r2_high;
   if (std::numeric_limits<T>::is_signed) {
+    const T safe_lower = std::nextafter(std::numeric_limits<T>::lowest() / 2, 0);
     unsafe = unsafe || r2_low < safe_lower;
   }
   if (unsafe) {

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -774,7 +774,8 @@ double Dimension::overlap_ratio(const Range& r1, const Range& r2) {
   const T safe_upper = std::nextafter(std::numeric_limits<T>::max() / 2, 0);
   bool unsafe = safe_upper < r2_high;
   if (std::numeric_limits<T>::is_signed) {
-    const T safe_lower = std::nextafter(std::numeric_limits<T>::lowest() / 2, 0);
+    const T safe_lower =
+        std::nextafter(std::numeric_limits<T>::lowest() / 2, 0);
     unsafe = unsafe || r2_low < safe_lower;
   }
   if (unsafe) {
@@ -794,12 +795,22 @@ double Dimension::overlap_ratio(const Range& r1, const Range& r2) {
   } else {
     if (denominator == 0) {
       /*
-       * If the denominator is zero, we have no easy-to-access information about
-       * the quotient, but the result must still be between 0 and 1. The
-       * denominator is larger than the numerator, so the numerator will also be
-       * zero. We could extract some information from the floating-point
-       * representation itself, but that's a lot of work. So tra-la-la, this is
-       * a tiny defect.
+       * If the variable `denominator` is zero, it's the result of rounding,
+       * since checking the "disjoint" and "subset" cases above has ensured that
+       * the endpoints of the denominator interval are distinct. Thus we have no
+       * easy-to-access information about the true quotient value, but
+       * mathematically it must be between 0 and 1, so we need either to return
+       * some value between 0 and 1 or to throw an exception stating that we
+       * don't support this case.
+       *
+       * The variable `denominator` is larger than the variable `numerator`, so
+       * the numerator is also be zero. We could extract some information from
+       * the floating-point representation itself, but that's a lot of work that
+       * doesn't seem justified at present. Throwing an exception would be
+       * better on principle, but the code in its current state now would not
+       * deal with that gracefully. As a compromise, therefore, we return a
+       * valid but non-computed value. It's a defect, but one that will rarely
+       * if ever arise in practice.
        */
       return 0.5;
     }

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -750,18 +750,19 @@ double Dimension::overlap_ratio(const Range& r1, const Range& r2) {
   auto overlap_end = std::min(d1[1], d2[1]);
   auto overlap_range = overlap_end - overlap_start;
   auto mbr_range = d2[1] - d2[0];
-  auto max = std::numeric_limits<double>::max();
   if (std::numeric_limits<T>::is_integer) {
     overlap_range += 1;
     mbr_range += 1;
   } else {
+    constexpr auto max = std::numeric_limits<double>::max();
     if (overlap_range == 0)
       overlap_range = std::nextafter(overlap_range, max);
     if (mbr_range == 0)
       mbr_range = std::nextafter(mbr_range, max);
   }
-
-  return (double)overlap_range / mbr_range;
+  auto ratio = (double)overlap_range / mbr_range;
+  assert(0.0 <= ratio && ratio <= 1.0);
+  return ratio;
 }
 
 double Dimension::overlap_ratio(const Range& r1, const Range& r2) const {

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -733,35 +733,86 @@ double Dimension::overlap_ratio<char>(const Range& r1, const Range& r2) {
 
 template <class T>
 double Dimension::overlap_ratio(const Range& r1, const Range& r2) {
+  // Verify that we have two intervals
   assert(!r1.empty());
   assert(!r2.empty());
-
   auto d1 = (const T*)r1.data();
   auto d2 = (const T*)r2.data();
-  assert(d1[0] <= d1[1]);
-  assert(d2[0] <= d2[1]);
+  const auto r1_low = d1[0];
+  const auto r1_high = d1[1];
+  auto r2_low = d2[0];
+  auto r2_high = d2[1];
+  assert(r1_low <= r1_high);
+  assert(r2_low <= r2_high);
 
-  // No overlap
-  if (d1[0] > d2[1] || d1[1] < d2[0])
+  // Special case: No overlap, intervals are disjoint
+  if (r1_low > r2_high || r1_high < r2_low)
     return 0.0;
+  // Special case: All overlap, interval r2 is a subset of interval r1
+  if (r1_low <= r2_low && r2_high <= r1_high)
+    return 1.0;
+  /*
+   * At this point we know that r2_low < r2_high, because we would have returned
+   * by now otherwise. Note that for floating point types, however, we cannot
+   * conclude that r2_high - r2_low > 0 because of the possibility of underflow.
+   */
+  auto intersection_low = std::max(r1_low, r2_low);
+  auto intersection_high = std::min(r1_high, r2_high);
+  /*
+   * The intersection is a proper subset of interval r1, either the upper bounds
+   * are distinct, or lower bounds are distinct, or both. This means that any
+   * result has to be strictly greater than zero and strictly less than 1.
+   */
+  /*
+   * Guard against overflow. If the outer interval has a bound with an absolute
+   * value that's "too large", meaning that it might lead to an overflow, we
+   * apply a shrinking transformation that preserves the ratio. We only need to
+   * check the outer interval because the intersection is strictly smaller. For
+   * unsigned types we only need to check the upper bound, since the lower bound
+   * is zero. For signed types we need to check both.
+   */
+  const T safe_upper = std::nextafter( std::numeric_limits<T>::max()/2, 0);
+  const T safe_lower = std::nextafter( std::numeric_limits<T>::min()/2, 0);
+  bool unsafe = safe_upper < r2_high;
+  if (std::numeric_limits<T>::is_signed) {
+    unsafe = unsafe || r2_low < safe_lower;
+  }
+  if (unsafe) {
+    r2_low /= 2;
+    r2_high /= 2;
+    intersection_low /= 2;
+    intersection_high /= 2;
+  }
 
   // Compute ratio
-  auto overlap_start = std::max(d1[0], d2[0]);
-  auto overlap_end = std::min(d1[1], d2[1]);
-  auto overlap_range = overlap_end - overlap_start;
-  auto mbr_range = d2[1] - d2[0];
+  auto numerator = intersection_high - intersection_low;
+  auto denominator = r2_high - r2_low;
   if (std::numeric_limits<T>::is_integer) {
-    overlap_range += 1;
-    mbr_range += 1;
+    // integer types count elements; they don't measure length
+    numerator += 1;
+    denominator += 1;
   } else {
-    constexpr auto max = std::numeric_limits<double>::max();
-    if (overlap_range == 0)
-      overlap_range = std::nextafter(overlap_range, max);
-    if (mbr_range == 0)
-      mbr_range = std::nextafter(mbr_range, max);
+    if (denominator == 0) {
+      /*
+       * If the denominator is zero, we have no easy-to-access information about
+       * the quotient, but the result must still be between 0 and 1. The
+       * denominator is larger than the numerator, so the numerator will also be
+       * zero. We could extract some information from the floating-point
+       * representation itself, but that's a lot of work. So tra-la-la, this is
+       * a tiny defect.
+       */
+      return 0.5;
+    }
+    // The rounded-to-zero numerator is handled in the general case below.
   }
-  auto ratio = (double)overlap_range / mbr_range;
-  assert(0.0 <= ratio && ratio <= 1.0);
+  auto ratio = (double)numerator / denominator;
+  // Round away from the endpoints if needed.
+  if (ratio == 0.0) {
+    ratio = std::nextafter(0, 1);
+  } else if (ratio == 1.0) {
+    ratio = std::nextafter(1, 0);
+  }
+  assert(0.0 < ratio && ratio < 1.0);
   return ratio;
 }
 

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -771,8 +771,8 @@ double Dimension::overlap_ratio(const Range& r1, const Range& r2) {
    * unsigned types we only need to check the upper bound, since the lower bound
    * is zero. For signed types we need to check both.
    */
-  const T safe_upper = std::nextafter( std::numeric_limits<T>::max()/2, 0);
-  const T safe_lower = std::nextafter( std::numeric_limits<T>::min()/2, 0);
+  const T safe_upper = std::nextafter(std::numeric_limits<T>::max() / 2, 0);
+  const T safe_lower = std::nextafter(std::numeric_limits<T>::min() / 2, 0);
   bool unsafe = safe_upper < r2_high;
   if (std::numeric_limits<T>::is_signed) {
     unsafe = unsafe || r2_low < safe_lower;

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -469,10 +469,10 @@ class Dimension {
   template <class T>
   static bool overlap(const Range& r1, const Range& r2);
 
-  /** Return ratio of the overalp of the two input 1D ranges over `r2`. */
+  /** Return ratio of the overlap of the two input 1D ranges over `r2`. */
   double overlap_ratio(const Range& r1, const Range& r2) const;
 
-  /** Return ratio of the overalp of the two input 1D ranges over `r2`. */
+  /** Return ratio of the overlap of the two input 1D ranges over `r2`. */
   template <class T>
   static double overlap_ratio(const Range& r1, const Range& r2);
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1214,7 +1214,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
   auto status = parallel_for(compute_tp, 0, num_threads, [&](uint64_t t) {
     auto r_start = range_start + t * ranges_per_thread;
     auto r_end =
-        std::min(range_start + (t + 1) * ranges_per_thread - 1, num_threads);
+        std::min(range_start + (t + 1) * ranges_per_thread - 1, range_end);
     auto r_coords = get_range_coords(r_start);
     for (uint64_t r = r_start; r <= r_end; ++r) {
       RETURN_NOT_OK(compute_relevant_fragment_est_result_sizes(

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1214,7 +1214,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
   auto status = parallel_for(compute_tp, 0, num_threads, [&](uint64_t t) {
     auto r_start = range_start + t * ranges_per_thread;
     auto r_end =
-        std::min(range_start + (t + 1) * ranges_per_thread - 1, range_end);
+        std::min(range_start + (t + 1) * ranges_per_thread - 1, num_threads);
     auto r_coords = get_range_coords(r_start);
     for (uint64_t r = r_start; r <= r_end; ++r) {
       RETURN_NOT_OK(compute_relevant_fragment_est_result_sizes(


### PR DESCRIPTION
`Dimension::overlap_ratio` was full of possible ways to overflow and give nonsense results. The tests added in this PR all (but one) failed in the old code, including some divide-by-zero triggered by overflow. The new code accounts for all the possibilities of overflow.

---
TYPE: BUG
DESC: Rewrite `Dimension::overlap_ratio`
