### PR TITLE
Verify that Domain::overlap_ratio returns something that's not NaN.

### DIFF
--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -682,7 +682,7 @@ double Domain::overlap_ratio(const NDRange& r1, const NDRange& r2) const {
     if (ratio == 0)
       ratio = std::nextafter(0, max);
   }
-
+  assert(!isnan(ratio));
   return ratio;
 }
 

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -682,7 +682,7 @@ double Domain::overlap_ratio(const NDRange& r1, const NDRange& r2) const {
     if (ratio == 0)
       ratio = std::nextafter(0, max);
   }
-  assert(!isnan(ratio));
+  assert(!std::isnan(ratio));
   return ratio;
 }
 


### PR DESCRIPTION
In the debugger I'm seeing NaN as a return value from overlap_ratio (dev branch). This PR checks to see if this is a just-my-problem or an actual problem.

---
TYPE: NO_HISTORY
DESC: this PR is a test to see if a particular defect is current passing CI
