### PR TITLE
Handle extra offset w/serialized incomplete query

### DIFF
--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -66,25 +66,32 @@ struct QueryBufferCopyState {
   /** Accumulated number of bytes copied into user's validity buffer. */
   uint64_t validity_size;
 
+  /** Track if the last query added the extra offset. If so we avoid the first
+   * 0th offset on the n+1 query. */
+  bool last_query_added_extra_offset;
+
   /** Constructor. */
   QueryBufferCopyState()
       : offset_size(0)
       , data_size(0)
-      , validity_size(0) {
+      , validity_size(0)
+      , last_query_added_extra_offset(false) {
   }
 
   /** Copy constructor. */
   QueryBufferCopyState(const QueryBufferCopyState& rhs)
       : offset_size(rhs.offset_size)
       , data_size(rhs.data_size)
-      , validity_size(rhs.validity_size) {
+      , validity_size(rhs.validity_size)
+      , last_query_added_extra_offset(rhs.last_query_added_extra_offset) {
   }
 
   /** Move constructor. */
   QueryBufferCopyState(QueryBufferCopyState&& rhs)
       : offset_size(rhs.offset_size)
       , data_size(rhs.data_size)
-      , validity_size(rhs.validity_size) {
+      , validity_size(rhs.validity_size)
+      , last_query_added_extra_offset(rhs.last_query_added_extra_offset) {
   }
 
   /** Destructor. */
@@ -96,6 +103,7 @@ struct QueryBufferCopyState {
     offset_size = rhs.offset_size;
     data_size = rhs.data_size;
     validity_size = rhs.validity_size;
+    last_query_added_extra_offset = rhs.last_query_added_extra_offset;
     return *this;
   }
 
@@ -104,6 +112,7 @@ struct QueryBufferCopyState {
     offset_size = rhs.offset_size;
     data_size = rhs.data_size;
     validity_size = rhs.validity_size;
+    last_query_added_extra_offset = rhs.last_query_added_extra_offset;
     return *this;
   }
 };


### PR DESCRIPTION
This adds handling for the extra offset that a user might request (i.e. for arrow) in serialized queries when there is incomplete queries.

The bug this fixes is that for every incomplete query we were adding n+2 extra offset because the first element of any query results has a 0 offset. This 0th offset is the same value as the "extra" offset included in the previous query.

The intent of the patch is to handle the fact that only the last part of the incomplete serialized query needs to include the extra offset. For any individual query we don't know if it is the last one or not. The last query in this case doesn't necessarily mean query complete, it could be the "last" in the sense the user buffers are full and we must let the user process the partial requests. To work around this issue of not knowing the last query, we instead remove the first offset of the current query if the query not the first one run. This works since, as mentioned, the extra offset is the same as the 0th offset in the n+1
query.


---
TYPE: BUG
DESC: Fix incorrect offset count with incomplete serialized queries and `sm.var_offsets.extra_element`
