### PR TITLE
replace ReadFromOffset with ReadRange (#2279)

### DIFF
--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -1106,7 +1106,10 @@ Status GCS::read(
   RETURN_NOT_OK(parse_gcs_uri(uri, &bucket_name, &object_path));
 
   google::cloud::storage::ObjectReadStream stream = client_->ReadObject(
-      bucket_name, object_path, google::cloud::storage::ReadFromOffset(offset));
+      bucket_name,
+      object_path,
+      google::cloud::storage::ReadRange(
+          offset, offset + length + read_ahead_length));
 
   if (!stream.status().ok()) {
     return LOG_STATUS(Status::GCSError(std::string(


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/pull/2279 to release-2.3.

TYPE: IMPROVEMENT
DESC: replace ReadFromOffset with ReadRange in GCS::read() to avoid excess gcs egress traffic