### PR TITLE
Conform stats to JSON

### DIFF
--- a/tiledb/sm/stats/global_stats.cc
+++ b/tiledb/sm/stats/global_stats.cc
@@ -98,11 +98,25 @@ void GlobalStats::register_stats(const tdb_shared_ptr<Stats>& stats) {
 std::string GlobalStats::dump_registered_stats() const {
   std::stringstream ss;
 
-  for (const auto& stats : registered_stats_) {
-    const std::string stats_dump = stats->dump();
-    if (!stats_dump.empty())
+  ss << "[\n";
+
+  bool printed_first_stats = false;
+  auto iter = registered_stats_.begin();
+  while (iter != registered_stats_.end()) {
+    const uint64_t indent_size = 2;
+    const std::string stats_dump = (*iter)->dump(indent_size, 1);
+    if (!stats_dump.empty()) {
+      if (printed_first_stats) {
+        ss << ",\n";
+      }
       ss << stats_dump;
+      printed_first_stats = true;
+    }
+
+    ++iter;
   }
+
+  ss << "\n]\n";
 
   return ss.str();
 }

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -63,7 +63,8 @@ void Stats::set_enabled(bool enabled) {
   enabled_ = enabled;
 }
 
-std::string Stats::dump() const {
+std::string Stats::dump(
+    const uint64_t indent_size, const uint64_t num_indents) const {
   std::unordered_map<std::string, double> flattened_timers;
   std::unordered_map<std::string, uint64_t> flattened_counters;
 
@@ -98,30 +99,58 @@ std::string Stats::dump() const {
         return a.first > b.first;
       });
 
+  // Build the indentation literal and the leading indentation literal.
+  const std::string indent(indent_size, ' ');
+  const std::string l_indent(indent_size * num_indents, ' ');
+
   std::stringstream ss;
-  ss << "--- Timers ---\n\n";
+  ss << l_indent << "{\n";
+
+  ss << l_indent << indent << "\"timers\": {\n";
+  bool printed_first_timer = false;
   for (const auto& timer : sorted_timers) {
     if (utils::parse::ends_with(timer.first, ".sum")) {
-      ss << timer.first << ": " << timer.second << "\n";
+      if (printed_first_timer) {
+        ss << ",\n";
+      }
+      ss << l_indent << indent << indent << "\"" << timer.first
+         << "\": " << timer.second << ",\n";
       auto stat = timer.first.substr(
           0, timer.first.size() - std::string(".sum").size());
       auto it = flattened_counters.find(stat + ".timer_count");
       assert(it != flattened_counters.end());
       auto avg = timer.second / it->second;
-      ss << stat + ".avg"
-         << ": " << avg << "\n";
+      ss << l_indent << indent << indent << "\"" << stat + ".avg"
+         << "\": " << avg;
+      printed_first_timer = true;
     }
   }
-  ss << "\n";
-  ss << "--- Counters ---\n\n";
+  if (printed_first_timer) {
+    ss << "\n";
+  }
+
+  ss << l_indent << indent << "},\n";
+  ss << l_indent << indent << "\"counters\": {\n";
+  bool printed_first_counter = false;
   for (const auto& counter : sorted_counters) {
     // Ignore the reserved "timer_count" counters.
     if (utils::parse::ends_with(counter.first, ".timer_count")) {
       continue;
     }
-    ss << counter.first << ": " << counter.second << "\n";
+
+    if (printed_first_counter) {
+      ss << ",\n";
+    }
+    ss << l_indent << indent << indent << "\"" << counter.first
+       << "\": " << counter.second;
+    printed_first_counter = true;
   }
-  ss << "\n";
+  if (printed_first_counter) {
+    ss << "\n";
+  }
+  ss << l_indent << indent << "}\n";
+
+  ss << l_indent << "}";
 
   return ss.str();
 }

--- a/tiledb/sm/stats/stats.h
+++ b/tiledb/sm/stats/stats.h
@@ -90,8 +90,14 @@ class Stats {
   /** Enable or disable statistics gathering. */
   void set_enabled(bool enabled);
 
-  /** Dumps the stats for this instance and all children in ASCII format. */
-  std::string dump() const;
+  /**
+   * Dumps the stats for this instance as a JSON dictionary of
+   * timers and stats.
+   *
+   * @param indent_size The number of spaces in an indentation.
+   * @param num_indents The number of leading indentations.
+   */
+  std::string dump(uint64_t indent_size, uint64_t num_indents) const;
 
   /** Returns the parent that manages this instance. */
   Stats* parent();


### PR DESCRIPTION
For 2.3, we refactored the stats. This broke the contract that the raw stats
were exported as a JSON string. This is a rudimentary patch to ensure that
our stats are formatted as a JSON. In the future, we could provide a real
hierachy of stats instead of flattened stats separated by periods.

Example output with two context objects in the lifetime of a process:
```
[
  {
    "timers": {
      "Context.StorageManager.write_store_frag_meta.sum": 0.00501233,
      "Context.StorageManager.write_store_frag_meta.avg": 0.00501233,
      "Context.StorageManager.write_array_meta.sum": 2.494e-06,
      "Context.StorageManager.write_array_meta.avg": 2.494e-06,
      "Context.StorageManager.read_load_array_schema.sum": 0.000171296,
      "Context.StorageManager.read_load_array_schema.avg": 0.000171296,
      "Context.StorageManager.Query.Writer.write.sum": 0.00736181,
      "Context.StorageManager.Query.Writer.write.avg": 0.00736181,
      "Context.StorageManager.Query.Writer.tiles.sum": 0.00199339,
      "Context.StorageManager.Query.Writer.tiles.avg": 0.000398678,
      "Context.StorageManager.Query.Writer.split_coords_buff.sum": 2.019e-06,
      "Context.StorageManager.Query.Writer.split_coords_buff.avg": 2.019e-06,
      "Context.StorageManager.Query.Writer.sort_coords.sum": 3.3193e-05,
      "Context.StorageManager.Query.Writer.sort_coords.avg": 3.3193e-05,
      "Context.StorageManager.Query.Writer.prepare_tiles.sum": 4.7035e-05,
      "Context.StorageManager.Query.Writer.prepare_tiles.avg": 4.7035e-05,
      "Context.StorageManager.Query.Writer.filter_tiles.sum": 0.000384188,
      "Context.StorageManager.Query.Writer.filter_tiles.avg": 0.000384188,
      "Context.StorageManager.Query.Writer.filter_tile.sum": 0.000951958,
      "Context.StorageManager.Query.Writer.filter_tile.avg": 0.00015866,
      "Context.StorageManager.Query.Writer.compute_coord_meta.sum": 1.3598e-05,
      "Context.StorageManager.Query.Writer.compute_coord_meta.avg": 1.3598e-05,
      "Context.StorageManager.Query.Writer.check_coord_oob.sum": 0.000202946,
      "Context.StorageManager.Query.Writer.check_coord_oob.avg": 0.000202946,
      "Context.StorageManager.Query.Writer.check_coord_dups.sum": 7.63e-07,
      "Context.StorageManager.Query.Writer.check_coord_dups.avg": 7.63e-07
    },
    "counters": {
      "Context.StorageManager.write_tile_var_sizes_size": 501,
      "Context.StorageManager.write_tile_var_offsets_size": 495,
      "Context.StorageManager.write_tile_validity_offsets_size": 495,
      "Context.StorageManager.write_tile_offsets_size": 495,
      "Context.StorageManager.write_rtree_size": 122,
      "Context.StorageManager.write_frag_meta_footer_size": 354,
      "Context.StorageManager.write_filtered_byte_num": 593,
      "Context.StorageManager.write_array_schema_size": 213,
      "Context.StorageManager.read_unfiltered_byte_num": 213,
      "Context.StorageManager.read_array_schema_size": 213,
      "Context.StorageManager.VFS.write_ops_num": 52,
      "Context.StorageManager.VFS.write_byte_num": 2997,
      "Context.StorageManager.VFS.read_ops_num": 3,
      "Context.StorageManager.VFS.read_byte_num": 185,
      "Context.StorageManager.Query.Writer.write_filtered_byte_num": 160,
      "Context.StorageManager.Query.Writer.tile_num": 1,
      "Context.StorageManager.Query.Writer.dim_var_num": 2,
      "Context.StorageManager.Query.Writer.dim_num": 3,
      "Context.StorageManager.Query.Writer.dim_fixed_num": 1,
      "Context.StorageManager.Query.Writer.cell_num": 6,
      "Context.StorageManager.Query.Writer.attr_num": 1,
      "Context.StorageManager.Query.Writer.attr_fixed_num": 1
    }
  },
  {
    "timers": {
      "Context.StorageManager.read_load_frag_meta.sum": 0.000192232,
      "Context.StorageManager.read_load_frag_meta.avg": 0.000192232,
      "Context.StorageManager.read_load_consolidated_frag_meta.sum": 1.361e-06,
      "Context.StorageManager.read_load_consolidated_frag_meta.avg": 1.361e-06,
      "Context.StorageManager.read_load_array_schema.sum": 0.000191914,
      "Context.StorageManager.read_load_array_schema.avg": 0.000191914,
      "Context.StorageManager.read_get_fragment_uris.sum": 0.000399343,
      "Context.StorageManager.read_get_fragment_uris.avg": 0.000399343,
      "Context.StorageManager.read_array_open_without_fragments.sum": 0.000299377,
      "Context.StorageManager.read_array_open_without_fragments.avg": 0.000299377,
      "Context.StorageManager.read_array_open.sum": 0.000657169,
      "Context.StorageManager.read_array_open.avg": 0.000657169,
      "Context.StorageManager.Query.Reader.unfilter_coord_tiles.sum": 0.000215985,
      "Context.StorageManager.Query.Reader.unfilter_coord_tiles.avg": 5.39963e-05,
      "Context.StorageManager.Query.Reader.unfilter_attr_tiles.sum": 3.612e-05,
      "Context.StorageManager.Query.Reader.unfilter_attr_tiles.avg": 3.612e-05,
      "Context.StorageManager.Query.Reader.read.sum": 0.0022285,
      "Context.StorageManager.Query.Reader.read.avg": 0.0022285,
      "Context.StorageManager.Query.Reader.init_state.sum": 3.1749e-05,
      "Context.StorageManager.Query.Reader.init_state.avg": 3.1749e-05,
      "Context.StorageManager.Query.Reader.copy_var_coords.sum": 2.5025e-05,
      "Context.StorageManager.Query.Reader.copy_var_coords.avg": 1.25125e-05,
      "Context.StorageManager.Query.Reader.copy_fixed_coords.sum": 1.0579e-05,
      "Context.StorageManager.Query.Reader.copy_fixed_coords.avg": 1.0579e-05,
      "Context.StorageManager.Query.Reader.copy_fixed_attr_values.sum": 6.999e-06,
      "Context.StorageManager.Query.Reader.copy_fixed_attr_values.avg": 6.999e-06,
      "Context.StorageManager.Query.Reader.copy_coords.sum": 4.5551e-05,
      "Context.StorageManager.Query.Reader.copy_coords.avg": 4.5551e-05,
      "Context.StorageManager.Query.Reader.copy_attr_values.sum": 0.000262054,
      "Context.StorageManager.Query.Reader.copy_attr_values.avg": 0.000262054,
      "Context.StorageManager.Query.Reader.coord_tiles.sum": 0.000855294,
      "Context.StorageManager.Query.Reader.coord_tiles.avg": 0.000427647,
      "Context.StorageManager.Query.Reader.compute_sparse_result_tiles.sum": 8.319e-06,
      "Context.StorageManager.Query.Reader.compute_sparse_result_tiles.avg": 8.319e-06,
      "Context.StorageManager.Query.Reader.compute_sparse_result_cell_slabs_sparse.sum": 1.008e-06,
      "Context.StorageManager.Query.Reader.compute_sparse_result_cell_slabs_sparse.avg": 1.008e-06,
      "Context.StorageManager.Query.Reader.compute_result_coords.sum": 0.00113645,
      "Context.StorageManager.Query.Reader.compute_result_coords.avg": 0.00113645,
      "Context.StorageManager.Query.Reader.compute_range_result_coords.sum": 1.7141e-05,
      "Context.StorageManager.Query.Reader.compute_range_result_coords.avg": 1.7141e-05,
      "Context.StorageManager.Query.Reader.attr_tiles.sum": 0.000197755,
      "Context.StorageManager.Query.Reader.attr_tiles.avg": 0.000197755,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.read_next_partition.sum": 0.000766346,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.read_next_partition.avg": 0.000766346,
      "Context.StorageManager.Query.Reader.Subarray.read_load_relevant_rtrees.sum": 0.000164004,
      "Context.StorageManager.Query.Reader.Subarray.read_load_relevant_rtrees.avg": 0.000164004,
      "Context.StorageManager.Query.Reader.Subarray.read_compute_tile_overlap.sum": 0.000373016,
      "Context.StorageManager.Query.Reader.Subarray.read_compute_tile_overlap.avg": 0.000373016,
      "Context.StorageManager.Query.Reader.Subarray.read_compute_relevant_tile_overlap.sum": 8.402e-05,
      "Context.StorageManager.Query.Reader.Subarray.read_compute_relevant_tile_overlap.avg": 8.402e-05,
      "Context.StorageManager.Query.Reader.Subarray.read_compute_relevant_frags.sum": 9.0534e-05,
      "Context.StorageManager.Query.Reader.Subarray.read_compute_relevant_frags.avg": 9.0534e-05
    },
    "counters": {
      "Context.StorageManager.read_unfiltered_byte_num": 401,
      "Context.StorageManager.read_tile_var_sizes_size": 32,
      "Context.StorageManager.read_tile_var_offsets_size": 32,
      "Context.StorageManager.read_tile_offsets_size": 64,
      "Context.StorageManager.read_rtree_size": 60,
      "Context.StorageManager.read_frag_meta_size": 362,
      "Context.StorageManager.read_array_schema_size": 213,
      "Context.StorageManager.VFS.read_ops_num": 38,
      "Context.StorageManager.VFS.read_byte_num": 1809,
      "Context.StorageManager.Query.Reader.result_num": 3,
      "Context.StorageManager.Query.Reader.read_unfiltered_byte_num": 160,
      "Context.StorageManager.Query.Reader.overlap_tile_num": 1,
      "Context.StorageManager.Query.Reader.loop_num": 1,
      "Context.StorageManager.Query.Reader.dim_var_num": 2,
      "Context.StorageManager.Query.Reader.dim_fixed_num": 1,
      "Context.StorageManager.Query.Reader.cell_num": 6,
      "Context.StorageManager.Query.Reader.attr_fixed_num": 1,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.compute_current_start_end.ranges": 1,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.compute_current_start_end.found": 1,
      "Context.StorageManager.Query.Reader.SubarrayPartitioner.compute_current_start_end.adjusted_ranges": 1,
      "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.tile_overlap_byte_size": 64,
      "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.relevant_fragment_num": 1,
      "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.ranges_requested": 1,
      "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.ranges_computed": 1,
      "Context.StorageManager.Query.Reader.Subarray.precompute_tile_overlap.fragment_num": 1
    }
  }
]
```

---

TYPE: NO_HISTORY

<long description>

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
