### PR TITLE
Fix ch7908: missing assignment for adjust_range_oob_func_ in internal Dimension constructor

### DIFF
--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -92,6 +92,7 @@ Dimension::Dimension(const Dimension* dim) {
   type_ = dim->type_;
 
   // Set fuctions
+  adjust_range_oob_func_ = dim->adjust_range_oob_func_;
   ceil_to_tile_func_ = dim->ceil_to_tile_func_;
   check_range_func_ = dim->check_range_func_;
   coincides_with_tiles_func_ = dim->coincides_with_tiles_func_;


### PR DESCRIPTION
Fixes segfault due to missing assignment of `adjust_range_oob_func_` pointer in the `Dimension::Dimension(const Dimension* dim)` signature.

---
TYPE: BUG
DESC: Fix ch7908: missing assignment for adjust_range_oob_func_ in a Dimension constructor
