### PR TITLE
Fix negative tile extent bug

### DIFF
--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1536,9 +1536,8 @@ Status Dimension::set_null_tile_extent_to_range() {
   T tile_extent;
 
   // Calculate the ratio of tile extent to max value of T
-  double tile_extent_ratio =
-      ((double)domain[1]) / std::numeric_limits<T>::max() -
-      ((double)domain[0]) / std::numeric_limits<T>::max();
+  double tile_extent_ratio = (1.0 * domain[1]) / std::numeric_limits<T>::max() -
+                             (1.0 * domain[0]) / std::numeric_limits<T>::max();
   if (tile_extent_ratio > 0.1) {
     tile_extent = std::numeric_limits<T>::max() / 10;
   } else {

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1533,7 +1533,16 @@ Status Dimension::set_null_tile_extent_to_range() {
 
   // Calculate new tile extent equal to domain range
   auto domain = (const T*)domain_.data();
-  T tile_extent = domain[1] - domain[0];
+  T tile_extent;
+  
+  // Calculate the ratio of tile extent to max value of T
+  double tile_extent_ratio = ((double)domain[1])/std::numeric_limits<T>::max() - ((double)domain[0])/std::numeric_limits<T>::max();
+  if(tile_extent_ratio>0.1) {
+    tile_extent=std::numeric_limits<T>::max()/10;
+  }
+  else {
+    tile_extent = domain[1] - domain[0];
+  }
 
   // We need to add 1 for integral domains
   if (std::is_integral<T>::value) {

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1534,13 +1534,14 @@ Status Dimension::set_null_tile_extent_to_range() {
   // Calculate new tile extent equal to domain range
   auto domain = (const T*)domain_.data();
   T tile_extent;
-  
+
   // Calculate the ratio of tile extent to max value of T
-  double tile_extent_ratio = ((double)domain[1])/std::numeric_limits<T>::max() - ((double)domain[0])/std::numeric_limits<T>::max();
-  if(tile_extent_ratio>0.1) {
-    tile_extent=std::numeric_limits<T>::max()/10;
-  }
-  else {
+  double tile_extent_ratio =
+      ((double)domain[1]) / std::numeric_limits<T>::max() -
+      ((double)domain[0]) / std::numeric_limits<T>::max();
+  if (tile_extent_ratio > 0.1) {
+    tile_extent = std::numeric_limits<T>::max() / 10;
+  } else {
     tile_extent = domain[1] - domain[0];
   }
 


### PR DESCRIPTION
This PR is fixing tile extent when domain range is too large(CH7282). For example, when we create a dimension like this:  domain.add_dimension(Dimension::create<int64_t>(ctx, "rows", {{-9223372036854775806, 9223372036854775807}}));
The result tile extent is -2 for this case. Here the domain[0] is INT64_MIN+2 and domain[1] is INT64_MAX. The default behavior is to set tile extent to domain[1]-domain[0]+1 which is out of range of an INT64 value. We have several ways to avoid this, here I tried to sed a limit of tile extent to the tenth of MAX value of a type. We can also set a constant as the max limit for numeric dimension. After we reach an agreement how we should do this, I will also remove some unnecessary codes in set_null_tile_extent_to_range(). 

---
TYPE:  BUG
DESC: Fix negative tile extent bug due to numeric values overflow
