### PR TITLE
Annotate consolidation/vacuum timestamp config parameters as experimental

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -961,11 +961,13 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    `array_meta` (remove consolidated array metadata files). <br>
  *    **Default**: fragments
  * - `sm.vacuum.timestamp_start` <br>
+ *    **Experimental** <br>
  *    When set, an array will be vacuumed between this value and
  *    `sm.vacuum.timestamp_end` (inclusive). <br>
  *    Only for `fragments` and `array_meta` vacuum mode. <br>
  *    **Default**: 0
  * - `sm.vacuum.timestamp_end` <br>
+ *    **Experimental** <br>
  *    When set, an array will be vacuumed between `sm.vacuum.timestamp_start`
  *    and this value (inclusive). <br>
  *    Only for `fragments` and `array_meta` vacuum mode. <br>
@@ -1003,11 +1005,13 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    considered for consolidation in a single step.<br>
  *    **Default**: 0.0
  * - `sm.consolidation.timestamp_start` <br>
+ *    **Experimental** <br>
  *    When set, an array will be consolidated between this value and
  *    `sm.consolidation.timestamp_end` (inclusive). <br>
  *    Only for `fragments` and `array_meta` consolidation mode. <br>
  *    **Default**: 0
  * - `sm.consolidation.timestamp_end` <br>
+ *    **Experimental** <br>
  *    When set, an array will be consolidated between
  *    `sm.consolidation.timestamp_start` and this value (inclusive). <br>
  *    Only for `fragments` and `array_meta` consolidation mode. <br>

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -309,11 +309,13 @@ class Config {
    *    `array_meta` (remove consolidated array metadata files). <br>
    *    **Default**: fragments
    * - `sm.vacuum.timestamp_start` <br>
+   *    **Experimental** <br>
    *    When set, an array will be vacuumed between this value and
    *    `sm.vacuum.timestamp_end` (inclusive). <br>
    *    Only for `fragments` and `array_meta` vacuum mode. <br>
    *    **Default**: 0
    * - `sm.vacuum.timestamp_end` <br>
+   *    **Experimental** <br>
    *    When set, an array will be vacuumed between `sm.vacuum.timestamp_start`
    *    and this value (inclusive). <br>
    *    Only for `fragments` and `array_meta` vacuum mode. <br>
@@ -351,11 +353,13 @@ class Config {
    *    considered for consolidation in a single step.<br>
    *    **Default**: 0.0
    * - `sm.consolidation.timestamp_start` <br>
+   *    **Experimental** <br>
    *    When set, an array will be consolidated between this value and
    *    `sm.consolidation.timestamp_end` (inclusive). <br>
    *    Only for `fragments` and `array_meta` consolidation mode. <br>
    *    **Default**: 0
    * - `sm.consolidation.timestamp_end` <br>
+   *    **Experimental** <br>
    *    When set, an array will be consolidated between
    *    `sm.consolidation.timestamp_start` and this value (inclusive). <br>
    *    Only for `fragments` and `array_meta` consolidation mode. <br>


### PR DESCRIPTION
We are not certain that we want to commit to configurating the consolidation
and vacuuming timestamp bounds in the config object. Mark them as experimental.

---

TYPE: NO_HISTORY