### PR TITLE
Changes to use bzip2 1.0.8 on windows

### DIFF
--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -84,7 +84,7 @@ if (NOT BZIP2_FOUND)
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         UPDATE_COMMAND ""
         PATCH_COMMAND 
-          cmake -E copy ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_bzip/CMakeLists.txt ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2
+          cmake -E copy ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_bzip2/CMakeLists.txt ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE

--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -84,7 +84,7 @@ if (NOT BZIP2_FOUND)
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         UPDATE_COMMAND ""
         PATCH_COMMAND 
-         curl -L https://github.com/TileDB-Inc/bzip2-windows/blob/6aba012dd7503c6f61a70ff05395aff3d5d864ab/bzip2-1.0.8/CMakeLists.txt?raw=true -o ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2/CMakeLists.txt
+          cmake -E copy ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_bzip/CMakeLists.txt ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE

--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -84,7 +84,7 @@ if (NOT BZIP2_FOUND)
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         UPDATE_COMMAND ""
         PATCH_COMMAND 
-         curl https://raw.githubusercontent.com/TileDB-Inc/bzip2-windows/master/bzip2-1.0.6/CMakeLists.txt -o ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2/CMakeLists.txt
+         curl -L https://github.com/TileDB-Inc/bzip2-windows/blob/6aba012dd7503c6f61a70ff05395aff3d5d864ab/bzip2-1.0.8/CMakeLists.txt?raw=true -o ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2/CMakeLists.txt
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE

--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -84,7 +84,7 @@ if (NOT BZIP2_FOUND)
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         UPDATE_COMMAND ""
         PATCH_COMMAND 
-          cmake -E copy ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_bzip2/CMakeLists.txt ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2
+          ${CMAKE_COMMAND} -E copy ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_bzip2/CMakeLists.txt ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE

--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -81,7 +81,7 @@ if (NOT BZIP2_FOUND)
         PREFIX "externals"
         URL "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
         URL_HASH SHA1=bf7badf7e248e0ecf465d33c2f5aeec774209227
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX} "${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2"
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         UPDATE_COMMAND ""
         PATCH_COMMAND 
          curl https://raw.githubusercontent.com/TileDB-Inc/bzip2-windows/master/bzip2-1.0.6/CMakeLists.txt -o ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2/CMakeLists.txt

--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -79,10 +79,12 @@ if (NOT BZIP2_FOUND)
     if (WIN32)
       ExternalProject_Add(ep_bzip2
         PREFIX "externals"
-        URL "https://github.com/TileDB-Inc/bzip2-windows/releases/download/v1.0.6/bzip2-1.0.6.zip"
-        URL_HASH SHA1=d11c3f0be92805a4c35f384845beb99eb6a96f6e
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
+        URL "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
+        URL_HASH SHA1=bf7badf7e248e0ecf465d33c2f5aeec774209227
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX} "${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2"
         UPDATE_COMMAND ""
+        PATCH_COMMAND 
+         curl https://raw.githubusercontent.com/TileDB-Inc/bzip2-windows/master/bzip2-1.0.6/CMakeLists.txt -o ${CMAKE_CURRENT_BINARY_DIR}/externals/src/ep_bzip2/CMakeLists.txt
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE

--- a/cmake/inputs/patches/ep_bzip2/CMakeLists.txt
+++ b/cmake/inputs/patches/ep_bzip2/CMakeLists.txt
@@ -1,0 +1,55 @@
+#
+# CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2017 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+project(bzip2)
+cmake_minimum_required(VERSION 2.8)
+
+set(SOURCES "blocksort.c" "huffman.c" "crctable.c" "randtable.c"
+"compress.c" "decompress.c" "bzlib.c")
+file(GLOB HEADERS "bzlib.h")
+
+# Set build flags
+if (WIN32)
+  set(CMAKE_C_FLAGS "/DWIN32 /D_FILE_OFFSET_BITS=64 /MD /Ox /nologo")
+else()
+  set(CMAKE_C_FLAGS "-D_FILE_OFFSET_BITS=64 -Wall -Winline -O2 -g")
+endif()
+
+# Create libraries
+add_library(bzip2_static STATIC ${SOURCES})
+set_target_properties(bzip2_static PROPERTIES OUTPUT_NAME "libbz2static")
+add_library(bzip2_shared SHARED ${SOURCES} libbz2.def)
+set_target_properties(bzip2_shared PROPERTIES OUTPUT_NAME "libbz2")
+
+# Install libraries
+install(
+  TARGETS bzip2_static bzip2_shared
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+install(FILES ${HEADERS} DESTINATION include)


### PR DESCRIPTION
Update bzip2 in windows build to 1.0.8

---
TYPE: IMPROVEMENT
DESC: Update bzip2 in windows build to 1.0.8
