### PR TITLE
Remove duplicate azure pipeline CI jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,56 +18,18 @@ stages:
       timeoutInMinutes: 90
       strategy:
         matrix:
-          linux_s3:
-            imageName: 'ubuntu-16.04'
-            TILEDB_S3: ON
-            TILEDB_STATIC: OFF
-            TILEDB_TOOLS: ON
-            CXX: g++
-          linux_hdfs:
-            imageName: 'ubuntu-16.04'
-            TILEDB_HDFS: ON
-            CXX: g++
-          linux_azure:
-            imageName: 'ubuntu-16.04'
-            TILEDB_AZURE: ON
-            TILEDB_STATIC: OFF
-            TILEDB_ARROW_TESTS: ON
-            CXX: g++
-          linux_gcs:
-            imageName: 'ubuntu-16.04'
-            TILEDB_GCS: ON
-            TILEDB_STATIC: OFF
-            CXX: g++
-          macOS:
-            imageName: 'macOS-10.14'
-            TILEDB_S3: ON
-            TILEDB_ARROW_TESTS: ON
-            CXX: clang++
-            ARTIFACT_OS: macOS
           macOS_azure:
             imageName: 'macOS-10.15'
             TILEDB_AZURE: ON
             TILEDB_SERIALIZATION: ON
             CXX: clang++
             ARTIFACT_OS: macOS_azure
-          macOS_gcs:
-            imageName: 'macOS-10.14'
-            TILEDB_GCS: ON
-            CXX: clang++
-            ARTIFACT_OS: macOS_gcs
           linux_asan:
             imageName: 'ubuntu-16.04'
             TILEDB_CI_ASAN: ON
             TILEDB_SERIALIZATION: ON
             CXX: g++-9
             CC: gcc-9   # Always run ASAN with matching compiler versions
-          linux_serialization:
-            imageName: 'ubuntu-16.04'
-            TILEDB_SERIALIZATION: ON
-            TILEDB_S3: ON
-            CXX: g++
-            BACKWARDS_COMPATIBILITY_ARRAYS: ON
 
       pool:
         vmImage: $(imageName)


### PR DESCRIPTION
This removes the CI jobs from azure pipelines that are currently under test
in GHA. This includes all linux jobs except ASAN and all mac jobs except Azure.

TYPE: NO_HISTORY