### PR TITLE
Fixing S3 build for OSX11

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -94,12 +94,21 @@ if (NOT AWSSDK_FOUND)
       set(CMAKE_GENERATOR_PLATFORM "")
     endif()
 
+    if (WIN32)
+      find_package(Git REQUIRED)
+      set(CONDITIONAL_PATCH cd ${CMAKE_SOURCE_DIR} && ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_awssdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch)
+    else()
+      set(CONDITIONAL_PATCH patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch)
+    endif()
+
     ExternalProject_Add(ep_awssdk
       PREFIX "externals"
       # Set download name to avoid collisions with only the version number in the filename
       DOWNLOAD_NAME ep_awssdk.zip
       URL "https://github.com/aws/aws-sdk-cpp/archive/1.8.84.zip"
       URL_HASH SHA1=e32a53a01c75ca7fdfe9feed9c5bbcedd98708e3
+      PATCH_COMMAND
+        ${CONDITIONAL_PATCH}
       CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${AWS_CMAKE_BUILD_TYPE}
         -DENABLE_TESTING=OFF

--- a/cmake/inputs/patches/ep_awssdk/awsccommon.patch
+++ b/cmake/inputs/patches/ep_awssdk/awsccommon.patch
@@ -1,0 +1,13 @@
+diff --git a/third-party/CMakeLists.txt b/third-party/CMakeLists.txt
+index b4cf1be2..64f10d43 100644
+--- a/third-party/CMakeLists.txt
++++ b/third-party/CMakeLists.txt
+@@ -15,7 +15,7 @@ set(AWS_DEPS_BUILD_DIR "${CMAKE_BINARY_DIR}/build" CACHE PATH "Dependencies buil
+ set(AWS_DEPS_DOWNLOAD_DIR "${AWS_DEPS_BUILD_DIR}/downloads" CACHE PATH "Dependencies download directory.")
+ 
+ set(AWS_C_COMMON_URL "https://github.com/awslabs/aws-c-common.git")
+-set(AWS_C_COMMON_TAG "v0.4.42")
++set(AWS_C_COMMON_TAG "v0.6.2")
+ include(BuildAwsCCommon)
+ 
+ set(AWS_CHECKSUMS_URL "https://github.com/awslabs/aws-checksums.git")


### PR DESCRIPTION
Patching the aws-c-common version to 0.6.2 for now as taking version
1.9 of the SDK is too involved.

---
TYPE: IMPROVEMENT
DESC: Fixing S3 build for OSX11