### PR TITLE
Multi-range single dimension query fix

### DIFF
--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -3337,8 +3337,12 @@ tdb_unique_ptr<Reader::ResultCellSlabsIndex> Reader::compute_rcs_index(
   // The result cell slab ranges must be sorted in ascending order for the
   // selective decompression intersection algorithm. For 1-dimensional arrays,
   // the result cell slab ranges are guaranteed to be sorted in ascending
-  // order. For arrays with more than one dimension, we must sort them.
-  if (array_schema_->dim_num() > 1) {
+  // order. For arrays with more than one dimension or multi range queries,
+  // we must sort them.
+  auto& partitioner = read_state_.partitioner_;
+  const auto& subarray = partitioner.current();
+  auto range_num = subarray.range_num();
+  if (array_schema_->dim_num() > 1 || range_num > 1) {
     struct RangeCompare {
       inline bool operator()(
           const std::pair<uint64_t, uint64_t>& a,

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -121,6 +121,10 @@ SubarrayPartitioner& SubarrayPartitioner::operator=(
 /*               API              */
 /* ****************************** */
 
+const Subarray& SubarrayPartitioner::current() const {
+  return current_.partition_;
+}
+
 Subarray& SubarrayPartitioner::current() {
   return current_.partition_;
 }

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -191,6 +191,9 @@ class SubarrayPartitioner {
   /* ********************************* */
 
   /** Returns the current partition. */
+  const Subarray& current() const;
+
+  /** Returns the current partition. */
   Subarray& current();
 
   /** Returns the current partition info. */


### PR DESCRIPTION
When submitting multi range single dimension queries, we skipped sorting
the result cell slabs which could give unpredictable behavior in the
filter pipeline. Now sorting for multi range queries.

---
TYPE: BUG
DESC: Multi-range single dimension query fix