### PR TITLE
Update prepare_release.py to fetch the original PR of each backport PR

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,7 +25,7 @@ jobs:
         run: pip install PyGithub
 
       - name: Update version and history
-        run: python ./scripts/prepare_release.py ${{ github.event.inputs.version }}
+        run: python ./scripts/prepare_release.py ${{ github.event.inputs.version }} --token="${{ secrets.GITHUB_TOKEN }}"
 
       - name: Commit and push updates
         uses: test-room-7/action-update-file@v1


### PR DESCRIPTION
Update `prepare_release.py` to fetch the original PR of each backport PR,  e.g. https://github.com/TileDB-Inc/TileDB/pull/2354 instead of https://github.com/TileDB-Inc/TileDB/pull/2355.

**Note**: the fix relies on backport PRs having `head.ref` that starts with `backport-{ORIGINAL_PR_NUM}` (e.g. `backport-2354-to-release-2.3`).

---
TYPE: NO_HISTORY 
