### PR TITLE
Check That Dimension's Bounds Fall Within Datatype's Numeric Limit

### DIFF
--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -1043,13 +1043,20 @@ class Dimension {
           "Domain check failed; Upper domain bound should "
           "not be smaller than the lower one"));
 
-    // Domain range must not exceed the maximum uint64_t number
-    // for integer domains
-    if ((uint64_t)(domain[1] - domain[0]) ==
-        std::numeric_limits<uint64_t>::max())
+    // Bounds should fall within numeric limits for given datatype
+    if (domain[0] < std::numeric_limits<T>::min() or
+        domain[0] > std::numeric_limits<T>::max()) {
       return LOG_STATUS(Status::DimensionError(
-          "Domain check failed; Domain range (upper + lower + 1) is larger "
-          "than the maximum uint64 number"));
+          "Domain check failed; lower bound of domain range exceeds "
+          "numeric limits for data type."));
+    }
+
+    if (domain[1] < std::numeric_limits<T>::min() or
+        domain[1] > std::numeric_limits<T>::max()) {
+      return LOG_STATUS(Status::DimensionError(
+          "Domain check failed; upper bound of domain range exceeds "
+          "numeric limits for data type."));
+    }
 
     return Status::Ok();
   }


### PR DESCRIPTION
* Previously, this check was to ensure that the range did not exceed the
  max value for uint64_t by calculating `(uint64_t)(domain[1] - domain[0])`.

  However, in cases such as using a domain of `(-2147483648, 2147483647)` for
  an `int32_t` datatype, `domain[1] - domain[0]` will overflow and result in -1
  despite the actual range, 4294967295, being less than the max value of
  `uint64_t`.

  This fix unblocks the following Clubhouse story: https://app.clubhouse.io/tiledb-inc/story/7271/cannot-round-trip-arrayschema-repr-with-datetime-dimension

---
TYPE: BUG
DESC: Check That Dimension's Bounds Fall Within Datatype's Numeric Limit
