### PR TITLE
Create class ByteVecValue from typedef

### DIFF
--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -108,10 +108,8 @@ TEST_CASE_METHOD(
   NDRange domain = {Range(&domain_vec[0], size), Range(&domain_vec[2], size)};
   std::vector<int32_t> tile_extents_vec = {2, 5};
   std::vector<ByteVecValue> tile_extents(2);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extents_vec[0], sizeof(int32_t));
-  tile_extents[1].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[1][0], &tile_extents_vec[1], sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extents_vec[0]);
+  tile_extents[1].assign_as<int32_t>(tile_extents_vec[1]);
   Layout layout = Layout::ROW_MAJOR;
 
   // Tile coords

--- a/test/src/unit-TileDomain.cc
+++ b/test/src/unit-TileDomain.cc
@@ -39,8 +39,7 @@ using namespace tiledb::sm;
 TEST_CASE("TileDomain: Test 1D", "[TileDomain][1d]") {
   int32_t tile_extent_v = 10;
   std::vector<ByteVecValue> tile_extents(1);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extent_v, sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extent_v);
   Layout layout = Layout::ROW_MAJOR;
 
   auto size = 2 * sizeof(int32_t);
@@ -75,10 +74,8 @@ TEST_CASE(
   std::vector<int32_t> domain_slice = {1, 10, 1, 10};
   std::vector<int32_t> tile_extents_vec = {2, 5};
   std::vector<ByteVecValue> tile_extents(2);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extents_vec[0], sizeof(int32_t));
-  tile_extents[1].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[1][0], &tile_extents_vec[1], sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extents_vec[0]);
+  tile_extents[1].assign_as<int32_t>(tile_extents_vec[1]);
   Layout layout = Layout::ROW_MAJOR;
 
   auto size = 2 * (sizeof(int32_t));
@@ -120,10 +117,8 @@ TEST_CASE(
   std::vector<int32_t> domain_slice = {4, 10, 2, 8};
   std::vector<int32_t> tile_extents_vec = {2, 5};
   std::vector<ByteVecValue> tile_extents(2);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extents_vec[0], sizeof(int32_t));
-  tile_extents[1].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[1][0], &tile_extents_vec[1], sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extents_vec[0]);
+  tile_extents[1].assign_as<int32_t>(tile_extents_vec[1]);
   Layout layout = Layout::ROW_MAJOR;
 
   auto size = 2 * (sizeof(int32_t));
@@ -160,10 +155,8 @@ TEST_CASE(
   std::vector<int32_t> domain_slice = {1, 10, 1, 10};
   std::vector<int32_t> tile_extents_vec = {2, 5};
   std::vector<ByteVecValue> tile_extents(2);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extents_vec[0], sizeof(int32_t));
-  tile_extents[1].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[1][0], &tile_extents_vec[1], sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extents_vec[0]);
+  tile_extents[1].assign_as<int32_t>(tile_extents_vec[1]);
   Layout layout = Layout::COL_MAJOR;
 
   auto size = 2 * (sizeof(int32_t));
@@ -200,10 +193,8 @@ TEST_CASE(
   std::vector<int32_t> domain_slice = {4, 10, 2, 8};
   std::vector<int32_t> tile_extents_vec = {2, 5};
   std::vector<ByteVecValue> tile_extents(2);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extents_vec[0], sizeof(int32_t));
-  tile_extents[1].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[1][0], &tile_extents_vec[1], sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extents_vec[0]);
+  tile_extents[1].assign_as<int32_t>(tile_extents_vec[1]);
   Layout layout = Layout::COL_MAJOR;
 
   auto size = 2 * (sizeof(int32_t));
@@ -239,10 +230,8 @@ TEST_CASE(
   std::vector<int32_t> domain_slice = {4, 10, 12, 18};
   std::vector<int32_t> tile_extents_vec = {2, 5};
   std::vector<ByteVecValue> tile_extents(2);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extents_vec[0], sizeof(int32_t));
-  tile_extents[1].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[1][0], &tile_extents_vec[1], sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extents_vec[0]);
+  tile_extents[1].assign_as<int32_t>(tile_extents_vec[1]);
   Layout layout = Layout::COL_MAJOR;
 
   auto size = 2 * (sizeof(int32_t));
@@ -273,10 +262,8 @@ TEST_CASE(
   std::vector<int32_t> domain_slice = {2, 10, 12, 18};
   std::vector<int32_t> tile_extents_vec = {2, 5};
   std::vector<ByteVecValue> tile_extents(2);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extents_vec[0], sizeof(int32_t));
-  tile_extents[1].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[1][0], &tile_extents_vec[1], sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extents_vec[0]);
+  tile_extents[1].assign_as<int32_t>(tile_extents_vec[1]);
   Layout layout = Layout::COL_MAJOR;
 
   auto size = 2 * (sizeof(int32_t));
@@ -312,10 +299,8 @@ TEST_CASE(
   std::vector<int32_t> domain_slice = {2, 10, 12, 18};
   std::vector<int32_t> tile_extents_vec = {2, 5};
   std::vector<ByteVecValue> tile_extents(2);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extents_vec[0], sizeof(int32_t));
-  tile_extents[1].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[1][0], &tile_extents_vec[1], sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extents_vec[0]);
+  tile_extents[1].assign_as<int32_t>(tile_extents_vec[1]);
   Layout layout = Layout::COL_MAJOR;
 
   auto size = 2 * (sizeof(int32_t));
@@ -340,10 +325,8 @@ TEST_CASE("TileDomain: Test 2D, covers", "[TileDomain][2d][covers]") {
   std::vector<int32_t> domain_slice_2 = {3, 6, 1, 7};
   std::vector<int32_t> tile_extents_vec = {2, 5};
   std::vector<ByteVecValue> tile_extents(2);
-  tile_extents[0].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[0][0], &tile_extents_vec[0], sizeof(int32_t));
-  tile_extents[1].resize(sizeof(int32_t));
-  std::memcpy(&tile_extents[1][0], &tile_extents_vec[1], sizeof(int32_t));
+  tile_extents[0].assign_as<int32_t>(tile_extents_vec[0]);
+  tile_extents[1].assign_as<int32_t>(tile_extents_vec[1]);
   Layout layout = Layout::COL_MAJOR;
 
   auto size = 2 * (sizeof(int32_t));

--- a/test/src/unit-dimension.cc
+++ b/test/src/unit-dimension.cc
@@ -527,10 +527,10 @@ TEST_CASE(
   auto max_bucket_val = ((uint64_t)1 << bits) - 1;
 
   auto val = d1.map_from_uint64(64424509, bits, max_bucket_val);
-  auto val_int32 = *(const int32_t*)(&val[0]);
+  auto val_int32 = *(const int32_t*)(val.data());
   CHECK(val_int32 == 3);
   val = d1.map_from_uint64(42949672, bits, max_bucket_val);
-  val_int32 = *(const int32_t*)(&val[0]);
+  val_int32 = *(const int32_t*)(val.data());
   CHECK(val_int32 == 2);
 }
 
@@ -548,10 +548,10 @@ TEST_CASE(
   auto max_bucket_val = ((uint64_t)1 << bits) - 1;
 
   auto val = d1.map_from_uint64(64424509, bits, max_bucket_val);
-  auto val_int32 = *(const int32_t*)(&val[0]);
+  auto val_int32 = *(const int32_t*)(val.data());
   CHECK(val_int32 == -47);
   val = d1.map_from_uint64(42949672, bits, max_bucket_val);
-  val_int32 = *(const int32_t*)(&val[0]);
+  val_int32 = *(const int32_t*)(val.data());
   CHECK(val_int32 == -48);
 }
 
@@ -569,10 +569,10 @@ TEST_CASE(
   auto max_bucket_val = ((uint64_t)1 << bits) - 1;
 
   auto val = d1.map_from_uint64(1503238527, bits, max_bucket_val);
-  auto val_int32 = *(const float*)(&val[0]);
+  auto val_int32 = *(const float*)(val.data());
   CHECK(round(100 * val_int32) == 70);
   val = d1.map_from_uint64(429496735, bits, max_bucket_val);
-  val_int32 = *(const float*)(&val[0]);
+  val_int32 = *(const float*)(val.data());
   CHECK(round(100 * val_int32) == 20);
 }
 
@@ -590,19 +590,19 @@ TEST_CASE(
   std::string v_str = std::string("star\0\0\0\0", 8);
   auto v = d1.map_to_uint64(v_str.data(), v_str.size(), bits, max_bucket_val);
   auto val = d1.map_from_uint64(v, bits, max_bucket_val);
-  auto val_str = std::string((const char*)(&val[0]), 8);
+  auto val_str = std::string((const char*)(val.data()), 8);
   CHECK(val_str == v_str);
 
   v_str = std::string("blue\0\0\0\0", 8);
   v = d1.map_to_uint64(v_str.data(), v_str.size(), bits, max_bucket_val);
   val = d1.map_from_uint64(v, bits, max_bucket_val);
-  val_str = std::string((const char*)(&val[0]), 4);
+  val_str = std::string((const char*)(val.data()), 4);
   CHECK(val_str == std::string("blud", 4));
 
   v_str = std::string("yellow\0\0", 8);
   v = d1.map_to_uint64(v_str.data(), v_str.size(), bits, max_bucket_val);
   val = d1.map_from_uint64(v, bits, max_bucket_val);
-  val_str = std::string((const char*)(&val[0]), 4);
+  val_str = std::string((const char*)(val.data()), 4);
   CHECK(val_str == std::string("yell", 4));
 }
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -151,6 +151,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/metadata/metadata.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/cancelable_tasks.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/constants.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/types.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/uri.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/utils.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/uuid.cc

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -118,7 +118,7 @@ Status Attribute::deserialize(ConstBuffer* buff, const uint32_t version) {
     assert(fill_value_size > 0);
     fill_value_.resize(fill_value_size);
     fill_value_.shrink_to_fit();
-    RETURN_NOT_OK(buff->read(&fill_value_[0], fill_value_size));
+    RETURN_NOT_OK(buff->read(fill_value_.data(), fill_value_size));
   } else {
     set_default_fill_value();
   }
@@ -196,7 +196,7 @@ Status Attribute::serialize(Buffer* buff, const uint32_t version) {
     auto fill_value_size = (uint64_t)fill_value_.size();
     assert(fill_value_size != 0);
     RETURN_NOT_OK(buff->write(&fill_value_size, sizeof(uint64_t)));
-    RETURN_NOT_OK(buff->write(&fill_value_[0], fill_value_.size()));
+    RETURN_NOT_OK(buff->write(fill_value_.data(), fill_value_.size()));
   }
 
   // Write nullable
@@ -277,7 +277,7 @@ Status Attribute::set_fill_value(const void* value, uint64_t size) {
 
   fill_value_.resize(size);
   fill_value_.shrink_to_fit();
-  std::memcpy(&fill_value_[0], value, size);
+  std::memcpy(fill_value_.data(), value, size);
 
   return Status::Ok();
 }
@@ -328,7 +328,7 @@ Status Attribute::set_fill_value(
 
   fill_value_.resize(size);
   fill_value_.shrink_to_fit();
-  std::memcpy(&fill_value_[0], value, size);
+  std::memcpy(fill_value_.data(), value, size);
   fill_value_validity_ = valid;
 
   return Status::Ok();
@@ -390,7 +390,7 @@ void Attribute::set_default_fill_value() {
   fill_value_.resize(cell_num * fill_size);
   fill_value_.shrink_to_fit();
   uint64_t offset = 0;
-  auto buff = (unsigned char*)&fill_value_[0];
+  auto buff = (unsigned char*)fill_value_.data();
   for (uint64_t i = 0; i < cell_num; ++i) {
     std::memcpy(buff + offset, fill_value, fill_size);
     offset += fill_size;

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -270,12 +270,12 @@ Status Dimension::deserialize(
   }
 
   // Load tile extent
-  tile_extent_.clear();
+  tile_extent_.assign_as_void();
   uint8_t null_tile_extent;
   RETURN_NOT_OK(buff->read(&null_tile_extent, sizeof(uint8_t)));
   if (null_tile_extent == 0) {
     tile_extent_.resize(coord_size());
-    RETURN_NOT_OK(buff->read(&tile_extent_[0], coord_size()));
+    RETURN_NOT_OK(buff->read(tile_extent_.data(), coord_size()));
   }
 
   set_ceil_to_tile_func();
@@ -344,22 +344,21 @@ void Dimension::ceil_to_tile(
     const Dimension* dim, const Range& r, uint64_t tile_num, ByteVecValue* v) {
   assert(dim != nullptr);
   assert(!r.empty());
-  assert(v != nullptr);
-  assert(!dim->tile_extent().empty());
+  assert(dim->tile_extent());
 
   auto tile_extent = *(const T*)dim->tile_extent().data();
   auto dim_dom = (const T*)dim->domain().data();
-  v->resize(sizeof(T));
   auto r_t = (const T*)r.data();
 
   T mid = tile_coord_low(tile_num + 1, r_t[0], tile_extent);
   uint64_t div = tile_idx(mid, dim_dom[0], tile_extent);
   T floored_mid = tile_coord_low(div, dim_dom[0], tile_extent);
-  T sp = (std::is_integral<T>::value) ?
-             floored_mid - 1 :
-             static_cast<T>(
-                 std::nextafter(floored_mid, std::numeric_limits<T>::lowest()));
-  std::memcpy(&(*v)[0], &sp, sizeof(T));
+  assert(v != nullptr);
+  v->assign_as<T>(
+      (std::is_integral<T>::value) ?
+          floored_mid - 1 :
+          static_cast<T>(
+              std::nextafter(floored_mid, std::numeric_limits<T>::lowest())));
 }
 
 void Dimension::ceil_to_tile(
@@ -395,7 +394,7 @@ template <class T>
 bool Dimension::coincides_with_tiles(const Dimension* dim, const Range& r) {
   assert(dim != nullptr);
   assert(!r.empty());
-  assert(!dim->tile_extent().empty());
+  assert(dim->tile_extent());
 
   auto dim_domain = (const T*)dim->domain().data();
   auto tile_extent = *(const T*)dim->tile_extent().data();
@@ -588,7 +587,7 @@ void Dimension::expand_to_tile(const Dimension* dim, Range* range) {
   assert(!range->empty());
 
   // Applicable only to regular tiles and integral domains
-  if (dim->tile_extent().empty() || !std::is_integral<T>::value)
+  if (!dim->tile_extent() || !std::is_integral<T>::value)
     return;
 
   auto tile_extent = *(const T*)dim->tile_extent().data();
@@ -837,14 +836,14 @@ double Dimension::overlap_ratio(const Range& r1, const Range& r2) const {
 template <>
 void Dimension::split_range<char>(
     const Range& r, const ByteVecValue& v, Range* r1, Range* r2) {
-  assert(!v.empty());
+  assert(v);
   assert(r1 != nullptr);
   assert(r2 != nullptr);
 
   // First range
   auto min_string = std::string("\x0", 1);
   auto new_r1_start = !r.start_str().empty() ? r.start_str() : min_string;
-  auto new_r1_end = std::string((const char*)v.data(), v.size());
+  auto new_r1_end = v.rvalue_as<std::string>();
   auto new_r1_end_size = (int)new_r1_end.size();
   int pos;
   for (pos = 0; pos < new_r1_end_size; ++pos) {
@@ -858,7 +857,7 @@ void Dimension::split_range<char>(
   r1->set_str_range(new_r1_start, new_r1_end);
 
   // Second range
-  auto new_r2_start = std::string((const char*)v.data(), v.size());
+  auto new_r2_start = v.rvalue_as<std::string>();
   // The following will make "a b -1 -4 0" -> "a c"
   for (pos = 0; pos < new_r1_end_size; ++pos) {
     if ((int)(signed char)new_r2_start[pos] < 0)
@@ -888,14 +887,14 @@ template <class T>
 void Dimension::split_range(
     const Range& r, const ByteVecValue& v, Range* r1, Range* r2) {
   assert(!r.empty());
-  assert(!v.empty());
+  assert(v);
   assert(r1 != nullptr);
   assert(r2 != nullptr);
 
   auto max = std::numeric_limits<T>::max();
   bool int_domain = std::is_integral<T>::value;
   auto r_t = (const T*)r.data();
-  auto v_t = *(const T*)(&v[0]);
+  auto v_t = *(const T*)(v.data());
   assert(v_t >= r_t[0]);
   assert(v_t < r_t[1]);
 
@@ -1010,8 +1009,7 @@ void Dimension::splitting_value(
   // the split value.
   const T sp = r_t[0] + static_cast<T>(r_t1.to_ullong());
 
-  v->resize(sizeof(T));
-  std::memcpy(&(*v)[0], &sp, sizeof(T));
+  v->assign_as<T>(sp);
   *unsplittable = !std::memcmp(&sp, &r_t[1], sizeof(T));
 }
 
@@ -1028,8 +1026,7 @@ void Dimension::splitting_value<float>(
   // dividing by 2.
   const float sp = r_t[0] + ((double)r_t[1] - (double)r_t[0]) / 2;
 
-  v->resize(sizeof(float));
-  std::memcpy(&(*v)[0], &sp, sizeof(float));
+  v->assign_as<float>(sp);
   *unsplittable = !std::memcmp(&sp, &r_t[1], sizeof(float));
 }
 
@@ -1046,8 +1043,7 @@ void Dimension::splitting_value<double>(
   // before dividing by 2.
   const double sp = r_t[0] + ((long double)r_t[1] - (long double)r_t[0]) / 2;
 
-  v->resize(sizeof(double));
-  std::memcpy(&(*v)[0], &sp, sizeof(double));
+  v->assign_as<double>(sp);
   *unsplittable = !std::memcmp(&sp, &r_t[1], sizeof(double));
 }
 
@@ -1071,7 +1067,7 @@ uint64_t Dimension::tile_num(const Dimension* dim, const Range& range) {
   assert(!range.empty());
 
   // Trivial cases
-  if (dim->tile_extent().empty())
+  if (!dim->tile_extent())
     return 1;
 
   auto tile_extent = *(const T*)dim->tile_extent().data();
@@ -1319,13 +1315,13 @@ ByteVecValue Dimension::map_from_uint64(
     T norm_coord_T =
         ceil(((value + 1) / (double)max_bucket_val) * dom_range_T - 1);
     T coord_T = norm_coord_T + dom_start_T;
-    std::memcpy(&ret[0], &coord_T, sizeof(T));
+    std::memcpy(ret.data(), &coord_T, sizeof(T));
   } else {  // Floating point types
     T norm_coord_T = ((value + 1) / (double)max_bucket_val) * dom_range_T;
     norm_coord_T =
         std::nextafter(norm_coord_T, std::numeric_limits<T>::lowest());
     T coord_T = norm_coord_T + dom_start_T;
-    std::memcpy(&ret[0], &coord_T, sizeof(T));
+    std::memcpy(ret.data(), &coord_T, sizeof(T));
   }
 
   return ret;
@@ -1338,7 +1334,7 @@ ByteVecValue Dimension::map_from_uint64<char>(
   (void)dim;
   (void)max_bucket_val;  // Not needed here
 
-  ByteVecValue ret(sizeof(uint64_t));  // 8 bytes
+  std::vector<uint8_t> ret(sizeof(uint64_t));  // 8 bytes
 
   uint64_t ret_uint64 = (value << (64 - bits));
   int ret_c;
@@ -1355,7 +1351,7 @@ ByteVecValue Dimension::map_from_uint64<char>(
   if (ret.back() != 128)
     ret.push_back(128);
 
-  return ret;
+  return ByteVecValue(std::move(ret));
 }
 
 bool Dimension::smaller_than(
@@ -1369,9 +1365,9 @@ bool Dimension::smaller_than(
     const Dimension* dim, const ByteVecValue& value, const Range& range) {
   assert(dim != nullptr);
   (void)dim;
-  assert(!value.empty());
+  assert(value);
 
-  auto value_T = *(const T*)(&value[0]);
+  auto value_T = *(const T*)(value.data());
   auto range_start_T = *(const T*)range.start();
   return value_T < range_start_T;
 }
@@ -1380,10 +1376,10 @@ template <>
 bool Dimension::smaller_than<char>(
     const Dimension* dim, const ByteVecValue& value, const Range& range) {
   assert(dim != nullptr);
-  assert(!value.empty());
+  assert(value);
   (void)dim;
 
-  auto value_str = std::string((const char*)&value[0], value.size());
+  auto value_str = value.rvalue_as<std::string>();
   auto range_start_str = range.start_str();
   auto range_end_str = range.end_str();
 
@@ -1432,9 +1428,9 @@ Status Dimension::serialize(Buffer* buff, uint32_t version) {
   RETURN_NOT_OK(buff->write(&domain_size, sizeof(uint64_t)));
   RETURN_NOT_OK(buff->write(domain_.data(), domain_size));
 
-  auto null_tile_extent = (uint8_t)((tile_extent_.empty()) ? 1 : 0);
+  auto null_tile_extent = (uint8_t)(tile_extent_ ? 0 : 1);
   RETURN_NOT_OK(buff->write(&null_tile_extent, sizeof(uint8_t)));
-  if (!tile_extent_.empty())
+  if (tile_extent_)
     RETURN_NOT_OK(buff->write(tile_extent_.data(), tile_extent_.size()));
 
   return Status::Ok();
@@ -1495,7 +1491,7 @@ Status Dimension::set_tile_extent(const void* tile_extent) {
   if (tile_extent != nullptr) {
     auto size = coord_size();
     te.resize(size);
-    std::memcpy(&te[0], tile_extent, size);
+    std::memcpy(te.data(), tile_extent, size);
   }
 
   return set_tile_extent(te);
@@ -1503,7 +1499,7 @@ Status Dimension::set_tile_extent(const void* tile_extent) {
 
 Status Dimension::set_tile_extent(const ByteVecValue& tile_extent) {
   if (type_ == Datatype::STRING_ASCII) {
-    if (tile_extent.empty())
+    if (!tile_extent)
       return Status::Ok();
     return LOG_STATUS(Status::DimensionError(
         std::string("Setting the tile extent to a dimension with type '") +
@@ -1580,7 +1576,7 @@ Status Dimension::set_null_tile_extent_to_range() {
 template <class T>
 Status Dimension::set_null_tile_extent_to_range() {
   // Applicable only to null extents
-  if (!tile_extent_.empty())
+  if (tile_extent_)
     return Status::Ok();
 
   // Check empty domain
@@ -1611,11 +1607,7 @@ Status Dimension::set_null_tile_extent_to_range() {
     // domain range
   }
 
-  // Allocate space
-  uint64_t type_size = sizeof(T);
-  tile_extent_.resize(type_size);
-  std::memcpy(&tile_extent_[0], &tile_extent, type_size);
-
+  tile_extent_.assign_as<T>(tile_extent);
   return Status::Ok();
 }
 
@@ -1743,7 +1735,7 @@ Status Dimension::check_tile_extent() const {
     return LOG_STATUS(
         Status::DimensionError("Tile extent check failed; Domain not set"));
 
-  if (tile_extent_.empty())
+  if (!tile_extent_)
     return Status::Ok();
 
   auto tile_extent = (const T*)tile_extent_.data();
@@ -1922,7 +1914,7 @@ std::string Dimension::domain_str() const {
 std::string Dimension::tile_extent_str() const {
   std::stringstream ss;
 
-  if (tile_extent_.empty())
+  if (!tile_extent_)
     return constants::null_str;
 
   const float* tile_extent_float32;

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -565,7 +565,7 @@ Status Domain::init(Layout cell_order, Layout tile_order) {
 
 bool Domain::null_tile_extents() const {
   for (unsigned d = 0; d < dim_num_; ++d) {
-    if (tile_extent(d).empty())
+    if (!tile_extent(d))
       return true;
   }
 
@@ -698,7 +698,7 @@ double Domain::overlap_ratio(const NDRange& r1, const NDRange& r2) const {
 template <class T>
 int Domain::tile_order_cmp(
     const Dimension* dim, const void* coord_a, const void* coord_b) {
-  if (dim->tile_extent().empty())
+  if (!dim->tile_extent())
     return 0;
 
   auto tile_extent = *(const T*)dim->tile_extent().data();
@@ -722,8 +722,8 @@ int Domain::tile_order_cmp(
     for (unsigned d = 0; d < dim_num_; ++d) {
       auto dim = dimension(d);
 
-      // Inapplicable to var-sized dimensions or empty tile extents
-      if (dim->var_size() || dim->tile_extent().empty())
+      // Inapplicable to var-sized dimensions or absent tile extents
+      if (dim->var_size() || !dim->tile_extent())
         continue;
 
       auto coord_size = dim->coord_size();
@@ -739,8 +739,8 @@ int Domain::tile_order_cmp(
     for (unsigned d = dim_num_ - 1;; --d) {
       auto dim = dimension(d);
 
-      // Inapplicable to var-sized dimensions or empty tile extents
-      if (!dim->var_size() && !dim->tile_extent().empty()) {
+      // Inapplicable to var-sized dimensions or absent tile extents
+      if (!dim->var_size() && dim->tile_extent()) {
         auto coord_size = dim->coord_size();
         auto ca = &(((unsigned char*)coord_buffs[d]->buffer_)[a * coord_size]);
         auto cb = &(((unsigned char*)coord_buffs[d]->buffer_)[b * coord_size]);

--- a/tiledb/sm/misc/types.cc
+++ b/tiledb/sm/misc/types.cc
@@ -1,0 +1,45 @@
+/**
+ * @file   types.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines common types for Query/Write/Read class usage
+ */
+
+#include "tiledb/sm/misc/types.h"
+
+namespace tiledb {
+namespace sm {
+
+template <>
+std::string ByteVecValue::rvalue_as<std::string>() const {
+  return std::string(
+      reinterpret_cast<const std::string::value_type*>(x.data()), x.size());
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/misc/types.cc
+++ b/tiledb/sm/misc/types.cc
@@ -38,7 +38,7 @@ namespace sm {
 template <>
 std::string ByteVecValue::rvalue_as<std::string>() const {
   return std::string(
-      reinterpret_cast<const std::string::value_type*>(x.data()), x.size());
+      reinterpret_cast<const std::string::value_type*>(x_.data()), x_.size());
 }
 
 }  // namespace sm

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -358,12 +358,6 @@ class ByteVecValue {
   }
 };
 
-template <>
-std::string ByteVecValue::rvalue_as<std::string>() const {
-  return std::string(
-      reinterpret_cast<const std::string::value_type*>(x.data()), x.size());
-}
-
 /** A byte vector. */
 typedef std::vector<uint8_t> ByteVec;
 

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -275,22 +275,22 @@ typedef std::vector<Range> NDRange;
 
 class ByteVecValue {
   typedef std::vector<uint8_t> Base;
-  std::vector<uint8_t> x;
+  std::vector<uint8_t> x_;
 
  public:
   typedef Base::size_type size_type;
   typedef Base::reference reference;
   /** Default constructor */
   ByteVecValue()
-      : x() {
+      : x_() {
   }
   /** Fixed-size constructor */
   explicit ByteVecValue(Base::size_type n)
-      : x(n) {
+      : x_(n) {
   }
   /** Move constructor from underlying vector type */
   explicit ByteVecValue(std::vector<uint8_t>&& y)
-      : x(std::move(y)) {
+      : x_(std::move(y)) {
   }
 
   /**
@@ -305,7 +305,7 @@ class ByteVecValue {
   template <class T>
   T& assign_as(T val = T()) {
     if (size() < sizeof(T))
-      x.resize(sizeof(T));
+      x_.resize(sizeof(T));
     T& a = *reinterpret_cast<T*>(data());
     a = val;
     return a;
@@ -313,7 +313,7 @@ class ByteVecValue {
 
   /// Remove any existing value.
   void assign_as_void() noexcept {
-    x.clear();
+    x_.clear();
   }
 
   /**
@@ -331,30 +331,30 @@ class ByteVecValue {
 
   /// Forwarded from vector
   void resize(size_type count) {
-    x.resize(count);
+    x_.resize(count);
   }
   /// Forwarded from vector
   void shrink_to_fit() {
-    x.shrink_to_fit();
+    x_.shrink_to_fit();
   }
   /// Forwarded from vector
   uint8_t* data() noexcept {
-    return x.data();
+    return x_.data();
   }
   /// Forwarded from vector
   const uint8_t* data() const noexcept {
-    return x.data();
+    return x_.data();
   }
   /// Forwarded from vector
   Base::size_type size() const noexcept {
-    return x.size();
+    return x_.size();
   }
   /**
    * Conversion to boolean in the style of std::optional.
    * @return True if a value is present, false otherwise.
    */
   explicit operator bool() const noexcept {
-    return !x.empty();
+    return !x_.empty();
   }
 };
 

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -260,14 +260,114 @@ class Range {
 /** An N-dimensional range, consisting of a vector of 1D ranges. */
 typedef std::vector<Range> NDRange;
 
-/** A value as a vector of bytes. */
-typedef std::vector<uint8_t> ByteVecValue;
+/** An untyped value, barely more than raw storage. This class is only
+ * transitional. All uses should be rewritten to use ordinary types. Consider
+ * it deprecated at creation.
+ *
+ * This class started off as a typedef for a byte vector. In its current state,
+ * it provides methods that capture common patterns of usage, avoiding bleeding
+ * all its abstraction into calling code. It's not perfect, and never will be.
+ *
+ * A minimal number of vector methods are forwarded outside the class to allow
+ * not-yet-converted code its legacy behavior. The incremental goal is to remove
+ * such functions as the code base evolves away from untyped variables entirely.
+ */
+
+class ByteVecValue {
+  typedef std::vector<uint8_t> Base;
+  std::vector<uint8_t> x;
+
+ public:
+  typedef Base::size_type size_type;
+  typedef Base::reference reference;
+  /** Default constructor */
+  ByteVecValue()
+      : x() {
+  }
+  /** Fixed-size constructor */
+  explicit ByteVecValue(Base::size_type n)
+      : x(n) {
+  }
+  /** Move constructor from underlying vector type */
+  explicit ByteVecValue(std::vector<uint8_t>&& y)
+      : x(std::move(y)) {
+  }
+
+  /**
+   * Performs an assignment as if a variable of type T were located at the
+   * beginning of storage.
+   *
+   * @post size() >= sizeof(T)
+   *
+   * @tparam T
+   * @return A reference to the phantom variable which was assigned.
+   */
+  template <class T>
+  T& assign_as(T val = T()) {
+    if (size() < sizeof(T))
+      x.resize(sizeof(T));
+    T& a = *reinterpret_cast<T*>(data());
+    a = val;
+    return a;
+  }
+
+  /// Remove any existing value.
+  void assign_as_void() noexcept {
+    x.clear();
+  }
+
+  /**
+   * Returns the value of a variable of type T as if it were located at the
+   * beginning of storage.
+   *
+   * Intentionally unimplemented in general and only certain specializations
+   * are available.
+   *
+   * @tparam T
+   * @return
+   */
+  template <class T>
+  T rvalue_as() const;
+
+  template <>
+  std::string rvalue_as<std::string>() const {
+    return std::string(
+        reinterpret_cast<const std::string::value_type*>(x.data()), x.size());
+  }
+
+  /// Forwarded from vector
+  void resize(size_type count) {
+    x.resize(count);
+  }
+  /// Forwarded from vector
+  void shrink_to_fit() {
+    x.shrink_to_fit();
+  }
+  /// Forwarded from vector
+  uint8_t* data() noexcept {
+    return x.data();
+  }
+  /// Forwarded from vector
+  const uint8_t* data() const noexcept {
+    return x.data();
+  }
+  /// Forwarded from vector
+  Base::size_type size() const noexcept {
+    return x.size();
+  }
+  /**
+   * Conversion to boolean in the style of std::optional.
+   * @return True if a value is present, false otherwise.
+   */
+  explicit operator bool() const noexcept {
+    return !x.empty();
+  }
+};
 
 /** A byte vector. */
 typedef std::vector<uint8_t> ByteVec;
 
 }  // namespace sm
-
 }  // namespace tiledb
 
 #endif  // TILEDB_TYPES_H

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -329,12 +329,6 @@ class ByteVecValue {
   template <class T>
   T rvalue_as() const;
 
-  template <>
-  std::string rvalue_as<std::string>() const {
-    return std::string(
-        reinterpret_cast<const std::string::value_type*>(x.data()), x.size());
-  }
-
   /// Forwarded from vector
   void resize(size_type count) {
     x.resize(count);
@@ -363,6 +357,12 @@ class ByteVecValue {
     return !x.empty();
   }
 };
+
+template <>
+std::string ByteVecValue::rvalue_as<std::string>() const {
+  return std::string(
+      reinterpret_cast<const std::string::value_type*>(x.data()), x.size());
+}
 
 /** A byte vector. */
 typedef std::vector<uint8_t> ByteVec;

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -458,7 +458,7 @@ void DenseTiler<T>::calculate_tile_and_subarray_strides() {
     tile_strides_el_[dim_num - 1] = 1;
     if (dim_num > 1) {
       for (auto d = dim_num - 2; d >= 0; --d) {
-        auto tile_extent = (const T*)(&domain->tile_extent(d + 1)[0]);
+        auto tile_extent = (const T*)(domain->tile_extent(d + 1).data());
         assert(tile_extent != nullptr);
         tile_strides_el_[d] = Dimension::tile_extent_mult<T>(
             tile_strides_el_[d + 1], *tile_extent);
@@ -468,7 +468,7 @@ void DenseTiler<T>::calculate_tile_and_subarray_strides() {
     tile_strides_el_[0] = 1;
     if (dim_num > 1) {
       for (auto d = 1; d < dim_num; ++d) {
-        auto tile_extent = (const T*)(&domain->tile_extent(d - 1)[0]);
+        auto tile_extent = (const T*)(domain->tile_extent(d - 1).data());
         assert(tile_extent != nullptr);
         tile_strides_el_[d] = Dimension::tile_extent_mult<T>(
             tile_strides_el_[d - 1], *tile_extent);

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -260,7 +260,7 @@ Status dimension_to_capnp(
 
   dimension_builder->setName(dimension->name());
   dimension_builder->setType(datatype_str(dimension->type()));
-  dimension_builder->setNullTileExtent(dimension->tile_extent().empty());
+  dimension_builder->setNullTileExtent(!dimension->tile_extent());
 
   // Only set the domain if its not empty/null. String dimensions have null
   // domains
@@ -271,7 +271,7 @@ Status dimension_to_capnp(
   }
 
   // Only set the tile extent if its not empty
-  if (!dimension->tile_extent().empty()) {
+  if (dimension->tile_extent()) {
     auto tile_extent_builder = dimension_builder->initTileExtent();
     RETURN_NOT_OK(utils::set_capnp_scalar(
         tile_extent_builder,


### PR DESCRIPTION
This PR is a transitional change toward eliminating untyped variables. It converts typedef `ByteVecValue` into a class. It has a number of methods to substitute for existing patterns of use, hiding implementation details and highlighting the results. Not all of these can be changed in this initial PR. In some cases no class exists that would adequately capture how the variable is being used. In other cases there are interactions with untyped read/write from buffers that need modifications in those classes.

A number of vector methods are forwarded for legacy behavior. Not all of them could be, but notably there's no more use of `operator[]`. It is not a goal of this PR to eliminate all of them; it will have to be a multi-step process.

The scope of this PR is to make just the changes already here. It's intent is to be pure refactoring, with zero changes in behavior.

---
TYPE: IMPROVEMENT
DESC: Create class ByteVecValue from typedef
