### PR TITLE
Fixes to hilbert calculations for double ranges.

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -748,7 +748,7 @@ TEST_CASE_METHOD(
     rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
     REQUIRE(rc == TILEDB_OK);
     // Check error with key
-    char key[32];
+    const char key[] = "0123456789abcdeF0123456789abcdeF";
     rc = tiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM", &err);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(err == nullptr);

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -1554,8 +1554,8 @@ TEST_CASE(
 
   // Write first fragment
   std::vector<int32_t> buff_a = {2, 3, 1, 4};
-  std::vector<float> buff_d1 = {0.1f, 0.1f, 0.4f, 0.5f};
-  std::vector<float> buff_d2 = {0.3f, 0.1f, 0.2f, 0.4f};
+  std::vector<float> buff_d1 = {0.1f, 0.100599997f, 0.4f, 0.5f};
+  std::vector<float> buff_d2 = {0.3f, 0.109373093f, 0.2f, 0.4f};
   write_2d_array<float, float>(
       array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED);
 

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -773,8 +773,24 @@ class Dimension {
    * Maps a uint64 value (produced by `map_to_uint64`) to its corresponding
    * value in the original dimension domain. `max_bucket_val` is the maximum
    * value used to discretize the original value.
+   * Applicable to integral values.
    */
-  template <class T>
+  template <
+      class T,
+      typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+  static ByteVecValue map_from_uint64(
+      const Dimension* dim, uint64_t value, int bits, uint64_t max_bucket_val);
+
+  /**
+   * Maps a uint64 value (produced by `map_to_uint64`) to its corresponding
+   * value in the original dimension domain. `max_bucket_val` is the maximum
+   * value used to discretize the original value.
+   * Applicable to floating point values.
+   */
+  template <
+      class T,
+      typename std::enable_if<std::is_floating_point<T>::value>::type* =
+          nullptr>
   static ByteVecValue map_from_uint64(
       const Dimension* dim, uint64_t value, int bits, uint64_t max_bucket_val);
 


### PR DESCRIPTION
This fixes a possible overflow with the Hilbert calculations when using
double ranges with maximum values. It also fixes the reverst calculation
of the range from the hilbert value.

---
TYPE: BUG
DESC: Fixes to hilbert calculations for double ranges.