### PR TITLE
Initial read refactor

### DIFF
--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -32,8 +32,10 @@
 
 #include "test/src/helpers.h"
 #include "test/src/vfs_helpers.h"
+#include "tiledb/sm/array_schema/tile_domain.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/query/read_cell_slab_iter.h"
+#include "tiledb/sm/query/reader.h"
 
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"

--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -101,7 +101,20 @@ TEST_CASE_METHOD(
     ReaderFx,
     "Reader: Compute result space tiles, 2D",
     "[Reader][2d][compute_result_space_tiles]") {
-  Reader reader(&g_helper_stats);
+  Config config;
+  std::unordered_map<std::string, tiledb::sm::QueryBuffer> buffers;
+  Subarray subarray;
+  QueryCondition condition;
+  Reader reader(
+      &g_helper_stats,
+      nullptr,
+      nullptr,
+      config,
+      buffers,
+      subarray,
+      Layout::ROW_MAJOR,
+      condition,
+      false);
   unsigned dim_num = 2;
   auto size = 2 * sizeof(int32_t);
   int32_t domain_vec[] = {1, 10, 1, 15};

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -748,7 +748,7 @@ TEST_CASE_METHOD(
     rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
     REQUIRE(rc == TILEDB_OK);
     // Check error with key
-    char key[32];
+    const char key[] = "0123456789abcdeF0123456789abcdeF";
     rc = tiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM", &err);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(err == nullptr);

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -250,6 +250,7 @@ void check_save_to_file() {
   ss << "sm.skip_est_size_partitioning false\n";
   ss << "sm.sub_partitioner_memory_budget 0\n";
   ss << "sm.tile_cache_size 10000000\n";
+  ss << "sm.use_refactored_readers false\n";
   ss << "sm.vacuum.mode fragments\n";
   ss << "sm.vacuum.timestamp_end " << std::to_string(UINT64_MAX) << "\n";
   ss << "sm.vacuum.timestamp_start 0\n";
@@ -538,6 +539,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.memory_budget"] = "5368709120";
   all_param_values["sm.memory_budget_var"] = "10737418240";
   all_param_values["sm.sub_partitioner_memory_budget"] = "0";
+  all_param_values["sm.use_refactored_readers"] = "false";
   all_param_values["sm.enable_signal_handlers"] = "true";
   all_param_values["sm.compute_concurrency_level"] =
       std::to_string(std::thread::hardware_concurrency());

--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -36,6 +36,8 @@
 #include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/query/reader.h"
+#include "tiledb/sm/query/writer.h"
 #include "tiledb/sm/serialization/query.h"
 
 #ifdef _WIN32
@@ -85,7 +87,7 @@ struct SerializationFx {
   }
 
   static void check_read_stats(const Query& query) {
-    auto stats = query.ptr()->query_->reader()->stats();
+    auto stats = ((sm::Writer*)query.ptr()->query_->strategy())->stats();
     REQUIRE(stats != nullptr);
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
@@ -96,7 +98,7 @@ struct SerializationFx {
   }
 
   static void check_write_stats(const Query& query) {
-    auto stats = query.ptr()->query_->writer()->stats();
+    auto stats = ((sm::Reader*)query.ptr()->query_->strategy())->stats();
     REQUIRE(stats != nullptr);
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -160,8 +160,10 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query_condition.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/reader.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/reader_base.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/result_tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/read_cell_slab_iter.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/strategy_base.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/writer.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/rest/rest_client.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/rtree/rtree.cc

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1041,6 +1041,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    query range in case sorting is much slower than the partitioning
  *    overhead. <br>
  *    **Default**: 0
+ * - `sm.use_refactored_readers` <br>
+ *    Use the refactored readers or not. <br>
+ *    **Default**: false
  * - `vfs.read_ahead_size` <br>
  *    The maximum byte size to read-ahead from the backend. <br>
  *    **Default**: 102400

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -75,6 +75,7 @@ const std::string Config::SM_SKIP_EST_SIZE_PARTITIONING = "false";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
 const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
 const std::string Config::SM_SUB_PARTITIONER_MEMORY_BUDGET = "0";
+const std::string Config::SM_USE_REFACTORED_READERS = "false";
 const std::string Config::SM_ENABLE_SIGNAL_HANDLERS = "true";
 const std::string Config::SM_COMPUTE_CONCURRENCY_LEVEL =
     utils::parse::to_str(std::thread::hardware_concurrency());
@@ -211,6 +212,7 @@ Config::Config() {
   param_values_["sm.memory_budget_var"] = SM_MEMORY_BUDGET_VAR;
   param_values_["sm.sub_partitioner_memory_budget"] =
       SM_SUB_PARTITIONER_MEMORY_BUDGET;
+  param_values_["sm.use_refactored_readers"] = SM_USE_REFACTORED_READERS;
   param_values_["sm.enable_signal_handlers"] = SM_ENABLE_SIGNAL_HANDLERS;
   param_values_["sm.compute_concurrency_level"] = SM_COMPUTE_CONCURRENCY_LEVEL;
   param_values_["sm.io_concurrency_level"] = SM_IO_CONCURRENCY_LEVEL;
@@ -465,6 +467,8 @@ Status Config::unset(const std::string& param) {
   } else if (param == "sm.sub_partitioner_memory_budget") {
     param_values_["sm.sub_partitioner_memory_budget"] =
         SM_SUB_PARTITIONER_MEMORY_BUDGET;
+  } else if (param == "sm.use_refactored_readers") {
+    param_values_["sm.use_refactored_readers"] = SM_USE_REFACTORED_READERS;
   } else if (param == "sm.enable_signal_handlers") {
     param_values_["sm.enable_signal_handlers"] = SM_ENABLE_SIGNAL_HANDLERS;
   } else if (param == "sm.compute_concurrency_level") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -154,6 +154,9 @@ class Config {
    */
   static const std::string SM_SUB_PARTITIONER_MEMORY_BUDGET;
 
+  /** Whether or not to use the refactored readers. */
+  static const std::string SM_USE_REFACTORED_READERS;
+
   /** Whether or not the signal handlers are installed. */
   static const std::string SM_ENABLE_SIGNAL_HANDLERS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -389,6 +389,9 @@ class Config {
    *    query range in case sorting is much slower than the partitioning
    *    overhead. <br>
    *    **Default**: 0
+   * - `sm.use_refactored_readers` <br>
+   *    Use the refactored readers or not. <br>
+   *    **Default**: false
    * - `vfs.read_ahead_size` <br>
    *    The maximum byte size to read-ahead from the backend. <br>
    *    **Default**: 102400

--- a/tiledb/sm/query/iquery_strategy.h
+++ b/tiledb/sm/query/iquery_strategy.h
@@ -1,0 +1,68 @@
+/**
+ * @file   iquery_strategy.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class IQueryStrategy.
+ */
+
+#ifndef TILEDB_IQUERY_STRATEGY_H
+#define TILEDB_IQUERY_STRATEGY_H
+
+#include "tiledb/common/status.h"
+#include "tiledb/sm/enums/layout.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class IQueryStrategy {
+ public:
+  /** Destructor. */
+  virtual ~IQueryStrategy() = default;
+
+  /** Initializes the strategy with the subarray layout. */
+  virtual Status init(const Layout& layout) = 0;
+
+  /** Performs a query using its set members. */
+  virtual Status dowork() = 0;
+
+  /** Finalizes the strategy. */
+  virtual Status finalize() = 0;
+
+  /** Returns of the query is incomplete. */
+  virtual bool incomplete() const = 0;
+
+  /** Resets the object */
+  virtual void reset() = 0;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_IQUERY_STRATEGY_H

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -36,7 +36,10 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/query/query_condition.h"
+#include "tiledb/sm/query/reader.h"
+#include "tiledb/sm/query/writer.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
@@ -56,35 +59,48 @@ namespace sm {
 
 Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
     : array_(array)
+    , layout_(Layout::ROW_MAJOR)
     , storage_manager_(storage_manager)
     , stats_(storage_manager_->stats()->create_child("Query"))
-    , reader_(stats_)
-    , writer_(stats_) {
-  assert(array != nullptr && array->is_open());
+    , has_coords_buffer_(false)
+    , has_zipped_coords_buffer_(false)
+    , coord_buffer_is_set_(false)
+    , coord_data_buffer_is_set_(false)
+    , coord_offsets_buffer_is_set_(false)
+    , data_buffer_name_("")
+    , offsets_buffer_name_("")
+    , disable_check_global_order_(false)
+    , sparse_mode_(false)
+    , fragment_uri_(fragment_uri) {
+  if (array != nullptr) {
+    assert(array->is_open());
+    array_schema_ = array->array_schema();
+
+    auto st = array->get_query_type(&type_);
+    assert(st.ok());
+
+    if (type_ == QueryType::WRITE) {
+      subarray_ = Subarray(array, stats_);
+    } else {
+      subarray_ = Subarray(array, Layout::ROW_MAJOR, stats_);
+    }
+
+    fragment_metadata_ = array->fragment_metadata();
+  } else {
+    type_ = QueryType::READ;
+  }
+
+  coords_info_.coords_buffer_ = nullptr;
+  coords_info_.coords_buffer_size_ = nullptr;
+  coords_info_.coords_num_ = 0;
+  coords_info_.has_coords_ = false;
 
   callback_ = nullptr;
   callback_data_ = nullptr;
-  layout_ = Layout::ROW_MAJOR;
   status_ = QueryStatus::UNINITIALIZED;
-  auto st = array->get_query_type(&type_);
-  assert(st.ok());
 
-  if (type_ == QueryType::WRITE)
-    writer_.set_storage_manager(storage_manager);
-  else
-    reader_.set_storage_manager(storage_manager);
-
-  if (type_ == QueryType::READ) {
-    reader_.set_storage_manager(storage_manager);
-    reader_.set_array(array);
-    reader_.set_array_schema(array->array_schema());
-    reader_.set_fragment_metadata(array->fragment_metadata());
-  } else {
-    writer_.set_storage_manager(storage_manager);
-    writer_.set_array(array);
-    writer_.set_array_schema(array->array_schema());
-    writer_.set_fragment_uri(fragment_uri);
-  }
+  if (storage_manager != nullptr)
+    config_ = storage_manager->config();
 }
 
 Query::~Query() = default;
@@ -95,7 +111,7 @@ Query::~Query() = default;
 
 Status Query::add_range(
     unsigned dim_idx, const void* start, const void* end, const void* stride) {
-  if (dim_idx >= array_->array_schema()->dim_num())
+  if (dim_idx >= array_schema_->dim_num())
     return LOG_STATUS(
         Status::QueryError("Cannot add range; Invalid dimension index"));
 
@@ -106,22 +122,45 @@ Status Query::add_range(
     return LOG_STATUS(Status::QueryError(
         "Cannot add range; Setting range stride is currently unsupported"));
 
-  if (array_->array_schema()->domain()->dimension(dim_idx)->var_size())
+  if (array_schema_->domain()->dimension(dim_idx)->var_size())
     return LOG_STATUS(
         Status::QueryError("Cannot add range; Range must be fixed-sized"));
 
   // Prepare a temp range
   std::vector<uint8_t> range;
-  uint8_t coord_size = array_->array_schema()->dimension(dim_idx)->coord_size();
+  uint8_t coord_size = array_schema_->dimension(dim_idx)->coord_size();
   range.resize(2 * coord_size);
   std::memcpy(&range[0], start, coord_size);
   std::memcpy(&range[coord_size], end, coord_size);
 
+  bool read_range_oob_error = true;
+  if (type_ == QueryType::READ) {
+    // Get read_range_oob config setting
+    bool found = false;
+    std::string read_range_oob = config_.get("sm.read_range_oob", &found);
+    assert(found);
+
+    if (read_range_oob != "error" && read_range_oob != "warn")
+      return LOG_STATUS(Status::QueryError(
+          "Invalid value " + read_range_oob +
+          " for sm.read_range_obb. Acceptable values are 'error' or 'warn'."));
+
+    read_range_oob_error = read_range_oob == "error";
+  } else {
+    if (!array_schema_->dense())
+      return LOG_STATUS(
+          Status::QueryError("Adding a subarray range to a write query is not "
+                             "supported in sparse arrays"));
+
+    if (subarray_.is_set(dim_idx))
+      return LOG_STATUS(
+          Status::QueryError("Cannot add range; Multi-range dense writes "
+                             "are not supported"));
+  }
+
   // Add range
   Range r(&range[0], 2 * coord_size);
-  if (type_ == QueryType::WRITE)
-    return writer_.add_range(dim_idx, std::move(r));
-  return reader_.add_range(dim_idx, std::move(r));
+  return subarray_.add_range(dim_idx, std::move(r), read_range_oob_error);
 }
 
 Status Query::add_range_var(
@@ -130,7 +169,7 @@ Status Query::add_range_var(
     uint64_t start_size,
     const void* end,
     uint64_t end_size) {
-  if (dim_idx >= array_->array_schema()->dim_num())
+  if (dim_idx >= array_schema_->dim_num())
     return LOG_STATUS(
         Status::QueryError("Cannot add range; Invalid dimension index"));
 
@@ -141,7 +180,7 @@ Status Query::add_range_var(
     return LOG_STATUS(Status::QueryError(
         "Cannot add range; Range start/end cannot have zero length"));
 
-  if (!array_->array_schema()->domain()->dimension(dim_idx)->var_size())
+  if (!array_schema_->domain()->dimension(dim_idx)->var_size())
     return LOG_STATUS(
         Status::QueryError("Cannot add range; Range must be variable-sized"));
 
@@ -149,16 +188,29 @@ Status Query::add_range_var(
     return LOG_STATUS(Status::QueryError(
         "Cannot add range; Function applicable only to reads"));
 
+  // Get read_range_oob config setting
+  bool found = false;
+  std::string read_range_oob = config_.get("sm.read_range_oob", &found);
+  assert(found);
+
+  if (read_range_oob != "error" && read_range_oob != "warn")
+    return LOG_STATUS(Status::QueryError(
+        "Invalid value " + read_range_oob +
+        " for sm.read_range_obb. Acceptable values are 'error' or 'warn'."));
+
   // Add range
   Range r;
   r.set_range_var(start, start_size, end, end_size);
-  return reader_.add_range(dim_idx, std::move(r));
+  return subarray_.add_range(dim_idx, std::move(r), read_range_oob == "error");
 }
 
 Status Query::get_range_num(unsigned dim_idx, uint64_t* range_num) const {
-  if (type_ == QueryType::WRITE)
-    return writer_.get_range_num(dim_idx, range_num);
-  return reader_.get_range_num(dim_idx, range_num);
+  if (type_ == QueryType::WRITE && !array_schema_->dense())
+    return LOG_STATUS(
+        Status::QueryError("Getting the number of ranges from a write query "
+                           "is not applicable to sparse arrays"));
+
+  return subarray_.get_range_num(dim_idx, range_num);
 }
 
 Status Query::get_range(
@@ -167,9 +219,13 @@ Status Query::get_range(
     const void** start,
     const void** end,
     const void** stride) const {
-  if (type_ == QueryType::WRITE)
-    return writer_.get_range(dim_idx, range_idx, start, end, stride);
-  return reader_.get_range(dim_idx, range_idx, start, end, stride);
+  if (type_ == QueryType::WRITE && !array_schema_->dense())
+    return LOG_STATUS(
+        Status::QueryError("Getting a range from a write query is not "
+                           "applicable to sparse arrays"));
+
+  *stride = nullptr;
+  return subarray_.get_range(dim_idx, range_idx, start, end);
 }
 
 Status Query::get_range_var_size(
@@ -178,21 +234,22 @@ Status Query::get_range_var_size(
     uint64_t* start_size,
     uint64_t* end_size) const {
   if (type_ == QueryType::WRITE)
-    return LOG_STATUS(Status::WriterError(
+    return LOG_STATUS(Status::QueryError(
         "Getting a var range size from a write query is not applicable"));
 
-  return reader_.get_range_var_size(dim_idx, range_idx, start_size, end_size);
+  return subarray_.get_range_var_size(dim_idx, range_idx, start_size, end_size);
+  ;
 }
 
 Status Query::get_range_var(
     unsigned dim_idx, uint64_t range_idx, void* start, void* end) const {
   if (type_ == QueryType::WRITE)
-    return LOG_STATUS(Status::WriterError(
+    return LOG_STATUS(Status::QueryError(
         "Getting a var range from a write query is not applicable"));
 
   uint64_t start_size = 0;
   uint64_t end_size = 0;
-  reader_.get_range_var_size(dim_idx, range_idx, &start_size, &end_size);
+  subarray_.get_range_var_size(dim_idx, range_idx, &start_size, &end_size);
 
   const void* range_start;
   const void* range_end;
@@ -212,8 +269,8 @@ Status Query::add_range_by_name(
     const void* end,
     const void* stride) {
   unsigned dim_idx;
-  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
-      dim_name, &dim_idx));
+  RETURN_NOT_OK(
+      array_schema_->domain()->get_dimension_index(dim_name, &dim_idx));
 
   return add_range(dim_idx, start, end, stride);
 }
@@ -225,8 +282,8 @@ Status Query::add_range_var_by_name(
     const void* end,
     uint64_t end_size) {
   unsigned dim_idx;
-  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
-      dim_name, &dim_idx));
+  RETURN_NOT_OK(
+      array_schema_->domain()->get_dimension_index(dim_name, &dim_idx));
 
   return add_range_var(dim_idx, start, start_size, end, end_size);
 }
@@ -234,8 +291,8 @@ Status Query::add_range_var_by_name(
 Status Query::get_range_num_from_name(
     const std::string& dim_name, uint64_t* range_num) const {
   unsigned dim_idx;
-  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
-      dim_name, &dim_idx));
+  RETURN_NOT_OK(
+      array_schema_->domain()->get_dimension_index(dim_name, &dim_idx));
 
   return get_range_num(dim_idx, range_num);
 }
@@ -247,8 +304,8 @@ Status Query::get_range_from_name(
     const void** end,
     const void** stride) const {
   unsigned dim_idx;
-  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
-      dim_name, &dim_idx));
+  RETURN_NOT_OK(
+      array_schema_->domain()->get_dimension_index(dim_name, &dim_idx));
 
   return get_range(dim_idx, range_idx, start, end, stride);
 }
@@ -259,8 +316,8 @@ Status Query::get_range_var_size_from_name(
     uint64_t* start_size,
     uint64_t* end_size) const {
   unsigned dim_idx;
-  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
-      dim_name, &dim_idx));
+  RETURN_NOT_OK(
+      array_schema_->domain()->get_dimension_index(dim_name, &dim_idx));
 
   return get_range_var_size(dim_idx, range_idx, start_size, end_size);
 }
@@ -271,8 +328,8 @@ Status Query::get_range_var_from_name(
     void* start,
     void* end) const {
   unsigned dim_idx;
-  RETURN_NOT_OK(array_->array_schema()->domain()->get_dimension_index(
-      dim_name, &dim_idx));
+  RETURN_NOT_OK(
+      array_schema_->domain()->get_dimension_index(dim_name, &dim_idx));
 
   return get_range_var(dim_idx, range_idx, start, end);
 }
@@ -288,37 +345,37 @@ Status Query::get_est_result_size(const char* name, uint64_t* size) {
         "Cannot get estimated result size; Name cannot be null"));
 
   if (name == constants::coords &&
-      !array_->array_schema()->domain()->all_dims_same_type())
+      !array_schema_->domain()->all_dims_same_type())
     return LOG_STATUS(Status::QueryError(
         "Cannot get estimated result size; Not applicable to zipped "
         "coordinates in arrays with heterogeneous domain"));
 
-  if (name == constants::coords &&
-      !array_->array_schema()->domain()->all_dims_fixed())
+  if (name == constants::coords && !array_schema_->domain()->all_dims_fixed())
     return LOG_STATUS(Status::QueryError(
         "Cannot get estimated result size; Not applicable to zipped "
         "coordinates in arrays with domains with variable-sized dimensions"));
 
-  if (array_->array_schema()->is_nullable(name))
-    return LOG_STATUS(Status::WriterError(
+  if (array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
         std::string(
             "Cannot get estimated result size; Input attribute/dimension '") +
         name + "' is nullable"));
 
-  if (array_->is_remote() && !reader_.est_result_size_computed()) {
+  if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
       return LOG_STATUS(
           Status::QueryError("Error in query estimate result size; remote "
                              "array with no rest client."));
 
-    array_->array_schema()->set_array_uri(array_->array_uri());
+    array_schema_->set_array_uri(array_->array_uri());
 
     RETURN_NOT_OK(
         rest_client->get_query_est_result_sizes(array_->array_uri(), this));
   }
 
-  return reader_.get_est_result_size(name, size);
+  return subarray_.get_est_result_size(
+      name, size, &config_, storage_manager_->compute_tp());
 }
 
 Status Query::get_est_result_size(
@@ -328,26 +385,27 @@ Status Query::get_est_result_size(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
-  if (array_->array_schema()->is_nullable(name))
-    return LOG_STATUS(Status::WriterError(
+  if (array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
         std::string(
             "Cannot get estimated result size; Input attribute/dimension '") +
         name + "' is nullable"));
 
-  if (array_->is_remote() && !reader_.est_result_size_computed()) {
+  if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
       return LOG_STATUS(
           Status::QueryError("Error in query estimate result size; remote "
                              "array with no rest client."));
 
-    array_->array_schema()->set_array_uri(array_->array_uri());
+    array_schema_->set_array_uri(array_->array_uri());
 
     RETURN_NOT_OK(
         rest_client->get_query_est_result_sizes(array_->array_uri(), this));
   }
 
-  return reader_.get_est_result_size(name, size_off, size_val);
+  return subarray_.get_est_result_size(
+      name, size_off, size_val, &config_, storage_manager_->compute_tp());
 }
 
 Status Query::get_est_result_size_nullable(
@@ -361,17 +419,17 @@ Status Query::get_est_result_size_nullable(
     return LOG_STATUS(Status::QueryError(
         "Cannot get estimated result size; Name cannot be null"));
 
-  if (!array_->array_schema()->attribute(name))
+  if (!array_schema_->attribute(name))
     return LOG_STATUS(Status::QueryError(
         "Cannot get estimated result size; Nullable API is only"
         "applicable to attributes"));
 
-  if (!array_->array_schema()->is_nullable(name))
-    return LOG_STATUS(Status::WriterError(
+  if (!array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
         std::string("Cannot get estimated result size; Input attribute '") +
         name + "' is not nullable"));
 
-  if (array_->is_remote() && !reader_.est_result_size_computed()) {
+  if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
       return LOG_STATUS(
@@ -383,7 +441,8 @@ Status Query::get_est_result_size_nullable(
                            "for nullable attributes in remote arrays."));
   }
 
-  return reader_.get_est_result_size_nullable(name, size_val, size_validity);
+  return subarray_.get_est_result_size_nullable(
+      name, size_val, size_validity, &config_, storage_manager_->compute_tp());
 }
 
 Status Query::get_est_result_size_nullable(
@@ -396,17 +455,17 @@ Status Query::get_est_result_size_nullable(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
-  if (!array_->array_schema()->attribute(name))
+  if (!array_schema_->attribute(name))
     return LOG_STATUS(Status::QueryError(
         "Cannot get estimated result size; Nullable API is only"
         "applicable to attributes"));
 
-  if (!array_->array_schema()->is_nullable(name))
-    return LOG_STATUS(Status::WriterError(
+  if (!array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
         std::string("Cannot get estimated result size; Input attribute '") +
         name + "' is not nullable"));
 
-  if (array_->is_remote() && !reader_.est_result_size_computed()) {
+  if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
       return LOG_STATUS(
@@ -418,42 +477,48 @@ Status Query::get_est_result_size_nullable(
                            "for nullable attributes in remote arrays."));
   }
 
-  return reader_.get_est_result_size_nullable(
-      name, size_off, size_val, size_validity);
+  return subarray_.get_est_result_size_nullable(
+      name,
+      size_off,
+      size_val,
+      size_validity,
+      &config_,
+      storage_manager_->compute_tp());
 }
 
 std::unordered_map<std::string, Subarray::ResultSize>
 Query::get_est_result_size_map() {
-  return reader_.get_est_result_size_map();
+  return subarray_.get_est_result_size_map(
+      &config_, storage_manager_->compute_tp());
 }
 
 std::unordered_map<std::string, Subarray::MemorySize>
 Query::get_max_mem_size_map() {
-  return reader_.get_max_mem_size_map();
+  return subarray_.get_max_mem_size_map(
+      &config_, storage_manager_->compute_tp());
 }
 
 Status Query::get_written_fragment_num(uint32_t* num) const {
   if (type_ != QueryType::WRITE)
-    return LOG_STATUS(Status::WriterError(
+    return LOG_STATUS(Status::QueryError(
         "Cannot get number of fragments; Applicable only to WRITE mode"));
 
-  *num = (uint32_t)writer_.written_fragment_info().size();
+  *num = (uint32_t)written_fragment_info_.size();
 
   return Status::Ok();
 }
 
 Status Query::get_written_fragment_uri(uint32_t idx, const char** uri) const {
   if (type_ != QueryType::WRITE)
-    return LOG_STATUS(Status::WriterError(
+    return LOG_STATUS(Status::QueryError(
         "Cannot get fragment URI; Applicable only to WRITE mode"));
 
-  auto& written_fragment_info = writer_.written_fragment_info();
-  auto num = (uint32_t)written_fragment_info.size();
+  auto num = (uint32_t)written_fragment_info_.size();
   if (idx >= num)
     return LOG_STATUS(
-        Status::WriterError("Cannot get fragment URI; Invalid fragment index"));
+        Status::QueryError("Cannot get fragment URI; Invalid fragment index"));
 
-  *uri = written_fragment_info[idx].uri_.c_str();
+  *uri = written_fragment_info_[idx].uri_.c_str();
 
   return Status::Ok();
 }
@@ -461,17 +526,16 @@ Status Query::get_written_fragment_uri(uint32_t idx, const char** uri) const {
 Status Query::get_written_fragment_timestamp_range(
     uint32_t idx, uint64_t* t1, uint64_t* t2) const {
   if (type_ != QueryType::WRITE)
-    return LOG_STATUS(Status::WriterError(
+    return LOG_STATUS(Status::QueryError(
         "Cannot get fragment timestamp range; Applicable only to WRITE mode"));
 
-  auto& written_fragment_info = writer_.written_fragment_info();
-  auto num = (uint32_t)written_fragment_info.size();
+  auto num = (uint32_t)written_fragment_info_.size();
   if (idx >= num)
-    return LOG_STATUS(Status::WriterError(
+    return LOG_STATUS(Status::QueryError(
         "Cannot get fragment timestamp range; Invalid fragment index"));
 
-  *t1 = written_fragment_info[idx].timestamp_range_.first;
-  *t2 = written_fragment_info[idx].timestamp_range_.second;
+  *t1 = written_fragment_info_[idx].timestamp_range_.first;
+  *t2 = written_fragment_info_[idx].timestamp_range_.second;
 
   return Status::Ok();
 }
@@ -485,21 +549,42 @@ Array* Query::array() {
 }
 
 const ArraySchema* Query::array_schema() const {
-  if (type_ == QueryType::WRITE)
-    return writer_.array_schema();
-  return reader_.array_schema();
+  return array_schema_;
 }
 
 std::vector<std::string> Query::buffer_names() const {
-  if (type_ == QueryType::WRITE)
-    return writer_.buffer_names();
-  return reader_.buffer_names();
+  std::vector<std::string> ret;
+
+  // Add to the buffer names the attributes, as well as the dimensions only if
+  // coords_buffer_ has not been set
+  for (const auto& it : buffers_) {
+    if (!array_schema_->is_dim(it.first) || (!coords_info_.coords_buffer_))
+      ret.push_back(it.first);
+  }
+
+  // Special zipped coordinates name
+  if (coords_info_.coords_buffer_)
+    ret.push_back(constants::coords);
+
+  return ret;
 }
 
 QueryBuffer Query::buffer(const std::string& name) const {
-  if (type_ == QueryType::WRITE)
-    return writer_.buffer(name);
-  return reader_.buffer(name);
+  // Special zipped coordinates
+  if (type_ == QueryType::WRITE && name == constants::coords)
+    return QueryBuffer(
+        coords_info_.coords_buffer_,
+        nullptr,
+        coords_info_.coords_buffer_size_,
+        nullptr);
+
+  // Attribute or dimension
+  auto buf = buffers_.find(name);
+  if (buf != buffers_.end())
+    return buf->second;
+
+  // Named buffer does not exist
+  return QueryBuffer{};
 }
 
 Status Query::finalize() {
@@ -512,12 +597,12 @@ Status Query::finalize() {
       return LOG_STATUS(Status::QueryError(
           "Error in query finalize; remote array with no rest client."));
 
-    array_->array_schema()->set_array_uri(array_->array_uri());
+    array_schema_->set_array_uri(array_->array_uri());
 
     return rest_client->finalize_query_to_rest(array_->array_uri(), this);
   }
 
-  RETURN_NOT_OK(writer_.finalize());
+  RETURN_NOT_OK(strategy_->finalize());
   status_ = QueryStatus::COMPLETED;
   return Status::Ok();
 }
@@ -537,9 +622,7 @@ Status Query::get_buffer(
     return LOG_STATUS(Status::QueryError(
         std::string("Cannot get buffer; '") + name + "' is var-sized"));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.get_data_buffer(name, buffer, buffer_size);
-  return reader_.get_data_buffer(name, buffer, buffer_size);
+  return get_data_buffer(name, buffer, buffer_size);
 }
 
 Status Query::get_buffer(
@@ -563,11 +646,23 @@ Status Query::get_buffer(
     return LOG_STATUS(Status::QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.get_buffer(
-        name, buffer_off, buffer_off_size, buffer_val, buffer_val_size);
-  return reader_.get_buffer(
-      name, buffer_off, buffer_off_size, buffer_val, buffer_val_size);
+  // Attribute or dimension
+  auto it = buffers_.find(name);
+  if (it != buffers_.end()) {
+    *buffer_off = (uint64_t*)it->second.buffer_;
+    *buffer_off_size = it->second.buffer_size_;
+    *buffer_val = it->second.buffer_var_;
+    *buffer_val_size = it->second.buffer_var_size_;
+    return Status::Ok();
+  }
+
+  // Named buffer does not exist
+  *buffer_off = nullptr;
+  *buffer_off_size = nullptr;
+  *buffer_val = nullptr;
+  *buffer_val_size = nullptr;
+
+  return Status::Ok();
 }
 
 Status Query::get_offsets_buffer(
@@ -587,9 +682,19 @@ Status Query::get_offsets_buffer(
     return LOG_STATUS(Status::QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.get_offsets_buffer(name, buffer_off, buffer_off_size);
-  return reader_.get_offsets_buffer(name, buffer_off, buffer_off_size);
+  // Attribute or dimension
+  auto it = buffers_.find(name);
+  if (it != buffers_.end()) {
+    *buffer_off = (uint64_t*)it->second.buffer_;
+    *buffer_off_size = it->second.buffer_size_;
+    return Status::Ok();
+  }
+
+  // Named buffer does not exist
+  *buffer_off = nullptr;
+  *buffer_off_size = nullptr;
+
+  return Status::Ok();
 }
 
 Status Query::get_data_buffer(
@@ -604,28 +709,47 @@ Status Query::get_data_buffer(
           name + "'"));
   }
 
-  if (type_ == QueryType::WRITE)
-    return writer_.get_data_buffer(name, buffer, buffer_size);
-  return reader_.get_data_buffer(name, buffer, buffer_size);
+  // Special zipped coordinates
+  if (type_ == QueryType::WRITE && name == constants::coords) {
+    *buffer = coords_info_.coords_buffer_;
+    *buffer_size = coords_info_.coords_buffer_size_;
+    return Status::Ok();
+  }
+
+  // Attribute or dimension
+  auto it = buffers_.find(name);
+  if (it != buffers_.end()) {
+    if (!array_schema_->var_size(name)) {
+      *buffer = it->second.buffer_;
+      *buffer_size = it->second.buffer_size_;
+    } else {
+      *buffer = it->second.buffer_var_;
+      *buffer_size = it->second.buffer_var_size_;
+    }
+    return Status::Ok();
+  }
+
+  // Named buffer does not exist
+  *buffer = nullptr;
+  *buffer_size = nullptr;
+
+  return Status::Ok();
 }
 
 Status Query::get_validity_buffer(
     const char* name,
     uint8_t** buffer_validity_bytemap,
     uint64_t** buffer_validity_bytemap_size) const {
-  const ValidityVector* vv = nullptr;
-
   // Check attribute
   auto array_schema = this->array_schema();
   if (!array_schema->is_nullable(name))
     return LOG_STATUS(Status::QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
-  if (type_ == QueryType::WRITE)
-    RETURN_NOT_OK(writer_.get_validity_buffer(name, &vv));
-  RETURN_NOT_OK(reader_.get_validity_buffer(name, &vv));
-
-  if (vv != nullptr) {
+  // Attribute or dimension
+  auto it = buffers_.find(name);
+  if (it != buffers_.end()) {
+    auto vv = &it->second.validity_vector_;
     *buffer_validity_bytemap = vv->bytemap();
     *buffer_validity_bytemap_size = vv->bytemap_size();
   }
@@ -688,11 +812,21 @@ Status Query::get_buffer(
     return LOG_STATUS(Status::QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.get_buffer_nullable(
-        name, buffer, buffer_size, validity_vector);
-  return reader_.get_buffer_nullable(
-      name, buffer, buffer_size, validity_vector);
+  // Attribute or dimension
+  auto it = buffers_.find(name);
+  if (it != buffers_.end()) {
+    *buffer = it->second.buffer_;
+    *buffer_size = it->second.buffer_size_;
+    *validity_vector = &it->second.validity_vector_;
+    return Status::Ok();
+  }
+
+  // Named buffer does not exist
+  *buffer = nullptr;
+  *buffer_size = nullptr;
+  *validity_vector = nullptr;
+
+  return Status::Ok();
 }
 
 Status Query::get_buffer(
@@ -715,21 +849,25 @@ Status Query::get_buffer(
     return LOG_STATUS(Status::QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.get_buffer_nullable(
-        name,
-        buffer_off,
-        buffer_off_size,
-        buffer_val,
-        buffer_val_size,
-        validity_vector);
-  return reader_.get_buffer_nullable(
-      name,
-      buffer_off,
-      buffer_off_size,
-      buffer_val,
-      buffer_val_size,
-      validity_vector);
+  // Attribute or dimension
+  auto it = buffers_.find(name);
+  if (it != buffers_.end()) {
+    *buffer_off = (uint64_t*)it->second.buffer_;
+    *buffer_off_size = it->second.buffer_size_;
+    *buffer_val = it->second.buffer_var_;
+    *buffer_val_size = it->second.buffer_var_size_;
+    *validity_vector = &it->second.validity_vector_;
+    return Status::Ok();
+  }
+
+  // Named buffer does not exist
+  *buffer_off = nullptr;
+  *buffer_off_size = nullptr;
+  *buffer_val = nullptr;
+  *buffer_val_size = nullptr;
+  *validity_vector = nullptr;
+
+  return Status::Ok();
 }
 
 Status Query::get_attr_serialization_state(
@@ -741,7 +879,12 @@ Status Query::get_attr_serialization_state(
 bool Query::has_results() const {
   if (status_ == QueryStatus::UNINITIALIZED || type_ == QueryType::WRITE)
     return false;
-  return !reader_.no_results();
+
+  for (const auto& it : buffers_) {
+    if (*(it.second.buffer_size_) != 0)
+      return true;
+  }
+  return false;
 }
 
 Status Query::init() {
@@ -764,11 +907,12 @@ Status Query::init() {
       return LOG_STATUS(Status::QueryError(errmsg.str()));
     }
 
-    if (type_ == QueryType::READ) {
-      RETURN_NOT_OK(reader_.init(layout_));
-    } else {  // Write
-      RETURN_NOT_OK(writer_.init(layout_));
-    }
+    RETURN_NOT_OK(check_buffer_names());
+
+    if (strategy_ == nullptr)
+      RETURN_NOT_OK(create_strategy());
+
+    RETURN_NOT_OK(strategy_->init(layout_));
   }
 
   status_ = QueryStatus::INPROGRESS;
@@ -777,15 +921,15 @@ Status Query::init() {
 }
 
 URI Query::first_fragment_uri() const {
-  if (type_ == QueryType::WRITE)
+  if (type_ == QueryType::WRITE || fragment_metadata_.empty())
     return URI();
-  return reader_.first_fragment_uri();
+  return fragment_metadata_.front()->fragment_uri();
 }
 
 URI Query::last_fragment_uri() const {
-  if (type_ == QueryType::WRITE)
+  if (type_ == QueryType::WRITE || fragment_metadata_.empty())
     return URI();
-  return reader_.last_fragment_uri();
+  return fragment_metadata_.back()->fragment_uri();
 }
 
 Layout Query::layout() const {
@@ -795,7 +939,7 @@ Layout Query::layout() const {
 const QueryCondition* Query::condition() const {
   if (type_ == QueryType::WRITE)
     return nullptr;
-  return reader_.condition();
+  return &condition_;
 }
 
 Status Query::cancel() {
@@ -810,11 +954,7 @@ Status Query::process() {
   status_ = QueryStatus::INPROGRESS;
 
   // Process query
-  Status st = Status::Ok();
-  if (type_ == QueryType::READ)
-    st = reader_.read();
-  else  // WRITE MODE
-    st = writer_.write();
+  Status st = strategy_->dowork();
 
   // Handle error
   if (!st.ok()) {
@@ -822,8 +962,16 @@ Status Query::process() {
     return st;
   }
 
+  if (type_ == QueryType::WRITE && layout_ == Layout::GLOBAL_ORDER) {
+    // reset coord buffer marker at end of global write
+    // this will allow for the user to properly set the next write batch
+    coord_buffer_is_set_ = false;
+    coord_data_buffer_is_set_ = false;
+    coord_offsets_buffer_is_set_ = false;
+  }
+
   // Check if the query is complete
-  bool completed = (type_ == QueryType::WRITE) ? true : !reader_.incomplete();
+  bool completed = !strategy_->incomplete();
 
   // Handle callback and status
   if (completed) {
@@ -837,40 +985,105 @@ Status Query::process() {
   return Status::Ok();
 }
 
-const Reader* Query::reader() const {
-  return &reader_;
+Status Query::create_strategy() {
+  if (type_ == QueryType::WRITE) {
+    strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+        Writer,
+        stats_->create_child("Writer"),
+        storage_manager_,
+        array_,
+        config_,
+        buffers_,
+        subarray_,
+        layout_,
+        written_fragment_info_,
+        disable_check_global_order_,
+        coords_info_,
+        fragment_uri_));
+  } else {
+    bool found = false;
+    bool use_refactored_readers = false;
+    RETURN_NOT_OK(config_.get<bool>(
+        "sm.use_refactored_readers", &use_refactored_readers, &found));
+    assert(found);
+
+    strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+        Reader,
+        stats_->create_child("Reader"),
+        storage_manager_,
+        array_,
+        config_,
+        buffers_,
+        subarray_,
+        layout_,
+        condition_,
+        sparse_mode_));
+  }
+
+  if (strategy_ == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot create strategy; allocation failed"));
+
+  return Status::Ok();
 }
 
-Reader* Query::reader() {
-  return &reader_;
-}
-
-const Writer* Query::writer() const {
-  return &writer_;
-}
-
-Writer* Query::writer() {
-  return &writer_;
+IQueryStrategy* Query::strategy() {
+  if (strategy_ == nullptr) {
+    create_strategy();
+  }
+  return strategy_.get();
 }
 
 Status Query::disable_check_global_order() {
+  if (status_ != QueryStatus::UNINITIALIZED)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot disable checking global order after initialization"));
+
   if (type_ == QueryType::READ)
     return LOG_STATUS(Status::QueryError(
         "Cannot disable checking global order; Applicable only to writes"));
 
-  writer_.disable_check_global_order();
+  disable_check_global_order_ = true;
+  return Status::Ok();
+}
+
+Status Query::check_buffer_names() {
+  if (type_ == QueryType::WRITE) {
+    // If the array is sparse, the coordinates must be provided
+    if (!array_schema_->dense() && !coords_info_.has_coords_)
+      return LOG_STATUS(Status::WriterError(
+          "Sparse array writes expect the coordinates of the "
+          "cells to be written"));
+
+    // If the layout is unordered, the coordinates must be provided
+    if (layout_ == Layout::UNORDERED && !coords_info_.has_coords_)
+      return LOG_STATUS(
+          Status::WriterError("Unordered writes expect the coordinates of the "
+                              "cells to be written"));
+
+    // All attributes/dimensions must be provided
+    auto expected_num = array_schema_->attribute_num();
+    expected_num += (coord_buffer_is_set_ || coord_data_buffer_is_set_ ||
+                     coord_offsets_buffer_is_set_) ?
+                        array_schema_->dim_num() :
+                        0;
+    if (buffers_.size() != expected_num)
+      return LOG_STATUS(Status::WriterError(
+          "Writes expect all attributes (and coordinates in "
+          "the sparse/unordered case) to be set"));
+  }
+
   return Status::Ok();
 }
 
 Status Query::check_set_fixed_buffer(const std::string& name) {
   if (name == constants::coords &&
-      !array_->array_schema()->domain()->all_dims_same_type())
+      !array_schema_->domain()->all_dims_same_type())
     return LOG_STATUS(Status::QueryError(
         "Cannot set buffer; Setting a buffer for zipped coordinates is not "
         "applicable to heterogeneous domains"));
 
-  if (name == constants::coords &&
-      !array_->array_schema()->domain()->all_dims_fixed())
+  if (name == constants::coords && !array_schema_->domain()->all_dims_fixed())
     return LOG_STATUS(Status::QueryError(
         "Cannot set buffer; Setting a buffer for zipped coordinates is not "
         "applicable to domains with variable-sized dimensions"));
@@ -879,10 +1092,16 @@ Status Query::check_set_fixed_buffer(const std::string& name) {
 }
 
 Status Query::set_config(const Config& config) {
-  if (type_ == QueryType::READ)
-    reader_.set_config(config);
-  else
-    writer_.set_config(config);
+  config_ = config;
+
+  return Status::Ok();
+}
+
+Status Query::set_coords_buffer(void* buffer, uint64_t* buffer_size) {
+  // Set zipped coordinates buffer
+  coords_info_.coords_buffer_ = buffer;
+  coords_info_.coords_buffer_size_ = buffer_size;
+  coords_info_.has_coords_ = true;
 
   return Status::Ok();
 }
@@ -894,9 +1113,88 @@ Status Query::set_buffer(
     const bool check_null_buffers) {
   RETURN_NOT_OK(check_set_fixed_buffer(name));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.set_buffer(name, buffer, buffer_size);
-  return reader_.set_buffer(name, buffer, buffer_size, check_null_buffers);
+  // Check buffer
+  if (check_null_buffers && buffer == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+
+  // Check buffer size
+  if (check_null_buffers && buffer_size == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+
+  // Array schema must exist
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; Array schema not set"));
+
+  // For easy reference
+  const bool is_dim = array_schema_->is_dim(name);
+  const bool is_attr = array_schema_->is_attr(name);
+
+  // Check that attribute/dimension exists
+  if (name != constants::coords && !is_dim && !is_attr)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
+        "'"));
+
+  // Must not be nullable
+  if (array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute/dimension '") + name +
+        "' is nullable"));
+
+  // Check that attribute/dimension is fixed-sized
+  const bool var_size =
+      (name != constants::coords && array_schema_->var_size(name));
+  if (var_size)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute/dimension '") + name +
+        "' is var-sized"));
+
+  // Check if zipped coordinates coexist with separate coordinate buffers
+  if ((is_dim && has_zipped_coords_buffer_) ||
+      (name == constants::coords && has_coords_buffer_))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set separate coordinate buffers and "
+                    "a zipped coordinate buffer in the same query")));
+
+  // Error if setting a new attribute/dimension after initialization
+  const bool exists = buffers_.find(name) != buffers_.end();
+  if (status_ != QueryStatus::UNINITIALIZED && !exists)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer for new attribute/dimension '") + name +
+        "' after initialization"));
+
+  if (name == constants::coords) {
+    has_zipped_coords_buffer_ = true;
+
+    // Set special function for zipped coordinates buffer
+    if (type_ == QueryType::WRITE)
+      return set_coords_buffer(buffer, buffer_size);
+  }
+
+  if (is_dim && type_ == QueryType::WRITE) {
+    // Check number of coordinates
+    uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
+    if (coord_buffer_is_set_ && coords_num != coords_info_.coords_num_)
+      return LOG_STATUS(Status::QueryError(
+          std::string("Cannot set buffer; Input buffer for dimension '") +
+          name +
+          "' has a different number of coordinates than previously "
+          "set coordinate buffers"));
+
+    coords_info_.coords_num_ = coords_num;
+    coord_buffer_is_set_ = true;
+    coords_info_.has_coords_ = true;
+  }
+
+  has_coords_buffer_ |= is_dim;
+
+  // Set attribute buffer
+  buffers_[name] = QueryBuffer(buffer, nullptr, buffer_size, nullptr);
+
+  return Status::Ok();
 }
 
 Status Query::set_data_buffer(
@@ -906,9 +1204,81 @@ Status Query::set_data_buffer(
     const bool check_null_buffers) {
   RETURN_NOT_OK(check_set_fixed_buffer(name));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.set_data_buffer(name, buffer, buffer_size);
-  return reader_.set_data_buffer(name, buffer, buffer_size, check_null_buffers);
+  // Check buffer
+  if (check_null_buffers && buffer == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+
+  // Check buffer size
+  if (check_null_buffers && buffer_size == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " buffer size is null"));
+
+  // Array schema must exist
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; Array schema not set"));
+
+  // For easy reference
+  const bool is_dim = array_schema_->is_dim(name);
+  const bool is_attr = array_schema_->is_attr(name);
+
+  // Check that attribute/dimension exists
+  if (name != constants::coords && !is_dim && !is_attr)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
+        "'"));
+
+  // Check if zipped coordinates coexist with separate coordinate buffers
+  if ((is_dim && has_zipped_coords_buffer_) ||
+      (name == constants::coords && has_coords_buffer_))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set separate coordinate buffers and "
+                    "a zipped coordinate buffer in the same query")));
+
+  // Error if setting a new attribute/dimension after initialization
+  const bool exists = buffers_.find(name) != buffers_.end();
+  if (status_ != QueryStatus::UNINITIALIZED && !exists)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer for new attribute/dimension '") + name +
+        "' after initialization"));
+
+  if (name == constants::coords) {
+    has_zipped_coords_buffer_ = true;
+
+    // Set special function for zipped coordinates buffer
+    if (type_ == QueryType::WRITE)
+      return set_coords_buffer(buffer, buffer_size);
+  }
+
+  if (is_dim && type_ == QueryType::WRITE) {
+    // Check number of coordinates
+    uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
+    if (coord_data_buffer_is_set_ && coords_num != coords_info_.coords_num_ &&
+        name == data_buffer_name_)
+      return LOG_STATUS(Status::QueryError(
+          std::string("Cannot set buffer; Input buffer for dimension '") +
+          name +
+          "' has a different number of coordinates than previously "
+          "set coordinate buffers"));
+
+    coords_info_.coords_num_ = coords_num;
+    coord_data_buffer_is_set_ = true;
+    data_buffer_name_ = name;
+    coords_info_.has_coords_ = true;
+  }
+
+  has_coords_buffer_ |= is_dim;
+
+  // Set attribute/dimension buffer on the appropriate buffer
+  if (!array_schema_->var_size(name))
+    // Fixed size data buffer
+    buffers_[name].set_data_buffer(buffer, buffer_size);
+  else
+    // Var sized data buffer
+    buffers_[name].set_data_var_buffer(buffer, buffer_size);
+
+  return Status::Ok();
 }
 
 Status Query::set_offsets_buffer(
@@ -918,11 +1288,68 @@ Status Query::set_offsets_buffer(
     const bool check_null_buffers) {
   RETURN_NOT_OK(check_set_fixed_buffer(name));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.set_offsets_buffer(
-        name, buffer_offsets, buffer_offsets_size);
-  return reader_.set_offsets_buffer(
-      name, buffer_offsets, buffer_offsets_size, check_null_buffers);
+  // Check buffer
+  if (check_null_buffers && buffer_offsets == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+
+  // Check buffer size
+  if (check_null_buffers && buffer_offsets_size == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " buffer size is null"));
+
+  // Array schema must exist
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; Array schema not set"));
+
+  // For easy reference
+  const bool is_dim = array_schema_->is_dim(name);
+  const bool is_attr = array_schema_->is_attr(name);
+
+  // Neither a dimension nor an attribute
+  if (!is_dim && !is_attr)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Invalid buffer name '") + name +
+        "' (it should be an attribute or dimension)"));
+
+  // Error if it is fixed-sized
+  if (!array_schema_->var_size(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute/dimension '") + name +
+        "' is fixed-sized"));
+
+  // Error if setting a new attribute/dimension after initialization
+  bool exists = buffers_.find(name) != buffers_.end();
+  if (status_ != QueryStatus::UNINITIALIZED && !exists)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer for new attribute/dimension '") + name +
+        "' after initialization"));
+
+  if (is_dim && type_ == QueryType::WRITE) {
+    // Check number of coordinates
+    uint64_t coords_num =
+        *buffer_offsets_size / constants::cell_var_offset_size;
+    if (coord_offsets_buffer_is_set_ &&
+        coords_num != coords_info_.coords_num_ && name != offsets_buffer_name_)
+      return LOG_STATUS(Status::QueryError(
+          std::string("Cannot set buffer; Input buffer for dimension '") +
+          name +
+          "' has a different number of coordinates than previously "
+          "set coordinate buffers"));
+
+    coords_info_.coords_num_ = coords_num;
+    coord_offsets_buffer_is_set_ = true;
+    coords_info_.has_coords_ = true;
+    offsets_buffer_name_ = name;
+  }
+
+  has_coords_buffer_ |= is_dim;
+
+  // Set attribute/dimension buffer
+  buffers_[name].set_offsets_buffer(buffer_offsets, buffer_offsets_size);
+
+  return Status::Ok();
 }
 
 Status Query::set_validity_buffer(
@@ -932,14 +1359,47 @@ Status Query::set_validity_buffer(
     const bool check_null_buffers) {
   RETURN_NOT_OK(check_set_fixed_buffer(name));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.set_validity_buffer(
-        name, buffer_validity_bytemap, buffer_validity_bytemap_size);
-  return reader_.set_validity_buffer(
-      name,
-      buffer_validity_bytemap,
-      buffer_validity_bytemap_size,
-      check_null_buffers);
+  ValidityVector validity_vector;
+  RETURN_NOT_OK(validity_vector.init_bytemap(
+      buffer_validity_bytemap, buffer_validity_bytemap_size));
+  // Check validity buffer
+  if (check_null_buffers && validity_vector.buffer() == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " validity buffer is null"));
+
+  // Check validity buffer size
+  if (check_null_buffers && validity_vector.buffer_size() == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " validity buffer size is null"));
+
+  // Array schema must exist
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; Array schema not set"));
+
+  // Must be an attribute
+  if (!array_schema_->is_attr(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Buffer name '") + name +
+        "' is not an attribute"));
+
+  // Must be nullable
+  if (!array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute '") + name +
+        "' is not nullable"));
+
+  // Error if setting a new attribute after initialization
+  const bool exists = buffers_.find(name) != buffers_.end();
+  if (status_ != QueryStatus::UNINITIALIZED && !exists)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer for new attribute '") + name +
+        "' after initialization"));
+
+  // Set attribute/dimension buffer
+  buffers_[name].set_validity_buffer(std::move(validity_vector));
+
+  return Status::Ok();
 }
 
 Status Query::set_buffer(
@@ -949,16 +1409,80 @@ Status Query::set_buffer(
     void* const buffer_val,
     uint64_t* const buffer_val_size,
     const bool check_null_buffers) {
-  if (type_ == QueryType::WRITE)
-    return writer_.set_buffer(
-        name, buffer_off, buffer_off_size, buffer_val, buffer_val_size);
-  return reader_.set_buffer(
-      name,
-      buffer_off,
-      buffer_off_size,
-      buffer_val,
-      buffer_val_size,
-      check_null_buffers);
+  // Check buffer
+  if (check_null_buffers && buffer_val == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+
+  // Check buffer size
+  if (check_null_buffers && buffer_val_size == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " buffer size is null"));
+
+  // Check offset buffer
+  if (check_null_buffers && buffer_off == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " offset buffer is null"));
+
+  // Check offset buffer size
+  if (check_null_buffers && buffer_off_size == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " offset buffer size is null"));
+
+  // Array schema must exist
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; Array schema not set"));
+
+  // For easy reference
+  const bool is_dim = array_schema_->is_dim(name);
+  const bool is_attr = array_schema_->is_attr(name);
+
+  // Check that attribute/dimension exists
+  if (!is_dim && !is_attr)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
+        "'"));
+
+  // Must not be nullable
+  if (array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute/dimension '") + name +
+        "' is nullable"));
+
+  // Check that attribute/dimension is var-sized
+  if (!array_schema_->var_size(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute/dimension '") + name +
+        "' is fixed-sized"));
+
+  // Error if setting a new attribute/dimension after initialization
+  const bool exists = buffers_.find(name) != buffers_.end();
+  if (status_ != QueryStatus::UNINITIALIZED && !exists)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer for new attribute/dimension '") + name +
+        "' after initialization"));
+
+  if (is_dim && type_ == QueryType::WRITE) {
+    // Check number of coordinates
+    uint64_t coords_num = *buffer_off_size / constants::cell_var_offset_size;
+    if (coord_buffer_is_set_ && coords_num != coords_info_.coords_num_)
+      return LOG_STATUS(Status::QueryError(
+          std::string("Cannot set buffer; Input buffer for dimension '") +
+          name +
+          "' has a different number of coordinates than previously "
+          "set coordinate buffers"));
+
+    coords_info_.coords_num_ = coords_num;
+    coord_buffer_is_set_ = true;
+    coords_info_.has_coords_ = true;
+  }
+
+  // Set attribute/dimension buffer
+  buffers_[name] =
+      QueryBuffer(buffer_off, buffer_val, buffer_off_size, buffer_val_size);
+
+  return Status::Ok();
 }
 
 Status Query::set_buffer_vbytemap(
@@ -1009,15 +1533,61 @@ Status Query::set_buffer(
     const bool check_null_buffers) {
   RETURN_NOT_OK(check_set_fixed_buffer(name));
 
-  if (type_ == QueryType::WRITE)
-    return writer_.set_buffer(
-        name, buffer, buffer_size, std::move(validity_vector));
-  return reader_.set_buffer(
-      name,
-      buffer,
-      buffer_size,
-      std::move(validity_vector),
-      check_null_buffers);
+  // Check buffer
+  if (check_null_buffers && buffer == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+
+  // Check buffer size
+  if (check_null_buffers && buffer_size == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " buffer size is null"));
+
+  // Check validity buffer offset
+  if (check_null_buffers && validity_vector.buffer() == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " validity buffer is null"));
+
+  // Check validity buffer size
+  if (check_null_buffers && validity_vector.buffer_size() == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " validity buffer size is null"));
+
+  // Array schema must exist
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; Array schema not set"));
+
+  // Must be an attribute
+  if (!array_schema_->is_attr(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Buffer name '") + name +
+        "' is not an attribute"));
+
+  // Must be fixed-size
+  if (array_schema_->var_size(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute '") + name +
+        "' is var-sized"));
+
+  // Must be nullable
+  if (!array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute '") + name +
+        "' is not nullable"));
+
+  // Error if setting a new attribute/dimension after initialization
+  const bool exists = buffers_.find(name) != buffers_.end();
+  if (status_ != QueryStatus::UNINITIALIZED && !exists)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer for new attribute '") + name +
+        "' after initialization"));
+
+  // Set attribute buffer
+  buffers_[name] = QueryBuffer(
+      buffer, nullptr, buffer_size, nullptr, std::move(validity_vector));
+
+  return Status::Ok();
 }
 
 Status Query::set_buffer(
@@ -1028,22 +1598,76 @@ Status Query::set_buffer(
     uint64_t* const buffer_val_size,
     ValidityVector&& validity_vector,
     const bool check_null_buffers) {
-  if (type_ == QueryType::WRITE)
-    return writer_.set_buffer(
-        name,
-        buffer_off,
-        buffer_off_size,
-        buffer_val,
-        buffer_val_size,
-        std::move(validity_vector));
-  return reader_.set_buffer(
-      name,
+  // Check buffer
+  if (check_null_buffers && buffer_val == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+
+  // Check buffer size
+  if (check_null_buffers && buffer_val_size == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " buffer size is null"));
+
+  // Check buffer offset
+  if (check_null_buffers && buffer_off == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " offset buffer is null"));
+
+  // Check buffer offset size
+  if (check_null_buffers && buffer_off_size == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " offset buffer size is null"));
+  ;
+
+  // Check validity buffer offset
+  if (check_null_buffers && validity_vector.buffer() == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " validity buffer is null"));
+
+  // Check validity buffer size
+  if (check_null_buffers && validity_vector.buffer_size() == nullptr)
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set buffer; " + name + " validity buffer size is null"));
+
+  // Array schema must exist
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set buffer; Array schema not set"));
+
+  // Must be an attribute
+  if (!array_schema_->is_attr(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Buffer name '") + name +
+        "' is not an attribute"));
+
+  // Must be var-size
+  if (!array_schema_->var_size(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute '") + name +
+        "' is fixed-sized"));
+
+  // Must be nullable
+  if (!array_schema_->is_nullable(name))
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer; Input attribute '") + name +
+        "' is not nullable"));
+
+  // Error if setting a new attribute after initialization
+  const bool exists = buffers_.find(name) != buffers_.end();
+  if (status_ != QueryStatus::UNINITIALIZED && !exists)
+    return LOG_STATUS(Status::QueryError(
+        std::string("Cannot set buffer for new attribute '") + name +
+        "' after initialization"));
+
+  // Set attribute/dimension buffer
+  buffers_[name] = QueryBuffer(
       buffer_off,
-      buffer_off_size,
       buffer_val,
+      buffer_off_size,
       buffer_val_size,
-      std::move(validity_vector),
-      check_null_buffers);
+      std::move(validity_vector));
+
+  return Status::Ok();
 }
 
 Status Query::set_est_result_size(
@@ -1053,7 +1677,7 @@ Status Query::set_est_result_size(
     return LOG_STATUS(Status::QueryError(
         "Cannot set estimated result size; Operation currently "
         "unsupported for write queries"));
-  return reader_.set_est_result_size(est_result_size, max_mem_size);
+  return subarray_.set_est_result_size(est_result_size, max_mem_size);
 }
 
 Status Query::set_layout(Layout layout) {
@@ -1062,6 +1686,7 @@ Status Query::set_layout(Layout layout) {
         "Cannot set layout; Hilbert order is not applicable to queries"));
 
   layout_ = layout;
+  subarray_.set_layout(layout);
   return Status::Ok();
 }
 
@@ -1070,15 +1695,39 @@ Status Query::set_condition(const QueryCondition& condition) {
     return LOG_STATUS(Status::QueryError(
         "Cannot set query condition; Operation only applicable "
         "to read queries"));
-  return reader_.set_condition(condition);
+
+  condition_ = condition;
+  return Status::Ok();
 }
 
 Status Query::set_sparse_mode(bool sparse_mode) {
+  if (status_ != QueryStatus::UNINITIALIZED)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set sparse mode after initialization"));
+
   if (type_ != QueryType::READ)
     return LOG_STATUS(Status::QueryError(
         "Cannot set sparse mode; Only applicable to read queries"));
 
-  return reader_.set_sparse_mode(sparse_mode);
+  if (!array_schema_->dense())
+    return LOG_STATUS(Status::QueryError(
+        "Cannot set sparse mode; Only applicable to dense arrays"));
+
+  bool all_sparse = true;
+  for (const auto& f : fragment_metadata_) {
+    if (f->dense()) {
+      all_sparse = false;
+      break;
+    }
+  }
+
+  if (!all_sparse)
+    return LOG_STATUS(
+        Status::QueryError("Cannot set sparse mode; Only applicable to opened "
+                           "dense arrays having only sparse fragments"));
+
+  sparse_mode_ = sparse_mode;
+  return Status::Ok();
 }
 
 void Query::set_status(QueryStatus status) {
@@ -1086,26 +1735,20 @@ void Query::set_status(QueryStatus status) {
 }
 
 Status Query::set_subarray(const void* subarray) {
-  if (!array_->array_schema()->domain()->all_dims_same_type())
+  if (!array_schema_->domain()->all_dims_same_type())
     return LOG_STATUS(
         Status::QueryError("Cannot set subarray; Function not applicable to "
                            "heterogeneous domains"));
 
-  if (!array_->array_schema()->domain()->all_dims_fixed())
+  if (!array_schema_->domain()->all_dims_fixed())
     return LOG_STATUS(
         Status::QueryError("Cannot set subarray; Function not applicable to "
                            "domains with variable-sized dimensions"));
 
-  // To construct the `Subarray` object, it needs the stats of
-  // the parent. Depending the type, the parent stats will either
-  // be from the `reader_` or `writer_`.
-  Stats* const parent_stats =
-      (type_ == QueryType::WRITE) ? writer_.stats() : reader_.stats();
-
   // Prepare a subarray object
-  Subarray sub(array_, layout_, parent_stats);
+  Subarray sub(array_, layout_, stats_);
   if (subarray != nullptr) {
-    auto dim_num = array_->array_schema()->dim_num();
+    auto dim_num = array_schema_->dim_num();
     auto s_ptr = (const unsigned char*)subarray;
     uint64_t offset = 0;
 
@@ -1125,7 +1768,7 @@ Status Query::set_subarray(const void* subarray) {
     }
 
     for (unsigned d = 0; d < dim_num; ++d) {
-      auto r_size = 2 * array_->array_schema()->dimension(d)->coord_size();
+      auto r_size = 2 * array_schema_->dimension(d)->coord_size();
       Range range(&s_ptr[offset], r_size);
       RETURN_NOT_OK(sub.add_range(d, std::move(range), err_on_range_oob));
       offset += r_size;
@@ -1133,36 +1776,46 @@ Status Query::set_subarray(const void* subarray) {
   }
 
   if (type_ == QueryType::WRITE) {
-    RETURN_NOT_OK(writer_.set_subarray(sub));
-  } else if (type_ == QueryType::READ) {
-    RETURN_NOT_OK(reader_.set_subarray(sub));
+    // Not applicable to sparse arrays
+    if (!array_schema_->dense())
+      return LOG_STATUS(Status::WriterError(
+          "Setting a subarray is not supported in sparse writes"));
+
+    // Subarray must be unary for dense writes
+    if (sub.range_num() != 1)
+      return LOG_STATUS(
+          Status::WriterError("Cannot set subarray; Multi-range dense writes "
+                              "are not supported"));
+    if (strategy_ != nullptr)
+      strategy_->reset();
   }
+
+  subarray_ = sub;
 
   status_ = QueryStatus::UNINITIALIZED;
 
   return Status::Ok();
 }
 
-Status Query::set_subarray_unsafe(const NDRange& subarray) {
-  // To construct the `Subarray` object, it needs the stats of
-  // the parent. Depending the type, the parent stats will either
-  // be from the `reader_` or `writer_`.
-  Stats* const parent_stats =
-      (type_ == QueryType::WRITE) ? writer_.stats() : reader_.stats();
+const Subarray* Query::subarray() const {
+  return &subarray_;
+}
 
+Status Query::set_subarray_unsafe(const Subarray& subarray) {
+  subarray_ = subarray;
+  return Status::Ok();
+}
+
+Status Query::set_subarray_unsafe(const NDRange& subarray) {
   // Prepare a subarray object
-  Subarray sub(array_, layout_, parent_stats);
+  Subarray sub(array_, layout_, stats_);
   if (!subarray.empty()) {
-    auto dim_num = array_->array_schema()->dim_num();
+    auto dim_num = array_schema_->dim_num();
     for (unsigned d = 0; d < dim_num; ++d)
       RETURN_NOT_OK(sub.add_range_unsafe(d, subarray[d]));
   }
 
-  if (type_ == QueryType::WRITE) {
-    RETURN_NOT_OK(writer_.set_subarray(sub));
-  } else if (type_ == QueryType::READ) {
-    RETURN_NOT_OK(reader_.set_subarray(sub));
-  }
+  subarray_ = sub;
 
   status_ = QueryStatus::UNINITIALIZED;
 
@@ -1172,68 +1825,35 @@ Status Query::set_subarray_unsafe(const NDRange& subarray) {
 Status Query::check_buffers_correctness() {
   // Iterate through each attribute
   for (auto& attr : buffer_names()) {
-    if (type_ == QueryType::WRITE) {
-      if (writer_.buffer(attr).buffer_ == nullptr)
-        return LOG_STATUS(
-            Status::QueryError(std::string("Data buffer is not set")));
-      if (array_->array_schema()->var_size(attr)) {
-        // Var-sized
-        // Check for data buffer under buffer_var
-        bool exists_data = writer_.buffer(attr).buffer_var_ != nullptr;
-        bool exists_offset = writer_.buffer(attr).buffer_ != nullptr;
-        if (!exists_data || !exists_offset) {
-          return LOG_STATUS(Status::QueryError(
-              std::string("Var-Sized input attribute/dimension '") + attr +
-              "' is not set correctly \nOffsets buffer is not set"));
-        }
-      } else {
-        // Fixed sized
-        bool exists_data = writer_.buffer(attr).buffer_ != nullptr;
-        bool exists_offset = writer_.buffer(attr).buffer_var_ != nullptr;
-        if (!exists_data || exists_offset) {
-          return LOG_STATUS(Status::QueryError(
-              std::string("Fix-Sized input attribute/dimension '") + attr +
-              "' is not set correctly \nOffsets buffer is not set"));
-        }
-      }
-      if (array_->array_schema()->is_nullable(attr)) {
-        bool exists_validity =
-            writer_.buffer(attr).validity_vector_.buffer() != nullptr;
-        if (!exists_validity) {
-          return LOG_STATUS(Status::QueryError(
-              std::string("Nullable input attribute/dimension '") + attr +
-              "' is not set correctly \nValidity buffer is not set"));
-        }
+    if (buffer(attr).buffer_ == nullptr)
+      return LOG_STATUS(
+          Status::QueryError(std::string("Data buffer is not set")));
+    if (array_schema_->var_size(attr)) {
+      // Var-sized
+      // Check for data buffer under buffer_var
+      bool exists_data = buffer(attr).buffer_var_ != nullptr;
+      bool exists_offset = buffer(attr).buffer_ != nullptr;
+      if (!exists_data || !exists_offset) {
+        return LOG_STATUS(Status::QueryError(
+            std::string("Var-Sized input attribute/dimension '") + attr +
+            "' is not set correctly \nOffsets buffer is not set"));
       }
     } else {
-      if (array_->array_schema()->var_size(attr)) {
-        // Var-sized
-        // Check for data buffer under buffer_var
-        bool exists_data = reader_.buffer(attr).buffer_var_ != nullptr;
-        bool exists_offset = reader_.buffer(attr).buffer_ != nullptr;
-        if (!exists_data || !exists_offset) {
-          return LOG_STATUS(Status::QueryError(
-              std::string("Var-Sized input attribute/dimension '") + attr +
-              "' is not set correctly \nOffsets buffer is not set"));
-        }
-      } else {
-        // Fixed sized
-        bool exists_data = reader_.buffer(attr).buffer_ != nullptr;
-        bool exists_offset = reader_.buffer(attr).buffer_var_ != nullptr;
-        if (!exists_data || exists_offset) {
-          return LOG_STATUS(Status::QueryError(
-              std::string("Fix-Sized input attribute/dimension '") + attr +
-              "' is not set correctly \nOffsets buffer is not set"));
-        }
+      // Fixed sized
+      bool exists_data = buffer(attr).buffer_ != nullptr;
+      bool exists_offset = buffer(attr).buffer_var_ != nullptr;
+      if (!exists_data || exists_offset) {
+        return LOG_STATUS(Status::QueryError(
+            std::string("Fix-Sized input attribute/dimension '") + attr +
+            "' is not set correctly \nOffsets buffer is not set"));
       }
-      if (array_->array_schema()->is_nullable(attr)) {
-        bool exists_validity =
-            reader_.buffer(attr).validity_vector_.buffer() != nullptr;
-        if (!exists_validity) {
-          return LOG_STATUS(Status::QueryError(
-              std::string("Nullable input attribute/dimension '") + attr +
-              "' is not set correctly \nValidity buffer is not set"));
-        }
+    }
+    if (array_schema_->is_nullable(attr)) {
+      bool exists_validity = buffer(attr).validity_vector_.buffer() != nullptr;
+      if (!exists_validity) {
+        return LOG_STATUS(Status::QueryError(
+            std::string("Nullable input attribute/dimension '") + attr +
+            "' is not set correctly \nValidity buffer is not set"));
       }
     }
   }
@@ -1254,7 +1874,7 @@ Status Query::submit() {
       return LOG_STATUS(Status::QueryError(
           "Error in query submission; remote array with no rest client."));
 
-    array_->array_schema()->set_array_uri(array_->array_uri());
+    array_schema_->set_array_uri(array_->array_uri());
     return rest_client->submit_query_to_rest(array_->array_uri(), this);
   }
   RETURN_NOT_OK(init());
@@ -1288,10 +1908,7 @@ QueryType Query::type() const {
 }
 
 const Config* Query::config() const {
-  if (type_ == QueryType::READ)
-    return reader_.config();
-  else
-    return writer_.config();
+  return &config_;
 }
 
 stats::Stats* Query::stats() const {

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -94,234 +94,41 @@ inline IterT skip_invalid_elements(IterT it, const IterT& end) {
 }  // namespace
 
 /* ****************************** */
-/*   CONSTRUCTORS & DESTRUCTORS   */
+/*          CONSTRUCTORS          */
 /* ****************************** */
 
-Reader::Reader(stats::Stats* const parent_stats)
-    : stats_(parent_stats->create_child("Reader"))
-    , array_(nullptr)
-    , array_schema_(nullptr)
-    , layout_(Layout::ROW_MAJOR)
-    , sparse_mode_(false)
-    , storage_manager_(nullptr)
-    , offsets_extra_element_(false)
-    , offsets_bitsize_(constants::cell_var_offset_size * 8) {
-}
-
-Reader::~Reader() {
+Reader::Reader(
+    stats::Stats* stats,
+    StorageManager* storage_manager,
+    Array* array,
+    Config& config,
+    std::unordered_map<std::string, QueryBuffer>& buffers,
+    Subarray& subarray,
+    Layout layout,
+    QueryCondition& condition,
+    bool sparse_mode)
+    : ReaderBase(
+          stats,
+          storage_manager,
+          array,
+          config,
+          buffers,
+          subarray,
+          layout,
+          condition)
+    , sparse_mode_(sparse_mode) {
 }
 
 /* ****************************** */
 /*               API              */
 /* ****************************** */
 
-const Array* Reader::array() const {
-  return array_;
-}
-
-Status Reader::add_range(unsigned dim_idx, Range&& range) {
-  // Get read_range_oob config setting
-  bool found = false;
-  std::string read_range_oob = config_.get("sm.read_range_oob", &found);
-  assert(found);
-
-  if (read_range_oob != "error" && read_range_oob != "warn")
-    return LOG_STATUS(Status::ReaderError(
-        "Invalid value " + read_range_oob +
-        " for sm.read_range_obb. Acceptable values are 'error' or 'warn'."));
-
-  return subarray_.add_range(
-      dim_idx, std::move(range), read_range_oob == "error");
-}
-
-Status Reader::get_range_num(unsigned dim_idx, uint64_t* range_num) const {
-  return subarray_.get_range_num(dim_idx, range_num);
-}
-
-Status Reader::get_range(
-    unsigned dim_idx,
-    uint64_t range_idx,
-    const void** start,
-    const void** end,
-    const void** stride) const {
-  *stride = nullptr;
-  return subarray_.get_range(dim_idx, range_idx, start, end);
-}
-
-Status Reader::get_range_var_size(
-    unsigned dim_idx,
-    uint64_t range_idx,
-    uint64_t* start_size,
-    uint64_t* end_size) const {
-  return subarray_.get_range_var_size(dim_idx, range_idx, start_size, end_size);
-}
-
-Status Reader::get_est_result_size(const char* name, uint64_t* size) {
-  return subarray_.get_est_result_size(
-      name, size, &config_, storage_manager_->compute_tp());
-}
-
-Status Reader::get_est_result_size(
-    const char* name, uint64_t* size_off, uint64_t* size_val) {
-  return subarray_.get_est_result_size(
-      name, size_off, size_val, &config_, storage_manager_->compute_tp());
-}
-
-Status Reader::get_est_result_size_nullable(
-    const char* name, uint64_t* size_val, uint64_t* size_validity) {
-  return subarray_.get_est_result_size_nullable(
-      name, size_val, size_validity, &config_, storage_manager_->compute_tp());
-}
-
-Status Reader::get_est_result_size_nullable(
-    const char* name,
-    uint64_t* size_off,
-    uint64_t* size_val,
-    uint64_t* size_validity) {
-  return subarray_.get_est_result_size_nullable(
-      name,
-      size_off,
-      size_val,
-      size_validity,
-      &config_,
-      storage_manager_->compute_tp());
-}
-
-const ArraySchema* Reader::array_schema() const {
-  return array_schema_;
-}
-
-std::vector<std::string> Reader::buffer_names() const {
-  std::vector<std::string> ret;
-  ret.reserve(buffers_.size());
-  for (const auto& it : buffers_)
-    ret.push_back(it.first);
-
-  return ret;
-}
-
-QueryBuffer Reader::buffer(const std::string& name) const {
-  auto buf = buffers_.find(name);
-  if (buf == buffers_.end())
-    return QueryBuffer{};
-  return buf->second;
+Status Reader::finalize() {
+  return Status::Ok();
 }
 
 bool Reader::incomplete() const {
   return read_state_.overflowed_ || !read_state_.done();
-}
-
-Status Reader::get_data_buffer(
-    const std::string& name, void** buffer, uint64_t** buffer_size) const {
-  auto it = buffers_.find(name);
-  if (it == buffers_.end()) {
-    *buffer = nullptr;
-    *buffer_size = nullptr;
-  } else {
-    if (!array_schema_->var_size(name)) {
-      *buffer = it->second.buffer_;
-      *buffer_size = it->second.buffer_size_;
-    } else {
-      *buffer = it->second.buffer_var_;
-      *buffer_size = it->second.buffer_var_size_;
-    }
-  }
-
-  return Status::Ok();
-}
-
-Status Reader::get_offsets_buffer(
-    const std::string& name,
-    uint64_t** buffer_off,
-    uint64_t** buffer_off_size) const {
-  auto it = buffers_.find(name);
-  if (it == buffers_.end()) {
-    *buffer_off = nullptr;
-    *buffer_off_size = nullptr;
-  } else {
-    *buffer_off = (uint64_t*)it->second.buffer_;
-    *buffer_off_size = it->second.buffer_size_;
-  }
-
-  return Status::Ok();
-}
-
-Status Reader::get_validity_buffer(
-    const std::string& name, const ValidityVector** validity_vector) const {
-  auto it = buffers_.find(name);
-  if (it == buffers_.end()) {
-    *validity_vector = nullptr;
-  } else {
-    *validity_vector = &it->second.validity_vector_;
-  }
-
-  return Status::Ok();
-}
-
-Status Reader::get_buffer(
-    const std::string& name,
-    uint64_t** buffer_off,
-    uint64_t** buffer_off_size,
-    void** buffer_val,
-    uint64_t** buffer_val_size) const {
-  auto it = buffers_.find(name);
-  if (it == buffers_.end()) {
-    *buffer_off = nullptr;
-    *buffer_off_size = nullptr;
-    *buffer_val = nullptr;
-    *buffer_val_size = nullptr;
-  } else {
-    *buffer_off = (uint64_t*)it->second.buffer_;
-    *buffer_off_size = it->second.buffer_size_;
-    *buffer_val = it->second.buffer_var_;
-    *buffer_val_size = it->second.buffer_var_size_;
-  }
-
-  return Status::Ok();
-}
-
-Status Reader::get_buffer_nullable(
-    const std::string& name,
-    void** buffer,
-    uint64_t** buffer_size,
-    const ValidityVector** valdity_vector) const {
-  auto it = buffers_.find(name);
-  if (it == buffers_.end()) {
-    *buffer = nullptr;
-    *buffer_size = nullptr;
-    *valdity_vector = nullptr;
-  } else {
-    *buffer = it->second.buffer_;
-    *buffer_size = it->second.buffer_size_;
-    *valdity_vector = &it->second.validity_vector_;
-  }
-
-  return Status::Ok();
-}
-
-Status Reader::get_buffer_nullable(
-    const std::string& name,
-    uint64_t** buffer_off,
-    uint64_t** buffer_off_size,
-    void** buffer_val,
-    uint64_t** buffer_val_size,
-    const ValidityVector** valdity_vector) const {
-  auto it = buffers_.find(name);
-  if (it == buffers_.end()) {
-    *buffer_off = nullptr;
-    *buffer_off_size = nullptr;
-    *buffer_val = nullptr;
-    *buffer_val_size = nullptr;
-    *valdity_vector = nullptr;
-  } else {
-    *buffer_off = (uint64_t*)it->second.buffer_;
-    *buffer_off_size = it->second.buffer_size_;
-    *buffer_val = it->second.buffer_var_;
-    *buffer_val_size = it->second.buffer_var_size_;
-    *valdity_vector = &it->second.validity_vector_;
-  }
-
-  return Status::Ok();
 }
 
 Status Reader::init(const Layout& layout) {
@@ -340,7 +147,8 @@ Status Reader::init(const Layout& layout) {
         "Cannot initialize reader; Dense reads must have a subarray set"));
 
   // Set layout
-  RETURN_NOT_OK(set_layout(layout));
+  layout_ = layout;
+  subarray_.set_layout(layout);
 
   // Check subarray
   RETURN_NOT_OK(check_subarray());
@@ -354,34 +162,6 @@ Status Reader::init(const Layout& layout) {
   RETURN_NOT_OK(check_validity_buffer_sizes());
 
   return Status::Ok();
-}
-
-URI Reader::first_fragment_uri() const {
-  if (fragment_metadata_.empty())
-    return URI();
-  return fragment_metadata_.front()->fragment_uri();
-}
-
-URI Reader::last_fragment_uri() const {
-  if (fragment_metadata_.empty())
-    return URI();
-  return fragment_metadata_.back()->fragment_uri();
-}
-
-Layout Reader::layout() const {
-  return layout_;
-}
-
-const QueryCondition* Reader::condition() const {
-  return &condition_;
-}
-
-bool Reader::no_results() const {
-  for (const auto& it : buffers_) {
-    if (*(it.second.buffer_size_) != 0)
-      return false;
-  }
-  return true;
 }
 
 const Reader::ReadState* Reader::read_state() const {
@@ -400,7 +180,7 @@ Status Reader::complete_read_loop() {
   return Status::Ok();
 }
 
-Status Reader::read() {
+Status Reader::dowork() {
   // Check that the query condition is valid.
   RETURN_NOT_OK(condition_.check(array_schema_));
 
@@ -444,13 +224,17 @@ Status Reader::read() {
         return complete_read_loop();
       }
     } else {
-      bool no_results = this->no_results();
+      bool has_results = false;
+      for (const auto& it : buffers_) {
+        if (*(it.second.buffer_size_) != 0)
+          has_results = true;
+      }
 
       // Need to reset unsplittable if the results fit after all
-      if (!no_results)
+      if (has_results)
         read_state_.unsplittable_ = false;
 
-      if (!no_results || read_state_.done()) {
+      if (has_results || read_state_.done()) {
         return complete_read_loop();
       }
 
@@ -461,534 +245,7 @@ Status Reader::read() {
   return Status::Ok();
 }
 
-void Reader::set_array(const Array* array) {
-  array_ = array;
-  subarray_ = Subarray(array, Layout::ROW_MAJOR, stats_);
-}
-
-void Reader::set_array_schema(const ArraySchema* array_schema) {
-  array_schema_ = array_schema;
-}
-
-Status Reader::set_buffer(
-    const std::string& name,
-    void* const buffer,
-    uint64_t* const buffer_size,
-    const bool check_null_buffers) {
-  // Check buffer
-  if (check_null_buffers && buffer == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (check_null_buffers && buffer_size == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; Array schema not set"));
-
-  // For easy reference
-  const bool is_dim = array_schema_->is_dim(name);
-  const bool is_attr = array_schema_->is_attr(name);
-
-  // Check that attribute/dimension exists
-  if (name != constants::coords && !is_dim && !is_attr)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
-        "'"));
-
-  // Must not be nullable
-  if (array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is nullable"));
-
-  // Check that attribute/dimension is fixed-sized
-  const bool var_size =
-      (name != constants::coords && array_schema_->var_size(name));
-  if (var_size)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is var-sized"));
-
-  // Check if zipped coordinates coexist with separate coordinate buffers
-  if ((is_dim && buffers_.find(constants::coords) != buffers_.end()) ||
-      (name == constants::coords && has_separate_coords()))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set separate coordinate buffers and "
-                    "a zipped coordinate buffer in the same query")));
-
-  // Error if setting a new attribute/dimension after initialization
-  const bool exists = buffers_.find(name) != buffers_.end();
-  if (read_state_.initialized_ && !exists)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer for new attribute/dimension '") + name +
-        "' after initialization"));
-
-  // Set attribute buffer
-  buffers_[name] = QueryBuffer(buffer, nullptr, buffer_size, nullptr);
-
-  return Status::Ok();
-}
-
-Status Reader::set_data_buffer(
-    const std::string& name,
-    void* const buffer,
-    uint64_t* const buffer_size,
-    bool check_null_buffers) {
-  // Check buffer
-  if (check_null_buffers && buffer == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (check_null_buffers && buffer_size == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; Array schema not set"));
-
-  // For easy reference
-  const bool is_dim = array_schema_->is_dim(name);
-  const bool is_attr = array_schema_->is_attr(name);
-
-  // Check that attribute/dimension exists
-  if (name != constants::coords && !is_dim && !is_attr)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
-        "'"));
-  // Check if zipped coordinates coexist with separate coordinate buffers
-  if ((is_dim && buffers_.find(constants::coords) != buffers_.end()) ||
-      (name == constants::coords && has_separate_coords()))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set separate coordinate buffers and "
-                    "a zipped coordinate buffer in the same query")));
-
-  // Error if setting a new attribute/dimension after initialization
-  const bool exists = buffers_.find(name) != buffers_.end();
-  if (read_state_.initialized_ && !exists)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer for new attribute/dimension '") + name +
-        "' after initialization"));
-
-  // Set attribute/dimension buffer on the appropriate buffer
-  if (!array_schema_->var_size(name))
-    // Fixed size data buffer
-    buffers_[name].set_data_buffer(buffer, buffer_size);
-  else
-    // Var sized data buffer
-    buffers_[name].set_data_var_buffer(buffer, buffer_size);
-
-  return Status::Ok();
-}
-
-Status Reader::set_offsets_buffer(
-    const std::string& name,
-    uint64_t* const buffer_off,
-    uint64_t* const buffer_off_size,
-    bool check_null_buffers) {
-  // Check buffer
-  if (check_null_buffers && buffer_off == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (check_null_buffers && buffer_off_size == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; Array schema not set"));
-
-  // For easy reference
-  const bool is_dim = array_schema_->is_dim(name);
-  const bool is_attr = array_schema_->is_attr(name);
-
-  // Neither a dimension nor an attribute
-  if (!is_dim && !is_attr)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Invalid buffer name '") + name +
-        "' (it should be an attribute or dimension)"));
-
-  // Error if it is fixed-sized
-  if (!array_schema_->var_size(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is fixed-sized"));
-
-  // Error if setting a new attribute/dimension after initialization
-  bool exists = buffers_.find(name) != buffers_.end();
-  if (read_state_.initialized_ && !exists)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer for new attribute/dimension '") + name +
-        "' after initialization"));
-
-  // Set attribute/dimension buffer
-  buffers_[name].set_offsets_buffer(buffer_off, buffer_off_size);
-
-  return Status::Ok();
-}
-
-Status Reader::set_validity_buffer(
-    const std::string& name,
-    uint8_t* const buffer_validity_bytemap,
-    uint64_t* const buffer_validity_bytemap_size,
-    bool check_null_buffers) {
-  ValidityVector validity_vector;
-  RETURN_NOT_OK(validity_vector.init_bytemap(
-      buffer_validity_bytemap, buffer_validity_bytemap_size));
-  // Check validity buffer
-  if (check_null_buffers && validity_vector.buffer() == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " validity buffer is null"));
-
-  // Check validity buffer size
-  if (check_null_buffers && validity_vector.buffer_size() == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " validity buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; Array schema not set"));
-
-  // Must be an attribute
-  if (!array_schema_->is_attr(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Buffer name '") + name +
-        "' is not an attribute"));
-
-  // Must be nullable
-  if (!array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is not nullable"));
-
-  // Error if setting a new attribute after initialization
-  const bool exists = buffers_.find(name) != buffers_.end();
-  if (read_state_.initialized_ && !exists)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer for new attribute '") + name +
-        "' after initialization"));
-
-  // Set attribute/dimension buffer
-  buffers_[name].set_validity_buffer(std::move(validity_vector));
-
-  return Status::Ok();
-}
-
-Status Reader::set_buffer(
-    const std::string& name,
-    uint64_t* const buffer_off,
-    uint64_t* const buffer_off_size,
-    void* const buffer_val,
-    uint64_t* const buffer_val_size,
-    const bool check_null_buffers) {
-  // Check buffer
-  if (check_null_buffers && buffer_val == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (check_null_buffers && buffer_val_size == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Check offset buffer
-  if (check_null_buffers && buffer_off == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " offset buffer is null"));
-
-  // Check offset buffer size
-  if (check_null_buffers && buffer_off_size == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " offset buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; Array schema not set"));
-
-  // For easy reference
-  const bool is_dim = array_schema_->is_dim(name);
-  const bool is_attr = array_schema_->is_attr(name);
-
-  // Check that attribute/dimension exists
-  if (!is_dim && !is_attr)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
-        "'"));
-
-  // Must not be nullable
-  if (array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is nullable"));
-
-  // Check that attribute/dimension is var-sized
-  if (!array_schema_->var_size(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is fixed-sized"));
-
-  // Error if setting a new attribute/dimension after initialization
-  const bool exists = buffers_.find(name) != buffers_.end();
-  if (read_state_.initialized_ && !exists)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer for new attribute/dimension '") + name +
-        "' after initialization"));
-
-  // Set attribute/dimension buffer
-  buffers_[name] =
-      QueryBuffer(buffer_off, buffer_val, buffer_off_size, buffer_val_size);
-
-  return Status::Ok();
-}
-
-Status Reader::set_buffer(
-    const std::string& name,
-    void* const buffer,
-    uint64_t* const buffer_size,
-    ValidityVector&& validity_vector,
-    const bool check_null_buffers) {
-  // Check buffer
-  if (check_null_buffers && buffer == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (check_null_buffers && buffer_size == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Check validity buffer offset
-  if (check_null_buffers && validity_vector.buffer() == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " validity buffer is null"));
-
-  // Check validity buffer size
-  if (check_null_buffers && validity_vector.buffer_size() == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " validity buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; Array schema not set"));
-
-  // Must be an attribute
-  if (!array_schema_->is_attr(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Buffer name '") + name +
-        "' is not an attribute"));
-
-  // Must be fixed-size
-  if (array_schema_->var_size(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is var-sized"));
-
-  // Must be nullable
-  if (!array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is not nullable"));
-
-  // Error if setting a new attribute/dimension after initialization
-  const bool exists = buffers_.find(name) != buffers_.end();
-  if (read_state_.initialized_ && !exists)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer for new attribute '") + name +
-        "' after initialization"));
-
-  // Set attribute buffer
-  buffers_[name] = QueryBuffer(
-      buffer, nullptr, buffer_size, nullptr, std::move(validity_vector));
-
-  return Status::Ok();
-}
-
-Status Reader::set_buffer(
-    const std::string& name,
-    uint64_t* const buffer_off,
-    uint64_t* const buffer_off_size,
-    void* const buffer_val,
-    uint64_t* const buffer_val_size,
-    ValidityVector&& validity_vector,
-    const bool check_null_buffers) {
-  // Check buffer
-  if (check_null_buffers && buffer_val == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (check_null_buffers && buffer_val_size == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Check buffer offset
-  if (check_null_buffers && buffer_off == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " offset buffer is null"));
-
-  // Check buffer offset size
-  if (check_null_buffers && buffer_off_size == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " offset buffer size is null"));
-  ;
-
-  // Check validity buffer offset
-  if (check_null_buffers && validity_vector.buffer() == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " validity buffer is null"));
-
-  // Check validity buffer size
-  if (check_null_buffers && validity_vector.buffer_size() == nullptr)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set buffer; " + name + " validity buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set buffer; Array schema not set"));
-
-  // Must be an attribute
-  if (!array_schema_->is_attr(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Buffer name '") + name +
-        "' is not an attribute"));
-
-  // Must be fixed-size
-  if (!array_schema_->var_size(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is fixed-sized"));
-
-  // Must be nullable
-  if (!array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is not nullable"));
-
-  // Error if setting a new attribute after initialization
-  const bool exists = buffers_.find(name) != buffers_.end();
-  if (read_state_.initialized_ && !exists)
-    return LOG_STATUS(Status::ReaderError(
-        std::string("Cannot set buffer for new attribute '") + name +
-        "' after initialization"));
-
-  // Set attribute/dimension buffer
-  buffers_[name] = QueryBuffer(
-      buffer_off,
-      buffer_val,
-      buffer_off_size,
-      buffer_val_size,
-      std::move(validity_vector));
-
-  return Status::Ok();
-}
-
-void Reader::set_fragment_metadata(
-    const std::vector<FragmentMetadata*>& fragment_metadata) {
-  fragment_metadata_ = fragment_metadata;
-}
-
-Status Reader::set_layout(Layout layout) {
-  layout_ = layout;
-  subarray_.set_layout(layout);
-
-  return Status::Ok();
-}
-
-Status Reader::set_condition(const QueryCondition& condition) {
-  condition_ = condition;
-
-  return Status::Ok();
-}
-
-Status Reader::set_sparse_mode(bool sparse_mode) {
-  if (!array_schema_->dense())
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set sparse mode; Only applicable to dense arrays"));
-
-  bool all_sparse = true;
-  for (const auto& f : fragment_metadata_) {
-    if (f->dense()) {
-      all_sparse = false;
-      break;
-    }
-  }
-
-  if (!all_sparse)
-    return LOG_STATUS(
-        Status::ReaderError("Cannot set sparse mode; Only applicable to opened "
-                            "dense arrays having only sparse fragments"));
-
-  sparse_mode_ = sparse_mode;
-  return Status::Ok();
-}
-
-void Reader::set_storage_manager(StorageManager* storage_manager) {
-  storage_manager_ = storage_manager;
-  set_config(storage_manager->config());
-}
-
-Status Reader::set_subarray(const Subarray& subarray) {
-  subarray_ = subarray;
-  layout_ = subarray.layout();
-
-  return Status::Ok();
-}
-
-const Subarray* Reader::subarray() const {
-  return &subarray_;
-}
-
-std::string Reader::offsets_mode() const {
-  return offsets_format_mode_;
-}
-
-Status Reader::set_offsets_mode(const std::string& offsets_mode) {
-  offsets_format_mode_ = offsets_mode;
-
-  return Status::Ok();
-}
-
-bool Reader::offsets_extra_element() const {
-  return offsets_extra_element_;
-}
-
-Status Reader::set_offsets_extra_element(bool add_extra_element) {
-  offsets_extra_element_ = add_extra_element;
-
-  return Status::Ok();
-}
-
-uint32_t Reader::offsets_bitsize() const {
-  return offsets_bitsize_;
-}
-
-Status Reader::set_offsets_bitsize(const uint32_t bitsize) {
-  if (bitsize != 32 && bitsize != 64) {
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot set offset bitsize to " + std::to_string(bitsize) +
-        "; Only 32 and 64 are acceptable bitsize values"));
-  }
-
-  offsets_bitsize_ = bitsize;
-  return Status::Ok();
-}
-
-Stats* Reader::stats() const {
-  return stats_;
+void Reader::reset() {
 }
 
 /* ********************************* */
@@ -1050,58 +307,8 @@ void Reader::compute_result_space_tiles(
 }
 
 /* ****************************** */
-/*          PRIVATE METHODS       */
+/*         PRIVATE METHODS        */
 /* ****************************** */
-
-Status Reader::check_subarray() const {
-  if (subarray_.layout() == Layout::GLOBAL_ORDER && subarray_.range_num() != 1)
-    return LOG_STATUS(Status::ReaderError(
-        "Cannot initialize reader; Multi-range subarrays with "
-        "global order layout are not supported"));
-
-  return Status::Ok();
-}
-
-Status Reader::check_validity_buffer_sizes() const {
-  // Verify that the validity buffer size for each
-  // nullable attribute is large enough to contain
-  // a validity value for each cell.
-  for (const auto& it : buffers_) {
-    const std::string& name = it.first;
-    if (array_schema_->is_nullable(name)) {
-      const uint64_t buffer_size = *it.second.buffer_size_;
-
-      uint64_t min_cell_num = 0;
-      if (array_schema_->var_size(name)) {
-        min_cell_num = buffer_size / constants::cell_var_offset_size;
-
-        // If the offsets buffer contains an extra element to mark
-        // the offset to the end of the data buffer, we do not need
-        // a validity value for that extra offset.
-        if (offsets_extra_element_)
-          min_cell_num = std::min<uint64_t>(0, min_cell_num - 1);
-      } else {
-        min_cell_num = buffer_size / array_schema_->cell_size(name);
-      }
-
-      const uint64_t buffer_validity_size =
-          *it.second.validity_vector_.buffer_size();
-      const uint64_t cell_validity_num =
-          buffer_validity_size / constants::cell_validity_size;
-
-      if (cell_validity_num < min_cell_num) {
-        std::stringstream ss;
-        ss << "Buffer sizes check failed; Invalid number of validity cells "
-              "given for ";
-        ss << "attribute '" << name << "'";
-        ss << " (" << cell_validity_num << " < " << min_cell_num << ")";
-        return LOG_STATUS(Status::ReaderError(ss.str()));
-      }
-    }
-  }
-
-  return Status::Ok();
-}
 
 void Reader::clear_tiles(
     const std::string& name,
@@ -3331,17 +2538,6 @@ Status Reader::read_tiles(
   return Status::Ok();
 }
 
-void Reader::reset_buffer_sizes() {
-  for (auto& it : buffers_) {
-    *(it.second.buffer_size_) = it.second.original_buffer_size_;
-    if (it.second.buffer_var_size_ != nullptr)
-      *(it.second.buffer_var_size_) = it.second.original_buffer_var_size_;
-    if (it.second.validity_vector_.buffer_size() != nullptr)
-      *(it.second.validity_vector_.buffer_size()) =
-          it.second.original_validity_vector_size_;
-  }
-}
-
 Status Reader::sort_result_coords(
     std::vector<ResultCoords>::iterator iter_begin,
     std::vector<ResultCoords>::iterator iter_end,
@@ -3728,17 +2924,6 @@ Status Reader::add_extra_offset() {
   return Status::Ok();
 }
 
-void Reader::zero_out_buffer_sizes() {
-  for (auto& buffer : buffers_) {
-    if (buffer.second.buffer_size_ != nullptr)
-      *(buffer.second.buffer_size_) = 0;
-    if (buffer.second.buffer_var_size_ != nullptr)
-      *(buffer.second.buffer_var_size_) = 0;
-    if (buffer.second.validity_vector_.buffer_size() != nullptr)
-      *(buffer.second.validity_vector_.buffer_size()) = 0;
-  }
-}
-
 bool Reader::sparse_tile_overwritten(
     unsigned frag_idx, uint64_t tile_idx) const {
   const auto& mbr = fragment_metadata_[frag_idx]->mbr(tile_idx);
@@ -3764,33 +2949,6 @@ void Reader::erase_coord_tiles(std::vector<ResultTile>* result_tiles) const {
   }
 }
 
-void Reader::get_dim_attr_stats() const {
-  for (const auto& it : buffers_) {
-    const auto& name = it.first;
-    auto var_size = array_schema_->var_size(name);
-    if (array_schema_->is_attr(name)) {
-      if (var_size) {
-        stats_->add_counter("attr_var_num", 1);
-      } else {
-        stats_->add_counter("attr_fixed_num", 1);
-      }
-      if (array_schema_->is_nullable(name)) {
-        stats_->add_counter("attr_nullable_num", 1);
-      }
-    } else {
-      if (var_size) {
-        stats_->add_counter("dim_var_num", 1);
-      } else {
-        if (name == constants::coords) {
-          stats_->add_counter("dim_zipped_num", 1);
-        } else {
-          stats_->add_counter("dim_fixed_num", 1);
-        }
-      }
-    }
-  }
-}
-
 void Reader::get_result_cell_stats(
     const std::vector<ResultCellSlab>& result_cell_slabs) const {
   uint64_t result_num = 0;
@@ -3811,38 +2969,6 @@ void Reader::get_result_tile_stats(
       cell_num += array_schema_->domain()->cell_num_per_tile();
   }
   stats_->add_counter("cell_num", cell_num);
-}
-
-Status Reader::set_config(const Config& config) {
-  config_ = config;
-
-  return Status::Ok();
-}
-
-const Config* Reader::config() const {
-  return &config_;
-}
-
-Status Reader::set_est_result_size(
-    std::unordered_map<std::string, Subarray::ResultSize>& est_result_size,
-    std::unordered_map<std::string, Subarray::MemorySize>& max_mem_size) {
-  return subarray_.set_est_result_size(est_result_size, max_mem_size);
-}
-
-std::unordered_map<std::string, Subarray::ResultSize>
-Reader::get_est_result_size_map() {
-  return subarray_.get_est_result_size_map(
-      &config_, storage_manager_->compute_tp());
-}
-
-bool Reader::est_result_size_computed() {
-  return subarray_.est_result_size_computed();
-}
-
-std::unordered_map<std::string, Subarray::MemorySize>
-Reader::get_max_mem_size_map() {
-  return subarray_.get_max_mem_size_map(
-      &config_, storage_manager_->compute_tp());
 }
 
 Status Reader::calculate_hilbert_values(

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -1,0 +1,139 @@
+/**
+ * @file   reader_base.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class ReaderBase.
+ */
+
+#include "tiledb/sm/query/reader_base.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/query/strategy_base.h"
+#include "tiledb/sm/subarray/subarray.h"
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*          CONSTRUCTORS          */
+/* ****************************** */
+
+ReaderBase::ReaderBase(
+    stats::Stats* stats,
+    StorageManager* storage_manager,
+    Array* array,
+    Config& config,
+    std::unordered_map<std::string, QueryBuffer>& buffers,
+    Subarray& subarray,
+    Layout layout,
+    QueryCondition& condition)
+    : StrategyBase(
+          stats, storage_manager, array, config, buffers, subarray, layout)
+    , condition_(condition) {
+  if (array != nullptr)
+    fragment_metadata_ = array->fragment_metadata();
+}
+
+/* ****************************** */
+/*        PROTECTED METHODS       */
+/* ****************************** */
+
+void ReaderBase::reset_buffer_sizes() {
+  for (auto& it : buffers_) {
+    *(it.second.buffer_size_) = it.second.original_buffer_size_;
+    if (it.second.buffer_var_size_ != nullptr)
+      *(it.second.buffer_var_size_) = it.second.original_buffer_var_size_;
+    if (it.second.validity_vector_.buffer_size() != nullptr)
+      *(it.second.validity_vector_.buffer_size()) =
+          it.second.original_validity_vector_size_;
+  }
+}
+
+void ReaderBase::zero_out_buffer_sizes() {
+  for (auto& buffer : buffers_) {
+    if (buffer.second.buffer_size_ != nullptr)
+      *(buffer.second.buffer_size_) = 0;
+    if (buffer.second.buffer_var_size_ != nullptr)
+      *(buffer.second.buffer_var_size_) = 0;
+    if (buffer.second.validity_vector_.buffer_size() != nullptr)
+      *(buffer.second.validity_vector_.buffer_size()) = 0;
+  }
+}
+
+Status ReaderBase::check_subarray() const {
+  if (subarray_.layout() == Layout::GLOBAL_ORDER && subarray_.range_num() != 1)
+    return LOG_STATUS(Status::ReaderError(
+        "Cannot initialize reader; Multi-range subarrays with "
+        "global order layout are not supported"));
+
+  return Status::Ok();
+}
+
+Status ReaderBase::check_validity_buffer_sizes() const {
+  // Verify that the validity buffer size for each
+  // nullable attribute is large enough to contain
+  // a validity value for each cell.
+  for (const auto& it : buffers_) {
+    const std::string& name = it.first;
+    if (array_schema_->is_nullable(name)) {
+      const uint64_t buffer_size = *it.second.buffer_size_;
+
+      uint64_t min_cell_num = 0;
+      if (array_schema_->var_size(name)) {
+        min_cell_num = buffer_size / constants::cell_var_offset_size;
+
+        // If the offsets buffer contains an extra element to mark
+        // the offset to the end of the data buffer, we do not need
+        // a validity value for that extra offset.
+        if (offsets_extra_element_)
+          min_cell_num = std::min<uint64_t>(0, min_cell_num - 1);
+      } else {
+        min_cell_num = buffer_size / array_schema_->cell_size(name);
+      }
+
+      const uint64_t buffer_validity_size =
+          *it.second.validity_vector_.buffer_size();
+      const uint64_t cell_validity_num =
+          buffer_validity_size / constants::cell_validity_size;
+
+      if (cell_validity_num < min_cell_num) {
+        std::stringstream ss;
+        ss << "Buffer sizes check failed; Invalid number of validity cells "
+              "given for ";
+        ss << "attribute '" << name << "'";
+        ss << " (" << cell_validity_num << " < " << min_cell_num << ")";
+        return LOG_STATUS(Status::ReaderError(ss.str()));
+      }
+    }
+  }
+
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -1,0 +1,106 @@
+/**
+ * @file   reader_base.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class ReaderBase.
+ */
+
+#ifndef TILEDB_READER_BASE_H
+#define TILEDB_READER_BASE_H
+
+#include "strategy_base.h"
+#include "tiledb/common/status.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/misc/types.h"
+
+namespace tiledb {
+namespace sm {
+
+class Array;
+class ArraySchema;
+class StorageManager;
+class Subarray;
+class QueryCondition;
+
+/** Processes read queries. */
+class ReaderBase : public StrategyBase {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  ReaderBase(
+      stats::Stats* stats,
+      StorageManager* storage_manager,
+      Array* array,
+      Config& config,
+      std::unordered_map<std::string, QueryBuffer>& buffers,
+      Subarray& subarray,
+      Layout layout,
+      QueryCondition& condition);
+
+  /** Destructor. */
+  ~ReaderBase() = default;
+
+ protected:
+  /* ********************************* */
+  /*       PROTECTED ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The query condition. */
+  QueryCondition& condition_;
+
+  /** The fragment metadata that the reader will focus on. */
+  std::vector<FragmentMetadata*> fragment_metadata_;
+
+  /* ********************************* */
+  /*         PROTECTED METHODS         */
+  /* ********************************* */
+
+  /**
+   * Resets the buffer sizes to the original buffer sizes. This is because
+   * the read query may alter the buffer sizes to reflect the size of
+   * the useful data (results) written in the buffers.
+   */
+  void reset_buffer_sizes();
+
+  /** Zeroes out the user buffer sizes, indicating an empty result. */
+  void zero_out_buffer_sizes();
+
+  /** Correctness checks for `subarray_`. */
+  Status check_subarray() const;
+
+  /** Correctness checks validity buffer sizes in `buffers_`. */
+  Status check_validity_buffer_sizes() const;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_READER_BASE_H

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -1,0 +1,140 @@
+/**
+ * @file   strategy_base.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class StrategyBase. It is a contract that defines the
+ * operations that a query can call on readers or writers.
+ */
+
+#include "tiledb/sm/query/strategy_base.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*          CONSTRUCTORS          */
+/* ****************************** */
+
+StrategyBase::StrategyBase(
+    stats::Stats* stats,
+    StorageManager* storage_manager,
+    Array* array,
+    Config& config,
+    std::unordered_map<std::string, QueryBuffer>& buffers,
+    Subarray& subarray,
+    Layout layout)
+    : stats_(stats)
+    , array_(array)
+    , config_(config)
+    , buffers_(buffers)
+    , layout_(layout)
+    , storage_manager_(storage_manager)
+    , subarray_(subarray)
+    , offsets_extra_element_(false)
+    , offsets_bitsize_(constants::cell_var_offset_size * 8) {
+  if (array != nullptr) {
+    array_schema_ = array->array_schema();
+  }
+}
+
+stats::Stats* StrategyBase::stats() const {
+  return stats_;
+}
+
+/* ****************************** */
+/*       PROTECTED METHODS        */
+/* ****************************** */
+
+void StrategyBase::get_dim_attr_stats() const {
+  for (const auto& it : buffers_) {
+    const auto& name = it.first;
+    auto var_size = array_schema_->var_size(name);
+    if (array_schema_->is_attr(name)) {
+      stats_->add_counter("attr_num", 1);
+      if (var_size) {
+        stats_->add_counter("attr_var_num", 1);
+      } else {
+        stats_->add_counter("attr_fixed_num", 1);
+      }
+      if (array_schema_->is_nullable(name)) {
+        stats_->add_counter("attr_nullable_num", 1);
+      }
+    } else {
+      stats_->add_counter("dim_num", 1);
+      if (var_size) {
+        stats_->add_counter("dim_var_num", 1);
+      } else {
+        if (name == constants::coords) {
+          stats_->add_counter("dim_zipped_num", 1);
+        } else {
+          stats_->add_counter("dim_fixed_num", 1);
+        }
+      }
+    }
+  }
+}
+
+std::string StrategyBase::offsets_mode() const {
+  return offsets_format_mode_;
+}
+
+Status StrategyBase::set_offsets_mode(const std::string& offsets_mode) {
+  offsets_format_mode_ = offsets_mode;
+
+  return Status::Ok();
+}
+
+bool StrategyBase::offsets_extra_element() const {
+  return offsets_extra_element_;
+}
+
+Status StrategyBase::set_offsets_extra_element(bool add_extra_element) {
+  offsets_extra_element_ = add_extra_element;
+
+  return Status::Ok();
+}
+
+uint32_t StrategyBase::offsets_bitsize() const {
+  return offsets_bitsize_;
+}
+
+Status StrategyBase::set_offsets_bitsize(const uint32_t bitsize) {
+  if (bitsize != 32 && bitsize != 64) {
+    return LOG_STATUS(Status::ReaderError(
+        "Cannot set offset bitsize to " + std::to_string(bitsize) +
+        "; Only 32 and 64 are acceptable bitsize values"));
+  }
+
+  offsets_bitsize_ = bitsize;
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -1,0 +1,152 @@
+/**
+ * @file   strategy_base.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class StrategyBase.
+ */
+
+#ifndef TILEDB_STRATEGY_BASE_H
+#define TILEDB_STRATEGY_BASE_H
+
+#include "tiledb/common/status.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/misc/types.h"
+
+namespace tiledb {
+namespace sm {
+
+class Array;
+class ArraySchema;
+class StorageManager;
+class Subarray;
+
+/** Processes read or write queries. */
+class StrategyBase {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  StrategyBase(
+      stats::Stats* stats,
+      StorageManager* storage_manager,
+      Array* array,
+      Config& config,
+      std::unordered_map<std::string, QueryBuffer>& buffers,
+      Subarray& subarray,
+      Layout layout);
+
+  /** Destructor. */
+  ~StrategyBase() = default;
+
+  /* ********************************* */
+  /*                 API               */
+  /* ********************************* */
+
+  /** Returns `stats_`. */
+  stats::Stats* stats() const;
+
+  /** Returns the configured offsets format mode. */
+  std::string offsets_mode() const;
+
+  /** Sets the offsets format mode. */
+  Status set_offsets_mode(const std::string& offsets_mode);
+
+  /** Returns `True` if offsets are configured to have an extra element. */
+  bool offsets_extra_element() const;
+
+  /** Sets if offsets are configured to have an extra element. */
+  Status set_offsets_extra_element(bool add_extra_element);
+
+  /** Returns the configured offsets bitsize */
+  uint32_t offsets_bitsize() const;
+
+  /** Sets the bitsize of offsets */
+  Status set_offsets_bitsize(const uint32_t bitsize);
+
+ protected:
+  /* ********************************* */
+  /*        PROTECTED ATTRIBUTES       */
+  /* ********************************* */
+
+  /** The class stats. */
+  stats::Stats* stats_;
+
+  /** The array. */
+  const Array* array_;
+
+  /** The array schema. */
+  const ArraySchema* array_schema_;
+
+  /** The config for query-level parameters only. */
+  Config& config_;
+
+  /**
+   * Maps attribute/dimension names to their buffers.
+   * `TILEDB_COORDS` may be used for the special zipped coordinates
+   * buffer.
+   * */
+  std::unordered_map<std::string, QueryBuffer>& buffers_;
+
+  /** The layout of the cells in the result of the subarray. */
+  Layout layout_;
+
+  /** The storage manager. */
+  StorageManager* storage_manager_;
+
+  /** The query subarray (initially the whole domain by default). */
+  Subarray& subarray_;
+
+  /** The offset format used for variable-sized attributes. */
+  std::string offsets_format_mode_;
+
+  /**
+   * If `true`, an extra element that points to the end of the values buffer
+   * will be added in the end of the offsets buffer of var-sized attributes
+   */
+  bool offsets_extra_element_;
+
+  /** The offset bitsize used for variable-sized attributes. */
+  uint32_t offsets_bitsize_;
+
+  /* ********************************* */
+  /*          PROTECTED METHODS        */
+  /* ********************************* */
+
+  /**
+   * Gets statistics about the number of attributes and dimensions in
+   * the query.
+   */
+  void get_dim_attr_stats() const;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_STRATEGY_BASE_H

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -62,29 +62,29 @@ namespace sm {
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
 
-Writer::Writer(stats::Stats* const parent_stats)
-    : stats_(parent_stats->create_child("Writer"))
-    , array_(nullptr)
-    , array_schema_(nullptr)
-    , coords_buffer_(nullptr)
-    , coords_buffer_size_(nullptr)
-    , coord_buffer_is_set_(false)
-    , coord_data_buffer_is_set_(false)
-    , coord_offsets_buffer_is_set_(false)
-    , coords_num_(0)
-    , data_buffer_name_("")
-    , offsets_buffer_name_("")
-    , disable_check_global_order_(false)
-    , has_coords_(false)
+Writer::Writer(
+    stats::Stats* stats,
+    StorageManager* storage_manager,
+    Array* array,
+    Config& config,
+    std::unordered_map<std::string, QueryBuffer>& buffers,
+    Subarray& subarray,
+    Layout layout,
+    std::vector<WrittenFragmentInfo>& written_fragment_info,
+    bool disable_check_global_order,
+    Query::CoordsInfo& coords_info,
+    URI fragment_uri)
+    : StrategyBase(
+          stats, storage_manager, array, config, buffers, subarray, layout)
+    , disable_check_global_order_(disable_check_global_order)
+    , coords_info_(coords_info)
     , check_coord_dups_(false)
     , check_coord_oob_(false)
     , check_global_order_(false)
     , dedup_coords_(false)
     , initialized_(false)
-    , layout_(Layout::ROW_MAJOR)
-    , storage_manager_(nullptr)
-    , offsets_extra_element_(false)
-    , offsets_bitsize_(constants::cell_var_offset_size * 8) {
+    , written_fragment_info_(written_fragment_info) {
+  fragment_uri_ = fragment_uri;
 }
 
 Writer::~Writer() {
@@ -95,226 +95,11 @@ Writer::~Writer() {
 /*               API              */
 /* ****************************** */
 
-const Array* Writer::array() const {
-  return array_;
-}
-
-Status Writer::add_range(unsigned dim_idx, Range&& range) {
-  if (!array_schema_->dense())
-    return LOG_STATUS(
-        Status::WriterError("Adding a subarray range to a write query is not "
-                            "supported in sparse arrays"));
-
-  if (subarray_.is_set(dim_idx))
-    return LOG_STATUS(
-        Status::WriterError("Cannot add range; Multi-range dense writes "
-                            "are not supported"));
-
-  return subarray_.add_range(dim_idx, std::move(range), true);
-}
-
-Status Writer::get_range_num(unsigned dim_idx, uint64_t* range_num) const {
-  if (!array_schema_->dense())
-    return LOG_STATUS(
-        Status::WriterError("Getting the number of ranges from a write query "
-                            "is not applicable to sparse arrays"));
-
-  return subarray_.get_range_num(dim_idx, range_num);
-}
-
-Status Writer::get_range(
-    unsigned dim_idx,
-    uint64_t range_idx,
-    const void** start,
-    const void** end,
-    const void** stride) const {
-  if (!array_schema_->dense())
-    return LOG_STATUS(
-        Status::WriterError("Getting a range from a write query is not "
-                            "applicable to sparse arrays"));
-
-  *stride = nullptr;
-  return subarray_.get_range(dim_idx, range_idx, start, end);
-}
-
-const ArraySchema* Writer::array_schema() const {
-  return array_schema_;
-}
-
-std::vector<std::string> Writer::buffer_names() const {
-  std::vector<std::string> ret;
-
-  // Add to the buffer names the attributes, as well as the dimensions only if
-  // coords_buffer_ has not been set
-  for (const auto& it : buffers_) {
-    if (!array_schema_->is_dim(it.first) || (!coords_buffer_))
-      ret.push_back(it.first);
-  }
-
-  // Special zipped coordinates name
-  if (coords_buffer_)
-    ret.push_back(constants::coords);
-
-  return ret;
-}
-
-QueryBuffer Writer::buffer(const std::string& name) const {
-  // Special zipped coordinates
-  if (name == constants::coords)
-    return QueryBuffer(coords_buffer_, nullptr, coords_buffer_size_, nullptr);
-
-  // Attribute or dimension
-  auto buf = buffers_.find(name);
-  if (buf != buffers_.end())
-    return buf->second;
-
-  // Named buffer does not exist
-  return QueryBuffer{};
-}
-
 Status Writer::finalize() {
   auto timer_se = stats_->start_timer("finalize");
 
   if (global_write_state_ != nullptr)
     return finalize_global_write_state();
-  return Status::Ok();
-}
-
-Status Writer::get_data_buffer(
-    const std::string& name, void** buffer, uint64_t** buffer_size) const {
-  // Special zipped coordinates
-  if (name == constants::coords) {
-    *buffer = coords_buffer_;
-    *buffer_size = coords_buffer_size_;
-    return Status::Ok();
-  }
-
-  // Attribute or dimension
-  auto it = buffers_.find(name);
-  if (it != buffers_.end()) {
-    if (!array_schema_->var_size(name)) {
-      *buffer = it->second.buffer_;
-      *buffer_size = it->second.buffer_size_;
-    } else {
-      *buffer = it->second.buffer_var_;
-      *buffer_size = it->second.buffer_var_size_;
-    }
-    return Status::Ok();
-  }
-
-  // Named buffer does not exist
-  *buffer = nullptr;
-  *buffer_size = nullptr;
-
-  return Status::Ok();
-}
-
-Status Writer::get_offsets_buffer(
-    const std::string& name,
-    uint64_t** buffer_off,
-    uint64_t** buffer_off_size) const {
-  // Attribute or dimension
-  auto it = buffers_.find(name);
-  if (it != buffers_.end()) {
-    *buffer_off = (uint64_t*)it->second.buffer_;
-    *buffer_off_size = it->second.buffer_size_;
-    return Status::Ok();
-  }
-
-  // Named buffer does not exist
-  *buffer_off = nullptr;
-  *buffer_off_size = nullptr;
-
-  return Status::Ok();
-}
-
-Status Writer::get_validity_buffer(
-    const std::string& name, const ValidityVector** validity_vector) const {
-  // Attribute or dimension
-  auto it = buffers_.find(name);
-  if (it != buffers_.end()) {
-    *validity_vector = &it->second.validity_vector_;
-    return Status::Ok();
-  }
-
-  // Named buffer does not exist
-  *validity_vector = nullptr;
-
-  return Status::Ok();
-}
-
-Status Writer::get_buffer(
-    const std::string& name,
-    uint64_t** buffer_off,
-    uint64_t** buffer_off_size,
-    void** buffer_val,
-    uint64_t** buffer_val_size) const {
-  // Attribute or dimension
-  auto it = buffers_.find(name);
-  if (it != buffers_.end()) {
-    *buffer_off = (uint64_t*)it->second.buffer_;
-    *buffer_off_size = it->second.buffer_size_;
-    *buffer_val = it->second.buffer_var_;
-    *buffer_val_size = it->second.buffer_var_size_;
-    return Status::Ok();
-  }
-
-  // Named buffer does not exist
-  *buffer_off = nullptr;
-  *buffer_off_size = nullptr;
-  *buffer_val = nullptr;
-  *buffer_val_size = nullptr;
-
-  return Status::Ok();
-}
-
-Status Writer::get_buffer_nullable(
-    const std::string& name,
-    void** buffer,
-    uint64_t** buffer_size,
-    const ValidityVector** validity_vector) const {
-  // Attribute or dimension
-  auto it = buffers_.find(name);
-  if (it != buffers_.end()) {
-    *buffer = it->second.buffer_;
-    *buffer_size = it->second.buffer_size_;
-    *validity_vector = &it->second.validity_vector_;
-    return Status::Ok();
-  }
-
-  // Named buffer does not exist
-  *buffer = nullptr;
-  *buffer_size = nullptr;
-  *validity_vector = nullptr;
-
-  return Status::Ok();
-}
-
-Status Writer::get_buffer_nullable(
-    const std::string& name,
-    uint64_t** buffer_off,
-    uint64_t** buffer_off_size,
-    void** buffer_val,
-    uint64_t** buffer_val_size,
-    const ValidityVector** validity_vector) const {
-  // Attribute or dimension
-  auto it = buffers_.find(name);
-  if (it != buffers_.end()) {
-    *buffer_off = (uint64_t*)it->second.buffer_;
-    *buffer_off_size = it->second.buffer_size_;
-    *buffer_val = it->second.buffer_var_;
-    *buffer_val_size = it->second.buffer_var_size_;
-    *validity_vector = &it->second.validity_vector_;
-    return Status::Ok();
-  }
-
-  // Named buffer does not exist
-  *buffer_off = nullptr;
-  *buffer_off_size = nullptr;
-  *buffer_val = nullptr;
-  *buffer_val_size = nullptr;
-  *validity_vector = nullptr;
-
   return Status::Ok();
 }
 
@@ -330,24 +115,6 @@ bool Writer::get_dedup_coords() const {
   return dedup_coords_;
 }
 
-std::string Writer::get_offsets_mode() const {
-  return offsets_format_mode_;
-}
-
-bool Writer::get_offsets_extra_element() const {
-  return offsets_extra_element_;
-}
-
-uint32_t Writer::get_offsets_bitsize() const {
-  return offsets_bitsize_;
-}
-
-Status Writer::set_config(const Config& config) {
-  config_ = config;
-
-  return Status::Ok();
-};
-
 void Writer::set_check_coord_dups(bool b) {
   check_coord_dups_ = b;
 }
@@ -358,29 +125,6 @@ void Writer::set_check_coord_oob(bool b) {
 
 void Writer::set_dedup_coords(bool b) {
   dedup_coords_ = b;
-}
-
-Status Writer::set_offsets_mode(const std::string& offsets_mode) {
-  offsets_format_mode_ = offsets_mode;
-
-  return Status::Ok();
-}
-
-Status Writer::set_offsets_extra_element(bool add_extra_element) {
-  offsets_extra_element_ = add_extra_element;
-
-  return Status::Ok();
-}
-
-Status Writer::set_offsets_bitsize(const uint32_t bitsize) {
-  if (bitsize != 32 && bitsize != 64) {
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set offset bitsize to " + std::to_string(bitsize) +
-        "; Only 32 and 64 are acceptable bitsize values"));
-  }
-
-  offsets_bitsize_ = bitsize;
-  return Status::Ok();
 }
 
 inline uint64_t Writer::get_offset_buffer_element(
@@ -523,12 +267,12 @@ Status Writer::init(const Layout& layout) {
 
   if (offsets_extra_element_)
     RETURN_NOT_OK(check_extra_element());
-  RETURN_NOT_OK(set_layout(layout));
+
+  layout_ = layout;
+  subarray_.set_layout(layout);
+
   RETURN_NOT_OK(check_subarray());
   RETURN_NOT_OK(check_buffer_sizes());
-  RETURN_NOT_OK(check_buffer_names());
-  if (array_schema_->dense())
-    RETURN_NOT_OK(subarray_.to_byte_vec(&subarray_flat_));
 
   optimize_layout_for_1D();
   RETURN_NOT_OK(check_var_attr_offsets());
@@ -537,558 +281,7 @@ Status Writer::init(const Layout& layout) {
   return Status::Ok();
 }
 
-Layout Writer::layout() const {
-  return layout_;
-}
-
-void Writer::set_array(const Array* array) {
-  array_ = array;
-  subarray_ = Subarray(array, stats_);
-}
-
-void Writer::set_array_schema(const ArraySchema* array_schema) {
-  array_schema_ = array_schema;
-}
-
-Status Writer::set_buffer(
-    const std::string& name, void* const buffer, uint64_t* const buffer_size) {
-  // Check buffer
-  if (buffer == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (buffer_size == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; Array schema not set"));
-
-  // Set special function for zipped coordinates buffer
-  if (name == constants::coords)
-    return set_coords_buffer(buffer, buffer_size);
-
-  // For easy reference
-  const bool is_dim = array_schema_->is_dim(name);
-  const bool is_attr = array_schema_->is_attr(name);
-
-  // Neither a dimension nor an attribute
-  if (!is_dim && !is_attr)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Invalid buffer name '") + name +
-        "' (it should be an attribute or dimension)"));
-
-  // Must not be nullable
-  if (array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is nullable"));
-
-  // Error if it is var-sized
-  if (array_schema_->var_size(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is var-sized"));
-
-  // Error if setting a new attribute/dimension after initialization
-  bool exists = buffers_.find(name) != buffers_.end();
-  if (initialized_ && !exists)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer for new attribute/dimension '") + name +
-        "' after initialization"));
-
-  // Check if zipped coordinates coexist with separate coordinate buffers
-  if (is_dim && coords_buffer_ != nullptr)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set separate coordinate buffers after "
-                    "having set the zipped coordinates buffer")));
-
-  if (is_dim) {
-    // Check number of coordinates
-    uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
-    if (coord_buffer_is_set_ && coords_num != coords_num_)
-      return LOG_STATUS(Status::WriterError(
-          std::string("Cannot set buffer; Input buffer for dimension '") +
-          name +
-          "' has a different number of coordinates than previously "
-          "set coordinate buffers"));
-
-    coords_num_ = coords_num;
-    coord_buffer_is_set_ = true;
-    has_coords_ = true;
-  }
-
-  // Set attribute/dimension buffer
-  buffers_[name] = QueryBuffer(buffer, nullptr, buffer_size, nullptr);
-
-  return Status::Ok();
-}
-
-Status Writer::set_data_buffer(
-    const std::string& name, void* const buffer, uint64_t* const buffer_size) {
-  // Check buffer
-  if (buffer == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (buffer_size == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; Array schema not set"));
-
-  // Set special function for zipped coordinates buffer
-  if (name == constants::coords)
-    return set_coords_buffer(buffer, buffer_size);
-
-  // For easy reference
-  const bool is_dim = array_schema_->is_dim(name);
-  const bool is_attr = array_schema_->is_attr(name);
-
-  // Neither a dimension nor an attribute
-  if (!is_dim && !is_attr)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Invalid buffer name '") + name +
-        "' (it should be an attribute or dimension)"));
-
-  // Error if setting a new attribute/dimension after initialization
-  bool exists = buffers_.find(name) != buffers_.end();
-  if (initialized_ && !exists)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer for new attribute/dimension '") + name +
-        "' after initialization"));
-
-  // Check if zipped coordinates coexist with separate coordinate buffers
-  if (is_dim && coords_buffer_ != nullptr)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set separate coordinate buffers after "
-                    "having set the zipped coordinates buffer")));
-
-  if (is_dim) {
-    // Check number of coordinates
-    uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
-    if (coord_data_buffer_is_set_ && coords_num != coords_num_ &&
-        name == data_buffer_name_)
-      return LOG_STATUS(Status::WriterError(
-          std::string("Cannot set buffer; Input buffer for dimension '") +
-          name +
-          "' has a different number of coordinates than previously "
-          "set coordinate buffers"));
-
-    coords_num_ = coords_num;
-    coord_data_buffer_is_set_ = true;
-    data_buffer_name_ = name;
-    has_coords_ = true;
-  }
-
-  // Set attribute/dimension buffer on the appropriate buffer
-  if (!array_schema_->var_size(name))
-    // Fixed size data buffer
-    buffers_[name].set_data_buffer(buffer, buffer_size);
-  else
-    // Var sized data buffer
-    buffers_[name].set_data_var_buffer(buffer, buffer_size);
-
-  return Status::Ok();
-}
-
-Status Writer::set_offsets_buffer(
-    const std::string& name,
-    uint64_t* const buffer_off,
-    uint64_t* const buffer_off_size) {
-  // Check buffer
-  if (buffer_off == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (buffer_off_size == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; Array schema not set"));
-
-  // For easy reference
-  const bool is_dim = array_schema_->is_dim(name);
-  const bool is_attr = array_schema_->is_attr(name);
-
-  // Neither a dimension nor an attribute
-  if (!is_dim && !is_attr)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Invalid buffer name '") + name +
-        "' (it should be an attribute or dimension)"));
-
-  // Error if it is fixed-sized
-  if (!array_schema_->var_size(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is fixed-sized"));
-
-  // Error if setting a new attribute/dimension after initialization
-  bool exists = buffers_.find(name) != buffers_.end();
-  if (initialized_ && !exists)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer for new attribute/dimension '") + name +
-        "' after initialization"));
-
-  if (is_dim) {
-    // Check number of coordinates
-    uint64_t coords_num = *buffer_off_size / constants::cell_var_offset_size;
-    if (coord_offsets_buffer_is_set_ && coords_num != coords_num_ &&
-        name != offsets_buffer_name_)
-      return LOG_STATUS(Status::WriterError(
-          std::string("Cannot set buffer; Input buffer for dimension '") +
-          name +
-          "' has a different number of coordinates than previously "
-          "set coordinate buffers"));
-
-    coords_num_ = coords_num;
-    coord_offsets_buffer_is_set_ = true;
-    has_coords_ = true;
-    offsets_buffer_name_ = name;
-  }
-
-  // Set attribute/dimension buffer
-  buffers_[name].set_offsets_buffer(buffer_off, buffer_off_size);
-
-  return Status::Ok();
-}
-
-Status Writer::set_validity_buffer(
-    const std::string& name,
-    uint8_t* const buffer_validity_bytemap,
-    uint64_t* const buffer_validity_bytemap_size) {
-  ValidityVector validity_vector;
-  RETURN_NOT_OK(validity_vector.init_bytemap(
-      buffer_validity_bytemap, buffer_validity_bytemap_size));
-  // Check validity buffer
-  if (validity_vector.buffer() == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " validity buffer is null"));
-
-  // Check validity buffer size
-  if (validity_vector.buffer_size() == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " validity buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; Array schema not set"));
-
-  // Must be an attribute
-  if (!array_schema_->is_attr(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Buffer name '") + name +
-        "' is not an attribute"));
-
-  // Must be nullable
-  if (!array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is not nullable"));
-
-  // Error if setting a new attribute after initialization
-  const bool exists = buffers_.find(name) != buffers_.end();
-  if (initialized_ && !exists)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer for new attribute '") + name +
-        "' after initialization"));
-
-  // Set attribute/dimension buffer
-  buffers_[name].set_validity_buffer(std::move(validity_vector));
-
-  return Status::Ok();
-}
-
-Status Writer::set_buffer(
-    const std::string& name,
-    uint64_t* const buffer_off,
-    uint64_t* const buffer_off_size,
-    void* const buffer_val,
-    uint64_t* const buffer_val_size) {
-  // Check buffer
-  if (buffer_val == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (buffer_val_size == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Check offset buffer
-  if (buffer_off == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " offset buffer is null"));
-
-  // Check offset buffer size
-  if (buffer_off_size == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " offset buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; Array schema not set"));
-
-  // For easy reference
-  const bool is_dim = array_schema_->is_dim(name);
-  const bool is_attr = array_schema_->is_attr(name);
-
-  // Neither a dimension nor an attribute
-  if (!is_dim && !is_attr)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Invalid buffer name '") + name +
-        "' (it should be an attribute or dimension)"));
-
-  // Must not be nullable
-  if (array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is nullable"));
-
-  // Error if it is fixed-sized
-  if (!array_schema_->var_size(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute/dimension '") + name +
-        "' is fixed-sized"));
-
-  // Error if setting a new attribute/dimension after initialization
-  bool exists = buffers_.find(name) != buffers_.end();
-  if (initialized_ && !exists)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer for new attribute/dimension '") + name +
-        "' after initialization"));
-
-  if (is_dim) {
-    // Check number of coordinates
-    uint64_t coords_num = *buffer_off_size / constants::cell_var_offset_size;
-    if (coord_buffer_is_set_ && coords_num != coords_num_)
-      return LOG_STATUS(Status::WriterError(
-          std::string("Cannot set buffer; Input buffer for dimension '") +
-          name +
-          "' has a different number of coordinates than previously "
-          "set coordinate buffers"));
-
-    coords_num_ = coords_num;
-    coord_buffer_is_set_ = true;
-    has_coords_ = true;
-  }
-
-  // Set attribute/dimension buffer
-  buffers_[name] =
-      QueryBuffer(buffer_off, buffer_val, buffer_off_size, buffer_val_size);
-
-  return Status::Ok();
-}
-
-Status Writer::set_buffer(
-    const std::string& name,
-    void* const buffer,
-    uint64_t* const buffer_size,
-    ValidityVector&& validity_vector) {
-  // Check buffer
-  if (buffer == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (buffer_size == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Check validity buffer
-  if (validity_vector.buffer() == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " validity buffer is null"));
-
-  // Check validity buffer size
-  if (validity_vector.buffer_size() == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " validity buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; Array schema not set"));
-
-  // Must be an attribute
-  if (!array_schema_->is_attr(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Buffer name '") + name +
-        "' is not an attribute"));
-
-  // Must be fixed-size
-  if (array_schema_->var_size(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is var-sized"));
-
-  // Must be nullable
-  if (!array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is not nullable"));
-
-  // Error if setting a new attribute after initialization
-  const bool exists = buffers_.find(name) != buffers_.end();
-  if (initialized_ && !exists)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer for new attribute '") + name +
-        "' after initialization"));
-
-  // Set attribute/dimension buffer
-  buffers_[name] = QueryBuffer(
-      buffer, nullptr, buffer_size, nullptr, std::move(validity_vector));
-
-  return Status::Ok();
-}
-
-Status Writer::set_buffer(
-    const std::string& name,
-    uint64_t* const buffer_off,
-    uint64_t* const buffer_off_size,
-    void* const buffer_val,
-    uint64_t* const buffer_val_size,
-    ValidityVector&& validity_vector) {
-  // Check buffer
-  if (buffer_val == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; " + name + " buffer is null"));
-
-  // Check buffer size
-  if (buffer_val_size == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " buffer size is null"));
-
-  // Check offset buffer
-  if (buffer_off == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " offset buffer is null"));
-
-  // Check offset buffer size
-  if (buffer_off_size == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " offset buffer size is null"));
-
-  // Check validity buffer
-  if (validity_vector.buffer() == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " validity buffer is null"));
-
-  // Check validity buffer size
-  if (validity_vector.buffer_size() == nullptr)
-    return LOG_STATUS(Status::WriterError(
-        "Cannot set buffer; " + name + " validity buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set buffer; Array schema not set"));
-
-  // Must be an attribute
-  if (!array_schema_->is_attr(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Buffer name '") + name +
-        "' is not an attribute"));
-
-  // Must be var-size
-  if (!array_schema_->var_size(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is fixed-sized"));
-
-  // Must be nullable
-  if (!array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer; Input attribute '") + name +
-        "' is not nullable"));
-
-  // Error if setting a new attribute after initialization
-  const bool exists = buffers_.find(name) != buffers_.end();
-  if (initialized_ && !exists)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set buffer for new attribute '") + name +
-        "' after initialization"));
-
-  // Set attribute/dimension buffer
-  buffers_[name] = QueryBuffer(
-      buffer_off,
-      buffer_val,
-      buffer_off_size,
-      buffer_val_size,
-      std::move(validity_vector));
-
-  return Status::Ok();
-}
-
-void Writer::set_fragment_uri(const URI& fragment_uri) {
-  fragment_uri_ = fragment_uri;
-}
-
-Status Writer::set_layout(Layout layout) {
-  layout_ = layout;
-  subarray_.set_layout(layout);
-
-  return Status::Ok();
-}
-
-void Writer::set_storage_manager(StorageManager* storage_manager) {
-  storage_manager_ = storage_manager;
-  set_config(storage_manager->config());
-}
-
-Status Writer::set_subarray(const Subarray& subarray) {
-  // Not applicable to sparse arrays
-  if (!array_schema_->dense())
-    return LOG_STATUS(Status::WriterError(
-        "Setting a subarray is not supported in sparse writes"));
-
-  // Subarray must be unary for dense writes
-  if (subarray.range_num() != 1)
-    return LOG_STATUS(
-        Status::WriterError("Cannot set subarray; Multi-range dense writes "
-                            "are not supported"));
-
-  // Reset the writer (this will nuke the global write state)
-  reset();
-
-  subarray_ = subarray;
-
-  // Set subarray_flat so calls to `subarray()` will reflect newly set value
-  RETURN_NOT_OK(subarray_.to_byte_vec(&subarray_flat_));
-
-  return Status::Ok();
-}
-
-const void* Writer::subarray() const {
-  // Only access subarray_flat_ if it is not empty
-  if (!subarray_flat_.empty())
-    return &subarray_flat_[0];
-
-  return nullptr;
-}
-
-const Subarray* Writer::subarray_ranges() const {
-  return &subarray_;
-}
-
-Stats* Writer::stats() const {
-  return stats_;
-}
-
-Status Writer::write() {
+Status Writer::dowork() {
   get_dim_attr_stats();
 
   auto timer_se = stats_->start_timer("write");
@@ -1112,10 +305,6 @@ Status Writer::write() {
   return Status::Ok();
 }
 
-const std::vector<WrittenFragmentInfo>& Writer::written_fragment_info() const {
-  return written_fragment_info_;
-}
-
 /* ****************************** */
 /*          PRIVATE METHODS       */
 /* ****************************** */
@@ -1124,32 +313,6 @@ Status Writer::add_written_fragment_info(const URI& uri) {
   std::pair<uint64_t, uint64_t> timestamp_range;
   RETURN_NOT_OK(utils::parse::get_timestamp_range(uri, &timestamp_range));
   written_fragment_info_.emplace_back(uri, timestamp_range);
-  return Status::Ok();
-}
-
-Status Writer::check_buffer_names() {
-  // If the array is sparse, the coordinates must be provided
-  if (!array_schema_->dense() && !has_coords_)
-    return LOG_STATUS(
-        Status::WriterError("Sparse array writes expect the coordinates of the "
-                            "cells to be written"));
-
-  // If the layout is unordered, the coordinates must be provided
-  if (layout_ == Layout::UNORDERED && !has_coords_)
-    return LOG_STATUS(Status::WriterError(
-        "Unordered writes expect the coordinates of the cells to be written"));
-
-  // All attributes/dimensions must be provided
-  auto expected_num = array_schema_->attribute_num();
-  expected_num += (coord_buffer_is_set_ || coord_data_buffer_is_set_ ||
-                   coord_offsets_buffer_is_set_) ?
-                      array_schema_->dim_num() :
-                      0;
-  if (buffers_.size() != expected_num)
-    return LOG_STATUS(
-        Status::WriterError("Writes expect all attributes (and coordinates in "
-                            "the sparse/unordered case) to be set"));
-
   return Status::Ok();
 }
 
@@ -1208,13 +371,13 @@ Status Writer::check_coord_dups(const std::vector<uint64_t>& cell_pos) const {
   if (array_schema_->allows_dups() || !check_coord_dups_ || dedup_coords_)
     return Status::Ok();
 
-  if (!has_coords_) {
+  if (!coords_info_.has_coords_) {
     return LOG_STATUS(
         Status::WriterError("Cannot check for coordinate duplicates; "
                             "Coordinates buffer not found"));
   }
 
-  if (coords_num_ < 2)
+  if (coords_info_.coords_num_ < 2)
     return Status::Ok();
 
   // Prepare auxiliary vectors for better performance
@@ -1233,7 +396,10 @@ Status Writer::check_coord_dups(const std::vector<uint64_t>& cell_pos) const {
   }
 
   auto status = parallel_for(
-      storage_manager_->compute_tp(), 1, coords_num_, [&](uint64_t i) {
+      storage_manager_->compute_tp(),
+      1,
+      coords_info_.coords_num_,
+      [&](uint64_t i) {
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
@@ -1252,10 +418,12 @@ Status Writer::check_coord_dups(const std::vector<uint64_t>& cell_pos) const {
             auto b = cell_pos[i - 1];
             auto off_a = offs[a];
             auto off_b = offs[b];
-            auto off_a_plus_1 =
-                (a == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[a + 1];
-            auto off_b_plus_1 =
-                (b == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[b + 1];
+            auto off_a_plus_1 = (a == coords_info_.coords_num_ - 1) ?
+                                    *(buffs_var_sizes[d]) :
+                                    offs[a + 1];
+            auto off_b_plus_1 = (b == coords_info_.coords_num_ - 1) ?
+                                    *(buffs_var_sizes[d]) :
+                                    offs[b + 1];
             auto size_a = off_a_plus_1 - off_a;
             auto size_b = off_b_plus_1 - off_b;
 
@@ -1299,13 +467,13 @@ Status Writer::check_coord_dups() const {
   if (array_schema_->allows_dups() || !check_coord_dups_ || dedup_coords_)
     return Status::Ok();
 
-  if (!has_coords_) {
+  if (!coords_info_.has_coords_) {
     return LOG_STATUS(
         Status::WriterError("Cannot check for coordinate duplicates; "
                             "Coordinates buffer not found"));
   }
 
-  if (coords_num_ < 2)
+  if (coords_info_.coords_num_ < 2)
     return Status::Ok();
 
   // Prepare auxiliary vectors for better performance
@@ -1324,7 +492,10 @@ Status Writer::check_coord_dups() const {
   }
 
   auto status = parallel_for(
-      storage_manager_->compute_tp(), 1, coords_num_, [&](uint64_t i) {
+      storage_manager_->compute_tp(),
+      1,
+      coords_info_.coords_num_,
+      [&](uint64_t i) {
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
@@ -1339,8 +510,9 @@ Status Writer::check_coord_dups() const {
             }
           } else {
             auto offs = (uint64_t*)buffs[d];
-            auto off_i_plus_1 =
-                (i == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[i + 1];
+            auto off_i_plus_1 = (i == coords_info_.coords_num_ - 1) ?
+                                    *(buffs_var_sizes[d]) :
+                                    offs[i + 1];
             auto size_i_minus_1 = offs[i] - offs[i - 1];
             auto size_i = off_i_plus_1 - offs[i];
 
@@ -1381,11 +553,11 @@ Status Writer::check_coord_oob() const {
   auto timer_se = stats_->start_timer("check_coord_oob");
 
   // Applicable only to sparse writes - exit if coordinates do not exist
-  if (!has_coords_)
+  if (!coords_info_.has_coords_)
     return Status::Ok();
 
   // Exit if there are no coordinates to write
-  if (coords_num_ == 0)
+  if (coords_info_.coords_num_ == 0)
     return Status::Ok();
 
   // Exit if all dimensions are strings
@@ -1406,7 +578,7 @@ Status Writer::check_coord_oob() const {
   auto status = parallel_for_2d(
       storage_manager_->compute_tp(),
       0,
-      coords_num_,
+      coords_info_.coords_num_,
       0,
       dim_num,
       [&](uint64_t c, unsigned d) {
@@ -1430,7 +602,7 @@ Status Writer::check_global_order() const {
     return Status::Ok();
 
   // Applicable only to sparse writes - exit if coordinates do not exist
-  if (!has_coords_ || coords_num_ < 2)
+  if (!coords_info_.has_coords_ || coords_info_.coords_num_ < 2)
     return Status::Ok();
 
   // Special case for Hilbert
@@ -1448,7 +620,10 @@ Status Writer::check_global_order() const {
   // Check if all coordinates fall in the domain in parallel
   auto domain = array_schema_->domain();
   auto status = parallel_for(
-      storage_manager_->compute_tp(), 0, coords_num_ - 1, [&](uint64_t i) {
+      storage_manager_->compute_tp(),
+      0,
+      coords_info_.coords_num_ - 1,
+      [&](uint64_t i) {
         auto tile_cmp = domain->tile_order_cmp(buffs, i, i + 1);
         auto fail =
             (tile_cmp > 0) ||
@@ -1481,12 +656,15 @@ Status Writer::check_global_order_hilbert() const {
   }
 
   // Compute hilbert values
-  std::vector<uint64_t> hilbert_values(coords_num_);
+  std::vector<uint64_t> hilbert_values(coords_info_.coords_num_);
   RETURN_NOT_OK(calculate_hilbert_values(buffs, &hilbert_values));
 
   // Check if all coordinates fall in the domain in parallel
   auto status = parallel_for(
-      storage_manager_->compute_tp(), 0, coords_num_ - 1, [&](uint64_t i) {
+      storage_manager_->compute_tp(),
+      0,
+      coords_info_.coords_num_ - 1,
+      [&](uint64_t i) {
         if (hilbert_values[i] > hilbert_values[i + 1]) {
           std::stringstream ss;
           ss << "Write failed; Coordinates " << coords_to_str(i);
@@ -1500,10 +678,6 @@ Status Writer::check_global_order_hilbert() const {
   RETURN_NOT_OK(status);
 
   return Status::Ok();
-}
-
-void Writer::disable_check_global_order() {
-  disable_check_global_order_ = true;
 }
 
 Status Writer::check_subarray() const {
@@ -1533,6 +707,23 @@ void Writer::clear_coord_buffers() {
     tdb_free(b);
   to_clean_.clear();
   coord_buffer_sizes_.clear();
+}
+
+std::vector<std::string> Writer::buffer_names() const {
+  std::vector<std::string> ret;
+
+  // Add to the buffer names the attributes, as well as the dimensions only if
+  // coords_buffer_ has not been set
+  for (const auto& it : buffers_) {
+    if (!array_schema_->is_dim(it.first) || (!coords_info_.coords_buffer_))
+      ret.push_back(it.first);
+  }
+
+  // Special zipped coordinates name
+  if (coords_info_.coords_buffer_)
+    ret.push_back(constants::coords);
+
+  return ret;
 }
 
 Status Writer::close_files(FragmentMetadata* meta) const {
@@ -1567,13 +758,13 @@ Status Writer::compute_coord_dups(
     std::set<uint64_t>* coord_dups) const {
   auto timer_se = stats_->start_timer("compute_coord_dups");
 
-  if (!has_coords_) {
+  if (!coords_info_.has_coords_) {
     return LOG_STATUS(
         Status::WriterError("Cannot check for coordinate duplicates; "
                             "Coordinates buffer not found"));
   }
 
-  if (coords_num_ < 2)
+  if (coords_info_.coords_num_ < 2)
     return Status::Ok();
 
   // Prepare auxiliary vectors for better performance
@@ -1593,7 +784,10 @@ Status Writer::compute_coord_dups(
 
   std::mutex mtx;
   auto status = parallel_for(
-      storage_manager_->compute_tp(), 1, coords_num_, [&](uint64_t i) {
+      storage_manager_->compute_tp(),
+      1,
+      coords_info_.coords_num_,
+      [&](uint64_t i) {
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
@@ -1612,10 +806,12 @@ Status Writer::compute_coord_dups(
             auto b = cell_pos[i - 1];
             auto off_a = offs[a];
             auto off_b = offs[b];
-            auto off_a_plus_1 =
-                (a == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[a + 1];
-            auto off_b_plus_1 =
-                (b == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[b + 1];
+            auto off_a_plus_1 = (a == coords_info_.coords_num_ - 1) ?
+                                    *(buffs_var_sizes[d]) :
+                                    offs[a + 1];
+            auto off_b_plus_1 = (b == coords_info_.coords_num_ - 1) ?
+                                    *(buffs_var_sizes[d]) :
+                                    offs[b + 1];
             auto size_a = off_a_plus_1 - off_a;
             auto size_b = off_b_plus_1 - off_b;
 
@@ -1653,13 +849,13 @@ Status Writer::compute_coord_dups(
 Status Writer::compute_coord_dups(std::set<uint64_t>* coord_dups) const {
   auto timer_se = stats_->start_timer("compute_coord_dups");
 
-  if (!has_coords_) {
+  if (!coords_info_.has_coords_) {
     return LOG_STATUS(
         Status::WriterError("Cannot check for coordinate duplicates; "
                             "Coordinates buffer not found"));
   }
 
-  if (coords_num_ < 2)
+  if (coords_info_.coords_num_ < 2)
     return Status::Ok();
 
   // Prepare auxiliary vectors for better performance
@@ -1679,7 +875,10 @@ Status Writer::compute_coord_dups(std::set<uint64_t>* coord_dups) const {
 
   std::mutex mtx;
   auto status = parallel_for(
-      storage_manager_->compute_tp(), 1, coords_num_, [&](uint64_t i) {
+      storage_manager_->compute_tp(),
+      1,
+      coords_info_.coords_num_,
+      [&](uint64_t i) {
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
@@ -1694,8 +893,9 @@ Status Writer::compute_coord_dups(std::set<uint64_t>* coord_dups) const {
             }
           } else {
             auto offs = (uint64_t*)buffs[d];
-            auto off_i_plus_1 =
-                (i == coords_num_ - 1) ? *(buffs_var_sizes[d]) : offs[i + 1];
+            auto off_i_plus_1 = (i == coords_info_.coords_num_ - 1) ?
+                                    *(buffs_var_sizes[d]) :
+                                    offs[i + 1];
             auto size_i_minus_1 = offs[i] - offs[i - 1];
             auto size_i = off_i_plus_1 - offs[i];
 
@@ -1736,7 +936,7 @@ Status Writer::compute_coords_metadata(
   auto timer_se = stats_->start_timer("compute_coord_meta");
 
   // Applicable only if there are coordinates
-  if (!has_coords_)
+  if (!coords_info_.has_coords_)
     return Status::Ok();
 
   // Check if tiles are empty
@@ -1927,7 +1127,7 @@ Status Writer::finalize_global_write_state() {
   }
 
   // Check if the total number of cells written is equal to the subarray size
-  if (!has_coords_) {  // This implies a dense array
+  if (!coords_info_.has_coords_) {  // This implies a dense array
     auto expected_cell_num =
         array_schema_->domain()->cell_num(subarray_.ndrange(0));
     if (cell_num != expected_cell_num) {
@@ -1970,7 +1170,7 @@ Status Writer::global_write() {
   auto uri = frag_meta->fragment_uri();
 
   // Check for coordinate duplicates
-  if (has_coords_) {
+  if (coords_info_.has_coords_) {
     RETURN_CANCEL_OR_ERROR(check_coord_dups());
     RETURN_CANCEL_OR_ERROR(check_global_order());
   }
@@ -2004,11 +1204,6 @@ Status Writer::global_write() {
 
   // No cells to be written
   if (tile_num == 0) {
-    // reset coord buffer marker at end of global write
-    // this will allow for the user to properly set the next write batch
-    coord_buffer_is_set_ = false;
-    coord_data_buffer_is_set_ = false;
-    coord_offsets_buffer_is_set_ = false;
     return Status::Ok();
   }
 
@@ -2029,12 +1224,6 @@ Status Writer::global_write() {
 
   // Increment the tile index base for the next global order write.
   frag_meta->set_tile_index_base(new_num_tiles);
-
-  // reset coord buffer marker at end of global write
-  // this will allow for the user to properly set the next write batch
-  coord_buffer_is_set_ = false;
-  coord_data_buffer_is_set_ = false;
-  coord_offsets_buffer_is_set_ = false;
 
   return Status::Ok();
 }
@@ -2131,8 +1320,8 @@ Status Writer::init_global_write_state() {
   global_write_state_.reset(new GlobalWriteState);
 
   // Create fragment
-  RETURN_NOT_OK(
-      create_fragment(!has_coords_, &(global_write_state_->frag_meta_)));
+  RETURN_NOT_OK(create_fragment(
+      !coords_info_.has_coords_, &(global_write_state_->frag_meta_)));
   auto uri = global_write_state_->frag_meta_->fragment_uri();
 
   // Initialize global write state for attribute and coordinates
@@ -2181,7 +1370,8 @@ Status Writer::init_tile(const std::string& name, Tile* tile) const {
   auto type = array_schema_->type(name);
   auto domain = array_schema_->domain();
   auto capacity = array_schema_->capacity();
-  auto cell_num_per_tile = has_coords_ ? capacity : domain->cell_num_per_tile();
+  auto cell_num_per_tile =
+      coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * cell_size;
 
   // Initialize
@@ -2197,7 +1387,8 @@ Status Writer::init_tile(
   auto type = array_schema_->type(name);
   auto domain = array_schema_->domain();
   auto capacity = array_schema_->capacity();
-  auto cell_num_per_tile = has_coords_ ? capacity : domain->cell_num_per_tile();
+  auto cell_num_per_tile =
+      coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * constants::cell_var_offset_size;
 
   // Initialize
@@ -2219,7 +1410,8 @@ Status Writer::init_tile_nullable(
   auto type = array_schema_->type(name);
   auto domain = array_schema_->domain();
   auto capacity = array_schema_->capacity();
-  auto cell_num_per_tile = has_coords_ ? capacity : domain->cell_num_per_tile();
+  auto cell_num_per_tile =
+      coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * cell_size;
 
   // Initialize
@@ -2244,7 +1436,8 @@ Status Writer::init_tile_nullable(
   auto type = array_schema_->type(name);
   auto domain = array_schema_->domain();
   auto capacity = array_schema_->capacity();
-  auto cell_num_per_tile = has_coords_ ? capacity : domain->cell_num_per_tile();
+  auto cell_num_per_tile =
+      coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * constants::cell_var_offset_size;
 
   // Initialize
@@ -2523,7 +1716,8 @@ Status Writer::prepare_full_tiles_fixed(
   auto capacity = array_schema_->capacity();
   auto cell_num = *buffer_size / cell_size;
   auto domain = array_schema_->domain();
-  auto cell_num_per_tile = has_coords_ ? capacity : domain->cell_num_per_tile();
+  auto cell_num_per_tile =
+      coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
 
   // Do nothing if there are no cells to write
   if (cell_num == 0)
@@ -2676,7 +1870,8 @@ Status Writer::prepare_full_tiles_var(
   auto capacity = array_schema_->capacity();
   auto cell_num = buffer_size / constants::cell_var_offset_size;
   auto domain = array_schema_->domain();
-  auto cell_num_per_tile = has_coords_ ? capacity : domain->cell_num_per_tile();
+  auto cell_num_per_tile =
+      coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto attr_datatype_size = datatype_size(array_schema_->type(name));
   uint64_t offset, var_size;
 
@@ -3106,8 +2301,8 @@ Status Writer::sort_coords(std::vector<uint64_t>* cell_pos) const {
   }
 
   // Populate cell_pos
-  cell_pos->resize(coords_num_);
-  for (uint64_t i = 0; i < coords_num_; ++i)
+  cell_pos->resize(coords_info_.coords_num_);
+  for (uint64_t i = 0; i < coords_info_.coords_num_; ++i)
     (*cell_pos)[i] = i;
 
   // Sort the coordinates in global order
@@ -3118,7 +2313,7 @@ Status Writer::sort_coords(std::vector<uint64_t>* cell_pos) const {
         cell_pos->end(),
         GlobalCmp(domain, &buffs));
   } else {  // Hilbert order
-    std::vector<uint64_t> hilbert_values(coords_num_);
+    std::vector<uint64_t> hilbert_values(coords_info_.coords_num_);
     RETURN_NOT_OK(calculate_hilbert_values(buffs, &hilbert_values));
     parallel_sort(
         storage_manager_->compute_tp(),
@@ -3134,14 +2329,14 @@ Status Writer::split_coords_buffer() {
   auto timer_se = stats_->start_timer("split_coords_buff");
 
   // Do nothing if the coordinates buffer is not set
-  if (coords_buffer_ == nullptr)
+  if (coords_info_.coords_buffer_ == nullptr)
     return Status::Ok();
 
   // For easy reference
   auto dim_num = array_schema_->dim_num();
   auto coord_size = array_schema_->domain()->dimension(0)->coord_size();
   auto coords_size = dim_num * coord_size;
-  coords_num_ = *coords_buffer_size_ / coords_size;
+  coords_info_.coords_num_ = *coords_info_.coords_buffer_size_ / coords_size;
 
   clear_coord_buffers();
 
@@ -3149,7 +2344,7 @@ Status Writer::split_coords_buffer() {
   for (unsigned d = 0; d < dim_num; ++d) {
     auto dim = array_schema_->dimension(d);
     const auto& dim_name = dim->name();
-    auto coord_buffer_size = coords_num_ * dim->coord_size();
+    auto coord_buffer_size = coords_info_.coords_num_ * dim->coord_size();
     auto it = coord_buffer_sizes_.emplace(dim_name, coord_buffer_size);
     QueryBuffer buff;
     buff.buffer_size_ = &(it.first->second);
@@ -3167,9 +2362,9 @@ Status Writer::split_coords_buffer() {
     auto coord_size = array_schema_->dimension(d)->coord_size();
     const auto& dim_name = array_schema_->dimension(d)->name();
     auto buff = (unsigned char*)(buffers_[dim_name].buffer_);
-    for (uint64_t c = 0; c < coords_num_; ++c) {
-      coord =
-          &(((unsigned char*)coords_buffer_)[c * coords_size + d * coord_size]);
+    for (uint64_t c = 0; c < coords_info_.coords_num_; ++c) {
+      coord = &(((unsigned char*)coords_info_
+                     .coords_buffer_)[c * coords_size + d * coord_size]);
       std::memcpy(&(buff[c * coord_size]), coord, coord_size);
     }
   }
@@ -3530,49 +2725,6 @@ void Writer::clean_up(const URI& uri) {
   global_write_state_.reset(nullptr);
 }
 
-Status Writer::set_coords_buffer(void* buffer, uint64_t* buffer_size) {
-  if (coord_data_buffer_is_set_)
-    return LOG_STATUS(Status::WriterError(
-        std::string("Cannot set zipped coordinates buffer after having set "
-                    "separate coordinate buffers")));
-
-  // Set zipped coordinates buffer
-  coords_buffer_ = buffer;
-  coords_buffer_size_ = buffer_size;
-  has_coords_ = true;
-
-  return Status::Ok();
-}
-
-void Writer::get_dim_attr_stats() const {
-  for (const auto& it : buffers_) {
-    const auto& name = it.first;
-    auto var_size = array_schema_->var_size(name);
-    if (array_schema_->is_attr(name)) {
-      stats_->add_counter("attr_num", 1);
-      if (var_size) {
-        stats_->add_counter("attr_var_num", 1);
-      } else {
-        stats_->add_counter("attr_fixed_num", 1);
-      }
-      if (array_schema_->is_nullable(name)) {
-        stats_->add_counter("attr_nullable_num", 1);
-      }
-    } else {
-      stats_->add_counter("dim_num", 1);
-      if (var_size) {
-        stats_->add_counter("dim_var_num", 1);
-      } else {
-        if (name == constants::coords) {
-          stats_->add_counter("dim_zipped_num", 1);
-        } else {
-          stats_->add_counter("dim_fixed_num", 1);
-        }
-      }
-    }
-  }
-}
-
 Status Writer::calculate_hilbert_values(
     const std::vector<const QueryBuffer*>& buffs,
     std::vector<uint64_t>* hilbert_values) const {
@@ -3582,14 +2734,17 @@ Status Writer::calculate_hilbert_values(
   auto max_bucket_val = ((uint64_t)1 << bits) - 1;
 
   // Calculate Hilbert values in parallel
-  assert(hilbert_values->size() >= coords_num_);
+  assert(hilbert_values->size() >= coords_info_.coords_num_);
   auto status = parallel_for(
-      storage_manager_->compute_tp(), 0, coords_num_, [&](uint64_t c) {
+      storage_manager_->compute_tp(),
+      0,
+      coords_info_.coords_num_,
+      [&](uint64_t c) {
         std::vector<uint64_t> coords(dim_num);
         for (uint32_t d = 0; d < dim_num; ++d) {
           auto dim = array_schema_->dimension(d);
           coords[d] = dim->map_to_uint64(
-              buffs[d], c, coords_num_, bits, max_bucket_val);
+              buffs[d], c, coords_info_.coords_num_, bits, max_bucket_val);
         }
         (*hilbert_values)[c] = h.coords_to_hilbert(&coords[0]);
 
@@ -3599,10 +2754,6 @@ Status Writer::calculate_hilbert_values(
   RETURN_NOT_OK_ELSE(status, LOG_STATUS(status));
 
   return Status::Ok();
-}
-
-const Config* Writer::config() const {
-  return &config_;
 }
 
 template <class T>

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -41,10 +41,12 @@
 #include "tiledb/sm/fragment/written_fragment_info.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/query/dense_tiler.h"
+#include "tiledb/sm/query/iquery_strategy.h"
+#include "tiledb/sm/query/query.h"
 #include "tiledb/sm/query/query_buffer.h"
+#include "tiledb/sm/query/strategy_base.h"
 #include "tiledb/sm/query/validity_vector.h"
 #include "tiledb/sm/stats/stats.h"
-#include "tiledb/sm/subarray/subarray.h"
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;
@@ -53,12 +55,11 @@ namespace tiledb {
 namespace sm {
 
 class Array;
-class ArraySchema;
 class FragmentMetadata;
 class StorageManager;
 
 /** Processes write queries. */
-class Writer {
+class Writer : public StrategyBase, public IQueryStrategy {
  public:
   /* ********************************* */
   /*          TYPE DEFINITIONS         */
@@ -84,7 +85,7 @@ class Writer {
      */
     std::unordered_map<std::string, uint64_t> cells_written_;
 
-    /** The fragment metadata. */
+    /** The fragment metadata that the writer will focus on. */
     tdb_shared_ptr<FragmentMetadata> frag_meta_;
   };
 
@@ -93,7 +94,18 @@ class Writer {
   /* ********************************* */
 
   /** Constructor. */
-  Writer(stats::Stats* parent_stats);
+  Writer(
+      stats::Stats* stats,
+      StorageManager* storage_manager,
+      Array* array,
+      Config& config,
+      std::unordered_map<std::string, QueryBuffer>& buffers,
+      Subarray& subarray,
+      Layout layout,
+      std::vector<WrittenFragmentInfo>& written_fragment_info,
+      bool disable_check_global_order,
+      Query::CoordsInfo& coords_info_,
+      URI fragment_uri = URI(""));
 
   /** Destructor. */
   ~Writer();
@@ -105,140 +117,16 @@ class Writer {
   /*                 API               */
   /* ********************************* */
 
-  /** Returns the array. */
-  const Array* array() const;
-
-  /** Adds a range to the subarray on the input dimension. */
-  Status add_range(unsigned dim_idx, Range&& range);
-
-  /**
-   * Disables checking the global order. Applicable only to writes.
-   * This option will supercede the config.
-   */
-  void disable_check_global_order();
-
-  /** Retrieves the number of ranges of the subarray for the given dimension. */
-  Status get_range_num(unsigned dim_idx, uint64_t* range_num) const;
-
-  /**
-   * Retrieves a range from a dimension in the form (start, end, stride).
-   *
-   * @param dim_idx The dimension to retrieve the range from.
-   * @param range_idx The id of the range to retrieve.
-   * @param start The range start to retrieve.
-   * @param end The range end to retrieve.
-   * @param stride The range stride to retrieve.
-   * @return Status
-   */
-  Status get_range(
-      unsigned dim_idx,
-      uint64_t range_idx,
-      const void** start,
-      const void** end,
-      const void** stride) const;
-
-  /** Returns the array schema. */
-  const ArraySchema* array_schema() const;
-
   /** Returns the names of the buffers set by the user for the write query. */
   std::vector<std::string> buffer_names() const;
 
-  /**
-   * Returns the query buffer for the given attribute/dimension name.
-   * The name can be TILEDB_COORDS.
-   */
-  QueryBuffer buffer(const std::string& name) const;
-
-  /** Finalizes the reader. */
+  /** Finalizes the writer. */
   Status finalize();
 
-  /**
-   * Retrieves the data buffer of a fixed-sized attribute/dimension.
-   *
-   * @param name The buffer name.
-   * @param buffer The buffer to be retrieved.
-   * @param buffer_size A pointer to the buffer size to be retrieved.
-   * @return Status
-   */
-  Status get_data_buffer(
-      const std::string& name, void** buffer, uint64_t** buffer_size) const;
-
-  /**
-   * Retrieves the offset buffer of a fixed-sized attribute/dimension.
-   *
-   * @param name The buffer name.
-   * @param buffer The buffer to be retrieved.
-   * @param buffer_size A pointer to the buffer size to be retrieved.
-   * @return Status
-   */
-  Status get_offsets_buffer(
-      const std::string& name, uint64_t** buffer, uint64_t** buffer_size) const;
-
-  /**
-   * Retrieves the validity buffer of a fixed-sized attribute/dimension.
-   *
-   * @param name The buffer name.
-   * @param buffer The buffer to be retrieved.
-   * @param buffer_size A pointer to the buffer size to be retrieved.
-   * @return Status
-   */
-  Status get_validity_buffer(
-      const std::string& name, const ValidityVector** validity_vector) const;
-
-  /**
-   * Retrieves the offsets and values buffers of a var-sized
-   * attribute/dimension.
-   *
-   * @param name The buffer attribute/dimension.
-   * @param buffer_off The offsets buffer to be retrieved.
-   * @param buffer_off_size A pointer to the offsets buffer size to be
-   * retrieved.
-   * @param buffer_val The values buffer to be retrieved.
-   * @param buffer_val_size A pointer to the values buffer size to be retrieved.
-   * @return Status
-   */
-  Status get_buffer(
-      const std::string& name,
-      uint64_t** buffer_off,
-      uint64_t** buffer_off_size,
-      void** buffer_val,
-      uint64_t** buffer_val_size) const;
-
-  /**
-   * Retrieves the buffer of a fixed-sized, nullable attribute.
-   *
-   * @param name The buffer name.
-   * @param buffer The buffer to be retrieved.
-   * @param buffer_size A pointer to the buffer size to be retrieved.
-   * @param validity_vector A pointer to the validity vector to be retrieved.
-   * @return Status
-   */
-  Status get_buffer_nullable(
-      const std::string& name,
-      void** buffer,
-      uint64_t** buffer_size,
-      const ValidityVector** validity_vector) const;
-
-  /**
-   * Retrieves the offsets and values buffers of a var-sized,
-   * nullable attribute.
-   *
-   * @param name The buffer attribute/dimension.
-   * @param buffer_off The offsets buffer to be retrieved.
-   * @param buffer_off_size A pointer to the offsets buffer size to be
-   * retrieved.
-   * @param buffer_val The values buffer to be retrieved.
-   * @param buffer_val_size A pointer to the values buffer size to be retrieved.
-   * @param validity_vector A pointer to the validity vector to be retrieved.
-   * @return Status
-   */
-  Status get_buffer_nullable(
-      const std::string& name,
-      uint64_t** buffer_off,
-      uint64_t** buffer_off_size,
-      void** buffer_val,
-      uint64_t** buffer_val_size,
-      const ValidityVector** validity_vector) const;
+  /** Writer is never in an imcomplete state. */
+  bool incomplete() const {
+    return false;
+  }
 
   /** Returns current setting of check_coord_dups_ */
   bool get_check_coord_dups() const;
@@ -249,142 +137,8 @@ class Writer {
   /** Returns current setting of dedup_coords_ */
   bool get_dedup_coords() const;
 
-  /** Returns the configured offsets format mode. */
-  std::string get_offsets_mode() const;
-
-  /** Returns `True` if offsets are configured to have an extra element. */
-  bool get_offsets_extra_element() const;
-
-  /** Returns the configured offsets bitsize */
-  uint32_t get_offsets_bitsize() const;
-
   /** Initializes the writer with the subarray layout. */
   Status init(const Layout& layout);
-
-  /** Returns the cell layout. */
-  Layout layout() const;
-
-  /** Sets the array. */
-  void set_array(const Array* array);
-
-  /*
-   * Sets the array schema. If the array is a kv store, then this
-   * function also sets global order as the default layout.
-   */
-  void set_array_schema(const ArraySchema* array_schema);
-
-  /**
-   * Sets the buffer for a fixed-sized attribute/dimension.
-   *
-   * @param name The attribute/dimension to set the buffer for.
-   * @param buffer The buffer that has the input data to be written.
-   * @param buffer_size The size of `buffer` in bytes.
-   * @return Status
-   */
-  Status set_buffer(
-      const std::string& name, void* const buffer, uint64_t* const buffer_size);
-
-  /**
-   * Sets the data buffer for a agnostic (fixed/var) sized attribute/dimension.
-   *
-   * @param name The attribute/dimension to set the buffer for.
-   * @param buffer The buffer that has the input data to be written.
-   * @param buffer_size The size of `buffer` in bytes.
-   * @return Status
-   */
-  Status set_data_buffer(
-      const std::string& name, void* buffer, uint64_t* buffer_size);
-
-  /**
-   * Sets the offset buffer for a agnostic (fixed/var) sized
-   * attribute/dimension.
-   *
-   * @param name The attribute/dimension to set the buffer for.
-   * @param buffer The buffer that has the input data to be written.
-   * @param buffer_size The size of `buffer` in bytes.
-   * @return Status
-   */
-  Status set_offsets_buffer(
-      const std::string& name, uint64_t* buffer, uint64_t* buffer_size);
-
-  /**
-   * Sets the validity buffer for a agnostic sized nullable attribute/dimension.
-   *
-   * @param name The attribute/dimension to set the buffer for.
-   * @param buffer The buffer that has the input data to be written.
-   * @param buffer_size The size of `buffer` in bytes.
-   * @return Status
-   */
-  Status set_validity_buffer(
-      const std::string& name, uint8_t* buffer, uint64_t* buffer_size);
-
-  /**
-   * Sets the buffer for a var-sized attribute/dimension.
-   *
-   * @param name The attribute/dimension to set the buffer for.
-   * @param buffer_off The buffer that has the input data to be written,
-   *     This buffer holds the starting offsets of each cell value in
-   *     `buffer_val`.
-   * @param buffer_off_size The size of `buffer_off` in bytes.
-   * @param buffer_val The buffer that has the input data to be written.
-   *     This buffer holds the actual var-sized cell values.
-   * @param buffer_val_size The size of `buffer_val` in bytes.
-   * @return Status
-   */
-  Status set_buffer(
-      const std::string& name,
-      uint64_t* buffer_off,
-      uint64_t* buffer_off_size,
-      void* buffer_val,
-      uint64_t* buffer_val_size);
-
-  /**
-   * Sets the buffer for a fixed-sized, nullable attribute.
-   *
-   * @param name The attribute to set the buffer for.
-   * @param buffer The buffer that has the input data to be written.
-   * @param buffer_size The size of `buffer` in bytes.
-   * @param validity_vector The validity vector associated with values in
-   * `buffer`.
-   * @return Status
-   */
-  Status set_buffer(
-      const std::string& name,
-      void* buffer,
-      uint64_t* buffer_size,
-      ValidityVector&& validity_vector);
-
-  /**
-   * Sets the buffer for a var-sized, nullable attribute.
-   *
-   * @param name The attribute to set the buffer for.
-   * @param buffer_off The buffer that has the input data to be written,
-   *     This buffer holds the starting offsets of each cell value in
-   *     `buffer_val`.
-   * @param buffer_off_size The size of `buffer_off` in bytes.
-   * @param buffer_val The buffer that has the input data to be written.
-   *     This buffer holds the actual var-sized cell values.
-   * @param buffer_val_size The size of `buffer_val` in bytes.
-   * @param validity_vector The validity vector associated with values in
-   * `buffer_val`.
-   * @return Status
-   */
-  Status set_buffer(
-      const std::string& name,
-      uint64_t* buffer_off,
-      uint64_t* buffer_off_size,
-      void* buffer_val,
-      uint64_t* buffer_val_size,
-      ValidityVector&& validity_vector);
-
-  /** Sets config for query-level parameters only. */
-  Status set_config(const Config& config);
-
-  /**
-   * Get the config of the writer
-   * @return Config
-   */
-  const Config* config() const;
 
   /** Sets current setting of check_coord_dups_ */
   void set_check_coord_dups(bool b);
@@ -395,71 +149,13 @@ class Writer {
   /** Sets current setting of dedup_coords_ */
   void set_dedup_coords(bool b);
 
-  /** Sets the offsets format mode. */
-  Status set_offsets_mode(const std::string& offsets_mode);
-
-  /** Sets if offsets are configured to have an extra element. */
-  Status set_offsets_extra_element(bool add_extra_element);
-
-  /** Sets the bitsize of offsets */
-  Status set_offsets_bitsize(const uint32_t bitsize);
-
-  /** Sets the fragment URI. Applicable only to write queries. */
-  void set_fragment_uri(const URI& fragment_uri);
-
-  /**
-   * Sets the cell layout of the query. The function will return an error
-   * if the queried array is a key-value store (because it has its default
-   * layout for both reads and writes.
-   */
-  Status set_layout(Layout layout);
-
-  /** Sets the storage manager. */
-  void set_storage_manager(StorageManager* storage_manager);
-
-  /** Sets the query subarray. */
-  Status set_subarray(const Subarray& subarray);
-
-  /* Return the subarray. */
-  const void* subarray() const;
-
-  /** Returns the query subarray object. */
-  const Subarray* subarray_ranges() const;
-
-  /** Returns `stats_`. */
-  stats::Stats* stats() const;
-
   /** Performs a write query using its set members. */
-  Status write();
-
-  /** Returns the written fragment info. */
-  const std::vector<WrittenFragmentInfo>& written_fragment_info() const;
+  Status dowork();
 
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
-
-  /** The class stats. */
-  stats::Stats* stats_;
-
-  /** The array. */
-  const Array* array_;
-
-  /** The array schema. */
-  const ArraySchema* array_schema_;
-
-  /** The config for query-level parameters only. */
-  Config config_;
-
-  /** Maps attribute/dimensions names to their buffers. */
-  std::unordered_map<std::string, QueryBuffer> buffers_;
-
-  /** The coordinates buffer potentially set by the user. */
-  void* coords_buffer_;
-
-  /** The coordinates buffer size potentially set by the user. */
-  uint64_t* coords_buffer_size_;
 
   /**
    * The sizes of the coordinate buffers in a map (dimension -> size).
@@ -468,35 +164,14 @@ class Writer {
    */
   std::unordered_map<std::string, uint64_t> coord_buffer_sizes_;
 
-  /** True if at least one separate coordinate buffer is set. */
-  bool coord_buffer_is_set_;
-
-  /** True if at least one separate data coordinate buffer is set. */
-  bool coord_data_buffer_is_set_;
-
-  /** True if at least one separate offsets coordinate buffer is set. */
-  bool coord_offsets_buffer_is_set_;
-
-  /** Keeps track of the number of coordinates across coordinate buffers. */
-  uint64_t coords_num_;
-
-  /** Keeps track of the name of the data buffer once set. */
-  std::string data_buffer_name_;
-
-  /** Keeps track of the name of the offsets buffer once set. */
-  std::string offsets_buffer_name_;
-
   /**
    * If `true`, it will not check if the written coordinates are
    * in the global order. This supercedes the config.
    */
   bool disable_check_global_order_;
 
-  /**
-   * True if either zipped coordinates buffer or separate coordinate
-   * buffers are set.
-   */
-  bool has_coords_;
+  /** Keeps track of the coords data. */
+  Query::CoordsInfo& coords_info_;
 
   /**
    * Meaningful only when `dedup_coords_` is `false`.
@@ -536,47 +211,11 @@ class Writer {
   /** True if the writer has been initialized. */
   bool initialized_;
 
-  /**
-   * The layout of the cells in the result of the subarray. Note
-   * that this may not be the same as what the user set to the
-   * query, as the Writer may calibrate it to boost performance.
-   */
-  Layout layout_;
-
-  /** The storage manager. */
-  StorageManager* storage_manager_;
-
-  /**
-   * The subarray the query is constrained on. It is represented
-   * as a flat byte vector for the (low, high) pairs of the
-   * subarray. This is used only in dense writes and, therefore,
-   * it is assumed that all dimensions have the same datatype.
-   */
-  std::vector<uint8_t> subarray_flat_;
-
-  /**
-   * The subarray object, used in dense writes. It has to be
-   * comprised of a single multi-dimensional range.
-   */
-  Subarray subarray_;
-
   /** Stores information about the written fragments. */
-  std::vector<WrittenFragmentInfo> written_fragment_info_;
+  std::vector<WrittenFragmentInfo>& written_fragment_info_;
 
   /** Allocated buffers that neeed to be cleaned upon destruction. */
   std::vector<void*> to_clean_;
-
-  /** The offset format used for variable-sized attributes. */
-  std::string offsets_format_mode_;
-
-  /**
-   * If `true`, an extra element that points to the end of the values buffer
-   * will be added in the end of the offsets buffer of var-sized attributes
-   */
-  bool offsets_extra_element_;
-
-  /** The offset bitsize used for variable-sized attributes. */
-  uint32_t offsets_bitsize_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */
@@ -584,9 +223,6 @@ class Writer {
 
   /** Adss a fragment to `written_fragment_info_`. */
   Status add_written_fragment_info(const URI& uri);
-
-  /** Checks if the buffers names have been appropriately set for the query. */
-  Status check_buffer_names();
 
   /** Correctness checks for buffer sizes. */
   Status check_buffer_sizes() const;
@@ -1257,19 +893,6 @@ class Writer {
    * in the global write state are empty.
    */
   bool all_last_tiles_empty() const;
-
-  /**
-   * Sets the (zipped) coordinates buffer (set with TILEDB_COORDS as the
-   * buffer name).
-   *
-   * @param buffer The buffer that has the input data to be written.
-   * @param buffer_size The size of `buffer` in bytes.
-   * @return Status
-   */
-  Status set_coords_buffer(void* buffer, uint64_t* buffer_size);
-
-  /** Gets statistics about dimensions and attributes written. */
-  void get_dim_attr_stats() const;
 
   /** Calculates the hilbert values of the input coordinate buffers. */
   Status calculate_hilbert_values(


### PR DESCRIPTION
This initial refactor for the readers prepares for the creation of all
new reader classes. To minimize duplicate code, the code for settings
and getting buffers, layout, subarray, config and query condition is
moved to the query. It also creates a new interface, IQueryStrategy,
which all readers and writers will implement and creates a basic class
hierarchy for the strategies. Finally, it creates the reader or writer
dynamically when the query is submitted as a IQueryStrategy.

---
TYPE: IMPROVEMENT
DESC: Initial read refactor
