### PR TITLE
Subarray partitioner, unordered should be unordered, even for Hilbert.

### DIFF
--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -939,9 +939,13 @@ void SubarrayPartitioner::compute_splitting_value_single_range(
   auto cell_order = array_schema->cell_order();
   assert(!range.is_unary());
   auto layout = subarray_.layout();
-  layout = (layout == Layout::UNORDERED || layout == Layout::GLOBAL_ORDER) ?
-               cell_order :
-               layout;
+  if (layout == Layout::UNORDERED && cell_order == Layout::HILBERT) {
+    cell_order = Layout::ROW_MAJOR;
+  } else {
+    layout = (layout == Layout::UNORDERED || layout == Layout::GLOBAL_ORDER) ?
+                 cell_order :
+                 layout;
+  }
   *splitting_dim = UINT32_MAX;
 
   // Special case for Hilbert cell order
@@ -1053,7 +1057,9 @@ Status SubarrayPartitioner::compute_splitting_value_multi_range(
   auto layout = subarray_.layout();
   auto array_schema = subarray_.array()->array_schema();
   auto dim_num = array_schema->dim_num();
-  auto cell_order = array_schema->cell_order();
+  auto cell_order = (array_schema->cell_order() == Layout::HILBERT) ?
+                        Layout::ROW_MAJOR :
+                        array_schema->cell_order();
   layout = (layout == Layout::UNORDERED) ? cell_order : layout;
   *splitting_dim = UINT32_MAX;
   uint64_t range_num;


### PR DESCRIPTION
---
TYPE: BUG
DESC: Subarray partitioner, unordered should be unordered, even for Hilbert.
