### PR TITLE
Process empty string ranges across entire domain computing result tiles

### DIFF
--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -476,18 +476,20 @@ inline uint8_t ResultTile::str_coord_intersects(
   bool geq_start = true;
   bool all_chars_match = true;
   uint64_t min_size = std::min<uint64_t>(c_size, range_start.size());
-  for (uint64_t i = 0; i < min_size; ++i) {
-    if (buff_str[c_offset + i] < range_start[i]) {
+  if (!range_start.empty()) {
+    for (uint64_t i = 0; i < min_size; ++i) {
+      if (buff_str[c_offset + i] < range_start[i]) {
+        geq_start = false;
+        all_chars_match = false;
+        break;
+      } else if (buff_str[c_offset + i] > range_start[i]) {
+        all_chars_match = false;
+        break;
+      }  // Else characters match
+    }
+    if (geq_start && all_chars_match && c_size < range_start.size()) {
       geq_start = false;
-      all_chars_match = false;
-      break;
-    } else if (buff_str[c_offset + i] > range_start[i]) {
-      all_chars_match = false;
-      break;
-    }  // Else characters match
-  }
-  if (geq_start && all_chars_match && c_size < range_start.size()) {
-    geq_start = false;
+    }
   }
 
   // Test against end
@@ -496,18 +498,20 @@ inline uint8_t ResultTile::str_coord_intersects(
     seq_end = true;
     all_chars_match = true;
     min_size = std::min<uint64_t>(c_size, range_end.size());
-    for (uint64_t i = 0; i < min_size; ++i) {
-      if (buff_str[c_offset + i] > range_end[i]) {
-        geq_start = false;
-        break;
-      } else if (buff_str[c_offset + i] < range_end[i]) {
-        all_chars_match = false;
-        break;
-      }  // Else characters match
-    }
-    if (seq_end && all_chars_match && c_size > range_end.size()) {
-      seq_end = false;
-    }
+    if (!range_end.empty()) {
+      for (uint64_t i = 0; i < min_size; ++i) {
+        if (buff_str[c_offset + i] > range_end[i]) {
+          geq_start = false;
+          break;
+        } else if (buff_str[c_offset + i] < range_end[i]) {
+          all_chars_match = false;
+          break;
+        }  // Else characters match
+      }
+      if (seq_end && all_chars_match && c_size > range_end.size()) {
+        seq_end = false;
+      }
+	}
   }
 
   return geq_start && seq_end;

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -511,7 +511,7 @@ inline uint8_t ResultTile::str_coord_intersects(
       if (seq_end && all_chars_match && c_size > range_end.size()) {
         seq_end = false;
       }
-	}
+    }
   }
 
   return geq_start && seq_end;


### PR DESCRIPTION
Force empty string range to cover entire domain in result_tile.c/str_coord_intersect() supporting correct results for both ch7331 and ch7065.

This solution may be obsoleted when empty string ranges are supported as first class citizens.

---
TYPE: BUG
DESC: Support empty string range as covering entire domain.
