### PR TITLE
Aws s3 canned bucket/object acl support

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -209,6 +209,9 @@ void check_save_to_file() {
   REQUIRE(rc == TILEDB_OK);
 
   std::stringstream ss;
+  // Items here need to be assigned to 'ss' in alphabetical order as
+  // an std::[ordered_]map is where the comparison values saved to file
+  // come from.
   ss << "config.env_var_prefix TILEDB_\n";
 #ifdef TILEDB_VERBOSE
   ss << "config.logging_level 1\n";
@@ -276,6 +279,7 @@ void check_save_to_file() {
   ss << "vfs.min_parallel_size 10485760\n";
   ss << "vfs.read_ahead_cache_size 10485760\n";
   ss << "vfs.read_ahead_size 102400\n";
+  ss << "vfs.s3.bucket_canned_acl NOT_SET\n";
   ss << "vfs.s3.connect_max_tries 5\n";
   ss << "vfs.s3.connect_scale_factor 25\n";
   ss << "vfs.s3.connect_timeout_ms 10800\n";
@@ -283,6 +287,7 @@ void check_save_to_file() {
   ss << "vfs.s3.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
   ss << "vfs.s3.multipart_part_size 5242880\n";
+  ss << "vfs.s3.object_canned_acl NOT_SET\n";
   ss << "vfs.s3.proxy_port 0\n";
   ss << "vfs.s3.proxy_scheme http\n";
   ss << "vfs.s3.region us-east-1\n";
@@ -622,6 +627,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.hdfs.username"] = "stavros";
   all_param_values["vfs.hdfs.kerb_ticket_cache_path"] = "";
   all_param_values["vfs.hdfs.name_node_uri"] = "";
+  all_param_values["vfs.s3.bucket_canned_acl"] = "NOT_SET";
+  all_param_values["vfs.s3.object_canned_acl"] = "NOT_SET";
 
   std::map<std::string, std::string> vfs_param_values;
   vfs_param_values["min_batch_gap"] = "512000";
@@ -680,6 +687,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["s3.proxy_scheme"] = "http";
   vfs_param_values["s3.proxy_username"] = "";
   vfs_param_values["s3.verify_ssl"] = "true";
+  vfs_param_values["s3.bucket_canned_acl"] = "NOT_SET";
+  vfs_param_values["s3.object_canned_acl"] = "NOT_SET";
   vfs_param_values["hdfs.username"] = "stavros";
   vfs_param_values["hdfs.kerb_ticket_cache_path"] = "";
   vfs_param_values["hdfs.name_node_uri"] = "";
@@ -735,6 +744,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   s3_param_values["proxy_scheme"] = "http";
   s3_param_values["proxy_username"] = "";
   s3_param_values["verify_ssl"] = "true";
+  s3_param_values["bucket_canned_acl"] = "NOT_SET";
+  s3_param_values["object_canned_acl"] = "NOT_SET";
 
   // Create an iterator and iterate over all parameters
   tiledb_config_iter_t* config_iter = nullptr;
@@ -762,6 +773,19 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
     CHECK(rc == TILEDB_OK);
     CHECK(error == nullptr);
   } while (!done);
+  // highlight any difference to aid the poor developer in event CHECK() fails.
+  for (auto i1 = all_param_values.begin(); i1 != all_param_values.end(); ++i1) {
+    if (all_iter_map.find(i1->first) == all_iter_map.end()) {
+      std::cout << "all_iter_map[\"" << i1->first << "\"] not found!"
+                << std::endl;
+    }
+  }
+  for (auto i1 = all_iter_map.begin(); i1 != all_iter_map.end(); ++i1) {
+    if (all_param_values.find(i1->first) == all_param_values.end()) {
+      std::cout << "all_param_values[\"" << i1->first << "\"] not found!"
+                << std::endl;
+    }
+  }
   CHECK(all_param_values == all_iter_map);
   tiledb_config_iter_free(&config_iter);
   CHECK(error == nullptr);
@@ -789,6 +813,19 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
     CHECK(rc == TILEDB_OK);
     CHECK(error == nullptr);
   } while (!done);
+  // highlight any difference to aid the poor developer in event CHECK() fails.
+  for (auto i1 = vfs_param_values.begin(); i1 != vfs_param_values.end(); ++i1) {
+    if (vfs_iter_map.find(i1->first) == vfs_iter_map.end()) {
+      std::cout << "vfs_iter_map[\"" << i1->first << "\"] not found!"
+                << std::endl;
+    }
+  }
+  for (auto i1 = vfs_iter_map.begin(); i1 != vfs_iter_map.end(); ++i1) {
+    if (vfs_param_values.find(i1->first) == vfs_param_values.end()) {
+      std::cout << "vfs_param_values[\"" << i1->first << "\"] not found!"
+                << std::endl;
+    }
+  }
   CHECK(vfs_param_values == vfs_iter_map);
   tiledb_config_iter_free(&config_iter);
 
@@ -869,6 +906,19 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
     CHECK(rc == TILEDB_OK);
     CHECK(error == nullptr);
   } while (!done);
+  // highlight any difference to aid the poor developer in event CHECK() fails.
+  for (auto i1 = s3_param_values.begin(); i1 != s3_param_values.end(); ++i1) {
+    if (s3_iter_map.find(i1->first) == s3_iter_map.end()) {
+      std::cout << "s3_iter_map[\"" << i1->first << "\"] not found!"
+                << std::endl;
+    }
+  }
+  for (auto i1 = s3_iter_map.begin(); i1 != s3_iter_map.end(); ++i1) {
+    if (s3_param_values.find(i1->first) == s3_param_values.end()) {
+      std::cout << "s3_param_values[\"" << i1->first << "\"] not found!"
+                << std::endl;
+    }
+  }
   CHECK(s3_param_values == s3_iter_map);
   tiledb_config_iter_free(&config_iter);
   CHECK(error == nullptr);

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -61,7 +61,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 55);
+  CHECK(names.size() == 57);
 }
 
 TEST_CASE(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1226,6 +1226,26 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The server-side encryption algorithm to use. Supported non-empty
  *    values are "aes256" and "kms" (AWS key management service). <br>
  *    **Default**: ""
+ * - `vfs.s3.bucket_canned_acl` <br>
+ *    Names of values found in Aws::S3::Model::BucketCannedACL enumeration.
+ *    "NOT_SET"
+ *    "private_"
+ *    "public_read"
+ *    "public_read_write"
+ *    "authenticated_read"
+ *    **Default**: "NOT_SET"
+ * - `vfs.s3.object_canned_acl` <br>
+ *    Names of values found in Aws::S3::Model::ObjectCannedACL enumeration.
+ *    (The first 5 are the same as for "vfs.s3.bucket_canned_acl".)
+ *    "NOT_SET"
+ *    "private_"
+ *    "public_read"
+ *    "public_read_write"
+ *    "authenticated_read"
+ *    (The following three items are found only in
+ *     Aws::S3::Model::ObjectCannedACL.) "aws_exec_read" "owner_read"
+ *    "bucket_owner_full_control"
+ *    **Default**: "NOT_SET"
  * - `vfs.hdfs.name_node_uri"` <br>
  *    Name node for HDFS. <br>
  *    **Default**: ""

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -157,7 +157,8 @@ const std::string Config::VFS_S3_VERIFY_SSL = "true";
 const std::string Config::VFS_HDFS_KERB_TICKET_CACHE_PATH = "";
 const std::string Config::VFS_HDFS_NAME_NODE_URI = "";
 const std::string Config::VFS_HDFS_USERNAME = "";
-
+const std::string Config::VFS_S3_OBJECT_CANNED_ACL = "NOT_SET";
+const std::string Config::VFS_S3_BUCKET_CANNED_ACL = "NOT_SET";
 /* ****************************** */
 /*        PRIVATE CONSTANTS       */
 /* ****************************** */
@@ -297,6 +298,8 @@ Config::Config() {
   param_values_["vfs.s3.proxy_password"] = VFS_S3_PROXY_PASSWORD;
   param_values_["vfs.s3.logging_level"] = VFS_S3_LOGGING_LEVEL;
   param_values_["vfs.s3.verify_ssl"] = VFS_S3_VERIFY_SSL;
+  param_values_["vfs.s3.object_canned_acl"] = VFS_S3_OBJECT_CANNED_ACL;
+  param_values_["vfs.s3.bucket_canned_acl"] = VFS_S3_BUCKET_CANNED_ACL;
   param_values_["vfs.hdfs.name_node_uri"] = VFS_HDFS_NAME_NODE_URI;
   param_values_["vfs.hdfs.username"] = VFS_HDFS_USERNAME;
   param_values_["vfs.hdfs.kerb_ticket_cache_path"] =

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -154,11 +154,11 @@ const std::string Config::VFS_S3_PROXY_USERNAME = "";
 const std::string Config::VFS_S3_PROXY_PASSWORD = "";
 const std::string Config::VFS_S3_LOGGING_LEVEL = "Off";
 const std::string Config::VFS_S3_VERIFY_SSL = "true";
+const std::string Config::VFS_S3_BUCKET_CANNED_ACL = "NOT_SET";
+const std::string Config::VFS_S3_OBJECT_CANNED_ACL = "NOT_SET";
 const std::string Config::VFS_HDFS_KERB_TICKET_CACHE_PATH = "";
 const std::string Config::VFS_HDFS_NAME_NODE_URI = "";
 const std::string Config::VFS_HDFS_USERNAME = "";
-const std::string Config::VFS_S3_OBJECT_CANNED_ACL = "NOT_SET";
-const std::string Config::VFS_S3_BUCKET_CANNED_ACL = "NOT_SET";
 /* ****************************** */
 /*        PRIVATE CONSTANTS       */
 /* ****************************** */
@@ -298,8 +298,8 @@ Config::Config() {
   param_values_["vfs.s3.proxy_password"] = VFS_S3_PROXY_PASSWORD;
   param_values_["vfs.s3.logging_level"] = VFS_S3_LOGGING_LEVEL;
   param_values_["vfs.s3.verify_ssl"] = VFS_S3_VERIFY_SSL;
-  param_values_["vfs.s3.object_canned_acl"] = VFS_S3_OBJECT_CANNED_ACL;
   param_values_["vfs.s3.bucket_canned_acl"] = VFS_S3_BUCKET_CANNED_ACL;
+  param_values_["vfs.s3.object_canned_acl"] = VFS_S3_OBJECT_CANNED_ACL;
   param_values_["vfs.hdfs.name_node_uri"] = VFS_HDFS_NAME_NODE_URI;
   param_values_["vfs.hdfs.username"] = VFS_HDFS_USERNAME;
   param_values_["vfs.hdfs.kerb_ticket_cache_path"] =
@@ -627,6 +627,10 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.s3.proxy_password"] = VFS_S3_PROXY_PASSWORD;
   } else if (param == "vfs.s3.verify_ssl") {
     param_values_["vfs.s3.verify_ssl"] = VFS_S3_VERIFY_SSL;
+  } else if (param == "vfs.s3.bucket_canned_acl") {
+    param_values_["vfs.s3.bucket_canned_acl"] = VFS_S3_BUCKET_CANNED_ACL;
+  } else if (param == "vfs.s3.object_canned_acl") {
+    param_values_["vfs.s3.object_canned_acl"] = VFS_S3_OBJECT_CANNED_ACL;
   } else if (param == "vfs.hdfs.name_node_uri") {
     param_values_["vfs.hdfs.name_node_uri"] = VFS_HDFS_NAME_NODE_URI;
   } else if (param == "vfs.hdfs.username") {
@@ -676,6 +680,7 @@ Status Config::sanity_check(
   uint32_t v32 = 0;
   float vf = 0.0f;
   int64_t vint64 = 0;
+  int chkno = -1;
 
   if (param == "rest.server_serialization_format") {
     SerializationType serialization_type;
@@ -770,6 +775,21 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &vint64));
   } else if (param == "vfs.s3.verify_ssl") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
+  } else if (
+      (chkno = 1, param == "vfs.s3.bucket_canned_acl") ||
+      (chkno = 2, param == "vfs.s3.object_canned_acl")) {
+    // first items valid for both ObjectCannedACL and BucketCannedACL
+    if (!((value == "NOT_SET") || (value == "private_") ||
+          (value == "public_read") || (value == "public_read_write") ||
+          (value == "authenticated_read") ||
+          // items only valid for ObjectCannedACL
+          (chkno == 2 &&
+           ((value == "aws_exec_read") || (value == "bucket_owner_read") ||
+            (value == "bucket_owner_full_control"))))) {
+      std::stringstream msg;
+      msg << "value " << param << " invalid canned acl for " << param;
+      return Status::Error(msg.str());
+    }
   }
 
   return Status::Ok();

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -425,6 +425,12 @@ class Config {
   /** HDFS default username. */
   static const std::string VFS_HDFS_USERNAME;
 
+  /** S3 default object canned ACL */
+  static const std::string Config::VFS_S3_OBJECT_CANNED_ACL;
+
+  /** S3 default bucket canned ACL */
+  static const std::string Config::VFS_S3_BUCKET_CANNED_ACL;
+
   /* ****************************** */
   /*        OTHER CONSTANTS         */
   /* ****************************** */

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -425,11 +425,11 @@ class Config {
   /** HDFS default username. */
   static const std::string VFS_HDFS_USERNAME;
 
-  /** S3 default object canned ACL */
-  static const std::string Config::VFS_S3_OBJECT_CANNED_ACL;
-
   /** S3 default bucket canned ACL */
-  static const std::string Config::VFS_S3_BUCKET_CANNED_ACL;
+  static const std::string VFS_S3_BUCKET_CANNED_ACL;
+
+  /** S3 default object canned ACL */
+  static const std::string VFS_S3_OBJECT_CANNED_ACL;
 
   /* ****************************** */
   /*        OTHER CONSTANTS         */

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -575,6 +575,26 @@ class Config {
    *    The server-side encryption algorithm to use. Supported non-empty
    *    values are "aes256" and "kms" (AWS key management service). <br>
    *    **Default**: ""
+   * - `vfs.s3.bucket_canned_acl` <br>
+   *    Names of values found in Aws::S3::Model::BucketCannedACL enumeration.
+   *    "NOT_SET"
+   *    "private_"
+   *    "public_read"
+   *    "public_read_write"
+   *    "authenticated_read"
+   *    **Default**: "NOT_SET"
+   * - `vfs.s3.object_canned_acl` <br>
+   *    Names of values found in Aws::S3::Model::ObjectCannedACL enumeration.
+   *    (The first 5 are the same as for "vfs.s3.bucket_canned_acl".)
+   *    "NOT_SET"
+   *    "private_"
+   *    "public_read"
+   *    "public_read_write"
+   *    "authenticated_read"
+   *    (The following three items are found only in
+   *     Aws::S3::Model::ObjectCannedACL.) "aws_exec_read" "owner_read"
+   *    "bucket_owner_full_control"
+   *    **Default**: "NOT_SET"
    * - `vfs.hdfs.name_node_uri"` <br>
    *    Name node for HDFS. <br>
    *    **Default**: ""

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -80,17 +80,16 @@ Aws::Utils::Logging::LogLevel aws_log_name_to_level(std::string loglevel) {
 /**
  * Return a S3 enum value for any recognized string or NOT_SET if
  * B) the string is not recognized to match any of the enum values
- * 
- * @param canned_acl_str A textual string naming one of the 
+ *
+ * @param canned_acl_str A textual string naming one of the
  *        Aws::S3::Model::ObjectCannedACL enum members.
  */
 Aws::S3::Model::ObjectCannedACL S3_ObjectCannedACL_from_str(
-  const std::string &canned_acl_str) {
-  if(canned_acl_str.empty())
+    const std::string& canned_acl_str) {
+  if (canned_acl_str.empty())
     return Aws::S3::Model::ObjectCannedACL::NOT_SET;
-    
 
-  if(canned_acl_str == "NOT_SET")
+  if (canned_acl_str == "NOT_SET")
     return Aws::S3::Model::ObjectCannedACL::NOT_SET;
   else if (canned_acl_str == "private_")
     return Aws::S3::Model::ObjectCannedACL::private_;
@@ -113,17 +112,16 @@ Aws::S3::Model::ObjectCannedACL S3_ObjectCannedACL_from_str(
 /**
  * Return a S3 enum value for any recognized string or NOT_SET if
  * B) the string is not recognized to match any of the enum values
- * 
- * @param canned_acl_str A textual string naming one of the 
+ *
+ * @param canned_acl_str A textual string naming one of the
  *        Aws::S3::Model::BucketCannedACL enum members.
  */
 Aws::S3::Model::BucketCannedACL S3_BucketCannedACL_from_str(
-  const std::string &canned_acl_str) {
-  if(canned_acl_str.empty())
+    const std::string& canned_acl_str) {
+  if (canned_acl_str.empty())
     return Aws::S3::Model::BucketCannedACL::NOT_SET;
-    
 
-  if(canned_acl_str == "NOT_SET")
+  if (canned_acl_str == "NOT_SET")
     return Aws::S3::Model::BucketCannedACL::NOT_SET;
   else if (canned_acl_str == "private_")
     return Aws::S3::Model::BucketCannedACL::private_;
@@ -275,16 +273,16 @@ Status S3::init(
 
   auto object_acl_str = config.get("vfs.s3.object_canned_acl", &found);
   assert(found);
-  if(found){
+  if (found) {
     object_canned_acl_ = S3_ObjectCannedACL_from_str(object_acl_str);
   }
-  
+
   auto bucket_acl_str = config.get("vfs.s3.bucket_canned_acl", &found);
   assert(found);
-  if(found){
+  if (found) {
     bucket_canned_acl_ = S3_BucketCannedACL_from_str(bucket_acl_str);
   }
-  
+
   auto sse = config.get("vfs.s3.sse", &found);
   assert(found);
 
@@ -345,8 +343,8 @@ Status S3::create_bucket(const URI& bucket) const {
     cfg.SetLocationConstraint(location_constraint);
     create_bucket_request.SetCreateBucketConfiguration(cfg);
   }
-  
-  if(bucket_canned_acl_ != Aws::S3::Model::BucketCannedACL::NOT_SET) {
+
+  if (bucket_canned_acl_ != Aws::S3::Model::BucketCannedACL::NOT_SET) {
     create_bucket_request.SetACL(bucket_canned_acl_);
   }
 
@@ -948,7 +946,7 @@ Status S3::touch(const URI& uri) const {
     put_object_request.SetServerSideEncryption(sse_);
   if (!sse_kms_key_id_.empty())
     put_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
-  if(object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
+  if (object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
     put_object_request.SetACL(object_canned_acl_);
   }
 
@@ -1270,7 +1268,7 @@ Status S3::copy_object(const URI& old_uri, const URI& new_uri) {
     copy_object_request.SetServerSideEncryption(sse_);
   if (!sse_kms_key_id_.empty())
     copy_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
-  if(object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
+  if (object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
     copy_object_request.SetACL(object_canned_acl_);
   }
 
@@ -1363,7 +1361,7 @@ Status S3::initiate_multipart_request(
   if (!sse_kms_key_id_.empty())
     multipart_upload_request.SetSSEKMSKeyId(
         Aws::String(sse_kms_key_id_.c_str()));
-  if(object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
+  if (object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
     multipart_upload_request.SetACL(object_canned_acl_);
   }
 
@@ -1494,7 +1492,7 @@ Status S3::flush_direct(const URI& uri) {
     put_object_request.SetServerSideEncryption(sse_);
   if (!sse_kms_key_id_.empty())
     put_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
-  if(object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
+  if (object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
     put_object_request.SetACL(object_canned_acl_);
   }
 

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -101,7 +101,7 @@ Aws::S3::Model::ObjectCannedACL S3_ObjectCannedACL_from_str(
     return Aws::S3::Model::ObjectCannedACL::authenticated_read;
   else if (canned_acl_str == "aws_exec_read")
     return Aws::S3::Model::ObjectCannedACL::aws_exec_read;
-  else if (canned_acl_str == "owner_read")
+  else if (canned_acl_str == "bucket_owner_read")
     return Aws::S3::Model::ObjectCannedACL::bucket_owner_read;
   else if (canned_acl_str == "bucket_owner_full_control")
     return Aws::S3::Model::ObjectCannedACL::bucket_owner_full_control;

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -76,6 +76,67 @@ Aws::Utils::Logging::LogLevel aws_log_name_to_level(std::string loglevel) {
   else
     return Aws::Utils::Logging::LogLevel::Off;
 }
+
+/**
+ * Return a S3 enum value for any recognized string or NOT_SET if
+ * B) the string is not recognized to match any of the enum values
+ * 
+ * @param canned_acl_str A textual string naming one of the 
+ *        Aws::S3::Model::ObjectCannedACL enum members.
+ */
+Aws::S3::Model::ObjectCannedACL S3_ObjectCannedACL_from_str(
+  const std::string &canned_acl_str) {
+  if(canned_acl_str.empty())
+    return Aws::S3::Model::ObjectCannedACL::NOT_SET;
+    
+
+  if(canned_acl_str == "NOT_SET")
+    return Aws::S3::Model::ObjectCannedACL::NOT_SET;
+  else if (canned_acl_str == "private_")
+    return Aws::S3::Model::ObjectCannedACL::private_;
+  else if (canned_acl_str == "public_read")
+    return Aws::S3::Model::ObjectCannedACL::public_read;
+  else if (canned_acl_str == "public_read_write")
+    return Aws::S3::Model::ObjectCannedACL::public_read_write;
+  else if (canned_acl_str == "authenticated_read")
+    return Aws::S3::Model::ObjectCannedACL::authenticated_read;
+  else if (canned_acl_str == "aws_exec_read")
+    return Aws::S3::Model::ObjectCannedACL::aws_exec_read;
+  else if (canned_acl_str == "owner_read")
+    return Aws::S3::Model::ObjectCannedACL::bucket_owner_read;
+  else if (canned_acl_str == "bucket_owner_full_control")
+    return Aws::S3::Model::ObjectCannedACL::bucket_owner_full_control;
+  else
+    return Aws::S3::Model::ObjectCannedACL::NOT_SET;
+}
+
+/**
+ * Return a S3 enum value for any recognized string or NOT_SET if
+ * B) the string is not recognized to match any of the enum values
+ * 
+ * @param canned_acl_str A textual string naming one of the 
+ *        Aws::S3::Model::BucketCannedACL enum members.
+ */
+Aws::S3::Model::BucketCannedACL S3_BucketCannedACL_from_str(
+  const std::string &canned_acl_str) {
+  if(canned_acl_str.empty())
+    return Aws::S3::Model::BucketCannedACL::NOT_SET;
+    
+
+  if(canned_acl_str == "NOT_SET")
+    return Aws::S3::Model::BucketCannedACL::NOT_SET;
+  else if (canned_acl_str == "private_")
+    return Aws::S3::Model::BucketCannedACL::private_;
+  else if (canned_acl_str == "public_read")
+    return Aws::S3::Model::BucketCannedACL::public_read;
+  else if (canned_acl_str == "public_read_write")
+    return Aws::S3::Model::BucketCannedACL::public_read_write;
+  else if (canned_acl_str == "authenticated_read")
+    return Aws::S3::Model::BucketCannedACL::authenticated_read;
+  else
+    return Aws::S3::Model::BucketCannedACL::NOT_SET;
+}
+
 }  // namespace
 
 using namespace tiledb::common;
@@ -125,7 +186,9 @@ S3::S3()
     , use_virtual_addressing_(false)
     , use_multipart_upload_(true)
     , request_payer_(Aws::S3::Model::RequestPayer::NOT_SET)
-    , sse_(Aws::S3::Model::ServerSideEncryption::NOT_SET) {
+    , sse_(Aws::S3::Model::ServerSideEncryption::NOT_SET)
+    , object_canned_acl_(Aws::S3::Model::ObjectCannedACL::NOT_SET)
+    , bucket_canned_acl_(Aws::S3::Model::BucketCannedACL::NOT_SET) {
 }
 
 S3::~S3() {
@@ -210,6 +273,18 @@ Status S3::init(
   if (request_payer)
     request_payer_ = Aws::S3::Model::RequestPayer::requester;
 
+  auto object_acl_str = config.get("vfs.s3.object_canned_acl", &found);
+  assert(found);
+  if(found){
+    object_canned_acl_ = S3_ObjectCannedACL_from_str(object_acl_str);
+  }
+  
+  auto bucket_acl_str = config.get("vfs.s3.bucket_canned_acl", &found);
+  assert(found);
+  if(found){
+    bucket_canned_acl_ = S3_BucketCannedACL_from_str(bucket_acl_str);
+  }
+  
   auto sse = config.get("vfs.s3.sse", &found);
   assert(found);
 
@@ -269,6 +344,10 @@ Status S3::create_bucket(const URI& bucket) const {
         GetBucketLocationConstraintForName(region_str);
     cfg.SetLocationConstraint(location_constraint);
     create_bucket_request.SetCreateBucketConfiguration(cfg);
+  }
+  
+  if(bucket_canned_acl_ != Aws::S3::Model::BucketCannedACL::NOT_SET) {
+    create_bucket_request.SetACL(bucket_canned_acl_);
   }
 
   auto create_bucket_outcome = client_->CreateBucket(create_bucket_request);
@@ -869,6 +948,9 @@ Status S3::touch(const URI& uri) const {
     put_object_request.SetServerSideEncryption(sse_);
   if (!sse_kms_key_id_.empty())
     put_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
+  if(object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
+    put_object_request.SetACL(object_canned_acl_);
+  }
 
   auto put_object_outcome = client_->PutObject(put_object_request);
   if (!put_object_outcome.IsSuccess()) {
@@ -1188,6 +1270,9 @@ Status S3::copy_object(const URI& old_uri, const URI& new_uri) {
     copy_object_request.SetServerSideEncryption(sse_);
   if (!sse_kms_key_id_.empty())
     copy_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
+  if(object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
+    copy_object_request.SetACL(object_canned_acl_);
+  }
 
   auto copy_object_outcome = client_->CopyObject(copy_object_request);
   if (!copy_object_outcome.IsSuccess()) {
@@ -1278,6 +1363,9 @@ Status S3::initiate_multipart_request(
   if (!sse_kms_key_id_.empty())
     multipart_upload_request.SetSSEKMSKeyId(
         Aws::String(sse_kms_key_id_.c_str()));
+  if(object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
+    multipart_upload_request.SetACL(object_canned_acl_);
+  }
 
   auto multipart_upload_outcome =
       client_->CreateMultipartUpload(multipart_upload_request);
@@ -1406,6 +1494,9 @@ Status S3::flush_direct(const URI& uri) {
     put_object_request.SetServerSideEncryption(sse_);
   if (!sse_kms_key_id_.empty())
     put_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
+  if(object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
+    put_object_request.SetACL(object_canned_acl_);
+  }
 
   auto put_object_outcome = client_->PutObject(put_object_request);
   if (!put_object_outcome.IsSuccess()) {

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -629,6 +629,12 @@ class S3 {
 
   /** Protects file_buffers map */
   std::mutex file_buffers_mtx_;
+  
+  /** If !NOT_SET assign to object requests supporting SetACL() */
+  Aws::S3::Model::ObjectCannedACL object_canned_acl_;
+
+  /** If !NOT_SET assign to bucket requests supporting SetACL() */
+  Aws::S3::Model::BucketCannedACL bucket_canned_acl_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -629,7 +629,7 @@ class S3 {
 
   /** Protects file_buffers map */
   std::mutex file_buffers_mtx_;
-  
+
   /** If !NOT_SET assign to object requests supporting SetACL() */
   Aws::S3::Model::ObjectCannedACL object_canned_acl_;
 


### PR DESCRIPTION
Implement config items to support setting Aws::S3::Model::{BucketCannedACL,ObjectCannedACL} on tiledb S3 requests using S3 classes that have the SetACL() methods

---
TYPE: FEATURE
DESC: Support setting via config s3 BucketCannedACL and ObjectCannedACL via SetACL() methods
