### PR TITLE
Change a condition that assumed MSVC was the only compiler for WIN32

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -236,8 +236,9 @@ add_executable(
   ${TILEDB_TEST_SOURCES}
 )
 
-# TODO: Remove when KV API has been removed.
-if (NOT WIN32)
+# We want tests to continue as normal even as the API is changing,
+# so don't warn for deprecations, since they'll be escalated to errors.
+if (NOT MSVC)
   target_compile_options(tiledb_unit PRIVATE -Wno-deprecated-declarations)
 endif()
 


### PR DESCRIPTION
Change a condition that assumed MSVC was the only compiler for WIN32. Old behavior caused deprecation warnings on clang64 in Windows, so when there are deprecated API calls, there are warnings escalated to errors, and the tests do not build.

---
TYPE: BUG
DESC: Change a condition that assumed MSVC was the only compiler for WIN32
