### PR TITLE
Change one straggler CHECK() to CHECK_SAFE() to avoid multi-threaded …

### DIFF
--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -947,7 +947,7 @@ void DenseArrayFx::write_dense_subarray_2D(
 
   // Close array
   rc = tiledb_array_close(ctx_, array);
-  CHECK(rc == TILEDB_OK);
+  CHECK_SAFE(rc == TILEDB_OK);
 
   // Clean up
   tiledb_array_free(&array);


### PR DESCRIPTION
Change one straggler CHECK() to CHECK_SAFE() to avoid multi-threaded conflicts that seem to most commonly,
though not always, occur with vs2017 'Debug' build.

---
TYPE: BUG
DESC: Use CHECK_SAFE() to avoid multi-threaded conflict
