### PR TITLE
Encapsulate spdlog.h

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -51,6 +51,7 @@
 #include "tiledb/sm/misc/utils.h"
 
 #include <chrono>
+#include <climits>
 #include <iostream>
 #include <sstream>
 #include <thread>

--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -35,10 +35,12 @@
 #include "tiledb/sm/c_api/tiledb.h"
 
 #include <climits>
+#include <cmath>
 #include <cstring>
 #include <iostream>
 
 using namespace tiledb::test;
+using std::ceil;
 
 const uint64_t DIM_DOMAIN[4] = {1, 10, 1, 10};
 

--- a/tiledb/common/logger.cc
+++ b/tiledb/common/logger.cc
@@ -27,15 +27,15 @@
  *
  * @section DESCRIPTION
  *
- * This file implements class Logger.
+ * This file defines class Logger, declared in logger.h, and the public logging
+ * functions, declared in logger_public.h.
  */
 
 #include "tiledb/common/logger.h"
 
-#include <spdlog/sinks/stdout_sinks.h>
+#include <spdlog/fmt/ostr.h>
 
-namespace tiledb {
-namespace common {
+namespace tiledb::common {
 
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -66,6 +66,53 @@ Logger::~Logger() {
   spdlog::drop("tiledb");
 }
 
+void Logger::trace(const char* msg) {
+  logger_->trace(msg);
+}
+
+void Logger::debug(const char* msg) {
+  logger_->debug(msg);
+}
+
+void Logger::info(const char* msg) {
+  logger_->info(msg);
+}
+
+void Logger::warn(const char* msg) {
+  logger_->warn(msg);
+}
+
+void Logger::error(const char* msg) {
+  logger_->error(msg);
+}
+
+void Logger::critical(const char* msg) {
+  logger_->critical(msg);
+}
+
+void Logger::set_level(Logger::Level lvl) {
+  switch (lvl) {
+    case Logger::Level::FATAL:
+      logger_->set_level(spdlog::level::critical);
+      break;
+    case Logger::Level::ERR:
+      logger_->set_level(spdlog::level::err);
+      break;
+    case Logger::Level::WARN:
+      logger_->set_level(spdlog::level::warn);
+      break;
+    case Logger::Level::INFO:
+      logger_->set_level(spdlog::level::info);
+      break;
+    case Logger::Level::DBG:
+      logger_->set_level(spdlog::level::debug);
+      break;
+    case Logger::Level::TRACE:
+      logger_->set_level(spdlog::level::trace);
+      break;
+  }
+}
+
 /* ********************************* */
 /*              GLOBAL               */
 /* ********************************* */
@@ -75,5 +122,41 @@ Logger& global_logger() {
   return l;
 }
 
-}  // namespace common
-}  // namespace tiledb
+/** Logs an error. */
+void LOG_TRACE(const std::string& msg) {
+  global_logger().trace(msg.c_str());
+}
+
+/** Logs an error. */
+void LOG_DEBUG(const std::string& msg) {
+  global_logger().debug(msg.c_str());
+}
+
+/** Logs an error. */
+void LOG_INFO(const std::string& msg) {
+  global_logger().info(msg.c_str());
+}
+
+/** Logs an error. */
+void LOG_WARN(const std::string& msg) {
+  global_logger().warn(msg.c_str());
+}
+
+/** Logs an error. */
+void LOG_ERROR(const std::string& msg) {
+  global_logger().error(msg.c_str());
+}
+
+/** Logs a status. */
+Status LOG_STATUS(const Status& st) {
+  global_logger().error(st.to_string().c_str());
+  return st;
+}
+
+/** Logs an error and exits with a non-zero status. */
+void LOG_FATAL(const std::string& msg) {
+  global_logger().error(msg.c_str());
+  exit(1);
+}
+
+}  // namespace tiledb::common

--- a/tiledb/common/logger_public.h
+++ b/tiledb/common/logger_public.h
@@ -1,0 +1,80 @@
+/**
+ * @file   logger_public.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines simple logging functions that can be exposed (by expedient)
+ * to the public API. Their implementations are in `logger.cc`. See the
+ * documentation in `logger.h` for the full story.
+ */
+
+#pragma once
+#ifndef TILEDB_LOGGER_PUBLIC_H
+#define TILEDB_LOGGER_PUBLIC_H
+
+#include "tiledb/common/status.h"
+
+namespace tiledb {
+namespace common {
+
+/** Logs an error. */
+void LOG_TRACE(const std::string& msg);
+
+/** Logs an error. */
+void LOG_DEBUG(const std::string& msg);
+
+/** Logs an error. */
+void LOG_INFO(const std::string& msg);
+
+/** Logs an error. */
+void LOG_WARN(const std::string& msg);
+
+/** Logs an error. */
+void LOG_ERROR(const std::string& msg);
+
+/** Logs a status. */
+Status LOG_STATUS(const Status& st);
+
+/** Logs an error and exits with a non-zero status. */
+void LOG_FATAL(const std::string& msg);
+
+}  // namespace common
+
+/*
+ * Make the simple log functions available to the `tiledb` namespace
+ */
+using common::LOG_DEBUG;
+using common::LOG_ERROR;
+using common::LOG_FATAL;
+using common::LOG_INFO;
+using common::LOG_STATUS;
+using common::LOG_TRACE;
+using common::LOG_WARN;
+
+}  // namespace tiledb
+
+#endif  // TILEDB_LOGGER_PUBLIC_H

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -53,7 +53,10 @@
 
 #include <cstdint>
 #include <cstring>
+#include <optional>
 #include <string>
+#include <tuple>
+using std::tuple, std::optional, std::nullopt;
 
 #include "tiledb/common/heap_memory.h"
 

--- a/tiledb/common/thread_pool.h
+++ b/tiledb/common/thread_pool.h
@@ -34,6 +34,7 @@
 #define TILEDB_THREAD_POOL_H
 
 #include <condition_variable>
+#include <functional>
 #include <mutex>
 #include <stack>
 #include <thread>
@@ -41,7 +42,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "tiledb/common/logger.h"
 #include "tiledb/common/macros.h"
 #include "tiledb/common/status.h"
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -48,6 +48,7 @@
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
 #include <cassert>
+#include <cmath>
 #include <iostream>
 
 using namespace tiledb::common;
@@ -201,8 +202,9 @@ Status Array::open(
     bool found = false;
     encryption_type_from_cfg = config_.get("sm.encryption_type", &found);
     assert(found);
-    RETURN_NOT_OK(
-        encryption_type_enum(encryption_type_from_cfg, &encryption_type));
+    auto [st, et] = encryption_type_enum(encryption_type_from_cfg);
+    RETURN_NOT_OK(st);
+    encryption_type = et.value();
 
     if (EncryptionKey::is_valid_key_length(
             encryption_type,

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/filter_type.h"
@@ -38,6 +39,7 @@
 
 #include <bitset>
 #include <cassert>
+#include <cmath>
 #include <iostream>
 
 using namespace tiledb::common;
@@ -1312,7 +1314,7 @@ ByteVecValue Dimension::map_from_uint64(
   // Essentially take the largest value in the bucket
   if (std::is_integral<T>::value) {  // Integers
     T norm_coord_T =
-        ceil(((value + 1) / (double)max_bucket_val) * dom_range_T - 1);
+        std::ceil(((value + 1) / (double)max_bucket_val) * dom_range_T - 1);
     T coord_T = norm_coord_T + dom_start_T;
     std::memcpy(ret.data(), &coord_T, sizeof(T));
   } else {  // Floating point types

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -34,12 +34,13 @@
 #define TILEDB_DIMENSION_H
 
 #include <bitset>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
 
-#include "tiledb/common/logger.h"
+#include "tiledb/common/logger_public.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/misc/utils.h"
@@ -445,7 +446,7 @@ class Dimension {
          << domain[0] << ", " << domain[1]
          << "]. Adjusting range lower bound to be " << domain[0]
          << " on dimension '" << dim->name() << "'";
-      global_logger().warn(ss.str().c_str());
+      LOG_WARN(ss.str());
 
       r[0] = domain[0];
     }
@@ -456,7 +457,7 @@ class Dimension {
          << domain[0] << ", " << domain[1]
          << "]. Adjusting range upper bound to be " << domain[1]
          << " on dimension '" << dim->name() << "'";
-      global_logger().warn(ss.str().c_str());
+      LOG_WARN(ss.str());
 
       r[1] = domain[1];
     }
@@ -485,7 +486,7 @@ class Dimension {
          << domain[0] << ", " << domain[1]
          << "]. Adjusting range lower bound to be " << domain[0]
          << " on dimension '" << dim->name() << "'";
-      global_logger().warn(ss.str().c_str());
+      LOG_WARN(ss.str());
 
       r[0] = domain[0];
     }
@@ -496,7 +497,7 @@ class Dimension {
          << domain[0] << ", " << domain[1]
          << "]. Adjusting range upper bound to be " << domain[1]
          << " on dimension '" << dim->name() << "'";
-      global_logger().warn(ss.str().c_str());
+      LOG_WARN(ss.str());
 
       r[1] = domain[1];
     }

--- a/tiledb/sm/buffer/buffer.cc
+++ b/tiledb/sm/buffer/buffer.cc
@@ -35,6 +35,7 @@
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 
+#include <algorithm>
 #include <iostream>
 
 using namespace tiledb::common;

--- a/tiledb/sm/buffer/buffer_list.cc
+++ b/tiledb/sm/buffer/buffer_list.cc
@@ -34,6 +34,8 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 
+#include <algorithm>
+
 using namespace tiledb::common;
 
 namespace tiledb {

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -217,10 +217,10 @@ int32_t tiledb_encryption_type_to_str(
 
 int32_t tiledb_encryption_type_from_str(
     const char* str, tiledb_encryption_type_t* encryption_type) {
-  tiledb::sm::EncryptionType val = tiledb::sm::EncryptionType::NO_ENCRYPTION;
-  if (!tiledb::sm::encryption_type_enum(str, &val).ok())
+  auto [st, et] = tiledb::sm::encryption_type_enum(str);
+  if (!st.ok())
     return TILEDB_ERR;
-  *encryption_type = (tiledb_encryption_type_t)val;
+  *encryption_type = (tiledb_encryption_type_t)et.value();
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/cache/lru_cache.h
+++ b/tiledb/sm/cache/lru_cache.h
@@ -33,7 +33,6 @@
 #ifndef TILEDB_LRU_CACHE_H
 #define TILEDB_LRU_CACHE_H
 
-#include "tiledb/common/logger.h"
 #include "tiledb/common/macros.h"
 #include "tiledb/common/status.h"
 

--- a/tiledb/sm/compressors/bzip_compressor.cc
+++ b/tiledb/sm/compressors/bzip_compressor.cc
@@ -35,6 +35,7 @@
 #include "tiledb/sm/buffer/buffer.h"
 
 #include <bzlib.h>
+#include <cmath>
 
 using namespace tiledb::common;
 
@@ -142,7 +143,7 @@ uint64_t BZip::overhead(uint64_t nbytes) {
   // To guarantee that the compressed data will fit in its buffer, allocate an
   // output buffer of size 1% larger than the uncompressed data, plus six
   // hundred extra bytes.
-  return static_cast<uint64_t>(ceil(nbytes * 0.01) + 600);
+  return uint64_t(std::ceil(nbytes * 0.01) + 600);
 }
 
 }  // namespace sm

--- a/tiledb/sm/compressors/gzip_compressor.cc
+++ b/tiledb/sm/compressors/gzip_compressor.cc
@@ -35,6 +35,7 @@
 #include "tiledb/sm/buffer/buffer.h"
 
 #include <zlib.h>
+#include <cmath>
 #include <iostream>
 
 using namespace tiledb::common;
@@ -135,7 +136,7 @@ Status GZip::decompress(
 }
 
 uint64_t GZip::overhead(uint64_t buffer_size) {
-  return 6 + 5 * uint64_t((ceil(buffer_size / 16834.0)));
+  return 6 + 5 * uint64_t((std::ceil(buffer_size / 16834.0)));
 }
 
 };  // namespace sm

--- a/tiledb/sm/compressors/lz4_compressor.cc
+++ b/tiledb/sm/compressors/lz4_compressor.cc
@@ -35,6 +35,7 @@
 #include "tiledb/sm/buffer/buffer.h"
 
 #include <lz4.h>
+#include <cmath>
 #include <limits>
 
 using namespace tiledb::common;
@@ -104,7 +105,7 @@ Status LZ4::decompress(
 uint64_t LZ4::overhead(uint64_t nbytes) {
   // So that we avoid overflow
   auto half_bound =
-      static_cast<uint64_t>(LZ4_compressBound((int)ceil(nbytes / 2.0)));
+      static_cast<uint64_t>(LZ4_compressBound((int)std::ceil(nbytes / 2.0)));
   return 2 * half_bound - nbytes;
 }
 

--- a/tiledb/sm/crypto/crypto_win32.h
+++ b/tiledb/sm/crypto/crypto_win32.h
@@ -35,6 +35,9 @@
 
 #ifdef _WIN32
 
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
 #include <windows.h>
 
 #include <bcrypt.h>

--- a/tiledb/sm/enums/encryption_type.h
+++ b/tiledb/sm/enums/encryption_type.h
@@ -61,16 +61,18 @@ inline const std::string& encryption_type_str(EncryptionType encryption_type) {
 }
 
 /** Returns the encryption type given a string representation. */
-inline Status encryption_type_enum(
-    const std::string& encryption_type_str, EncryptionType* encryption_type) {
+inline tuple<Status, optional<EncryptionType>> encryption_type_enum(
+    const std::string& encryption_type_str) {
+  EncryptionType encryption_type;
   if (encryption_type_str == constants::no_encryption_str)
-    *encryption_type = EncryptionType::NO_ENCRYPTION;
+    encryption_type = EncryptionType::NO_ENCRYPTION;
   else if (encryption_type_str == constants::aes_256_gcm_str)
-    *encryption_type = EncryptionType::AES_256_GCM;
+    encryption_type = EncryptionType::AES_256_GCM;
   else {
-    return Status::Error("Invalid EncryptionType " + encryption_type_str);
+    return {Status::Error("Invalid EncryptionType " + encryption_type_str),
+            nullopt};
   }
-  return Status::Ok();
+  return {Status::Ok(), encryption_type};
 }
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -32,7 +32,7 @@
 
 #ifdef HAVE_AZURE
 
-#if defined(_WIN32)
+#if !defined(NOMINMAX)
 #define NOMINMAX  // avoid min/max macros from windows headers
 #endif
 

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -34,6 +34,9 @@
 #define TILEDB_AZURE_H
 
 #ifdef HAVE_AZURE
+#if !defined(NOMINMAX)
+#define NOMINMAX  // avoid min/max macros from windows headers
+#endif
 #include <base64.h>
 #include <blob/blob_client.h>
 #include <retry.h>

--- a/tiledb/sm/filesystem/hdfs_filesystem.cc
+++ b/tiledb/sm/filesystem/hdfs_filesystem.cc
@@ -49,7 +49,9 @@
 
 #include <dlfcn.h>
 #include <cassert>
+#include <climits>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <sstream>
 

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -30,6 +30,7 @@
  * This file implements the in-memory filesystem class
  */
 
+#include <algorithm>
 #include <mutex>
 #include <sstream>
 #include <unordered_set>
@@ -292,7 +293,7 @@ class MemFilesystem::Directory : public MemFilesystem::FSNode {
       names.emplace_back(full_path + child.first);
     }
 
-    sort(names.begin(), names.end());
+    std::sort(names.begin(), names.end());
     *children = names;
 
     return Status::Ok();

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -39,7 +39,10 @@
 #include "tiledb/sm/misc/utils.h"
 
 #include <dirent.h>
+#include <fcntl.h>
 #include <limits.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include <fstream>
 #include <future>

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -49,6 +49,9 @@
 #include "tiledb/sm/misc/utils.h"
 
 #ifdef _WIN32
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
 #include <Windows.h>
 #undef GetMessage  // workaround for
                    // https://github.com/aws/aws-sdk-cpp/issues/402

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -34,7 +34,6 @@
 #define TILEDB_S3_H
 
 #ifdef HAVE_S3
-#include "tiledb/common/logger.h"
 #include "tiledb/common/rwlock.h"
 #include "tiledb/common/status.h"
 #include "tiledb/common/thread_pool.h"

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -972,7 +972,7 @@ Status VFS::init(
   }
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
   win_.init(config_, io_tp_);
 #else
   posix_.init(config_, io_tp_);

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -37,9 +37,13 @@
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/utils.h"
 
+#if !defined(NOMINMAX)
+#define NOMINMAX  // suppress definition of min/max macros in Windows headers
+#endif
 #include <Shlwapi.h>
 #include <Windows.h>
 #include <wininet.h>  // For INTERNET_MAX_URL_LENGTH
+#include <algorithm>
 #include <cassert>
 #include <fstream>
 #include <iostream>

--- a/tiledb/sm/filter/filter_buffer.cc
+++ b/tiledb/sm/filter/filter_buffer.cc
@@ -35,6 +35,8 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/filter/filter_storage.h"
 
+#include <algorithm>
+
 using namespace tiledb::common;
 
 namespace tiledb {

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/fragment/fragment_info.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
@@ -461,8 +462,9 @@ Status FragmentInfo::load(
     std::string encryption_type_from_cfg =
         config.get("sm.encryption_type", &found);
     assert(found);
-    RETURN_NOT_OK(
-        encryption_type_enum(encryption_type_from_cfg, &encryption_type));
+    auto [st, et] = encryption_type_enum(encryption_type_from_cfg);
+    RETURN_NOT_OK(st);
+    encryption_type = et.value();
     EncryptionKey encryption_key_cfg;
     uint32_t key_length = 0;
 

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -35,11 +35,9 @@
 
 #include <cassert>
 #include <cstring>
+#include <string>
 #include <vector>
-
-#include "tiledb/common/logger.h"
-
-using namespace tiledb::common;
+#include "tiledb/common/logger_public.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -38,6 +38,7 @@
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/uri.h"
 
+#include <algorithm>
 #include <iostream>
 #include <set>
 #include <sstream>

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -35,11 +35,13 @@
 #define TILEDB_UTILS_H
 
 #include <cassert>
+#include <cmath>
 #include <string>
 #include <type_traits>
 #include <vector>
 
 #include "constants.h"
+#include "tiledb/common/logger_public.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/misc/types.h"
 

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/query/dense_tiler.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"

--- a/tiledb/sm/query/dense_tiler.h
+++ b/tiledb/sm/query/dense_tiler.h
@@ -33,7 +33,6 @@
 #ifndef TILEDB_DENSE_TILER_H
 #define TILEDB_DENSE_TILER_H
 
-#include "tiledb/common/logger.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/query/query_buffer.h"

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -38,7 +38,6 @@
 #include <utility>
 #include <vector>
 
-#include "tiledb/common/logger.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"

--- a/tiledb/sm/query/query_buffer.h
+++ b/tiledb/sm/query/query_buffer.h
@@ -33,7 +33,6 @@
 #ifndef TILEDB_QUERY_BUFFER_H
 #define TILEDB_QUERY_BUFFER_H
 
-#include "tiledb/common/logger.h"
 #include "tiledb/common/macros.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/query/validity_vector.h"

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -35,7 +35,6 @@
 
 #include <unordered_set>
 
-#include "tiledb/common/logger.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/enums/query_condition_op.h"

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/query/reader_base.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/query/strategy_base.h"

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -32,6 +32,7 @@
  */
 
 #include "tiledb/sm/query/strategy_base.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 

--- a/tiledb/sm/query/validity_vector.h
+++ b/tiledb/sm/query/validity_vector.h
@@ -35,7 +35,6 @@
 
 #include <vector>
 
-#include "tiledb/common/logger.h"
 #include "tiledb/common/macros.h"
 #include "tiledb/common/status.h"
 

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -35,6 +35,9 @@
 
 #ifdef TILEDB_SERIALIZATION
 
+#if !defined(NOMINMAX)
+#define NOMINMAX  // curl may include windows headers
+#endif
 #include <curl/curl.h>
 #include <cstdlib>
 #include <functional>

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -39,6 +39,11 @@
 #endif
 // clang-format on
 
+// Something, somewhere seems to be defining TIME_MS as a macro
+#if defined(TIME_MS)
+#undef TIME_MS
+#endif
+
 #include <cassert>
 
 #include "tiledb/common/logger.h"

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -38,6 +38,7 @@
 #include "tiledb/sm/misc/utils.h"
 
 #include <cassert>
+#include <cmath>
 #include <iostream>
 #include <list>
 
@@ -102,7 +103,7 @@ Status RTree::build_tree() {
     return Status::Ok();
 
   // Build the tree bottom up
-  auto height = (size_t)ceil(utils::math::log(fanout_, leaf_num)) + 1;
+  auto height = (size_t)std::ceil(utils::math::log(fanout_, leaf_num)) + 1;
   for (size_t i = 0; i < height - 1; ++i) {
     auto new_level = build_level(levels_.back());
     levels_.emplace_back(new_level);
@@ -284,7 +285,7 @@ Status RTree::deserialize(
 
 RTree::Level RTree::build_level(const Level& level) {
   auto cur_mbr_num = (uint64_t)level.size();
-  Level new_level((uint64_t)ceil((double)cur_mbr_num / fanout_));
+  Level new_level((uint64_t)std::ceil((double)cur_mbr_num / fanout_));
   auto new_mbr_num = (uint64_t)new_level.size();
 
   uint64_t mbrs_visited = 0;

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -38,6 +38,7 @@
 #include "tiledb-rest.h"
 
 #include "tiledb/common/heap_memory.h"
+#include "tiledb/common/logger_public.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -33,6 +33,7 @@
 #include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/misc/utils.h"
 
+#include <algorithm>
 #include <cassert>
 #include <sstream>
 #include <vector>

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -540,8 +540,9 @@ Status StorageManager::array_consolidate(
     bool found = false;
     encryption_type_from_cfg = config->get("sm.encryption_type", &found);
     assert(found);
-    RETURN_NOT_OK(
-        encryption_type_enum(encryption_type_from_cfg, &encryption_type));
+    auto [st, et] = encryption_type_enum(encryption_type_from_cfg);
+    RETURN_NOT_OK(st);
+    encryption_type = et.value();
 
     if (EncryptionKey::is_valid_key_length(
             encryption_type,
@@ -762,8 +763,9 @@ Status StorageManager::array_metadata_consolidate(
     bool found = false;
     encryption_type_from_cfg = config->get("sm.encryption_type", &found);
     assert(found);
-    RETURN_NOT_OK(
-        encryption_type_enum(encryption_type_from_cfg, &encryption_type));
+    auto [st, et] = encryption_type_enum(encryption_type_from_cfg);
+    RETURN_NOT_OK(st);
+    encryption_type = et.value();
 
     if (EncryptionKey::is_valid_key_length(
             encryption_type,
@@ -826,11 +828,11 @@ Status StorageManager::array_create(
     std::string encryption_type_from_cfg =
         config_.get("sm.encryption_type", &found);
     assert(found);
-    EncryptionType encryption_type_cfg;
-    RETURN_NOT_OK(
-        encryption_type_enum(encryption_type_from_cfg, &encryption_type_cfg));
-    EncryptionKey encryption_key_cfg;
+    auto [st, etc] = encryption_type_enum(encryption_type_from_cfg);
+    RETURN_NOT_OK(st);
+    EncryptionType encryption_type_cfg = etc.value();
 
+    EncryptionKey encryption_key_cfg;
     if (encryption_key_from_cfg.empty()) {
       RETURN_NOT_OK(
           encryption_key_cfg.set_key(encryption_type_cfg, nullptr, 0));
@@ -1682,11 +1684,11 @@ Status StorageManager::load_array_schema(
     std::string encryption_type_from_cfg =
         config_.get("sm.encryption_type", &found);
     assert(found);
-    EncryptionType encryption_type_cfg;
-    RETURN_NOT_OK(
-        encryption_type_enum(encryption_type_from_cfg, &encryption_type_cfg));
-    EncryptionKey encryption_key_cfg;
+    auto [st, etc] = encryption_type_enum(encryption_type_from_cfg);
+    RETURN_NOT_OK(st);
+    EncryptionType encryption_type_cfg = etc.value();
 
+    EncryptionKey encryption_key_cfg;
     if (encryption_key_from_cfg.empty()) {
       RETURN_NOT_OK(
           encryption_key_cfg.set_key(encryption_type_cfg, nullptr, 0));

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/subarray/subarray.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/attribute.h"
@@ -44,6 +45,7 @@
 #include "tiledb/sm/stats/global_stats.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <sstream>
 #include <unordered_set>
@@ -544,7 +546,7 @@ Status Subarray::get_est_result_size(
 
   // Compute tile overlap for each fragment
   RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
-  *size = static_cast<uint64_t>(ceil(est_result_size_[name].size_fixed_));
+  *size = static_cast<uint64_t>(std::ceil(est_result_size_[name].size_fixed_));
 
   // If the size is non-zero, ensure it is large enough to
   // contain at least one cell.
@@ -597,8 +599,10 @@ Status Subarray::get_est_result_size(
 
   // Compute tile overlap for each fragment
   RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
-  *size_off = static_cast<uint64_t>(ceil(est_result_size_[name].size_fixed_));
-  *size_val = static_cast<uint64_t>(ceil(est_result_size_[name].size_var_));
+  *size_off =
+      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_fixed_));
+  *size_val =
+      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_var_));
 
   // If the value size is non-zero, ensure both it and the offset size
   // are large enough to contain at least one cell. Otherwise, ensure
@@ -659,9 +663,9 @@ Status Subarray::get_est_result_size_nullable(
 
   // Compute tile overlap for each fragment
   RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
-  *size = static_cast<uint64_t>(ceil(est_result_size_[name].size_fixed_));
+  *size = static_cast<uint64_t>(std::ceil(est_result_size_[name].size_fixed_));
   *size_validity =
-      static_cast<uint64_t>(ceil(est_result_size_[name].size_validity_));
+      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_validity_));
 
   // If the size is non-zero, ensure it is large enough to
   // contain at least one cell.
@@ -716,10 +720,12 @@ Status Subarray::get_est_result_size_nullable(
 
   // Compute tile overlap for each fragment
   RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
-  *size_off = static_cast<uint64_t>(ceil(est_result_size_[name].size_fixed_));
-  *size_val = static_cast<uint64_t>(ceil(est_result_size_[name].size_var_));
+  *size_off =
+      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_fixed_));
+  *size_val =
+      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_var_));
   *size_validity =
-      static_cast<uint64_t>(ceil(est_result_size_[name].size_validity_));
+      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_validity_));
 
   // If the value size is non-zero, ensure both it and the offset and
   // validity sizes are large enough to contain at least one cell. Otherwise,
@@ -1210,7 +1216,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
   auto all_dims_same_type = array_schema->domain()->all_dims_same_type();
   auto all_dims_fixed = array_schema->domain()->all_dims_fixed();
   auto num_threads = compute_tp->concurrency_level();
-  auto ranges_per_thread = (uint64_t)ceil((double)range_num / num_threads);
+  auto ranges_per_thread = (uint64_t)std::ceil((double)range_num / num_threads);
   auto status = parallel_for(compute_tp, 0, num_threads, [&](uint64_t t) {
     auto r_start = range_start + t * ranges_per_thread;
     auto r_end =
@@ -2417,7 +2423,7 @@ Status Subarray::compute_relevant_fragment_tile_overlap(
   const auto range_num = fn_ctx->range_len_;
 
   const auto ranges_per_thread =
-      (uint64_t)ceil((double)range_num / num_threads);
+      (uint64_t)std::ceil((double)range_num / num_threads);
   const auto status = parallel_for(compute_tp, 0, num_threads, [&](uint64_t t) {
     const auto r_start = fn_ctx->range_idx_offset_ + (t * ranges_per_thread);
     const auto r_end = fn_ctx->range_idx_offset_ +

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -33,7 +33,6 @@
 #ifndef TILEDB_SUBARRAY_H
 #define TILEDB_SUBARRAY_H
 
-#include "tiledb/common/logger.h"
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/subarray/subarray_partitioner.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/attribute.h"

--- a/tiledb/sm/tile/chunked_buffer.cc
+++ b/tiledb/sm/tile/chunked_buffer.cc
@@ -32,6 +32,7 @@
 
 #include "tiledb/sm/tile/chunked_buffer.h"
 #include "tiledb/common/heap_memory.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/misc/utils.h"
 
 #include <cstdlib>

--- a/tiledb/sm/tile/chunked_buffer.h
+++ b/tiledb/sm/tile/chunked_buffer.h
@@ -70,7 +70,6 @@
 #ifndef TILEDB_CHUNKED_BUFFER_H
 #define TILEDB_CHUNKED_BUFFER_H
 
-#include "tiledb/common/logger.h"
 #include "tiledb/common/status.h"
 
 #include <cinttypes>


### PR DESCRIPTION
The inclusion of spdlog.h in logger.h was causing it to bleed into TileDB headers. This change moves inclusion of spdlog.h from logger.h to logger.cc, so that it's no longer visible externally.

---
TYPE: IMPROVEMENT
DESC: Encapsulate spdlog.h
