### PR TITLE
Update OSX target to 10.14 for release artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ stages:
       TILEDB_STATIC: OFF
       TILEDB_SERIALIZATION: ON
       TILEDB_FORCE_BUILD_DEPS: ON
-      MACOSX_DEPLOYMENT_TARGET: 10.13
+      MACOSX_DEPLOYMENT_TARGET: 10.14
     jobs:
      - job:
        strategy:


### PR DESCRIPTION
Update OSX target to 10.14 for release artifacts. This is needed for full c++17 support.

---
TYPE: IMPROVEMENT
DESC: Update OSX target to 10.14 for release artifacts