### PR TITLE
Remove dimension range bounds check in capnp deserialization path

### DIFF
--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1461,6 +1461,12 @@ Status Dimension::set_domain(const Range& domain) {
   return Status::Ok();
 }
 
+Status Dimension::set_domain_unsafe(const void* domain) {
+  domain_ = Range(domain, 2 * coord_size());
+
+  return Status::Ok();
+}
+
 Status Dimension::set_filter_pipeline(const FilterPipeline* pipeline) {
   if (pipeline == nullptr)
     return LOG_STATUS(Status::DimensionError(

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -802,6 +802,9 @@ class Dimension {
   /** Sets the domain. */
   Status set_domain(const Range& domain);
 
+  /** Sets the domain without type, null, or bounds checks. */
+  Status set_domain_unsafe(const void* domain);
+
   /** Sets the filter pipeline for this dimension. */
   Status set_filter_pipeline(const FilterPipeline* pipeline);
 

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -299,7 +299,7 @@ Status dimension_from_capnp(
     Buffer domain_buffer;
     RETURN_NOT_OK(
         utils::copy_capnp_list(domain_reader, dim_type, &domain_buffer));
-    RETURN_NOT_OK((*dimension)->set_domain(domain_buffer.data()));
+    RETURN_NOT_OK((*dimension)->set_domain_unsafe(domain_buffer.data()));
   }
 
   if (dimension_reader.hasFilterPipeline()) {


### PR DESCRIPTION
Fix ch8416, failure to read array written with tiledb 2.2 via REST.

In TileDB 2.3.1 we improved the correctness of bounds-checking for
dimension ranges: https://github.com/TileDB-Inc/TileDB/pull/2361

Previously we were checking range against std::numeric_limits<uint64_t>,
but the range and extent slots may only hold the same type as the
dimension. The new check precludes reading of arrays written with <2.3.1
with `tiledb://` URIs because the capnp deserialization path goes
through `Dimension::set_domain`. Other VFS backends are still readable
because reads go through `Dimension::deserialize`, which does not check
bounds.

Note that the last cell in arrays written with dimensions at datatype bounds
will be a phantom cell (eg UInt16 dimension cell 65535 is not readable
despite the domain range showing `(0,65535)`). There is no functional
change in this respect relative to 2.2 or 2.3.0.

---
Specifically, when deserializing an array with UInt16 type and dimension range `(0,65535)`, we hit this error: https://github.com/TileDB-Inc/TileDB/blob/75b1d0a2a84b54c702112d4881662f8ba28c1168/tiledb/sm/array_schema/dimension.h#L1047-L1053

```
[TileDB::Dimension] Error: Domain check failed; Domain range (upper + lower + 1) is larger than the maximum unsigned number
```

via
```

  * frame #0: 0x00000001032eb0e1 libtiledb.dylib`tiledb::common::Status tiledb::sm::Dimension::check_domain<unsigned short, (void*)0>(this=0x0000000101a58200) const at dimension.h:1049:9
    frame #1: 0x00000001032e84a8 libtiledb.dylib`tiledb::sm::Dimension::check_domain(this=0x0000000101a58200) const at dimension.cc:1644:14
    frame #2: 0x00000001032e8323 libtiledb.dylib`tiledb::sm::Dimension::set_domain(this=0x0000000101a58200, domain=0x00007ffeefbfd188) at dimension.cc:1459:3
    frame #3: 0x00000001032e8208 libtiledb.dylib`tiledb::sm::Dimension::set_domain(this=0x0000000101a58200, domain=0x00000001007dac20) at dimension.cc:1451:10
    frame #4: 0x0000000103a3cb58 libtiledb.dylib`tiledb::sm::serialization::dimension_from_capnp(dimension_reader=0x00007ffeefbfd5f0, dimension=0x00007ffeefbfd5e8) at array_schema.cc:302:5
    frame #5: 0x0000000103a3f858 libtiledb.dylib`tiledb::sm::serialization::domain_from_capnp(domain_reader=0x00007ffeefbfd9d8, domain=0x00007ffeefbfd9d0) at array_schema.cc:426:5
    frame #6: 0x0000000103a415dc libtiledb.dylib`tiledb::sm::serialization::array_schema_from_capnp(schema_reader=0x00007ffeefbfdd90, array_schema=0x00007ffeefbfe170) at array_schema.cc:520:3
```


---
TYPE: BUG
DESC: Fix ch8416, failure to read array written with tiledb 2.2 via REST
