### PR TITLE
Fix ch7582: use the correct buffer for validity deserialization

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1138,7 +1138,8 @@ Status query_from_capnp(
           std::memcpy(data_dest, attribute_buffer_start, fixedlen_size);
           attribute_buffer_start += fixedlen_size;
           if (nullable) {
-            char* validity_dest = (char*)existing_validity_buffer + curr_validity_size;
+            char* validity_dest =
+                (char*)existing_validity_buffer + curr_validity_size;
             std::memcpy(
                 validity_dest, attribute_buffer_start, validitylen_size);
             attribute_buffer_start += validitylen_size;

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1134,11 +1134,11 @@ Status query_from_capnp(
         } else {
           // Fixed size attribute; buffers already set.
           char* data_dest = (char*)existing_buffer + curr_data_size;
-          char* validity_dest = (char*)existing_buffer + curr_validity_size;
 
           std::memcpy(data_dest, attribute_buffer_start, fixedlen_size);
           attribute_buffer_start += fixedlen_size;
           if (nullable) {
+            char* validity_dest = (char*)existing_validity_buffer + curr_validity_size;
             std::memcpy(
                 validity_dest, attribute_buffer_start, validitylen_size);
             attribute_buffer_start += validitylen_size;


### PR DESCRIPTION
Fix ch7582: use the correct buffer for validity deserialization

Also add checks for dense result values after serialization, which fails before the fix.

---
TYPE: BUG
DESC: Fix ch7582: use the correct buffer for validity deserialization