### PR TITLE
[Backport release-2.3] Fix ch7582: use the correct buffer for validity deserialization

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1126,11 +1126,12 @@ Status query_from_capnp(
         } else {
           // Fixed size attribute; buffers already set.
           char* data_dest = (char*)existing_buffer + curr_data_size;
-          char* validity_dest = (char*)existing_buffer + curr_validity_size;
 
           std::memcpy(data_dest, attribute_buffer_start, fixedlen_size);
           attribute_buffer_start += fixedlen_size;
           if (nullable) {
+            char* validity_dest =
+                (char*)existing_validity_buffer + curr_validity_size;
             std::memcpy(
                 validity_dest, attribute_buffer_start, validitylen_size);
             attribute_buffer_start += validitylen_size;


### PR DESCRIPTION
Backport 6984e29384d from https://github.com/TileDB-Inc/TileDB/pull/2407

TYPE: BUG
DESC: Fix ch7582: use the correct buffer for validity deserialization