### PR TITLE
Sparse global order reader: getting rid of the result cell slab copy.

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1045,7 +1045,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Use the refactored readers or not. <br>
  *    **Default**: false
  * - `sm.mem.total_budget` <br>
- *    Memory budget for the sparse global order reader. <br>
+ *    Memory budget for readers and writers. <br>
  *    **Default**: \10GB
  * - `vfs.read_ahead_size` <br>
  *    The maximum byte size to read-ahead from the backend. <br>

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -157,7 +157,7 @@ class Config {
   /** Whether or not to use the refactored readers. */
   static const std::string SM_USE_REFACTORED_READERS;
 
-  /** Maximum memory budget for the sparse global order reader. */
+  /** Maximum memory budget for readers and writers. */
   static const std::string SM_MEM_TOTAL_BUDGET;
 
   /** Whether or not the signal handlers are installed. */

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -393,7 +393,7 @@ class Config {
    *    Use the refactored readers or not. <br>
    *    **Default**: false
    * - `sm.mem.total_budget` <br>
-   *    Memory budget for the sparse global order reader. <br>
+   *    Memory budget for readers and writers. <br>
    *    **Default**: \10GB
    * - `vfs.read_ahead_size` <br>
    *    The maximum byte size to read-ahead from the backend. <br>

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -831,7 +831,8 @@ Status Reader::compute_result_coords(
   // Preload zipped coordinate tile offsets. Note that this will
   // ignore fragments with a version >= 5.
   auto& subarray = read_state_.partitioner_.current();
-  RETURN_CANCEL_OR_ERROR(load_tile_offsets(subarray, {constants::coords}));
+  std::vector<std::string> zipped_coords_names = {constants::coords};
+  RETURN_CANCEL_OR_ERROR(load_tile_offsets(subarray, &zipped_coords_names));
 
   // Preload unzipped coordinate tile offsets. Note that this will
   // ignore fragments with a version < 5.
@@ -840,24 +841,25 @@ Status Reader::compute_result_coords(
   dim_names.reserve(dim_num);
   for (unsigned d = 0; d < dim_num; ++d)
     dim_names.emplace_back(array_schema_->dimension(d)->name());
-  RETURN_CANCEL_OR_ERROR(load_tile_offsets(subarray, dim_names));
+  RETURN_CANCEL_OR_ERROR(load_tile_offsets(subarray, &dim_names));
 
   // Read and unfilter zipped coordinate tiles. Note that
   // this will ignore fragments with a version >= 5. Unfilter
   // with a nullptr `rcs_index` argument to bypass selective
   // unfiltering.
   RETURN_CANCEL_OR_ERROR(
-      read_coordinate_tiles({constants::coords}, tmp_result_tiles));
+      read_coordinate_tiles(&zipped_coords_names, &tmp_result_tiles));
   RETURN_CANCEL_OR_ERROR(
-      unfilter_tiles(constants::coords, tmp_result_tiles, nullptr));
+      unfilter_tiles(constants::coords, &tmp_result_tiles, nullptr));
 
   // Read and unfilter unzipped coordinate tiles. Note that
   // this will ignore fragments with a version < 5. Unfilter
   // with a nullptr `rcs_index` argument to bypass selective
   // unfiltering.
-  RETURN_CANCEL_OR_ERROR(read_coordinate_tiles(dim_names, tmp_result_tiles));
+  RETURN_CANCEL_OR_ERROR(read_coordinate_tiles(&dim_names, &tmp_result_tiles));
   for (const auto& dim_name : dim_names) {
-    RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, tmp_result_tiles, nullptr));
+    RETURN_CANCEL_OR_ERROR(
+        unfilter_tiles(dim_name, &tmp_result_tiles, nullptr));
   }
 
   // Fetch the sub partitioner's memory budget.
@@ -1096,7 +1098,7 @@ Status Reader::dense_read() {
       &result_cell_slabs));
 
   auto stride = array_schema_->domain()->stride<T>(subarray.layout());
-  apply_query_condition(&result_cell_slabs, result_tiles, subarray, stride);
+  apply_query_condition(&result_cell_slabs, &result_tiles, subarray, stride);
 
   get_result_tile_stats(result_tiles);
   get_result_cell_stats(result_cell_slabs);
@@ -1105,8 +1107,8 @@ Status Reader::dense_read() {
   erase_coord_tiles(&sparse_result_tiles);
 
   // Needed when copying the cells
-  RETURN_NOT_OK(
-      copy_attribute_values(stride, result_tiles, result_cell_slabs, subarray));
+  RETURN_NOT_OK(copy_attribute_values(
+      stride, &result_tiles, &result_cell_slabs, subarray));
   read_state_.overflowed_ = copy_overflowed_;
 
   // Fill coordinates if the user requested them
@@ -1505,13 +1507,13 @@ Status Reader::sparse_read() {
   result_coords.clear();
 
   auto& subarray = read_state_.partitioner_.current();
-  apply_query_condition(&result_cell_slabs, result_tiles, subarray);
+  apply_query_condition(&result_cell_slabs, &result_tiles, subarray);
   get_result_tile_stats(result_tiles);
   get_result_cell_stats(result_cell_slabs);
 
-  RETURN_NOT_OK(copy_coordinates(result_tiles, result_cell_slabs));
+  RETURN_NOT_OK(copy_coordinates(&result_tiles, &result_cell_slabs));
   RETURN_NOT_OK(copy_attribute_values(
-      UINT64_MAX, result_tiles, result_cell_slabs, subarray));
+      UINT64_MAX, &result_tiles, &result_cell_slabs, subarray));
   read_state_.overflowed_ = copy_overflowed_;
 
   return Status::Ok();

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -65,6 +65,9 @@ ReaderBase::ReaderBase(
     , copy_overflowed_(false) {
   if (array != nullptr)
     fragment_metadata_ = array->fragment_metadata();
+
+  auto uint64_t_max = std::numeric_limits<uint64_t>::max();
+  copy_end_ = std::pair<uint64_t, uint64_t>(uint64_t_max, uint64_t_max);
 }
 
 /* ****************************** */
@@ -73,8 +76,8 @@ ReaderBase::ReaderBase(
 
 void ReaderBase::clear_tiles(
     const std::string& name,
-    const std::vector<ResultTile*>& result_tiles) const {
-  for (auto& result_tile : result_tiles)
+    const std::vector<ResultTile*>* result_tiles) const {
+  for (auto& result_tile : *result_tiles)
     result_tile->erase_tile(name);
 }
 
@@ -151,7 +154,7 @@ Status ReaderBase::check_validity_buffer_sizes() const {
 }
 
 Status ReaderBase::load_tile_offsets(
-    Subarray& subarray, const std::vector<std::string>& names) {
+    Subarray& subarray, const std::vector<std::string>* names) {
   auto timer_se = stats_->start_timer("load_tile_offsets");
   const auto encryption_key = array_->encryption_key();
 
@@ -172,8 +175,8 @@ Status ReaderBase::load_tile_offsets(
 
         // Filter the 'names' for format-specific names.
         std::vector<std::string> filtered_names;
-        filtered_names.reserve(names.size());
-        for (const auto& name : names) {
+        filtered_names.reserve(names->size());
+        for (const auto& name : *names) {
           // Applicable for zipped coordinates only to versions < 5
           if (name == constants::coords && format_version >= 5)
             continue;
@@ -276,34 +279,37 @@ Status ReaderBase::init_tile_nullable(
 }
 
 Status ReaderBase::read_attribute_tiles(
-    const std::vector<std::string>& names,
-    const std::vector<ResultTile*>& result_tiles) const {
+    const std::vector<std::string>* names,
+    const std::vector<ResultTile*>* result_tiles) const {
   auto timer_se = stats_->start_timer("attr_tiles");
   return read_tiles(names, result_tiles);
 }
 
 Status ReaderBase::read_coordinate_tiles(
-    const std::vector<std::string>& names,
-    const std::vector<ResultTile*>& result_tiles) const {
+    const std::vector<std::string>* names,
+    const std::vector<ResultTile*>* result_tiles) const {
   auto timer_se = stats_->start_timer("coord_tiles");
   return read_tiles(names, result_tiles);
 }
 
 Status ReaderBase::read_tiles(
-    const std::vector<std::string>& names,
-    const std::vector<ResultTile*>& result_tiles) const {
+    const std::vector<std::string>* names,
+    const std::vector<ResultTile*>* result_tiles) const {
   // Shortcut for empty tile vec
-  if (result_tiles.empty())
+  if (result_tiles->empty())
     return Status::Ok();
 
   // Reading tiles are thread safe. However, we will perform
   // them on this thread if there is only one read to perform.
-  if (names.size() == 1) {
-    RETURN_NOT_OK(read_tiles(names[0], result_tiles));
+  if (names->size() == 1) {
+    RETURN_NOT_OK(read_tiles(names->at(0), result_tiles));
   } else {
     const auto status = parallel_for(
-        storage_manager_->compute_tp(), 0, names.size(), [&](const uint64_t i) {
-          RETURN_NOT_OK(read_tiles(names[i], result_tiles));
+        storage_manager_->compute_tp(),
+        0,
+        names->size(),
+        [&](const uint64_t i) {
+          RETURN_NOT_OK(read_tiles(names->at(i), result_tiles));
           return Status::Ok();
         });
 
@@ -315,9 +321,9 @@ Status ReaderBase::read_tiles(
 
 Status ReaderBase::read_tiles(
     const std::string& name,
-    const std::vector<ResultTile*>& result_tiles) const {
+    const std::vector<ResultTile*>* result_tiles) const {
   // Shortcut for empty tile vec
-  if (result_tiles.empty())
+  if (result_tiles->empty())
     return Status::Ok();
 
   // Read the tiles asynchronously
@@ -334,10 +340,10 @@ Status ReaderBase::read_tiles(
 
 Status ReaderBase::read_tiles(
     const std::string& name,
-    const std::vector<ResultTile*>& result_tiles,
+    const std::vector<ResultTile*>* result_tiles,
     std::vector<ThreadPool::Task>* const tasks) const {
   // Shortcut for empty tile vec
-  if (result_tiles.empty())
+  if (result_tiles->empty())
     return Status::Ok();
 
   // For each tile, read from its fragment.
@@ -347,7 +353,7 @@ Status ReaderBase::read_tiles(
 
   // Gather the unique fragments indexes for which there are tiles
   std::unordered_set<uint32_t> fragment_idxs_set;
-  for (const auto& tile : result_tiles)
+  for (const auto& tile : *result_tiles)
     fragment_idxs_set.emplace(tile->frag_idx());
 
   // Put fragment indexes in a vector
@@ -361,7 +367,7 @@ Status ReaderBase::read_tiles(
 
   // Populate the list of regions per file to be read.
   std::map<URI, std::vector<std::tuple<uint64_t, void*, uint64_t>>> all_regions;
-  for (const auto& tile : result_tiles) {
+  for (const auto& tile : *result_tiles) {
     FragmentMetadata* const fragment = fragment_metadata_[tile->frag_idx()];
     const uint32_t format_version = fragment->format_version();
 
@@ -517,7 +523,7 @@ Status ReaderBase::read_tiles(
 
 Status ReaderBase::unfilter_tiles(
     const std::string& name,
-    const std::vector<ResultTile*>& result_tiles,
+    const std::vector<ResultTile*>* result_tiles,
     const ResultCellSlabsIndex* const rcs_index) const {
   auto stat_type = (array_schema_->is_attr(name)) ? "unfilter_attr_tiles" :
                                                     "unfilter_coord_tiles";
@@ -525,12 +531,12 @@ Status ReaderBase::unfilter_tiles(
 
   auto var_size = array_schema_->var_size(name);
   auto nullable = array_schema_->is_nullable(name);
-  auto num_tiles = static_cast<uint64_t>(result_tiles.size());
+  auto num_tiles = static_cast<uint64_t>(result_tiles->size());
   auto encryption_key = array_->encryption_key();
 
   auto status = parallel_for(
       storage_manager_->compute_tp(), 0, num_tiles, [&, this](uint64_t i) {
-        ResultTile* const tile = result_tiles[i];
+        ResultTile* const tile = result_tiles->at(i);
 
         auto& fragment = fragment_metadata_[tile->frag_idx()];
         auto format_version = fragment->format_version();
@@ -789,11 +795,11 @@ Status ReaderBase::unfilter_tile_nullable(
 }
 
 Status ReaderBase::copy_coordinates(
-    const std::vector<ResultTile*>& result_tiles,
-    std::vector<ResultCellSlab>& result_cell_slabs) {
+    const std::vector<ResultTile*>* result_tiles,
+    std::vector<ResultCellSlab>* result_cell_slabs) {
   auto timer_se = stats_->start_timer("copy_coordinates");
 
-  if (result_cell_slabs.empty() && result_tiles.empty()) {
+  if (result_cell_slabs->empty() && result_tiles->empty()) {
     zero_out_buffer_sizes();
     return Status::Ok();
   }
@@ -803,8 +809,8 @@ Status ReaderBase::copy_coordinates(
   // Build a list of coordinate names to copy, separating them by
   // whether they are of fixed or variable length. The motivation
   // is that copying fixed and variable cells require two different
-  // context caches. Processing them separately allows us to maintain
-  // a single context cache at the same time to reduce memory use.
+  // cell slab partitions. Processing them separately allows us to
+  // reduce memory use.
   std::vector<std::string> fixed_names;
   std::vector<std::string> var_names;
 
@@ -823,10 +829,12 @@ Status ReaderBase::copy_coordinates(
 
   // Copy result cells for fixed-sized coordinates.
   if (!fixed_names.empty()) {
-    CopyFixedCellsContextCache ctx_cache;
+    std::vector<size_t> fixed_cs_partitions;
+    compute_fixed_cs_partitions(result_cell_slabs, &fixed_cs_partitions);
+
     for (const auto& name : fixed_names) {
-      RETURN_CANCEL_OR_ERROR(
-          copy_fixed_cells(name, stride, result_cell_slabs, &ctx_cache));
+      RETURN_CANCEL_OR_ERROR(copy_fixed_cells(
+          name, stride, result_cell_slabs, &fixed_cs_partitions));
       if (clear_coords_tiles_on_copy_)
         clear_tiles(name, result_tiles);
     }
@@ -834,10 +842,18 @@ Status ReaderBase::copy_coordinates(
 
   // Copy result cells for var-sized coordinates.
   if (!var_names.empty()) {
-    CopyVarCellsContextCache ctx_cache;
+    std::vector<std::pair<size_t, size_t>> var_cs_partitions;
+    size_t total_var_cs_length;
+    compute_var_cs_partitions(
+        result_cell_slabs, &var_cs_partitions, &total_var_cs_length);
+
     for (const auto& name : var_names) {
-      RETURN_CANCEL_OR_ERROR(
-          copy_var_cells(name, stride, result_cell_slabs, &ctx_cache));
+      RETURN_CANCEL_OR_ERROR(copy_var_cells(
+          name,
+          stride,
+          result_cell_slabs,
+          &var_cs_partitions,
+          total_var_cs_length));
       if (clear_coords_tiles_on_copy_)
         clear_tiles(name, result_tiles);
     }
@@ -848,12 +864,12 @@ Status ReaderBase::copy_coordinates(
 
 Status ReaderBase::copy_attribute_values(
     const uint64_t stride,
-    const std::vector<ResultTile*>& result_tiles,
-    std::vector<ResultCellSlab>& result_cell_slabs,
+    const std::vector<ResultTile*>* result_tiles,
+    std::vector<ResultCellSlab>* result_cell_slabs,
     Subarray& subarray) {
   auto timer_se = stats_->start_timer("copy_attr_values");
 
-  if (result_cell_slabs.empty() && result_tiles.empty()) {
+  if (result_cell_slabs->empty() && result_tiles->empty()) {
     zero_out_buffer_sizes();
     return Status::Ok();
   }
@@ -895,22 +911,16 @@ Status ReaderBase::copy_attribute_values(
 Status ReaderBase::copy_fixed_cells(
     const std::string& name,
     uint64_t stride,
-    const std::vector<ResultCellSlab>& result_cell_slabs,
-    CopyFixedCellsContextCache* const ctx_cache) {
-  assert(ctx_cache);
-
+    const std::vector<ResultCellSlab>* result_cell_slabs,
+    std::vector<size_t>* fixed_cs_partitions) {
   auto stat_type = (array_schema_->is_attr(name)) ? "copy_fixed_attr_values" :
                                                     "copy_fixed_coords";
   auto timer_se = stats_->start_timer(stat_type);
 
-  if (result_cell_slabs.empty()) {
+  if (result_cell_slabs->empty()) {
     zero_out_buffer_sizes();
     return Status::Ok();
   }
-
-  // Perform a lazy initialization of the context cache for copying
-  // fixed cells.
-  populate_cfc_ctx_cache(result_cell_slabs, ctx_cache);
 
   auto it = buffers_.find(name);
   auto buffer_size = it->second.buffer_size_;
@@ -918,12 +928,18 @@ Status ReaderBase::copy_fixed_cells(
 
   // Precompute the cell range destination offsets in the buffer.
   uint64_t buffer_offset = 0;
-  tdb_unique_ptr<std::vector<uint64_t>> cs_offsets =
-      ctx_cache->get_cs_offsets();
-  for (uint64_t i = 0; i < cs_offsets->size(); i++) {
-    const auto& cs = result_cell_slabs[i];
-    auto bytes_to_copy = cs.length_ * cell_size;
-    (*cs_offsets)[i] = buffer_offset;
+  auto size = std::min<uint64_t>(result_cell_slabs->size(), copy_end_.first);
+  std::vector<uint64_t> cs_offsets(size);
+  for (uint64_t i = 0; i < cs_offsets.size(); i++) {
+    const auto& cs = result_cell_slabs->at(i);
+
+    auto cs_length = cs.length_;
+    if (i == copy_end_.first - 1) {
+      cs_length = copy_end_.second;
+    }
+
+    auto bytes_to_copy = cs_length * cell_size;
+    cs_offsets[i] = buffer_offset;
     buffer_offset += bytes_to_copy;
   }
 
@@ -940,13 +956,13 @@ Status ReaderBase::copy_fixed_cells(
       std::placeholders::_1,
       &name,
       stride,
-      &result_cell_slabs,
-      *cs_offsets,
-      *ctx_cache->cs_partitions());
+      result_cell_slabs,
+      &cs_offsets,
+      fixed_cs_partitions);
   auto status = parallel_for(
       storage_manager_->compute_tp(),
       0,
-      ctx_cache->cs_partitions()->size(),
+      fixed_cs_partitions->size(),
       std::move(copy_fn));
 
   RETURN_NOT_OK(status);
@@ -961,14 +977,32 @@ Status ReaderBase::copy_fixed_cells(
   return Status::Ok();
 }
 
-void ReaderBase::populate_cfc_ctx_cache(
-    const std::vector<ResultCellSlab>& result_cell_slabs,
-    CopyFixedCellsContextCache* const ctx_cache) {
+void ReaderBase::compute_fixed_cs_partitions(
+    const std::vector<ResultCellSlab>* result_cell_slabs,
+    std::vector<size_t>* fixed_cs_partitions) {
+  if (result_cell_slabs->empty()) {
+    return;
+  }
+
   const int num_copy_threads =
       storage_manager_->compute_tp()->concurrency_level();
 
-  // Initialize the context cache. This is a no-op if already initialized.
-  ctx_cache->initialize(result_cell_slabs, num_copy_threads);
+  // Calculate the partition sizes.
+  auto num_cs = std::min<uint64_t>(result_cell_slabs->size(), copy_end_.first);
+  const uint64_t num_cs_partitions =
+      std::min<uint64_t>(num_copy_threads, num_cs);
+  const uint64_t cs_per_partition = num_cs / num_cs_partitions;
+  const uint64_t cs_per_partition_carry = num_cs % num_cs_partitions;
+
+  // Calculate the partition offsets.
+  uint64_t num_cs_partitioned = 0;
+  fixed_cs_partitions->reserve(num_cs_partitions);
+  for (uint64_t i = 0; i < num_cs_partitions; ++i) {
+    const uint64_t num_cs_in_partition =
+        cs_per_partition + ((i < cs_per_partition_carry) ? 1 : 0);
+    num_cs_partitioned += num_cs_in_partition;
+    fixed_cs_partitions->emplace_back(num_cs_partitioned);
+  }
 }
 
 uint64_t ReaderBase::offsets_bytesize() const {
@@ -982,8 +1016,8 @@ Status ReaderBase::copy_partitioned_fixed_cells(
     const std::string* const name,
     const uint64_t stride,
     const std::vector<ResultCellSlab>* const result_cell_slabs,
-    const std::vector<uint64_t>& cs_offsets,
-    const std::vector<size_t>& cs_partitions) {
+    const std::vector<uint64_t>* cs_offsets,
+    const std::vector<size_t>* cs_partitions) {
   assert(name);
   assert(result_cell_slabs);
 
@@ -1004,17 +1038,28 @@ Status ReaderBase::copy_partitioned_fixed_cells(
 
   // Calculate the partition to operate on.
   const uint64_t cs_idx_start =
-      partition_idx == 0 ? 0 : cs_partitions[partition_idx - 1];
-  const uint64_t cs_idx_end = cs_partitions[partition_idx];
+      partition_idx == 0 ? 0 : cs_partitions->at(partition_idx - 1);
+  const uint64_t cs_idx_end = cs_partitions->at(partition_idx);
 
   // Copy the cells.
   for (uint64_t cs_idx = cs_idx_start; cs_idx < cs_idx_end; ++cs_idx) {
+    // If there was an overflow and we fixed it, don't copy past the new
+    // result cell slabs.
+    if (cs_idx >= copy_end_.first) {
+      break;
+    }
+
     const auto& cs = (*result_cell_slabs)[cs_idx];
-    uint64_t offset = cs_offsets[cs_idx];
+    uint64_t offset = cs_offsets->at(cs_idx);
+
+    auto cs_length = cs.length_;
+    if (cs_idx == copy_end_.first - 1) {
+      cs_length = copy_end_.second;
+    }
 
     // Copy
     if (cs.tile_ == nullptr) {  // Empty range
-      auto bytes_to_copy = cs.length_ * cell_size;
+      auto bytes_to_copy = cs_length * cell_size;
       auto fill_num = bytes_to_copy / fill_value_size;
       for (uint64_t j = 0; j < fill_num; ++j) {
         std::memcpy(buffer + offset, fill_value.data(), fill_value_size);
@@ -1031,14 +1076,14 @@ Status ReaderBase::copy_partitioned_fixed_cells(
       if (stride == UINT64_MAX) {
         if (!nullable)
           RETURN_NOT_OK(
-              cs.tile_->read(*name, buffer, offset, cs.start_, cs.length_));
+              cs.tile_->read(*name, buffer, offset, cs.start_, cs_length));
         else
           RETURN_NOT_OK(cs.tile_->read_nullable(
-              *name, buffer, offset, cs.start_, cs.length_, buffer_validity));
+              *name, buffer, offset, cs.start_, cs_length, buffer_validity));
       } else {
         auto cell_offset = offset;
         auto start = cs.start_;
-        for (uint64_t j = 0; j < cs.length_; ++j) {
+        for (uint64_t j = 0; j < cs_length; ++j) {
           if (!nullable)
             RETURN_NOT_OK(cs.tile_->read(*name, buffer, cell_offset, start, 1));
           else
@@ -1057,36 +1102,29 @@ Status ReaderBase::copy_partitioned_fixed_cells(
 Status ReaderBase::copy_var_cells(
     const std::string& name,
     const uint64_t stride,
-    std::vector<ResultCellSlab>& result_cell_slabs,
-    CopyVarCellsContextCache* const ctx_cache) {
-  assert(ctx_cache);
-
+    std::vector<ResultCellSlab>* result_cell_slabs,
+    std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
+    size_t total_cs_length) {
   auto stat_type = (array_schema_->is_attr(name)) ? "copy_var_attr_values" :
                                                     "copy_var_coords";
   auto timer_se = stats_->start_timer(stat_type);
 
-  if (result_cell_slabs.empty()) {
+  if (result_cell_slabs->empty()) {
     zero_out_buffer_sizes();
     return Status::Ok();
   }
 
-  // Perform a lazy initialization of the context cache for copying
-  // fixed cells.
-  populate_cvc_ctx_cache(result_cell_slabs, ctx_cache);
+  std::vector<uint64_t> offset_offsets_per_cs(total_cs_length);
+  std::vector<uint64_t> var_offsets_per_cs(total_cs_length);
 
   // Compute the destinations of offsets and var-len data in the buffers.
   uint64_t total_offset_size, total_var_size, total_validity_size;
-  tdb_unique_ptr<std::vector<uint64_t>> offset_offsets_per_cs =
-      ctx_cache->get_offset_offsets_per_cs();
-  tdb_unique_ptr<std::vector<uint64_t>> var_offsets_per_cs =
-      ctx_cache->get_var_offsets_per_cs();
-
   RETURN_NOT_OK(compute_var_cell_destinations(
       name,
       stride,
       result_cell_slabs,
-      offset_offsets_per_cs.get(),
-      var_offsets_per_cs.get(),
+      &offset_offsets_per_cs,
+      &var_offsets_per_cs,
       &total_offset_size,
       &total_var_size,
       &total_validity_size));
@@ -1103,15 +1141,12 @@ Status ReaderBase::copy_var_cells(
       std::placeholders::_1,
       &name,
       stride,
-      &result_cell_slabs,
-      offset_offsets_per_cs.get(),
-      var_offsets_per_cs.get(),
-      ctx_cache->cs_partitions());
+      result_cell_slabs,
+      &offset_offsets_per_cs,
+      &var_offsets_per_cs,
+      var_cs_partitions);
   auto status = parallel_for(
-      storage_manager_->compute_tp(),
-      0,
-      ctx_cache->cs_partitions()->size(),
-      copy_fn);
+      storage_manager_->compute_tp(), 0, var_cs_partitions->size(), copy_fn);
 
   RETURN_NOT_OK(status);
 
@@ -1124,20 +1159,67 @@ Status ReaderBase::copy_var_cells(
   return Status::Ok();
 }
 
-void ReaderBase::populate_cvc_ctx_cache(
-    const std::vector<ResultCellSlab>& result_cell_slabs,
-    CopyVarCellsContextCache* const ctx_cache) {
+void ReaderBase::compute_var_cs_partitions(
+    const std::vector<ResultCellSlab>* result_cell_slabs,
+    std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
+    size_t* total_var_cs_length) {
+  if (result_cell_slabs->empty()) {
+    return;
+  }
+
   const int num_copy_threads =
       storage_manager_->compute_tp()->concurrency_level();
 
-  // Initialize the context cache. This is a no-op if already initialized.
-  ctx_cache->initialize(result_cell_slabs, num_copy_threads);
+  // Calculate the partition range.
+  const uint64_t num_cs =
+      std::min<uint64_t>(result_cell_slabs->size(), copy_end_.first);
+  const uint64_t num_cs_partitions =
+      std::min<uint64_t>(num_copy_threads, num_cs);
+  const uint64_t cs_per_partition = num_cs / num_cs_partitions;
+  const uint64_t cs_per_partition_carry = num_cs % num_cs_partitions;
+
+  // Compute the boundary between each partition. Each boundary
+  // is represented by an `std::pair` that contains the total
+  // length of each cell slab in the leading partition and an
+  // exclusive cell slab index that ends the partition.
+  uint64_t next_partition_idx = cs_per_partition;
+  if (cs_per_partition_carry > 0)
+    ++next_partition_idx;
+
+  *total_var_cs_length = 0;
+  var_cs_partitions->reserve(num_cs_partitions);
+  for (uint64_t cs_idx = 0; cs_idx < num_cs; cs_idx++) {
+    if (cs_idx == next_partition_idx) {
+      var_cs_partitions->emplace_back(*total_var_cs_length, cs_idx);
+
+      // The final partition may contain extra cell slabs that did
+      // not evenly divide into the partition range. Set the
+      // `next_partition_idx` to zero and build the last boundary
+      // after this for-loop.
+      if (var_cs_partitions->size() == num_cs_partitions) {
+        next_partition_idx = 0;
+      } else {
+        next_partition_idx += cs_per_partition;
+        if (cs_idx < (cs_per_partition_carry - 1))
+          ++next_partition_idx;
+      }
+    }
+
+    auto cs_length = result_cell_slabs->at(cs_idx).length_;
+    if (cs_idx == copy_end_.first - 1) {
+      cs_length = copy_end_.second;
+    }
+    *total_var_cs_length += cs_length;
+  }
+
+  // Store the final boundary.
+  var_cs_partitions->emplace_back(*total_var_cs_length, num_cs);
 }
 
 Status ReaderBase::compute_var_cell_destinations(
     const std::string& name,
     uint64_t stride,
-    std::vector<ResultCellSlab>& result_cell_slabs,
+    std::vector<ResultCellSlab>* result_cell_slabs,
     std::vector<uint64_t>* offset_offsets_per_cs,
     std::vector<uint64_t>* var_offsets_per_cs,
     uint64_t* total_offset_size,
@@ -1145,7 +1227,7 @@ Status ReaderBase::compute_var_cell_destinations(
     uint64_t* total_validity_size) {
   // For easy reference
   auto nullable = array_schema_->is_nullable(name);
-  auto num_cs = result_cell_slabs.size();
+  auto num_cs = std::min<uint64_t>(result_cell_slabs->size(), copy_end_.first);
   auto offset_size = offsets_bytesize();
   ByteVecValue fill_value;
   if (array_schema_->is_attr(name))
@@ -1166,7 +1248,12 @@ Status ReaderBase::compute_var_cell_destinations(
   *total_validity_size = 0;
   size_t total_cs_length = 0;
   for (uint64_t cs_idx = 0; cs_idx < num_cs; cs_idx++) {
-    const auto& cs = result_cell_slabs[cs_idx];
+    const auto& cs = result_cell_slabs->at(cs_idx);
+
+    auto cs_length = cs.length_;
+    if (cs_idx == copy_end_.first - 1) {
+      cs_length = copy_end_.second;
+    }
 
     // Get tile information, if the range is nonempty.
     uint64_t* tile_offsets = nullptr;
@@ -1193,7 +1280,8 @@ Status ReaderBase::compute_var_cell_destinations(
     // Compute the destinations for each cell in the range.
     uint64_t dest_vec_idx = 0;
     stride = (stride == UINT64_MAX) ? 1 : stride;
-    for (auto cell_idx = cs.start_; dest_vec_idx < cs.length_;
+
+    for (auto cell_idx = cs.start_; dest_vec_idx < cs_length;
          cell_idx += stride, dest_vec_idx++) {
       // Get size of variable-sized cell
       uint64_t cell_var_size = 0;
@@ -1211,24 +1299,13 @@ Status ReaderBase::compute_var_cell_destinations(
           (buffer_validity_size &&
            *total_validity_size + constants::cell_validity_size >
                *buffer_validity_size)) {
-        // Try to fix the overflow by reducing the result cell slabs.
+        // Try to fix the overflow by reducing the result cell slabs to copy.
+        // TODO Consider fixing the partitions.
         if (fix_var_sized_overflows_) {
-          // Remove slabs until we reach the one that caused the overflow.
-          while (result_cell_slabs.size() != cs_idx + 1) {
-            result_cell_slabs.pop_back();
-          }
-
-          // Adjust the length of the result cell slab.
-          auto length = cell_idx - result_cell_slabs.back().start_;
-          result_cell_slabs.back().length_ = length;
-
-          // If the overflow occured on the first cell, remove the slab.
-          if (length == 0) {
-            result_cell_slabs.pop_back();
-          }
+          copy_end_ = std::pair<uint64_t, uint64_t>(cs_idx + 1, cell_idx);
 
           // Cannot even copy one cell, return overflow.
-          if (result_cell_slabs.size() == 0) {
+          if (cs_idx == 0 && cell_idx == result_cell_slabs->front().start_) {
             copy_overflowed_ = true;
           }
         } else {
@@ -1252,7 +1329,7 @@ Status ReaderBase::compute_var_cell_destinations(
         *total_validity_size += constants::cell_validity_size;
     }
 
-    total_cs_length += cs.length_;
+    total_cs_length += cs_length;
   }
 
   // In case an extra offset is configured, we need to account memory for it on
@@ -1304,10 +1381,15 @@ Status ReaderBase::copy_partitioned_var_cells(
   for (uint64_t cs_idx = start_cs_idx; cs_idx < end_cs_idx; ++cs_idx) {
     // If there was an overflow and we fixed it, don't copy past the new
     // result cell slabs.
-    if (cs_idx >= result_cell_slabs->size()) {
+    if (cs_idx >= copy_end_.first) {
       break;
     }
     const auto& cs = (*result_cell_slabs)[cs_idx];
+
+    auto cs_length = cs.length_;
+    if (cs_idx == copy_end_.first - 1) {
+      cs_length = copy_end_.second;
+    }
 
     // Get tile information, if the range is nonempty.
     uint64_t* tile_offsets = nullptr;
@@ -1335,7 +1417,7 @@ Status ReaderBase::copy_partitioned_var_cells(
     // Copy each cell in the range
     uint64_t dest_vec_idx = 0;
     stride = (stride == UINT64_MAX) ? 1 : stride;
-    for (auto cell_idx = cs.start_; dest_vec_idx < cs.length_;
+    for (auto cell_idx = cs.start_; dest_vec_idx < cs_length;
          cell_idx += stride, dest_vec_idx++) {
       auto offset_offsets = (*offset_offsets_per_cs)[arr_offset + dest_vec_idx];
       auto offset_dest = buffer + offset_offsets;
@@ -1374,7 +1456,7 @@ Status ReaderBase::copy_partitioned_var_cells(
       }
     }
 
-    arr_offset += cs.length_;
+    arr_offset += cs_length;
   }
 
   return Status::Ok();
@@ -1382,8 +1464,8 @@ Status ReaderBase::copy_partitioned_var_cells(
 
 Status ReaderBase::process_tiles(
     const std::unordered_map<std::string, ProcessTileFlags>& names,
-    const std::vector<ResultTile*>& result_tiles,
-    std::vector<ResultCellSlab>& result_cell_slabs,
+    const std::vector<ResultTile*>* result_tiles,
+    std::vector<ResultCellSlab>* result_cell_slabs,
     Subarray& subarray,
     const uint64_t stride) {
   // If a name needs to be read, we put it on `read_names` vector (it may
@@ -1406,7 +1488,7 @@ Status ReaderBase::process_tiles(
 
   // Pre-load all attribute offsets into memory for attributes
   // to be read.
-  load_tile_offsets(subarray, read_names);
+  load_tile_offsets(subarray, &read_names);
 
   // Get the maximum number of attributes to read and unfilter in parallel.
   // Each attribute requires additional memory to buffer reads into
@@ -1419,18 +1501,27 @@ Status ReaderBase::process_tiles(
 
   // Instantiate context caches for copying fixed and variable
   // cells.
-  CopyFixedCellsContextCache fixed_ctx_cache;
-  CopyVarCellsContextCache var_ctx_cache;
+  std::vector<size_t> fixed_cs_partitions;
+  compute_fixed_cs_partitions(result_cell_slabs, &fixed_cs_partitions);
+
+  std::vector<std::pair<size_t, size_t>> var_cs_partitions;
+  size_t total_var_cs_length;
+  compute_var_cs_partitions(
+      result_cell_slabs, &var_cs_partitions, &total_var_cs_length);
 
   // Handle attribute/dimensions that need to be copied but do
   // not need to be read.
   for (const auto& copy_name : copy_names) {
     if (!array_schema_->var_size(copy_name))
       RETURN_CANCEL_OR_ERROR(copy_fixed_cells(
-          copy_name, stride, result_cell_slabs, &fixed_ctx_cache));
+          copy_name, stride, result_cell_slabs, &fixed_cs_partitions));
     else
-      RETURN_CANCEL_OR_ERROR(
-          copy_var_cells(copy_name, stride, result_cell_slabs, &var_ctx_cache));
+      RETURN_CANCEL_OR_ERROR(copy_var_cells(
+          copy_name,
+          stride,
+          result_cell_slabs,
+          &var_cs_partitions,
+          total_var_cs_length));
     clear_tiles(copy_name, result_tiles);
   }
 
@@ -1450,7 +1541,7 @@ Status ReaderBase::process_tiles(
 
     // Read the tiles for the names in `inner_names`. Each attribute
     // name will be read concurrently.
-    RETURN_CANCEL_OR_ERROR(read_attribute_tiles(inner_names, result_tiles));
+    RETURN_CANCEL_OR_ERROR(read_attribute_tiles(&inner_names, result_tiles));
 
     // Copy the cells into the associated `buffers_`, and then clear the cells
     // from the tiles. The cell copies are not thread safe. Clearing tiles are
@@ -1474,10 +1565,14 @@ Status ReaderBase::process_tiles(
       if (flags & ProcessTileFlag::COPY) {
         if (!array_schema_->var_size(inner_name)) {
           RETURN_CANCEL_OR_ERROR(copy_fixed_cells(
-              inner_name, stride, result_cell_slabs, &fixed_ctx_cache));
+              inner_name, stride, result_cell_slabs, &fixed_cs_partitions));
         } else {
           RETURN_CANCEL_OR_ERROR(copy_var_cells(
-              inner_name, stride, result_cell_slabs, &var_ctx_cache));
+              inner_name,
+              stride,
+              result_cell_slabs,
+              &var_cs_partitions,
+              total_var_cs_length));
         }
         clear_tiles(inner_name, result_tiles);
       }
@@ -1490,7 +1585,7 @@ Status ReaderBase::process_tiles(
 }
 
 tdb_unique_ptr<ReaderBase::ResultCellSlabsIndex> ReaderBase::compute_rcs_index(
-    const std::vector<ResultCellSlab>& result_cell_slabs,
+    const std::vector<ResultCellSlab>* result_cell_slabs,
     Subarray& subarray) const {
   // Build an association from the result tile to the cell slab ranges
   // that it contains.
@@ -1498,8 +1593,8 @@ tdb_unique_ptr<ReaderBase::ResultCellSlabsIndex> ReaderBase::compute_rcs_index(
       tdb_unique_ptr<ReaderBase::ResultCellSlabsIndex>(
           tdb_new(ResultCellSlabsIndex));
 
-  std::vector<ResultCellSlab>::const_iterator it = result_cell_slabs.cbegin();
-  while (it != result_cell_slabs.cend()) {
+  std::vector<ResultCellSlab>::const_iterator it = result_cell_slabs->cbegin();
+  while (it != result_cell_slabs->cend()) {
     std::pair<uint64_t, uint64_t> range =
         std::make_pair(it->start_, it->start_ + it->length_);
     if (rcs_index->find(it->tile_) == rcs_index->end()) {
@@ -1542,7 +1637,7 @@ tdb_unique_ptr<ReaderBase::ResultCellSlabsIndex> ReaderBase::compute_rcs_index(
 
 Status ReaderBase::apply_query_condition(
     std::vector<ResultCellSlab>* const result_cell_slabs,
-    const std::vector<ResultTile*>& result_tiles,
+    const std::vector<ResultTile*>* result_tiles,
     Subarray& subarray,
     uint64_t stride) {
   if (condition_.empty() || result_cell_slabs->empty())
@@ -1560,7 +1655,7 @@ Status ReaderBase::apply_query_condition(
 
   // Each element in `names` has been flagged with `ProcessTileFlag::READ`.
   // This will read the tiles, but will not copy them into the user buffers.
-  process_tiles(names, result_tiles, *result_cell_slabs, subarray, stride);
+  process_tiles(names, result_tiles, result_cell_slabs, subarray, stride);
 
   // The `UINT64_MAX` is a sentinel value to indicate that we do not
   // use a stride in the cell index calculation. To simplify our logic,

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -86,291 +86,6 @@ class ReaderBase : public StrategyBase {
       unordered_map<ResultTile*, std::vector<std::pair<uint64_t, uint64_t>>>
           ResultCellSlabsIndex;
 
-  class CopyFixedCellsContextCache {
-   public:
-    /** Constructor. */
-    CopyFixedCellsContextCache()
-        : initialized_(false)
-        , num_cs_(0) {
-    }
-
-    /** Destructor. */
-    ~CopyFixedCellsContextCache() = default;
-
-    DISABLE_COPY_AND_COPY_ASSIGN(CopyFixedCellsContextCache);
-    DISABLE_MOVE_AND_MOVE_ASSIGN(CopyFixedCellsContextCache);
-
-    /**
-     * Initializes this instance on the first invocation, otherwise
-     * this is a no-op.
-     *
-     * @param result_cell_slabs The cell slabs.
-     * @param num_copy_threads The number of threads used in the copy path.
-     */
-    void initialize(
-        const std::vector<ResultCellSlab>& result_cell_slabs,
-        const int num_copy_threads) {
-      // Without locking the `mutex_`, check if this instance
-      // has been initialized.
-      if (initialized_)
-        return;
-
-      std::lock_guard<std::mutex> lg(mutex_);
-
-      // Re-check if this instance has been initialized.
-      if (initialized_)
-        return;
-
-      // Store the number of cell slabs.
-      num_cs_ = result_cell_slabs.size();
-
-      // Calculate the partition sizes.
-      const uint64_t num_cs_partitions =
-          std::min<uint64_t>(num_copy_threads, num_cs_);
-      const uint64_t cs_per_partition = num_cs_ / num_cs_partitions;
-      const uint64_t cs_per_partition_carry = num_cs_ % num_cs_partitions;
-
-      // Calculate the partition offsets.
-      uint64_t num_cs_partitioned = 0;
-      cs_partitions_.reserve(num_cs_partitions);
-      for (uint64_t i = 0; i < num_cs_partitions; ++i) {
-        const uint64_t num_cs_in_partition =
-            cs_per_partition + ((i < cs_per_partition_carry) ? 1 : 0);
-        num_cs_partitioned += num_cs_in_partition;
-        cs_partitions_.emplace_back(num_cs_partitioned);
-      }
-
-      initialized_ = true;
-    }
-
-    /** Returns the `cs_partitions_`. */
-    const std::vector<size_t>* cs_partitions() const {
-      // We do protect this with `mutex_` because it is only
-      // mutated on initialization.
-      return &cs_partitions_;
-    }
-
-    /** Returns a pre-sized vector to store cell slab offsets. */
-    tdb_unique_ptr<std::vector<uint64_t>> get_cs_offsets() {
-      std::lock_guard<std::mutex> lg(mutex_);
-
-      // Re-use a vector in the `cs_offsets_cache_` if possible,
-      // otherwise create a new vector of size `num_cs_`.
-      tdb_unique_ptr<std::vector<uint64_t>> cs_offsets;
-      if (!cs_offsets_cache_.empty()) {
-        cs_offsets = std::move(cs_offsets_cache_.front());
-        assert(cs_offsets->size() == num_cs_);
-        cs_offsets_cache_.pop();
-      } else {
-        cs_offsets =
-            tdb_unique_ptr<std::vector<uint64_t>>(new std::vector<uint64_t>());
-        cs_offsets->resize(num_cs_);
-      }
-
-      return cs_offsets;
-    }
-
-    /** Returns a vector fetched from `get_cs_offsets`. */
-    void cache_cs_offsets(tdb_unique_ptr<std::vector<uint64_t>>&& cs_offsets) {
-      assert(cs_offsets->size() == num_cs_);
-      std::lock_guard<std::mutex> lg(mutex_);
-      cs_offsets_cache_.push(std::move(cs_offsets));
-    }
-
-   private:
-    /** Protects all member variables. */
-    std::mutex mutex_;
-
-    /** True if the context cache has been initialized. */
-    bool initialized_;
-
-    /**
-     * Logical partitions of `cs_offsets`. Each element is the
-     * partition's starting index.
-     */
-    std::vector<size_t> cs_partitions_;
-
-    /** The number of cell slabs. */
-    size_t num_cs_;
-
-    /**
-     * A pool of vectors that maps the index of each cell slab
-     * to its offset in the output buffer.
-     */
-    std::queue<tdb_unique_ptr<std::vector<uint64_t>>> cs_offsets_cache_;
-  };
-
-  class CopyVarCellsContextCache {
-   public:
-    /** Constructor. */
-    CopyVarCellsContextCache()
-        : initialized_(false)
-        , total_cs_length_(0) {
-    }
-
-    /** Destructor. */
-    ~CopyVarCellsContextCache() = default;
-
-    DISABLE_COPY_AND_COPY_ASSIGN(CopyVarCellsContextCache);
-    DISABLE_MOVE_AND_MOVE_ASSIGN(CopyVarCellsContextCache);
-
-    /**
-     * Initializes this instance on the first invocation, otherwise
-     * this is a no-op.
-     *
-     * @param result_cell_slabs The cell slabs.
-     * @param num_copy_threads The number of threads used in the copy path.
-     */
-    void initialize(
-        const std::vector<ResultCellSlab>& result_cell_slabs,
-        const int num_copy_threads) {
-      // Without locking the `mutex_`, check if this instance
-      // has been initialized.
-      if (initialized_)
-        return;
-
-      std::lock_guard<std::mutex> lg(mutex_);
-
-      // Re-check if this instance has been initialized.
-      if (initialized_)
-        return;
-
-      // Calculate the partition range.
-      const uint64_t num_cs = result_cell_slabs.size();
-      const uint64_t num_cs_partitions =
-          std::min<uint64_t>(num_copy_threads, num_cs);
-      const uint64_t cs_per_partition = num_cs / num_cs_partitions;
-      const uint64_t cs_per_partition_carry = num_cs % num_cs_partitions;
-
-      // Compute the boundary between each partition. Each boundary
-      // is represented by an `std::pair` that contains the total
-      // length of each cell slab in the leading partition and an
-      // exclusive cell slab index that ends the partition.
-      uint64_t next_partition_idx = cs_per_partition;
-      if (cs_per_partition_carry > 0)
-        ++next_partition_idx;
-
-      total_cs_length_ = 0;
-      cs_partitions_.reserve(num_cs_partitions);
-      for (uint64_t cs_idx = 0; cs_idx < num_cs; cs_idx++) {
-        if (cs_idx == next_partition_idx) {
-          cs_partitions_.emplace_back(total_cs_length_, cs_idx);
-
-          // The final partition may contain extra cell slabs that did
-          // not evenly divide into the partition range. Set the
-          // `next_partition_idx` to zero and build the last boundary
-          // after this for-loop.
-          if (cs_partitions_.size() == num_cs_partitions) {
-            next_partition_idx = 0;
-          } else {
-            next_partition_idx += cs_per_partition;
-            if (cs_idx < (cs_per_partition_carry - 1))
-              ++next_partition_idx;
-          }
-        }
-
-        total_cs_length_ += result_cell_slabs[cs_idx].length_;
-      }
-
-      // Store the final boundary.
-      cs_partitions_.emplace_back(total_cs_length_, num_cs);
-    }
-
-    /** Returns the `cs_partitions_`. */
-    const std::vector<std::pair<size_t, size_t>>* cs_partitions() const {
-      // We do protect this with `mutex_` because it is only
-      // mutated on initialization.
-      return &cs_partitions_;
-    }
-
-    /** Returns a pre-sized vector to store offset-offsets per cell slab. */
-    tdb_unique_ptr<std::vector<uint64_t>> get_offset_offsets_per_cs() {
-      std::lock_guard<std::mutex> lg(mutex_);
-
-      // Re-use a vector in the `offset_offsets_per_cs_cache_` if possible,
-      // otherwise create a new vector of size `total_cs_length_`.
-      tdb_unique_ptr<std::vector<uint64_t>> offset_offsets_per_cs;
-      if (!offset_offsets_per_cs_cache_.empty()) {
-        offset_offsets_per_cs = std::move(offset_offsets_per_cs_cache_.front());
-        assert(offset_offsets_per_cs->size() == total_cs_length_);
-        offset_offsets_per_cs_cache_.pop();
-      } else {
-        offset_offsets_per_cs =
-            tdb_unique_ptr<std::vector<uint64_t>>(new std::vector<uint64_t>());
-        offset_offsets_per_cs->resize(total_cs_length_);
-      }
-
-      return offset_offsets_per_cs;
-    }
-
-    /** Returns a vector fetched from `get_offset_offsets_per_cs`. */
-    void cache_offset_offsets_per_cs(
-        tdb_unique_ptr<std::vector<uint64_t>>&& offset_offsets_per_cs) {
-      assert(offset_offsets_per_cs->size() == total_cs_length_);
-      std::lock_guard<std::mutex> lg(mutex_);
-      offset_offsets_per_cs_cache_.push(std::move(offset_offsets_per_cs));
-    }
-
-    /** Returns a pre-sized vector to store var-offsets per cell slab. */
-    tdb_unique_ptr<std::vector<uint64_t>> get_var_offsets_per_cs() {
-      std::lock_guard<std::mutex> lg(mutex_);
-
-      // Re-use a vector in the `var_offsets_per_cs_cache_` if possible,
-      // otherwise create a new vector of size `total_cs_length_`.
-      tdb_unique_ptr<std::vector<uint64_t>> var_offsets_per_cs;
-      if (!var_offsets_per_cs_cache_.empty()) {
-        var_offsets_per_cs = std::move(var_offsets_per_cs_cache_.front());
-        assert(var_offsets_per_cs->size() == total_cs_length_);
-        var_offsets_per_cs_cache_.pop();
-      } else {
-        var_offsets_per_cs =
-            tdb_unique_ptr<std::vector<uint64_t>>(new std::vector<uint64_t>());
-        var_offsets_per_cs->resize(total_cs_length_);
-      }
-
-      return var_offsets_per_cs;
-    }
-
-    /** Returns a vector fetched from `get_var_offsets_per_cs`. */
-    void cache_var_offsets_per_cs(
-        tdb_unique_ptr<std::vector<uint64_t>>&& var_offsets_per_cs) {
-      assert(var_offsets_per_cs->size() == total_cs_length_);
-      std::lock_guard<std::mutex> lg(mutex_);
-      var_offsets_per_cs_cache_.push(std::move(var_offsets_per_cs));
-    }
-
-   private:
-    /** Protects all member variables. */
-    std::mutex mutex_;
-
-    /** True if the context cache has been initialized. */
-    bool initialized_;
-
-    /**
-     * Logical partitions for both `offset_offsets_per_cs` and
-     * `var_offsets_per_cs`. Each element contains a pair, where the
-     * first pair-element is the partition's starting index and the
-     * second pair-element is the number of cell slabs in the partition.
-     */
-    std::vector<std::pair<size_t, size_t>> cs_partitions_;
-
-    /** The total size of all cell slabs. */
-    size_t total_cs_length_;
-
-    /**
-     * A pool of vectors that maps each cell slab to its offset
-     * for its attribute offsets.
-     */
-    std::queue<tdb_unique_ptr<std::vector<uint64_t>>>
-        offset_offsets_per_cs_cache_;
-
-    /**
-     * A pool of vectors that maps each cell slab to its offset
-     * for its variable-length data.
-     */
-    std::queue<tdb_unique_ptr<std::vector<uint64_t>>> var_offsets_per_cs_cache_;
-  };
-
   /* ********************************* */
   /*       PROTECTED ATTRIBUTES        */
   /* ********************************* */
@@ -393,6 +108,13 @@ class ReaderBase : public StrategyBase {
   /** Was there an overflow during copying tiles. */
   bool copy_overflowed_;
 
+  /**
+   * Used to specify where in the result cell slabs to end the copy
+   * operations. First is the size of the result cell slabs, second is
+   * the length of the last result cell slab.
+   */
+  std::pair<uint64_t, uint64_t> copy_end_;
+
   /* ********************************* */
   /*         PROTECTED METHODS         */
   /* ********************************* */
@@ -406,7 +128,7 @@ class ReaderBase : public StrategyBase {
    */
   void clear_tiles(
       const std::string& name,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<ResultTile*>* result_tiles) const;
 
   /**
    * Resets the buffer sizes to the original buffer sizes. This is because
@@ -433,7 +155,7 @@ class ReaderBase : public StrategyBase {
    * @return Status
    */
   Status load_tile_offsets(
-      Subarray& subarray, const std::vector<std::string>& names);
+      Subarray& subarray, const std::vector<std::string>* names);
 
   /**
    * Initializes a fixed-sized tile.
@@ -504,8 +226,8 @@ class ReaderBase : public StrategyBase {
    * @return Status
    */
   Status read_attribute_tiles(
-      const std::vector<std::string>& names,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<std::string>* names,
+      const std::vector<ResultTile*>* result_tiles) const;
 
   /**
    * Concurrently executes `read_tiles` for each name in `names`. This
@@ -518,8 +240,8 @@ class ReaderBase : public StrategyBase {
    * @return Status
    */
   Status read_coordinate_tiles(
-      const std::vector<std::string>& names,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<std::string>* names,
+      const std::vector<ResultTile*>* result_tiles) const;
 
   /**
    * Concurrently executes `read_tiles` for each name in `names`.
@@ -530,8 +252,8 @@ class ReaderBase : public StrategyBase {
    * @return Status
    */
   Status read_tiles(
-      const std::vector<std::string>& names,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<std::string>* names,
+      const std::vector<ResultTile*>* result_tiles) const;
 
   /**
    * Retrieves the tiles on a particular attribute or dimension and stores it
@@ -544,7 +266,7 @@ class ReaderBase : public StrategyBase {
    */
   Status read_tiles(
       const std::string& name,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<ResultTile*>* result_tiles) const;
 
   /**
    * Retrieves the tiles on a particular attribute or dimension and stores it
@@ -561,7 +283,7 @@ class ReaderBase : public StrategyBase {
    */
   Status read_tiles(
       const std::string& name,
-      const std::vector<ResultTile*>& result_tiles,
+      const std::vector<ResultTile*>* result_tiles,
       std::vector<ThreadPool::Task>* tasks) const;
 
   /**
@@ -577,7 +299,7 @@ class ReaderBase : public StrategyBase {
    */
   Status unfilter_tiles(
       const std::string& name,
-      const std::vector<ResultTile*>& result_tiles,
+      const std::vector<ResultTile*>* result_tiles,
       const ResultCellSlabsIndex* const rcs_index) const;
 
   /**
@@ -661,8 +383,8 @@ class ReaderBase : public StrategyBase {
    * It also appropriately cleans up the used result tiles.
    */
   Status copy_coordinates(
-      const std::vector<ResultTile*>& result_tiles,
-      std::vector<ResultCellSlab>& result_cell_slabs);
+      const std::vector<ResultTile*>* result_tiles,
+      std::vector<ResultCellSlab>* result_cell_slabs);
 
   /**
    * Copies the result attribute values to the user buffers.
@@ -670,8 +392,8 @@ class ReaderBase : public StrategyBase {
    */
   Status copy_attribute_values(
       uint64_t stride,
-      const std::vector<ResultTile*>& result_tiles,
-      std::vector<ResultCellSlab>& result_cell_slabs,
+      const std::vector<ResultTile*>* result_tiles,
+      std::vector<ResultCellSlab>* result_cell_slabs,
       Subarray& subarray);
 
   /**
@@ -683,25 +405,24 @@ class ReaderBase : public StrategyBase {
    *     cell slabs are all contiguous. Otherwise, each cell in the
    *     result cell slabs are `stride` cells apart from each other.
    * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param ctx_cache An opaque context cache that may be shared between
-   *     calls to improve performance.
+   * @param fixed_cs_partitions The cell slab partitions.
    * @return Status
    */
   Status copy_fixed_cells(
       const std::string& name,
       uint64_t stride,
-      const std::vector<ResultCellSlab>& result_cell_slabs,
-      CopyFixedCellsContextCache* ctx_cache);
+      const std::vector<ResultCellSlab>* result_cell_slabs,
+      std::vector<size_t>* fixed_cs_partitions);
 
   /**
-   * Populates 'ctx_cache' for fixed-sized cell copying.
+   * Compute cs partitions for fixed-sized cell copying.
    *
    * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param ctx_cache The context cache to populate.
+   * @param fixed_cs_partitions The output partitions.
    */
-  void populate_cfc_ctx_cache(
-      const std::vector<ResultCellSlab>& result_cell_slabs,
-      CopyFixedCellsContextCache* ctx_cache);
+  void compute_fixed_cs_partitions(
+      const std::vector<ResultCellSlab>* result_cell_slabs,
+      std::vector<size_t>* fixed_cs_partitions);
 
   /**
    * Returns the configured bytesize for var-sized attribute offsets
@@ -728,8 +449,8 @@ class ReaderBase : public StrategyBase {
       const std::string* name,
       uint64_t stride,
       const std::vector<ResultCellSlab>* result_cell_slabs,
-      const std::vector<uint64_t>& cs_offsets,
-      const std::vector<size_t>& cs_partitions);
+      const std::vector<uint64_t>* cs_offsets,
+      const std::vector<size_t>* cs_partitions);
 
   /**
    * Copies the cells for the input **var-sized** attribute/dimension and result
@@ -740,25 +461,28 @@ class ReaderBase : public StrategyBase {
    *     cell slabs are all contiguous. Otherwise, each cell in the
    *     result cell slabs are `stride` cells apart from each other.
    * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param ctx_cache An opaque context cache that may be shared between
-   *     calls to improve performance.
+   * @param var_cs_partitions The cell slab partitions.
+   * @param total_cs_length The total cell slab length.
    * @return Status
    */
   Status copy_var_cells(
       const std::string& name,
       uint64_t stride,
-      std::vector<ResultCellSlab>& result_cell_slabs,
-      CopyVarCellsContextCache* ctx_cache);
+      std::vector<ResultCellSlab>* result_cell_slabs,
+      std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
+      size_t total_var_cs_length);
 
   /**
-   * Populates 'ctx_cache' for var-sized cell copying.
+   * Compute cs partitions for var-sized cell copying.
    *
    * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param ctx_cache The context cache to populate.
+   * @param var_cs_partitions The output partitions.
+   * @param total_var_cs_length The total cell slab length.
    */
-  void populate_cvc_ctx_cache(
-      const std::vector<ResultCellSlab>& result_cell_slabs,
-      CopyVarCellsContextCache* ctx_cache);
+  void compute_var_cs_partitions(
+      const std::vector<ResultCellSlab>* result_cell_slabs,
+      std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
+      size_t* total_var_cs_length);
 
   /**
    * Computes offsets into destination buffers for the given
@@ -787,7 +511,7 @@ class ReaderBase : public StrategyBase {
   Status compute_var_cell_destinations(
       const std::string& name,
       uint64_t stride,
-      std::vector<ResultCellSlab>& result_cell_slabs,
+      std::vector<ResultCellSlab>* result_cell_slabs,
       std::vector<uint64_t>* offset_offsets_per_cs,
       std::vector<uint64_t>* var_offsets_per_cs,
       uint64_t* total_offset_size,
@@ -797,7 +521,7 @@ class ReaderBase : public StrategyBase {
   /**
    * Copies the cells for the input **var-sized** attribute/dimension and result
    * cell slabs into the corresponding result buffers for the
-   * partition in `ctx_cache` at index `partition_idx`.
+   * partition in `cs_partitions` at index `partition_idx`.
    *
    * @param name The partition index.
    * @param name The targeted attribute/dimension.
@@ -834,8 +558,8 @@ class ReaderBase : public StrategyBase {
    */
   Status process_tiles(
       const std::unordered_map<std::string, ProcessTileFlags>& names,
-      const std::vector<ResultTile*>& result_tiles,
-      std::vector<ResultCellSlab>& result_cell_slabs,
+      const std::vector<ResultTile*>* result_tiles,
+      std::vector<ResultCellSlab>* result_cell_slabs,
       Subarray& subarray,
       uint64_t stride);
 
@@ -844,7 +568,7 @@ class ReaderBase : public StrategyBase {
    * to the cell slabs it contains.
    */
   tdb_unique_ptr<ResultCellSlabsIndex> compute_rcs_index(
-      const std::vector<ResultCellSlab>& result_cell_slabs,
+      const std::vector<ResultCellSlab>* result_cell_slabs,
       Subarray& subarray) const;
 
   /**
@@ -861,7 +585,7 @@ class ReaderBase : public StrategyBase {
    */
   Status apply_query_condition(
       std::vector<ResultCellSlab>* result_cell_slabs,
-      const std::vector<ResultTile*>& result_tiles,
+      const std::vector<ResultTile*>* result_tiles,
       Subarray& subarray,
       uint64_t stride = UINT64_MAX);
 };

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -232,11 +232,11 @@ class SparseGlobalOrderReader : public ReaderBase, public IQueryStrategy {
   Status merge_result_cell_slabs(uint64_t memory_budget, T cmp);
 
   /** Resize the output buffers to the correct size after copying. */
-  Status resize_output_buffers(std::vector<ResultCellSlab>& copied);
+  Status resize_output_buffers();
 
   /** Clean up processed data after copying and get ready for the next
    * iteration. */
-  Status end_iteration(std::vector<ResultCellSlab>& copied);
+  Status end_iteration();
 };
 
 }  // namespace sm


### PR DESCRIPTION
This gets rid of the need for a copy of the result cell slabs by keeping
and index of where to end the copy operations in ReaderBase.

Also noticed the context caches were only used to store cell slab
partitions so moved the code to generate those to simple functions.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: no more result cell slab copy.
