### PR TITLE
Deprecate *_with_key APIs, remove deprecated instances

### DIFF
--- a/examples/cpp_api/encryption.cc
+++ b/examples/cpp_api/encryption.cc
@@ -44,8 +44,11 @@ std::string array_name("encrypted_array");
 const char encryption_key[32 + 1] = "0123456789abcdeF0123456789abcdeF";
 
 void create_array() {
-  // Create a TileDB context.
-  Context ctx;
+  // Create a TileDB context with AES-256_GCM encryption.
+  tiledb::Config cfg;
+  cfg["sm.encryption_type"] = "AES_256_GCM";
+  cfg["sm.encryption_key"] = encryption_key;
+  Context ctx(cfg);
 
   // The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
   Domain domain(ctx);
@@ -59,13 +62,8 @@ void create_array() {
   // Add a single attribute "a" so each (i,j) cell can store an integer.
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
-  // Create the (empty) encrypted array with AES-256-GCM.
-  Array::create(
-      array_name,
-      schema,
-      TILEDB_AES_256_GCM,
-      encryption_key,
-      (uint32_t)strlen(encryption_key));
+  // Create the (empty) encrypted array.
+  Array::create(array_name, schema);
 }
 
 void write_array() {

--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -218,17 +218,17 @@ TEST_CASE(
   for (const auto& group_versions : versions_iter) {
     tiledb::ObjectIter obj_iter(ctx, group_versions.uri());
     for (const auto& object : obj_iter) {
+      tiledb::Config cfg;
+      cfg["sm.encryption_type"] = "AES_256_GCM";
+      cfg["sm.encryption_key"] = encryption_key.c_str();
+      Context ctx_cfg(cfg);
+      bool encrypted = false;
       Array* array;
 
       // Check for if array is encrypted based on name for now
       if (object.uri().find("_encryption_AES_256_GCM") != std::string::npos) {
-        array = new Array(
-            ctx,
-            object.uri(),
-            TILEDB_READ,
-            TILEDB_AES_256_GCM,
-            encryption_key.c_str(),
-            static_cast<uint32_t>(encryption_key.size() * sizeof(char)));
+        encrypted = true;
+        array = new Array(ctx_cfg, object.uri(), TILEDB_READ);
       } else {
         array = new Array(ctx, object.uri(), TILEDB_READ);
       }
@@ -253,7 +253,7 @@ TEST_CASE(
         continue;
       }
 
-      Query query(ctx, *array);
+      auto query = new Query(encrypted ? ctx_cfg : ctx, *array);
 
       std::unordered_map<std::string, std::tuple<uint64_t*, void*, uint8_t*>>
           buffers;
@@ -268,7 +268,7 @@ TEST_CASE(
         switch (attr.second.type()) {
           case TILEDB_INT8: {
             set_buffer_wrapper<int8_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -280,7 +280,7 @@ TEST_CASE(
           }
           case TILEDB_UINT8: {
             set_buffer_wrapper<uint8_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -292,7 +292,7 @@ TEST_CASE(
           }
           case TILEDB_INT16: {
             set_buffer_wrapper<int16_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -304,7 +304,7 @@ TEST_CASE(
           }
           case TILEDB_UINT16: {
             set_buffer_wrapper<uint16_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -316,7 +316,7 @@ TEST_CASE(
           }
           case TILEDB_INT32: {
             set_buffer_wrapper<int32_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -328,7 +328,7 @@ TEST_CASE(
           }
           case TILEDB_UINT32: {
             set_buffer_wrapper<uint32_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -340,7 +340,7 @@ TEST_CASE(
           }
           case TILEDB_INT64: {
             set_buffer_wrapper<int64_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -352,7 +352,7 @@ TEST_CASE(
           }
           case TILEDB_UINT64: {
             set_buffer_wrapper<uint64_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -364,7 +364,7 @@ TEST_CASE(
           }
           case TILEDB_FLOAT32: {
             set_buffer_wrapper<float>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -376,7 +376,7 @@ TEST_CASE(
           }
           case TILEDB_FLOAT64: {
             set_buffer_wrapper<double>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -409,7 +409,7 @@ TEST_CASE(
           case TILEDB_TIME_FS:
           case TILEDB_TIME_AS: {
             set_buffer_wrapper<int64_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -424,7 +424,7 @@ TEST_CASE(
           case TILEDB_STRING_UTF8:
           case TILEDB_ANY: {
             set_buffer_wrapper<char>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -437,7 +437,7 @@ TEST_CASE(
           case TILEDB_STRING_UTF16:
           case TILEDB_STRING_UCS2: {
             set_buffer_wrapper<char16_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -450,7 +450,7 @@ TEST_CASE(
           case TILEDB_STRING_UTF32:
           case TILEDB_STRING_UCS4: {
             set_buffer_wrapper<char32_t>(
-                &query,
+                query,
                 attribute_name,
                 var_sized,
                 nullable,
@@ -471,43 +471,43 @@ TEST_CASE(
       switch (domain.type()) {
         case TILEDB_INT8:
           set_query_coords<int8_t>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_UINT8:
           set_query_coords<uint8_t>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_INT16:
           set_query_coords<int16_t>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_UINT16:
           set_query_coords<uint16_t>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_INT32:
           set_query_coords<int32_t>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_UINT32:
           set_query_coords<uint32_t>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_INT64:
           set_query_coords<int64_t>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_UINT64:
           set_query_coords<uint64_t>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_FLOAT32:
           set_query_coords<float>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_FLOAT64:
           set_query_coords<double>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         case TILEDB_DATETIME_YEAR:
         case TILEDB_DATETIME_MONTH:
@@ -532,14 +532,15 @@ TEST_CASE(
         case TILEDB_TIME_FS:
         case TILEDB_TIME_AS:
           set_query_coords<int64_t>(
-              domain, &query, &coordinates, &expected_coordinates);
+              domain, query, &coordinates, &expected_coordinates);
           break;
         default:
           REQUIRE(false);
       }
 
       // Submit query
-      query.submit();
+      query->submit();
+      delete query;
 
       REQUIRE(memcmp(coordinates, expected_coordinates, coords_size) == 0);
       std::free(coordinates);
@@ -713,22 +714,22 @@ TEST_CASE(
   for (const auto& group_versions : versions_iter) {
     tiledb::ObjectIter obj_iter(ctx, group_versions.uri());
     for (const auto& object : obj_iter) {
+      tiledb::Config cfg;
+      cfg["sm.encryption_type"] = "AES_256_GCM";
+      cfg["sm.encryption_key"] = encryption_key.c_str();
+      Context ctx_cfg(cfg);
+      bool encrypted = false;
       Array* array;
 
       // Check for if array is encrypted based on name for now
       if (object.uri().find("_encryption_AES_256_GCM") != std::string::npos) {
-        array = new Array(
-            ctx,
-            object.uri(),
-            TILEDB_READ,
-            TILEDB_AES_256_GCM,
-            encryption_key.c_str(),
-            static_cast<uint32_t>(encryption_key.size() * sizeof(char)));
+        encrypted = true;
+        array = new Array(ctx_cfg, object.uri(), TILEDB_READ);
       } else {
         array = new Array(ctx, object.uri(), TILEDB_READ);
       }
 
-      Query query(ctx, *array);
+      auto query = new Query(encrypted ? ctx_cfg : ctx, *array);
 
       std::unordered_map<std::string, std::tuple<uint64_t*, void*, uint8_t*>>
           buffers;
@@ -741,7 +742,7 @@ TEST_CASE(
         switch (attr.second.type()) {
           case TILEDB_INT8: {
             set_buffer_wrapper<int8_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -753,7 +754,7 @@ TEST_CASE(
           }
           case TILEDB_UINT8: {
             set_buffer_wrapper<uint8_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -765,7 +766,7 @@ TEST_CASE(
           }
           case TILEDB_INT16: {
             set_buffer_wrapper<int16_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -777,7 +778,7 @@ TEST_CASE(
           }
           case TILEDB_UINT16: {
             set_buffer_wrapper<uint16_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -789,7 +790,7 @@ TEST_CASE(
           }
           case TILEDB_INT32: {
             set_buffer_wrapper<int32_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -801,7 +802,7 @@ TEST_CASE(
           }
           case TILEDB_UINT32: {
             set_buffer_wrapper<uint32_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -813,7 +814,7 @@ TEST_CASE(
           }
           case TILEDB_INT64: {
             set_buffer_wrapper<int64_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -825,7 +826,7 @@ TEST_CASE(
           }
           case TILEDB_UINT64: {
             set_buffer_wrapper<uint64_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -837,7 +838,7 @@ TEST_CASE(
           }
           case TILEDB_FLOAT32: {
             set_buffer_wrapper<float>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -849,7 +850,7 @@ TEST_CASE(
           }
           case TILEDB_FLOAT64: {
             set_buffer_wrapper<double>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -882,7 +883,7 @@ TEST_CASE(
           case TILEDB_TIME_FS:
           case TILEDB_TIME_AS: {
             set_buffer_wrapper<int64_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -898,7 +899,7 @@ TEST_CASE(
           case TILEDB_STRING_UTF8:
           case TILEDB_ANY: {
             set_buffer_wrapper<char>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -911,7 +912,7 @@ TEST_CASE(
           case TILEDB_STRING_UTF16:
           case TILEDB_STRING_UCS2: {
             set_buffer_wrapper<char16_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -924,7 +925,7 @@ TEST_CASE(
           case TILEDB_STRING_UTF32:
           case TILEDB_STRING_UCS4: {
             set_buffer_wrapper<char32_t>(
-                &query,
+                query,
                 attribute_name,
                 attr.second.variable_sized(),
                 attr.second.nullable(),
@@ -954,43 +955,43 @@ TEST_CASE(
         switch (dim.type()) {
           case TILEDB_INT8:
             set_query_dimension_buffer<int8_t>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_UINT8:
             set_query_dimension_buffer<uint8_t>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_INT16:
             set_query_dimension_buffer<int16_t>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_UINT16:
             set_query_dimension_buffer<uint16_t>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_INT32:
             set_query_dimension_buffer<int32_t>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_UINT32:
             set_query_dimension_buffer<uint32_t>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_INT64:
             set_query_dimension_buffer<int64_t>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_UINT64:
             set_query_dimension_buffer<uint64_t>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_FLOAT32:
             set_query_dimension_buffer<float>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_FLOAT64:
             set_query_dimension_buffer<double>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_DATETIME_YEAR:
           case TILEDB_DATETIME_MONTH:
@@ -1015,13 +1016,13 @@ TEST_CASE(
           case TILEDB_TIME_FS:
           case TILEDB_TIME_AS:
             set_query_dimension_buffer<int64_t>(
-                domain, i, &query, &buffer, &expected_results);
+                domain, i, query, &buffer, &expected_results);
             break;
           case TILEDB_STRING_ASCII: {
             set_query_var_dimension_buffer<char>(
                 domain,
                 i,
-                &query,
+                query,
                 &offsets,
                 &buffer,
                 &expected_offsets,
@@ -1038,7 +1039,8 @@ TEST_CASE(
       }
 
       // Submit query
-      query.submit();
+      query->submit();
+      delete query;
 
       for (uint64_t i = 0; i < ndim; ++i) {
         auto& offsets = dim_offsets[i];

--- a/test/src/unit-cppapi-fragment_info.cc
+++ b/test/src/unit-cppapi-fragment_info.cc
@@ -44,7 +44,11 @@ const std::string array_name = "fragment_info_array";
 TEST_CASE(
     "C++ API: Test fragment info, errors", "[cppapi][fragment_info][errors]") {
   // Create TileDB context
-  Context ctx;
+  std::string key = "12345678901234567890123456789012";
+  tiledb::Config cfg;
+  cfg["sm.encryption_type"] = "AES_256_GCM";
+  cfg["sm.encryption_key"] = key.c_str();
+  Context ctx(cfg);
   VFS vfs(ctx);
   remove_dir(array_name, ctx.ptr().get(), vfs.ptr().get());
 
@@ -73,9 +77,8 @@ TEST_CASE(
       TILEDB_ROW_MAJOR,
       2);
 
-  // Array is not encrypted
-  std::string key = "12345678901234567890123456789012";
-  CHECK_THROWS(fragment_info.load(TILEDB_AES_256_GCM, key));
+  // Load fragment info, array is encrypted
+  fragment_info.load();
 
   // Write a dense fragment
   QueryBuffers buffers;

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3099,8 +3099,6 @@ TILEDB_EXPORT int32_t tiledb_array_schema_load(
     tiledb_array_schema_t** array_schema);
 
 /**
- * This is a deprecated API.
- *
  * Retrieves the schema of an encrypted array from the disk, creating an array
  * schema struct.
  *
@@ -3124,7 +3122,7 @@ TILEDB_EXPORT int32_t tiledb_array_schema_load(
  * @param array_schema The array schema to be retrieved, or `NULL` upon error.
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int32_t tiledb_array_schema_load_with_key(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_schema_load_with_key(
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_encryption_type_t encryption_type,
@@ -5104,8 +5102,6 @@ TILEDB_EXPORT int32_t tiledb_array_open(
     tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t query_type);
 
 /**
- * This is a deprecated API.
- *
  * Similar to `tiledb_array_open`, but this function takes as input a
  * timestamp, representing time in milliseconds ellapsed since
  * 1970-01-01 00:00:00 +0000 (UTC). Opening the array at a
@@ -5138,15 +5134,13 @@ TILEDB_EXPORT int32_t tiledb_array_open(
  *      `timestamp{start, end}` values should be set to a config that's set to
  *       the array object before opening the array.
  */
-TILEDB_EXPORT int32_t tiledb_array_open_at(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_open_at(
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_query_type_t query_type,
     uint64_t timestamp);
 
 /**
- * This is a deprecated API.
- *
  * Opens an encrypted array using the given encryption key. This function has
  * the same semantics as `tiledb_array_open()` but is used for encrypted arrays.
  *
@@ -5174,7 +5168,7 @@ TILEDB_EXPORT int32_t tiledb_array_open_at(
  *
  * @note The config should be set before opening an array.
  */
-TILEDB_EXPORT int32_t tiledb_array_open_with_key(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_open_with_key(
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_query_type_t query_type,
@@ -5183,8 +5177,6 @@ TILEDB_EXPORT int32_t tiledb_array_open_with_key(
     uint32_t key_length);
 
 /**
- * This is a deprecated API.
- *
  * Similar to `tiledb_array_open_with_key`, but this function takes as
  * input a timestamp, representing time in milliseconds ellapsed since
  * 1970-01-01 00:00:00 +0000 (UTC). Opening the array at a
@@ -5220,7 +5212,7 @@ TILEDB_EXPORT int32_t tiledb_array_open_with_key(
  * @note This function is applicable only to read queries.
  * @note The config should be set before opening an array.
  */
-TILEDB_EXPORT int32_t tiledb_array_open_at_with_key(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_open_at_with_key(
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_query_type_t query_type,
@@ -5273,8 +5265,6 @@ TILEDB_EXPORT int32_t
 tiledb_array_reopen(tiledb_ctx_t* ctx, tiledb_array_t* array);
 
 /**
- * This is a deprecated API.
- *
  * Reopens a TileDB array (the array must be already open) at a specific
  * timestamp.
  *
@@ -5299,11 +5289,10 @@ tiledb_array_reopen(tiledb_ctx_t* ctx, tiledb_array_t* array);
  *      interval, the `timestamp{start, end}` values and subsequent config
  *      object should be reset for the array before reopening.
  */
-TILEDB_EXPORT int32_t tiledb_array_reopen_at(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_reopen_at(
     tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t timestamp);
 
 /**
- * This is a deprecated API.
  * The start/end timestamps for opening an array
  * are now set in the config.
  *
@@ -5329,7 +5318,7 @@ TILEDB_EXPORT int32_t tiledb_array_reopen_at(
  *
  * @note The array does not need to be open to use this function.
  */
-TILEDB_EXPORT int32_t tiledb_array_get_timestamp(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_get_timestamp(
     tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t* timestamp);
 
 /**
@@ -5479,8 +5468,6 @@ TILEDB_EXPORT int32_t tiledb_array_create(
     const tiledb_array_schema_t* array_schema);
 
 /**
- * This is a deprecated API.
- *
  * Creates a new encrypted TileDB array given an input schema.
  *
  * Encrypted arrays can only be created through this function.
@@ -5502,7 +5489,7 @@ TILEDB_EXPORT int32_t tiledb_array_create(
  * @param key_length Length in bytes of the encryption key.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int32_t tiledb_array_create_with_key(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_create_with_key(
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const tiledb_array_schema_t* array_schema,
@@ -5539,8 +5526,6 @@ TILEDB_EXPORT int32_t tiledb_array_consolidate(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config);
 
 /**
- * This is a deprecated API.
- *
  * Depending on the consoliation mode in the config, consolidates either the
  * fragment files, fragment metadata files, or array metadata files into a
  * single file.
@@ -5569,7 +5554,7 @@ TILEDB_EXPORT int32_t tiledb_array_consolidate(
  *
  * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
  */
-TILEDB_EXPORT int32_t tiledb_array_consolidate_with_key(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_consolidate_with_key(
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_encryption_type_t encryption_type,
@@ -6087,8 +6072,6 @@ TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_consolidate_metadata(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config);
 
 /**
- * This is a deprecated API.
- *
  * Consolidates the array metadata of an encrypted array into a single file.
  *
  * You must first finalize all queries to the array before consolidation can
@@ -7011,8 +6994,6 @@ TILEDB_EXPORT int32_t tiledb_fragment_info_load(
     tiledb_ctx_t* ctx, tiledb_fragment_info_t* fragment_info);
 
 /**
- * This is a deprecated API.
- *
  * Loads the fragment info from an encrypted array.
  *
  * **Example:**
@@ -7029,7 +7010,7 @@ TILEDB_EXPORT int32_t tiledb_fragment_info_load(
  * @param key_length Length in bytes of the encryption key.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int32_t tiledb_fragment_info_load_with_key(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_fragment_info_load_with_key(
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     tiledb_encryption_type_t encryption_type,

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -87,7 +87,17 @@ class Array {
       const Context& ctx,
       const std::string& array_uri,
       tiledb_query_type_t query_type)
-      : Array(ctx, array_uri, query_type, TILEDB_NO_ENCRYPTION, nullptr, 0) {
+      : ctx_(ctx)
+      , schema_(ArraySchema(ctx, (tiledb_array_schema_t*)nullptr)) {
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    tiledb_array_t* array;
+    ctx.handle_error(tiledb_array_alloc(c_ctx, array_uri.c_str(), &array));
+    array_ = std::shared_ptr<tiledb_array_t>(array, deleter_);
+    ctx.handle_error(tiledb_array_open(c_ctx, array, query_type));
+
+    tiledb_array_schema_t* array_schema;
+    ctx.handle_error(tiledb_array_get_schema(c_ctx, array, &array_schema));
+    schema_ = ArraySchema(ctx, array_schema);
   }
 
   /**
@@ -147,6 +157,7 @@ class Array {
    * @param encryption_key The encryption key to use.
    */
   // clang-format on
+  TILEDB_DEPRECATED
   Array(
       const Context& ctx,
       const std::string& array_uri,
@@ -403,7 +414,13 @@ class Array {
    * @throws TileDBError if the array is already open or other error occurred.
    */
   void open(tiledb_query_type_t query_type) {
-    open(query_type, TILEDB_NO_ENCRYPTION, nullptr, 0);
+    auto& ctx = ctx_.get();
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    ctx.handle_error(tiledb_array_open(c_ctx, array_.get(), query_type));
+    tiledb_array_schema_t* array_schema;
+    ctx.handle_error(
+        tiledb_array_get_schema(c_ctx, array_.get(), &array_schema));
+    schema_ = ArraySchema(ctx, array_schema);
   }
 
   /**
@@ -716,7 +733,8 @@ class Array {
       const Context& ctx,
       const std::string& uri,
       Config* const config = nullptr) {
-    consolidate(ctx, uri, TILEDB_NO_ENCRYPTION, nullptr, 0, config);
+    ctx.handle_error(tiledb_array_consolidate(
+        ctx.ptr().get(), uri.c_str(), config ? config->ptr().get() : nullptr));
   }
 
   /**
@@ -830,7 +848,11 @@ class Array {
    * @param schema The array schema.
    */
   static void create(const std::string& uri, const ArraySchema& schema) {
-    create(uri, schema, TILEDB_NO_ENCRYPTION, nullptr, 0);
+    auto& ctx = schema.context();
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    ctx.handle_error(tiledb_array_schema_check(c_ctx, schema.ptr().get()));
+    ctx.handle_error(
+        tiledb_array_create(c_ctx, uri.c_str(), schema.ptr().get()));
   }
 
   /**
@@ -1302,7 +1324,7 @@ class Array {
     }
 
     (*config_aux)["sm.consolidation.mode"] = "array_meta";
-    consolidate(ctx, uri, TILEDB_NO_ENCRYPTION, nullptr, 0, config_aux);
+    consolidate(ctx, uri, config_aux);
   }
 
   /**
@@ -1332,6 +1354,7 @@ class Array {
    * @param key_length Length in bytes of the encryption key.
    * @param config Configuration parameters for the consolidation.
    */
+  TILEDB_DEPRECATED
   static void consolidate_metadata(
       const Context& ctx,
       const std::string& uri,

--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -126,7 +126,11 @@ class ArraySchema : public Schema {
    * @param uri URI of array
    */
   ArraySchema(const Context& ctx, const std::string& uri)
-      : ArraySchema(ctx, uri, TILEDB_NO_ENCRYPTION, nullptr, 0) {
+      : Schema(ctx) {
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    tiledb_array_schema_t* schema;
+    ctx.handle_error(tiledb_array_schema_load(c_ctx, uri.c_str(), &schema));
+    schema_ = std::shared_ptr<tiledb_array_schema_t>(schema, deleter_);
   }
 
   /**

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1227,7 +1227,7 @@ class Query {
     else if (name == "__coords")
       impl::type_check<T>(schema_.domain().type());
 
-    return set_buffer(name, buff, nelements, sizeof(T));
+    return set_data_buffer(name, buff, nelements, sizeof(T));
   }
 
   /**
@@ -1249,7 +1249,7 @@ class Query {
   template <typename T>
   TILEDB_DEPRECATED Query& set_buffer(
       const std::string& name, std::vector<T>& buf) {
-    return set_buffer(name, buf.data(), buf.size(), sizeof(T));
+    return set_data_buffer(name, buf.data(), buf.size(), sizeof(T));
   }
 
   /**
@@ -1283,7 +1283,7 @@ class Query {
       element_size =
           tiledb_datatype_size(schema_.domain().dimension(name).type());
 
-    return set_buffer(name, buff, nelements, element_size);
+    return set_data_buffer(name, buff, nelements, element_size);
   }
 
   /**
@@ -1331,8 +1331,9 @@ class Query {
     else if (is_dim)
       impl::type_check<T>(schema_.domain().dimension(name).type());
 
-    return set_buffer(
-        name, offsets, offset_nelements, data, data_nelements, sizeof(T));
+    set_data_buffer(name, data, data_nelements, sizeof(T));
+    set_offsets_buffer(name, offsets, offset_nelements);
+    return *this;
   }
 
   /**
@@ -1368,8 +1369,9 @@ class Query {
                           schema_.domain().dimension(name).type();
     size_t element_size = tiledb_datatype_size(type);
 
-    return set_buffer(
-        name, offsets, offset_nelements, data, data_nelements, element_size);
+    set_data_buffer(name, data, data_nelements, element_size);
+    set_offsets_buffer(name, offsets, offset_nelements);
+    return *this;
   }
 
   /**
@@ -1410,13 +1412,9 @@ class Query {
     else if (is_dim)
       impl::type_check<T>(schema_.domain().dimension(name).type());
 
-    return set_buffer(
-        name,
-        offsets.data(),
-        offsets.size(),
-        data.data(),
-        data.size(),
-        sizeof(T));
+    set_data_buffer(name, data.data(), data.size(), sizeof(T));
+    set_offsets_buffer(name, offsets.data(), offsets.size());
+    return *this;
   }
 
   /**
@@ -1442,7 +1440,9 @@ class Query {
     else if (is_dim)
       impl::type_check<T>(schema_.domain().dimension(name).type());
 
-    return set_buffer(name, buf.first, buf.second);
+    set_data_buffer(name, buf.second);
+    set_offsets_buffer(name, buf.first);
+    return *this;
   }
 
   /**
@@ -1468,13 +1468,9 @@ class Query {
     else if (is_dim)
       impl::type_check<char>(schema_.domain().dimension(name).type());
 
-    return set_buffer(
-        name,
-        offsets.data(),
-        offsets.size(),
-        &data[0],
-        data.size(),
-        sizeof(char));
+    set_data_buffer(name, &data[0], data.size(), sizeof(char));
+    set_offsets_buffer(name, offsets.data(), offsets.size());
+    return *this;
   }
 
   /**
@@ -1761,13 +1757,9 @@ class Query {
     else
       impl::type_check<T>(schema_.attribute(name).type());
 
-    return set_buffer_nullable(
-        name,
-        data,
-        data_nelements,
-        sizeof(T),
-        validity_bytemap,
-        validity_bytemap_nelements);
+    set_data_buffer(name, data, data_nelements);
+    set_validity_buffer(name, validity_bytemap, validity_bytemap_nelements);
+    return *this;
   }
 
   /**
@@ -1794,13 +1786,9 @@ class Query {
       const std::string& name,
       std::vector<T>& buf,
       std::vector<uint8_t>& validity_bytemap) {
-    return set_buffer_nullable(
-        name,
-        buf.data(),
-        buf.size(),
-        sizeof(T),
-        validity_bytemap.data(),
-        validity_bytemap.size());
+    set_data_buffer(name, buf.data(), buf.size(), sizeof(T));
+    set_validity_buffer(name, validity_bytemap.data(), validity_bytemap.size());
+    return *this;
   }
 
   /**
@@ -1833,13 +1821,9 @@ class Query {
     // Compute element size (in bytes).
     size_t element_size = tiledb_datatype_size(schema_.attribute(name).type());
 
-    return set_buffer_nullable(
-        name,
-        data,
-        data_nelements,
-        element_size,
-        validity_bytemap,
-        validity_bytemap_nelements);
+    set_data_buffer(name, data, data_nelements, element_size);
+    set_validity_buffer(name, validity_bytemap, validity_bytemap_nelements);
+    return *this;
   }
 
   /**
@@ -1878,15 +1862,10 @@ class Query {
     auto type = schema_.attribute(name).type();
     size_t element_size = tiledb_datatype_size(type);
 
-    return set_buffer_nullable(
-        name,
-        offsets,
-        offset_nelements,
-        data,
-        data_nelements,
-        element_size,
-        validity_bytemap,
-        validity_bytemap_nelements);
+    set_data_buffer(name, data, data_nelements, element_size);
+    set_offsets_buffer(name, offsets, offset_nelements);
+    set_validity_buffer(name, validity_bytemap, validity_bytemap_nelements);
+    return *this;
   }
 
   /**
@@ -1928,15 +1907,10 @@ class Query {
     else
       impl::type_check<T>(schema_.attribute(name).type());
 
-    return set_buffer_nullable(
-        name,
-        offsets.data(),
-        offsets.size(),
-        data.data(),
-        data.size(),
-        sizeof(T),
-        validity_bytemap.data(),
-        validity_bytemap.size());
+    set_data_buffer(name, data.data(), data.size(), sizeof(T));
+    set_offsets_buffer(name, offsets.data(), offsets.size());
+    set_validity_buffer(name, validity_bytemap.data(), validity_bytemap.size());
+    return *this;
   }
 
   /**
@@ -1959,8 +1933,10 @@ class Query {
           "' does not exist");
     impl::type_check<T>(schema_.attribute(name).type());
 
-    return set_buffer_nullable(
-        name, std::get<0>(buf), std::get<1>(buf), std::get<2>(buf));
+    set_data_buffer(name, std::get<1>(buf));
+    set_offsets_buffer(name, std::get<0>(buf));
+    set_validity_buffer(name, std::get<2>(buf));
+    return *this;
   }
 
   /**
@@ -1986,15 +1962,10 @@ class Query {
     else
       impl::type_check<char>(schema_.attribute(name).type());
 
-    return set_buffer_nullable(
-        name,
-        offsets.data(),
-        offsets.size(),
-        &data[0],
-        data.size(),
-        sizeof(char),
-        validity_bytemap.data(),
-        validity_bytemap.size());
+    set_data_buffer(name, &data[0], data.size(), sizeof(char));
+    set_offsets_buffer(name, offsets.data(), offsets.size());
+    set_validity_buffer(name, validity_bytemap.data(), validity_bytemap.size());
+    return *this;
   }
 
   /**
@@ -2019,7 +1990,7 @@ class Query {
           "'!");
     }
 
-    ctx.handle_error(tiledb_query_get_buffer(
+    ctx.handle_error(tiledb_query_get_data_buffer(
         ctx.ptr().get(), query_.get(), name.c_str(), data, &data_nbytes));
 
     assert(*data_nbytes % elem_size_iter->second == 0);
@@ -2057,14 +2028,10 @@ class Query {
           "'!");
     }
 
-    ctx.handle_error(tiledb_query_get_buffer_var(
-        ctx.ptr().get(),
-        query_.get(),
-        name.c_str(),
-        offsets,
-        &offsets_nbytes,
-        data,
-        &data_nbytes));
+    ctx.handle_error(tiledb_query_get_data_buffer(
+        ctx.ptr().get(), query_.get(), name.c_str(), data, &data_nbytes));
+    ctx.handle_error(tiledb_query_get_offsets_buffer(
+        ctx.ptr().get(), query_.get(), name.c_str(), offsets, &offsets_nbytes));
 
     assert(*data_nbytes % elem_size_iter->second == 0);
     assert(*offsets_nbytes % sizeof(uint64_t) == 0);
@@ -2187,12 +2154,12 @@ class Query {
           "'!");
     }
 
-    ctx.handle_error(tiledb_query_get_buffer_nullable(
+    ctx.handle_error(tiledb_query_get_data_buffer(
+        ctx.ptr().get(), query_.get(), name.c_str(), data, &data_nbytes));
+    ctx.handle_error(tiledb_query_get_validity_buffer(
         ctx.ptr().get(),
         query_.get(),
         name.c_str(),
-        data,
-        &data_nbytes,
         validity_bytemap,
         &validity_bytemap_nbytes));
 
@@ -2238,14 +2205,14 @@ class Query {
           "'!");
     }
 
-    ctx.handle_error(tiledb_query_get_buffer_var_nullable(
+    ctx.handle_error(tiledb_query_get_data_buffer(
+        ctx.ptr().get(), query_.get(), name.c_str(), data, &data_nbytes));
+    ctx.handle_error(tiledb_query_get_offsets_buffer(
+        ctx.ptr().get(), query_.get(), name.c_str(), offsets, &offsets_nbytes));
+    ctx.handle_error(tiledb_query_get_validity_buffer(
         ctx.ptr().get(),
         query_.get(),
         name.c_str(),
-        offsets,
-        &offsets_nbytes,
-        data,
-        &data_nbytes,
         validity_bytemap,
         &validity_bytemap_nbytes));
 
@@ -2369,7 +2336,7 @@ class Query {
     size_t size = nelements * element_size;
     buff_sizes_[attr] = std::tuple<uint64_t, uint64_t, uint64_t>(0, size, 0);
     element_sizes_[attr] = element_size;
-    ctx.handle_error(tiledb_query_set_buffer(
+    ctx.handle_error(tiledb_query_set_data_buffer(
         ctx.ptr().get(),
         query_.get(),
         attr.c_str(),
@@ -2404,14 +2371,18 @@ class Query {
     element_sizes_[attr] = data_element_size;
     buff_sizes_[attr] =
         std::tuple<uint64_t, uint64_t, uint64_t>(offset_size, data_size, 0);
-    ctx.handle_error(tiledb_query_set_buffer_var(
+    ctx.handle_error(tiledb_query_set_data_buffer(
+        ctx.ptr().get(),
+        query_.get(),
+        attr.c_str(),
+        data,
+        &std::get<1>(buff_sizes_[attr])));
+    ctx.handle_error(tiledb_query_set_offsets_buffer(
         ctx.ptr().get(),
         query_.get(),
         attr.c_str(),
         offsets,
-        &std::get<0>(buff_sizes_[attr]),
-        data,
-        &std::get<1>(buff_sizes_[attr])));
+        &std::get<0>(buff_sizes_[attr])));
     return *this;
   }
 
@@ -2473,12 +2444,16 @@ class Query {
     buff_sizes_[attr] =
         std::tuple<uint64_t, uint64_t, uint64_t>(0, data_size, validity_size);
     element_sizes_[attr] = data_element_size;
-    ctx.handle_error(tiledb_query_set_buffer_nullable(
+    ctx.handle_error(tiledb_query_set_data_buffer(
         ctx.ptr().get(),
         query_.get(),
         attr.c_str(),
         data,
-        &std::get<1>(buff_sizes_[attr]),
+        &std::get<1>(buff_sizes_[attr])));
+    ctx.handle_error(tiledb_query_set_validity_buffer(
+        ctx.ptr().get(),
+        query_.get(),
+        attr.c_str(),
         validity_bytemap,
         &std::get<2>(buff_sizes_[attr])));
     return *this;
@@ -2515,14 +2490,22 @@ class Query {
     element_sizes_[attr] = data_element_size;
     buff_sizes_[attr] = std::tuple<uint64_t, uint64_t, uint64_t>(
         offset_size, data_size, validity_size);
-    ctx.handle_error(tiledb_query_set_buffer_var_nullable(
+    ctx.handle_error(tiledb_query_set_data_buffer(
+        ctx.ptr().get(),
+        query_.get(),
+        attr.c_str(),
+        data,
+        &std::get<1>(buff_sizes_[attr])));
+    ctx.handle_error(tiledb_query_set_offsets_buffer(
         ctx.ptr().get(),
         query_.get(),
         attr.c_str(),
         offsets,
-        &std::get<0>(buff_sizes_[attr]),
-        data,
-        &std::get<1>(buff_sizes_[attr]),
+        &std::get<0>(buff_sizes_[attr])));
+    ctx.handle_error(tiledb_query_set_validity_buffer(
+        ctx.ptr().get(),
+        query_.get(),
+        attr.c_str(),
         validity_bytemap,
         &std::get<2>(buff_sizes_[attr])));
     return *this;


### PR DESCRIPTION
This will finish deprecating the `*_with_key` APIs. In doing so, the APIs that _called_ deprecated APIs are now changed, fixing the issue in the example projects (ch8698). Some tests have also been changed to remove the deprecated APIs. 

TYPE: DEPRECATION
DESC: Complete deprecation of all *_with_key APIs.
