### PR TITLE
Sparse global order reader: initial memory budget improvements.

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -43,6 +43,7 @@
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/open_array_memory_tracker.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile.h"
@@ -65,12 +66,14 @@ FragmentMetadata::FragmentMetadata(
     const ArraySchema* array_schema,
     const URI& fragment_uri,
     const std::pair<uint64_t, uint64_t>& timestamp_range,
+    OpenArrayMemoryTracker* memory_tracker,
     bool dense)
     : storage_manager_(storage_manager)
     , array_schema_(array_schema)
     , dense_(dense)
     , fragment_uri_(fragment_uri)
-    , timestamp_range_(timestamp_range) {
+    , timestamp_range_(timestamp_range)
+    , memory_tracker_(memory_tracker) {
   has_consolidated_footer_ = false;
   rtree_ = RTree(array_schema_->domain(), constants::rtree_fanout);
   meta_file_size_ = 0;
@@ -892,12 +895,24 @@ Status FragmentMetadata::load_rtree(const EncryptionKey& encryption_key) {
 
   storage_manager_->stats()->add_counter("read_rtree_size", buff.size());
 
+  // Use the serialized buffer size to approximate memory usage of the rtree.
+  if (!memory_tracker_->take_memory(buff.size())) {
+    return LOG_STATUS(Status::FragmentMetadataError(
+        "Cannot load R-tree; Insufficient memory budget"));
+  }
+
   ConstBuffer cbuff(&buff);
   RETURN_NOT_OK(rtree_.deserialize(&cbuff, array_schema_->domain(), version_));
 
   loaded_metadata_.rtree_ = true;
 
   return Status::Ok();
+}
+
+void FragmentMetadata::free_rtree() {
+  auto freed = rtree_.free_memory();
+  memory_tracker_->release_memory(freed);
+  loaded_metadata_.rtree_ = false;
 }
 
 Status FragmentMetadata::load_tile_var_sizes(
@@ -1618,9 +1633,15 @@ Status FragmentMetadata::load_tile_offsets(ConstBuffer* buff) {
     if (tile_offsets_num == 0)
       continue;
 
+    auto size = tile_offsets_num * sizeof(uint64_t);
+    if (!memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status::FragmentMetadataError(
+          "Cannot load tile offsets; Insufficient memory budget"));
+    }
+
     // Get tile offsets
     tile_offsets_[i].resize(tile_offsets_num);
-    st = buff->read(&tile_offsets_[i][0], tile_offsets_num * sizeof(uint64_t));
+    st = buff->read(&tile_offsets_[i][0], size);
     if (!st.ok()) {
       return LOG_STATUS(Status::FragmentMetadataError(
           "Cannot load fragment metadata; Reading tile offsets failed"));
@@ -1647,9 +1668,14 @@ Status FragmentMetadata::load_tile_offsets(unsigned idx, ConstBuffer* buff) {
 
   // Get tile offsets
   if (tile_offsets_num != 0) {
+    auto size = tile_offsets_num * sizeof(uint64_t);
+    if (!memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status::FragmentMetadataError(
+          "Cannot load tile offsets; Insufficient memory budget"));
+    }
+
     tile_offsets_[idx].resize(tile_offsets_num);
-    st =
-        buff->read(&tile_offsets_[idx][0], tile_offsets_num * sizeof(uint64_t));
+    st = buff->read(&tile_offsets_[idx][0], size);
     if (!st.ok()) {
       return LOG_STATUS(Status::FragmentMetadataError(
           "Cannot load fragment metadata; Reading tile offsets failed"));
@@ -1689,10 +1715,15 @@ Status FragmentMetadata::load_tile_var_offsets(ConstBuffer* buff) {
     if (tile_var_offsets_num == 0)
       continue;
 
+    auto size = tile_var_offsets_num * sizeof(uint64_t);
+    if (!memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status::FragmentMetadataError(
+          "Cannot load tile var offsets; Insufficient memory budget"));
+    }
+
     // Get variable tile offsets
     tile_var_offsets_[i].resize(tile_var_offsets_num);
-    st = buff->read(
-        &tile_var_offsets_[i][0], tile_var_offsets_num * sizeof(uint64_t));
+    st = buff->read(&tile_var_offsets_[i][0], size);
     if (!st.ok()) {
       return LOG_STATUS(Status::FragmentMetadataError(
           "Cannot load fragment metadata; Reading variable tile offsets "
@@ -1721,9 +1752,14 @@ Status FragmentMetadata::load_tile_var_offsets(
 
   // Get variable tile offsets
   if (tile_var_offsets_num != 0) {
+    auto size = tile_var_offsets_num * sizeof(uint64_t);
+    if (!memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status::FragmentMetadataError(
+          "Cannot load tile var offsets; Insufficient memory budget"));
+    }
+
     tile_var_offsets_[idx].resize(tile_var_offsets_num);
-    st = buff->read(
-        &tile_var_offsets_[idx][0], tile_var_offsets_num * sizeof(uint64_t));
+    st = buff->read(&tile_var_offsets_[idx][0], size);
     if (!st.ok()) {
       return LOG_STATUS(Status::FragmentMetadataError(
           "Cannot load fragment metadata; Reading variable tile offsets "
@@ -1762,10 +1798,15 @@ Status FragmentMetadata::load_tile_var_sizes(ConstBuffer* buff) {
     if (tile_var_sizes_num == 0)
       continue;
 
+    auto size = tile_var_sizes_num * sizeof(uint64_t);
+    if (!memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status::FragmentMetadataError(
+          "Cannot load tile var sizes; Insufficient memory budget"));
+    }
+
     // Get variable tile sizes
     tile_var_sizes_[i].resize(tile_var_sizes_num);
-    st = buff->read(
-        &tile_var_sizes_[i][0], tile_var_sizes_num * sizeof(uint64_t));
+    st = buff->read(&tile_var_sizes_[i][0], size);
     if (!st.ok()) {
       return LOG_STATUS(Status::FragmentMetadataError(
           "Cannot load fragment metadata; Reading variable tile sizes "
@@ -1792,9 +1833,14 @@ Status FragmentMetadata::load_tile_var_sizes(unsigned idx, ConstBuffer* buff) {
 
   // Get variable tile sizes
   if (tile_var_sizes_num != 0) {
+    auto size = tile_var_sizes_num * sizeof(uint64_t);
+    if (!memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status::FragmentMetadataError(
+          "Cannot load tile var sizes; Insufficient memory budget"));
+    }
+
     tile_var_sizes_[idx].resize(tile_var_sizes_num);
-    st = buff->read(
-        &tile_var_sizes_[idx][0], tile_var_sizes_num * sizeof(uint64_t));
+    st = buff->read(&tile_var_sizes_[idx][0], size);
     if (!st.ok()) {
       return LOG_STATUS(Status::FragmentMetadataError(
           "Cannot load fragment metadata; Reading variable tile sizes "
@@ -1821,10 +1867,14 @@ Status FragmentMetadata::load_tile_validity_offsets(
 
   // Get tile offsets
   if (tile_validity_offsets_num != 0) {
+    auto size = tile_validity_offsets_num * sizeof(uint64_t);
+    if (!memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status::FragmentMetadataError(
+          "Cannot load tile validity offsets; Insufficient memory budget"));
+    }
+
     tile_validity_offsets_[idx].resize(tile_validity_offsets_num);
-    st = buff->read(
-        &tile_validity_offsets_[idx][0],
-        tile_validity_offsets_num * sizeof(uint64_t));
+    st = buff->read(&tile_validity_offsets_[idx][0], size);
 
     if (!st.ok()) {
       return LOG_STATUS(Status::FragmentMetadataError(
@@ -2307,6 +2357,11 @@ Status FragmentMetadata::read_file_footer(
   RETURN_NOT_OK(get_footer_offset_and_size(footer_offset, footer_size));
 
   storage_manager_->stats()->add_counter("read_frag_meta_size", *footer_size);
+
+  if (!memory_tracker_->take_memory(*footer_size)) {
+    return LOG_STATUS(Status::FragmentMetadataError(
+        "Cannot load file footer; Insufficient memory budget"));
+  }
 
   // Read footer
   return storage_manager_->read(

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -51,6 +51,7 @@ namespace sm {
 class ArraySchema;
 class Buffer;
 class EncryptionKey;
+class OpenArrayMemoryTracker;
 class StorageManager;
 
 /** Stores the metadata structures of a fragment. */
@@ -69,6 +70,7 @@ class FragmentMetadata {
    * @param timestamp_range The timestamp range of the fragment.
    *     In TileDB, timestamps are in ms elapsed since
    *     1970-01-01 00:00:00 +0000 (UTC).
+   * @param memory_tracker Memory tracker for all fragment metadatas.
    * @param dense Indicates whether the fragment is dense or sparse.
    */
   FragmentMetadata(
@@ -76,6 +78,7 @@ class FragmentMetadata {
       const ArraySchema* array_schema,
       const URI& fragment_uri,
       const std::pair<uint64_t, uint64_t>& timestamp_range,
+      OpenArrayMemoryTracker* memory_tracker,
       bool dense = true);
 
   /** Destructor. */
@@ -499,6 +502,9 @@ class FragmentMetadata {
   /** Loads the R-tree from storage. */
   Status load_rtree(const EncryptionKey& encryption_key);
 
+  /** Frees the memory associated with the rtree. */
+  void free_rtree();
+
   /**
    * Loads the variable tile sizes for the input attribute or dimension idx
    * from storage.
@@ -674,6 +680,9 @@ class FragmentMetadata {
 
   /** Stores the generic tile offsets, facilitating loading. */
   GenericTileOffsets gt_offsets_;
+
+  /** Pointer to the memory tracking structure maintained by the array. */
+  OpenArrayMemoryTracker* memory_tracker_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -997,6 +997,7 @@ Status Writer::create_fragment(
       array_schema_,
       uri,
       timestamp_range,
+      nullptr,
       dense);
 
   RETURN_NOT_OK((*frag_meta)->init(subarray_.ndrange(0)));

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -54,6 +54,7 @@ namespace sm {
 RTree::RTree() {
   domain_ = nullptr;
   fanout_ = 0;
+  deserialized_buffer_size_ = 0;
 }
 
 RTree::RTree(const Domain* domain, unsigned fanout)
@@ -113,6 +114,13 @@ Status RTree::build_tree() {
   std::reverse(std::begin(levels_), std::end(levels_));
 
   return Status::Ok();
+}
+
+uint64_t RTree::free_memory() {
+  auto ret = deserialized_buffer_size_;
+  levels_.clear();
+  deserialized_buffer_size_ = 0;
+  return ret;
 }
 
 unsigned RTree::dim_num() const {
@@ -336,6 +344,7 @@ Status RTree::deserialize_v1_v4(ConstBuffer* cbuff, const Domain* domain) {
   }
 
   domain_ = domain;
+  deserialized_buffer_size_ = cbuff->size();
 
   return Status::Ok();
 }
@@ -376,6 +385,7 @@ Status RTree::deserialize_v5(ConstBuffer* cbuff, const Domain* domain) {
   }
 
   domain_ = domain;
+  deserialized_buffer_size_ = cbuff->size();
 
   return Status::Ok();
 }

--- a/tiledb/sm/rtree/rtree.h
+++ b/tiledb/sm/rtree/rtree.h
@@ -89,6 +89,9 @@ class RTree {
   /** Builds the RTree bottom-up on the current leaf level. */
   Status build_tree();
 
+  /** Frees the memory associated with the rtree. */
+  uint64_t free_memory();
+
   /** The number of dimensions of the R-tree. */
   unsigned dim_num() const;
 
@@ -211,6 +214,12 @@ class RTree {
    * always consists of a single MBR.
    */
   std::vector<Level> levels_;
+
+  /**
+   * Stores the size of the buffer used to deserialize the data, used for
+   * memory tracking pusposes on reads.
+   */
+  uint64_t deserialized_buffer_size_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -118,6 +118,10 @@ FragmentMetadata* OpenArray::fragment_metadata(const URI& uri) const {
   return (it == fragment_metadata_set_.end()) ? nullptr : it->second;
 }
 
+OpenArrayMemoryTracker* OpenArray::memory_tracker() {
+  return &memory_tracker_;
+}
+
 tdb_shared_ptr<Buffer> OpenArray::array_metadata(const URI& uri) const {
   std::lock_guard<std::mutex> lock(local_mtx_);
   auto it = array_metadata_.find(uri.to_string());

--- a/tiledb/sm/storage_manager/open_array.h
+++ b/tiledb/sm/storage_manager/open_array.h
@@ -44,6 +44,7 @@
 #include "tiledb/sm/filesystem/filelock.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/uri.h"
+#include "tiledb/sm/storage_manager/open_array_memory_tracker.h"
 
 using namespace tiledb::common;
 
@@ -125,6 +126,9 @@ class OpenArray {
    */
   FragmentMetadata* fragment_metadata(const URI& uri) const;
 
+  /** Returns the memory tracker to be used by all fragment metadatas. */
+  OpenArrayMemoryTracker* memory_tracker();
+
   /**
    * Returns the constant buffer storing the serialized array metadata
    * of the input URI, or `nullptr` if the array metadata do not exist.
@@ -197,6 +201,9 @@ class OpenArray {
    * loaded in `fragment_metadata_`.
    */
   std::unordered_map<std::string, FragmentMetadata*> fragment_metadata_set_;
+
+  /** The memory tracker for the fragment metadata. */
+  OpenArrayMemoryTracker memory_tracker_;
 
   /**
    * A map of URI strings to array metadata. The map stores the serialized

--- a/tiledb/sm/storage_manager/open_array_memory_tracker.h
+++ b/tiledb/sm/storage_manager/open_array_memory_tracker.h
@@ -1,0 +1,106 @@
+/**
+ * @file   open_array_memory_tracker.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class OpenArrayMemoryTracker.
+ */
+
+#ifndef TILEDB_OPEN_ARRAY_MEMORY_TRACKER_H
+#define TILEDB_OPEN_ARRAY_MEMORY_TRACKER_H
+
+#include "tiledb/common/status.h"
+
+namespace tiledb {
+namespace sm {
+
+class OpenArrayMemoryTracker {
+ public:
+  /** Constructor. */
+  OpenArrayMemoryTracker() {
+    memory_usage_ = 0;
+    memory_budget_ = std::numeric_limits<uint32_t>::max();
+  };
+
+  /** Destructor. */
+  ~OpenArrayMemoryTracker() = default;
+
+  DISABLE_COPY_AND_COPY_ASSIGN(OpenArrayMemoryTracker);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(OpenArrayMemoryTracker);
+
+  /**
+   * Take memory from the budget.
+   *
+   * @param size The memory size.
+   * @return true if the memory is available, false otherwise.
+   */
+  bool take_memory(uint64_t size) {
+    std::lock_guard<std::mutex> lg(mutex_);
+    if (memory_usage_ + size <= memory_budget_) {
+      memory_usage_ += size;
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Release memory from the budget.
+   *
+   * @param size The memory size.
+   */
+  void release_memory(uint64_t size) {
+    std::lock_guard<std::mutex> lg(mutex_);
+    memory_usage_ -= size;
+  }
+
+  /**
+   * Set the memory budget.
+   *
+   * @param size The memory budget size.
+   */
+  void set_budget(uint64_t size) {
+    std::lock_guard<std::mutex> lg(mutex_);
+    memory_budget_ = size;
+  }
+
+ private:
+  /** Protects all member variables. */
+  std::mutex mutex_;
+
+  /** Memory usage for tracked structures. */
+  uint64_t memory_usage_;
+
+  /** Memory budget. */
+  uint64_t memory_budget_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_OPEN_ARRAY_MEMORY_TRACKER_H

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -880,6 +880,19 @@ Status StorageManager::array_create(
   return Status::Ok();
 }
 
+OpenArrayMemoryTracker* StorageManager::array_get_memory_tracker(
+    const URI& array_uri) {
+  // Lock mutex
+  std::lock_guard<std::mutex> lock{open_array_for_reads_mtx_};
+
+  // Find the open array to retrieve the memory tracker.
+  auto it = open_arrays_for_reads_.find(array_uri.to_string());
+  if (it == open_arrays_for_reads_.end())
+    return nullptr;
+
+  return it->second->memory_tracker();
+}
+
 Status StorageManager::array_get_non_empty_domain(
     Array* array, NDRange* domain, bool* is_empty) {
   if (domain == nullptr)
@@ -1485,7 +1498,12 @@ Status StorageManager::get_fragment_info(
 
   // Get fragment non-empty domain
   FragmentMetadata meta(
-      this, array.array_schema(), fragment_uri, timestamp_range, !sparse);
+      this,
+      array.array_schema(),
+      fragment_uri,
+      timestamp_range,
+      array_get_memory_tracker(array.array_uri()),
+      !sparse);
   RETURN_NOT_OK(meta.load(*array.encryption_key(), nullptr, 0));
 
   // This is important for format version > 2
@@ -2458,10 +2476,16 @@ Status StorageManager::load_fragment_metadata(
             array_schema,
             sf.uri_,
             sf.timestamp_range_,
+            open_array->memory_tracker(),
             !sparse);
       } else {  // Format version > 2
         metadata = tdb_new(
-            FragmentMetadata, this, array_schema, sf.uri_, sf.timestamp_range_);
+            FragmentMetadata,
+            this,
+            array_schema,
+            sf.uri_,
+            sf.timestamp_range_,
+            open_array->memory_tracker());
       }
 
       // Potentially find the basic fragment metadata in the consolidated

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -71,6 +71,7 @@ class FragmentMetadata;
 class FragmentInfo;
 class Metadata;
 class OpenArray;
+class OpenArrayMemoryTracker;
 class Query;
 class RestClient;
 class VFS;
@@ -338,6 +339,14 @@ class StorageManager {
       const URI& array_uri,
       ArraySchema* array_schema,
       const EncryptionKey& encryption_key);
+
+  /**
+   * Gets the memory tracker for an open array.
+   *
+   * @param array_uri The array URI.
+   * @return The memory tracker.
+   */
+  OpenArrayMemoryTracker* array_get_memory_tracker(const URI& array_uri);
 
   /**
    * Retrieves the non-empty domain from an array. This is the union of the

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -271,6 +271,14 @@ void Subarray::clear() {
   add_or_coalesce_range_func_.clear();
 }
 
+void Subarray::clear_tile_overlap() {
+  tile_overlap_.clear();
+}
+
+uint64_t Subarray::tile_overlap_byte_size() const {
+  return tile_overlap_.byte_size();
+}
+
 bool Subarray::coincides_with_tiles() const {
   if (range_num() != 1)
     return false;

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -244,6 +244,16 @@ class Subarray {
   /** Clears the contents of the subarray. */
   void clear();
 
+  /** Clears the contents of the tile overlap. */
+  void clear_tile_overlap();
+
+  /**
+   * Returns the size of the tile overlap data.
+   *
+   * @return Size of the tile overlap data.
+   */
+  uint64_t tile_overlap_byte_size() const;
+
   /**
    * Returns true if the subarray is unary and it coincides with
    * tile boundaries.


### PR DESCRIPTION
Add memory management to Fragment Metadata for rtrees and tile offsets
loading. A budget cap is set on the array by the reader, when we reach
it, it fails the operations. Also keep track of how much data is
currently used for future memory budget calculations.

Freeing rtrees and tile overlap after computing relevant tiles if a
subarray is set.

Move away from using a bitset to determine the next tiles to load and
using a list of tile ranges instead. This is better since for most of
our use cases when having a subarray, the number of tiles is low.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: initial memory budget improvements.
