### PR TITLE
First revision of the Interval class.

### DIFF
--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -1,0 +1,65 @@
+name: unit-test-standalone
+on:
+  push:
+  pull_request:
+
+env:
+  BACKWARDS_COMPATIBILITY_ARRAYS: OFF
+  TILEDB_S3: OFF
+  TILEDB_AZURE: OFF
+  TILEDB_GCS: OFF
+  TILEDB_SERIALIZATION: OFF
+  TILEDB_STATIC: OFF
+  TILEDB_TOOLS: ON
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, ubuntu-latest]
+    name: Build - ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Print env'
+        run: |
+          echo "'uname -s' is:"
+          echo "uname: " $(uname)
+          echo "uname -m: " $(uname -m)
+          echo "uname -r:" $(uname -r)
+          echo "uname -s: " $(uname -s)
+          echo "uname -v: " $(uname -v)
+          printenv
+        shell: bash
+
+      - name: 'Install system headers (OSX 10.14 only)'
+        run: |
+          set -e pipefail
+          open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+          sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -allowUntrusted -target /
+        shell: bash
+        if: ${{ runner.os == 'macOS' && env.imageName == 'macOS-10.14' }}
+
+      - name: 'Build and run interval unit test'
+        id: test
+        run: |
+
+          mkdir -p $GITHUB_WORKSPACE/build
+          pushd $GITHUB_WORKSPACE/build
+
+          cmake .. \
+            -DTILEDB_AZURE=${TILEDB_AZURE}\
+            -DTILEDB_GCS=${TILEDB_GCS} \
+            -DTILEDB_S3=${TILEDB_S3} \
+            -DTILEDB_SERIALIZATION=${TILEDB_SERIALIZATION}
+          make -j4
+          # Build all unit tests
+          make -C tiledb tests -j4
+          # Run all unit tests
+          make -C tiledb test ARGS="-R '^unit_'"
+
+          popd
+      - name: "Print log files (failed build only)"
+        run: |
+          source $GITHUB_WORKSPACE/scripts/ci/print_logs.sh
+        if: ${{ failure() }} # only run this job if the build step failed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,11 @@ add_subdirectory(examples)
 # Build unit tests
 if (TILEDB_TESTS)
   add_subdirectory(test)
+
+  # Add cmake target for "tests" to build all unit tests executables
+  add_custom_target(tests)
+  add_dependencies(tests tiledb_unit)
+  add_dependencies(tests unit_interval)
 endif()
 
 # Build tools

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(Catch_EP REQUIRED)
 option(TILEDB_TESTS_AWS_S3_CONFIG "Use an S3 config appropriate for AWS in tests" OFF)
 option(TILEDB_TESTS_ENABLE_REST "Enables REST tests (requires running REST server)" OFF)
 
+
 # Arrow integration test config and dependencies
 # Override from environment if not set in cache
 if (NOT DEFINED $CACHE{TILEDB_ARROW_TESTS})

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -34,8 +34,14 @@
 cmake_policy(SET CMP0063 NEW)
 
 ############################################################
+# Subdirectories
+############################################################
+
+add_subdirectory(common)
+
+############################################################
 # Source files
-###########################################################
+############################################################
 
 # The core header directory.
 set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
@@ -94,6 +100,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/logger.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/status.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/thread_pool.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/interval/interval.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/array_schema.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/attribute.cc

--- a/tiledb/common/CMakeLists.txt
+++ b/tiledb/common/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# tiledb/common/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2021 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+add_subdirectory(interval)

--- a/tiledb/common/CMakeLists.txt
+++ b/tiledb/common/CMakeLists.txt
@@ -25,4 +25,6 @@
 # THE SOFTWARE.
 #
 
-add_subdirectory(interval)
+if (TILEDB_TESTS)
+    add_subdirectory(interval)
+endif()

--- a/tiledb/common/interval/CMakeLists.txt
+++ b/tiledb/common/interval/CMakeLists.txt
@@ -45,3 +45,9 @@ target_sources(unit_interval PUBLIC
         test/unit_interval_predicates.cc
         test/unit_interval_types.cc
 )
+
+add_test(
+        NAME "unit_interval"
+        COMMAND $<TARGET_FILE:unit_interval>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/tiledb/common/interval/CMakeLists.txt
+++ b/tiledb/common/interval/CMakeLists.txt
@@ -1,0 +1,47 @@
+#
+# tiledb/common/interval/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2021 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+cmake_policy(SET CMP0076 NEW)  # CMake 3.13 - converts relative paths to absolute
+find_package(Catch_EP REQUIRED)
+
+add_executable(unit_interval EXCLUDE_FROM_ALL)
+target_link_libraries(unit_interval PUBLIC Catch2::Catch2)
+
+# Sources for code under test
+target_sources(unit_interval PUBLIC
+  interval.cc
+)
+
+# Sources for tests
+target_sources(unit_interval PUBLIC
+  test/main.cc
+        test/unit_interval_bound.cc
+        test/unit_interval_constructors.cc
+        test/unit_interval_operations.cc
+        test/unit_interval_predicates.cc
+        test/unit_interval_types.cc
+)

--- a/tiledb/common/interval/interval.cc
+++ b/tiledb/common/interval/interval.cc
@@ -37,11 +37,15 @@ namespace tiledb::common::detail {
 /*
  * Instantiations for marker class objects.
  */
-static constexpr IntervalBase::empty_set_t empty_set();
-static constexpr IntervalBase::single_point_t single_point();
-static constexpr IntervalBase::open_t open();
-static constexpr IntervalBase::closed_t closed();
-static constexpr IntervalBase::minus_infinity_t minus_infinity();
-static constexpr IntervalBase::plus_infinity_t plus_infinity();
+static constexpr IntervalBase::empty_set_t empty_set =
+    IntervalBase::empty_set_t();
+static constexpr IntervalBase::single_point_t single_point =
+    IntervalBase::single_point_t();
+static constexpr IntervalBase::open_t open = IntervalBase::open_t();
+static constexpr IntervalBase::closed_t closed = IntervalBase::closed_t();
+static constexpr IntervalBase::minus_infinity_t minus_infinity =
+    IntervalBase::minus_infinity_t();
+static constexpr IntervalBase::plus_infinity_t plus_infinity =
+    IntervalBase::plus_infinity_t();
 
 }  // namespace tiledb::common::detail

--- a/tiledb/common/interval/interval.cc
+++ b/tiledb/common/interval/interval.cc
@@ -1,0 +1,47 @@
+/**
+ * @file   interval.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the non-template parts of class Interval.
+ */
+
+#include "interval.h"
+
+namespace tiledb::common::detail {
+
+/*
+ * Instantiations for marker class objects.
+ */
+static constexpr IntervalBase::empty_set_t empty_set;
+static constexpr IntervalBase::single_point_t single_point;
+static constexpr IntervalBase::open_t open;
+static constexpr IntervalBase::closed_t closed;
+static constexpr IntervalBase::minus_infinity_t minus_infinity;
+static constexpr IntervalBase::plus_infinity_t plus_infinity;
+
+}  // namespace tiledb::common::detail

--- a/tiledb/common/interval/interval.cc
+++ b/tiledb/common/interval/interval.cc
@@ -32,20 +32,4 @@
 
 #include "interval.h"
 
-namespace tiledb::common::detail {
-
-/*
- * Instantiations for marker class objects.
- */
-static constexpr IntervalBase::empty_set_t empty_set =
-    IntervalBase::empty_set_t();
-static constexpr IntervalBase::single_point_t single_point =
-    IntervalBase::single_point_t();
-static constexpr IntervalBase::open_t open = IntervalBase::open_t();
-static constexpr IntervalBase::closed_t closed = IntervalBase::closed_t();
-static constexpr IntervalBase::minus_infinity_t minus_infinity =
-    IntervalBase::minus_infinity_t();
-static constexpr IntervalBase::plus_infinity_t plus_infinity =
-    IntervalBase::plus_infinity_t();
-
-}  // namespace tiledb::common::detail
+namespace tiledb::common::detail {}  // namespace tiledb::common::detail

--- a/tiledb/common/interval/interval.cc
+++ b/tiledb/common/interval/interval.cc
@@ -37,11 +37,11 @@ namespace tiledb::common::detail {
 /*
  * Instantiations for marker class objects.
  */
-static constexpr IntervalBase::empty_set_t empty_set;
-static constexpr IntervalBase::single_point_t single_point;
-static constexpr IntervalBase::open_t open;
-static constexpr IntervalBase::closed_t closed;
-static constexpr IntervalBase::minus_infinity_t minus_infinity;
-static constexpr IntervalBase::plus_infinity_t plus_infinity;
+static constexpr IntervalBase::empty_set_t empty_set();
+static constexpr IntervalBase::single_point_t single_point();
+static constexpr IntervalBase::open_t open();
+static constexpr IntervalBase::closed_t closed();
+static constexpr IntervalBase::minus_infinity_t minus_infinity();
+static constexpr IntervalBase::plus_infinity_t plus_infinity();
 
 }  // namespace tiledb::common::detail

--- a/tiledb/common/interval/interval.h
+++ b/tiledb/common/interval/interval.h
@@ -1,0 +1,1483 @@
+/**
+ * @file   interval.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines classes for set-theoretic intervals. The operations are
+ * standard ones on sets: intersection, union (where defined), partial ordering,
+ * etc. Intervals are defined for any totally ordered set. All integral and
+ * floating-point types are totally ordered, but so also are strings of totally
+ * ordered symbols. In particular, no arithmetic operations such as addition are
+ * assumed. For this sense, see
+ *      https://en.wikipedia.org/wiki/Interval_(mathematics)
+ *
+ * To avoid confusion, there is another, different use for intervals that is
+ * prevalent, which is to use interval arithmetic to represent error bounds.
+ * This not the purpose here. For this other sense, see
+ *      https://en.wikipedia.org/wiki/Interval_arithmetic
+ *
+ * Three foundational kinds of intervals are from integral types, floating point
+ * types, and strings.
+ *
+ * @subsection Requirements on the set
+ *
+ * Total ordering means there is a trichotomous order predicate `<` such that
+ * for any `x` and `y`, exactly one of `x < y`, `y < x` or `x == y` is true.
+ * In C++20, this is formalized as `std::totally_ordered` and the comparison
+ * predicate as `operator<=>`.
+ *
+ * @subsection Definition of an interval
+ *
+ * An interval is a subset given by a lower bound and an upper bound, either of
+ * which may be absent ("infinite bound"), and either of which may be open
+ * (`<`), denoted with parentheses `()`, or closed (`<=`), denoted with square
+ * brackets `[]`. Here's a list of the possible defining inequalities
+ *      a < x < b           open, open
+ *      a < x <= b          open, closed
+ *      a <= x < b          closed, open
+ *      a <= x <= b         closed, closed
+ *      x < b               missing, open
+ *      x <= b              missing, closed
+ *      a < x               open, missing
+ *      a <= x              closed, missing
+ *      <no constraint>     missing, missing (i.e. the whole set)
+ * These inequalities are the fundamental defining predicates of an interval,
+ * from which all else follows.
+ *
+ * The empty set is a valid interval, since there is no
+ * requirement that the upper bound be greater than the lower bound. A set
+ * consisting of a single point `a` is also a valid interval, with upper and
+ * lower bounds equal and both closed. The entire set is also valid interval,
+ * the case where both bounds are absent.
+ *
+ * All told, there are 11 distinct kinds of intervals under this definition. The
+ * bounds are non-degenerate: `a < b`. It will be clear that a simplistic
+ * representation of an interval as two values is inadequate.
+ *
+ * Group 1
+ *      ∅        empty set
+ * Group 2
+ *      [a,a]    single point, closed
+ * Group 3
+ *      (a,b)    finite, open
+ *      (a,b]    finite, half-open half-closed
+ *      [a,b)    finite, half-closed half-open
+ *      [a,b]    finite, closed
+ * Group 4
+ *      (a,+∞)   half-infinite, lower half-open
+ *      [a,+∞)   half-infinite, lower half-closed
+ * Group 5
+ *      (-∞,b)   half-infinite, upper half-open
+ *      (-∞,b]   half-infinite, upper half-closed
+ * Group 6
+ *      (-∞,+∞)  bi-infinite
+ *
+ * In the implementation, each of these intervals has its own marked
+ * constructor.
+ *
+ * @subsection Motivation
+ *
+ * For practical applications, it suffices to use the union a set of intervals
+ * to represent arbitrary subsets of an ordered set. Every subset representable
+ * as a set of intervals has a canonical representation as a set of ordered,
+ * strictly separable intervals. This representation provides a solid foundation
+ * for parallel and distributed processing.
+ *
+ * @section Operations
+ *
+ * @subsection Set membership
+ *
+ * An interval is a kind of set. Not much more to be said.
+ *
+ * @subsection Intersection
+ *
+ * The intersection of two intervals is always an interval. This is one of the
+ * reasons that the empty set should be considered an interval. (Mathematically
+ * speaking, this closure property means that intervals are a meet-lattice.)
+ *
+ * @subsection Comparison, strict separation, and adjacency
+ *
+ * Intervals are partially ordered under a quantified comparison predicate. I_1
+ * is less than I_2 if every t_1 in I_1 is less than every t_2 in I_2. Intervals
+ * that intersect are never ordered, since for a common element x, x (as a
+ * member of one set) is never less than x (as a member of the other).
+ *
+ * The empty set acts atypically here. Because universal quantifier over an
+ * empty set is true, the empty set is less than every set and every set is less
+ * than the empty set: ∅ < I < ∅. As a result, we must exclude the empty set
+ * from the domain of `<` when considered as a partial order. If intervals that
+ * intersect are not ordered, intervals that are disjoint (i.e. don't intersect)
+ * are ordered only if neither is empty.
+ *
+ * Two points are separable if there's a third distinct point between them. Two
+ * intervals I_1 and I_2 are separable if every point in I_1 is separable from
+ * every point in I_2. Separable intervals are always disjoint and ordered.
+ *
+ * Disjoint intervals, though, are not always separable; they may not have any
+ * point between them. For example consider the intervals [a,b) and [b,c).
+ * Disjoint intervals that are not strictly separable are called adjacent.
+ *
+ * The empty set is disjoint with every other set, but it's also inseparable
+ * from every set. The definition of separability is a universal quantifer over
+ * points in the set, so it's true for the empty set. Hence the empty set is
+ * also adjacent to every set.
+ *
+ * @subsection Union
+ *
+ * The union of two intervals is not always an interval, but it can be. The
+ * union of separable intervals is never an interval. If two non-empty intervals
+ * are not separable, they either intersect or they're adjacent, and in both of
+ * these cases their union is an interval. Union with the empty set is also
+ * defined; it's the identity operator.
+ *
+ * @section Complications
+ *
+ * Of course it's not as simple as the above description might indicate. Some
+ * complications are theoretical, some are practical.
+ *
+ * @subsection Finite types vs. infinite ideas
+ *
+ * We consider the defining inequalities as upon the mathematical sets on which
+ * the intervals are defined, with specific types being finite subsets of them.
+ * This matter with boundaries. Consider the integer interval [0,+infinity)
+ * represented with k-bit integers. As a representation, it's the same as the
+ * interval [0,2^k-1], but we don't use 2^k-1 as a placeholder for "unbounded".
+ * If we consider the same interval in 2k-bit integers, we still have
+ * [0,+infinity), not [0,2^(2k)-1].
+ *
+ * In the case of floating point numbers, larger floating point representations
+ * admit larger exponents, so we consider those types as dense sets.
+ * Accordingly, we abjure the use of `std::nextafter` here, since it's a
+ * representation-dependent increment.
+ *
+ * If type `T` is a subset of type `U` (e.g. `uint8_t` and `uint16_t`, `float`
+ * and `double`), then we have a faithful conversion of values in `T` to values
+ * in `U`. We also have a conversion from `Interval<T>` to `Interval<U>`. These
+ * conversions must keep the defining inequalities intact. Less obviously, we
+ * want the same behavior converting from integral types to floating point
+ * types.
+ *
+ * @subsection Discrete vs. dense types
+ *
+ * A dense set is one that, given any two points, there is another point between
+ * them. A discrete set is one where adjacent points are separated from each
+ * other by gaps. Dense types are canonically defined by their inequalities, but
+ * discrete ones are not. Consider the interval [1,3] over the integers. It's a
+ * set with three elements {1,2,3} and has three additional representations as
+ * intervals: [1,4) (0,3] (0,4). For the integers, the inequalities a<x and
+ * a+1<=x are equivalent to each other, likewise x<b and x<=b-1. We are
+ * providing set-theoretic operations for `Interval` and thus we remain agnostic
+ * about how a particular set is represented is such operations.
+ *
+ * Discrete and dense are concepts that are rightly associated with upper and
+ * lower neighborhoods of points. Consider a set with lexicographic ordering,
+ * for example strings of the symbols {A,B,C,D}. On the upper side, there's
+ * always a gap. The first string after `B` is `BA' and there are no strings
+ * between them. There is, however, no last string before `B`, because some
+ * element of the sequence `AD`, `ADD`, `ADDD`, ... is always after every
+ * element that comes before `B`. This is true for every string (except the
+ * empty string and the first string `A`), so such sets are generically
+ * left-dense and right-discrete.
+ *
+ * In order to evaluate set-theoretic function and to encompass all these cases,
+ * we therefore require an adjacency predicate for the base type. Adjacency is
+ * always false for floating point numbers and can be evaluated as a+1==b for
+ * integral types. For lexicographic ordering, the adjacency requirement is more
+ * involved, but basically says that they can differ in at most their last
+ * symbol and that the last symbols have to be adjacent.
+ *
+ * An open interval on a discrete set may only have a single element. In that
+ * case the bounds are twice-adjacent--the lower bound is adjacent to the
+ * element and the element is adjacent to the upper bound.
+ *
+ * @subsection Extended elements. Elements that aren't ordered.
+ *
+ * Floating point types have two infinity values. In the parlance of IEEE 754,
+ * these are "extended numbers". Infinite values are meaningful when used as
+ * constructor arguments, but not as ordinary elements. Infinite values, for
+ * consistency, are not stored as bounds, but converted to unbounded intervals.
+ *
+ * Floating point types have two NaN values, quiet and signaling, though the
+ * difference is not relevant here. NaN values are not meaningful as numbers.
+ * Accordingly, we can't accept NaN as a bound, and so constructors that accept
+ * a raw type cannot be labelled `noexcept`. Type members that are not numbers
+ * cannot be elements of a set of numbers (obviously?).
+ */
+
+#pragma once
+#ifndef TILEDB_INTERVAL_H
+#define TILEDB_INTERVAL_H
+
+#include <optional>
+#include <stdexcept>
+#include <tuple>
+
+using std::tuple, std::optional, std::nullopt;
+
+namespace tiledb::common {
+namespace detail {
+
+/**
+ * Interval<T> cannot be instantiated without defining TypeTraits<T>. The
+ * necessary traits involve adjacency, infinite elements, and unordered
+ * elements.
+ *
+ * This default traits class should not be instantiated. Its members are only
+ * declared and not defined. They're all declared [[maybe_unused]] to silence
+ * warnings, since specializations of this class are used. The documentation for
+ * the declarations in this class are about the requirements of a traits
+ * specialization.
+ *
+ * @tparam T Each interval is a subset of the set of all T.
+ * @tparam Enable Allows specializations with enable_if
+ */
+template <class T, typename Enable = T>
+struct TypeTraits {
+  /**
+   * Returns a pair of predicates "adjacent" and "twice-adjacent". `a` is
+   * adjacent to `b` if `a < b` and there is no `c` such that `a < c < b'. `a`
+   * is twice-adjacent to `b` if `a < b` and there exists a `c` such that `a` is
+   * adjacent to `c` and `c` is adjacent to `b`.
+   */
+  [[maybe_unused]] static tuple<bool, bool> adjacency(T, T);
+
+  /**
+   * Returns the predicate "adjacent".
+   */
+  [[maybe_unused]] static bool adjacent(T, T);
+
+  /**
+   * Predicate constant that T contains unordered elements. Floating point types
+   * contain NaN values, which are not ordered and thus unsuitable as interval
+   * bounds.
+   *
+   * Used as a `if constexpr` guard for calling `is_ordered`.
+   */
+  [[maybe_unused]] static const bool has_unordered_elements;
+
+  /**
+   * Predicate constant that T contains infinite elements, that is, an element
+   * that represents an infinity. An infinite element presented as an interval
+   * bound needs to be mapped to a canonical form.
+   */
+  [[maybe_unused]] static const bool has_infinite_elements;
+
+  /**
+   * Predicate function that an element of T is a number. This function allows
+   * excluding floating-point NaN as an interval bound.
+   *
+   * This function need not be defined for types that do not have unordered
+   * elements. All occurences appear within an `if constexpr` guard with
+   * `has_unordered_elements`.
+   */
+  [[maybe_unused]] static bool is_ordered(T);
+
+  /**
+   * Predicate function that an element of T is a finite number. This function
+   * allows detecting floating point infinities as interval bounds in
+   * constructors.
+   */
+  [[maybe_unused]] static bool is_finite(T);
+
+  /**
+   * Predicate function that an infinite element is positive infinity. Returns
+   * false otherwise.
+   *
+   * @precondition argument is an infinite element
+   */
+  [[maybe_unused]] static bool is_infinity_positive(T);
+};
+
+/**
+ * Specialization of TypeTraits for integral types. Integral types have
+ * non-trivial adjacency, no unordered elements, and no infinite elements.
+ */
+template <class T>
+struct TypeTraits<
+    T,
+    typename std::enable_if<std::is_integral<T>::value, T>::type> {
+  /**
+   * Adjacency for integral types means that the lower is one less than the
+   * upper.
+   */
+  static tuple<bool, bool> adjacency(T a, T b) {
+    if (a >= b) {
+      return {false, false};
+    }
+    // Assert: a < b
+    // Assert: a+1 cannot overflow. b-1 cannot overflow
+    return {a + 1 == b, a + 1 == b - 1};
+  }
+
+  /**
+   * Adjacency for integral types means that the lower is one less than the
+   * upper.
+   */
+  static bool adjacent(T a, T b) {
+    if (a >= b) {
+      return false;
+    }
+    // Assert: a < b
+    // Assert: a+1 cannot overflow.
+    return a + 1 == b;
+  }
+
+  static constexpr bool has_unordered_elements = false;
+  static constexpr bool has_infinite_elements = false;
+};
+
+/**
+ * Specialization of TypeTraits for floating-point types. Floating point numbers
+ * have trivial adjacency and presence of both unordered and infinite elements.
+ */
+template <class T>
+struct TypeTraits<
+    T,
+    typename std::enable_if<std::is_floating_point<T>::value, T>::type> {
+  /**
+   * Floating point numbers are never adjacent.
+   */
+  static tuple<bool, bool> adjacency(T, T) {
+    return {false, false};
+  };
+
+  static bool adjacent(T, T) {
+    return false;
+  };
+
+  static constexpr bool has_unordered_elements = true;
+  static constexpr bool has_infinite_elements = true;
+
+  /**
+   * An extended number is either finite or infinite, but must not be NaN.
+   */
+  static bool is_ordered(T x) {
+    return !isnan(x);
+  }
+
+  /**
+   * Floating point types have infinite elements.
+   */
+  static bool is_finite(T x) {
+    return isfinite(x);
+  }
+
+  /**
+   * Floating point infinities compare with finite values.
+   */
+  static bool is_infinity_positive(T x) {
+    return x > 0;
+  }
+};
+
+/**
+ * Non-template base class for `Interval`.
+ */
+struct IntervalBase {
+  /** Marks a constructor for the empty set */
+  static constexpr class empty_set_t {
+  } empty_set;
+  /** Marks a constructor for a single-point set */
+  static constexpr class single_point_t {
+  } single_point;
+  /** Marks a boundary as open in a constructor */
+  static constexpr class open_t {
+  } open;
+  /** Marks a boundary as closed in a constructor */
+  static constexpr class closed_t {
+  } closed;
+  /** Mark a lower boundary as infinite (i.e. not present) */
+  static constexpr class minus_infinity_t {
+  } minus_infinity;
+  /** Mark an upper boundary as infinite (i.e. not present) */
+  static constexpr class plus_infinity_t { } plus_infinity; };
+
+}  // namespace detail
+
+// Forward declaration
+template <class T>
+class WhiteboxInterval;
+
+/**
+ * @class Interval
+ *
+ * Intervals are immutable upon construction. That is to say that intervals are
+ * a value class. The value of an Interval variable changes by assignment, not
+ * by manipulating its innards in any other way.
+ *
+ * The implementation uses as direct a representation as is possible, with as
+ * few encoding tricks as possible. Lower and upper bounds use std::optional for
+ * storage, with no meaning assigned to a null. The value of a bound is absent
+ * when logically consistent, as is the case with the empty set and with
+ * infinite bounds. Other aspects of the interval are encoded directly with
+ * boolean values. There are eight of them, which fortuitously fit into a single
+ * byte as bit fields.
+ *
+ * The public constructors do not throw exceptions when the argument elements
+ * are ordered, either ordinary or extended (infinite). The only time a
+ * constructor will throw is when an argument is unordered, notably NaN. For
+ * types with unordered elements, the constructors are not marked `noexcept`,
+ * although this is out of expediency rather than necessity. Also not present is
+ * an auxiliary class for "the ordered elements of T", which would also allow
+ * `noexcept` constructors.
+ *
+ * @tparam T A type whose values include a totally ordered set
+ */
+template <class T>
+class Interval : public detail::IntervalBase {
+  typedef detail::TypeTraits<T> Traits;
+  /**
+   * WhiteboxInterval makes available internals of Interval for testing.
+   */
+  friend class WhiteboxInterval<T>;
+
+  /**
+   * @var Lower bound of the interval, if one exists.
+   *
+   * @invariant lower_bound.has_value() \iff is_lower_bound_open_ \or
+   * is_lower_bound_closed_
+   */
+  optional<T> lower_bound_;
+  /**
+   * @var Upper bound of the interval, if one exists.
+   *
+   * @invariant upper_bound.has_value() \iff is_upper_bound_open_ \or
+   * is_upper_bound_closed_
+   */
+  optional<T> upper_bound_;
+  /*
+   * The various types of interval as stored as precomputed predicate values
+   * about the various aspects of the class. The predicates values are stored as
+   * bit fields.
+   */
+  /**
+   * @var is_empty_ True if and only if the interval is the empty set.
+   *
+   * @invariant is_empty_ \implies !has_single_point_
+   * @invariant is_empty_ \implies !is_lower_open_
+   * @invariant is_empty_ \implies !is_lower_closed_
+   * @invariant is_empty_ \implies !is_lower_infinite_
+   * @invariant is_empty_ \implies !is_upper_open_
+   * @invariant is_empty_ \implies !is_upper_closed_
+   * @invariant is_empty_ \implies !is_upper_infinite_
+   * @invariant is_empty_ \implies !lower_bound.has_value()
+   * @invariant is_empty_ \implies !upper_bound.has_value()
+   */
+  bool is_empty_ : 1;
+  /**
+   * @var is_single_point_ True iff and only iff the interval consists of a set
+   * containing a single element.
+   *
+   * @invariant has_single_point_ \implies !is_empty_
+   * @invariant has_single_point_ \implies !is_lower_infinite_
+   * @invariant has_single_point_ \implies !is_upper_infinite_
+   *
+   * @invariant has_single_point_ \implies ( lower_bound == upper_bound \or
+   * adjacent(lower_bound, upper_bound) \or
+   * twice_adjacent(lower_bound,upper_bound) )
+   *
+   * @invariant ( has_single_point_ \and lower_bound == upper_bound ) \implies
+   * is_lower_closed_ \and is_upper_closed_
+   *
+   * @invariant ( has_single_point_ \and adjacent(lower_bound, upper_bound) )
+   * \implies (( is_lower_closed_ \and is_upper_open_ ) \or ( is_lower_open_
+   * \and is_upper_closed_ ))
+   *
+   * @invariant ( has_single_point_ \and twice_adjacent(lower_bound,
+   * upper_bound) ) \implies ( is_lower_open_ \and is_upper_open_ )
+   */
+  bool has_single_point_ : 1;
+  /**
+   * @var is_lower_open_
+   *
+   * @invariant is_lower_open_ \implies !is_lower_closed
+   * @invariant is_lower_open_ \implies !is_lower_infinite_
+   * @invariant is_lower_open_ \implies lower_bound.has_value()
+   */
+  bool is_lower_open_ : 1;
+  /**
+   * @var is_lower_closed_
+   *
+   * @invariant is_lower_closed \implies !is_lower_open_
+   * @invariant is_lower_closed \implies !is_lower_infinite_
+   * @invariant is_lower_closed_ \implies lower_bound.has_value()
+   */
+  bool is_lower_closed_ : 1;
+  /**
+   * @var is_lower_infinite_
+   *
+   * @invariant is_lower_infinite_ \implies !is_lower_open
+   * @invariant is_lower_infinite_ \implies !is_lower_closed
+   * @invariant is_lower_infinite_ \implies !lower_bound.has_value()
+   */
+  bool is_lower_infinite_ : 1;
+  /**
+   * @var is_upper_open_
+   *
+   * @invariant is_upper_open_ \implies !is_upper_closed
+   * @invariant is_upper_open_ \implies !is_upper_infinite_
+   * @invariant is_upper_open_ \implies upper_bound.has_value()
+   */
+  bool is_upper_open_ : 1;
+  /**
+   * @var is_upper_closed_
+   *
+   * @invariant is_upper_closed \implies !is_upper_open_
+   * @invariant is_upper_closed \implies !is_upper_infinite_
+   * @invariant is_upper_closed_ \implies upper_bound.has_value()
+   */
+  bool is_upper_closed_ : 1;
+  /**
+   * @var is_upper_infinite_
+   *
+   * @invariant is_upper_infinite_ \implies !is_upper_open
+   * @invariant is_upper_infinite_ \implies !is_upper_closed
+   * @invariant is_upper_infinite_ \implies !upper_bound.has_value()
+   */
+  bool is_upper_infinite_ : 1;
+
+  /**
+   * A Bound is auxiliary class to support the construction of Interval object.
+   * Each contains data for either an upper or lower bound. Objects have life
+   * span confined to the duration of object construction.
+   *
+   * It's possible for a bound (an inequality) to not be satisfiable in four
+   * cases, and only when the template argument T contains infinite elements.
+   * The non-satisfiable bounds are +infinity < x, x < -infinity, and likewise
+   * for <=. A non-satisfiable bound must instantiate an empty set.
+   *
+   * @invariant satisfiable_ \implies is_open_ || is_closed_ \implies
+   * bound.has_value()
+   *
+   * @invariant satisfiable_ \implies exactly one of is_open_, is_closed_, or
+   * is_finite_ is true
+   */
+  struct Bound {
+    optional<T> bound_;
+    bool is_open_;
+    bool is_closed_;
+    bool is_infinite_;
+    bool is_satisfiable_;
+    /**
+     * Finite constructor uses T for the bound instead of optional<T>.
+     */
+    Bound(T bound, bool is_closed) noexcept
+        : bound_(bound)
+        , is_open_(!is_closed)
+        , is_closed_(is_closed)
+        , is_infinite_(false)
+        , is_satisfiable_(true) {
+    }
+
+    /**
+     * Special constructor for cases where the bound is nullopt.
+     */
+    Bound(bool is_infinite, bool is_satisfiable) noexcept
+        : bound_(nullopt)
+        , is_open_(false)
+        , is_closed_(false)
+        , is_infinite_(is_infinite)
+        , is_satisfiable_(is_satisfiable) {
+    }
+
+    /**
+     * Extraction constructor for copying individual lower or upper bounds out
+     * of an Interval.
+     */
+    Bound(
+        optional<T> bound,
+        bool is_open,
+        bool is_closed,
+        bool is_infinite) noexcept
+        : bound_(bound)
+        , is_open_(is_open)
+        , is_closed_(is_closed)
+        , is_infinite_(is_infinite)
+        , is_satisfiable_(true) {
+    }
+
+    /**
+     * When comparing bound `left` and `right` as lower bounds, we are comparing
+     * intervals `Left = left,+infinity)` and `Right = right,+infinity)`. We
+     * want the inequality convention for bounds to follow that for elements of
+     * T, so that, say `Left < Right` when `x < y` (disregarding adjacency).
+     * This makes the less-than relationship on Bounds the superset relationship
+     * on their Intervals extended to infinity.
+     *
+     * In other words, `Left < Right` when there exist elements in `Left`
+     * that are less than every element in `Right`.
+     *
+     * @param right. The right hand side of a comparison left < right. This
+     * interval is the left hand side.
+     * @return 0 if Left = Right as sets, -1 if Left is a proper superset of
+     * Right, +1 otherwise
+     * @precondition is_satisfiable && right.is_satisfiable. In other words,
+     * this function is only for bounds of already-constructed Interval objects.
+     */
+    int compare_as_lower(Bound right) const {
+      // Check the precondition anyway.
+      // Could be converted to an NDEBUG-dependent assertion later.
+      if (!is_satisfiable_ || !right.is_satisfiable_) {
+        throw std::invalid_argument(
+            "Interval::Bound::compare_as_lower - "
+            "Non-satisfiable bounds are not comparable.");
+      }
+      // Assert: Both bounds are satisfiable
+      if (is_infinite_ || right.is_infinite_) {
+        return is_infinite_ ? (right.is_infinite_ ? 0 : -1) : +1;
+      }
+      // Assert: Bound bounds are finite.
+      T left_bound = bound_.value();
+      T right_bound = right.bound_.value();
+      if ((is_open_ && right.is_open_) || (is_closed_ && right.is_closed_)) {
+        /*
+         * When both bounds are the same type, comparison is the same as the
+         * underlying set.
+         */
+        return left_bound < right_bound ? -1 :
+                                          left_bound == right_bound ? 0 : +1;
+      }
+      if (is_open_ && right.is_closed_) {
+        if (right_bound <= left_bound) {
+          return +1;
+        }
+        if (Traits::adjacent(left_bound, right_bound)) {
+          return 0;
+        }
+        return -1;
+      }
+      // else: Left is closed and right is open
+      if (left_bound <= right_bound) {
+        return -1;
+      }
+      if (Traits::adjacent(right_bound, left_bound)) {
+        return 0;
+      }
+      return +1;
+    }
+
+    /**
+     * When comparing bound `left` and `right` as upper bounds, we are comparing
+     * intervals `Left = (-infinity,left` and `Right = (-infinity,right`. We
+     * want the inequality convention for bounds to follow that for elements of
+     * T, so that, say `Left < Right` when `x < y` (disregarding adjacency).
+     * This makes the less-than relationship on Bounds the subset relationship
+     * on their Intervals extended to infinity.
+     *
+     * @param right. The right hand side of a comparison left < right. This
+     * interval is the left hand side.
+     * @return 0 if Left = Right as sets, -1 if Left is a proper subset of
+     * Right, +1 otherwise
+     * @precondition is_satisfiable && right.is_satisfiable. In other words,
+     * this function is only for bounds of already-constructed Interval objects.
+     */
+    int compare_as_upper(Bound right) const {
+      // Check the precondition anyway.
+      // Could be converted to an NDEBUG-dependent assertion later.
+      if (!is_satisfiable_ || !right.is_satisfiable_) {
+        throw std::invalid_argument(
+            "Interval::Bound::compare_as_lower - "
+            "Non-satisfiable bounds are not comparable.");
+      }
+      // Assert: Both bounds are satisfiable
+      if (is_infinite_ || right.is_infinite_) {
+        return is_infinite_ ? (right.is_infinite_ ? 0 : +1) : -1;
+      }
+      // Assert: Bound bounds are finite.
+      T left_bound = bound_.value();
+      T right_bound = right.bound_.value();
+      if ((is_open_ && right.is_open_) || (is_closed_ && right.is_closed_)) {
+        /*
+         * When both bounds are the same type, comparison is the same as the
+         * underlying set.
+         */
+        return left_bound < right_bound ? -1 :
+                                          left_bound == right_bound ? 0 : +1;
+      }
+      if (is_open_ && right.is_closed_) {
+        /*
+         * ...,left) vs. ...,right]
+         *
+         * If `left == right`, then the open side (Left) does not contain the
+         * point `right` and the closed side (Right) does. In this case Left is
+         * a proper subset of Right and we return -1.
+         *
+         * For adjacency types, the sets are equal when `right` is adjacent to
+         * `left`. This requires `right < left`.
+         */
+        if (left_bound <= right_bound) {
+          return -1;
+        }
+        if (Traits::adjacent(right_bound, left_bound)) {
+          return 0;
+        }
+        return +1;
+      }
+      // else: Left is closed and right is open
+      if (left_bound >= right_bound) {
+        return +1;
+      }
+      if (Traits::adjacent(left_bound, right_bound)) {
+        return 0;
+      }
+      return -1;
+    }
+
+    /**
+     * When comparing bound `left` and `right` as upper bounds, we are comparing
+     * intervals `Left = (-infinity,left` and `Right = right,+infinity)`. We
+     * say that `Left < Right` if the sets are disjoint. If they are disjoint,
+     * they can be adjacent. The return value of this function captures these
+     * three possibilities.
+     *
+     * Note: This comparison is for bounds from different intervals. A different
+     * kind of mixed comparison would swap left and right. This isn't needed
+     * outside the constructor. For the analogue, see `adjust_bounds`.
+     *
+     * @return -1 if Left < Right and Left is not adjacent to Right. 0 if Left <
+     * Right and Left is adjacent to Right. +1 if Left and Right have a
+     * non-trivial intersection.
+     */
+    int compare_as_mixed(Bound right) const {
+      // Check the precondition anyway.
+      // Could be converted to an NDEBUG-dependent assertion later.
+      if (!is_satisfiable_ || !right.is_satisfiable_) {
+        throw std::invalid_argument(
+            "Interval::Bound::compare_as_lower - "
+            "Non-satisfiable bounds are not comparable.");
+      }
+      // Assert: Both bounds are satisfiable
+      if (is_infinite_ || right.is_infinite_) {
+        return +1;
+      }
+      // Assert: Bound bounds are finite.
+      T left_bound = bound_.value();
+      T right_bound = right.bound_.value();
+      if (is_open_ && right.is_open_) {
+        return left_bound <= right_bound ?
+                   -1 :
+                   Traits::adjacent(right_bound, left_bound) ? 0 : +1;
+      }
+      if (is_closed_ && right.is_closed_) {
+        return right_bound <= left_bound ?
+                   +1 :
+                   Traits::adjacent(left_bound, right_bound) ? 0 : -1;
+      }
+      /*
+       * Bounds are mixed
+       */
+      return left_bound < right_bound ? -1 : left_bound == right_bound ? 0 : +1;
+    }
+  };
+
+  /**
+   * A null bound from an argument.
+   */
+  static Bound BoundNull() {
+    return Bound(false, false);
+  }
+
+  /**
+   * An infinite bound from an argument.
+   */
+  static Bound BoundInfinity() {
+    return Bound(true, true);
+  }
+
+  /**
+   * Extract the lower bound from this interval.
+   */
+  Bound BoundLower() const {
+    return Bound(
+        lower_bound_, is_lower_open_, is_lower_closed_, is_lower_infinite_);
+  }
+
+  /**
+   * Extract the upper bound from this interval.
+   */
+  Bound BoundUpper() const {
+    return Bound(
+        upper_bound_, is_upper_open_, is_upper_closed_, is_upper_infinite_);
+  }
+
+  /**
+   * Standard constructor. All member variables of the class are constant; this
+   * constructor simply forwards all its arguments as initializers. Arguments
+   * must be checked in advance to ensure all the class invariants are
+   * satisfied, so it's not public.
+   *
+   * Note that the satisfiability member of a Bound is ignored here. It's used
+   * only when adjusting bounds, to create a empty set if a bound is not
+   * satisfiable.
+   *
+   * @precondition lower, upper are both ordered, non-exceptional elements
+   */
+  explicit Interval(Bound lower, Bound upper, bool empty, bool single) noexcept
+      : lower_bound_(lower.bound_)
+      , upper_bound_(upper.bound_)
+      , is_empty_(empty)
+      , has_single_point_(single)
+      , is_lower_open_(lower.is_open_)
+      , is_lower_closed_(lower.is_closed_)
+      , is_lower_infinite_(lower.is_infinite_)
+      , is_upper_open_(upper.is_open_)
+      , is_upper_closed_(upper.is_closed_)
+      , is_upper_infinite_(upper.is_infinite_) {
+  }
+
+  /**
+   * Interval constructor from the return value of an argument validator.
+   *
+   * @param x a tuple of lower and upper bounds and empty/single flags.
+   */
+  explicit Interval(tuple<Bound, Bound, bool, bool> x) noexcept
+      : Interval(
+            std::get<0>(x), std::get<1>(x), std::get<2>(x), std::get<3>(x)) {
+  }
+
+  /**
+   * Adjusts a pair of bounds into correct interval constructor arguments. Maps
+   * non-satisfiable bounds to empty intervals. Evaluates the single-point
+   * predicate.
+   *
+   * @param lower, upper. Ordinary elements of T. May not include extended or
+   * unordered elements.
+   * @return constructor arguments
+   *
+   * @precondition lower and upper bounds have been normalized
+   */
+  tuple<Bound, Bound, bool, bool> adjust_bounds(
+      Bound lower, Bound upper) noexcept {
+    if (!lower.is_satisfiable_ || !upper.is_satisfiable_) {
+      // If either of the bounds are not satisfiable, we have an empty set.
+      return {BoundNull(), BoundNull(), true, false};
+    }
+    if (lower.is_infinite_ || upper.is_infinite_) {
+      // If either bound is infinite, it's neither empty nor single-point.
+      return {lower, upper, false, false};
+    }
+
+    // Both bounds are neither empty nor infinite, so each has finite bounds.
+    T lower_value = lower.bound_.value();
+    T upper_value = upper.bound_.value();
+
+    if (lower_value > upper_value) {
+      //  If the lower bound is larger than the upper, it's always an empty set.
+      return {BoundNull(), BoundNull(), true, false};
+    }
+
+    if (lower_value == upper_value) {
+      if (lower.is_closed_ && upper.is_closed_) {
+        // Exactly one element can satisfy the inequalities.
+        return {lower, upper, false, true};
+      } else {
+        // The inequalities can't be simultaneously satisfied.
+        return {BoundNull(), BoundNull(), true, false};
+      }
+    }
+
+    /*
+     * We have the ordinary case where lower_value < upper_value.
+     *
+     * In only one case we still have the empty set, where we have an
+     * open interval and adjacent bounds. In all other cases the set is not
+     * empty.
+     *
+     * We have single-point sets in a handful of cases. If the interval is open,
+     * it has a single point when the bounds are twice-adjacent. If there
+     * interval is half-open on side and half-closed on the other, it has a
+     * single point when the bounds are adjacent.
+     */
+    if (lower.is_open_ && upper.is_open_) {
+      /*
+       * This is the only case where we need to calculate twice-adjacency, and
+       * we generically need to calculate adjacency at the same time.
+       */
+      auto [adjacent, twice_adjacent] =
+          Traits::adjacency(lower_value, upper_value);
+      if (adjacent) {
+        return {BoundNull(), BoundNull(), true, false};
+      } else {
+        return {lower, upper, false, twice_adjacent};
+      }
+    } else if (lower.is_closed_ && upper.is_closed_) {
+      // We have checked for the single-point case already.
+      return {lower, upper, false, false};
+    } else {
+      // Assert: This interval is half-open on side, half-closed on the other.
+      return {lower, upper, false, Traits::adjacent(lower_value, upper_value)};
+    }
+  }
+
+  /**
+   * Normalize a boundary value specified as either an open or closed bound of
+   * an interval. (In other words, this function is not called for
+   * infinite-marked bounds.) Unordered elements are rejected as invalid.
+   * Infinite elements are converted into an infinite boundary specification.
+   *
+   * This is the only part of the constructor machinery that originates an
+   * exception. It only happens when T has unordered elements (such as NaN) and
+   * one is passed as an argument.
+   *
+   * @param bound An arbitrary value of T
+   * @param is_closed True
+   * @param is_for_upper_bound
+   * @return bound, is_open, is_closed, is_infinite, not_satisfiable
+   *
+   * @precondition [in] bound is ordered. Throws if not.
+   * @postcondition [out] bound is an ordinary element and not infinite
+   */
+  Bound normalize_bound(T bound, bool is_closed, bool is_for_upper_bound) {
+    if constexpr (Traits::has_unordered_elements) {
+      if (!Traits::is_ordered(bound)) {
+        throw std::invalid_argument(
+            "Interval::constructor - "
+            "Unordered member is invalid as an interval bound");
+      }
+    }
+    if constexpr (!Traits::has_infinite_elements) {
+      return Bound(bound, is_closed);
+    } else {
+      if (Traits::is_finite(bound)) {
+        return Bound(bound, is_closed);
+      } else {
+        bool positive = Traits::is_infinity_positive(T(bound));
+        if ((is_for_upper_bound && !positive) ||
+            (!is_for_upper_bound && positive)) {
+          // We have either x < -infinity or +infinity < x, both of which
+          // represent the empty set.
+          return BoundNull();
+        }
+        // Otherwise we convert to an infinite bound
+        return BoundInfinity();
+      }
+    }
+  }
+
+ public:
+  /**
+   * Empty constructor is disabled.
+   */
+  Interval() = delete;
+
+  /**
+   * Default copy constructor
+   */
+  Interval(const Interval&) = default;
+
+  /**
+   * Default move constructor
+   */
+  Interval(Interval&&) noexcept = default;
+
+  /**
+   * Default copy assignment
+   */
+  Interval& operator=(const Interval&) = default;
+
+  /**
+   * Default move assignment
+   */
+  Interval& operator=(Interval&&) noexcept = default;
+
+  /**
+   * Empty set constructor.
+   *
+   * Empty sets may also be constructed with boundaries that define an empty
+   * set, such as the lower bound being greater than the upper bound. This
+   * constructor is for those situations where the user specifically intends
+   * the empty set as a value.
+   */
+  explicit Interval(const empty_set_t&) noexcept
+      : lower_bound_(nullopt)
+      , upper_bound_(nullopt)
+      , is_empty_(true)
+      , has_single_point_(false)
+      , is_lower_open_(false)
+      , is_lower_closed_(false)
+      , is_lower_infinite_(false)
+      , is_upper_open_(false)
+      , is_upper_closed_(false)
+      , is_upper_infinite_(false){};
+
+  /**
+   * Single-point set constructor.
+   *
+   * Single-point sets may also be constructed in another situation,
+   * specifically as a closed interval with equal upper and lower bounds.
+   */
+  Interval(const single_point_t&, T x)
+      : Interval(adjust_bounds(
+            normalize_bound(x, true, false), normalize_bound(x, true, true))){};
+
+  /**
+   * Finite set constructor: open
+   */
+  Interval(const open_t&, T lower, T upper, const open_t&)
+      : Interval(adjust_bounds(
+            normalize_bound(lower, false, false),
+            normalize_bound(upper, false, true))){};
+
+  /**
+   * Finite set constructor: half-open, half-closed
+   */
+  Interval(const open_t&, T lower, T upper, const closed_t&)
+      : Interval(adjust_bounds(
+            normalize_bound(lower, false, false),
+            normalize_bound(upper, true, true))){};
+
+  /**
+   * Finite set constructor: half-closed, half-open
+   */
+  Interval(const closed_t&, T lower, T upper, const open_t&)
+      : Interval(adjust_bounds(
+            normalize_bound(lower, true, false),
+            normalize_bound(upper, false, true))){};
+
+  /**
+   * Finite set constructor: closed
+   */
+  Interval(const closed_t&, T lower, T upper, const closed_t&)
+      : Interval(adjust_bounds(
+            normalize_bound(lower, true, false),
+            normalize_bound(upper, true, true))){};
+
+  /**
+   * Lower-infinite set constructor: upper half-open
+   */
+  Interval(const minus_infinity_t&, T upper, const open_t&)
+      : Interval(adjust_bounds(
+            BoundInfinity(), normalize_bound(upper, false, true))){};
+
+  /**
+   * Lower-infinite set constructor: upper half-closed
+   */
+  Interval(const minus_infinity_t&, T upper, const closed_t&)
+      : Interval(adjust_bounds(
+            BoundInfinity(), normalize_bound(upper, true, true))){};
+
+  /**
+   * Upper-infinite set constructor: lower half-open
+   */
+  Interval(const open_t&, T lower, const plus_infinity_t&)
+      : Interval(adjust_bounds(
+            normalize_bound(lower, false, false), BoundInfinity())){};
+
+  /**
+   * Upper-infinite set constructor: lower half-closed
+   */
+  Interval(const closed_t&, T lower, const plus_infinity_t&)
+      : Interval(adjust_bounds(
+            normalize_bound(lower, true, false), BoundInfinity())){};
+
+  /**
+   * Bi-infinite set constructor
+   */
+  Interval(const minus_infinity_t&, const plus_infinity_t&) noexcept
+      : lower_bound_(nullopt)
+      , upper_bound_(nullopt)
+      , is_empty_(false)
+      , has_single_point_(false)
+      , is_lower_open_(false)
+      , is_lower_closed_(false)
+      , is_lower_infinite_(true)
+      , is_upper_open_(false)
+      , is_upper_closed_(false)
+      , is_upper_infinite_(true){};
+
+  [[nodiscard]] bool lower_bound_has_value() const noexcept {
+    return lower_bound_.has_value();
+  }
+  [[nodiscard]] bool upper_bound_has_value() const noexcept {
+    return upper_bound_.has_value();
+  }
+  /**
+   * Accessor for the lower bound. Throws std::bad_optional_access if the
+   * lower bound is nullopt.
+   *
+   * @precondition lower_bound_has_value()
+   */
+  T lower_bound() const {
+    return lower_bound_.value();
+  }
+  /**
+   * Accessor for the upper bound. Throws std::bad_optional_access if the
+   * upper bound is nullopt.
+   *
+   * @precondition upper_bound_has_value()
+   */
+  T upper_bound() const {
+    return upper_bound_.value();
+  }
+  [[nodiscard]] bool is_empty() const noexcept {
+    return is_empty_;
+  }
+  [[nodiscard]] bool has_single_point() const noexcept {
+    return has_single_point_;
+  }
+  [[nodiscard]] bool is_lower_bound_open() const noexcept {
+    return is_lower_open_;
+  }
+  [[nodiscard]] bool is_lower_bound_closed() const noexcept {
+    return is_lower_closed_;
+  }
+  [[nodiscard]] bool is_lower_bound_infinite() const noexcept {
+    return is_lower_infinite_;
+  }
+  [[nodiscard]] bool is_upper_bound_open() const noexcept {
+    return is_upper_open_;
+  }
+  [[nodiscard]] bool is_upper_bound_closed() const noexcept {
+    return is_upper_closed_;
+  }
+  [[nodiscard]] bool is_upper_bound_infinite() const noexcept {
+    return is_upper_infinite_;
+  }
+  /**
+   * Predicate that an interval can be cut into two adjacent intervals, each
+   * of which is not empty. This predicate is equivalent to an interval having
+   * more than a single element.
+   */
+  [[nodiscard]] bool can_split_nontrivially() const noexcept {
+    return !is_empty_ && !has_single_point_;
+  }
+
+  /**
+   * Two intervals are equal if they are equal as sets.
+   *
+   * @param y The right-hand-side operand. This interval is the left-hand-side.
+   */
+  bool operator==(const Interval<T>& y) const {
+    if (is_empty_ && y.is_empty_) {
+      return true;
+    } else if (is_empty_ || y.is_empty_) {
+      return false;
+    }
+    return (BoundLower().compare_as_lower(y.BoundLower()) == 0) &&
+           (BoundUpper().compare_as_upper(y.BoundUpper()) == 0);
+  }
+
+  /**
+   * Compare to another interval. Convention is that this interval is the
+   * operand on the left side of and the argument is that on the right side.
+   *
+   * The first return value is a three-way comparison value. Return is -1 if
+   * this interval is disjoint and less than the argument. Return is +1 if this
+   * interval is disjoint and greater than the argument. Return is 0 if this
+   * interval and the argument have a non-empty intersection. The empty interval
+   * is excluded from comparison.
+   *
+   * The second return value is a predicate that the intervals are adjacent. If
+   * the first return is 0, then the second is always false, since intersecting
+   * sets cannot be adjacent.
+   *
+   * Has much of the same logic as `interval_union`, but neither is reducible
+   * to the other.
+   */
+  template <class T>
+  tuple<int, bool> compare(const Interval<T>& y) const {
+    if (is_empty_) {
+      throw std::domain_error(
+          "Interval::compare - "
+          "The empty set cannot be compared");
+    } else if (y.is_empty_) {
+      throw std::invalid_argument(
+          "Interval::compare - "
+          "The empty set cannot be compared");
+    }
+
+    // Calculate which of the two lower bounds is smaller than the other.
+    Bound left_lower = BoundLower();
+    Bound right_lower = y.BoundLower();
+    int c_lower = left_lower.compare_as_lower(right_lower);
+    // Calculate which of the two upper bounds is larger than the other.
+    Bound left_upper = BoundUpper();
+    Bound right_upper = y.BoundUpper();
+    int c_upper = left_upper.compare_as_upper(right_upper);
+    /*
+     * Compare the greatest lower bound with the least upper bound. If the
+     * result is positive, the intervals intersect.
+     */
+    Bound least_upper_bound = c_upper < 0 ? left_upper : right_upper;
+    Bound greatest_lower_bound = c_lower < 0 ? right_lower : left_lower;
+    int c_middle = least_upper_bound.compare_as_mixed(greatest_lower_bound);
+    if (c_middle > 0) {
+      return {0, false};
+    }
+    /*
+     * At this point the intervals are disjoint, so we can use the comparison
+     * for either upper or lower bounds; they're the same in this situation.
+     *
+     * If c_middle is zero, the intervals are adjacent.
+     */
+    return {c_lower < 0 ? -1 : +1, c_middle == 0};
+  }
+
+  /**
+   * Membership predicate that the argument is an element of the interval.
+   */
+  bool is_member(T x) noexcept {
+    if constexpr (Traits::has_unordered_elements) {
+      if (!Traits::is_ordered(x)) {
+        // An unordered element is not a member of any interval.
+        return false;
+      }
+    }
+    if (is_empty_) {
+      // No element is a member of the empty set.
+      return false;
+    }
+    // Check that the lower bound is satisfied.
+    if (!is_lower_infinite_ && x < lower_bound_) {
+      return false;
+    }
+    if (is_lower_open_ && x == lower_bound_) {
+      return false;
+    }
+    // Check that the upper bound is satisfied.
+    if (!is_upper_infinite_ && upper_bound_ < x) {
+      return false;
+    }
+    if (is_upper_open_ && upper_bound_ == x) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * A three-way analog to `is_member`. Unlike that function, this one can have
+   * invalid arguments. There's also a restriction on the domain; this interval
+   * must not be empty, because we have no way of returning a meaningful result
+   * in that case.
+   *
+   * @return 0 if is_member(x). negative if x is less than every member of this
+   * interval. positive if x is greater than every member of this interval.
+   *
+   * @precondition This interval must not be empty.
+   * @precondition Argument must be an ordered element.
+   */
+  int compare(T x) {
+    if constexpr (Traits::has_unordered_elements) {
+      if (!Traits::is_ordered(x)) {
+        // An unordered element is not a member of any interval.
+        throw std::invalid_argument(
+            "Interval::compare - "
+            "Unordered element cannot be compared.");
+      }
+    }
+    if (is_empty_) {
+      /*
+       * The definition of < is universally quantified over set members. An
+       * empty universal quantifier is always true, so for any interval I, both
+       * ∅ < I and I < ∅. Since we can't return both +1 and -1 simultaneously,
+       * we've excluded the empty set from the domain of this function.
+       */
+      throw std::domain_error(
+          "Interval::compare - "
+          "Empty set cannot be compared.");
+    }
+    // Check that the lower bound is satisfied. Return early if one is not.
+    if (!is_lower_infinite_ && x < lower_bound_) {
+      return -1;
+    }
+    if (is_lower_open_ && x == lower_bound_) {
+      return -1;
+    }
+    // Check that the upper bound is satisfied.
+    if (!is_upper_infinite_ && upper_bound_ < x) {
+      return +1;
+    }
+    if (is_upper_open_ && upper_bound_ == x) {
+      return +1;
+    }
+    return 0;
+  }
+
+  /**
+   * Calculate the intersection of another interval with this one.
+   */
+  Interval<T> intersection(Interval<T> y) {
+    /*
+     * The empty set always has an empty intersection.
+     */
+    if (is_empty_ || y.is_empty_) {
+      return Interval(empty_set);
+    }
+    /*
+     * Because of adjacency, the bounds may be equal as sets but have different
+     * representations. If this is the case, prefer a closed bound. A closed
+     * bound has a greater value as a lower bound, what we want on the lower
+     * side. An closed bound has a lesser value as an upper bound, what we want
+     * on the upper side.
+     */
+    // Calculate which of the two lower bounds is larger than the other.
+    Bound a = BoundLower();
+    Bound b = y.BoundLower();
+    int c = a.compare_as_lower(b);
+    Bound greatest_lower_bound = (c < 0 || (c == 0 && b.is_closed_)) ? b : a;
+    // Calculate which of the two upper bounds is smaller than the other.
+    a = BoundUpper();
+    b = y.BoundUpper();
+    c = a.compare_as_upper(b);
+    Bound least_upper_bound = (c < 0 || (c == 0 && a.is_closed_)) ? a : b;
+    // Adjust the bounds as normal. Empty intersection is calculated here.
+    return Interval(adjust_bounds(greatest_lower_bound, least_upper_bound));
+  }
+
+  /**
+   * Calculate the union of another interval with this one.
+   *
+   * The set union of two intervals is always a set, but it's not always an
+   * interval. This function calculates a union when the result is an interval
+   * and returns `{false,nullopt}` when it's not.
+   *
+   * We can't call this function `union` because it's a reserved word.
+   */
+  tuple<bool, optional<Interval<T>>> interval_union(Interval<T> y) {
+    /*
+     * An empty set gives the identity function on the other operand.
+     */
+    if (is_empty_) {
+      return {true, y};
+    }
+    if (y.is_empty_) {
+      return {true, *this};
+    }
+    // Calculate which of the two lower bounds is smaller than the other.
+    Bound left_lower = BoundLower();
+    Bound right_lower = y.BoundLower();
+    int c_lower = left_lower.compare_as_lower(right_lower);
+    // Calculate which of the two upper bounds is larger than the other.
+    Bound left_upper = BoundUpper();
+    Bound right_upper = y.BoundUpper();
+    int c_upper = left_upper.compare_as_upper(right_upper);
+    /*
+     * Compare the greatest lower bound with the least upper bound. If they're
+     * separable, the union isn't defined. We don't need to favor closed bounds,
+     * since they don't appear in the result.
+     */
+    Bound greatest_lower_bound = c_lower < 0 ? right_lower : left_lower;
+    Bound least_upper_bound = c_upper < 0 ? left_upper : right_upper;
+    if (least_upper_bound.compare_as_mixed(greatest_lower_bound) < 0) {
+      return {false, nullopt};
+    }
+    Bound least_lower_bound =
+        (c_lower < 0 || (c_lower == 0 && left_lower.is_closed_)) ? left_lower :
+                                                                   right_lower;
+    Bound greatest_upper_bound =
+        (c_upper < 0 || (c_upper == 0 && right_upper.is_closed_)) ?
+            right_upper :
+            left_upper;
+    return {true,
+            Interval(adjust_bounds(least_lower_bound, greatest_upper_bound))};
+  }
+
+  /**
+   * Cut this interval into two pieces at a given point.
+   *
+   * The default result is a pair of intersections of this interval with
+   * `(-infinity,cut_point)` and `[cut_point,+infinity)`. If this interval is
+   * empty, then both results are empty. If this interval is not empty, then
+   * all the points of this interval are in one of the two results, and at most
+   * one of the resulting intervals may be empty.
+   *
+   * The non-default result intersects with `(-infinity,cut_point]` and
+   * `(cut_point,+infinity)`. It's the same but for the cut point, which moves
+   * to the other side if it's an element of this interval.
+   *
+   * @param cut_point. An arbitrary point of T; it does not need to be a member
+   * of this interval.
+   *
+   * @param lower_open_upper_closed. If true, cut with `(-infinity,cut_point)`
+   * and `[cut_point,+infinity)`. If false, cut with `(-infinity,cut_point]`
+   * and `(cut_point,+infinity)`.
+   */
+  tuple<Interval<T>, Interval<T>> cut(
+      T cut_point, bool lower_open_upper_closed = true) {
+    if (is_empty_) {
+      /**
+       * The empty set always splits into two empty sets.
+       */
+      return {Interval<T>(empty_set), Interval<T>(empty_set)};
+    }
+    // Assert: This interval is not empty.
+    // This is a precondition for calling `compare_three_way` below.
+
+    if constexpr (Traits::has_unordered_elements) {
+      if (!Traits::is_ordered(cut_point)) {
+        throw std::invalid_argument(
+            "Interval::cut - "
+            "Unordered element invalid as a cut point.");
+      }
+    }
+    // Assert: cut_point is an ordered element
+    // This is a precondition for calling `compare_three_way` below.
+
+    int c;
+    if constexpr (Traits::has_infinite_elements) {
+      if (Traits::is_finite(cut_point)) {
+        c = compare(cut_point);
+      } else {
+        /*
+         * The two intervals for a positive infinite cut point are the whole set
+         * (below) and the empty set (above); the order is reversed for negative
+         * infinite. The result case is like the cut point being outside the
+         * interval, but the outcome does not depend on set membership.
+         */
+        c = Traits::is_infinity_positive(cut_point) ? +1 : -1;
+      }
+      // Assert: c == 0 \implies cut_point is finite
+    } else {
+      c = compare(cut_point);
+      // Assert: cut_point is finite
+    }
+    // Assert: c == 0 \implies cut_point is finite
+
+    /*
+     * A cut at a non-member element returns this interval and an empty
+     * interval, the order depending on whether the cut point is above or
+     * below the interval.
+     */
+    if (c > 0) {
+      return {*this, Interval<T>(empty_set)};
+    } else if (c < 0) {
+      return {Interval<T>(empty_set), *this};
+    }
+    // Assert: c == 0 and thus cut_point is finite
+    // Assert: c == 0 and thus cut_point is a member of this interval
+
+    return {Interval(adjust_bounds(
+                BoundLower(), Bound(cut_point, !lower_open_upper_closed))),
+            Interval(adjust_bounds(
+                Bound(cut_point, lower_open_upper_closed), BoundUpper()))};
+  }
+
+};  // namespace tiledb::common
+
+}  // namespace tiledb::common
+
+#endif  // TILEDB_INTERVAL_H

--- a/tiledb/common/interval/interval.h
+++ b/tiledb/common/interval/interval.h
@@ -400,21 +400,23 @@ struct TypeTraits<
 struct IntervalBase {
   /** Marks a constructor for the empty set */
   static constexpr class empty_set_t {
-  } empty_set;
+  } empty_set = empty_set_t();
   /** Marks a constructor for a single-point set */
   static constexpr class single_point_t {
-  } single_point;
+  } single_point = single_point_t();
   /** Marks a boundary as open in a constructor */
   static constexpr class open_t {
-  } open;
+  } open = open_t();
   /** Marks a boundary as closed in a constructor */
   static constexpr class closed_t {
-  } closed;
+  } closed = closed_t();
   /** Mark a lower boundary as infinite (i.e. not present) */
   static constexpr class minus_infinity_t {
-  } minus_infinity;
+  } minus_infinity = minus_infinity_t();
   /** Mark an upper boundary as infinite (i.e. not present) */
-  static constexpr class plus_infinity_t { } plus_infinity; };
+  static constexpr class plus_infinity_t {
+  } plus_infinity = plus_infinity_t();
+};
 
 }  // namespace detail
 

--- a/tiledb/common/interval/interval.h
+++ b/tiledb/common/interval/interval.h
@@ -232,11 +232,13 @@
 #ifndef TILEDB_INTERVAL_H
 #define TILEDB_INTERVAL_H
 
+#include <cmath>
 #include <optional>
 #include <stdexcept>
 #include <tuple>
 
-using std::tuple, std::optional, std::nullopt;
+using std::tuple, std::optional, std::nullopt, std::isnan, std::isinf,
+    std::isfinite;
 
 namespace tiledb::common {
 namespace detail {
@@ -1200,7 +1202,6 @@ class Interval : public detail::IntervalBase {
    * Has much of the same logic as `interval_union`, but neither is reducible
    * to the other.
    */
-  template <class T>
   tuple<int, bool> compare(const Interval<T>& y) const {
     if (is_empty_) {
       throw std::domain_error(

--- a/tiledb/common/interval/test/main.cc
+++ b/tiledb/common/interval/test/main.cc
@@ -74,9 +74,9 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-        "Interval/TestTypeTraits - Floating-point not-finite elements",
-        "[interval]",
-        TypesUnderTest) {
+    "Interval/TestTypeTraits - Floating-point not-finite elements",
+    "[interval]",
+    TypesUnderTest) {
   typedef TestType T;
   typedef Interval<T> I;
   typedef TestTypeTraits<T> Tr;
@@ -90,4 +90,3 @@ TEMPLATE_LIST_TEST_CASE(
     CHECK(isnan(Tr::NaN));
   }
 }
-

--- a/tiledb/common/interval/test/main.cc
+++ b/tiledb/common/interval/test/main.cc
@@ -78,15 +78,14 @@ TEMPLATE_LIST_TEST_CASE(
     "[interval]",
     TypesUnderTest) {
   typedef TestType T;
-  typedef Interval<T> I;
   typedef TestTypeTraits<T> Tr;
 
   if constexpr (std::is_floating_point_v<T>) {
     // Verify that we've defined non-numeric traits correctly
-    CHECK(isinf(T(Tr::positive_infinity)));
+    CHECK(std::isinf(T(Tr::positive_infinity)));
     CHECK(Tr::positive_infinity > 0);
-    CHECK(isinf(Tr::negative_infinity));
+    CHECK(std::isinf(Tr::negative_infinity));
     CHECK(Tr::negative_infinity < 0);
-    CHECK(isnan(Tr::NaN));
+    CHECK(std::isnan(Tr::NaN));
   }
 }

--- a/tiledb/common/interval/test/main.cc
+++ b/tiledb/common/interval/test/main.cc
@@ -1,0 +1,93 @@
+/**
+ * @file main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()` for Interval tests, for independent
+ * compilation away from any larger test suite. It also provides tests for
+ * support code within `unit_interval.h`.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <cmath>
+#include "unit_interval.h"
+
+/*
+ * The type lists need to be in sorted order for the tests to be valid.
+ *
+ * When you're not careful about rounding, you can inadvertently create values
+ * that look distinct but actually are not.
+ */
+TEMPLATE_LIST_TEST_CASE(
+    "Interval/Test - Sorted, distinct values in test lists",
+    "[interval]",
+    TypesUnderTest) {
+  typedef TestType T;
+  typedef TestTypeTraits<T> Tr;
+
+  SECTION("outer") {
+    std::vector v(Tr::outer);
+    REQUIRE(v.size() >= 1);
+    size_t n = v.size() - 1;
+    for (unsigned int j = 0; j < n; ++j) {
+      CHECK(v[j] != v[j + 1]);
+      if (v[j] != v[j + 1]) {
+        CHECK(v[j] < v[j + 1]);
+      }
+    }
+  }
+  SECTION("inner") {
+    std::vector v(Tr::inner);
+    REQUIRE(v.size() >= 1);
+    size_t n = v.size() - 1;
+    for (unsigned int j = 0; j < n; ++j) {
+      CHECK(v[j] != v[j + 1]);
+      if (v[j] != v[j + 1]) {
+        CHECK(v[j] < v[j + 1]);
+      }
+    }
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE(
+        "Interval/TestTypeTraits - Floating-point not-finite elements",
+        "[interval]",
+        TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef TestTypeTraits<T> Tr;
+
+  if constexpr (std::is_floating_point_v<T>) {
+    // Verify that we've defined non-numeric traits correctly
+    CHECK(isinf(T(Tr::positive_infinity)));
+    CHECK(Tr::positive_infinity > 0);
+    CHECK(isinf(Tr::negative_infinity));
+    CHECK(Tr::negative_infinity < 0);
+    CHECK(isnan(Tr::NaN));
+  }
+}
+

--- a/tiledb/common/interval/test/unit_interval.h
+++ b/tiledb/common/interval/test/unit_interval.h
@@ -49,9 +49,9 @@ inline bool implies(bool x, bool y) {
   return !x || y;
 }
 
-//=======================================================
-// class WhiteboxInterval
-//=======================================================
+/* ******************************** */
+/*       class WhiteboxInterval     */
+/* ******************************** */
 
 // forward declaration
 template <class T>
@@ -140,23 +140,21 @@ class WhiteboxInterval : public Interval<T> {
 
 }  // namespace tiledb::common
 
-//=======================================================
-// Types under test
-//=======================================================
+/* ******************************** */
+/*          Types under rest        */
+/* ******************************** */
 
 /**
  * List of types used to instantiate generic test cases
  */
 typedef tuple<uint16_t, uint64_t, int16_t, double> TypesUnderTest;
 
-//==================================
 /**
  * Test type traits allow generic instantiation by Catch from a list of types.
  */
 template <class T, class Enable = T>
 class TestTypeTraits;
 
-//==================================
 /**
  * Test traits for unsigned integral values
  */
@@ -174,7 +172,6 @@ class TestTypeTraits<
       0, 1, 2, 3, 99, 100, 101, max - 1, max};
 };
 
-//==================================
 /**
  * Test traits for signed integral values
  */
@@ -193,7 +190,6 @@ class TestTypeTraits<
       min, min + 1, -101, -100, -99, -2, -1, 0, 1, 2, 3, max - 1, max};
 };
 
-//==================================
 /**
  * Test traits for unsigned integral values
  */
@@ -237,9 +233,9 @@ class TestTypeTraits<
   static constexpr T NaN = std::numeric_limits<T>::quiet_NaN();
 };
 
-//=======================================================
-// is_adjacent
-//=======================================================
+/* ******************************** */
+/*             is_adjacent          */
+/* ******************************** */
 
 /**
  * Independent access to adjacency testing
@@ -256,9 +252,9 @@ bool is_adjacent([[maybe_unused]] T x, [[maybe_unused]] T y) {
   }
 }
 
-//=======================================================
-// Choose generator for Catch
-//=======================================================
+/* ******************************** */
+/*   Choose generator for Catch     */
+/* ******************************** */
 
 /**
  * A generator for Catch. Given a list L and a number K, it generates every way
@@ -371,9 +367,9 @@ choose(unsigned int k, std::initializer_list<T> list) {
       std::make_unique<ChooseGenerator<T>>(k, list));
 }
 
-//=======================================================
-// Verification of class invariants
-//=======================================================
+/* ************************************ */
+/*   Verification of class invariants   */
+/* ************************************ */
 
 /**
  * Checks that all the class invariants of an Interval object are satisfied.

--- a/tiledb/common/interval/test/unit_interval.h
+++ b/tiledb/common/interval/test/unit_interval.h
@@ -34,9 +34,10 @@
 #ifndef TILEDB_UNIT_INTERVAL_H
 #define TILEDB_UNIT_INTERVAL_H
 
-#include <cmath>
-
 #include <catch.hpp>
+#include <cmath>
+#include <optional>
+
 #include "../interval.h"
 using namespace tiledb::common;
 
@@ -243,8 +244,9 @@ class TestTypeTraits<
 /**
  * Independent access to adjacency testing
  */
+
 template <class T>
-bool is_adjacent(T x, T y) {
+bool is_adjacent([[maybe_unused]] T x, [[maybe_unused]] T y) {
   if constexpr (std::is_integral_v<T>) {
     return (x < std::numeric_limits<T>::max()) && x + 1 == y;
   } else if constexpr (std::is_floating_point_v<T>) {
@@ -295,8 +297,8 @@ class ChooseGenerator : public Catch::Generators::IGenerator<std::vector<T>> {
       , list_(list)
       , finished(false)
       , n_(list.size())
-      , it(k_ + 1)
-      , rv(k_) {
+      , rv(k_)
+      , it(k_ + 1) {
     if (n_ < k) {
       // We can't choose more elements than we have.
       throw std::invalid_argument(
@@ -341,7 +343,7 @@ class ChooseGenerator : public Catch::Generators::IGenerator<std::vector<T>> {
     return true;
   }
 
-  value_type const& get() const {
+  value_type const& get() const override {
     if constexpr (true) {
       for (unsigned int j = 0; j < k_; ++j) {
         rv[j] = T();

--- a/tiledb/common/interval/test/unit_interval.h
+++ b/tiledb/common/interval/test/unit_interval.h
@@ -1,0 +1,494 @@
+/**
+ * @file   unit_interval.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines common test functions for class Interval and its supporting
+ * classes.
+ */
+
+#ifndef TILEDB_UNIT_INTERVAL_H
+#define TILEDB_UNIT_INTERVAL_H
+
+#include <cmath>
+
+#include <catch.hpp>
+#include "../interval.h"
+using namespace tiledb::common;
+
+inline bool iff(bool x, bool y) {
+  return (x && y) || (!x && !y);
+}
+
+inline bool implies(bool x, bool y) {
+  return !x || y;
+}
+
+//=======================================================
+// class WhiteboxInterval
+//=======================================================
+
+// forward declaration
+template <class T>
+void test_interval_invariants(const Interval<T>&);
+
+namespace tiledb::common {
+
+template <class T>
+class WhiteboxInterval : public Interval<T> {
+  typedef Interval<T> Base;
+
+ public:
+  typedef typename Base::Bound Bound;
+
+  explicit WhiteboxInterval(Interval<T> x)
+      : Base(x) {
+    /*
+     * We could check the class invariants here, but we'll leave that to the
+     * constructor tests.
+     */
+  }
+
+  explicit operator Interval<T>() {
+    return *this;
+  }
+
+  void check_equality(Interval<T> expected) {
+    if (expected.is_empty()) {
+      CHECK(Base::is_empty_);
+    } else if (Base::is_empty_) {
+      CHECK(expected.Base::is_empty_);  // will fail
+    } else {
+      // Both z and z1 are not empty
+      CHECK(*this == expected);
+      CHECK(iff(Base::has_single_point_, expected.Base::has_single_point_));
+      // Lower
+      CHECK(iff(Base::is_lower_infinite_, expected.Base::is_lower_infinite_));
+      CHECK(iff(Base::is_lower_open_, expected.Base::is_lower_open_));
+      CHECK(iff(Base::is_lower_closed_, expected.Base::is_lower_closed_));
+      if (!Base::is_lower_infinite_ && !expected.Base::is_lower_infinite_) {
+        CHECK(
+            Base::lower_bound_.value() == expected.Base::lower_bound_.value());
+      }
+      // Upper
+      CHECK(iff(Base::is_upper_infinite_, expected.Base::is_upper_infinite_));
+      CHECK(iff(Base::is_upper_open_, expected.Base::is_upper_open_));
+      CHECK(iff(Base::is_upper_closed_, expected.Base::is_upper_closed_));
+      if (!Base::is_upper_infinite_ && !expected.Base::is_upper_infinite_) {
+        CHECK(
+            Base::upper_bound_.value() == expected.Base::upper_bound_.value());
+      }
+    }
+  }
+
+  WhiteboxInterval<T> intersection(WhiteboxInterval<T> y) {
+    auto z = WhiteboxInterval<T>(Base::intersection(y));
+    auto z1 = y.Base::intersection(*this);
+    z.check_equality(z1);
+    return z;
+  }
+
+  tuple<bool, optional<WhiteboxInterval<T>>> interval_union(
+      WhiteboxInterval<T> y) {
+    auto [b, z] = Base::interval_union(y);
+    auto [b1, z1] = y.Base::interval_union(*this);
+    CHECK(iff(b, b1));
+    if (b && b1) {
+      WhiteboxInterval<T> zv(z.value());
+      zv.check_equality(z1.value());
+      return {true, zv};
+    } else {
+      return {false, nullopt};
+    }
+  }
+
+  static Bound finite_bound(T x, bool is_closed) {
+    return Bound(x, is_closed);
+  }
+  static Bound infinite_bound() {
+    return Base::BoundInfinity();
+  }
+  static Bound emptyset_bound() {
+    return Base::BoundNull;
+  }
+};
+
+}  // namespace tiledb::common
+
+//=======================================================
+// Types under test
+//=======================================================
+
+/**
+ * List of types used to instantiate generic test cases
+ */
+typedef tuple<uint16_t, uint64_t, int16_t, double> TypesUnderTest;
+
+//==================================
+/**
+ * Test type traits allow generic instantiation by Catch from a list of types.
+ */
+template <class T, class Enable = T>
+class TestTypeTraits;
+
+//==================================
+/**
+ * Test traits for unsigned integral values
+ */
+template <class T>
+class TestTypeTraits<
+    T,
+    typename std::enable_if<
+        std::is_integral_v<T> && std::is_unsigned_v<T>,
+        T>::type> {
+  static constexpr auto max = std::numeric_limits<T>::max();
+
+ public:
+  static constexpr std::initializer_list<T> outer = {
+      0, 1, 2, 100, max - 1, max};
+  static constexpr std::initializer_list<T> inner = {
+      0, 1, 2, 3, 99, 100, 101, max - 1, max};
+};
+
+//==================================
+/**
+ * Test traits for signed integral values
+ */
+template <class T>
+class TestTypeTraits<
+    T,
+    typename std::enable_if<
+        std::is_integral_v<T> && std::is_signed_v<T>,
+        T>::type> {
+  static constexpr auto min = std::numeric_limits<T>::min();
+  static constexpr auto max = std::numeric_limits<T>::max();
+
+ public:
+  static constexpr std::initializer_list<T> outer = {
+      min, min + 1, -100, 0, 1, 2, 100, max - 1, max};
+  static constexpr std::initializer_list<T> inner = {
+      min, min + 1, -101, -100, -99, -2, -1, 0, 1, 2, 3, max - 1, max};
+};
+
+//==================================
+/**
+ * Test traits for unsigned integral values
+ */
+template <class T>
+class TestTypeTraits<
+    T,
+    typename std::enable_if<std::is_floating_point_v<T>, T>::type> {
+  /*
+   * We can't just add or subract 1.0 to extreme limits because it's small
+   * enough to disappear after rounding. Instead, `almost_one` is the largest
+   * mantissa that's less than one.
+   *
+   * We might have used std::nextafter(), but it's not declared constexpr and
+   * thus can't be evaluated within a static constexpr initializer.
+   */
+  static constexpr T almost_one = 1.0 - std::numeric_limits<T>::epsilon();
+  static constexpr T min = std::numeric_limits<T>::lowest();
+  static constexpr T almost_min = min * almost_one;
+  static constexpr T max = std::numeric_limits<T>::max();
+  static constexpr T almost_max = max * almost_one;
+
+ public:
+  static constexpr std::initializer_list<T> outer = {
+      min, almost_min, -100.0, 0.0, 1.0, 2.0, 100.0, almost_max, max};
+  static constexpr std::initializer_list<T> inner = {min,
+                                                     almost_min,
+                                                     -100.01,
+                                                     -100.0,
+                                                     -99.99,
+                                                     -2.0,
+                                                     -1.0,
+                                                     0,
+                                                     0.9,
+                                                     1.0,
+                                                     1.1,
+                                                     almost_max,
+                                                     max};
+
+  static constexpr T positive_infinity = std::numeric_limits<T>::infinity();
+  static constexpr T negative_infinity = -1.0 * positive_infinity;
+  static constexpr T NaN = std::numeric_limits<T>::quiet_NaN();
+};
+
+//=======================================================
+// is_adjacent
+//=======================================================
+
+/**
+ * Independent access to adjacency testing
+ */
+template <class T>
+bool is_adjacent(T x, T y) {
+  if constexpr (std::is_integral_v<T>) {
+    return (x < std::numeric_limits<T>::max()) && x + 1 == y;
+  } else if constexpr (std::is_floating_point_v<T>) {
+    return false;
+  } else {
+    REQUIRE((false && "unsupported type"));
+  }
+}
+
+//=======================================================
+// Choose generator for Catch
+//=======================================================
+
+/**
+ * A generator for Catch. Given a list L and a number K, it generates every way
+ * of choosing K elements from L. Each generated subset of L is in the same
+ * order as the elements appear in L.
+ *
+ * @tparam T The underlying type that we're choosing from.
+ */
+template <class T>
+class ChooseGenerator : public Catch::Generators::IGenerator<std::vector<T>> {
+  unsigned int k_;
+  const std::vector<T> list_;
+  bool finished;
+  /// The length of the list to draw from.
+  size_t n_;
+  /**
+   * Return value for the generator. Catch needs a generator to return
+   * references, so we need something to reference.
+   */
+  mutable std::vector<T> rv;
+
+  /**
+   * A list of iterators of length `k_ + 1`. The last entry in the list always
+   * contains `list_.cend()`. The iteration preserves list order because the
+   * iterators always remain in sorted order.
+   *
+   * @invariant i < j \implies it[i] is prior to it[j]
+   */
+  std::vector<typename decltype(list_)::const_iterator> it;
+
+ public:
+  typedef std::vector<T> value_type;
+
+  ChooseGenerator(unsigned int k, std::initializer_list<T> list)
+      : k_(k)
+      , list_(list)
+      , finished(false)
+      , n_(list.size())
+      , it(k_ + 1)
+      , rv(k_) {
+    if (n_ < k) {
+      // We can't choose more elements than we have.
+      throw std::invalid_argument(
+          "ChooseGenerator - "
+          "asking for more choices than there are possibilities");
+    }
+    // Initialize the iterators
+    it[0] = list_.cbegin();
+    for (unsigned int j = 1; j < k_; ++j) {
+      it[j] = it[j - 1];
+      ++it[j];
+    }
+    it[k_] = list_.cend();
+  }
+
+  bool next() override {
+    unsigned int j;
+    /*
+     * Try incrementing from the back end until we can increment without bumping
+     * up against the next one in line.
+     */
+    for (j = k_; j > 0; --j) {
+      auto x = it[j - 1];
+      ++x;
+      if (x != it[j]) {
+        it[j - 1] = x;
+        break;
+      }
+    }
+    if (j == 0) {
+      // We can't move forward any more
+      return false;
+    }
+    /*
+     * Reinitialize the starting sequence starting with the one after the
+     * successful increment.
+     */
+    for (; j < k_; ++j) {
+      it[j] = it[j - 1];
+      ++it[j];
+    }
+    return true;
+  }
+
+  value_type const& get() const {
+    if constexpr (true) {
+      for (unsigned int j = 0; j < k_; ++j) {
+        rv[j] = T();
+      }
+    }
+    for (unsigned int j = 0; j < k_; ++j) {
+      rv[j] = *it[j];
+    }
+    return rv;
+  }
+};
+
+/**
+ * Factory for `ChooseGenerator` as the Catch framework requires to consume it.
+ * @tparam T The underlying type that we're choosing from.
+ * @param k The number of element of `list` to choose from.
+ * @param list The list from which elements are taken.
+ * @return An instance of `ChooseGenerator` wrapped as Catch requires.
+ */
+template <class T>
+Catch::Generators::GeneratorWrapper<typename ChooseGenerator<T>::value_type>
+choose(unsigned int k, std::initializer_list<T> list) {
+  return Catch::Generators::GeneratorWrapper<
+      typename ChooseGenerator<T>::value_type>(
+      std::make_unique<ChooseGenerator<T>>(k, list));
+}
+
+//=======================================================
+// Verification of class invariants
+//=======================================================
+
+/**
+ * Checks that all the class invariants of an Interval object are satisfied.
+ *
+ * Note that the checks here are made in the same order that they're documented
+ * in the code. This is for ease of auditing that all the invariants are checked
+ * in this function.
+ *
+ * @tparam T Type for Interval<T>
+ * @param x The object under test
+ */
+template <class T>
+void test_interval_invariants(const Interval<T>& x) {
+  typedef detail::TypeTraits<T> Traits;
+
+  CHECK(
+      iff(x.lower_bound_has_value(),
+          x.is_lower_bound_open() || x.is_lower_bound_closed()));
+
+  CHECK(
+      iff(x.upper_bound_has_value(),
+          x.is_upper_bound_open() || x.is_upper_bound_closed()));
+
+  if (x.is_empty()) {
+    CHECK(!x.has_single_point());
+    CHECK(!x.is_lower_bound_open());
+    CHECK(!x.is_lower_bound_closed());
+    CHECK(!x.is_lower_bound_infinite());
+    CHECK(!x.is_upper_bound_open());
+    CHECK(!x.is_upper_bound_closed());
+    CHECK(!x.is_upper_bound_infinite());
+    CHECK(!x.lower_bound_has_value());
+    CHECK(!x.upper_bound_has_value());
+  }
+
+  if (x.has_single_point()) {
+    CHECK(!x.is_empty());
+    CHECK(!x.is_lower_bound_infinite());
+    REQUIRE(x.lower_bound_has_value());
+    CHECK(!x.is_upper_bound_infinite());
+    REQUIRE(x.upper_bound_has_value());
+    T a = x.lower_bound(), b = x.upper_bound();
+    if (x.is_lower_bound_closed() && x.is_upper_bound_closed()) {
+      REQUIRE(a == b);
+    } else if (
+        (x.is_lower_bound_open() && x.is_upper_bound_closed()) ||
+        (x.is_lower_bound_closed() && x.is_upper_bound_open())) {
+      if constexpr (std::is_integral_v<T>) {
+        REQUIRE(a < b);
+        CHECK(a + 1 == b);
+        CHECK(Traits::adjacent(a, b));
+      } else if constexpr (std::is_floating_point_v<T>) {
+        REQUIRE(
+            (false && "single-point intervals for floating point are closed"));
+      } else {
+        REQUIRE((false && "unknown type"));
+      }
+    } else if (x.is_lower_bound_open() && x.is_upper_bound_open()) {
+      if constexpr (std::is_integral_v<T>) {
+        auto [adj1, adj2] = Traits::adjacency(a, b);
+        REQUIRE(a < b);
+        CHECK(a + 1 == b - 1);
+        CHECK(adj2);
+        CHECK_FALSE(adj1);
+      } else if constexpr (std::is_floating_point_v<T>) {
+        REQUIRE(
+            (false && "single-point intervals for floating point are closed"));
+      } else {
+        REQUIRE((false && "unknown type"));
+      }
+    } else {
+      REQUIRE(false);  // logic error
+    }
+  }
+
+  if (x.is_lower_bound_open()) {
+    CHECK(!x.is_lower_bound_closed());
+    CHECK(!x.is_lower_bound_infinite());
+    CHECK(x.lower_bound_has_value());
+  }
+
+  if (x.is_lower_bound_closed()) {
+    CHECK(!x.is_lower_bound_open());
+    CHECK(!x.is_lower_bound_infinite());
+    CHECK(x.lower_bound_has_value());
+  }
+
+  if (x.is_lower_bound_infinite()) {
+    CHECK(!x.is_lower_bound_open());
+    CHECK(!x.is_lower_bound_closed());
+    CHECK(!x.lower_bound_has_value());
+  }
+
+  if (x.is_upper_bound_open()) {
+    CHECK(!x.is_upper_bound_closed());
+    CHECK(!x.is_upper_bound_infinite());
+    CHECK(x.upper_bound_has_value());
+  }
+
+  if (x.is_upper_bound_closed()) {
+    CHECK(!x.is_upper_bound_open());
+    CHECK(!x.is_upper_bound_infinite());
+    CHECK(x.upper_bound_has_value());
+  }
+
+  if (x.is_upper_bound_infinite()) {
+    CHECK(!x.is_upper_bound_open());
+    CHECK(!x.is_upper_bound_closed());
+    CHECK(!x.upper_bound_has_value());
+  }
+
+  if (x.lower_bound_has_value() && x.upper_bound_has_value()) {
+    T a = x.lower_bound(), b = x.upper_bound();
+    CHECK(a <= b);
+  }
+}
+
+#endif  // TILEDB_UNIT_INTERVAL_H

--- a/tiledb/common/interval/test/unit_interval.h
+++ b/tiledb/common/interval/test/unit_interval.h
@@ -162,9 +162,8 @@ class TestTypeTraits;
 template <class T>
 class TestTypeTraits<
     T,
-    typename std::enable_if<
-        std::is_integral_v<T> && std::is_unsigned_v<T>,
-        T>::type> {
+    typename std::enable_if<std::is_integral_v<T> && std::is_unsigned_v<T>, T>::
+        type> {
   static constexpr auto max = std::numeric_limits<T>::max();
 
  public:
@@ -181,9 +180,8 @@ class TestTypeTraits<
 template <class T>
 class TestTypeTraits<
     T,
-    typename std::enable_if<
-        std::is_integral_v<T> && std::is_signed_v<T>,
-        T>::type> {
+    typename std::enable_if<std::is_integral_v<T> && std::is_signed_v<T>, T>::
+        type> {
   static constexpr auto min = std::numeric_limits<T>::min();
   static constexpr auto max = std::numeric_limits<T>::max();
 

--- a/tiledb/common/interval/test/unit_interval.h
+++ b/tiledb/common/interval/test/unit_interval.h
@@ -233,7 +233,7 @@ class TestTypeTraits<
                                                      max};
 
   static constexpr T positive_infinity = std::numeric_limits<T>::infinity();
-  static constexpr T negative_infinity = -1.0 * positive_infinity;
+  static constexpr T negative_infinity = -std::numeric_limits<T>::infinity();
   static constexpr T NaN = std::numeric_limits<T>::quiet_NaN();
 };
 

--- a/tiledb/common/interval/test/unit_interval_bound.cc
+++ b/tiledb/common/interval/test/unit_interval_bound.cc
@@ -269,13 +269,13 @@ TEMPLATE_LIST_TEST_CASE(
        * Bounds equivalent to ...,i-1] and [j+1,... Adjacency happens when
        * `(i-1)+1==j+1`, that is `i==j+1`
        */
-      if ( j == std::numeric_limits<T>::max() ) {
+      if (j == std::numeric_limits<T>::max()) {
         // Can't add 1 to 'j', but every `i` is less than `j+1`
         expected = -1;
-      }  else {
-        expected = (i < j+1) ? -1 : (i == j+1) ? 0 : +1;
+      } else {
+        expected = (i < j + 1) ? -1 : (i == j + 1) ? 0 : +1;
       }
-    } else if constexpr(std::is_floating_point_v<T>) {
+    } else if constexpr (std::is_floating_point_v<T>) {
       expected = i <= j ? -1 : +1;
     } else {
       REQUIRE((false && "unsupported type"));
@@ -286,14 +286,14 @@ TEMPLATE_LIST_TEST_CASE(
     auto x = WI::finite_bound(i, false);
     auto y = WI::finite_bound(j, true);
     int c = x.compare_as_mixed(y);
-    int expected = (i < j) ? -1 : (i == j) ? 0 : +1 ;
+    int expected = (i < j) ? -1 : (i == j) ? 0 : +1;
     CHECK(c == expected);
   }
   DYNAMIC_SECTION("Bound...," << i << "] < Bound(" << j << ",...") {
     auto x = WI::finite_bound(i, true);
     auto y = WI::finite_bound(j, false);
     int c = x.compare_as_mixed(y);
-    int expected = (i < j) ? -1 : (i == j) ? 0 : +1 ;
+    int expected = (i < j) ? -1 : (i == j) ? 0 : +1;
     CHECK(c == expected);
   }
   DYNAMIC_SECTION("Bound...," << i << "] < Bound[" << j << ",...") {
@@ -305,13 +305,13 @@ TEMPLATE_LIST_TEST_CASE(
       /*
        * Adjacency happens when `i+1==j`
        */
-      if ( i == std::numeric_limits<T>::max() ) {
+      if (i == std::numeric_limits<T>::max()) {
         // Can't add 1 to 'i', but every `j` is less than `i+1`
         expected = +1;
-      }  else {
-        expected = (i+1 < j) ? -1 : (i+1 == j) ? 0 : +1;
+      } else {
+        expected = (i + 1 < j) ? -1 : (i + 1 == j) ? 0 : +1;
       }
-    } else if constexpr(std::is_floating_point_v<T>) {
+    } else if constexpr (std::is_floating_point_v<T>) {
       expected = (i < j) ? -1 : +1;
     } else {
       REQUIRE((false && "unsupported type"));

--- a/tiledb/common/interval/test/unit_interval_bound.cc
+++ b/tiledb/common/interval/test/unit_interval_bound.cc
@@ -41,7 +41,6 @@
 TEMPLATE_LIST_TEST_CASE(
     "Interval::Bound::compare_as_lower", "[interval]", TypesUnderTest) {
   typedef TestType T;
-  typedef Interval<T> I;
   typedef WhiteboxInterval<T> WI;
   typedef TestTypeTraits<T> Tr;
 
@@ -140,7 +139,6 @@ TEMPLATE_LIST_TEST_CASE(
 TEMPLATE_LIST_TEST_CASE(
     "Interval::Bound::compare_as_upper", "[interval]", TypesUnderTest) {
   typedef TestType T;
-  typedef Interval<T> I;
   typedef WhiteboxInterval<T> WI;
   typedef TestTypeTraits<T> Tr;
 
@@ -231,7 +229,6 @@ TEMPLATE_LIST_TEST_CASE(
 TEMPLATE_LIST_TEST_CASE(
     "Interval::Bound::compare_as_mixed", "[interval]", TypesUnderTest) {
   typedef TestType T;
-  typedef Interval<T> I;
   typedef WhiteboxInterval<T> WI;
   typedef TestTypeTraits<T> Tr;
 

--- a/tiledb/common/interval/test/unit_interval_bound.cc
+++ b/tiledb/common/interval/test/unit_interval_bound.cc
@@ -1,0 +1,321 @@
+/**
+ * @file unit_interval_bound.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines tests for the Interval::Bounds inner class.
+ *
+ * The comparison tests for bounds do not include the null bound in the tests.
+ * The simplest reason to state is that they're excluded by precondition from
+ * the comparison functions, so we can't include them. More broadly, though,
+ * empty bounds aren't considered ordered, and the empty set is always treated
+ * separately in any of the comparison functions.
+ */
+
+#include "unit_interval.h"
+
+TEMPLATE_LIST_TEST_CASE(
+    "Interval::Bound::compare_as_lower", "[interval]", TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef WhiteboxInterval<T> WI;
+  typedef TestTypeTraits<T> Tr;
+
+  auto inf = WI::infinite_bound();
+  SECTION("Bound(-inf,... < Bound(-inf,...") {
+    CHECK(inf.compare_as_lower(inf) == 0);
+  }
+  T i = GENERATE_REF(values(Tr::outer));
+  DYNAMIC_SECTION("Bound(-inf,... < Bound(" << i << ",...") {
+    auto x = WI::finite_bound(i, false);
+    CHECK(inf.compare_as_lower(x) < 0);
+  }
+  DYNAMIC_SECTION("Bound(-inf,... < Bound[" << i << ",...") {
+    auto x = WI::finite_bound(i, true);
+    CHECK(inf.compare_as_lower(x) < 0);
+  }
+  DYNAMIC_SECTION("Bound(" << i << ",... < Bound(-inf,...") {
+    auto x = WI::finite_bound(i, false);
+    CHECK(x.compare_as_lower(inf) > 0);
+  }
+  DYNAMIC_SECTION("Bound[" << i << ",... < Bound(-inf,...") {
+    auto x = WI::finite_bound(i, true);
+    CHECK(x.compare_as_lower(inf) > 0);
+  }
+
+  T j = GENERATE_REF(values(Tr::inner));
+  DYNAMIC_SECTION("Bound(" << i << ",... < Bound(" << j << ",...") {
+    auto x = WI::finite_bound(i, false);
+    auto y = WI::finite_bound(j, false);
+    int c = x.compare_as_lower(y);
+    int expected = i == j ? 0 : i < j ? -1 : +1;
+    CHECK(c == expected);
+  }
+  DYNAMIC_SECTION("Bound(" << i << ",... < Bound[" << j << ",...") {
+    auto x = WI::finite_bound(i, false);
+    auto y = WI::finite_bound(j, true);
+    int c = x.compare_as_lower(y);
+    int expected;
+    if constexpr (std::is_integral_v<T>) {
+      if (i < std::numeric_limits<T>::max()) {
+        expected = (i + 1 == j) ? 0 : (i + 1 < j) ? -1 : +1;
+      } else {
+        /*
+         * An open lower bound with max value is equivalent to [max+1,... and
+         * will overflow. It's also larger than any closed bound.
+         */
+        expected = +1;
+      }
+    } else if constexpr (std::is_floating_point_v<T>) {
+      /*
+       * When i = j, the closed bound has one extra point. Thus the closed bound
+       * is a superset of the open bound. The closed bound is on the right and
+       * thus we expect +1.
+       */
+      expected = i < j ? -1 : +1;
+    } else {
+      REQUIRE(false && "Unsupported type");
+    }
+    CHECK(c == expected);
+  }
+  DYNAMIC_SECTION("Bound[" << i << ",... < Bound(" << j << ",...") {
+    auto x = WI::finite_bound(i, true);
+    auto y = WI::finite_bound(j, false);
+    int c = x.compare_as_lower(y);
+    int expected;
+    if constexpr (std::is_integral_v<T>) {
+      if (j < std::numeric_limits<T>::max()) {
+        expected = (i == j + 1) ? 0 : (i < j + 1) ? -1 : +1;
+      } else {
+        /*
+         * An open lower bound with max value is equivalent to [max+1,... and
+         * will overflow. It's also larger than any closed bound.
+         */
+        expected = -1;
+      }
+    } else if constexpr (std::is_floating_point_v<T>) {
+      /*
+       * Just like the above test except that the closed bound is on the left
+       * and thus we expect -1 when i == j.
+       */
+      expected = i <= j ? -1 : +1;
+    } else {
+      REQUIRE(false && "Unsupported type");
+    }
+    CHECK(c == expected);
+  }
+  DYNAMIC_SECTION("Bound[" << i << ",... < Bound[" << j << ",...") {
+    auto x = WI::finite_bound(i, true);
+    auto y = WI::finite_bound(j, true);
+    int c = x.compare_as_lower(y);
+    int expected = i == j ? 0 : i < j ? -1 : +1;
+    CHECK(c == expected);
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "Interval::Bound::compare_as_upper", "[interval]", TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef WhiteboxInterval<T> WI;
+  typedef TestTypeTraits<T> Tr;
+
+  auto inf = WI::infinite_bound();
+  SECTION("Bound(-inf,... < Bound(-inf,...") {
+    CHECK(inf.compare_as_upper(inf) == 0);
+  }
+
+  T i = GENERATE_REF(values(Tr::outer));
+  DYNAMIC_SECTION("Bound...,+inf) < Bound...," << i << ")") {
+    auto x = WI::finite_bound(i, false);
+    CHECK(inf.compare_as_upper(x) > 0);
+  }
+  DYNAMIC_SECTION("Bound...,+inf) < Bound...," << i << "]") {
+    auto x = WI::finite_bound(i, true);
+    CHECK(inf.compare_as_upper(x) > 0);
+  }
+  DYNAMIC_SECTION("Bound...," << i << ") < Bound...,+inf)") {
+    auto x = WI::finite_bound(i, false);
+    CHECK(x.compare_as_upper(inf) < 0);
+  }
+  DYNAMIC_SECTION("Bound...," << i << "] < Bound...,+inf)") {
+    auto x = WI::finite_bound(i, true);
+    CHECK(x.compare_as_upper(inf) < 0);
+  }
+
+  T j = GENERATE_REF(values(Tr::inner));
+  DYNAMIC_SECTION("Bound...," << i << ") < Bound...," << j << ")") {
+    auto x = WI::finite_bound(i, false);
+    auto y = WI::finite_bound(j, false);
+    int c = x.compare_as_upper(y);
+    int expected = i == j ? 0 : i < j ? -1 : +1;
+    CHECK(c == expected);
+  }
+  DYNAMIC_SECTION("Bound...," << i << ") < Bound...," << j << "]") {
+    auto x = WI::finite_bound(i, false);
+    auto y = WI::finite_bound(j, true);
+    int c = x.compare_as_upper(y);
+    int expected;
+    if constexpr (std::is_integral_v<T>) {
+      if (j < std::numeric_limits<T>::max()) {
+        expected = (i == j + 1) ? 0 : (i < j + 1) ? -1 : +1;
+      } else {
+        /*
+         * An open upper bound with max value is a superset of every open bound,
+         * so the left side is the subset.
+         */
+        expected = -1;
+      }
+    } else if constexpr (std::is_floating_point_v<T>) {
+      expected = i <= j ? -1 : +1;
+    } else {
+      REQUIRE(false && "Unsupported type");
+    }
+    CHECK(c == expected);
+  }
+  DYNAMIC_SECTION("Bound...," << i << "] < Bound...," << j << ")") {
+    auto x = WI::finite_bound(i, true);
+    auto y = WI::finite_bound(j, false);
+    int c = x.compare_as_upper(y);
+    int expected;
+    if constexpr (std::is_integral_v<T>) {
+      if (i < std::numeric_limits<T>::max()) {
+        expected = (i + 1 == j) ? 0 : (i + 1 < j) ? -1 : +1;
+      } else {
+        /*
+         * An open upper bound with max value is a superset of every open bound,
+         * so the right side is the subset.
+         */
+        expected = +1;
+      }
+    } else if constexpr (std::is_floating_point_v<T>) {
+      expected = i < j ? -1 : +1;
+    } else {
+      REQUIRE(false && "Unsupported type");
+    }
+    CHECK(c == expected);
+  }
+  DYNAMIC_SECTION("Bound...," << i << "] < Bound...," << j << "]") {
+    auto x = WI::finite_bound(i, true);
+    auto y = WI::finite_bound(j, true);
+    int c = x.compare_as_upper(y);
+    int expected = i == j ? 0 : i < j ? -1 : +1;
+    CHECK(c == expected);
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "Interval::Bound::compare_as_mixed", "[interval]", TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef WhiteboxInterval<T> WI;
+  typedef TestTypeTraits<T> Tr;
+
+  auto inf = WI::infinite_bound();
+  SECTION("Bound...,+inf) < Bound(-inf,...") {
+    CHECK(inf.compare_as_mixed(inf) > 0);
+  }
+
+  T i = GENERATE_REF(values(Tr::outer));
+  DYNAMIC_SECTION("Bound...,+inf) < Bound(" << i << ",...") {
+    auto x = WI::finite_bound(i, false);
+    CHECK(inf.compare_as_mixed(x) > 0);
+  }
+  DYNAMIC_SECTION("Bound...,+inf) < Bound[" << i << ",...") {
+    auto x = WI::finite_bound(i, true);
+    CHECK(inf.compare_as_mixed(x) > 0);
+  }
+  DYNAMIC_SECTION("Bound...," << i << ") < Bound(-inf,...") {
+    auto x = WI::finite_bound(i, false);
+    CHECK(x.compare_as_mixed(inf) > 0);
+  }
+  DYNAMIC_SECTION("Bound...," << i << "] < Bound(-inf,...") {
+    auto x = WI::finite_bound(i, true);
+    CHECK(x.compare_as_mixed(inf) > 0);
+  }
+
+  T j = GENERATE_REF(values(Tr::inner));
+  DYNAMIC_SECTION("Bound...," << i << ") < Bound(" << j << ",...") {
+    auto x = WI::finite_bound(i, false);
+    auto y = WI::finite_bound(j, false);
+    int c = x.compare_as_mixed(y);
+    int expected;
+    if constexpr (std::is_integral_v<T>) {
+      /*
+       * Bounds equivalent to ...,i-1] and [j+1,... Adjacency happens when
+       * `(i-1)+1==j+1`, that is `i==j+1`
+       */
+      if ( j == std::numeric_limits<T>::max() ) {
+        // Can't add 1 to 'j', but every `i` is less than `j+1`
+        expected = -1;
+      }  else {
+        expected = (i < j+1) ? -1 : (i == j+1) ? 0 : +1;
+      }
+    } else if constexpr(std::is_floating_point_v<T>) {
+      expected = i <= j ? -1 : +1;
+    } else {
+      REQUIRE((false && "unsupported type"));
+    }
+    CHECK(c == expected);
+  }
+  DYNAMIC_SECTION("Bound...," << i << ") < Bound[" << j << ",...") {
+    auto x = WI::finite_bound(i, false);
+    auto y = WI::finite_bound(j, true);
+    int c = x.compare_as_mixed(y);
+    int expected = (i < j) ? -1 : (i == j) ? 0 : +1 ;
+    CHECK(c == expected);
+  }
+  DYNAMIC_SECTION("Bound...," << i << "] < Bound(" << j << ",...") {
+    auto x = WI::finite_bound(i, true);
+    auto y = WI::finite_bound(j, false);
+    int c = x.compare_as_mixed(y);
+    int expected = (i < j) ? -1 : (i == j) ? 0 : +1 ;
+    CHECK(c == expected);
+  }
+  DYNAMIC_SECTION("Bound...," << i << "] < Bound[" << j << ",...") {
+    auto x = WI::finite_bound(i, true);
+    auto y = WI::finite_bound(j, true);
+    int c = x.compare_as_mixed(y);
+    int expected;
+    if constexpr (std::is_integral_v<T>) {
+      /*
+       * Adjacency happens when `i+1==j`
+       */
+      if ( i == std::numeric_limits<T>::max() ) {
+        // Can't add 1 to 'i', but every `j` is less than `i+1`
+        expected = +1;
+      }  else {
+        expected = (i+1 < j) ? -1 : (i+1 == j) ? 0 : +1;
+      }
+    } else if constexpr(std::is_floating_point_v<T>) {
+      expected = (i < j) ? -1 : +1;
+    } else {
+      REQUIRE((false && "unsupported type"));
+    }
+    CHECK(c == expected);
+  }
+}

--- a/tiledb/common/interval/test/unit_interval_constructors.cc
+++ b/tiledb/common/interval/test/unit_interval_constructors.cc
@@ -1,0 +1,276 @@
+/**
+ * @file unit_interval_constructors.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines tests for the constructors of class Interval.
+ */
+
+#include <initializer_list>
+#include "unit_interval.h"
+
+TEMPLATE_LIST_TEST_CASE(
+    "Interval::Interval", "[interval][constructor]", TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef TestTypeTraits<T> Tr;
+
+  SECTION("Zero arguments") {
+    SECTION("Empty set") {
+      I x(I::empty_set);
+      test_interval_invariants(x);
+      CHECK(x.is_empty());
+    }
+    SECTION("(-infinity,+infinity)") {
+      I x(I::minus_infinity, I::plus_infinity);
+      test_interval_invariants(x);
+      CHECK(!x.is_empty());
+      CHECK(!x.has_single_point());
+      CHECK(x.is_lower_bound_infinite());
+      CHECK(x.is_upper_bound_infinite());
+    }
+  }
+  SECTION("One argument") {
+    T i = GENERATE_REF(values(Tr::outer));
+    DYNAMIC_SECTION("single point [" << i << "," << i << "]") {
+      I x(I::single_point, i);
+      test_interval_invariants(x);
+      CHECK(x.has_single_point());
+    }
+    DYNAMIC_SECTION("(-infinity," << i << ")") {
+      I x(I::minus_infinity, i, I::open);
+      test_interval_invariants(x);
+      CHECK(x.is_lower_bound_infinite());
+      CHECK(x.is_upper_bound_open());
+    }
+    DYNAMIC_SECTION("(-infinity," << i << "]") {
+      I x(I::minus_infinity, i, I::closed);
+      test_interval_invariants(x);
+      CHECK(x.is_lower_bound_infinite());
+      CHECK(x.is_upper_bound_closed());
+    }
+    DYNAMIC_SECTION("(" << i << ",+infinity)") {
+      I x(I::open, i, I::plus_infinity);
+      test_interval_invariants(x);
+      CHECK(x.is_lower_bound_open());
+      CHECK(x.is_upper_bound_infinite());
+    }
+    DYNAMIC_SECTION("[" << i << ",+infinity)") {
+      I x(I::closed, i, I::plus_infinity);
+      CHECK(x.is_lower_bound_closed());
+      CHECK(x.is_upper_bound_infinite());
+      test_interval_invariants(x);
+    }
+  }
+  if constexpr (std::is_floating_point_v<T>) {
+    SECTION("One argument with infinite values") {
+      SECTION("single point [+infinite_value,+infinite_value]") {
+        I x(I::single_point, Tr::positive_infinity);
+        test_interval_invariants(x);
+        CHECK(x.is_empty());
+      }
+      SECTION("single point [-infinite_value,-infinite_value]") {
+        I x(I::single_point, Tr::negative_infinity);
+        test_interval_invariants(x);
+        CHECK(x.is_empty());
+      }
+      SECTION("(-infinity,+infinite_value)") {
+        I x(I::minus_infinity, Tr::positive_infinity, I::open);
+        test_interval_invariants(x);
+        CHECK(x.is_lower_bound_infinite());
+        CHECK(x.is_upper_bound_infinite());
+      }
+      SECTION("(-infinity,-infinite_value)") {
+        I x(I::minus_infinity, Tr::negative_infinity, I::open);
+        test_interval_invariants(x);
+        CHECK(x.is_empty());
+      }
+      SECTION("(-infinity,+infinite_value]") {
+        I x(I::minus_infinity, Tr::positive_infinity, I::closed);
+        test_interval_invariants(x);
+        CHECK(x.is_lower_bound_infinite());
+        CHECK(x.is_upper_bound_infinite());
+      }
+      SECTION("(-infinity,-infinite_value]") {
+        I x(I::minus_infinity, Tr::negative_infinity, I::closed);
+        test_interval_invariants(x);
+        CHECK(x.is_empty());
+      }
+      SECTION("(-infinite_value,+infinity)") {
+        I x(I::open, Tr::negative_infinity, I::plus_infinity);
+        test_interval_invariants(x);
+        CHECK(x.is_lower_bound_infinite());
+        CHECK(x.is_upper_bound_infinite());
+      }
+      SECTION("(+infinite_value,+infinity)") {
+        I x(I::open, Tr::positive_infinity, I::plus_infinity);
+        test_interval_invariants(x);
+        CHECK(x.is_empty());
+      }
+      SECTION("[-infinite_value,+infinity)") {
+        I x(I::closed, Tr::negative_infinity, I::plus_infinity);
+        test_interval_invariants(x);
+        CHECK(x.is_lower_bound_infinite());
+        CHECK(x.is_upper_bound_infinite());
+      }
+      SECTION("[+infinite_value,+infinity)") {
+        I x(I::closed, Tr::positive_infinity, I::plus_infinity);
+        test_interval_invariants(x);
+        CHECK(x.is_empty());
+      }
+    }
+  }
+  SECTION("Two arguments") {
+    T i = GENERATE_REF(values(Tr::outer));
+    T j = GENERATE_REF(values(Tr::inner));
+    DYNAMIC_SECTION("(" << i << "," << j << ")") {
+      I x(I::open, i, j, I::open);
+      test_interval_invariants(x);
+      CHECK(implies(!x.is_empty(), x.is_lower_bound_open()));
+      CHECK(implies(!x.is_empty(), x.is_upper_bound_open()));
+      if constexpr (std::is_integral_v<T>) {
+        // Initial i < j guards against overflow
+        CHECK(implies(i < j && i + 1 < j, !x.is_empty()));
+        CHECK(implies(i < j && i + 1 == j - 1, x.has_single_point()));
+      } else if constexpr (std::is_floating_point_v<T>) {
+        CHECK(implies(i < j, !x.is_empty()));
+        CHECK(!x.has_single_point());
+      } else {
+        REQUIRE(false && "unexpected type");
+      }
+    }
+    DYNAMIC_SECTION("(" << i << "," << j << "]") {
+      I x(I::open, i, j, I::closed);
+      test_interval_invariants(x);
+      CHECK(implies(!x.is_empty(), x.is_lower_bound_open()));
+      CHECK(implies(!x.is_empty(), x.is_upper_bound_closed()));
+      CHECK(implies(i < j, !x.is_empty()));
+      if constexpr (std::is_integral_v<T>) {
+        CHECK(implies(i < j && i == j - 1, x.has_single_point()));
+      } else if constexpr (std::is_floating_point_v<T>) {
+        CHECK(!x.has_single_point());
+      }
+    }
+    DYNAMIC_SECTION("[" << i << "," << j << ")") {
+      I x(I::closed, i, j, I::open);
+      test_interval_invariants(x);
+      CHECK(implies(!x.is_empty(), x.is_lower_bound_closed()));
+      CHECK(implies(!x.is_empty(), x.is_upper_bound_open()));
+      CHECK(implies(i < j, !x.is_empty()));
+      if constexpr (std::is_integral_v<T>) {
+        CHECK(implies(i < j && i == j - 1, x.has_single_point()));
+      } else if constexpr (std::is_floating_point_v<T>) {
+        CHECK(!x.has_single_point());
+      }
+    }
+    DYNAMIC_SECTION("[" << i << "," << j << "]") {
+      I x(I::closed, i, j, I::closed);
+      test_interval_invariants(x);
+      CHECK(implies(!x.is_empty(), x.is_lower_bound_closed()));
+      CHECK(implies(!x.is_empty(), x.is_upper_bound_closed()));
+      CHECK(implies(i <= j, !x.is_empty()));
+      CHECK(implies(i == j, x.has_single_point()));
+    }
+  }
+}
+
+/*
+ * However odd these tests might look, they're here because IEEE754 defines a
+ * totalOrder function that puts -0.0 before +0.0, which makes totalOrder
+ * something other than a mathematical total ordering. These tests detect
+ * whether a floating point environment is following that standard with an
+ * abundance of zeal.
+ */
+TEST_CASE("Interval::Interval - Floating-point Zero", "[interval]") {
+  CHECK(std::signbit(-0.0f));
+  CHECK(std::signbit(+0.0f / -1.0f));
+  CHECK(std::signbit(-0.0f / 1.0f));
+  CHECK(!std::signbit(+0.0f));
+  CHECK(!std::signbit(+0.0f / +1.0f));
+  CHECK(!std::signbit(-0.0f / -1.0f));
+  CHECK(-0.0f == +0.0f);
+  CHECK(!(-0.0f < +0.0f));
+  CHECK(!(+0.0f < -0.0f));
+  typedef float T;
+  typedef Interval<T> I;
+  {
+    INFO("(-0.0,+0.0)");
+    I x(I::open, -0.0, +0.0, I::open);
+    test_interval_invariants(x);
+    CHECK(x.is_empty());
+    CHECK(!x.has_single_point());
+  }
+  {
+    INFO("(-0.0,+0.0]");
+    I x(I::open, -0.0, +0.0, I::closed);
+    test_interval_invariants(x);
+    CHECK(x.is_empty());
+    CHECK(!x.has_single_point());
+  }
+  {
+    INFO("[-0.0,+0.0)");
+    I x(I::closed, -0.0, +0.0, I::open);
+    test_interval_invariants(x);
+    CHECK(x.is_empty());
+    CHECK(!x.has_single_point());
+  }
+  {
+    INFO("[-0.0,+0.0]");
+    I x(I::closed, -0.0, +0.0, I::closed);
+    test_interval_invariants(x);
+    CHECK(!x.is_empty());
+    CHECK(x.has_single_point());
+  }
+  {
+    INFO("(+0.0,-0.0)");
+    I x(I::open, +0.0, -0.0, I::open);
+    test_interval_invariants(x);
+    CHECK(x.is_empty());
+    CHECK(!x.has_single_point());
+  }
+  {
+    INFO("(+0.0,-0.0]");
+    I x(I::open, +0.0, -0.0, I::closed);
+    test_interval_invariants(x);
+    CHECK(x.is_empty());
+    CHECK(!x.has_single_point());
+  }
+  {
+    INFO("[+0.0,-0.0)");
+    I x(I::closed, +0.0, -0.0, I::open);
+    test_interval_invariants(x);
+    CHECK(x.is_empty());
+    CHECK(!x.has_single_point());
+  }
+  {
+    INFO("[+0.0,-0.0]");
+    I x(I::closed, +0.0, -0.0, I::closed);
+    test_interval_invariants(x);
+    CHECK(!x.is_empty());
+    CHECK(x.has_single_point());
+  }
+}

--- a/tiledb/common/interval/test/unit_interval_operations.cc
+++ b/tiledb/common/interval/test/unit_interval_operations.cc
@@ -43,9 +43,9 @@
 
 #include "unit_interval.h"
 
-//=======================================================
-// Tests for Interval::intersection()
-//=======================================================
+/* ************************************** */
+/*   Tests for Interval::intersection()   */
+/* ************************************** */
 
 template <class T>
 void check_intersection(
@@ -1055,9 +1055,9 @@ TEMPLATE_LIST_TEST_CASE(
   }
 }
 
-//=======================================================
-// Tests for Interval::union()
-//=======================================================
+/* ******************************** */
+/*    Tests for Interval::union()   */
+/* ******************************** */
 
 /**
  * Check that a union produces the expected result, except if either of the
@@ -1451,9 +1451,9 @@ TEMPLATE_LIST_TEST_CASE(
   }
 }
 
-//=======================================================
-// Tests for Interval::cut()
-//=======================================================
+/* ******************************** */
+/*     Tests for Interval::cut()    */
+/* ******************************** */
 
 template <class T>
 void check_cut(

--- a/tiledb/common/interval/test/unit_interval_operations.cc
+++ b/tiledb/common/interval/test/unit_interval_operations.cc
@@ -1,0 +1,1718 @@
+/**
+ * @file unit_interval_operations.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines tests for the operations of class Interval: intersection,
+ * union, and cut.
+ *
+ * @section Test Generators
+ *
+ * Testing interval operations requires two intervals, requiring four points for
+ * the bounds. The "choose(4,...)" generator chooses 4 elements from a list.
+ * More accurately, it enumerates all the ways of choosing 4 elements, and the
+ * number of elements it enumerates is a fourth-degree polynomial in the length
+ * of the list. (It's the binomial coefficient N-choose-4.) At 8 elements it
+ * yields 70 elements; at 9 it's 136. It's enough to exhaustively test
+ * everything without going completely overboard.
+ */
+
+#include "unit_interval.h"
+
+//=======================================================
+// Tests for Interval::intersection()
+//=======================================================
+
+template <class T>
+void check_intersection(
+    Interval<T> left, Interval<T> right, Interval<T> expected) {
+  typedef WhiteboxInterval<T> WI;
+  WI z = WI(left).intersection(WI(right));
+  z.check_equality(expected);
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "Interval::intersection", "[interval][intersection]", TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef WhiteboxInterval<T> WI;
+  typedef TestTypeTraits<T> Tr;
+  const I empty(I::empty_set);
+
+  SECTION("Four unique endpoints") {
+    // Order A-B-C-D
+    SECTION("A-B and C-D: Disjoint") {
+      /*
+       * The bounds of A and D not likely to trigger faults here, so we only
+       * test open and closed intervals. This means we have four sections
+       * instead of 16.
+       */
+      std::vector<T> v = GENERATE(choose(4, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2], d = v[3];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect (" << c << "," << d << ")") {
+        check_intersection(
+            I(I::open, a, b, I::open), I(I::open, c, d, I::open), empty);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect [" << c << "," << d << "]") {
+        check_intersection(
+            I(I::open, a, b, I::open), I(I::closed, c, d, I::closed), empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect (" << c << "," << d << ")") {
+        check_intersection(
+            I(I::closed, a, b, I::closed), I(I::open, c, d, I::open), empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect [" << c << "," << d << "]") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, c, d, I::closed),
+            empty);
+      }
+    }
+    SECTION("Inf-B and C-D: Disjoint") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto b = v[0], c = v[1], d = v[2];
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect (" << c << "," << d << ")") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open), I(I::open, c, d, I::open), empty);
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect [" << c << "," << d << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::closed, c, d, I::closed),
+            empty);
+      }
+    }
+    SECTION("A-B and C-Inf: Disjoint") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect (" << c << ",+infinity)") {
+        check_intersection(
+            I(I::open, a, b, I::open), I(I::open, c, I::plus_infinity), empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect (" << c << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::open, c, I::plus_infinity),
+            empty);
+      }
+    }
+    SECTION("Inf-B and C-Inf: Disjoint") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const auto b = v[0], c = v[1];
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect (" << c << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::open, c, I::plus_infinity),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "[-infinity," << b << "] intersect (" << c << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::open, c, I::plus_infinity),
+            empty);
+      }
+    }
+
+    // Order A-C-B-D
+    SECTION("A-C and B-D: Overlap") {
+      /*
+       * The bounds of A and D not likely to trigger faults here, so we only
+       * test open and closed intervals. This means we have four sections
+       * instead of 16.
+       */
+      std::vector<T> v = GENERATE(choose(4, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2], d = v[3];
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") intersect (" << b << "," << d << ")") {
+        check_intersection(
+            I(I::open, a, c, I::open),
+            I(I::open, b, d, I::open),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") intersect [" << b << "," << d << "]") {
+        check_intersection(
+            I(I::open, a, c, I::open),
+            I(I::closed, b, d, I::closed),
+            I(I::closed, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] intersect (" << b << "," << d << ")") {
+        check_intersection(
+            I(I::closed, a, c, I::closed),
+            I(I::open, b, d, I::open),
+            I(I::open, b, c, I::closed));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] intersect [" << b << "," << d << "]") {
+        check_intersection(
+            I(I::closed, a, c, I::closed),
+            I(I::closed, b, d, I::closed),
+            I(I::closed, b, c, I::closed));
+      }
+    }
+    SECTION("Inf-C and B-D: Overlap") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto b = v[0], c = v[1], d = v[2];
+      DYNAMIC_SECTION(
+          "(-infinity," << c << ") intersect (" << b << "," << d << ")") {
+        check_intersection(
+            I(I::minus_infinity, c, I::open),
+            I(I::open, b, d, I::open),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << c << ") intersect [" << b << "," << d << "]") {
+        check_intersection(
+            I(I::minus_infinity, c, I::open),
+            I(I::closed, b, d, I::closed),
+            I(I::closed, b, c, I::open));
+      }
+    }
+    SECTION("A-C and B-Inf: Overlap") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::open, a, c, I::open),
+            I(I::open, b, I::plus_infinity),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, c, I::closed),
+            I(I::open, b, I::plus_infinity),
+            I(I::open, b, c, I::closed));
+      }
+    }
+    SECTION("Inf-C and B-Inf: Overlap") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto b = v[0], c = v[1];
+      DYNAMIC_SECTION(
+          "(-infinity," << c << ") intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, c, I::open),
+            I(I::open, b, I::plus_infinity),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << c << "] intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, c, I::closed),
+            I(I::open, b, I::plus_infinity),
+            I(I::open, b, c, I::closed));
+      }
+    }
+
+    // Order A-D-B-C
+    SECTION("A-D and B-C: Surround") {
+      /*
+       * These tests simultaneously exercise A vs. B bounds and C vs. D bounds.
+       * Any defects here are unlikely to be correlated, so we don't exercise
+       * them independently. This means we have four sections instead of 16.
+       */
+      std::vector<T> v = GENERATE(choose(4, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2], d = v[3];
+      DYNAMIC_SECTION(
+          "(" << a << "," << d << ") intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::open, a, d, I::open),
+            I(I::open, b, c, I::open),
+            I(I::open, b, c, I::open));
+      }
+
+      DYNAMIC_SECTION(
+          "(" << a << "," << d << ") intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::open, a, d, I::open),
+            I(I::closed, b, c, I::closed),
+            I(I::closed, b, c, I::closed));
+      }
+
+      DYNAMIC_SECTION(
+          "[" << a << "," << d << "] intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::closed, a, d, I::closed),
+            I(I::open, b, c, I::open),
+            I(I::open, b, c, I::open));
+      }
+
+      DYNAMIC_SECTION(
+          "[" << a << "," << d << "] intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::closed, a, d, I::closed),
+            I(I::closed, b, c, I::closed),
+            I(I::closed, b, c, I::closed));
+      }
+    }
+    SECTION("Inf-D and B-C: Surround") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto b = v[0], c = v[1], d = v[2];
+      DYNAMIC_SECTION(
+          "(-infinity," << d << ") intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::minus_infinity, d, I::open),
+            I(I::open, b, c, I::open),
+            I(I::open, b, c, I::open));
+      }
+
+      DYNAMIC_SECTION(
+          "(-infinity," << d << ") intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, d, I::open),
+            I(I::closed, b, c, I::closed),
+            I(I::closed, b, c, I::closed));
+      }
+    }
+    SECTION("A-Inf and B-C: Surround") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << ",+infinity) intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::open, a, I::plus_infinity),
+            I(I::open, b, c, I::open),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << ",+infinity) intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::open, a, I::plus_infinity),
+            I(I::closed, b, c, I::closed),
+            I(I::closed, b, c, I::closed));
+      }
+    }
+    SECTION("Inf-Inf and B-C: Surround") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const auto b = v[0], c = v[1];
+      DYNAMIC_SECTION(
+          "(-infinity,+infinity) intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::minus_infinity, I::plus_infinity),
+            I(I::open, b, c, I::open),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity,+infinity) intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, I::plus_infinity),
+            I(I::closed, b, c, I::closed),
+            I(I::closed, b, c, I::closed));
+      }
+    }
+  }
+  SECTION("Three unique endpoints") {
+    SECTION("A-A and B-C: Disjoint") {
+      /*
+       * The open interval (a,a) is empty, so we don't use it here.
+       *
+       * We test A vs. B on the lower and A vs. C on the upper. Correlated
+       * defects are unlikely here, so we don't test them independently. This
+       * means we have two cases instead of four.
+       */
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const T a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "[" << a << "," << a << "] intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::closed, a, a, I::closed), I(I::open, b, c, I::open), empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << a << "] intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::closed, a, a, I::closed),
+            I(I::closed, b, c, I::closed),
+            empty);
+      }
+    }
+    // No sections for A=-inf, since (-inf, -inf) is the empty set
+    SECTION("A-A and B-Inf: Disjoint") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION(
+          "[" << a << "," << a << "] intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, a, I::closed),
+            I(I::open, b, I::plus_infinity),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << a << "] intersect [" << b << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, a, I::closed),
+            I(I::closed, b, I::plus_infinity),
+            empty);
+      }
+    }
+
+    SECTION("A-B and A-C: Surround, Degenerate Lower") {
+      /*
+       * We test A vs. A and  B vs. C in all four cases each. Correlated
+       * failure is unlikely, so we don't test them independently. This yields
+       * four sections instead of 16.
+       */
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const T a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect (" << a << "," << c << ")") {
+        check_intersection(
+            I(I::open, a, b, I::open),
+            I(I::open, a, c, I::open),
+            I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect [" << a << "," << c << "]") {
+        check_intersection(
+            I(I::open, a, b, I::open),
+            I(I::closed, a, c, I::closed),
+            I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect (" << a << "," << c << ")") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::open, a, c, I::open),
+            I(I::open, a, b, I::closed));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect [" << a << "," << c << "]") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, a, c, I::closed),
+            I(I::closed, a, b, I::closed));
+      }
+    }
+    SECTION("Inf-B and Inf-C: Surround, Degenerate Lower") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T b = v[0], c = v[1];
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect (-infinity," << c << ")") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::minus_infinity, c, I::open),
+            I(I::minus_infinity, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect (-infinity," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::minus_infinity, c, I::closed),
+            I(I::minus_infinity, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect (-infinity," << c << ")") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::minus_infinity, c, I::open),
+            I(I::minus_infinity, b, I::closed));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect (-infinity," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::minus_infinity, c, I::closed),
+            I(I::minus_infinity, b, I::closed));
+      }
+    }
+    SECTION("A-B and A-Inf: Surround, Degenerate Lower") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect (" << a << ",+infinity)") {
+        check_intersection(
+            I(I::open, a, b, I::open),
+            I(I::open, a, I::plus_infinity),
+            I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect [" << a << ",+infinity)") {
+        check_intersection(
+            I(I::open, a, b, I::open),
+            I(I::closed, a, I::plus_infinity),
+            I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect (" << a << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::open, a, I::plus_infinity),
+            I(I::open, a, b, I::closed));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect [" << a << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, a, I::plus_infinity),
+            I(I::closed, a, b, I::closed));
+      }
+    }
+    SECTION("Inf-B and Inf-Inf: Surround, Degenerate Lower") {
+      T b = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect (-infinity,+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::minus_infinity, I::plus_infinity),
+            I(I::minus_infinity, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect (-infinity,+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::minus_infinity, I::plus_infinity),
+            I(I::minus_infinity, b, I::closed));
+      }
+    }
+
+    SECTION("A-B and B-C: Adjacent") {
+      /*
+       * Bounds at A and C are unlikely to trigger faults, so we don't
+       * generate all possible permutations. We test all four B vs. B bounds
+       * with A and C always closed to avoid empty operands. This yields four
+       * sections instead of 16.
+       */
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const T a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") intersect (" << b << "," << c << "]") {
+        check_intersection(
+            I(I::closed, a, b, I::open), I(I::open, b, c, I::closed), empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::closed, a, b, I::open), I(I::closed, b, c, I::closed), empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect (" << b << "," << c << "]") {
+        check_intersection(
+            I(I::closed, a, b, I::closed), I(I::open, b, c, I::closed), empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, b, c, I::closed),
+            I(I::single_point, b));
+      }
+    }
+    SECTION("Inf-B and B-C: Adjacent") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T b = v[0], c = v[1];
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect (" << b << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::open, b, c, I::closed),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::closed, b, c, I::closed),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect (" << b << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::open, b, c, I::closed),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::closed, b, c, I::closed),
+            I(I::single_point, b));
+      }
+    }
+    SECTION("A-B and B-Inf: Adjacent") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, b, I::open),
+            I(I::open, b, I::plus_infinity),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") intersect [" << b << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, b, I::open),
+            I(I::closed, b, I::plus_infinity),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::open, b, I::plus_infinity),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect [" << b << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, b, I::plus_infinity),
+            I(I::single_point, b));
+      }
+    }
+    SECTION("Inf-B and B-Inf: Adjacent") {
+      const T b = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::open, b, I::plus_infinity),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect [" << b << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::closed, b, I::plus_infinity),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::open, b, I::plus_infinity),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect [" << b << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::closed, b, I::plus_infinity),
+            I(I::single_point, b));
+      }
+    }
+
+    SECTION("A-B and C-C: Disjoint") {
+      /*
+       * See "Disjoint: A-A and B-C". This section is the same after swapping
+       * low and high.
+       */
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const T a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect [" << c << "," << c << "]") {
+        check_intersection(
+            I(I::open, a, b, I::open), I(I::closed, c, c, I::closed), empty);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect [" << c << "," << c << "]") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, c, c, I::closed),
+            empty);
+      }
+    }
+    // No sections for C=inf, since (+inf, +inf) is the empty set
+    SECTION("Inf-B and C-C: Disjoint") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T b = v[0], c = v[1];
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect [" << c << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::closed, c, c, I::closed),
+            empty);
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect [" << c << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::closed, c, c, I::closed),
+            empty);
+      }
+    }
+
+    SECTION("A-C and B-B: Surround") {
+      /*
+       * Like the disjoint cases, we only test with [b,b].
+       *
+       * Correlated faults with lower A vs. B and upper B vs. C bounds are
+       * unlikely, so we exercise A-B with only open and closed intervals.
+       * This yields two sections instead of four.
+       */
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const T a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") intersect [" << b << "," << b << "]") {
+        check_intersection(
+            I(I::open, a, c, I::open),
+            I(I::closed, b, b, I::closed),
+            I(I::closed, b, b, I::closed));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] intersect [" << b << "," << b << "]") {
+        check_intersection(
+            I(I::closed, a, c, I::closed),
+            I(I::closed, b, b, I::closed),
+            I(I::closed, b, b, I::closed));
+      }
+    }
+    SECTION("Inf-C and B-B: Surround") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T b = v[0], c = v[1];
+      DYNAMIC_SECTION(
+          "(-infinity," << c << ") intersect [" << b << "," << b << "]") {
+        check_intersection(
+            I(I::minus_infinity, c, I::open),
+            I(I::closed, b, b, I::closed),
+            I(I::closed, b, b, I::closed));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << c << "] intersect [" << b << "," << b << "]") {
+        check_intersection(
+            I(I::minus_infinity, c, I::closed),
+            I(I::closed, b, b, I::closed),
+            I(I::closed, b, b, I::closed));
+      }
+    }
+    SECTION("A-Inf and B-B: Surround") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION(
+          "(" << a << ",+infinity) intersect [" << b << "," << b << "]") {
+        check_intersection(
+            I(I::open, a, I::plus_infinity),
+            I(I::closed, b, b, I::closed),
+            I(I::closed, b, b, I::closed));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << ",+infinity) intersect [" << b << "," << b << "]") {
+        check_intersection(
+            I(I::closed, a, I::plus_infinity),
+            I(I::closed, b, b, I::closed),
+            I(I::closed, b, b, I::closed));
+      }
+    }
+    SECTION("Inf-Inf and B-B: Surround") {
+      T b = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION(
+          "(-infinity,+infinity) intersect [" << b << "," << b << "]") {
+        check_intersection(
+            I(I::minus_infinity, I::plus_infinity),
+            I(I::closed, b, b, I::closed),
+            I(I::closed, b, b, I::closed));
+      }
+    }
+
+    SECTION("A-C and B-C: Surround, Degenerate Upper") {
+      /*
+       * See "Surround, Degenerate Lower: A-B and A-C". This section is the
+       * same after swapping low and high.
+       */
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const T a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::open, a, c, I::open),
+            I(I::open, b, c, I::open),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::open, a, c, I::open),
+            I(I::closed, b, c, I::closed),
+            I(I::closed, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::closed, a, c, I::closed),
+            I(I::open, b, c, I::open),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::closed, a, c, I::closed),
+            I(I::closed, b, c, I::closed),
+            I(I::closed, b, c, I::closed));
+      }
+    }
+    SECTION("Inf-C and B-C: Surround, Degenerate Upper") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T b = v[0], c = v[1];
+      DYNAMIC_SECTION(
+          "(-infinity," << c << ") intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::minus_infinity, c, I::open),
+            I(I::open, b, c, I::open),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << c << ") intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, c, I::open),
+            I(I::closed, b, c, I::closed),
+            I(I::closed, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << c << "] intersect (" << b << "," << c << ")") {
+        check_intersection(
+            I(I::minus_infinity, c, I::closed),
+            I(I::open, b, c, I::open),
+            I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << c << "] intersect [" << b << "," << c << "]") {
+        check_intersection(
+            I(I::minus_infinity, c, I::closed),
+            I(I::closed, b, c, I::closed),
+            I(I::closed, b, c, I::closed));
+      }
+    }
+    SECTION("A-Inf and B-Inf: Surround, Degenerate Upper") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION(
+          "(" << a << ",+infinity) intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::open, a, I::plus_infinity),
+            I(I::open, b, I::plus_infinity),
+            I(I::open, b, I::plus_infinity));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << ",+infinity) intersect [" << b << ",+infinity)") {
+        check_intersection(
+            I(I::open, a, I::plus_infinity),
+            I(I::closed, b, I::plus_infinity),
+            I(I::closed, b, I::plus_infinity));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << ",+infinity) intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, I::plus_infinity),
+            I(I::open, b, I::plus_infinity),
+            I(I::open, b, I::plus_infinity));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << ",+infinity) intersect [" << b << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, I::plus_infinity),
+            I(I::closed, b, I::plus_infinity),
+            I(I::closed, b, I::plus_infinity));
+      }
+    }
+    SECTION("Inf-Inf and B-Inf: Surround, Degenerate Upper") {
+      const T b = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION(
+          "(-infinity,+infinity) intersect (" << b << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, I::plus_infinity),
+            I(I::open, b, I::plus_infinity),
+            I(I::open, b, I::plus_infinity));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity,+infinity) intersect [" << b << ",+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, I::plus_infinity),
+            I(I::closed, b, I::plus_infinity),
+            I(I::closed, b, I::plus_infinity));
+      }
+    }
+  }
+
+  SECTION("Two unique endpoints") {
+    SECTION("A-B and A-B: Identical") {
+      /*
+       * We test the open interval and the closed interval against each of the
+       * others.
+       */
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect (" << a << "," << b << ")") {
+        check_intersection(
+            I(I::open, a, b, I::open),
+            I(I::open, a, b, I::open),
+            I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect (" << a << "," << b << "]") {
+        check_intersection(
+            I(I::open, a, b, I::open),
+            I(I::open, a, b, I::closed),
+            I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect [" << a << "," << b << ")") {
+        check_intersection(
+            I(I::open, a, b, I::closed),
+            I(I::closed, a, b, I::open),
+            I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") intersect [" << a << "," << b << "]") {
+        check_intersection(
+            I(I::open, a, b, I::open),
+            I(I::closed, a, b, I::closed),
+            I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << "] intersect [" << a << "," << b << "]") {
+        check_intersection(
+            I(I::open, a, b, I::closed),
+            I(I::closed, a, b, I::closed),
+            I(I::open, a, b, I::closed));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") intersect [" << a << "," << b << "]") {
+        check_intersection(
+            I(I::closed, a, b, I::open),
+            I(I::closed, a, b, I::closed),
+            I(I::closed, a, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] intersect [" << a << "," << b << "]") {
+        check_intersection(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, a, b, I::closed),
+            I(I::closed, a, b, I::closed));
+      }
+    }
+    SECTION("Inf-B and Inf-B: Identical") {
+      const T b = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect (-infinity," << b << ")") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::minus_infinity, b, I::open),
+            I(I::minus_infinity, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << ") intersect (-infinity," << b << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::open),
+            I(I::minus_infinity, b, I::closed),
+            I(I::minus_infinity, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect (-infinity," << b << ")") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::minus_infinity, b, I::open),
+            I(I::minus_infinity, b, I::open));
+      }
+      DYNAMIC_SECTION(
+          "(-infinity," << b << "] intersect (-infinity," << b << "]") {
+        check_intersection(
+            I(I::minus_infinity, b, I::closed),
+            I(I::minus_infinity, b, I::closed),
+            I(I::minus_infinity, b, I::closed));
+      }
+    }
+    SECTION("A-Inf and A-Inf: Identical") {
+      const T a = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION(
+          "(" << a << ",+infinity) intersect (" << a << ",+infinity)") {
+        check_intersection(
+            I(I::open, a, I::plus_infinity),
+            I(I::open, a, I::plus_infinity),
+            I(I::open, a, I::plus_infinity));
+      }
+      DYNAMIC_SECTION(
+          "(" << a << ",+infinity) intersect [" << a << ",+infinity)") {
+        check_intersection(
+            I(I::open, a, I::plus_infinity),
+            I(I::closed, a, I::plus_infinity),
+            I(I::open, a, I::plus_infinity));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << ",+infinity) intersect (" << a << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, I::plus_infinity),
+            I(I::open, a, I::plus_infinity),
+            I(I::open, a, I::plus_infinity));
+      }
+      DYNAMIC_SECTION(
+          "[" << a << ",+infinity) intersect [" << a << ",+infinity)") {
+        check_intersection(
+            I(I::closed, a, I::plus_infinity),
+            I(I::closed, a, I::plus_infinity),
+            I(I::closed, a, I::plus_infinity));
+      }
+    }
+    SECTION("Inf-Inf and Inf-Inf: Identical") {
+      DYNAMIC_SECTION("(-infinity,+infinity) intersect (-infinity,+infinity)") {
+        check_intersection(
+            I(I::minus_infinity, I::plus_infinity),
+            I(I::minus_infinity, I::plus_infinity),
+            I(I::minus_infinity, I::plus_infinity));
+      }
+    }
+
+    SECTION("A-B and Empty") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION("(" << a << "," << b << ") intersect empty") {
+        check_intersection(I(I::open, a, b, I::open), empty, empty);
+      }
+      DYNAMIC_SECTION("(" << a << "," << b << "] intersect empty") {
+        check_intersection(I(I::open, a, b, I::closed), empty, empty);
+      }
+      DYNAMIC_SECTION("[" << a << "," << b << ") intersect empty") {
+        check_intersection(I(I::closed, a, b, I::open), empty, empty);
+      }
+      DYNAMIC_SECTION("[" << a << "," << b << "] intersect empty") {
+        check_intersection(I(I::closed, a, b, I::closed), empty, empty);
+      }
+    }
+    SECTION("Inf-B and Empty") {
+      const T b = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION("(-infinity," << b << ") intersect empty") {
+        check_intersection(I(I::minus_infinity, b, I::open), empty, empty);
+      }
+      DYNAMIC_SECTION("(-infinity," << b << "] intersect empty") {
+        check_intersection(I(I::minus_infinity, b, I::closed), empty, empty);
+      }
+    }
+    SECTION("A-Inf and Empty") {
+      const T a = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION("(" << a << ",+infinity,) intersect empty") {
+        check_intersection(I(I::open, a, I::plus_infinity), empty, empty);
+      }
+      DYNAMIC_SECTION("[" << a << ",+infinity,) intersect empty") {
+        check_intersection(I(I::closed, a, I::plus_infinity), empty, empty);
+      }
+    }
+    SECTION("Inf-Inf and Empty") {
+      DYNAMIC_SECTION("(-infinity,+infinity,) intersect empty") {
+        check_intersection(
+            I(I::minus_infinity, I::plus_infinity), empty, empty);
+      }
+    }
+
+    SECTION("A-A and B-B: Disjoint") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION(
+          "[" << a << "," << a << "] intersect [" << b << "," << b << "]") {
+        check_intersection(I(I::single_point, a), I(I::single_point, b), empty);
+      }
+    }
+  }
+
+  SECTION("One unique endpoint") {
+    SECTION("A-A and A-A: Identical") {
+      const T a = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION("(" << a << ",+infinity,) intersect empty") {
+        I x(I::single_point, a);
+        check_intersection(x, x, x);
+      }
+    }
+    SECTION("A-A and Empty") {
+      const T a = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION("(" << a << ",+infinity,) intersect empty") {
+        check_intersection(I(I::single_point, a), empty, empty);
+      }
+    }
+  }
+}
+
+//=======================================================
+// Tests for Interval::union()
+//=======================================================
+
+/**
+ * Check that a union produces the expected result, except if either of the
+ * operands is empty, in which case it cheats and overrides the expected result
+ * internally.
+ */
+template <class T>
+void check_union(
+    Interval<T> left,
+    Interval<T> right,
+    tuple<bool, optional<Interval<T>>> expected) {
+  typedef WhiteboxInterval<T> WI;
+  if (left.is_empty()) {
+    expected = {true, right};
+  } else if (right.is_empty()) {
+    expected = {true, left};
+  }
+  auto [b, z] = WI(left).interval_union(WI(right));
+  bool expected_b = std::get<0>(expected);
+  if (!expected_b) {
+    CHECK(!b);
+  } else if (!b) {
+    CHECK(!expected_b);
+  } else {
+    // Assert: b and expected_b
+    Interval<T> expected_z = std::get<1>(expected).value();
+    WI(z.value()).check_equality(expected_z);
+  }
+  /*
+   * Verify that comparing the intervals matches the expected union outcome.
+   *
+   * By construction, if the intervals are disjoint then the left one is
+   * less than the right one.
+   */
+  if (left.is_empty() || right.is_empty()) {
+    return;
+  }
+  auto [c1, b1] = left.compare(right);
+  auto [c2, b2] = right.compare(left);
+  if (b) {
+    // the intervals should be either intersecting or adjacent
+    CHECK((c1 == 0 || b1));
+    CHECK((c2 == 0 || b2));
+  } else {
+    // the intervals should be disjoint and not adjacent
+    CHECK(c1 < 0);
+    CHECK(!b1);
+    CHECK(c2 > 0);
+    CHECK(!b2);
+  }
+  if (c1 < 0) {
+    CHECK(c2 > 0);
+    CHECK(b1 == b2);
+  } else if (c1 == 0) {
+    CHECK(c2 == 0);
+    CHECK(!b1);
+    CHECK(!b2);
+  } else {
+    CHECK(c2 <= 0);  // Will fail; test case is malformed.
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "Interval::interval_union",
+    "[interval][union][compare/interval]",
+    TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef TestTypeTraits<T> Tr;
+
+  // TODO: Tests with infinite bounds
+
+  SECTION("Four unique endpoints") {
+    SECTION("Disjoint: A-B and C-D") {
+      /*
+       * The intervals in this section are all disjoint by construction. If one
+       * of the operands is empty, though, the union will be defined.
+       */
+      std::vector<T> v = GENERATE(choose(4, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2], d = v[3];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") union (" << c << "," << d << ")") {
+        check_union(
+            I(I::open, a, b, I::open),
+            I(I::open, c, d, I::open),
+            {false, nullopt});
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") union [" << c << "," << d << "]") {
+        check_union(
+            I(I::open, a, b, I::open),
+            I(I::closed, c, d, I::closed),
+            {false, nullopt});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] union (" << c << "," << d << ")") {
+        check_union(
+            I(I::closed, a, b, I::closed),
+            I(I::open, c, d, I::open),
+            {false, nullopt});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] union [" << c << "," << d << "]") {
+        bool adj = is_adjacent(b, c);
+        optional<I> expected(
+            adj ? optional(I(I::closed, a, d, I::closed)) : nullopt);
+        check_union(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, c, d, I::closed),
+            {adj, expected});
+      }
+    }
+    SECTION("Overlap: A-C and B-D") {
+      std::vector<T> v = GENERATE(choose(4, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2], d = v[3];
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") union (" << b << "," << d << ")") {
+        check_union(
+            I(I::open, a, c, I::open),
+            I(I::open, b, d, I::open),
+            {true, I(I::open, a, d, I::open)});
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") union [" << b << "," << d << "]") {
+        // If a is adjacent to b, the result will have a closed lower bound
+        bool adj = is_adjacent(a, b);
+        I expected =
+            adj ? I(I::closed, b, d, I::closed) : I(I::open, a, d, I::closed);
+        check_union(
+            I(I::open, a, c, I::open),
+            I(I::closed, b, d, I::closed),
+            {true, expected});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] union (" << b << "," << d << ")") {
+        // If c is adjacent to d, the result will have a closed upper bound
+        bool adj = is_adjacent(c, d);
+        I expected =
+            adj ? I(I::closed, a, c, I::closed) : I(I::closed, a, d, I::open);
+        check_union(
+            I(I::closed, a, c, I::closed),
+            I(I::open, b, d, I::open),
+            {true, expected});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] union [" << b << "," << d << "]") {
+        check_union(
+            I(I::closed, a, c, I::closed),
+            I(I::closed, b, d, I::closed),
+            {true, I(I::closed, a, d, I::closed)});
+      }
+    }
+    SECTION("Surround: A-D and B-C") {
+      std::vector<T> v = GENERATE(choose(4, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2], d = v[3];
+      DYNAMIC_SECTION(
+          "(" << a << "," << d << ") union (" << b << "," << c << ")") {
+        check_union(
+            I(I::open, a, d, I::open),
+            I(I::open, b, c, I::open),
+            {true, I(I::open, a, d, I::open)});
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << d << ") union [" << b << "," << c << "]") {
+        // If a is adjacent to b, the result will have a closed lower bound
+        // If c is adjacent to d, the result will have a closed upper bound
+        bool adj_lower = is_adjacent(a, b);
+        bool adj_upper = is_adjacent(c, d);
+        I expected = adj_lower ? (adj_upper ? I(I::closed, b, c, I::closed) :
+                                              I(I::closed, b, d, I::open)) :
+                                 (adj_upper ? I(I::open, a, c, I::closed) :
+                                              I(I::open, a, d, I::open));
+        check_union(
+            I(I::open, a, d, I::open),
+            I(I::closed, b, c, I::closed),
+            {true, expected});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << d << "] union (" << b << "," << c << ")") {
+        check_union(
+            I(I::closed, a, d, I::closed),
+            I(I::open, b, c, I::open),
+            {true, I(I::closed, a, d, I::closed)});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << d << "] union [" << b << "," << c << "]") {
+        check_union(
+            I(I::closed, a, d, I::closed),
+            I(I::closed, b, c, I::closed),
+            {true, I(I::closed, a, d, I::closed)});
+      }
+    }
+  }
+  SECTION("Three unique endpoints") {
+    SECTION("Disjoint: A-A and B-C") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "[" << a << "," << a << "] union (" << b << "," << c << ")") {
+        check_union(
+            I(I::closed, a, a, I::closed),
+            I(I::open, b, c, I::open),
+            {false, nullopt});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << a << "] union [" << b << "," << c << "]") {
+        // If `a` is adjacent to `b`, then the union is defined.
+        bool adj = is_adjacent(a, b);
+        optional<I> expected =
+            adj ? optional(I(I::closed, a, c, I::closed)) : nullopt;
+        check_union(
+            I(I::closed, a, a, I::closed),
+            I(I::closed, b, c, I::closed),
+            {adj, expected});
+      }
+    }
+    SECTION("Surround, Degenerate Lower: A-B and A-C") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") union (" << a << "," << c << ")") {
+        check_union(
+            I(I::open, a, b, I::open),
+            I(I::open, a, c, I::open),
+            {true, I(I::open, a, c, I::open)});
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") union [" << a << "," << c << "]") {
+        check_union(
+            I(I::open, a, b, I::open),
+            I(I::closed, a, c, I::closed),
+            {true, I(I::closed, a, c, I::closed)});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] union (" << a << "," << c << ")") {
+        // If b and c are adjacent, the result will have a closed upper bound
+        bool adj = is_adjacent(b, c);
+        I expected =
+            adj ? I(I::closed, a, b, I::closed) : I(I::closed, a, c, I::open);
+        check_union(
+            I(I::closed, a, b, I::closed),
+            I(I::open, a, c, I::open),
+            {true, expected});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] union [" << a << "," << c << "]") {
+        check_union(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, a, c, I::closed),
+            {true, I(I::closed, a, c, I::closed)});
+      }
+    }
+    SECTION("Adjacent: A-B and B-C") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") union (" << b << "," << c << "]") {
+        check_union(
+            I(I::closed, a, b, I::open),
+            I(I::open, b, c, I::closed),
+            {false, nullopt});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") union [" << b << "," << c << "]") {
+        check_union(
+            I(I::closed, a, b, I::open),
+            I(I::closed, b, c, I::closed),
+            {true, I(I::closed, a, c, I::closed)});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] union (" << b << "," << c << "]") {
+        check_union(
+            I(I::closed, a, b, I::closed),
+            I(I::open, b, c, I::closed),
+            {true, I(I::closed, a, c, I::closed)});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] union [" << b << "," << c << "]") {
+        check_union(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, b, c, I::closed),
+            {true, I(I::closed, a, c, I::closed)});
+      }
+    }
+    SECTION("Disjoint: A-B and C-C") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") union [" << c << "," << c << "]") {
+        check_union(
+            I(I::open, a, b, I::open),
+            I(I::closed, c, c, I::closed),
+            {false, nullopt});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] union [" << c << "," << c << "]") {
+        // If b and c are adjacent, the union is an interval.
+        bool adj = is_adjacent(b, c);
+        optional<I> expected =
+            adj ? optional(I(I::closed, a, c, I::closed)) : nullopt;
+        check_union(
+            I(I::closed, a, b, I::closed),
+            I(I::closed, c, c, I::closed),
+            {adj, expected});
+      }
+    }
+    SECTION("Surround: A-C and B-B") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") union [" << b << "," << b << "]") {
+        // If `a` is adjacent to `b`, the result will have a closed lower bound.
+        // If `b` is adjacent to `c`, the result will have a closed upper bound.
+        bool adj_lower = is_adjacent(a, b);
+        bool adj_upper = is_adjacent(b, c);
+        I expected = adj_lower ? (adj_upper ? I(I::closed, b, b, I::closed) :
+                                              I(I::closed, b, c, I::open)) :
+                                 (adj_upper ? I(I::open, a, b, I::closed) :
+                                              I(I::open, a, c, I::open));
+        check_union(
+            I(I::open, a, c, I::open),
+            I(I::closed, b, b, I::closed),
+            {true, expected});
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << "] union [" << b << "," << b << "]") {
+        // If `a` is adjacent to `b`, the result will have a closed lower bound.
+        bool adj = is_adjacent(a, b);
+        I expected =
+            adj ? I(I::closed, b, c, I::closed) : I(I::open, a, c, I::closed);
+        check_union(
+            I(I::open, a, c, I::closed),
+            I(I::closed, b, b, I::closed),
+            {true, expected});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << ") union [" << b << "," << b << "]") {
+        // If `b` is adjacent to `c`, the result will have a closed upper bound.
+        bool adj = is_adjacent(b, c);
+        I expected =
+            adj ? I(I::closed, a, b, I::closed) : I(I::closed, a, c, I::open);
+        check_union(
+            I(I::closed, a, c, I::open),
+            I(I::closed, b, b, I::closed),
+            {true, expected});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] union [" << b << "," << b << "]") {
+        check_union(
+            I(I::closed, a, c, I::closed),
+            I(I::closed, b, b, I::closed),
+            {true, I(I::closed, a, c, I::closed)});
+      }
+    }
+    SECTION("Surround, Degenerate Upper: A-C and B-C") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") union (" << b << "," << c << ")") {
+        check_union(
+            I(I::open, a, c, I::open),
+            I(I::open, b, c, I::open),
+            {true, I(I::open, a, c, I::open)});
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") union [" << b << "," << c << "]") {
+        // If `a` is adjacent to `b`, the result will have a closed lower bound.
+        bool adj = is_adjacent(a, b);
+        I expected =
+            adj ? I(I::closed, b, c, I::closed) : I(I::open, a, c, I::closed);
+        check_union(
+            I(I::open, a, c, I::open),
+            I(I::closed, b, c, I::closed),
+            {true, expected});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] union (" << b << "," << c << ")") {
+        check_union(
+            I(I::closed, a, c, I::closed),
+            I(I::open, b, c, I::open),
+            {true, I(I::closed, a, c, I::closed)});
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] union [" << b << "," << c << "]") {
+        check_union(
+            I(I::closed, a, c, I::closed),
+            I(I::closed, b, c, I::closed),
+            {true, I(I::closed, a, c, I::closed)});
+      }
+    }
+  }
+}
+
+//=======================================================
+// Tests for Interval::cut()
+//=======================================================
+
+template <class T>
+void check_cut(
+    Interval<T> x,
+    T y,
+    Interval<T> expected_z_below,
+    Interval<T> expected_z_above,
+    bool is_result_lower_open) {
+  typedef WhiteboxInterval<T> WI;
+  auto [z_below, z_above] = x.cut(y, is_result_lower_open);
+  WI(z_below).check_equality(expected_z_below);
+  WI(z_above).check_equality(expected_z_above);
+  /*
+   * Verify that we recover the original interval as the union of the two
+   * cut pieces.
+   *
+   * We don't use check_equality here because a reunion after a cut is not
+   * required to have the same representation as the original, merely to
+   * represent the same set.
+   */
+  auto [x_reunited, x_reunion] = z_below.interval_union(z_above);
+  REQUIRE(x_reunited);
+  CHECK(x == x_reunion.value());
+  /*
+   * Verify that compare() shows that the two cut pieces are adjacent.
+   */
+  if (!z_below.is_empty() && !z_above.is_empty()) {
+    auto [c, adj] = z_below.compare(z_above);
+    CHECK(c < 0);
+    CHECK(adj);
+  }
+}
+
+/*
+ * These tests are tagged with `union` and `compare(interval)` because they're
+ * also tested in `check_cut`. It checks that adjacent interval reunite and
+ * that they're seen as adjacent.
+ */
+TEMPLATE_LIST_TEST_CASE(
+    "Interval::cut",
+    "[interval][cut][union][compare/interval]",
+    TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef TestTypeTraits<T> Tr;
+  I empty(I::empty_set);
+
+  // TODO: Tests with infinite bounds
+
+  SECTION("Three unique points") {
+    SECTION("Trivial: cut A-B at C") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") cut at " << c << ", lower open") {
+        I x(I::open, a, b, I::open);
+        check_cut(x, c, x, empty, true);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") cut at " << c << ", lower closed") {
+        I x(I::open, a, b, I::open);
+        check_cut(x, c, x, empty, false);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] cut at " << c << ", lower open") {
+        I x(I::closed, a, b, I::closed);
+        check_cut(x, c, x, empty, true);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] cut at " << c << ", lower closed") {
+        I x(I::closed, a, b, I::closed);
+        check_cut(x, c, x, empty, false);
+      }
+    }
+    SECTION("Ordinary: cut A-C at B") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") cut at " << b << ", lower open") {
+        I x(I::open, a, c, I::open);
+        I z0(I::open, a, b, I::open), z1(I::closed, b, c, I::open);
+        check_cut(x, b, z0, z1, true);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << ") cut at " << b << ", lower closed") {
+        I x(I::open, a, c, I::open);
+        I z0(I::open, a, b, I::closed), z1(I::open, b, c, I::open);
+        check_cut(x, b, z0, z1, false);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << "] cut at " << b << ", lower open") {
+        I x(I::open, a, c, I::closed);
+        I z0(I::open, a, b, I::open), z1(I::closed, b, c, I::closed);
+        check_cut(x, b, z0, z1, true);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << c << "] cut at " << b << ", lower closed") {
+        I x(I::open, a, c, I::closed);
+        I z0(I::open, a, b, I::closed), z1(I::open, b, c, I::closed);
+        check_cut(x, b, z0, z1, false);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << ") cut at " << b << ", lower open") {
+        I x(I::closed, a, c, I::open);
+        I z0(I::closed, a, b, I::open), z1(I::closed, b, c, I::open);
+        check_cut(x, b, z0, z1, true);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << ") cut at " << b << ", lower closed") {
+        I x(I::closed, a, c, I::open);
+        I z0(I::closed, a, b, I::closed), z1(I::open, b, c, I::open);
+        check_cut(x, b, z0, z1, false);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] cut at " << b << ", lower open") {
+        I x(I::closed, a, c, I::closed);
+        I z0(I::closed, a, b, I::open), z1(I::closed, b, c, I::closed);
+        check_cut(x, b, z0, z1, true);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << c << "] cut at " << b << ", lower closed") {
+        I x(I::closed, a, c, I::closed);
+        I z0(I::closed, a, b, I::closed), z1(I::open, b, c, I::closed);
+        check_cut(x, b, z0, z1, false);
+      }
+    }
+    SECTION("Trivial: cut B-C at A") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const auto a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(
+          "(" << b << "," << c << ") cut at " << a << ", lower open") {
+        I x(I::open, b, c, I::open);
+        check_cut(x, a, empty, x, true);
+      }
+      DYNAMIC_SECTION(
+          "(" << b << "," << c << ") cut at " << a << ", lower closed") {
+        I x(I::open, b, c, I::open);
+        check_cut(x, a, empty, x, false);
+      }
+      DYNAMIC_SECTION(
+          "[" << b << "," << c << "] cut at " << a << ", lower open") {
+        I x(I::closed, b, c, I::closed);
+        check_cut(x, a, empty, x, true);
+      }
+      DYNAMIC_SECTION(
+          "[" << b << "," << c << "] cut at " << a << ", lower closed") {
+        I x(I::closed, b, c, I::closed);
+        check_cut(x, a, empty, x, false);
+      }
+    }
+  }
+  SECTION("Two unique points") {
+    SECTION("Lower: cut A-B at A") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const auto a = v[0], b = v[1];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") cut at " << a << ", lower open") {
+        I x(I::open, a, b, I::open);
+        check_cut(x, a, empty, x, true);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") cut at " << a << ", lower closed") {
+        I x(I::open, a, b, I::open);
+        check_cut(x, a, empty, x, false);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << "] cut at " << a << ", lower open") {
+        I x(I::open, a, b, I::closed);
+        check_cut(x, a, empty, x, true);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << "] cut at " << a << ", lower closed") {
+        I x(I::open, a, b, I::closed);
+        check_cut(x, a, empty, x, false);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") cut at " << a << ", lower open") {
+        I x(I::closed, a, b, I::open);
+        check_cut(x, a, empty, x, true);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") cut at " << a << ", lower closed") {
+        I x(I::closed, a, b, I::open);
+        I z0(I::single_point, a), z1(I::open, a, b, I::open);
+        check_cut(x, a, z0, z1, false);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] cut at " << a << ", lower open") {
+        I x(I::closed, a, b, I::closed);
+        check_cut(x, a, empty, x, true);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] cut at " << a << ", lower closed") {
+        I x(I::closed, a, b, I::closed);
+        I z0(I::single_point, a), z1(I::open, a, b, I::closed);
+        check_cut(x, a, z0, z1, false);
+      }
+    }
+    SECTION("Upper: cut A-B at B") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const auto a = v[0], b = v[1];
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") cut at " << b << ", lower open") {
+        I x(I::open, a, b, I::open);
+        check_cut(x, b, x, empty, true);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << ") cut at " << b << ", lower closed") {
+        I x(I::open, a, b, I::open);
+        check_cut(x, b, x, empty, false);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << "] cut at " << b << ", lower open") {
+        I x(I::open, a, b, I::closed);
+        I z0(I::open, a, b, I::open), z1(I::single_point, b);
+        check_cut(x, b, z0, z1, true);
+      }
+      DYNAMIC_SECTION(
+          "(" << a << "," << b << "] cut at " << b << ", lower closed") {
+        I x(I::open, a, b, I::closed);
+        check_cut(x, b, x, empty, false);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") cut at " << b << ", lower open") {
+        I x(I::closed, a, b, I::open);
+        check_cut(x, b, x, empty, true);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << ") cut at " << b << ", lower closed") {
+        I x(I::closed, a, b, I::open);
+        check_cut(x, b, x, empty, false);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] cut at " << b << ", lower open") {
+        I x(I::closed, a, b, I::closed);
+        I z0(I::closed, a, b, I::open), z1(I::single_point, b);
+        check_cut(x, b, z0, z1, true);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << b << "] cut at " << b << ", lower closed") {
+        I x(I::closed, a, b, I::closed);
+        check_cut(x, b, x, empty, false);
+      }
+    }
+  }
+  SECTION("One unique point") {
+    SECTION("Cut A-A at A") {
+      T a = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION(
+          "[" << a << "," << a << "] cut at " << a << ", lower open") {
+        I x(I::closed, a, a, I::closed);
+        check_cut(x, a, empty, x, true);
+      }
+      DYNAMIC_SECTION(
+          "[" << a << "," << a << "] cut at " << a << ", lower closed") {
+        I x(I::closed, a, a, I::closed);
+        check_cut(x, a, x, empty, false);
+      }
+    }
+  }
+}

--- a/tiledb/common/interval/test/unit_interval_operations.cc
+++ b/tiledb/common/interval/test/unit_interval_operations.cc
@@ -59,7 +59,6 @@ TEMPLATE_LIST_TEST_CASE(
     "Interval::intersection", "[interval][intersection]", TypesUnderTest) {
   typedef TestType T;
   typedef Interval<T> I;
-  typedef WhiteboxInterval<T> WI;
   typedef TestTypeTraits<T> Tr;
   const I empty(I::empty_set);
 

--- a/tiledb/common/interval/test/unit_interval_predicates.cc
+++ b/tiledb/common/interval/test/unit_interval_predicates.cc
@@ -1,0 +1,220 @@
+/**
+ * @file unit_interval_predicates.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines tests for the predicates of class Interval: interval vs.
+ * interval comparison, set membership, point vs. interval comparison.
+ */
+
+#include "unit_interval.h"
+
+//=======================================================
+// Equality
+//=======================================================
+/*
+ * The tests for `operator==` are incorporated into `check_equality()`, which is
+ * used in all the operation tests.
+ */
+
+//=======================================================
+// Interval comparison
+//=======================================================
+/*
+ * Most of the tests for interval comparison are integrated into the tests for
+ * `interval_union` and `cut`.
+ *
+ * In `check_union`, the union only succeeds if the intervals intersect or
+ * adjacent. Union success is correlated against the return value from
+ * `compare`. `compare` is anti-symmetrical, so its return values are also
+ * checked against the result when the arguments are swapped.
+ *
+ * In `check_cut`, the cut intervals are tested for adjacency. These tests cover
+ * the generic adjacency test, when an upper half-open (resp. closed) interval
+ * is adjacent to a lower half-closed (resp. open) one. The tests below for
+ * adjacency are confined to the closed vs. closed case, where additional kinds
+ * of adjacency may occur.
+ */
+
+TEMPLATE_LIST_TEST_CASE(
+    "Interval::compare", "[Interval][compare/interval]", TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef TestTypeTraits<T> Tr;
+  SECTION("closed A-B compare-to closed C-D") {
+    /*
+     * The integer test sequences all have at least one choose-4 subsequence
+     * that will yield adjacent closed intervals, for example [0,1] and [2,100].
+     */
+    std::vector<T> v = GENERATE(choose(4, Tr::outer));
+    const auto a = v[0], b = v[1], c = v[2], d = v[3];
+
+    DYNAMIC_SECTION(
+        "[" << a << "," << b << "] compare-to [" << c << "," << d << "]") {
+      bool expected_adj = is_adjacent(b, c);
+      I x(I::closed, a, b, I::closed), y(I::closed, c, d, I::closed);
+      auto [cmp, adj] = x.compare(y);
+      CHECK(cmp < 0);
+      CHECK(adj == expected_adj);
+      auto [cmp2, adj2] = y.compare(x);
+      CHECK(cmp2 > 0);
+      CHECK(adj2 == expected_adj);
+    }
+  }
+}
+
+//=======================================================
+// Point comparison
+//=======================================================
+
+template <class T>
+void check_point_below(T x, Interval<T> y) {
+  CHECK(!y.is_member(x));
+  if (!y.is_empty()) {
+    CHECK(y.compare(x) < 0);
+  }
+}
+
+template <class T>
+void check_point_inside(T x, Interval<T> y) {
+  if (!y.is_empty()) {
+    CHECK(y.is_member(x));
+    CHECK(y.compare(x) == 0);
+  } else {
+    CHECK(!y.is_member(x));
+  }
+}
+
+template <class T>
+void check_point_above(T x, Interval<T> y) {
+  CHECK(!y.is_member(x));
+  if (!y.is_empty()) {
+    CHECK(y.compare(x) > 0);
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "Interval::is_member",
+    "[Interval][is_member][compare/point]",
+    TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef TestTypeTraits<T> Tr;
+
+  SECTION("Three unique points") {
+    SECTION("A member of B-C") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const T a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(a << " is-member-of (" << b << "," << c << ")") {
+        check_point_below(a, I(I::open, b, c, I::open));
+      }
+      DYNAMIC_SECTION(a << " is-member-of (" << b << "," << c << "]") {
+        check_point_below(a, I(I::open, b, c, I::closed));
+      }
+      DYNAMIC_SECTION(a << " is-member-of [" << b << "," << c << ")") {
+        check_point_below(a, I(I::closed, b, c, I::open));
+      }
+      DYNAMIC_SECTION(a << " is-member-of [" << b << "," << c << "]") {
+        check_point_below(a, I(I::closed, b, c, I::closed));
+      }
+    }
+    SECTION("B member of A-C") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const T a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(b << " is-member-of (" << a << "," << c << ")") {
+        check_point_inside(b, I(I::open, a, c, I::open));
+      }
+      DYNAMIC_SECTION(b << " is-member-of (" << a << "," << c << "]") {
+        check_point_inside(b, I(I::open, a, c, I::closed));
+      }
+      DYNAMIC_SECTION(b << " is-member-of [" << a << "," << c << ")") {
+        check_point_inside(b, I(I::closed, a, c, I::open));
+      }
+      DYNAMIC_SECTION(b << " is-member-of [" << a << "," << c << "]") {
+        check_point_inside(b, I(I::closed, a, c, I::closed));
+      }
+    }
+    SECTION("C member of A-B") {
+      std::vector<T> v = GENERATE(choose(3, Tr::outer));
+      const T a = v[0], b = v[1], c = v[2];
+      DYNAMIC_SECTION(c << " is-member-of (" << a << "," << b << ")") {
+        check_point_above(c, I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(c << " is-member-of (" << a << "," << b << "]") {
+        check_point_above(c, I(I::open, a, b, I::closed));
+      }
+      DYNAMIC_SECTION(c << " is-member-of [" << a << "," << b << ")") {
+        check_point_above(c, I(I::closed, a, b, I::open));
+      }
+      DYNAMIC_SECTION(c << " is-member-of [" << a << "," << b << "]") {
+        check_point_above(c, I(I::closed, a, b, I::closed));
+      }
+    }
+  }
+  SECTION("Two unique points") {
+    SECTION("A member of A-B") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION(a << " is-member-of (" << a << "," << b << ")") {
+        check_point_below(a, I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(a << " is-member-of (" << a << "," << b << "]") {
+        check_point_below(a, I(I::open, a, b, I::closed));
+      }
+      DYNAMIC_SECTION(a << " is-member-of [" << a << "," << b << ")") {
+        check_point_inside(a, I(I::closed, a, b, I::open));
+      }
+      DYNAMIC_SECTION(a << " is-member-of [" << a << "," << b << "]") {
+        check_point_inside(a, I(I::closed, a, b, I::closed));
+      }
+    }
+    SECTION("B member of A-B") {
+      std::vector<T> v = GENERATE(choose(2, Tr::outer));
+      const T a = v[0], b = v[1];
+      DYNAMIC_SECTION(b << " is-member-of (" << a << "," << b << ")") {
+        check_point_above(b, I(I::open, a, b, I::open));
+      }
+      DYNAMIC_SECTION(b << " is-member-of (" << a << "," << b << "]") {
+        check_point_inside(b, I(I::open, a, b, I::closed));
+      }
+      DYNAMIC_SECTION(b << " is-member-of [" << a << "," << b << ")") {
+        check_point_above(b, I(I::closed, a, b, I::open));
+      }
+      DYNAMIC_SECTION(b << " is-member-of [" << a << "," << b << "]") {
+        check_point_inside(b, I(I::closed, a, b, I::closed));
+      }
+    }
+  }
+  SECTION("One unique point") {
+    SECTION("A member of A-A") {
+      T a = GENERATE(values(Tr::outer));
+      DYNAMIC_SECTION(a << " is-member-of [" << a << "," << a << "]") {
+        check_point_inside(a, I(I::closed, a, a, I::closed));
+      }
+    }
+  }
+}

--- a/tiledb/common/interval/test/unit_interval_predicates.cc
+++ b/tiledb/common/interval/test/unit_interval_predicates.cc
@@ -33,17 +33,17 @@
 
 #include "unit_interval.h"
 
-//=======================================================
-// Equality
-//=======================================================
+/* ****************************** */
+/*             Equality           */
+/* ****************************** */
 /*
  * The tests for `operator==` are incorporated into `check_equality()`, which is
  * used in all the operation tests.
  */
 
-//=======================================================
-// Interval comparison
-//=======================================================
+/* ****************************** */
+/*       Interval comparison      */
+/* ****************************** */
 /*
  * Most of the tests for interval comparison are integrated into the tests for
  * `interval_union` and `cut`.
@@ -87,9 +87,9 @@ TEMPLATE_LIST_TEST_CASE(
   }
 }
 
-//=======================================================
-// Point comparison
-//=======================================================
+/* ****************************** */
+/*         Point comparison       */
+/* ****************************** */
 
 template <class T>
 void check_point_below(T x, Interval<T> y) {

--- a/tiledb/common/interval/test/unit_interval_types.cc
+++ b/tiledb/common/interval/test/unit_interval_types.cc
@@ -35,7 +35,6 @@
 
 TEMPLATE_LIST_TEST_CASE("TypeTraits", "[interval]", TypesUnderTest) {
   typedef TestType T;
-  typedef Interval<T> I;
   typedef detail::TypeTraits<T> Traits;
   typedef TestTypeTraits<T> Tr;
 

--- a/tiledb/common/interval/test/unit_interval_types.cc
+++ b/tiledb/common/interval/test/unit_interval_types.cc
@@ -1,0 +1,60 @@
+/**
+ * @file unit_interval_types.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines test functions for the classes and functions that provide
+ * type support for class Interval.
+ */
+
+#include "unit_interval.h"
+
+TEMPLATE_LIST_TEST_CASE("TypeTraits", "[interval]", TypesUnderTest) {
+  typedef TestType T;
+  typedef Interval<T> I;
+  typedef detail::TypeTraits<T> Traits;
+  typedef TestTypeTraits<T> Tr;
+
+  std::vector<T> v = GENERATE(choose(2, Tr::inner));
+  T i = v[0], j = v[1];
+  auto [adjacent, twice_adjacent] = Traits::adjacency(i, j);
+  if constexpr (std::is_integral_v<T>) {
+    CHECK(!(adjacent && twice_adjacent));
+    if (i < j) {
+      CHECK(iff(adjacent, i + 1 == j));
+      CHECK(iff(twice_adjacent, i + 1 == j - 1));
+    } else {
+      CHECK(!adjacent);
+      CHECK(!twice_adjacent);
+    }
+  } else if constexpr (std::is_floating_point_v<T>) {
+    CHECK_FALSE(adjacent);
+    CHECK_FALSE(twice_adjacent);
+  } else {
+    REQUIRE((false && "unknown type"));
+  }
+}

--- a/tiledb/sm/buffer/buffer.cc
+++ b/tiledb/sm/buffer/buffer.cc
@@ -43,9 +43,9 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
-//=======================================================
-// BufferBase
-//=======================================================
+/* ****************************** */
+/*          BufferBase            */
+/* ****************************** */
 
 BufferBase::BufferBase()
     : data_(nullptr)
@@ -141,9 +141,9 @@ void BufferBase::assert_offset_is_valid(uint64_t offset) const {
   }
 }
 
-//=======================================================
-// Buffer
-//=======================================================
+/* ****************************** */
+/*            Buffer              */
+/* ****************************** */
 
 Buffer::Buffer()
     : BufferBase()
@@ -361,9 +361,9 @@ Status Buffer::ensure_alloced_size(const uint64_t nbytes) {
   return this->realloc(new_alloc_size);
 }
 
-//=======================================================
-// ConstBuffer
-//=======================================================
+/* ****************************** */
+/*          ConstBuffer           */
+/* ****************************** */
 
 ConstBuffer::ConstBuffer(Buffer* buff)
     : ConstBuffer(buff->data(), buff->size()) {
@@ -377,9 +377,9 @@ uint64_t ConstBuffer::nbytes_left_to_read() const {
   return size_ - offset_;
 }
 
-//=======================================================
-// PreallocatedBuffer
-//=======================================================
+/* ****************************** */
+/*       PreallocatedBuffer       */
+/* ****************************** */
 
 PreallocatedBuffer::PreallocatedBuffer(const void* data, const uint64_t size)
     : BufferBase(data, size) {

--- a/tiledb/sm/buffer/buffer.h
+++ b/tiledb/sm/buffer/buffer.h
@@ -44,9 +44,9 @@ namespace sm {
 
 class ConstBuffer;
 
-//=======================================================
-// BufferBase
-//=======================================================
+/* ****************************** */
+/*          BufferBase            */
+/* ****************************** */
 /**
  * Base class for `Buffer`, `ConstBuffer`, and `PreallocatedBuffer`
  *
@@ -129,9 +129,9 @@ class BufferBase {
   uint64_t offset_;
 };
 
-//=======================================================
-// Buffer
-//=======================================================
+/* ****************************** */
+/*            Buffer              */
+/* ****************************** */
 /**
  * General-purpose buffer. Manages own memory. Writeable.
  */
@@ -318,9 +318,9 @@ class Buffer : public BufferBase {
   Status ensure_alloced_size(uint64_t nbytes);
 };
 
-//=======================================================
-// ConstBuffer
-//=======================================================
+/* ****************************** */
+/*          ConstBuffer           */
+/* ****************************** */
 /**
  * A read-only buffer fully-initialized at construction. It does not manage
  * memory; its storage is subordinate to some other object.
@@ -378,9 +378,9 @@ class ConstBuffer : public BufferBase {
   }
 };
 
-//=======================================================
-// PreallocatedBuffer
-//=======================================================
+/* ****************************** */
+/*       PreallocatedBuffer       */
+/* ****************************** */
 /**
  * Writeable buffer that uses pre-allocated storage provided externally. Does
  * not expand storage on write.


### PR DESCRIPTION
First revision of the Interval class. Operations are intersection, union, and cut. Predicates are equality, interval comparison, set membership, and point comparison. All combinations of open, closed, and infinite bounds are supported, including empty sets.

There's a deficiency still here, that the unit tests aren't quite complete; tests with infinite bound for intersection and cut aren't done yet. Schedule won out over final completion.

---
TYPE: FEATURE
DESC: First revision of the Interval class
