### PR TITLE
[Azure] Add Azure shared access signature (SAS) support

### DIFF
--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -91,8 +91,9 @@ shared_ptr_exceptions = {
     ],
     "s3.h": ["std::shared_ptr<S3ThreadPoolExecutor>"],
     "azure.cc": [
-        "std::shared_ptr<azure::storage_lite::shared_key_credential>",
+        "std::shared_ptr<azure::storage_lite::storage_credential>",
         "std::shared_ptr<azure::storage_lite::storage_account>",
+        "azure::storage_lite::shared_access_signature_credential>"
     ],
 }
 
@@ -112,6 +113,7 @@ make_shared_exceptions = {
         "std::make_shared<azure::storage_lite::storage_account>",
         "std::make_shared<azure::storage_lite::tinyxml2_parser>",
         "std::make_shared<AzureRetryPolicy>",
+        "std::make_shared<"
     ],
 }
 

--- a/scripts/install-azurite.sh
+++ b/scripts/install-azurite.sh
@@ -46,7 +46,7 @@ install_brew_pkgs() {
 }
 
 install_deps() {
-  AZURITE_PACKAGE="azurite@3.6.0"
+  AZURITE_PACKAGE="azurite@3.13.1"
   if [[ $OSTYPE == linux* ]]; then
     if [ -n "$(command -v apt-get)" ]; then
       install_apt_pkgs

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -177,9 +177,15 @@ void check_save_to_file() {
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
 
-  // Check that aws secret access key is not serialized.
+  // Check that azure account key is not serialized.
   rc = tiledb_config_set(
       config, "vfs.azure.storage_account_key", "secret", &error);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+
+  // Check that azure SAS token is not serialized.
+  rc = tiledb_config_set(
+      config, "vfs.azure.storage_sas_token", "secret", &error);
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
 
@@ -583,6 +589,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["vfs.gcs.request_timeout_ms"] = "3000";
   all_param_values["vfs.azure.storage_account_name"] = "";
   all_param_values["vfs.azure.storage_account_key"] = "";
+  all_param_values["vfs.azure.storage_sas_token"] = "";
   all_param_values["vfs.azure.blob_endpoint"] = "";
   all_param_values["vfs.azure.block_list_block_size"] = "5242880";
   all_param_values["vfs.azure.max_parallel_ops"] =
@@ -646,6 +653,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   vfs_param_values["gcs.request_timeout_ms"] = "3000";
   vfs_param_values["azure.storage_account_name"] = "";
   vfs_param_values["azure.storage_account_key"] = "";
+  vfs_param_values["azure.storage_sas_token"] = "";
   vfs_param_values["azure.blob_endpoint"] = "";
   vfs_param_values["azure.block_list_block_size"] = "5242880";
   vfs_param_values["azure.max_parallel_ops"] =
@@ -706,6 +714,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   std::map<std::string, std::string> azure_param_values;
   azure_param_values["storage_account_name"] = "";
   azure_param_values["storage_account_key"] = "";
+  azure_param_values["storage_sas_token"] = "";
   azure_param_values["blob_endpoint"] = "";
   azure_param_values["block_list_block_size"] = "5242880";
   azure_param_values["max_parallel_ops"] =

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -61,7 +61,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi], [cppapi-config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 57);
+  CHECK(names.size() == 58);
 }
 
 TEST_CASE(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1079,6 +1079,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `vfs.azure.storage_account_key` <br>
  *    Set the Azure Storage Account key. <br>
  *    **Default**: ""
+ * - `vfs.azure.storage_sas_token` <br>
+ *    Set the Azure Storage SAS (shared access signature) token. <br>
+ *    **Default**: ""
  * - `vfs.azure.blob_endpoint` <br>
  *    Overrides the default Azure Storage Blob endpoint. If empty, the endpoint
  *    will be constructed from the storage account name. This should not include

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -111,6 +111,7 @@ const std::string Config::VFS_READ_AHEAD_SIZE = "102400";          // 100KiB
 const std::string Config::VFS_READ_AHEAD_CACHE_SIZE = "10485760";  // 10MiB;
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_NAME = "";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_KEY = "";
+const std::string Config::VFS_AZURE_STORAGE_SAS_TOKEN = "";
 const std::string Config::VFS_AZURE_BLOB_ENDPOINT = "";
 const std::string Config::VFS_AZURE_USE_HTTPS = "true";
 const std::string Config::VFS_AZURE_MAX_PARALLEL_OPS =
@@ -169,6 +170,7 @@ const char Config::COMMENT_START = '#';
 const std::set<std::string> Config::unserialized_params_ = {
     "vfs.azure.storage_account_name",
     "vfs.azure.storage_account_key",
+    "vfs.azure.storage_sas_token",
     "vfs.s3.proxy_username",
     "vfs.s3.proxy_password",
     "vfs.s3.aws_access_key_id",
@@ -254,6 +256,7 @@ Config::Config() {
       VFS_AZURE_STORAGE_ACCOUNT_NAME;
   param_values_["vfs.azure.storage_account_key"] =
       VFS_AZURE_STORAGE_ACCOUNT_KEY;
+  param_values_["vfs.azure.storage_sas_token"] = VFS_AZURE_STORAGE_SAS_TOKEN;
   param_values_["vfs.azure.blob_endpoint"] = VFS_AZURE_BLOB_ENDPOINT;
   param_values_["vfs.azure.use_https"] = VFS_AZURE_USE_HTTPS;
   param_values_["vfs.azure.max_parallel_ops"] = VFS_AZURE_MAX_PARALLEL_OPS;
@@ -542,6 +545,8 @@ Status Config::unset(const std::string& param) {
   } else if (param == "vfs.azure.storage_account_key") {
     param_values_["vfs.azure.storage_account_key"] =
         VFS_AZURE_STORAGE_ACCOUNT_KEY;
+  } else if (param == "vfs.azure.storage_sas_token") {
+    param_values_["vfs.azure.storage_sas_token"] = VFS_AZURE_STORAGE_SAS_TOKEN;
   } else if (param == "vfs.azure.blob_endpoint") {
     param_values_["vfs.azure.blob_endpoint"] = VFS_AZURE_BLOB_ENDPOINT;
   } else if (param == "vfs.azure.use_https") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -289,6 +289,9 @@ class Config {
   /** Azure storage account key. */
   static const std::string VFS_AZURE_STORAGE_ACCOUNT_KEY;
 
+  /** Azure storage account SAS (shared access signature) token. */
+  static const std::string VFS_AZURE_STORAGE_SAS_TOKEN;
+
   /** Azure blob endpoint. */
   static const std::string VFS_AZURE_BLOB_ENDPOINT;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -428,6 +428,9 @@ class Config {
    * - `vfs.azure.storage_account_key` <br>
    *    Set the Azure Storage Account key. <br>
    *    **Default**: ""
+   * - `vfs.azure.storage_sas_token` <br>
+   *    Set the Azure Storage SAS (shared access signature) token. <br>
+   *    **Default**: ""
    * - `vfs.azure.blob_endpoint` <br>
    *    Overrides the default Azure Storage Blob endpoint. If empty, the
    *    endpoint will be constructed from the storage account name. This

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -75,7 +75,7 @@ Status Context::init(Config* const config) {
       tiledb::sm::StorageManager(&compute_tp_, &io_tp_, stats_.get());
   if (storage_manager_ == nullptr)
     return LOG_STATUS(Status::ContextError(
-        "Cannot initialize contextl Storage manager allocation failed"));
+        "Cannot initialize context Storage manager allocation failed"));
 
   // Initialize storage manager
   return storage_manager_->init(config);


### PR DESCRIPTION
Add Azure SAS token config support and new config option

  'azure.storage_sas_token'

This has been tested successfully against the Azure Blob service,
but note that the test config is disabled because it currently
fails with the Azurite emulator.

<long description>

---
TYPE: FEATURE
DESC: Added Azure SAS token config support and new config option
