### PR TITLE
Isolate azure cpp lite in externals/install

### DIFF
--- a/cmake/Modules/FindAzureSDK_EP.cmake
+++ b/cmake/Modules/FindAzureSDK_EP.cmake
@@ -94,17 +94,6 @@ if (NOT AZURESDK_FOUND)
     endif()
 
     if (WIN32)
-      if(MSVC)
-        set(CXXFLAGS_DEF " -I${TILEDB_EP_AZURE_INSTALL_PREFIX}/include /Dazure_storage_lite_EXPORTS /DCURL_STATICLIB=1 ${CMAKE_CXX_FLAGS}")
-        set(CFLAGS_DEF " -I${TILEDB_EP_INSTALL_PREFIX}/azure/include /Dazure_storage_lite_EXPORTS                  ${CMAKE_C_FLAGS}")
-      endif()
-    else()
-      #put our switch first in case other items are empty, leaving problematic blank space at beginning
-      set(CFLAGS_DEF "-fPIC ${CMAKE_C_FLAGS}")
-      set(CXXFLAGS_DEF "-fPIC ${CMAKE_CXX_FLAGS}")
-    endif()
-
-    if (WIN32)
         # needed for applying patches on windows
         find_package(Git REQUIRED)
         #see comment on this answer - https://stackoverflow.com/a/45698220
@@ -112,6 +101,12 @@ if (NOT AZURESDK_FOUND)
     else()
         set(PATCH patch -N -p1)
     endif()
+
+    # NOTE:
+    # - CURL_NO_CURL_CMAKE (CMake 3.17+) is used because azure-cpp-lite only uses
+    #   CURL_LIBRARIES/CURL_INCLUDE_DIRS, not `curl::curl` target.
+    #   In CMake 3.17+, CMake's built-in FindCURL defers to the curl-installed
+    #   CMake config file, which *does not* set `CURL_*` variables.
 
     if(WIN32)
       ExternalProject_Add(ep_azuresdk
@@ -124,14 +119,13 @@ if (NOT AZURESDK_FOUND)
           -DBUILD_SHARED_LIBS=OFF
           -DBUILD_TESTS=OFF
           -DBUILD_SAMPLES=OFF
+          -DCURL_NO_CURL_CMAKE=ON
           -DCMAKE_PREFIX_PATH=${TILEDB_EP_INSTALL_PREFIX}
           -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_AZURE_INSTALL_PREFIX}
-          -DCMAKE_CXX_FLAGS=${CXXFLAGS_DEF}
-          -DCMAKE_C_FLAGS=${CFLAGS_DEF}
           -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
         PATCH_COMMAND
           cd ${CMAKE_SOURCE_DIR} &&
-          ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_azuresdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/remove-uuid-dep.patch
+          ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_azuresdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0-patchset.patch
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE
@@ -148,12 +142,12 @@ if (NOT AZURESDK_FOUND)
         CMAKE_ARGS
           -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
           -DBUILD_SHARED_LIBS=OFF
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           -DBUILD_TESTS=OFF
           -DBUILD_SAMPLES=OFF
+          -DCURL_NO_CURL_CMAKE=ON
           -DCMAKE_PREFIX_PATH=${TILEDB_EP_INSTALL_PREFIX}
           -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_AZURE_INSTALL_PREFIX}
-          -DCMAKE_CXX_FLAGS=${CXXFLAGS_DEF}
-          -DCMAKE_C_FLAGS=${CFLAGS_DEF}
           -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
         PATCH_COMMAND
           echo starting patching for azure &&

--- a/cmake/Modules/FindAzureSDK_EP.cmake
+++ b/cmake/Modules/FindAzureSDK_EP.cmake
@@ -30,27 +30,30 @@
 # Include some common helper functions.
 include(TileDBCommon)
 
+# This is the install subdirectory for azure headers and libs, to avoid pollution
+set(TILEDB_EP_AZURE_INSTALL_PREFIX "${TILEDB_EP_INSTALL_PREFIX}/azurecpplite")
+
 # First check for a static version in the EP prefix.
 find_library(AZURESDK_LIBRARIES
   NAMES
     libazure-storage-lite${CMAKE_STATIC_LIBRARY_SUFFIX}
     azure-storage-lite${CMAKE_STATIC_LIBRARY_SUFFIX}
-  PATHS ${TILEDB_EP_INSTALL_PREFIX}
+  PATHS "${TILEDB_EP_AZURE_INSTALL_PREFIX}"
   PATH_SUFFIXES lib
   NO_DEFAULT_PATH
 )
 
 #on win32... '.lib' also used for lib ref'ing .dll!!!
 #So, if perchance, in some environments, a .lib existed along with its corresponding .dll,
-#then we could be incorrectly assuming/attempting a static build and probably will fail to 
-#appropriately include/package the .dll, since the code is (incorrectly) assuming .lib is indicative of a 
+#then we could be incorrectly assuming/attempting a static build and probably will fail to
+#appropriately include/package the .dll, since the code is (incorrectly) assuming .lib is indicative of a
 #static library being used.
 
 if (AZURESDK_LIBRARIES)
   set(AZURESDK_STATIC_EP_FOUND TRUE)
   find_path(AZURESDK_INCLUDE_DIR
     NAMES get_blob_request_base.h
-    PATHS ${TILEDB_EP_INSTALL_PREFIX}
+    PATHS "${TILEDB_EP_AZURE_INSTALL_PREFIX}"
     PATH_SUFFIXES include
     NO_DEFAULT_PATH
   )
@@ -92,15 +95,15 @@ if (NOT AZURESDK_FOUND)
 
     if (WIN32)
       if(MSVC)
-        set(CXXFLAGS_DEF " -I${TILEDB_EP_INSTALL_PREFIX}/include /Dazure_storage_lite_EXPORTS /DCURL_STATICLIB=1 ${CMAKE_CXX_FLAGS}")
-        set(CFLAGS_DEF " -I${TILEDB_EP_INSTALL_PREFIX}/include /Dazure_storage_lite_EXPORTS                  ${CMAKE_C_FLAGS}")
+        set(CXXFLAGS_DEF " -I${TILEDB_EP_AZURE_INSTALL_PREFIX}/include /Dazure_storage_lite_EXPORTS /DCURL_STATICLIB=1 ${CMAKE_CXX_FLAGS}")
+        set(CFLAGS_DEF " -I${TILEDB_EP_INSTALL_PREFIX}/azure/include /Dazure_storage_lite_EXPORTS                  ${CMAKE_C_FLAGS}")
       endif()
     else()
       #put our switch first in case other items are empty, leaving problematic blank space at beginning
       set(CFLAGS_DEF "-fPIC ${CMAKE_C_FLAGS}")
       set(CXXFLAGS_DEF "-fPIC ${CMAKE_CXX_FLAGS}")
     endif()
-    
+
     if (WIN32)
         # needed for applying patches on windows
         find_package(Git REQUIRED)
@@ -109,7 +112,7 @@ if (NOT AZURESDK_FOUND)
     else()
         set(PATCH patch -N -p1)
     endif()
-    
+
     if(WIN32)
       ExternalProject_Add(ep_azuresdk
         PREFIX "externals"
@@ -122,7 +125,7 @@ if (NOT AZURESDK_FOUND)
           -DBUILD_TESTS=OFF
           -DBUILD_SAMPLES=OFF
           -DCMAKE_PREFIX_PATH=${TILEDB_EP_INSTALL_PREFIX}
-          -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
+          -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_AZURE_INSTALL_PREFIX}
           -DCMAKE_CXX_FLAGS=${CXXFLAGS_DEF}
           -DCMAKE_C_FLAGS=${CFLAGS_DEF}
           -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
@@ -148,7 +151,7 @@ if (NOT AZURESDK_FOUND)
           -DBUILD_TESTS=OFF
           -DBUILD_SAMPLES=OFF
           -DCMAKE_PREFIX_PATH=${TILEDB_EP_INSTALL_PREFIX}
-          -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
+          -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_AZURE_INSTALL_PREFIX}
           -DCMAKE_CXX_FLAGS=${CXXFLAGS_DEF}
           -DCMAKE_C_FLAGS=${CFLAGS_DEF}
           -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}

--- a/cmake/inputs/patches/README.md
+++ b/cmake/inputs/patches/README.md
@@ -1,0 +1,28 @@
+TileDB patches
+--------------
+
+TileDB dependencies must be built against source packages of released software versions.
+
+To simplify patchset maintenance, we may also fork a specific repository version in
+the TileDB-Inc organization.
+
+Several illustrative examples, using the Azure CPP Lite dependency:
+- applying a patchset to a repo fork:
+
+    ```
+    git clone https://github.com/Azure/azure-storage-cpplite
+    cd azure-storage-cpplite
+    git am /path/to/TileDB/cmake/inputs/patches/ep_azure/v0.3.0-patchset.patch
+    ```
+
+- re-creating the patchset from updated fork:
+
+    ```
+    cd azure-storage-cpplite
+    # commit or cherry-pick changes
+    git format-patch v0.3.0 --stdout > /path/to/TileDB/cmake/inputs/patches/ep_azure/v0.3.0-patchset.patch
+    # git add, commit, push to TileDB-Inc fork
+    ```
+
+  Note that the target branch above is for illustration only. The target version should match the version
+  of the dependency used in the `cmake/Modules/Find<DEP>.cmake` file.    

--- a/cmake/inputs/patches/ep_azuresdk/v0.3.0-patchset.patch
+++ b/cmake/inputs/patches/ep_azuresdk/v0.3.0-patchset.patch
@@ -1,0 +1,93 @@
+From 4e58dda184d9dbe405a8a21ad6aa9a1e46057831 Mon Sep 17 00:00:00 2001
+From: Joe maley <joe@tiledb.io>
+Date: Tue, 18 Feb 2020 15:54:40 -0500
+Subject: [PATCH 1/2] remove uuid dependency
+
+Signed-off-by: Isaiah Norton <ihnorton@users.noreply.github.com>
+---
+ CMakeLists.txt  | 10 +++++-----
+ src/utility.cpp |  9 ++++++++-
+ 2 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dfb441e..cefd897 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -147,11 +147,11 @@ if (UNIX)
+     list(APPEND EXTRA_LIBRARIES ${GNUTLS_LIBRARIES})
+   endif()
+ 
+-  if(NOT APPLE)
+-    find_package(PkgConfig REQUIRED)
+-    pkg_check_modules(uuid REQUIRED IMPORTED_TARGET uuid)
+-    list(APPEND EXTRA_LIBRARIES PkgConfig::uuid)
+-  endif()
++#  if(NOT APPLE)
++#    find_package(PkgConfig REQUIRED)
++#    pkg_check_modules(uuid REQUIRED IMPORTED_TARGET uuid)
++#    list(APPEND EXTRA_LIBRARIES PkgConfig::uuid)
++#  endif()
+ elseif(WIN32)
+   list(APPEND EXTRA_LIBRARIES rpcrt4 bcrypt)
+   target_compile_definitions(azure-storage-lite PRIVATE azure_storage_lite_EXPORTS NOMINMAX)
+diff --git a/src/utility.cpp b/src/utility.cpp
+index 747fcb1..07593e0 100644
+--- a/src/utility.cpp
++++ b/src/utility.cpp
+@@ -8,7 +8,7 @@
+ #define WIN32_LEAN_AND_MEAN
+ #include <Windows.h>
+ #else
+-#include <uuid/uuid.h>
++//#include <uuid/uuid.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <fcntl.h>
+@@ -26,6 +26,7 @@ namespace azure {  namespace storage_lite {
+         return str;
+     }
+ 
++/*
+     std::string get_uuid()
+     {
+         std::string res;
+@@ -46,6 +47,12 @@ namespace azure {  namespace storage_lite {
+ 
+         return res;
+     }
++*/
++
++    std::string get_uuid() {
++      std::cerr << "azure::storage_lite::get_uuid() unimplemented" << std::endl;
++      exit(1);
++    }
+ 
+     bool create_or_resize_file(const std::string& path, unsigned long long length) noexcept
+     {
+-- 
+2.22.0.windows.1
+
+
+From e9908d8c1956a05f5b33d8ffecd971c2b437e5aa Mon Sep 17 00:00:00 2001
+From: Jinming Hu <jinmhu@microsoft.com>
+Date: Sun, 21 Jun 2020 22:44:31 +0800
+Subject: [PATCH 2/2] Fix build error on VS2019
+
+---
+ src/base64.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/base64.cpp b/src/base64.cpp
+index e6dead7..0b3e18e 100644
+--- a/src/base64.cpp
++++ b/src/base64.cpp
+@@ -1,5 +1,6 @@
+ #include <array>
+ #include <cstring>
++#include <stdexcept>
+ 
+ #include "base64.h"
+ 
+-- 
+2.22.0.windows.1
+


### PR DESCRIPTION
Isolate azure cpp lite in externals/install. Simplifies removing/rebuilding the EP without a full clean build.

---
TYPE: NO_HISTORY
DESC: Isolate azure cpp lite in externals/install
