### PR TITLE
All c_api error paths should reset pointer to null

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -651,6 +651,7 @@ int32_t tiledb_buffer_alloc(tiledb_ctx_t* ctx, tiledb_buffer_t** buffer) {
   (*buffer)->buffer_ = new (std::nothrow) tiledb::sm::Buffer();
   if ((*buffer)->buffer_ == nullptr) {
     delete *buffer;
+    *buffer = nullptr;
     auto st = Status::Error("Failed to allocate TileDB buffer object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -749,6 +750,7 @@ int32_t tiledb_buffer_list_alloc(
   (*buffer_list)->buffer_list_ = new (std::nothrow) tiledb::sm::BufferList;
   if ((*buffer_list)->buffer_list_ == nullptr) {
     delete *buffer_list;
+    *buffer_list = nullptr;
     auto st = Status::Error("Failed to allocate TileDB buffer list object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -811,6 +813,7 @@ int32_t tiledb_buffer_list_get_buffer(
       new (std::nothrow) tiledb::sm::Buffer(b->data(), b->size());
   if ((*buffer)->buffer_ == nullptr) {
     delete *buffer;
+    *buffer = nullptr;
     auto st = Status::Error("Failed to allocate TileDB buffer object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -888,8 +891,10 @@ int32_t tiledb_config_alloc(tiledb_config_t** config, tiledb_error_t** error) {
         Status::Error("Cannot create config object; Memory allocation failed");
     LOG_STATUS(st);
     create_error(error, st);
-    if (*config != nullptr)
+    if (*config != nullptr) {
       delete *config;
+      *config = nullptr;
+    }
     return TILEDB_OOM;
   }
 
@@ -1176,6 +1181,7 @@ int32_t tiledb_ctx_get_config(tiledb_ctx_t* ctx, tiledb_config_t** config) {
   (*config)->config_ = new (std::nothrow) tiledb::sm::Config();
   if ((*config)->config_ == nullptr) {
     delete (*config);
+    *config = nullptr;
     return TILEDB_OOM;
   }
 
@@ -1290,6 +1296,7 @@ int32_t tiledb_filter_alloc(
       tiledb::sm::Filter::create(static_cast<tiledb::sm::FilterType>(type));
   if ((*filter)->filter_ == nullptr) {
     delete *filter;
+    *filter = nullptr;
     auto st = Status::Error("Failed to allocate TileDB filter object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -1379,6 +1386,7 @@ int32_t tiledb_filter_list_alloc(
   (*filter_list)->pipeline_ = new (std::nothrow) tiledb::sm::FilterPipeline();
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
+    *filter_list = nullptr;
     auto st = Status::Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -1523,6 +1531,7 @@ int32_t tiledb_attribute_alloc(
       tiledb::sm::Attribute(name, static_cast<tiledb::sm::Datatype>(type));
   if ((*attr)->attr_ == nullptr) {
     delete *attr;
+    *attr = nullptr;
     auto st = Status::Error("Failed to allocate TileDB attribute object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -1631,6 +1640,7 @@ int32_t tiledb_attribute_get_filter_list(
       new (std::nothrow) tiledb::sm::FilterPipeline(attr->attr_->filters());
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
+    *filter_list = nullptr;
     auto st = Status::Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -1743,6 +1753,7 @@ int32_t tiledb_domain_alloc(tiledb_ctx_t* ctx, tiledb_domain_t** domain) {
   (*domain)->domain_ = new (std::nothrow) tiledb::sm::Domain();
   if ((*domain)->domain_ == nullptr) {
     delete *domain;
+    *domain = nullptr;
     auto st = Status::Error("Failed to allocate TileDB domain object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -1922,6 +1933,7 @@ int32_t tiledb_dimension_get_filter_list(
       new (std::nothrow) tiledb::sm::FilterPipeline(dim->dim_->filters());
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
+    *filter_list = nullptr;
     auto st = Status::Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2015,6 +2027,7 @@ int32_t tiledb_domain_get_dimension_from_index(
       tiledb::sm::Dimension(domain->domain_->dimension(index));
   if ((*dim)->dim_ == nullptr) {
     delete *dim;
+    *dim = nullptr;
     auto st = Status::Error("Failed to allocate TileDB dimension object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2057,6 +2070,7 @@ int32_t tiledb_domain_get_dimension_from_name(
   (*dim)->dim_ = new (std::nothrow) tiledb::sm::Dimension(found_dim);
   if ((*dim)->dim_ == nullptr) {
     delete *dim;
+    *dim = nullptr;
     auto st = Status::Error("Failed to allocate TileDB dimension object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2292,6 +2306,8 @@ int32_t tiledb_array_schema_load_with_key(
   // Check array name
   tiledb::sm::URI uri(array_uri);
   if (uri.is_invalid()) {
+    delete *array_schema;
+    *array_schema = nullptr;
     auto st = Status::Error("Failed to load array schema; Invalid array URI");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2302,6 +2318,8 @@ int32_t tiledb_array_schema_load_with_key(
     // Check REST client
     auto rest_client = ctx->ctx_->storage_manager()->rest_client();
     if (rest_client == nullptr) {
+      delete *array_schema;
+      *array_schema = nullptr;
       auto st = Status::Error(
           "Failed to load array schema; remote array with no REST client.");
       LOG_STATUS(st);
@@ -2314,6 +2332,7 @@ int32_t tiledb_array_schema_load_with_key(
             rest_client->get_array_schema_from_rest(
                 uri, &(*array_schema)->array_schema_))) {
       delete *array_schema;
+      *array_schema = nullptr;
       return TILEDB_ERR;
     }
   } else {
@@ -2324,8 +2343,11 @@ int32_t tiledb_array_schema_load_with_key(
             key.set_key(
                 static_cast<tiledb::sm::EncryptionType>(encryption_type),
                 encryption_key,
-                key_length)))
+                key_length))) {
+      delete *array_schema;
+      *array_schema = nullptr;
       return TILEDB_ERR;
+    }
 
     // Load array schema
     auto storage_manager = ctx->ctx_->storage_manager();
@@ -2335,6 +2357,7 @@ int32_t tiledb_array_schema_load_with_key(
             storage_manager->load_array_schema(
                 uri, key, &((*array_schema)->array_schema_)))) {
       delete *array_schema;
+      *array_schema = nullptr;
       return TILEDB_ERR;
     }
   }
@@ -2398,6 +2421,7 @@ int32_t tiledb_array_schema_get_coords_filter_list(
       tiledb::sm::FilterPipeline(array_schema->array_schema_->coords_filters());
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
+    *filter_list = nullptr;
     auto st = Status::Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2429,6 +2453,7 @@ int32_t tiledb_array_schema_get_offsets_filter_list(
       array_schema->array_schema_->cell_var_offsets_filters());
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
+    *filter_list = nullptr;
     auto st = Status::Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2460,6 +2485,7 @@ int32_t tiledb_array_schema_get_domain(
       tiledb::sm::Domain(array_schema->array_schema_->domain());
   if ((*domain)->domain_ == nullptr) {
     delete *domain;
+    *domain = nullptr;
     auto st =
         Status::Error("Failed to allocate TileDB domain object in object");
     LOG_STATUS(st);
@@ -2543,6 +2569,7 @@ int32_t tiledb_array_schema_get_attribute_from_index(
   // Check for allocation error
   if ((*attr)->attr_ == nullptr) {
     delete *attr;
+    *attr = nullptr;
     auto st = Status::Error("Failed to allocate TileDB attribute");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2589,6 +2616,7 @@ int32_t tiledb_array_schema_get_attribute_from_name(
   // Check for allocation error
   if ((*attr)->attr_ == nullptr) {
     delete *attr;
+    *attr = nullptr;
     auto st = Status::Error("Failed to allocate TileDB attribute");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2733,6 +2761,7 @@ int32_t tiledb_query_get_config(
   (*config)->config_ = new (std::nothrow) tiledb::sm::Config();
   if ((*config)->config_ == nullptr) {
     delete (*config);
+    *config = nullptr;
     return TILEDB_OOM;
   }
 
@@ -3571,6 +3600,7 @@ int32_t tiledb_query_condition_alloc(
     LOG_STATUS(st);
     save_error(ctx, st);
     delete *cond;
+    *cond = nullptr;
     return TILEDB_OOM;
   }
 
@@ -3645,6 +3675,7 @@ int32_t tiledb_query_condition_combine(
     LOG_STATUS(st);
     save_error(ctx, st);
     delete *combined_cond;
+    *combined_cond = nullptr;
     return TILEDB_OOM;
   }
 
@@ -3920,6 +3951,7 @@ int32_t tiledb_array_get_config(
   *((*config)->config_) = array->array_->config();
   if ((*config)->config_ == nullptr) {
     delete (*config);
+    *config = nullptr;
     return TILEDB_OOM;
   }
 
@@ -4674,6 +4706,7 @@ int32_t tiledb_vfs_alloc(
     LOG_STATUS(st);
     save_error(ctx, st);
     delete *vfs;
+    *vfs = nullptr;
     return TILEDB_OOM;
   }
 
@@ -4723,6 +4756,7 @@ int32_t tiledb_vfs_get_config(
   (*config)->config_ = new (std::nothrow) tiledb::sm::Config();
   if ((*config)->config_ == nullptr) {
     delete (*config);
+    *config = nullptr;
     return TILEDB_OOM;
   }
 
@@ -5287,6 +5321,7 @@ int32_t tiledb_deserialize_array_schema(
               (tiledb::sm::SerializationType)serialize_type,
               *buffer->buffer_))) {
     delete *array_schema;
+    *array_schema = nullptr;
     return TILEDB_ERR;
   }
 
@@ -5668,6 +5703,7 @@ int32_t tiledb_deserialize_config(
               (tiledb::sm::SerializationType)serialize_type,
               *buffer->buffer_))) {
     delete *config;
+    *config = nullptr;
     return TILEDB_ERR;
   }
 


### PR DESCRIPTION
If we allocate any pointers, we not only need to delete them but we should reset them to `nullptr`.

This was highlighted by TileDB-Go where on error we did not see a `nullptr` of the original object and our garbage collection attempted to call the free() function when the structure had already been deleted.
x-ref: https://github.com/TileDB-Inc/TileDB-Go/pull/181

---
TYPE: BUG
DESC: Fix c-api error paths always resetting any alloced pointers to nullptr in-addition to deleting
