### PR TITLE
Augment output to help diagnose when 'legitimate' failures of config …

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -796,10 +796,29 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
     CHECK(error == nullptr);
   } while (!done);
   // highlight any difference to aid the poor developer in event CHECK() fails.
+  // If tiledb environment config variables have been set to something different
+  // from default configuration (such as 
+  // "set/export TILEDB_VFS_S3_AWS_ACCESS_KEY_ID=minio"), 
+  // these can legitimately differ from the defaults expected!
   for (auto i1 = all_param_values.begin(); i1 != all_param_values.end(); ++i1) {
-    if (all_iter_map.find(i1->first) == all_iter_map.end()) {
+    if (auto i2 = all_iter_map.find(i1->first); i2 == all_iter_map.end()) {
       std::cout << "all_iter_map[\"" << i1->first << "\"] not found!"
                 << std::endl;
+    } else {
+      if (i1->first != i2->first) {
+        std::cout << "huh? i1->first != i2->first, \"" << i1->first
+                  << "\" vs \"" << i2->first << std::endl;
+      } else if (i2->second != i1->second) {
+        std::cout << "values for key \"" << i1->first << "\", "
+                                      << "\"" << i2->second << "\" != "
+                                      << "\"" << i1->second << "\"" << std::endl;
+      } else if( all_param_values[i1->first] != all_iter_map[i1->first]) {
+        // if i1->first == i2->first, then should not be possible to be here, but just in case...
+        std::cout << " apv[k] != aim[k], k \""
+            << i1->first << "\", "
+            << "\"" << all_param_values[i1->first] << "\" != \""
+            << all_iter_map[i1->first] << "\"" << std::endl;
+      }
     }
   }
   for (auto i1 = all_iter_map.begin(); i1 != all_iter_map.end(); ++i1) {
@@ -807,6 +826,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       std::cout << "all_param_values[\"" << i1->first << "\"] not found!"
                 << std::endl;
     }
+    //else, for all like keys, unlike values should have been reported in previous loop.
   }
   CHECK(all_param_values == all_iter_map);
   tiledb_config_iter_free(&config_iter);
@@ -837,9 +857,26 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   } while (!done);
   // highlight any difference to aid the poor developer in event CHECK() fails.
   for (auto i1 = vfs_param_values.begin(); i1 != vfs_param_values.end(); ++i1) {
-    if (vfs_iter_map.find(i1->first) == vfs_iter_map.end()) {
+    if (auto i2 = vfs_iter_map.find(i1->first); i2 == vfs_iter_map.end()) {
       std::cout << "vfs_iter_map[\"" << i1->first << "\"] not found!"
                 << std::endl;
+    } else {
+      if (i1->first != i2->first) {
+        std::cout << "huh? i1->first != i2->first, \"" << i1->first
+                  << "\" vs \"" << i2->first << std::endl;
+      } else if (i2->second != i1->second) {
+        std::cout << "values for key \"" << i1->first << "\", "
+                  << "\"" << i2->second << "\" != "
+                  << "\"" << i1->second << "\"" << std::endl;
+      } else if (vfs_param_values[i1->first] != vfs_iter_map[i1->first]) {
+        // if i1->first == i2->first, then should not be possible to be here,
+        // but just in case...
+        std::cout << " apv[k] != aim[k], k \"" << i1->first << "\", "
+                  << "\"" << vfs_param_values[i1->first] << "\" != \""
+                  << vfs_iter_map[i1->first] << "\"" << std::endl;
+        // std::cout << " apv/aim [\"" << i1->first << "\"], \"" <<
+        // all_param_values[i1->first] << " != \"" <<
+      }
     }
   }
   for (auto i1 = vfs_iter_map.begin(); i1 != vfs_iter_map.end(); ++i1) {
@@ -930,9 +967,26 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   } while (!done);
   // highlight any difference to aid the poor developer in event CHECK() fails.
   for (auto i1 = s3_param_values.begin(); i1 != s3_param_values.end(); ++i1) {
-    if (s3_iter_map.find(i1->first) == s3_iter_map.end()) {
+    if (auto i2 = s3_iter_map.find(i1->first); i2 == s3_iter_map.end()) {
       std::cout << "s3_iter_map[\"" << i1->first << "\"] not found!"
                 << std::endl;
+    } else {
+      if (i1->first != i2->first) {
+        std::cout << "huh? i1->first != i2->first, \"" << i1->first
+                  << "\" vs \"" << i2->first << std::endl;
+      } else if (i2->second != i1->second) {
+        std::cout << "values for key \"" << i1->first << "\", "
+                  << "\"" << i2->second << "\" != "
+                  << "\"" << i1->second << "\"" << std::endl;
+      } else if (s3_param_values[i1->first] != s3_iter_map[i1->first]) {
+        // if i1->first == i2->first, then should not be possible to be here,
+        // but just in case...
+        std::cout << " apv[k] != aim[k], k \"" << i1->first << "\", "
+                  << "\"" << s3_param_values[i1->first] << "\" != \""
+                  << s3_iter_map[i1->first] << "\"" << std::endl;
+        // std::cout << " apv/aim [\"" << i1->first << "\"], \"" <<
+        // all_param_values[i1->first] << " != \"" <<
+      }
     }
   }
   for (auto i1 = s3_iter_map.begin(); i1 != s3_iter_map.end(); ++i1) {

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -797,8 +797,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   } while (!done);
   // highlight any difference to aid the poor developer in event CHECK() fails.
   // If tiledb environment config variables have been set to something different
-  // from default configuration (such as 
-  // "set/export TILEDB_VFS_S3_AWS_ACCESS_KEY_ID=minio"), 
+  // from default configuration (such as
+  // "set/export TILEDB_VFS_S3_AWS_ACCESS_KEY_ID=minio"),
   // these can legitimately differ from the defaults expected!
   for (auto i1 = all_param_values.begin(); i1 != all_param_values.end(); ++i1) {
     if (auto i2 = all_iter_map.find(i1->first); i2 == all_iter_map.end()) {
@@ -810,14 +810,14 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
                   << "\" vs \"" << i2->first << std::endl;
       } else if (i2->second != i1->second) {
         std::cout << "values for key \"" << i1->first << "\", "
-                                      << "\"" << i2->second << "\" != "
-                                      << "\"" << i1->second << "\"" << std::endl;
-      } else if( all_param_values[i1->first] != all_iter_map[i1->first]) {
-        // if i1->first == i2->first, then should not be possible to be here, but just in case...
-        std::cout << " apv[k] != aim[k], k \""
-            << i1->first << "\", "
-            << "\"" << all_param_values[i1->first] << "\" != \""
-            << all_iter_map[i1->first] << "\"" << std::endl;
+                  << "\"" << i2->second << "\" != "
+                  << "\"" << i1->second << "\"" << std::endl;
+      } else if (all_param_values[i1->first] != all_iter_map[i1->first]) {
+        // if i1->first == i2->first, then should not be possible to be here,
+        // but just in case...
+        std::cout << " apv[k] != aim[k], k \"" << i1->first << "\", "
+                  << "\"" << all_param_values[i1->first] << "\" != \""
+                  << all_iter_map[i1->first] << "\"" << std::endl;
       }
     }
   }
@@ -826,7 +826,8 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       std::cout << "all_param_values[\"" << i1->first << "\"] not found!"
                 << std::endl;
     }
-    //else, for all like keys, unlike values should have been reported in previous loop.
+    // else, for all like keys, unlike values should have been reported in
+    // previous loop.
   }
   CHECK(all_param_values == all_iter_map);
   tiledb_config_iter_free(&config_iter);


### PR DESCRIPTION
…variable lists/values checking occur reporting 'FAILED:'

'FAILED:' may occur if/when tiledb config variables are set/overridden from environment,
perhaps for *nix build config with --enable-s3 --enable-azure as follows
export TILEDB_VFS_S3_AWS_ACCESS_KEY_ID=minio
export TILEDB_VFS_S3_AWS_SECRET_ACCESS_KEY=miniosecretkey
export TILEDB_VFS_S3_SCHEME=http
or the windows equivalents -EnableS3 -EnableAzure and subsequent 'set's.

---
TYPE: IMPROVEMENT
DESC: increased diag output for differences reported by tiledb_unit (some of which may be reasonable)
