### PR TITLE
Add patch for missing stdexcept header for Azure

### DIFF
--- a/cmake/Modules/FindAzureSDK_EP.cmake
+++ b/cmake/Modules/FindAzureSDK_EP.cmake
@@ -157,6 +157,7 @@ if (NOT AZURESDK_FOUND)
           echo starting patching for azure &&
           ${PATCH} < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/remove-uuid-dep.patch &&
           ${PATCH} < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/azurite-support.patch &&
+              ${PATCH} < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/azure-storage-lite-base64.patch &&
           echo done patches for azure
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE


### PR DESCRIPTION
This backports adding a patch for fix a missing include on newer gcc/vsc++ compilers for the AzureSDK


---
TYPE: BUG
DESC: Add a patch for fix a missing include on newer gcc/vsc++ compilers for the AzureSDK
