### PR TITLE
Initial sparse unordered with duplicates reader.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -255,7 +255,16 @@ void check_save_to_file() {
   ss << "sm.mem.reader.sparse_global_order.ratio_array_data 0.1\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_coords 0.5\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_query_condition 0.25\n";
+  ss << "sm.mem.reader.sparse_global_order.ratio_rcs 0.05\n";
+  ss << "sm.mem.reader.sparse_global_order.ratio_result_tiles 0.05\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_tile_ranges 0.1\n";
+  ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data 0.1\n";
+  ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_coords 0.5\n";
+  ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition "
+        "0.25\n";
+  ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_rcs 0.05\n";
+  ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles 0.05\n";
+  ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges 0.1\n";
   ss << "sm.mem.total_budget 10737418240\n";
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
@@ -562,6 +571,22 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
       "0.1";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_array_data"] =
       "0.1";
+  all_param_values["sm.mem.reader.sparse_global_order.ratio_result_tiles"] =
+      "0.05";
+  all_param_values["sm.mem.reader.sparse_global_order.ratio_rcs"] = "0.05";
+  all_param_values["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
+      "0.5";
+  all_param_values
+      ["sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition"] =
+          "0.25";
+  all_param_values
+      ["sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges"] = "0.1";
+  all_param_values
+      ["sm.mem.reader.sparse_unordered_with_dups.ratio_array_data"] = "0.1";
+  all_param_values
+      ["sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles"] = "0.05";
+  all_param_values["sm.mem.reader.sparse_unordered_with_dups.ratio_rcs"] =
+      "0.05";
   all_param_values["sm.enable_signal_handlers"] = "true";
   all_param_values["sm.compute_concurrency_level"] =
       std::to_string(std::thread::hardware_concurrency());

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -163,6 +163,8 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/result_tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/read_cell_slab_iter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/sparse_global_order_reader.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/sparse_index_reader_base.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/strategy_base.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/writer.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/rest/rest_client.cc

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -116,6 +116,7 @@ enum class StatusCode : char {
   Attribute,
   WriteCellSlabIter,
   SparseGlobalOrderReaderError,
+  SparseUnorderedWithDupsReaderError,
   Reader,
   Writer,
   PreallocatedBuffer,
@@ -344,6 +345,12 @@ class Status {
    * message **/
   static Status SparseGlobalOrderReaderError(const std::string& msg) {
     return Status(StatusCode::SparseGlobalOrderReaderError, msg, -1);
+  }
+
+  /** Return a SparseUnorderedWithDupsReaderError error class Status with a
+   * given message **/
+  static Status SparseUnorderedWithDupsReaderError(const std::string& msg) {
+    return Status(StatusCode::SparseUnorderedWithDupsReaderError, msg, -1);
   }
 
   /** Return a ReaderError error class Status with a given message **/

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1058,6 +1058,38 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Ratio of the budget allocated for array data in the sparse global
  *    order reader. <br>
  *    **Default**: 0.1
+ * - `sm.mem.reader.sparse_global_order.ratio_result_tiles` <br>
+ *    Ratio of the budget allocated for result tiles in the sparse global
+ *    order reader. <br>
+ *    **Default**: 0.05
+ * - `sm.mem.reader.sparse_global_order.ratio_rcs` <br>
+ *    Ratio of the budget allocated for result cell slabs in the sparse
+ *    global order reader. <br>
+ *    **Default**: 0.05
+ * - `sm.mem.reader.sparse_unordered_with_dups.ratio_coords` <br>
+ *    Ratio of the budget allocated for coordinates in the sparse unordered
+ *    with duplicates reader. <br>
+ *    **Default**: 0.5
+ * - `sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition` <br>
+ *    Ratio of the budget allocated for the query condition in the sparse
+ *    unordered with duplicates reader. <br>
+ *    **Default**: 0.25
+ * - `sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges` <br>
+ *    Ratio of the budget allocated for tile ranges in the sparse unordered
+ *    with duplicates reader. <br>
+ *    **Default**: 0.1
+ * - `sm.mem.reader.sparse_unordered_with_dups.ratio_array_data` <br>
+ *    Ratio of the budget allocated for array data in the sparse unordered
+ *    with duplicates reader. <br>
+ *    **Default**: 0.1
+ * - `sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles` <br>
+ *    Ratio of the budget allocated for result tiles in the sparse
+ *    unordered with duplicates reader. <br>
+ *    **Default**: 0.05
+ * - `sm.mem.reader.sparse_unordered_with_dups.ratio_rcs` <br>
+ *    Ratio of the budget allocated for result cell slabs in the sparse
+ *    unordered with duplicates reader. <br>
+ *    **Default**: 0.05
  * - `vfs.read_ahead_size` <br>
  *    The maximum byte size to read-ahead from the backend. <br>
  *    **Default**: 102400

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -81,6 +81,20 @@ const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION =
     "0.25";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES = "0.1";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA = "0.1";
+const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RESULT_TILES =
+    "0.05";
+const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RCS = "0.05";
+const std::string Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS =
+    "0.5";
+const std::string
+    Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION = "0.25";
+const std::string Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_TILE_RANGES =
+    "0.1";
+const std::string Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_ARRAY_DATA =
+    "0.1";
+const std::string Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RESULT_TILES =
+    "0.05";
+const std::string Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RCS = "0.05";
 const std::string Config::SM_ENABLE_SIGNAL_HANDLERS = "true";
 const std::string Config::SM_COMPUTE_CONCURRENCY_LEVEL =
     utils::parse::to_str(std::thread::hardware_concurrency());
@@ -228,6 +242,23 @@ Config::Config() {
       SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES;
   param_values_["sm.mem.reader.sparse_global_order.ratio_array_data"] =
       SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA;
+  param_values_["sm.mem.reader.sparse_global_order.ratio_result_tiles"] =
+      SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RESULT_TILES;
+  param_values_["sm.mem.reader.sparse_global_order.ratio_rcs"] =
+      SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RCS;
+  param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
+      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS;
+  param_values_
+      ["sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition"] =
+          SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION;
+  param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges"] =
+      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_TILE_RANGES;
+  param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_array_data"] =
+      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_ARRAY_DATA;
+  param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles"] =
+      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RESULT_TILES;
+  param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_rcs"] =
+      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RCS;
   param_values_["sm.enable_signal_handlers"] = SM_ENABLE_SIGNAL_HANDLERS;
   param_values_["sm.compute_concurrency_level"] = SM_COMPUTE_CONCURRENCY_LEVEL;
   param_values_["sm.io_concurrency_level"] = SM_IO_CONCURRENCY_LEVEL;
@@ -499,6 +530,38 @@ Status Config::unset(const std::string& param) {
   } else if (param == "sm.mem.reader.sparse_global_order.ratio_array_data") {
     param_values_["sm.mem.reader.sparse_global_order.ratio_array_data"] =
         SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA;
+  } else if (param == "sm.mem.reader.sparse_global_order.ratio_result_tiles") {
+    param_values_["sm.mem.reader.sparse_global_order.ratio_result_tiles"] =
+        SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RESULT_TILES;
+  } else if (param == "sm.mem.reader.sparse_global_order.ratio_rcs") {
+    param_values_["sm.mem.reader.sparse_global_order.ratio_rcs"] =
+        SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RCS;
+  } else if (param == "sm.mem.reader.sparse_unordered_with_dups.ratio_coords") {
+    param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
+        SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS;
+  } else if (
+      param ==
+      "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition") {
+    param_values_
+        ["sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition"] =
+            SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION;
+  } else if (
+      param == "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges") {
+    param_values_
+        ["sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges"] =
+            SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_TILE_RANGES;
+  } else if (
+      param == "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data") {
+    param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_array_data"] =
+        SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_ARRAY_DATA;
+  } else if (
+      param == "sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles") {
+    param_values_
+        ["sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles"] =
+            SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RESULT_TILES;
+  } else if (param == "sm.mem.reader.sparse_unordered_with_dups.ratio_rcs") {
+    param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_rcs"] =
+        SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RCS;
   } else if (param == "sm.enable_signal_handlers") {
     param_values_["sm.enable_signal_handlers"] = SM_ENABLE_SIGNAL_HANDLERS;
   } else if (param == "sm.compute_concurrency_level") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -164,6 +164,47 @@ class Config {
   /** Ratio of the sparse global order reader budget used for array data. */
   static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA;
 
+  /** Ratio of the sparse global order reader budget used for result tiles. */
+  static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RESULT_TILES;
+
+  /** Ratio of the sparse global order reader budget used for result cell slabs.
+   */
+  static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RCS;
+
+  /** Ratio of the sparse unordered with dups reader budget used for coords. */
+  static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS;
+
+  /**
+   * Ratio of the sparse unordered with dups reader budget used for query
+   * condition.
+   */
+  static const std::string
+      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION;
+
+  /**
+   * Ratio of the sparse unordered with dups reader budget used for tile
+   * ranges.
+   */
+  static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_TILE_RANGES;
+
+  /**
+   * Ratio of the sparse unordered with dups reader budget used for array
+   * data.
+   */
+  static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_ARRAY_DATA;
+
+  /**
+   * Ratio of the sparse unordered with dups reader budget used for result
+   * tiles.
+   */
+  static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RESULT_TILES;
+
+  /**
+   * Ratio of the sparse unordered with dups reader budget used for result
+   * cell slabs.
+   */
+  static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RCS;
+
   /** Whether or not the signal handlers are installed. */
   static const std::string SM_ENABLE_SIGNAL_HANDLERS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -406,6 +406,37 @@ class Config {
    *    Ratio of the budget allocated for array data in the sparse global
    *    order reader. <br>
    *    **Default**: 0.1
+   * - `sm.mem.reader.sparse_global_order.ratio_result_tiles` <br>
+   *    Ratio of the budget allocated for result tiles in the sparse global
+   *    order reader. <br>
+   *    **Default**: 0.05
+   * - `sm.mem.reader.sparse_global_order.ratio_rcs` <br>
+   *    Ratio of the budget allocated for result cell slabs in the sparse
+   *    global order reader. <br>
+   *    **Default**: 0.05
+   * - `sm.mem.reader.sparse_unordered_with_dups.ratio_coords` <br>
+   *    Ratio of the budget allocated for coordinates in the sparse unordered
+   *    with duplicates reader. <br>
+   *    **Default**: 0.5
+   * - `sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition` <br>
+   *    Ratio of the budget allocated for the query condition in the sparse
+   *    unordered with duplicates reader. <br>
+   *    **Default**: 0.25
+   * - `sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges` <br>
+   *    Ratio of the budget allocated for tile ranges in the sparse unordered
+   *    with duplicates reader. <br>
+   *    **Default**: 0.1
+   * - `sm.mem.reader.sparse_unordered_with_dups.ratio_array_data` <br>
+   *    Ratio of the budget allocated for array data in the sparse unordered
+   *    with duplicates reader. <br>
+   *    **Default**: 0.1
+   * - `sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles` <br>
+   *    Ratio of the budget allocated for result tiles in the sparse
+   *    unordered with duplicates reader. <br>
+   *    **Default**: 0.05
+   * - `sm.mem.reader.sparse_unordered_with_dups.ratio_rcs` <br>
+   *    Ratio of the budget allocated for result cell slabs in the sparse
+   *    unordered with duplicates reader. <br>
    * - `vfs.read_ahead_size` <br>
    *    The maximum byte size to read-ahead from the backend. <br>
    *    **Default**: 102400

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -40,6 +40,7 @@
 #include "tiledb/sm/query/query_condition.h"
 #include "tiledb/sm/query/reader.h"
 #include "tiledb/sm/query/sparse_global_order_reader.h"
+#include "tiledb/sm/query/sparse_unordered_with_dups_reader.h"
 #include "tiledb/sm/query/writer.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
@@ -1011,6 +1012,20 @@ Status Query::create_strategy() {
         use_default = false;
         strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
             SparseGlobalOrderReader,
+            stats_->create_child("Reader"),
+            storage_manager_,
+            array_,
+            config_,
+            buffers_,
+            subarray_,
+            layout_,
+            condition_));
+      } else if (
+          !array_schema_->dense() && layout_ == Layout::UNORDERED &&
+          array_schema_->allows_dups()) {
+        use_default = false;
+        strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+            SparseUnorderedWithDupsReader,
             stats_->create_child("Reader"),
             storage_manager_,
             array_,

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -66,7 +66,7 @@ SparseGlobalOrderReader::SparseGlobalOrderReader(
     Subarray& subarray,
     Layout layout,
     QueryCondition& condition)
-    : ReaderBase(
+    : SparseIndexReaderBase(
           stats,
           storage_manager,
           array,
@@ -74,19 +74,7 @@ SparseGlobalOrderReader::SparseGlobalOrderReader(
           buffers,
           subarray,
           layout,
-          condition)
-    , done_adding_result_tiles_(false)
-    , initial_data_loaded_(false)
-    , memory_budget_(0)
-    , memory_used_for_coords_total_(0)
-    , memory_used_qc_tiles_(0)
-    , memory_used_rcs_(0)
-    , memory_used_result_tiles_(0)
-    , memory_used_result_tile_ranges_(0)
-    , memory_budget_ratio_coords_(0.5)
-    , memory_budget_ratio_query_condition_(0.25)
-    , memory_budget_ratio_tile_ranges_(0.1)
-    , memory_budget_ratio_array_data_(0.1) {
+          condition) {
   // Defines specific bahavior in the tile copy code for this reader.
   fix_var_sized_overflows_ = true;
   clear_coords_tiles_on_copy_ = false;
@@ -137,22 +125,32 @@ Status SparseGlobalOrderReader::init() {
   assert(found);
   RETURN_NOT_OK(config_.get<double>(
       "sm.mem.reader.sparse_global_order.ratio_array_data",
-      &memory_budget_ratio_coords_,
+      &memory_budget_ratio_array_data_,
       &found));
   assert(found);
   RETURN_NOT_OK(config_.get<double>(
       "sm.mem.reader.sparse_global_order.ratio_coords",
-      &memory_budget_ratio_query_condition_,
+      &memory_budget_ratio_coords_,
       &found));
   assert(found);
   RETURN_NOT_OK(config_.get<double>(
       "sm.mem.reader.sparse_global_order.ratio_query_condition",
-      &memory_budget_ratio_tile_ranges_,
+      &memory_budget_ratio_query_condition_,
       &found));
   assert(found);
   RETURN_NOT_OK(config_.get<double>(
       "sm.mem.reader.sparse_global_order.ratio_tile_ranges",
-      &memory_budget_ratio_array_data_,
+      &memory_budget_ratio_tile_ranges_,
+      &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<double>(
+      "sm.mem.reader.sparse_global_order.ratio_result_tiles",
+      &memory_budget_ratio_result_tiles_,
+      &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<double>(
+      "sm.mem.reader.sparse_global_order.ratio_rcs",
+      &memory_budget_ratio_rcs_,
       &found));
   assert(found);
 
@@ -163,10 +161,13 @@ Status SparseGlobalOrderReader::init() {
 }
 
 Status SparseGlobalOrderReader::dowork() {
+  auto timer_se = stats_->start_timer("dowork");
+
+  // For easy reference.
+  auto fragment_num = fragment_metadata_.size();
+
   // Check that the query condition is valid.
   RETURN_NOT_OK(condition_.check(array_schema_));
-
-  auto timer_se = stats_->start_timer("dowork");
 
   get_dim_attr_stats();
 
@@ -181,6 +182,10 @@ Status SparseGlobalOrderReader::dowork() {
   }
 
   reset_buffer_sizes();
+
+  // Make sure we have enough space for tiles data.
+  memory_used_for_coords_.resize(fragment_num);
+  result_tiles_.resize(fragment_num);
 
   // Load initial data, if not loaded already.
   RETURN_NOT_OK(load_initial_data());
@@ -307,84 +312,10 @@ Status SparseGlobalOrderReader::dowork() {
 void SparseGlobalOrderReader::reset() {
 }
 
-Status SparseGlobalOrderReader::load_initial_data() {
-  if (initial_data_loaded_)
-    return Status::Ok();
-
-  auto timer_se = stats_->start_timer("load_initial_data");
-
-  // For easy reference.
-  auto fragment_num = fragment_metadata_.size();
-
-  // Make sure we have enough space for tiles data.
-  result_tiles_.resize(fragment_num);
-  read_state_.frag_tile_idx_.resize(fragment_num);
-  all_tiles_loaded_.resize(fragment_num);
-  memory_used_for_coords_.resize(fragment_num);
-
-  // Calculate a bit vector of the tiles in the subarray, if set.
-  if (subarray_.is_set()) {
-    // We have the full memory budget at this point, use it.
-    array_memory_tracker_->set_budget(memory_budget_);
-
-    // TODO Tile overlap computation will not stop if it exceeds memory budget.
-    RETURN_NOT_OK(subarray_.precompute_tile_overlap(
-        0, 0, &config_, storage_manager_->compute_tp()));
-
-    // Free the rtrees from memory.
-    for (auto frag_md : fragment_metadata_) {
-      frag_md->free_rtree();
-    }
-
-    // Compute tile ranges.
-    RETURN_CANCEL_OR_ERROR(compute_result_tiles_ranges(
-        memory_budget_ * memory_budget_ratio_tile_ranges_));
-  }
-
-  // Set a limit to the array memory.
-  array_memory_tracker_->set_budget(
-      memory_budget_ * memory_budget_ratio_array_data_);
-
-  // Preload zipped coordinate tile offsets. Note that this will
-  // ignore fragments with a version >= 5.
-  std::vector<std::string> zipped_coords_names = {constants::coords};
-  RETURN_CANCEL_OR_ERROR(load_tile_offsets(&subarray_, &zipped_coords_names));
-
-  // Preload unzipped coordinate tile offsets. Note that this will
-  // ignore fragments with a version < 5.
-  const auto dim_num = array_schema_->dim_num();
-  dim_names_.reserve(dim_num);
-  is_dim_var_size_.reserve(dim_num);
-  for (unsigned d = 0; d < dim_num; ++d) {
-    dim_names_.emplace_back(array_schema_->dimension(d)->name());
-    is_dim_var_size_[d] = array_schema_->var_size(dim_names_[d]);
-  }
-  RETURN_CANCEL_OR_ERROR(load_tile_offsets(&subarray_, &dim_names_));
-
-  initial_data_loaded_ = true;
-  return Status::Ok();
-}
-
-Status SparseGlobalOrderReader::get_coord_tiles_size(
-    unsigned dim_num, unsigned f, uint64_t t, uint64_t* tiles_size) {
-  *tiles_size = 0;
-  for (unsigned d = 0; d < dim_num; d++) {
-    *tiles_size += fragment_metadata_[f]->tile_size(dim_names_[d], t);
-
-    if (is_dim_var_size_[d]) {
-      uint64_t temp = 0;
-      RETURN_NOT_OK(fragment_metadata_[f]->tile_var_size(
-          *array_->encryption_key(), dim_names_[d], t, &temp));
-      *tiles_size += temp;
-    }
-  }
-
-  return Status::Ok();
-}
-
 Status SparseGlobalOrderReader::add_result_tile(
     unsigned dim_num,
-    uint64_t memory_budget,
+    uint64_t memory_budget_result_tiles,
+    uint64_t memory_budget_coords_tiles,
     unsigned f,
     uint64_t t,
     const Domain* domain,
@@ -394,7 +325,7 @@ Status SparseGlobalOrderReader::add_result_tile(
   RETURN_NOT_OK(get_coord_tiles_size(dim_num, f, t, &tiles_size));
 
   // Don't load more tiles than the memory budget.
-  if (memory_used_for_coords_[f] + tiles_size > memory_budget) {
+  if (memory_used_for_coords_[f] + tiles_size > memory_budget_coords_tiles) {
     *budget_exceeded = true;
     return Status::Ok();
   }
@@ -405,7 +336,7 @@ Status SparseGlobalOrderReader::add_result_tile(
   std::unique_lock<std::mutex> lck(mem_budget_mtx_);
   memory_used_for_coords_total_ += tiles_size;
   memory_used_result_tiles_ += sizeof(ResultTile);
-  if (memory_used_result_tiles_ > memory_budget) {
+  if (memory_used_result_tiles_ > memory_budget_result_tiles) {
     *budget_exceeded = true;
   }
 
@@ -425,11 +356,11 @@ Status SparseGlobalOrderReader::create_result_tiles(bool* tiles_found) {
   for (auto all_loaded : all_tiles_loaded_)
     num_fragments_to_process += !all_loaded;
 
-  // Add 2 "fragments" to account for result cell slabs and result tiles.
-  num_fragments_to_process += 2;
-
   per_fragment_memory_ =
       memory_budget_ * memory_budget_ratio_coords_ / num_fragments_to_process;
+
+  uint64_t memory_budget_result_tiles =
+      memory_budget_ * memory_budget_ratio_result_tiles_;
 
   // Create result tiles.
   if (subarray_.is_set()) {
@@ -440,10 +371,10 @@ Status SparseGlobalOrderReader::create_result_tiles(bool* tiles_found) {
           uint64_t t = 0;
           bool budget_exceeded = false;
           while (range_it != result_tile_ranges_[f].end()) {
-            bool budget_exceeded = false;
             for (t = range_it->first; t <= range_it->second; t++) {
               RETURN_NOT_OK(add_result_tile(
                   dim_num,
+                  memory_budget_result_tiles,
                   per_fragment_memory_,
                   f,
                   t,
@@ -479,7 +410,13 @@ Status SparseGlobalOrderReader::create_result_tiles(bool* tiles_found) {
 
           for (t = start; t < tile_num; t++) {
             RETURN_NOT_OK(add_result_tile(
-                dim_num, per_fragment_memory_, f, t, domain, &budget_exceeded));
+                dim_num,
+                memory_budget_result_tiles,
+                per_fragment_memory_,
+                f,
+                t,
+                domain,
+                &budget_exceeded));
             *tiles_found = true;
 
             if (budget_exceeded)
@@ -534,22 +471,24 @@ Status SparseGlobalOrderReader::compute_result_cell_slab() {
   }
 
   // Compute the result cell slabs with the loaded coordinate tiles.
+  uint64_t memory_budget_rcs = memory_budget_ratio_rcs_ * memory_budget_;
   if (array_schema_->cell_order() == Layout::HILBERT) {
     // Account for this in memory budget.
     std::vector<std::vector<uint64_t>> values(fragment_metadata_.size());
     RETURN_CANCEL_OR_ERROR(merge_result_cell_slabs(
-        per_fragment_memory_,
+        memory_budget_rcs,
         HilbertCmpReverse(array_schema_->domain(), &values)));
   } else {
     RETURN_CANCEL_OR_ERROR(merge_result_cell_slabs(
-        per_fragment_memory_, GlobalCmpReverse(array_schema_->domain())));
+        memory_budget_rcs, GlobalCmpReverse(array_schema_->domain())));
   }
 
   // TODO This can be moved before calculating result cell slabs.
   // Finally apply the query condition.
   uint64_t memory_budget_tiles =
       memory_budget_ * memory_budget_ratio_query_condition_;
-  uint64_t memory_budget_rcs = per_fragment_memory_ - memory_used_rcs_;
+
+  memory_budget_rcs -= memory_used_rcs_;
   uint64_t memory_used_tiles = 0;
   RETURN_CANCEL_OR_ERROR(apply_query_condition(
       &read_state_.result_cell_slabs_,
@@ -562,91 +501,6 @@ Status SparseGlobalOrderReader::compute_result_cell_slab() {
   memory_used_rcs_ =
       read_state_.result_cell_slabs_.size() * sizeof(ResultCellSlab);
   memory_used_qc_tiles_ += memory_used_tiles;
-
-  return Status::Ok();
-}
-
-Status SparseGlobalOrderReader::compute_result_tiles_ranges(
-    uint64_t memory_budget) {
-  auto timer_se = stats_->start_timer("compute_result_tiles_ranges");
-
-  // For easy reference.
-  auto range_num = subarray_.range_num();
-  auto fragment_num = fragment_metadata_.size();
-
-  // To sort the ranges, we need double the memory of the tile overlap data.
-  if (subarray_.tile_overlap_byte_size() > memory_budget_ / 2) {
-    return LOG_STATUS(Status::SparseGlobalOrderReaderError(
-        "Exceeded memory budget for tile overlap"));
-  }
-
-  // Build vectors of sorted ranges, per fragments.
-  std::vector<std::vector<std::pair<uint64_t, uint64_t>>> sorted_ranges;
-  sorted_ranges.resize(fragment_num);
-
-  auto status = parallel_for(
-      storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
-        // Filter out ranges that are smaller than the tile index.
-        auto tile_idx = read_state_.frag_tile_idx_[f].first;
-        for (uint64_t r = 0; r < range_num; ++r) {
-          // Inset range of tiles.
-          const auto& tile_ranges = subarray_.tile_overlap(f, r)->tile_ranges_;
-          for (const auto& tr : tile_ranges) {
-            // Make sure all ranges start at a minumum at the tile index.
-            if (tile_idx <= tr.second)
-              sorted_ranges[f].emplace_back(
-                  std::max(tile_idx, tr.first), tr.second);
-          }
-
-          // Insert single tiles.
-          const auto& o_tiles = subarray_.tile_overlap(f, r)->tiles_;
-          for (const auto& o_tile : o_tiles) {
-            if (tile_idx <= o_tile.first)
-              sorted_ranges[f].emplace_back(o_tile.first, o_tile.first);
-          }
-        }
-
-        std::sort(sorted_ranges[f].begin(), sorted_ranges[f].end());
-        return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, LOG_STATUS(status));
-
-  // Free memory for tile overlap data.
-  subarray_.clear_tile_overlap();
-
-  // Go though the sorted list of ranges, and coalesce them.
-  result_tile_ranges_.resize(fragment_num);
-  status = parallel_for(
-      storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
-        auto it = sorted_ranges[f].begin();
-        while (it != sorted_ranges[f].end()) {
-          auto it2 = it + 1;
-          while (it2 != sorted_ranges[f].end()) {
-            // Same start, we can ignore *it* since *it2* end will be greater.
-            if (it->first == it2->first) {
-              it++;
-            } else if (it2->first <= it->second) {
-              // The start of the second range is included in the first.
-              it->second = std::max(it->second, it2->second);
-            } else {
-              // We start a new range.
-              break;
-            }
-            it2++;
-          }
-          result_tile_ranges_[f].emplace_back(it->first, it->second);
-          memory_used_result_tile_ranges_ += 2 * sizeof(uint64_t);
-
-          // If we busted our memory budget, exit.
-          if (memory_used_result_tile_ranges_ >= memory_budget)
-            return LOG_STATUS(Status::SparseGlobalOrderReaderError(
-                "Exceeded memory budget for result tile ranges"));
-
-          it = it2;
-        }
-        return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, LOG_STATUS(status));
 
   return Status::Ok();
 }
@@ -677,7 +531,7 @@ Status SparseGlobalOrderReader::add_next_tile_to_queue(
 
     // Calculate the bitmap for the cells.
     RETURN_NOT_OK(compute_coord_tiles_result_bitmap(
-        subarray_set, tile, coord_tiles_result_bitmap));
+        subarray_set, tile, &coord_tiles_result_bitmap[frag_idx]));
 
     // Calculate hilbert values, this is templated out for non hilbert code.
     RETURN_NOT_OK(calculate_hilbert_values(
@@ -797,40 +651,6 @@ Status SparseGlobalOrderReader::calculate_hilbert_values<HilbertCmpReverse>(
 
   // Set the values in the comparator.
   cmp.set_values_for_fragment(frag_idx, hilbert_values);
-
-  return Status::Ok();
-}
-
-Status SparseGlobalOrderReader::compute_coord_tiles_result_bitmap(
-    bool subarray_set,
-    ResultTile* tile,
-    std::vector<std::vector<uint8_t>>& coord_tiles_result_bitmap) {
-  auto timer_se = stats_->start_timer("compute_coord_tiles_result_bitmap");
-
-  // No subarray means we process all cells.
-  if (!subarray_set)
-    return Status::Ok();
-
-  // For easy reference.
-  auto coords_num = tile->cell_num();
-  auto dim_num = array_schema_->dim_num();
-  auto cell_order = array_schema_->cell_order();
-  auto range_coords = subarray_.get_range_coords(0);
-
-  std::vector<uint8_t> result_bitmap(coords_num, 1);
-
-  // Compute result and overwritten bitmap per dimension
-  for (unsigned d = 0; d < dim_num; ++d) {
-    // For col-major cell ordering, iterate the dimensions
-    // in reverse.
-    const unsigned dim_idx =
-        cell_order == Layout::COL_MAJOR ? dim_num - d - 1 : d;
-    const auto& ranges = subarray_.ranges_for_dim(dim_idx);
-    RETURN_NOT_OK(tile->compute_results_sparse(
-        dim_idx, ranges[range_coords[dim_idx]], &result_bitmap, cell_order));
-  }
-
-  coord_tiles_result_bitmap[tile->frag_idx()] = std::move(result_bitmap);
 
   return Status::Ok();
 }
@@ -1039,58 +859,6 @@ Status SparseGlobalOrderReader::merge_result_cell_slabs(
 
   return Status::Ok();
 };
-
-Status SparseGlobalOrderReader::resize_output_buffers() {
-  // Count number of elements actually copied.
-  uint64_t cells_copied = 0;
-  for (uint64_t i = 0; i < copy_end_.first - 1; i++) {
-    cells_copied += read_state_.result_cell_slabs_[i].length_;
-  }
-
-  cells_copied += copy_end_.second;
-
-  // Resize buffers if the result cell slabs was truncated.
-  for (auto& it : buffers_) {
-    const auto& name = it.first;
-    const auto size = *it.second.buffer_size_;
-    uint64_t num_cells = 0;
-
-    if (array_schema_->var_size(name)) {
-      // Get the current number of cells from the offsets buffer.
-      num_cells = size / constants::cell_var_offset_size;
-
-      // Remove an element if the extra element flag is set.
-      if (offsets_extra_element_ && num_cells > 0)
-        num_cells--;
-
-      // Buffer should be resized.
-      if (num_cells > cells_copied) {
-        // Offsets buffer is trivial.
-        *(it.second.buffer_size_) =
-            cells_copied * constants::cell_var_offset_size +
-            offsets_extra_element_;
-
-        // Since we shrink the buffer, there is an offset for the next element
-        // loaded, use it.
-        *(it.second.buffer_var_size_) =
-            ((uint64_t*)it.second.buffer_)[cells_copied];
-      }
-    } else {
-      // Always adjust the size for fixed size attributes.
-      auto cell_size = array_schema_->cell_size(name);
-      *(it.second.buffer_size_) = cells_copied * cell_size;
-    }
-
-    // Always adjust validity vector size, if present.
-    if (num_cells > cells_copied) {
-      if (it.second.validity_vector_.buffer_size() != nullptr)
-        *(it.second.validity_vector_.buffer_size()) =
-            num_cells * constants::cell_validity_size;
-    }
-  }
-
-  return Status::Ok();
-}
 
 Status SparseGlobalOrderReader::remove_result_tile(
     unsigned frag_idx, std::list<ResultTile>::iterator rt) {

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -1,0 +1,342 @@
+/**
+ * @file   sparse_index_reader_base.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class SparseIndexReaderBase.
+ */
+
+#include "tiledb/sm/query/sparse_index_reader_base.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/fragment/fragment_metadata.h"
+#include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/query/query_macros.h"
+#include "tiledb/sm/query/strategy_base.h"
+#include "tiledb/sm/storage_manager/open_array_memory_tracker.h"
+#include "tiledb/sm/subarray/subarray.h"
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*          CONSTRUCTORS          */
+/* ****************************** */
+
+SparseIndexReaderBase::SparseIndexReaderBase(
+    stats::Stats* stats,
+    StorageManager* storage_manager,
+    Array* array,
+    Config& config,
+    std::unordered_map<std::string, QueryBuffer>& buffers,
+    Subarray& subarray,
+    Layout layout,
+    QueryCondition& condition)
+    : ReaderBase(
+          stats,
+          storage_manager,
+          array,
+          config,
+          buffers,
+          subarray,
+          layout,
+          condition)
+    , done_adding_result_tiles_(false)
+    , initial_data_loaded_(false)
+    , memory_budget_(0)
+    , array_memory_tracker_(nullptr)
+    , memory_used_for_coords_total_(0)
+    , memory_used_qc_tiles_(0)
+    , memory_used_rcs_(0)
+    , memory_used_result_tiles_(0)
+    , memory_used_result_tile_ranges_(0)
+    , memory_budget_ratio_coords_(0.5)
+    , memory_budget_ratio_query_condition_(0.25)
+    , memory_budget_ratio_tile_ranges_(0.1)
+    , memory_budget_ratio_array_data_(0.1)
+    , memory_budget_ratio_result_tiles_(0.05)
+    , memory_budget_ratio_rcs_(0.05) {
+}
+
+/* ****************************** */
+/*        PROTECTED METHODS       */
+/* ****************************** */
+
+Status SparseIndexReaderBase::get_coord_tiles_size(
+    unsigned dim_num, unsigned f, uint64_t t, uint64_t* tiles_size) {
+  *tiles_size = 0;
+  for (unsigned d = 0; d < dim_num; d++) {
+    *tiles_size += fragment_metadata_[f]->tile_size(dim_names_[d], t);
+
+    if (is_dim_var_size_[d]) {
+      uint64_t temp = 0;
+      RETURN_NOT_OK(fragment_metadata_[f]->tile_var_size(
+          *array_->encryption_key(), dim_names_[d], t, &temp));
+      *tiles_size += temp;
+    }
+  }
+
+  return Status::Ok();
+}
+
+Status SparseIndexReaderBase::load_initial_data() {
+  if (initial_data_loaded_)
+    return Status::Ok();
+
+  auto timer_se = stats_->start_timer("load_initial_data");
+
+  // For easy reference.
+  auto fragment_num = fragment_metadata_.size();
+
+  // Make sure we have enough space for tiles data.
+  read_state_.frag_tile_idx_.resize(fragment_num);
+  all_tiles_loaded_.resize(fragment_num);
+
+  // Calculate ranges of tiles in the subarray, if set.
+  if (subarray_.is_set()) {
+    // We have the full memory budget at this point, use it.
+    array_memory_tracker_->set_budget(memory_budget_);
+
+    // TODO Tile overlap computation will not stop if it exceeds memory budget.
+    RETURN_NOT_OK(subarray_.precompute_tile_overlap(
+        0, 0, &config_, storage_manager_->compute_tp()));
+
+    // Free the rtrees from memory.
+    for (auto frag_md : fragment_metadata_) {
+      frag_md->free_rtree();
+    }
+
+    // Compute tile ranges.
+    RETURN_CANCEL_OR_ERROR(compute_result_tiles_ranges(
+        memory_budget_ * memory_budget_ratio_tile_ranges_));
+  }
+
+  // Set a limit to the array memory.
+  array_memory_tracker_->set_budget(
+      memory_budget_ * memory_budget_ratio_array_data_);
+
+  // Set a limit to the array memory.
+  array_memory_tracker_->set_budget(
+      memory_budget_ * memory_budget_ratio_array_data_);
+
+  // Preload zipped coordinate tile offsets. Note that this will
+  // ignore fragments with a version >= 5.
+  std::vector<std::string> zipped_coords_names = {constants::coords};
+  RETURN_CANCEL_OR_ERROR(load_tile_offsets(&subarray_, &zipped_coords_names));
+
+  // Preload unzipped coordinate tile offsets. Note that this will
+  // ignore fragments with a version < 5.
+  const auto dim_num = array_schema_->dim_num();
+  dim_names_.reserve(dim_num);
+  is_dim_var_size_.reserve(dim_num);
+  for (unsigned d = 0; d < dim_num; ++d) {
+    dim_names_.emplace_back(array_schema_->dimension(d)->name());
+    is_dim_var_size_[d] = array_schema_->var_size(dim_names_[d]);
+  }
+  RETURN_CANCEL_OR_ERROR(load_tile_offsets(&subarray_, &dim_names_));
+
+  initial_data_loaded_ = true;
+  return Status::Ok();
+}
+
+Status SparseIndexReaderBase::compute_result_tiles_ranges(
+    uint64_t memory_budget) {
+  auto timer_se = stats_->start_timer("compute_result_tiles_ranges");
+
+  // For easy reference.
+  auto range_num = subarray_.range_num();
+  auto fragment_num = fragment_metadata_.size();
+
+  // To sort the ranges, we need double the memory of the tile overlap data.
+  if (subarray_.tile_overlap_byte_size() > memory_budget_ / 2) {
+    return LOG_STATUS(
+        Status::ReaderError("Exceeded memory budget for tile overlap"));
+  }
+
+  // Build vectors of sorted ranges, per fragments.
+  std::vector<std::vector<std::pair<uint64_t, uint64_t>>> sorted_ranges;
+  sorted_ranges.resize(fragment_num);
+
+  auto status = parallel_for(
+      storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
+        // Filter out ranges that are smaller than the tile index.
+        auto tile_idx = read_state_.frag_tile_idx_[f].first;
+        for (uint64_t r = 0; r < range_num; ++r) {
+          // Inset range of tiles.
+          const auto& tile_ranges = subarray_.tile_overlap(f, r)->tile_ranges_;
+          for (const auto& tr : tile_ranges) {
+            // Make sure all ranges start at a minumum at the tile index.
+            if (tile_idx <= tr.second)
+              sorted_ranges[f].emplace_back(
+                  std::max(tile_idx, tr.first), tr.second);
+          }
+
+          // Insert single tiles.
+          const auto& o_tiles = subarray_.tile_overlap(f, r)->tiles_;
+          for (const auto& o_tile : o_tiles) {
+            if (tile_idx <= o_tile.first)
+              sorted_ranges[f].emplace_back(o_tile.first, o_tile.first);
+          }
+        }
+
+        std::sort(sorted_ranges[f].begin(), sorted_ranges[f].end());
+        return Status::Ok();
+      });
+  RETURN_NOT_OK_ELSE(status, LOG_STATUS(status));
+
+  // Free memory for tile overlap data.
+  subarray_.clear_tile_overlap();
+
+  // Go though the sorted list of ranges, and coalesce them.
+  result_tile_ranges_.resize(fragment_num);
+  status = parallel_for(
+      storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
+        auto it = sorted_ranges[f].begin();
+        while (it != sorted_ranges[f].end()) {
+          auto it2 = it + 1;
+          while (it2 != sorted_ranges[f].end()) {
+            // Same start, we can ignore *it* since *it2* end will be greater.
+            if (it->first == it2->first) {
+              it++;
+            } else if (it2->first <= it->second) {
+              // The start of the second range is included in the first.
+              it->second = std::max(it->second, it2->second);
+            } else {
+              // We start a new range.
+              break;
+            }
+            it2++;
+          }
+          result_tile_ranges_[f].emplace_back(it->first, it->second);
+          memory_used_result_tile_ranges_ += 2 * sizeof(uint64_t);
+
+          // If we busted our memory budget, exit.
+          if (memory_used_result_tile_ranges_ >= memory_budget)
+            return LOG_STATUS(Status::ReaderError(
+                "Exceeded memory budget for result tile ranges"));
+
+          it = it2;
+        }
+        return Status::Ok();
+      });
+  RETURN_NOT_OK_ELSE(status, LOG_STATUS(status));
+
+  return Status::Ok();
+}
+
+Status SparseIndexReaderBase::compute_coord_tiles_result_bitmap(
+    bool subarray_set,
+    ResultTile* tile,
+    std::vector<uint8_t>* coord_tiles_result_bitmap) {
+  auto timer_se = stats_->start_timer("compute_coord_tiles_result_bitmap");
+
+  // No subarray means we process all cells.
+  if (!subarray_set)
+    return Status::Ok();
+
+  // For easy reference.
+  auto coords_num = tile->cell_num();
+  auto dim_num = array_schema_->dim_num();
+  auto cell_order = array_schema_->cell_order();
+  auto range_coords = subarray_.get_range_coords(0);
+
+  std::vector<uint8_t> result_bitmap(coords_num, 1);
+
+  // Compute result and overwritten bitmap per dimension
+  for (unsigned d = 0; d < dim_num; ++d) {
+    // For col-major cell ordering, iterate the dimensions
+    // in reverse.
+    const unsigned dim_idx =
+        cell_order == Layout::COL_MAJOR ? dim_num - d - 1 : d;
+    if (!subarray_.is_default(dim_idx)) {
+      const auto& ranges = subarray_.ranges_for_dim(dim_idx);
+      RETURN_NOT_OK(tile->compute_results_sparse(
+          dim_idx, ranges[range_coords[dim_idx]], &result_bitmap, cell_order));
+    }
+  }
+
+  *coord_tiles_result_bitmap = std::move(result_bitmap);
+
+  return Status::Ok();
+}
+
+Status SparseIndexReaderBase::resize_output_buffers() {
+  // Count number of elements actually copied.
+  uint64_t cells_copied = 0;
+  for (uint64_t i = 0; i < copy_end_.first - 1; i++) {
+    cells_copied += read_state_.result_cell_slabs_[i].length_;
+  }
+
+  cells_copied += copy_end_.second;
+
+  // Resize buffers if the result cell slabs was truncated.
+  for (auto& it : buffers_) {
+    const auto& name = it.first;
+    const auto size = *it.second.buffer_size_;
+    uint64_t num_cells = 0;
+
+    if (array_schema_->var_size(name)) {
+      // Get the current number of cells from the offsets buffer.
+      num_cells = size / constants::cell_var_offset_size;
+
+      // Remove an element if the extra element flag is set.
+      if (offsets_extra_element_ && num_cells > 0)
+        num_cells--;
+
+      // Buffer should be resized.
+      if (num_cells > cells_copied) {
+        // Offsets buffer is trivial.
+        *(it.second.buffer_size_) =
+            cells_copied * constants::cell_var_offset_size +
+            offsets_extra_element_;
+
+        // Since we shrink the buffer, there is an offset for the next element
+        // loaded, use it.
+        *(it.second.buffer_var_size_) =
+            ((uint64_t*)it.second.buffer_)[cells_copied];
+      }
+    } else {
+      // Always adjust the size for fixed size attributes.
+      auto cell_size = array_schema_->cell_size(name);
+      *(it.second.buffer_size_) = cells_copied * cell_size;
+    }
+
+    // Always adjust validity vector size, if present.
+    if (num_cells > cells_copied) {
+      if (it.second.validity_vector_.buffer_size() != nullptr)
+        *(it.second.validity_vector_.buffer_size()) =
+            num_cells * constants::cell_validity_size;
+    }
+  }
+
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -1,0 +1,185 @@
+/**
+ * @file   sparse_index_reader_base.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class SparseIndexReaderBase.
+ */
+
+#ifndef TILEDB_SPARSE_INDEX_READER_BASE_H
+#define TILEDB_SPARSE_INDEX_READER_BASE_H
+
+#include <queue>
+#include "reader_base.h"
+#include "tiledb/common/status.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/query/query_condition.h"
+#include "tiledb/sm/query/result_cell_slab.h"
+
+namespace tiledb {
+namespace sm {
+
+class Array;
+class ArraySchema;
+class OpenArrayMemoryTracker;
+class StorageManager;
+class Subarray;
+
+/** Processes read queries. */
+class SparseIndexReaderBase : public ReaderBase {
+ public:
+  /* ********************************* */
+  /*          TYPE DEFINITIONS         */
+  /* ********************************* */
+
+  /** The state for a read sparse global order query. */
+  struct ReadState {
+    /** The result cell slabs currently in process. */
+    std::vector<ResultCellSlab> result_cell_slabs_;
+
+    /** The tile index inside of each fragments. */
+    std::vector<std::pair<uint64_t, uint64_t>> frag_tile_idx_;
+  };
+
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  SparseIndexReaderBase(
+      stats::Stats* stats,
+      StorageManager* storage_manager,
+      Array* array,
+      Config& config,
+      std::unordered_map<std::string, QueryBuffer>& buffers,
+      Subarray& subarray,
+      Layout layout,
+      QueryCondition& condition);
+
+  /** Destructor. */
+  ~SparseIndexReaderBase() = default;
+
+ protected:
+  /* ********************************* */
+  /*       PROTECTED ATTRIBUTES        */
+  /* ********************************* */
+
+  /** Read state. */
+  ReadState read_state_;
+
+  /** Is the reader done with the query. */
+  bool done_adding_result_tiles_;
+
+  /** Have we loaded all thiles for this fragment. */
+  std::vector<bool> all_tiles_loaded_;
+
+  /** Dimension names. */
+  std::vector<std::string> dim_names_;
+
+  /** Are dimensions var sized. */
+  std::vector<bool> is_dim_var_size_;
+
+  /** Sorted list, per fragments of tiles ranges in the subarray, if set. */
+  std::vector<std::list<std::pair<uint64_t, uint64_t>>> result_tile_ranges_;
+
+  /** Have ve loaded the initial data. */
+  bool initial_data_loaded_;
+
+  /** Total memory budget. */
+  uint64_t memory_budget_;
+
+  /** Mutex protecting memory budget variables. */
+  std::mutex mem_budget_mtx_;
+
+  /** Memory tracker object for the array. */
+  OpenArrayMemoryTracker* array_memory_tracker_;
+
+  /** Memory used for coordinates tiles. */
+  uint64_t memory_used_for_coords_total_;
+
+  /** Memory used for query condition tiles. */
+  uint64_t memory_used_qc_tiles_;
+
+  /** Memory used for result cell slabs. */
+  uint64_t memory_used_rcs_;
+
+  /** Memory used for result tiles. */
+  uint64_t memory_used_result_tiles_;
+
+  /** Memory used for result tile ranges. */
+  uint64_t memory_used_result_tile_ranges_;
+
+  /** How much of the memory budget is reserved for coords. */
+  double memory_budget_ratio_coords_;
+
+  /** How much of the memory budget is reserved for query condition. */
+  double memory_budget_ratio_query_condition_;
+
+  /** How much of the memory budget is reserved for tile ranges. */
+  double memory_budget_ratio_tile_ranges_;
+
+  /** How much of the memory budget is reserved for array data. */
+  double memory_budget_ratio_array_data_;
+
+  /** How much of the memory budget is reserved for result tiles. */
+  double memory_budget_ratio_result_tiles_;
+
+  /** How much of the memory budget is reserved for result cell slabs. */
+  double memory_budget_ratio_rcs_;
+
+  /* ********************************* */
+  /*         PROTECTED METHODS         */
+  /* ********************************* */
+
+  /** Get the coordinate tiles size for a dimension. */
+  Status get_coord_tiles_size(
+      unsigned dim_num, unsigned f, uint64_t t, uint64_t* tiles_size);
+
+  /** Load tile offsets and result tile ranges. */
+  Status load_initial_data();
+
+  /**
+   * Computes info about the which tiles are in subarray,
+   * making sure maximum budget is respected.
+   */
+  Status compute_result_tiles_ranges(uint64_t memory_budget);
+
+  /** Compute the result bitmap for a tile. */
+  Status compute_coord_tiles_result_bitmap(
+      bool subarray_set,
+      ResultTile* tile,
+      std::vector<uint8_t>* coord_tiles_result_bitmap);
+
+  /** Resize the output buffers to the correct size after copying. */
+  Status resize_output_buffers();
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_SPARSE_INDEX_READER_BASE_H

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1,0 +1,633 @@
+/**
+ * @file   sparse_unordered_with_dups_reader.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class SparseUnorderedWithDupsReader.
+ */
+
+#include "tiledb/sm/query/sparse_unordered_with_dups_reader.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/fragment/fragment_metadata.h"
+#include "tiledb/sm/misc/comparators.h"
+#include "tiledb/sm/misc/hilbert.h"
+#include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/query/query_macros.h"
+#include "tiledb/sm/query/result_tile.h"
+#include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/open_array_memory_tracker.h"
+#include "tiledb/sm/storage_manager/storage_manager.h"
+#include "tiledb/sm/subarray/subarray.h"
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm::stats;
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*          CONSTRUCTORS          */
+/* ****************************** */
+
+SparseUnorderedWithDupsReader::SparseUnorderedWithDupsReader(
+    stats::Stats* stats,
+    StorageManager* storage_manager,
+    Array* array,
+    Config& config,
+    std::unordered_map<std::string, QueryBuffer>& buffers,
+    Subarray& subarray,
+    Layout layout,
+    QueryCondition& condition)
+    : SparseIndexReaderBase(
+          stats,
+          storage_manager,
+          array,
+          config,
+          buffers,
+          subarray,
+          layout,
+          condition) {
+  // Defines specific bahavior in the tile copy code for this reader.
+  fix_var_sized_overflows_ = true;
+  clear_coords_tiles_on_copy_ = false;
+  array_memory_tracker_ =
+      storage_manager_->array_get_memory_tracker(array->array_uri());
+}
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+bool SparseUnorderedWithDupsReader::incomplete() const {
+  return copy_overflowed_ || !read_state_.result_cell_slabs_.empty() ||
+         !done_adding_result_tiles_;
+}
+
+Status SparseUnorderedWithDupsReader::init() {
+  // Sanity checks
+  if (storage_manager_ == nullptr)
+    return LOG_STATUS(Status::SparseUnorderedWithDupsReaderError(
+        "Cannot initialize sparse global order reader; Storage manager not "
+        "set"));
+  if (array_schema_ == nullptr)
+    return LOG_STATUS(Status::SparseUnorderedWithDupsReaderError(
+        "Cannot initialize sparse global order reader; Array schema not set"));
+  if (buffers_.empty())
+    return LOG_STATUS(Status::SparseUnorderedWithDupsReaderError(
+        "Cannot initialize sparse global order reader; Buffers not set"));
+
+  // Check subarray
+  RETURN_NOT_OK(check_subarray());
+
+  // Load offset configuration options.
+  bool found = false;
+  RETURN_NOT_OK(config_.get<bool>(
+      "sm.var_offsets.extra_element", &offsets_extra_element_, &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<uint32_t>(
+      "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
+  if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
+    return LOG_STATUS(Status::SparseUnorderedWithDupsReaderError(
+        "Cannot initialize reader; "
+        "Unsupported offsets bitsize in configuration"));
+  }
+  assert(found);
+  RETURN_NOT_OK(
+      config_.get<uint64_t>("sm.mem.total_budget", &memory_budget_, &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<double>(
+      "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data",
+      &memory_budget_ratio_array_data_,
+      &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<double>(
+      "sm.mem.reader.sparse_unordered_with_dups.ratio_coords",
+      &memory_budget_ratio_coords_,
+      &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<double>(
+      "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition",
+      &memory_budget_ratio_query_condition_,
+      &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<double>(
+      "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges",
+      &memory_budget_ratio_tile_ranges_,
+      &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<double>(
+      "sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles",
+      &memory_budget_ratio_result_tiles_,
+      &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<double>(
+      "sm.mem.reader.sparse_unordered_with_dups.ratio_rcs",
+      &memory_budget_ratio_rcs_,
+      &found));
+  assert(found);
+
+  // Check the validity buffer sizes.
+  RETURN_NOT_OK(check_validity_buffer_sizes());
+
+  return Status::Ok();
+}
+
+Status SparseUnorderedWithDupsReader::dowork() {
+  auto timer_se = stats_->start_timer("dowork");
+
+  // Check that the query condition is valid.
+  RETURN_NOT_OK(condition_.check(array_schema_));
+
+  get_dim_attr_stats();
+
+  // Reset the copy overflow flag.
+  copy_overflowed_ = false;
+
+  // Handle empty array.
+  if (fragment_metadata_.empty()) {
+    done_adding_result_tiles_ = true;
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  reset_buffer_sizes();
+
+  // Load initial data, if not loaded already.
+  RETURN_NOT_OK(load_initial_data());
+
+  // If the result cell slab is empty, populate it.
+  if (read_state_.result_cell_slabs_.empty())
+    RETURN_NOT_OK(compute_result_cell_slab());
+
+  // No more tiles to process, done.
+  if (read_state_.result_cell_slabs_.empty()) {
+    done_adding_result_tiles_ = true;
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  // First try to limit the maximum number of cells we copy using the size
+  // of the output buffers for fixed sized attributes. Later we will validate
+  // the memory budget. This is the first line of defence used to try to prevent
+  // overflows when copying data.
+  uint64_t num_cells = std::numeric_limits<uint64_t>::max();
+  for (const auto& it : buffers_) {
+    const auto& name = it.first;
+    const auto size = *it.second.buffer_size_;
+    if (array_schema_->var_size(name)) {
+      auto temp_num_cells = size / constants::cell_var_offset_size;
+
+      if (offsets_extra_element_ && temp_num_cells > 0)
+        temp_num_cells--;
+
+      num_cells = std::min(num_cells, temp_num_cells);
+    } else {
+      auto temp_num_cells = size / array_schema_->cell_size(name);
+      num_cells = std::min(num_cells, temp_num_cells);
+    }
+  }
+
+  // User gave us some empty buffers, exit.
+  if (num_cells == 0) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  // Compute an initial boundary for the copy. Also generate a set of the
+  // ResultTile pointers to use later. Tiles in tmp_result_tiles should be
+  // unique and come in the same order as in the result cell slabs to work
+  // with copy_attribute_values.
+  auto it = read_state_.result_cell_slabs_.begin();
+  std::unordered_set<ResultTile*> result_tiles_set;
+  std::vector<ResultTile*> tmp_result_tiles;
+  copy_end_.first = 0;
+  while (it != read_state_.result_cell_slabs_.end()) {
+    // Add the ResultTile* to our list if it's not in there already.
+    if (result_tiles_set.find(it->tile_) == result_tiles_set.end()) {
+      result_tiles_set.emplace(it->tile_);
+      tmp_result_tiles.push_back(it->tile_);
+    }
+
+    if (it->length_ > num_cells) {
+      copy_end_.first++;
+      copy_end_.second = num_cells;
+      break;
+    } else {
+      copy_end_.first++;
+      num_cells -= it->length_;
+      it++;
+    }
+  }
+
+  if (it == read_state_.result_cell_slabs_.end()) {
+    auto& last_rcs = read_state_.result_cell_slabs_.back();
+    copy_end_.second = last_rcs.length_;
+  }
+
+  // No longer needed.
+  result_tiles_set.clear();
+
+  // TODO Whenever a buffer overflows in copy, move it to the front of the
+  //      list, this way we will prevent reading tiles we don't need on
+  //      future reads.
+
+  // Copy the coordinates data.
+  RETURN_NOT_OK(
+      copy_coordinates(&tmp_result_tiles, &read_state_.result_cell_slabs_));
+
+  // copy_coordinates will only have an unrecoverable overflow if a single cell
+  // is too big for the user's buffers.
+  if (copy_overflowed_) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  // Calculate memory budget. For array data, copy_attribute_values might load
+  // more tile offsets so use the max budget.
+  uint64_t memory_budget_copy =
+      memory_budget_ - memory_used_qc_tiles_ - memory_used_rcs_ -
+      memory_used_result_tiles_ - memory_used_result_tile_ranges_ -
+      memory_budget_ratio_array_data_ * memory_budget_;
+
+  // Copy the attributes data.
+  RETURN_NOT_OK(copy_attribute_values(
+      UINT64_MAX,
+      &tmp_result_tiles,
+      &read_state_.result_cell_slabs_,
+      subarray_,
+      memory_budget_copy));
+
+  // copy_coordinates will only have an unrecoverable overflow if a single cell
+  // is too big for the user's buffers.
+  if (copy_overflowed_) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  // Fix the output buffer sizes.
+  RETURN_NOT_OK(resize_output_buffers());
+
+  // End the iteration.
+  RETURN_NOT_OK(end_iteration());
+
+  return Status::Ok();
+}
+
+void SparseUnorderedWithDupsReader::reset() {
+}
+
+Status SparseUnorderedWithDupsReader::add_result_tile(
+    unsigned dim_num,
+    uint64_t memory_budget_result_tiles,
+    uint64_t memory_budget_qc_tiles,
+    uint64_t memory_budget_coords_tiles,
+    unsigned f,
+    uint64_t t,
+    const Domain* domain,
+    bool* budget_exceeded) {
+  // Calculate memory consumption for this tile.
+  uint64_t tiles_size = 0;
+  RETURN_NOT_OK(get_coord_tiles_size(dim_num, f, t, &tiles_size));
+
+  // Don't load more tiles than the memory budget.
+  if (memory_used_for_coords_total_ + tiles_size > memory_budget_coords_tiles) {
+    *budget_exceeded = true;
+    return Status::Ok();
+  }
+
+  memory_used_for_coords_total_ += tiles_size;
+
+  result_tiles_.emplace_back(f, t, domain);
+
+  if (!condition_.empty()) {
+    uint64_t tiles_size = 0;
+    for (auto& name : condition_.field_names()) {
+      // Calculate memory consumption for this tile.
+      uint64_t tile_size = 0;
+      RETURN_NOT_OK(
+          get_attribute_tile_size(name, &result_tiles_.back(), &tile_size));
+      tiles_size += tile_size;
+    }
+
+    memory_used_qc_tiles_ += tiles_size;
+    if (memory_used_qc_tiles_ > memory_budget_qc_tiles) {
+      *budget_exceeded = true;
+    }
+  }
+
+  memory_used_result_tiles_ += sizeof(ResultTile);
+  if (memory_used_result_tiles_ > memory_budget_result_tiles) {
+    *budget_exceeded = true;
+  }
+
+  return Status::Ok();
+}
+
+Status SparseUnorderedWithDupsReader::create_result_tiles(bool* tiles_found) {
+  auto timer_se = stats_->start_timer("create_result_tiles");
+
+  // For easy reference.
+  auto fragment_num = fragment_metadata_.size();
+  auto domain = array_schema_->domain();
+  auto dim_num = array_schema_->dim_num();
+
+  if (!condition_.empty()) {
+    // To respect the memory budget, we only load as many tiles as we can
+    // process for the query condition. Load the tiles offsets first.
+    std::vector<std::string> names(condition_.field_names().size());
+    for (auto& name : condition_.field_names()) {
+      names.emplace_back(name);
+    }
+
+    load_tile_offsets(&subarray_, &names);
+  }
+
+  uint64_t memory_budget_result_tiles =
+      memory_budget_ * memory_budget_ratio_result_tiles_;
+  uint64_t memory_budget_qc_tiles =
+      memory_budget_ * memory_budget_ratio_query_condition_;
+  uint64_t memory_budget_coords = memory_budget_ * memory_budget_ratio_coords_;
+
+  // Create result tiles.
+  if (subarray_.is_set()) {
+    // Load as many tiles as the memory budget allows.
+    bool budget_exceeded = false;
+    unsigned int f = 0;
+    while (f < fragment_num && !budget_exceeded) {
+      auto range_it = result_tile_ranges_[f].begin();
+      uint64_t t = 0;
+      while (range_it != result_tile_ranges_[f].end()) {
+        for (t = range_it->first; t <= range_it->second; t++) {
+          RETURN_NOT_OK(add_result_tile(
+              dim_num,
+              memory_budget_result_tiles,
+              memory_budget_qc_tiles,
+              memory_budget_coords,
+              f,
+              t,
+              domain,
+              &budget_exceeded));
+          *tiles_found = true;
+
+          if (budget_exceeded)
+            break;
+        }
+
+        if (budget_exceeded)
+          break;
+        range_it++;
+      }
+
+      all_tiles_loaded_[f] = !budget_exceeded;
+      f++;
+    }
+  } else {
+    // Load as many tiles as the memory budget allows.
+    bool budget_exceeded = false;
+    unsigned int f = 0;
+    while (f < fragment_num && !budget_exceeded) {
+      uint64_t t = 0;
+      auto tile_num = fragment_metadata_[f]->tile_num();
+
+      // Figure out the start index.
+      auto start = read_state_.frag_tile_idx_[f].first;
+      if (!result_tiles_.empty() && result_tiles_.back().frag_idx() == f) {
+        start = std::max(start, result_tiles_.back().tile_idx() + 1);
+      }
+
+      for (t = start; t < tile_num; t++) {
+        RETURN_NOT_OK(add_result_tile(
+            dim_num,
+            memory_budget_result_tiles,
+            memory_budget_qc_tiles,
+            memory_budget_coords,
+            f,
+            t,
+            domain,
+            &budget_exceeded));
+        *tiles_found = true;
+
+        if (budget_exceeded)
+          break;
+      }
+
+      all_tiles_loaded_[f] = !budget_exceeded;
+      f++;
+    }
+  }
+
+  bool done_adding_result_tiles = true;
+  for (unsigned int f = 0; f < fragment_num; f++) {
+    done_adding_result_tiles &= all_tiles_loaded_[f];
+  }
+
+  done_adding_result_tiles_ = done_adding_result_tiles;
+  return Status::Ok();
+}
+
+Status SparseUnorderedWithDupsReader::compute_result_cell_slab() {
+  auto timer_se = stats_->start_timer("compute_result_cell_slab");
+
+  // Create the result tiles we are going to process.
+  bool tiles_found = false;
+  RETURN_NOT_OK(create_result_tiles(&tiles_found));
+
+  // No tiles found, return.
+  if (!tiles_found) {
+    return Status::Ok();
+  }
+
+  // Maintain a temporary vector with pointers to result tiles, so that
+  // `read_tiles`, `unfilter_tiles` can work without changes.
+  std::vector<ResultTile*> tmp_result_tiles;
+  for (auto& result_tile : result_tiles_)
+    tmp_result_tiles.push_back(&result_tile);
+
+  // Read and unfilter zipped coordinate tiles. Note that
+  // this will ignore fragments with a version >= 5.
+  std::vector<std::string> zipped_coords_names = {constants::coords};
+  RETURN_CANCEL_OR_ERROR(
+      read_coordinate_tiles(&zipped_coords_names, &tmp_result_tiles));
+  RETURN_CANCEL_OR_ERROR(unfilter_tiles(constants::coords, &tmp_result_tiles));
+
+  // Read and unfilter unzipped coordinate tiles. Note that
+  // this will ignore fragments with a version < 5.
+  RETURN_CANCEL_OR_ERROR(read_coordinate_tiles(&dim_names_, &tmp_result_tiles));
+  for (const auto& dim_name : dim_names_) {
+    RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, &tmp_result_tiles));
+  }
+
+  // Compute the result cell slabs with the loaded coordinate tiles.
+  uint64_t memory_budget_rcs = memory_budget_ratio_rcs_ * memory_budget_;
+  RETURN_CANCEL_OR_ERROR(create_result_cell_slabs(memory_budget_rcs));
+
+  // TODO This can be moved before calculating result cell slabs.
+  // Finally apply the query condition.
+  uint64_t memory_budget_tiles =
+      memory_budget_ * memory_budget_ratio_query_condition_;
+  uint64_t memory_used_tiles = 0;
+  RETURN_CANCEL_OR_ERROR(apply_query_condition(
+      &read_state_.result_cell_slabs_,
+      &tmp_result_tiles,
+      &subarray_,
+      std::numeric_limits<uint64_t>::max(),
+      memory_budget_rcs,
+      memory_budget_tiles,
+      &memory_used_tiles));
+  memory_used_rcs_ =
+      read_state_.result_cell_slabs_.size() * sizeof(ResultCellSlab);
+  memory_used_qc_tiles_ += memory_used_tiles;
+
+  return Status::Ok();
+}
+
+Status SparseUnorderedWithDupsReader::create_result_cell_slabs(
+    uint64_t memory_budget) {
+  auto timer_se = stats_->start_timer("create_result_cell_slabs");
+
+  // For easy reference.
+  bool subarray_set = subarray_.is_set();
+
+  for (auto& rt : result_tiles_) {
+    // Get the cell index we were processing.
+    auto cell_idx = read_state_.frag_tile_idx_[rt.frag_idx()].second;
+
+    // If no subarray is set, add all cells.
+    if (!subarray_set) {
+      read_state_.result_cell_slabs_.emplace_back(
+          &rt, cell_idx, rt.cell_num() - cell_idx);
+      memory_used_rcs_ += sizeof(ResultCellSlab);
+    } else {
+      // Calculate the bitmap for the cells.
+      std::vector<uint8_t> coord_tiles_result_bitmap;
+      RETURN_NOT_OK(compute_coord_tiles_result_bitmap(
+          subarray_set, &rt, &coord_tiles_result_bitmap));
+
+      // Process all cells, when there is a "hole" in the cell contiguity,
+      // push a new cell slab.
+      auto start = cell_idx;
+      uint64_t length = 0;
+      for (auto c = cell_idx; c < rt.cell_num(); c++) {
+        if (!coord_tiles_result_bitmap[c]) {
+          if (length != 0) {
+            read_state_.result_cell_slabs_.emplace_back(&rt, start, length);
+            memory_used_rcs_ += sizeof(ResultCellSlab);
+            start = c + 1;
+            length = 0;
+          }
+        } else {
+          length++;
+        }
+      }
+
+      // Add the last cell slab.
+      if (length != 0) {
+        read_state_.result_cell_slabs_.emplace_back(&rt, start, length);
+        memory_used_rcs_ += sizeof(ResultCellSlab);
+      }
+    }
+
+    read_state_.frag_tile_idx_[rt.frag_idx()] =
+        std::pair<uint64_t, uint64_t>(rt.tile_idx() + 1, 0);
+
+    // If we busted our memory budget, exit.
+    if (memory_used_rcs_ >= memory_budget)
+      break;
+  }
+
+  return Status::Ok();
+};
+
+Status SparseUnorderedWithDupsReader::remove_result_tile(
+    unsigned frag_idx, std::list<ResultTile>::iterator rt) {
+  // Remove coord tile size from memory budget.
+  auto tile_idx = rt->tile_idx();
+  uint64_t tiles_size = 0;
+  RETURN_NOT_OK(get_coord_tiles_size(
+      array_schema_->dim_num(), frag_idx, tile_idx, &tiles_size));
+  memory_used_for_coords_total_ -= tiles_size;
+
+  for (const auto& name : condition_.field_names()) {
+    uint64_t tile_size = 0;
+    RETURN_NOT_OK(get_attribute_tile_size(name, &*rt, &tile_size));
+    memory_used_qc_tiles_ -= tile_size;
+  }
+
+  // Delete the tile.
+  result_tiles_.erase(rt);
+
+  std::unique_lock<std::mutex> lck(mem_budget_mtx_);
+  memory_used_result_tiles_ -= sizeof(ResultTile);
+
+  return Status::Ok();
+}
+
+Status SparseUnorderedWithDupsReader::end_iteration() {
+  // Remove the processed cell slabs.
+  auto& new_front = read_state_.result_cell_slabs_[copy_end_.first - 1];
+
+  // If the last cell slab processed wasn't processed fully, split it.
+  if (new_front.length_ != copy_end_.second) {
+    new_front.start_ += copy_end_.second;
+    new_front.length_ -= copy_end_.second;
+    copy_end_.first--;
+  }
+
+  // Clear result tiles that are not necessary anymore.
+  while (result_tiles_.front().frag_idx() != new_front.tile_->frag_idx() ||
+         result_tiles_.front().tile_idx() != new_front.tile_->tile_idx()) {
+    auto f = result_tiles_.front().frag_idx();
+    RETURN_NOT_OK(remove_result_tile(f, result_tiles_.begin()));
+  }
+
+  // Erase from the vector.
+  read_state_.result_cell_slabs_.erase(
+      read_state_.result_cell_slabs_.begin(),
+      read_state_.result_cell_slabs_.begin() + copy_end_.first);
+
+  // If the result cell slabs are empty, check if we need to remove the last
+  // tile.
+  auto last_f = result_tiles_.front().frag_idx();
+  if (read_state_.result_cell_slabs_.empty() &&
+      result_tiles_.front().tile_idx() <
+          read_state_.frag_tile_idx_[last_f].first) {
+    RETURN_NOT_OK(remove_result_tile(last_f, result_tiles_.begin()));
+  }
+
+  auto uint64_t_max = std::numeric_limits<uint64_t>::max();
+  copy_end_ = std::pair<uint64_t, uint64_t>(uint64_t_max, uint64_t_max);
+
+  array_memory_tracker_->set_budget(std::numeric_limits<uint64_t>::max());
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -1,5 +1,5 @@
 /**
- * @file   sparse_global_order_reader.h
+ * @file   sparse_unordered_with_dups_reader.h
  *
  * @section LICENSE
  *
@@ -27,11 +27,11 @@
  *
  * @section DESCRIPTION
  *
- * This file defines class SparseGlobalOrderReader.
+ * This file defines class SparseUnorderedWithDupsReader.
  */
 
-#ifndef TILEDB_SPARSE_GLOBAL_ORDER_READER
-#define TILEDB_SPARSE_GLOBAL_ORDER_READER
+#ifndef TILEDB_SPARSE_UNORDERED_WITH_DUPS_READER
+#define TILEDB_SPARSE_UNORDERED_WITH_DUPS_READER
 
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -52,16 +52,16 @@ namespace sm {
 class Array;
 class StorageManager;
 
-/** Processes sparse global order read queries. */
-class SparseGlobalOrderReader : public SparseIndexReaderBase,
-                                public IQueryStrategy {
+/** Processes sparse unordered with duplicates read queries. */
+class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
+                                      public IQueryStrategy {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
   /** Constructor. */
-  SparseGlobalOrderReader(
+  SparseUnorderedWithDupsReader(
       stats::Stats* stats,
       StorageManager* storage_manager,
       Array* array,
@@ -72,10 +72,10 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       QueryCondition& condition);
 
   /** Destructor. */
-  ~SparseGlobalOrderReader() = default;
+  ~SparseUnorderedWithDupsReader() = default;
 
-  DISABLE_COPY_AND_COPY_ASSIGN(SparseGlobalOrderReader);
-  DISABLE_MOVE_AND_MOVE_ASSIGN(SparseGlobalOrderReader);
+  DISABLE_COPY_AND_COPY_ASSIGN(SparseUnorderedWithDupsReader);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(SparseUnorderedWithDupsReader);
 
   /* ********************************* */
   /*                 API               */
@@ -108,13 +108,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /* ********************************* */
 
   /** The result tiles currently loaded. */
-  std::vector<std::list<ResultTile>> result_tiles_;
-
-  /** Memory used for coordinates tiles per fragment. */
-  std::vector<uint64_t> memory_used_for_coords_;
-
-  /** Memory budget per fragment. */
-  double per_fragment_memory_;
+  std::list<ResultTile> result_tiles_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */
@@ -124,6 +118,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   Status add_result_tile(
       unsigned dim_num,
       uint64_t memory_budget_result_tiles,
+      uint64_t memory_budget_qc_tiles,
       uint64_t memory_budget_coords_tiles,
       unsigned f,
       uint64_t t,
@@ -136,35 +131,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /** Populate a result cell slab to process. */
   Status compute_result_cell_slab();
 
-  /**
-   * Add a new tile to the queue of tiles currently being processed
-   *  for a specific fragment.
-   */
-  template <class T>
-  Status add_next_tile_to_queue(
-      bool subarray_set,
-      unsigned int frag_idx,
-      uint64_t cell_idx,
-      std::vector<std::list<ResultTile>::iterator>& result_tiles_it,
-      std::vector<bool>& result_tile_used,
-      std::vector<std::vector<uint8_t>>& coord_tiles_result_bitmap,
-      std::priority_queue<ResultCoords, std::vector<ResultCoords>, T>&
-          tile_queue,
-      std::mutex& tile_queue_mutex,
-      T& cmp,
-      bool* need_more_tiles);
-
-  /** Computes a tile's Hilbert values, stores them in the comparator. */
-  template <class T>
-  Status calculate_hilbert_values(
-      bool subarray_set,
-      ResultTile* tile,
-      std::vector<std::vector<uint8_t>>& coord_tiles_result_bitmap,
-      T& cmp);
-
-  /** Compute the result cell slabs once tiles are loaded. */
-  template <class T>
-  Status merge_result_cell_slabs(uint64_t memory_budget, T cmp);
+  /** Create the result cell slabs once tiles are loaded. */
+  Status create_result_cell_slabs(uint64_t memory_budget);
 
   /** Remove a result tile from memory */
   Status remove_result_tile(
@@ -178,4 +146,4 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
 }  // namespace sm
 }  // namespace tiledb
 
-#endif  // TILEDB_SPARSE_GLOBAL_ORDER_READER
+#endif  // TILEDB_SPARSE_UNORDERED_WITH_DUPS_READER


### PR DESCRIPTION
This adds a reader for the sparse unordered with duplicated case. The
reader simply returns all data within the subarray (if set) by
processing all fragments in order. It is hidden behind the same
configuration option as the sparse global order reader but when enabled,
all unit tests are passing.

In this first version, there is simple memory budget management but
serialization is not yet supported.

Also including small fixes to memory management for the sparse global
order reader.

---
TYPE: IMPROVEMENT
DESC: Initial sparse unordered with duplicates reader.
