### PR TITLE
Introduce malloc_trim on Linux

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -252,6 +252,7 @@ void check_save_to_file() {
   ss << "sm.io_concurrency_level " << std::thread::hardware_concurrency()
      << "\n";
   ss << "sm.max_tile_overlap_size 314572800\n";
+  ss << "sm.mem.malloc_trim true\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_array_data 0.1\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_coords 0.5\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_query_condition 0.25\n";
@@ -563,6 +564,7 @@ TEST_CASE("C API: Test config iter", "[capi], [config]") {
   all_param_values["sm.memory_budget"] = "5368709120";
   all_param_values["sm.memory_budget_var"] = "10737418240";
   all_param_values["sm.use_refactored_readers"] = "false";
+  all_param_values["sm.mem.malloc_trim"] = "true";
   all_param_values["sm.mem.total_budget"] = "10737418240";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_coords"] = "0.5";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_query_condition"] =

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -98,6 +98,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/heap_memory.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/heap_profiler.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/logger.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/memory.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/status.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/thread_pool.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/interval/interval.cc

--- a/tiledb/common/memory.cc
+++ b/tiledb/common/memory.cc
@@ -1,0 +1,58 @@
+/**
+ * @file   memory.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains implementation common memory functions
+ */
+
+#ifdef __linux__
+#include <features.h>
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
+#endif
+
+#include <sstream>
+#include "tiledb/common/logger.h"
+
+namespace tiledb {
+namespace common {
+void tdb_malloc_trim() {
+  std::stringstream ss;
+#if defined(__linux__) && defined(__GLIBC__)
+  int ret = malloc_trim(0);
+  ss << "malloc_trim ";
+  if (ret == 0)
+    ss << "did not unmap memory";
+  else
+    ss << "did unmap memory";
+  LOG_TRACE(ss.str());
+#endif
+}
+}  // namespace common
+}  // namespace tiledb

--- a/tiledb/common/memory.h
+++ b/tiledb/common/memory.h
@@ -1,0 +1,43 @@
+/**
+ * @file   memory.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines common memory functions
+ */
+
+#ifndef TILEDB_COMMON_H
+#define TILEDB_COMMON_H
+
+#include "tiledb/common/logger.h"
+
+namespace tiledb {
+namespace common {
+void tdb_malloc_trim();
+}  // namespace common
+}  // namespace tiledb
+#endif  // TILEDB_COMMON_H

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1042,6 +1042,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  * - `sm.use_refactored_readers` <br>
  *    Use the refactored readers or not. <br>
  *    **Default**: false
+ * - `sm.mem.malloc_trim` <br>
+ *    Should malloc_trim be called on context and query destruction? This might
+ * reduce residual memory usage. <br>
+ *    **Default**: true
  * - `sm.mem.total_budget` <br>
  *    Memory budget for readers and writers. <br>
  *    **Default**: 10GB

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -75,6 +75,7 @@ const std::string Config::SM_SKIP_EST_SIZE_PARTITIONING = "false";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
 const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
 const std::string Config::SM_USE_REFACTORED_READERS = "false";
+const std::string Config::SM_MEM_MALLOC_TRIM = "true";
 const std::string Config::SM_MEM_TOTAL_BUDGET = "10737418240";  // 10GB;
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS = "0.5";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION =
@@ -233,6 +234,7 @@ Config::Config() {
   param_values_["sm.memory_budget"] = SM_MEMORY_BUDGET;
   param_values_["sm.memory_budget_var"] = SM_MEMORY_BUDGET_VAR;
   param_values_["sm.use_refactored_readers"] = SM_USE_REFACTORED_READERS;
+  param_values_["sm.mem.malloc_trim"] = SM_MEM_MALLOC_TRIM;
   param_values_["sm.mem.total_budget"] = SM_MEM_TOTAL_BUDGET;
   param_values_["sm.mem.reader.sparse_global_order.ratio_coords"] =
       SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS;
@@ -515,6 +517,8 @@ Status Config::unset(const std::string& param) {
     param_values_["sm.memory_budget_var"] = SM_MEMORY_BUDGET_VAR;
   } else if (param == "sm.use_refactored_readers") {
     param_values_["sm.use_refactored_readers"] = SM_USE_REFACTORED_READERS;
+  } else if (param == "sm.mem.malloc_trim") {
+    param_values_["sm.mem.malloc_trim"] = SM_MEM_MALLOC_TRIM;
   } else if (param == "sm.mem.total_budget") {
     param_values_["sm.mem.total_budget"] = SM_MEM_TOTAL_BUDGET;
   } else if (param == "sm.mem.reader.sparse_global_order.ratio_coords") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -147,6 +147,9 @@ class Config {
   /** Whether or not to use the refactored readers. */
   static const std::string SM_USE_REFACTORED_READERS;
 
+  /** Should malloc_trim be called on query/ctx destructors. */
+  static const std::string SM_MEM_MALLOC_TRIM;
+
   /** Maximum memory budget for readers and writers. */
   static const std::string SM_MEM_TOTAL_BUDGET;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -387,6 +387,10 @@ class Config {
    * - `sm.use_refactored_readers` <br>
    *    Use the refactored readers or not. <br>
    *    **Default**: false
+   * - `sm.mem.malloc_trim` <br>
+   *    Should malloc_trim be called on context and query destruction? This
+   *    might reduce residual memory usage. <br>
+   *    **Default**: true
    * - `sm.mem.total_budget` <br>
    *    Memory budget for readers and writers. <br>
    *    **Default**: 10GB

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -33,6 +33,7 @@
 #include "tiledb/sm/query/query.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
+#include "tiledb/common/memory.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/enums/query_type.h"
@@ -105,7 +106,15 @@ Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
     config_ = storage_manager->config();
 }
 
-Query::~Query() = default;
+Query::~Query() {
+  bool found = false;
+  bool use_malloc_trim = false;
+  const Status& st =
+      config_.get<bool>("sm.mem.malloc_trim", &use_malloc_trim, &found);
+  if (st.ok() && found && use_malloc_trim) {
+    tdb_malloc_trim();
+  }
+};
 
 /* ****************************** */
 /*               API              */

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -32,6 +32,7 @@
 
 #include "tiledb/sm/storage_manager/context.h"
 #include "tiledb/common/logger.h"
+#include "tiledb/common/memory.h"
 
 using namespace tiledb::common;
 
@@ -49,6 +50,14 @@ Context::Context()
 }
 
 Context::~Context() {
+  bool found = false;
+  bool use_malloc_trim = false;
+  const Status& st = storage_manager_->config().get<bool>(
+      "sm.mem.malloc_trim", &use_malloc_trim, &found);
+  if (st.ok() && found && use_malloc_trim) {
+    tdb_malloc_trim();
+  }
+
   // Delete the `storage_manager_` to ensure it is destructed
   // before the `compute_tp_` and `io_tp_` objects that it
   // references.


### PR DESCRIPTION
TileDB currently has some deficiencies in how we alloc and free internal memory. There is short and medium term efforts to improve this, however `malloc_trim` provides a (potentially) large benefit to users on Linux until improvements are finalized.

The main issue is TileDB allocs, and reallocs buffers that can be very small in size while tiles are read and run through the filter pipeline, along with other operations such as schema reading, metadata reading, etc. The potentially large number of small allocations or reallocation can cause fragmentation and can also cause the arena allocator to no unmap memory that has been freed. This happens in a most obvious way on Linux with glibc allocation in that a long running process might see
memory usage creep upwards after every query is finished but not necessarily immediately drop on query completion or context destruction. This is because while the process is running the allocator might not unmap the memory pages due to the usage patterns.

The short term solution is we introduce calls to `malloc_trim` on context destruction and on query class destruction for linux only.

---
TYPE: IMPROVEMENT
DESC: Add calls to \`malloc_trim\` on context and query destruction linux to potentially reduce idle memory usage
