### PR TITLE
Fix quickstart link

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,7 +18,7 @@ Useful Links
 
 - `Main Developer Docs <https://docs.tiledb.com/>`_
 - `Installation <https://docs.tiledb.com/developer/installation/quick-install>`_
-- `Quickstart <https://docs.tiledb.com/developer/quickstart>`_
+- `Quickstart <https://docs.tiledb.com/main/solutions/tiledb-embedded/usage>`_
 - `TileDB Github Repo <https://github.com/TileDB-Inc/TileDB>`_
 - `TileDB, Inc. Official Website <https://tiledb.com>`_
 


### PR DESCRIPTION
TYPE: IMPROVEMENT
DESC: `index.rst` has a broken `Quickstart` link. I _think_ this is a good replacement -- please let me know if not! :) 
