### PR TITLE
Query::set_layout: setting the layout on the subarray.

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -956,6 +956,11 @@ Status Query::set_layout(Layout layout) {
         "Cannot set layout; Hilbert order is not applicable to queries"));
 
   layout_ = layout;
+  if (type_ == QueryType::WRITE) {
+    RETURN_NOT_OK(writer_.set_layout(layout));
+  } else if (type_ == QueryType::READ) {
+    RETURN_NOT_OK(reader_.set_layout(layout));
+  }
   return Status::Ok();
 }
 


### PR DESCRIPTION
When setting the layout on a query, we did not set the layout on the
subarray. In python, the code will then go and call the size estimation
API  and cache the range offsets (range_offsets_) with the wrong layout.
When running the query later, these are not computed again and in some
cases will create this segfault.

---
TYPE: IMPROVEMENT
DESC: Query::set_layout: setting the layout on the subarray.
