### PR TITLE
Setup new tiledb_experimental c-api headers

### DIFF
--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -47,6 +47,7 @@
 #include "tiledb/sm/filesystem/posix.h"
 #endif
 #include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
 #include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/misc/utils.h"

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TILEDB_PUBLIC_HEADERS
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb.h
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb_enum.h
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb_version.h
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb_experimental.h
 )
 
 if (TILEDB_SERIALIZATION)
@@ -103,7 +104,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/interval/interval.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/array_schema.cc
-  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/array_schema_evolution.cc  
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/array_schema_evolution.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/attribute.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/dimension.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/domain.cc

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -36,6 +36,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
 #include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/config/config.h"

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -518,9 +518,6 @@ typedef struct tiledb_attribute_t tiledb_attribute_t;
 /** A TileDB array schema. */
 typedef struct tiledb_array_schema_t tiledb_array_schema_t;
 
-/** A TileDB array schema. */
-typedef struct tiledb_array_schema_evolution_t tiledb_array_schema_evolution_t;
-
 /** A TileDB dimension. */
 typedef struct tiledb_dimension_t tiledb_dimension_t;
 
@@ -3413,85 +3410,6 @@ TILEDB_EXPORT int32_t tiledb_array_schema_dump(
     tiledb_ctx_t* ctx, const tiledb_array_schema_t* array_schema, FILE* out);
 
 /* ********************************* */
-/*            SCHEMA EVOLUTION       */
-/* ********************************* */
-
-/**
- * Creates a TileDB schema evolution object.
- *
- * **Example:**
- *
- * @code{.c}
- * tiledb_array_schema_evolution_t* array_schema_evolution;
- * tiledb_array_schema_evolution_alloc(ctx, &array_schema_evolution);
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param array_schema_evolution The TileDB schema evolution to be created.
- * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
- */
-TILEDB_EXPORT int32_t tiledb_array_schema_evolution_alloc(
-    tiledb_ctx_t* ctx,
-    tiledb_array_schema_evolution_t** array_schema_evolution);
-
-/**
- * Destroys an array schema evolution, freeing associated memory.
- *
- * **Example:**
- *
- * @code{.c}
- * tiledb_array_schema_evolution_free(&array_schema_evolution);
- * @endcode
- *
- * @param array_schema_evolution The array schema evolution to be destroyed.
- */
-TILEDB_EXPORT void tiledb_array_schema_evolution_free(
-    tiledb_array_schema_evolution_t** array_schema_evolution);
-
-/**
- * Adds an attribute to an array schema evolution.
- *
- * **Example:**
- *
- * @code{.c}
- * tiledb_attribute_t* attr;
- * tiledb_attribute_alloc(ctx, "my_attr", TILEDB_INT32, &attr);
- * tiledb_array_schema_evolution_add_attribute(ctx, array_schema_evolution,
- * attr);
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param array_schema_evolution The schema evolution.
- * @param attr The attribute to be added.
- * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
- */
-TILEDB_EXPORT int32_t tiledb_array_schema_evolution_add_attribute(
-    tiledb_ctx_t* ctx,
-    tiledb_array_schema_evolution_t* array_schema_evolution,
-    tiledb_attribute_t* attribute);
-
-/**
- * Drops an attribute to an array schema evolution.
- *
- * **Example:**
- *
- * @code{.c}
- * const char* attribute_name="a1";
- * tiledb_array_schema_evolution_drop_attribute(ctx, array_schema_evolution,
- * attribute_name);
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param array_schema_evolution The schema evolution.
- * @param attribute_name The name of the attribute to be dropped.
- * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
- */
-TILEDB_EXPORT int32_t tiledb_array_schema_evolution_drop_attribute(
-    tiledb_ctx_t* ctx,
-    tiledb_array_schema_evolution_t* array_schema_evolution,
-    const char* attribute_name);
-
-/* ********************************* */
 /*               QUERY               */
 /* ********************************* */
 
@@ -6201,26 +6119,6 @@ TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_consolidate_metadata_with_key(
     const void* encryption_key,
     uint32_t key_length,
     tiledb_config_t* config);
-
-/**
- * Evolve array schema of an array.
- *
- * **Example:**
- *
- * @code{.c}
- * const char* array_uri="test_array";
- * tiledb_array_evolve(ctx, array_uri,array_schema_evolution);
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param array_uri The uri of the array.
- * @param array_schema_evolution The schema evolution.
- * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
- */
-TILEDB_EXPORT int32_t tiledb_array_evolve(
-    tiledb_ctx_t* ctx,
-    const char* array_uri,
-    tiledb_array_schema_evolution_t* array_schema_evolution);
 
 /* ********************************* */
 /*          OBJECT MANAGEMENT        */

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -1,0 +1,159 @@
+/**
+ * @file   tiledb_experimental.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares experimental C API for TileDB.
+ * Experimental APIs to do not fall under the API compatibility guarantees and
+ * might change between TileDB versions
+ */
+
+#ifndef TILEDB_EXPERIMENTAL_H
+#define TILEDB_EXPERIMENTAL_H
+
+#include "tiledb.h"
+
+/* ********************************* */
+/*               MACROS              */
+/* ********************************* */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** A TileDB array schema. */
+typedef struct tiledb_array_schema_evolution_t tiledb_array_schema_evolution_t;
+
+/* ********************************* */
+/*      ARRAY SCHEMA EVOLUTION       */
+/* ********************************* */
+
+/**
+ * Creates a TileDB schema evolution object.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_schema_evolution_t* array_schema_evolution;
+ * tiledb_array_schema_evolution_alloc(ctx, &array_schema_evolution);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_schema_evolution The TileDB schema evolution to be created.
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_schema_evolution_alloc(
+    tiledb_ctx_t* ctx,
+    tiledb_array_schema_evolution_t** array_schema_evolution);
+
+/**
+ * Destroys an array schema evolution, freeing associated memory.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_schema_evolution_free(&array_schema_evolution);
+ * @endcode
+ *
+ * @param array_schema_evolution The array schema evolution to be destroyed.
+ */
+TILEDB_EXPORT void tiledb_array_schema_evolution_free(
+    tiledb_array_schema_evolution_t** array_schema_evolution);
+
+/**
+ * Adds an attribute to an array schema evolution.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_attribute_t* attr;
+ * tiledb_attribute_alloc(ctx, "my_attr", TILEDB_INT32, &attr);
+ * tiledb_array_schema_evolution_add_attribute(ctx, array_schema_evolution,
+ * attr);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_schema_evolution The schema evolution.
+ * @param attr The attribute to be added.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_schema_evolution_add_attribute(
+    tiledb_ctx_t* ctx,
+    tiledb_array_schema_evolution_t* array_schema_evolution,
+    tiledb_attribute_t* attribute);
+
+/**
+ * Drops an attribute to an array schema evolution.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * const char* attribute_name="a1";
+ * tiledb_array_schema_evolution_drop_attribute(ctx, array_schema_evolution,
+ * attribute_name);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_schema_evolution The schema evolution.
+ * @param attribute_name The name of the attribute to be dropped.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_schema_evolution_drop_attribute(
+    tiledb_ctx_t* ctx,
+    tiledb_array_schema_evolution_t* array_schema_evolution,
+    const char* attribute_name);
+
+/* ********************************* */
+/*               ARRAY               */
+/* ********************************* */
+
+/**
+ * Evolve array schema of an array.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * const char* array_uri="test_array";
+ * tiledb_array_evolve(ctx, array_uri,array_schema_evolution);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_uri The uri of the array.
+ * @param array_schema_evolution The schema evolution.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_evolve(
+    tiledb_ctx_t* ctx,
+    const char* array_uri,
+    tiledb_array_schema_evolution_t* array_schema_evolution);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TILEDB_EXPERIMENTAL_H


### PR DESCRIPTION
Array Schema evolution is the first use of this new c-api header. The goal is to allow introducing new features into TileDB before we stabilize the c-api/cpp-api. Experimental APIs allow for modifications between TileDB versions. This allows for real world use to determine if the API achieves what users are requesting.

On disk format is ALWAYS guaranteed.

---
TYPE: C_API
DESC: Introduce new \`tiledb_experimental.h\` c-api header for new feature that don't have a stabilized api yet