### PR TITLE
Fix the std::bad_allocation error 

### DIFF
--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -37,7 +37,6 @@
 #include "tiledb/sm/fragment/fragment_metadata.h"
 
 #include <cassert>
-#include <chrono>
 #include <iostream>
 #include <list>
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -174,6 +174,7 @@ std::string ResultTile::coord_string(uint64_t pos, unsigned dim_idx) const {
   Status st = coord_tile_off.buffer()->read(
       &offset, pos * sizeof(uint64_t), sizeof(uint64_t));
   assert(st.ok());
+
   uint64_t next_offset = 0;
   if (pos == cell_num - 1) {
     next_offset = val_size;

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -37,8 +37,10 @@
 #include "tiledb/sm/fragment/fragment_metadata.h"
 
 #include <cassert>
+#include <chrono>
 #include <iostream>
 #include <list>
+#include <thread>
 
 using namespace tiledb::common;
 
@@ -184,9 +186,10 @@ std::string ResultTile::coord_string(uint64_t pos, unsigned dim_idx) const {
     assert(st.ok());
   }
 
-  auto size = next_offset - offset;
+  auto size = (next_offset > offset) ? (next_offset - offset) : 0;
 
   auto* buffer = static_cast<char*>(coord_tile_val.buffer()->data()) + offset;
+
   return std::string(buffer, size);
 }
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -40,7 +40,6 @@
 #include <chrono>
 #include <iostream>
 #include <list>
-#include <thread>
 
 using namespace tiledb::common;
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -170,25 +170,20 @@ std::string ResultTile::coord_string(uint64_t pos, unsigned dim_idx) const {
   assert(!coord_tile_val.empty());
   auto cell_num = coord_tile_off.cell_num();
   auto val_size = coord_tile_val.size();
-
   uint64_t offset = 0;
-  coord_tile_off.buffer()->set_offset(pos * sizeof(uint64_t));
-  Status st = coord_tile_off.buffer()->read(&offset, sizeof(uint64_t));
+  Status st = coord_tile_off.buffer()->read(
+      &offset, pos * sizeof(uint64_t), sizeof(uint64_t));
   assert(st.ok());
-
   uint64_t next_offset = 0;
   if (pos == cell_num - 1) {
     next_offset = val_size;
   } else {
-    coord_tile_off.buffer()->set_offset((pos + 1) * sizeof(uint64_t));
-    st = coord_tile_off.buffer()->read(&next_offset, sizeof(uint64_t));
+    st = coord_tile_off.buffer()->read(
+        &next_offset, (pos + 1) * sizeof(uint64_t), sizeof(uint64_t));
     assert(st.ok());
   }
-
-  auto size = (next_offset > offset) ? (next_offset - offset) : 0;
-
+  auto size = next_offset - offset;
   auto* buffer = static_cast<char*>(coord_tile_val.buffer()->data()) + offset;
-
   return std::string(buffer, size);
 }
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -170,6 +170,7 @@ std::string ResultTile::coord_string(uint64_t pos, unsigned dim_idx) const {
   assert(!coord_tile_val.empty());
   auto cell_num = coord_tile_off.cell_num();
   auto val_size = coord_tile_val.size();
+
   uint64_t offset = 0;
   Status st = coord_tile_off.buffer()->read(
       &offset, pos * sizeof(uint64_t), sizeof(uint64_t));
@@ -182,7 +183,9 @@ std::string ResultTile::coord_string(uint64_t pos, unsigned dim_idx) const {
         &next_offset, (pos + 1) * sizeof(uint64_t), sizeof(uint64_t));
     assert(st.ok());
   }
+
   auto size = next_offset - offset;
+
   auto* buffer = static_cast<char*>(coord_tile_val.buffer()->data()) + offset;
   return std::string(buffer, size);
 }


### PR DESCRIPTION
This PR is for the bug found by Dirk in story 9772. I found that the core dump happened in ResultTile::coord_string when next_offse is less than offset. Since they are unsigned 64bit integers, the negative (next_offset-offset) is casted to a very large unsigned 64bit integer. This might not be from the dataset(stringEx). It is more likely from the removal of chunk_buffer in PR2445.  

---
TYPE:  BUG 
DESC: When we ran an example with a string dimension, sometimes it threw out a std::bad_allocation error.
