### PR TITLE
only set cmake policy CMP0076 if cmake version in use knows about it

### DIFF
--- a/tiledb/common/interval/CMakeLists.txt
+++ b/tiledb/common/interval/CMakeLists.txt
@@ -25,7 +25,9 @@
 # THE SOFTWARE.
 #
 
-cmake_policy(SET CMP0076 NEW)  # CMake 3.13 - converts relative paths to absolute
+if (POLICY CMP0076) # CMP0076 unknown to vs2017 cmake version 3.12.18081601-MSVC_2
+  cmake_policy(SET CMP0076 NEW)  # CMake 3.13 - converts relative paths to absolute
+endif()
 find_package(Catch_EP REQUIRED)
 
 add_executable(unit_interval EXCLUDE_FROM_ALL)


### PR DESCRIPTION
vs2017 cmake version 3.12.18081601-MSVC_2 generates error trying to set POLICY CMP0076 that it does not support.
Check for knowledge of that policy and only modify it if cmake version in use knows about it.

---
TYPE: BUG
DESC: only set cmake policy CMP0076 if cmake version in use knows about it
