### PR TITLE
silence bogus vs2017 warning about unreferenced variable

### DIFF
--- a/COMPILER_WORKAROUNDS.md
+++ b/COMPILER_WORKAROUNDS.md
@@ -1,0 +1,11 @@
+# Compiler Workarounds
+
+This document lists the files, functions and lines in which we have implemented compiler specific workarounds.
+
+The goal is one day, we compilers get upgraded the items in this document can be removed.
+
+## Workaround List
+
+| File | Line | Function | Compiler| Workaround |
+| ---- | ---- | -------- | ------- | ---------- |
+| tiledb/common/interval/interval.h | 967 | `Bound normalize_bound(T bound, bool is_closed, bool is_for_upper_bound)` | VS2017 | `(void)is_for_upper_bound;` |

--- a/tiledb/common/interval/interval.h
+++ b/tiledb/common/interval/interval.h
@@ -964,6 +964,7 @@ class Interval : public detail::IntervalBase {
       }
     }
     if constexpr (!Traits::has_infinite_elements) {
+      (void)is_for_upper_bound;
       return Bound(bound, is_closed);
     } else {
       if (Traits::is_finite(bound)) {

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -40,6 +40,7 @@
 #include <cstring>
 #include <iostream>
 #include <sstream>
+#include <algorithm>
 
 #ifdef _WIN32
 #include <locale>  //provides needed visibility of two-argument tolower() prototype for win32

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -40,7 +40,6 @@
 #include <cstring>
 #include <iostream>
 #include <sstream>
-#include <algorithm>
 
 #ifdef _WIN32
 #include <locale>  //provides needed visibility of two-argument tolower() prototype for win32


### PR DESCRIPTION
Silence bogus vs2017 warning about unreferenced variable likely due to vs2017 bug not seeing variable referenced in generated code of method in template class because the referencing path is excluded due to 'if constexpr' clauses.

---
TYPE: BUG
DESC: Silence bogus vs2017 warning about unreferenced variable
