### PR TITLE
Close array after fragment info load

### DIFF
--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -527,6 +527,8 @@ Status FragmentInfo::load(
   for (const auto& f : fragments_)
     unconsolidated_metadata_num_ += (uint32_t)!f.has_consolidated_footer();
 
+  array.close();
+
   return Status::Ok();
 }
 


### PR DESCRIPTION
The fragment info object opens the array but never explicitly closes this. A new unit test on #2222 exposed this bug. I wanted to break this change out to make sure it doesn't get lost.

The effect of this is on local file system arrays, if the fragment info is loaded in a process the array remains forever in read mode, which prevents vacuuming from getting an exclusive lock.
 
---
TYPE: BUG
DESC: Close array after loading FragmentInfo
