### PR TITLE
Allow empty attribute writes. (#2461)

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -393,8 +393,100 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic]") {
   }
 }
 
-TEST_CASE(
-    "C++ API: Incorrect buffer size and offsets", "[cppapi][invalid-offsets]") {
+TEST_CASE("C++ API: Zero length buffer", "[cppapi][zero-length]") {
+  const std::string array_name_1d = "cpp_unit_array_1d";
+  Context ctx;
+  VFS vfs(ctx);
+
+  tiledb_layout_t write_layout = TILEDB_GLOBAL_ORDER;
+  tiledb_array_type_t array_type = TILEDB_DENSE;
+
+  SECTION("SPARSE") {
+    array_type = TILEDB_SPARSE;
+    SECTION("GLOBAL_ORDER") {
+      write_layout = TILEDB_GLOBAL_ORDER;
+    }
+
+    SECTION("UNORDERED") {
+      write_layout = TILEDB_UNORDERED;
+    }
+  }
+
+  SECTION("DENSE") {
+    array_type = TILEDB_DENSE;
+    SECTION("GLOBAL_ORDER") {
+      write_layout = TILEDB_GLOBAL_ORDER;
+    }
+
+    SECTION("UNORDERED") {
+      write_layout = TILEDB_UNORDERED;
+    }
+  }
+
+  if (vfs.is_dir(array_name_1d))
+    vfs.remove_dir(array_name_1d);
+
+  ArraySchema schema(ctx, array_type);
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int32_t>(ctx, "d", {{0, 1000}}, 1001));
+  schema.set_domain(domain);
+  schema.add_attribute(Attribute::create<std::vector<int32_t>>(ctx, "a"));
+  schema.add_attribute(Attribute::create<uint64_t>(ctx, "b"));
+  Array::create(array_name_1d, schema);
+
+  {
+    Array array(ctx, array_name_1d, TILEDB_WRITE);
+
+    std::vector<int32_t> a, coord = {0, 1, 2};
+    std::vector<uint64_t> a_offset = {0, 0, 0};
+    std::vector<uint64_t> b = {1, 2, 3};
+
+    a.reserve(10);
+    a = {};
+    Query q(ctx, array, TILEDB_WRITE);
+    q.set_layout(write_layout);
+    q.set_buffer("d", coord);
+    q.set_buffer("a", a_offset, a);
+    q.set_buffer("b", b);
+    q.submit();
+    q.finalize();
+
+    array.close();
+  }
+
+  {
+    Array array(ctx, array_name_1d, TILEDB_READ);
+
+    std::vector<int32_t> a(3);
+    std::vector<uint64_t> a_offset = {1, 1, 1};
+    std::vector<uint64_t> b(3);
+
+    a.reserve(10);
+    a = {};
+    const std::vector<int> subarray = {0, 2};
+    Query q(ctx, array, TILEDB_READ);
+    q.set_layout(TILEDB_GLOBAL_ORDER);
+    q.set_subarray(subarray);
+    q.set_buffer("a", a_offset, a);
+    q.set_buffer("b", b);
+    REQUIRE(q.submit() == Query::Status::COMPLETE);
+    CHECK((int)q.result_buffer_elements()["a"].first == 3);
+    CHECK((int)q.result_buffer_elements()["a"].second == 0);
+    CHECK((int)q.result_buffer_elements()["b"].second == 3);
+
+    array.close();
+
+    for (size_t i = 0; i < 3; i++) {
+      CHECK(a_offset[i] == 0);
+      CHECK(b[i] == i + 1);
+    }
+  }
+
+  if (vfs.is_dir(array_name_1d))
+    vfs.remove_dir(array_name_1d);
+}
+
+TEST_CASE("C++ API: Incorrect offsets", "[cppapi][invalid-offsets]") {
   const std::string array_name_1d = "cpp_unit_array_1d";
   Context ctx;
   VFS vfs(ctx);
@@ -412,18 +504,6 @@ TEST_CASE(
 
   std::vector<int32_t> a, coord = {10, 20, 30};
   std::vector<uint64_t> a_offset = {0, 0, 0};
-
-  // Test case where backing buffer for vector is non-null, but size is 0.
-  // For bug https://github.com/TileDB-Inc/TileDB/issues/590
-  {
-    a.reserve(10);
-    a = {};
-    Query q(ctx, array, TILEDB_WRITE);
-    q.set_layout(TILEDB_GLOBAL_ORDER);
-    q.set_coordinates(coord);
-    q.set_buffer("a", a_offset, a);
-    REQUIRE_THROWS(q.submit());
-  }
 
   // Test case of non-ascending offsets
   {

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -386,10 +386,6 @@ Status Writer::check_var_attr_offsets() const {
           "Invalid offsets for attribute " + attr + "; offset " +
           std::to_string(prev_offset) + " specified for buffer of size " +
           std::to_string(*buffer_val_size)));
-    else if (prev_offset == *buffer_val_size)
-      return LOG_STATUS(Status::WriterError(
-          "Invalid offsets for attribute " + attr +
-          "; zero length single cell writes are not supported"));
 
     for (uint64_t i = 1; i < num_offsets; i++) {
       uint64_t cur_offset = get_offset_buffer_element(buffer_off, i);
@@ -1852,9 +1848,9 @@ Status Writer::filter_last_tiles(
           // Note making shallow clones here, as it's not necessary to copy the
           // underlying tile Buffers.
           tiles_ref.push_back(last_tile.clone(false));
-          if (!last_tile_var.empty())
+          if (array_schema_->var_size(*name))
             tiles_ref.push_back(last_tile_var.clone(false));
-          if (!last_tile_validity.empty())
+          if (array_schema_->is_nullable(*name))
             tiles_ref.push_back(last_tile_validity.clone(false));
         }
         return Status::Ok();


### PR DESCRIPTION
The error condition hit when trying to set an empty attribute has now
been removed and a small fix to the global order writer was made. This
allowed to successfully write and read empty attributes. Moreover,
looking at the unit test that validated this error, it referenced
https://github.com/TileDB-Inc/TileDB/issues/590 which showed code that
originally segfaulted and caused the addition of the error condition.
This code, with the removal of the error condition, does not segfault
anymore. A valid attribute file is also successfully written to disk.

---
TYPE: IMPROVEMENT
DESC: Allow empty attribute writes.