### PR TITLE
Allow null data pointers for writes.

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -403,11 +403,20 @@ TEST_CASE("C++ API: Zero length buffer", "[cppapi][zero-length]") {
 
   tiledb_layout_t write_layout = TILEDB_GLOBAL_ORDER;
   tiledb_array_type_t array_type = TILEDB_DENSE;
+  bool null_pointer = true;
 
   SECTION("SPARSE") {
     array_type = TILEDB_SPARSE;
     SECTION("GLOBAL_ORDER") {
       write_layout = TILEDB_GLOBAL_ORDER;
+
+      SECTION("NULL_PTR") {
+        null_pointer = true;
+      }
+
+      SECTION("NON_NULL_PTR") {
+        null_pointer = false;
+      }
     }
 
     SECTION("UNORDERED") {
@@ -419,6 +428,14 @@ TEST_CASE("C++ API: Zero length buffer", "[cppapi][zero-length]") {
     array_type = TILEDB_DENSE;
     SECTION("GLOBAL_ORDER") {
       write_layout = TILEDB_GLOBAL_ORDER;
+
+      SECTION("NULL_PTR") {
+        null_pointer = true;
+      }
+
+      SECTION("NON_NULL_PTR") {
+        null_pointer = false;
+      }
     }
 
     SECTION("UNORDERED") {
@@ -444,7 +461,10 @@ TEST_CASE("C++ API: Zero length buffer", "[cppapi][zero-length]") {
     std::vector<uint64_t> a_offset = {0, 0, 0};
     std::vector<uint64_t> b = {1, 2, 3};
 
-    a.reserve(10);
+    if (!null_pointer) {
+      a.reserve(10);
+    }
+
     a = {};
     Query q(ctx, array, TILEDB_WRITE);
     q.set_layout(write_layout);

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1247,8 +1247,9 @@ Status Query::set_data_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
-    return LOG_STATUS(
-        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+    if (type_ != QueryType::WRITE || *buffer_size != 0)
+      return LOG_STATUS(
+          Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
@@ -1452,8 +1453,9 @@ Status Query::set_buffer(
     const bool check_null_buffers) {
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
-    return LOG_STATUS(
-        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+    if (type_ != QueryType::WRITE || *buffer_val_size != 0)
+      return LOG_STATUS(
+          Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_val_size == nullptr)
@@ -1641,8 +1643,9 @@ Status Query::set_buffer(
     const bool check_null_buffers) {
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
-    return LOG_STATUS(
-        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+    if (type_ != QueryType::WRITE || *buffer_val_size != 0)
+      return LOG_STATUS(
+          Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_val_size == nullptr)
@@ -1881,7 +1884,8 @@ Status Query::check_buffers_correctness() {
       // Check for data buffer under buffer_var
       bool exists_data = buffer(attr).buffer_var_ != nullptr;
       bool exists_offset = buffer(attr).buffer_ != nullptr;
-      if (!exists_data || !exists_offset) {
+      if ((!exists_data && *buffer(attr).buffer_var_size_ != 0) ||
+          !exists_offset) {
         return LOG_STATUS(Status::QueryError(
             std::string("Var-Sized input attribute/dimension '") + attr +
             "' is not set correctly \nOffsets buffer is not set"));


### PR DESCRIPTION
As a minor follow up to #2476 we expand the empty attribute writes to allow the data buffer to be null. This is useful for C++ users who might be using `std::vector` for their underlying data buffer where the vector's `std::vector::data()` will return `nullptr` when the vector is empty.

---
TYPE: IMPROVEMENT
DESC: Allow null data pointers for writes.
