### PR TITLE
Adjustments to Schema Evolution New Attribute Reads

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -77,6 +77,7 @@ if (TILEDB_CPP_API)
   file(GLOB TILEDB_CPP_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/cpp_api/*.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/cpp_api/tiledb"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../tiledb/sm/cpp_api/tiledb_experimental"
   )
 
   foreach(HEADER ${TILEDB_CPP_HEADERS})

--- a/examples/cpp_api/array_schema_evolution.cc
+++ b/examples/cpp_api/array_schema_evolution.cc
@@ -1,0 +1,202 @@
+/**
+ * @file   array_schema_evolution.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * When run, this program will create a simple 2D sparse array, write some data
+ * to it, and read a slice of the data back, then show adding a column, writing
+ * a second time and getting results back
+ */
+
+#include <iostream>
+#include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
+
+using namespace tiledb;
+
+// Name of array.
+std::string array_uri("array_schema_evolution_array");
+
+void create_array(const Context& ctx) {
+  // The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{1, 4}}, 4))
+      .add_dimension(Dimension::create<int>(ctx, "cols", {{1, 4}}, 4));
+
+  // The array will be sparse.
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+
+  // Add a single attribute "a" so each (i,j) cell can store an integer.
+  schema.add_attribute(Attribute::create<int>(ctx, "a"));
+
+  // Create the (empty) array on disk.
+  Array::create(array_uri, schema);
+}
+
+void write_array(const Context& ctx) {
+  // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
+  std::vector<int> coords_rows = {1, 2, 2};
+  std::vector<int> coords_cols = {1, 4, 3};
+  std::vector<int> data = {1, 2, 3};
+
+  // Open the array for writing and create the query.
+  Array array(ctx, array_uri, TILEDB_WRITE);
+  Query query(ctx, array, TILEDB_WRITE);
+  query.set_layout(TILEDB_UNORDERED)
+      .set_data_buffer("a", data)
+      .set_data_buffer("rows", coords_rows)
+      .set_data_buffer("cols", coords_cols);
+
+  // Perform the write and close the array.
+  query.submit();
+  array.close();
+}
+
+void write_array2(const Context& ctx) {
+  // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
+  std::vector<int> coords_rows = {3};
+  std::vector<int> coords_cols = {1};
+  std::vector<int> a_data = {4};
+  std::vector<int> b_data = {4};
+
+  // Open the array for writing and create the query.
+  Array array(ctx, array_uri, TILEDB_WRITE);
+  Query query(ctx, array, TILEDB_WRITE);
+  query.set_layout(TILEDB_UNORDERED)
+      .set_data_buffer("a", a_data)
+      .set_data_buffer("b", b_data)
+      .set_data_buffer("rows", coords_rows)
+      .set_data_buffer("cols", coords_cols);
+
+  // Perform the write and close the array.
+  query.submit();
+  array.close();
+}
+
+void read_array(const Context& ctx) {
+  // Prepare the array for reading
+  Array array(ctx, array_uri, TILEDB_READ);
+
+  // Slice only rows 1, 2 and cols 2, 3, 4
+  const std::vector<int> subarray = {1, 2, 2, 4};
+
+  // Prepare the vector that will hold the result.
+  // We take an upper bound on the result size, as we do not
+  // know a priori how big it is (since the array is sparse)
+  std::vector<int> data(3);
+  std::vector<int> coords_rows(3);
+  std::vector<int> coords_cols(3);
+
+  // Prepare the query
+  Query query(ctx, array, TILEDB_READ);
+  query.set_subarray(subarray)
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_data_buffer("a", data)
+      .set_data_buffer("rows", coords_rows)
+      .set_data_buffer("cols", coords_cols);
+
+  // Submit the query and close the array.
+  query.submit();
+  array.close();
+
+  // Print out the results.
+  auto result_num = (int)query.result_buffer_elements()["a"].second;
+  for (int r = 0; r < result_num; r++) {
+    int i = coords_rows[r];
+    int j = coords_cols[r];
+    int a = data[r];
+    std::cout << "Cell (" << i << ", " << j << ") has data " << a << "\n";
+  }
+}
+
+void read_array2(const Context& ctx) {
+  // Prepare the array for reading
+  Array array(ctx, array_uri, TILEDB_READ);
+
+  // Prepare the vector that will hold the result.
+  // We take an upper bound on the result size, as we do not
+  // know a priori how big it is (since the array is sparse)
+  std::vector<int> a_data(4);
+  std::vector<uint32_t> b_data(4);
+  std::vector<int> coords_rows(4);
+  std::vector<int> coords_cols(4);
+
+  // Prepare the query
+  Query query(ctx, array, TILEDB_READ);
+  query.add_range(0, 1, 4)
+      .add_range(1, 1, 4)
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_data_buffer("a", a_data)
+      .set_data_buffer("b", b_data)
+      .set_data_buffer("rows", coords_rows)
+      .set_data_buffer("cols", coords_cols);
+
+  // Submit the query and close the array.
+  query.submit();
+  array.close();
+
+  // Print out the results.
+  auto result_num = (int)query.result_buffer_elements()["a"].second;
+  for (int r = 0; r < result_num; r++) {
+    int i = coords_rows[r];
+    int j = coords_cols[r];
+    int a = a_data[r];
+    int b = b_data[r];
+    std::cout << "Cell (" << i << ", " << j << ") has data " << a << ", " << b
+              << "\n";
+  }
+}
+
+void array_schema_evolve(const Context& ctx) {
+  ArraySchemaEvolution schemaEvolution = ArraySchemaEvolution(ctx);
+
+  // Add attribute b
+  Attribute b = Attribute::create<uint32_t>(ctx, "b");
+  uint32_t fill_value = 1;
+  b.set_fill_value(&fill_value, sizeof(fill_value));
+  schemaEvolution.add_attribute(b);
+
+  // evolve array
+  schemaEvolution.array_evolve(array_uri);
+}
+
+int main() {
+  Config cfg;
+  Context ctx(cfg);
+
+  if (Object::object(ctx, array_uri).type() != Object::Type::Array) {
+    create_array(ctx);
+    write_array(ctx);
+    read_array(ctx);
+    array_schema_evolve(ctx);
+    write_array2(ctx);
+  }
+
+  read_array2(ctx);
+  return 0;
+}

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -401,3 +401,237 @@ TEST_CASE(
     vfs.remove_dir(array_uri);
   }
 }
+
+TEST_CASE(
+    "C++ API: SchemaEvolution, add attributes and read",
+    "[cppapi][schema][evolution][add]") {
+  using namespace tiledb;
+  Context ctx;
+  VFS vfs(ctx);
+
+  std::string array_uri = "test_schema_evolution_array_read";
+
+  // Create
+  {
+    Domain domain(ctx);
+    auto id1 = Dimension::create<int>(ctx, "d1", {{-100, 100}}, 10);
+    auto id2 = Dimension::create<int>(ctx, "d2", {{0, 100}}, 5);
+    domain.add_dimension(id1).add_dimension(id2);
+
+    auto a = Attribute::create<int>(ctx, "a");
+
+    ArraySchema schema(ctx, TILEDB_SPARSE);
+    schema.set_domain(domain);
+    schema.add_attribute(a);
+    schema.set_cell_order(TILEDB_ROW_MAJOR);
+    schema.set_tile_order(TILEDB_COL_MAJOR);
+
+    if (vfs.is_dir(array_uri)) {
+      vfs.remove_dir(array_uri);
+    }
+
+    Array::create(array_uri, schema);
+  }
+
+  // Write data
+  {
+    // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
+    std::vector<int> d1_data = {1, 2, 2};
+    std::vector<int> d2_data = {1, 4, 3};
+    std::vector<int> data = {1, 2, 3};
+
+    // Open the array for writing and create the query.
+    Array array(ctx, array_uri, TILEDB_WRITE);
+    Query query(ctx, array, TILEDB_WRITE);
+    query.set_layout(TILEDB_UNORDERED)
+        .set_data_buffer("a", data)
+        .set_data_buffer("d1", d1_data)
+        .set_data_buffer("d2", d2_data);
+
+    // Perform the write and close the array.
+    query.submit();
+    array.close();
+  }
+
+  // Read
+  {
+    // Prepare the array for reading
+    Array array(ctx, array_uri, TILEDB_READ);
+
+    // Prepare the vector that will hold the result.
+    // We take an upper bound on the result size, as we do not
+    // know a priori how big it is (since the array is sparse)
+    std::vector<int> data(3);
+    std::vector<int> d1_data(3);
+    std::vector<int> d2_data(3);
+
+    // Prepare the query
+    Query query(ctx, array, TILEDB_READ);
+    query.add_range(0, 1, 4)
+        .add_range(1, 1, 4)
+        .set_layout(TILEDB_ROW_MAJOR)
+        .set_data_buffer("a", data)
+        .set_data_buffer("d1", d1_data)
+        .set_data_buffer("d2", d2_data);
+
+    // Submit the query and close the array.
+    query.submit();
+    array.close();
+
+    // Compare the results.
+    auto result_num = (int)query.result_buffer_elements()["a"].second;
+    CHECK(result_num == 3);
+    CHECK_THAT(data, Catch::Matchers::Equals(std::vector<int>{1, 3, 2}));
+    CHECK_THAT(d1_data, Catch::Matchers::Equals(std::vector<int>{1, 2, 2}));
+    CHECK_THAT(d2_data, Catch::Matchers::Equals(std::vector<int>{1, 3, 4}));
+  }
+
+  // Evolve
+  {
+    ArraySchemaEvolution schemaEvolution = ArraySchemaEvolution(ctx);
+
+    // Add attribute b
+    Attribute b = Attribute::create<uint32_t>(ctx, "b");
+    uint32_t fill_value = 1;
+    b.set_fill_value(&fill_value, sizeof(fill_value));
+    schemaEvolution.add_attribute(b);
+
+    Attribute c = Attribute::create<uint32_t>(ctx, "c");
+    uint32_t fill_value_c = 2;
+    c.set_nullable(true);
+    c.set_fill_value(&fill_value_c, sizeof(fill_value_c), false);
+    schemaEvolution.add_attribute(c);
+
+    Attribute d = Attribute::create<std::string>(ctx, "d");
+    std::string fill_value_d = "test";
+    d.set_fill_value(fill_value_d.c_str(), fill_value_d.size());
+    schemaEvolution.add_attribute(d);
+
+    Attribute e = Attribute::create<std::string>(ctx, "e");
+    std::string fill_value_e = "n";
+    e.set_nullable(true);
+    e.set_fill_value(fill_value_e.c_str(), fill_value_e.size(), false);
+    schemaEvolution.add_attribute(e);
+
+    // evolve array
+    schemaEvolution.array_evolve(array_uri);
+
+    // read schema
+    auto read_schema = Array::load_schema(ctx, array_uri);
+
+    auto attrs = read_schema.attributes();
+    CHECK(attrs.count("a") == 1);
+    CHECK(attrs.count("b") == 1);
+    CHECK(attrs.count("c") == 1);
+    CHECK(attrs.count("d") == 1);
+    CHECK(attrs.count("e") == 1);
+  }
+
+  // Write again
+  {
+    // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
+    std::vector<int> d1_data = {3};
+    std::vector<int> d2_data = {1};
+    std::vector<int> a_data = {4};
+    std::vector<uint32_t> b_data = {4};
+    std::vector<uint32_t> c_data = {40};
+    std::vector<uint8_t> c_validity = {1};
+    std::vector<char> d_data = {'d'};
+    std::vector<uint64_t> d_offsets = {0};
+    std::vector<char> e_data = {'e'};
+    std::vector<uint64_t> e_offsets = {0};
+    std::vector<uint8_t> e_validity = {1};
+
+    // Open the array for writing and create the query.
+    Array array(ctx, array_uri, TILEDB_WRITE);
+    Query query(ctx, array, TILEDB_WRITE);
+    query.set_layout(TILEDB_UNORDERED)
+        .set_data_buffer("a", a_data)
+        .set_data_buffer("b", b_data)
+        .set_data_buffer("c", c_data)
+        .set_validity_buffer("c", c_validity)
+        .set_data_buffer("d", d_data)
+        .set_offsets_buffer("d", d_offsets)
+        .set_data_buffer("e", e_data)
+        .set_validity_buffer("e", e_validity)
+        .set_offsets_buffer("e", e_offsets)
+        .set_data_buffer("d1", d1_data)
+        .set_data_buffer("d2", d2_data);
+
+    // Perform the write and close the array.
+    query.submit();
+    array.close();
+  }
+
+  // Read Again
+  {
+    // Prepare the array for reading
+    Array array(ctx, array_uri, TILEDB_READ);
+
+    // Prepare the vector that will hold the result.
+    // We take an upper bound on the result size, as we do not
+    // know a priori how big it is (since the array is sparse)
+    std::vector<int> a_data(4);
+    std::vector<uint32_t> b_data(4);
+    std::vector<uint32_t> c_data(4);
+    std::vector<uint8_t> c_validity(4);
+    std::vector<char> d_data(13);
+    std::vector<uint64_t> d_offsets(4);
+    std::vector<char> e_data(4);
+    std::vector<uint8_t> e_validity(4);
+    std::vector<uint64_t> e_offsets(4);
+    std::vector<int> d1_data(4);
+    std::vector<int> d2_data(4);
+
+    // Prepare the query
+    Query query(ctx, array, TILEDB_READ);
+    query.add_range(0, 1, 4)
+        .add_range(1, 1, 4)
+        .set_layout(TILEDB_ROW_MAJOR)
+        .set_data_buffer("a", a_data)
+        .set_data_buffer("b", b_data)
+        .set_data_buffer("c", c_data)
+        .set_validity_buffer("c", c_validity)
+        .set_data_buffer("d", d_data)
+        .set_offsets_buffer("d", d_offsets)
+        .set_data_buffer("e", e_data)
+        .set_offsets_buffer("e", e_offsets)
+        .set_validity_buffer("e", e_validity)
+        .set_data_buffer("d1", d1_data)
+        .set_data_buffer("d2", d2_data);
+
+    // Submit the query and close the array.
+    query.submit();
+    array.close();
+
+    // Compare the results.
+    auto result_num = (int)query.result_buffer_elements()["a"].second;
+    CHECK(result_num == 4);
+    CHECK_THAT(a_data, Catch::Matchers::Equals(std::vector<int>{1, 3, 2, 4}));
+    CHECK_THAT(
+        b_data, Catch::Matchers::Equals(std::vector<uint32_t>{1, 1, 1, 4}));
+    CHECK_THAT(
+        c_data, Catch::Matchers::Equals(std::vector<uint32_t>{2, 2, 2, 40}));
+    CHECK_THAT(
+        c_validity, Catch::Matchers::Equals(std::vector<uint8_t>{0, 0, 0, 1}));
+    CHECK_THAT(
+        d_data,
+        Catch::Matchers::Equals(std::vector<char>{
+            't', 'e', 's', 't', 't', 'e', 's', 't', 't', 'e', 's', 't', 'd'}));
+    CHECK_THAT(
+        d_offsets, Catch::Matchers::Equals(std::vector<uint64_t>{0, 4, 8, 12}));
+    CHECK_THAT(
+        e_data, Catch::Matchers::Equals(std::vector<char>{'n', 'n', 'n', 'e'}));
+    CHECK_THAT(
+        e_offsets, Catch::Matchers::Equals(std::vector<uint64_t>{0, 1, 2, 3}));
+    CHECK_THAT(
+        e_validity, Catch::Matchers::Equals(std::vector<uint8_t>{0, 0, 0, 1}));
+    CHECK_THAT(d1_data, Catch::Matchers::Equals(std::vector<int>{1, 2, 2, 3}));
+    CHECK_THAT(d2_data, Catch::Matchers::Equals(std::vector<int>{1, 3, 4, 1}));
+  }
+
+  // Clean up
+  if (vfs.is_dir(array_uri)) {
+    vfs.remove_dir(array_uri);
+  }
+}

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -502,6 +502,7 @@ Status ArraySchema::add_attribute(const Attribute* attr, bool check_special) {
   attributes_.emplace_back(new_attr);
   attribute_map_[new_attr->name()] = new_attr;
 
+  RETURN_NOT_OK(generate_uri());
   return Status::Ok();
 }
 

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -378,6 +378,10 @@ bool ArraySchema::is_dim(const std::string& name) const {
   return this->dimension(name) != nullptr;
 }
 
+bool ArraySchema::is_field(const std::string& name) const {
+  return is_attr(name) || is_dim(name) || name == constants::coords;
+}
+
 bool ArraySchema::is_nullable(const std::string& name) const {
   const Attribute* const attr = this->attribute(name);
   if (attr == nullptr)

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -199,6 +199,9 @@ class ArraySchema {
   /** Returns true if the input name is a dimension. */
   bool is_dim(const std::string& name) const;
 
+  /** Returns true if the input name is a dimension, attribute or coords. */
+  bool is_field(const std::string& name) const;
+
   /** Returns true if the input name is nullable. */
   bool is_nullable(const std::string& name) const;
 
@@ -332,6 +335,9 @@ class ArraySchema {
   /** Returns the schema name. If it is not set, will returns error status. */
   Status get_name(std::string* name) const;
 
+  /** Generates a new array schema URI. */
+  Status generate_uri();
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -426,9 +432,6 @@ class ArraySchema {
 
   /** Clears all members. Use with caution! */
   void clear();
-
-  /** Generates a new array schema URI. */
-  Status generate_uri();
 };
 
 }  // namespace sm

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -82,17 +82,8 @@ FragmentMetadata::FragmentMetadata(
   sparse_tile_num_ = 0;
   footer_size_ = 0;
   footer_offset_ = 0;
-  auto attributes = array_schema_->attributes();
-  for (unsigned i = 0; i < attributes.size(); ++i) {
-    auto attr_name = attributes[i]->name();
-    idx_map_[attr_name] = i;
-  }
-  idx_map_[constants::coords] = array_schema_->attribute_num();
-  for (unsigned i = 0; i < array_schema_->dim_num(); ++i) {
-    auto dim_name = array_schema_->dimension(i)->name();
-    idx_map_[dim_name] = array_schema_->attribute_num() + 1 + i;
-  }
 
+  build_idx_map();
   array_schema_->get_name(&array_schema_name_);
 }
 
@@ -162,6 +153,9 @@ void FragmentMetadata::set_tile_validity_offset(
 
 void FragmentMetadata::set_array_schema(ArraySchema* array_schema) {
   array_schema_ = array_schema;
+
+  // Rebuild index mapping
+  build_idx_map();
 }
 
 uint64_t FragmentMetadata::cell_num() const {
@@ -2621,6 +2615,25 @@ void FragmentMetadata::clean_up() {
   storage_manager_->close_file(fragment_metadata_uri);
   storage_manager_->vfs()->remove_file(fragment_metadata_uri);
   storage_manager_->array_xunlock(array_uri);
+}
+
+const ArraySchema* FragmentMetadata::array_schema() const {
+  return array_schema_;
+}
+
+void FragmentMetadata::build_idx_map() {
+  idx_map_.clear();
+
+  auto attributes = array_schema_->attributes();
+  for (unsigned i = 0; i < attributes.size(); ++i) {
+    auto attr_name = attributes[i]->name();
+    idx_map_[attr_name] = i;
+  }
+  idx_map_[constants::coords] = array_schema_->attribute_num();
+  for (unsigned i = 0; i < array_schema_->dim_num(); ++i) {
+    auto dim_name = array_schema_->dimension(i)->name();
+    idx_map_[dim_name] = array_schema_->attribute_num() + 1 + i;
+  }
 }
 
 // Explicit template instantiations

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -236,7 +236,11 @@ class FragmentMetadata {
    * versions if it is not `nullptr`.
    */
   Status load(
-      const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset);
+      const EncryptionKey& encryption_key,
+      Buffer* f_buff,
+      uint64_t offset,
+      std::unordered_map<std::string, tiledb_shared_ptr<ArraySchema>>
+          array_schemas);
 
   /** Stores all the metadata to storage. */
   Status store(const EncryptionKey& encryption_key);
@@ -942,7 +946,11 @@ class FragmentMetadata {
    * it is not `nullptr` (version 3 or after).
    */
   Status load_v3_or_higher(
-      const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset);
+      const EncryptionKey& encryption_key,
+      Buffer* f_buff,
+      uint64_t offset,
+      std::unordered_map<std::string, tiledb_shared_ptr<ArraySchema>>
+          array_schemas);
 
   /**
    * Loads the footer of the metadata file, which contains
@@ -951,7 +959,11 @@ class FragmentMetadata {
    * will be loaded from `f_buff`.
    */
   Status load_footer(
-      const EncryptionKey& encryption_key, Buffer* f_buff, uint64_t offset);
+      const EncryptionKey& encryption_key,
+      Buffer* f_buff,
+      uint64_t offset,
+      std::unordered_map<std::string, tiledb_shared_ptr<ArraySchema>>
+          array_schemas);
 
   /** Writes the sizes of each attribute file to the buffer. */
   Status write_file_sizes(Buffer* buff) const;

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -547,6 +547,13 @@ class FragmentMetadata {
   Status load_tile_validity_offsets(
       const EncryptionKey& encryption_key, std::vector<std::string>&& names);
 
+  /**
+   * Returns ArraySchema
+   *
+   * @return
+   */
+  const ArraySchema* array_schema() const;
+
  private:
   /* ********************************* */
   /*          TYPE DEFINITIONS         */
@@ -1133,6 +1140,11 @@ class FragmentMetadata {
    * return std::string The encoded dimension/attribute name.
    */
   std::string encode_name(const std::string& name) const;
+
+  /**
+   * This builds the index mapping for attribute/dimension name to id.
+   */
+  void build_idx_map();
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1881,8 +1881,8 @@ Status Query::check_buffers_correctness() {
   // Iterate through each attribute
   for (auto& attr : buffer_names()) {
     if (buffer(attr).buffer_ == nullptr)
-      return LOG_STATUS(
-          Status::QueryError(std::string("Data buffer is not set")));
+      return LOG_STATUS(Status::QueryError(
+          std::string("Data buffer is not set for " + attr)));
     if (array_schema_->var_size(attr)) {
       // Var-sized
       // Check for data buffer under buffer_var

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -176,14 +176,20 @@ Status ReaderBase::load_tile_offsets(
         // Filter the 'names' for format-specific names.
         std::vector<std::string> filtered_names;
         filtered_names.reserve(names->size());
+        auto schema = fragment->array_schema();
         for (const auto& name : *names) {
           // Applicable for zipped coordinates only to versions < 5
           if (name == constants::coords && format_version >= 5)
             continue;
 
           // Applicable to separate coordinates only to versions >= 5
-          const auto is_dim = array_schema_->is_dim(name);
+          const auto is_dim = schema->is_dim(name);
           if (is_dim && format_version < 5)
+            continue;
+
+          // Not a member of array schema, this field was added in array schema
+          // evolution, ignore for this fragment's tile offsets
+          if (!schema->is_field(name))
             continue;
 
           filtered_names.emplace_back(name);
@@ -378,6 +384,11 @@ Status ReaderBase::read_tiles(
     // Applicable to separate coordinates only to versions >= 5
     const bool is_dim = array_schema_->is_dim(name);
     if (is_dim && format_version < 5)
+      continue;
+
+    // If the fragment doesn't have the attribute, this is a schema evolution
+    // field and will be treated with fill-in value instead of reading from disk
+    if (!fragment->array_schema()->is_field(name))
       continue;
 
     // Initialize the tile(s)
@@ -999,7 +1010,18 @@ Status ReaderBase::copy_partitioned_fixed_cells(
     }
 
     // Copy
-    if (cs.tile_ == nullptr) {  // Empty range
+
+    // First we check if this is an older (pre TileDB 2.0) array with zipped
+    // coordinates and the user has requested split buffer if so we should
+    // proceed to copying the tile If not, and there is no tile or the tile is
+    // empty for the field then this is a read of an older fragment in schema
+    // evolution. In that case we want to set the field to fill values for this
+    // for this tile.
+    const bool split_buffer_for_zipped_coords =
+        array_schema_->is_dim(*name) && cs.tile_->stores_zipped_coords();
+    if ((cs.tile_ == nullptr || cs.tile_->tile_tuple(*name) == nullptr) &&
+        !split_buffer_for_zipped_coords) {  // Empty range or attributed added
+                                            // in schema evolution
       auto bytes_to_copy = cs_length * cell_size;
       auto fill_num = bytes_to_copy / fill_value_size;
       for (uint64_t j = 0; j < fill_num; ++j) {
@@ -1200,7 +1222,7 @@ Status ReaderBase::compute_var_cell_destinations(
     uint64_t* tile_offsets = nullptr;
     uint64_t tile_cell_num = 0;
     uint64_t tile_var_size = 0;
-    if (cs.tile_ != nullptr) {
+    if (cs.tile_ != nullptr && cs.tile_->tile_tuple(name) != nullptr) {
       const auto tile_tuple = cs.tile_->tile_tuple(name);
       const auto& tile = std::get<0>(*tile_tuple);
       const auto& tile_var = std::get<1>(*tile_tuple);
@@ -1221,7 +1243,7 @@ Status ReaderBase::compute_var_cell_destinations(
          cell_idx += stride, dest_vec_idx++) {
       // Get size of variable-sized cell
       uint64_t cell_var_size = 0;
-      if (cs.tile_ == nullptr) {
+      if (cs.tile_ == nullptr || cs.tile_->tile_tuple(name) == nullptr) {
         cell_var_size = fill_value_size;
       } else {
         cell_var_size =
@@ -1331,7 +1353,7 @@ Status ReaderBase::copy_partitioned_var_cells(
     Tile* tile_var = nullptr;
     Tile* tile_validity = nullptr;
     uint64_t tile_cell_num = 0;
-    if (cs.tile_ != nullptr) {
+    if (cs.tile_ != nullptr && cs.tile_->tile_tuple(*name) != nullptr) {
       const auto tile_tuple = cs.tile_->tile_tuple(*name);
       Tile* const tile = &std::get<0>(*tile_tuple);
       tile_var = &std::get<1>(*tile_tuple);
@@ -1363,7 +1385,7 @@ Status ReaderBase::copy_partitioned_var_cells(
       std::memcpy(offset_dest, &var_offset, offset_size);
 
       // Copy variable-sized value
-      if (cs.tile_ == nullptr) {
+      if (cs.tile_ == nullptr || cs.tile_->tile_tuple(*name) == nullptr) {
         std::memcpy(var_dest, fill_value.data(), fill_value_size);
         if (nullable)
           std::memset(

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -2613,15 +2613,7 @@ Status StorageManager::load_fragment_metadata(
           tdb_delete(metadata));
       open_array->insert_fragment_metadata(metadata);
     }
-    auto array_schema_name = metadata->array_schema_name();
-    tdb_shared_ptr<ArraySchema> frag_array_schema(nullptr);
-    RETURN_NOT_OK(
-        open_array->get_array_schema(array_schema_name, &frag_array_schema));
-    if (!frag_array_schema) {
-      return LOG_STATUS(Status::StorageManagerError(
-          "Cannot load fragment metadata; Null fragment array schema"));
-    }
-    metadata->set_array_schema(frag_array_schema.get());
+
     (*fragment_metadata)[f] = metadata;
     return Status::Ok();
   });


### PR DESCRIPTION
This PR makes two adjustments. First we update the fragment footer, the array schema is (naively) used to compute the size of the footer based on the attribute/dimension count. As such as need to load the schema name first, then load the proper schema and use this computing the remaining footer size. We have short term goals to change all on disk data to be self contained (i.e. include the "computed" numbers needed in the file itself), however due to pending 2.4 release we shuffle around footer for v10 to support schema evolution.

The second adjustment is minor tweaks to the read path to fully support reading new attributes from older fragments by using the fill-in value. Unit tests are added for fixed, fixed nullable, var length and var length nullable attributes.

~Note for simplicity this PR is set to merge into #2467 . I plan to merge that one first, then switch this PR to dev. I've set the base for readability of the changes for review.~

[ch 10165]

---
TYPE: IMPROVEMENT
DESC: Adjustments to schema evolution new attribute reads
