### PR TITLE
Stop reading REST data when length is 0

### DIFF
--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -541,7 +541,7 @@ size_t RestClient::post_data_write_cb(
   // consumption by overwriting the serialized query objects that we
   // have already processed.
   const uint64_t length = scratch->size() - scratch->offset();
-  if (scratch->offset() != 0) {
+  if (scratch->offset() != 0 && length != 0) {
     const uint64_t offset = scratch->offset();
     scratch->reset_offset();
 


### PR DESCRIPTION
If we have perfectly aligned the scratch space and curl has no more data we should not attempt to shuffle any further data around as we are about to return.

---
TYPE: BUG
DESC: Fix handling curl REST request having all data in single call back