### PR TITLE
Increase release build timeout, macos is being a bit slow on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,6 +78,7 @@ stages:
       MACOSX_DEPLOYMENT_TARGET: 10.14
     jobs:
      - job:
+       timeoutInMinutes: 90
        strategy:
          matrix:
            linux:


### PR DESCRIPTION
Increase release build timeout, macos is being a bit slow on Azure. This way on next release we don't need to worry.

---
TYPE: NO_HISTORY
DESC: NO_HISTORY
