### PR TITLE
Use manylinux2010 image for azure linux CI and release builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,7 +139,7 @@ stages:
          displayName: 'Add artifacts to GitHub Release'
          inputs:
            gitHubConnection: TileDB-Inc-Release
-           repositoryName: TileDB-Inc/TileDB
+           repositoryName: $(Build.Repository.Name)
            addChangeLog: false
            action: edit
            tag: $(Build.SourceBranchName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,11 @@ pr:
   branches:
     include:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string
+
+variables:
+  - name: MANYLINUX_IMAGE
+    value: quay.io/pypa/manylinux2010_x86_64:2021-06-07-00faba2
+
 stages:
   - stage: CI
     condition: and(not(startsWith(variables['Build.SourceBranch'], 'refs/tags')), not(startsWith(variables['Build.SourceBranchName'], 'build-')))
@@ -35,16 +40,6 @@ stages:
         vmImage: $(imageName)
       steps:
       - template: scripts/azure-linux_mac.yml
-
-    #- job: CentOS6_manylinux1
-    #    container:
-    #      image: quay.io/pypa/manylinux1_x86_64:2020-12-05-08e76f2
-    #    variables:
-    #      CXX: g++
-    #      TILEDB_FORCE_BUILD_DEPS: ON
-    #      TILEDB_BUILD_ENABLE: "s3,azure,serialization,static-tiledb"
-    #    steps:
-    #    - template: scripts/azure-centos6.yml
 
     - job: Windows
       strategy:
@@ -83,6 +78,7 @@ stages:
          matrix:
            linux:
              imageName: 'ubuntu-20.04'
+             containerImage: $(MANYLINUX_CONTAINER)
              CXX: g++
              ARTIFACT_OS: 'linux'
              ARTIFACT_ARCH: 'x86_64'


### PR DESCRIPTION
Use manylinux2010 image for linux CI and release builds

---
TYPE: NO_HISTORY
DESC: Use manylinux2010 image for azure linux CI and release builds
