### PR TITLE
Support empty string writes for dimensions

### DIFF
--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -1672,6 +1672,21 @@ TEST_CASE_METHOD(
   char s1[] = "a";
   char s2[] = "ee";
 
+  // Check we can add empty ranges
+  rc = tiledb_query_add_range_var(ctx_, query, 0, s1, 0, s2, 2);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_add_range_var(ctx_, query, 0, s1, 1, s2, 0);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_add_range_var(ctx_, query, 0, nullptr, 0, s2, 2);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_add_range_var(ctx_, query, 0, s1, 1, nullptr, 0);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean query and re-alloc
+  tiledb_query_free(&query);
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  CHECK(rc == TILEDB_OK);
+
   // Check errors when adding range
   rc = tiledb_query_add_range(ctx_, query, 0, s1, s2, nullptr);
   CHECK(rc == TILEDB_ERR);
@@ -1680,10 +1695,6 @@ TEST_CASE_METHOD(
   rc = tiledb_query_add_range_var(ctx_, query, 0, nullptr, 1, s2, 2);
   CHECK(rc == TILEDB_ERR);
   rc = tiledb_query_add_range_var(ctx_, query, 0, s1, 1, nullptr, 2);
-  CHECK(rc == TILEDB_ERR);
-  rc = tiledb_query_add_range_var(ctx_, query, 0, s1, 0, s2, 2);
-  CHECK(rc == TILEDB_ERR);
-  rc = tiledb_query_add_range_var(ctx_, query, 0, s1, 1, s2, 0);
   CHECK(rc == TILEDB_ERR);
 
   // Add string range

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1288,16 +1288,50 @@ TEST_CASE(
   std::string s1("a", 1);
   std::string s2("ee", 2);
   Query query_r(ctx, array_r, TILEDB_READ);
-  query_r.add_range(0, s1, s2);
-  CHECK_THROWS(query_r.add_range(1, s1, s2));
-  CHECK_THROWS(query_r.add_range(0, "", s2));
-  CHECK_THROWS(query_r.add_range(0, s1, ""));
 
-  // Check range
-  CHECK_THROWS(query_r.range(1, 1));
-  std::array<std::string, 2> range = query_r.range(0, 0);
-  CHECK(range[0] == s1);
-  CHECK(range[1] == s2);
+  SECTION("Non empty range") {
+    query_r.add_range(0, s1, s2);
+    CHECK_THROWS(query_r.add_range(1, s1, s2));
+
+    // Check range
+    CHECK_THROWS(query_r.range(1, 1));
+    std::array<std::string, 2> range = query_r.range(0, 0);
+    CHECK(range[0] == s1);
+    CHECK(range[1] == s2);
+  }
+
+  SECTION("Empty first range") {
+    query_r.add_range(0, "", s2);
+    CHECK_THROWS(query_r.add_range(1, "", s2));
+
+    // Check range
+    CHECK_THROWS(query_r.range(1, 1));
+    std::array<std::string, 2> range = query_r.range(0, 0);
+    CHECK(range[0] == "");
+    CHECK(range[1] == s2);
+  }
+
+  SECTION("Empty second range") {
+    query_r.add_range(0, s1, "");
+    CHECK_THROWS(query_r.add_range(1, s1, ""));
+
+    // Check range
+    CHECK_THROWS(query_r.range(1, 1));
+    std::array<std::string, 2> range = query_r.range(0, 0);
+    CHECK(range[0] == s1);
+    CHECK(range[1] == "");
+  }
+
+  SECTION("Empty ranges") {
+    query_r.add_range(0, std::string(""), std::string(""));
+    CHECK_THROWS(query_r.add_range(1, std::string(""), std::string("")));
+
+    // Check range
+    CHECK_THROWS(query_r.range(1, 1));
+    std::array<std::string, 2> range = query_r.range(0, 0);
+    CHECK(range[0] == "");
+    CHECK(range[1] == "");
+  }
 
   std::string data;
   data.resize(10);

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -527,8 +527,6 @@ void Dimension::expand_range_v(const void* v, Range* r) const {
 void Dimension::expand_range_var_v(const char* v, uint64_t v_size, Range* r) {
   assert(v != nullptr);
   assert(r != nullptr);
-  assert(!r->empty());
-  assert(v_size != 0);
 
   auto start = r->start_str();
   auto end = r->end_str();
@@ -555,8 +553,6 @@ void Dimension::expand_range(const Range& r1, Range* r2) const {
 
 void Dimension::expand_range_var(const Range& r1, Range* r2) const {
   assert(type_ == Datatype::STRING_ASCII);
-  assert(!r1.empty());
-  assert(!r2->empty());
 
   auto r1_start = r1.start_str();
   auto r1_end = r1.end_str();

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -184,13 +184,6 @@ Status Query::add_range_var(
     return LOG_STATUS(
         Status::QueryError("Cannot add range; Invalid dimension index"));
 
-  if (start == nullptr || end == nullptr)
-    return LOG_STATUS(Status::QueryError("Cannot add range; Invalid range"));
-
-  if (start_size == 0 || end_size == 0)
-    return LOG_STATUS(Status::QueryError(
-        "Cannot add range; Range start/end cannot have zero length"));
-
   if (!array_schema_->domain()->dimension(dim_idx)->var_size())
     return LOG_STATUS(
         Status::QueryError("Cannot add range; Range must be variable-sized"));

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -184,6 +184,10 @@ Status Query::add_range_var(
     return LOG_STATUS(
         Status::QueryError("Cannot add range; Invalid dimension index"));
 
+  if ((start == nullptr && start_size != 0) ||
+      (end == nullptr && end_size != 0))
+    return LOG_STATUS(Status::QueryError("Cannot add range; Invalid range"));
+
   if (!array_schema_->domain()->dimension(dim_idx)->var_size())
     return LOG_STATUS(
         Status::QueryError("Cannot add range; Range must be variable-sized"));

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -165,8 +165,6 @@ const void* ResultTile::zipped_coord(uint64_t pos, unsigned dim_idx) const {
 std::string ResultTile::coord_string(uint64_t pos, unsigned dim_idx) const {
   const auto& coord_tile_off = std::get<0>(coord_tiles_[dim_idx].second);
   const auto& coord_tile_val = std::get<1>(coord_tiles_[dim_idx].second);
-  assert(!coord_tile_off.empty());
-  assert(!coord_tile_val.empty());
   auto cell_num = coord_tile_off.cell_num();
   auto val_size = coord_tile_val.size();
 


### PR DESCRIPTION
Support empty string writes for dimensions, tests to be added. This has been validated for the basic use case in TileDB-VCF.

---
TYPE: IMPROVEMENT
DESC: Support writing empty strings for dimensions
