### PR TITLE
Eliminate `Buffer` member variable in class `EncryptionKey`

### DIFF
--- a/tiledb/sm/crypto/encryption_key.cc
+++ b/tiledb/sm/crypto/encryption_key.cc
@@ -40,7 +40,9 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
-EncryptionKey::EncryptionKey() : encryption_type_(EncryptionType::NO_ENCRYPTION), key_length_(0) {
+EncryptionKey::EncryptionKey()
+    : encryption_type_(EncryptionType::NO_ENCRYPTION)
+    , key_length_(0) {
   std::memset(key_, 0, max_key_length_);
 }
 
@@ -56,7 +58,6 @@ Status EncryptionKey::set_key(
     EncryptionType encryption_type,
     const void* key_bytes,
     uint32_t key_length) {
-  
   if (!is_valid_key_length(encryption_type, key_length))
     return LOG_STATUS(Status::EncryptionError(
         "Cannot create key; invalid key length for encryption type."));

--- a/tiledb/sm/crypto/encryption_key.h
+++ b/tiledb/sm/crypto/encryption_key.h
@@ -87,11 +87,17 @@ class EncryptionKey {
       uint32_t key_length);
 
  private:
-  /** Buffer holding the encryption key. */
-  Buffer key_;
-
-  /** The encryption type. */
+   /** The encryption type. */
   EncryptionType encryption_type_;
+
+  /** Size of the array storing the encryption key. */
+  static const uint32_t max_key_length_ = 32;
+  
+  /** Array holding the actual encryption key. */
+  char key_[max_key_length_];
+  
+  /** Length of the stored encryption key. */
+  uint32_t key_length_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/crypto/encryption_key.h
+++ b/tiledb/sm/crypto/encryption_key.h
@@ -87,17 +87,17 @@ class EncryptionKey {
       uint32_t key_length);
 
  private:
-   /** The encryption type. */
+  /** The encryption type. */
   EncryptionType encryption_type_;
 
   /** Size of the array storing the encryption key. */
-  static const uint32_t max_key_length_ = 32;
-  
+  constexpr static size_t max_key_length_ = 32;
+
   /** Array holding the actual encryption key. */
-  char key_[max_key_length_];
-  
+  std::byte key_[max_key_length_];
+
   /** Length of the stored encryption key. */
-  uint32_t key_length_;
+  size_t key_length_;
 };
 
 }  // namespace sm


### PR DESCRIPTION
Replace Buffer key_ with char key_[32] in class EncryptionKey, per shortcut story id 9561.  To avoid having explicit magic number 32, I created a static const max_key_length_ to set the array size.  Also added a member variable key_length_ to keep track of the key size.  The key() member function still returns a ConstBuffer.

---
TYPE: IMPROVEMENT
DESC: Replace Buffer key_ with char key_[32] per shortcut story id 9561
