### PR TITLE
Fix ch10191: check cell_val_num for varlen status instead of result count

### DIFF
--- a/test/src/unit_arrow.py
+++ b/test/src/unit_arrow.py
@@ -89,19 +89,21 @@ class DataFactory():
 
     # var-len (strings)
     self.data['tiledb_char'] = np.array([rand_ascii_bytes(np.random.randint(1,100))
-                                       for _ in range(col_size)])
+                                       for _ in range(col_size)]).astype("S1")
     self.data['utf_string1'] = np.array([rand_utf8(np.random.randint(1, 100))
-                                       for _ in range(col_size)])
+                                       for _ in range(col_size)]).astype("U0")
 
     # another version with some important cells set to empty
     self.data['utf_string2'] = np.array([rand_utf8(np.random.randint(0, 100))
-                                       for _ in range(col_size)])
-    self.data['utf_string2'][0] = ''
-    self.data['utf_string2'][1] = ''
-    self.data['utf_string2'][3] = ''
-    self.data['utf_string2'][-1] = ''
-    self.data['utf_string2'][-2] = ''
-    self.data['utf_string2'][-3] = ''
+                                       for _ in range(col_size)]).astype("U0")
+
+    utf_string2 = self.data['utf_string2']
+    for i in range(len(utf_string2)):
+        self.data['utf_string2'][i] = ''
+    range_start = len(utf_string2) - 1
+    range_end = len(utf_string2) % 3
+    for i in range(range_start, range_end, -1):
+        self.data['utf_string2'][i] = ''
 
     self.data['datetime_ns'] = rand_datetime64_array(col_size)
 

--- a/tiledb/sm/cpp_api/attribute.h
+++ b/tiledb/sm/cpp_api/attribute.h
@@ -456,7 +456,7 @@ class Attribute {
    *
    * @return Whether the attribute is nullable.
    */
-  bool nullable() {
+  bool nullable() const {
     auto& ctx = ctx_.get();
     uint8_t nullable;
     ctx.handle_error(

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -2091,8 +2091,6 @@ class Query {
     ctx.handle_error(tiledb_query_get_offsets_buffer(
         ctx.ptr().get(), query_.get(), name.c_str(), offsets, &offsets_nbytes));
 
-    assert(*offsets_nbytes % sizeof(uint64_t) == 0);
-
     *offsets_nelements = (*offsets_nbytes) / sizeof(uint64_t);
 
     return *this;


### PR DESCRIPTION
- Expand Arrow testing to test a range of column sizes including 0
- Fix ch10191: check cell_val_num for varlen status instead of result count
- Some minor C++ API fixes

---
TYPE: BUG
DESC: Fix ch10191: check cell_val_num for varlen status instead of result count
