### PR TITLE
Fix build on GCC 7.3: missing include

### DIFF
--- a/tiledb/sm/crypto/encryption_key.h
+++ b/tiledb/sm/crypto/encryption_key.h
@@ -36,6 +36,8 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/buffer/buffer.h"
 
+#include <cstddef>
+
 using namespace tiledb::common;
 
 namespace tiledb {


### PR DESCRIPTION
Fix build on GCC 7.3: missing include

Not sure why this didn't affect CI.

---
TYPE: NO_HISTORY
DESC: Fix build on GCC 7.3: missing include
