### PR TITLE
Silence CMake a little more (with h/t to @ihnorton for these two changes)

### DIFF
--- a/cmake/Modules/FindCatch_EP.cmake
+++ b/cmake/Modules/FindCatch_EP.cmake
@@ -30,6 +30,9 @@
 #   - CATCH2_FOUND, whether Catch has been found
 #   - The Catch::Catch imported target
 
+# Include some common helper functions.
+include(TileDBCommon)
+
 # Search the path set during the superbuild for the EP.
 message(STATUS "searching for catch in ${TILEDB_EP_SOURCE_DIR}")
 set(CATCH_PATHS ${TILEDB_EP_SOURCE_DIR}/ep_catch/single_include)

--- a/cmake/Modules/TileDBCommon.cmake
+++ b/cmake/Modules/TileDBCommon.cmake
@@ -97,3 +97,5 @@ function(install_target_libs LIB_TARGET)
   endif()
 endfunction()
 
+# Suppress warnings from find_package_handle_standard_args usage w/ *_EP targets
+set(FPHSA_NAME_MISMATCHED TRUE)


### PR DESCRIPTION
CMake can issue more line noise than is needed from some of the externally source libraries if these are found in places other than the default location.  This patch fixes this as validated over a few builds over the last few days.

---
TYPE: IMPROVEMENT 
DESC: More concise cmake output during build
