### PR TITLE
Support upgrading array version

### DIFF
--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -1168,3 +1168,99 @@ TEST_CASE(
     }
   }
 }
+
+TEST_CASE(
+    "Backwards compatibility: Upgrades an array of older version and "
+    "write/read it",
+    "[backwards-compat][upgrade-version][write-read-new-version]") {
+  std::string array_name(arrays_dir + "/non_split_coords_v1_4_0");
+  Context ctx;
+  std::string schema_folder;
+  std::string fragment_uri;
+
+  try {
+    // Upgrades version
+    Array::upgrade_version(ctx, array_name);
+
+    // Read using upgraded version
+    Array array_read1(ctx, array_name, TILEDB_READ);
+    std::vector<int> subarray_read1 = {1, 4, 10, 10};
+    std::vector<int> a_read1;
+    a_read1.resize(4);
+    std::vector<int> d1_read1;
+    d1_read1.resize(4);
+    std::vector<int> d2_read1;
+    d2_read1.resize(4);
+
+    Query query_read1(ctx, array_read1);
+    query_read1.set_subarray(subarray_read1)
+        .set_layout(TILEDB_ROW_MAJOR)
+        .set_data_buffer("a", a_read1)
+        .set_data_buffer("d1", d1_read1)
+        .set_data_buffer("d2", d2_read1);
+
+    query_read1.submit();
+    array_read1.close();
+
+    for (int i = 0; i < 4; i++) {
+      REQUIRE(a_read1[i] == i + 1);
+    }
+
+    // Write
+    Array array_write(ctx, array_name, TILEDB_WRITE);
+    std::vector<int> subarray_write = {1, 2, 10, 10};
+    std::vector<int> a_write = {11, 12};
+    std::vector<int> d1_write = {1, 2};
+    std::vector<int> d2_write = {10, 10};
+
+    Query query_write(ctx, array_write, TILEDB_WRITE);
+
+    query_write.set_layout(TILEDB_GLOBAL_ORDER);
+    query_write.set_data_buffer("a", a_write);
+    query_write.set_data_buffer("d1", d1_write);
+    query_write.set_data_buffer("d2", d2_write);
+
+    query_write.submit();
+    query_write.finalize();
+    array_write.close();
+
+    fragment_uri = query_write.fragment_uri(0);
+
+    // Read again
+    Array array_read2(ctx, array_name, TILEDB_READ);
+    std::vector<int> subarray_read2 = {1, 4, 10, 10};
+    std::vector<int> a_read2;
+    a_read2.resize(4);
+    std::vector<int> d1_read2;
+    d1_read2.resize(4);
+    std::vector<int> d2_read2;
+    d2_read2.resize(4);
+
+    Query query_read2(ctx, array_read2);
+    query_read2.set_subarray(subarray_read2)
+        .set_layout(TILEDB_ROW_MAJOR)
+        .set_data_buffer("a", a_read2)
+        .set_data_buffer("d1", d1_read2)
+        .set_data_buffer("d2", d2_read2);
+
+    query_read2.submit();
+    array_read2.close();
+
+    for (int i = 0; i < 2; i++) {
+      REQUIRE(a_read2[i] == i + 11);
+    }
+    for (int i = 2; i < 3; i++) {
+      REQUIRE(a_read2[i] == i + 1);
+    }
+
+    // Clean up
+    schema_folder = array_read2.uri() + "/__schema";
+
+    VFS vfs(ctx);
+    vfs.remove_dir(fragment_uri);
+    vfs.remove_file(fragment_uri + ".ok");
+    vfs.remove_dir(schema_folder);
+  } catch (const std::exception& e) {
+    CHECK(false);
+  }
+}

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4801,6 +4801,38 @@ int32_t tiledb_array_evolve(
   return TILEDB_OK;
 }
 
+int32_t tiledb_array_upgrade_version(tiledb_ctx_t* ctx, const char* array_uri) {
+  // Sanity Checks
+  if (sanity_check(ctx) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Check array name
+  tiledb::sm::URI uri(array_uri);
+  if (uri.is_invalid()) {
+    auto st = Status::Error("Failed to find the array; Invalid array URI");
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
+
+  // Create key
+  tiledb::sm::EncryptionKey key;
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          key.set_key(
+              static_cast<tiledb::sm::EncryptionType>(TILEDB_NO_ENCRYPTION),
+              nullptr,
+              0)))
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx, ctx->ctx_->storage_manager()->array_upgrade_version(uri, key)))
+    return TILEDB_ERR;
+
+  // Success
+  return TILEDB_OK;
+}
+
 /* ****************************** */
 /*         OBJECT MANAGEMENT      */
 /* ****************************** */

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -152,6 +152,23 @@ TILEDB_EXPORT int32_t tiledb_array_evolve(
     const char* array_uri,
     tiledb_array_schema_evolution_t* array_schema_evolution);
 
+/**
+ * Upgrade array to the latest format version.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * const char* array_uri="test_array";
+ * tiledb_array_upgrade_version(ctx, array_uri);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_uri The uri of the array.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t
+tiledb_array_upgrade_version(tiledb_ctx_t* ctx, const char* array_uri);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -153,7 +153,7 @@ TILEDB_EXPORT int32_t tiledb_array_evolve(
     tiledb_array_schema_evolution_t* array_schema_evolution);
 
 /**
- * Upgrade array to the latest format version.
+ * Upgrades an array to the latest format version.
  *
  * **Example:**
  *

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -38,6 +38,7 @@
 #include "array_schema.h"
 #include "context.h"
 #include "tiledb.h"
+#include "tiledb_experimental.h"
 #include "type.h"
 
 #include <unordered_map>
@@ -1412,6 +1413,24 @@ class Array {
         encryption_key.data(),
         (uint32_t)encryption_key.size(),
         config_aux);
+  }
+
+  /**
+   * @brief Upgrades an array to the latest format version.
+   *
+   *
+   * **Example:**
+   * @code{.cpp}
+   * tiledb::Array::upgrade_version(ctx, "array_name");
+   * @endcode
+   *
+   * @param ctx TileDB context
+   * @param array_uri The URI of the TileDB array to be upgraded.
+   */
+  static void upgrade_version(
+      const Context& ctx, const std::string& array_uri) {
+    ctx.handle_error(
+        tiledb_array_upgrade_version(ctx.ptr().get(), array_uri.c_str()));
   }
 
   /**

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -345,12 +345,23 @@ class StorageManager {
    *
    * @param array_uri The URI of the array to be evolved.
    * @param schema_evolution The schema evolution.
+   * @param encryption_key The encryption key to use.
    * @return Status
    */
   Status array_evolve_schema(
       const URI& array_uri,
       ArraySchemaEvolution* array_schema,
       const EncryptionKey& encryption_key);
+
+  /**
+   * Upgrade a TileDB array to latest format version.
+   *
+   * @param array_uri The URI of the array to be upgraded.
+   * @param encryption_key The encryption key to use.
+   * @return Status
+   */
+  Status array_upgrade_version(
+      const URI& array_uri, const EncryptionKey& encryption_key);
 
   /**
    * Gets the memory tracker for an open array.


### PR DESCRIPTION
Add tiledb_array_upgrade_version in c-api. This enables upgrading older version arrays to the latest version. Also added unit tests that can read and write after upgrading.

---
TYPE: FEATURE
DESC: Support upgrading an older version array to the latest version
