### PR TITLE
Fix and update HDFS CI

### DIFF
--- a/.github/workflows/build-ubuntu16.04-HDFS.yml
+++ b/.github/workflows/build-ubuntu16.04-HDFS.yml
@@ -1,4 +1,4 @@
-name: build-ubuntu-16.04-HDFS
+name: build-ubuntu-20.04-HDFS
 on:
   push:
     branches:
@@ -16,10 +16,10 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
     timeout-minutes: 90
-    name: Build - ubuntu-16.04 - HDFS
+    name: Build - ubuntu-20.04 - HDFS
     steps:
       - uses: actions/checkout@v2
       - name: 'Print env'
@@ -46,6 +46,7 @@ jobs:
       - name: 'Build and test libtiledb'
         id: test
         run: |
+          set -exo pipefail
 
           # - run: |
           # Start HDFS server if enabled
@@ -57,7 +58,7 @@ jobs:
           source scripts/install-hadoop.sh
           source scripts/run-hadoop.sh
 
-          bootstrap_args="${bootstrap_args} --enable-hdfs";
+          bootstrap_args=" --enable-hdfs";
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
 
           # Bypass Catch2 Framework stdout interception with awk on test output

--- a/scripts/install-hadoop.sh
+++ b/scripts/install-hadoop.sh
@@ -200,6 +200,10 @@ function passwordless_ssh {
   fi
   sudo apt-get --reinstall install -y openssh-server openssh-client || die "error (re)installing openssh"
   mkdir ~/.ssh
+
+  # reset permissions to avoid ssh errors for world-readable directory
+  chmod og-rw ~
+
   ssh-keygen -t rsa -P "" -f ~/.ssh/id_rsa
   cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
   ssh-keyscan -H localhost >> ~/.ssh/known_hosts

--- a/scripts/install-hadoop.sh
+++ b/scripts/install-hadoop.sh
@@ -113,6 +113,14 @@ function setup_mapred_xml {
 <value>localhost:9010</value>
 <description>The tracker of MapReduce</description>
 </property>
+<property>
+<name>mapreduce.map.log.level</name>
+<value>WARN</value>
+</property>
+<property>
+<name>mapreduce.reduce.log.level</name>
+<value>WARN</value>
+</property>
 </configuration>
 EOT
   tmpfile=/tmp/hadoop_mapred.xml

--- a/scripts/install-hadoop.sh
+++ b/scripts/install-hadoop.sh
@@ -27,7 +27,7 @@
 # Installs and configures HDFS.
 set -x
 
-HADOOP_VERSION="3.2.1"
+HADOOP_VERSION="3.3.1"
 
 die() {
   echo "$@" 1>&2 ; popd 2>/dev/null; exit 1


### PR DESCRIPTION
- Update HDFS CI runner to Ubuntu 20.04
- Fix passwordless SSH for HDFS scripts
  - set home permissions
- Add test for fast-fail if passwordless SSH is not available
- Bump Hadoop version to 3.3.1
  - set node username
- Bump JRE to 11
- Set Hadoop log level to WARN to reduce noise

---
TYPE: NO_HISTORY
DESC: Fix and update HDFS CI
