### PR TITLE
Support for setting the root path of arrays

### DIFF
--- a/test/src/unit-uri.cc
+++ b/test/src/unit-uri.cc
@@ -257,22 +257,3 @@ TEST_CASE("URI: Test Windows paths", "[uri]") {
 }
 
 #endif
-
-TEST_CASE("URI: Test local root path", "[uri]") {
-  tiledb::Config config;
-#ifdef _WIN32
-  config.set("vfs.local_root_path", "C:/tmp");
-#else
-  config.set("vfs.local_root_path", "/tmp");
-#endif
-  tiledb::Context ctx(config);
-  URI uri("test_root_path");
-  CHECK(!uri.is_invalid());
-  CHECK(URI::is_file(uri.to_string()));
-#ifdef _WIN32
-  CHECK(uri.to_string() == "file:///C:/tmp/test_root_path");
-#else
-  CHECK(uri.to_string() == "file:///tmp/test_root_path");
-#endif
-  ctx.config().set("vfs.local_root_path", "");
-}

--- a/test/src/unit-uri.cc
+++ b/test/src/unit-uri.cc
@@ -31,6 +31,8 @@
  */
 
 #include <catch.hpp>
+#include "tiledb/sm/cpp_api/config.h"
+#include "tiledb/sm/cpp_api/context.h"
 #include "tiledb/sm/misc/uri.h"
 
 #ifdef _WIN32
@@ -255,3 +257,22 @@ TEST_CASE("URI: Test Windows paths", "[uri]") {
 }
 
 #endif
+
+TEST_CASE("URI: Test local root path", "[uri]") {
+  tiledb::Config config;
+#ifdef _WIN32
+  config.set("vfs.local_root_path", "C:/tmp");
+#else
+  config.set("vfs.local_root_path", "/tmp");
+#endif
+  tiledb::Context ctx(config);
+  URI uri("test_root_path");
+  CHECK(!uri.is_invalid());
+  CHECK(URI::is_file(uri.to_string()));
+#ifdef _WIN32
+  CHECK(uri.to_string() == "file:///C:/tmp/test_root_path");
+#else
+  CHECK(uri.to_string() == "file:///tmp/test_root_path");
+#endif
+  ctx.config().set("vfs.local_root_path", "");
+}

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -504,5 +504,6 @@ TEST_CASE("VFS: Test local root path", "[vfs][uri]") {
   CHECK(uri.to_string() == "file:///tmp/test_root_path_array");
 #endif
 
-  vfs.terminate();
+  // Set the local_root_path back to empty
+  REQUIRE(vfs.set_local_root_path("").ok());
 }

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -479,3 +479,30 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
     vfs.terminate();
   }
 }
+
+TEST_CASE("VFS: Test local root path", "[vfs][uri]") {
+  ThreadPool compute_tp;
+  ThreadPool io_tp;
+  REQUIRE(compute_tp.init(1).ok());
+  REQUIRE(io_tp.init(1).ok());
+
+  Config config;
+#ifdef _WIN32
+  REQUIRE(config.set("vfs.local_root_path", "C:/tmp").ok());
+#else
+  REQUIRE(config.set("vfs.local_root_path", "/tmp").ok());
+#endif
+
+  VFS vfs;
+  REQUIRE(
+      vfs.init(&g_helper_stats, &compute_tp, &io_tp, nullptr, &config).ok());
+  std::string array_name = "test_root_path_array";
+  URI uri(array_name);
+#ifdef _WIN32
+  CHECK(uri.to_string() == "file:///C:/tmp/test_root_path_array");
+#else
+  CHECK(uri.to_string() == "file:///tmp/test_root_path_array");
+#endif
+
+  vfs.terminate();
+}

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -114,7 +114,9 @@ void Posix::adjacent_slashes_dedup(std::string* path) {
 std::string Posix::abs_path(
     const std::string& path, const std::string& root_path = "") {
   std::string local_path = path;
-  if (root_path.length() > 0) {
+  if (root_path.length() > 0 && (!utils::parse::starts_with(path, "/")) &&
+      (!utils::parse::starts_with(path, "file:")) &&
+      (!utils::parse::starts_with(path, "."))) {
     local_path = root_path + "/" + path;
   }
   std::string resolved_path = abs_path_internal(local_path);

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -114,7 +114,7 @@ void Posix::adjacent_slashes_dedup(std::string* path) {
 std::string Posix::abs_path(
     const std::string& path, const std::string& root_path = "") {
   std::string local_path = path;
-  if (local_path.length() > 0) {
+  if (root_path.length() > 0) {
     local_path = root_path + "/" + path;
   }
   std::string resolved_path = abs_path_internal(local_path);

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -111,8 +111,13 @@ void Posix::adjacent_slashes_dedup(std::string* path) {
       path->end());
 }
 
-std::string Posix::abs_path(const std::string& path) {
-  std::string resolved_path = abs_path_internal(path);
+std::string Posix::abs_path(
+    const std::string& path, const std::string& root_path = "") {
+  std::string local_path = path;
+  if (local_path.length() > 0) {
+    local_path = root_path + "/" + path;
+  }
+  std::string resolved_path = abs_path_internal(local_path);
 
   // Ensure the returned has the same postfix slash as 'path'.
   if (utils::parse::ends_with(path, "/")) {

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -67,7 +67,8 @@ class Posix {
    * Returns the absolute posix (string) path of the input in the
    * form "file://<absolute path>"
    */
-  static std::string abs_path(const std::string& path);
+  static std::string abs_path(
+      const std::string& path, const std::string& root_path);
 
   /**
    * Creates a new directory.

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -114,6 +114,14 @@ class VFS {
   static std::string abs_path(const std::string& path);
 
   /**
+   * Sets the root path for local file system.
+   *
+   * @param root_path The root path.
+   * @return Status
+   */
+  static Status set_local_root_path(const std::string& root_path);
+
+  /**
    * Return a config object containing the VFS parameters. All other non-VFS
    * parameters will are set to default values.
    */
@@ -659,6 +667,9 @@ class VFS {
 
   /** The read-ahead cache. */
   tdb_unique_ptr<ReadAheadCache> read_ahead_cache_;
+
+  /** The local root path. */
+  static std::string local_root_path_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -77,13 +77,18 @@ std::string get_last_error_msg() {
 }
 }  // namespace
 
-std::string Win::abs_path(const std::string& path) {
+std::string Win::abs_path(
+    const std::string& path, const std::string& root_path = "") {
+  std::string rootpath = root_path;
+  if (rootpath.length() == 0) {
+    rootpath = current_dir();
+  }
   if (path.length() == 0) {
-    return current_dir();
+    return rootpath;
   }
   std::string full_path;
   if (PathIsRelative(path.c_str())) {
-    full_path = current_dir() + "\\" + path;
+    full_path = rootpath + "\\" + path;
   } else {
     full_path = path;
   }

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -63,7 +63,8 @@ class Win {
    * Returns the absolute (string) path of the input in the
    * form of a Windows path.
    */
-  static std::string abs_path(const std::string& path);
+  static std::string abs_path(
+      const std::string& path, const std::string& root_path);
 
   /**
    * Creates a new directory.


### PR DESCRIPTION
This PR is to provide capability to set the root directory of a tiledb context to a user specified location on the local file system.  Instead of using current working directory, we can set config parameter "vfs.local_root_path" or env to specify the root directory.  

---
TYPE: FEATURE
DESC: Provide capability to set the root path of a context
