### PR TITLE
Use sparse global order reader for unordered without duplicates queries.

### DIFF
--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -31,6 +31,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/misc/utils.h"
 
@@ -332,8 +333,14 @@ TEST_CASE(
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts[TILEDB_COORDS].second / 2;
-  REQUIRE(result_num == 1);
-  REQUIRE(data[0] == 'c');
+  if (test::use_refactored_readers()) {
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'c');
+    REQUIRE(data[1] == 'n');
+  } else {
+    REQUIRE(result_num == 1);
+    REQUIRE(data[0] == 'c');
+  }
 
   // Resubmit
   st = query.submit();
@@ -341,50 +348,79 @@ TEST_CASE(
   result_elts = query.result_buffer_elements();
   result_num = result_elts[TILEDB_COORDS].second / 2;
   REQUIRE(result_num == 2);
-  REQUIRE(data[0] == 'n');
-  REQUIRE(data[1] == 'd');
+
+  if (test::use_refactored_readers()) {
+    REQUIRE(data[0] == 'd');
+    REQUIRE(data[1] == 'e');
+  } else {
+    REQUIRE(data[0] == 'n');
+    REQUIRE(data[1] == 'd');
+  }
 
   // Resubmit
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts[TILEDB_COORDS].second / 2;
-  REQUIRE(result_num == 1);
-  REQUIRE(data[0] == 'e');
+  if (test::use_refactored_readers()) {
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'f');
+    REQUIRE(data[1] == 'g');
+  } else {
+    REQUIRE(result_num == 1);
+    REQUIRE(data[0] == 'e');
+  }
 
   // Resubmit
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts[TILEDB_COORDS].second / 2;
-  REQUIRE(result_num == 1);
-  REQUIRE(data[0] == 'f');
+  if (test::use_refactored_readers()) {
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'h');
+    REQUIRE(data[1] == 'i');
+  } else {
+    REQUIRE(result_num == 1);
+    REQUIRE(data[0] == 'f');
+  }
 
   // Resubmit
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  if (test::use_refactored_readers()) {
+    REQUIRE(st == Query::Status::COMPLETE);
+  } else {
+    REQUIRE(st == Query::Status::INCOMPLETE);
+  }
   result_elts = query.result_buffer_elements();
   result_num = result_elts[TILEDB_COORDS].second / 2;
-  REQUIRE(result_num == 2);
-  REQUIRE(data[0] == 'g');
-  REQUIRE(data[1] == 'h');
 
-  // Resubmit
-  st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
-  result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
-  REQUIRE(result_num == 1);
-  REQUIRE(data[0] == 'i');
+  if (test::use_refactored_readers()) {
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'j');
+    REQUIRE(data[1] == 'k');
+  } else {
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'g');
+    REQUIRE(data[1] == 'h');
 
-  // Resubmit
-  st = query.submit();
-  REQUIRE(st == Query::Status::COMPLETE);
-  result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
-  REQUIRE(result_num == 2);
-  REQUIRE(data[0] == 'j');
-  REQUIRE(data[1] == 'k');
+    // Resubmit
+    st = query.submit();
+    REQUIRE(st == Query::Status::INCOMPLETE);
+    result_elts = query.result_buffer_elements();
+    result_num = result_elts[TILEDB_COORDS].second / 2;
+    REQUIRE(result_num == 1);
+    REQUIRE(data[0] == 'i');
+
+    // Resubmit
+    st = query.submit();
+    REQUIRE(st == Query::Status::COMPLETE);
+    result_elts = query.result_buffer_elements();
+    result_num = result_elts[TILEDB_COORDS].second / 2;
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'j');
+    REQUIRE(data[1] == 'k');
+  }
 
   // Close array.
   array.close();


### PR DESCRIPTION
TYPE: IMPROVEMENT
DESC: Use sparse global order reader for unordered without duplicates queries.