### PR TITLE
Add CMakeUserPresets.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ doc/source/_build
 doc/source/_sidebar.rst.inc
 doc/source/gensidebar.pyc
 examples/cmake_project/build
+CMakeUserPresets.json


### PR DESCRIPTION
Adding the user-preset file to `.gitignore` allows them to be used without obstacle

---
TYPE: IMPROVEMENT
DESC: Add CMakeUserPresets.json to .gitignore
