### PR TITLE
Reset the size of scratch buffer for each REST query

### DIFF
--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -554,16 +554,21 @@ size_t RestClient::post_data_write_cb(
     // there will be an overlap in the memory of the source and
     // destination.
     if (length <= offset) {
+      scratch->reset_size();
       st = scratch->write(scratch->data(offset), length);
     } else {
       Buffer aux;
       st = aux.write(scratch->data(offset), length);
       if (st.ok()) {
+        scratch->reset_size();
         st = scratch->write(aux.data(), aux.size());
       }
     }
 
     assert(st.ok());
+    if (!st.ok()) {
+      LOG_STATUS(st);
+    }
     assert(scratch->size() == length);
   }
 


### PR DESCRIPTION
This fixes a bug in which the scratch buffer used for the partial curl call back did not reset it size after processing. After we complete processing one query we copy the "left over" data which is part of the next incomplete query (usually 1-2KB of curl data only) to the start of the scratch buffer. This lets us reuse the scratch buffer and not have to resize or realloc it. We need to reset the "valid" byte size to only the copied amount.

---
TYPE:BUG
DESC: Fix curl/REST query scratch size to reset after each query is processed.
