### PR TITLE
Backport new reader fixes to release-2.4

### DIFF
--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -197,6 +197,12 @@ class SparseIndexReaderBase : public ReaderBase {
 
   /** Resize the output buffers to the correct size after copying. */
   Status resize_output_buffers();
+
+  /**
+   * Adds an extra offset in the end of the offsets buffer indicating the
+   * returned data size if an attribute is var-sized.
+   */
+  Status add_extra_offset();
 };
 
 }  // namespace sm


### PR DESCRIPTION
Backport fixes from
- https://github.com/TileDB-Inc/TileDB/pull/2530
- https://github.com/TileDB-Inc/TileDB/pull/2538

---

TYPE: NO_HISTORY
DESC: Backport fixes from #2530 and #2538