### PR TITLE
Array Metadata should POST to REST with timestamps

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -296,7 +296,8 @@ Status Array::close() {
       if (rest_client == nullptr)
         return LOG_STATUS(Status::ArrayError(
             "Error closing array; remote array with no REST client."));
-      RETURN_NOT_OK(rest_client->post_array_metadata_to_rest(array_uri_, this));
+      RETURN_NOT_OK(rest_client->post_array_metadata_to_rest(
+          array_uri_, timestamp_start_, timestamp_end_opened_at_, this));
     }
 
     // Storage manager does not own the array schema for remote arrays.

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -298,7 +298,11 @@ Status RestClient::get_array_metadata_from_rest(
       array, serialization_type_, returned_data);
 }
 
-Status RestClient::post_array_metadata_to_rest(const URI& uri, Array* array) {
+Status RestClient::post_array_metadata_to_rest(
+    const URI& uri,
+    uint64_t timestamp_start,
+    uint64_t timestamp_end,
+    Array* array) {
   if (array == nullptr)
     return LOG_STATUS(Status::RestError(
         "Error posting array metadata to REST; array is null."));
@@ -318,7 +322,10 @@ Status RestClient::post_array_metadata_to_rest(const URI& uri, Array* array) {
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
   const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) + "/array_metadata";
+                          "/" + curlc.url_escape(array_uri) +
+                          "/array_metadata?" +
+                          "start_timestamp=" + std::to_string(timestamp_start) +
+                          "&end_timestamp=" + std::to_string(timestamp_end);
 
   // Put the data
   Buffer returned_data;
@@ -858,7 +865,8 @@ Status RestClient::get_array_metadata_from_rest(
       Status::RestError("Cannot use rest client; serialization not enabled."));
 }
 
-Status RestClient::post_array_metadata_to_rest(const URI&, Array*) {
+Status RestClient::post_array_metadata_to_rest(
+    const URI&, uint64_t, uint64_t, Array*) {
   return LOG_STATUS(
       Status::RestError("Cannot use rest client; serialization not enabled."));
 }

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -137,10 +137,16 @@ class RestClient {
    * Posts the array's metadata to the REST server.
    *
    * @param uri Array URI
+   * @param timestamp_start Inclusive starting timestamp at which to open array
+   * @param timestamp_end Inclusive ending timestamp at which to open array
    * @param array Array to update/post metadata for.
    * @return Status
    */
-  Status post_array_metadata_to_rest(const URI& uri, Array* array);
+  Status post_array_metadata_to_rest(
+      const URI& uri,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
+      Array* array);
 
   /**
    * Post a data query to rest server


### PR DESCRIPTION
This fixes an issue that timestamp based writes for metadata were not posted to REST with that timestamp.

---
TYPE: BUG
DESC: REST array metadata writes should post with timestamps
