### PR TITLE
Refactored dense reader: fixing output buffer offsets with multi-ranges.

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1517,3 +1517,57 @@ TEST_CASE(
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 }
+
+TEST_CASE(
+    "C++ API: Read subarray with multiple ranges",
+    "[cppapi][dense][multi-range]") {
+  const std::string array_name = "cpp_unit_array";
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  // Create
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 3}}, 4))
+      .add_dimension(Dimension::create<int>(ctx, "cols", {{0, 3}}, 4));
+  ArraySchema schema(ctx, TILEDB_DENSE);
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  schema.add_attribute(Attribute::create<int>(ctx, "a"));
+  Array::create(array_name, schema);
+
+  // Write
+  std::vector<int> data_w = {
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w);
+  query_w.set_subarray({0, 3, 0, 3})
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_data_buffer("a", data_w);
+  query_w.submit();
+  array_w.close();
+
+  // Read
+  Array array(ctx, array_name, TILEDB_READ);
+  Query query(ctx, array);
+  std::vector<int> data(12);
+  query.add_range(0, 0, 1)
+      .add_range(0, 3, 3)
+      .add_range(1, 0, 3)
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_data_buffer("a", data);
+  query.submit();
+  array.close();
+
+  for (int i = 0; i < 8; i++) {
+    REQUIRE(data[i] == i + 1);
+  }
+
+  for (int i = 8; i < 12; i++) {
+    REQUIRE(data[i] == i + 5);
+  }
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+}

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -1441,7 +1441,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "C++ API: Test Hilbert, 2d, floa32, multiple fragments, read in "
+    "C++ API: Test Hilbert, 2d, float32, multiple fragments, read in "
     "global order",
     "[cppapi][hilbert][2d][float32][read][multiple-fragments][global-"
     "order]") {

--- a/tiledb/sm/query/dense_reader.h
+++ b/tiledb/sm/query/dense_reader.h
@@ -135,6 +135,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       Subarray* subarray,
       std::vector<Subarray>* tile_subarrays,
       std::vector<uint64_t>* tile_offsets,
+      const std::vector<uint64_t>* const range_offsets,
       std::map<const DimType*, ResultSpaceTile<DimType>>* result_space_tiles,
       std::vector<uint8_t>* qc_result);
 
@@ -155,6 +156,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray* const subarray,
       const std::vector<Subarray>* const tile_subarrays,
       const std::vector<uint64_t>* const tile_offsets,
+      const std::vector<uint64_t>* const range_offsets,
       std::map<const DimType*, ResultSpaceTile<DimType>>* result_space_tiles,
       const std::vector<uint8_t>* const qc_result);
 
@@ -186,7 +188,10 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
   Status get_dest_cell_offset_row_col(
       const int32_t dim_num,
       const Subarray* const subarray,
+      const Subarray* const tile_subarray,
       const DimType* const coords,
+      const DimType* const range_coords,
+      const std::vector<uint64_t>* const range_offsets,
       uint64_t* cell_offset);
 
   /** Copy fixed tiles to the output buffers. */
@@ -201,6 +206,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray* const subarray,
       const Subarray* const tile_subarray,
       const uint64_t global_cell_offset,
+      const std::vector<uint64_t>* const range_offsets,
       const std::vector<uint8_t>* const qc_result);
 
   /** Copy a tile var offsets to the output buffers. */
@@ -216,6 +222,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray* const tile_subarray,
       const uint64_t global_cell_offset,
       std::vector<std::vector<void*>>* var_data,
+      const std::vector<uint64_t>* const range_offsets,
       const std::vector<uint8_t>* const qc_result);
 
   /** Copy a var tile to the output buffers. */
@@ -229,6 +236,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray* const tile_subarray,
       const uint64_t global_cell_offset,
       std::vector<std::vector<void*>>* var_data,
+      const std::vector<uint64_t>* const range_offsets,
       bool last_tile,
       std::vector<uint64_t>* var_buffer_sizes);
 

--- a/tiledb/sm/subarray/cell_slab_iter.cc
+++ b/tiledb/sm/subarray/cell_slab_iter.cc
@@ -97,6 +97,11 @@ CellSlab<T> CellSlabIter<T>::cell_slab() const {
 }
 
 template <class T>
+T* CellSlabIter<T>::range_coords() {
+  return range_coords_.data();
+}
+
+template <class T>
 bool CellSlabIter<T>::end() const {
   return end_;
 }

--- a/tiledb/sm/subarray/cell_slab_iter.h
+++ b/tiledb/sm/subarray/cell_slab_iter.h
@@ -160,6 +160,9 @@ class CellSlabIter {
   /** Returns the current cell slab. */
   CellSlab<T> cell_slab() const;
 
+  /** Returns the current range coords. */
+  T* range_coords();
+
   /** Checks if the iterator has reached the end. */
   bool end() const;
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -569,6 +569,13 @@ class Subarray {
   /** Returns the flattened 1D id of the range with the input coordinates. */
   uint64_t range_idx(const std::vector<uint64_t>& range_coords) const;
 
+  /** Returns the flattened 1D id of the range with the input coordinates for
+   * the original subarray. */
+  template <class T>
+  void get_original_range_coords(
+      const T* const range_coords,
+      std::vector<uint64_t>* original_range_coords) const;
+
   /** The total number of multi-dimensional ranges in the subarray. */
   uint64_t range_num() const;
 
@@ -744,6 +751,9 @@ class Subarray {
 
   /** Returns `stats_`. */
   stats::Stats* stats() const;
+
+  /** Stores a vector of 1D ranges per dimension. */
+  std::vector<std::vector<uint64_t>> original_range_idx_;
 
  private:
   /* ********************************* */


### PR DESCRIPTION
When a partition includes multiple-ranges, the destination of the cell
slabs was only computed properly for the first range. For the subsequent
ranges, we need to compute how many cells were already in the previous
ranges and start to copy data at that point. We also need to use the
correct range start coordinates to compute the correct offset inside
of that particular subarray for the copy.

---
TYPE: IMPROVEMENT
DESC: Refactored dense reader: fixing output buffer offsets with multi-ranges.