### PR TITLE
Query object now owns its REST scratch space

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -104,6 +104,8 @@ Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
 
   if (storage_manager != nullptr)
     config_ = storage_manager->config();
+
+  rest_scratch_ = tdb_make_shared(Buffer);
 }
 
 Query::~Query() {
@@ -1966,6 +1968,10 @@ const Config* Query::config() const {
 
 stats::Stats* Query::stats() const {
   return stats_;
+}
+
+tdb_shared_ptr<Buffer> Query::rest_scratch() const {
+  return rest_scratch_;
 }
 
 /* ****************************** */

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -852,6 +852,9 @@ class Query {
   /** Returns the internal stats object. */
   stats::Stats* stats() const;
 
+  /** Returns the scratch space used for REST requests. */
+  tdb_shared_ptr<Buffer> rest_scratch() const;
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -944,6 +947,9 @@ class Query {
 
   /** The name of the new fragment to be created for writes. */
   URI fragment_uri_;
+
+  /* Scratch space used for REST requests. */
+  tdb_shared_ptr<Buffer> rest_scratch_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -270,12 +270,12 @@ class RestClient {
    *    map is updated accordingly.
    * @return Number of acknowledged bytes
    */
-  size_t post_data_write_cb(
-      bool reset,
-      void* contents,
-      size_t content_nbytes,
-      bool* skip_retries,
-      Buffer* scratch,
+  size_t query_post_call_back(
+      const bool reset,
+      void* constcontents,
+      const size_t content_nbytes,
+      bool* constskip_retries,
+      tdb_shared_ptr<Buffer> scratch,
       Query* query,
       serialization::CopyState* copy_state);
 


### PR DESCRIPTION
This is an improvement that optimizes REST requests. When a query overflows the user buffer we might have the next part of the query already loaded into the scratch buffer. As such we should avoid discarding it and instead keep the lifetime the same as the query itself. This optimizes the user's next call to submit where the user resumes the incomplete.

---
TYPE: IMPROVEMENT
DESC: REST scratch buffer is now owned by the query to allow reuse
