### PR TITLE
Pin docutils to fix doc build, pending sphinx update for latest version

### DIFF
--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -3,3 +3,4 @@ breathe==4.26.1
 sphinxcontrib-contentui==0.2.5
 sphinx_rtd_theme==0.5.0
 cmake==3.18.0
+docutils < 0.18 # pin pending https://github.com/sphinx-doc/sphinx/issues/9777


### PR DESCRIPTION
Pin docutils to fix doc build, pending sphinx update for latest version

Fixes warning-as-error following docutils release without a corresponding sphinx update yet:
```
/home/vivian/TileDB-Py/doc/venv/lib/python3.8/site-packages/sphinx/util/nodes.py:55: FutureWarning:
   The iterable returned by Node.traverse()
   will become an iterator instead of a list in Docutils > 0.16.
  for classifier in reversed(node.parent.traverse(nodes.classifier)):
```

x-ref: https://github.com/TileDB-Inc/TileDB-Py/pull/765

---
TYPE: NO_HISTORY
DESC: Pin docutils to fix doc build, pending sphinx update for latest version

