### PR TITLE
Splitting config for refactored readers.

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -47,7 +47,7 @@ namespace test {
 // Command line arguments.
 extern std::string g_vfs;
 
-bool use_refactored_readers() {
+bool use_refactored_dense_reader() {
   const char* value = nullptr;
   tiledb_config_t* cfg;
   tiledb_error_t* err = nullptr;
@@ -55,11 +55,51 @@ bool use_refactored_readers() {
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(err == nullptr);
 
-  rc = tiledb_config_get(cfg, "sm.use_refactored_readers", &value, &err);
+  rc = tiledb_config_get(cfg, "sm.query.dense.reader", &value, &err);
   CHECK(rc == TILEDB_OK);
   CHECK(err == nullptr);
 
-  bool use_refactored_readers = strcmp(value, "true") == 0;
+  bool use_refactored_readers = strcmp(value, "refactored") == 0;
+
+  tiledb_config_free(&cfg);
+
+  return use_refactored_readers;
+}
+
+bool use_refactored_sparse_global_order_reader() {
+  const char* value = nullptr;
+  tiledb_config_t* cfg;
+  tiledb_error_t* err = nullptr;
+  auto rc = tiledb_config_alloc(&cfg, &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+
+  rc = tiledb_config_get(
+      cfg, "sm.query.sparse_global_order.reader", &value, &err);
+  CHECK(rc == TILEDB_OK);
+  CHECK(err == nullptr);
+
+  bool use_refactored_readers = strcmp(value, "refactored") == 0;
+
+  tiledb_config_free(&cfg);
+
+  return use_refactored_readers;
+}
+
+bool use_refactored_sparse_unordered_with_dups_reader() {
+  const char* value = nullptr;
+  tiledb_config_t* cfg;
+  tiledb_error_t* err = nullptr;
+  auto rc = tiledb_config_alloc(&cfg, &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+
+  rc = tiledb_config_get(
+      cfg, "sm.query.sparse_unordered_with_dups.reader", &value, &err);
+  CHECK(rc == TILEDB_OK);
+  CHECK(err == nullptr);
+
+  bool use_refactored_readers = strcmp(value, "refactored") == 0;
 
   tiledb_config_free(&cfg);
 

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -106,11 +106,25 @@ struct QueryBuffer {
 typedef std::map<std::string, QueryBuffer> QueryBuffers;
 
 /**
- * Get the config for using the refactored readers.
+ * Get the config for using the refactored dense reader.
  *
- * @return Using the refactored readers or not.
+ * @return Using the refactored reader or not.
  */
-bool use_refactored_readers();
+bool use_refactored_dense_reader();
+
+/**
+ * Get the config for using the refactored sparse global order reader.
+ *
+ * @return Using the refactored reader or not.
+ */
+bool use_refactored_sparse_global_order_reader();
+
+/**
+ * Get the config for using the refactored unordered with dups reader.
+ *
+ * @return Using the refactored reader or not.
+ */
+bool use_refactored_sparse_unordered_with_dups_reader();
 
 /**
  * Checks that the input partitioner produces the input partitions

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -270,11 +270,13 @@ void check_save_to_file() {
   ss << "sm.mem.total_budget 10737418240\n";
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
+  ss << "sm.query.dense.reader legacy\n";
+  ss << "sm.query.sparse_global_order.reader legacy\n";
+  ss << "sm.query.sparse_unordered_with_dups.reader refactored\n";
   ss << "sm.read_range_oob warn\n";
   ss << "sm.skip_checksum_validation false\n";
   ss << "sm.skip_est_size_partitioning false\n";
   ss << "sm.tile_cache_size 10000000\n";
-  ss << "sm.use_refactored_readers false\n";
   ss << "sm.vacuum.mode fragments\n";
   ss << "sm.vacuum.timestamp_end " << std::to_string(UINT64_MAX) << "\n";
   ss << "sm.vacuum.timestamp_start 0\n";
@@ -568,7 +570,9 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.skip_est_size_partitioning"] = "false";
   all_param_values["sm.memory_budget"] = "5368709120";
   all_param_values["sm.memory_budget_var"] = "10737418240";
-  all_param_values["sm.use_refactored_readers"] = "false";
+  all_param_values["sm.query.dense.reader"] = "legacy";
+  all_param_values["sm.query.sparse_global_order.reader"] = "legacy";
+  all_param_values["sm.query.sparse_unordered_with_dups.reader"] = "refactored";
   all_param_values["sm.mem.malloc_trim"] = "true";
   all_param_values["sm.mem.total_budget"] = "10737418240";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_coords"] = "0.5";

--- a/test/src/unit-capi-incomplete.cc
+++ b/test/src/unit-capi-incomplete.cc
@@ -1049,8 +1049,9 @@ void IncompleteFx::check_sparse_until_complete() {
   rc = tiledb_query_get_status(ctx_, query, &status);
   CHECK(rc == TILEDB_OK);
   CHECK(
-      status ==
-      (use_refactored_readers() ? TILEDB_COMPLETED : TILEDB_INCOMPLETE));
+      status == (use_refactored_sparse_global_order_reader() ?
+                     TILEDB_COMPLETED :
+                     TILEDB_INCOMPLETE));
 
   // Check buffer
   c_buffer_a1[0] = 1;
@@ -1061,7 +1062,7 @@ void IncompleteFx::check_sparse_until_complete() {
    * Old reader needs an extra round here to finish processing all the
    * partitions in the subarray. New reader is done earlier.
    */
-  if (!use_refactored_readers()) {
+  if (!use_refactored_sparse_global_order_reader()) {
     // Submit query
     rc = tiledb_query_submit(ctx_, query);
     REQUIRE(rc == TILEDB_OK);

--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -31,7 +31,7 @@
  */
 
 #include "catch.hpp"
-
+#include "test/src/helpers.h"
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
@@ -651,13 +651,33 @@ TEST_CASE_METHOD(
     check_read_stats(query);
 
     // We expect all cells where `a1` >= `cmp_value` to be filtered
-    // out.
+    // out. For the refactored reader, filtered out means the value is
+    // replaced with the fill value.
     auto result_el = query.result_buffer_elements_nullable();
-    REQUIRE(std::get<1>(result_el["a1"]) == 5);
-    REQUIRE(std::get<1>(result_el["a2"]) == 10);
-    REQUIRE(std::get<2>(result_el["a2"]) == 5);
-    REQUIRE(std::get<0>(result_el["a3"]) == 5);
-    REQUIRE(std::get<1>(result_el["a3"]) == 15);
+    if (test::use_refactored_dense_reader()) {
+      REQUIRE(std::get<1>(result_el["a1"]) == 100);
+      REQUIRE(std::get<1>(result_el["a2"]) == 200);
+      REQUIRE(std::get<2>(result_el["a2"]) == 100);
+      REQUIRE(std::get<0>(result_el["a3"]) == 100);
+      REQUIRE(std::get<1>(result_el["a3"]) == 110);
+
+      auto null_val = std::numeric_limits<uint32_t>::max();
+      auto null_val_char = std::numeric_limits<int8_t>::min();
+      for (uint64_t i = 5; i < 100; i++) {
+        REQUIRE(a1[i] == null_val);
+        REQUIRE(a2[i * 2] == null_val);
+        REQUIRE(a2[i * 2 + 1] == null_val);
+        REQUIRE(a2_nullable[i] == 0);
+        REQUIRE(a3_offsets[i] == 10 + i);
+        REQUIRE(a3_data[10 + i] == null_val_char);
+      }
+    } else {
+      REQUIRE(std::get<1>(result_el["a1"]) == 5);
+      REQUIRE(std::get<1>(result_el["a2"]) == 10);
+      REQUIRE(std::get<2>(result_el["a2"]) == 5);
+      REQUIRE(std::get<0>(result_el["a3"]) == 5);
+      REQUIRE(std::get<1>(result_el["a3"]) == 15);
+    }
 
     REQUIRE(check_result(a1, expected_results["a1"], 0, 5));
     REQUIRE(check_result(a2, expected_results["a2"], 0, 10));

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -407,9 +407,10 @@ TEST_CASE(
 
     // Check results again
     CHECK(
-        query_r.query_status() == (test::use_refactored_readers() ?
-                                       Query::Status::COMPLETE :
-                                       Query::Status::INCOMPLETE));
+        query_r.query_status() ==
+        (test::use_refactored_sparse_global_order_reader() ?
+             Query::Status::COMPLETE :
+             Query::Status::INCOMPLETE));
     CHECK(query_r.result_buffer_elements()["a"].second == 2);
     c_buff_a = {4, 1};
     c_buff_d1 = {5, 4};
@@ -422,7 +423,7 @@ TEST_CASE(
      * Old reader needs an extra round here to finish processing all the
      * partitions in the subarray. New reader is done earlier.
      */
-    if (!test::use_refactored_readers()) {
+    if (!test::use_refactored_sparse_global_order_reader()) {
       // Read until complete
       CHECK_NOTHROW(query_r.submit());
       CHECK(query_r.query_status() == Query::Status::COMPLETE);
@@ -869,9 +870,10 @@ TEST_CASE(
 
     // Check results again
     CHECK(
-        query_r.query_status() == (test::use_refactored_readers() ?
-                                       Query::Status::COMPLETE :
-                                       Query::Status::INCOMPLETE));
+        query_r.query_status() ==
+        (test::use_refactored_sparse_global_order_reader() ?
+             Query::Status::COMPLETE :
+             Query::Status::INCOMPLETE));
     CHECK(query_r.result_buffer_elements()["a"].second == 2);
     c_buff_a = {4, 1};
     c_buff_d1 = {-45, -46};
@@ -884,7 +886,7 @@ TEST_CASE(
      * Old reader needs an extra round here to finish processing all the
      * partitions in the subarray. New reader is done earlier.
      */
-    if (!test::use_refactored_readers()) {
+    if (!test::use_refactored_sparse_global_order_reader()) {
       // Read until complete
       CHECK_NOTHROW(query_r.submit());
       CHECK(query_r.query_status() == Query::Status::COMPLETE);
@@ -1284,9 +1286,10 @@ TEST_CASE(
 
     // Check results again
     CHECK(
-        query_r.query_status() == (test::use_refactored_readers() ?
-                                       Query::Status::COMPLETE :
-                                       Query::Status::INCOMPLETE));
+        query_r.query_status() ==
+        (test::use_refactored_sparse_global_order_reader() ?
+             Query::Status::COMPLETE :
+             Query::Status::INCOMPLETE));
     CHECK(query_r.result_buffer_elements()["a"].second == 2);
     c_buff_a = {1, 4};
     c_buff_d1 = {0.41f, 0.4f};
@@ -1299,7 +1302,7 @@ TEST_CASE(
      * Old reader needs an extra round here to finish processing all the
      * partitions in the subarray. New reader is done earlier.
      */
-    if (!test::use_refactored_readers()) {
+    if (!test::use_refactored_sparse_global_order_reader()) {
       // Read until complete
       CHECK_NOTHROW(query_r.submit());
       CHECK(query_r.query_status() == Query::Status::COMPLETE);
@@ -1338,9 +1341,10 @@ TEST_CASE(
 
     // Check results again
     CHECK(
-        query_r.query_status() == (test::use_refactored_readers() ?
-                                       Query::Status::COMPLETE :
-                                       Query::Status::INCOMPLETE));
+        query_r.query_status() ==
+        (test::use_refactored_sparse_global_order_reader() ?
+             Query::Status::COMPLETE :
+             Query::Status::INCOMPLETE));
     CHECK(query_r.result_buffer_elements()["a"].second == 2);
     c_buff_a = {1, 4};
     c_buff_d1 = {0.41f, 0.4f};
@@ -1353,7 +1357,7 @@ TEST_CASE(
      * Old reader needs an extra round here to finish processing all the
      * partitions in the subarray. New reader is done earlier.
      */
-    if (!test::use_refactored_readers()) {
+    if (!test::use_refactored_sparse_global_order_reader()) {
       // Read until complete
       CHECK_NOTHROW(query_r.submit());
       CHECK(query_r.query_status() == Query::Status::COMPLETE);
@@ -2050,7 +2054,7 @@ TEST_CASE(
      * Refactored reader tries to fill as much as possible.
      * Old reader splits partition in two.
      */
-    if (test::use_refactored_readers()) {
+    if (test::use_refactored_sparse_global_order_reader()) {
       CHECK(query_r.result_buffer_elements()["a"].second == 3);
       c_buff_a = {3, 2, 1};
       c_buff_d1 = std::string("dogcamel33");
@@ -2087,7 +2091,7 @@ TEST_CASE(
     r_off_d2.resize(query_r.result_buffer_elements()["d2"].first);
     r_buff_a.resize(query_r.result_buffer_elements()["a"].second);
 
-    if (test::use_refactored_readers()) {
+    if (test::use_refactored_sparse_global_order_reader()) {
       CHECK(query_r.result_buffer_elements()["a"].second == 1);
       c_buff_a = {4};
       c_buff_d1 = std::string("1a");
@@ -2154,7 +2158,7 @@ TEST_CASE(
      * Refactored reader tries to fill as much as possible.
      * Old reader splits partition in two.
      */
-    if (test::use_refactored_readers()) {
+    if (test::use_refactored_sparse_global_order_reader()) {
       CHECK(query_r.result_buffer_elements()["a"].second == 3);
       c_buff_a = {3, 2, 1};
       c_buff_d1 = std::string("dogcamel33");
@@ -2191,7 +2195,7 @@ TEST_CASE(
     r_off_d2.resize(query_r.result_buffer_elements()["d2"].first);
     r_buff_a.resize(query_r.result_buffer_elements()["a"].second);
 
-    if (test::use_refactored_readers()) {
+    if (test::use_refactored_sparse_global_order_reader()) {
       CHECK(query_r.result_buffer_elements()["a"].second == 1);
       c_buff_a = {4};
       c_buff_d1 = std::string("1a");

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -333,7 +333,7 @@ TEST_CASE(
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts[TILEDB_COORDS].second / 2;
-  if (test::use_refactored_readers()) {
+  if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'c');
     REQUIRE(data[1] == 'n');
@@ -349,7 +349,7 @@ TEST_CASE(
   result_num = result_elts[TILEDB_COORDS].second / 2;
   REQUIRE(result_num == 2);
 
-  if (test::use_refactored_readers()) {
+  if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(data[0] == 'd');
     REQUIRE(data[1] == 'e');
   } else {
@@ -362,7 +362,7 @@ TEST_CASE(
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts[TILEDB_COORDS].second / 2;
-  if (test::use_refactored_readers()) {
+  if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'f');
     REQUIRE(data[1] == 'g');
@@ -376,7 +376,7 @@ TEST_CASE(
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts[TILEDB_COORDS].second / 2;
-  if (test::use_refactored_readers()) {
+  if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'h');
     REQUIRE(data[1] == 'i');
@@ -387,7 +387,7 @@ TEST_CASE(
 
   // Resubmit
   st = query.submit();
-  if (test::use_refactored_readers()) {
+  if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(st == Query::Status::COMPLETE);
   } else {
     REQUIRE(st == Query::Status::INCOMPLETE);
@@ -395,7 +395,7 @@ TEST_CASE(
   result_elts = query.result_buffer_elements();
   result_num = result_elts[TILEDB_COORDS].second / 2;
 
-  if (test::use_refactored_readers()) {
+  if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'j');
     REQUIRE(data[1] == 'k');

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1036,9 +1036,17 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The offsets format (`bytes` or `elements`) to be used for
  *    var-sized attributes.<br>
  *    **Default**: bytes
- * - `sm.use_refactored_readers` <br>
- *    Use the refactored readers or not. <br>
- *    **Default**: false
+ * - `sm.query.dense.reader` <br>
+ *    Which reader to use for dense queries. "refactored" or "legacy".<br>
+ *    **Default**: lagacy
+ * - `sm.query.sparse_global_order.reader` <br>
+ *    Which reader to use for sparse global order queries. "refactored"
+ *    or "legacy".<br>
+ *    **Default**: legacy
+ * - `sm.query.sparse_unordered_with_dups.reader` <br>
+ *    Which reader to use for sparse unordered with dups queries.
+ *    "refactored" or "legacy".<br>
+ *    **Default**: refactored
  * - `sm.mem.malloc_trim` <br>
  *    Should malloc_trim be called on context and query destruction? This might
  * reduce residual memory usage. <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -75,7 +75,10 @@ const std::string Config::SM_TILE_CACHE_SIZE = "10000000";
 const std::string Config::SM_SKIP_EST_SIZE_PARTITIONING = "false";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
 const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
-const std::string Config::SM_USE_REFACTORED_READERS = "false";
+const std::string Config::SM_QUERY_DENSE_READER = "legacy";
+const std::string Config::SM_QUERY_SPARSE_GLOBAL_ORDER_READER = "legacy";
+const std::string Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER =
+    "refactored";
 const std::string Config::SM_MEM_MALLOC_TRIM = "true";
 const std::string Config::SM_MEM_TOTAL_BUDGET = "10737418240";  // 10GB;
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS = "0.5";
@@ -235,7 +238,11 @@ Config::Config() {
       SM_SKIP_EST_SIZE_PARTITIONING;
   param_values_["sm.memory_budget"] = SM_MEMORY_BUDGET;
   param_values_["sm.memory_budget_var"] = SM_MEMORY_BUDGET_VAR;
-  param_values_["sm.use_refactored_readers"] = SM_USE_REFACTORED_READERS;
+  param_values_["sm.query.dense.reader"] = SM_QUERY_DENSE_READER;
+  param_values_["sm.query.sparse_global_order.reader"] =
+      SM_QUERY_SPARSE_GLOBAL_ORDER_READER;
+  param_values_["sm.query.sparse_unordered_with_dups.reader"] =
+      SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER;
   param_values_["sm.mem.malloc_trim"] = SM_MEM_MALLOC_TRIM;
   param_values_["sm.mem.total_budget"] = SM_MEM_TOTAL_BUDGET;
   param_values_["sm.mem.reader.sparse_global_order.ratio_coords"] =
@@ -519,8 +526,14 @@ Status Config::unset(const std::string& param) {
     param_values_["sm.memory_budget"] = SM_MEMORY_BUDGET;
   } else if (param == "sm.memory_budget_var") {
     param_values_["sm.memory_budget_var"] = SM_MEMORY_BUDGET_VAR;
-  } else if (param == "sm.use_refactored_readers") {
-    param_values_["sm.use_refactored_readers"] = SM_USE_REFACTORED_READERS;
+  } else if (param == "sm.query.dense.reader") {
+    param_values_["sm.query.dense.reader"] = SM_QUERY_DENSE_READER;
+  } else if (param == "sm.query.sparse_global_order.reader") {
+    param_values_["sm.query.sparse_global_order.reader"] =
+        SM_QUERY_SPARSE_GLOBAL_ORDER_READER;
+  } else if (param == "sm.query.sparse_unordered_with_dups.reader") {
+    param_values_["sm.query.sparse_unordered_with_dups.reader"] =
+        SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER;
   } else if (param == "sm.mem.malloc_trim") {
     param_values_["sm.mem.malloc_trim"] = SM_MEM_MALLOC_TRIM;
   } else if (param == "sm.mem.total_budget") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -147,8 +147,14 @@ class Config {
    */
   static const std::string SM_MEMORY_BUDGET_VAR;
 
-  /** Whether or not to use the refactored readers. */
-  static const std::string SM_USE_REFACTORED_READERS;
+  /** Which reader to use for dense queries. */
+  static const std::string SM_QUERY_DENSE_READER;
+
+  /** Which reader to use for sparse global order queries. */
+  static const std::string SM_QUERY_SPARSE_GLOBAL_ORDER_READER;
+
+  /** Which reader to use for sparse unordered with dups queries. */
+  static const std::string SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER;
 
   /** Should malloc_trim be called on query/ctx destructors. */
   static const std::string SM_MEM_MALLOC_TRIM;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -384,9 +384,17 @@ class Config {
    *    The offsets format (`bytes` or `elements`) to be used for
    *    var-sized attributes.<br>
    *    **Default**: bytes
-   * - `sm.use_refactored_readers` <br>
-   *    Use the refactored readers or not. <br>
-   *    **Default**: false
+   * - `sm.query.dense.reader` <br>
+   *    Which reader to use for dense queries. "refactored" or "legacy".<br>
+   *    **Default**: lagacy
+   * - `sm.query.sparse_global_order.reader` <br>
+   *    Which reader to use for sparse global order queries. "refactored"
+   *    or "legacy".<br>
+   *    **Default**: legacy
+   * - `sm.query.sparse_unordered_with_dups.reader` <br>
+   *    Which reader to use for sparse unordered with dups queries.
+   *    "refactored" or "legacy".<br>
+   *    **Default**: refactored
    * - `sm.mem.malloc_trim` <br>
    *    Should malloc_trim be called on context and query destruction? This
    *    might reduce residual memory usage. <br>

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -857,6 +857,15 @@ class Query {
   /** Returns the scratch space used for REST requests. */
   tdb_shared_ptr<Buffer> rest_scratch() const;
 
+  /** Use the refactored dense reader or not. */
+  bool use_refactored_dense_reader();
+
+  /** Use the refactored sparse global order reader or not. */
+  bool use_refactored_sparse_global_order_reader();
+
+  /** Use the refactored sparse unordered with dups reader or not. */
+  bool use_refactored_sparse_unordered_with_dups_reader();
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -578,7 +578,7 @@ Status Consolidator::create_queries(
   RETURN_NOT_OK((*query_r)->set_layout(Layout::GLOBAL_ORDER));
 
   // Refactored reader optimizes for no subarray.
-  if (!config_.use_refactored_readers_ ||
+  if (!config_.use_refactored_reader_ ||
       array_for_reads->array_schema()->dense())
     RETURN_NOT_OK((*query_r)->set_subarray_unsafe(subarray));
 
@@ -890,9 +890,10 @@ Status Consolidator::set_config(const Config* config) {
   RETURN_NOT_OK(merged_config.get<uint64_t>(
       "sm.consolidation.timestamp_end", &config_.timestamp_end_, &found));
   assert(found);
-  RETURN_NOT_OK(merged_config.get<bool>(
-      "sm.use_refactored_readers", &config_.use_refactored_readers_, &found));
+  std::string reader =
+      merged_config.get("sm.query.sparse_global_order.reader", &found);
   assert(found);
+  config_.use_refactored_reader_ = reader.compare("reafctored") == 0;
 
   // Sanity checks
   if (config_.min_frags_ > config_.max_frags_)

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -99,8 +99,8 @@ class Consolidator {
     uint64_t timestamp_start_;
     /** End time for consolidation. */
     uint64_t timestamp_end_;
-    /** Are the refactored readers in use or not */
-    bool use_refactored_readers_;
+    /** Is the refactored reader in use or not */
+    bool use_refactored_reader_;
   };
 
   /* ********************************* */


### PR DESCRIPTION
This change splits the use_refactored_readers setting in 3 settings:
sm.query.sparse_global_order.reader
sm.query.sparse_unordered_with_dups.reader
sm.query.dense.reader
Set to either “refactored” or “legacy”.

Also fixing one serialization test for the refactored dense reader.

---
TYPE: IMPROVEMENT
DESC: Splitting config for refactored readers.
