### PR TITLE
Replace raw with shared_ptr in stats

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -44,6 +44,8 @@ std::mutex catch2_macro_mutex;
 namespace tiledb {
 namespace test {
 
+using tiledb::sm::stats::Stats;
+
 // Command line arguments.
 extern std::string g_vfs;
 
@@ -104,6 +106,11 @@ bool use_refactored_sparse_unordered_with_dups_reader() {
   tiledb_config_free(&cfg);
 
   return use_refactored_readers;
+}
+
+tdb_shared_ptr<Stats> g_helper_stats(void) {
+  static tdb_shared_ptr<Stats> g_helper_stats = tdb_make_shared(Stats, "test");
+  return g_helper_stats;
 }
 
 template <class T>
@@ -560,7 +567,7 @@ void create_subarray(
     tiledb::sm::Layout layout,
     tiledb::sm::Subarray* subarray,
     bool coalesce_ranges) {
-  tiledb::sm::Subarray ret(array, layout, &g_helper_stats, coalesce_ranges);
+  tiledb::sm::Subarray ret(array, layout, g_helper_stats(), coalesce_ranges);
 
   auto dim_num = (unsigned)ranges.size();
   for (unsigned d = 0; d < dim_num; ++d) {

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -74,7 +74,7 @@ namespace test {
 // A dummy `Stats` instance. This is useful for constructing
 // objects that require a parent `Stats` object. These stats are
 // never used.
-static tiledb::sm::stats::Stats g_helper_stats("test");
+tdb_shared_ptr<tiledb::sm::stats::Stats> g_helper_stats(void);
 
 // For easy reference
 typedef std::pair<tiledb_filter_type_t, int> Compressor;

--- a/test/src/unit-DenseTiler.cc
+++ b/test/src/unit-DenseTiler.cc
@@ -203,11 +203,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler1.tile_num() == 2);
@@ -220,11 +220,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {6, 9};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler2.tile_num() == 1);
@@ -262,11 +262,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -294,11 +294,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {7, 8};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan2 = tiler2.copy_plan(0);
@@ -314,11 +314,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub3[] = {7, 8};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3}, sizeof(sub3), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan3 = tiler3.copy_plan(0);
@@ -359,11 +359,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0;
@@ -384,11 +384,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {7, 10};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile2;
@@ -400,11 +400,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub3[] = {7, 10};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3}, sizeof(sub3), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile3;
@@ -441,11 +441,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0;
@@ -491,11 +491,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {-2, 1};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0;
@@ -545,11 +545,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler1.tile_num() == 4);
@@ -563,11 +563,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {7, 9};
   int32_t sub2_1[] = {23, 27};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler2.tile_num() == 1);
@@ -581,11 +581,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler3.tile_num() == 4);
@@ -599,11 +599,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {7, 10};
   int32_t sub4_1[] = {23, 27};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler4.tile_num() == 1);
@@ -645,11 +645,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler1.tile_num() == 4);
@@ -663,11 +663,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {7, 9};
   int32_t sub2_1[] = {23, 27};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler2.tile_num() == 1);
@@ -681,11 +681,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler3.tile_num() == 4);
@@ -699,11 +699,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {7, 10};
   int32_t sub4_1[] = {23, 27};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, test::g_helper_stats());
 
   // Test correctness of initialization
   CHECK(tiler4.tile_num() == 1);
@@ -745,11 +745,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -800,11 +800,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan2_0 = tiler2.copy_plan(0);
@@ -822,11 +822,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan3_0 = tiler3.copy_plan(0);
@@ -881,11 +881,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan4_0 = tiler4.copy_plan(0);
@@ -932,11 +932,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -991,11 +991,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan2_0 = tiler2.copy_plan(0);
@@ -1014,11 +1014,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan3_0 = tiler3.copy_plan(0);
@@ -1069,11 +1069,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan4_0 = tiler4.copy_plan(0);
@@ -1119,11 +1119,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 9};
   int32_t sub1_1[] = {11, 20};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -1180,11 +1180,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {1, 5};
   int32_t sub1_1[] = {8, 12};
-  Subarray subarray1(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test correctness of copy plan for tile 0
   auto copy_plan1_0 = tiler1.copy_plan(0);
@@ -1242,11 +1242,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0;
@@ -1305,14 +1305,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
   buff_a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile2_0;
@@ -1339,14 +1339,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
   buff_a = {1, 6, 11, 2, 7, 12, 3, 8, 13, 4, 9, 14, 5, 10, 15};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile3_0;
@@ -1405,14 +1405,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
   buff_a = {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile4_0;
@@ -1468,11 +1468,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0;
@@ -1542,14 +1542,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
   buff_a = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile2_0;
@@ -1594,14 +1594,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
   buff_a = {1, 6, 11, 2, 7, 12, 3, 8, 13, 4, 9, 14, 5, 10, 15};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile3_0;
@@ -1671,14 +1671,14 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
   buff_a = {1, 7, 13, 2, 8, 14, 3, 9, 15, 4, 10, 16, 5, 11, 17, 6, 12, 18};
   buff_a_size = sizeof(buff_a);
   buffers["a"] = QueryBuffer(&buff_a[0], nullptr, &buff_a_size, nullptr);
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile4_0;
@@ -1755,11 +1755,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 9};
   int32_t sub1_1[] = {11, 20};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0;
@@ -1816,11 +1816,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {1, 5};
   int32_t sub1_1[] = {8, 12};
-  Subarray subarray1(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0;
@@ -1871,11 +1871,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0;
@@ -1903,11 +1903,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {7, 10};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile2;
@@ -1920,11 +1920,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub3[] = {7, 10};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3}, sizeof(sub3), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile3;
@@ -1965,11 +1965,11 @@ TEST_CASE_METHOD(
   // Create subarray
   open_array(array_name, TILEDB_READ);
   int32_t sub1[] = {3, 6};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1}, sizeof(sub1), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0_a1;
@@ -2001,11 +2001,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub2[] = {7, 10};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2}, sizeof(sub2), &subarray2);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile2_a1;
@@ -2021,11 +2021,11 @@ TEST_CASE_METHOD(
   close_array();
   open_array(array_name, TILEDB_READ);
   int32_t sub3[] = {7, 10};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3}, sizeof(sub3), &subarray3);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile3_a1;
@@ -2078,11 +2078,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0;
@@ -2144,7 +2144,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -2158,7 +2158,7 @@ TEST_CASE_METHOD(
       &buff_a_size,
       nullptr,
       ValidityVector(&buff_a_n[0], &buff_a_n_size));
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile2_0;
@@ -2197,7 +2197,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub3_0[] = {4, 6};
   int32_t sub3_1[] = {18, 22};
-  Subarray subarray3(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray3(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub3_0, sub3_1}, sizeof(sub3_0), &subarray3);
 
   // Create DenseTiler
@@ -2211,7 +2211,7 @@ TEST_CASE_METHOD(
       &buff_a_size,
       nullptr,
       ValidityVector(&buff_a_n[0], &buff_a_n_size));
-  DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler3(&buffers, &subarray3, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile3_0;
@@ -2273,7 +2273,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub4_0[] = {3, 5};
   int32_t sub4_1[] = {13, 18};
-  Subarray subarray4(array_->array_, Layout::COL_MAJOR, &test::g_helper_stats);
+  Subarray subarray4(array_->array_, Layout::COL_MAJOR, test::g_helper_stats());
   add_ranges({sub4_0, sub4_1}, sizeof(sub4_0), &subarray4);
 
   // Create DenseTiler
@@ -2287,7 +2287,7 @@ TEST_CASE_METHOD(
       &buff_a_size,
       nullptr,
       ValidityVector(&buff_a_n[0], &buff_a_n_size));
-  DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler4(&buffers, &subarray4, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile4_0;
@@ -2361,11 +2361,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -2497,7 +2497,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -2509,7 +2509,7 @@ TEST_CASE_METHOD(
   buff_a_val_size = buff_a_val.size();
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;
@@ -2657,11 +2657,11 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
-  DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler1(&buffers, &subarray1, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -2793,7 +2793,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -2824,7 +2824,7 @@ TEST_CASE_METHOD(
   buff_a_val_size = buff_a_val.size() * sizeof(int32_t);
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
-  DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
+  DenseTiler<int32_t> tiler2(&buffers, &subarray2, test::g_helper_stats());
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;
@@ -2973,12 +2973,12 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
   DenseTiler<int32_t> tiler1(
-      &buffers, &subarray1, &test::g_helper_stats, "bytes", 64, true);
+      &buffers, &subarray1, test::g_helper_stats(), "bytes", 64, true);
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -3110,7 +3110,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -3143,7 +3143,7 @@ TEST_CASE_METHOD(
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
   DenseTiler<int32_t> tiler2(
-      &buffers, &subarray2, &test::g_helper_stats, "bytes", 64, true);
+      &buffers, &subarray2, test::g_helper_stats(), "bytes", 64, true);
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;
@@ -3278,12 +3278,12 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
   DenseTiler<int32_t> tiler1(
-      &buffers, &subarray1, &test::g_helper_stats, "elements", 64, false);
+      &buffers, &subarray1, test::g_helper_stats(), "elements", 64, false);
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -3415,7 +3415,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -3431,7 +3431,7 @@ TEST_CASE_METHOD(
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
   DenseTiler<int32_t> tiler2(
-      &buffers, &subarray2, &test::g_helper_stats, "elements", 64, false);
+      &buffers, &subarray2, test::g_helper_stats(), "elements", 64, false);
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;
@@ -3566,12 +3566,12 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub1_0[] = {4, 6};
   int32_t sub1_1[] = {18, 22};
-  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray1(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub1_0, sub1_1}, sizeof(sub1_0), &subarray1);
 
   // Create DenseTiler
   DenseTiler<int32_t> tiler1(
-      &buffers, &subarray1, &test::g_helper_stats, "elements", 32, false);
+      &buffers, &subarray1, test::g_helper_stats(), "elements", 32, false);
 
   // Test get tile 0
   Tile tile1_0_off, tile1_0_val;
@@ -3703,7 +3703,7 @@ TEST_CASE_METHOD(
   open_array(array_name, TILEDB_READ);
   int32_t sub2_0[] = {3, 5};
   int32_t sub2_1[] = {13, 18};
-  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, &test::g_helper_stats);
+  Subarray subarray2(array_->array_, Layout::ROW_MAJOR, test::g_helper_stats());
   add_ranges({sub2_0, sub2_1}, sizeof(sub2_0), &subarray2);
 
   // Create DenseTiler
@@ -3719,7 +3719,7 @@ TEST_CASE_METHOD(
   buffers["a"] = QueryBuffer(
       &buff_a_off[0], &buff_a_val[0], &buff_a_off_size, &buff_a_val_size);
   DenseTiler<int32_t> tiler2(
-      &buffers, &subarray2, &test::g_helper_stats, "elements", 32, false);
+      &buffers, &subarray2, test::g_helper_stats(), "elements", 32, false);
 
   // Test get tile 0
   Tile tile2_0_off, tile2_0_val;

--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -108,7 +108,7 @@ TEST_CASE_METHOD(
   Subarray subarray;
   QueryCondition condition;
   Reader reader(
-      &g_helper_stats,
+      g_helper_stats(),
       tdb_make_shared(Logger, ""),
       nullptr,
       nullptr,

--- a/test/src/unit-SubarrayPartitioner-dense.cc
+++ b/test/src/unit-SubarrayPartitioner-dense.cc
@@ -261,7 +261,7 @@ void SubarrayPartitionerDenseFx::test_subarray_partitioner(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), budget);
   CHECK(st.ok());
 
@@ -289,7 +289,7 @@ void SubarrayPartitionerDenseFx::test_subarray_partitioner(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
 
   // Note: this is necessary, otherwise the subarray partitioner does
   // not check if the memory budget is exceeded for attributes whose
@@ -570,7 +570,7 @@ TEST_CASE_METHOD(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   auto st = subarray_partitioner.set_result_budget("a", 100 * sizeof(int));
   CHECK(st.ok());
   st = subarray_partitioner.set_result_budget("b", 1, 1);

--- a/test/src/unit-SubarrayPartitioner-error.cc
+++ b/test/src/unit-SubarrayPartitioner-error.cc
@@ -139,7 +139,7 @@ TEST_CASE_METHOD(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   uint64_t budget, budget_off, budget_val;
 
   auto st = subarray_partitioner.get_result_budget("a", &budget);

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -352,7 +352,7 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), budget);
   CHECK(st.ok());
 
@@ -382,7 +382,7 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
       memory_budget_var,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   auto st = subarray_partitioner.set_result_budget(attr.c_str(), result_budget);
   CHECK(st.ok());
 
@@ -410,7 +410,7 @@ void SubarrayPartitionerSparseFx::test_subarray_partitioner(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
 
   // Note: this is necessary, otherwise the subarray partitioner does
   // not check if the memory budget is exceeded for attributes whose
@@ -691,7 +691,7 @@ TEST_CASE_METHOD(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   auto st = subarray_partitioner.set_result_budget("a", 100);
   CHECK(st.ok());
   st = subarray_partitioner.set_result_budget("b", 1, 1);
@@ -2280,7 +2280,7 @@ TEST_CASE_METHOD(
   }
 
   // Check unsplittable
-  tiledb::sm::Subarray subarray(array->array_, layout, &g_helper_stats);
+  tiledb::sm::Subarray subarray(array->array_, layout, g_helper_stats());
   tiledb::sm::Range r;
   r.set_str_range("bb", "bb");
   subarray.add_range(0, std::move(r), true);
@@ -2294,7 +2294,7 @@ TEST_CASE_METHOD(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   auto st = partitioner.set_result_budget("d", 10);
   CHECK(!st.ok());
   uint64_t budget = 0;
@@ -2317,7 +2317,7 @@ TEST_CASE_METHOD(
   CHECK(range->end_str() == std::string("bb", 2));
 
   // Check full
-  tiledb::sm::Subarray subarray_full(array->array_, layout, &g_helper_stats);
+  tiledb::sm::Subarray subarray_full(array->array_, layout, g_helper_stats());
   r.set_str_range("a", "bb");
   subarray_full.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_full(
@@ -2327,7 +2327,7 @@ TEST_CASE_METHOD(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   st = partitioner_full.set_result_budget("d", 16, 4);
   CHECK(st.ok());
   CHECK(partitioner_full.get_result_budget("d", &budget_off, &budget_val).ok());
@@ -2343,7 +2343,7 @@ TEST_CASE_METHOD(
   CHECK(range->end_str() == std::string("bb", 2));
 
   // Check split
-  tiledb::sm::Subarray subarray_split(array->array_, layout, &g_helper_stats);
+  tiledb::sm::Subarray subarray_split(array->array_, layout, g_helper_stats());
   r.set_str_range("a", "bb");
   subarray_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split(
@@ -2353,7 +2353,7 @@ TEST_CASE_METHOD(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   st = partitioner_split.set_result_budget("d", 10, 4);
   CHECK(st.ok());
   CHECK(
@@ -2380,7 +2380,7 @@ TEST_CASE_METHOD(
 
   // Check no split 2 MBRs
   tiledb::sm::Subarray subarray_no_split(
-      array->array_, layout, &g_helper_stats);
+      array->array_, layout, g_helper_stats());
   r.set_str_range("bb", "cc");
   subarray_no_split.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_no_split(
@@ -2390,7 +2390,7 @@ TEST_CASE_METHOD(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   st = partitioner_no_split.set_result_budget("d", 16, 10);
   CHECK(st.ok());
   CHECK(partitioner_no_split.get_result_budget("d", &budget_off, &budget_val)
@@ -2408,7 +2408,8 @@ TEST_CASE_METHOD(
   CHECK(range->end_str() == std::string("cc", 2));
 
   // Check split 2 MBRs
-  tiledb::sm::Subarray subarray_split_2(array->array_, layout, &g_helper_stats);
+  tiledb::sm::Subarray subarray_split_2(
+      array->array_, layout, g_helper_stats());
   r.set_str_range("bb", "cc");
   subarray_split_2.add_range(0, std::move(r), true);
   SubarrayPartitioner partitioner_split_2(
@@ -2418,7 +2419,7 @@ TEST_CASE_METHOD(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   st = partitioner_split_2.set_result_budget("d", 8, 10);
   CHECK(st.ok());
   CHECK(partitioner_split_2.get_result_budget("d", &budget_off, &budget_val)
@@ -2545,7 +2546,7 @@ TEST_CASE_METHOD(
     layout = Layout::UNORDERED;
   }
 
-  tiledb::sm::Subarray subarray(array->array_, layout, &g_helper_stats);
+  tiledb::sm::Subarray subarray(array->array_, layout, g_helper_stats());
   tiledb::sm::Range r;
   r.set_str_range("cc", "ccd");
   subarray.add_range(0, std::move(r), true);
@@ -2559,7 +2560,7 @@ TEST_CASE_METHOD(
       memory_budget_var_,
       0,
       &tp,
-      &g_helper_stats);
+      g_helper_stats());
   auto st = partitioner.set_result_budget("d", 10, 4);
   CHECK(st.ok());
   CHECK(partitioner.get_result_budget("d", &budget_off, &budget_val).ok());

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -536,7 +536,7 @@ TEST_CASE("Filter: Test empty pipeline", "[filter]") {
   FilterPipeline pipeline;
   ThreadPool tp;
   CHECK(tp.init(4).ok());
-  CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+  CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
   // Check new size and number of chunks
   CHECK(tile.buffer()->size() == 0);
@@ -565,7 +565,7 @@ TEST_CASE("Filter: Test empty pipeline", "[filter]") {
     tile.filtered_buffer()->advance_offset(sizeof(uint64_t));
   }
 
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
   CHECK(tile.buffer()->size() != 0);
   CHECK(tile.filtered_buffer()->size() == 0);
   CHECK(tile.buffer() == &buffer);
@@ -608,7 +608,7 @@ TEST_CASE("Filter: Test simple in-place pipeline", "[filter]") {
   CHECK(pipeline.add_filter(Add1InPlace()).ok());
 
   SECTION("- Single stage") {
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
     // Check new size and number of chunks
     CHECK(tile.buffer()->size() == 0);
@@ -637,7 +637,8 @@ TEST_CASE("Filter: Test simple in-place pipeline", "[filter]") {
       tile.filtered_buffer()->advance_offset(sizeof(uint64_t));
     }
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -654,7 +655,7 @@ TEST_CASE("Filter: Test simple in-place pipeline", "[filter]") {
     // Add a few more +1 filters and re-run.
     CHECK(pipeline.add_filter(Add1InPlace()).ok());
     CHECK(pipeline.add_filter(Add1InPlace()).ok());
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
     // Check new size and number of chunks
     CHECK(tile.buffer()->size() == 0);
@@ -683,7 +684,8 @@ TEST_CASE("Filter: Test simple in-place pipeline", "[filter]") {
       tile.filtered_buffer()->advance_offset(sizeof(uint64_t));
     }
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -728,7 +730,7 @@ TEST_CASE("Filter: Test simple out-of-place pipeline", "[filter]") {
   CHECK(pipeline.add_filter(Add1OutOfPlace()).ok());
 
   SECTION("- Single stage") {
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
     // Check new size and number of chunks
     CHECK(tile.buffer()->size() == 0);
@@ -757,7 +759,8 @@ TEST_CASE("Filter: Test simple out-of-place pipeline", "[filter]") {
       tile.filtered_buffer()->advance_offset(sizeof(uint64_t));
     }
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -774,7 +777,7 @@ TEST_CASE("Filter: Test simple out-of-place pipeline", "[filter]") {
     // Add a few more +1 filters and re-run.
     CHECK(pipeline.add_filter(Add1OutOfPlace()).ok());
     CHECK(pipeline.add_filter(Add1OutOfPlace()).ok());
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
     // Check new size and number of chunks
     CHECK(tile.buffer()->size() == 0);
@@ -803,7 +806,8 @@ TEST_CASE("Filter: Test simple out-of-place pipeline", "[filter]") {
       tile.filtered_buffer()->advance_offset(sizeof(uint64_t));
     }
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -849,7 +853,7 @@ TEST_CASE("Filter: Test mixed in- and out-of-place pipeline", "[filter]") {
   CHECK(pipeline.add_filter(Add1OutOfPlace()).ok());
   CHECK(pipeline.add_filter(Add1InPlace()).ok());
   CHECK(pipeline.add_filter(Add1OutOfPlace()).ok());
-  CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+  CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
   CHECK(tile.buffer()->size() == 0);
   CHECK(
@@ -878,7 +882,7 @@ TEST_CASE("Filter: Test mixed in- and out-of-place pipeline", "[filter]") {
   }
 
   // Set up test data
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
   CHECK(tile.buffer()->size() != 0);
   CHECK(tile.filtered_buffer()->size() == 0);
   CHECK(tile.buffer() == &buffer);
@@ -936,12 +940,13 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(pipeline.add_filter(Add1OutOfPlace()).ok());
     CHECK(pipeline.add_filter(CompressionFilter(Compressor::LZ4, 5)).ok());
 
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     // Check compression worked
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() < nelts * sizeof(uint64_t));
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer()->size() == nelts * sizeof(uint64_t));
@@ -959,12 +964,13 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(pipeline.add_filter(PseudoChecksumFilter()).ok());
     CHECK(pipeline.add_filter(CompressionFilter(Compressor::LZ4, 5)).ok());
 
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     // Check compression worked
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() < nelts * sizeof(uint64_t));
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer()->size() == nelts * sizeof(uint64_t));
@@ -984,12 +990,13 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(pipeline.add_filter(Add1OutOfPlace()).ok());
     CHECK(pipeline.add_filter(CompressionFilter(Compressor::LZ4, 5)).ok());
 
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     // Check compression worked
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() < nelts * sizeof(uint64_t));
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer()->size() == nelts * sizeof(uint64_t));
@@ -1036,7 +1043,7 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter]") {
   CHECK(pipeline.add_filter(PseudoChecksumFilter()).ok());
 
   SECTION("- Single stage") {
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
     // Check new size and number of chunks
     CHECK(tile.buffer()->size() == 0);
@@ -1070,7 +1077,8 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter]") {
       tile.filtered_buffer()->advance_offset(sizeof(uint64_t));
     }
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -1087,7 +1095,7 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter]") {
     CHECK(pipeline.add_filter(Add1OutOfPlace()).ok());
     CHECK(pipeline.add_filter(Add1InPlace()).ok());
     CHECK(pipeline.add_filter(PseudoChecksumFilter()).ok());
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
     // Compute the second (final) checksum value.
     uint64_t expected_checksum_2 = 0;
@@ -1130,7 +1138,8 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter]") {
       tile.filtered_buffer()->advance_offset(sizeof(uint64_t));
     }
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -1185,7 +1194,7 @@ TEST_CASE("Filter: Test pipeline modify filter", "[filter]") {
   CHECK(add_n != nullptr);
   add_n->set_increment(2);
 
-  CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+  CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
   CHECK(tile.buffer()->size() == 0);
   CHECK(tile.filtered_buffer()->size() != 0);
@@ -1211,7 +1220,7 @@ TEST_CASE("Filter: Test pipeline modify filter", "[filter]") {
     tile.filtered_buffer()->advance_offset(sizeof(uint64_t));
   }
 
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
   CHECK(tile.buffer()->size() != 0);
   CHECK(tile.filtered_buffer()->size() == 0);
   CHECK(tile.buffer() == &buffer);
@@ -1272,7 +1281,7 @@ TEST_CASE("Filter: Test pipeline copy", "[filter]") {
   CHECK(add_n_2 != nullptr);
   CHECK(add_n_2->increment() == 2);
 
-  CHECK(pipeline_copy.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+  CHECK(pipeline_copy.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
   CHECK(tile.buffer()->size() == 0);
   CHECK(tile.filtered_buffer()->size() != 0);
@@ -1302,7 +1311,7 @@ TEST_CASE("Filter: Test pipeline copy", "[filter]") {
     tile.filtered_buffer()->advance_offset(sizeof(uint64_t));
   }
 
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
   CHECK(tile.buffer()->size() != 0);
   CHECK(tile.filtered_buffer()->size() == 0);
   CHECK(tile.buffer() == &buffer);
@@ -1401,10 +1410,11 @@ TEST_CASE("Filter: Test random pipeline", "[filter]") {
     }
 
     // End result should always be the same as the input.
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() != 0);
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     auto* buffer = tile.buffer();
@@ -1450,11 +1460,11 @@ TEST_CASE(
   CHECK(tp.init(4).ok());
   ChecksumMD5Filter md5_filter;
   CHECK(md5_pipeline.add_filter(md5_filter).ok());
-  CHECK(md5_pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+  CHECK(md5_pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
   CHECK(tile.buffer()->size() == 0);
   CHECK(tile.filtered_buffer()->size() != 0);
-  CHECK(
-      md5_pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(md5_pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config)
+            .ok());
   CHECK(tile.buffer()->size() != 0);
   CHECK(tile.filtered_buffer()->size() == 0);
   auto* internal_buffer = tile.buffer();
@@ -1469,10 +1479,10 @@ TEST_CASE(
   FilterPipeline sha_256_pipeline;
   ChecksumMD5Filter sha_256_filter;
   CHECK(sha_256_pipeline.add_filter(sha_256_filter).ok());
-  CHECK(sha_256_pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+  CHECK(sha_256_pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
   CHECK(tile.buffer()->size() == 0);
   CHECK(tile.filtered_buffer()->size() != 0);
-  CHECK(sha_256_pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config)
+  CHECK(sha_256_pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config)
             .ok());
   CHECK(tile.buffer()->size() != 0);
   CHECK(tile.filtered_buffer()->size() == 0);
@@ -1516,7 +1526,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter]") {
   CHECK(pipeline.add_filter(BitWidthReductionFilter()).ok());
 
   SECTION("- Single stage") {
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() != 0);
@@ -1550,7 +1560,8 @@ TEST_CASE("Filter: Test bit width reduction", "[filter]") {
     auto compressed_size = tile.filtered_buffer()->size();
     CHECK(compressed_size < nelts * sizeof(uint64_t));
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -1570,11 +1581,11 @@ TEST_CASE("Filter: Test bit width reduction", "[filter]") {
       pipeline.get_filter<BitWidthReductionFilter>()->set_max_window_size(
           window_size);
 
-      CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+      CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
       CHECK(tile.buffer()->size() == 0);
       CHECK(tile.filtered_buffer()->size() != 0);
-      CHECK(
-          pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+      CHECK(pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config)
+                .ok());
       CHECK(tile.buffer()->size() != 0);
       CHECK(tile.filtered_buffer()->size() == 0);
       CHECK(tile.buffer() == &buffer);
@@ -1610,10 +1621,11 @@ TEST_CASE("Filter: Test bit width reduction", "[filter]") {
 
     Tile tile(Datatype::UINT64, cell_size, dim_num, &buffer, false);
 
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() != 0);
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -1654,10 +1666,11 @@ TEST_CASE("Filter: Test bit width reduction", "[filter]") {
 
     Tile tile(Datatype::INT32, cell_size, dim_num, &buffer, false);
 
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() != 0);
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -1688,10 +1701,11 @@ TEST_CASE("Filter: Test bit width reduction", "[filter]") {
 
     Tile tile(Datatype::UINT64, cell_size, dim_num, &buffer, false);
 
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() != 0);
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -1738,7 +1752,7 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter]") {
   CHECK(pipeline.add_filter(PositiveDeltaFilter()).ok());
 
   SECTION("- Single stage") {
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() != 0);
@@ -1771,7 +1785,8 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter]") {
         encoded_size == pipeline_metadata_size + filter_metadata_size +
                             nelts * sizeof(uint64_t));
 
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -1791,11 +1806,11 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter]") {
       pipeline.get_filter<PositiveDeltaFilter>()->set_max_window_size(
           window_size);
 
-      CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+      CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
       CHECK(tile.buffer()->size() == 0);
       CHECK(tile.filtered_buffer()->size() != 0);
-      CHECK(
-          pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+      CHECK(pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config)
+                .ok());
       CHECK(tile.buffer()->size() != 0);
       CHECK(tile.filtered_buffer()->size() == 0);
       CHECK(tile.buffer() == &buffer);
@@ -1816,7 +1831,7 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter]") {
       CHECK(buffer.write(&val, sizeof(uint64_t)).ok());
     }
 
-    CHECK(!pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(!pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
   }
 
   buffer.clear();
@@ -1851,10 +1866,11 @@ TEST_CASE("Filter: Test bitshuffle", "[filter]") {
   CHECK(pipeline.add_filter(BitshuffleFilter()).ok());
 
   SECTION("- Single stage") {
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() != 0);
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -1884,11 +1900,11 @@ TEST_CASE("Filter: Test bitshuffle", "[filter]") {
 
     Tile tile2(Datatype::UINT32, cell_size, dim_num, &buffer2, false);
 
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile2, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile2, &tp).ok());
     CHECK(tile2.buffer()->size() == 0);
     CHECK(tile2.filtered_buffer()->size() != 0);
     CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile2, &tp, config).ok());
+        pipeline.run_reverse(test::g_helper_stats(), &tile2, &tp, config).ok());
     CHECK(tile2.buffer()->size() != 0);
     CHECK(tile2.filtered_buffer()->size() == 0);
     CHECK(tile2.buffer() == &buffer2);
@@ -1935,10 +1951,11 @@ TEST_CASE("Filter: Test byteshuffle", "[filter]") {
   CHECK(pipeline.add_filter(ByteshuffleFilter()).ok());
 
   SECTION("- Single stage") {
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() != 0);
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -1968,11 +1985,11 @@ TEST_CASE("Filter: Test byteshuffle", "[filter]") {
 
     Tile tile2(Datatype::UINT32, cell_size, dim_num, &buffer2, false);
 
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile2, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile2, &tp).ok());
     CHECK(tile2.buffer()->size() == 0);
     CHECK(tile2.filtered_buffer()->size() != 0);
     CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile2, &tp, config).ok());
+        pipeline.run_reverse(test::g_helper_stats(), &tile2, &tp, config).ok());
     CHECK(tile2.buffer()->size() != 0);
     CHECK(tile2.filtered_buffer()->size() == 0);
     CHECK(tile2.buffer() == &buffer2);
@@ -2020,7 +2037,7 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     CHECK(pipeline.add_filter(EncryptionAES256GCMFilter()).ok());
 
     // No key set
-    CHECK(!pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(!pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
 
     // Create and set a key
     char key[32];
@@ -2030,10 +2047,11 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     CHECK(filter->set_key(key).ok());
 
     // Check success
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     CHECK(tile.buffer()->size() == 0);
     CHECK(tile.filtered_buffer()->size() != 0);
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);
@@ -2046,18 +2064,19 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     }
 
     // Check error decrypting with wrong key.
-    CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &tp).ok());
+    CHECK(pipeline.run_forward(test::g_helper_stats(), &tile, &tp).ok());
     key[0]++;
     CHECK(filter->set_key(key).ok());
     CHECK(
-        !pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+        !pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
 
     // Fix key and check success. Note: this test depends on the implementation
     // leaving the tile data unmodified when the decryption fails, which is not
     // true in general use of the filter pipeline.
     key[0]--;
     CHECK(filter->set_key(key).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(test::g_helper_stats(), &tile, &tp, config).ok());
     CHECK(tile.buffer()->size() != 0);
     CHECK(tile.filtered_buffer()->size() == 0);
     CHECK(tile.buffer() == &buffer);

--- a/test/src/unit-s3-no-multipart.cc
+++ b/test/src/unit-s3-no-multipart.cc
@@ -75,7 +75,7 @@ S3DirectFx::S3DirectFx() {
   REQUIRE(config.set("vfs.s3.multipart_part_size", "10000000").ok());
   REQUIRE(config.set("vfs.s3.use_multipart_upload", "false").ok());
   REQUIRE(thread_pool_.init(2).ok());
-  REQUIRE(s3_.init(&g_helper_stats, config, &thread_pool_).ok());
+  REQUIRE(s3_.init(g_helper_stats(), config, &thread_pool_).ok());
 
   // Create bucket
   bool exists;

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -71,7 +71,7 @@ S3Fx::S3Fx() {
   REQUIRE(config.set("vfs.s3.verify_ssl", "false").ok());
 #endif
   REQUIRE(thread_pool_.init(2).ok());
-  REQUIRE(s3_.init(&g_helper_stats, config, &thread_pool_).ok());
+  REQUIRE(s3_.init(g_helper_stats(), config, &thread_pool_).ok());
 
   // Create bucket
   bool exists;
@@ -363,7 +363,7 @@ TEST_CASE_METHOD(S3Fx, "Test S3 use BucketCannedACL", "[s3]") {
   auto try_with_bucket_canned_acl = [&](const char* bucket_acl_to_try) {
     REQUIRE(config.set("vfs.s3.bucket_canned_acl", bucket_acl_to_try).ok());
     tiledb::sm::S3 s3_;
-    REQUIRE(s3_.init(&g_helper_stats, config, &thread_pool_).ok());
+    REQUIRE(s3_.init(g_helper_stats(), config, &thread_pool_).ok());
 
     // Create bucket
     bool exists;
@@ -526,7 +526,7 @@ TEST_CASE_METHOD(S3Fx, "Test S3 use Bucket/Object CannedACL", "[s3]") {
     REQUIRE(config.set("vfs.s3.object_canned_acl", object_acl_to_try).ok());
 
     tiledb::sm::S3 s3_;
-    REQUIRE(s3_.init(&g_helper_stats, config, &thread_pool_).ok());
+    REQUIRE(s3_.init(g_helper_stats(), config, &thread_pool_).ok());
 
     // Create bucket
     bool exists;

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -48,7 +48,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
   URI testfile("vfs_unit_test_data");
   std::unique_ptr<VFS> vfs(new VFS);
   REQUIRE(
-      vfs->init(&g_helper_stats, &compute_tp, &io_tp, nullptr, nullptr).ok());
+      vfs->init(g_helper_stats(), &compute_tp, &io_tp, nullptr, nullptr).ok());
 
   bool exists = false;
   REQUIRE(vfs->is_file(testfile, &exists).ok());
@@ -70,8 +70,8 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     // Check reading in one batch: single read operation.
     std::memset(data_read, 0, nelts * sizeof(uint32_t));
     batches.emplace_back(0, data_read, nelts * sizeof(uint32_t));
-    REQUIRE(
-        vfs->init(&g_helper_stats, &compute_tp, &io_tp, nullptr, nullptr).ok());
+    REQUIRE(vfs->init(g_helper_stats(), &compute_tp, &io_tp, nullptr, nullptr)
+                .ok());
     REQUIRE(vfs->read_all(testfile, batches, &io_tp, &tasks).ok());
     REQUIRE(io_tp.wait_all(tasks).ok());
     tasks.clear();
@@ -112,7 +112,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     vfs_config.set("vfs.min_batch_size", "0");
     vfs_config.set("vfs.min_batch_gap", "0");
     REQUIRE(vfs->init(
-                   &g_helper_stats,
+                   g_helper_stats(),
                    &compute_tp,
                    &io_tp,
                    &default_config,
@@ -161,7 +161,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     Config default_config, vfs_config;
     vfs_config.set("vfs.min_batch_size", "0");
     REQUIRE(vfs->init(
-                   &g_helper_stats,
+                   g_helper_stats(),
                    &compute_tp,
                    &io_tp,
                    &default_config,
@@ -187,7 +187,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     Config default_config, vfs_config;
     vfs_config.set("vfs.min_batch_gap", "0");
     REQUIRE(vfs->init(
-                   &g_helper_stats,
+                   g_helper_stats(),
                    &compute_tp,
                    &io_tp,
                    &default_config,
@@ -209,10 +209,13 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
   }
 
   Config default_config, vfs_config;
-  REQUIRE(
-      vfs->init(
-             &g_helper_stats, &compute_tp, &io_tp, &default_config, &vfs_config)
-          .ok());
+  REQUIRE(vfs->init(
+                 g_helper_stats(),
+                 &compute_tp,
+                 &io_tp,
+                 &default_config,
+                 &vfs_config)
+              .ok());
   REQUIRE(vfs->is_file(testfile, &exists).ok());
   if (exists)
     REQUIRE(vfs->remove_file(testfile).ok());
@@ -231,7 +234,7 @@ TEST_CASE("VFS: Test long paths (Win32)", "[vfs][windows]") {
   std::unique_ptr<VFS> vfs(new VFS);
   std::string tmpdir_base = tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
   REQUIRE(
-      vfs->init(&g_helper_stats, &compute_tp, &io_tp, nullptr, nullptr).ok());
+      vfs->init(g_helper_stats(), &compute_tp, &io_tp, nullptr, nullptr).ok());
   REQUIRE(vfs->create_dir(URI(tmpdir_base)).ok());
 
   SECTION("- Deep hierarchy") {
@@ -283,7 +286,7 @@ TEST_CASE("VFS: Test long posix paths", "[vfs]") {
 
   std::unique_ptr<VFS> vfs(new VFS);
   REQUIRE(
-      vfs->init(&g_helper_stats, &compute_tp, &io_tp, nullptr, nullptr).ok());
+      vfs->init(g_helper_stats(), &compute_tp, &io_tp, nullptr, nullptr).ok());
 
   std::string tmpdir_base = Posix::current_dir() + "/tiledb_test/";
   REQUIRE(vfs->create_dir(URI(tmpdir_base)).ok());
@@ -400,7 +403,7 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
 
     VFS vfs;
     REQUIRE(
-        vfs.init(&g_helper_stats, &compute_tp, &io_tp, nullptr, &config).ok());
+        vfs.init(g_helper_stats(), &compute_tp, &io_tp, nullptr, &config).ok());
 
     bool exists = false;
     if (root.is_s3() || root.is_azure()) {

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -203,7 +203,7 @@ S3::~S3() {
 /* ********************************* */
 
 Status S3::init(
-    stats::Stats* const parent_stats,
+    tdb_shared_ptr<stats::Stats> const parent_stats,
     const Config& config,
     ThreadPool* const thread_pool) {
   // already initialized
@@ -212,7 +212,7 @@ Status S3::init(
 
   assert(state_ == State::UNINITIALIZED);
 
-  stats_ = parent_stats->create_child("S3");
+  stats_ = parent_stats->create_child("S3", parent_stats);
 
   if (thread_pool == nullptr) {
     return LOG_STATUS(

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -114,7 +114,7 @@ class S3 {
    * @return Status
    */
   Status init(
-      stats::Stats* parent_stats,
+      tdb_shared_ptr<stats::Stats> parent_stats,
       const Config& config,
       ThreadPool* thread_pool);
 
@@ -361,7 +361,7 @@ class S3 {
    public:
     /** Constructor. */
     S3RetryStrategy(
-        stats::Stats* const s3_stats,
+        tdb_shared_ptr<stats::Stats> const s3_stats,
         const uint64_t max_retries,
         const uint64_t scale_factor)
         : s3_stats_(s3_stats)
@@ -422,7 +422,7 @@ class S3 {
 
    private:
     /** The S3 `stats_`. */
-    stats::Stats* s3_stats_;
+    tdb_shared_ptr<stats::Stats> s3_stats_;
 
     /** The maximum number of retries after an error. */
     uint64_t max_retries_;
@@ -553,7 +553,7 @@ class S3 {
   /* ********************************* */
 
   /** The class stats. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The current state. */
   State state_;

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -914,12 +914,12 @@ Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
 }
 
 Status VFS::init(
-    stats::Stats* const parent_stats,
+    tdb_shared_ptr<stats::Stats> const parent_stats,
     ThreadPool* const compute_tp,
     ThreadPool* const io_tp,
     const Config* const ctx_config,
     const Config* const vfs_config) {
-  stats_ = parent_stats->create_child("VFS");
+  stats_ = parent_stats->create_child("VFS", parent_stats);
 
   assert(compute_tp);
   assert(io_tp);

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -274,7 +274,7 @@ class VFS {
    * @return Status
    */
   Status init(
-      stats::Stats* parent_stats,
+      tdb_shared_ptr<stats::Stats> parent_stats,
       ThreadPool* compute_tp,
       ThreadPool* io_tp,
       const Config* ctx_config,
@@ -631,7 +631,7 @@ class VFS {
 #endif
 
   /** The class stats. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The in-memory filesystem which is always supported */
   MemFilesystem memfs_;

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -353,7 +353,7 @@ uint32_t FilterPipeline::max_chunk_size() const {
 }
 
 Status FilterPipeline::run_forward(
-    stats::Stats* const writer_stats,
+    tdb_shared_ptr<stats::Stats> const writer_stats,
     Tile* const tile,
     ThreadPool* const compute_tp) const {
   current_tile_ = tile;
@@ -379,7 +379,7 @@ Status FilterPipeline::run_forward(
 }
 
 Status FilterPipeline::run_reverse(
-    stats::Stats* const reader_stats,
+    tdb_shared_ptr<stats::Stats> const reader_stats,
     Tile* const tile,
     ThreadPool* const compute_tp,
     const Config& config) const {
@@ -389,7 +389,7 @@ Status FilterPipeline::run_reverse(
 }
 
 Status FilterPipeline::run_reverse_internal(
-    stats::Stats* const reader_stats,
+    tdb_shared_ptr<stats::Stats> const reader_stats,
     Tile* tile,
     ThreadPool* const compute_tp,
     const Config& config) const {

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -178,7 +178,9 @@ class FilterPipeline {
    * @return Status
    */
   Status run_forward(
-      stats::Stats* writer_stats, Tile* tile, ThreadPool* compute_tp) const;
+      tdb_shared_ptr<stats::Stats> writer_stats,
+      Tile* tile,
+      ThreadPool* compute_tp) const;
 
   /**
    * Runs the pipeline in reverse on the given filtered tile. This is used
@@ -218,7 +220,7 @@ class FilterPipeline {
    * @return Status
    */
   Status run_reverse(
-      stats::Stats* reader_stats,
+      tdb_shared_ptr<stats::Stats> reader_stats,
       Tile* tile,
       ThreadPool* compute_tp,
       const Config& config) const;
@@ -310,7 +312,7 @@ class FilterPipeline {
    * @return Status
    */
   Status run_reverse_internal(
-      stats::Stats* reader_stats,
+      tdb_shared_ptr<stats::Stats> reader_stats,
       Tile* tile,
       ThreadPool* compute_tp,
       const Config& config) const;

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -58,7 +58,7 @@ namespace sm {
 /* ****************************** */
 
 DenseReader::DenseReader(
-    stats::Stats* stats,
+    tdb_shared_ptr<stats::Stats> stats,
     tdb_shared_ptr<Logger> logger,
     StorageManager* storage_manager,
     Array* array,

--- a/tiledb/sm/query/dense_reader.h
+++ b/tiledb/sm/query/dense_reader.h
@@ -60,7 +60,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
 
   /** Constructor. */
   DenseReader(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       tdb_shared_ptr<Logger> logger,
       StorageManager* storage_manager,
       Array* array,

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -53,11 +53,11 @@ template <class T>
 DenseTiler<T>::DenseTiler(
     const std::unordered_map<std::string, QueryBuffer>* buffers,
     const Subarray* subarray,
-    Stats* const parent_stats,
+    tdb_shared_ptr<Stats> const parent_stats,
     const std::string& offsets_format_mode,
     uint64_t offsets_bitsize,
     bool offsets_extra_element)
-    : stats_(parent_stats->create_child("DenseTiler"))
+    : stats_(parent_stats->create_child("DenseTiler", parent_stats))
     , array_schema_(subarray->array()->array_schema())
     , buffers_(buffers)
     , subarray_(subarray)

--- a/tiledb/sm/query/dense_tiler.h
+++ b/tiledb/sm/query/dense_tiler.h
@@ -146,7 +146,7 @@ class DenseTiler {
   DenseTiler(
       const std::unordered_map<std::string, QueryBuffer>* buffers,
       const Subarray* subarray,
-      stats::Stats* const parent_stats,
+      tdb_shared_ptr<stats::Stats> const parent_stats,
       const std::string& offsets_format_mode = "bytes",
       uint64_t offsets_bitsize = 64,
       bool offsets_extra_element = false);
@@ -239,7 +239,7 @@ class DenseTiler {
   /* ********************************* */
 
   /** The stats for the dense tiler. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The class logger. */
   tdb_shared_ptr<Logger> logger_;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -65,7 +65,8 @@ Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
     : array_(array)
     , layout_(Layout::ROW_MAJOR)
     , storage_manager_(storage_manager)
-    , stats_(storage_manager_->stats()->create_child("Query"))
+    , stats_(storage_manager_->stats()->create_child(
+          "Query", storage_manager_->stats()))
     , logger_(storage_manager->logger()->clone("Query", ++logger_id_))
     , has_coords_buffer_(false)
     , has_zipped_coords_buffer_(false)
@@ -999,7 +1000,7 @@ Status Query::create_strategy() {
   if (type_ == QueryType::WRITE) {
     strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
         Writer,
-        stats_->create_child("Writer"),
+        stats_->create_child("Writer", stats_),
         logger_,
         storage_manager_,
         array_,
@@ -1019,7 +1020,7 @@ Status Query::create_strategy() {
       use_default = false;
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
           SparseUnorderedWithDupsReader,
-          stats_->create_child("Reader"),
+          stats_->create_child("Reader", stats_),
           logger_,
           storage_manager_,
           array_,
@@ -1037,7 +1038,7 @@ Status Query::create_strategy() {
       use_default = false;
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
           SparseGlobalOrderReader,
-          stats_->create_child("Reader"),
+          stats_->create_child("Reader", stats_),
           logger_,
           storage_manager_,
           array_,
@@ -1055,7 +1056,7 @@ Status Query::create_strategy() {
         use_default = false;
         strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
             DenseReader,
-            stats_->create_child("Reader"),
+            stats_->create_child("Reader", stats_),
             logger_,
             storage_manager_,
             array_,
@@ -1070,7 +1071,7 @@ Status Query::create_strategy() {
     if (use_default) {
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
           Reader,
-          stats_->create_child("Reader"),
+          stats_->create_child("Reader", stats_),
           logger_,
           storage_manager_,
           array_,
@@ -1975,7 +1976,7 @@ const Config* Query::config() const {
   return &config_;
 }
 
-stats::Stats* Query::stats() const {
+tdb_shared_ptr<stats::Stats> Query::stats() const {
   return stats_;
 }
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -852,7 +852,7 @@ class Query {
   QueryType type() const;
 
   /** Returns the internal stats object. */
-  stats::Stats* stats() const;
+  tdb_shared_ptr<stats::Stats> stats() const;
 
   /** Returns the scratch space used for REST requests. */
   tdb_shared_ptr<Buffer> rest_scratch() const;
@@ -905,7 +905,7 @@ class Query {
   tdb_unique_ptr<IQueryStrategy> strategy_;
 
   /** The class stats. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The class logger. */
   tdb_shared_ptr<Logger> logger_;

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -93,7 +93,7 @@ inline IterT skip_invalid_elements(IterT it, const IterT& end) {
 /* ****************************** */
 
 Reader::Reader(
-    stats::Stats* stats,
+    tdb_shared_ptr<stats::Stats> stats,
     tdb_shared_ptr<Logger> logger,
     StorageManager* storage_manager,
     Array* array,

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -65,7 +65,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
 
   /** Constructor. */
   Reader(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       tdb_shared_ptr<Logger> logger,
       StorageManager* storage_manager,
       Array* array,

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -50,7 +50,7 @@ namespace sm {
 /* ****************************** */
 
 ReaderBase::ReaderBase(
-    stats::Stats* stats,
+    tdb_shared_ptr<stats::Stats> stats,
     tdb_shared_ptr<Logger> logger,
     StorageManager* storage_manager,
     Array* array,

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -106,7 +106,7 @@ class ReaderBase : public StrategyBase {
 
   /** Constructor. */
   ReaderBase(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       tdb_shared_ptr<Logger> logger,
       StorageManager* storage_manager,
       Array* array,

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -59,7 +59,7 @@ namespace sm {
 /* ****************************** */
 
 SparseGlobalOrderReader::SparseGlobalOrderReader(
-    stats::Stats* stats,
+    tdb_shared_ptr<stats::Stats> stats,
     tdb_shared_ptr<Logger> logger,
     StorageManager* storage_manager,
     Array* array,

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -65,7 +65,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
 
   /** Constructor. */
   SparseGlobalOrderReader(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       tdb_shared_ptr<Logger> logger,
       StorageManager* storage_manager,
       Array* array,

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -50,7 +50,7 @@ namespace sm {
 /* ****************************** */
 
 SparseIndexReaderBase::SparseIndexReaderBase(
-    stats::Stats* stats,
+    tdb_shared_ptr<stats::Stats> stats,
     tdb_shared_ptr<Logger> logger,
     StorageManager* storage_manager,
     Array* array,

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -83,7 +83,7 @@ class SparseIndexReaderBase : public ReaderBase {
 
   /** Constructor. */
   SparseIndexReaderBase(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       tdb_shared_ptr<Logger> logger,
       StorageManager* storage_manager,
       Array* array,

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -58,7 +58,7 @@ namespace sm {
 /* ****************************** */
 
 SparseUnorderedWithDupsReader::SparseUnorderedWithDupsReader(
-    stats::Stats* stats,
+    tdb_shared_ptr<stats::Stats> stats,
     tdb_shared_ptr<Logger> logger,
     StorageManager* storage_manager,
     Array* array,

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -65,7 +65,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
 
   /** Constructor. */
   SparseUnorderedWithDupsReader(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       tdb_shared_ptr<Logger> logger,
       StorageManager* storage_manager,
       Array* array,

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -44,7 +44,7 @@ namespace sm {
 /* ****************************** */
 
 StrategyBase::StrategyBase(
-    stats::Stats* stats,
+    tdb_shared_ptr<stats::Stats> stats,
     tdb_shared_ptr<Logger> logger,
     StorageManager* storage_manager,
     Array* array,
@@ -68,7 +68,7 @@ StrategyBase::StrategyBase(
   }
 }
 
-stats::Stats* StrategyBase::stats() const {
+tdb_shared_ptr<stats::Stats> StrategyBase::stats() const {
   return stats_;
 }
 

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -55,7 +55,7 @@ class StrategyBase {
 
   /** Constructor. */
   StrategyBase(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       tdb_shared_ptr<Logger> logger,
       StorageManager* storage_manager,
       Array* array,
@@ -72,7 +72,7 @@ class StrategyBase {
   /* ********************************* */
 
   /** Returns `stats_`. */
-  stats::Stats* stats() const;
+  tdb_shared_ptr<stats::Stats> stats() const;
 
   /** Returns the configured offsets format mode. */
   std::string offsets_mode() const;
@@ -98,7 +98,7 @@ class StrategyBase {
   /* ********************************* */
 
   /** The class stats. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The class logger. */
   tdb_shared_ptr<Logger> logger_;

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -60,7 +60,7 @@ namespace sm {
 /* ****************************** */
 
 Writer::Writer(
-    stats::Stats* stats,
+    tdb_shared_ptr<stats::Stats> stats,
     tdb_shared_ptr<Logger> logger,
     StorageManager* storage_manager,
     Array* array,

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -92,7 +92,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
 
   /** Constructor. */
   Writer(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       tdb_shared_ptr<Logger> logger,
       StorageManager* storage_manager,
       Array* array,

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -426,7 +426,7 @@ Status Curl::set_content_type(
 }
 
 Status Curl::make_curl_request(
-    stats::Stats* const stats,
+    tdb_shared_ptr<stats::Stats> const stats,
     const char* url,
     CURLcode* curl_code,
     Buffer* returned_data) const {
@@ -439,7 +439,7 @@ Status Curl::make_curl_request(
 }
 
 Status Curl::make_curl_request(
-    stats::Stats* const stats,
+    tdb_shared_ptr<stats::Stats> const stats,
     const char* url,
     CURLcode* curl_code,
     PostResponseCb&& cb) const {
@@ -452,7 +452,7 @@ Status Curl::make_curl_request(
 }
 
 Status Curl::make_curl_request_common(
-    stats::Stats* const stats,
+    tdb_shared_ptr<stats::Stats> const stats,
     const char* const url,
     CURLcode* const curl_code,
     size_t (*write_cb)(void*, size_t, size_t, void*),
@@ -647,7 +647,7 @@ std::string Curl::get_curl_errstr(CURLcode curl_code) const {
 }
 
 Status Curl::post_data(
-    stats::Stats* const stats,
+    tdb_shared_ptr<stats::Stats> const stats,
     const std::string& url,
     const SerializationType serialization_type,
     const BufferList* data,
@@ -669,7 +669,7 @@ Status Curl::post_data(
 }
 
 Status Curl::post_data(
-    stats::Stats* const stats,
+    tdb_shared_ptr<stats::Stats> const stats,
     const std::string& url,
     const SerializationType serialization_type,
     const BufferList* data,
@@ -731,7 +731,7 @@ Status Curl::post_data_common(
 }
 
 Status Curl::get_data(
-    stats::Stats* const stats,
+    tdb_shared_ptr<stats::Stats> const stats,
     const std::string& url,
     SerializationType serialization_type,
     Buffer* returned_data,
@@ -764,7 +764,7 @@ Status Curl::get_data(
 }
 
 Status Curl::delete_data(
-    stats::Stats* const stats,
+    tdb_shared_ptr<stats::Stats> const stats,
     const std::string& url,
     SerializationType serialization_type,
     Buffer* returned_data,

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -142,7 +142,7 @@ class Curl {
    * @return Status
    */
   Status post_data(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       const std::string& url,
       SerializationType serialization_type,
       const BufferList* data,
@@ -178,7 +178,7 @@ class Curl {
    * @return Status
    */
   Status post_data(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       const std::string& url,
       SerializationType serialization_type,
       const BufferList* data,
@@ -212,7 +212,7 @@ class Curl {
    * @return Status
    */
   Status get_data(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       const std::string& url,
       SerializationType serialization_type,
       Buffer* returned_data,
@@ -230,7 +230,7 @@ class Curl {
    * @return Status
    */
   Status delete_data(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       const std::string& url,
       SerializationType serialization_type,
       Buffer* returned_data,
@@ -294,7 +294,7 @@ class Curl {
    * @return Status
    */
   Status make_curl_request(
-      stats::Stats* const stats,
+      tdb_shared_ptr<stats::Stats> const stats,
       const char* url,
       CURLcode* curl_code,
       Buffer* returned_data) const;
@@ -310,7 +310,7 @@ class Curl {
    * @return Status
    */
   Status make_curl_request(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       const char* url,
       CURLcode* curl_code,
       PostResponseCb&& write_cb) const;
@@ -326,7 +326,7 @@ class Curl {
    * @return Status
    */
   Status make_curl_request_common(
-      stats::Stats* stats,
+      tdb_shared_ptr<stats::Stats> stats,
       const char* url,
       CURLcode* curl_code,
       size_t (*write_cb)(void*, size_t, size_t, void*),

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -75,14 +75,14 @@ RestClient::RestClient()
 }
 
 Status RestClient::init(
-    stats::Stats* const parent_stats,
+    tdb_shared_ptr<stats::Stats> const parent_stats,
     const Config* config,
     ThreadPool* compute_tp) {
   if (config == nullptr)
     return LOG_STATUS(
         Status::RestError("Error initializing rest client; config is null."));
 
-  stats_ = parent_stats->create_child("RestClient");
+  stats_ = parent_stats->create_child("RestClient", parent_stats);
 
   config_ = config;
   compute_tp_ = compute_tp;
@@ -824,7 +824,8 @@ RestClient::RestClient() {
   (void)serialization_type_;
 }
 
-Status RestClient::init(stats::Stats*, const Config*, ThreadPool*) {
+Status RestClient::init(
+    tdb_shared_ptr<stats::Stats>, const Config*, ThreadPool*) {
   return LOG_STATUS(
       Status::RestError("Cannot use rest client; serialization not enabled."));
 }

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -59,7 +59,9 @@ class RestClient {
 
   /** Initialize the REST client with the given config. */
   Status init(
-      stats::Stats* parent_stats, const Config* config, ThreadPool* compute_tp);
+      tdb_shared_ptr<stats::Stats> parent_stats,
+      const Config* config,
+      ThreadPool* compute_tp);
 
   /** Sets a header that will be attached to all requests. */
   Status set_header(const std::string& name, const std::string& value);
@@ -190,7 +192,7 @@ class RestClient {
   /* ********************************* */
 
   /** The class stats. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The TileDB config options (contains server and auth info). */
   const Config* config_;

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -105,7 +105,7 @@ Status stats_to_capnp(Stats& stats, capnp::Stats::Builder* stats_builder) {
 }
 
 Status stats_from_capnp(
-    const capnp::Stats::Reader& stats_reader, Stats* stats) {
+    const capnp::Stats::Reader& stats_reader, tdb_shared_ptr<Stats> stats) {
   if (stats_reader.hasCounters()) {
     auto counters = stats->counters();
     auto counters_reader = stats_reader.getCounters();
@@ -175,7 +175,7 @@ Status subarray_to_capnp(
   }
 
   // If stats object exists set its cap'n proto object
-  stats::Stats* stats = subarray->stats();
+  tdb_shared_ptr<stats::Stats> stats = subarray->stats();
   if (stats != nullptr) {
     auto stats_builder = builder->initStats();
     RETURN_NOT_OK(stats_to_capnp(*stats, &stats_builder));
@@ -235,7 +235,7 @@ Status subarray_from_capnp(
 
   // If cap'n proto object has stats set it on c++ object
   if (reader.hasStats()) {
-    stats::Stats* stats = subarray->stats();
+    tdb_shared_ptr<stats::Stats> stats = subarray->stats();
     // We should always have a stats here
     if (stats != nullptr) {
       RETURN_NOT_OK(stats_from_capnp(reader.getStats(), stats));
@@ -332,7 +332,7 @@ Status subarray_partitioner_to_capnp(
   builder->setMemoryBudgetValidity(mem_budget_validity);
 
   // If stats object exists set its cap'n proto object
-  stats::Stats* stats = partitioner.stats();
+  tdb_shared_ptr<stats::Stats> stats = partitioner.stats();
   if (stats != nullptr) {
     auto stats_builder = builder->initStats();
     RETURN_NOT_OK(stats_to_capnp(*stats, &stats_builder));
@@ -342,7 +342,7 @@ Status subarray_partitioner_to_capnp(
 }
 
 Status subarray_partitioner_from_capnp(
-    Stats* reader_stats,
+    tdb_shared_ptr<Stats> reader_stats,
     const Config* config,
     const Array* array,
     const capnp::SubarrayPartitioner::Reader& reader,
@@ -718,7 +718,7 @@ Status reader_to_capnp(
   }
 
   // If stats object exists set its cap'n proto object
-  stats::Stats* stats = reader.stats();
+  tdb_shared_ptr<stats::Stats> stats = reader.stats();
   if (stats != nullptr) {
     auto stats_builder = reader_builder->initStats();
     RETURN_NOT_OK(stats_to_capnp(*stats, &stats_builder));
@@ -752,7 +752,7 @@ Status index_reader_to_capnp(
   }
 
   // If stats object exists set its cap'n proto object
-  stats::Stats* stats = reader.stats();
+  tdb_shared_ptr<stats::Stats> stats = reader.stats();
   if (stats != nullptr) {
     auto stats_builder = reader_builder->initStats();
     RETURN_NOT_OK(stats_to_capnp(*stats, &stats_builder));
@@ -787,7 +787,7 @@ Status dense_reader_to_capnp(
   }
 
   // If stats object exists set its cap'n proto object
-  stats::Stats* stats = reader.stats();
+  tdb_shared_ptr<stats::Stats> stats = reader.stats();
   if (stats != nullptr) {
     auto stats_builder = reader_builder->initStats();
     RETURN_NOT_OK(stats_to_capnp(*stats, &stats_builder));
@@ -868,7 +868,7 @@ Status reader_from_capnp(
 
   // If cap'n proto object has stats set it on c++ object
   if (reader_reader.hasStats()) {
-    stats::Stats* stats = reader->stats();
+    tdb_shared_ptr<stats::Stats> stats = reader->stats();
     // We should always have a stats here
     if (stats != nullptr) {
       RETURN_NOT_OK(stats_from_capnp(reader_reader.getStats(), stats));
@@ -910,7 +910,7 @@ Status index_reader_from_capnp(
 
   // If cap'n proto object has stats set it on c++ object
   if (reader_reader.hasStats()) {
-    stats::Stats* stats = reader->stats();
+    tdb_shared_ptr<stats::Stats> stats = reader->stats();
     // We should always have a stats here
     if (stats != nullptr) {
       RETURN_NOT_OK(stats_from_capnp(reader_reader.getStats(), stats));
@@ -953,7 +953,7 @@ Status dense_reader_from_capnp(
 
   // If cap'n proto object has stats set it on c++ object
   if (reader_reader.hasStats()) {
-    stats::Stats* stats = reader->stats();
+    tdb_shared_ptr<stats::Stats> stats = reader->stats();
     // We should always have a stats here
     if (stats != nullptr) {
       RETURN_NOT_OK(stats_from_capnp(reader_reader.getStats(), stats));
@@ -990,7 +990,7 @@ Status writer_to_capnp(
   }
 
   // If stats object exists set its cap'n proto object
-  stats::Stats* stats = writer.stats();
+  tdb_shared_ptr<stats::Stats> stats = writer.stats();
   if (stats != nullptr) {
     auto stats_builder = writer_builder->initStats();
     RETURN_NOT_OK(stats_to_capnp(*stats, &stats_builder));
@@ -1007,7 +1007,7 @@ Status writer_from_capnp(
 
   // If cap'n proto object has stats set it on c++ object
   if (writer_reader.hasStats()) {
-    stats::Stats* stats = writer->stats();
+    tdb_shared_ptr<stats::Stats> stats = writer->stats();
     // We should always have a stats here
     if (stats != nullptr) {
       RETURN_NOT_OK(stats_from_capnp(writer_reader.getStats(), stats));
@@ -1170,7 +1170,7 @@ Status query_to_capnp(Query& query, capnp::Query::Builder* query_builder) {
   RETURN_NOT_OK(config_to_capnp(config, &config_builder));
 
   // If stats object exists set its cap'n proto object
-  stats::Stats* stats = query.stats();
+  tdb_shared_ptr<stats::Stats> stats = query.stats();
   if (stats != nullptr) {
     auto stats_builder = query_builder->initStats();
     RETURN_NOT_OK(stats_to_capnp(*stats, &stats_builder));
@@ -1807,7 +1807,7 @@ Status query_from_capnp(
 
   // If cap'n proto object has stats set it on c++ object
   if (query_reader.hasStats()) {
-    stats::Stats* stats = query->stats();
+    tdb_shared_ptr<stats::Stats> stats = query->stats();
     // We should always have a stats here
     if (stats != nullptr) {
       RETURN_NOT_OK(stats_from_capnp(query_reader.getStats(), stats));

--- a/tiledb/sm/stats/global_stats.cc
+++ b/tiledb/sm/stats/global_stats.cc
@@ -94,7 +94,7 @@ void GlobalStats::reset() {
   }
 }
 
-void GlobalStats::register_stats(const tdb_shared_ptr<Stats>& stats) {
+void GlobalStats::register_stats(const tdb_shared_ptr<Stats> stats) {
   std::unique_lock<std::mutex> ul(mtx_);
   registered_stats_.emplace_back(stats);
 }

--- a/tiledb/sm/stats/global_stats.h
+++ b/tiledb/sm/stats/global_stats.h
@@ -97,7 +97,7 @@ class GlobalStats {
    * will be aggregated and dumped with the other registered
    * stats.
    */
-  void register_stats(const tdb_shared_ptr<Stats>& stats);
+  void register_stats(const tdb_shared_ptr<Stats> stats);
 
   /** Dump the current stats to the given file. */
   void dump(FILE* out) const;

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -61,7 +61,8 @@ namespace sm {
 
 Consolidator::Consolidator(StorageManager* storage_manager)
     : storage_manager_(storage_manager)
-    , stats_(storage_manager_->stats()->create_child("Consolidator")) {
+    , stats_(storage_manager_->stats()->create_child(
+          "Consolidator", storage_manager_->stats())) {
 }
 
 Consolidator::~Consolidator() = default;

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -172,7 +172,7 @@ class Consolidator {
   StorageManager* storage_manager_;
 
   /** The class stats. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /* ********************************* */
   /*          PRIVATE METHODS           */

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -84,7 +84,7 @@ Status Context::init(Config* const config) {
 
   // Create storage manager
   storage_manager_ = new (std::nothrow)
-      tiledb::sm::StorageManager(&compute_tp_, &io_tp_, stats_.get(), logger_);
+      tiledb::sm::StorageManager(&compute_tp_, &io_tp_, stats_, logger_);
   if (storage_manager_ == nullptr)
     return logger_->status(Status::ContextError(
         "Cannot initialize context Storage manager allocation failed"));
@@ -120,8 +120,8 @@ ThreadPool* Context::io_tp() const {
   return &io_tp_;
 }
 
-stats::Stats* Context::stats() const {
-  return stats_.get();
+tdb_shared_ptr<stats::Stats> Context::stats() const {
+  return stats_;
 }
 
 Status Context::init_thread_pools(Config* const config) {

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -83,7 +83,7 @@ class Context {
   ThreadPool* io_tp() const;
 
   /** Returns the internal stats object. */
-  stats::Stats* stats() const;
+  tdb_shared_ptr<stats::Stats> stats() const;
 
  private:
   /* ********************************* */

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -78,9 +78,9 @@ namespace sm {
 StorageManager::StorageManager(
     ThreadPool* const compute_tp,
     ThreadPool* const io_tp,
-    stats::Stats* const parent_stats,
+    tdb_shared_ptr<stats::Stats> const parent_stats,
     tdb_shared_ptr<Logger> logger)
-    : stats_(parent_stats->create_child("StorageManager"))
+    : stats_(parent_stats->create_child("StorageManager", parent_stats))
     , logger_(logger->clone("Context", ++logger_id_))
     , cancellation_in_progress_(false)
     , queries_in_progress_(0)
@@ -2464,7 +2464,7 @@ Status StorageManager::write(const URI& uri, void* data, uint64_t size) const {
   return vfs_->write(uri, data, size);
 }
 
-stats::Stats* StorageManager::stats() {
+tdb_shared_ptr<stats::Stats> StorageManager::stats() {
   return stats_;
 }
 

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -116,7 +116,7 @@ class StorageManager {
   StorageManager(
       ThreadPool* compute_tp,
       ThreadPool* io_tp,
-      stats::Stats* parent_stats,
+      tdb_shared_ptr<stats::Stats> parent_stats,
       tdb_shared_ptr<Logger> logger);
 
   /** Destructor. */
@@ -997,7 +997,7 @@ class StorageManager {
   Status write(const URI& uri, void* data, uint64_t size) const;
 
   /** Returns `stats_`. */
-  stats::Stats* stats();
+  tdb_shared_ptr<stats::Stats> stats();
 
   /** Returns the internal logger object. */
   tdb_shared_ptr<Logger> logger() const;
@@ -1035,7 +1035,7 @@ class StorageManager {
   /* ********************************* */
 
   /** The class stats. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The class logger. */
   tdb_shared_ptr<Logger> logger_;

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -70,16 +70,18 @@ Subarray::Subarray()
 }
 
 Subarray::Subarray(
-    const Array* array, Stats* const parent_stats, const bool coalesce_ranges)
+    const Array* array,
+    tdb_shared_ptr<Stats> const parent_stats,
+    const bool coalesce_ranges)
     : Subarray(array, Layout::UNORDERED, parent_stats, coalesce_ranges) {
 }
 
 Subarray::Subarray(
     const Array* const array,
     const Layout layout,
-    Stats* const parent_stats,
+    tdb_shared_ptr<Stats> const parent_stats,
     const bool coalesce_ranges)
-    : stats_(parent_stats->create_child("Subarray"))
+    : stats_(parent_stats->create_child("Subarray", parent_stats))
     , array_(array)
     , layout_(layout)
     , cell_order_(array_->array_schema()->cell_order())
@@ -2646,7 +2648,7 @@ std::vector<unsigned>* Subarray::relevant_fragments() {
   return &relevant_fragments_;
 }
 
-stats::Stats* Subarray::stats() const {
+tdb_shared_ptr<stats::Stats> Subarray::stats() const {
   return stats_;
 }
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -174,7 +174,7 @@ class Subarray {
    */
   Subarray(
       const Array* array,
-      stats::Stats* parent_stats,
+      tdb_shared_ptr<stats::Stats> parent_stats,
       bool coalesce_ranges = true);
 
   /**
@@ -191,7 +191,7 @@ class Subarray {
   Subarray(
       const Array* array,
       Layout layout,
-      stats::Stats* parent_stats,
+      tdb_shared_ptr<stats::Stats> parent_stats,
       bool coalesce_ranges = true);
 
   /**
@@ -754,7 +754,7 @@ class Subarray {
       std::vector<uint64_t>* end_coords) const;
 
   /** Returns `stats_`. */
-  stats::Stats* stats() const;
+  tdb_shared_ptr<stats::Stats> stats() const;
 
   /** Stores a vector of 1D ranges per dimension. */
   std::vector<std::vector<uint64_t>> original_range_idx_;
@@ -825,7 +825,7 @@ class Subarray {
   /* ********************************* */
 
   /** The class stats. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The array the subarray object is associated with. */
   const Array* array_;

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -70,8 +70,8 @@ SubarrayPartitioner::SubarrayPartitioner(
     const uint64_t memory_budget_var,
     const uint64_t memory_budget_validity,
     ThreadPool* const compute_tp,
-    Stats* const parent_stats)
-    : stats_(parent_stats->create_child("SubarrayPartitioner"))
+    tdb_shared_ptr<Stats> const parent_stats)
+    : stats_(parent_stats->create_child("SubarrayPartitioner", parent_stats))
     , config_(config)
     , subarray_(subarray)
     , memory_budget_(memory_budget)
@@ -640,7 +640,7 @@ Subarray* SubarrayPartitioner::subarray() {
   return &subarray_;
 }
 
-stats::Stats* SubarrayPartitioner::stats() const {
+tdb_shared_ptr<stats::Stats> SubarrayPartitioner::stats() const {
   return stats_;
 }
 

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -169,7 +169,7 @@ class SubarrayPartitioner {
       uint64_t memory_budget_var,
       uint64_t memory_budget_validity,
       ThreadPool* compute_tp,
-      stats::Stats* parent_stats);
+      tdb_shared_ptr<stats::Stats> parent_stats);
 
   /** Destructor. */
   ~SubarrayPartitioner();
@@ -330,7 +330,7 @@ class SubarrayPartitioner {
   Subarray* subarray();
 
   /** Returns `stats_`. */
-  stats::Stats* stats() const;
+  tdb_shared_ptr<stats::Stats> stats() const;
 
  private:
   /* ********************************* */
@@ -338,7 +338,7 @@ class SubarrayPartitioner {
   /* ********************************* */
 
   /** The class stats. */
-  stats::Stats* stats_;
+  tdb_shared_ptr<stats::Stats> stats_;
 
   /** The config. */
   const Config* config_;


### PR DESCRIPTION
As part of the work to introduce a base class for Observability (stats, logging etc) for our core classes, we need to unify the interface to stats and logger for all classes. 

For stats we would use sometimes smart pointers and most of the times raw pointers, so this PR is about transitioning every usage of stats to use `tdb_shared_ptr,` in compliance with our goal to eliminate raw pointers as much as possible.

---
TYPE: IMPROVEMENT
DESC: Replace raw with shared_ptr in stats
