### PR TITLE
Clarify error messages for set_data_buffer and set_offset_buffer

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1885,28 +1885,34 @@ Status Query::set_subarray_unsafe(const NDRange& subarray) {
 Status Query::check_buffers_correctness() {
   // Iterate through each attribute
   for (auto& attr : buffer_names()) {
-    if (buffer(attr).buffer_ == nullptr)
-      return logger_->status(Status::QueryError(
-          std::string("Data buffer is not set for " + attr)));
     if (array_schema_->var_size(attr)) {
-      // Var-sized
-      // Check for data buffer under buffer_var
-      bool exists_data = buffer(attr).buffer_var_ != nullptr;
-      bool exists_offset = buffer(attr).buffer_ != nullptr;
-      if ((!exists_data && *buffer(attr).buffer_var_size_ != 0) ||
-          !exists_offset) {
+      // Check for data buffer under buffer_var and offsets buffer under buffer
+      if (type_ == QueryType::READ) {
+        if (buffer(attr).buffer_var_ == nullptr) {
+          return logger_->status(Status::QueryError(
+              std::string("Var-Sized input attribute/dimension '") + attr +
+              "' is not set correctly. \nVar size buffer is not set."));
+        }
+      } else {
+        if (buffer(attr).buffer_var_ == nullptr &&
+            *buffer(attr).buffer_var_size_ != 0) {
+          return logger_->status(Status::QueryError(
+              std::string("Var-Sized input attribute/dimension '") + attr +
+              "' is not set correctly. \nVar size buffer is not set and buffer "
+              "size if not 0."));
+        }
+      }
+      if (buffer(attr).buffer_ == nullptr) {
         return logger_->status(Status::QueryError(
             std::string("Var-Sized input attribute/dimension '") + attr +
-            "' is not set correctly \nOffsets buffer is not set"));
+            "' is not set correctly. \nOffsets buffer is not set."));
       }
     } else {
       // Fixed sized
-      bool exists_data = buffer(attr).buffer_ != nullptr;
-      bool exists_offset = buffer(attr).buffer_var_ != nullptr;
-      if (!exists_data || exists_offset) {
+      if (buffer(attr).buffer_ == nullptr) {
         return logger_->status(Status::QueryError(
             std::string("Fix-Sized input attribute/dimension '") + attr +
-            "' is not set correctly \nOffsets buffer is not set"));
+            "' is not set correctly. \nData buffer is not set."));
       }
     }
     if (array_schema_->is_nullable(attr)) {


### PR DESCRIPTION
A client had a problem with their code telling them their data buffer was not set when it appeared to be set properly. Upon closer inspection, we realized they were using var-sized data and needed to set the offset buffer and were actually just getting a misleading error message. This fix should alleviate further confusion. Note, this change also ensures null buffers are only allowed on write queries. 
[ch11838]

TYPE: IMPROVEMENT
DESC: Clarify error messages in `check_buffers_correctness()`
