### PR TITLE
Add doc and HISTORY entries for fragment_info_get_array_schema{_name}

### DIFF
--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -634,6 +634,10 @@ Fragment Info
     :project: TileDB-C
 .. doxygenfunction:: tiledb_fragment_info_load_with_key
     :project: TileDB-C
+.. doxygenfunction:: tiledb_fragment_info_get_array_schema
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_fragment_info_get_array_schema_name
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_fragment_info_get_fragment_num
     :project: TileDB-C
 .. doxygenfunction:: tiledb_fragment_info_get_fragment_uri


### PR DESCRIPTION
TYPE: IMPROVEMENT
DESC: Add tiledb_fragment_info_get_array_schema_name
TYPE: C_API
DESC: Add tiledb_fragment_info_get_array_schema_name for fetching array name used by fragment
TYPE: CPP_API
DESC: Add FragmentInfo::array_schema_name for fetching array name used by fragment
TYPE: C_API
DESC: Add tiledb_fragment_info_get_array_schema for fetching array schema used by fragment
TYPE: CPP_API
DESC: Add FragmentInfo::array_schema for fetching array schema used by fragment

<long description>

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
