### PR TITLE
Revert "Run github actions on all branches, not just PRs"

### DIFF
--- a/.github/workflows/build-macOS10.14-GCS.yml
+++ b/.github/workflows/build-macOS10.14-GCS.yml
@@ -1,7 +1,13 @@
 name: build-macos-10.14-GCS
 on:
   push:
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
+    branches:
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_GCS: ON

--- a/.github/workflows/build-macOS10.14-S3.yml
+++ b/.github/workflows/build-macOS10.14-S3.yml
@@ -1,7 +1,13 @@
 name: build-macos-10.14-S3
 on:
   push:
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
+    branches:
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_S3: ON

--- a/.github/workflows/build-ubuntu16.04-HDFS.yml
+++ b/.github/workflows/build-ubuntu16.04-HDFS.yml
@@ -1,7 +1,13 @@
 name: build-ubuntu-20.04-HDFS
 on:
   push:
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
+    branches:
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_HDFS: ON

--- a/.github/workflows/build-ubuntu20.04-AZURE.yml
+++ b/.github/workflows/build-ubuntu20.04-AZURE.yml
@@ -1,7 +1,13 @@
 name: build-ubuntu-20.04-AZURE
 on:
   push:
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
+    branches:
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_AZURE: ON

--- a/.github/workflows/build-ubuntu20.04-GCS.yml
+++ b/.github/workflows/build-ubuntu20.04-GCS.yml
@@ -1,7 +1,13 @@
 name: build-ubuntu-20.04-GCS
 on:
   push:
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
+    branches:
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_GCS: ON

--- a/.github/workflows/build-ubuntu20.04-S3.yml
+++ b/.github/workflows/build-ubuntu20.04-S3.yml
@@ -1,7 +1,13 @@
 name: build-ubuntu-20.04-S3
 on:
   push:
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
+    branches:
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_STATIC: OFF

--- a/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
+++ b/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
@@ -1,7 +1,13 @@
 name: build-ubuntu-20.04-SERIALIZATION
 on:
   push:
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
   pull_request:
+    branches:
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
 env:
   TILEDB_SERIALIZATION: ON # NOTE: currently defined directly inline
   CXX: g++


### PR DESCRIPTION
Reverts TileDB-Inc/TileDB#2589 . That changes caused all CI jobs to run twice, not what we want.

TYPE: NO_HISTORY
DESC: NO_HISTORY