### PR TITLE
Unordered reads should be allowed for dense arrays

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1770,7 +1770,8 @@ Status Query::set_layout(Layout layout) {
     return logger_->status(Status::QueryError(
         "Cannot set layout; Hilbert order is not applicable to queries"));
 
-  if (array_schema_->dense() && layout == Layout::UNORDERED) {
+  if (type_ == QueryType::WRITE && array_schema_->dense() &&
+      layout == Layout::UNORDERED) {
     return logger_->status(Status::QueryError(
         "Unordered writes are only possible for sparse arrays"));
   }


### PR DESCRIPTION
#2504 removed support for sparse writes to dense arrays but the conditional check is incorrect and blocks unordered reads also. This PR fixes the checking in `set_subarray`.

---
TYPE: BUG
DESC: Unordered reads should be allowed for dense arrays
