### PR TITLE
Move `Status::*Error` to `Status_*Error`

### DIFF
--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -371,7 +371,7 @@ class PseudoChecksumFilter : public tiledb::sm::Filter {
     }
 
     if (sum != input_sum)
-      return Status::FilterError("Filter error; sum does not match.");
+      return Status_FilterError("Filter error; sum does not match.");
 
     // The output metadata is just a view on the input metadata, skipping the
     // checksum bytes.
@@ -471,7 +471,7 @@ class Add1IncludingMetadataFilter : public tiledb::sm::Filter {
     (void)config;
 
     if (input_metadata->size() != 2 * sizeof(uint32_t))
-      return Status::FilterError("Unexpected input metadata length");
+      return Status_FilterError("Unexpected input metadata length");
 
     uint32_t orig_input_size, orig_md_size;
     RETURN_NOT_OK(input_metadata->read(&orig_input_size, sizeof(uint32_t)));

--- a/test/src/unit-status.cc
+++ b/test/src/unit-status.cc
@@ -38,31 +38,14 @@ using namespace tiledb::common;
 TEST_CASE("Status: Test ok", "[status]") {
   Status st = Status::Ok();
   CHECK(st.ok());
-  st = Status::Error("err msg");
+  st = Status_Error("err msg");
   CHECK(!st.ok());
-}
-
-TEST_CASE("Status: Test code and message", "[status]") {
-  Status ok = Status::Ok();
-  CHECK(StatusCode::Ok == ok.code());
-
-  Status err = Status::Error("err msg");
-  CHECK(StatusCode::Error == err.code());
-  CHECK_THAT(err.message(), Catch::Equals("err msg"));
 }
 
 TEST_CASE("Status: Test to_string", "[status]") {
   Status ok = Status::Ok();
   CHECK_THAT(ok.to_string(), Catch::Equals("Ok"));
 
-  Status err = Status::Error("err msg");
+  Status err = Status_Error("err msg");
   CHECK_THAT(err.to_string(), Catch::Equals("Error: err msg"));
-}
-
-TEST_CASE("Status: Test code_to_string", "[status]") {
-  Status ok = Status::Ok();
-  CHECK_THAT(ok.code_to_string(), Catch::Equals("Ok"));
-
-  Status err = Status::Error("err message");
-  CHECK_THAT(err.code_to_string(), Catch::Equals("Error"));
 }

--- a/test/src/unit-threadpool.cc
+++ b/test/src/unit-threadpool.cc
@@ -86,7 +86,7 @@ TEST_CASE("ThreadPool: Test wait status", "[threadpool]") {
   for (int i = 0; i < 100; i++) {
     results.push_back(pool.execute([&result, i]() {
       result++;
-      return i == 50 ? Status::Error("Generic error") : Status::Ok();
+      return i == 50 ? Status_Error("Generic error") : Status::Ok();
     }));
   }
   REQUIRE(!pool.wait_all(results).ok());

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -106,6 +106,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/logger.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/memory.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/status.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/status_code.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/stdx_string.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/interval/interval.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array.cc

--- a/tiledb/common/CMakeLists.txt
+++ b/tiledb/common/CMakeLists.txt
@@ -42,7 +42,7 @@ set(TILEDB_COMMON_SOURCES ${COMMON_SOURCES} PARENT_SCOPE)
 # `baseline` object library
 #
 add_library(baseline OBJECT
-    logger.cc status.cc governor/governor.cc heap_profiler.cc heap_memory.cc
+    logger.cc status.cc status_code.cc governor/governor.cc heap_profiler.cc heap_memory.cc
 )
 find_package(Spdlog_EP REQUIRED)
 target_link_libraries(baseline PUBLIC spdlog::spdlog)

--- a/tiledb/common/logger.h
+++ b/tiledb/common/logger.h
@@ -433,7 +433,7 @@ inline Status logger_format_from_string(
   else if (format_type_str == "JSON")
     *format_type = Logger::Format::JSON;
   else {
-    return Status::Error("Unsupported logging format: " + format_type_str);
+    return Status_Error("Unsupported logging format: " + format_type_str);
   }
   return Status::Ok();
 }

--- a/tiledb/common/status.cc
+++ b/tiledb/common/status.cc
@@ -48,10 +48,12 @@
 #include "tiledb/common/status.h"
 #include <cassert>
 
-namespace tiledb {
-namespace common {
+namespace tiledb::common {
 
-Status::Status(StatusCode code, const std::string& msg) {
+/**
+ * General constructor for arbitrary status
+ */
+Status::Status(StatusCode code, const std::string_view& msg) {
   assert(code != StatusCode::Ok);
   size_t msg_size = msg.size();
   // assert(msg_size < std::numeric_limits<uint32_t>::max());
@@ -61,7 +63,7 @@ Status::Status(StatusCode code, const std::string& msg) {
   result[4] = static_cast<char>(code);
   int16_t reserved = 0;
   memcpy(result + 5, &reserved, sizeof(reserved));
-  memcpy(result + 7, msg.c_str(), msg_size);
+  memcpy(result + 7, msg.data(), msg_size);
   state_ = result;
 }
 
@@ -74,7 +76,9 @@ const char* Status::copy_state(const char* state) {
 }
 
 std::string Status::to_string() const {
-  std::string result(code_to_string());
+  auto sc =
+      (state_ == nullptr) ? StatusCode::Ok : static_cast<StatusCode>(state_[4]);
+  std::string result = common::to_string(sc);
   if (state_ == nullptr) {
     return result;
   }
@@ -85,164 +89,4 @@ std::string Status::to_string() const {
   return result;
 }
 
-std::string Status::code_to_string() const {
-  if (state_ == nullptr)
-    return "Ok";
-
-  const char* type;
-  switch (code()) {
-    case StatusCode::Ok:
-      type = "Ok";
-      break;
-    case StatusCode::Error:
-      type = "Error";
-      break;
-    case StatusCode::StorageManager:
-      type = "[TileDB::StorageManager] Error";
-      break;
-    case StatusCode::FragmentMetadata:
-      type = "[TileDB::FragmentMetadata] Error";
-      break;
-    case StatusCode::ArraySchema:
-      type = "[TileDB::ArraySchema] Error";
-      break;
-    case StatusCode::Metadata:
-      type = "[TileDB::Metadata] Error";
-      break;
-    case StatusCode::IO:
-      type = "[TileDB::IO] Error";
-      break;
-    case StatusCode::Mem:
-      type = "[TileDB::Mem] Error";
-      break;
-    case StatusCode::GZip:
-      type = "[TileDB::GZip] Error";
-      break;
-    case StatusCode::Compression:
-      type = "[TileDB::Compression] Error";
-      break;
-    case StatusCode::Tile:
-      type = "[TileDB::Tile] Error";
-      break;
-    case StatusCode::TileIO:
-      type = "[TileDB::TileIO] Error";
-      break;
-    case StatusCode::Buffer:
-      type = "[TileDB::Buffer] Error";
-      break;
-    case StatusCode::Query:
-      type = "[TileDB::Query] Error";
-      break;
-    case StatusCode::ValidityVector:
-      type = "[TileDB::ValidityVector] Error";
-      break;
-    case StatusCode::VFS:
-      type = "[TileDB::VFS] Error";
-      break;
-    case StatusCode::ConstBuffer:
-      type = "[TileDB::ConstBuffer] Error";
-      break;
-    case StatusCode::Dimension:
-      type = "[TileDB::Dimension] Error";
-      break;
-    case StatusCode::Domain:
-      type = "[TileDB::Domain] Error";
-      break;
-    case StatusCode::Consolidator:
-      type = "[TileDB::Consolidator] Error";
-      break;
-    case StatusCode::LRUCache:
-      type = "[TileDB::LRUCache] Error";
-      break;
-    case StatusCode::KV:
-      type = "[TileDB::KV] Error";
-      break;
-    case StatusCode::KVItem:
-      type = "[TileDB::KVItem] Error";
-      break;
-    case StatusCode::KVIter:
-      type = "[TileDB::KVIter] Error";
-      break;
-    case StatusCode::Config:
-      type = "[TileDB::Config] Error";
-      break;
-    case StatusCode::Utils:
-      type = "[TileDB::Utils] Error";
-      break;
-    case StatusCode::FS_S3:
-      type = "[TileDB::S3] Error";
-      break;
-    case StatusCode::FS_HDFS:
-      type = "[TileDB::HDFS] Error";
-      break;
-    case StatusCode::FS_MEM:
-      type = "[TileDB::MemFS] Error";
-      break;
-    case StatusCode::Attribute:
-      type = "[TileDB::Attribute] Error";
-      break;
-    case StatusCode::WriteCellSlabIter:
-      type = "[TileDB::WriteCellSlabIter] Error";
-      break;
-    case StatusCode::Reader:
-      type = "[TileDB::Reader] Error";
-      break;
-    case StatusCode::Writer:
-      type = "[TileDB::Writer] Error";
-      break;
-    case StatusCode::PreallocatedBuffer:
-      type = "[TileDB::PreallocatedBuffer] Error";
-      break;
-    case StatusCode::Filter:
-      type = "[TileDB::Filter] Error";
-      break;
-    case StatusCode::Encryption:
-      type = "[TileDB::Encryption] Error";
-      break;
-    case StatusCode::Array:
-      type = "[TileDB::Array] Error";
-      break;
-    case StatusCode::VFSFileHandleError:
-      type = "[TileDB::VFSFileHandle] Error";
-      break;
-    case StatusCode::ContextError:
-      type = "[TileDB::Context] Error";
-      break;
-    case StatusCode::SubarrayError:
-      type = "[TileDB::Subarray] Error";
-      break;
-    case StatusCode::SubarrayPartitionerError:
-      type = "[TileDB::SubarrayPartitioner] Error";
-      break;
-    case StatusCode::RTreeError:
-      type = "[TileDB::RTree] Error";
-      break;
-    case StatusCode::CellSlabIterError:
-      type = "[TileDB::CellSlabIter] Error";
-      break;
-    case StatusCode::RestError:
-      type = "[TileDB::REST] Error";
-      break;
-    case StatusCode::SerializationError:
-      type = "[TileDB::Serialization] Error";
-      break;
-    case StatusCode::ThreadPoolError:
-      type = "[TileDB::ThreadPool] Error";
-      break;
-    case StatusCode::FragmentInfoError:
-      type = "[TileDB::FragmentInfo] Error";
-      break;
-    case StatusCode::DenseTilerError:
-      type = "[TileDB::DenseTiler] Error";
-      break;
-    case StatusCode::QueryConditionError:
-      type = "[TileDB::QueryCondition] Error";
-      break;
-    default:
-      type = "[TileDB::?] Error:";
-  }
-  return std::string(type);
-}
-
-}  // namespace common
-}  // namespace tiledb
+}  // namespace tiledb::common

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -58,6 +58,7 @@
 #include <tuple>
 using std::tuple, std::optional, std::nullopt;
 
+#include "status_code.h"
 #include "tiledb/common/heap_memory.h"
 
 namespace tiledb {
@@ -80,73 +81,6 @@ namespace common {
     }                                \
   } while (false)
 
-#define RETURN_NOT_OK_TUPLE(s)   \
-  do {                           \
-    Status _s = (s);             \
-    if (!_s.ok()) {              \
-      return {_s, std::nullopt}; \
-    }                            \
-  } while (false)
-
-enum class StatusCode : char {
-  Ok,
-  Error,
-  StorageManager,
-  FragmentMetadata,
-  ArraySchema,
-  ArraySchemaEvolution,
-  Metadata,
-  IO,
-  Mem,
-  GZip,
-  Compression,
-  Tile,
-  TileIO,
-  Buffer,
-  Query,
-  ValidityVector,
-  VFS,
-  ConstBuffer,
-  Dimension,
-  Domain,
-  Consolidator,
-  LRUCache,
-  KV,
-  KVItem,
-  KVIter,
-  Config,
-  Utils,
-  FS_S3,
-  FS_AZURE,
-  FS_GCS,
-  FS_HDFS,
-  FS_MEM,
-  Attribute,
-  WriteCellSlabIter,
-  SparseGlobalOrderReaderError,
-  SparseUnorderedWithDupsReaderError,
-  DenseReaderError,
-  Reader,
-  Writer,
-  PreallocatedBuffer,
-  Filter,
-  Encryption,
-  Array,
-  VFSFileHandleError,
-  ContextError,
-  SubarrayError,
-  SubarrayPartitionerError,
-  RTreeError,
-  CellSlabIterError,
-  RestError,
-  SerializationError,
-  ChecksumError,
-  ThreadPoolError,
-  FragmentInfoError,
-  DenseTilerError,
-  QueryConditionError
-};
-
 class Status {
  public:
   /* ********************************* */
@@ -161,7 +95,14 @@ class Status {
   /**
    * General constructor for arbitrary status
    */
-  Status(StatusCode code, const std::string& msg);
+  Status(StatusCode code, const std::string_view& msg);
+
+  /**
+   * General constructor for arbitrary status
+   */
+  Status(StatusCode code, const std::string& msg)
+      : Status(code, std::string_view{msg}) {
+  }
 
   /** Destructor. */
   ~Status() {
@@ -179,286 +120,6 @@ class Status {
     return Status();
   }
 
-  /**  Return a generic Error class Status **/
-  static Status Error(const std::string& msg) {
-    return Status(StatusCode::Error, msg);
-  }
-
-  /** Return a StorageManager error class Status with a given message **/
-  static Status StorageManagerError(const std::string& msg) {
-    return Status(StatusCode::StorageManager, msg);
-  }
-
-  /** Return a FragmentMetadata error class Status with a given message **/
-  static Status FragmentMetadataError(const std::string& msg) {
-    return Status(StatusCode::FragmentMetadata, msg);
-  }
-
-  /** Return a ArraySchema error class Status with a given message **/
-  static Status ArraySchemaError(const std::string& msg) {
-    return Status(StatusCode::ArraySchema, msg);
-  }
-
-  /** Return a ArraySchemaEvolution error class Status with a given message **/
-  static Status ArraySchemaEvolutionError(const std::string& msg) {
-    return Status(StatusCode::ArraySchemaEvolution, msg);
-  }
-
-  /** Return a Metadata error class Status with a given message **/
-  static Status MetadataError(const std::string& msg) {
-    return Status(StatusCode::Metadata, msg);
-  }
-
-  /** Return a IO error class Status with a given message **/
-  static Status IOError(const std::string& msg) {
-    return Status(StatusCode::IO, msg);
-  }
-
-  /** Return a Memory error class Status with a given message **/
-  static Status MemError(const std::string& msg) {
-    return Status(StatusCode::Mem, msg);
-  }
-
-  /** Return a ArrayError error class Status with a given message **/
-  static Status GZipError(const std::string& msg) {
-    return Status(StatusCode::GZip, msg);
-  }
-
-  /** Return a ArrayError error class Status with a given message **/
-  static Status ChecksumError(const std::string& msg) {
-    return Status(StatusCode::ChecksumError, msg);
-  }
-
-  /** Return a ArrayError error class Status with a given message **/
-  static Status CompressionError(const std::string& msg) {
-    return Status(StatusCode::Compression, msg);
-  }
-
-  /** Return a TileError error class Status with a given message **/
-  static Status TileError(const std::string& msg) {
-    return Status(StatusCode::Tile, msg);
-  }
-
-  /** Return a TileIOError error class Status with a given message **/
-  static Status TileIOError(const std::string& msg) {
-    return Status(StatusCode::TileIO, msg);
-  }
-
-  /** Return a BufferError error class Status with a given message **/
-  static Status BufferError(const std::string& msg) {
-    return Status(StatusCode::Buffer, msg);
-  }
-
-  /** Return a QueryError error class Status with a given message **/
-  static Status QueryError(const std::string& msg) {
-    return Status(StatusCode::Query, msg);
-  }
-
-  /** Return a ValidityVectorError error class Status with a given message **/
-  static Status ValidityVectorError(const std::string& msg) {
-    return Status(StatusCode::ValidityVector, msg);
-  }
-
-  /** Return a VFSError error class Status with a given message **/
-  static Status VFSError(const std::string& msg) {
-    return Status(StatusCode::VFS, msg);
-  }
-
-  /** Return a ConstBufferError error class Status with a given message **/
-  static Status ConstBufferError(const std::string& msg) {
-    return Status(StatusCode::ConstBuffer, msg);
-  }
-
-  /** Return a DimensionError error class Status with a given message **/
-  static Status DimensionError(const std::string& msg) {
-    return Status(StatusCode::Dimension, msg);
-  }
-
-  /** Return a DomainError error class Status with a given message **/
-  static Status DomainError(const std::string& msg) {
-    return Status(StatusCode::Domain, msg);
-  }
-
-  /** Return a ConsolidatorError error class Status with a given message **/
-  static Status ConsolidatorError(const std::string& msg) {
-    return Status(StatusCode::Consolidator, msg);
-  }
-
-  /** Return a LRUCacheError error class Status with a given message **/
-  static Status LRUCacheError(const std::string& msg) {
-    return Status(StatusCode::LRUCache, msg);
-  }
-
-  /** Return a KVError error class Status with a given message **/
-  static Status KVError(const std::string& msg) {
-    return Status(StatusCode::KV, msg);
-  }
-
-  /** Return a KVItemError error class Status with a given message **/
-  static Status KVItemError(const std::string& msg) {
-    return Status(StatusCode::KVItem, msg);
-  }
-
-  /** Return a KVIterError error class Status with a given message **/
-  static Status KVIterError(const std::string& msg) {
-    return Status(StatusCode::KVIter, msg);
-  }
-
-  /** Return a ConfigError error class Status with a given message **/
-  static Status ConfigError(const std::string& msg) {
-    return Status(StatusCode::Config, msg);
-  }
-
-  /** Return a UtilsError error class Status with a given message **/
-  static Status UtilsError(const std::string& msg) {
-    return Status(StatusCode::Utils, msg);
-  }
-
-  /** Return a UtilsError error class Status with a given message **/
-  static Status S3Error(const std::string& msg) {
-    return Status(StatusCode::FS_S3, msg);
-  }
-
-  /** Return a UtilsError error class Status with a given message **/
-  static Status AzureError(const std::string& msg) {
-    return Status(StatusCode::FS_AZURE, msg);
-  }
-
-  /** Return a UtilsError error class Status with a given message **/
-  static Status GCSError(const std::string& msg) {
-    return Status(StatusCode::FS_GCS, msg);
-  }
-
-  /** Return a UtilsError error class Status with a given message **/
-  static Status HDFSError(const std::string& msg) {
-    return Status(StatusCode::FS_HDFS, msg);
-  }
-
-  /** Return a MemFSError error class Status with a given message **/
-  static Status MemFSError(const std::string& msg) {
-    return Status(StatusCode::FS_MEM, msg);
-  }
-
-  /** Return a AttributeError error class Status with a given message **/
-  static Status AttributeError(const std::string& msg) {
-    return Status(StatusCode::Attribute, msg);
-  }
-
-  /** Return a WriteCellSlabIterError error class Status with a given message
-   * **/
-  static Status WriteCellSlabIterError(const std::string& msg) {
-    return Status(StatusCode::WriteCellSlabIter, msg);
-  }
-
-  /** Return a SparseGlobalOrderReaderError error class Status with a given
-   * message **/
-  static Status SparseGlobalOrderReaderError(const std::string& msg) {
-    return Status(StatusCode::SparseGlobalOrderReaderError, msg);
-  }
-
-  /** Return a SparseUnorderedWithDupsReaderError error class Status with a
-   * given message **/
-  static Status SparseUnorderedWithDupsReaderError(const std::string& msg) {
-    return Status(StatusCode::SparseUnorderedWithDupsReaderError, msg);
-  }
-
-  /** Return a DenseReaderError error class Status with a given message **/
-  static Status DenseReaderError(const std::string& msg) {
-    return Status(StatusCode::DenseReaderError, msg);
-  }
-
-  /** Return a ReaderError error class Status with a given message **/
-  static Status ReaderError(const std::string& msg) {
-    return Status(StatusCode::Reader, msg);
-  }
-
-  /** Return a WriterError error class Status with a given message **/
-  static Status WriterError(const std::string& msg) {
-    return Status(StatusCode::Writer, msg);
-  }
-
-  /** Return a PreallocatedBufferError error class Status with a given message
-   * **/
-  static Status PreallocatedBufferError(const std::string& msg) {
-    return Status(StatusCode::PreallocatedBuffer, msg);
-  }
-
-  /** Return a FilterError error class Status with a given message **/
-  static Status FilterError(const std::string& msg) {
-    return Status(StatusCode::Filter, msg);
-  }
-
-  /** Return a EncryptionError error class Status with a given message **/
-  static Status EncryptionError(const std::string& msg) {
-    return Status(StatusCode::Encryption, msg);
-  }
-
-  /** Return an ArrayError error class Status with a given message **/
-  static Status ArrayError(const std::string& msg) {
-    return Status(StatusCode::Array, msg);
-  }
-
-  /** Return a VFSFileHandle error class Status with a given message **/
-  static Status VFSFileHandleError(const std::string& msg) {
-    return Status(StatusCode::VFSFileHandleError, msg);
-  }
-
-  /** Return a ContextError error class Status with a given message **/
-  static Status ContextError(const std::string& msg) {
-    return Status(StatusCode::ContextError, msg);
-  }
-
-  /** Return a SubarrayError error class Status with a given message **/
-  static Status SubarrayError(const std::string& msg) {
-    return Status(StatusCode::SubarrayError, msg);
-  }
-
-  /** Return a SubarrayPartitionerError error class Status with a given message
-   * **/
-  static Status SubarrayPartitionerError(const std::string& msg) {
-    return Status(StatusCode::SubarrayPartitionerError, msg);
-  }
-
-  /** Return a RTreeError error class Status with a given message **/
-  static Status RTreeError(const std::string& msg) {
-    return Status(StatusCode::RTreeError, msg);
-  }
-
-  /** Return a CellSlabIterError error class Status with a given message **/
-  static Status CellSlabIterError(const std::string& msg) {
-    return Status(StatusCode::CellSlabIterError, msg);
-  }
-
-  /** Return a RestError error class Status with a given message **/
-  static Status RestError(const std::string& msg) {
-    return Status(StatusCode::RestError, msg);
-  }
-
-  /** Return a SerializationError error class Status with a given message **/
-  static Status SerializationError(const std::string& msg) {
-    return Status(StatusCode::SerializationError, msg);
-  }
-
-  /** Return a ThreadPoolError error class Status with a given message **/
-  static Status ThreadPoolError(const std::string& msg) {
-    return Status(StatusCode::ThreadPoolError, msg);
-  }
-
-  /** Return a FragmentInfoError error class Status with a given message **/
-  static Status FragmentInfoError(const std::string& msg) {
-    return Status(StatusCode::FragmentInfoError, msg);
-  }
-
-  /** Return a DenseTilerError error class Status with a given message **/
-  static Status DenseTilerError(const std::string& msg) {
-    return Status(StatusCode::DenseTilerError, msg);
-  }
-
-  /** Return a QueryConditionError error class Status with a given message **/
-  static Status QueryConditionError(const std::string& msg) {
-    return Status(StatusCode::QueryConditionError, msg);
-  }
-
   /** Returns true iff the status indicates success **/
   bool ok() const {
     return (state_ == nullptr);
@@ -469,16 +130,6 @@ class Status {
    * printing.  Return "Ok" for success.
    */
   std::string to_string() const;
-
-  /** Return a string representation of the status code **/
-  std::string code_to_string() const;
-
-  /** Return the status code of this Status object **/
-  StatusCode code() const {
-    return (
-        (state_ == nullptr) ? StatusCode::Ok :
-                              static_cast<StatusCode>(state_[4]));
-  }
 
   /** Return an std::string copy of the Status message **/
   std::string message() const {
@@ -525,6 +176,218 @@ inline void Status::operator=(const Status& s) {
   }
 }
 
+inline Status Status_Error(const std::string& msg) {
+  return {StatusCode::Error, msg};
+};
+
+/** Return a StorageManager error class Status with a given message **/
+inline Status Status_StorageManagerError(const std::string& msg) {
+  return Status(StatusCode::StorageManager, msg);
+}
+/**  Return a success status **/
+inline Status Status_Ok() {
+  return Status();
+}
+/** Return a FragmentMetadata error class Status with a given message **/
+inline Status Status_FragmentMetadataError(const std::string& msg) {
+  return Status(StatusCode::FragmentMetadata, msg);
+}
+/** Return a ArraySchema error class Status with a given message **/
+inline Status Status_ArraySchemaError(const std::string& msg) {
+  return Status(StatusCode::ArraySchema, msg);
+}
+/** Return a ArraySchemaEvolution error class Status with a given message **/
+inline Status Status_ArraySchemaEvolutionError(const std::string& msg) {
+  return Status(StatusCode::ArraySchemaEvolution, msg);
+}
+/** Return a Metadata error class Status with a given message **/
+inline Status Status_MetadataError(const std::string& msg) {
+  return Status(StatusCode::Metadata, msg);
+}
+/** Return a IO error class Status with a given message **/
+inline Status Status_IOError(const std::string& msg) {
+  return Status(StatusCode::IO, msg);
+}
+/** Return a GZip error class Status with a given message **/
+inline Status Status_GZipError(const std::string& msg) {
+  return Status(StatusCode::GZip, msg);
+}
+/** Return a ChecksumError error class Status with a given message **/
+inline Status Status_ChecksumError(const std::string& msg) {
+  return Status(StatusCode::ChecksumError, msg);
+}
+/** Return a Compression error class Status with a given message **/
+inline Status Status_CompressionError(const std::string& msg) {
+  return Status(StatusCode::Compression, msg);
+}
+/** Return a Tile error class Status with a given message **/
+inline Status Status_TileError(const std::string& msg) {
+  return Status(StatusCode::Tile, msg);
+}
+/** Return a TileIO error class Status with a given message **/
+inline Status Status_TileIOError(const std::string& msg) {
+  return Status(StatusCode::TileIO, msg);
+}
+/** Return a Buffer error class Status with a given message **/
+inline Status Status_BufferError(const std::string& msg) {
+  return Status(StatusCode::Buffer, msg);
+}
+/** Return a Query error class Status with a given message **/
+inline Status Status_QueryError(const std::string& msg) {
+  return Status(StatusCode::Query, msg);
+}
+/** Return a ValidityVector error class Status with a given message **/
+inline Status Status_ValidityVectorError(const std::string& msg) {
+  return Status(StatusCode::ValidityVector, msg);
+}
+/** Return a Status_VFSError error class Status with a given message **/
+inline Status Status_VFSError(const std::string& msg) {
+  return Status(StatusCode::VFS, msg);
+}
+/** Return a Dimension error class Status with a given message **/
+inline Status Status_DimensionError(const std::string& msg) {
+  return Status(StatusCode::Dimension, msg);
+}
+/** Return a Domain error class Status with a given message **/
+inline Status Status_DomainError(const std::string& msg) {
+  return Status(StatusCode::Domain, msg);
+}
+/** Return a Consolidator error class Status with a given message **/
+inline Status Status_ConsolidatorError(const std::string& msg) {
+  return Status(StatusCode::Consolidator, msg);
+}
+/** Return a LRUCache error class Status with a given message **/
+inline Status Status_LRUCacheError(const std::string& msg) {
+  return Status(StatusCode::LRUCache, msg);
+}
+/** Return a Config error class Status with a given message **/
+inline Status Status_ConfigError(const std::string& msg) {
+  return Status(StatusCode::Config, msg);
+}
+/** Return a Utils error class Status with a given message **/
+inline Status Status_UtilsError(const std::string& msg) {
+  return Status(StatusCode::Utils, msg);
+}
+/** Return a FS_S3 error class Status with a given message **/
+inline Status Status_S3Error(const std::string& msg) {
+  return Status(StatusCode::FS_S3, msg);
+}
+/** Return a FS_AZURE error class Status with a given message **/
+inline Status Status_AzureError(const std::string& msg) {
+  return Status(StatusCode::FS_AZURE, msg);
+}
+/** Return a FS_GCS error class Status with a given message **/
+inline Status Status_GCSError(const std::string& msg) {
+  return Status(StatusCode::FS_GCS, msg);
+}
+/** Return a FS_HDFS error class Status with a given message **/
+inline Status Status_HDFSError(const std::string& msg) {
+  return Status(StatusCode::FS_HDFS, msg);
+}
+/** Return a FS_MEM error class Status with a given message **/
+inline Status Status_MemFSError(const std::string& msg) {
+  return Status(StatusCode::FS_MEM, msg);
+}
+/** Return a Attribute error class Status with a given message **/
+inline Status Status_AttributeError(const std::string& msg) {
+  return Status(StatusCode::Attribute, msg);
+}
+/** Return a Status_SparseGlobalOrderReaderError error class Status with a
+ * given message **/
+inline Status Status_SparseGlobalOrderReaderError(const std::string& msg) {
+  return Status(StatusCode::SparseGlobalOrderReaderError, msg);
+}
+/** Return a Status_SparseUnorderedWithDupsReaderError error class Status with
+ * a given message **/
+inline Status Status_SparseUnorderedWithDupsReaderError(const std::string& msg) {
+  return Status(StatusCode::SparseUnorderedWithDupsReaderError, msg);
+}
+/** Return a Status_DenseReaderError error class Status with a given message
+ * **/
+inline Status Status_DenseReaderError(const std::string& msg) {
+  return Status(StatusCode::DenseReaderError, msg);
+}
+/** Return a Reader error class Status with a given message **/
+inline Status Status_ReaderError(const std::string& msg) {
+  return Status(StatusCode::Reader, msg);
+}
+/** Return a Writer error class Status with a given message **/
+inline Status Status_WriterError(const std::string& msg) {
+  return Status(StatusCode::Writer, msg);
+}
+/** Return a PreallocatedBuffer error class Status with a given message
+ * **/
+inline Status Status_PreallocatedBufferError(const std::string& msg) {
+  return Status(StatusCode::PreallocatedBuffer, msg);
+}
+/** Return a Status_FilterError error class Status with a given message **/
+inline Status Status_FilterError(const std::string& msg) {
+  return Status(StatusCode::Filter, msg);
+}
+/** Return a Encryption error class Status with a given message **/
+inline Status Status_EncryptionError(const std::string& msg) {
+  return Status(StatusCode::Encryption, msg);
+}
+/** Return an Array error class Status with a given message **/
+inline Status Status_ArrayError(const std::string& msg) {
+  return Status(StatusCode::Array, msg);
+}
+/** Return a VFSFileHandle error class Status with a given message **/
+inline Status Status_VFSFileHandleError(const std::string& msg) {
+  return Status(StatusCode::VFSFileHandleError, msg);
+}
+/** Return a Status_ContextError error class Status with a given message **/
+inline Status Status_ContextError(const std::string& msg) {
+  return Status(StatusCode::ContextError, msg);
+}
+/** Return a Status_SubarrayError error class Status with a given message **/
+inline Status Status_SubarrayError(const std::string& msg) {
+  return Status(StatusCode::SubarrayError, msg);
+}
+/** Return a Status_SubarrayPartitionerError error class Status with a given
+ * message
+ * **/
+inline Status Status_SubarrayPartitionerError(const std::string& msg) {
+  return Status(StatusCode::SubarrayPartitionerError, msg);
+}
+/** Return a Status_RTreeError error class Status with a given message **/
+inline Status Status_RTreeError(const std::string& msg) {
+  return Status(StatusCode::RTreeError, msg);
+}
+/** Return a Status_CellSlabIterError error class Status with a given message
+ * **/
+inline Status Status_CellSlabIterError(const std::string& msg) {
+  return Status(StatusCode::CellSlabIterError, msg);
+}
+/** Return a Status_RestError error class Status with a given message **/
+inline Status Status_RestError(const std::string& msg) {
+  return Status(StatusCode::RestError, msg);
+}
+/** Return a Status_SerializationError error class Status with a given message
+ * **/
+inline Status Status_SerializationError(const std::string& msg) {
+  return Status(StatusCode::SerializationError, msg);
+}
+/** Return a Status_ThreadPoolError error class Status with a given message
+ * **/
+inline Status Status_ThreadPoolError(const std::string& msg) {
+  return Status(StatusCode::ThreadPoolError, msg);
+}
+/** Return a Status_FragmentInfoError error class Status with a given message
+ * **/
+inline Status Status_FragmentInfoError(const std::string& msg) {
+  return Status(StatusCode::FragmentInfoError, msg);
+}
+/** Return a Status_DenseTilerError error class Status with a given message
+ * **/
+inline Status Status_DenseTilerError(const std::string& msg) {
+  return Status(StatusCode::DenseTilerError, msg);
+}
+/** Return a Status_QueryConditionError error class Status with a given
+ * message **/
+inline Status Status_QueryConditionError(const std::string& msg) {
+  return Status(StatusCode::QueryConditionError, msg);
+}
 }  // namespace common
 }  // namespace tiledb
 

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -81,6 +81,14 @@ namespace common {
     }                                \
   } while (false)
 
+#define RETURN_NOT_OK_TUPLE(s)   \
+  do {                           \
+    Status _s = (s);             \
+    if (!_s.ok()) {              \
+      return {_s, std::nullopt}; \
+    }                            \
+  } while (false)
+
 class Status {
  public:
   /* ********************************* */

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -299,7 +299,8 @@ inline Status Status_SparseGlobalOrderReaderError(const std::string& msg) {
 }
 /** Return a Status_SparseUnorderedWithDupsReaderError error class Status with
  * a given message **/
-inline Status Status_SparseUnorderedWithDupsReaderError(const std::string& msg) {
+inline Status Status_SparseUnorderedWithDupsReaderError(
+    const std::string& msg) {
   return Status(StatusCode::SparseUnorderedWithDupsReaderError, msg);
 }
 /** Return a Status_DenseReaderError error class Status with a given message

--- a/tiledb/common/status_code.cc
+++ b/tiledb/common/status_code.cc
@@ -1,0 +1,116 @@
+//
+// Created by EH on 11/6/2021.
+//
+
+#include "status_code.h"
+
+namespace tiledb::common {
+
+std::string_view to_string_view(const StatusCode& sc) {
+  switch (sc) {
+    case StatusCode::Ok:
+      return "Ok";
+    case StatusCode::Error:
+      return "Error";
+    case StatusCode::StorageManager:
+      return "[TileDB::StorageManager] Error";
+    case StatusCode::FragmentMetadata:
+      return "[TileDB::FragmentMetadata] Error";
+    case StatusCode::ArraySchema:
+      return "[TileDB::ArraySchema] Error";
+    case StatusCode::Metadata:
+      return "[TileDB::Metadata] Error";
+    case StatusCode::IO:
+      return "[TileDB::IO] Error";
+    case StatusCode::Mem:
+      return "[TileDB::Mem] Error";
+    case StatusCode::GZip:
+      return "[TileDB::GZip] Error";
+    case StatusCode::Compression:
+      return "[TileDB::Compression] Error";
+    case StatusCode::Tile:
+      return "[TileDB::Tile] Error";
+    case StatusCode::TileIO:
+      return "[TileDB::TileIO] Error";
+    case StatusCode::Buffer:
+      return "[TileDB::Buffer] Error";
+    case StatusCode::Query:
+      return "[TileDB::Query] Error";
+    case StatusCode::ValidityVector:
+      return "[TileDB::ValidityVector] Error";
+    case StatusCode::VFS:
+      return "[TileDB::VFS] Error";
+    case StatusCode::ConstBuffer:
+      return "[TileDB::ConstBuffer] Error";
+    case StatusCode::Dimension:
+      return "[TileDB::Dimension] Error";
+    case StatusCode::Domain:
+      return "[TileDB::Domain] Error";
+    case StatusCode::Consolidator:
+      return "[TileDB::Consolidator] Error";
+    case StatusCode::LRUCache:
+      return "[TileDB::LRUCache] Error";
+    case StatusCode::KV:
+      return "[TileDB::KV] Error";
+    case StatusCode::KVItem:
+      return "[TileDB::KVItem] Error";
+    case StatusCode::KVIter:
+      return "[TileDB::KVIter] Error";
+    case StatusCode::Config:
+      return "[TileDB::Config] Error";
+    case StatusCode::Utils:
+      return "[TileDB::Utils] Error";
+    case StatusCode::FS_S3:
+      return "[TileDB::S3] Error";
+    case StatusCode::FS_HDFS:
+      return "[TileDB::HDFS] Error";
+    case StatusCode::Attribute:
+      return "[TileDB::Attribute] Error";
+    case StatusCode::WriteCellSlabIter:
+      return "[TileDB::WriteCellSlabIter] Error";
+    case StatusCode::Reader:
+      return "[TileDB::Reader] Error";
+    case StatusCode::Writer:
+      return "[TileDB::Writer] Error";
+    case StatusCode::PreallocatedBuffer:
+      return "[TileDB::PreallocatedBuffer] Error";
+    case StatusCode::Filter:
+      return "[TileDB::Filter] Error";
+    case StatusCode::Encryption:
+      return "[TileDB::Encryption] Error";
+    case StatusCode::Array:
+      return "[TileDB::Array] Error";
+    case StatusCode::VFSFileHandleError:
+      return "[TileDB::VFSFileHandle] Error";
+    case StatusCode::ContextError:
+      return "[TileDB::Context] Error";
+    case StatusCode::SubarrayError:
+      return "[TileDB::Subarray] Error";
+    case StatusCode::SubarrayPartitionerError:
+      return "[TileDB::SubarrayPartitioner] Error";
+    case StatusCode::RTreeError:
+      return "[TileDB::RTree] Error";
+    case StatusCode::CellSlabIterError:
+      return "[TileDB::CellSlabIter] Error";
+    case StatusCode::RestError:
+      return "[TileDB::REST] Error";
+    case StatusCode::SerializationError:
+      return "[TileDB::Serialization] Error";
+    case StatusCode::ThreadPoolError:
+      return "[TileDB::ThreadPool] Error";
+    case StatusCode::FragmentInfoError:
+      return "[TileDB::FragmentInfo] Error";
+    case StatusCode::DenseTilerError:
+      return "[TileDB::DenseTiler] Error";
+    case StatusCode::QueryConditionError:
+      return "[TileDB::QueryCondition] Error";
+    default:
+      return "[TileDB::?] Error:";
+  }
+}
+
+std::string to_string(const StatusCode& sc) {
+  return std::string(to_string_view(sc));
+}
+
+}  // namespace tiledb::common

--- a/tiledb/common/status_code.cc
+++ b/tiledb/common/status_code.cc
@@ -1,6 +1,30 @@
-//
-// Created by EH on 11/6/2021.
-//
+/**
+ * @file tiledb/common/status_code.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #include "status_code.h"
 

--- a/tiledb/common/status_code.h
+++ b/tiledb/common/status_code.h
@@ -1,0 +1,105 @@
+/**
+ * @file status_code.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef TILEDB_STATUS_CODE_H
+#define TILEDB_STATUS_CODE_H
+
+#include <string>
+
+namespace tiledb::common {
+
+/**
+ * StatusCode is a legacy identifier for the area of code where an error arises.
+ *
+ * This class has exactly one use: to identify a string constant used to print
+ * status messages. It could have been `const char*` for all it does.
+ */
+enum class StatusCode : char {
+  Ok,
+  Error,
+  StorageManager,
+  FragmentMetadata,
+  ArraySchema,
+  ArraySchemaEvolution,
+  Metadata,
+  IO,
+  Mem,
+  GZip,
+  Compression,
+  Tile,
+  TileIO,
+  Buffer,
+  Query,
+  ValidityVector,
+  VFS,
+  ConstBuffer,
+  Dimension,
+  Domain,
+  Consolidator,
+  LRUCache,
+  KV,
+  KVItem,
+  KVIter,
+  Config,
+  Utils,
+  FS_S3,
+  FS_AZURE,
+  FS_GCS,
+  FS_HDFS,
+  FS_MEM,
+  Attribute,
+  WriteCellSlabIter,
+  SparseGlobalOrderReaderError,
+  SparseUnorderedWithDupsReaderError,
+  DenseReaderError,
+  Reader,
+  Writer,
+  PreallocatedBuffer,
+  Filter,
+  Encryption,
+  Array,
+  VFSFileHandleError,
+  ContextError,
+  SubarrayError,
+  SubarrayPartitionerError,
+  RTreeError,
+  CellSlabIterError,
+  RestError,
+  SerializationError,
+  ChecksumError,
+  ThreadPoolError,
+  FragmentInfoError,
+  DenseTilerError,
+  QueryConditionError
+};
+
+std::string to_string(const StatusCode& sc);
+std::string_view to_string_view(const StatusCode& sc);
+
+}  // namespace tiledb::common
+
+#endif  // TILEDB_STATUS_CODE_H

--- a/tiledb/common/thread_pool/thread_pool.cc
+++ b/tiledb/common/thread_pool/thread_pool.cc
@@ -213,8 +213,7 @@ std::vector<Status> ThreadPool::wait_all_status(std::vector<Task>& tasks) {
   for (auto& task : tasks) {
     if (!task.valid()) {
       LOG_ERROR("Waiting on invalid task future.");
-      statuses.push_back(
-          Status_ThreadPoolError("Invalid task future"));
+      statuses.push_back(Status_ThreadPoolError("Invalid task future"));
     } else {
       Status status = wait_or_work(std::move(task));
       if (!status.ok()) {

--- a/tiledb/common/thread_pool/thread_pool.cc
+++ b/tiledb/common/thread_pool/thread_pool.cc
@@ -58,7 +58,7 @@ ThreadPool::~ThreadPool() {
 
 Status ThreadPool::init(const uint64_t concurrency_level) {
   if (concurrency_level == 0) {
-    return Status::ThreadPoolError(
+    return Status_ThreadPoolError(
         "Unable to initialize a thread pool with a concurrency level of 0.");
   }
 
@@ -72,7 +72,7 @@ Status ThreadPool::init(const uint64_t concurrency_level) {
     try {
       threads_.emplace_back([this]() { worker(*this); });
     } catch (const std::exception& e) {
-      st = Status::ThreadPoolError(
+      st = Status_ThreadPoolError(
           "Error initializing thread pool of concurrency level " +
           std::to_string(concurrency_level) + "; " + e.what());
       LOG_STATUS(st);
@@ -213,7 +213,8 @@ std::vector<Status> ThreadPool::wait_all_status(std::vector<Task>& tasks) {
   for (auto& task : tasks) {
     if (!task.valid()) {
       LOG_ERROR("Waiting on invalid task future.");
-      statuses.push_back(Status::ThreadPoolError("Invalid task future"));
+      statuses.push_back(
+          Status_ThreadPoolError("Invalid task future"));
     } else {
       Status status = wait_or_work(std::move(task));
       if (!status.ok()) {

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -130,11 +130,11 @@ Status Array::open_without_fragments(
   std::unique_lock<std::mutex> lck(mtx_);
 
   if (is_open_)
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         "Cannot open array without fragments; Array already open"));
 
   if (remote_ && encryption_type != EncryptionType::NO_ENCRYPTION)
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         "Cannot open array; encrypted remote arrays are not supported."));
 
   // Copy the key bytes.
@@ -148,7 +148,7 @@ Status Array::open_without_fragments(
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return LOG_STATUS(Status::ArrayError(
+      return LOG_STATUS(Status_ArrayError(
           "Cannot open array; remote array with no REST client."));
     RETURN_NOT_OK(rest_client->get_array_schema_from_rest(
         array_uri_, &array_schema_latest_));
@@ -202,8 +202,7 @@ Status Array::open(
   std::unique_lock<std::mutex> lck(mtx_);
 
   if (is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot open array; Array already open"));
+    return LOG_STATUS(Status_ArrayError("Cannot open array; Array already open"));
 
   std::string encryption_key_from_cfg;
   if (!encryption_key) {
@@ -238,7 +237,7 @@ Status Array::open(
   }
 
   if (remote_ && encryption_type != EncryptionType::NO_ENCRYPTION)
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         "Cannot open array; encrypted remote arrays are not supported."));
 
   // Copy the key bytes.
@@ -264,7 +263,7 @@ Status Array::open(
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return LOG_STATUS(Status::ArrayError(
+      return LOG_STATUS(Status_ArrayError(
           "Cannot open array; remote array with no REST client."));
     RETURN_NOT_OK(rest_client->get_array_schema_from_rest(
         array_uri_, &array_schema_latest_));
@@ -320,7 +319,7 @@ Status Array::close() {
       metadata_loaded_ = true;
       auto rest_client = storage_manager_->rest_client();
       if (rest_client == nullptr)
-        return LOG_STATUS(Status::ArrayError(
+        return LOG_STATUS(Status_ArrayError(
             "Error closing array; remote array with no REST client."));
       RETURN_NOT_OK(rest_client->post_array_metadata_to_rest(
           array_uri_, timestamp_start_, timestamp_end_opened_at_, this));
@@ -369,8 +368,8 @@ Status Array::get_array_schema(ArraySchema** array_schema) const {
 
   // Error if the array is not open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get array schema; Array is not open"));
+    return LOG_STATUS(Status_ArrayError(
+        "Cannot get array schema; Array is not open"));
 
   *array_schema = array_schema_latest_;
 
@@ -382,8 +381,7 @@ Status Array::get_query_type(QueryType* query_type) const {
 
   // Error if the array is not open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get query_type; Array is not open"));
+    return LOG_STATUS(Status_ArrayError("Cannot get query_type; Array is not open"));
 
   *query_type = query_type_;
 
@@ -395,29 +393,27 @@ Status Array::get_max_buffer_size(
   std::unique_lock<std::mutex> lck(mtx_);
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get max buffer size; Array is not open"));
+    return LOG_STATUS(Status_ArrayError(
+        "Cannot get max buffer size; Array is not open"));
 
   // Error if the array was not opened in read mode
   if (query_type_ != QueryType::READ)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get max buffer size; "
-                           "Array was not opened in read mode"));
+    return LOG_STATUS(Status_ArrayError("Cannot get max buffer size; "
+                                  "Array was not opened in read mode"));
 
   // Check if name is null
   if (name == nullptr)
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         "Cannot get max buffer size; Attribute/Dimension name is null"));
 
   // Not applicable to heterogeneous domains
   if (!array_schema_latest_->domain()->all_dims_same_type())
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get max buffer size; Function not "
-                           "applicable to heterogeneous domains"));
+    return LOG_STATUS(Status_ArrayError("Cannot get max buffer size; Function not "
+                                  "applicable to heterogeneous domains"));
 
   // Not applicable to variable-sized dimensions
   if (!array_schema_latest_->domain()->all_dims_fixed())
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         "Cannot get max buffer size; Function not "
         "applicable to domains with variable-sized dimensions"));
 
@@ -427,13 +423,13 @@ Status Array::get_max_buffer_size(
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         std::string("Cannot get max buffer size; Attribute/Dimension '") +
         name + "' does not exist"));
 
   // Check if attribute/dimension is fixed sized
   if (array_schema_latest_->var_size(name))
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         std::string("Cannot get max buffer size; Attribute/Dimension '") +
         name + "' is var-sized"));
 
@@ -456,29 +452,27 @@ Status Array::get_max_buffer_size(
 
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get max buffer size; Array is not open"));
+    return LOG_STATUS(Status_ArrayError(
+        "Cannot get max buffer size; Array is not open"));
 
   // Error if the array was not opened in read mode
   if (query_type_ != QueryType::READ)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get max buffer size; "
-                           "Array was not opened in read mode"));
+    return LOG_STATUS(Status_ArrayError("Cannot get max buffer size; "
+                                  "Array was not opened in read mode"));
 
   // Check if name is null
   if (name == nullptr)
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         "Cannot get max buffer size; Attribute/Dimension name is null"));
 
   // Not applicable to heterogeneous domains
   if (!array_schema_latest_->domain()->all_dims_same_type())
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get max buffer size; Function not "
-                           "applicable to heterogeneous domains"));
+    return LOG_STATUS(Status_ArrayError("Cannot get max buffer size; Function not "
+                                  "applicable to heterogeneous domains"));
 
   // Not applicable to variable-sized dimensions
   if (!array_schema_latest_->domain()->all_dims_fixed())
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         "Cannot get max buffer size; Function not "
         "applicable to domains with variable-sized dimensions"));
 
@@ -487,13 +481,13 @@ Status Array::get_max_buffer_size(
   // Check if attribute/dimension exists
   auto it = last_max_buffer_sizes_.find(name);
   if (it == last_max_buffer_sizes_.end())
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         std::string("Cannot get max buffer size; Attribute/Dimension '") +
         name + "' does not exist"));
 
   // Check if attribute/dimension is var-sized
   if (!array_schema_latest_->var_size(name))
-    return LOG_STATUS(Status::ArrayError(
+    return LOG_STATUS(Status_ArrayError(
         std::string("Cannot get max buffer size; Attribute/Dimension '") +
         name + "' is fixed-sized"));
 
@@ -524,13 +518,12 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   std::unique_lock<std::mutex> lck(mtx_);
 
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot reopen array; Array is not open"));
+    return LOG_STATUS(Status_ArrayError("Cannot reopen array; Array is not open"));
 
   if (query_type_ != QueryType::READ)
     return LOG_STATUS(
-        Status::ArrayError("Cannot reopen array; Array was "
-                           "not opened in read mode"));
+        Status_ArrayError("Cannot reopen array; Array was "
+                                  "not opened in read mode"));
 
   clear_last_max_buffer_sizes();
 
@@ -616,19 +609,18 @@ Status Array::set_uri_serialized(const std::string& uri) {
 Status Array::delete_metadata(const char* key) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot delete metadata. Array is not open"));
+    return LOG_STATUS(Status_ArrayError("Cannot delete metadata. Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::WRITE)
     return LOG_STATUS(
-        Status::ArrayError("Cannot delete metadata. Array was "
-                           "not opened in write mode"));
+        Status_ArrayError("Cannot delete metadata. Array was "
+                                  "not opened in write mode"));
 
   // Check if key is null
   if (key == nullptr)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot delete metadata. Key cannot be null"));
+    return LOG_STATUS(Status_ArrayError(
+        "Cannot delete metadata. Key cannot be null"));
 
   RETURN_NOT_OK(metadata_.del(key));
 
@@ -642,24 +634,22 @@ Status Array::put_metadata(
     const void* value) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot put metadata; Array is not open"));
+    return LOG_STATUS(Status_ArrayError("Cannot put metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::WRITE)
     return LOG_STATUS(
-        Status::ArrayError("Cannot put metadata; Array was "
-                           "not opened in write mode"));
+        Status_ArrayError("Cannot put metadata; Array was "
+                                  "not opened in write mode"));
 
   // Check if key is null
   if (key == nullptr)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot put metadata; Key cannot be null"));
+    return LOG_STATUS(Status_ArrayError("Cannot put metadata; Key cannot be null"));
 
   // Check if value type is ANY
   if (value_type == Datatype::ANY)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot put metadata; Value type cannot be ANY"));
+    return LOG_STATUS(Status_ArrayError(
+        "Cannot put metadata; Value type cannot be ANY"));
 
   RETURN_NOT_OK(metadata_.put(key, value_type, value_num, value));
 
@@ -673,19 +663,17 @@ Status Array::get_metadata(
     const void** value) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get metadata; Array is not open"));
+    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::READ)
     return LOG_STATUS(
-        Status::ArrayError("Cannot get metadata; Array was "
-                           "not opened in read mode"));
+        Status_ArrayError("Cannot get metadata; Array was "
+                                  "not opened in read mode"));
 
   // Check if key is null
   if (key == nullptr)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get metadata; Key cannot be null"));
+    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Key cannot be null"));
 
   // Load array metadata, if not loaded yet
   if (!metadata_loaded_)
@@ -705,14 +693,13 @@ Status Array::get_metadata(
     const void** value) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get metadata; Array is not open"));
+    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::READ)
     return LOG_STATUS(
-        Status::ArrayError("Cannot get metadata; Array was "
-                           "not opened in read mode"));
+        Status_ArrayError("Cannot get metadata; Array was "
+                                  "not opened in read mode"));
 
   // Load array metadata, if not loaded yet
   if (!metadata_loaded_)
@@ -727,14 +714,13 @@ Status Array::get_metadata(
 Status Array::get_metadata_num(uint64_t* num) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get number of metadata; Array is not open"));
+    return LOG_STATUS(Status_ArrayError(
+        "Cannot get number of metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::READ)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get number of metadata; Array was "
-                           "not opened in read mode"));
+    return LOG_STATUS(Status_ArrayError("Cannot get number of metadata; Array was "
+                                  "not opened in read mode"));
 
   // Load array metadata, if not loaded yet
   if (!metadata_loaded_)
@@ -749,19 +735,17 @@ Status Array::has_metadata_key(
     const char* key, Datatype* value_type, bool* has_key) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get metadata; Array is not open"));
+    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::READ)
     return LOG_STATUS(
-        Status::ArrayError("Cannot get metadata; Array was "
-                           "not opened in read mode"));
+        Status_ArrayError("Cannot get metadata; Array was "
+                                  "not opened in read mode"));
 
   // Check if key is null
   if (key == nullptr)
-    return LOG_STATUS(
-        Status::ArrayError("Cannot get metadata; Key cannot be null"));
+    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Key cannot be null"));
 
   // Load array metadata, if not loaded yet
   if (!metadata_loaded_)
@@ -812,9 +796,9 @@ void Array::clear_last_max_buffer_sizes() {
 Status Array::compute_max_buffer_sizes(const void* subarray) {
   // Applicable only to domains where all dimensions have the same type
   if (!array_schema_latest_->domain()->all_dims_same_type())
-    return LOG_STATUS(
-        Status::ArrayError("Cannot compute max buffer sizes; Inapplicable when "
-                           "dimension domains have different types"));
+    return LOG_STATUS(Status_ArrayError(
+        "Cannot compute max buffer sizes; Inapplicable when "
+        "dimension domains have different types"));
 
   // Allocate space for max buffer sizes subarray
   auto dim_num = array_schema_latest_->dim_num();
@@ -857,7 +841,7 @@ Status Array::compute_max_buffer_sizes(
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return LOG_STATUS(Status::ArrayError(
+      return LOG_STATUS(Status_ArrayError(
           "Cannot get max buffer sizes; remote array with no REST client."));
     return rest_client->get_array_max_buffer_sizes(
         array_uri_, array_schema_latest_, subarray, buffer_sizes);
@@ -935,7 +919,7 @@ Status Array::load_metadata() {
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return LOG_STATUS(Status::ArrayError(
+      return LOG_STATUS(Status_ArrayError(
           "Cannot load metadata; remote array with no REST client."));
     RETURN_NOT_OK(rest_client->get_array_metadata_from_rest(
         array_uri_, timestamp_start_, timestamp_end_opened_at_, this));
@@ -955,7 +939,7 @@ Status Array::load_remote_non_empty_domain() {
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return LOG_STATUS(Status::ArrayError(
+      return LOG_STATUS(Status_ArrayError(
           "Cannot load metadata; remote array with no REST client."));
     RETURN_NOT_OK(rest_client->get_array_non_empty_domain(
         this, timestamp_start_, timestamp_end_opened_at_));
@@ -987,7 +971,7 @@ Status Array::compute_non_empty_domain() {
         // If the fragment's non-empty domain is indeed empty, lets log it so
         // the user gets a message warning that this fragment might be corrupt
         // Note: LOG_STATUS only prints if TileDB is built in verbose mode.
-        LOG_STATUS(Status::ArrayError(
+        LOG_STATUS(Status_ArrayError(
             "Non empty domain unexpectedly empty for fragment: " +
             fragment_metadata_[j]->fragment_uri().to_string()));
       }

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -202,7 +202,8 @@ Status Array::open(
   std::unique_lock<std::mutex> lck(mtx_);
 
   if (is_open_)
-    return LOG_STATUS(Status_ArrayError("Cannot open array; Array already open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot open array; Array already open"));
 
   std::string encryption_key_from_cfg;
   if (!encryption_key) {
@@ -368,8 +369,8 @@ Status Array::get_array_schema(ArraySchema** array_schema) const {
 
   // Error if the array is not open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError(
-        "Cannot get array schema; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get array schema; Array is not open"));
 
   *array_schema = array_schema_latest_;
 
@@ -381,7 +382,8 @@ Status Array::get_query_type(QueryType* query_type) const {
 
   // Error if the array is not open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError("Cannot get query_type; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get query_type; Array is not open"));
 
   *query_type = query_type_;
 
@@ -393,13 +395,14 @@ Status Array::get_max_buffer_size(
   std::unique_lock<std::mutex> lck(mtx_);
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError(
-        "Cannot get max buffer size; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get max buffer size; Array is not open"));
 
   // Error if the array was not opened in read mode
   if (query_type_ != QueryType::READ)
-    return LOG_STATUS(Status_ArrayError("Cannot get max buffer size; "
-                                  "Array was not opened in read mode"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get max buffer size; "
+                          "Array was not opened in read mode"));
 
   // Check if name is null
   if (name == nullptr)
@@ -408,8 +411,9 @@ Status Array::get_max_buffer_size(
 
   // Not applicable to heterogeneous domains
   if (!array_schema_latest_->domain()->all_dims_same_type())
-    return LOG_STATUS(Status_ArrayError("Cannot get max buffer size; Function not "
-                                  "applicable to heterogeneous domains"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get max buffer size; Function not "
+                          "applicable to heterogeneous domains"));
 
   // Not applicable to variable-sized dimensions
   if (!array_schema_latest_->domain()->all_dims_fixed())
@@ -452,13 +456,14 @@ Status Array::get_max_buffer_size(
 
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError(
-        "Cannot get max buffer size; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get max buffer size; Array is not open"));
 
   // Error if the array was not opened in read mode
   if (query_type_ != QueryType::READ)
-    return LOG_STATUS(Status_ArrayError("Cannot get max buffer size; "
-                                  "Array was not opened in read mode"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get max buffer size; "
+                          "Array was not opened in read mode"));
 
   // Check if name is null
   if (name == nullptr)
@@ -467,8 +472,9 @@ Status Array::get_max_buffer_size(
 
   // Not applicable to heterogeneous domains
   if (!array_schema_latest_->domain()->all_dims_same_type())
-    return LOG_STATUS(Status_ArrayError("Cannot get max buffer size; Function not "
-                                  "applicable to heterogeneous domains"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get max buffer size; Function not "
+                          "applicable to heterogeneous domains"));
 
   // Not applicable to variable-sized dimensions
   if (!array_schema_latest_->domain()->all_dims_fixed())
@@ -518,12 +524,13 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   std::unique_lock<std::mutex> lck(mtx_);
 
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError("Cannot reopen array; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot reopen array; Array is not open"));
 
   if (query_type_ != QueryType::READ)
     return LOG_STATUS(
         Status_ArrayError("Cannot reopen array; Array was "
-                                  "not opened in read mode"));
+                          "not opened in read mode"));
 
   clear_last_max_buffer_sizes();
 
@@ -609,18 +616,19 @@ Status Array::set_uri_serialized(const std::string& uri) {
 Status Array::delete_metadata(const char* key) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError("Cannot delete metadata. Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot delete metadata. Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::WRITE)
     return LOG_STATUS(
         Status_ArrayError("Cannot delete metadata. Array was "
-                                  "not opened in write mode"));
+                          "not opened in write mode"));
 
   // Check if key is null
   if (key == nullptr)
-    return LOG_STATUS(Status_ArrayError(
-        "Cannot delete metadata. Key cannot be null"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot delete metadata. Key cannot be null"));
 
   RETURN_NOT_OK(metadata_.del(key));
 
@@ -634,22 +642,24 @@ Status Array::put_metadata(
     const void* value) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError("Cannot put metadata; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot put metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::WRITE)
     return LOG_STATUS(
         Status_ArrayError("Cannot put metadata; Array was "
-                                  "not opened in write mode"));
+                          "not opened in write mode"));
 
   // Check if key is null
   if (key == nullptr)
-    return LOG_STATUS(Status_ArrayError("Cannot put metadata; Key cannot be null"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot put metadata; Key cannot be null"));
 
   // Check if value type is ANY
   if (value_type == Datatype::ANY)
-    return LOG_STATUS(Status_ArrayError(
-        "Cannot put metadata; Value type cannot be ANY"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot put metadata; Value type cannot be ANY"));
 
   RETURN_NOT_OK(metadata_.put(key, value_type, value_num, value));
 
@@ -663,17 +673,19 @@ Status Array::get_metadata(
     const void** value) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::READ)
     return LOG_STATUS(
         Status_ArrayError("Cannot get metadata; Array was "
-                                  "not opened in read mode"));
+                          "not opened in read mode"));
 
   // Check if key is null
   if (key == nullptr)
-    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Key cannot be null"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get metadata; Key cannot be null"));
 
   // Load array metadata, if not loaded yet
   if (!metadata_loaded_)
@@ -693,13 +705,14 @@ Status Array::get_metadata(
     const void** value) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::READ)
     return LOG_STATUS(
         Status_ArrayError("Cannot get metadata; Array was "
-                                  "not opened in read mode"));
+                          "not opened in read mode"));
 
   // Load array metadata, if not loaded yet
   if (!metadata_loaded_)
@@ -714,13 +727,14 @@ Status Array::get_metadata(
 Status Array::get_metadata_num(uint64_t* num) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError(
-        "Cannot get number of metadata; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get number of metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::READ)
-    return LOG_STATUS(Status_ArrayError("Cannot get number of metadata; Array was "
-                                  "not opened in read mode"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get number of metadata; Array was "
+                          "not opened in read mode"));
 
   // Load array metadata, if not loaded yet
   if (!metadata_loaded_)
@@ -735,17 +749,19 @@ Status Array::has_metadata_key(
     const char* key, Datatype* value_type, bool* has_key) {
   // Check if array is open
   if (!is_open_)
-    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Array is not open"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get metadata; Array is not open"));
 
   // Check mode
   if (query_type_ != QueryType::READ)
     return LOG_STATUS(
         Status_ArrayError("Cannot get metadata; Array was "
-                                  "not opened in read mode"));
+                          "not opened in read mode"));
 
   // Check if key is null
   if (key == nullptr)
-    return LOG_STATUS(Status_ArrayError("Cannot get metadata; Key cannot be null"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot get metadata; Key cannot be null"));
 
   // Load array metadata, if not loaded yet
   if (!metadata_loaded_)
@@ -796,9 +812,9 @@ void Array::clear_last_max_buffer_sizes() {
 Status Array::compute_max_buffer_sizes(const void* subarray) {
   // Applicable only to domains where all dimensions have the same type
   if (!array_schema_latest_->domain()->all_dims_same_type())
-    return LOG_STATUS(Status_ArrayError(
-        "Cannot compute max buffer sizes; Inapplicable when "
-        "dimension domains have different types"));
+    return LOG_STATUS(
+        Status_ArrayError("Cannot compute max buffer sizes; Inapplicable when "
+                          "dimension domains have different types"));
 
   // Allocate space for max buffer sizes subarray
   auto dim_num = array_schema_latest_->dim_num();

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -219,8 +219,8 @@ const FilterPipeline& ArraySchema::cell_validity_filters() const {
 
 Status ArraySchema::check() const {
   if (domain_ == nullptr)
-    return LOG_STATUS(Status_ArraySchemaError(
-        "Array schema check failed; Domain not set"));
+    return LOG_STATUS(
+        Status_ArraySchemaError("Array schema check failed; Domain not set"));
 
   auto dim_num = this->dim_num();
   if (dim_num == 0)
@@ -236,9 +236,9 @@ Status ArraySchema::check() const {
   if (array_type_ == ArrayType::DENSE) {
     auto type = domain_->dimension(0)->type();
     if (datatype_is_real(type)) {
-      return LOG_STATUS(Status_ArraySchemaError(
-          "Array schema check failed; Dense arrays "
-          "cannot have floating point domains"));
+      return LOG_STATUS(
+          Status_ArraySchemaError("Array schema check failed; Dense arrays "
+                                  "cannot have floating point domains"));
     }
     if (attributes_.size() == 0) {
       return LOG_STATUS(Status_ArraySchemaError(
@@ -249,9 +249,9 @@ Status ArraySchema::check() const {
   RETURN_NOT_OK(check_double_delta_compressor());
 
   if (!check_attribute_dimension_names())
-    return LOG_STATUS(Status_ArraySchemaError(
-        "Array schema check failed; Attributes "
-        "and dimensions must have unique names"));
+    return LOG_STATUS(
+        Status_ArraySchemaError("Array schema check failed; Attributes "
+                                "and dimensions must have unique names"));
 
   // Success
   return Status::Ok();
@@ -517,13 +517,14 @@ Status ArraySchema::add_attribute(const Attribute* attr, bool check_special) {
 Status ArraySchema::drop_attribute(const std::string& attr_name) {
   std::lock_guard<std::mutex> lock(mtx_);
   if (attr_name.empty()) {
-    return LOG_STATUS(Status_ArraySchemaError(
-        "Cannot remove an empty name attribute"));
+    return LOG_STATUS(
+        Status_ArraySchemaError("Cannot remove an empty name attribute"));
   }
 
   if (attribute_map_.find(attr_name) == attribute_map_.end()) {
     // Not exists.
-    return LOG_STATUS(Status_ArraySchemaError("Cannot remove a non-exist attribute"));
+    return LOG_STATUS(
+        Status_ArraySchemaError("Cannot remove a non-exist attribute"));
   }
   attribute_map_.erase(attr_name);
 
@@ -654,9 +655,9 @@ Status ArraySchema::set_cell_var_offsets_filter_pipeline(
 
 Status ArraySchema::set_cell_order(Layout cell_order) {
   if (dense() && cell_order == Layout::HILBERT)
-    return LOG_STATUS(Status_ArraySchemaError(
-        "Cannot set cell order; Hilbert order is only "
-        "applicable to sparse arrays"));
+    return LOG_STATUS(
+        Status_ArraySchemaError("Cannot set cell order; Hilbert order is only "
+                                "applicable to sparse arrays"));
 
   cell_order_ = cell_order;
 
@@ -671,8 +672,8 @@ Status ArraySchema::set_cell_validity_filter_pipeline(
 
 Status ArraySchema::set_domain(Domain* domain) {
   if (domain == nullptr)
-    return LOG_STATUS(Status_ArraySchemaError(
-        "Cannot set domain; Input domain is nullptr"));
+    return LOG_STATUS(
+        Status_ArraySchemaError("Cannot set domain; Input domain is nullptr"));
 
   if (domain->dim_num() == 0)
     return LOG_STATUS(Status_ArraySchemaError(
@@ -680,9 +681,9 @@ Status ArraySchema::set_domain(Domain* domain) {
 
   if (array_type_ == ArrayType::DENSE) {
     if (!domain->all_dims_same_type())
-      return LOG_STATUS(Status_ArraySchemaError(
-          "Cannot set domain; In dense arrays, all "
-          "dimensions must have the same datatype"));
+      return LOG_STATUS(
+          Status_ArraySchemaError("Cannot set domain; In dense arrays, all "
+                                  "dimensions must have the same datatype"));
 
     auto type = domain->dimension(0)->type();
     if (!datatype_is_integer(type) && !datatype_is_datetime(type) &&
@@ -769,7 +770,8 @@ void ArraySchema::set_uri(const URI& uri) {
 
 Status ArraySchema::get_uri(URI* uri) {
   if (uri_.is_invalid()) {
-    return LOG_STATUS(Status_ArraySchemaError("Error in ArraySchema; invalid URI"));
+    return LOG_STATUS(
+        Status_ArraySchemaError("Error in ArraySchema; invalid URI"));
   }
   *uri = uri_;
   return Status::Ok();
@@ -785,7 +787,8 @@ std::string ArraySchema::name() {
 
 Status ArraySchema::get_name(std::string* name) const {
   if (name_.empty()) {
-    return LOG_STATUS(Status_ArraySchemaError("Error in ArraySchema; Empty name"));
+    return LOG_STATUS(
+        Status_ArraySchemaError("Error in ArraySchema; Empty name"));
   }
   *name = name_;
   return Status::Ok();
@@ -828,9 +831,9 @@ Status ArraySchema::check_double_delta_compressor() const {
     const auto& dim_filters = dim->filters();
     auto dim_type = dim->type();
     if (datatype_is_real(dim_type) && dim_filters.empty())
-      return LOG_STATUS(Status_ArraySchemaError(
-          "Real dimension cannot inherit coordinate "
-          "filters with DOUBLE DELTA compression"));
+      return LOG_STATUS(
+          Status_ArraySchemaError("Real dimension cannot inherit coordinate "
+                                  "filters with DOUBLE DELTA compression"));
   }
 
   return Status::Ok();

--- a/tiledb/sm/array_schema/array_schema_evolution.cc
+++ b/tiledb/sm/array_schema/array_schema_evolution.cc
@@ -76,7 +76,7 @@ Status ArraySchemaEvolution::evolve_schema(
     const ArraySchema* orig_schema, ArraySchema** new_schema) {
   std::lock_guard<std::mutex> lock(mtx_);
   if (orig_schema == nullptr) {
-    return LOG_STATUS(Status::ArraySchemaEvolutionError(
+    return LOG_STATUS(Status_ArraySchemaEvolutionError(
         "Cannot evolve schema; Input array schema is null"));
   }
 
@@ -106,12 +106,12 @@ Status ArraySchemaEvolution::add_attribute(const Attribute* attr) {
   std::lock_guard<std::mutex> lock(mtx_);
   // Sanity check
   if (attr == nullptr)
-    return LOG_STATUS(Status::ArraySchemaEvolutionError(
+    return LOG_STATUS(Status_ArraySchemaEvolutionError(
         "Cannot add attribute; Input attribute is null"));
 
   if (attributes_to_add_map_.find(attr->name()) !=
       attributes_to_add_map_.end()) {
-    return LOG_STATUS(Status::ArraySchemaEvolutionError(
+    return LOG_STATUS(Status_ArraySchemaEvolutionError(
         "Cannot add attribute; Input attribute name is already there"));
   }
 

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -262,7 +262,7 @@ Status Attribute::serialize(Buffer* buff, const uint32_t version) {
 
 Status Attribute::set_cell_val_num(unsigned int cell_val_num) {
   if (type_ == Datatype::ANY)
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot set number of values per cell; Attribute datatype `ANY` is "
         "always variable-sized"));
 
@@ -284,15 +284,14 @@ Status Attribute::get_nullable(bool* const nullable) {
 
 Status Attribute::set_filter_pipeline(const FilterPipeline* pipeline) {
   if (pipeline == nullptr)
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot set filter pipeline to attribute; Pipeline cannot be null"));
 
   for (unsigned i = 0; i < pipeline->size(); ++i) {
     if (datatype_is_real(type_) &&
         pipeline->get_filter(i)->type() == FilterType::FILTER_DOUBLE_DELTA)
-      return LOG_STATUS(
-          Status::AttributeError("Cannot set DOUBLE DELTA filter to a "
-                                 "dimension with a real datatype"));
+      return LOG_STATUS(Status_AttributeError("Cannot set DOUBLE DELTA filter to a "
+                                        "dimension with a real datatype"));
   }
 
   filters_ = *pipeline;
@@ -306,22 +305,22 @@ void Attribute::set_name(const std::string& name) {
 
 Status Attribute::set_fill_value(const void* value, uint64_t size) {
   if (value == nullptr) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot set fill value; Input value cannot be null"));
   }
 
   if (size == 0) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot set fill value; Input size cannot be 0"));
   }
 
   if (nullable()) {
-    return LOG_STATUS(
-        Status::AttributeError("Cannot set fill value; Attribute is nullable"));
+    return LOG_STATUS(Status_AttributeError(
+        "Cannot set fill value; Attribute is nullable"));
   }
 
   if (!var_size() && size != cell_size()) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot set fill value; Input size is not the same as cell size"));
   }
 
@@ -334,18 +333,18 @@ Status Attribute::set_fill_value(const void* value, uint64_t size) {
 
 Status Attribute::get_fill_value(const void** value, uint64_t* size) const {
   if (value == nullptr) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot get fill value; Input value cannot be null"));
   }
 
   if (size == nullptr) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot get fill value; Input size cannot be null"));
   }
 
   if (nullable()) {
-    return LOG_STATUS(
-        Status::AttributeError("Cannot get fill value; Attribute is nullable"));
+    return LOG_STATUS(Status_AttributeError(
+        "Cannot get fill value; Attribute is nullable"));
   }
 
   *value = fill_value_.data();
@@ -357,22 +356,22 @@ Status Attribute::get_fill_value(const void** value, uint64_t* size) const {
 Status Attribute::set_fill_value(
     const void* value, uint64_t size, uint8_t valid) {
   if (value == nullptr) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot set fill value; Input value cannot be null"));
   }
 
   if (size == 0) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot set fill value; Input size cannot be 0"));
   }
 
   if (!nullable()) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot set fill value; Attribute is not nullable"));
   }
 
   if (!var_size() && size != cell_size()) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot set fill value; Input size is not the same as cell size"));
   }
 
@@ -387,17 +386,17 @@ Status Attribute::set_fill_value(
 Status Attribute::get_fill_value(
     const void** value, uint64_t* size, uint8_t* valid) const {
   if (value == nullptr) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot get fill value; Input value cannot be null"));
   }
 
   if (size == nullptr) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot get fill value; Input size cannot be null"));
   }
 
   if (!nullable()) {
-    return LOG_STATUS(Status::AttributeError(
+    return LOG_STATUS(Status_AttributeError(
         "Cannot get fill value; Attribute is not nullable"));
   }
 

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -290,8 +290,9 @@ Status Attribute::set_filter_pipeline(const FilterPipeline* pipeline) {
   for (unsigned i = 0; i < pipeline->size(); ++i) {
     if (datatype_is_real(type_) &&
         pipeline->get_filter(i)->type() == FilterType::FILTER_DOUBLE_DELTA)
-      return LOG_STATUS(Status_AttributeError("Cannot set DOUBLE DELTA filter to a "
-                                        "dimension with a real datatype"));
+      return LOG_STATUS(
+          Status_AttributeError("Cannot set DOUBLE DELTA filter to a "
+                                "dimension with a real datatype"));
   }
 
   filters_ = *pipeline;
@@ -310,13 +311,13 @@ Status Attribute::set_fill_value(const void* value, uint64_t size) {
   }
 
   if (size == 0) {
-    return LOG_STATUS(Status_AttributeError(
-        "Cannot set fill value; Input size cannot be 0"));
+    return LOG_STATUS(
+        Status_AttributeError("Cannot set fill value; Input size cannot be 0"));
   }
 
   if (nullable()) {
-    return LOG_STATUS(Status_AttributeError(
-        "Cannot set fill value; Attribute is nullable"));
+    return LOG_STATUS(
+        Status_AttributeError("Cannot set fill value; Attribute is nullable"));
   }
 
   if (!var_size() && size != cell_size()) {
@@ -343,8 +344,8 @@ Status Attribute::get_fill_value(const void** value, uint64_t* size) const {
   }
 
   if (nullable()) {
-    return LOG_STATUS(Status_AttributeError(
-        "Cannot get fill value; Attribute is nullable"));
+    return LOG_STATUS(
+        Status_AttributeError("Cannot get fill value; Attribute is nullable"));
   }
 
   *value = fill_value_.data();
@@ -361,8 +362,8 @@ Status Attribute::set_fill_value(
   }
 
   if (size == 0) {
-    return LOG_STATUS(Status_AttributeError(
-        "Cannot set fill value; Input size cannot be 0"));
+    return LOG_STATUS(
+        Status_AttributeError("Cannot set fill value; Input size cannot be 0"));
   }
 
   if (!nullable()) {

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -135,9 +135,9 @@ unsigned int Dimension::cell_val_num() const {
 Status Dimension::set_cell_val_num(unsigned int cell_val_num) {
   // Error checkls
   if (datatype_is_string(type_) && cell_val_num != constants::var_num)
-    return LOG_STATUS(Status_DimensionError(
-        "Cannot set non-variable number of values per "
-        "coordinate for a string dimension"));
+    return LOG_STATUS(
+        Status_DimensionError("Cannot set non-variable number of values per "
+                              "coordinate for a string dimension"));
   if (!datatype_is_string(type_) && cell_val_num != 1)
     return LOG_STATUS(Status_DimensionError(
         "Cannot set number of values per coordinate; Currently only one value "
@@ -1608,8 +1608,9 @@ Status Dimension::set_filter_pipeline(const FilterPipeline* pipeline) {
   for (unsigned i = 0; i < pipeline->size(); ++i) {
     if (datatype_is_real(type_) &&
         pipeline->get_filter(i)->type() == FilterType::FILTER_DOUBLE_DELTA)
-      return LOG_STATUS(Status_DimensionError("Cannot set DOUBLE DELTA filter to a "
-                                        "dimension with a real datatype"));
+      return LOG_STATUS(
+          Status_DimensionError("Cannot set DOUBLE DELTA filter to a "
+                                "dimension with a real datatype"));
   }
 
   filters_ = *pipeline;
@@ -1701,15 +1702,15 @@ Status Dimension::set_null_tile_extent_to_range() {
     case Datatype::STRING_ASCII:
       return Status::Ok();  // Do nothing for strings
     default:
-      return LOG_STATUS(Status_DimensionError(
-          "Cannot set null tile extent to domain range; "
-          "Invalid dimension domain type"));
+      return LOG_STATUS(
+          Status_DimensionError("Cannot set null tile extent to domain range; "
+                                "Invalid dimension domain type"));
   }
 
   assert(false);
-  return LOG_STATUS(Status_DimensionError(
-      "Cannot set null tile extent to domain range; "
-      "Unsupported dimension type"));
+  return LOG_STATUS(
+      Status_DimensionError("Cannot set null tile extent to domain range; "
+                            "Unsupported dimension type"));
 }
 
 template <class T>
@@ -1871,8 +1872,8 @@ Status Dimension::check_tile_extent() const {
 template <class T>
 Status Dimension::check_tile_extent() const {
   if (domain_.empty())
-    return LOG_STATUS(Status_DimensionError(
-        "Tile extent check failed; Domain not set"));
+    return LOG_STATUS(
+        Status_DimensionError("Tile extent check failed; Domain not set"));
 
   if (!tile_extent_)
     return Status::Ok();
@@ -1889,8 +1890,9 @@ Status Dimension::check_tile_extent() const {
           "Tile extent check failed; Tile extent must be greater than 0"));
 
     if (*tile_extent > (domain[1] - domain[0] + 1))
-      return LOG_STATUS(Status_DimensionError("Tile extent check failed; Tile extent "
-                                        "exceeds dimension domain range"));
+      return LOG_STATUS(
+          Status_DimensionError("Tile extent check failed; Tile extent "
+                                "exceeds dimension domain range"));
   } else {
     // Check if tile extent is 0
     if (*tile_extent == 0)
@@ -1900,8 +1902,9 @@ Status Dimension::check_tile_extent() const {
     // Check if tile extent exceeds domain
     uint64_t range = (uint64_t)domain[1] - (uint64_t)domain[0] + 1;
     if (uint64_t(*tile_extent) > range)
-      return LOG_STATUS(Status_DimensionError("Tile extent check failed; Tile extent "
-                                        "exceeds dimension domain range"));
+      return LOG_STATUS(
+          Status_DimensionError("Tile extent check failed; Tile extent "
+                                "exceeds dimension domain range"));
 
     // In the worst case one tile extent will be added to the upper domain
     // for the dense case, so check if the expanded domain will exceed type

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -135,11 +135,11 @@ unsigned int Dimension::cell_val_num() const {
 Status Dimension::set_cell_val_num(unsigned int cell_val_num) {
   // Error checkls
   if (datatype_is_string(type_) && cell_val_num != constants::var_num)
-    return LOG_STATUS(
-        Status::DimensionError("Cannot set non-variable number of values per "
-                               "coordinate for a string dimension"));
+    return LOG_STATUS(Status_DimensionError(
+        "Cannot set non-variable number of values per "
+        "coordinate for a string dimension"));
   if (!datatype_is_string(type_) && cell_val_num != 1)
-    return LOG_STATUS(Status::DimensionError(
+    return LOG_STATUS(Status_DimensionError(
         "Cannot set number of values per coordinate; Currently only one value "
         "per coordinate is supported"));
 
@@ -381,7 +381,7 @@ Status Dimension::check_range(const Range& range) const {
   std::string err_msg;
   auto ret = check_range_func_(this, range, &err_msg);
   if (!ret)
-    return LOG_STATUS(Status::DimensionError(err_msg));
+    return LOG_STATUS(Status_DimensionError(err_msg));
   return Status::Ok();
 }
 
@@ -625,7 +625,7 @@ Status Dimension::oob(const void* coord) const {
   std::string err_msg;
   auto ret = oob_func_(this, coord, &err_msg);
   if (ret)
-    return Status::DimensionError(err_msg);
+    return Status_DimensionError(err_msg);
   return Status::Ok();
 }
 
@@ -1574,7 +1574,7 @@ Status Dimension::set_domain(const void* domain) {
   if (type_ == Datatype::STRING_ASCII) {
     if (domain == nullptr)
       return Status::Ok();
-    return LOG_STATUS(Status::DimensionError(
+    return LOG_STATUS(Status_DimensionError(
         std::string("Setting the domain to a dimension with type '") +
         datatype_str(type_) + "' is not supported"));
   }
@@ -1602,15 +1602,14 @@ Status Dimension::set_domain_unsafe(const void* domain) {
 
 Status Dimension::set_filter_pipeline(const FilterPipeline* pipeline) {
   if (pipeline == nullptr)
-    return LOG_STATUS(Status::DimensionError(
+    return LOG_STATUS(Status_DimensionError(
         "Cannot set filter pipeline to dimension; Pipeline cannot be null"));
 
   for (unsigned i = 0; i < pipeline->size(); ++i) {
     if (datatype_is_real(type_) &&
         pipeline->get_filter(i)->type() == FilterType::FILTER_DOUBLE_DELTA)
-      return LOG_STATUS(
-          Status::DimensionError("Cannot set DOUBLE DELTA filter to a "
-                                 "dimension with a real datatype"));
+      return LOG_STATUS(Status_DimensionError("Cannot set DOUBLE DELTA filter to a "
+                                        "dimension with a real datatype"));
   }
 
   filters_ = *pipeline;
@@ -1622,7 +1621,7 @@ Status Dimension::set_tile_extent(const void* tile_extent) {
   if (type_ == Datatype::STRING_ASCII) {
     if (tile_extent == nullptr)
       return Status::Ok();
-    return LOG_STATUS(Status::DimensionError(
+    return LOG_STATUS(Status_DimensionError(
         std::string("Setting the tile extent to a dimension with type '") +
         datatype_str(type_) + "' is not supported"));
   }
@@ -1641,12 +1640,12 @@ Status Dimension::set_tile_extent(const ByteVecValue& tile_extent) {
   if (type_ == Datatype::STRING_ASCII) {
     if (!tile_extent)
       return Status::Ok();
-    return LOG_STATUS(Status::DimensionError(
+    return LOG_STATUS(Status_DimensionError(
         std::string("Setting the tile extent to a dimension with type '") +
         datatype_str(type_) + "' is not supported"));
   }
   if (domain_.empty())
-    return LOG_STATUS(Status::DimensionError(
+    return LOG_STATUS(Status_DimensionError(
         "Cannot set tile extent; Domain must be set first"));
 
   tile_extent_ = tile_extent;
@@ -1702,15 +1701,15 @@ Status Dimension::set_null_tile_extent_to_range() {
     case Datatype::STRING_ASCII:
       return Status::Ok();  // Do nothing for strings
     default:
-      return LOG_STATUS(
-          Status::DimensionError("Cannot set null tile extent to domain range; "
-                                 "Invalid dimension domain type"));
+      return LOG_STATUS(Status_DimensionError(
+          "Cannot set null tile extent to domain range; "
+          "Invalid dimension domain type"));
   }
 
   assert(false);
-  return LOG_STATUS(
-      Status::DimensionError("Cannot set null tile extent to domain range; "
-                             "Unsupported dimension type"));
+  return LOG_STATUS(Status_DimensionError(
+      "Cannot set null tile extent to domain range; "
+      "Unsupported dimension type"));
 }
 
 template <class T>
@@ -1721,7 +1720,7 @@ Status Dimension::set_null_tile_extent_to_range() {
 
   // Check empty domain
   if (domain_.empty())
-    return LOG_STATUS(Status::DimensionError(
+    return LOG_STATUS(Status_DimensionError(
         "Cannot set tile extent to domain range; Domain not set"));
 
   // Calculate new tile extent equal to domain range
@@ -1732,7 +1731,7 @@ Status Dimension::set_null_tile_extent_to_range() {
   if (std::is_integral<T>::value) {
     if (domain[0] == std::numeric_limits<T>::min() &&
         domain[1] == std::numeric_limits<T>::max()) {
-      return LOG_STATUS(Status::DimensionError(
+      return LOG_STATUS(Status_DimensionError(
           "Cannot set null tile extent to domain range; "
           "Domain range exceeds domain type max numeric limit"));
     }
@@ -1813,7 +1812,7 @@ Status Dimension::check_domain() const {
     case Datatype::TIME_AS:
       return check_domain<int64_t>();
     default:
-      return LOG_STATUS(Status::DimensionError(
+      return LOG_STATUS(Status_DimensionError(
           "Domain check failed; Invalid dimension domain type"));
   }
 }
@@ -1864,7 +1863,7 @@ Status Dimension::check_tile_extent() const {
     case Datatype::TIME_AS:
       return check_tile_extent<int64_t>();
     default:
-      return LOG_STATUS(Status::DimensionError(
+      return LOG_STATUS(Status_DimensionError(
           "Tile extent check failed; Invalid dimension domain type"));
   }
 }
@@ -1872,8 +1871,8 @@ Status Dimension::check_tile_extent() const {
 template <class T>
 Status Dimension::check_tile_extent() const {
   if (domain_.empty())
-    return LOG_STATUS(
-        Status::DimensionError("Tile extent check failed; Domain not set"));
+    return LOG_STATUS(Status_DimensionError(
+        "Tile extent check failed; Domain not set"));
 
   if (!tile_extent_)
     return Status::Ok();
@@ -1886,25 +1885,23 @@ Status Dimension::check_tile_extent() const {
   if (!is_int) {
     // Check if tile extent is negative or 0
     if (*tile_extent <= 0)
-      return LOG_STATUS(Status::DimensionError(
+      return LOG_STATUS(Status_DimensionError(
           "Tile extent check failed; Tile extent must be greater than 0"));
 
     if (*tile_extent > (domain[1] - domain[0] + 1))
-      return LOG_STATUS(
-          Status::DimensionError("Tile extent check failed; Tile extent "
-                                 "exceeds dimension domain range"));
+      return LOG_STATUS(Status_DimensionError("Tile extent check failed; Tile extent "
+                                        "exceeds dimension domain range"));
   } else {
     // Check if tile extent is 0
     if (*tile_extent == 0)
-      return LOG_STATUS(Status::DimensionError(
+      return LOG_STATUS(Status_DimensionError(
           "Tile extent check failed; Tile extent must not be 0"));
 
     // Check if tile extent exceeds domain
     uint64_t range = (uint64_t)domain[1] - (uint64_t)domain[0] + 1;
     if (uint64_t(*tile_extent) > range)
-      return LOG_STATUS(
-          Status::DimensionError("Tile extent check failed; Tile extent "
-                                 "exceeds dimension domain range"));
+      return LOG_STATUS(Status_DimensionError("Tile extent check failed; Tile extent "
+                                        "exceeds dimension domain range"));
 
     // In the worst case one tile extent will be added to the upper domain
     // for the dense case, so check if the expanded domain will exceed type
@@ -1941,7 +1938,7 @@ Status Dimension::check_tile_extent_upper_floor_internal(
   const bool exceeds =
       upper_floor > upper_floor_max || upper_floor > extent_max;
   if (exceeds) {
-    return LOG_STATUS(Status::DimensionError(
+    return LOG_STATUS(Status_DimensionError(
         "Tile extent check failed; domain max expanded to multiple of tile "
         "extent exceeds max value representable by domain type. Reduce "
         "domain max by 1 tile extent to allow for expansion."));

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -1100,11 +1100,11 @@ class Dimension {
 
     // Check for NAN and INF
     if (std::isinf(domain[0]) || std::isinf(domain[1]))
-      return LOG_STATUS(Status_DimensionError(
-          "Domain check failed; domain contains NaN"));
+      return LOG_STATUS(
+          Status_DimensionError("Domain check failed; domain contains NaN"));
     if (std::isnan(domain[0]) || std::isnan(domain[1]))
-      return LOG_STATUS(Status_DimensionError(
-          "Domain check failed; domain contains NaN"));
+      return LOG_STATUS(
+          Status_DimensionError("Domain check failed; domain contains NaN"));
 
     // Upper bound should not be smaller than lower
     if (domain[1] < domain[0])

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -1072,7 +1072,7 @@ class Dimension {
 
     // Upper bound should not be smaller than lower
     if (domain[1] < domain[0])
-      return LOG_STATUS(Status::DimensionError(
+      return LOG_STATUS(Status_DimensionError(
           "Domain check failed; Upper domain bound should "
           "not be smaller than the lower one"));
 
@@ -1080,7 +1080,7 @@ class Dimension {
     // for integer domains
     if (domain[0] == std::numeric_limits<T>::min() &&
         domain[1] == std::numeric_limits<T>::max())
-      return LOG_STATUS(Status::DimensionError(
+      return LOG_STATUS(Status_DimensionError(
           "Domain check failed; Domain range (upper + lower + 1) is larger "
           "than the maximum unsigned number"));
 
@@ -1100,15 +1100,15 @@ class Dimension {
 
     // Check for NAN and INF
     if (std::isinf(domain[0]) || std::isinf(domain[1]))
-      return LOG_STATUS(
-          Status::DimensionError("Domain check failed; domain contains NaN"));
+      return LOG_STATUS(Status_DimensionError(
+          "Domain check failed; domain contains NaN"));
     if (std::isnan(domain[0]) || std::isnan(domain[1]))
-      return LOG_STATUS(
-          Status::DimensionError("Domain check failed; domain contains NaN"));
+      return LOG_STATUS(Status_DimensionError(
+          "Domain check failed; domain contains NaN"));
 
     // Upper bound should not be smaller than lower
     if (domain[1] < domain[0])
-      return LOG_STATUS(Status::DimensionError(
+      return LOG_STATUS(Status_DimensionError(
           "Domain check failed; Upper domain bound should "
           "not be smaller than the lower one"));
 

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -520,7 +520,7 @@ Status Domain::get_dimension_index(
     }
   }
 
-  return Status::DomainError(
+  return Status_DomainError(
       "Cannot get dimension index; Invalid dimension name");
 }
 

--- a/tiledb/sm/buffer/buffer.cc
+++ b/tiledb/sm/buffer/buffer.cc
@@ -395,8 +395,7 @@ uint64_t PreallocatedBuffer::free_space() const {
 
 Status PreallocatedBuffer::write(const void* buffer, const uint64_t nbytes) {
   if (nbytes > size_ - offset_)
-    return Status_PreallocatedBufferError(
-        "Write would overflow buffer.");
+    return Status_PreallocatedBufferError("Write would overflow buffer.");
 
   std::memcpy((char*)data_ + offset_, buffer, nbytes);
   offset_ += nbytes;

--- a/tiledb/sm/buffer/buffer.cc
+++ b/tiledb/sm/buffer/buffer.cc
@@ -117,7 +117,7 @@ bool BufferBase::end() const {
 
 Status BufferBase::read(void* destination, const uint64_t nbytes) {
   if (nbytes > size_ - offset_) {
-    return LOG_STATUS(Status::BufferError(
+    return LOG_STATUS(Status_BufferError(
         "Read buffer overflow; may not read beyond buffer size"));
   }
   std::memcpy(destination, static_cast<char*>(data_) + offset_, nbytes);
@@ -128,7 +128,7 @@ Status BufferBase::read(void* destination, const uint64_t nbytes) {
 Status BufferBase::read(
     void* destination, const uint64_t offset, const uint64_t nbytes) {
   if (nbytes > size_ - offset) {
-    return LOG_STATUS(Status::BufferError(
+    return LOG_STATUS(Status_BufferError(
         "Read buffer overflow; may not read beyond buffer size"));
   }
   std::memcpy(destination, static_cast<char*>(data_) + offset, nbytes);
@@ -229,21 +229,21 @@ bool Buffer::owns_data() const {
 
 Status Buffer::realloc(const uint64_t nbytes) {
   if (!owns_data_) {
-    return LOG_STATUS(Status::BufferError(
+    return LOG_STATUS(Status_BufferError(
         "Cannot reallocate buffer; Buffer does not own data"));
   }
 
   if (data_ == nullptr) {
     data_ = tdb_malloc(nbytes);
     if (data_ == nullptr) {
-      return LOG_STATUS(Status::BufferError(
+      return LOG_STATUS(Status_BufferError(
           "Cannot allocate buffer; Memory allocation failed"));
     }
     alloced_size_ = nbytes;
   } else if (nbytes > alloced_size_) {
     auto new_data = tdb_realloc(data_, nbytes);
     if (new_data == nullptr) {
-      return LOG_STATUS(Status::BufferError(
+      return LOG_STATUS(Status_BufferError(
           "Cannot reallocate buffer; Memory allocation failed"));
     }
     data_ = new_data;
@@ -274,7 +274,7 @@ Status Buffer::swap(Buffer& other) {
 Status Buffer::write(ConstBuffer* buff) {
   // Sanity check
   if (!owns_data_)
-    return LOG_STATUS(Status::BufferError(
+    return LOG_STATUS(Status_BufferError(
         "Cannot write to buffer; Buffer does not own the already stored data"));
 
   const uint64_t bytes_left_to_write = alloced_size_ - offset_;
@@ -292,7 +292,7 @@ Status Buffer::write(ConstBuffer* buff) {
 Status Buffer::write(ConstBuffer* buff, const uint64_t nbytes) {
   // Sanity check
   if (!owns_data_)
-    return LOG_STATUS(Status::BufferError(
+    return LOG_STATUS(Status_BufferError(
         "Cannot write to buffer; Buffer does not own the already stored data"));
 
   RETURN_NOT_OK(ensure_alloced_size(offset_ + nbytes));
@@ -307,7 +307,7 @@ Status Buffer::write(ConstBuffer* buff, const uint64_t nbytes) {
 Status Buffer::write(const void* buffer, const uint64_t nbytes) {
   // Sanity check
   if (!owns_data_)
-    return LOG_STATUS(Status::BufferError(
+    return LOG_STATUS(Status_BufferError(
         "Cannot write to buffer; Buffer does not own the already stored data"));
 
   RETURN_NOT_OK(ensure_alloced_size(offset_ + nbytes));
@@ -323,7 +323,7 @@ Status Buffer::write(
     const void* buffer, const uint64_t offset, const uint64_t nbytes) {
   // Sanity check
   if (!owns_data_)
-    return LOG_STATUS(Status::BufferError(
+    return LOG_STATUS(Status_BufferError(
         "Cannot write to buffer; Buffer does not own the already stored data"));
 
   RETURN_NOT_OK(ensure_alloced_size(offset + nbytes));
@@ -395,7 +395,8 @@ uint64_t PreallocatedBuffer::free_space() const {
 
 Status PreallocatedBuffer::write(const void* buffer, const uint64_t nbytes) {
   if (nbytes > size_ - offset_)
-    return Status::PreallocatedBufferError("Write would overflow buffer.");
+    return Status_PreallocatedBufferError(
+        "Write would overflow buffer.");
 
   std::memcpy((char*)data_ + offset_, buffer, nbytes);
   offset_ += nbytes;

--- a/tiledb/sm/buffer/buffer_list.cc
+++ b/tiledb/sm/buffer/buffer_list.cc
@@ -54,7 +54,7 @@ Status BufferList::add_buffer(Buffer&& buffer) {
 
 Status BufferList::get_buffer(uint64_t index, Buffer** buffer) {
   if (index >= buffers_.size())
-    return LOG_STATUS(Status::BufferError(
+    return LOG_STATUS(Status_BufferError(
         "Cannot get buffer " + std::to_string(index) +
         " from buffer list; index out of bounds."));
 
@@ -72,7 +72,7 @@ Status BufferList::read(void* dest, uint64_t nbytes) {
   RETURN_NOT_OK(read(dest, nbytes, &bytes_read));
 
   if (bytes_read != nbytes)
-    return LOG_STATUS(Status::BufferError(
+    return LOG_STATUS(Status_BufferError(
         "BufferList error; could not read requested byte count."));
 
   return Status::Ok();
@@ -130,10 +130,11 @@ Status BufferList::seek(off_t offset, int whence) {
     case SEEK_CUR:
       return read(nullptr, offset);
     case SEEK_END:
-      return Status::BufferError(
+      return Status_BufferError(
           "SEEK_END operation not supported for BufferList");
     default:
-      return Status::BufferError("Invalid seek operation for BufferList");
+      return Status_BufferError(
+          "Invalid seek operation for BufferList");
   }
 
   return Status::Ok();

--- a/tiledb/sm/buffer/buffer_list.cc
+++ b/tiledb/sm/buffer/buffer_list.cc
@@ -133,8 +133,7 @@ Status BufferList::seek(off_t offset, int whence) {
       return Status_BufferError(
           "SEEK_END operation not supported for BufferList");
     default:
-      return Status_BufferError(
-          "Invalid seek operation for BufferList");
+      return Status_BufferError("Invalid seek operation for BufferList");
   }
 
   return Status::Ok();

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -375,7 +375,7 @@ inline int32_t sanity_check(
     tiledb_ctx_t* ctx, const tiledb_subarray_t* subarray) {
   if (subarray == nullptr || subarray->subarray_ == nullptr ||
       subarray->subarray_->array() == nullptr) {
-    auto st = Status::Error("Invalid TileDB subarray object");
+    auto st = Status_Error("Invalid TileDB subarray object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -3797,7 +3797,7 @@ int32_t tiledb_subarray_alloc(
 
   // Error if array is not open
   if (!array->array_->is_open()) {
-    auto st = Status::Error("Cannot create subarray; array is not open");
+    auto st = Status_Error("Cannot create subarray; array is not open");
     *subarray = nullptr;
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -3807,7 +3807,7 @@ int32_t tiledb_subarray_alloc(
   // Create a buffer struct
   *subarray = new (std::nothrow) tiledb_subarray_t;
   if (*subarray == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB subarray object");
+    auto st = Status_Error("Failed to allocate TileDB subarray object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -3827,7 +3827,7 @@ int32_t tiledb_subarray_alloc(
   }
   if ((*subarray)->subarray_ == nullptr) {
     delete *subarray;
-    auto st = Status::Error("Failed to allocate TileDB subarray object");
+    auto st = Status_Error("Failed to allocate TileDB subarray object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -441,8 +441,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_config_t* config) {
 inline int32_t sanity_check(
     tiledb_config_iter_t* config_iter, tiledb_error_t** error) {
   if (config_iter == nullptr || config_iter->config_iter_ == nullptr) {
-    auto st =
-        Status_Error("Cannot set config; Invalid config iterator object");
+    auto st = Status_Error("Cannot set config; Invalid config iterator object");
     LOG_STATUS(st);
     create_error(error, st);
     return TILEDB_ERR;
@@ -2608,8 +2607,7 @@ int32_t tiledb_array_schema_get_domain(
   if ((*domain)->domain_ == nullptr) {
     delete *domain;
     *domain = nullptr;
-    auto st =
-        Status_Error("Failed to allocate TileDB domain object in object");
+    auto st = Status_Error("Failed to allocate TileDB domain object in object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2781,8 +2779,8 @@ int32_t tiledb_array_schema_evolution_alloc(
   // Create schema evolution struct
   *array_schema_evolution = new (std::nothrow) tiledb_array_schema_evolution_t;
   if (*array_schema_evolution == nullptr) {
-    auto st = Status_Error(
-        "Failed to allocate TileDB array schema evolution object");
+    auto st =
+        Status_Error("Failed to allocate TileDB array schema evolution object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2794,8 +2792,8 @@ int32_t tiledb_array_schema_evolution_alloc(
   if ((*array_schema_evolution)->array_schema_evolution_ == nullptr) {
     delete *array_schema_evolution;
     *array_schema_evolution = nullptr;
-    auto st = Status_Error(
-        "Failed to allocate TileDB array schema evolution object");
+    auto st =
+        Status_Error("Failed to allocate TileDB array schema evolution object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -4271,8 +4269,7 @@ int32_t tiledb_array_alloc(
   // Check array URI
   auto uri = tiledb::sm::URI(array_uri);
   if (uri.is_invalid()) {
-    auto st =
-        Status_Error("Failed to create TileDB array object; Invalid URI");
+    auto st = Status_Error("Failed to create TileDB array object; Invalid URI");
     delete *array;
     *array = nullptr;
     LOG_STATUS(st);
@@ -5736,8 +5733,7 @@ int32_t tiledb_vfs_ls(
   if (sanity_check(ctx) == TILEDB_ERR)
     return TILEDB_ERR;
   if (callback == nullptr) {
-    auto st =
-        Status_Error("Cannot initiate VFS ls; Invalid callback function");
+    auto st = Status_Error("Cannot initiate VFS ls; Invalid callback function");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -6022,8 +6018,8 @@ int32_t tiledb_deserialize_array_schema_evolution(
   // Create array schema struct
   *array_schema_evolution = new (std::nothrow) tiledb_array_schema_evolution_t;
   if (*array_schema_evolution == nullptr) {
-    auto st = Status_Error(
-        "Failed to allocate TileDB array schema evolution object");
+    auto st =
+        Status_Error("Failed to allocate TileDB array schema evolution object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -363,7 +363,7 @@ static bool create_error(tiledb_error_t** error, const Status& st) {
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_array_t* array) {
   if (array == nullptr || array->array_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB array object");
+    auto st = Status_Error("Invalid TileDB array object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -385,7 +385,7 @@ inline int32_t sanity_check(
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_buffer_t* buffer) {
   if (buffer == nullptr || buffer->buffer_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB buffer object");
+    auto st = Status_Error("Invalid TileDB buffer object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -396,7 +396,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_buffer_t* buffer) {
 inline int32_t sanity_check(
     tiledb_ctx_t* ctx, const tiledb_buffer_list_t* buffer_list) {
   if (buffer_list == nullptr || buffer_list->buffer_list_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB buffer list object");
+    auto st = Status_Error("Invalid TileDB buffer list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -406,7 +406,7 @@ inline int32_t sanity_check(
 
 inline int32_t sanity_check(tiledb_config_t* config, tiledb_error_t** error) {
   if (config == nullptr || config->config_ == nullptr) {
-    auto st = Status::Error("Cannot set config; Invalid config object");
+    auto st = Status_Error("Cannot set config; Invalid config object");
     LOG_STATUS(st);
     create_error(error, st);
     return TILEDB_ERR;
@@ -418,7 +418,7 @@ inline int32_t sanity_check(tiledb_config_t* config, tiledb_error_t** error) {
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, tiledb_config_t* config) {
   if (config == nullptr || config->config_ == nullptr) {
-    auto st = Status::Error("Cannot set config; Invalid config object");
+    auto st = Status_Error("Cannot set config; Invalid config object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -429,7 +429,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, tiledb_config_t* config) {
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_config_t* config) {
   if (config == nullptr || config->config_ == nullptr) {
-    auto st = Status::Error("Cannot set config; Invalid config object");
+    auto st = Status_Error("Cannot set config; Invalid config object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -442,7 +442,7 @@ inline int32_t sanity_check(
     tiledb_config_iter_t* config_iter, tiledb_error_t** error) {
   if (config_iter == nullptr || config_iter->config_iter_ == nullptr) {
     auto st =
-        Status::Error("Cannot set config; Invalid config iterator object");
+        Status_Error("Cannot set config; Invalid config iterator object");
     LOG_STATUS(st);
     create_error(error, st);
     return TILEDB_ERR;
@@ -456,7 +456,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx) {
   if (ctx == nullptr)
     return TILEDB_ERR;
   if (ctx->ctx_ == nullptr || ctx->ctx_->storage_manager() == nullptr) {
-    auto st = Status::Error("Invalid TileDB context");
+    auto st = Status_Error("Invalid TileDB context");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -466,7 +466,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx) {
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_error_t* err) {
   if (err == nullptr) {
-    auto st = Status::Error("Invalid TileDB error object");
+    auto st = Status_Error("Invalid TileDB error object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -476,7 +476,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_error_t* err) {
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_attribute_t* attr) {
   if (attr == nullptr || attr->attr_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB attribute object");
+    auto st = Status_Error("Invalid TileDB attribute object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -486,7 +486,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_attribute_t* attr) {
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_filter_t* filter) {
   if (filter == nullptr || filter->filter_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB filter object");
+    auto st = Status_Error("Invalid TileDB filter object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -497,7 +497,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_filter_t* filter) {
 inline int32_t sanity_check(
     tiledb_ctx_t* ctx, const tiledb_filter_list_t* filter_list) {
   if (filter_list == nullptr || filter_list->pipeline_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB filter list object");
+    auto st = Status_Error("Invalid TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -507,7 +507,7 @@ inline int32_t sanity_check(
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_dimension_t* dim) {
   if (dim == nullptr || dim->dim_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB dimension object");
+    auto st = Status_Error("Invalid TileDB dimension object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -518,7 +518,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_dimension_t* dim) {
 inline int32_t sanity_check(
     tiledb_ctx_t* ctx, const tiledb_array_schema_t* array_schema) {
   if (array_schema == nullptr || array_schema->array_schema_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB array schema object");
+    auto st = Status_Error("Invalid TileDB array schema object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -531,7 +531,7 @@ inline int32_t sanity_check(
     const tiledb_array_schema_evolution_t* schema_evolution) {
   if (schema_evolution == nullptr ||
       schema_evolution->array_schema_evolution_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB array schema evolution object");
+    auto st = Status_Error("Invalid TileDB array schema evolution object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -541,7 +541,7 @@ inline int32_t sanity_check(
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_domain_t* domain) {
   if (domain == nullptr || domain->domain_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB domain object");
+    auto st = Status_Error("Invalid TileDB domain object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -551,7 +551,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_domain_t* domain) {
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_query_t* query) {
   if (query == nullptr || query->query_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB query object");
+    auto st = Status_Error("Invalid TileDB query object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -562,7 +562,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_query_t* query) {
 inline int32_t sanity_check(
     tiledb_ctx_t* ctx, const tiledb_query_condition_t* cond) {
   if (cond == nullptr || cond->query_condition_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB query condition object");
+    auto st = Status_Error("Invalid TileDB query condition object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -572,7 +572,7 @@ inline int32_t sanity_check(
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_vfs_t* vfs) {
   if (vfs == nullptr || vfs->vfs_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB virtual filesystem object");
+    auto st = Status_Error("Invalid TileDB virtual filesystem object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -582,7 +582,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_vfs_t* vfs) {
 
 inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_vfs_fh_t* fh) {
   if (fh == nullptr || fh->vfs_fh_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB virtual filesystem file handle");
+    auto st = Status_Error("Invalid TileDB virtual filesystem file handle");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -593,7 +593,7 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_vfs_fh_t* fh) {
 inline int32_t sanity_check(
     tiledb_ctx_t* ctx, const tiledb_fragment_info_t* fragment_info) {
   if (fragment_info == nullptr || fragment_info->fragment_info_ == nullptr) {
-    auto st = Status::Error("Invalid TileDB fragment info object");
+    auto st = Status_Error("Invalid TileDB fragment info object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -605,7 +605,7 @@ inline int32_t check_filter_type(
     tiledb_ctx_t* ctx, tiledb_filter_t* filter, tiledb_filter_type_t type) {
   auto cpp_type = static_cast<tiledb::sm::FilterType>(type);
   if (filter->filter_->type() != cpp_type) {
-    auto st = Status::FilterError(
+    auto st = Status_FilterError(
         "Invalid filter type (expected " + filter_type_str(cpp_type) + ")");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -627,7 +627,7 @@ inline int32_t check_filter_type(
     try {                                                                  \
       _s = (stmt);                                                         \
     } catch (const std::exception& e) {                                    \
-      auto st = Status::Error(                                             \
+      auto st = Status_Error(                                              \
           std::string("Internal TileDB uncaught exception; ") + e.what()); \
       LOG_STATUS(st);                                                      \
       save_error(ctx, st);                                                 \
@@ -683,7 +683,7 @@ int32_t tiledb_buffer_alloc(tiledb_ctx_t* ctx, tiledb_buffer_t** buffer) {
   // Create a buffer struct
   *buffer = new (std::nothrow) tiledb_buffer_t;
   if (*buffer == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB buffer object");
+    auto st = Status_Error("Failed to allocate TileDB buffer object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -694,7 +694,7 @@ int32_t tiledb_buffer_alloc(tiledb_ctx_t* ctx, tiledb_buffer_t** buffer) {
   if ((*buffer)->buffer_ == nullptr) {
     delete *buffer;
     *buffer = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB buffer object");
+    auto st = Status_Error("Failed to allocate TileDB buffer object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -782,7 +782,7 @@ int32_t tiledb_buffer_list_alloc(
   // Create a buffer list struct
   *buffer_list = new (std::nothrow) tiledb_buffer_list_t;
   if (*buffer_list == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB buffer list object");
+    auto st = Status_Error("Failed to allocate TileDB buffer list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -793,7 +793,7 @@ int32_t tiledb_buffer_list_alloc(
   if ((*buffer_list)->buffer_list_ == nullptr) {
     delete *buffer_list;
     *buffer_list = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB buffer list object");
+    auto st = Status_Error("Failed to allocate TileDB buffer list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -844,7 +844,7 @@ int32_t tiledb_buffer_list_get_buffer(
   // Create a buffer struct
   *buffer = new (std::nothrow) tiledb_buffer_t;
   if (*buffer == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB buffer object");
+    auto st = Status_Error("Failed to allocate TileDB buffer object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -856,7 +856,7 @@ int32_t tiledb_buffer_list_get_buffer(
   if ((*buffer)->buffer_ == nullptr) {
     delete *buffer;
     *buffer = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB buffer object");
+    auto st = Status_Error("Failed to allocate TileDB buffer object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -920,7 +920,7 @@ int32_t tiledb_config_alloc(tiledb_config_t** config, tiledb_error_t** error) {
   *config = new (std::nothrow) tiledb_config_t;
   if (*config == nullptr) {
     auto st =
-        Status::Error("Cannot create config object; Memory allocation failed");
+        Status_Error("Cannot create config object; Memory allocation failed");
     LOG_STATUS(st);
     create_error(error, st);
     return TILEDB_OOM;
@@ -930,7 +930,7 @@ int32_t tiledb_config_alloc(tiledb_config_t** config, tiledb_error_t** error) {
   (*config)->config_ = new (std::nothrow) tiledb::sm::Config();
   if ((*config)->config_ == nullptr) {
     auto st =
-        Status::Error("Cannot create config object; Memory allocation failed");
+        Status_Error("Cannot create config object; Memory allocation failed");
     LOG_STATUS(st);
     create_error(error, st);
     if (*config != nullptr) {
@@ -989,7 +989,7 @@ int32_t tiledb_config_load_from_file(
     return TILEDB_ERR;
 
   if (filename == nullptr) {
-    auto st = Status::Error("Cannot load from file; Invalid filename");
+    auto st = Status_Error("Cannot load from file; Invalid filename");
     LOG_STATUS(st);
     create_error(error, st);
   }
@@ -1007,7 +1007,7 @@ int32_t tiledb_config_save_to_file(
     return TILEDB_ERR;
 
   if (filename == nullptr) {
-    auto st = Status::Error("Cannot save to file; Invalid filename");
+    auto st = Status_Error("Cannot save to file; Invalid filename");
     LOG_STATUS(st);
     create_error(error, st);
   }
@@ -1033,7 +1033,7 @@ int32_t tiledb_config_unset(
 
 int32_t tiledb_config_compare(
     tiledb_config_t* lhs, tiledb_config_t* rhs, uint8_t* equal) {
-  auto st = Status::Error("Invalid \"equal\" argument");
+  auto st = Status_Error("Invalid \"equal\" argument");
   if (equal == nullptr)
     LOG_STATUS(st);
   tiledb_error_t* error = nullptr;
@@ -1062,7 +1062,7 @@ int32_t tiledb_config_iter_alloc(
 
   *config_iter = new (std::nothrow) tiledb_config_iter_t;
   if (*config_iter == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Cannot create config iterator object; Memory allocation failed");
     LOG_STATUS(st);
     create_error(error, st);
@@ -1073,7 +1073,7 @@ int32_t tiledb_config_iter_alloc(
   (*config_iter)->config_iter_ =
       new (std::nothrow) tiledb::sm::ConfigIter(config->config_, prefix_str);
   if ((*config_iter)->config_iter_ == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Cannot create config iterator object; Memory allocation failed");
     LOG_STATUS(st);
     create_error(error, st);
@@ -1192,7 +1192,7 @@ int32_t tiledb_ctx_alloc(tiledb_config_t* config, tiledb_ctx_t** ctx) try {
   delete (*ctx)->ctx_;
   delete (*ctx);
   (*ctx) = nullptr;
-  auto st = Status::Error(
+  auto st = Status_Error(
       std::string("Internal TileDB uncaught std::bad_alloc exception; ") +
       e.what());
   LOG_STATUS(st);
@@ -1201,7 +1201,7 @@ int32_t tiledb_ctx_alloc(tiledb_config_t* config, tiledb_ctx_t** ctx) try {
   delete (*ctx)->ctx_;
   delete (*ctx);
   (*ctx) = nullptr;
-  auto st = Status::Error(
+  auto st = Status_Error(
       std::string("Internal TileDB uncaught exception; ") + e.what());
   LOG_STATUS(st);
   return TILEDB_ERR;
@@ -1320,7 +1320,7 @@ int32_t tiledb_group_create(tiledb_ctx_t* ctx, const char* group_uri) {
 
   // Check for error
   if (group_uri == nullptr) {
-    auto st = Status::Error("Invalid group directory argument is NULL");
+    auto st = Status_Error("Invalid group directory argument is NULL");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -1347,7 +1347,7 @@ int32_t tiledb_filter_alloc(
   // Create a filter struct
   *filter = new (std::nothrow) tiledb_filter_t;
   if (*filter == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB filter object");
+    auto st = Status_Error("Failed to allocate TileDB filter object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1359,7 +1359,7 @@ int32_t tiledb_filter_alloc(
   if ((*filter)->filter_ == nullptr) {
     delete *filter;
     *filter = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB filter object");
+    auto st = Status_Error("Failed to allocate TileDB filter object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1438,7 +1438,7 @@ int32_t tiledb_filter_list_alloc(
   // Create a filter struct
   *filter_list = new (std::nothrow) tiledb_filter_list_t;
   if (*filter_list == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1449,7 +1449,7 @@ int32_t tiledb_filter_list_alloc(
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
     *filter_list = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1525,7 +1525,7 @@ int32_t tiledb_filter_list_get_filter_from_index(
   }
 
   if (index >= nfilters) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Filter " + std::to_string(index) + " out of bounds, filter list has " +
         std::to_string(nfilters) + " filters.");
     LOG_STATUS(st);
@@ -1535,7 +1535,7 @@ int32_t tiledb_filter_list_get_filter_from_index(
 
   auto f = filter_list->pipeline_->get_filter(index);
   if (f == nullptr) {
-    auto st = Status::Error("Failed to retrieve filter at index");
+    auto st = Status_Error("Failed to retrieve filter at index");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -1543,7 +1543,7 @@ int32_t tiledb_filter_list_get_filter_from_index(
 
   *filter = new (std::nothrow) tiledb_filter_t;
   if (*filter == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB filter object");
+    auto st = Status_Error("Failed to allocate TileDB filter object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1582,7 +1582,7 @@ int32_t tiledb_attribute_alloc(
   // Create an attribute struct
   *attr = new (std::nothrow) tiledb_attribute_t;
   if (*attr == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB attribute object");
+    auto st = Status_Error("Failed to allocate TileDB attribute object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1594,7 +1594,7 @@ int32_t tiledb_attribute_alloc(
   if ((*attr)->attr_ == nullptr) {
     delete *attr;
     *attr = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB attribute object");
+    auto st = Status_Error("Failed to allocate TileDB attribute object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1691,7 +1691,7 @@ int32_t tiledb_attribute_get_filter_list(
   // Create a filter list struct
   *filter_list = new (std::nothrow) tiledb_filter_list_t;
   if (*filter_list == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1703,7 +1703,7 @@ int32_t tiledb_attribute_get_filter_list(
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
     *filter_list = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1805,7 +1805,7 @@ int32_t tiledb_domain_alloc(tiledb_ctx_t* ctx, tiledb_domain_t** domain) {
   // Create a domain struct
   *domain = new (std::nothrow) tiledb_domain_t;
   if (*domain == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB domain object");
+    auto st = Status_Error("Failed to allocate TileDB domain object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1816,7 +1816,7 @@ int32_t tiledb_domain_alloc(tiledb_ctx_t* ctx, tiledb_domain_t** domain) {
   if ((*domain)->domain_ == nullptr) {
     delete *domain;
     *domain = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB domain object");
+    auto st = Status_Error("Failed to allocate TileDB domain object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1839,14 +1839,14 @@ int32_t tiledb_domain_get_type(
     return TILEDB_ERR;
 
   if (domain->domain_->dim_num() == 0) {
-    auto st = Status::Error("Cannot get domain type; Domain has no dimensions");
+    auto st = Status_Error("Cannot get domain type; Domain has no dimensions");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
   }
 
   if (!domain->domain_->all_dims_same_type()) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Cannot get domain type; Not applicable to heterogeneous dimensions");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -1904,7 +1904,7 @@ int32_t tiledb_dimension_alloc(
   // Create a dimension struct
   *dim = new (std::nothrow) tiledb_dimension_t;
   if (*dim == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB dimension object");
+    auto st = Status_Error("Failed to allocate TileDB dimension object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1916,7 +1916,7 @@ int32_t tiledb_dimension_alloc(
   if ((*dim)->dim_ == nullptr) {
     delete *dim;
     *dim = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB dimension object");
+    auto st = Status_Error("Failed to allocate TileDB dimension object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1984,7 +1984,7 @@ int32_t tiledb_dimension_get_filter_list(
   // Create a filter list struct
   *filter_list = new (std::nothrow) tiledb_filter_list_t;
   if (*filter_list == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -1996,7 +1996,7 @@ int32_t tiledb_dimension_get_filter_list(
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
     *filter_list = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2073,14 +2073,14 @@ int32_t tiledb_domain_get_dimension_from_index(
     std::ostringstream errmsg;
     errmsg << "Dimension " << index << " out of bounds, domain has rank "
            << ndim;
-    auto st = Status::DomainError(errmsg.str());
+    auto st = Status_DomainError(errmsg.str());
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
   }
   *dim = new (std::nothrow) tiledb_dimension_t;
   if (*dim == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB dimension object");
+    auto st = Status_Error("Failed to allocate TileDB dimension object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2090,7 +2090,7 @@ int32_t tiledb_domain_get_dimension_from_index(
   if ((*dim)->dim_ == nullptr) {
     delete *dim;
     *dim = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB dimension object");
+    auto st = Status_Error("Failed to allocate TileDB dimension object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2116,7 +2116,7 @@ int32_t tiledb_domain_get_dimension_from_name(
   auto found_dim = domain->domain_->dimension(name_string);
 
   if (found_dim == nullptr) {
-    auto st = Status::DomainError(
+    auto st = Status_DomainError(
         std::string("Dimension '") + name + "' does not exist");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2125,7 +2125,7 @@ int32_t tiledb_domain_get_dimension_from_name(
 
   *dim = new (std::nothrow) tiledb_dimension_t;
   if (*dim == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB dimension object");
+    auto st = Status_Error("Failed to allocate TileDB dimension object");
     save_error(ctx, st);
     return TILEDB_OOM;
   }
@@ -2133,7 +2133,7 @@ int32_t tiledb_domain_get_dimension_from_name(
   if ((*dim)->dim_ == nullptr) {
     delete *dim;
     *dim = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB dimension object");
+    auto st = Status_Error("Failed to allocate TileDB dimension object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2174,7 +2174,7 @@ int32_t tiledb_array_schema_alloc(
   // Create array schema struct
   *array_schema = new (std::nothrow) tiledb_array_schema_t;
   if (*array_schema == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB array schema object");
+    auto st = Status_Error("Failed to allocate TileDB array schema object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2186,7 +2186,7 @@ int32_t tiledb_array_schema_alloc(
   if ((*array_schema)->array_schema_ == nullptr) {
     delete *array_schema;
     *array_schema = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB array schema object");
+    auto st = Status_Error("Failed to allocate TileDB array schema object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2348,7 +2348,7 @@ int32_t tiledb_array_schema_load(
   // Create array schema
   *array_schema = new (std::nothrow) tiledb_array_schema_t;
   if (*array_schema == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB array schema object");
+    auto st = Status_Error("Failed to allocate TileDB array schema object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2357,7 +2357,7 @@ int32_t tiledb_array_schema_load(
   // Check array name
   tiledb::sm::URI uri(array_uri);
   if (uri.is_invalid()) {
-    auto st = Status::Error("Failed to load array schema; Invalid array URI");
+    auto st = Status_Error("Failed to load array schema; Invalid array URI");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -2367,7 +2367,7 @@ int32_t tiledb_array_schema_load(
     // Check REST client
     auto rest_client = ctx->ctx_->storage_manager()->rest_client();
     if (rest_client == nullptr) {
-      auto st = Status::Error(
+      auto st = Status_Error(
           "Failed to load array schema; remote array with no REST client.");
       LOG_STATUS(st);
       save_error(ctx, st);
@@ -2419,7 +2419,7 @@ int32_t tiledb_array_schema_load_with_key(
   // Create array schema
   *array_schema = new (std::nothrow) tiledb_array_schema_t;
   if (*array_schema == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB array schema object");
+    auto st = Status_Error("Failed to allocate TileDB array schema object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2430,7 +2430,7 @@ int32_t tiledb_array_schema_load_with_key(
   if (uri.is_invalid()) {
     delete *array_schema;
     *array_schema = nullptr;
-    auto st = Status::Error("Failed to load array schema; Invalid array URI");
+    auto st = Status_Error("Failed to load array schema; Invalid array URI");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -2442,7 +2442,7 @@ int32_t tiledb_array_schema_load_with_key(
     if (rest_client == nullptr) {
       delete *array_schema;
       *array_schema = nullptr;
-      auto st = Status::Error(
+      auto st = Status_Error(
           "Failed to load array schema; remote array with no REST client.");
       LOG_STATUS(st);
       save_error(ctx, st);
@@ -2532,7 +2532,7 @@ int32_t tiledb_array_schema_get_coords_filter_list(
   // Create a filter list struct
   *filter_list = new (std::nothrow) tiledb_filter_list_t;
   if (*filter_list == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2544,7 +2544,7 @@ int32_t tiledb_array_schema_get_coords_filter_list(
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
     *filter_list = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2564,7 +2564,7 @@ int32_t tiledb_array_schema_get_offsets_filter_list(
   // Create a filter list struct
   *filter_list = new (std::nothrow) tiledb_filter_list_t;
   if (*filter_list == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2576,7 +2576,7 @@ int32_t tiledb_array_schema_get_offsets_filter_list(
   if ((*filter_list)->pipeline_ == nullptr) {
     delete *filter_list;
     *filter_list = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB filter list object");
+    auto st = Status_Error("Failed to allocate TileDB filter list object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2596,7 +2596,7 @@ int32_t tiledb_array_schema_get_domain(
   // Create a domain struct
   *domain = new (std::nothrow) tiledb_domain_t;
   if (*domain == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB domain object");
+    auto st = Status_Error("Failed to allocate TileDB domain object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2609,7 +2609,7 @@ int32_t tiledb_array_schema_get_domain(
     delete *domain;
     *domain = nullptr;
     auto st =
-        Status::Error("Failed to allocate TileDB domain object in object");
+        Status_Error("Failed to allocate TileDB domain object in object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2668,7 +2668,7 @@ int32_t tiledb_array_schema_get_attribute_from_index(
     errmsg << "Attribute index: " << index << " out of bounds given "
            << attribute_num << " attributes in array "
            << array_schema->array_schema_->array_uri().to_string();
-    auto st = Status::ArraySchemaError(errmsg.str());
+    auto st = Status_ArraySchemaError(errmsg.str());
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -2679,7 +2679,7 @@ int32_t tiledb_array_schema_get_attribute_from_index(
 
   *attr = new (std::nothrow) tiledb_attribute_t;
   if (*attr == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB attribute");
+    auto st = Status_Error("Failed to allocate TileDB attribute");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2692,7 +2692,7 @@ int32_t tiledb_array_schema_get_attribute_from_index(
   if ((*attr)->attr_ == nullptr) {
     delete *attr;
     *attr = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB attribute");
+    auto st = Status_Error("Failed to allocate TileDB attribute");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2717,7 +2717,7 @@ int32_t tiledb_array_schema_get_attribute_from_name(
   std::string name_string(name);
   auto found_attr = array_schema->array_schema_->attribute(name_string);
   if (found_attr == nullptr) {
-    auto st = Status::ArraySchemaError(
+    auto st = Status_ArraySchemaError(
         std::string("Attribute name: ") +
         (name_string.empty() ? "<anonymous>" : name) +
         " does not exist for array " +
@@ -2728,7 +2728,7 @@ int32_t tiledb_array_schema_get_attribute_from_name(
   }
   *attr = new (std::nothrow) tiledb_attribute_t;
   if (*attr == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB attribute");
+    auto st = Status_Error("Failed to allocate TileDB attribute");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2739,7 +2739,7 @@ int32_t tiledb_array_schema_get_attribute_from_name(
   if ((*attr)->attr_ == nullptr) {
     delete *attr;
     *attr = nullptr;
-    auto st = Status::Error("Failed to allocate TileDB attribute");
+    auto st = Status_Error("Failed to allocate TileDB attribute");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -2781,7 +2781,7 @@ int32_t tiledb_array_schema_evolution_alloc(
   // Create schema evolution struct
   *array_schema_evolution = new (std::nothrow) tiledb_array_schema_evolution_t;
   if (*array_schema_evolution == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to allocate TileDB array schema evolution object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2794,7 +2794,7 @@ int32_t tiledb_array_schema_evolution_alloc(
   if ((*array_schema_evolution)->array_schema_evolution_ == nullptr) {
     delete *array_schema_evolution;
     *array_schema_evolution = nullptr;
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to allocate TileDB array schema evolution object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2867,7 +2867,7 @@ int32_t tiledb_query_alloc(
 
   // Error if array is not open
   if (!array->array_->is_open()) {
-    auto st = Status::Error("Cannot create query; Input array is not open");
+    auto st = Status_Error("Cannot create query; Input array is not open");
     *query = nullptr;
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2887,7 +2887,7 @@ int32_t tiledb_query_alloc(
                   static_cast<tiledb::sm::QueryType>(query_type))
            << ")";
     *query = nullptr;
-    auto st = Status::Error(errmsg.str());
+    auto st = Status_Error(errmsg.str());
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -2896,7 +2896,7 @@ int32_t tiledb_query_alloc(
   // Create query struct
   *query = new (std::nothrow) tiledb_query_t;
   if (*query == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to allocate TileDB query object; Memory allocation failed");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -2907,7 +2907,7 @@ int32_t tiledb_query_alloc(
   (*query)->query_ = new (std::nothrow)
       tiledb::sm::Query(ctx->ctx_->storage_manager(), array->array_);
   if ((*query)->query_ == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to allocate TileDB query object; Memory allocation failed");
     delete *query;
     *query = nullptr;
@@ -3452,7 +3452,7 @@ int32_t tiledb_query_get_array(
   // Create array datatype
   *array = new (std::nothrow) tiledb_array_t;
   if (*array == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB array object; Memory allocation error");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -3465,7 +3465,7 @@ int32_t tiledb_query_get_array(
   if ((*array)->array_ == nullptr) {
     delete *array;
     *array = nullptr;
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB array object; Memory allocation "
         "error");
     LOG_STATUS(st);
@@ -4138,7 +4138,7 @@ int32_t tiledb_query_condition_alloc(
   // Create query condition struct
   *cond = new (std::nothrow) tiledb_query_condition_t;
   if (*cond == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB query condition object; Memory allocation "
         "error");
     LOG_STATUS(st);
@@ -4149,7 +4149,7 @@ int32_t tiledb_query_condition_alloc(
   // Create QueryCondition object
   (*cond)->query_condition_ = new (std::nothrow) tiledb::sm::QueryCondition();
   if ((*cond)->query_condition_ == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB query condition object");
+    auto st = Status_Error("Failed to allocate TileDB query condition object");
     LOG_STATUS(st);
     save_error(ctx, st);
     delete *cond;
@@ -4212,7 +4212,7 @@ int32_t tiledb_query_condition_combine(
   // Create the combined query condition struct
   *combined_cond = new (std::nothrow) tiledb_query_condition_t;
   if (*combined_cond == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB query condition object; Memory allocation "
         "error");
     LOG_STATUS(st);
@@ -4224,7 +4224,7 @@ int32_t tiledb_query_condition_combine(
   (*combined_cond)->query_condition_ =
       new (std::nothrow) tiledb::sm::QueryCondition();
   if ((*combined_cond)->query_condition_ == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB query condition object");
+    auto st = Status_Error("Failed to allocate TileDB query condition object");
     LOG_STATUS(st);
     save_error(ctx, st);
     delete *combined_cond;
@@ -4261,7 +4261,7 @@ int32_t tiledb_array_alloc(
   // Create array struct
   *array = new (std::nothrow) tiledb_array_t;
   if (*array == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB array object; Memory allocation error");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -4272,7 +4272,7 @@ int32_t tiledb_array_alloc(
   auto uri = tiledb::sm::URI(array_uri);
   if (uri.is_invalid()) {
     auto st =
-        Status::Error("Failed to create TileDB array object; Invalid URI");
+        Status_Error("Failed to create TileDB array object; Invalid URI");
     delete *array;
     *array = nullptr;
     LOG_STATUS(st);
@@ -4286,7 +4286,7 @@ int32_t tiledb_array_alloc(
   if ((*array)->array_ == nullptr) {
     delete *array;
     *array = nullptr;
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB array object; Memory allocation "
         "error");
     LOG_STATUS(st);
@@ -4541,7 +4541,7 @@ int32_t tiledb_array_get_schema(
 
   *array_schema = new (std::nothrow) tiledb_array_schema_t;
   if (*array_schema == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB array schema");
+    auto st = Status_Error("Failed to allocate TileDB array schema");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -4591,7 +4591,7 @@ int32_t tiledb_array_create(
   // Check array name
   tiledb::sm::URI uri(array_uri);
   if (uri.is_invalid()) {
-    auto st = Status::Error("Failed to create array; Invalid array URI");
+    auto st = Status_Error("Failed to create array; Invalid array URI");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -4601,7 +4601,7 @@ int32_t tiledb_array_create(
     // Check REST client
     auto rest_client = ctx->ctx_->storage_manager()->rest_client();
     if (rest_client == nullptr) {
-      auto st = Status::Error(
+      auto st = Status_Error(
           "Failed to create array; remote array with no REST client.");
       LOG_STATUS(st);
       save_error(ctx, st);
@@ -4649,7 +4649,7 @@ int32_t tiledb_array_create_with_key(
   // Check array name
   tiledb::sm::URI uri(array_uri);
   if (uri.is_invalid()) {
-    auto st = Status::Error("Failed to create array; Invalid array URI");
+    auto st = Status_Error("Failed to create array; Invalid array URI");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -4658,7 +4658,7 @@ int32_t tiledb_array_create_with_key(
   if (uri.is_tiledb()) {
     // Check unencrypted
     if (encryption_type != TILEDB_NO_ENCRYPTION) {
-      auto st = Status::Error(
+      auto st = Status_Error(
           "Failed to create array; encrypted remote arrays are not "
           "supported.");
       LOG_STATUS(st);
@@ -4669,7 +4669,7 @@ int32_t tiledb_array_create_with_key(
     // Check REST client
     auto rest_client = ctx->ctx_->storage_manager()->rest_client();
     if (rest_client == nullptr) {
-      auto st = Status::Error(
+      auto st = Status_Error(
           "Failed to create array; remote array with no REST client.");
       LOG_STATUS(st);
       save_error(ctx, st);
@@ -5126,7 +5126,7 @@ int32_t tiledb_array_evolve(
   // Check array name
   tiledb::sm::URI uri(array_uri);
   if (uri.is_invalid()) {
-    auto st = Status::Error("Failed to create array; Invalid array URI");
+    auto st = Status_Error("Failed to create array; Invalid array URI");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -5161,7 +5161,7 @@ int32_t tiledb_array_upgrade_version(
   // Check array name
   tiledb::sm::URI uri(array_uri);
   if (uri.is_invalid()) {
-    auto st = Status::Error("Failed to find the array; Invalid array URI");
+    auto st = Status_Error("Failed to find the array; Invalid array URI");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -5226,7 +5226,7 @@ int32_t tiledb_object_walk(
   if (sanity_check(ctx) == TILEDB_ERR)
     return TILEDB_ERR;
   if (callback == nullptr) {
-    auto st = Status::Error("Cannot initiate walk; Invalid callback function");
+    auto st = Status_Error("Cannot initiate walk; Invalid callback function");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -5277,7 +5277,7 @@ int32_t tiledb_object_ls(
     return TILEDB_ERR;
   if (callback == nullptr) {
     auto st =
-        Status::Error("Cannot initiate object ls; Invalid callback function");
+        Status_Error("Cannot initiate object ls; Invalid callback function");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -5327,7 +5327,7 @@ int32_t tiledb_vfs_alloc(
     return TILEDB_ERR;
 
   if (config != nullptr && config->config_ == nullptr) {
-    auto st = Status::Error("Cannot create VFS; Invalid config");
+    auto st = Status_Error("Cannot create VFS; Invalid config");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -5337,7 +5337,7 @@ int32_t tiledb_vfs_alloc(
   *vfs = new (std::nothrow) tiledb_vfs_t;
   if (*vfs == nullptr) {
     auto st =
-        Status::Error("Failed to allocate TileDB virtual filesystem object");
+        Status_Error("Failed to allocate TileDB virtual filesystem object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -5347,7 +5347,7 @@ int32_t tiledb_vfs_alloc(
   (*vfs)->vfs_ = new (std::nothrow) tiledb::sm::VFS();
   if ((*vfs)->vfs_ == nullptr) {
     auto st =
-        Status::Error("Failed to allocate TileDB virtual filesystem object");
+        Status_Error("Failed to allocate TileDB virtual filesystem object");
     LOG_STATUS(st);
     save_error(ctx, st);
     delete *vfs;
@@ -5633,7 +5633,7 @@ int32_t tiledb_vfs_open(
 
   *fh = new (std::nothrow) tiledb_vfs_fh_t;
   if (*fh == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB VFS file handle; Memory allocation error");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -5644,7 +5644,7 @@ int32_t tiledb_vfs_open(
   auto fh_uri = tiledb::sm::URI(uri);
   if (fh_uri.is_invalid()) {
     auto st =
-        Status::Error("Failed to create TileDB VFS file handle; Invalid URI");
+        Status_Error("Failed to create TileDB VFS file handle; Invalid URI");
     delete *fh;
     *fh = nullptr;
     LOG_STATUS(st);
@@ -5657,7 +5657,7 @@ int32_t tiledb_vfs_open(
   (*fh)->vfs_fh_ =
       new (std::nothrow) tiledb::sm::VFSFileHandle(fh_uri, vfs->vfs_, vfs_mode);
   if ((*fh)->vfs_fh_ == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB VFS file handle; Memory allocation error");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -5737,7 +5737,7 @@ int32_t tiledb_vfs_ls(
     return TILEDB_ERR;
   if (callback == nullptr) {
     auto st =
-        Status::Error("Cannot initiate VFS ls; Invalid callback function");
+        Status_Error("Cannot initiate VFS ls; Invalid callback function");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_ERR;
@@ -5955,7 +5955,7 @@ int32_t tiledb_deserialize_array_schema(
   // Create array schema struct
   *array_schema = new (std::nothrow) tiledb_array_schema_t;
   if (*array_schema == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB array schema object");
+    auto st = Status_Error("Failed to allocate TileDB array schema object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -6022,7 +6022,7 @@ int32_t tiledb_deserialize_array_schema_evolution(
   // Create array schema struct
   *array_schema_evolution = new (std::nothrow) tiledb_array_schema_evolution_t;
   if (*array_schema_evolution == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to allocate TileDB array schema evolution object");
     LOG_STATUS(st);
     save_error(ctx, st);
@@ -6405,7 +6405,7 @@ int32_t tiledb_deserialize_config(
   // Create array schema struct
   *config = new (std::nothrow) tiledb_config_t;
   if (*config == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB config object");
+    auto st = Status_Error("Failed to allocate TileDB config object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;
@@ -6464,7 +6464,7 @@ int32_t tiledb_fragment_info_alloc(
   // Create fragment info struct
   *fragment_info = new (std::nothrow) tiledb_fragment_info_t;
   if (*fragment_info == nullptr) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB fragment info object; Memory allocation "
         "error");
     LOG_STATUS(st);
@@ -6475,7 +6475,7 @@ int32_t tiledb_fragment_info_alloc(
   // Check array URI
   auto uri = tiledb::sm::URI(array_uri);
   if (uri.is_invalid()) {
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB fragment info object; Invalid URI");
     delete *fragment_info;
     *fragment_info = nullptr;
@@ -6490,7 +6490,7 @@ int32_t tiledb_fragment_info_alloc(
   if ((*fragment_info)->fragment_info_ == nullptr) {
     delete *fragment_info;
     *fragment_info = nullptr;
-    auto st = Status::Error(
+    auto st = Status_Error(
         "Failed to create TileDB fragment info object; Memory allocation "
         "error");
     LOG_STATUS(st);
@@ -7032,7 +7032,7 @@ int32_t tiledb_fragment_info_get_array_schema(
   // Create array schema
   *array_schema = new (std::nothrow) tiledb_array_schema_t;
   if (*array_schema == nullptr) {
-    auto st = Status::Error("Failed to allocate TileDB array schema object");
+    auto st = Status_Error("Failed to allocate TileDB array schema object");
     LOG_STATUS(st);
     save_error(ctx, st);
     return TILEDB_OOM;

--- a/tiledb/sm/cache/buffer_lru_cache.cc
+++ b/tiledb/sm/cache/buffer_lru_cache.cc
@@ -77,8 +77,8 @@ Status BufferLRUCache::read(
 
   // Check the bounds of the read.
   if (cached_buffer->size() < offset + nbytes) {
-    return LOG_STATUS(
-        Status::LRUCacheError("Failed to read item; Byte range out of bounds"));
+    return LOG_STATUS(Status_LRUCacheError(
+        "Failed to read item; Byte range out of bounds"));
   }
 
   // Copy the requested range intout the output `buffer`.

--- a/tiledb/sm/cache/buffer_lru_cache.cc
+++ b/tiledb/sm/cache/buffer_lru_cache.cc
@@ -77,8 +77,8 @@ Status BufferLRUCache::read(
 
   // Check the bounds of the read.
   if (cached_buffer->size() < offset + nbytes) {
-    return LOG_STATUS(Status_LRUCacheError(
-        "Failed to read item; Byte range out of bounds"));
+    return LOG_STATUS(
+        Status_LRUCacheError("Failed to read item; Byte range out of bounds"));
   }
 
   // Copy the requested range intout the output `buffer`.

--- a/tiledb/sm/compressors/bzip_compressor.cc
+++ b/tiledb/sm/compressors/bzip_compressor.cc
@@ -46,7 +46,7 @@ Status BZip::compress(
     int level, ConstBuffer* input_buffer, Buffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed compressing with BZip; invalid buffer format"));
 
   // Compress
@@ -65,21 +65,21 @@ Status BZip::compress(
   if (rc != BZ_OK) {
     switch (rc) {
       case BZ_CONFIG_ERROR:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip compression error: library has been miscompiled");
       case BZ_PARAM_ERROR:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip compression error: 'output_buffer' or 'output_buffer_size' "
             "is NULL");
       case BZ_MEM_ERROR:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip compression error: insufficient memory");
       case BZ_OUTBUFF_FULL:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip compression error: compressed size exceeds limits for "
             "'output_buffer_size'");
       default:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip compression error: unknown error code");
     }
   }
@@ -95,7 +95,7 @@ Status BZip::decompress(
     ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed decompressing with BZip; invalid buffer format"));
 
   // Decompress
@@ -112,22 +112,22 @@ Status BZip::decompress(
   if (rc != BZ_OK) {
     switch (rc) {
       case BZ_CONFIG_ERROR:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip decompression error: library has been miscompiled");
       case BZ_PARAM_ERROR:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip decompression error: 'output_buffer' or 'output_buffer_size' "
             "is NULL");
       case BZ_MEM_ERROR:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip decompression error: insufficient memory");
       case BZ_DATA_ERROR:
       case BZ_DATA_ERROR_MAGIC:
       case BZ_UNEXPECTED_EOF:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip decompression error: compressed data is corrupted");
       default:
-        return Status::CompressionError(
+        return Status_CompressionError(
             "BZip decompression error: unknown error code ");
     }
   }

--- a/tiledb/sm/compressors/dd_compressor.cc
+++ b/tiledb/sm/compressors/dd_compressor.cc
@@ -106,13 +106,13 @@ Status DoubleDelta::compress(
       return DoubleDelta::compress<uint8_t>(input_buffer, output_buffer);
     case Datatype::FLOAT32:
     case Datatype::FLOAT64:
-      return LOG_STATUS(Status::CompressionError(
+      return LOG_STATUS(Status_CompressionError(
           "Cannot compress tile with DoubleDelta; Float "
           "datatypes are not supported"));
   }
 
   assert(false);
-  return LOG_STATUS(Status::CompressionError(
+  return LOG_STATUS(Status_CompressionError(
       "Cannot compress tile with DoubleDelta; Not supported datatype"));
 }
 
@@ -172,13 +172,13 @@ Status DoubleDelta::decompress(
       return DoubleDelta::decompress<uint8_t>(input_buffer, output_buffer);
     case Datatype::FLOAT32:
     case Datatype::FLOAT64:
-      return LOG_STATUS(Status::CompressionError(
+      return LOG_STATUS(Status_CompressionError(
           "Cannot decompress tile with DoubleDelta; Float "
           "datatypes are not supported"));
   }
 
   assert(false);
-  return LOG_STATUS(Status::CompressionError(
+  return LOG_STATUS(Status_CompressionError(
       "Cannot decompress tile with DoubleDelta; Not supported datatype"));
 }
 
@@ -267,9 +267,9 @@ Status DoubleDelta::compute_bitsize(
   }
   // Handle error
   if (delta_out_of_bounds) {
-    return LOG_STATUS(
-        Status::CompressionError("Cannot compress with DoubleDelta; Some "
-                                 "negative double delta is out of bounds"));
+    return LOG_STATUS(Status_CompressionError(
+        "Cannot compress with DoubleDelta; Some "
+        "negative double delta is out of bounds"));
   }
   // Calculate bitsize of the maximum absolute double delta
   do {

--- a/tiledb/sm/compressors/dd_compressor.cc
+++ b/tiledb/sm/compressors/dd_compressor.cc
@@ -267,9 +267,9 @@ Status DoubleDelta::compute_bitsize(
   }
   // Handle error
   if (delta_out_of_bounds) {
-    return LOG_STATUS(Status_CompressionError(
-        "Cannot compress with DoubleDelta; Some "
-        "negative double delta is out of bounds"));
+    return LOG_STATUS(
+        Status_CompressionError("Cannot compress with DoubleDelta; Some "
+                                "negative double delta is out of bounds"));
   }
   // Calculate bitsize of the maximum absolute double delta
   do {

--- a/tiledb/sm/compressors/gzip_compressor.cc
+++ b/tiledb/sm/compressors/gzip_compressor.cc
@@ -65,8 +65,7 @@ Status GZip::compress(
 
   if (ret != Z_OK) {
     (void)deflateEnd(&strm);
-    return LOG_STATUS(
-        Status_GZipError("Cannot compress with GZIP"));
+    return LOG_STATUS(Status_GZipError("Cannot compress with GZIP"));
   }
 
   // Compress
@@ -81,8 +80,7 @@ Status GZip::compress(
 
   // Return
   if (ret == Z_STREAM_ERROR || strm.avail_in != 0)
-    return LOG_STATUS(
-        Status_GZipError("Cannot compress with GZIP"));
+    return LOG_STATUS(Status_GZipError("Cannot compress with GZIP"));
 
   // Set size of compressed data
   uint64_t compressed_size = output_buffer->free_space() - strm.avail_out;
@@ -111,8 +109,7 @@ Status GZip::decompress(
   ret = inflateInit(&strm);
 
   if (ret != Z_OK) {
-    return LOG_STATUS(
-        Status_GZipError("Cannot decompress with GZIP"));
+    return LOG_STATUS(Status_GZipError("Cannot decompress with GZIP"));
   }
 
   // Decompress
@@ -123,7 +120,8 @@ Status GZip::decompress(
   ret = inflate(&strm, Z_FINISH);
 
   if (ret != Z_STREAM_END) {
-    return LOG_STATUS(Status_GZipError("Cannot decompress with GZIP, Stream Error"));
+    return LOG_STATUS(
+        Status_GZipError("Cannot decompress with GZIP, Stream Error"));
   }
 
   // Set size of decompressed data

--- a/tiledb/sm/compressors/gzip_compressor.cc
+++ b/tiledb/sm/compressors/gzip_compressor.cc
@@ -47,11 +47,11 @@ Status GZip::compress(
     int level, ConstBuffer* input_buffer, Buffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed compressing with GZip; invalid buffer format"));
 
   if (level > GZip::maximum_level())
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed compressing with GZip; invalid compression level."));
 
   int ret;
@@ -65,7 +65,8 @@ Status GZip::compress(
 
   if (ret != Z_OK) {
     (void)deflateEnd(&strm);
-    return LOG_STATUS(Status::GZipError("Cannot compress with GZIP"));
+    return LOG_STATUS(
+        Status_GZipError("Cannot compress with GZIP"));
   }
 
   // Compress
@@ -80,7 +81,8 @@ Status GZip::compress(
 
   // Return
   if (ret == Z_STREAM_ERROR || strm.avail_in != 0)
-    return LOG_STATUS(Status::GZipError("Cannot compress with GZIP"));
+    return LOG_STATUS(
+        Status_GZipError("Cannot compress with GZIP"));
 
   // Set size of compressed data
   uint64_t compressed_size = output_buffer->free_space() - strm.avail_out;
@@ -94,7 +96,7 @@ Status GZip::decompress(
     ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed decompressing with GZip; invalid buffer format"));
 
   int ret;
@@ -109,7 +111,8 @@ Status GZip::decompress(
   ret = inflateInit(&strm);
 
   if (ret != Z_OK) {
-    return LOG_STATUS(Status::GZipError("Cannot decompress with GZIP"));
+    return LOG_STATUS(
+        Status_GZipError("Cannot decompress with GZIP"));
   }
 
   // Decompress
@@ -120,8 +123,7 @@ Status GZip::decompress(
   ret = inflate(&strm, Z_FINISH);
 
   if (ret != Z_STREAM_END) {
-    return LOG_STATUS(
-        Status::GZipError("Cannot decompress with GZIP, Stream Error"));
+    return LOG_STATUS(Status_GZipError("Cannot decompress with GZIP, Stream Error"));
   }
 
   // Set size of decompressed data

--- a/tiledb/sm/compressors/lz4_compressor.cc
+++ b/tiledb/sm/compressors/lz4_compressor.cc
@@ -47,7 +47,7 @@ Status LZ4::compress(
     int level, ConstBuffer* input_buffer, Buffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed compressing with LZ4; invalid buffer format"));
 
   // TODO: level is ignored using the simple api interface
@@ -69,7 +69,7 @@ Status LZ4::compress(
 
   // Check error
   if (ret < 0)
-    return Status::CompressionError("LZ4 compression failed");
+    return Status_CompressionError("LZ4 compression failed");
 
   // Set size of compressed data
   output_buffer->advance_size(static_cast<uint64_t>(ret));
@@ -82,7 +82,7 @@ Status LZ4::decompress(
     ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed decompressing with LZ4; invalid buffer format"));
 
   // Decompress
@@ -94,7 +94,7 @@ Status LZ4::decompress(
 
   // Check error
   if (ret < 0)
-    return Status::CompressionError("LZ4 decompression failed");
+    return Status_CompressionError("LZ4 decompression failed");
 
   // Set size of decompressed data
   output_buffer->advance_offset(static_cast<uint64_t>(ret));

--- a/tiledb/sm/compressors/rle_compressor.cc
+++ b/tiledb/sm/compressors/rle_compressor.cc
@@ -46,7 +46,7 @@ Status RLE::compress(
     uint64_t value_size, ConstBuffer* input_buffer, Buffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed compressing with RLE; null input buffer"));
   unsigned int cur_run_len = 1;
   unsigned int max_run_len = 65535;
@@ -61,7 +61,7 @@ Status RLE::compress(
 
   // Sanity check on input buffer
   if (input_buffer->size() % value_size != 0) {
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed compressing with RLE; invalid input buffer format"));
   }
 
@@ -103,7 +103,7 @@ Status RLE::decompress(
     PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed decompressing with RLE; null input buffer"));
 
   auto input_cur = static_cast<const unsigned char*>(input_buffer->data());
@@ -117,7 +117,7 @@ Status RLE::decompress(
 
   // Sanity check on input buffer format
   if (input_buffer->size() % run_size != 0) {
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed decompressing with RLE; invalid input buffer format"));
   }
 

--- a/tiledb/sm/compressors/zstd_compressor.cc
+++ b/tiledb/sm/compressors/zstd_compressor.cc
@@ -46,14 +46,14 @@ Status ZStd::compress(
     int level, ConstBuffer* input_buffer, Buffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed compressing with ZStd; invalid buffer format"));
 
   // Create context
   std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx(
       ZSTD_createCCtx(), ZSTD_freeCCtx);
   if (ctx.get() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         std::string("ZStd compression failed; could not allocate context.")));
 
   // Compress
@@ -68,7 +68,7 @@ Status ZStd::compress(
   // Handle error
   if (ZSTD_isError(zstd_ret) != 0) {
     const char* msg = ZSTD_getErrorName(zstd_ret);
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         std::string("ZStd compression failed: ") + msg));
   }
 
@@ -86,11 +86,11 @@ Status ZStd::decompress(
     PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed decompressing with ZStd; invalid buffer format"));
 
   if (decompress_ctx_pool == nullptr) {
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         "Failed decompressing with ZStd; Resource pool not initialized"));
   }
 
@@ -108,7 +108,7 @@ Status ZStd::decompress(
   // Check error
   if (ZSTD_isError(zstd_ret) != 0) {
     const char* msg = ZSTD_getErrorName(zstd_ret);
-    return LOG_STATUS(Status::CompressionError(
+    return LOG_STATUS(Status_CompressionError(
         std::string("ZStd decompression failed: ") + msg));
   }
 

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -366,14 +366,13 @@ Config::~Config() = default;
 Status Config::load_from_file(const std::string& filename) {
   // Do nothing if filename is empty
   if (filename.empty())
-    return LOG_STATUS(
-        Status::ConfigError("Cannot load from file; Invalid filename"));
+    return LOG_STATUS(Status_ConfigError("Cannot load from file; Invalid filename"));
 
   std::ifstream ifs(filename);
   if (!ifs.is_open()) {
     std::stringstream msg;
     msg << "Failed to open config file '" << filename << "'";
-    return LOG_STATUS(Status::ConfigError(msg.str()));
+    return LOG_STATUS(Status_ConfigError(msg.str()));
   }
 
   size_t linenum = 0;
@@ -394,7 +393,7 @@ Status Config::load_from_file(const std::string& filename) {
       std::stringstream msg;
       msg << "Failed to parse config file '" << filename << "'; ";
       msg << "Missing parameter value (line: " << linenum << ")";
-      return LOG_STATUS(Status::ConfigError(msg.str()));
+      return LOG_STATUS(Status_ConfigError(msg.str()));
     }
 
     // Parse extra
@@ -403,7 +402,7 @@ Status Config::load_from_file(const std::string& filename) {
       std::stringstream msg;
       msg << "Failed to parse config file '" << filename << "'; ";
       msg << "Invalid line format (line: " << linenum << ")";
-      return LOG_STATUS(Status::ConfigError(msg.str()));
+      return LOG_STATUS(Status_ConfigError(msg.str()));
     }
 
     // Set param-value pair
@@ -417,14 +416,13 @@ Status Config::load_from_file(const std::string& filename) {
 Status Config::save_to_file(const std::string& filename) {
   // Do nothing if filename is empty
   if (filename.empty())
-    return LOG_STATUS(
-        Status::ConfigError("Cannot save to file; Invalid filename"));
+    return LOG_STATUS(Status_ConfigError("Cannot save to file; Invalid filename"));
 
   std::ofstream ofs(filename);
   if (!ofs.is_open()) {
     std::stringstream msg;
     msg << "Failed to open config file '" << filename << "' for writing";
-    return LOG_STATUS(Status::ConfigError(msg.str()));
+    return LOG_STATUS(Status_ConfigError(msg.str()));
   }
   for (auto& pv : param_values_) {
     if (unserialized_params_.count(pv.first) != 0)
@@ -806,8 +804,7 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &v32));
   } else if (param == "config.logging_format") {
     if (value != "DEFAULT" && value != "JSON")
-      return LOG_STATUS(
-          Status::ConfigError("Invalid logging format parameter value"));
+      return LOG_STATUS(Status_ConfigError("Invalid logging format parameter value"));
   } else if (param == "sm.dedup_coords") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "sm.check_coord_dups") {
@@ -846,8 +843,7 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "sm.var_offsets.mode") {
     if (value != "bytes" && value != "elements")
-      return LOG_STATUS(
-          Status::ConfigError("Invalid offsets format parameter value"));
+      return LOG_STATUS(Status_ConfigError("Invalid offsets format parameter value"));
   } else if (param == "vfs.min_parallel_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_batch_gap") {
@@ -866,8 +862,7 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.s3.scheme") {
     if (value != "http" && value != "https")
-      return LOG_STATUS(
-          Status::ConfigError("Invalid S3 scheme parameter value"));
+      return LOG_STATUS(Status_ConfigError("Invalid S3 scheme parameter value"));
   } else if (param == "vfs.s3.use_virtual_addressing") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "vfs.s3.skit_init") {
@@ -905,7 +900,7 @@ Status Config::sanity_check(
             (value == "bucket_owner_full_control"))))) {
       std::stringstream msg;
       msg << "value " << param << " invalid canned acl for " << param;
-      return Status::Error(msg.str());
+      return Status_Error(msg.str());
     }
   }
 

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -366,7 +366,8 @@ Config::~Config() = default;
 Status Config::load_from_file(const std::string& filename) {
   // Do nothing if filename is empty
   if (filename.empty())
-    return LOG_STATUS(Status_ConfigError("Cannot load from file; Invalid filename"));
+    return LOG_STATUS(
+        Status_ConfigError("Cannot load from file; Invalid filename"));
 
   std::ifstream ifs(filename);
   if (!ifs.is_open()) {
@@ -416,7 +417,8 @@ Status Config::load_from_file(const std::string& filename) {
 Status Config::save_to_file(const std::string& filename) {
   // Do nothing if filename is empty
   if (filename.empty())
-    return LOG_STATUS(Status_ConfigError("Cannot save to file; Invalid filename"));
+    return LOG_STATUS(
+        Status_ConfigError("Cannot save to file; Invalid filename"));
 
   std::ofstream ofs(filename);
   if (!ofs.is_open()) {
@@ -804,7 +806,8 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &v32));
   } else if (param == "config.logging_format") {
     if (value != "DEFAULT" && value != "JSON")
-      return LOG_STATUS(Status_ConfigError("Invalid logging format parameter value"));
+      return LOG_STATUS(
+          Status_ConfigError("Invalid logging format parameter value"));
   } else if (param == "sm.dedup_coords") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "sm.check_coord_dups") {
@@ -843,7 +846,8 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "sm.var_offsets.mode") {
     if (value != "bytes" && value != "elements")
-      return LOG_STATUS(Status_ConfigError("Invalid offsets format parameter value"));
+      return LOG_STATUS(
+          Status_ConfigError("Invalid offsets format parameter value"));
   } else if (param == "vfs.min_parallel_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_batch_gap") {
@@ -862,7 +866,8 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.s3.scheme") {
     if (value != "http" && value != "https")
-      return LOG_STATUS(Status_ConfigError("Invalid S3 scheme parameter value"));
+      return LOG_STATUS(
+          Status_ConfigError("Invalid S3 scheme parameter value"));
   } else if (param == "vfs.s3.use_virtual_addressing") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "vfs.s3.skit_init") {

--- a/tiledb/sm/crypto/crypto.cc
+++ b/tiledb/sm/crypto/crypto.cc
@@ -53,16 +53,16 @@ Status Crypto::encrypt_aes256gcm(
     PreallocatedBuffer* output_iv,
     PreallocatedBuffer* output_tag) {
   if (key->size() != AES256GCM_KEY_BYTES)
-    return LOG_STATUS(
-        Status::EncryptionError("AES-256-GCM error; unexpected key length."));
+    return LOG_STATUS(Status_EncryptionError(
+        "AES-256-GCM error; unexpected key length."));
   if (iv != nullptr && iv->size() != AES256GCM_IV_BYTES)
-    return LOG_STATUS(
-        Status::EncryptionError("AES-256-GCM error; unexpected IV length."));
+    return LOG_STATUS(Status_EncryptionError(
+        "AES-256-GCM error; unexpected IV length."));
   if (output_iv == nullptr || output_iv->size() != AES256GCM_IV_BYTES)
-    return LOG_STATUS(Status::EncryptionError(
+    return LOG_STATUS(Status_EncryptionError(
         "AES-256-GCM error; invalid output IV buffer."));
   if (output_tag == nullptr || output_tag->size() != AES256GCM_TAG_BYTES)
-    return LOG_STATUS(Status::EncryptionError(
+    return LOG_STATUS(Status_EncryptionError(
         "AES-256-GCM error; invalid output tag buffer."));
 
 #ifdef _WIN32
@@ -81,14 +81,11 @@ Status Crypto::decrypt_aes256gcm(
     ConstBuffer* input,
     Buffer* output) {
   if (key == nullptr || key->size() != AES256GCM_KEY_BYTES)
-    return LOG_STATUS(
-        Status::EncryptionError("AES-256-GCM error; invalid key."));
+    return LOG_STATUS(Status_EncryptionError("AES-256-GCM error; invalid key."));
   if (iv == nullptr || iv->size() != AES256GCM_IV_BYTES)
-    return LOG_STATUS(
-        Status::EncryptionError("AES-256-GCM error; invalid IV."));
+    return LOG_STATUS(Status_EncryptionError("AES-256-GCM error; invalid IV."));
   if (tag == nullptr || tag->size() != AES256GCM_TAG_BYTES)
-    return LOG_STATUS(
-        Status::EncryptionError("AES-256-GCM error; invalid tag."));
+    return LOG_STATUS(Status_EncryptionError("AES-256-GCM error; invalid tag."));
 
 #ifdef _WIN32
   return Win32CNG::decrypt_aes256gcm(key, iv, tag, input, output);

--- a/tiledb/sm/crypto/crypto.cc
+++ b/tiledb/sm/crypto/crypto.cc
@@ -53,14 +53,14 @@ Status Crypto::encrypt_aes256gcm(
     PreallocatedBuffer* output_iv,
     PreallocatedBuffer* output_tag) {
   if (key->size() != AES256GCM_KEY_BYTES)
-    return LOG_STATUS(Status_EncryptionError(
-        "AES-256-GCM error; unexpected key length."));
+    return LOG_STATUS(
+        Status_EncryptionError("AES-256-GCM error; unexpected key length."));
   if (iv != nullptr && iv->size() != AES256GCM_IV_BYTES)
-    return LOG_STATUS(Status_EncryptionError(
-        "AES-256-GCM error; unexpected IV length."));
+    return LOG_STATUS(
+        Status_EncryptionError("AES-256-GCM error; unexpected IV length."));
   if (output_iv == nullptr || output_iv->size() != AES256GCM_IV_BYTES)
-    return LOG_STATUS(Status_EncryptionError(
-        "AES-256-GCM error; invalid output IV buffer."));
+    return LOG_STATUS(
+        Status_EncryptionError("AES-256-GCM error; invalid output IV buffer."));
   if (output_tag == nullptr || output_tag->size() != AES256GCM_TAG_BYTES)
     return LOG_STATUS(Status_EncryptionError(
         "AES-256-GCM error; invalid output tag buffer."));
@@ -81,11 +81,13 @@ Status Crypto::decrypt_aes256gcm(
     ConstBuffer* input,
     Buffer* output) {
   if (key == nullptr || key->size() != AES256GCM_KEY_BYTES)
-    return LOG_STATUS(Status_EncryptionError("AES-256-GCM error; invalid key."));
+    return LOG_STATUS(
+        Status_EncryptionError("AES-256-GCM error; invalid key."));
   if (iv == nullptr || iv->size() != AES256GCM_IV_BYTES)
     return LOG_STATUS(Status_EncryptionError("AES-256-GCM error; invalid IV."));
   if (tag == nullptr || tag->size() != AES256GCM_TAG_BYTES)
-    return LOG_STATUS(Status_EncryptionError("AES-256-GCM error; invalid tag."));
+    return LOG_STATUS(
+        Status_EncryptionError("AES-256-GCM error; invalid tag."));
 
 #ifdef _WIN32
   return Win32CNG::decrypt_aes256gcm(key, iv, tag, input, output);

--- a/tiledb/sm/crypto/crypto_win32.cc
+++ b/tiledb/sm/crypto/crypto_win32.cc
@@ -113,8 +113,8 @@ Status Win32CNG::encrypt_aes256gcm(
           sizeof(BCRYPT_CHAIN_MODE_GCM),
           0))) {
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(Status_EncryptionError(
-        "Win32CNG error; error setting chaining mode."));
+    return LOG_STATUS(
+        Status_EncryptionError("Win32CNG error; error setting chaining mode."));
   }
 
   // Initialize authentication info struct.
@@ -155,8 +155,8 @@ Status Win32CNG::encrypt_aes256gcm(
           key_buffer.size(),
           0))) {
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(Status_EncryptionError(
-        "Win32CNG error; error importing key blob."));
+    return LOG_STATUS(
+        Status_EncryptionError("Win32CNG error; error importing key blob."));
   }
 
   // Encrypt the input.
@@ -174,7 +174,8 @@ Status Win32CNG::encrypt_aes256gcm(
           0))) {
     BCryptDestroyKey(key_handle);
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(Status_EncryptionError("Win32CNG error; error encrypting."));
+    return LOG_STATUS(
+        Status_EncryptionError("Win32CNG error; error encrypting."));
   }
 
   output->advance_size(output_len);
@@ -217,8 +218,8 @@ Status Win32CNG::decrypt_aes256gcm(
           sizeof(BCRYPT_CHAIN_MODE_GCM),
           0))) {
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(Status_EncryptionError(
-        "Win32CNG error; error setting chaining mode."));
+    return LOG_STATUS(
+        Status_EncryptionError("Win32CNG error; error setting chaining mode."));
   }
 
   // Initialize authentication info struct.
@@ -259,8 +260,8 @@ Status Win32CNG::decrypt_aes256gcm(
           key_buffer.size(),
           0))) {
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(Status_EncryptionError(
-        "Win32CNG error; error importing key blob."));
+    return LOG_STATUS(
+        Status_EncryptionError("Win32CNG error; error importing key blob."));
   }
 
   // Decrypt the input.
@@ -278,7 +279,8 @@ Status Win32CNG::decrypt_aes256gcm(
           0))) {
     BCryptDestroyKey(key_handle);
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(Status_EncryptionError("Win32CNG error; error decrypting."));
+    return LOG_STATUS(
+        Status_EncryptionError("Win32CNG error; error decrypting."));
   }
 
   if (output->owns_data())
@@ -356,8 +358,7 @@ Status Win32CNG::hash_bytes(
   // close the hash
   if (!NT_SUCCESS(BCryptFinishHash(
           hash, (PUCHAR)output->data(), output->alloced_size(), 0))) {
-    return Status_ChecksumError(
-        "Win32CNG error; could not close hash object.");
+    return Status_ChecksumError("Win32CNG error; could not close hash object.");
   }
 
   return Status::Ok();

--- a/tiledb/sm/crypto/crypto_win32.cc
+++ b/tiledb/sm/crypto/crypto_win32.cc
@@ -54,13 +54,13 @@ Status Win32CNG::get_random_bytes(unsigned num_bytes, Buffer* output) {
   BCRYPT_ALG_HANDLE alg_handle;
   if (!NT_SUCCESS(BCryptOpenAlgorithmProvider(
           &alg_handle, BCRYPT_RNG_ALGORITHM, nullptr, 0)))
-    return Status::EncryptionError(
+    return Status_EncryptionError(
         "Win32CNG error; generating random bytes: error opening algorithm.");
 
   if (!NT_SUCCESS(BCryptGenRandom(
           alg_handle, (unsigned char*)output->cur_data(), num_bytes, 0))) {
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return Status::EncryptionError(
+    return Status_EncryptionError(
         "Win32CNG error; generating random bytes: error generating bytes.");
   }
 
@@ -103,7 +103,7 @@ Status Win32CNG::encrypt_aes256gcm(
   BCRYPT_ALG_HANDLE alg_handle;
   if (!NT_SUCCESS(BCryptOpenAlgorithmProvider(
           &alg_handle, BCRYPT_AES_ALGORITHM, nullptr, 0))) {
-    return LOG_STATUS(Status::EncryptionError(
+    return LOG_STATUS(Status_EncryptionError(
         "Win32CNG error; error opening algorithm provider."));
   }
   if (!NT_SUCCESS(BCryptSetProperty(
@@ -113,7 +113,7 @@ Status Win32CNG::encrypt_aes256gcm(
           sizeof(BCRYPT_CHAIN_MODE_GCM),
           0))) {
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(Status::EncryptionError(
+    return LOG_STATUS(Status_EncryptionError(
         "Win32CNG error; error setting chaining mode."));
   }
 
@@ -155,8 +155,8 @@ Status Win32CNG::encrypt_aes256gcm(
           key_buffer.size(),
           0))) {
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(
-        Status::EncryptionError("Win32CNG error; error importing key blob."));
+    return LOG_STATUS(Status_EncryptionError(
+        "Win32CNG error; error importing key blob."));
   }
 
   // Encrypt the input.
@@ -174,8 +174,7 @@ Status Win32CNG::encrypt_aes256gcm(
           0))) {
     BCryptDestroyKey(key_handle);
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(
-        Status::EncryptionError("Win32CNG error; error encrypting."));
+    return LOG_STATUS(Status_EncryptionError("Win32CNG error; error encrypting."));
   }
 
   output->advance_size(output_len);
@@ -200,7 +199,7 @@ Status Win32CNG::decrypt_aes256gcm(
     if (output->free_space() < required_space)
       RETURN_NOT_OK(output->realloc(output->alloced_size() + required_space));
   } else if (output->size() < required_space) {
-    return LOG_STATUS(Status::EncryptionError(
+    return LOG_STATUS(Status_EncryptionError(
         "Win32CNG error; cannot decrypt: output buffer too small."));
   }
 
@@ -208,7 +207,7 @@ Status Win32CNG::decrypt_aes256gcm(
   BCRYPT_ALG_HANDLE alg_handle;
   if (!NT_SUCCESS(BCryptOpenAlgorithmProvider(
           &alg_handle, BCRYPT_AES_ALGORITHM, nullptr, 0))) {
-    return LOG_STATUS(Status::EncryptionError(
+    return LOG_STATUS(Status_EncryptionError(
         "Win32CNG error; error opening algorithm provider."));
   }
   if (!NT_SUCCESS(BCryptSetProperty(
@@ -218,7 +217,7 @@ Status Win32CNG::decrypt_aes256gcm(
           sizeof(BCRYPT_CHAIN_MODE_GCM),
           0))) {
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(Status::EncryptionError(
+    return LOG_STATUS(Status_EncryptionError(
         "Win32CNG error; error setting chaining mode."));
   }
 
@@ -260,8 +259,8 @@ Status Win32CNG::decrypt_aes256gcm(
           key_buffer.size(),
           0))) {
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(
-        Status::EncryptionError("Win32CNG error; error importing key blob."));
+    return LOG_STATUS(Status_EncryptionError(
+        "Win32CNG error; error importing key blob."));
   }
 
   // Decrypt the input.
@@ -279,8 +278,7 @@ Status Win32CNG::decrypt_aes256gcm(
           0))) {
     BCryptDestroyKey(key_handle);
     BCryptCloseAlgorithmProvider(alg_handle, 0);
-    return LOG_STATUS(
-        Status::EncryptionError("Win32CNG error; error decrypting."));
+    return LOG_STATUS(Status_EncryptionError("Win32CNG error; error decrypting."));
   }
 
   if (output->owns_data())
@@ -315,7 +313,7 @@ Status Win32CNG::hash_bytes(
   BCRYPT_ALG_HANDLE alg_handle;
   if (!NT_SUCCESS(
           BCryptOpenAlgorithmProvider(&alg_handle, hash_algorithm, NULL, 0))) {
-    return Status::ChecksumError(
+    return Status_ChecksumError(
         "Win32CNG error; could not open of hash algorithm.");
   }
 
@@ -328,7 +326,7 @@ Status Win32CNG::hash_bytes(
           sizeof(DWORD),
           &cbData,
           0))) {
-    return Status::ChecksumError(
+    return Status_ChecksumError(
         "Win32CNG error; could not get size of hash object.");
   }
 
@@ -346,19 +344,19 @@ Status Win32CNG::hash_bytes(
           NULL,
           0,
           0))) {
-    return Status::ChecksumError(
+    return Status_ChecksumError(
         "Win32CNG error; could not create hash object.");
   }
 
   // hash some data
   if (!NT_SUCCESS(BCryptHashData(hash, (PBYTE)input, input_read_size, 0))) {
-    return Status::ChecksumError("Win32CNG error; could not hash data.");
+    return Status_ChecksumError("Win32CNG error; could not hash data.");
   }
 
   // close the hash
   if (!NT_SUCCESS(BCryptFinishHash(
           hash, (PUCHAR)output->data(), output->alloced_size(), 0))) {
-    return Status::ChecksumError(
+    return Status_ChecksumError(
         "Win32CNG error; could not close hash object.");
   }
 

--- a/tiledb/sm/crypto/encryption_key.cc
+++ b/tiledb/sm/crypto/encryption_key.cc
@@ -59,7 +59,7 @@ Status EncryptionKey::set_key(
     const void* key_bytes,
     uint32_t key_length) {
   if (!is_valid_key_length(encryption_type, key_length))
-    return LOG_STATUS(Status::EncryptionError(
+    return LOG_STATUS(Status_EncryptionError(
         "Cannot create key; invalid key length for encryption type."));
 
   encryption_type_ = encryption_type;

--- a/tiledb/sm/crypto/encryption_key_validation.cc
+++ b/tiledb/sm/crypto/encryption_key_validation.cc
@@ -76,12 +76,10 @@ Status EncryptionKeyValidation::check_encryption_key(
   }
 
   if (output.size() != ENCRYPTION_KEY_CHECK_DATA.size())
-    return LOG_STATUS(
-        Status_EncryptionError("Invalid encryption key."));
+    return LOG_STATUS(Status_EncryptionError("Invalid encryption key."));
   for (uint64_t i = 0; i < output.size(); i++) {
     if (output.value<char>(i * sizeof(char)) != ENCRYPTION_KEY_CHECK_DATA[i])
-      return LOG_STATUS(
-          Status_EncryptionError("Invalid encryption key."));
+      return LOG_STATUS(Status_EncryptionError("Invalid encryption key."));
   }
 
   return Status::Ok();

--- a/tiledb/sm/crypto/encryption_key_validation.cc
+++ b/tiledb/sm/crypto/encryption_key_validation.cc
@@ -71,15 +71,17 @@ Status EncryptionKeyValidation::check_encryption_key(
       break;
     }
     default:
-      return LOG_STATUS(Status::EncryptionError(
+      return LOG_STATUS(Status_EncryptionError(
           "Invalid encryption key; invalid encryption type."));
   }
 
   if (output.size() != ENCRYPTION_KEY_CHECK_DATA.size())
-    return LOG_STATUS(Status::EncryptionError("Invalid encryption key."));
+    return LOG_STATUS(
+        Status_EncryptionError("Invalid encryption key."));
   for (uint64_t i = 0; i < output.size(); i++) {
     if (output.value<char>(i * sizeof(char)) != ENCRYPTION_KEY_CHECK_DATA[i])
-      return LOG_STATUS(Status::EncryptionError("Invalid encryption key."));
+      return LOG_STATUS(
+          Status_EncryptionError("Invalid encryption key."));
   }
 
   return Status::Ok();
@@ -117,7 +119,7 @@ Status EncryptionKeyValidation::init_encryption_key_check_data(
       break;
     }
     default:
-      return LOG_STATUS(Status::EncryptionError(
+      return LOG_STATUS(Status_EncryptionError(
           "Invalid encryption key; invalid encryption type."));
   }
 

--- a/tiledb/sm/enums/array_type.h
+++ b/tiledb/sm/enums/array_type.h
@@ -69,7 +69,7 @@ inline Status array_type_enum(
   else if (array_type_str == constants::sparse_str)
     *array_type_enum = ArrayType::SPARSE;
   else {
-    return Status::Error("Invalid ArrayType " + array_type_str);
+    return Status_Error("Invalid ArrayType " + array_type_str);
   }
   return Status::Ok();
 }

--- a/tiledb/sm/enums/compressor.h
+++ b/tiledb/sm/enums/compressor.h
@@ -102,7 +102,7 @@ inline Status compressor_enum(
   else if (compressor_type_str == constants::double_delta_str)
     *compressor = Compressor::DOUBLE_DELTA;
   else {
-    return Status::Error("Invalid Compressor " + compressor_type_str);
+    return Status_Error("Invalid Compressor " + compressor_type_str);
   }
   return Status::Ok();
 }

--- a/tiledb/sm/enums/datatype.h
+++ b/tiledb/sm/enums/datatype.h
@@ -291,7 +291,7 @@ inline Status datatype_enum(
   else if (datatype_str == constants::time_as_str)
     *datatype = Datatype::TIME_AS;
   else {
-    return Status::Error("Invalid Datatype " + datatype_str);
+    return Status_Error("Invalid Datatype " + datatype_str);
   }
   return Status::Ok();
 }

--- a/tiledb/sm/enums/encryption_type.h
+++ b/tiledb/sm/enums/encryption_type.h
@@ -69,7 +69,7 @@ inline tuple<Status, optional<EncryptionType>> encryption_type_enum(
   else if (encryption_type_str == constants::aes_256_gcm_str)
     encryption_type = EncryptionType::AES_256_GCM;
   else {
-    return {Status::Error("Invalid EncryptionType " + encryption_type_str),
+    return {Status_Error("Invalid EncryptionType " + encryption_type_str),
             nullopt};
   }
   return {Status::Ok(), encryption_type};

--- a/tiledb/sm/enums/filesystem.h
+++ b/tiledb/sm/enums/filesystem.h
@@ -78,7 +78,7 @@ inline Status filesystem_enum(
   else if (filesystem_type_str == constants::filesystem_type_mem_str)
     *filesystem_type = Filesystem::MEMFS;
   else
-    return Status::Error("Invalid Filesystem " + filesystem_type_str);
+    return Status_Error("Invalid Filesystem " + filesystem_type_str);
 
   return Status::Ok();
 }

--- a/tiledb/sm/enums/filter_option.h
+++ b/tiledb/sm/enums/filter_option.h
@@ -75,7 +75,7 @@ inline Status filter_option_enum(
       constants::filter_option_positive_delta_max_window_str)
     *filter_option_ = FilterOption::POSITIVE_DELTA_MAX_WINDOW;
   else
-    return Status::Error("Invalid FilterOption " + filter_option_str);
+    return Status_Error("Invalid FilterOption " + filter_option_str);
 
   return Status::Ok();
 }

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -120,7 +120,7 @@ inline Status filter_type_enum(
   else if (filter_type_str == constants::filter_checksum_sha256_str)
     *filter_type = FilterType::FILTER_CHECKSUM_SHA256;
   else {
-    return Status::Error("Invalid FilterType " + filter_type_str);
+    return Status_Error("Invalid FilterType " + filter_type_str);
   }
   return Status::Ok();
 }

--- a/tiledb/sm/enums/layout.h
+++ b/tiledb/sm/enums/layout.h
@@ -82,7 +82,7 @@ inline Status layout_enum(const std::string& layout_str, Layout* layout) {
   else if (layout_str == constants::hilbert_str)
     *layout = Layout::HILBERT;
   else {
-    return Status::Error("Invalid Layout " + layout_str);
+    return Status_Error("Invalid Layout " + layout_str);
   }
   return Status::Ok();
 }

--- a/tiledb/sm/enums/object_type.h
+++ b/tiledb/sm/enums/object_type.h
@@ -67,7 +67,7 @@ inline Status object_type_enum(
   else if (object_type_str == constants::object_type_array_str)
     *object_type = ObjectType::ARRAY;
   else
-    return Status::Error("Invalid ObjectType " + object_type_str);
+    return Status_Error("Invalid ObjectType " + object_type_str);
 
   return Status::Ok();
 }

--- a/tiledb/sm/enums/query_condition_combination_op.h
+++ b/tiledb/sm/enums/query_condition_combination_op.h
@@ -85,7 +85,7 @@ inline Status query_condition_combination_op_enum(
       constants::query_condition_combination_op_not_str)
     *query_condition_combination_op = QueryConditionCombinationOp::NOT;
   else {
-    return Status::Error(
+    return Status_Error(
         "Invalid QueryConditionCombinationOp " +
         query_condition_combination_op_str);
   }

--- a/tiledb/sm/enums/query_condition_op.h
+++ b/tiledb/sm/enums/query_condition_op.h
@@ -89,7 +89,7 @@ inline Status query_condition_op_enum(
   else if (query_condition_op_str == constants::query_condition_op_ne_str)
     *query_condition_op = QueryConditionOp::NE;
   else {
-    return Status::Error("Invalid QueryConditionOp " + query_condition_op_str);
+    return Status_Error("Invalid QueryConditionOp " + query_condition_op_str);
   }
   return Status::Ok();
 }

--- a/tiledb/sm/enums/query_status.h
+++ b/tiledb/sm/enums/query_status.h
@@ -81,7 +81,7 @@ inline Status query_status_enum(
   else if (query_status_str == constants::query_status_uninitialized_str)
     *query_status = QueryStatus::UNINITIALIZED;
   else {
-    return Status::Error("Invalid QueryStatus " + query_status_str);
+    return Status_Error("Invalid QueryStatus " + query_status_str);
   }
   return Status::Ok();
 }

--- a/tiledb/sm/enums/query_type.h
+++ b/tiledb/sm/enums/query_type.h
@@ -68,7 +68,7 @@ inline Status query_type_enum(
   else if (query_type_str == constants::query_type_write_str)
     *query_type = QueryType::WRITE;
   else {
-    return Status::Error("Invalid QueryType " + query_type_str);
+    return Status_Error("Invalid QueryType " + query_type_str);
   }
   return Status::Ok();
 }

--- a/tiledb/sm/enums/serialization_type.h
+++ b/tiledb/sm/enums/serialization_type.h
@@ -70,7 +70,7 @@ inline Status serialization_type_enum(
   else if (serialization_type_str == constants::serialization_type_capnp_str)
     *serialization_type = SerializationType::CAPNP;
   else {
-    return Status::Error("Invalid SerializationType " + serialization_type_str);
+    return Status_Error("Invalid SerializationType " + serialization_type_str);
   }
   return Status::Ok();
 }

--- a/tiledb/sm/enums/vfs_mode.h
+++ b/tiledb/sm/enums/vfs_mode.h
@@ -68,7 +68,7 @@ inline Status vfsmode_enum(const std::string& vfsmode_str, VFSMode* vfsmode) {
   else if (vfsmode_str == constants::vfsmode_append_str)
     *vfsmode = VFSMode::VFS_APPEND;
   else
-    return Status::Error("Invalid VFSMode " + vfsmode_str);
+    return Status_Error("Invalid VFSMode " + vfsmode_str);
 
   return Status::Ok();
 }

--- a/tiledb/sm/enums/walk_order.h
+++ b/tiledb/sm/enums/walk_order.h
@@ -65,7 +65,7 @@ inline Status walkorder_enum(
   else if (walkorder_str == constants::walkorder_postorder_str)
     *walkorder = WalkOrder::POSTORDER;
   else
-    return Status::Error("Invalid WalkOrder " + walkorder_str);
+    return Status_Error("Invalid WalkOrder " + walkorder_str);
 
   return Status::Ok();
 }

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -1127,14 +1127,14 @@ Status Azure::upload_block(
           length);
 
   if (!result.valid()) {
-    return LOG_STATUS(Status_AzureError(
-        std::string("Upload block failed on: " + blob_path)));
+    return LOG_STATUS(
+        Status_AzureError(std::string("Upload block failed on: " + blob_path)));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status_AzureError(
-        std::string("Upload block failed on: " + blob_path)));
+    return LOG_STATUS(
+        Status_AzureError(std::string("Upload block failed on: " + blob_path)));
   }
 
   return Status::Ok();

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -75,7 +75,7 @@ Azure::~Azure() {
 Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
   if (thread_pool == nullptr) {
     return LOG_STATUS(
-        Status::AzureError("Can't initialize with null thread pool."));
+        Status_AzureError("Can't initialize with null thread pool."));
   }
 
   thread_pool_ = thread_pool;
@@ -181,7 +181,7 @@ Status Azure::create_container(const URI& uri) const {
   assert(client_);
 
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
@@ -191,13 +191,13 @@ Status Azure::create_container(const URI& uri) const {
   std::future<azure::storage_lite::storage_outcome<void>> result =
       client_->create_container(container_name);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Create container failed on: " + uri.to_string())));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Create container failed on: " + uri.to_string())));
   }
 
@@ -219,7 +219,7 @@ Status Azure::wait_for_container_to_propagate(
         std::chrono::milliseconds(constants::azure_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::AzureError(std::string(
+  return LOG_STATUS(Status_AzureError(std::string(
       "Timed out waiting on container to propogate: " + container_name)));
 }
 
@@ -239,7 +239,7 @@ Status Azure::wait_for_container_to_be_deleted(
         std::chrono::milliseconds(constants::azure_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::AzureError(std::string(
+  return LOG_STATUS(Status_AzureError(std::string(
       "Timed out waiting on container to be deleted: " + container_name)));
 }
 
@@ -257,7 +257,7 @@ Status Azure::flush_blob(const URI& uri) {
   }
 
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
@@ -330,13 +330,13 @@ Status Azure::flush_blob(const URI& uri) {
       client_->put_block_list(
           container_name, blob_path, block_list, empty_metadata);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Flush blob failed on: " + uri.to_string())));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Flush blob failed on: " + uri.to_string())));
   }
 
@@ -357,7 +357,7 @@ void Azure::finish_block_list_upload(const URI& uri) {
 
 Status Azure::flush_blob_direct(const URI& uri) {
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
@@ -392,13 +392,13 @@ Status Azure::flush_blob_direct(const URI& uri) {
           empty_metadata,
           write_cache_buffer->size());
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Flush blob failed on: " + uri.to_string())));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Flush blob failed on: " + uri.to_string())));
   }
 
@@ -415,7 +415,7 @@ Status Azure::is_empty_container(const URI& uri, bool* is_empty) const {
   assert(is_empty);
 
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
@@ -426,7 +426,7 @@ Status Azure::is_empty_container(const URI& uri, bool* is_empty) const {
       azure::storage_lite::list_blobs_segmented_response>>
       result = client_->list_blobs_segmented(container_name, "", "", "", 1);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("List blobs failed on: " + uri.to_string())));
   }
 
@@ -434,7 +434,7 @@ Status Azure::is_empty_container(const URI& uri, bool* is_empty) const {
       azure::storage_lite::list_blobs_segmented_response>
       outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("List blobs failed on: " + uri.to_string())));
   }
 
@@ -450,7 +450,7 @@ Status Azure::is_container(const URI& uri, bool* const is_container) const {
   assert(is_container);
 
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
@@ -469,7 +469,7 @@ Status Azure::is_container(
       azure::storage_lite::container_property>>
       result = client_->get_container_properties(container_name);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Get container properties failed on: " + container_name)));
   }
 
@@ -477,13 +477,13 @@ Status Azure::is_container(
       outcome = result.get();
   if (!outcome.success()) {
     *is_container = false;
-    return Status::Ok();
+    return Status_Ok();
   }
 
   azure::storage_lite::container_property response = outcome.response();
 
   *is_container = response.valid();
-  return Status::Ok();
+  return Status_Ok();
 }
 
 Status Azure::is_dir(const URI& uri, bool* const exists) const {
@@ -493,7 +493,7 @@ Status Azure::is_dir(const URI& uri, bool* const exists) const {
   std::vector<std::string> paths;
   RETURN_NOT_OK(ls(uri, &paths, "/", 1));
   *exists = (bool)paths.size();
-  return Status::Ok();
+  return Status_Ok();
 }
 
 Status Azure::is_blob(const URI& uri, bool* const is_blob) const {
@@ -517,7 +517,7 @@ Status Azure::is_blob(
       azure::storage_lite::storage_outcome<azure::storage_lite::blob_property>>
       result = client_->get_blob_properties(container_name, blob_path);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Get blob properties failed on: " + blob_path)));
   }
 
@@ -525,13 +525,13 @@ Status Azure::is_blob(
       outcome = result.get();
   if (!outcome.success()) {
     *is_blob = false;
-    return Status::Ok();
+    return Status_Ok();
   }
 
   azure::storage_lite::blob_property response = outcome.response();
 
   *is_blob = response.valid();
-  return Status::Ok();
+  return Status_Ok();
 }
 
 std::string Azure::remove_front_slash(const std::string& path) const {
@@ -569,7 +569,7 @@ Status Azure::ls(
   const URI uri_dir = uri.add_trailing_slash();
 
   if (!uri_dir.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri_dir.to_string())));
   }
 
@@ -588,7 +588,7 @@ Status Azure::ls(
             blob_path,
             max_paths > 0 ? max_paths : 5000);
     if (!result.valid()) {
-      return LOG_STATUS(Status::AzureError(
+      return LOG_STATUS(Status_AzureError(
           std::string("List blobs failed on: " + uri_dir.to_string())));
     }
 
@@ -596,7 +596,7 @@ Status Azure::ls(
         azure::storage_lite::list_blobs_segmented_response>
         outcome = result.get();
     if (!outcome.success()) {
-      return LOG_STATUS(Status::AzureError(
+      return LOG_STATUS(Status_AzureError(
           std::string("List blobs failed on: " + uri_dir.to_string())));
     }
 
@@ -626,12 +626,12 @@ Status Azure::copy_blob(const URI& old_uri, const URI& new_uri) {
   assert(client_);
 
   if (!old_uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + old_uri.to_string())));
   }
 
   if (!new_uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + new_uri.to_string())));
   }
 
@@ -647,13 +647,13 @@ Status Azure::copy_blob(const URI& old_uri, const URI& new_uri) {
       client_->start_copy(
           old_container_name, old_blob_path, new_container_name, new_blob_path);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Copy blob failed on: " + old_uri.to_string())));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Copy blob failed on: " + old_uri.to_string())));
   }
 
@@ -676,7 +676,7 @@ Status Azure::wait_for_blob_to_propagate(
         std::chrono::milliseconds(constants::azure_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::AzureError(
+  return LOG_STATUS(Status_AzureError(
       std::string("Timed out waiting on blob to propogate: " + blob_path)));
 }
 
@@ -696,7 +696,7 @@ Status Azure::wait_for_blob_to_be_deleted(
         std::chrono::milliseconds(constants::azure_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::AzureError(
+  return LOG_STATUS(Status_AzureError(
       std::string("Timed out waiting on blob to be deleted: " + blob_path)));
 }
 
@@ -718,7 +718,7 @@ Status Azure::blob_size(const URI& uri, uint64_t* const nbytes) const {
   assert(nbytes);
 
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
@@ -731,7 +731,7 @@ Status Azure::blob_size(const URI& uri, uint64_t* const nbytes) const {
       result =
           client_->list_blobs_segmented(container_name, "", "", blob_path, 1);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Get blob size failed on: " + uri.to_string())));
   }
 
@@ -739,7 +739,7 @@ Status Azure::blob_size(const URI& uri, uint64_t* const nbytes) const {
       azure::storage_lite::list_blobs_segmented_response>
       outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Get blob size failed on: " + uri.to_string())));
   }
 
@@ -747,7 +747,7 @@ Status Azure::blob_size(const URI& uri, uint64_t* const nbytes) const {
       outcome.response();
 
   if (response.blobs.empty()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Get blob size failed on: " + uri.to_string())));
   }
 
@@ -769,7 +769,7 @@ Status Azure::read(
   assert(client_);
 
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
@@ -782,13 +782,13 @@ Status Azure::read(
       client_->download_blob_to_stream(
           container_name, blob_path, offset, length + read_ahead_length, ss);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Read blob failed on: " + uri.to_string())));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Read blob failed on: " + uri.to_string())));
   }
 
@@ -796,7 +796,7 @@ Status Azure::read(
   *length_returned = ss.gcount();
 
   if (*length_returned < length) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Read operation read unexpected number of bytes.")));
   }
 
@@ -815,13 +815,13 @@ Status Azure::remove_container(const URI& uri) const {
   std::future<azure::storage_lite::storage_outcome<void>> result =
       client_->delete_container(container_name);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Remove container failed on: " + uri.to_string())));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Remove container failed on: " + uri.to_string())));
   }
 
@@ -839,13 +839,13 @@ Status Azure::remove_blob(const URI& uri) const {
       client_->delete_blob(
           container_name, blob_path, false /* delete_snapshots */);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Remove blob failed on: " + uri.to_string())));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Remove blob failed on: " + uri.to_string())));
   }
 
@@ -868,12 +868,12 @@ Status Azure::touch(const URI& uri) const {
   assert(client_);
 
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
   if (uri.to_string().back() == '/') {
-    return LOG_STATUS(Status::AzureError(std::string(
+    return LOG_STATUS(Status_AzureError(std::string(
         "Cannot create file; URI is a directory: " + uri.to_string())));
   }
 
@@ -893,13 +893,13 @@ Status Azure::touch(const URI& uri) const {
       client_->upload_block_blob_from_stream(
           container_name, blob_path, empty_ss, empty_metadata);
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Touch blob failed on: " + uri.to_string())));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Touch blob failed on: " + uri.to_string())));
   }
 
@@ -909,7 +909,7 @@ Status Azure::touch(const URI& uri) const {
 Status Azure::write(
     const URI& uri, const void* const buffer, const uint64_t length) {
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
@@ -924,7 +924,7 @@ Status Azure::write(
       std::stringstream errmsg;
       errmsg << "Direct write failed! " << nbytes_filled
              << " bytes written to buffer, " << length << " bytes requested.";
-      return LOG_STATUS(Status::AzureError(errmsg.str()));
+      return LOG_STATUS(Status_AzureError(errmsg.str()));
     } else {
       return Status::Ok();
     }
@@ -1012,7 +1012,7 @@ Status Azure::write_blocks(
     const uint64_t length,
     const bool last_block) {
   if (!uri.is_azure()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("URI is not an Azure URI: " + uri.to_string())));
   }
 
@@ -1028,7 +1028,7 @@ Status Azure::write_blocks(
 
   if (!last_block && length % block_list_block_size_ != 0) {
     return LOG_STATUS(
-        Status::AzureError("Length not evenly divisible by block size"));
+        Status_AzureError("Length not evenly divisible by block size"));
   }
 
   // Protect 'block_list_upload_states_' from concurrent read and writes.
@@ -1127,13 +1127,13 @@ Status Azure::upload_block(
           length);
 
   if (!result.valid()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Upload block failed on: " + blob_path)));
   }
 
   azure::storage_lite::storage_outcome<void> outcome = result.get();
   if (!outcome.success()) {
-    return LOG_STATUS(Status::AzureError(
+    return LOG_STATUS(Status_AzureError(
         std::string("Upload block failed on: " + blob_path)));
   }
 

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -74,7 +74,7 @@ GCS::~GCS() {
 Status GCS::init(const Config& config, ThreadPool* const thread_pool) {
   if (thread_pool == nullptr) {
     return LOG_STATUS(
-        Status::GCSError("Can't initialize with null thread pool."));
+        Status_GCSError("Can't initialize with null thread pool."));
   }
 
   assert(state_ == State::UNINITIALIZED);
@@ -147,7 +147,7 @@ Status GCS::init_client() const {
           google::cloud::storage::oauth2::GoogleDefaultCredentials(
               channel_options);
       if (!status_or_creds) {
-        return LOG_STATUS(Status::GCSError(
+        return LOG_STATUS(Status_GCSError(
             "Failed to initialize GCS credentials: " +
             status_or_creds.status().message()));
       }
@@ -161,12 +161,12 @@ Status GCS::init_client() const {
             std::chrono::milliseconds(request_timeout_ms_)));
     client_ = google::cloud::StatusOr<google::cloud::storage::Client>(client);
     if (!client_) {
-      return LOG_STATUS(Status::GCSError(
+      return LOG_STATUS(Status_GCSError(
           "Failed to initialize GCS Client; " + client_.status().message()));
     }
   } catch (const std::exception& e) {
     return LOG_STATUS(
-        Status::GCSError("Failed to initialize GCS: " + std::string(e.what())));
+        Status_GCSError("Failed to initialize GCS: " + std::string(e.what())));
   }
 
   return Status::Ok();
@@ -176,7 +176,7 @@ Status GCS::create_bucket(const URI& uri) const {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -188,7 +188,7 @@ Status GCS::create_bucket(const URI& uri) const {
           bucket_name, project_id_, google::cloud::storage::BucketMetadata());
 
   if (!bucket_metadata.ok()) {
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Create bucket failed on: " + uri.to_string() + " (" +
         bucket_metadata.status().message() + ")")));
   }
@@ -200,7 +200,7 @@ Status GCS::empty_bucket(const URI& uri) const {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -212,7 +212,7 @@ Status GCS::is_empty_bucket(const URI& uri, bool* is_empty) const {
   assert(is_empty);
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -225,7 +225,7 @@ Status GCS::is_empty_bucket(const URI& uri, bool* is_empty) const {
   for (const google::cloud::StatusOr<google::cloud::storage::ObjectMetadata>&
            object_metadata : objects_reader) {
     if (!object_metadata) {
-      return LOG_STATUS(Status::GCSError(std::string(
+      return LOG_STATUS(Status_GCSError(std::string(
           "List bucket objects failed on: " + uri.to_string() + " (" +
           object_metadata.status().message() + ")")));
     }
@@ -243,7 +243,7 @@ Status GCS::is_bucket(const URI& uri, bool* const is_bucket) const {
   assert(is_bucket);
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -266,7 +266,7 @@ Status GCS::is_bucket(
       *is_bucket = false;
       return Status::Ok();
     } else {
-      return LOG_STATUS(Status::GCSError(std::string(
+      return LOG_STATUS(Status_GCSError(std::string(
           "Get bucket failed on: " + bucket_name + " (" + status.message() +
           ")")));
     }
@@ -281,7 +281,7 @@ Status GCS::is_dir(const URI& uri, bool* const exists) const {
   assert(exists);
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -295,7 +295,7 @@ Status GCS::remove_bucket(const URI& uri) const {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -307,7 +307,7 @@ Status GCS::remove_bucket(const URI& uri) const {
 
   const google::cloud::Status status = client_->DeleteBucket(bucket_name);
   if (!status.ok()) {
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Delete bucket failed on: " + uri.to_string() + " (" +
         status.message() + ")")));
   }
@@ -319,7 +319,7 @@ Status GCS::remove_object(const URI& uri) const {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -330,7 +330,7 @@ Status GCS::remove_object(const URI& uri) const {
   const google::cloud::Status status =
       client_->DeleteObject(bucket_name, object_path);
   if (!status.ok()) {
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Delete object failed on: " + uri.to_string() + " (" +
         status.message() + ")")));
   }
@@ -342,7 +342,7 @@ Status GCS::remove_dir(const URI& uri) const {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -390,7 +390,7 @@ Status GCS::ls(
   const URI uri_dir = uri.add_trailing_slash();
 
   if (!uri_dir.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri_dir.to_string())));
   }
 
@@ -408,7 +408,7 @@ Status GCS::ls(
     if (!object_metadata.ok()) {
       const google::cloud::Status status = object_metadata.status();
 
-      return LOG_STATUS(Status::GCSError(std::string(
+      return LOG_STATUS(Status_GCSError(std::string(
           "List objects failed on: " + uri.to_string() + " (" +
           status.message() + ")")));
     }
@@ -449,12 +449,12 @@ Status GCS::copy_object(const URI& old_uri, const URI& new_uri) {
   RETURN_NOT_OK(init_client());
 
   if (!old_uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + old_uri.to_string())));
   }
 
   if (!new_uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + new_uri.to_string())));
   }
 
@@ -473,7 +473,7 @@ Status GCS::copy_object(const URI& old_uri, const URI& new_uri) {
   if (!object_metadata.ok()) {
     const google::cloud::Status status = object_metadata.status();
 
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Copy object failed on: " + old_uri.to_string() + " (" +
         status.message() + ")")));
   }
@@ -497,7 +497,7 @@ Status GCS::wait_for_object_to_propagate(
         std::chrono::milliseconds(constants::gcs_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::GCSError(
+  return LOG_STATUS(Status_GCSError(
       std::string("Timed out waiting on object to propogate: " + object_path)));
 }
 
@@ -517,7 +517,7 @@ Status GCS::wait_for_object_to_be_deleted(
         std::chrono::milliseconds(constants::gcs_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::GCSError(std::string(
+  return LOG_STATUS(Status_GCSError(std::string(
       "Timed out waiting on object to be deleted: " + object_path)));
 }
 
@@ -535,7 +535,7 @@ Status GCS::wait_for_bucket_to_propagate(const std::string& bucket_name) const {
         std::chrono::milliseconds(constants::gcs_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::GCSError(
+  return LOG_STATUS(Status_GCSError(
       std::string("Timed out waiting on bucket to propogate: " + bucket_name)));
 }
 
@@ -555,7 +555,7 @@ Status GCS::wait_for_bucket_to_be_deleted(
         std::chrono::milliseconds(constants::gcs_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::GCSError(std::string(
+  return LOG_STATUS(Status_GCSError(std::string(
       "Timed out waiting on bucket to be deleted: " + bucket_name)));
 }
 
@@ -576,7 +576,7 @@ Status GCS::touch(const URI& uri) const {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -590,7 +590,7 @@ Status GCS::touch(const URI& uri) const {
   if (!object_metadata.ok()) {
     const google::cloud::Status status = object_metadata.status();
 
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Touch object failed on: " + uri.to_string() + " (" + status.message() +
         ")")));
   }
@@ -603,7 +603,7 @@ Status GCS::is_object(const URI& uri, bool* const is_object) const {
   assert(is_object);
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -631,7 +631,7 @@ Status GCS::is_object(
       *is_object = false;
       return Status::Ok();
     } else {
-      return LOG_STATUS(Status::GCSError(std::string(
+      return LOG_STATUS(Status_GCSError(std::string(
           "Get object failed on: " + object_path + " (" + status.message() +
           ")")));
     }
@@ -645,7 +645,7 @@ Status GCS::is_object(
 Status GCS::write(
     const URI& uri, const void* const buffer, const uint64_t length) {
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -660,7 +660,7 @@ Status GCS::write(
       std::stringstream errmsg;
       errmsg << "Direct write failed! " << nbytes_filled
              << " bytes written to buffer, " << length << " bytes requested.";
-      return LOG_STATUS(Status::GCSError(errmsg.str()));
+      return LOG_STATUS(Status_GCSError(errmsg.str()));
     } else {
       return Status::Ok();
     }
@@ -702,7 +702,7 @@ Status GCS::object_size(const URI& uri, uint64_t* const nbytes) const {
   assert(nbytes);
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -716,7 +716,7 @@ Status GCS::object_size(const URI& uri, uint64_t* const nbytes) const {
   if (!object_metadata.ok()) {
     const google::cloud::Status status = object_metadata.status();
 
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Get object size failed on: " + object_path + " (" + status.message() +
         ")")));
   }
@@ -774,7 +774,7 @@ Status GCS::write_parts(
     const uint64_t length,
     const bool last_part) {
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not an GCS URI: " + uri.to_string())));
   }
 
@@ -790,7 +790,7 @@ Status GCS::write_parts(
 
   if (!last_part && length % multi_part_part_size_ != 0) {
     return LOG_STATUS(
-        Status::S3Error("Length not evenly divisible by part size"));
+        Status_S3Error("Length not evenly divisible by part size"));
   }
 
   std::string bucket_name;
@@ -903,7 +903,7 @@ Status GCS::upload_part(
   if (!object_metadata.ok()) {
     const google::cloud::Status status = object_metadata.status();
 
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Upload part failed on: " + object_part_path + " (" + status.message() +
         ")")));
   }
@@ -915,7 +915,7 @@ Status GCS::flush_object(const URI& uri) {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not a GCS URI: " + uri.to_string())));
   }
 
@@ -1002,7 +1002,7 @@ Status GCS::flush_object(const URI& uri) {
   if (!object_metadata.ok()) {
     const google::cloud::Status status = object_metadata.status();
 
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Compse object failed on: " + uri.to_string() + " (" +
         status.message() + ")")));
   }
@@ -1033,7 +1033,7 @@ Status GCS::delete_part(
   const google::cloud::Status status =
       client_->DeleteObject(bucket_name, part_path);
   if (!status.ok()) {
-    return Status::GCSError(std::string(
+    return Status_GCSError(std::string(
         "Delete part failed on: " + part_path + " (" + status.message() + ")"));
   }
 
@@ -1079,7 +1079,7 @@ Status GCS::flush_object_direct(const URI& uri) {
   if (!object_metadata.ok()) {
     const google::cloud::Status status = object_metadata.status();
 
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Write object failed on: " + uri.to_string() + " (" + status.message() +
         ")")));
   }
@@ -1097,7 +1097,7 @@ Status GCS::read(
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_gcs()) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("URI is not an GCS URI: " + uri.to_string())));
   }
 
@@ -1112,7 +1112,7 @@ Status GCS::read(
           offset, offset + length + read_ahead_length));
 
   if (!stream.status().ok()) {
-    return LOG_STATUS(Status::GCSError(std::string(
+    return LOG_STATUS(Status_GCSError(std::string(
         "Read object failed on: " + uri.to_string() + " (" +
         stream.status().message() + ")")));
   }
@@ -1123,7 +1123,7 @@ Status GCS::read(
   stream.Close();
 
   if (*length_returned < length) {
-    return LOG_STATUS(Status::GCSError(
+    return LOG_STATUS(Status_GCSError(
         std::string("Read operation read unexpected number of bytes.")));
   }
 

--- a/tiledb/sm/filesystem/hdfs_filesystem.cc
+++ b/tiledb/sm/filesystem/hdfs_filesystem.cc
@@ -65,7 +65,7 @@ namespace hdfs {
 
 Status close_library(void* handle) {
   if (dlclose(handle)) {
-    return Status::HDFSError(dlerror());
+    return Status_HDFSError(dlerror());
   }
   return Status::Ok();
 }
@@ -73,7 +73,7 @@ Status close_library(void* handle) {
 Status load_library(const char* library_filename, void** handle) {
   *handle = dlopen(library_filename, RTLD_NOW | RTLD_LOCAL);
   if (!*handle) {
-    return Status::HDFSError(dlerror());
+    return Status_HDFSError(dlerror());
   }
   return Status::Ok();
 }
@@ -81,7 +81,7 @@ Status load_library(const char* library_filename, void** handle) {
 Status library_symbol(void* handle, const char* symbol_name, void** symbol) {
   *symbol = dlsym(handle, symbol_name);
   if (!*symbol) {
-    return Status::HDFSError(dlerror());
+    return Status_HDFSError(dlerror());
   }
   return Status::Ok();
 }
@@ -182,7 +182,7 @@ class LibHDFS {
     // Use the path as specified in the libhdfs documentation.
     const char* hdfs_home = getenv("HADOOP_HOME");
     if (hdfs_home == nullptr) {
-      status_ = Status::HDFSError("Environment variable HADOOP_HOME not set");
+      status_ = Status_HDFSError("Environment variable HADOOP_HOME not set");
       return;
     }
 #if defined(__APPLE__)
@@ -229,7 +229,7 @@ Status HDFS::init(const Config& config) {
   }
   struct hdfsBuilder* builder = libhdfs_->hdfsNewBuilder();
   if (builder == nullptr) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         "Failed to connect to hdfs, could not create connection builder"));
   }
   libhdfs_->hdfsBuilderSetForceNewInstance(builder);
@@ -246,7 +246,7 @@ Status HDFS::init(const Config& config) {
   hdfs_ = libhdfs_->hdfsBuilderConnect(builder);
   if (hdfs_ == nullptr) {
     // TODO: errno for better options
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Failed to connect to HDFS namenode: ") + name_node_uri));
   }
   return Status::Ok();
@@ -255,7 +255,7 @@ Status HDFS::init(const Config& config) {
 Status HDFS::disconnect() {
   RETURN_NOT_OK(libhdfs_->status());
   if (libhdfs_->hdfsDisconnect(hdfs_) != 0) {
-    return LOG_STATUS(Status::HDFSError("Failed to disconnect hdfs"));
+    return LOG_STATUS(Status_HDFSError("Failed to disconnect hdfs"));
   }
   hdfs_ = nullptr;
   return Status::Ok();
@@ -265,7 +265,7 @@ Status HDFS::disconnect() {
 Status HDFS::connect(hdfsFS* fs) {
   RETURN_NOT_OK(libhdfs_->status());
   if (hdfs_ == nullptr) {
-    return LOG_STATUS(Status::HDFSError("Not connected to HDFS namenode"));
+    return LOG_STATUS(Status_HDFSError("Not connected to HDFS namenode"));
   }
   *fs = hdfs_;
   return Status::Ok();
@@ -299,13 +299,13 @@ Status HDFS::create_dir(const URI& uri) {
   bool dir_exists = false;
   RETURN_NOT_OK(is_dir(uri, &dir_exists));
   if (dir_exists) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot create directory ") + uri.to_string() +
         "'; Directory already exists"));
   }
   int ret = libhdfs_->hdfsCreateDirectory(fs, uri.to_path().c_str());
   if (ret < 0) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot create directory ") + uri.to_string()));
   }
   return Status::Ok();
@@ -317,7 +317,7 @@ Status HDFS::remove_dir(const URI& uri) {
   int rc = libhdfs_->hdfsDelete(fs, uri.to_path().c_str(), 1);
   if (rc < 0) {
     return LOG_STATUS(
-        Status::HDFSError("Cannot remove path: " + uri.to_string()));
+        Status_HDFSError("Cannot remove path: " + uri.to_string()));
   }
   return Status::Ok();
 }
@@ -326,14 +326,14 @@ Status HDFS::move_path(const URI& old_uri, const URI& new_uri) {
   hdfsFS fs = nullptr;
   RETURN_NOT_OK(connect(&fs));
   if (libhdfs_->hdfsExists(fs, new_uri.to_path().c_str()) == 0) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         "Cannot move path " + old_uri.to_string() + " to " +
         new_uri.to_string() + "; path exists."));
   }
   int ret = libhdfs_->hdfsRename(
       fs, old_uri.to_path().c_str(), new_uri.to_path().c_str());
   if (ret < 0) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         "Error moving path " + old_uri.to_string() + " to " +
         new_uri.to_string()));
   }
@@ -364,7 +364,7 @@ Status HDFS::is_file(const URI& uri, bool* is_file) {
 
 Status HDFS::touch(const URI& uri) {
   if (uri.to_string().back() == '/') {
-    return LOG_STATUS(Status::HDFSError(std::string(
+    return LOG_STATUS(Status_HDFSError(std::string(
         "Cannot create file; URI is a directory: " + uri.to_string())));
   }
 
@@ -373,13 +373,13 @@ Status HDFS::touch(const URI& uri) {
   hdfsFile writeFile =
       libhdfs_->hdfsOpenFile(fs, uri.to_path().c_str(), O_WRONLY, 0, 0, 0);
   if (!writeFile) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot create file ") + uri.to_string() +
         "; File opening error"));
   }
   // Close file
   if (libhdfs_->hdfsCloseFile(fs, writeFile)) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot create file ") + uri.to_string() +
         "; File closing error"));
   }
@@ -391,7 +391,7 @@ Status HDFS::remove_file(const URI& uri) {
   RETURN_NOT_OK(connect(&fs));
   int ret = libhdfs_->hdfsDelete(fs, uri.to_path().c_str(), 0);
   if (ret < 0) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot delete file ") + uri.to_string()));
   }
   return Status::Ok();
@@ -403,19 +403,19 @@ Status HDFS::read(const URI& uri, off_t offset, void* buffer, uint64_t length) {
   hdfsFile readFile =
       libhdfs_->hdfsOpenFile(fs, uri.to_path().c_str(), O_RDONLY, length, 0, 0);
   if (!readFile) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot read file ") + uri.to_string() +
         ": file open error"));
   }
   if (offset > std::numeric_limits<tOffset>::max()) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot read from from '") + uri.to_string() +
         "'; offset > typemax(tOffset)"));
   }
   tOffset off = static_cast<tOffset>(offset);
   int ret = libhdfs_->hdfsSeek(fs, readFile, off);
   if (ret < 0) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot seek to offset ") + uri.to_string()));
   }
   uint64_t bytes_to_read = length;
@@ -425,7 +425,7 @@ Status HDFS::read(const URI& uri, off_t offset, void* buffer, uint64_t length) {
     tSize bytes_read =
         libhdfs_->hdfsRead(fs, readFile, static_cast<void*>(buffptr), nbytes);
     if (bytes_read < 0) {
-      return LOG_STATUS(Status::HDFSError(
+      return LOG_STATUS(Status_HDFSError(
           "Cannot read from file " + uri.to_string() + "; File reading error"));
     }
     bytes_to_read -= bytes_read;
@@ -434,7 +434,7 @@ Status HDFS::read(const URI& uri, off_t offset, void* buffer, uint64_t length) {
 
   // Close file
   if (libhdfs_->hdfsCloseFile(fs, readFile)) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot read from file ") + uri.to_string() +
         "; File closing error"));
   }
@@ -450,7 +450,7 @@ Status HDFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
   hdfsFile write_file = libhdfs_->hdfsOpenFile(
       fs, uri.to_path().c_str(), flags, constants::max_write_bytes, 0, 0);
   if (!write_file) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot write to file ") + uri.to_string() +
         "; File opening error"));
   }
@@ -466,7 +466,7 @@ Status HDFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
         constants::max_write_bytes);
     if (bytes_written < 0 ||
         static_cast<uint64_t>(bytes_written) != constants::max_write_bytes) {
-      return LOG_STATUS(Status::HDFSError(
+      return LOG_STATUS(Status_HDFSError(
           std::string("Cannot write to file ") + uri.to_string() +
           "; File writing error"));
     }
@@ -477,13 +477,13 @@ Status HDFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
       fs, write_file, buffer_bytes_ptr + buffer_bytes_written, buffer_size);
   if (bytes_written < 0 ||
       static_cast<uint64_t>(bytes_written) != buffer_size) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot write to file '") + uri.to_string() +
         "'; File writing error"));
   }
   // Close file
   if (libhdfs_->hdfsCloseFile(fs, write_file)) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot write to file ") + uri.to_string() +
         "; File closing error"));
   }
@@ -503,18 +503,18 @@ Status HDFS::sync(const URI& uri) {
   hdfsFile file = libhdfs_->hdfsOpenFile(
       fs, uri.to_path().c_str(), O_WRONLY | O_APPEND, 0, 0, 0);
   if (!file) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot sync file '") + uri.to_string() +
         "'; File open error"));
   }
   // Sync
   if (libhdfs_->hdfsHFlush(fs, file)) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Failed syncing file '") + uri.to_string() + "'"));
   }
   // Close file
   if (libhdfs_->hdfsCloseFile(fs, file)) {
-    return LOG_STATUS(Status::HDFSError(
+    return LOG_STATUS(Status_HDFSError(
         std::string("Cannot sync file ") + uri.to_string() +
         "; File closing error"));
   }
@@ -529,7 +529,7 @@ Status HDFS::ls(const URI& uri, std::vector<std::string>* paths) {
       libhdfs_->hdfsListDirectory(fs, uri.to_path().c_str(), &numEntries);
   if (fileList == NULL) {
     if (errno) {
-      return LOG_STATUS(Status::HDFSError(
+      return LOG_STATUS(Status_HDFSError(
           std::string("Cannot list files in ") + uri.to_string()));
     }
   }
@@ -550,14 +550,14 @@ Status HDFS::file_size(const URI& uri, uint64_t* nbytes) {
   hdfsFileInfo* fileInfo = libhdfs_->hdfsGetPathInfo(fs, uri.to_path().c_str());
   if (fileInfo == nullptr) {
     return LOG_STATUS(
-        Status::HDFSError(std::string("Not a file ") + uri.to_string()));
+        Status_HDFSError(std::string("Not a file ") + uri.to_string()));
   }
   if ((char)(fileInfo->mKind) == 'F') {
     *nbytes = static_cast<uint64_t>(fileInfo->mSize);
   } else {
     libhdfs_->hdfsFreeFileInfo(fileInfo, 1);
     return LOG_STATUS(
-        Status::HDFSError(std::string("Not a file ") + uri.to_string()));
+        Status_HDFSError(std::string("Not a file ") + uri.to_string()));
   }
   libhdfs_->hdfsFreeFileInfo(fileInfo, 1);
   return Status::Ok();

--- a/tiledb/sm/filesystem/hdfs_filesystem.cc
+++ b/tiledb/sm/filesystem/hdfs_filesystem.cc
@@ -391,8 +391,8 @@ Status HDFS::remove_file(const URI& uri) {
   RETURN_NOT_OK(connect(&fs));
   int ret = libhdfs_->hdfsDelete(fs, uri.to_path().c_str(), 0);
   if (ret < 0) {
-    return LOG_STATUS(Status_HDFSError(
-        std::string("Cannot delete file ") + uri.to_string()));
+    return LOG_STATUS(
+        Status_HDFSError(std::string("Cannot delete file ") + uri.to_string()));
   }
   return Status::Ok();
 }

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -190,8 +190,8 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
     assert(buffer);
 
     if (offset + nbytes > size_)
-      return LOG_STATUS(Status_MemFSError(
-          "Cannot read from file; Read exceeds file size"));
+      return LOG_STATUS(
+          Status_MemFSError("Cannot read from file; Read exceeds file size"));
 
     memcpy(buffer, (char*)data_ + offset, nbytes);
     return Status::Ok();
@@ -220,8 +220,8 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
       new_data = tdb_realloc(data_, size_ + nbytes);
 
       if (new_data == nullptr) {
-        return LOG_STATUS(Status_MemFSError(
-            "Out of memory, cannot append new data to file"));
+        return LOG_STATUS(
+            Status_MemFSError("Out of memory, cannot append new data to file"));
       }
 
       memcpy((char*)new_data + size_, data, nbytes);
@@ -358,8 +358,8 @@ Status MemFilesystem::file_size(
   RETURN_NOT_OK(lookup_node(path, &cur, &cur_lock));
 
   if (cur == nullptr) {
-    return LOG_STATUS(Status_MemFSError(
-        std::string("Cannot get file size of :" + path)));
+    return LOG_STATUS(
+        Status_MemFSError(std::string("Cannot get file size of :" + path)));
   }
 
   return cur->get_size(size);
@@ -419,8 +419,8 @@ Status MemFilesystem::move(
     const std::string& old_path, const std::string& new_path) const {
   std::vector<std::string> old_path_tokens = tokenize(old_path);
   if (old_path_tokens.size() <= 1) {
-    return LOG_STATUS(Status_MemFSError(
-        std::string("Cannot move the root directory")));
+    return LOG_STATUS(
+        Status_MemFSError(std::string("Cannot move the root directory")));
   }
 
   // Remove the last token so that `old_path_tokens` contains the path
@@ -449,8 +449,8 @@ Status MemFilesystem::move(
   // parent of the new node.
   std::vector<std::string> new_path_tokens = tokenize(new_path);
   if (new_path_tokens.size() <= 1) {
-    return LOG_STATUS(Status_MemFSError(
-        std::string("Cannot move to the root directory")));
+    return LOG_STATUS(
+        Status_MemFSError(std::string("Cannot move to the root directory")));
   }
 
   // Remove the last token so that `new_path_tokens` contains the path
@@ -514,13 +514,13 @@ Status MemFilesystem::remove(const std::string& path, const bool is_dir) const {
   }
 
   if (cur == root_.get()) {
-    return LOG_STATUS(Status_MemFSError(
-        std::string("Cannot remove the root directory")));
+    return LOG_STATUS(
+        Status_MemFSError(std::string("Cannot remove the root directory")));
   }
 
   if (cur->is_dir() != is_dir) {
-    return LOG_STATUS(Status_MemFSError(
-        std::string("Remove failed, wrong file type")));
+    return LOG_STATUS(
+        Status_MemFSError(std::string("Remove failed, wrong file type")));
   }
 
   cur_lock.unlock();

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -164,7 +164,7 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
     (void)full_path;
     (void)children;
 
-    return LOG_STATUS(Status::MemFSError(
+    return LOG_STATUS(Status_MemFSError(
         std::string("Cannot get children, the path is a file")));
   }
 
@@ -190,8 +190,8 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
     assert(buffer);
 
     if (offset + nbytes > size_)
-      return LOG_STATUS(
-          Status::MemFSError("Cannot read from file; Read exceeds file size"));
+      return LOG_STATUS(Status_MemFSError(
+          "Cannot read from file; Read exceeds file size"));
 
     memcpy(buffer, (char*)data_ + offset, nbytes);
     return Status::Ok();
@@ -203,14 +203,14 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
     assert(data);
 
     if ((data == nullptr) || nbytes == 0) {
-      return LOG_STATUS(Status::MemFSError(
+      return LOG_STATUS(Status_MemFSError(
           std::string("Wrong input buffer or size when writing to file")));
     }
 
     if (data_ == nullptr) {
       data_ = tdb_malloc(nbytes);
       if (data_ == nullptr) {
-        return LOG_STATUS(Status::MemFSError(
+        return LOG_STATUS(Status_MemFSError(
             std::string("Out of memory, cannot write to file")));
       }
       memcpy(data_, data, nbytes);
@@ -220,7 +220,7 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
       new_data = tdb_realloc(data_, size_ + nbytes);
 
       if (new_data == nullptr) {
-        return LOG_STATUS(Status::MemFSError(
+        return LOG_STATUS(Status_MemFSError(
             "Out of memory, cannot append new data to file"));
       }
 
@@ -310,7 +310,7 @@ class MemFilesystem::Directory : public MemFilesystem::FSNode {
     assert(size);
 
     (void)size;
-    return LOG_STATUS(Status::MemFSError(
+    return LOG_STATUS(Status_MemFSError(
         std::string("Cannot get size, the path is a directory")));
   }
 
@@ -322,7 +322,7 @@ class MemFilesystem::Directory : public MemFilesystem::FSNode {
     (void)offset;
     (void)buffer;
     (void)nbytes;
-    return LOG_STATUS(Status::MemFSError(
+    return LOG_STATUS(Status_MemFSError(
         std::string("Cannot read contents, the path is a directory")));
   }
 
@@ -332,7 +332,7 @@ class MemFilesystem::Directory : public MemFilesystem::FSNode {
 
     (void)data;
     (void)nbytes;
-    return LOG_STATUS(Status::MemFSError(
+    return LOG_STATUS(Status_MemFSError(
         std::string("Cannot append contents, the path is a directory")));
   }
 };
@@ -358,8 +358,8 @@ Status MemFilesystem::file_size(
   RETURN_NOT_OK(lookup_node(path, &cur, &cur_lock));
 
   if (cur == nullptr) {
-    return LOG_STATUS(
-        Status::MemFSError(std::string("Cannot get file size of :" + path)));
+    return LOG_STATUS(Status_MemFSError(
+        std::string("Cannot get file size of :" + path)));
   }
 
   return cur->get_size(size);
@@ -400,7 +400,7 @@ Status MemFilesystem::ls(
     dir = dir + token + "/";
 
     if (cur->children_.count(token) != 1) {
-      return LOG_STATUS(Status::MemFSError(
+      return LOG_STATUS(Status_MemFSError(
           std::string("Unable to list on non-existent path ") + path));
     }
 
@@ -419,8 +419,8 @@ Status MemFilesystem::move(
     const std::string& old_path, const std::string& new_path) const {
   std::vector<std::string> old_path_tokens = tokenize(old_path);
   if (old_path_tokens.size() <= 1) {
-    return LOG_STATUS(
-        Status::MemFSError(std::string("Cannot move the root directory")));
+    return LOG_STATUS(Status_MemFSError(
+        std::string("Cannot move the root directory")));
   }
 
   // Remove the last token so that `old_path_tokens` contains the path
@@ -436,7 +436,7 @@ Status MemFilesystem::move(
 
   // Detach `old_path` from the directory tree.
   if (old_node_parent->children_.count(old_path_last_token) == 0) {
-    return LOG_STATUS(Status::MemFSError(
+    return LOG_STATUS(Status_MemFSError(
         std::string("Move failed, file not found: " + old_path)));
   }
   tdb_unique_ptr<FSNode> old_node_ptr =
@@ -449,8 +449,8 @@ Status MemFilesystem::move(
   // parent of the new node.
   std::vector<std::string> new_path_tokens = tokenize(new_path);
   if (new_path_tokens.size() <= 1) {
-    return LOG_STATUS(
-        Status::MemFSError(std::string("Cannot move to the root directory")));
+    return LOG_STATUS(Status_MemFSError(
+        std::string("Cannot move to the root directory")));
   }
 
   // Remove the last token so that `new_path_tokens` contains the path
@@ -480,7 +480,7 @@ Status MemFilesystem::read(
   RETURN_NOT_OK(lookup_node(path, &node, &node_lock));
 
   if (node == nullptr) {
-    return LOG_STATUS(Status::MemFSError(
+    return LOG_STATUS(Status_MemFSError(
         std::string("File not found, read failed for : " + path)));
   }
 
@@ -502,7 +502,7 @@ Status MemFilesystem::remove(const std::string& path, const bool is_dir) const {
     assert(!parent || parent_lock.mutex() == &parent->mutex_);
 
     if (!cur->has_child(token)) {
-      return LOG_STATUS(Status::MemFSError(
+      return LOG_STATUS(Status_MemFSError(
           std::string("File not found, remove failed for : " + path)));
     }
 
@@ -514,13 +514,13 @@ Status MemFilesystem::remove(const std::string& path, const bool is_dir) const {
   }
 
   if (cur == root_.get()) {
-    return LOG_STATUS(
-        Status::MemFSError(std::string("Cannot remove the root directory")));
+    return LOG_STATUS(Status_MemFSError(
+        std::string("Cannot remove the root directory")));
   }
 
   if (cur->is_dir() != is_dir) {
-    return LOG_STATUS(
-        Status::MemFSError(std::string("Remove failed, wrong file type")));
+    return LOG_STATUS(Status_MemFSError(
+        std::string("Remove failed, wrong file type")));
   }
 
   cur_lock.unlock();
@@ -552,7 +552,7 @@ Status MemFilesystem::create_dir_internal(
     if (!cur->has_child(token)) {
       cur->children_[token] = tdb_unique_ptr<FSNode>(tdb_new(Directory));
     } else if (!cur->is_dir()) {
-      return LOG_STATUS(Status::MemFSError(std::string(
+      return LOG_STATUS(Status_MemFSError(std::string(
           "Cannot create directory, a file with that name exists already: " +
           path)));
     }
@@ -590,7 +590,7 @@ Status MemFilesystem::touch_internal(
     assert(cur_lock.mutex() == &cur->mutex_);
 
     if (!cur->has_child(token)) {
-      return LOG_STATUS(Status::MemFSError(std::string(
+      return LOG_STATUS(Status_MemFSError(std::string(
           "Failed to create file, the parent directory doesn't exist.")));
     }
 
@@ -599,7 +599,7 @@ Status MemFilesystem::touch_internal(
   }
 
   if (!cur->is_dir()) {
-    return LOG_STATUS(Status::MemFSError(std::string(
+    return LOG_STATUS(Status_MemFSError(std::string(
         "Failed to create file, the parent directory doesn't exist.")));
   }
 

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -1515,7 +1515,7 @@ Status S3::flush_direct(const URI& uri) {
   if (md5_hex.str() != put_object_outcome.GetResult().GetETag()) {
     return LOG_STATUS(
         Status_S3Error("Object uploaded successfully, but MD5 hash does not "
-                        "match result from server!' "));
+                       "match result from server!' "));
   }
 
   wait_for_object_to_propagate(

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -218,7 +218,7 @@ Status S3::init(
 
   if (thread_pool == nullptr) {
     return LOG_STATUS(
-        Status::S3Error("Can't initialize with null thread pool."));
+        Status_S3Error("Can't initialize with null thread pool."));
   }
 
   bool found = false;
@@ -301,12 +301,12 @@ Status S3::init(
       sse_ = Aws::S3::Model::ServerSideEncryption::aws_kms;
       sse_kms_key_id_ = sse_kms_key_id;
       if (sse_kms_key_id_.empty()) {
-        return Status::S3Error(
+        return Status_S3Error(
             "Config parameter 'vfs.s3.sse_kms_key_id' must be set "
             "for kms server-side encryption.");
       }
     } else {
-      return Status::S3Error(
+      return Status_S3Error(
           "Unknown 'vfs.s3.sse' config value " + sse +
           "; supported values are 'aes256' and 'kms'.");
     }
@@ -315,7 +315,7 @@ Status S3::init(
   // Ensure `sse_kms_key_id` was only set for kms encryption.
   if (!sse_kms_key_id.empty() &&
       sse_ != Aws::S3::Model::ServerSideEncryption::aws_kms) {
-    return Status::S3Error(
+    return Status_S3Error(
         "Config parameter 'vfs.s3.sse_kms_key_id' may only be "
         "set for 'vfs.s3.sse' == 'kms'.");
   }
@@ -330,7 +330,7 @@ Status S3::create_bucket(const URI& bucket) const {
   RETURN_NOT_OK(init_client());
 
   if (!bucket.is_s3()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("URI is not an S3 URI: " + bucket.to_string())));
   }
 
@@ -355,7 +355,7 @@ Status S3::create_bucket(const URI& bucket) const {
 
   auto create_bucket_outcome = client_->CreateBucket(create_bucket_request);
   if (!create_bucket_outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Failed to create S3 bucket ") + bucket.to_string() +
         outcome_error_message(create_bucket_outcome)));
   }
@@ -377,7 +377,7 @@ Status S3::remove_bucket(const URI& bucket) const {
   delete_bucket_request.SetBucket(aws_uri.GetAuthority());
   auto delete_bucket_outcome = client_->DeleteBucket(delete_bucket_request);
   if (!delete_bucket_outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Failed to remove S3 bucket ") + bucket.to_string() +
         outcome_error_message(delete_bucket_outcome)));
   }
@@ -413,7 +413,7 @@ Status S3::disconnect() {
                 make_multipart_complete_request(*state);
             auto outcome = client_->CompleteMultipartUpload(complete_request);
             if (!outcome.IsSuccess()) {
-              const Status st = LOG_STATUS(Status::S3Error(
+              const Status st = LOG_STATUS(Status_S3Error(
                   std::string("Failed to disconnect and flush S3 objects. ") +
                   outcome_error_message(outcome)));
               if (!st.ok()) {
@@ -425,7 +425,7 @@ Status S3::disconnect() {
                 make_multipart_abort_request(*state);
             auto outcome = client_->AbortMultipartUpload(abort_request);
             if (!outcome.IsSuccess()) {
-              const Status st = LOG_STATUS(Status::S3Error(
+              const Status st = LOG_STATUS(Status_S3Error(
                   std::string("Failed to disconnect and flush S3 objects. ") +
                   outcome_error_message(outcome)));
               if (!st.ok()) {
@@ -469,7 +469,7 @@ Status S3::flush_object(const URI& uri) {
     return flush_direct(uri);
   }
   if (!uri.is_s3()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("URI is not an S3 URI: " + uri.to_string())));
   }
 
@@ -503,7 +503,7 @@ Status S3::flush_object(const URI& uri) {
         make_multipart_complete_request(*state);
     auto outcome = client_->CompleteMultipartUpload(complete_request);
     if (!outcome.IsSuccess()) {
-      return LOG_STATUS(Status::S3Error(
+      return LOG_STATUS(Status_S3Error(
           std::string("Failed to flush S3 object ") + uri.c_str() +
           outcome_error_message(outcome)));
     }
@@ -574,7 +574,7 @@ Status S3::finish_flush_object(
   tdb_delete(buff);
 
   if (!outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Failed to flush S3 object ") + uri.c_str() +
         outcome_error_message(outcome)));
   }
@@ -588,7 +588,7 @@ Status S3::is_empty_bucket(const URI& bucket, bool* is_empty) const {
   bool exists;
   RETURN_NOT_OK(is_bucket(bucket, &exists));
   if (!exists)
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         "Cannot check if bucket is empty; Bucket does not exist"));
 
   Aws::Http::URI aws_uri = bucket.c_str();
@@ -601,7 +601,7 @@ Status S3::is_empty_bucket(const URI& bucket, bool* is_empty) const {
   auto list_objects_outcome = client_->ListObjects(list_objects_request);
 
   if (!list_objects_outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Failed to list s3 objects in bucket ") + bucket.c_str() +
         outcome_error_message(list_objects_outcome)));
   }
@@ -616,7 +616,7 @@ Status S3::is_bucket(const URI& uri, bool* const exists) const {
   init_client();
 
   if (!uri.is_s3()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("URI is not an S3 URI: " + uri.to_string())));
   }
 
@@ -633,7 +633,7 @@ Status S3::is_object(const URI& uri, bool* const exists) const {
   init_client();
 
   if (!uri.is_s3()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("URI is not an S3 URI: " + uri.to_string())));
   }
 
@@ -682,7 +682,7 @@ Status S3::ls(
   auto prefix_str = prefix_dir.to_string();
   if (!prefix_dir.is_s3()) {
     return LOG_STATUS(
-        Status::S3Error(std::string("URI is not an S3 URI: " + prefix_str)));
+        Status_S3Error(std::string("URI is not an S3 URI: " + prefix_str)));
   }
 
   Aws::Http::URI aws_uri = prefix_str.c_str();
@@ -704,7 +704,7 @@ Status S3::ls(
     auto list_objects_outcome = client_->ListObjects(list_objects_request);
 
     if (!list_objects_outcome.IsSuccess())
-      return LOG_STATUS(Status::S3Error(
+      return LOG_STATUS(Status_S3Error(
           std::string("Error while listing with prefix '") + prefix_str +
           "' and delimiter '" + delimiter + "'" +
           outcome_error_message(list_objects_outcome)));
@@ -805,7 +805,7 @@ Status S3::object_size(const URI& uri, uint64_t* nbytes) const {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_s3()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("URI is not an S3 URI: " + uri.to_string())));
   }
 
@@ -820,7 +820,7 @@ Status S3::object_size(const URI& uri, uint64_t* nbytes) const {
   auto head_object_outcome = client_->HeadObject(head_object_request);
 
   if (!head_object_outcome.IsSuccess())
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         "Cannot retrieve S3 object size; Error while listing file " +
         uri.to_string() + outcome_error_message(head_object_outcome)));
   *nbytes =
@@ -839,7 +839,7 @@ Status S3::read(
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_s3()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("URI is not an S3 URI: " + uri.to_string())));
   }
 
@@ -864,7 +864,7 @@ Status S3::read(
 
   auto get_object_outcome = client_->GetObject(get_object_request);
   if (!get_object_outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Failed to read S3 object ") + uri.c_str() +
         outcome_error_message(get_object_outcome)));
   }
@@ -872,7 +872,7 @@ Status S3::read(
   *length_returned =
       static_cast<uint64_t>(get_object_outcome.GetResult().GetContentLength());
   if (*length_returned < length) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Read operation returned different size of bytes ") +
         std::to_string(*length_returned) + " vs " + std::to_string(length)));
   }
@@ -884,7 +884,7 @@ Status S3::remove_object(const URI& uri) const {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_s3()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("URI is not an S3 URI: " + uri.to_string())));
   }
 
@@ -897,7 +897,7 @@ Status S3::remove_object(const URI& uri) const {
 
   auto delete_object_outcome = client_->DeleteObject(delete_object_request);
   if (!delete_object_outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Failed to delete S3 object '") + uri.c_str() +
         outcome_error_message(delete_object_outcome)));
   }
@@ -922,12 +922,12 @@ Status S3::touch(const URI& uri) const {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_s3()) {
-    return LOG_STATUS(Status::S3Error(std::string(
+    return LOG_STATUS(Status_S3Error(std::string(
         "Cannot create file; URI is not an S3 URI: " + uri.to_string())));
   }
 
   if (uri.to_string().back() == '/') {
-    return LOG_STATUS(Status::S3Error(std::string(
+    return LOG_STATUS(Status_S3Error(std::string(
         "Cannot create file; URI is a directory: " + uri.to_string())));
   }
 
@@ -957,7 +957,7 @@ Status S3::touch(const URI& uri) const {
 
   auto put_object_outcome = client_->PutObject(put_object_request);
   if (!put_object_outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Cannot touch object '") + uri.c_str() +
         outcome_error_message(put_object_outcome)));
   }
@@ -972,7 +972,7 @@ Status S3::write(const URI& uri, const void* buffer, uint64_t length) {
   RETURN_NOT_OK(init_client());
 
   if (!uri.is_s3()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("URI is not an S3 URI: " + uri.to_string())));
   }
 
@@ -992,7 +992,7 @@ Status S3::write(const URI& uri, const void* buffer, uint64_t length) {
     std::stringstream errmsg;
     errmsg << "Direct write failed! " << nbytes_filled
            << " bytes written to buffer, " << length << " bytes requested.";
-    return LOG_STATUS(Status::S3Error(errmsg.str()));
+    return LOG_STATUS(Status_S3Error(errmsg.str()));
   }
 
   // Flush file buffer
@@ -1040,7 +1040,7 @@ Status S3::init_client() const {
           credentials_provider_->GetAWSCredentials();
       if (credentials.IsExpiredOrEmpty()) {
         return LOG_STATUS(
-            Status::S3Error(std::string("Credentials is expired or empty.")));
+            Status_S3Error(std::string("Credentials is expired or empty.")));
       }
     }
     return Status::Ok();
@@ -1186,7 +1186,7 @@ Status S3::init_client() const {
       break;
     case 1:
     case 2:
-      return Status::S3Error(
+      return Status_S3Error(
           "Insufficient authentication credentials; "
           "Both access key id and secret key are needed");
     case 3: {
@@ -1222,7 +1222,7 @@ Status S3::init_client() const {
       break;
     }
     default:
-      return Status::S3Error(
+      return Status_S3Error(
           "Ambiguous authentication credentials; both permanent and temporary "
           "authentication credentials are configured");
   }
@@ -1279,7 +1279,7 @@ Status S3::copy_object(const URI& old_uri, const URI& new_uri) {
 
   auto copy_object_outcome = client_->CopyObject(copy_object_request);
   if (!copy_object_outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Failed to copy S3 object ") + old_uri.c_str() + " to " +
         new_uri.c_str() + outcome_error_message(copy_object_outcome)));
   }
@@ -1373,7 +1373,7 @@ Status S3::initiate_multipart_request(
   auto multipart_upload_outcome =
       client_->CreateMultipartUpload(multipart_upload_request);
   if (!multipart_upload_outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Failed to create multipart request for object '") +
         path_c_str + outcome_error_message(multipart_upload_outcome)));
   }
@@ -1418,7 +1418,7 @@ Status S3::wait_for_object_to_propagate(
         std::chrono::milliseconds(constants::s3_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::S3Error(
+  return LOG_STATUS(Status_S3Error(
       "Failed waiting for object " +
       std::string(object_key.c_str(), object_key.size()) + " to be created."));
 }
@@ -1439,7 +1439,7 @@ Status S3::wait_for_object_to_be_deleted(
         std::chrono::milliseconds(constants::s3_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::S3Error(
+  return LOG_STATUS(Status_S3Error(
       "Failed waiting for object " +
       std::string(object_key.c_str(), object_key.size()) + " to be deleted."));
 }
@@ -1459,7 +1459,7 @@ Status S3::wait_for_bucket_to_be_created(const URI& bucket_uri) const {
         std::chrono::milliseconds(constants::s3_attempt_sleep_ms));
   }
 
-  return LOG_STATUS(Status::S3Error(
+  return LOG_STATUS(Status_S3Error(
       "Failed waiting for bucket " + bucket_uri.to_string() +
       " to be created."));
 }
@@ -1503,7 +1503,7 @@ Status S3::flush_direct(const URI& uri) {
 
   auto put_object_outcome = client_->PutObject(put_object_request);
   if (!put_object_outcome.IsSuccess()) {
-    return LOG_STATUS(Status::S3Error(
+    return LOG_STATUS(Status_S3Error(
         std::string("Cannot write object '") + uri.c_str() +
         outcome_error_message(put_object_outcome)));
   }
@@ -1514,7 +1514,7 @@ Status S3::flush_direct(const URI& uri) {
   md5_hex << "\"" << Aws::Utils::HashingUtils::HexEncode(md5_hash) << "\"";
   if (md5_hex.str() != put_object_outcome.GetResult().GetETag()) {
     return LOG_STATUS(
-        Status::S3Error("Object uploaded successfully, but MD5 hash does not "
+        Status_S3Error("Object uploaded successfully, but MD5 hash does not "
                         "match result from server!' "));
   }
 
@@ -1540,7 +1540,7 @@ Status S3::write_multipart(
 
   if (!last_part && length % multipart_part_size_ != 0) {
     return LOG_STATUS(
-        Status::S3Error("Length not evenly divisible by part length"));
+        Status_S3Error("Length not evenly divisible by part length"));
   }
 
   const Aws::Http::URI aws_uri(uri.c_str());
@@ -1644,7 +1644,7 @@ Status S3::write_multipart(
     if (!aggregate_st.ok()) {
       std::stringstream errmsg;
       errmsg << "S3 parallel write multipart error; " << aggregate_st.message();
-      LOG_STATUS(Status::S3Error(errmsg.str()));
+      LOG_STATUS(Status_S3Error(errmsg.str()));
     }
     return aggregate_st;
   }
@@ -1697,7 +1697,7 @@ Status S3::get_make_upload_part_req(
   if (!success) {
     UniqueReadLock unique_rl(&multipart_upload_rwlock_);
     auto state = &multipart_upload_states_.at(uri_path);
-    Status st = Status::S3Error(
+    Status st = Status_S3Error(
         std::string("Failed to upload part of S3 object '") + uri.c_str() +
         outcome_error_message(upload_part_outcome));
     // Lock multipart state

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -115,8 +115,8 @@ Config VFS::config() const {
 
 Status VFS::create_dir(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError(
-        "Cannot create directory; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot create directory; VFS not initialized"));
 
   if (!uri.is_s3() && !uri.is_azure() && !uri.is_gcs()) {
     bool is_dir;
@@ -152,7 +152,8 @@ Status VFS::create_dir(const URI& uri) const {
     // It is a noop for Azure
     return Status::Ok();
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -172,8 +173,8 @@ Status VFS::create_dir(const URI& uri) const {
 
 Status VFS::dir_size(const URI& dir_name, uint64_t* dir_size) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError(
-        "Cannot get directory size; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot get directory size; VFS not initialized"));
 
   // Sanity check
   bool is_dir;
@@ -210,7 +211,8 @@ Status VFS::dir_size(const URI& dir_name, uint64_t* dir_size) const {
 
 Status VFS::touch(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot touch file; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot touch file; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -237,7 +239,8 @@ Status VFS::touch(const URI& uri) const {
 #ifdef HAVE_AZURE
     return azure_.touch(uri);
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -256,8 +259,8 @@ Status VFS::touch(const URI& uri) const {
 
 Status VFS::cancel_all_tasks() {
   if (!init_)
-    return LOG_STATUS(Status_VFSError(
-        "Cannot cancel all tasks; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot cancel all tasks; VFS not initialized"));
 
   cancelable_tasks_.cancel_all_tasks();
   return Status::Ok();
@@ -265,15 +268,15 @@ Status VFS::cancel_all_tasks() {
 
 Status VFS::create_bucket(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot create bucket; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot create bucket; VFS not initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.create_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(
-        Status_VFSError(std::string("S3 is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("S3 is not supported")));
 #endif
   }
   if (uri.is_azure()) {
@@ -289,8 +292,7 @@ Status VFS::create_bucket(const URI& uri) const {
     return gcs_.create_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(
-        Status_VFSError(std::string("GCS is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("GCS is not supported")));
 #endif
   }
   return LOG_STATUS(Status_VFSError(
@@ -300,15 +302,15 @@ Status VFS::create_bucket(const URI& uri) const {
 
 Status VFS::remove_bucket(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot remove bucket; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot remove bucket; VFS not initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.remove_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(
-        Status_VFSError(std::string("S3 is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("S3 is not supported")));
 #endif
   }
   if (uri.is_azure()) {
@@ -324,8 +326,7 @@ Status VFS::remove_bucket(const URI& uri) const {
     return gcs_.remove_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(
-        Status_VFSError(std::string("GCS is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("GCS is not supported")));
 #endif
   }
   return LOG_STATUS(Status_VFSError(
@@ -337,15 +338,14 @@ Status VFS::empty_bucket(const URI& uri) const {
   if (!init_)
     return LOG_STATUS(
         Status_VFSError("Cannot empty bucket; VFS not "
-                                "initialized"));
+                        "initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.empty_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(
-        Status_VFSError(std::string("S3 is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("S3 is not supported")));
 #endif
   }
   if (uri.is_azure()) {
@@ -361,8 +361,7 @@ Status VFS::empty_bucket(const URI& uri) const {
     return gcs_.empty_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(
-        Status_VFSError(std::string("GCS is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("GCS is not supported")));
 #endif
   }
   return LOG_STATUS(Status_VFSError(
@@ -374,7 +373,7 @@ Status VFS::is_empty_bucket(const URI& uri, bool* is_empty) const {
   if (!init_)
     return LOG_STATUS(
         Status_VFSError("Cannot check if bucket is empty; "
-                                "VFS not initialized"));
+                        "VFS not initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
@@ -382,8 +381,7 @@ Status VFS::is_empty_bucket(const URI& uri, bool* is_empty) const {
 #else
     (void)uri;
     (void)is_empty;
-    return LOG_STATUS(
-        Status_VFSError(std::string("S3 is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("S3 is not supported")));
 #endif
   }
   if (uri.is_azure()) {
@@ -401,8 +399,7 @@ Status VFS::is_empty_bucket(const URI& uri, bool* is_empty) const {
 #else
     (void)uri;
     (void)is_empty;
-    return LOG_STATUS(
-        Status_VFSError(std::string("GCS is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("GCS is not supported")));
 #endif
   }
   return LOG_STATUS(Status_VFSError(
@@ -414,7 +411,7 @@ Status VFS::remove_dir(const URI& uri) const {
   if (!init_)
     return LOG_STATUS(
         Status_VFSError("Cannot remove directory; VFS not "
-                                "initialized"));
+                        "initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -438,7 +435,8 @@ Status VFS::remove_dir(const URI& uri) const {
 #ifdef HAVE_AZURE
     return azure_.remove_dir(uri);
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   } else if (uri.is_gcs()) {
 #ifdef HAVE_GCS
@@ -449,13 +447,15 @@ Status VFS::remove_dir(const URI& uri) const {
   } else if (uri.is_memfs()) {
     return memfs_.remove(uri.to_path(), true);
   } else {
-    return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
+    return LOG_STATUS(
+        Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
   }
 }
 
 Status VFS::remove_file(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot remove file; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot remove file; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -482,7 +482,8 @@ Status VFS::remove_file(const URI& uri) const {
 #ifdef HAVE_AZURE
     return azure_.remove_blob(uri);
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -495,13 +496,14 @@ Status VFS::remove_file(const URI& uri) const {
   if (uri.is_memfs()) {
     return memfs_.remove(uri.to_path(), false);
   }
-  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(
+      Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::max_parallel_ops(const URI& uri, uint64_t* ops) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError(
-        "Cannot get max parallel ops; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot get max parallel ops; VFS not initialized"));
 
   bool found;
   *ops = 0;
@@ -534,7 +536,8 @@ Status VFS::max_parallel_ops(const URI& uri, uint64_t* ops) const {
 
 Status VFS::file_size(const URI& uri, uint64_t* size) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot get file size; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot get file size; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -561,7 +564,8 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
 #ifdef HAVE_AZURE
     return azure_.blob_size(uri, size);
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -574,12 +578,14 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
   if (uri.is_memfs()) {
     return memfs_.file_size(uri.to_path(), size);
   }
-  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(
+      Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::is_dir(const URI& uri, bool* is_dir) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot check directory; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot check directory; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -610,7 +616,8 @@ Status VFS::is_dir(const URI& uri, bool* is_dir) const {
     return azure_.is_dir(uri, is_dir);
 #else
     *is_dir = false;
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -625,12 +632,14 @@ Status VFS::is_dir(const URI& uri, bool* is_dir) const {
     *is_dir = memfs_.is_dir(uri.to_path());
     return Status::Ok();
   }
-  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(
+      Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::is_file(const URI& uri, bool* is_file) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot check file; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot check file; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -662,7 +671,8 @@ Status VFS::is_file(const URI& uri, bool* is_file) const {
     return azure_.is_blob(uri, is_file);
 #else
     *is_file = false;
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -677,12 +687,14 @@ Status VFS::is_file(const URI& uri, bool* is_file) const {
     *is_file = memfs_.is_file(uri.to_path());
     return Status::Ok();
   }
-  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(
+      Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot check bucket; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot check bucket; VFS not initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
@@ -699,7 +711,8 @@ Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
     return Status::Ok();
 #else
     *is_bucket = false;
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -712,7 +725,8 @@ Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
 #endif
   }
 
-  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(
+      Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::init(
@@ -795,8 +809,7 @@ Status VFS::terminate() {
 
 Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
   if (!init_)
-    return LOG_STATUS(
-        Status_VFSError("Cannot list; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot list; VFS not initialized"));
 
   std::vector<std::string> paths;
   if (parent.is_file()) {
@@ -821,7 +834,8 @@ Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
 #ifdef HAVE_AZURE
     RETURN_NOT_OK(azure_.ls(parent, &paths));
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   } else if (parent.is_gcs()) {
 #ifdef HAVE_GCS
@@ -836,8 +850,8 @@ Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
       path.insert(0, "mem://");
     }
   } else {
-    return LOG_STATUS(Status_VFSError(
-        "Unsupported URI scheme: " + parent.to_string()));
+    return LOG_STATUS(
+        Status_VFSError("Unsupported URI scheme: " + parent.to_string()));
   }
   parallel_sort(compute_tp_, paths.begin(), paths.end());
   for (auto& path : paths) {
@@ -875,7 +889,8 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_HDFS
       return hdfs_->move_path(old_uri, new_uri);
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without HDFS support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
@@ -899,7 +914,8 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_AZURE
       return azure_.move_object(old_uri, new_uri);
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without Azure support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
@@ -911,7 +927,8 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_GCS
       return gcs_.move_object(old_uri, new_uri);
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without GCS support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
@@ -934,7 +951,8 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
 
 Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot move directory; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot move directory; VFS not initialized"));
 
   // File
   if (old_uri.is_file()) {
@@ -955,7 +973,8 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_HDFS
       return hdfs_->move_path(old_uri, new_uri);
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without HDFS support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
@@ -979,7 +998,8 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_AZURE
       return azure_.move_dir(old_uri, new_uri);
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without Azure support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
@@ -991,7 +1011,8 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_GCS
       return gcs_.move_dir(old_uri, new_uri);
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without GCS support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
@@ -1043,7 +1064,8 @@ Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
       return LOG_STATUS(Status_IOError(
           std::string("Copying files on HDFS is not yet supported.")));
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without HDFS support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Copying files across filesystems is not supported yet"));
@@ -1068,7 +1090,8 @@ Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
       return LOG_STATUS(Status_IOError(
           std::string("Copying files on Azure is not yet supported.")));
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without Azure support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Copying files across filesystems is not supported yet"));
@@ -1081,7 +1104,8 @@ Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
       return LOG_STATUS(Status_IOError(
           std::string("Copying files on GCS is not yet supported.")));
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without GCS support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Copying files across filesystems is not supported yet"));
@@ -1095,7 +1119,8 @@ Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
 
 Status VFS::copy_dir(const URI& old_uri, const URI& new_uri) {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot copy directory; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot copy directory; VFS not initialized"));
 
   // File
   if (old_uri.is_file()) {
@@ -1118,7 +1143,8 @@ Status VFS::copy_dir(const URI& old_uri, const URI& new_uri) {
       return LOG_STATUS(Status_IOError(
           std::string("Copying directories on HDFS is not yet supported.")));
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without HDFS support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Copying directories across filesystems is not supported yet"));
@@ -1143,7 +1169,8 @@ Status VFS::copy_dir(const URI& old_uri, const URI& new_uri) {
       return LOG_STATUS(Status_IOError(
           std::string("Copying directories on Azure is not yet supported.")));
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without Azure support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Copying directories across filesystems is not supported yet"));
@@ -1156,7 +1183,8 @@ Status VFS::copy_dir(const URI& old_uri, const URI& new_uri) {
       return LOG_STATUS(Status_IOError(
           std::string("Copying directories on GCS is not yet supported.")));
 #else
-      return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
+      return LOG_STATUS(
+          Status_VFSError("TileDB was built without GCS support"));
 #endif
     return LOG_STATUS(Status_VFSError(
         "Copying directories across filesystems is not supported yet"));
@@ -1177,8 +1205,7 @@ Status VFS::read(
   stats_->add_counter("read_byte_num", nbytes);
 
   if (!init_)
-    return LOG_STATUS(
-        Status_VFSError("Cannot read; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot read; VFS not initialized"));
 
   // Get config params
   bool found;
@@ -1295,7 +1322,8 @@ Status VFS::read_impl(
     return read_ahead_impl(
         read_fn, uri, offset, buffer, nbytes, use_read_ahead);
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -1319,7 +1347,8 @@ Status VFS::read_impl(
     return memfs_.read(uri.to_path(), offset, buffer, nbytes);
   }
 
-  return LOG_STATUS(Status_VFSError("Unsupported URI schemes: " + uri.to_string()));
+  return LOG_STATUS(
+      Status_VFSError("Unsupported URI schemes: " + uri.to_string()));
 }
 
 Status VFS::read_ahead_impl(
@@ -1509,8 +1538,7 @@ bool VFS::supports_uri_scheme(const URI& uri) const {
 
 Status VFS::sync(const URI& uri) {
   if (!init_)
-    return LOG_STATUS(
-        Status_VFSError("Cannot sync; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot sync; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -1537,7 +1565,8 @@ Status VFS::sync(const URI& uri) {
 #ifdef HAVE_AZURE
     return Status::Ok();
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -1550,7 +1579,8 @@ Status VFS::sync(const URI& uri) {
   if (uri.is_memfs()) {
     return Status::Ok();
   }
-  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(
+      Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::open_file(const URI& uri, VFSMode mode) {
@@ -1610,7 +1640,8 @@ Status VFS::open_file(const URI& uri, VFSMode mode) {
 
 Status VFS::close_file(const URI& uri) {
   if (!init_)
-    return LOG_STATUS(Status_VFSError("Cannot close file; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot close file; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -1637,7 +1668,8 @@ Status VFS::close_file(const URI& uri) {
 #ifdef HAVE_AZURE
     return azure_.flush_blob(uri);
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -1650,7 +1682,8 @@ Status VFS::close_file(const URI& uri) {
   if (uri.is_memfs()) {
     return Status::Ok();
   }
-  return LOG_STATUS(Status_VFSError("Unsupported URI schemes: " + uri.to_string()));
+  return LOG_STATUS(
+      Status_VFSError("Unsupported URI schemes: " + uri.to_string()));
 }
 
 Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
@@ -1658,8 +1691,7 @@ Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
   stats_->add_counter("write_ops_num", 1);
 
   if (!init_)
-    return LOG_STATUS(
-        Status_VFSError("Cannot write; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot write; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -1686,7 +1718,8 @@ Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
 #ifdef HAVE_AZURE
     return azure_.write(uri, buffer, buffer_size);
 #else
-    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(
+        Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -1699,7 +1732,8 @@ Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
   if (uri.is_memfs()) {
     return memfs_.write(uri.to_path(), buffer, buffer_size);
   }
-  return LOG_STATUS(Status_VFSError("Unsupported URI schemes: " + uri.to_string()));
+  return LOG_STATUS(
+      Status_VFSError("Unsupported URI schemes: " + uri.to_string()));
 }
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -115,8 +115,8 @@ Config VFS::config() const {
 
 Status VFS::create_dir(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot create directory; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError(
+        "Cannot create directory; VFS not initialized"));
 
   if (!uri.is_s3() && !uri.is_azure() && !uri.is_gcs()) {
     bool is_dir;
@@ -136,8 +136,7 @@ Status VFS::create_dir(const URI& uri) const {
 #ifdef HAVE_HDFS
     return hdfs_->create_dir(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
@@ -145,7 +144,7 @@ Status VFS::create_dir(const URI& uri) const {
     // It is a noop for S3
     return Status::Ok();
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
@@ -153,8 +152,7 @@ Status VFS::create_dir(const URI& uri) const {
     // It is a noop for Azure
     return Status::Ok();
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -162,26 +160,26 @@ Status VFS::create_dir(const URI& uri) const {
     // It is a noop for GCS
     return Status::Ok();
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     return memfs_.create_dir(uri.to_path());
   }
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       std::string("Unsupported URI scheme: ") + uri.to_string()));
 }
 
 Status VFS::dir_size(const URI& dir_name, uint64_t* dir_size) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot get directory size; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError(
+        "Cannot get directory size; VFS not initialized"));
 
   // Sanity check
   bool is_dir;
   RETURN_NOT_OK(this->is_dir(dir_name, &is_dir));
   if (!is_dir)
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         std::string("Cannot get directory size; Input '") +
         dir_name.to_string() + "' is not a directory"));
 
@@ -212,8 +210,7 @@ Status VFS::dir_size(const URI& dir_name, uint64_t* dir_size) const {
 
 Status VFS::touch(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot touch file; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot touch file; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -226,43 +223,41 @@ Status VFS::touch(const URI& uri) const {
 #ifdef HAVE_HDFS
     return hdfs_->touch(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.touch(uri);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
     return azure_.touch(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
     return gcs_.touch(uri);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     return memfs_.touch(uri.to_path());
   }
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       std::string("Unsupported URI scheme: ") + uri.to_string()));
 }
 
 Status VFS::cancel_all_tasks() {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot cancel all tasks; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError(
+        "Cannot cancel all tasks; VFS not initialized"));
 
   cancelable_tasks_.cancel_all_tasks();
   return Status::Ok();
@@ -270,15 +265,15 @@ Status VFS::cancel_all_tasks() {
 
 Status VFS::create_bucket(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot create bucket; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot create bucket; VFS not initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.create_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(Status::VFSError(std::string("S3 is not supported")));
+    return LOG_STATUS(
+        Status_VFSError(std::string("S3 is not supported")));
 #endif
   }
   if (uri.is_azure()) {
@@ -286,7 +281,7 @@ Status VFS::create_bucket(const URI& uri) const {
     return azure_.create_container(uri);
 #else
     (void)uri;
-    return LOG_STATUS(Status::VFSError(std::string("Azure is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("Azure is not supported")));
 #endif
   }
   if (uri.is_gcs()) {
@@ -294,25 +289,26 @@ Status VFS::create_bucket(const URI& uri) const {
     return gcs_.create_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(Status::VFSError(std::string("GCS is not supported")));
+    return LOG_STATUS(
+        Status_VFSError(std::string("GCS is not supported")));
 #endif
   }
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       std::string("Cannot create bucket; Unsupported URI scheme: ") +
       uri.to_string()));
 }
 
 Status VFS::remove_bucket(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot remove bucket; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot remove bucket; VFS not initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.remove_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(Status::VFSError(std::string("S3 is not supported")));
+    return LOG_STATUS(
+        Status_VFSError(std::string("S3 is not supported")));
 #endif
   }
   if (uri.is_azure()) {
@@ -320,7 +316,7 @@ Status VFS::remove_bucket(const URI& uri) const {
     return azure_.remove_container(uri);
 #else
     (void)uri;
-    return LOG_STATUS(Status::VFSError(std::string("Azure is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("Azure is not supported")));
 #endif
   }
   if (uri.is_gcs()) {
@@ -328,10 +324,11 @@ Status VFS::remove_bucket(const URI& uri) const {
     return gcs_.remove_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(Status::VFSError(std::string("GCS is not supported")));
+    return LOG_STATUS(
+        Status_VFSError(std::string("GCS is not supported")));
 #endif
   }
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       std::string("Cannot remove bucket; Unsupported URI scheme: ") +
       uri.to_string()));
 }
@@ -339,15 +336,16 @@ Status VFS::remove_bucket(const URI& uri) const {
 Status VFS::empty_bucket(const URI& uri) const {
   if (!init_)
     return LOG_STATUS(
-        Status::VFSError("Cannot empty bucket; VFS not "
-                         "initialized"));
+        Status_VFSError("Cannot empty bucket; VFS not "
+                                "initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.empty_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(Status::VFSError(std::string("S3 is not supported")));
+    return LOG_STATUS(
+        Status_VFSError(std::string("S3 is not supported")));
 #endif
   }
   if (uri.is_azure()) {
@@ -355,7 +353,7 @@ Status VFS::empty_bucket(const URI& uri) const {
     return azure_.empty_container(uri);
 #else
     (void)uri;
-    return LOG_STATUS(Status::VFSError(std::string("Azure is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("Azure is not supported")));
 #endif
   }
   if (uri.is_gcs()) {
@@ -363,10 +361,11 @@ Status VFS::empty_bucket(const URI& uri) const {
     return gcs_.empty_bucket(uri);
 #else
     (void)uri;
-    return LOG_STATUS(Status::VFSError(std::string("GCS is not supported")));
+    return LOG_STATUS(
+        Status_VFSError(std::string("GCS is not supported")));
 #endif
   }
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       std::string("Cannot empty bucket; Unsupported URI scheme: ") +
       uri.to_string()));
 }
@@ -374,8 +373,8 @@ Status VFS::empty_bucket(const URI& uri) const {
 Status VFS::is_empty_bucket(const URI& uri, bool* is_empty) const {
   if (!init_)
     return LOG_STATUS(
-        Status::VFSError("Cannot check if bucket is empty; "
-                         "VFS not initialized"));
+        Status_VFSError("Cannot check if bucket is empty; "
+                                "VFS not initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
@@ -383,7 +382,8 @@ Status VFS::is_empty_bucket(const URI& uri, bool* is_empty) const {
 #else
     (void)uri;
     (void)is_empty;
-    return LOG_STATUS(Status::VFSError(std::string("S3 is not supported")));
+    return LOG_STATUS(
+        Status_VFSError(std::string("S3 is not supported")));
 #endif
   }
   if (uri.is_azure()) {
@@ -392,7 +392,7 @@ Status VFS::is_empty_bucket(const URI& uri, bool* is_empty) const {
 #else
     (void)uri;
     (void)is_empty;
-    return LOG_STATUS(Status::VFSError(std::string("Azure is not supported")));
+    return LOG_STATUS(Status_VFSError(std::string("Azure is not supported")));
 #endif
   }
   if (uri.is_gcs()) {
@@ -401,10 +401,11 @@ Status VFS::is_empty_bucket(const URI& uri, bool* is_empty) const {
 #else
     (void)uri;
     (void)is_empty;
-    return LOG_STATUS(Status::VFSError(std::string("GCS is not supported")));
+    return LOG_STATUS(
+        Status_VFSError(std::string("GCS is not supported")));
 #endif
   }
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       std::string("Cannot remove bucket; Unsupported URI scheme: ") +
       uri.to_string()));
 }
@@ -412,8 +413,8 @@ Status VFS::is_empty_bucket(const URI& uri, bool* is_empty) const {
 Status VFS::remove_dir(const URI& uri) const {
   if (!init_)
     return LOG_STATUS(
-        Status::VFSError("Cannot remove directory; VFS not "
-                         "initialized"));
+        Status_VFSError("Cannot remove directory; VFS not "
+                                "initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -425,40 +426,36 @@ Status VFS::remove_dir(const URI& uri) const {
 #ifdef HAVE_HDFS
     return hdfs_->remove_dir(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   } else if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.remove_dir(uri);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   } else if (uri.is_azure()) {
 #ifdef HAVE_AZURE
     return azure_.remove_dir(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   } else if (uri.is_gcs()) {
 #ifdef HAVE_GCS
     return gcs_.remove_dir(uri);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   } else if (uri.is_memfs()) {
     return memfs_.remove(uri.to_path(), true);
   } else {
-    return LOG_STATUS(
-        Status::VFSError("Unsupported URI scheme: " + uri.to_string()));
+    return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
   }
 }
 
 Status VFS::remove_file(const URI& uri) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot remove file; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot remove file; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -471,43 +468,40 @@ Status VFS::remove_file(const URI& uri) const {
 #ifdef HAVE_HDFS
     return hdfs_->remove_file(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.remove_object(uri);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
     return azure_.remove_blob(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
     return gcs_.remove_object(uri);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     return memfs_.remove(uri.to_path(), false);
   }
-  return LOG_STATUS(
-      Status::VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::max_parallel_ops(const URI& uri, uint64_t* ops) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot get max parallel ops; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError(
+        "Cannot get max parallel ops; VFS not initialized"));
 
   bool found;
   *ops = 0;
@@ -540,8 +534,7 @@ Status VFS::max_parallel_ops(const URI& uri, uint64_t* ops) const {
 
 Status VFS::file_size(const URI& uri, uint64_t* size) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot get file size; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot get file size; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -554,43 +547,39 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
 #ifdef HAVE_HDFS
     return hdfs_->file_size(uri, size);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.object_size(uri, size);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
     return azure_.blob_size(uri, size);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
     return gcs_.object_size(uri, size);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     return memfs_.file_size(uri.to_path(), size);
   }
-  return LOG_STATUS(
-      Status::VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::is_dir(const URI& uri, bool* is_dir) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot check directory; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot check directory; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -605,8 +594,7 @@ Status VFS::is_dir(const URI& uri, bool* is_dir) const {
     return hdfs_->is_dir(uri, is_dir);
 #else
     *is_dir = false;
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
@@ -614,7 +602,7 @@ Status VFS::is_dir(const URI& uri, bool* is_dir) const {
     return s3_.is_dir(uri, is_dir);
 #else
     *is_dir = false;
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
@@ -622,8 +610,7 @@ Status VFS::is_dir(const URI& uri, bool* is_dir) const {
     return azure_.is_dir(uri, is_dir);
 #else
     *is_dir = false;
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -631,21 +618,19 @@ Status VFS::is_dir(const URI& uri, bool* is_dir) const {
     return gcs_.is_dir(uri, is_dir);
 #else
     *is_dir = false;
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     *is_dir = memfs_.is_dir(uri.to_path());
     return Status::Ok();
   }
-  return LOG_STATUS(
-      Status::VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::is_file(const URI& uri, bool* is_file) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot check file; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot check file; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -660,8 +645,7 @@ Status VFS::is_file(const URI& uri, bool* is_file) const {
     return hdfs_->is_file(uri, is_file);
 #else
     *is_file = false;
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
@@ -670,7 +654,7 @@ Status VFS::is_file(const URI& uri, bool* is_file) const {
     return Status::Ok();
 #else
     *is_file = false;
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
@@ -678,8 +662,7 @@ Status VFS::is_file(const URI& uri, bool* is_file) const {
     return azure_.is_blob(uri, is_file);
 #else
     *is_file = false;
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -687,21 +670,19 @@ Status VFS::is_file(const URI& uri, bool* is_file) const {
     return gcs_.is_object(uri, is_file);
 #else
     *is_file = false;
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     *is_file = memfs_.is_file(uri.to_path());
     return Status::Ok();
   }
-  return LOG_STATUS(
-      Status::VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot check bucket; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot check bucket; VFS not initialized"));
 
   if (uri.is_s3()) {
 #ifdef HAVE_S3
@@ -709,7 +690,7 @@ Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
     return Status::Ok();
 #else
     *is_bucket = false;
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
@@ -718,8 +699,7 @@ Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
     return Status::Ok();
 #else
     *is_bucket = false;
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -728,12 +708,11 @@ Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
     return Status::Ok();
 #else
     *is_bucket = false;
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
 
-  return LOG_STATUS(
-      Status::VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::init(
@@ -788,7 +767,7 @@ Status VFS::init(
     // We should print some warning here, this LOG_STATUS only prints in
     // verbose mode. Since this is called in the init of the context, we
     // can't return the error through the normal set it on the context.
-    LOG_STATUS(Status::GCSError(
+    LOG_STATUS(Status_GCSError(
         "GCS failed to initialize, GCS support will not be available in this "
         "context: " +
         st.message()));
@@ -816,7 +795,8 @@ Status VFS::terminate() {
 
 Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
   if (!init_)
-    return LOG_STATUS(Status::VFSError("Cannot list; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot list; VFS not initialized"));
 
   std::vector<std::string> paths;
   if (parent.is_file()) {
@@ -829,27 +809,25 @@ Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
 #ifdef HAVE_HDFS
     RETURN_NOT_OK(hdfs_->ls(parent, &paths));
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   } else if (parent.is_s3()) {
 #ifdef HAVE_S3
     RETURN_NOT_OK(s3_.ls(parent, &paths));
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   } else if (parent.is_azure()) {
 #ifdef HAVE_AZURE
     RETURN_NOT_OK(azure_.ls(parent, &paths));
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   } else if (parent.is_gcs()) {
 #ifdef HAVE_GCS
     RETURN_NOT_OK(gcs_.ls(parent, &paths));
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   } else if (parent.is_memfs()) {
     RETURN_NOT_OK(memfs_.ls(parent.to_path(), &paths));
@@ -858,8 +836,8 @@ Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
       path.insert(0, "mem://");
     }
   } else {
-    return LOG_STATUS(
-        Status::VFSError("Unsupported URI scheme: " + parent.to_string()));
+    return LOG_STATUS(Status_VFSError(
+        "Unsupported URI scheme: " + parent.to_string()));
   }
   parallel_sort(compute_tp_, paths.begin(), paths.end());
   for (auto& path : paths) {
@@ -870,8 +848,7 @@ Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
 
 Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot move file; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot move file; VFS not initialized"));
 
   // If new_uri exists, delete it or raise an error based on `force`
   bool is_file;
@@ -888,7 +865,7 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
       return posix_.move_path(old_uri.to_path(), new_uri.to_path());
 #endif
     }
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -898,10 +875,9 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_HDFS
       return hdfs_->move_path(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without HDFS support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -911,10 +887,9 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_S3
       return s3_.move_object(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without S3 support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -924,10 +899,9 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_AZURE
       return azure_.move_object(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without Azure support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -937,10 +911,9 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_GCS
       return gcs_.move_object(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without GCS support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -949,20 +922,19 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
     if (new_uri.is_memfs()) {
       return memfs_.move(old_uri.to_path(), new_uri.to_path());
     }
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
   // Unsupported filesystem
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       "Unsupported URI schemes: " + old_uri.to_string() + ", " +
       new_uri.to_string()));
 }
 
 Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot move directory; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot move directory; VFS not initialized"));
 
   // File
   if (old_uri.is_file()) {
@@ -973,7 +945,7 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
       return posix_.move_path(old_uri.to_path(), new_uri.to_path());
 #endif
     }
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -983,10 +955,9 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_HDFS
       return hdfs_->move_path(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without HDFS support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -996,10 +967,9 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_S3
       return s3_.move_dir(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without S3 support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -1009,10 +979,9 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_AZURE
       return azure_.move_dir(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without Azure support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -1022,10 +991,9 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_GCS
       return gcs_.move_dir(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without GCS support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
@@ -1034,20 +1002,19 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
     if (new_uri.is_memfs()) {
       return memfs_.move(old_uri.to_path(), new_uri.to_path());
     }
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Moving files across filesystems is not supported yet"));
   }
 
   // Unsupported filesystem
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       "Unsupported URI schemes: " + old_uri.to_string() + ", " +
       new_uri.to_string()));
 }
 
 Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot copy file; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot copy file; VFS not initialized"));
 
   // If new_uri exists, delete it or raise an error based on `force`
   bool is_file;
@@ -1059,13 +1026,13 @@ Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
   if (old_uri.is_file()) {
     if (new_uri.is_file()) {
 #ifdef _WIN32
-      return LOG_STATUS(Status::IOError(
+      return LOG_STATUS(Status_IOError(
           std::string("Copying files on Windows is not yet supported.")));
 #else
       return posix_.copy_file(old_uri.to_path(), new_uri.to_path());
 #endif
     }
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying files across filesystems is not supported yet"));
   }
 
@@ -1073,13 +1040,12 @@ Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
   if (old_uri.is_hdfs()) {
     if (new_uri.is_hdfs())
 #ifdef HAVE_HDFS
-      return LOG_STATUS(Status::IOError(
+      return LOG_STATUS(Status_IOError(
           std::string("Copying files on HDFS is not yet supported.")));
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without HDFS support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying files across filesystems is not supported yet"));
   }
 
@@ -1089,10 +1055,9 @@ Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_S3
       return s3_.copy_file(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without S3 support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying files across filesystems is not supported yet"));
   }
 
@@ -1100,13 +1065,12 @@ Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
   if (old_uri.is_azure()) {
     if (new_uri.is_azure())
 #ifdef HAVE_AZURE
-      return LOG_STATUS(Status::IOError(
+      return LOG_STATUS(Status_IOError(
           std::string("Copying files on Azure is not yet supported.")));
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without Azure support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying files across filesystems is not supported yet"));
   }
 
@@ -1114,38 +1078,36 @@ Status VFS::copy_file(const URI& old_uri, const URI& new_uri) {
   if (old_uri.is_gcs()) {
     if (new_uri.is_gcs())
 #ifdef HAVE_GCS
-      return LOG_STATUS(Status::IOError(
+      return LOG_STATUS(Status_IOError(
           std::string("Copying files on GCS is not yet supported.")));
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without GCS support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying files across filesystems is not supported yet"));
   }
 
   // Unsupported filesystem
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       "Unsupported URI schemes: " + old_uri.to_string() + ", " +
       new_uri.to_string()));
 }
 
 Status VFS::copy_dir(const URI& old_uri, const URI& new_uri) {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot copy directory; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot copy directory; VFS not initialized"));
 
   // File
   if (old_uri.is_file()) {
     if (new_uri.is_file()) {
 #ifdef _WIN32
-      return LOG_STATUS(Status::IOError(
+      return LOG_STATUS(Status_IOError(
           std::string("Copying directories on Windows is not yet supported.")));
 #else
       return posix_.copy_dir(old_uri.to_path(), new_uri.to_path());
 #endif
     }
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying directories across filesystems is not supported yet"));
   }
 
@@ -1153,13 +1115,12 @@ Status VFS::copy_dir(const URI& old_uri, const URI& new_uri) {
   if (old_uri.is_hdfs()) {
     if (new_uri.is_hdfs())
 #ifdef HAVE_HDFS
-      return LOG_STATUS(Status::IOError(
+      return LOG_STATUS(Status_IOError(
           std::string("Copying directories on HDFS is not yet supported.")));
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without HDFS support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying directories across filesystems is not supported yet"));
   }
 
@@ -1169,10 +1130,9 @@ Status VFS::copy_dir(const URI& old_uri, const URI& new_uri) {
 #ifdef HAVE_S3
       return s3_.copy_dir(old_uri, new_uri);
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without S3 support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying directories across filesystems is not supported yet"));
   }
 
@@ -1180,13 +1140,12 @@ Status VFS::copy_dir(const URI& old_uri, const URI& new_uri) {
   if (old_uri.is_azure()) {
     if (new_uri.is_azure())
 #ifdef HAVE_AZURE
-      return LOG_STATUS(Status::IOError(
+      return LOG_STATUS(Status_IOError(
           std::string("Copying directories on Azure is not yet supported.")));
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without Azure support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying directories across filesystems is not supported yet"));
   }
 
@@ -1194,18 +1153,17 @@ Status VFS::copy_dir(const URI& old_uri, const URI& new_uri) {
   if (old_uri.is_gcs()) {
     if (new_uri.is_gcs())
 #ifdef HAVE_GCS
-      return LOG_STATUS(Status::IOError(
+      return LOG_STATUS(Status_IOError(
           std::string("Copying directories on GCS is not yet supported.")));
 #else
-      return LOG_STATUS(
-          Status::VFSError("TileDB was built without GCS support"));
+      return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
-    return LOG_STATUS(Status::VFSError(
+    return LOG_STATUS(Status_VFSError(
         "Copying directories across filesystems is not supported yet"));
   }
 
   // Unsupported filesystem
-  return LOG_STATUS(Status::VFSError(
+  return LOG_STATUS(Status_VFSError(
       "Unsupported URI schemes: " + old_uri.to_string() + ", " +
       new_uri.to_string()));
 }
@@ -1219,7 +1177,8 @@ Status VFS::read(
   stats_->add_counter("read_byte_num", nbytes);
 
   if (!init_)
-    return LOG_STATUS(Status::VFSError("Cannot read; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot read; VFS not initialized"));
 
   // Get config params
   bool found;
@@ -1272,7 +1231,7 @@ Status VFS::read(
       std::stringstream errmsg;
       errmsg << "VFS parallel read error '" << uri.to_string() << "'; "
              << st.message();
-      return LOG_STATUS(Status::VFSError(errmsg.str()));
+      return LOG_STATUS(Status_VFSError(errmsg.str()));
     }
     return st;
   }
@@ -1302,8 +1261,7 @@ Status VFS::read_impl(
 #ifdef HAVE_HDFS
     return hdfs_->read(uri, offset, buffer, nbytes);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
@@ -1320,7 +1278,7 @@ Status VFS::read_impl(
     return read_ahead_impl(
         read_fn, uri, offset, buffer, nbytes, use_read_ahead);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
@@ -1337,8 +1295,7 @@ Status VFS::read_impl(
     return read_ahead_impl(
         read_fn, uri, offset, buffer, nbytes, use_read_ahead);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
@@ -1355,15 +1312,14 @@ Status VFS::read_impl(
     return read_ahead_impl(
         read_fn, uri, offset, buffer, nbytes, use_read_ahead);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     return memfs_.read(uri.to_path(), offset, buffer, nbytes);
   }
 
-  return LOG_STATUS(
-      Status::VFSError("Unsupported URI schemes: " + uri.to_string()));
+  return LOG_STATUS(Status_VFSError("Unsupported URI schemes: " + uri.to_string()));
 }
 
 Status VFS::read_ahead_impl(
@@ -1435,7 +1391,7 @@ Status VFS::read_all(
     std::vector<ThreadPool::Task>* tasks,
     const bool use_read_ahead) {
   if (!init_)
-    return LOG_STATUS(Status::VFSError("Cannot read all; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot read all; VFS not initialized"));
 
   if (regions.empty())
     return Status::Ok();
@@ -1553,7 +1509,8 @@ bool VFS::supports_uri_scheme(const URI& uri) const {
 
 Status VFS::sync(const URI& uri) {
   if (!init_)
-    return LOG_STATUS(Status::VFSError("Cannot sync; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot sync; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -1566,43 +1523,39 @@ Status VFS::sync(const URI& uri) {
 #ifdef HAVE_HDFS
     return hdfs_->sync(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return Status::Ok();
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
     return Status::Ok();
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
     return Status::Ok();
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     return Status::Ok();
   }
-  return LOG_STATUS(
-      Status::VFSError("Unsupported URI scheme: " + uri.to_string()));
+  return LOG_STATUS(Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
 Status VFS::open_file(const URI& uri, VFSMode mode) {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot open file; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot open file; VFS not initialized"));
 
   bool is_file;
   RETURN_NOT_OK(this->is_file(uri, &is_file));
@@ -1610,7 +1563,7 @@ Status VFS::open_file(const URI& uri, VFSMode mode) {
   switch (mode) {
     case VFSMode::VFS_READ:
       if (!is_file)
-        return LOG_STATUS(Status::VFSError(
+        return LOG_STATUS(Status_VFSError(
             std::string("Cannot open file '") + uri.c_str() +
             "'; File does not exist"));
       break;
@@ -1621,31 +1574,31 @@ Status VFS::open_file(const URI& uri, VFSMode mode) {
     case VFSMode::VFS_APPEND:
       if (uri.is_s3()) {
 #ifdef HAVE_S3
-        return LOG_STATUS(Status::VFSError(
+        return LOG_STATUS(Status_VFSError(
             std::string("Cannot open file '") + uri.c_str() +
             "'; S3 does not support append mode"));
 #else
-        return LOG_STATUS(Status::VFSError(
+        return LOG_STATUS(Status_VFSError(
             "Cannot open file; TileDB was built without S3 support"));
 #endif
       }
       if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-        return LOG_STATUS(Status::VFSError(
+        return LOG_STATUS(Status_VFSError(
             std::string("Cannot open file '") + uri.c_str() +
             "'; Azure does not support append mode"));
 #else
-        return LOG_STATUS(Status::VFSError(
+        return LOG_STATUS(Status_VFSError(
             "Cannot open file; TileDB was built without Azure support"));
 #endif
       }
       if (uri.is_gcs()) {
 #ifdef HAVE_GCS
-        return LOG_STATUS(Status::VFSError(
+        return LOG_STATUS(Status_VFSError(
             std::string("Cannot open file '") + uri.c_str() +
             "'; GCS does not support append mode"));
 #else
-        return LOG_STATUS(Status::VFSError(
+        return LOG_STATUS(Status_VFSError(
             "Cannot open file; TileDB was built without GCS support"));
 #endif
       }
@@ -1657,8 +1610,7 @@ Status VFS::open_file(const URI& uri, VFSMode mode) {
 
 Status VFS::close_file(const URI& uri) {
   if (!init_)
-    return LOG_STATUS(
-        Status::VFSError("Cannot close file; VFS not initialized"));
+    return LOG_STATUS(Status_VFSError("Cannot close file; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -1671,37 +1623,34 @@ Status VFS::close_file(const URI& uri) {
 #ifdef HAVE_HDFS
     return hdfs_->sync(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.flush_object(uri);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
     return azure_.flush_blob(uri);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
     return gcs_.flush_object(uri);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     return Status::Ok();
   }
-  return LOG_STATUS(
-      Status::VFSError("Unsupported URI schemes: " + uri.to_string()));
+  return LOG_STATUS(Status_VFSError("Unsupported URI schemes: " + uri.to_string()));
 }
 
 Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
@@ -1709,7 +1658,8 @@ Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
   stats_->add_counter("write_ops_num", 1);
 
   if (!init_)
-    return LOG_STATUS(Status::VFSError("Cannot write; VFS not initialized"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot write; VFS not initialized"));
 
   if (uri.is_file()) {
 #ifdef _WIN32
@@ -1722,37 +1672,34 @@ Status VFS::write(const URI& uri, const void* buffer, uint64_t buffer_size) {
 #ifdef HAVE_HDFS
     return hdfs_->write(uri, buffer, buffer_size);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without HDFS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without HDFS support"));
 #endif
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
     return s3_.write(uri, buffer, buffer_size);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without S3 support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));
 #endif
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
     return azure_.write(uri, buffer, buffer_size);
 #else
-    return LOG_STATUS(
-        Status::VFSError("TileDB was built without Azure support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without Azure support"));
 #endif
   }
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
     return gcs_.write(uri, buffer, buffer_size);
 #else
-    return LOG_STATUS(Status::VFSError("TileDB was built without GCS support"));
+    return LOG_STATUS(Status_VFSError("TileDB was built without GCS support"));
 #endif
   }
   if (uri.is_memfs()) {
     return memfs_.write(uri.to_path(), buffer, buffer_size);
   }
-  return LOG_STATUS(
-      Status::VFSError("Unsupported URI schemes: " + uri.to_string()));
+  return LOG_STATUS(Status_VFSError("Unsupported URI schemes: " + uri.to_string()));
 }
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/vfs_file_handle.cc
+++ b/tiledb/sm/filesystem/vfs_file_handle.cc
@@ -61,7 +61,7 @@ Status VFSFileHandle::close() {
   if (!is_open_) {
     std::stringstream msg;
     msg << "Cannot close file '" << uri_.to_string() << "'; File is not open";
-    auto st = Status::VFSFileHandleError(msg.str());
+    auto st = Status_VFSFileHandleError(msg.str());
     return LOG_STATUS(st);
   }
 
@@ -94,7 +94,7 @@ Status VFSFileHandle::read(uint64_t offset, void* buffer, uint64_t nbytes) {
     std::stringstream msg;
     msg << "Cannot read from file '" << uri_.to_string()
         << "'; File is not open";
-    auto st = Status::VFSFileHandleError(msg.str());
+    auto st = Status_VFSFileHandleError(msg.str());
     return LOG_STATUS(st);
   }
 
@@ -105,7 +105,7 @@ Status VFSFileHandle::sync() {
   if (!is_open_) {
     std::stringstream msg;
     msg << "Cannot sync file '" << uri_.to_string() << "'; File is not open";
-    auto st = Status::VFSFileHandleError(msg.str());
+    auto st = Status_VFSFileHandleError(msg.str());
     return LOG_STATUS(st);
   }
 
@@ -121,7 +121,7 @@ Status VFSFileHandle::write(const void* buffer, uint64_t nbytes) {
     std::stringstream msg;
     msg << "Cannot write to file '" << uri_.to_string()
         << "'; File is not open";
-    auto st = Status::VFSFileHandleError(msg.str());
+    auto st = Status_VFSFileHandleError(msg.str());
     return LOG_STATUS(st);
   }
 

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -145,8 +145,7 @@ std::string Win::current_dir() {
   unsigned long length = GetCurrentDirectory(0, nullptr);
   char* path = (char*)tdb_malloc(length * sizeof(char));
   if (path == nullptr || GetCurrentDirectory(length, path) == 0) {
-    LOG_STATUS(Status_IOError(
-        std::string("Failed to get current directory.")));
+    LOG_STATUS(Status_IOError(std::string("Failed to get current directory.")));
   }
   dir = path;
   tdb_free(path);
@@ -202,8 +201,8 @@ err:
   if (find_h != INVALID_HANDLE_VALUE) {
     FindClose(find_h);
   }
-  return LOG_STATUS(Status_IOError(
-      std::string("Failed to remove directory '" + path + "'")));
+  return LOG_STATUS(
+      Status_IOError(std::string("Failed to remove directory '" + path + "'")));
 }
 
 Status Win::remove_dir(const std::string& path) const {
@@ -217,8 +216,8 @@ Status Win::remove_dir(const std::string& path) const {
 
 Status Win::remove_file(const std::string& path) const {
   if (!DeleteFile(path.c_str())) {
-    return LOG_STATUS(Status_IOError(
-        std::string("Failed to delete file '" + path + "'")));
+    return LOG_STATUS(
+        Status_IOError(std::string("Failed to delete file '" + path + "'")));
   }
   return Status::Ok();
 }
@@ -249,7 +248,8 @@ Status Win::file_size(const std::string& path, uint64_t* size) const {
 
 Status Win::init(const Config& config, ThreadPool* vfs_thread_pool) {
   if (vfs_thread_pool == nullptr) {
-    return LOG_STATUS(Status_VFSError("Cannot initialize with null thread pool"));
+    return LOG_STATUS(
+        Status_VFSError("Cannot initialize with null thread pool"));
   }
 
   config_ = config;
@@ -379,13 +379,14 @@ Status Win::sync(const std::string& path) const {
       FILE_ATTRIBUTE_NORMAL,
       NULL);
   if (file_h == INVALID_HANDLE_VALUE) {
-    return LOG_STATUS(Status_IOError(
-        "Cannot sync file '" + path + "'; File opening error"));
+    return LOG_STATUS(
+        Status_IOError("Cannot sync file '" + path + "'; File opening error"));
   }
 
   if (FlushFileBuffers(file_h) == 0) {
     CloseHandle(file_h);
-    return LOG_STATUS(Status_IOError("Cannot sync file '" + path + "'; Sync error"));
+    return LOG_STATUS(
+        Status_IOError("Cannot sync file '" + path + "'; Sync error"));
   }
 
   if (CloseHandle(file_h) == 0) {
@@ -427,8 +428,8 @@ Status Win::write(
   LARGE_INTEGER file_size_lg_int;
   if (!GetFileSizeEx(file_h, &file_size_lg_int)) {
     CloseHandle(file_h);
-    return LOG_STATUS(Status_IOError(
-        "Cannot write to file '" + path + "'; File size error"));
+    return LOG_STATUS(
+        Status_IOError("Cannot write to file '" + path + "'; File size error"));
   }
   uint64_t file_offset = file_size_lg_int.QuadPart;
   // Ensure that each thread is responsible for at least min_parallel_size
@@ -438,7 +439,8 @@ Status Win::write(
   if (num_ops == 1) {
     if (!write_at(file_h, file_offset, buffer, buffer_size).ok()) {
       CloseHandle(file_h);
-      return LOG_STATUS(Status_IOError(std::string("Cannot write to file '") + path));
+      return LOG_STATUS(
+          Status_IOError(std::string("Cannot write to file '") + path));
     }
   } else {
     std::vector<ThreadPool::Task> results;

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -99,7 +99,7 @@ std::string Win::abs_path(const std::string& path) {
   char result[MAX_PATH];
   std::string str_result;
   if (PathCanonicalize(result, full_path.c_str()) == FALSE) {
-    LOG_STATUS(Status::IOError(std::string("Cannot canonicalize path.")));
+    LOG_STATUS(Status_IOError(std::string("Cannot canonicalize path.")));
   } else {
     str_result = result;
   }
@@ -108,12 +108,12 @@ std::string Win::abs_path(const std::string& path) {
 
 Status Win::create_dir(const std::string& path) const {
   if (is_dir(path)) {
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         std::string("Cannot create directory '") + path +
         "'; Directory already exists"));
   }
   if (CreateDirectory(path.c_str(), nullptr) == 0) {
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         std::string("Cannot create directory '") + path +
         "': " + get_last_error_msg()));
   }
@@ -134,7 +134,7 @@ Status Win::touch(const std::string& filename) const {
       FILE_ATTRIBUTE_NORMAL,
       nullptr);
   if (file_h == INVALID_HANDLE_VALUE || CloseHandle(file_h) == 0) {
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         std::string("Failed to create file '") + filename + "'"));
   }
   return Status::Ok();
@@ -145,8 +145,8 @@ std::string Win::current_dir() {
   unsigned long length = GetCurrentDirectory(0, nullptr);
   char* path = (char*)tdb_malloc(length * sizeof(char));
   if (path == nullptr || GetCurrentDirectory(length, path) == 0) {
-    LOG_STATUS(
-        Status::IOError(std::string("Failed to get current directory.")));
+    LOG_STATUS(Status_IOError(
+        std::string("Failed to get current directory.")));
   }
   dir = path;
   tdb_free(path);
@@ -202,7 +202,7 @@ err:
   if (find_h != INVALID_HANDLE_VALUE) {
     FindClose(find_h);
   }
-  return LOG_STATUS(Status::IOError(
+  return LOG_STATUS(Status_IOError(
       std::string("Failed to remove directory '" + path + "'")));
 }
 
@@ -210,15 +210,15 @@ Status Win::remove_dir(const std::string& path) const {
   if (is_dir(path)) {
     return recursively_remove_directory(path);
   } else {
-    return LOG_STATUS(Status::IOError(std::string(
+    return LOG_STATUS(Status_IOError(std::string(
         "Failed to delete path '" + path + "'; not a valid path.")));
   }
 }
 
 Status Win::remove_file(const std::string& path) const {
   if (!DeleteFile(path.c_str())) {
-    return LOG_STATUS(
-        Status::IOError(std::string("Failed to delete file '" + path + "'")));
+    return LOG_STATUS(Status_IOError(
+        std::string("Failed to delete file '" + path + "'")));
   }
   return Status::Ok();
 }
@@ -234,12 +234,12 @@ Status Win::file_size(const std::string& path, uint64_t* size) const {
       FILE_ATTRIBUTE_NORMAL,
       NULL);
   if (file_h == INVALID_HANDLE_VALUE) {
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         std::string("Failed to get file size for '" + path + "'")));
   }
   if (!GetFileSizeEx(file_h, &nbytes)) {
     CloseHandle(file_h);
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         std::string("Failed to get file size for '" + path + "'")));
   }
   *size = nbytes.QuadPart;
@@ -249,8 +249,7 @@ Status Win::file_size(const std::string& path, uint64_t* size) const {
 
 Status Win::init(const Config& config, ThreadPool* vfs_thread_pool) {
   if (vfs_thread_pool == nullptr) {
-    return LOG_STATUS(
-        Status::VFSError("Cannot initialize with null thread pool"));
+    return LOG_STATUS(Status_VFSError("Cannot initialize with null thread pool"));
   }
 
   config_ = config;
@@ -307,14 +306,14 @@ err:
     FindClose(find_h);
   }
   std::string errmsg("Failed to list directory \"" + path + "\"");
-  return LOG_STATUS(Status::IOError(errmsg));
+  return LOG_STATUS(Status_IOError(errmsg));
 }
 
 Status Win::move_path(
     const std::string& old_path, const std::string& new_path) const {
   if (MoveFileEx(
           old_path.c_str(), new_path.c_str(), MOVEFILE_REPLACE_EXISTING) == 0) {
-    return LOG_STATUS(Status::IOError(std::string(
+    return LOG_STATUS(Status_IOError(std::string(
         "Failed to rename '" + old_path + "' to '" + new_path + "'.")));
   }
   return Status::Ok();
@@ -336,7 +335,7 @@ Status Win::read(
       FILE_ATTRIBUTE_NORMAL,
       NULL);
   if (file_h == INVALID_HANDLE_VALUE) {
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         "Cannot read from file '" + path + "'; File opening error"));
   }
 
@@ -344,7 +343,7 @@ Status Win::read(
   offset_lg_int.QuadPart = offset;
   if (SetFilePointerEx(file_h, offset_lg_int, NULL, FILE_BEGIN) == 0) {
     CloseHandle(file_h);
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         "Cannot read from file '" + path + "'; File seek error"));
   }
 
@@ -352,12 +351,12 @@ Status Win::read(
   if (ReadFile(file_h, buffer, nbytes, &num_bytes_read, NULL) == 0 ||
       num_bytes_read != nbytes) {
     CloseHandle(file_h);
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         "Cannot read from file '" + path + "'; File read error"));
   }
 
   if (CloseHandle(file_h) == 0) {
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         "Cannot read from file '" + path + "'; File closing error"));
   }
 
@@ -380,18 +379,17 @@ Status Win::sync(const std::string& path) const {
       FILE_ATTRIBUTE_NORMAL,
       NULL);
   if (file_h == INVALID_HANDLE_VALUE) {
-    return LOG_STATUS(
-        Status::IOError("Cannot sync file '" + path + "'; File opening error"));
+    return LOG_STATUS(Status_IOError(
+        "Cannot sync file '" + path + "'; File opening error"));
   }
 
   if (FlushFileBuffers(file_h) == 0) {
     CloseHandle(file_h);
-    return LOG_STATUS(
-        Status::IOError("Cannot sync file '" + path + "'; Sync error"));
+    return LOG_STATUS(Status_IOError("Cannot sync file '" + path + "'; Sync error"));
   }
 
   if (CloseHandle(file_h) == 0) {
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         "Cannot read from file '" + path + "'; File closing error"));
   }
 
@@ -422,14 +420,14 @@ Status Win::write(
       FILE_ATTRIBUTE_NORMAL,
       NULL);
   if (file_h == INVALID_HANDLE_VALUE) {
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         "Cannot write to file '" + path + "'; File opening error"));
   }
   // Get the current file size.
   LARGE_INTEGER file_size_lg_int;
   if (!GetFileSizeEx(file_h, &file_size_lg_int)) {
     CloseHandle(file_h);
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         "Cannot write to file '" + path + "'; File size error"));
   }
   uint64_t file_offset = file_size_lg_int.QuadPart;
@@ -440,8 +438,7 @@ Status Win::write(
   if (num_ops == 1) {
     if (!write_at(file_h, file_offset, buffer, buffer_size).ok()) {
       CloseHandle(file_h);
-      return LOG_STATUS(
-          Status::IOError(std::string("Cannot write to file '") + path));
+      return LOG_STATUS(Status_IOError(std::string("Cannot write to file '") + path));
     }
   } else {
     std::vector<ThreadPool::Task> results;
@@ -464,12 +461,12 @@ Status Win::write(
       CloseHandle(file_h);
       std::stringstream errmsg;
       errmsg << "Cannot write to file '" << path << "'; " << st.message();
-      return LOG_STATUS(Status::IOError(errmsg.str()));
+      return LOG_STATUS(Status_IOError(errmsg.str()));
     }
   }
   // Always close the handle.
   if (CloseHandle(file_h) == 0) {
-    return LOG_STATUS(Status::IOError(
+    return LOG_STATUS(Status_IOError(
         "Cannot write to file '" + path + "'; File closing error"));
   }
   return st;
@@ -501,7 +498,7 @@ Status Win::write_at(
             &bytes_written,
             &ov) == 0 ||
         bytes_written != constants::max_write_bytes) {
-      return LOG_STATUS(Status::IOError(std::string(
+      return LOG_STATUS(Status_IOError(std::string(
           "Cannot write to file; File writing error: " +
           get_last_error_msg())));
     }
@@ -518,7 +515,7 @@ Status Win::write_at(
           file_h, byte_buffer + byte_idx, buffer_size, &bytes_written, &ov) ==
           0 ||
       bytes_written != buffer_size) {
-    return LOG_STATUS(Status::IOError(std::string(
+    return LOG_STATUS(Status_IOError(std::string(
         "Cannot write to file; File writing error: " + get_last_error_msg())));
   }
   return Status::Ok();
@@ -533,7 +530,7 @@ std::string Win::uri_from_path(const std::string& path) {
   char uri[INTERNET_MAX_URL_LENGTH];
   std::string str_uri;
   if (UrlCreateFromPath(path.c_str(), uri, &uri_length, 0) != S_OK) {
-    LOG_STATUS(Status::IOError(
+    LOG_STATUS(Status_IOError(
         std::string("Failed to convert path '" + path + "' to URI.")));
   }
   str_uri = uri;
@@ -559,7 +556,7 @@ std::string Win::path_from_uri(const std::string& uri) {
   std::string str_path;
   if (PathCreateFromUrl(uri_with_scheme.c_str(), path, &path_length, 0) !=
       S_OK) {
-    LOG_STATUS(Status::IOError(std::string(
+    LOG_STATUS(Status_IOError(std::string(
         "Failed to convert URI '" + uri_with_scheme + "' to path.")));
   }
   str_path = path;

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -158,7 +158,8 @@ Status BitWidthReductionFilter::run_forward(
       return run_forward<int64_t>(
           tile, input_metadata, input, output_metadata, output);
     default:
-      return LOG_STATUS(Status_FilterError("Cannot filter; Unsupported input type"));
+      return LOG_STATUS(
+          Status_FilterError("Cannot filter; Unsupported input type"));
   }
 }
 
@@ -334,7 +335,8 @@ Status BitWidthReductionFilter::run_reverse(
       return run_reverse<int64_t>(
           tile, input_metadata, input, output_metadata, output);
     default:
-      return LOG_STATUS(Status_FilterError("Cannot filter; Unsupported input type"));
+      return LOG_STATUS(
+          Status_FilterError("Cannot filter; Unsupported input type"));
   }
 }
 

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -158,8 +158,7 @@ Status BitWidthReductionFilter::run_forward(
       return run_forward<int64_t>(
           tile, input_metadata, input, output_metadata, output);
     default:
-      return LOG_STATUS(
-          Status::FilterError("Cannot filter; Unsupported input type"));
+      return LOG_STATUS(Status_FilterError("Cannot filter; Unsupported input type"));
   }
 }
 
@@ -335,8 +334,7 @@ Status BitWidthReductionFilter::run_reverse(
       return run_reverse<int64_t>(
           tile, input_metadata, input, output_metadata, output);
     default:
-      return LOG_STATUS(
-          Status::FilterError("Cannot filter; Unsupported input type"));
+      return LOG_STATUS(Status_FilterError("Cannot filter; Unsupported input type"));
   }
 }
 
@@ -514,7 +512,7 @@ Status BitWidthReductionFilter::read_compressed_value(
 Status BitWidthReductionFilter::set_option_impl(
     FilterOption option, const void* value) {
   if (value == nullptr)
-    return LOG_STATUS(Status::FilterError(
+    return LOG_STATUS(Status_FilterError(
         "Bit width reduction filter error; invalid option value"));
 
   switch (option) {
@@ -522,7 +520,7 @@ Status BitWidthReductionFilter::set_option_impl(
       max_window_size_ = *(uint32_t*)value;
       return Status::Ok();
     default:
-      return LOG_STATUS(Status::FilterError(
+      return LOG_STATUS(Status_FilterError(
           "Bit width reduction filter error; unknown option"));
   }
 }
@@ -534,7 +532,7 @@ Status BitWidthReductionFilter::get_option_impl(
       *(uint32_t*)value = max_window_size_;
       return Status::Ok();
     default:
-      return LOG_STATUS(Status::FilterError(
+      return LOG_STATUS(Status_FilterError(
           "Bit width reduction filter error; unknown option"));
   }
 }

--- a/tiledb/sm/filter/bitshuffle_filter.cc
+++ b/tiledb/sm/filter/bitshuffle_filter.cc
@@ -134,25 +134,25 @@ Status BitshuffleFilter::shuffle_part(
 
   switch (bytes_processed) {
     case -1:
-      return LOG_STATUS(
-          Status::FilterError("Bitshuffle error; Failed to allocate memory."));
+      return LOG_STATUS(Status_FilterError(
+          "Bitshuffle error; Failed to allocate memory."));
     case -11:
-      return LOG_STATUS(Status::FilterError("Bitshuffle error; Missing SSE."));
+      return LOG_STATUS(Status_FilterError("Bitshuffle error; Missing SSE."));
     case -12:
-      return LOG_STATUS(Status::FilterError("Bitshuffle error; Missing AVX."));
+      return LOG_STATUS(Status_FilterError("Bitshuffle error; Missing AVX."));
     case -80:
-      return LOG_STATUS(Status::FilterError(
+      return LOG_STATUS(Status_FilterError(
           "Bitshuffle error; Input size not a multiple of 8."));
     case -81:
-      return LOG_STATUS(Status::FilterError(
+      return LOG_STATUS(Status_FilterError(
           "Bitshuffle error; Block size not a multiple of 8."));
     case -91:
-      return LOG_STATUS(
-          Status::FilterError("Bitshuffle error; Decompression error, wrong "
-                              "number of bytes processed."));
+      return LOG_STATUS(Status_FilterError(
+          "Bitshuffle error; Decompression error, wrong "
+          "number of bytes processed."));
     default: {
       if (bytes_processed != (int64_t)part->size())
-        return LOG_STATUS(Status::FilterError(
+        return LOG_STATUS(Status_FilterError(
             "Bitshuffle error; Unhandled internal error code " +
             std::to_string(bytes_processed)));
       break;
@@ -220,25 +220,25 @@ Status BitshuffleFilter::unshuffle_part(
 
   switch (bytes_processed) {
     case -1:
-      return LOG_STATUS(
-          Status::FilterError("Bitshuffle error; Failed to allocate memory."));
+      return LOG_STATUS(Status_FilterError(
+          "Bitshuffle error; Failed to allocate memory."));
     case -11:
-      return LOG_STATUS(Status::FilterError("Bitshuffle error; Missing SSE."));
+      return LOG_STATUS(Status_FilterError("Bitshuffle error; Missing SSE."));
     case -12:
-      return LOG_STATUS(Status::FilterError("Bitshuffle error; Missing AVX."));
+      return LOG_STATUS(Status_FilterError("Bitshuffle error; Missing AVX."));
     case -80:
-      return LOG_STATUS(Status::FilterError(
+      return LOG_STATUS(Status_FilterError(
           "Bitshuffle error; Input size not a multiple of 8."));
     case -81:
-      return LOG_STATUS(Status::FilterError(
+      return LOG_STATUS(Status_FilterError(
           "Bitshuffle error; Block size not a multiple of 8."));
     case -91:
-      return LOG_STATUS(
-          Status::FilterError("Bitshuffle error; Decompression error, wrong "
-                              "number of bytes processed."));
+      return LOG_STATUS(Status_FilterError(
+          "Bitshuffle error; Decompression error, wrong "
+          "number of bytes processed."));
     default: {
       if (bytes_processed != (int64_t)part->size())
-        return LOG_STATUS(Status::FilterError(
+        return LOG_STATUS(Status_FilterError(
             "Bitshuffle error; Unhandled internal error code " +
             std::to_string(bytes_processed)));
       break;

--- a/tiledb/sm/filter/bitshuffle_filter.cc
+++ b/tiledb/sm/filter/bitshuffle_filter.cc
@@ -134,8 +134,8 @@ Status BitshuffleFilter::shuffle_part(
 
   switch (bytes_processed) {
     case -1:
-      return LOG_STATUS(Status_FilterError(
-          "Bitshuffle error; Failed to allocate memory."));
+      return LOG_STATUS(
+          Status_FilterError("Bitshuffle error; Failed to allocate memory."));
     case -11:
       return LOG_STATUS(Status_FilterError("Bitshuffle error; Missing SSE."));
     case -12:
@@ -147,9 +147,9 @@ Status BitshuffleFilter::shuffle_part(
       return LOG_STATUS(Status_FilterError(
           "Bitshuffle error; Block size not a multiple of 8."));
     case -91:
-      return LOG_STATUS(Status_FilterError(
-          "Bitshuffle error; Decompression error, wrong "
-          "number of bytes processed."));
+      return LOG_STATUS(
+          Status_FilterError("Bitshuffle error; Decompression error, wrong "
+                             "number of bytes processed."));
     default: {
       if (bytes_processed != (int64_t)part->size())
         return LOG_STATUS(Status_FilterError(
@@ -220,8 +220,8 @@ Status BitshuffleFilter::unshuffle_part(
 
   switch (bytes_processed) {
     case -1:
-      return LOG_STATUS(Status_FilterError(
-          "Bitshuffle error; Failed to allocate memory."));
+      return LOG_STATUS(
+          Status_FilterError("Bitshuffle error; Failed to allocate memory."));
     case -11:
       return LOG_STATUS(Status_FilterError("Bitshuffle error; Missing SSE."));
     case -12:
@@ -233,9 +233,9 @@ Status BitshuffleFilter::unshuffle_part(
       return LOG_STATUS(Status_FilterError(
           "Bitshuffle error; Block size not a multiple of 8."));
     case -91:
-      return LOG_STATUS(Status_FilterError(
-          "Bitshuffle error; Decompression error, wrong "
-          "number of bytes processed."));
+      return LOG_STATUS(
+          Status_FilterError("Bitshuffle error; Decompression error, wrong "
+                             "number of bytes processed."));
     default: {
       if (bytes_processed != (int64_t)part->size())
         return LOG_STATUS(Status_FilterError(

--- a/tiledb/sm/filter/checksum_md5_filter.cc
+++ b/tiledb/sm/filter/checksum_md5_filter.cc
@@ -263,7 +263,7 @@ Status ChecksumMD5Filter::compare_checksum_part(
     message << md5string_existing;
     message << " got ";
     message << md5string;
-    return Status::ChecksumError(message.str());
+    return Status_ChecksumError(message.str());
   }
 
   return Status::Ok();

--- a/tiledb/sm/filter/checksum_sha256_filter.cc
+++ b/tiledb/sm/filter/checksum_sha256_filter.cc
@@ -263,7 +263,7 @@ Status ChecksumSHA256Filter::compare_checksum_part(
     message << shastring_existing;
     message << " got ";
     message << shastring;
-    return Status::ChecksumError(message.str());
+    return Status_ChecksumError(message.str());
   }
 
   return Status::Ok();

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -169,16 +169,16 @@ Compressor CompressionFilter::filter_to_compressor(FilterType type) {
 Status CompressionFilter::set_option_impl(
     FilterOption option, const void* value) {
   if (value == nullptr)
-    return LOG_STATUS(
-        Status::FilterError("Compression filter error; invalid option value"));
+    return LOG_STATUS(Status_FilterError(
+        "Compression filter error; invalid option value"));
 
   switch (option) {
     case FilterOption::COMPRESSION_LEVEL:
       level_ = *(int*)value;
       return Status::Ok();
     default:
-      return LOG_STATUS(
-          Status::FilterError("Compression filter error; unknown option"));
+      return LOG_STATUS(Status_FilterError(
+          "Compression filter error; unknown option"));
   }
 }
 
@@ -189,8 +189,8 @@ Status CompressionFilter::get_option_impl(
       *(int*)value = level_;
       return Status::Ok();
     default:
-      return LOG_STATUS(
-          Status::FilterError("Compression filter error; unknown option"));
+      return LOG_STATUS(Status_FilterError(
+          "Compression filter error; unknown option"));
   }
 }
 
@@ -208,8 +208,7 @@ Status CompressionFilter::run_forward(
   }
 
   if (input->size() > std::numeric_limits<uint32_t>::max())
-    return LOG_STATUS(
-        Status::FilterError("Input is too large to be compressed."));
+    return LOG_STATUS(Status_FilterError("Input is too large to be compressed."));
 
   // Compute the upper bound on the size of the output.
   std::vector<ConstBuffer> data_parts = input->buffers(),
@@ -320,8 +319,7 @@ Status CompressionFilter::compress_part(
   }
 
   if (output->size() > std::numeric_limits<uint32_t>::max())
-    return LOG_STATUS(
-        Status::FilterError("Compressed output exceeds uint32 max."));
+    return LOG_STATUS(Status_FilterError("Compressed output exceeds uint32 max."));
 
   // Write part original and compressed size to metadata
   uint32_t input_size = (uint32_t)part->size(),
@@ -349,7 +347,7 @@ Status CompressionFilter::decompress_part(
   if (output->owns_data()) {
     RETURN_NOT_OK(output->realloc(output->alloced_size() + uncompressed_size));
   } else if (output->offset() + uncompressed_size > output->size()) {
-    return LOG_STATUS(Status::FilterError(
+    return LOG_STATUS(Status_FilterError(
         "CompressionFilter error; output buffer too small."));
   }
 

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -169,16 +169,16 @@ Compressor CompressionFilter::filter_to_compressor(FilterType type) {
 Status CompressionFilter::set_option_impl(
     FilterOption option, const void* value) {
   if (value == nullptr)
-    return LOG_STATUS(Status_FilterError(
-        "Compression filter error; invalid option value"));
+    return LOG_STATUS(
+        Status_FilterError("Compression filter error; invalid option value"));
 
   switch (option) {
     case FilterOption::COMPRESSION_LEVEL:
       level_ = *(int*)value;
       return Status::Ok();
     default:
-      return LOG_STATUS(Status_FilterError(
-          "Compression filter error; unknown option"));
+      return LOG_STATUS(
+          Status_FilterError("Compression filter error; unknown option"));
   }
 }
 
@@ -189,8 +189,8 @@ Status CompressionFilter::get_option_impl(
       *(int*)value = level_;
       return Status::Ok();
     default:
-      return LOG_STATUS(Status_FilterError(
-          "Compression filter error; unknown option"));
+      return LOG_STATUS(
+          Status_FilterError("Compression filter error; unknown option"));
   }
 }
 
@@ -208,7 +208,8 @@ Status CompressionFilter::run_forward(
   }
 
   if (input->size() > std::numeric_limits<uint32_t>::max())
-    return LOG_STATUS(Status_FilterError("Input is too large to be compressed."));
+    return LOG_STATUS(
+        Status_FilterError("Input is too large to be compressed."));
 
   // Compute the upper bound on the size of the output.
   std::vector<ConstBuffer> data_parts = input->buffers(),
@@ -319,7 +320,8 @@ Status CompressionFilter::compress_part(
   }
 
   if (output->size() > std::numeric_limits<uint32_t>::max())
-    return LOG_STATUS(Status_FilterError("Compressed output exceeds uint32 max."));
+    return LOG_STATUS(
+        Status_FilterError("Compressed output exceeds uint32 max."));
 
   // Write part original and compressed size to metadata
   uint32_t input_size = (uint32_t)part->size(),

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.cc
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.cc
@@ -77,8 +77,7 @@ Status EncryptionAES256GCMFilter::run_forward(
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
   if (key_bytes_ == nullptr)
-    return LOG_STATUS(
-        Status_FilterError("Encryption error; bad key."));
+    return LOG_STATUS(Status_FilterError("Encryption error; bad key."));
 
   // Allocate an initial output buffer.
   RETURN_NOT_OK(output->prepend_buffer(input->size()));
@@ -125,7 +124,8 @@ Status EncryptionAES256GCMFilter::encrypt_part(
       &key, nullptr, part, output, &output_iv, &output_tag));
 
   if (output->size() > std::numeric_limits<uint32_t>::max())
-    return LOG_STATUS(Status_FilterError("Encrypted output exceeds uint32 max."));
+    return LOG_STATUS(
+        Status_FilterError("Encrypted output exceeds uint32 max."));
 
   // Write metadata.
   uint32_t input_size = (uint32_t)part->size(),
@@ -147,8 +147,7 @@ Status EncryptionAES256GCMFilter::run_reverse(
     const Config& config) const {
   (void)config;
   if (key_bytes_ == nullptr)
-    return LOG_STATUS(
-        Status_FilterError("Encryption error; bad key."));
+    return LOG_STATUS(Status_FilterError("Encryption error; bad key."));
 
   // Read the number of parts from input metadata.
   uint32_t num_metadata_parts, num_data_parts;
@@ -194,8 +193,8 @@ Status EncryptionAES256GCMFilter::decrypt_part(
   if (output->owns_data()) {
     RETURN_NOT_OK(output->realloc(output->alloced_size() + plaintext_size));
   } else if (output->offset() + plaintext_size > output->size()) {
-    return LOG_STATUS(Status_FilterError(
-        "Encryption error; output buffer too small."));
+    return LOG_STATUS(
+        Status_FilterError("Encryption error; output buffer too small."));
   }
 
   // Set up the input buffer.
@@ -215,13 +214,13 @@ Status EncryptionAES256GCMFilter::set_key(const EncryptionKey& key) {
   auto key_buff = key.key();
 
   if (key.encryption_type() != EncryptionType::AES_256_GCM)
-    return LOG_STATUS(Status_FilterError(
-        "Encryption error; invalid key encryption type."));
+    return LOG_STATUS(
+        Status_FilterError("Encryption error; invalid key encryption type."));
 
   if (key_buff.data() == nullptr ||
       key_buff.size() != Crypto::AES256GCM_KEY_BYTES)
-    return LOG_STATUS(Status_FilterError(
-        "Encryption error; invalid key for AES-256-GCM."));
+    return LOG_STATUS(
+        Status_FilterError("Encryption error; invalid key for AES-256-GCM."));
 
   key_bytes_ = key_buff.data();
 

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.cc
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.cc
@@ -77,7 +77,8 @@ Status EncryptionAES256GCMFilter::run_forward(
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
   if (key_bytes_ == nullptr)
-    return LOG_STATUS(Status::FilterError("Encryption error; bad key."));
+    return LOG_STATUS(
+        Status_FilterError("Encryption error; bad key."));
 
   // Allocate an initial output buffer.
   RETURN_NOT_OK(output->prepend_buffer(input->size()));
@@ -124,8 +125,7 @@ Status EncryptionAES256GCMFilter::encrypt_part(
       &key, nullptr, part, output, &output_iv, &output_tag));
 
   if (output->size() > std::numeric_limits<uint32_t>::max())
-    return LOG_STATUS(
-        Status::FilterError("Encrypted output exceeds uint32 max."));
+    return LOG_STATUS(Status_FilterError("Encrypted output exceeds uint32 max."));
 
   // Write metadata.
   uint32_t input_size = (uint32_t)part->size(),
@@ -147,7 +147,8 @@ Status EncryptionAES256GCMFilter::run_reverse(
     const Config& config) const {
   (void)config;
   if (key_bytes_ == nullptr)
-    return LOG_STATUS(Status::FilterError("Encryption error; bad key."));
+    return LOG_STATUS(
+        Status_FilterError("Encryption error; bad key."));
 
   // Read the number of parts from input metadata.
   uint32_t num_metadata_parts, num_data_parts;
@@ -193,8 +194,8 @@ Status EncryptionAES256GCMFilter::decrypt_part(
   if (output->owns_data()) {
     RETURN_NOT_OK(output->realloc(output->alloced_size() + plaintext_size));
   } else if (output->offset() + plaintext_size > output->size()) {
-    return LOG_STATUS(
-        Status::FilterError("Encryption error; output buffer too small."));
+    return LOG_STATUS(Status_FilterError(
+        "Encryption error; output buffer too small."));
   }
 
   // Set up the input buffer.
@@ -214,13 +215,13 @@ Status EncryptionAES256GCMFilter::set_key(const EncryptionKey& key) {
   auto key_buff = key.key();
 
   if (key.encryption_type() != EncryptionType::AES_256_GCM)
-    return LOG_STATUS(
-        Status::FilterError("Encryption error; invalid key encryption type."));
+    return LOG_STATUS(Status_FilterError(
+        "Encryption error; invalid key encryption type."));
 
   if (key_buff.data() == nullptr ||
       key_buff.size() != Crypto::AES256GCM_KEY_BYTES)
-    return LOG_STATUS(
-        Status::FilterError("Encryption error; invalid key for AES-256-GCM."));
+    return LOG_STATUS(Status_FilterError(
+        "Encryption error; invalid key for AES-256-GCM."));
 
   key_bytes_ = key_buff.data();
 

--- a/tiledb/sm/filter/filter.cc
+++ b/tiledb/sm/filter/filter.cc
@@ -52,8 +52,7 @@ Filter* Filter::clone() const {
 
 Status Filter::get_option(FilterOption option, void* value) const {
   if (value == nullptr)
-    return LOG_STATUS(
-        Status::FilterError("Cannot get option; null value pointer"));
+    return LOG_STATUS(Status_FilterError("Cannot get option; null value pointer"));
 
   return get_option_impl(option, value);
 }
@@ -82,8 +81,7 @@ Status Filter::serialize(Buffer* buff) const {
   // Compute and write metadata length
   if (buff->size() < buff_size ||
       buff->size() - buff_size > std::numeric_limits<uint32_t>::max())
-    return LOG_STATUS(
-        Status::FilterError("Filter metadata exceeds max length"));
+    return LOG_STATUS(Status_FilterError("Filter metadata exceeds max length"));
   metadata_len = static_cast<uint32_t>(buff->size() - buff_size);
   std::memcpy(
       buff->data(metadata_length_offset), &metadata_len, sizeof(uint32_t));
@@ -94,13 +92,15 @@ Status Filter::serialize(Buffer* buff) const {
 Status Filter::get_option_impl(FilterOption option, void* value) const {
   (void)option;
   (void)value;
-  return LOG_STATUS(Status::FilterError("Filter does not support options."));
+  return LOG_STATUS(
+      Status_FilterError("Filter does not support options."));
 }
 
 Status Filter::set_option_impl(FilterOption option, const void* value) {
   (void)option;
   (void)value;
-  return LOG_STATUS(Status::FilterError("Filter does not support options."));
+  return LOG_STATUS(
+      Status_FilterError("Filter does not support options."));
 }
 
 Status Filter::deserialize_impl(ConstBuffer* buff) {

--- a/tiledb/sm/filter/filter.cc
+++ b/tiledb/sm/filter/filter.cc
@@ -52,7 +52,8 @@ Filter* Filter::clone() const {
 
 Status Filter::get_option(FilterOption option, void* value) const {
   if (value == nullptr)
-    return LOG_STATUS(Status_FilterError("Cannot get option; null value pointer"));
+    return LOG_STATUS(
+        Status_FilterError("Cannot get option; null value pointer"));
 
   return get_option_impl(option, value);
 }
@@ -92,15 +93,13 @@ Status Filter::serialize(Buffer* buff) const {
 Status Filter::get_option_impl(FilterOption option, void* value) const {
   (void)option;
   (void)value;
-  return LOG_STATUS(
-      Status_FilterError("Filter does not support options."));
+  return LOG_STATUS(Status_FilterError("Filter does not support options."));
 }
 
 Status Filter::set_option_impl(FilterOption option, const void* value) {
   (void)option;
   (void)value;
-  return LOG_STATUS(
-      Status_FilterError("Filter does not support options."));
+  return LOG_STATUS(Status_FilterError("Filter does not support options."));
 }
 
 Status Filter::deserialize_impl(ConstBuffer* buff) {

--- a/tiledb/sm/filter/filter_buffer.cc
+++ b/tiledb/sm/filter/filter_buffer.cc
@@ -175,7 +175,8 @@ Status FilterBuffer::copy_to(void* dest) const {
 Status FilterBuffer::get_const_buffer(
     uint64_t nbytes, ConstBuffer* buffer) const {
   if (current_buffer_ == buffers_.end())
-    return LOG_STATUS(Status_FilterError("FilterBuffer error; no current buffer."));
+    return LOG_STATUS(
+        Status_FilterError("FilterBuffer error; no current buffer."));
 
   Buffer* buf = current_buffer_->buffer();
   uint64_t bytes_in_buf = buf->size() - current_relative_offset_;
@@ -264,8 +265,8 @@ bool FilterBuffer::read_only() const {
 
 Status FilterBuffer::write(const void* buffer, uint64_t nbytes) {
   if (read_only_)
-    return LOG_STATUS(Status_FilterError(
-        "FilterBuffer error; cannot set write: read-only."));
+    return LOG_STATUS(
+        Status_FilterError("FilterBuffer error; cannot set write: read-only."));
 
   uint64_t bytes_left = nbytes;
   uint64_t src_offset = 0;
@@ -329,8 +330,8 @@ Status FilterBuffer::write(const void* buffer, uint64_t nbytes) {
 
 Status FilterBuffer::write(FilterBuffer* other, uint64_t nbytes) {
   if (read_only_)
-    return LOG_STATUS(Status_FilterError(
-        "FilterBuffer error; cannot write: read-only."));
+    return LOG_STATUS(
+        Status_FilterError("FilterBuffer error; cannot write: read-only."));
 
   auto list_node = other->current_buffer_;
   uint64_t relative_offset = other->current_relative_offset_;
@@ -459,13 +460,13 @@ Status FilterBuffer::prepend_buffer(uint64_t nbytes) {
 
     // Check for errors
     if (!fixed_allocation_op_allowed_)
-      return LOG_STATUS(Status_FilterError(
-          "FilterBuffer error; cannot prepend buffer: "
-          "fixed allocation is set."));
+      return LOG_STATUS(
+          Status_FilterError("FilterBuffer error; cannot prepend buffer: "
+                             "fixed allocation is set."));
     else if (nbytes > buffers_.front().buffer()->size())
-      return LOG_STATUS(Status_FilterError(
-          "FilterBuffer error; cannot prepend buffer: "
-          "fixed allocation not large enough."));
+      return LOG_STATUS(
+          Status_FilterError("FilterBuffer error; cannot prepend buffer: "
+                             "fixed allocation not large enough."));
 
     // Disallow further operations
     fixed_allocation_op_allowed_ = false;
@@ -493,8 +494,9 @@ Status FilterBuffer::append_view(
       return LOG_STATUS(Status_FilterError(
           "FilterBuffer error; cannot append view: fixed allocation set."));
     else if (nbytes > buffers_.front().buffer()->size())
-      return LOG_STATUS(Status_FilterError("FilterBuffer error; cannot append view: "
-                                     "fixed allocation not large enough."));
+      return LOG_STATUS(
+          Status_FilterError("FilterBuffer error; cannot append view: "
+                             "fixed allocation not large enough."));
 
     // Disallow further operations
     fixed_allocation_op_allowed_ = false;
@@ -543,8 +545,8 @@ Status FilterBuffer::append_view(const FilterBuffer* other) {
 
 Status FilterBuffer::clear() {
   if (read_only_)
-    return LOG_STATUS(Status_FilterError(
-        "FilterBuffer error; cannot clear: read-only."));
+    return LOG_STATUS(
+        Status_FilterError("FilterBuffer error; cannot clear: read-only."));
 
   offset_ = 0;
 

--- a/tiledb/sm/filter/filter_create.cc
+++ b/tiledb/sm/filter/filter_create.cc
@@ -84,14 +84,14 @@ Status tiledb::sm::FilterCreate::deserialize(
 
   auto* f = make(static_cast<FilterType>(type));
   if (f == nullptr)
-    return LOG_STATUS(Status::FilterError("Deserialization error."));
+    return LOG_STATUS(Status_FilterError("Deserialization error."));
 
   auto offset = buff->offset();
   RETURN_NOT_OK_ELSE(f->deserialize_impl(buff), tdb_delete(f));
 
   if (buff->offset() - offset != filter_metadata_len) {
     tdb_delete(f);
-    return LOG_STATUS(Status::FilterError(
+    return LOG_STATUS(Status_FilterError(
         "Deserialization error; unexpected metadata length"));
   }
 

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -177,7 +177,7 @@ Status FilterPipeline::filter_chunks_forward(
     if (final_stage_output_data.size() > std::numeric_limits<uint32_t>::max() ||
         final_stage_output_metadata.size() >
             std::numeric_limits<uint32_t>::max())
-      return LOG_STATUS(Status::FilterError(
+      return LOG_STATUS(Status_FilterError(
           "Filter error; filtered chunk size exceeds uint32_t"));
 
     // Leave space for the chunk sizes and the data itself.
@@ -400,13 +400,12 @@ Status FilterPipeline::run_reverse_internal(
     const Config& config) const {
   Buffer* const filtered_buffer = tile->filtered_buffer();
   if (filtered_buffer == nullptr)
-    return LOG_STATUS(
-        Status::FilterError("Filter error; tile has null buffer."));
+    return LOG_STATUS(Status_FilterError("Filter error; tile has null buffer."));
 
   assert(tile->buffer());
   assert(tile->buffer()->size() == 0);
   if (tile->buffer()->size() > 0)
-    return LOG_STATUS(Status::FilterError(
+    return LOG_STATUS(Status_FilterError(
         "Filter error; tile has allocated uncompressed chunk buffers."));
 
   // First make a pass over the tile to get the chunk information.
@@ -541,7 +540,7 @@ Status FilterPipeline::append_encryption_filter(
     case EncryptionType::AES_256_GCM:
       return pipeline->add_filter(EncryptionAES256GCMFilter(encryption_key));
     default:
-      return LOG_STATUS(Status::FilterError(
+      return LOG_STATUS(Status_FilterError(
           "Error appending encryption filter; unknown type."));
   }
 }

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -400,7 +400,8 @@ Status FilterPipeline::run_reverse_internal(
     const Config& config) const {
   Buffer* const filtered_buffer = tile->filtered_buffer();
   if (filtered_buffer == nullptr)
-    return LOG_STATUS(Status_FilterError("Filter error; tile has null buffer."));
+    return LOG_STATUS(
+        Status_FilterError("Filter error; tile has null buffer."));
 
   assert(tile->buffer());
   assert(tile->buffer()->size() == 0);

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -357,7 +357,7 @@ Status FilterPipeline::run_forward(
     Tile* const tile,
     ThreadPool* const compute_tp) const {
   RETURN_NOT_OK(
-      tile ? Status::Ok() : Status::Error("invalid argument: null Tile*"));
+      tile ? Status::Ok() : Status_Error("invalid argument: null Tile*"));
 
   writer_stats->add_counter("write_filtered_byte_num", tile->size());
 

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -120,7 +120,8 @@ Status PositiveDeltaFilter::run_forward(
       return run_forward<int64_t>(
           tile, input_metadata, input, output_metadata, output);
     default:
-      return LOG_STATUS(Status_FilterError("Cannot filter; Unsupported input type"));
+      return LOG_STATUS(
+          Status_FilterError("Cannot filter; Unsupported input type"));
   }
 }
 
@@ -292,7 +293,8 @@ Status PositiveDeltaFilter::run_reverse(
       return run_reverse<int64_t>(
           tile, input_metadata, input, output_metadata, output);
     default:
-      return LOG_STATUS(Status_FilterError("Cannot filter; Unsupported input type"));
+      return LOG_STATUS(
+          Status_FilterError("Cannot filter; Unsupported input type"));
   }
 }
 
@@ -359,8 +361,8 @@ Status PositiveDeltaFilter::set_option_impl(
       max_window_size_ = *(uint32_t*)value;
       return Status::Ok();
     default:
-      return LOG_STATUS(Status_FilterError(
-          "Positive delta filter error; unknown option"));
+      return LOG_STATUS(
+          Status_FilterError("Positive delta filter error; unknown option"));
   }
 }
 
@@ -371,8 +373,8 @@ Status PositiveDeltaFilter::get_option_impl(
       *(uint32_t*)value = max_window_size_;
       return Status::Ok();
     default:
-      return LOG_STATUS(Status_FilterError(
-          "Positive delta filter error; unknown option"));
+      return LOG_STATUS(
+          Status_FilterError("Positive delta filter error; unknown option"));
   }
 }
 

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -120,8 +120,7 @@ Status PositiveDeltaFilter::run_forward(
       return run_forward<int64_t>(
           tile, input_metadata, input, output_metadata, output);
     default:
-      return LOG_STATUS(
-          Status::FilterError("Cannot filter; Unsupported input type"));
+      return LOG_STATUS(Status_FilterError("Cannot filter; Unsupported input type"));
   }
 }
 
@@ -210,7 +209,7 @@ Status PositiveDeltaFilter::encode_part(
       for (uint32_t j = 0; j < window_nelts; j++) {
         T curr_value = input->value<T>();
         if (curr_value < prev_value)
-          return LOG_STATUS(Status::FilterError(
+          return LOG_STATUS(Status_FilterError(
               "Positive delta filter error: delta is not positive."));
 
         T delta = curr_value - prev_value;
@@ -293,8 +292,7 @@ Status PositiveDeltaFilter::run_reverse(
       return run_reverse<int64_t>(
           tile, input_metadata, input, output_metadata, output);
     default:
-      return LOG_STATUS(
-          Status::FilterError("Cannot filter; Unsupported input type"));
+      return LOG_STATUS(Status_FilterError("Cannot filter; Unsupported input type"));
   }
 }
 
@@ -353,7 +351,7 @@ Status PositiveDeltaFilter::run_reverse(
 Status PositiveDeltaFilter::set_option_impl(
     FilterOption option, const void* value) {
   if (value == nullptr)
-    return LOG_STATUS(Status::FilterError(
+    return LOG_STATUS(Status_FilterError(
         "Positive delta filter error; invalid option value"));
 
   switch (option) {
@@ -361,8 +359,8 @@ Status PositiveDeltaFilter::set_option_impl(
       max_window_size_ = *(uint32_t*)value;
       return Status::Ok();
     default:
-      return LOG_STATUS(
-          Status::FilterError("Positive delta filter error; unknown option"));
+      return LOG_STATUS(Status_FilterError(
+          "Positive delta filter error; unknown option"));
   }
 }
 
@@ -373,8 +371,8 @@ Status PositiveDeltaFilter::get_option_impl(
       *(uint32_t*)value = max_window_size_;
       return Status::Ok();
     default:
-      return LOG_STATUS(
-          Status::FilterError("Positive delta filter error; unknown option"));
+      return LOG_STATUS(Status_FilterError(
+          "Positive delta filter error; unknown option"));
   }
 }
 

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -132,11 +132,11 @@ void FragmentInfo::dump(FILE* out) const {
 
 Status FragmentInfo::get_dense(uint32_t fid, int32_t* dense) const {
   if (dense == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot check if fragment is dense; Dense argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot check if fragment is dense; Invalid fragment index"));
 
   *dense = (int32_t)!fragments_[fid].sparse();
@@ -146,11 +146,11 @@ Status FragmentInfo::get_dense(uint32_t fid, int32_t* dense) const {
 
 Status FragmentInfo::get_sparse(uint32_t fid, int32_t* sparse) const {
   if (sparse == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot check if fragment is sparse; Sparse argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot check if fragment is sparse; Invalid fragment index"));
 
   *sparse = (int32_t)fragments_[fid].sparse();
@@ -164,11 +164,11 @@ uint32_t FragmentInfo::fragment_num() const {
 
 Status FragmentInfo::get_cell_num(uint32_t fid, uint64_t* cell_num) const {
   if (cell_num == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; Cell number argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; Invalid fragment index"));
 
   *cell_num = fragments_[fid].cell_num();
@@ -178,11 +178,11 @@ Status FragmentInfo::get_cell_num(uint32_t fid, uint64_t* cell_num) const {
 
 Status FragmentInfo::get_fragment_size(uint32_t fid, uint64_t* size) const {
   if (size == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; Size argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; Invalid fragment index"));
 
   *size = fragments_[fid].fragment_size();
@@ -192,11 +192,11 @@ Status FragmentInfo::get_fragment_size(uint32_t fid, uint64_t* size) const {
 
 Status FragmentInfo::get_fragment_uri(uint32_t fid, const char** uri) const {
   if (uri == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; URI argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; Invalid fragment index"));
 
   *uri = fragments_[fid].uri().c_str();
@@ -206,11 +206,11 @@ Status FragmentInfo::get_fragment_uri(uint32_t fid, const char** uri) const {
 
 Status FragmentInfo::get_to_vacuum_uri(uint32_t fid, const char** uri) const {
   if (uri == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get URI of fragment to vacuum; URI argument cannot be null"));
 
   if (fid >= to_vacuum_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get URI of fragment to vacuum; Invalid fragment index"));
 
   *uri = to_vacuum_[fid].c_str();
@@ -221,15 +221,15 @@ Status FragmentInfo::get_to_vacuum_uri(uint32_t fid, const char** uri) const {
 Status FragmentInfo::get_timestamp_range(
     uint32_t fid, uint64_t* start, uint64_t* end) const {
   if (start == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get timestamp range; Start argument cannot be null"));
 
   if (end == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get timestamp range; End argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; Invalid fragment index"));
 
   auto range = fragments_[fid].timestamp_range();
@@ -242,21 +242,21 @@ Status FragmentInfo::get_timestamp_range(
 Status FragmentInfo::get_non_empty_domain(
     uint32_t fid, uint32_t did, void* domain) const {
   if (domain == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain; Domain argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain; Invalid fragment index"));
 
   const auto& non_empty_domain = fragments_[fid].non_empty_domain();
 
   if (did >= non_empty_domain.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain; Invalid dimension index"));
 
   if (non_empty_domain[did].var_size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain; Dimension is variable-sized"));
 
   assert(!non_empty_domain[did].empty());
@@ -269,7 +269,7 @@ Status FragmentInfo::get_non_empty_domain(
 Status FragmentInfo::get_non_empty_domain(
     uint32_t fid, const char* dim_name, void* domain) const {
   if (dim_name == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain; Dimension name argument cannot be null"));
 
   uint32_t did;
@@ -284,7 +284,7 @@ Status FragmentInfo::get_non_empty_domain(
     auto msg =
         std::string("Cannot get non-empty domain; Invalid dimension name '") +
         dim_name + "'";
-    return LOG_STATUS(Status::FragmentInfoError(msg));
+    return LOG_STATUS(Status_FragmentInfoError(msg));
   }
 
   return get_non_empty_domain(fid, did, domain);
@@ -296,27 +296,27 @@ Status FragmentInfo::get_non_empty_domain_var_size(
     uint64_t* start_size,
     uint64_t* end_size) const {
   if (start_size == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get non-empty domain var size; Start "
-                                  "size argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get non-empty domain var size; Start "
+        "size argument cannot be null"));
 
   if (end_size == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get non-empty domain var size; End "
-                                  "size argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get non-empty domain var size; End "
+        "size argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var size; Invalid fragment index"));
 
   const auto& non_empty_domain = fragments_[fid].non_empty_domain();
 
   if (did >= non_empty_domain.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var size; Invalid dimension index"));
 
   if (!non_empty_domain[did].var_size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var size; Dimension is fixed sized"));
 
   assert(!non_empty_domain[did].empty());
@@ -332,9 +332,9 @@ Status FragmentInfo::get_non_empty_domain_var_size(
     uint64_t* start_size,
     uint64_t* end_size) const {
   if (dim_name == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get non-empty domain var size; "
-                                  "Dimension name argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get non-empty domain var size; "
+        "Dimension name argument cannot be null"));
 
   uint32_t did;
   for (did = 0; did < dim_names_.size(); ++did) {
@@ -349,7 +349,7 @@ Status FragmentInfo::get_non_empty_domain_var_size(
         std::string(
             "Cannot get non-empty domain var size; Invalid dimension name '") +
         dim_name + "'";
-    return LOG_STATUS(Status::FragmentInfoError(msg));
+    return LOG_STATUS(Status_FragmentInfoError(msg));
   }
 
   return get_non_empty_domain_var_size(fid, did, start_size, end_size);
@@ -358,26 +358,26 @@ Status FragmentInfo::get_non_empty_domain_var_size(
 Status FragmentInfo::get_non_empty_domain_var(
     uint32_t fid, uint32_t did, void* start, void* end) const {
   if (start == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get non-empty domain var; Domain "
-                                  "start argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get non-empty domain var; Domain "
+        "start argument cannot be null"));
 
   if (end == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var; Domain end argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var; Invalid fragment index"));
 
   const auto& non_empty_domain = fragments_[fid].non_empty_domain();
 
   if (did >= non_empty_domain.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var; Invalid dimension index"));
 
   if (!non_empty_domain[did].var_size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var; Dimension is fixed-sized"));
 
   assert(!non_empty_domain[did].empty());
@@ -392,9 +392,9 @@ Status FragmentInfo::get_non_empty_domain_var(
 Status FragmentInfo::get_non_empty_domain_var(
     uint32_t fid, const char* dim_name, void* start, void* end) const {
   if (dim_name == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get non-empty domain var; Dimension "
-                                  "name argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get non-empty domain var; Dimension "
+        "name argument cannot be null"));
 
   uint32_t did;
   for (did = 0; did < dim_names_.size(); ++did) {
@@ -409,7 +409,7 @@ Status FragmentInfo::get_non_empty_domain_var(
         std::string(
             "Cannot get non-empty domain var; Invalid dimension name '") +
         dim_name + "'";
-    return LOG_STATUS(Status::FragmentInfoError(msg));
+    return LOG_STATUS(Status_FragmentInfoError(msg));
   }
 
   return get_non_empty_domain_var(fid, did, start, end);
@@ -417,11 +417,11 @@ Status FragmentInfo::get_non_empty_domain_var(
 
 Status FragmentInfo::get_mbr_num(uint32_t fid, uint64_t* mbr_num) {
   if (mbr_num == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; MBR number argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; Invalid fragment index"));
 
   if (!fragments_[fid].sparse()) {
@@ -439,32 +439,31 @@ Status FragmentInfo::get_mbr_num(uint32_t fid, uint64_t* mbr_num) {
 Status FragmentInfo::get_mbr(
     uint32_t fid, uint32_t mid, uint32_t did, void* mbr) {
   if (mbr == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get MBR; mbr argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR; Invalid fragment index"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get MBR; Invalid fragment index"));
 
   if (!fragments_[fid].sparse())
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR; Fragment is not sparse"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get MBR; Fragment is not sparse"));
 
   auto meta = fragments_[fid].meta();
   RETURN_NOT_OK(meta->load_rtree(*array_->encryption_key()));
   const auto& mbrs = meta->mbrs();
 
   if (mid >= mbrs.size())
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR; Invalid MBR index"));
+    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR; Invalid MBR index"));
 
   const auto& minimum_bounding_rectangle = mbrs[mid];
   if (did >= minimum_bounding_rectangle.size())
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR; Invalid dimension index"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get MBR; Invalid dimension index"));
 
   if (minimum_bounding_rectangle[did].var_size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get MBR; Dimension is variable-sized"));
 
   assert(!minimum_bounding_rectangle[did].empty());
@@ -479,7 +478,7 @@ Status FragmentInfo::get_mbr(
 Status FragmentInfo::get_mbr(
     uint32_t fid, uint32_t mid, const char* dim_name, void* mbr) {
   if (dim_name == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain; Dimension name argument cannot be null"));
 
   uint32_t did;
@@ -494,7 +493,7 @@ Status FragmentInfo::get_mbr(
     auto msg =
         std::string("Cannot get non-empty domain; Invalid dimension name '") +
         dim_name + "'";
-    return LOG_STATUS(Status::FragmentInfoError(msg));
+    return LOG_STATUS(Status_FragmentInfoError(msg));
   }
 
   return get_mbr(fid, mid, did, mbr);
@@ -507,39 +506,36 @@ Status FragmentInfo::get_mbr_var_size(
     uint64_t* start_size,
     uint64_t* end_size) {
   if (start_size == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR var size; Start "
-                                  "size argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR var size; Start "
+                                         "size argument cannot be null"));
 
   if (end_size == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR var size; End "
-                                  "size argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR var size; End "
+                                         "size argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get MBR var size; Invalid fragment index"));
 
   if (!fragments_[fid].sparse())
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR; Fragment is not sparse"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get MBR; Fragment is not sparse"));
 
   auto meta = fragments_[fid].meta();
   RETURN_NOT_OK(meta->load_rtree(*array_->encryption_key()));
   const auto& mbrs = meta->mbrs();
 
   if (mid >= mbrs.size())
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR; Invalid mbr index"));
+    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR; Invalid mbr index"));
 
   const auto& minimum_bounding_rectangle = mbrs[mid];
 
   if (did >= minimum_bounding_rectangle.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get MBR var size; Invalid dimension index"));
 
   if (!minimum_bounding_rectangle[did].var_size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get MBR var size; Dimension is fixed sized"));
 
   assert(!minimum_bounding_rectangle[did].empty());
@@ -556,9 +552,9 @@ Status FragmentInfo::get_mbr_var_size(
     uint64_t* start_size,
     uint64_t* end_size) {
   if (dim_name == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR var size; "
-                                  "Dimension name argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get MBR var size; "
+        "Dimension name argument cannot be null"));
 
   uint32_t did;
   for (did = 0; did < dim_names_.size(); ++did) {
@@ -572,7 +568,7 @@ Status FragmentInfo::get_mbr_var_size(
     auto msg =
         std::string("Cannot get MBR var size; Invalid dimension name '") +
         dim_name + "'";
-    return LOG_STATUS(Status::FragmentInfoError(msg));
+    return LOG_STATUS(Status_FragmentInfoError(msg));
   }
 
   return get_mbr_var_size(fid, mid, did, start_size, end_size);
@@ -581,38 +577,37 @@ Status FragmentInfo::get_mbr_var_size(
 Status FragmentInfo::get_mbr_var(
     uint32_t fid, uint32_t mid, uint32_t did, void* start, void* end) {
   if (start == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get non-empty domain var; Domain "
-                                  "start argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get non-empty domain var; Domain "
+        "start argument cannot be null"));
 
   if (end == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var; Domain end argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var; Invalid fragment index"));
 
   if (!fragments_[fid].sparse())
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR; Fragment is not sparse"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get MBR; Fragment is not sparse"));
 
   auto meta = fragments_[fid].meta();
   RETURN_NOT_OK(meta->load_rtree(*array_->encryption_key()));
   const auto& mbrs = meta->mbrs();
 
   if (mid >= mbrs.size())
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get MBR; Invalid mbr index"));
+    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR; Invalid mbr index"));
 
   const auto& minimum_bounding_rectangle = mbrs[mid];
 
   if (did >= minimum_bounding_rectangle.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var; Invalid dimension index"));
 
   if (!minimum_bounding_rectangle[did].var_size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get non-empty domain var; Dimension is fixed-sized"));
 
   assert(!minimum_bounding_rectangle[did].empty());
@@ -631,9 +626,9 @@ Status FragmentInfo::get_mbr_var(
 Status FragmentInfo::get_mbr_var(
     uint32_t fid, uint32_t mid, const char* dim_name, void* start, void* end) {
   if (dim_name == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot get non-empty domain var; Dimension "
-                                  "name argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot get non-empty domain var; Dimension "
+        "name argument cannot be null"));
 
   uint32_t did;
   for (did = 0; did < dim_names_.size(); ++did) {
@@ -648,7 +643,7 @@ Status FragmentInfo::get_mbr_var(
         std::string(
             "Cannot get non-empty domain var; Invalid dimension name '") +
         dim_name + "'";
-    return LOG_STATUS(Status::FragmentInfoError(msg));
+    return LOG_STATUS(Status_FragmentInfoError(msg));
   }
 
   return get_mbr_var(fid, mid, did, start, end);
@@ -656,11 +651,11 @@ Status FragmentInfo::get_mbr_var(
 
 Status FragmentInfo::get_version(uint32_t fid, uint32_t* version) const {
   if (version == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get version; Version argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get version; Invalid fragment index"));
 
   *version = fragments_[fid].format_version();
@@ -671,11 +666,11 @@ Status FragmentInfo::get_version(uint32_t fid, uint32_t* version) const {
 Status FragmentInfo::get_array_schema(
     uint32_t fid, ArraySchema** array_schema) {
   if (array_schema == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get array schema; schema argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get array schema; Invalid fragment index"));
   URI schema_uri;
   uint32_t version = fragments_[fid].format_version();
@@ -696,11 +691,11 @@ Status FragmentInfo::get_array_schema(
 Status FragmentInfo::get_array_schema_name(
     uint32_t fid, const char** schema_name) {
   if (schema_name == nullptr)
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get array schema URI; schema name argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status::FragmentInfoError(
+    return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get array schema name; Invalid fragment index"));
 
   uint32_t version = fragments_[fid].format_version();
@@ -716,14 +711,14 @@ Status FragmentInfo::get_array_schema_name(
 Status FragmentInfo::has_consolidated_metadata(
     uint32_t fid, int32_t* has) const {
   if (has == nullptr)
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot check if fragment has consolidated "
-                                  "metadata; Has argument cannot be null"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot check if fragment has consolidated "
+        "metadata; Has argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(
-        Status::FragmentInfoError("Cannot check if fragment has consolidated "
-                                  "metadata; Invalid fragment index"));
+    return LOG_STATUS(Status_FragmentInfoError(
+        "Cannot check if fragment has consolidated "
+        "metadata; Invalid fragment index"));
 
   *has = fragments_[fid].has_consolidated_footer();
 
@@ -788,7 +783,7 @@ Status FragmentInfo::load(
   if (!is_array) {
     auto msg = std::string("Cannot load fragment info; Array '") +
                array_uri_.to_string() + "' does not exist";
-    return LOG_STATUS(Status::FragmentInfoError(msg));
+    return LOG_STATUS(Status_FragmentInfoError(msg));
   }
 
   RETURN_NOT_OK(

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -296,14 +296,14 @@ Status FragmentInfo::get_non_empty_domain_var_size(
     uint64_t* start_size,
     uint64_t* end_size) const {
   if (start_size == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get non-empty domain var size; Start "
-        "size argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get non-empty domain var size; Start "
+                                 "size argument cannot be null"));
 
   if (end_size == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get non-empty domain var size; End "
-        "size argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get non-empty domain var size; End "
+                                 "size argument cannot be null"));
 
   if (fid >= fragments_.size())
     return LOG_STATUS(Status_FragmentInfoError(
@@ -332,9 +332,9 @@ Status FragmentInfo::get_non_empty_domain_var_size(
     uint64_t* start_size,
     uint64_t* end_size) const {
   if (dim_name == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get non-empty domain var size; "
-        "Dimension name argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get non-empty domain var size; "
+                                 "Dimension name argument cannot be null"));
 
   uint32_t did;
   for (did = 0; did < dim_names_.size(); ++did) {
@@ -358,9 +358,9 @@ Status FragmentInfo::get_non_empty_domain_var_size(
 Status FragmentInfo::get_non_empty_domain_var(
     uint32_t fid, uint32_t did, void* start, void* end) const {
   if (start == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get non-empty domain var; Domain "
-        "start argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get non-empty domain var; Domain "
+                                 "start argument cannot be null"));
 
   if (end == nullptr)
     return LOG_STATUS(Status_FragmentInfoError(
@@ -392,9 +392,9 @@ Status FragmentInfo::get_non_empty_domain_var(
 Status FragmentInfo::get_non_empty_domain_var(
     uint32_t fid, const char* dim_name, void* start, void* end) const {
   if (dim_name == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get non-empty domain var; Dimension "
-        "name argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get non-empty domain var; Dimension "
+                                 "name argument cannot be null"));
 
   uint32_t did;
   for (did = 0; did < dim_names_.size(); ++did) {
@@ -443,24 +443,25 @@ Status FragmentInfo::get_mbr(
         "Cannot get MBR; mbr argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get MBR; Invalid fragment index"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR; Invalid fragment index"));
 
   if (!fragments_[fid].sparse())
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get MBR; Fragment is not sparse"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR; Fragment is not sparse"));
 
   auto meta = fragments_[fid].meta();
   RETURN_NOT_OK(meta->load_rtree(*array_->encryption_key()));
   const auto& mbrs = meta->mbrs();
 
   if (mid >= mbrs.size())
-    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR; Invalid MBR index"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR; Invalid MBR index"));
 
   const auto& minimum_bounding_rectangle = mbrs[mid];
   if (did >= minimum_bounding_rectangle.size())
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get MBR; Invalid dimension index"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR; Invalid dimension index"));
 
   if (minimum_bounding_rectangle[did].var_size())
     return LOG_STATUS(Status_FragmentInfoError(
@@ -506,27 +507,30 @@ Status FragmentInfo::get_mbr_var_size(
     uint64_t* start_size,
     uint64_t* end_size) {
   if (start_size == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR var size; Start "
-                                         "size argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR var size; Start "
+                                 "size argument cannot be null"));
 
   if (end_size == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR var size; End "
-                                         "size argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR var size; End "
+                                 "size argument cannot be null"));
 
   if (fid >= fragments_.size())
     return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get MBR var size; Invalid fragment index"));
 
   if (!fragments_[fid].sparse())
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get MBR; Fragment is not sparse"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR; Fragment is not sparse"));
 
   auto meta = fragments_[fid].meta();
   RETURN_NOT_OK(meta->load_rtree(*array_->encryption_key()));
   const auto& mbrs = meta->mbrs();
 
   if (mid >= mbrs.size())
-    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR; Invalid mbr index"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR; Invalid mbr index"));
 
   const auto& minimum_bounding_rectangle = mbrs[mid];
 
@@ -552,9 +556,9 @@ Status FragmentInfo::get_mbr_var_size(
     uint64_t* start_size,
     uint64_t* end_size) {
   if (dim_name == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get MBR var size; "
-        "Dimension name argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR var size; "
+                                 "Dimension name argument cannot be null"));
 
   uint32_t did;
   for (did = 0; did < dim_names_.size(); ++did) {
@@ -577,9 +581,9 @@ Status FragmentInfo::get_mbr_var_size(
 Status FragmentInfo::get_mbr_var(
     uint32_t fid, uint32_t mid, uint32_t did, void* start, void* end) {
   if (start == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get non-empty domain var; Domain "
-        "start argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get non-empty domain var; Domain "
+                                 "start argument cannot be null"));
 
   if (end == nullptr)
     return LOG_STATUS(Status_FragmentInfoError(
@@ -590,15 +594,16 @@ Status FragmentInfo::get_mbr_var(
         "Cannot get non-empty domain var; Invalid fragment index"));
 
   if (!fragments_[fid].sparse())
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get MBR; Fragment is not sparse"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR; Fragment is not sparse"));
 
   auto meta = fragments_[fid].meta();
   RETURN_NOT_OK(meta->load_rtree(*array_->encryption_key()));
   const auto& mbrs = meta->mbrs();
 
   if (mid >= mbrs.size())
-    return LOG_STATUS(Status_FragmentInfoError("Cannot get MBR; Invalid mbr index"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get MBR; Invalid mbr index"));
 
   const auto& minimum_bounding_rectangle = mbrs[mid];
 
@@ -626,9 +631,9 @@ Status FragmentInfo::get_mbr_var(
 Status FragmentInfo::get_mbr_var(
     uint32_t fid, uint32_t mid, const char* dim_name, void* start, void* end) {
   if (dim_name == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get non-empty domain var; Dimension "
-        "name argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get non-empty domain var; Dimension "
+                                 "name argument cannot be null"));
 
   uint32_t did;
   for (did = 0; did < dim_names_.size(); ++did) {
@@ -655,8 +660,8 @@ Status FragmentInfo::get_version(uint32_t fid, uint32_t* version) const {
         "Cannot get version; Version argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get version; Invalid fragment index"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot get version; Invalid fragment index"));
 
   *version = fragments_[fid].format_version();
 
@@ -711,14 +716,14 @@ Status FragmentInfo::get_array_schema_name(
 Status FragmentInfo::has_consolidated_metadata(
     uint32_t fid, int32_t* has) const {
   if (has == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot check if fragment has consolidated "
-        "metadata; Has argument cannot be null"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot check if fragment has consolidated "
+                                 "metadata; Has argument cannot be null"));
 
   if (fid >= fragments_.size())
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot check if fragment has consolidated "
-        "metadata; Invalid fragment index"));
+    return LOG_STATUS(
+        Status_FragmentInfoError("Cannot check if fragment has consolidated "
+                                 "metadata; Invalid fragment index"));
 
   *has = fragments_[fid].has_consolidated_footer();
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -304,7 +304,7 @@ Status FragmentMetadata::add_max_buffer_sizes_dense(
       return add_max_buffer_sizes_dense<int64_t>(
           static_cast<const int64_t*>(subarray), buffer_sizes);
     default:
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot compute add read buffer sizes for dense array; Unsupported "
           "domain type"));
   }
@@ -773,7 +773,7 @@ Status FragmentMetadata::file_offset(
   assert(it != idx_map_.end());
   auto idx = it->second;
   if (!loaded_metadata_.tile_offsets_[idx])
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Trying to access metadata that's not loaded"));
 
   *offset = tile_offsets_[idx][tile_idx];
@@ -786,7 +786,7 @@ Status FragmentMetadata::file_var_offset(
   assert(it != idx_map_.end());
   auto idx = it->second;
   if (!loaded_metadata_.tile_var_offsets_[idx])
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Trying to access metadata that's not loaded"));
 
   *offset = tile_var_offsets_[idx][tile_idx];
@@ -799,7 +799,7 @@ Status FragmentMetadata::file_validity_offset(
   assert(it != idx_map_.end());
   auto idx = it->second;
   if (!loaded_metadata_.tile_validity_offsets_[idx])
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Trying to access metadata that's not loaded"));
 
   *offset = tile_validity_offsets_[idx][tile_idx];
@@ -820,7 +820,7 @@ Status FragmentMetadata::persisted_tile_size(
   assert(it != idx_map_.end());
   auto idx = it->second;
   if (!loaded_metadata_.tile_offsets_[idx])
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Trying to access metadata that's not loaded"));
 
   auto tile_num = this->tile_num();
@@ -840,7 +840,7 @@ Status FragmentMetadata::persisted_tile_var_size(
   auto idx = it->second;
 
   if (!loaded_metadata_.tile_var_offsets_[idx])
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Trying to access metadata that's not loaded"));
 
   auto tile_num = this->tile_num();
@@ -859,7 +859,7 @@ Status FragmentMetadata::persisted_tile_validity_size(
   assert(it != idx_map_.end());
   auto idx = it->second;
   if (!loaded_metadata_.tile_validity_offsets_[idx])
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Trying to access metadata that's not loaded"));
 
   auto tile_num = this->tile_num();
@@ -887,7 +887,7 @@ Status FragmentMetadata::tile_var_size(
   assert(it != idx_map_.end());
   auto idx = it->second;
   if (!loaded_metadata_.tile_var_sizes_[idx])
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Trying to access metadata that's not loaded"));
   *tile_size = tile_var_sizes_[idx][tile_idx];
 
@@ -943,7 +943,7 @@ Status FragmentMetadata::load_rtree(const EncryptionKey& encryption_key) {
   auto memory_tracker = storage_manager_->array_memory_tracker(array_uri_);
   assert(memory_tracker);
   if (!memory_tracker->take_memory(buff.size())) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load R-tree; Insufficient memory budget; Needed " +
         std::to_string(buff.size()) + " but only had " +
         std::to_string(memory_tracker->get_memory_available()) +
@@ -1419,7 +1419,7 @@ Status FragmentMetadata::load_file_sizes_v1_v4(ConstBuffer* buff) {
       buff->read(&file_sizes_[0], (attribute_num + 1) * sizeof(uint64_t));
 
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load fragment metadata; Reading tile offsets failed"));
   }
 
@@ -1436,7 +1436,7 @@ Status FragmentMetadata::load_file_sizes_v5_or_higher(ConstBuffer* buff) {
   Status st = buff->read(&file_sizes_[0], num * sizeof(uint64_t));
 
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load fragment metadata; Reading tile offsets failed"));
   }
 
@@ -1460,7 +1460,7 @@ Status FragmentMetadata::load_file_var_sizes_v1_v4(ConstBuffer* buff) {
   Status st = buff->read(&file_var_sizes_[0], attribute_num * sizeof(uint64_t));
 
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load fragment metadata; Reading tile offsets failed"));
   }
 
@@ -1477,7 +1477,7 @@ Status FragmentMetadata::load_file_var_sizes_v5_or_higher(ConstBuffer* buff) {
   Status st = buff->read(&file_var_sizes_[0], num * sizeof(uint64_t));
 
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load fragment metadata; Reading tile offsets failed"));
   }
 
@@ -1493,7 +1493,7 @@ Status FragmentMetadata::load_file_validity_sizes(ConstBuffer* buff) {
   Status st = buff->read(&file_validity_sizes_[0], num * sizeof(uint64_t));
 
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load fragment metadata; Reading tile offsets failed"));
   }
 
@@ -1506,7 +1506,7 @@ Status FragmentMetadata::load_last_tile_cell_num(ConstBuffer* buff) {
   // Get last tile cell number
   Status st = buff->read(&last_tile_cell_num_, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load fragment metadata; Reading last tile cell number "
         "failed"));
   }
@@ -1675,7 +1675,7 @@ Status FragmentMetadata::load_tile_offsets(ConstBuffer* buff) {
     // Get number of tile offsets
     st = buff->read(&tile_offsets_num, sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading number of tile offsets "
           "failed"));
     }
@@ -1687,7 +1687,7 @@ Status FragmentMetadata::load_tile_offsets(ConstBuffer* buff) {
     auto memory_tracker = storage_manager_->array_memory_tracker(array_uri_);
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load tile offsets; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker->get_memory_available()) +
@@ -1699,7 +1699,7 @@ Status FragmentMetadata::load_tile_offsets(ConstBuffer* buff) {
     tile_offsets_[i].resize(tile_offsets_num);
     st = buff->read(&tile_offsets_[i][0], size);
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading tile offsets failed"));
     }
   }
@@ -1717,7 +1717,7 @@ Status FragmentMetadata::load_tile_offsets(unsigned idx, ConstBuffer* buff) {
   // Get number of tile offsets
   st = buff->read(&tile_offsets_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load fragment metadata; Reading number of tile offsets "
         "failed"));
   }
@@ -1728,7 +1728,7 @@ Status FragmentMetadata::load_tile_offsets(unsigned idx, ConstBuffer* buff) {
     auto memory_tracker = storage_manager_->array_memory_tracker(array_uri_);
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load tile offsets; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker->get_memory_available()) +
@@ -1739,7 +1739,7 @@ Status FragmentMetadata::load_tile_offsets(unsigned idx, ConstBuffer* buff) {
     tile_offsets_[idx].resize(tile_offsets_num);
     st = buff->read(&tile_offsets_[idx][0], size);
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading tile offsets failed"));
     }
   }
@@ -1770,7 +1770,7 @@ Status FragmentMetadata::load_tile_var_offsets(ConstBuffer* buff) {
     st = buff->read(&tile_var_offsets_num, sizeof(uint64_t));
     if (!st.ok()) {
       LOG_STATUS(st);
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading number of variable tile "
           "offsets failed"));
     }
@@ -1782,7 +1782,7 @@ Status FragmentMetadata::load_tile_var_offsets(ConstBuffer* buff) {
     auto memory_tracker = storage_manager_->array_memory_tracker(array_uri_);
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load tile var offsets; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker->get_memory_available()) +
@@ -1795,7 +1795,7 @@ Status FragmentMetadata::load_tile_var_offsets(ConstBuffer* buff) {
     st = buff->read(&tile_var_offsets_[i][0], size);
     if (!st.ok()) {
       LOG_STATUS(st);
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading variable tile offsets "
           "failed"));
     }
@@ -1816,7 +1816,7 @@ Status FragmentMetadata::load_tile_var_offsets(
   st = buff->read(&tile_var_offsets_num, sizeof(uint64_t));
   if (!st.ok()) {
     LOG_STATUS(st);
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load fragment metadata; Reading number of variable tile "
         "offsets failed"));
   }
@@ -1827,7 +1827,7 @@ Status FragmentMetadata::load_tile_var_offsets(
     auto memory_tracker = storage_manager_->array_memory_tracker(array_uri_);
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load tile var offsets; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker->get_memory_available()) +
@@ -1839,7 +1839,7 @@ Status FragmentMetadata::load_tile_var_offsets(
     st = buff->read(&tile_var_offsets_[idx][0], size);
     if (!st.ok()) {
       LOG_STATUS(st);
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading variable tile offsets "
           "failed"));
     }
@@ -1868,7 +1868,7 @@ Status FragmentMetadata::load_tile_var_sizes(ConstBuffer* buff) {
     // Get number of tile sizes
     st = buff->read(&tile_var_sizes_num, sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading number of variable tile "
           "sizes failed"));
     }
@@ -1880,7 +1880,7 @@ Status FragmentMetadata::load_tile_var_sizes(ConstBuffer* buff) {
     auto memory_tracker = storage_manager_->array_memory_tracker(array_uri_);
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load tile var sizes; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker->get_memory_available()) +
@@ -1892,7 +1892,7 @@ Status FragmentMetadata::load_tile_var_sizes(ConstBuffer* buff) {
     tile_var_sizes_[i].resize(tile_var_sizes_num);
     st = buff->read(&tile_var_sizes_[i][0], size);
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading variable tile sizes "
           "failed"));
     }
@@ -1910,7 +1910,7 @@ Status FragmentMetadata::load_tile_var_sizes(unsigned idx, ConstBuffer* buff) {
   // Get number of tile sizes
   st = buff->read(&tile_var_sizes_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load fragment metadata; Reading number of variable tile "
         "sizes failed"));
   }
@@ -1921,7 +1921,7 @@ Status FragmentMetadata::load_tile_var_sizes(unsigned idx, ConstBuffer* buff) {
     auto memory_tracker = storage_manager_->array_memory_tracker(array_uri_);
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load tile var sizes; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker->get_memory_available()) +
@@ -1932,7 +1932,7 @@ Status FragmentMetadata::load_tile_var_sizes(unsigned idx, ConstBuffer* buff) {
     tile_var_sizes_[idx].resize(tile_var_sizes_num);
     st = buff->read(&tile_var_sizes_[idx][0], size);
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading variable tile sizes "
           "failed"));
     }
@@ -1949,10 +1949,10 @@ Status FragmentMetadata::load_tile_validity_offsets(
   // Get number of tile offsets
   st = buff->read(&tile_validity_offsets_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(
-        Status::FragmentMetadataError("Cannot load fragment metadata; Reading "
-                                      "number of validity tile offsets "
-                                      "failed"));
+    return LOG_STATUS(Status_FragmentMetadataError(
+        "Cannot load fragment metadata; Reading "
+        "number of validity tile offsets "
+        "failed"));
   }
 
   // Get tile offsets
@@ -1961,7 +1961,7 @@ Status FragmentMetadata::load_tile_validity_offsets(
     auto memory_tracker = storage_manager_->array_memory_tracker(array_uri_);
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load tile validity offsets; Insufficient memory budget; "
           "Needed " +
           std::to_string(size) + " but only had " +
@@ -1974,7 +1974,7 @@ Status FragmentMetadata::load_tile_validity_offsets(
     st = buff->read(&tile_validity_offsets_[idx][0], size);
 
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load fragment metadata; Reading validity tile offsets "
           "failed"));
     }
@@ -2108,7 +2108,7 @@ Status FragmentMetadata::load_array_schema_name(ConstBuffer* buff) {
   uint64_t size = 0;
   RETURN_NOT_OK(buff->read(&size, sizeof(uint64_t)));
   if (size == 0) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load array schema name; Size of schema name is zero"));
   }
   array_schema_name_.resize(size);
@@ -2275,7 +2275,7 @@ Status FragmentMetadata::write_file_sizes(Buffer* buff) const {
   auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
   Status st = buff->write(&file_sizes_[0], num * sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot serialize fragment metadata; Writing file sizes failed"));
   }
 
@@ -2290,7 +2290,7 @@ Status FragmentMetadata::write_file_var_sizes(Buffer* buff) const {
   auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
   Status st = buff->write(&file_var_sizes_[0], num * sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot serialize fragment metadata; Writing file sizes failed"));
   }
 
@@ -2308,7 +2308,7 @@ Status FragmentMetadata::write_file_validity_sizes(Buffer* buff) const {
   auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
   Status st = buff->write(&file_validity_sizes_[0], num * sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot serialize fragment metadata; Writing file sizes failed"));
   }
 
@@ -2332,7 +2332,7 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
   // Write R-Tree offset
   auto st = buff->write(&gt_offsets_.rtree_, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot serialize fragment metadata; Writing R-Tree offset failed"));
   }
 
@@ -2340,7 +2340,7 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
   for (unsigned i = 0; i < num; ++i) {
     st = buff->write(&gt_offsets_.tile_offsets_[i], sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot serialize fragment metadata; Writing tile offsets failed"));
     }
   }
@@ -2349,9 +2349,9 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
   for (unsigned i = 0; i < num; ++i) {
     st = buff->write(&gt_offsets_.tile_var_offsets_[i], sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(
-          Status::FragmentMetadataError("Cannot serialize fragment metadata; "
-                                        "Writing tile var offsets failed"));
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot serialize fragment metadata; "
+          "Writing tile var offsets failed"));
     }
   }
 
@@ -2359,7 +2359,7 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
   for (unsigned i = 0; i < num; ++i) {
     st = buff->write(&gt_offsets_.tile_var_sizes_[i], sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot serialize fragment metadata; Writing tile var sizes failed"));
     }
   }
@@ -2370,7 +2370,7 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
       st =
           buff->write(&gt_offsets_.tile_validity_offsets_[i], sizeof(uint64_t));
       if (!st.ok()) {
-        return LOG_STATUS(Status::FragmentMetadataError(
+        return LOG_STATUS(Status_FragmentMetadataError(
             "Cannot serialize fragment metadata; Writing tile offsets failed"));
       }
     }
@@ -2382,7 +2382,7 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
 Status FragmentMetadata::write_array_schema_name(Buffer* buff) const {
   uint64_t size = array_schema_name_.size();
   if (size == 0) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot write array schema name; Size of schema name is zero"));
   }
   RETURN_NOT_OK(buff->write(&size, sizeof(uint64_t)));
@@ -2402,9 +2402,9 @@ Status FragmentMetadata::write_last_tile_cell_num(Buffer* buff) const {
 
   Status st = buff->write(&last_tile_cell_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(
-        Status::FragmentMetadataError("Cannot serialize fragment metadata; "
-                                      "Writing last tile cell number failed"));
+    return LOG_STATUS(Status_FragmentMetadataError(
+        "Cannot serialize fragment metadata; "
+        "Writing last tile cell number failed"));
   }
   return Status::Ok();
 }
@@ -2505,7 +2505,7 @@ Status FragmentMetadata::read_file_footer(
   auto memory_tracker = storage_manager_->array_memory_tracker(array_uri_);
   assert(memory_tracker);
   if (!memory_tracker->take_memory(*footer_size)) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load file footer; Insufficient memory budget; Needed " +
         std::to_string(*footer_size) + " but only had " +
         std::to_string(memory_tracker->get_memory_available()) +
@@ -2573,7 +2573,7 @@ Status FragmentMetadata::write_tile_offsets(unsigned idx, Buffer* buff) {
   uint64_t tile_offsets_num = tile_offsets_[idx].size();
   st = buff->write(&tile_offsets_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot serialize fragment metadata; Writing number of tile offsets "
         "failed"));
   }
@@ -2583,7 +2583,7 @@ Status FragmentMetadata::write_tile_offsets(unsigned idx, Buffer* buff) {
     st = buff->write(
         &tile_offsets_[idx][0], tile_offsets_num * sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot serialize fragment metadata; Writing tile offsets failed"));
     }
   }
@@ -2612,7 +2612,7 @@ Status FragmentMetadata::write_tile_var_offsets(unsigned idx, Buffer* buff) {
   uint64_t tile_var_offsets_num = tile_var_offsets_[idx].size();
   st = buff->write(&tile_var_offsets_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot serialize fragment metadata; Writing number of "
         "variable tile offsets failed"));
   }
@@ -2622,7 +2622,7 @@ Status FragmentMetadata::write_tile_var_offsets(unsigned idx, Buffer* buff) {
     st = buff->write(
         &tile_var_offsets_[idx][0], tile_var_offsets_num * sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot serialize fragment metadata; Writing "
           "variable tile offsets failed"));
     }
@@ -2650,7 +2650,7 @@ Status FragmentMetadata::write_tile_var_sizes(unsigned idx, Buffer* buff) {
   uint64_t tile_var_sizes_num = tile_var_sizes_[idx].size();
   st = buff->write(&tile_var_sizes_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status::FragmentMetadataError(
+    return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot serialize fragment metadata; Writing number of "
         "variable tile sizes failed"));
   }
@@ -2660,9 +2660,9 @@ Status FragmentMetadata::write_tile_var_sizes(unsigned idx, Buffer* buff) {
     st = buff->write(
         &tile_var_sizes_[idx][0], tile_var_sizes_num * sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(
-          Status::FragmentMetadataError("Cannot serialize fragment metadata; "
-                                        "Writing variable tile sizes failed"));
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot serialize fragment metadata; "
+          "Writing variable tile sizes failed"));
     }
   }
   return Status::Ok();
@@ -2689,10 +2689,10 @@ Status FragmentMetadata::write_tile_validity_offsets(
   uint64_t tile_validity_offsets_num = tile_validity_offsets_[idx].size();
   st = buff->write(&tile_validity_offsets_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(
-        Status::FragmentMetadataError("Cannot serialize fragment metadata; "
-                                      "Writing number of validity tile offsets "
-                                      "failed"));
+    return LOG_STATUS(Status_FragmentMetadataError(
+        "Cannot serialize fragment metadata; "
+        "Writing number of validity tile offsets "
+        "failed"));
   }
 
   // Write tile offsets
@@ -2701,7 +2701,7 @@ Status FragmentMetadata::write_tile_validity_offsets(
         &tile_validity_offsets_[idx][0],
         tile_validity_offsets_num * sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(Status::FragmentMetadataError(
+      return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot serialize fragment metadata; Writing tile offsets failed"));
     }
   }

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1949,10 +1949,10 @@ Status FragmentMetadata::load_tile_validity_offsets(
   // Get number of tile offsets
   st = buff->read(&tile_validity_offsets_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status_FragmentMetadataError(
-        "Cannot load fragment metadata; Reading "
-        "number of validity tile offsets "
-        "failed"));
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot load fragment metadata; Reading "
+                                     "number of validity tile offsets "
+                                     "failed"));
   }
 
   // Get tile offsets
@@ -2349,9 +2349,9 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
   for (unsigned i = 0; i < num; ++i) {
     st = buff->write(&gt_offsets_.tile_var_offsets_[i], sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(Status_FragmentMetadataError(
-          "Cannot serialize fragment metadata; "
-          "Writing tile var offsets failed"));
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing tile var offsets failed"));
     }
   }
 
@@ -2402,9 +2402,9 @@ Status FragmentMetadata::write_last_tile_cell_num(Buffer* buff) const {
 
   Status st = buff->write(&last_tile_cell_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status_FragmentMetadataError(
-        "Cannot serialize fragment metadata; "
-        "Writing last tile cell number failed"));
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                     "Writing last tile cell number failed"));
   }
   return Status::Ok();
 }
@@ -2660,9 +2660,9 @@ Status FragmentMetadata::write_tile_var_sizes(unsigned idx, Buffer* buff) {
     st = buff->write(
         &tile_var_sizes_[idx][0], tile_var_sizes_num * sizeof(uint64_t));
     if (!st.ok()) {
-      return LOG_STATUS(Status_FragmentMetadataError(
-          "Cannot serialize fragment metadata; "
-          "Writing variable tile sizes failed"));
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing variable tile sizes failed"));
     }
   }
   return Status::Ok();
@@ -2689,10 +2689,10 @@ Status FragmentMetadata::write_tile_validity_offsets(
   uint64_t tile_validity_offsets_num = tile_validity_offsets_[idx].size();
   st = buff->write(&tile_validity_offsets_num, sizeof(uint64_t));
   if (!st.ok()) {
-    return LOG_STATUS(Status_FragmentMetadataError(
-        "Cannot serialize fragment metadata; "
-        "Writing number of validity tile offsets "
-        "failed"));
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                     "Writing number of validity tile offsets "
+                                     "failed"));
   }
 
   // Write tile offsets

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -2147,7 +2147,7 @@ Status FragmentMetadata::load_v1_v2(
   if (schema != array_schemas.end()) {
     set_array_schema(schema->second.get());
   } else {
-    return Status::FragmentMetadataError(
+    return Status_FragmentMetadataError(
         "Could not find schema" + array_schema_name_ +
         " in map of schemas loaded.\n" +
         "Consider reloading the array to check for new array schemas.");
@@ -2213,7 +2213,7 @@ Status FragmentMetadata::load_footer(
     if (schema != array_schemas.end()) {
       set_array_schema(schema->second.get());
     } else {
-      return Status::FragmentMetadataError(
+      return Status_FragmentMetadataError(
           "Could not find schema" + array_schema_name_ +
           " in map of schemas loaded.\n" +
           "Consider reloading the array to check for new array schemas.");
@@ -2226,7 +2226,7 @@ Status FragmentMetadata::load_footer(
     if (schema != array_schemas.end()) {
       set_array_schema(schema->second.get());
     } else {
-      return Status::FragmentMetadataError(
+      return Status_FragmentMetadataError(
           "Could not find schema" + array_schema_name_ +
           " in map of schemas loaded.\n" +
           "Consider reloading the array to check for new array schemas.");

--- a/tiledb/sm/global_state/libcurl_state.cc
+++ b/tiledb/sm/global_state/libcurl_state.cc
@@ -47,7 +47,7 @@ Status init_libcurl() {
 #ifdef TILEDB_SERIALIZATION
   auto rc = curl_global_init(CURL_GLOBAL_DEFAULT);
   if (rc != 0)
-    return LOG_STATUS(Status::Error(
+    return LOG_STATUS(Status_Error(
         "Cannot initialize libcurl global state: got non-zero return code " +
         std::to_string(rc)));
 #endif

--- a/tiledb/sm/global_state/signal_handlers.cc
+++ b/tiledb/sm/global_state/signal_handlers.cc
@@ -114,14 +114,14 @@ static BOOL WINAPI win_ctrl_handler(DWORD dwCtrlType) {
 
 Status SignalHandlers::initialize() {
   if (signal(SIGINT, tiledb_signal_handler) == SIG_ERR) {
-    return Status::Error(
+    return Status_Error(
         std::string("Failed to install Win32 SIGINT handler: ") +
         strerror(errno));
   }
 
   // Win32 applications should also handle Ctrl-Break.
   if (SetConsoleCtrlHandler(win_ctrl_handler, TRUE) == 0) {
-    return Status::Error(std::string("Failed to install Win32 ctrl handler"));
+    return Status_Error(std::string("Failed to install Win32 ctrl handler"));
   }
   return Status::Ok();
 }
@@ -144,7 +144,7 @@ Status SignalHandlers::initialize() {
 
   // Remember the previous signal handler so we can call it before ours.
   if (sigaction(SIGINT, NULL, &old_action) != 0) {
-    return Status::Error(
+    return Status_Error(
         std::string("Failed to get old SIGINT handler: ") + strerror(errno));
   }
   old_sigint_handler = old_action.sa_handler;
@@ -155,7 +155,7 @@ Status SignalHandlers::initialize() {
   action.sa_flags = 0;
   action.sa_handler = tiledb_signal_handler;
   if (sigaction(SIGINT, &action, &old_action) != 0) {
-    return Status::Error(
+    return Status_Error(
         std::string("Failed to install SIGINT handler: ") + strerror(errno));
   }
 

--- a/tiledb/sm/global_state/watchdog.cc
+++ b/tiledb/sm/global_state/watchdog.cc
@@ -68,7 +68,7 @@ Status Watchdog::initialize() {
   try {
     thread_ = std::thread([this]() { watchdog_thread(this); });
   } catch (const std::exception& e) {
-    return Status::Error(
+    return Status_Error(
         std::string("Could not initialize watchdog thread; ") + e.what());
   }
   return Status::Ok();

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -252,8 +252,8 @@ Status Metadata::get(
     build_metadata_index();
 
   if (index >= metadata_index_.size())
-    return LOG_STATUS(Status_MetadataError(
-        "Cannot get metadata; index out of bounds"));
+    return LOG_STATUS(
+        Status_MetadataError("Cannot get metadata; index out of bounds"));
 
   // Get key
   auto& key_str = *(metadata_index_[index].first);

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -252,8 +252,8 @@ Status Metadata::get(
     build_metadata_index();
 
   if (index >= metadata_index_.size())
-    return LOG_STATUS(
-        Status::MetadataError("Cannot get metadata; index out of bounds"));
+    return LOG_STATUS(Status_MetadataError(
+        "Cannot get metadata; index out of bounds"));
 
   // Get key
   auto& key_str = *(metadata_index_[index].first);

--- a/tiledb/sm/misc/cancelable_tasks.cc
+++ b/tiledb/sm/misc/cancelable_tasks.cc
@@ -86,7 +86,7 @@ Status CancelableTasks::fn_wrapper(
     if (--outstanding_tasks_ == 0) {
       outstanding_tasks_cv_.notify_all();
     }
-    return Status::Error("Task cancelled before execution.");
+    return Status_Error("Task cancelled before execution.");
   } else {
     lck.unlock();
     Status st = fn();

--- a/tiledb/sm/misc/parse_argument.cc
+++ b/tiledb/sm/misc/parse_argument.cc
@@ -50,7 +50,7 @@ Status convert(const std::string& str, int* value) {
   if (!is_int(str)) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to int; Invalid argument";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   }
 
   try {
@@ -58,11 +58,11 @@ Status convert(const std::string& str, int* value) {
   } catch (std::invalid_argument& e) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to int; Invalid argument";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   } catch (std::out_of_range& e) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to int; Value out of range";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   }
 
   return Status::Ok();
@@ -72,7 +72,7 @@ Status convert(const std::string& str, uint32_t* value) {
   if (!is_uint(str)) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to uint32_t; Invalid argument";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   }
 
   try {
@@ -83,11 +83,11 @@ Status convert(const std::string& str, uint32_t* value) {
   } catch (std::invalid_argument& e) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to uint32_t; Invalid argument";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   } catch (std::out_of_range& e) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to uint32_t; Value out of range";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   }
 
   return Status::Ok();
@@ -97,7 +97,7 @@ Status convert(const std::string& str, uint64_t* value) {
   if (!is_uint(str)) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to uint64_t; Invalid argument";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   }
 
   try {
@@ -105,11 +105,11 @@ Status convert(const std::string& str, uint64_t* value) {
   } catch (std::invalid_argument& e) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to uint64_t; Invalid argument";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   } catch (std::out_of_range& e) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to uint64_t; Value out of range";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   }
 
   return Status::Ok();
@@ -119,7 +119,7 @@ Status convert(const std::string& str, int64_t* value) {
   if (!is_int(str)) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to int64_t; Invalid argument";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   }
 
   try {
@@ -127,11 +127,11 @@ Status convert(const std::string& str, int64_t* value) {
   } catch (std::invalid_argument& e) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to int64_t; Invalid argument";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   } catch (std::out_of_range& e) {
     auto errmsg = std::string("Failed to convert string '") + str +
                   "' to int64_t; Value out of range";
-    return LOG_STATUS(Status::UtilsError(errmsg));
+    return LOG_STATUS(Status_UtilsError(errmsg));
   }
 
   return Status::Ok();
@@ -141,10 +141,10 @@ Status convert(const std::string& str, float* value) {
   try {
     *value = std::stof(str);
   } catch (std::invalid_argument& e) {
-    return LOG_STATUS(Status::UtilsError(
+    return LOG_STATUS(Status_UtilsError(
         "Failed to convert string to float32_t; Invalid argument"));
   } catch (std::out_of_range& e) {
-    return LOG_STATUS(Status::UtilsError(
+    return LOG_STATUS(Status_UtilsError(
         "Failed to convert string to float32_t; Value out of range"));
   }
 
@@ -155,10 +155,10 @@ Status convert(const std::string& str, double* value) {
   try {
     *value = std::stod(str);
   } catch (std::invalid_argument& e) {
-    return LOG_STATUS(Status::UtilsError(
+    return LOG_STATUS(Status_UtilsError(
         "Failed to convert string to float64_t; Invalid argument"));
   } catch (std::out_of_range& e) {
-    return LOG_STATUS(Status::UtilsError(
+    return LOG_STATUS(Status_UtilsError(
         "Failed to convert string to float64_t; Value out of range"));
   }
 
@@ -173,7 +173,7 @@ Status convert(const std::string& str, bool* value) {
   } else if (lvalue == "false") {
     *value = false;
   } else {
-    return LOG_STATUS(Status::UtilsError(
+    return LOG_STATUS(Status_UtilsError(
         "Failed to convert string to bool; Value not 'true' or 'false'"));
   }
 
@@ -189,7 +189,7 @@ Status convert(const std::string& str, SerializationType* value) {
     *value = SerializationType::CAPNP;
   } else {
     return LOG_STATUS(
-        Status::UtilsError("Failed to convert string to SerializationType; "
+        Status_UtilsError("Failed to convert string to SerializationType; "
                            "Value not 'json' or 'capnp'"));
   }
 

--- a/tiledb/sm/misc/parse_argument.cc
+++ b/tiledb/sm/misc/parse_argument.cc
@@ -190,7 +190,7 @@ Status convert(const std::string& str, SerializationType* value) {
   } else {
     return LOG_STATUS(
         Status_UtilsError("Failed to convert string to SerializationType; "
-                           "Value not 'json' or 'capnp'"));
+                          "Value not 'json' or 'capnp'"));
   }
 
   return Status::Ok();

--- a/tiledb/sm/misc/parse_argument.h
+++ b/tiledb/sm/misc/parse_argument.h
@@ -95,11 +95,11 @@ Status convert(const std::string& str, std::vector<T>* value) {
     } while (end != std::string::npos);
 
   } catch (std::invalid_argument& e) {
-    return LOG_STATUS(Status::UtilsError(
+    return LOG_STATUS(Status_UtilsError(
         "Failed to convert string to vector of " +
         std::string(typeid(T).name()) + "; Invalid argument"));
   } catch (std::out_of_range& e) {
-    return LOG_STATUS(Status::UtilsError(
+    return LOG_STATUS(Status_UtilsError(
         "Failed to convert string to vector of " +
         std::string(typeid(T).name()) + "; Value out of range"));
   }

--- a/tiledb/sm/misc/uri.cc
+++ b/tiledb/sm/misc/uri.cc
@@ -186,7 +186,7 @@ bool URI::is_tiledb() const {
 Status URI::get_rest_components(
     std::string* array_namespace, std::string* array_uri) const {
   const std::string prefix = "tiledb://";
-  const auto error_st = Status::RestError(
+  const auto error_st = Status_RestError(
       "Invalid array URI for REST service; expected format is "
       "'tiledb://<namespace>/<array-name>' or "
       "'tiledb://<namespace>/<array-uri>'.");

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -181,7 +181,7 @@ template <>
 Status check_template_type_to_datatype<int8_t>(Datatype datatype) {
   if (datatype == Datatype::INT8)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type int8_t but datatype is not Datatype::INT8");
 }
 template <>
@@ -193,7 +193,7 @@ Status check_template_type_to_datatype<uint8_t>(Datatype datatype) {
   else if (datatype == Datatype::STRING_UTF8)
     return Status::Ok();
 
-  return Status::Error(
+  return Status_Error(
       "Template of type uint8_t but datatype is not Datatype::UINT8 nor "
       "Datatype::STRING_ASCII nor atatype::STRING_UTF8");
 }
@@ -201,7 +201,7 @@ template <>
 Status check_template_type_to_datatype<int16_t>(Datatype datatype) {
   if (datatype == Datatype::INT16)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type int16_t but datatype is not Datatype::INT16");
 }
 template <>
@@ -212,7 +212,7 @@ Status check_template_type_to_datatype<uint16_t>(Datatype datatype) {
     return Status::Ok();
   else if (datatype == Datatype::STRING_UCS2)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type uint16_t but datatype is not Datatype::UINT16 nor "
       "Datatype::STRING_UTF16 nor Datatype::STRING_UCS2");
 }
@@ -220,7 +220,7 @@ template <>
 Status check_template_type_to_datatype<int32_t>(Datatype datatype) {
   if (datatype == Datatype::INT32)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type int32_t but datatype is not Datatype::INT32");
 }
 template <>
@@ -231,7 +231,7 @@ Status check_template_type_to_datatype<uint32_t>(Datatype datatype) {
     return Status::Ok();
   else if (datatype == Datatype::STRING_UCS4)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type uint32_t but datatype is not Datatype::UINT32 nor "
       "Datatype::STRING_UTF32 nor Datatype::STRING_UCS4");
 }
@@ -239,35 +239,35 @@ template <>
 Status check_template_type_to_datatype<int64_t>(Datatype datatype) {
   if (datatype == Datatype::INT64)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type int64_t but datatype is not Datatype::INT64");
 }
 template <>
 Status check_template_type_to_datatype<uint64_t>(Datatype datatype) {
   if (datatype == Datatype::UINT64)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type uint64_t but datatype is not Datatype::UINT64");
 }
 template <>
 Status check_template_type_to_datatype<float>(Datatype datatype) {
   if (datatype == Datatype::FLOAT32)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type float but datatype is not Datatype::FLOAT32");
 }
 template <>
 Status check_template_type_to_datatype<double>(Datatype datatype) {
   if (datatype == Datatype::FLOAT64)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type double but datatype is not Datatype::FLOAT64");
 }
 template <>
 Status check_template_type_to_datatype<char>(Datatype datatype) {
   if (datatype == Datatype::CHAR)
     return Status::Ok();
-  return Status::Error(
+  return Status_Error(
       "Template of type char but datatype is not Datatype::CHAR");
 }
 

--- a/tiledb/sm/misc/uuid.cc
+++ b/tiledb/sm/misc/uuid.cc
@@ -59,24 +59,26 @@ static std::mutex uuid_mtx;
  */
 Status generate_uuid_win32(std::string* uuid_str) {
   if (uuid_str == nullptr)
-    return Status::UtilsError("Null UUID string argument");
+    return Status_UtilsError("Null UUID string argument");
 
   UUID uuid;
   RPC_STATUS rc = UuidCreate(&uuid);
   if (rc != RPC_S_OK)
-    return Status::UtilsError("Unable to generate Win32 UUID: creation error");
+    return Status_UtilsError(
+        "Unable to generate Win32 UUID: creation error");
 
   char* buf = nullptr;
   rc = UuidToStringA(&uuid, reinterpret_cast<RPC_CSTR*>(&buf));
   if (rc != RPC_S_OK)
-    return Status::UtilsError(
+    return Status_UtilsError(
         "Unable to generate Win32 UUID: string conversion error");
 
   *uuid_str = std::string(buf);
 
   rc = RpcStringFreeA(reinterpret_cast<RPC_CSTR*>(&buf));
   if (rc != RPC_S_OK)
-    return Status::UtilsError("Unable to generate Win32 UUID: free error");
+    return Status_UtilsError(
+        "Unable to generate Win32 UUID: free error");
 
   return Status::Ok();
 }
@@ -91,7 +93,7 @@ Status generate_uuid_win32(std::string* uuid_str) {
  */
 Status generate_uuid_openssl(std::string* uuid_str) {
   if (uuid_str == nullptr)
-    return Status::UtilsError("Null UUID string argument");
+    return Status_UtilsError("Null UUID string argument");
 
   union {
     struct {
@@ -109,7 +111,7 @@ Status generate_uuid_openssl(std::string* uuid_str) {
   if (rc < 1) {
     char err_msg[256];
     ERR_error_string_n(ERR_get_error(), err_msg, sizeof(err_msg));
-    return Status::UtilsError(
+    return Status_UtilsError(
         "Cannot generate random bytes with OpenSSL: " + std::string(err_msg));
   }
 
@@ -138,7 +140,7 @@ Status generate_uuid_openssl(std::string* uuid_str) {
       uuid.node[5]);
 
   if (rc < 0)
-    return Status::UtilsError("Error formatting UUID string");
+    return Status_UtilsError("Error formatting UUID string");
 
   *uuid_str = std::string(buf);
 
@@ -149,7 +151,7 @@ Status generate_uuid_openssl(std::string* uuid_str) {
 
 Status generate_uuid(std::string* uuid, bool hyphenate) {
   if (uuid == nullptr)
-    return Status::UtilsError("Null UUID string argument");
+    return Status_UtilsError("Null UUID string argument");
 
   std::string uuid_str;
   {

--- a/tiledb/sm/misc/uuid.cc
+++ b/tiledb/sm/misc/uuid.cc
@@ -64,8 +64,7 @@ Status generate_uuid_win32(std::string* uuid_str) {
   UUID uuid;
   RPC_STATUS rc = UuidCreate(&uuid);
   if (rc != RPC_S_OK)
-    return Status_UtilsError(
-        "Unable to generate Win32 UUID: creation error");
+    return Status_UtilsError("Unable to generate Win32 UUID: creation error");
 
   char* buf = nullptr;
   rc = UuidToStringA(&uuid, reinterpret_cast<RPC_CSTR*>(&buf));
@@ -77,8 +76,7 @@ Status generate_uuid_win32(std::string* uuid_str) {
 
   rc = RpcStringFreeA(reinterpret_cast<RPC_CSTR*>(&buf));
   if (rc != RPC_S_OK)
-    return Status_UtilsError(
-        "Unable to generate Win32 UUID: free error");
+    return Status_UtilsError("Unable to generate Win32 UUID: free error");
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -91,16 +91,16 @@ bool DenseReader::incomplete() const {
 Status DenseReader::init() {
   // Sanity checks.
   if (storage_manager_ == nullptr)
-    return LOG_STATUS(Status::DenseReaderError(
+    return LOG_STATUS(Status_DenseReaderError(
         "Cannot initialize dense reader; Storage manager not set"));
   if (array_schema_ == nullptr)
-    return LOG_STATUS(Status::DenseReaderError(
+    return LOG_STATUS(Status_DenseReaderError(
         "Cannot initialize dense reader; Array schema not set"));
   if (buffers_.empty())
-    return LOG_STATUS(Status::DenseReaderError(
+    return LOG_STATUS(Status_DenseReaderError(
         "Cannot initialize dense reader; Buffers not set"));
   if (!subarray_.is_set())
-    return LOG_STATUS(Status::ReaderError(
+    return LOG_STATUS(Status_ReaderError(
         "Cannot initialize reader; Dense reads must have a subarray set"));
 
   // Check subarray.
@@ -225,7 +225,7 @@ Status DenseReader::dense_read() {
     case Datatype::TIME_AS:
       return dense_read<int64_t, OffType>();
     default:
-      return LOG_STATUS(Status::ReaderError(
+      return LOG_STATUS(Status_ReaderError(
           "Cannot read dense array; Unsupported domain type"));
   }
 
@@ -379,10 +379,10 @@ Status DenseReader::init_read_state() {
   // Check subarray.
   if (subarray_.layout() == Layout::GLOBAL_ORDER && subarray_.range_num() != 1)
     return LOG_STATUS(
-        Status::ReaderError("Cannot initialize read "
-                            "state; Multi-range "
-                            "subarrays do not "
-                            "support global order"));
+        Status_ReaderError("Cannot initialize read "
+                                   "state; Multi-range "
+                                   "subarrays do not "
+                                   "support global order"));
 
   // Get config values.
   bool found = false;
@@ -399,9 +399,9 @@ Status DenseReader::init_read_state() {
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    return LOG_STATUS(
-        Status::ReaderError("Cannot initialize reader; Unsupported offsets "
-                            "format in configuration"));
+    return LOG_STATUS(Status_ReaderError(
+        "Cannot initialize reader; Unsupported offsets "
+        "format in configuration"));
   }
   elements_mode_ = offsets_format_mode_ == "elements";
 
@@ -412,9 +412,9 @@ Status DenseReader::init_read_state() {
   RETURN_NOT_OK(config_.get<uint32_t>(
       "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    return LOG_STATUS(
-        Status::ReaderError("Cannot initialize reader; Unsupported offsets "
-                            "bitsize in configuration"));
+    return LOG_STATUS(Status_ReaderError(
+        "Cannot initialize reader; Unsupported offsets "
+        "bitsize in configuration"));
   }
   assert(found);
 
@@ -1411,7 +1411,7 @@ Status DenseReader::add_extra_offset() {
                       datatype_size(array_schema_->type(name));
       memcpy(buffer + *it.second.buffer_size_, &elements, offsets_bytesize());
     } else {
-      return LOG_STATUS(Status::ReaderError(
+      return LOG_STATUS(Status_ReaderError(
           "Cannot add extra offset to buffer; Unsupported offsets format"));
     }
 

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -380,9 +380,9 @@ Status DenseReader::init_read_state() {
   if (subarray_.layout() == Layout::GLOBAL_ORDER && subarray_.range_num() != 1)
     return LOG_STATUS(
         Status_ReaderError("Cannot initialize read "
-                                   "state; Multi-range "
-                                   "subarrays do not "
-                                   "support global order"));
+                           "state; Multi-range "
+                           "subarrays do not "
+                           "support global order"));
 
   // Get config values.
   bool found = false;
@@ -399,9 +399,9 @@ Status DenseReader::init_read_state() {
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    return LOG_STATUS(Status_ReaderError(
-        "Cannot initialize reader; Unsupported offsets "
-        "format in configuration"));
+    return LOG_STATUS(
+        Status_ReaderError("Cannot initialize reader; Unsupported offsets "
+                           "format in configuration"));
   }
   elements_mode_ = offsets_format_mode_ == "elements";
 
@@ -412,9 +412,9 @@ Status DenseReader::init_read_state() {
   RETURN_NOT_OK(config_.get<uint32_t>(
       "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    return LOG_STATUS(Status_ReaderError(
-        "Cannot initialize reader; Unsupported offsets "
-        "bitsize in configuration"));
+    return LOG_STATUS(
+        Status_ReaderError("Cannot initialize reader; Unsupported offsets "
+                           "bitsize in configuration"));
   }
   assert(found);
 

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -193,13 +193,12 @@ Status DenseTiler<T>::get_tile(
 
   // Checks
   if (id >= tile_num_)
-    return LOG_STATUS(
-        Status::DenseTilerError("Cannot get tile; Invalid tile id"));
+    return LOG_STATUS(Status_DenseTilerError("Cannot get tile; Invalid tile id"));
   if (!array_schema_->is_attr(name))
-    return LOG_STATUS(Status::DenseTilerError(
+    return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));
   if (array_schema_->var_size(name))
-    return LOG_STATUS(Status::DenseTilerError(
+    return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name +
         "' is not a fixed-sized attribute"));
 
@@ -228,13 +227,12 @@ Status DenseTiler<T>::get_tile_null(
     uint64_t id, const std::string& name, Tile* tile) const {
   // Checks
   if (id >= tile_num_)
-    return LOG_STATUS(
-        Status::DenseTilerError("Cannot get tile; Invalid tile id"));
+    return LOG_STATUS(Status_DenseTilerError("Cannot get tile; Invalid tile id"));
   if (!array_schema_->is_attr(name))
-    return LOG_STATUS(Status::DenseTilerError(
+    return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));
   if (!array_schema_->is_nullable(name))
-    return LOG_STATUS(Status::DenseTilerError(
+    return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name +
         "' is not a nullable attribute"));
 
@@ -265,13 +263,12 @@ Status DenseTiler<T>::get_tile_var(
     Tile* tile_val) const {
   // Checks
   if (id >= tile_num_)
-    return LOG_STATUS(
-        Status::DenseTilerError("Cannot get tile; Invalid tile id"));
+    return LOG_STATUS(Status_DenseTilerError("Cannot get tile; Invalid tile id"));
   if (!array_schema_->is_attr(name))
-    return LOG_STATUS(Status::DenseTilerError(
+    return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));
   if (!array_schema_->var_size(name))
-    return LOG_STATUS(Status::DenseTilerError(
+    return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name +
         "' is not a var-sized attribute"));
 

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -193,7 +193,8 @@ Status DenseTiler<T>::get_tile(
 
   // Checks
   if (id >= tile_num_)
-    return LOG_STATUS(Status_DenseTilerError("Cannot get tile; Invalid tile id"));
+    return LOG_STATUS(
+        Status_DenseTilerError("Cannot get tile; Invalid tile id"));
   if (!array_schema_->is_attr(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));
@@ -227,7 +228,8 @@ Status DenseTiler<T>::get_tile_null(
     uint64_t id, const std::string& name, Tile* tile) const {
   // Checks
   if (id >= tile_num_)
-    return LOG_STATUS(Status_DenseTilerError("Cannot get tile; Invalid tile id"));
+    return LOG_STATUS(
+        Status_DenseTilerError("Cannot get tile; Invalid tile id"));
   if (!array_schema_->is_attr(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));
@@ -263,7 +265,8 @@ Status DenseTiler<T>::get_tile_var(
     Tile* tile_val) const {
   // Checks
   if (id >= tile_num_)
-    return LOG_STATUS(Status_DenseTilerError("Cannot get tile; Invalid tile id"));
+    return LOG_STATUS(
+        Status_DenseTilerError("Cannot get tile; Invalid tile id"));
   if (!array_schema_->is_attr(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -130,20 +130,19 @@ Query::~Query() {
 Status Query::add_range(
     unsigned dim_idx, const void* start, const void* end, const void* stride) {
   if (dim_idx >= array_schema_->dim_num())
-    return logger_->status(
-        Status::QueryError("Cannot add range; Invalid dimension index"));
+    return logger_->status(Status_QueryError("Cannot add range; Invalid dimension index"));
 
   if (start == nullptr || end == nullptr)
     return logger_->status(
-        Status::QueryError("Cannot add range; Invalid range"));
+        Status_QueryError("Cannot add range; Invalid range"));
 
   if (stride != nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot add range; Setting range stride is currently unsupported"));
 
   if (array_schema_->domain()->dimension(dim_idx)->var_size())
-    return logger_->status(
-        Status::QueryError("Cannot add range; Range must be fixed-sized"));
+    return logger_->status(Status_QueryError(
+        "Cannot add range; Range must be fixed-sized"));
 
   // Prepare a temp range
   std::vector<uint8_t> range;
@@ -160,21 +159,21 @@ Status Query::add_range(
     assert(found);
 
     if (read_range_oob != "error" && read_range_oob != "warn")
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           "Invalid value " + read_range_oob +
           " for sm.read_range_obb. Acceptable values are 'error' or 'warn'."));
 
     read_range_oob_error = read_range_oob == "error";
   } else {
     if (!array_schema_->dense())
-      return logger_->status(
-          Status::QueryError("Adding a subarray range to a write query is not "
-                             "supported in sparse arrays"));
+      return logger_->status(Status_QueryError(
+          "Adding a subarray range to a write query is not "
+          "supported in sparse arrays"));
 
     if (subarray_.is_set(dim_idx))
-      return logger_->status(
-          Status::QueryError("Cannot add range; Multi-range dense writes "
-                             "are not supported"));
+      return logger_->status(Status_QueryError(
+          "Cannot add range; Multi-range dense writes "
+          "are not supported"));
   }
 
   // Add range
@@ -189,20 +188,19 @@ Status Query::add_range_var(
     const void* end,
     uint64_t end_size) {
   if (dim_idx >= array_schema_->dim_num())
-    return logger_->status(
-        Status::QueryError("Cannot add range; Invalid dimension index"));
+    return logger_->status(Status_QueryError("Cannot add range; Invalid dimension index"));
 
   if ((start == nullptr && start_size != 0) ||
       (end == nullptr && end_size != 0))
     return logger_->status(
-        Status::QueryError("Cannot add range; Invalid range"));
+        Status_QueryError("Cannot add range; Invalid range"));
 
   if (!array_schema_->domain()->dimension(dim_idx)->var_size())
-    return logger_->status(
-        Status::QueryError("Cannot add range; Range must be variable-sized"));
+    return logger_->status(Status_QueryError(
+        "Cannot add range; Range must be variable-sized"));
 
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot add range; Function applicable only to reads"));
 
   // Get read_range_oob config setting
@@ -211,7 +209,7 @@ Status Query::add_range_var(
   assert(found);
 
   if (read_range_oob != "error" && read_range_oob != "warn")
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Invalid value " + read_range_oob +
         " for sm.read_range_obb. Acceptable values are 'error' or 'warn'."));
 
@@ -223,9 +221,9 @@ Status Query::add_range_var(
 
 Status Query::get_range_num(unsigned dim_idx, uint64_t* range_num) const {
   if (type_ == QueryType::WRITE && !array_schema_->dense())
-    return logger_->status(
-        Status::QueryError("Getting the number of ranges from a write query "
-                           "is not applicable to sparse arrays"));
+    return logger_->status(Status_QueryError(
+        "Getting the number of ranges from a write query "
+        "is not applicable to sparse arrays"));
 
   return subarray_.get_range_num(dim_idx, range_num);
 }
@@ -237,9 +235,8 @@ Status Query::get_range(
     const void** end,
     const void** stride) const {
   if (type_ == QueryType::WRITE && !array_schema_->dense())
-    return logger_->status(
-        Status::QueryError("Getting a range from a write query is not "
-                           "applicable to sparse arrays"));
+    return logger_->status(Status_QueryError("Getting a range from a write query is not "
+                                  "applicable to sparse arrays"));
 
   *stride = nullptr;
   return subarray_.get_range(dim_idx, range_idx, start, end);
@@ -251,7 +248,7 @@ Status Query::get_range_var_size(
     uint64_t* start_size,
     uint64_t* end_size) const {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Getting a var range size from a write query is not applicable"));
 
   return subarray_.get_range_var_size(dim_idx, range_idx, start_size, end_size);
@@ -261,7 +258,7 @@ Status Query::get_range_var_size(
 Status Query::get_range_var(
     unsigned dim_idx, uint64_t range_idx, void* start, void* end) const {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Getting a var range from a write query is not applicable"));
 
   uint64_t start_size = 0;
@@ -353,27 +350,27 @@ Status Query::get_range_var_from_name(
 
 Status Query::get_est_result_size(const char* name, uint64_t* size) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
   if (name == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Name cannot be null"));
 
   if (name == constants::coords &&
       !array_schema_->domain()->all_dims_same_type())
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Not applicable to zipped "
         "coordinates in arrays with heterogeneous domain"));
 
   if (name == constants::coords && !array_schema_->domain()->all_dims_fixed())
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Not applicable to zipped "
         "coordinates in arrays with domains with variable-sized dimensions"));
 
   if (array_schema_->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string(
             "Cannot get estimated result size; Input attribute/dimension '") +
         name + "' is nullable"));
@@ -381,9 +378,9 @@ Status Query::get_est_result_size(const char* name, uint64_t* size) {
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(
-          Status::QueryError("Error in query estimate result size; remote "
-                             "array with no rest client."));
+      return logger_->status(Status_QueryError(
+          "Error in query estimate result size; remote "
+          "array with no rest client."));
 
     array_schema_->set_array_uri(array_->array_uri());
 
@@ -398,12 +395,12 @@ Status Query::get_est_result_size(const char* name, uint64_t* size) {
 Status Query::get_est_result_size(
     const char* name, uint64_t* size_off, uint64_t* size_val) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
   if (array_schema_->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string(
             "Cannot get estimated result size; Input attribute/dimension '") +
         name + "' is nullable"));
@@ -411,9 +408,9 @@ Status Query::get_est_result_size(
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(
-          Status::QueryError("Error in query estimate result size; remote "
-                             "array with no rest client."));
+      return logger_->status(Status_QueryError(
+          "Error in query estimate result size; remote "
+          "array with no rest client."));
 
     array_schema_->set_array_uri(array_->array_uri());
 
@@ -428,34 +425,34 @@ Status Query::get_est_result_size(
 Status Query::get_est_result_size_nullable(
     const char* name, uint64_t* size_val, uint64_t* size_validity) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
   if (name == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Name cannot be null"));
 
   if (!array_schema_->attribute(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Nullable API is only"
         "applicable to attributes"));
 
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get estimated result size; Input attribute '") +
         name + "' is not nullable"));
 
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(
-          Status::QueryError("Error in query estimate result size; remote "
-                             "array with no rest client."));
+      return logger_->status(Status_QueryError(
+          "Error in query estimate result size; remote "
+          "array with no rest client."));
 
-    return logger_->status(
-        Status::QueryError("Error in query estimate result size; unimplemented "
-                           "for nullable attributes in remote arrays."));
+    return logger_->status(Status_QueryError(
+        "Error in query estimate result size; unimplemented "
+        "for nullable attributes in remote arrays."));
   }
 
   return subarray_.get_est_result_size_nullable(
@@ -468,30 +465,30 @@ Status Query::get_est_result_size_nullable(
     uint64_t* size_val,
     uint64_t* size_validity) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
   if (!array_schema_->attribute(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get estimated result size; Nullable API is only"
         "applicable to attributes"));
 
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get estimated result size; Input attribute '") +
         name + "' is not nullable"));
 
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(
-          Status::QueryError("Error in query estimate result size; remote "
-                             "array with no rest client."));
+      return logger_->status(Status_QueryError(
+          "Error in query estimate result size; remote "
+          "array with no rest client."));
 
-    return logger_->status(
-        Status::QueryError("Error in query estimate result size; unimplemented "
-                           "for nullable attributes in remote arrays."));
+    return logger_->status(Status_QueryError(
+        "Error in query estimate result size; unimplemented "
+        "for nullable attributes in remote arrays."));
   }
 
   return subarray_.get_est_result_size_nullable(
@@ -517,7 +514,7 @@ Query::get_max_mem_size_map() {
 
 Status Query::get_written_fragment_num(uint32_t* num) const {
   if (type_ != QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get number of fragments; Applicable only to WRITE mode"));
 
   *num = (uint32_t)written_fragment_info_.size();
@@ -527,13 +524,13 @@ Status Query::get_written_fragment_num(uint32_t* num) const {
 
 Status Query::get_written_fragment_uri(uint32_t idx, const char** uri) const {
   if (type_ != QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get fragment URI; Applicable only to WRITE mode"));
 
   auto num = (uint32_t)written_fragment_info_.size();
   if (idx >= num)
-    return logger_->status(
-        Status::QueryError("Cannot get fragment URI; Invalid fragment index"));
+    return logger_->status(Status_QueryError(
+        "Cannot get fragment URI; Invalid fragment index"));
 
   *uri = written_fragment_info_[idx].uri_.c_str();
 
@@ -543,12 +540,12 @@ Status Query::get_written_fragment_uri(uint32_t idx, const char** uri) const {
 Status Query::get_written_fragment_timestamp_range(
     uint32_t idx, uint64_t* t1, uint64_t* t2) const {
   if (type_ != QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get fragment timestamp range; Applicable only to WRITE mode"));
 
   auto num = (uint32_t)written_fragment_info_.size();
   if (idx >= num)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot get fragment timestamp range; Invalid fragment index"));
 
   *t1 = written_fragment_info_[idx].timestamp_range_.first;
@@ -611,7 +608,7 @@ Status Query::finalize() {
   if (array_->is_remote()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           "Error in query finalize; remote array with no rest client."));
 
     array_schema_->set_array_uri(array_->array_uri());
@@ -631,12 +628,12 @@ Status Query::get_buffer(
   if (name != constants::coords) {
     if (array_schema->attribute(name) == nullptr &&
         array_schema->dimension(name) == nullptr)
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           std::string("Cannot get buffer; Invalid attribute/dimension name '") +
           name + "'"));
   }
   if (array_schema->var_size(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is var-sized"));
 
   return get_data_buffer(name, buffer, buffer_size);
@@ -651,16 +648,16 @@ Status Query::get_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (name == constants::coords) {
-    return logger_->status(
-        Status::QueryError("Cannot get buffer; Coordinates are not var-sized"));
+    return logger_->status(Status_QueryError(
+        "Cannot get buffer; Coordinates are not var-sized"));
   }
   if (array_schema->attribute(name) == nullptr &&
       array_schema->dimension(name) == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute/dimension name '") +
         name + "'"));
   if (!array_schema->var_size(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
 
   // Attribute or dimension
@@ -687,16 +684,16 @@ Status Query::get_offsets_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (name == constants::coords) {
-    return logger_->status(
-        Status::QueryError("Cannot get buffer; Coordinates are not var-sized"));
+    return logger_->status(Status_QueryError(
+        "Cannot get buffer; Coordinates are not var-sized"));
   }
   if (array_schema->attribute(name) == nullptr &&
       array_schema->dimension(name) == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute/dimension name '") +
         name + "'"));
   if (!array_schema->var_size(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
 
   // Attribute or dimension
@@ -721,7 +718,7 @@ Status Query::get_data_buffer(
   if (name != constants::coords) {
     if (array_schema->attribute(name) == nullptr &&
         array_schema->dimension(name) == nullptr)
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           std::string("Cannot get buffer; Invalid attribute/dimension name '") +
           name + "'"));
   }
@@ -760,7 +757,7 @@ Status Query::get_validity_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
   // Attribute or dimension
@@ -819,14 +816,14 @@ Status Query::get_buffer(
   // Check nullable attribute
   auto array_schema = this->array_schema();
   if (array_schema->attribute(name) == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute name '") + name +
         "'"));
   if (array_schema->var_size(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is var-sized"));
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
   // Attribute or dimension
@@ -856,14 +853,14 @@ Status Query::get_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (array_schema->attribute(name) == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute name '") + name +
         "'"));
   if (!array_schema->var_size(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
   // Attribute or dimension
@@ -909,7 +906,7 @@ Status Query::init() {
   if (status_ == QueryStatus::UNINITIALIZED) {
     // Check if the array got closed
     if (array_ == nullptr || !array_->is_open())
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           "Cannot init query; The associated array is not open"));
 
     // Check if the array got re-opened with a different query type
@@ -921,7 +918,7 @@ Status Query::init() {
              << "Associated array query type does not match query type: "
              << "(" << query_type_str(array_query_type)
              << " != " << query_type_str(type_) << ")";
-      return logger_->status(Status::QueryError(errmsg.str()));
+      return logger_->status(Status_QueryError(errmsg.str()));
     }
 
     RETURN_NOT_OK(check_buffer_names());
@@ -963,8 +960,8 @@ Status Query::cancel() {
 
 Status Query::process() {
   if (status_ == QueryStatus::UNINITIALIZED)
-    return logger_->status(
-        Status::QueryError("Cannot process query; Query is not initialized"));
+    return logger_->status(Status_QueryError(
+        "Cannot process query; Query is not initialized"));
   status_ = QueryStatus::INPROGRESS;
 
   // Process query
@@ -1111,8 +1108,7 @@ Status Query::create_strategy() {
   }
 
   if (strategy_ == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot create strategy; allocation failed"));
+    return logger_->status(Status_QueryError("Cannot create strategy; allocation failed"));
 
   return Status::Ok();
 }
@@ -1130,11 +1126,11 @@ void Query::clear_strategy() {
 
 Status Query::disable_check_global_order() {
   if (status_ != QueryStatus::UNINITIALIZED)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot disable checking global order after initialization"));
 
   if (type_ == QueryType::READ)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot disable checking global order; Applicable only to writes"));
 
   disable_check_global_order_ = true;
@@ -1145,15 +1141,15 @@ Status Query::check_buffer_names() {
   if (type_ == QueryType::WRITE) {
     // If the array is sparse, the coordinates must be provided
     if (!array_schema_->dense() && !coords_info_.has_coords_)
-      return logger_->status(Status::WriterError(
+      return logger_->status(Status_WriterError(
           "Sparse array writes expect the coordinates of the "
           "cells to be written"));
 
     // If the layout is unordered, the coordinates must be provided
     if (layout_ == Layout::UNORDERED && !coords_info_.has_coords_)
-      return logger_->status(
-          Status::WriterError("Unordered writes expect the coordinates of the "
-                              "cells to be written"));
+      return logger_->status(Status_WriterError(
+          "Unordered writes expect the coordinates of the "
+          "cells to be written"));
 
     // All attributes/dimensions must be provided
     auto expected_num = array_schema_->attribute_num();
@@ -1162,7 +1158,7 @@ Status Query::check_buffer_names() {
                         array_schema_->dim_num() :
                         0;
     if (buffers_.size() != expected_num)
-      return logger_->status(Status::WriterError(
+      return logger_->status(Status_WriterError(
           "Writes expect all attributes (and coordinates in "
           "the sparse/unordered case) to be set"));
   }
@@ -1173,12 +1169,12 @@ Status Query::check_buffer_names() {
 Status Query::check_set_fixed_buffer(const std::string& name) {
   if (name == constants::coords &&
       !array_schema_->domain()->all_dims_same_type())
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; Setting a buffer for zipped coordinates is not "
         "applicable to heterogeneous domains"));
 
   if (name == constants::coords && !array_schema_->domain()->all_dims_fixed())
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; Setting a buffer for zipped coordinates is not "
         "applicable to domains with variable-sized dimensions"));
 
@@ -1218,18 +1214,17 @@ Status Query::set_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+    return logger_->status(Status_QueryError(
+        "Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+    return logger_->status(Status_QueryError(
+        "Cannot set buffer; " + name + " buffer is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
@@ -1237,13 +1232,13 @@ Status Query::set_buffer(
 
   // Check that attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
         "'"));
 
   // Must not be nullable
   if (array_schema_->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is nullable"));
 
@@ -1251,21 +1246,21 @@ Status Query::set_buffer(
   const bool var_size =
       (name != constants::coords && array_schema_->var_size(name));
   if (var_size)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is var-sized"));
 
   // Check if zipped coordinates coexist with separate coordinate buffers
   if ((is_dim && has_zipped_coords_buffer_) ||
       (name == constants::coords && has_coords_buffer_))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set separate coordinate buffers and "
                     "a zipped coordinate buffer in the same query")));
 
   // Error if setting a new attribute/dimension after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
@@ -1281,7 +1276,7 @@ Status Query::set_buffer(
     // Check number of coordinates
     uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
     if (coord_buffer_is_set_ && coords_num != coords_info_.coords_num_)
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           std::string("Cannot set buffer; Input buffer for dimension '") +
           name +
           "' has a different number of coordinates than previously "
@@ -1310,18 +1305,17 @@ Status Query::set_data_buffer(
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
     if (type_ != QueryType::WRITE || *buffer_size != 0)
-      return logger_->status(
-          Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+      return logger_->status(Status_QueryError(
+          "Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
@@ -1329,26 +1323,26 @@ Status Query::set_data_buffer(
 
   // Check that attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
         "'"));
 
   if (array_schema_->dense() && type_ == QueryType::WRITE && !is_attr) {
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Dense write queries cannot set dimension buffers")));
   }
 
   // Check if zipped coordinates coexist with separate coordinate buffers
   if ((is_dim && has_zipped_coords_buffer_) ||
       (name == constants::coords && has_coords_buffer_))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set separate coordinate buffers and "
                     "a zipped coordinate buffer in the same query")));
 
   // Error if setting a new attribute/dimension after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
@@ -1365,7 +1359,7 @@ Status Query::set_data_buffer(
     uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
     if (coord_data_buffer_is_set_ && coords_num != coords_info_.coords_num_ &&
         name == data_buffer_name_)
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           std::string("Cannot set buffer; Input buffer for dimension '") +
           name +
           "' has a different number of coordinates than previously "
@@ -1399,18 +1393,17 @@ Status Query::set_offsets_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer_offsets == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+    return logger_->status(Status_QueryError(
+        "Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_offsets_size == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
@@ -1418,20 +1411,20 @@ Status Query::set_offsets_buffer(
 
   // Neither a dimension nor an attribute
   if (!is_dim && !is_attr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Invalid buffer name '") + name +
         "' (it should be an attribute or dimension)"));
 
   // Error if it is fixed-sized
   if (!array_schema_->var_size(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is fixed-sized"));
 
   // Error if setting a new attribute/dimension after initialization
   bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
@@ -1441,7 +1434,7 @@ Status Query::set_offsets_buffer(
         *buffer_offsets_size / constants::cell_var_offset_size;
     if (coord_offsets_buffer_is_set_ &&
         coords_num != coords_info_.coords_num_ && name == offsets_buffer_name_)
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           std::string("Cannot set buffer; Input buffer for dimension '") +
           name +
           "' has a different number of coordinates than previously "
@@ -1473,35 +1466,34 @@ Status Query::set_validity_buffer(
       buffer_validity_bytemap, buffer_validity_bytemap_size));
   // Check validity buffer
   if (check_null_buffers && validity_vector.buffer() == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer is null"));
 
   // Check validity buffer size
   if (check_null_buffers && validity_vector.buffer_size() == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Buffer name '") + name +
         "' is not an attribute"));
 
   // Must be nullable
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is not nullable"));
 
   // Error if setting a new attribute after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute '") + name +
         "' after initialization"));
 
@@ -1521,28 +1513,27 @@ Status Query::set_buffer(
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
     if (type_ != QueryType::WRITE || *buffer_val_size != 0)
-      return logger_->status(
-          Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+      return logger_->status(Status_QueryError(
+          "Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_val_size == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Check offset buffer
   if (check_null_buffers && buffer_off == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " offset buffer is null"));
 
   // Check offset buffer size
   if (check_null_buffers && buffer_off_size == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " offset buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
@@ -1550,26 +1541,26 @@ Status Query::set_buffer(
 
   // Check that attribute/dimension exists
   if (!is_dim && !is_attr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
         "'"));
 
   // Must not be nullable
   if (array_schema_->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is nullable"));
 
   // Check that attribute/dimension is var-sized
   if (!array_schema_->var_size(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is fixed-sized"));
 
   // Error if setting a new attribute/dimension after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
@@ -1577,7 +1568,7 @@ Status Query::set_buffer(
     // Check number of coordinates
     uint64_t coords_num = *buffer_off_size / constants::cell_var_offset_size;
     if (coord_buffer_is_set_ && coords_num != coords_info_.coords_num_)
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           std::string("Cannot set buffer; Input buffer for dimension '") +
           name +
           "' has a different number of coordinates than previously "
@@ -1645,51 +1636,50 @@ Status Query::set_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+    return logger_->status(Status_QueryError(
+        "Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Check validity buffer offset
   if (check_null_buffers && validity_vector.buffer() == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer is null"));
 
   // Check validity buffer size
   if (check_null_buffers && validity_vector.buffer_size() == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Buffer name '") + name +
         "' is not an attribute"));
 
   // Must be fixed-size
   if (array_schema_->var_size(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is var-sized"));
 
   // Must be nullable
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is not nullable"));
 
   // Error if setting a new attribute/dimension after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute '") + name +
         "' after initialization"));
 
@@ -1711,62 +1701,61 @@ Status Query::set_buffer(
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
     if (type_ != QueryType::WRITE || *buffer_val_size != 0)
-      return logger_->status(
-          Status::QueryError("Cannot set buffer; " + name + " buffer is null"));
+      return logger_->status(Status_QueryError(
+          "Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_val_size == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Check buffer offset
   if (check_null_buffers && buffer_off == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " offset buffer is null"));
 
   // Check buffer offset size
   if (check_null_buffers && buffer_off_size == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " offset buffer size is null"));
   ;
 
   // Check validity buffer offset
   if (check_null_buffers && validity_vector.buffer() == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer is null"));
 
   // Check validity buffer size
   if (check_null_buffers && validity_vector.buffer_size() == nullptr)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
-        Status::QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Buffer name '") + name +
         "' is not an attribute"));
 
   // Must be var-size
   if (!array_schema_->var_size(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is fixed-sized"));
 
   // Must be nullable
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is not nullable"));
 
   // Error if setting a new attribute after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute '") + name +
         "' after initialization"));
 
@@ -1782,7 +1771,7 @@ Status Query::set_est_result_size(
     std::unordered_map<std::string, Subarray::ResultSize>& est_result_size,
     std::unordered_map<std::string, Subarray::MemorySize>& max_mem_size) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set estimated result size; Operation currently "
         "unsupported for write queries"));
   return subarray_.set_est_result_size(est_result_size, max_mem_size);
@@ -1796,16 +1785,15 @@ Status Query::set_layout_unsafe(Layout layout) {
 
 Status Query::set_layout(Layout layout) {
   if (type_ == QueryType::READ && status_ != QueryStatus::UNINITIALIZED)
-    return logger_->status(
-        Status::QueryError("Cannot set layout after initialization"));
+    return logger_->status(Status_QueryError("Cannot set layout after initialization"));
 
   if (layout == Layout::HILBERT)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set layout; Hilbert order is not applicable to queries"));
 
   if (type_ == QueryType::WRITE && array_schema_->dense() &&
       layout == Layout::UNORDERED) {
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Unordered writes are only possible for sparse arrays"));
   }
 
@@ -1816,7 +1804,7 @@ Status Query::set_layout(Layout layout) {
 
 Status Query::set_condition(const QueryCondition& condition) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status::QueryError(
+    return logger_->status(Status_QueryError(
         "Cannot set query condition; Operation only applicable "
         "to read queries"));
 
@@ -1830,14 +1818,14 @@ void Query::set_status(QueryStatus status) {
 
 Status Query::set_subarray(const void* subarray) {
   if (!array_schema_->domain()->all_dims_same_type())
-    return logger_->status(
-        Status::QueryError("Cannot set subarray; Function not applicable to "
-                           "heterogeneous domains"));
+    return logger_->status(Status_QueryError(
+        "Cannot set subarray; Function not applicable to "
+        "heterogeneous domains"));
 
   if (!array_schema_->domain()->all_dims_fixed())
-    return logger_->status(
-        Status::QueryError("Cannot set subarray; Function not applicable to "
-                           "domains with variable-sized dimensions"));
+    return logger_->status(Status_QueryError(
+        "Cannot set subarray; Function not applicable to "
+        "domains with variable-sized dimensions"));
 
   // Prepare a subarray object
   Subarray sub(array_, layout_, stats_, logger_);
@@ -1854,7 +1842,7 @@ Status Query::set_subarray(const void* subarray) {
           config()->get("sm.read_range_oob", &found);
       assert(found);
       if (read_range_oob_str != "error" && read_range_oob_str != "warn")
-        return logger_->status(Status::QueryError(
+        return logger_->status(Status_QueryError(
             "Invalid value " + read_range_oob_str +
             " for sm.read_range_obb. Acceptable values are 'error' or "
             "'warn'."));
@@ -1872,14 +1860,14 @@ Status Query::set_subarray(const void* subarray) {
   if (type_ == QueryType::WRITE) {
     // Not applicable to sparse arrays
     if (!array_schema_->dense())
-      return logger_->status(Status::WriterError(
+      return logger_->status(Status_WriterError(
           "Setting a subarray is not supported in sparse writes"));
 
     // Subarray must be unary for dense writes
     if (sub.range_num() != 1)
-      return logger_->status(
-          Status::WriterError("Cannot set subarray; Multi-range dense writes "
-                              "are not supported"));
+      return logger_->status(Status_WriterError(
+          "Cannot set subarray; Multi-range dense writes "
+          "are not supported"));
     if (strategy_ != nullptr)
       strategy_->reset();
   }
@@ -1945,6 +1933,7 @@ Status Query::set_subarray_unsafe(const NDRange& subarray) {
 Status Query::check_buffers_correctness() {
   // Iterate through each attribute
   for (auto& attr : buffer_names()) {
+      return logger_->status(Status_QueryError(
     if (array_schema_->var_size(attr)) {
       // Check for data buffer under buffer_var and offsets buffer under buffer
       if (type_ == QueryType::READ) {
@@ -1963,14 +1952,14 @@ Status Query::check_buffers_correctness() {
         }
       }
       if (buffer(attr).buffer_ == nullptr) {
-        return logger_->status(Status::QueryError(
+        return logger_->status(Status_QueryError(
             std::string("Var-Sized input attribute/dimension '") + attr +
             "' is not set correctly. \nOffsets buffer is not set."));
       }
     } else {
       // Fixed sized
       if (buffer(attr).buffer_ == nullptr) {
-        return logger_->status(Status::QueryError(
+        return logger_->status(Status_QueryError(
             std::string("Fix-Sized input attribute/dimension '") + attr +
             "' is not set correctly. \nData buffer is not set."));
       }
@@ -1978,7 +1967,7 @@ Status Query::check_buffers_correctness() {
     if (array_schema_->is_nullable(attr)) {
       bool exists_validity = buffer(attr).validity_vector_.buffer() != nullptr;
       if (!exists_validity) {
-        return logger_->status(Status::QueryError(
+        return logger_->status(Status_QueryError(
             std::string("Nullable input attribute/dimension '") + attr +
             "' is not set correctly \nValidity buffer is not set"));
       }
@@ -1999,7 +1988,7 @@ Status Query::submit() {
   if (array_->is_remote()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(Status::QueryError(
+      return logger_->status(Status_QueryError(
           "Error in query submission; remote array with no rest client."));
 
     array_schema_->set_array_uri(array_->array_uri());
@@ -2020,9 +2009,9 @@ Status Query::submit_async(
   }
   RETURN_NOT_OK(init());
   if (array_->is_remote())
-    return logger_->status(
-        Status::QueryError("Error in async query submission; async queries not "
-                           "supported for remote arrays."));
+    return logger_->status(Status_QueryError(
+        "Error in async query submission; async queries not "
+        "supported for remote arrays."));
 
   callback_ = callback;
   callback_data_ = callback_data;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -130,7 +130,8 @@ Query::~Query() {
 Status Query::add_range(
     unsigned dim_idx, const void* start, const void* end, const void* stride) {
   if (dim_idx >= array_schema_->dim_num())
-    return logger_->status(Status_QueryError("Cannot add range; Invalid dimension index"));
+    return logger_->status(
+        Status_QueryError("Cannot add range; Invalid dimension index"));
 
   if (start == nullptr || end == nullptr)
     return logger_->status(
@@ -141,8 +142,8 @@ Status Query::add_range(
         "Cannot add range; Setting range stride is currently unsupported"));
 
   if (array_schema_->domain()->dimension(dim_idx)->var_size())
-    return logger_->status(Status_QueryError(
-        "Cannot add range; Range must be fixed-sized"));
+    return logger_->status(
+        Status_QueryError("Cannot add range; Range must be fixed-sized"));
 
   // Prepare a temp range
   std::vector<uint8_t> range;
@@ -166,14 +167,14 @@ Status Query::add_range(
     read_range_oob_error = read_range_oob == "error";
   } else {
     if (!array_schema_->dense())
-      return logger_->status(Status_QueryError(
-          "Adding a subarray range to a write query is not "
-          "supported in sparse arrays"));
+      return logger_->status(
+          Status_QueryError("Adding a subarray range to a write query is not "
+                            "supported in sparse arrays"));
 
     if (subarray_.is_set(dim_idx))
-      return logger_->status(Status_QueryError(
-          "Cannot add range; Multi-range dense writes "
-          "are not supported"));
+      return logger_->status(
+          Status_QueryError("Cannot add range; Multi-range dense writes "
+                            "are not supported"));
   }
 
   // Add range
@@ -188,7 +189,8 @@ Status Query::add_range_var(
     const void* end,
     uint64_t end_size) {
   if (dim_idx >= array_schema_->dim_num())
-    return logger_->status(Status_QueryError("Cannot add range; Invalid dimension index"));
+    return logger_->status(
+        Status_QueryError("Cannot add range; Invalid dimension index"));
 
   if ((start == nullptr && start_size != 0) ||
       (end == nullptr && end_size != 0))
@@ -196,8 +198,8 @@ Status Query::add_range_var(
         Status_QueryError("Cannot add range; Invalid range"));
 
   if (!array_schema_->domain()->dimension(dim_idx)->var_size())
-    return logger_->status(Status_QueryError(
-        "Cannot add range; Range must be variable-sized"));
+    return logger_->status(
+        Status_QueryError("Cannot add range; Range must be variable-sized"));
 
   if (type_ == QueryType::WRITE)
     return logger_->status(Status_QueryError(
@@ -221,9 +223,9 @@ Status Query::add_range_var(
 
 Status Query::get_range_num(unsigned dim_idx, uint64_t* range_num) const {
   if (type_ == QueryType::WRITE && !array_schema_->dense())
-    return logger_->status(Status_QueryError(
-        "Getting the number of ranges from a write query "
-        "is not applicable to sparse arrays"));
+    return logger_->status(
+        Status_QueryError("Getting the number of ranges from a write query "
+                          "is not applicable to sparse arrays"));
 
   return subarray_.get_range_num(dim_idx, range_num);
 }
@@ -235,8 +237,9 @@ Status Query::get_range(
     const void** end,
     const void** stride) const {
   if (type_ == QueryType::WRITE && !array_schema_->dense())
-    return logger_->status(Status_QueryError("Getting a range from a write query is not "
-                                  "applicable to sparse arrays"));
+    return logger_->status(
+        Status_QueryError("Getting a range from a write query is not "
+                          "applicable to sparse arrays"));
 
   *stride = nullptr;
   return subarray_.get_range(dim_idx, range_idx, start, end);
@@ -378,9 +381,9 @@ Status Query::get_est_result_size(const char* name, uint64_t* size) {
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(Status_QueryError(
-          "Error in query estimate result size; remote "
-          "array with no rest client."));
+      return logger_->status(
+          Status_QueryError("Error in query estimate result size; remote "
+                            "array with no rest client."));
 
     array_schema_->set_array_uri(array_->array_uri());
 
@@ -408,9 +411,9 @@ Status Query::get_est_result_size(
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(Status_QueryError(
-          "Error in query estimate result size; remote "
-          "array with no rest client."));
+      return logger_->status(
+          Status_QueryError("Error in query estimate result size; remote "
+                            "array with no rest client."));
 
     array_schema_->set_array_uri(array_->array_uri());
 
@@ -446,13 +449,13 @@ Status Query::get_est_result_size_nullable(
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(Status_QueryError(
-          "Error in query estimate result size; remote "
-          "array with no rest client."));
+      return logger_->status(
+          Status_QueryError("Error in query estimate result size; remote "
+                            "array with no rest client."));
 
-    return logger_->status(Status_QueryError(
-        "Error in query estimate result size; unimplemented "
-        "for nullable attributes in remote arrays."));
+    return logger_->status(
+        Status_QueryError("Error in query estimate result size; unimplemented "
+                          "for nullable attributes in remote arrays."));
   }
 
   return subarray_.get_est_result_size_nullable(
@@ -482,13 +485,13 @@ Status Query::get_est_result_size_nullable(
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(Status_QueryError(
-          "Error in query estimate result size; remote "
-          "array with no rest client."));
+      return logger_->status(
+          Status_QueryError("Error in query estimate result size; remote "
+                            "array with no rest client."));
 
-    return logger_->status(Status_QueryError(
-        "Error in query estimate result size; unimplemented "
-        "for nullable attributes in remote arrays."));
+    return logger_->status(
+        Status_QueryError("Error in query estimate result size; unimplemented "
+                          "for nullable attributes in remote arrays."));
   }
 
   return subarray_.get_est_result_size_nullable(
@@ -529,8 +532,8 @@ Status Query::get_written_fragment_uri(uint32_t idx, const char** uri) const {
 
   auto num = (uint32_t)written_fragment_info_.size();
   if (idx >= num)
-    return logger_->status(Status_QueryError(
-        "Cannot get fragment URI; Invalid fragment index"));
+    return logger_->status(
+        Status_QueryError("Cannot get fragment URI; Invalid fragment index"));
 
   *uri = written_fragment_info_[idx].uri_.c_str();
 
@@ -648,8 +651,8 @@ Status Query::get_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (name == constants::coords) {
-    return logger_->status(Status_QueryError(
-        "Cannot get buffer; Coordinates are not var-sized"));
+    return logger_->status(
+        Status_QueryError("Cannot get buffer; Coordinates are not var-sized"));
   }
   if (array_schema->attribute(name) == nullptr &&
       array_schema->dimension(name) == nullptr)
@@ -684,8 +687,8 @@ Status Query::get_offsets_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (name == constants::coords) {
-    return logger_->status(Status_QueryError(
-        "Cannot get buffer; Coordinates are not var-sized"));
+    return logger_->status(
+        Status_QueryError("Cannot get buffer; Coordinates are not var-sized"));
   }
   if (array_schema->attribute(name) == nullptr &&
       array_schema->dimension(name) == nullptr)
@@ -960,8 +963,8 @@ Status Query::cancel() {
 
 Status Query::process() {
   if (status_ == QueryStatus::UNINITIALIZED)
-    return logger_->status(Status_QueryError(
-        "Cannot process query; Query is not initialized"));
+    return logger_->status(
+        Status_QueryError("Cannot process query; Query is not initialized"));
   status_ = QueryStatus::INPROGRESS;
 
   // Process query
@@ -1108,7 +1111,8 @@ Status Query::create_strategy() {
   }
 
   if (strategy_ == nullptr)
-    return logger_->status(Status_QueryError("Cannot create strategy; allocation failed"));
+    return logger_->status(
+        Status_QueryError("Cannot create strategy; allocation failed"));
 
   return Status::Ok();
 }
@@ -1147,9 +1151,9 @@ Status Query::check_buffer_names() {
 
     // If the layout is unordered, the coordinates must be provided
     if (layout_ == Layout::UNORDERED && !coords_info_.has_coords_)
-      return logger_->status(Status_WriterError(
-          "Unordered writes expect the coordinates of the "
-          "cells to be written"));
+      return logger_->status(
+          Status_WriterError("Unordered writes expect the coordinates of the "
+                             "cells to be written"));
 
     // All attributes/dimensions must be provided
     auto expected_num = array_schema_->attribute_num();
@@ -1158,9 +1162,9 @@ Status Query::check_buffer_names() {
                         array_schema_->dim_num() :
                         0;
     if (buffers_.size() != expected_num)
-      return logger_->status(Status_WriterError(
-          "Writes expect all attributes (and coordinates in "
-          "the sparse/unordered case) to be set"));
+      return logger_->status(
+          Status_WriterError("Writes expect all attributes (and coordinates in "
+                             "the sparse/unordered case) to be set"));
   }
 
   return Status::Ok();
@@ -1214,17 +1218,18 @@ Status Query::set_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
-    return logger_->status(Status_QueryError(
-        "Cannot set buffer; " + name + " buffer is null"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
-    return logger_->status(Status_QueryError(
-        "Cannot set buffer; " + name + " buffer is null"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
@@ -1305,8 +1310,8 @@ Status Query::set_data_buffer(
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
     if (type_ != QueryType::WRITE || *buffer_size != 0)
-      return logger_->status(Status_QueryError(
-          "Cannot set buffer; " + name + " buffer is null"));
+      return logger_->status(
+          Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
@@ -1315,7 +1320,8 @@ Status Query::set_data_buffer(
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
@@ -1393,8 +1399,8 @@ Status Query::set_offsets_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer_offsets == nullptr)
-    return logger_->status(Status_QueryError(
-        "Cannot set buffer; " + name + " buffer is null"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_offsets_size == nullptr)
@@ -1403,7 +1409,8 @@ Status Query::set_offsets_buffer(
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
@@ -1476,7 +1483,8 @@ Status Query::set_validity_buffer(
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
@@ -1513,8 +1521,8 @@ Status Query::set_buffer(
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
     if (type_ != QueryType::WRITE || *buffer_val_size != 0)
-      return logger_->status(Status_QueryError(
-          "Cannot set buffer; " + name + " buffer is null"));
+      return logger_->status(
+          Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_val_size == nullptr)
@@ -1533,7 +1541,8 @@ Status Query::set_buffer(
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
@@ -1636,8 +1645,8 @@ Status Query::set_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
-    return logger_->status(Status_QueryError(
-        "Cannot set buffer; " + name + " buffer is null"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
@@ -1656,7 +1665,8 @@ Status Query::set_buffer(
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
@@ -1701,8 +1711,8 @@ Status Query::set_buffer(
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
     if (type_ != QueryType::WRITE || *buffer_val_size != 0)
-      return logger_->status(Status_QueryError(
-          "Cannot set buffer; " + name + " buffer is null"));
+      return logger_->status(
+          Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_val_size == nullptr)
@@ -1732,7 +1742,8 @@ Status Query::set_buffer(
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(Status_QueryError("Cannot set buffer; Array schema not set"));
+    return logger_->status(
+        Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
@@ -1785,7 +1796,8 @@ Status Query::set_layout_unsafe(Layout layout) {
 
 Status Query::set_layout(Layout layout) {
   if (type_ == QueryType::READ && status_ != QueryStatus::UNINITIALIZED)
-    return logger_->status(Status_QueryError("Cannot set layout after initialization"));
+    return logger_->status(
+        Status_QueryError("Cannot set layout after initialization"));
 
   if (layout == Layout::HILBERT)
     return logger_->status(Status_QueryError(
@@ -1818,14 +1830,14 @@ void Query::set_status(QueryStatus status) {
 
 Status Query::set_subarray(const void* subarray) {
   if (!array_schema_->domain()->all_dims_same_type())
-    return logger_->status(Status_QueryError(
-        "Cannot set subarray; Function not applicable to "
-        "heterogeneous domains"));
+    return logger_->status(
+        Status_QueryError("Cannot set subarray; Function not applicable to "
+                          "heterogeneous domains"));
 
   if (!array_schema_->domain()->all_dims_fixed())
-    return logger_->status(Status_QueryError(
-        "Cannot set subarray; Function not applicable to "
-        "domains with variable-sized dimensions"));
+    return logger_->status(
+        Status_QueryError("Cannot set subarray; Function not applicable to "
+                          "domains with variable-sized dimensions"));
 
   // Prepare a subarray object
   Subarray sub(array_, layout_, stats_, logger_);
@@ -1865,9 +1877,9 @@ Status Query::set_subarray(const void* subarray) {
 
     // Subarray must be unary for dense writes
     if (sub.range_num() != 1)
-      return logger_->status(Status_WriterError(
-          "Cannot set subarray; Multi-range dense writes "
-          "are not supported"));
+      return logger_->status(
+          Status_WriterError("Cannot set subarray; Multi-range dense writes "
+                             "are not supported"));
     if (strategy_ != nullptr)
       strategy_->reset();
   }
@@ -1934,7 +1946,7 @@ Status Query::check_buffers_correctness() {
   // Iterate through each attribute
   for (auto& attr : buffer_names()) {
       return logger_->status(Status_QueryError(
-    if (array_schema_->var_size(attr)) {
+          std::string("Data buffer is not set for " + attr)));    if (array_schema_->var_size(attr)) {
       // Check for data buffer under buffer_var and offsets buffer under buffer
       if (type_ == QueryType::READ) {
         if (buffer(attr).buffer_var_ == nullptr) {
@@ -2009,9 +2021,9 @@ Status Query::submit_async(
   }
   RETURN_NOT_OK(init());
   if (array_->is_remote())
-    return logger_->status(Status_QueryError(
-        "Error in async query submission; async queries not "
-        "supported for remote arrays."));
+    return logger_->status(
+        Status_QueryError("Error in async query submission; async queries not "
+                          "supported for remote arrays."));
 
   callback_ = callback;
   callback_data_ = callback_data;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1950,14 +1950,14 @@ Status Query::check_buffers_correctness() {
       // Check for data buffer under buffer_var and offsets buffer under buffer
       if (type_ == QueryType::READ) {
         if (buffer(attr).buffer_var_ == nullptr) {
-          return logger_->status(Status::QueryError(
+          return logger_->status(Status_QueryError(
               std::string("Var-Sized input attribute/dimension '") + attr +
               "' is not set correctly. \nVar size buffer is not set."));
         }
       } else {
         if (buffer(attr).buffer_var_ == nullptr &&
             *buffer(attr).buffer_var_size_ != 0) {
-          return logger_->status(Status::QueryError(
+          return logger_->status(Status_QueryError(
               std::string("Var-Sized input attribute/dimension '") + attr +
               "' is not set correctly. \nVar size buffer is not set and buffer "
               "size if not 0."));

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -83,8 +83,7 @@ Status QueryCondition::init(
     const uint64_t condition_value_size,
     const QueryConditionOp op) {
   if (!clauses_.empty()) {
-    return Status_QueryConditionError(
-        "Cannot reinitialize query condition");
+    return Status_QueryConditionError("Cannot reinitialize query condition");
   }
 
   clauses_.emplace_back(

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -812,7 +812,6 @@ Status QueryCondition::apply(
         stride,
         *result_cell_slabs,
         &tmp_result_cell_slabs));
-        return Status_QueryConditionError(
     *result_cell_slabs = tmp_result_cell_slabs;
   }
 
@@ -1529,7 +1528,7 @@ Status QueryCondition::apply_clause_sparse(
           clause, result_tile, var_size, result_bitmap);
       break;
     default:
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Cannot perform query comparison; Unknown query "
           "condition operator");
   }
@@ -1546,7 +1545,7 @@ Status QueryCondition::apply_clause_sparse(
   const Attribute* const attribute =
       array_schema->attribute(clause.field_name_);
   if (!attribute) {
-    return Status::QueryConditionError(
+    return Status_QueryConditionError(
         "Unknown attribute " + clause.field_name_);
   }
 
@@ -1639,7 +1638,7 @@ Status QueryCondition::apply_clause_sparse(
     case Datatype::STRING_UCS2:
     case Datatype::STRING_UCS4:
     default:
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Cannot perform query comparison; Unsupported query "
           "conditional type on " +
           clause.field_name_);

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -83,7 +83,8 @@ Status QueryCondition::init(
     const uint64_t condition_value_size,
     const QueryConditionOp op) {
   if (!clauses_.empty()) {
-    return Status::QueryConditionError("Cannot reinitialize query condition");
+    return Status_QueryConditionError(
+        "Cannot reinitialize query condition");
   }
 
   clauses_.emplace_back(
@@ -99,27 +100,27 @@ Status QueryCondition::check(const ArraySchema* const array_schema) const {
 
     const Attribute* const attribute = array_schema->attribute(field_name);
     if (!attribute) {
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Clause field name is not an attribute " + field_name);
     }
 
     if (clause.condition_value_ == nullptr) {
       if (clause.op_ != QueryConditionOp::EQ &&
           clause.op_ != QueryConditionOp::NE) {
-        return Status::QueryConditionError(
+        return Status_QueryConditionError(
             "Null value can only be used with equality operators");
       }
 
       if ((!attribute->nullable()) &&
           attribute->type() != Datatype::STRING_ASCII) {
-        return Status::QueryConditionError(
+        return Status_QueryConditionError(
             "Null value can only be used with nullable attributes");
       }
     }
 
     if (attribute->var_size() && attribute->type() != Datatype::STRING_ASCII &&
         clause.condition_value_ != nullptr) {
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Clause non-empty attribute may only be var-sized for ASCII "
           "strings: " +
           field_name);
@@ -128,7 +129,7 @@ Status QueryCondition::check(const ArraySchema* const array_schema) const {
     if (attribute->cell_val_num() != 1 &&
         attribute->type() != Datatype::STRING_ASCII &&
         (!attribute->var_size())) {
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Clause attribute must have one value per cell for non-string fixed "
           "size "
           "attributes: " +
@@ -140,7 +141,7 @@ Status QueryCondition::check(const ArraySchema* const array_schema) const {
         !(attribute->nullable() && clause.condition_value_ == nullptr) &&
         attribute->type() != Datatype::STRING_ASCII &&
         (!attribute->var_size())) {
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Clause condition value size mismatch: " +
           std::to_string(attribute->cell_size()) +
           " != " + std::to_string(condition_value_size));
@@ -148,14 +149,14 @@ Status QueryCondition::check(const ArraySchema* const array_schema) const {
 
     switch (attribute->type()) {
       case Datatype::ANY:
-        return Status::QueryConditionError(
+        return Status_QueryConditionError(
             "Clause attribute type may not be of type 'ANY': " + field_name);
       case Datatype::STRING_UTF8:
       case Datatype::STRING_UTF16:
       case Datatype::STRING_UTF32:
       case Datatype::STRING_UCS2:
       case Datatype::STRING_UCS4:
-        return Status::QueryConditionError(
+        return Status_QueryConditionError(
             "Clause attribute type may not be a UTF/UCS string: " + field_name);
       default:
         break;
@@ -171,7 +172,7 @@ Status QueryCondition::combine(
     QueryCondition* const combined_cond) const {
   assert(combination_op == QueryConditionCombinationOp::AND);
   if (combination_op != QueryConditionCombinationOp::AND) {
-    return Status::QueryConditionError(
+    return Status_QueryConditionError(
         "Cannot combine query conditions; Only the 'AND' "
         "combination op is supported");
   }
@@ -622,7 +623,7 @@ Status QueryCondition::apply_clause(
           out_result_cell_slabs);
       break;
     default:
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Cannot perform query comparison; Unknown query "
           "condition operator");
   }
@@ -639,7 +640,7 @@ Status QueryCondition::apply_clause(
   const Attribute* const attribute =
       array_schema->attribute(clause.field_name_);
   if (!attribute) {
-    return Status::QueryConditionError(
+    return Status_QueryConditionError(
         "Unknown attribute " + clause.field_name_);
   }
 
@@ -783,7 +784,7 @@ Status QueryCondition::apply_clause(
     case Datatype::STRING_UCS2:
     case Datatype::STRING_UCS4:
     default:
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Cannot perform query comparison; Unsupported query "
           "conditional type on " +
           clause.field_name_);
@@ -812,6 +813,7 @@ Status QueryCondition::apply(
         stride,
         *result_cell_slabs,
         &tmp_result_cell_slabs));
+        return Status_QueryConditionError(
     *result_cell_slabs = tmp_result_cell_slabs;
   }
 
@@ -1019,7 +1021,7 @@ Status QueryCondition::apply_clause_dense(
           result_buffer);
       break;
     default:
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Cannot perform query comparison; Unknown query "
           "condition operator");
   }
@@ -1041,7 +1043,7 @@ Status QueryCondition::apply_clause_dense(
   const Attribute* const attribute =
       array_schema->attribute(clause.field_name_);
   if (!attribute) {
-    return Status::QueryConditionError(
+    return Status_QueryConditionError(
         "Unknown attribute " + clause.field_name_);
   }
 
@@ -1236,7 +1238,7 @@ Status QueryCondition::apply_clause_dense(
     case Datatype::STRING_UCS2:
     case Datatype::STRING_UCS4:
     default:
-      return Status::QueryConditionError(
+      return Status_QueryConditionError(
           "Cannot perform query comparison; Unsupported query "
           "conditional type on " +
           clause.field_name_);

--- a/tiledb/sm/query/query_macros.h
+++ b/tiledb/sm/query/query_macros.h
@@ -49,7 +49,7 @@ namespace sm {
     if (!_s.ok()) {                                            \
       return _s;                                               \
     } else if (storage_manager_->cancellation_in_progress()) { \
-      return Status_QueryError("Query cancelled.");           \
+      return Status_QueryError("Query cancelled.");            \
     }                                                          \
   } while (false)
 #endif
@@ -68,7 +68,7 @@ namespace sm {
       return _s;                                               \
     } else if (storage_manager_->cancellation_in_progress()) { \
       _else;                                                   \
-      return Status_QueryError("Query cancelled.");           \
+      return Status_QueryError("Query cancelled.");            \
     }                                                          \
   } while (false)
 #endif
@@ -85,7 +85,7 @@ namespace sm {
       outer_st = _s;                                           \
       break;                                                   \
     } else if (storage_manager_->cancellation_in_progress()) { \
-      outer_st = Status_QueryError("Query cancelled.");       \
+      outer_st = Status_QueryError("Query cancelled.");        \
       break;                                                   \
     }                                                          \
   } while (false)

--- a/tiledb/sm/query/query_macros.h
+++ b/tiledb/sm/query/query_macros.h
@@ -49,7 +49,7 @@ namespace sm {
     if (!_s.ok()) {                                            \
       return _s;                                               \
     } else if (storage_manager_->cancellation_in_progress()) { \
-      return Status::QueryError("Query cancelled.");           \
+      return Status_QueryError("Query cancelled.");           \
     }                                                          \
   } while (false)
 #endif
@@ -68,7 +68,7 @@ namespace sm {
       return _s;                                               \
     } else if (storage_manager_->cancellation_in_progress()) { \
       _else;                                                   \
-      return Status::QueryError("Query cancelled.");           \
+      return Status_QueryError("Query cancelled.");           \
     }                                                          \
   } while (false)
 #endif
@@ -85,7 +85,7 @@ namespace sm {
       outer_st = _s;                                           \
       break;                                                   \
     } else if (storage_manager_->cancellation_in_progress()) { \
-      outer_st = Status::QueryError("Query cancelled.");       \
+      outer_st = Status_QueryError("Query cancelled.");       \
       break;                                                   \
     }                                                          \
   } while (false)

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -132,11 +132,11 @@ Status Reader::init() {
     return logger_->status(Status_ReaderError(
         "Cannot initialize reader; Storage manager not set"));
   if (array_schema_ == nullptr)
-    return logger_->status(Status_ReaderError(
-        "Cannot initialize reader; Array metadata not set"));
+    return logger_->status(
+        Status_ReaderError("Cannot initialize reader; Array metadata not set"));
   if (buffers_.empty())
-    return logger_->status(Status_ReaderError(
-        "Cannot initialize reader; Buffers not set"));
+    return logger_->status(
+        Status_ReaderError("Cannot initialize reader; Buffers not set"));
   if (array_schema_->dense() && !subarray_.is_set())
     return logger_->status(Status_ReaderError(
         "Cannot initialize reader; Dense reads must have a subarray set"));
@@ -302,8 +302,7 @@ Status Reader::compute_result_cell_slabs(
   auto coords_end = result_coords.end();
   auto it = skip_invalid_elements(result_coords.begin(), coords_end);
   if (it == coords_end) {
-    return logger_->status(
-        Status_ReaderError("Unexpected empty cell range."));
+    return logger_->status(Status_ReaderError("Unexpected empty cell range."));
   }
   uint64_t start_pos = it->pos_;
   uint64_t end_pos = start_pos;
@@ -983,9 +982,9 @@ Status Reader::init_read_state() {
   if (subarray_.layout() == Layout::GLOBAL_ORDER && subarray_.range_num() != 1)
     return logger_->status(
         Status_ReaderError("Cannot initialize read "
-                                   "state; Multi-range "
-                                   "subarrays do not "
-                                   "support global order"));
+                           "state; Multi-range "
+                           "subarrays do not "
+                           "support global order"));
 
   // Get config
   bool found = false;
@@ -1000,9 +999,9 @@ Status Reader::init_read_state() {
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    return logger_->status(Status_ReaderError(
-        "Cannot initialize reader; Unsupported offsets "
-        "format in configuration"));
+    return logger_->status(
+        Status_ReaderError("Cannot initialize reader; Unsupported offsets "
+                           "format in configuration"));
   }
   RETURN_NOT_OK(config_.get<bool>(
       "sm.var_offsets.extra_element", &offsets_extra_element_, &found));
@@ -1010,9 +1009,9 @@ Status Reader::init_read_state() {
   RETURN_NOT_OK(config_.get<uint32_t>(
       "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    return logger_->status(Status_ReaderError(
-        "Cannot initialize reader; Unsupported offsets "
-        "bitsize in configuration"));
+    return logger_->status(
+        Status_ReaderError("Cannot initialize reader; Unsupported offsets "
+                           "bitsize in configuration"));
   }
   assert(found);
 

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -129,16 +129,16 @@ bool Reader::incomplete() const {
 Status Reader::init() {
   // Sanity checks
   if (storage_manager_ == nullptr)
-    return logger_->status(Status::ReaderError(
+    return logger_->status(Status_ReaderError(
         "Cannot initialize reader; Storage manager not set"));
   if (array_schema_ == nullptr)
-    return logger_->status(Status::ReaderError(
+    return logger_->status(Status_ReaderError(
         "Cannot initialize reader; Array metadata not set"));
   if (buffers_.empty())
-    return logger_->status(
-        Status::ReaderError("Cannot initialize reader; Buffers not set"));
+    return logger_->status(Status_ReaderError(
+        "Cannot initialize reader; Buffers not set"));
   if (array_schema_->dense() && !subarray_.is_set())
-    return logger_->status(Status::ReaderError(
+    return logger_->status(Status_ReaderError(
         "Cannot initialize reader; Dense reads must have a subarray set"));
 
   // Check subarray
@@ -302,7 +302,8 @@ Status Reader::compute_result_cell_slabs(
   auto coords_end = result_coords.end();
   auto it = skip_invalid_elements(result_coords.begin(), coords_end);
   if (it == coords_end) {
-    return logger_->status(Status::ReaderError("Unexpected empty cell range."));
+    return logger_->status(
+        Status_ReaderError("Unexpected empty cell range."));
   }
   uint64_t start_pos = it->pos_;
   uint64_t end_pos = start_pos;
@@ -892,7 +893,7 @@ Status Reader::dense_read() {
     case Datatype::TIME_AS:
       return dense_read<int64_t>();
     default:
-      return logger_->status(Status::ReaderError(
+      return logger_->status(Status_ReaderError(
           "Cannot read dense array; Unsupported domain type"));
   }
 
@@ -981,10 +982,10 @@ Status Reader::init_read_state() {
   // Check subarray
   if (subarray_.layout() == Layout::GLOBAL_ORDER && subarray_.range_num() != 1)
     return logger_->status(
-        Status::ReaderError("Cannot initialize read "
-                            "state; Multi-range "
-                            "subarrays do not "
-                            "support global order"));
+        Status_ReaderError("Cannot initialize read "
+                                   "state; Multi-range "
+                                   "subarrays do not "
+                                   "support global order"));
 
   // Get config
   bool found = false;
@@ -999,9 +1000,9 @@ Status Reader::init_read_state() {
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    return logger_->status(
-        Status::ReaderError("Cannot initialize reader; Unsupported offsets "
-                            "format in configuration"));
+    return logger_->status(Status_ReaderError(
+        "Cannot initialize reader; Unsupported offsets "
+        "format in configuration"));
   }
   RETURN_NOT_OK(config_.get<bool>(
       "sm.var_offsets.extra_element", &offsets_extra_element_, &found));
@@ -1009,9 +1010,9 @@ Status Reader::init_read_state() {
   RETURN_NOT_OK(config_.get<uint32_t>(
       "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    return logger_->status(
-        Status::ReaderError("Cannot initialize reader; Unsupported offsets "
-                            "bitsize in configuration"));
+    return logger_->status(Status_ReaderError(
+        "Cannot initialize reader; Unsupported offsets "
+        "bitsize in configuration"));
   }
   assert(found);
 
@@ -1169,7 +1170,7 @@ Status Reader::add_extra_offset() {
           &elements,
           offsets_bytesize());
     } else {
-      return logger_->status(Status::ReaderError(
+      return logger_->status(Status_ReaderError(
           "Cannot add extra offset to buffer; Unsupported offsets format"));
     }
   }

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -173,7 +173,7 @@ void ReaderBase::zero_out_buffer_sizes() {
 
 Status ReaderBase::check_subarray() const {
   if (subarray_.layout() == Layout::GLOBAL_ORDER && subarray_.range_num() != 1)
-    return logger_->status(Status::ReaderError(
+    return logger_->status(Status_ReaderError(
         "Cannot initialize reader; Multi-range subarrays with "
         "global order layout are not supported"));
 
@@ -213,7 +213,7 @@ Status ReaderBase::check_validity_buffer_sizes() const {
               "given for ";
         ss << "attribute '" << name << "'";
         ss << " (" << cell_validity_num << " < " << min_cell_num << ")";
-        return logger_->status(Status::ReaderError(ss.str()));
+        return logger_->status(Status_ReaderError(ss.str()));
       }
     }
   }
@@ -1574,7 +1574,7 @@ Status ReaderBase::process_tiles(
       for (uint64_t i = 0; i < result_cell_slabs->size(); i++) {
         if (result_cell_slabs->at(i).tile_ == last_tile) {
           if (i == 0) {
-            return Status::ReaderError(
+            return Status_ReaderError(
                 "Unable to copy one tile with current budget");
           }
           last_idx = i;
@@ -1771,9 +1771,9 @@ Status ReaderBase::fill_dense_coords(const Subarray& subarray) {
   // This path does not use result cell slabs, which will fill coordinates
   // for cells that should be filtered out.
   if (!condition_.empty()) {
-    return logger_->status(
-        Status::ReaderError("Cannot read dense coordinates; dense coordinate "
-                            "reads are unsupported with a query condition"));
+    return logger_->status(Status_ReaderError(
+        "Cannot read dense coordinates; dense coordinate "
+        "reads are unsupported with a query condition"));
   }
 
   // Prepare buffers

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -1771,9 +1771,9 @@ Status ReaderBase::fill_dense_coords(const Subarray& subarray) {
   // This path does not use result cell slabs, which will fill coordinates
   // for cells that should be filtered out.
   if (!condition_.empty()) {
-    return logger_->status(Status_ReaderError(
-        "Cannot read dense coordinates; dense coordinate "
-        "reads are unsupported with a query condition"));
+    return logger_->status(
+        Status_ReaderError("Cannot read dense coordinates; dense coordinate "
+                           "reads are unsupported with a query condition"));
   }
 
   // Prepare buffers

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -495,10 +495,9 @@ Status SparseGlobalOrderReader::create_result_tiles(bool* tiles_found) {
                   t);
 
               if (result_tiles_[f].empty())
-                return logger_->status(
-                    Status_SparseGlobalOrderReaderError(
-                        "Cannot load a single tile for fragment, increase memory "
-                        "budget"));
+                return logger_->status(Status_SparseGlobalOrderReaderError(
+                    "Cannot load a single tile for fragment, increase memory "
+                    "budget"));
               break;
             }
             range_it++;
@@ -541,10 +540,9 @@ Status SparseGlobalOrderReader::create_result_tiles(bool* tiles_found) {
                   t);
 
               if (result_tiles_[f].empty())
-                return logger_->status(
-                    Status_SparseGlobalOrderReaderError(
-                        "Cannot load a single tile for fragment, increase memory "
-                        "budget"));
+                return logger_->status(Status_SparseGlobalOrderReaderError(
+                    "Cannot load a single tile for fragment, increase memory "
+                    "budget"));
               break;
             }
           }

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -495,9 +495,10 @@ Status SparseGlobalOrderReader::create_result_tiles(bool* tiles_found) {
                   t);
 
               if (result_tiles_[f].empty())
-                return logger_->status(Status::SparseGlobalOrderReaderError(
-                    "Cannot load a single tile for fragment, increase memory "
-                    "budget"));
+                return logger_->status(
+                    Status_SparseGlobalOrderReaderError(
+                        "Cannot load a single tile for fragment, increase memory "
+                        "budget"));
               break;
             }
             range_it++;
@@ -540,9 +541,10 @@ Status SparseGlobalOrderReader::create_result_tiles(bool* tiles_found) {
                   t);
 
               if (result_tiles_[f].empty())
-                return logger_->status(Status::SparseGlobalOrderReaderError(
-                    "Cannot load a single tile for fragment, increase memory "
-                    "budget"));
+                return logger_->status(
+                    Status_SparseGlobalOrderReaderError(
+                        "Cannot load a single tile for fragment, increase memory "
+                        "budget"));
               break;
             }
           }

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -235,8 +235,8 @@ Status SparseIndexReaderBase::load_initial_data() {
 
     if (memory_used_result_tile_ranges_ >
         memory_budget_ratio_tile_ranges_ * memory_budget_)
-      return logger_->status(
-          Status::ReaderError("Exceeded memory budget for result tile ranges"));
+      return logger_->status(Status_ReaderError(
+          "Exceeded memory budget for result tile ranges"));
   }
 
   // Set a limit to the array memory.
@@ -642,7 +642,7 @@ Status SparseIndexReaderBase::add_extra_offset() {
           &elements,
           offsets_bytesize());
     } else {
-      return logger_->status(Status::ReaderError(
+      return logger_->status(Status_ReaderError(
           "Cannot add extra offset to buffer; Unsupported offsets format"));
     }
   }

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -103,14 +103,14 @@ typename SparseIndexReaderBase::ReadState* SparseIndexReaderBase::read_state() {
 Status SparseIndexReaderBase::init() {
   // Sanity checks
   if (storage_manager_ == nullptr)
-    return logger_->status(Status::ReaderError(
+    return logger_->status(Status_ReaderError(
         "Cannot initialize sparse global order reader; Storage manager not "
         "set"));
   if (array_schema_ == nullptr)
-    return logger_->status(Status::ReaderError(
+    return logger_->status(Status_ReaderError(
         "Cannot initialize sparse global order reader; Array schema not set"));
   if (buffers_.empty())
-    return logger_->status(Status::ReaderError(
+    return logger_->status(Status_ReaderError(
         "Cannot initialize sparse global order reader; Buffers not set"));
 
   // Check subarray
@@ -122,7 +122,7 @@ Status SparseIndexReaderBase::init() {
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
     return logger_->status(
-        Status::ReaderError("Cannot initialize reader; Unsupported offsets "
+        Status_ReaderError("Cannot initialize reader; Unsupported offsets "
                             "format in configuration"));
   }
   elements_mode_ = offsets_format_mode_ == "elements";
@@ -134,7 +134,7 @@ Status SparseIndexReaderBase::init() {
       "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
     return logger_->status(
-        Status::ReaderError("Cannot initialize reader; "
+        Status_ReaderError("Cannot initialize reader; "
                             "Unsupported offsets bitsize in configuration"));
   }
 

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -123,7 +123,7 @@ Status SparseIndexReaderBase::init() {
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
     return logger_->status(
         Status_ReaderError("Cannot initialize reader; Unsupported offsets "
-                            "format in configuration"));
+                           "format in configuration"));
   }
   elements_mode_ = offsets_format_mode_ == "elements";
 
@@ -135,7 +135,7 @@ Status SparseIndexReaderBase::init() {
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
     return logger_->status(
         Status_ReaderError("Cannot initialize reader; "
-                            "Unsupported offsets bitsize in configuration"));
+                           "Unsupported offsets bitsize in configuration"));
   }
 
   // Check the validity buffer sizes.

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -235,8 +235,8 @@ Status SparseIndexReaderBase::load_initial_data() {
 
     if (memory_used_result_tile_ranges_ >
         memory_budget_ratio_tile_ranges_ * memory_budget_)
-      return logger_->status(Status_ReaderError(
-          "Exceeded memory budget for result tile ranges"));
+      return logger_->status(
+          Status_ReaderError("Exceeded memory budget for result tile ranges"));
   }
 
   // Set a limit to the array memory.

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -370,9 +370,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
                 f,
                 t);
             if (result_tiles_[0].empty())
-              return logger_->status(
-                  Status_SparseUnorderedWithDupsReaderError(
-                      "Cannot load a single tile, increase memory budget"));
+              return logger_->status(Status_SparseUnorderedWithDupsReaderError(
+                  "Cannot load a single tile, increase memory budget"));
             break;
           }
         }

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -319,7 +319,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
                   t);
               if (result_tiles_[0].empty())
                 return logger_->status(
-                    Status::SparseUnorderedWithDupsReaderError(
+                    Status_SparseUnorderedWithDupsReaderError(
                         "Cannot load a single tile, increase memory budget"));
               break;
             }
@@ -370,8 +370,9 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
                 f,
                 t);
             if (result_tiles_[0].empty())
-              return logger_->status(Status::SparseUnorderedWithDupsReaderError(
-                  "Cannot load a single tile, increase memory budget"));
+              return logger_->status(
+                  Status_SparseUnorderedWithDupsReaderError(
+                      "Cannot load a single tile, increase memory budget"));
             break;
           }
         }

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1152,7 +1152,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
   RETURN_NOT_OK_ELSE(status, logger_->status(status));
 
   if (max_rt_idx == 0)
-    return Status::SparseUnorderedWithDupsReaderError(
+    return Status_SparseUnorderedWithDupsReaderError(
         "Unable to copy one tile with current budget/buffers");
 
   // Resize the result tiles vector.
@@ -1219,7 +1219,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
   }
 
   if (*var_buffer_size == 0) {
-    return Status::SparseUnorderedWithDupsReaderError(
+    return Status_SparseUnorderedWithDupsReaderError(
         "Var size buffer cannot fit a single cell for var attribute");
   }
 

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -131,7 +131,7 @@ uint32_t StrategyBase::offsets_bitsize() const {
 
 Status StrategyBase::set_offsets_bitsize(const uint32_t bitsize) {
   if (bitsize != 32 && bitsize != 64) {
-    return logger_->status(Status::ReaderError(
+    return logger_->status(Status_ReaderError(
         "Cannot set offset bitsize to " + std::to_string(bitsize) +
         "; Only 32 and 64 are acceptable bitsize values"));
   }

--- a/tiledb/sm/query/validity_vector.h
+++ b/tiledb/sm/query/validity_vector.h
@@ -108,7 +108,7 @@ class ValidityVector {
    */
   Status init_bytemap(uint8_t* const bytemap, uint64_t* bytemap_size) {
     if (buffer_ != nullptr)
-      return Status::ValidityVectorError(
+      return Status_ValidityVectorError(
           "ValidityVector instance already initialized");
 
     buffer_ = bytemap;

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -211,14 +211,14 @@ Status Writer::check_var_attr_offsets() const {
 Status Writer::init() {
   // Sanity checks
   if (storage_manager_ == nullptr)
-    return logger_->status(Status_WriterError(
-        "Cannot initialize query; Storage manager not set"));
+    return logger_->status(
+        Status_WriterError("Cannot initialize query; Storage manager not set"));
   if (array_schema_ == nullptr)
-    return logger_->status(Status_WriterError(
-        "Cannot initialize writer; Array schema not set"));
+    return logger_->status(
+        Status_WriterError("Cannot initialize writer; Array schema not set"));
   if (buffers_.empty())
-    return logger_->status(Status_WriterError(
-        "Cannot initialize writer; Buffers not set"));
+    return logger_->status(
+        Status_WriterError("Cannot initialize writer; Buffers not set"));
   if (array_schema_->dense() &&
       (layout_ == Layout::ROW_MAJOR || layout_ == Layout::COL_MAJOR)) {
     for (const auto& b : buffers_) {
@@ -248,9 +248,9 @@ Status Writer::init() {
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    return logger_->status(Status_WriterError(
-        "Cannot initialize writer; Unsupported offsets "
-        "format in configuration"));
+    return logger_->status(
+        Status_WriterError("Cannot initialize writer; Unsupported offsets "
+                           "format in configuration"));
   }
   RETURN_NOT_OK(config_.get<bool>(
       "sm.var_offsets.extra_element", &offsets_extra_element_, &found));
@@ -258,9 +258,9 @@ Status Writer::init() {
   RETURN_NOT_OK(config_.get<uint32_t>(
       "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    return logger_->status(Status_WriterError(
-        "Cannot initialize writer; Unsupported offsets "
-        "bitsize in configuration"));
+    return logger_->status(
+        Status_WriterError("Cannot initialize writer; Unsupported offsets "
+                           "bitsize in configuration"));
   }
   assert(found);
 
@@ -376,8 +376,9 @@ Status Writer::check_coord_dups(const std::vector<uint64_t>& cell_pos) const {
     return Status::Ok();
 
   if (!coords_info_.has_coords_) {
-    return logger_->status(Status_WriterError("Cannot check for coordinate duplicates; "
-                                   "Coordinates buffer not found"));
+    return logger_->status(
+        Status_WriterError("Cannot check for coordinate duplicates; "
+                           "Coordinates buffer not found"));
   }
 
   if (coords_info_.coords_num_ < 2)
@@ -471,8 +472,9 @@ Status Writer::check_coord_dups() const {
     return Status::Ok();
 
   if (!coords_info_.has_coords_) {
-    return logger_->status(Status_WriterError("Cannot check for coordinate duplicates; "
-                                   "Coordinates buffer not found"));
+    return logger_->status(
+        Status_WriterError("Cannot check for coordinate duplicates; "
+                           "Coordinates buffer not found"));
   }
 
   if (coords_info_.coords_num_ < 2)
@@ -684,8 +686,8 @@ Status Writer::check_global_order_hilbert() const {
 
 Status Writer::check_subarray() const {
   if (array_schema_ == nullptr)
-    return logger_->status(Status_WriterError(
-        "Cannot check subarray; Array schema not set"));
+    return logger_->status(
+        Status_WriterError("Cannot check subarray; Array schema not set"));
 
   if (array_schema_->dense()) {
     if (subarray_.range_num() != 1)
@@ -694,10 +696,10 @@ Status Writer::check_subarray() const {
                               "are not supported"));
 
     if (layout_ == Layout::GLOBAL_ORDER && !subarray_.coincides_with_tiles())
-      return logger_->status(Status_WriterError(
-          "Cannot initialize query; In global writes for "
-          "dense arrays, the subarray "
-          "must coincide with the tile bounds"));
+      return logger_->status(
+          Status_WriterError("Cannot initialize query; In global writes for "
+                             "dense arrays, the subarray "
+                             "must coincide with the tile bounds"));
   }
   return Status::Ok();
 }
@@ -761,8 +763,9 @@ Status Writer::compute_coord_dups(
   auto timer_se = stats_->start_timer("compute_coord_dups");
 
   if (!coords_info_.has_coords_) {
-    return logger_->status(Status_WriterError("Cannot check for coordinate duplicates; "
-                                   "Coordinates buffer not found"));
+    return logger_->status(
+        Status_WriterError("Cannot check for coordinate duplicates; "
+                           "Coordinates buffer not found"));
   }
 
   if (coords_info_.coords_num_ < 2)
@@ -851,8 +854,9 @@ Status Writer::compute_coord_dups(std::set<uint64_t>* coord_dups) const {
   auto timer_se = stats_->start_timer("compute_coord_dups");
 
   if (!coords_info_.has_coords_) {
-    return logger_->status(Status_WriterError("Cannot check for coordinate duplicates; "
-                                   "Coordinates buffer not found"));
+    return logger_->status(
+        Status_WriterError("Cannot check for coordinate duplicates; "
+                           "Coordinates buffer not found"));
   }
 
   if (coords_info_.coords_num_ < 2)
@@ -1311,9 +1315,9 @@ bool Writer::all_last_tiles_empty() const {
 Status Writer::init_global_write_state() {
   // Create global array state object
   if (global_write_state_ != nullptr)
-    return logger_->status(Status_WriterError(
-        "Cannot initialize global write state; State not "
-        "properly finalized"));
+    return logger_->status(
+        Status_WriterError("Cannot initialize global write state; State not "
+                           "properly finalized"));
   global_write_state_.reset(new GlobalWriteState);
 
   // Create fragment

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -692,7 +692,7 @@ Status Writer::check_subarray() const {
   if (array_schema_->dense()) {
     if (subarray_.range_num() != 1)
       return LOG_STATUS(
-          Status::WriterError("Multi-range dense writes "
+          Status_WriterError("Multi-range dense writes "
                               "are not supported"));
 
     if (layout_ == Layout::GLOBAL_ORDER && !subarray_.coincides_with_tiles())

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -176,7 +176,7 @@ Status Writer::check_var_attr_offsets() const {
     // Allow the initial offset to be equal to the size, this indicates
     // the first and only value in the buffer is to be empty
     if (prev_offset > *buffer_val_size)
-      return logger_->status(Status::WriterError(
+      return logger_->status(Status_WriterError(
           "Invalid offsets for attribute " + attr + "; offset " +
           std::to_string(prev_offset) + " specified for buffer of size " +
           std::to_string(*buffer_val_size)));
@@ -184,7 +184,7 @@ Status Writer::check_var_attr_offsets() const {
     for (uint64_t i = 1; i < num_offsets; i++) {
       uint64_t cur_offset = get_offset_buffer_element(buffer_off, i);
       if (cur_offset < prev_offset)
-        return logger_->status(Status::WriterError(
+        return logger_->status(Status_WriterError(
             "Invalid offsets for attribute " + attr +
             "; offsets must be given in "
             "strictly ascending order."));
@@ -196,7 +196,7 @@ Status Writer::check_var_attr_offsets() const {
            get_offset_buffer_element(
                buffer_off, (i < num_offsets - 1 ? i + 1 : i)) !=
                *buffer_val_size))
-        return logger_->status(Status::WriterError(
+        return logger_->status(Status_WriterError(
             "Invalid offsets for attribute " + attr + "; offset " +
             std::to_string(cur_offset) + " specified for buffer of size " +
             std::to_string(*buffer_val_size)));
@@ -211,19 +211,19 @@ Status Writer::check_var_attr_offsets() const {
 Status Writer::init() {
   // Sanity checks
   if (storage_manager_ == nullptr)
-    return logger_->status(Status::WriterError(
+    return logger_->status(Status_WriterError(
         "Cannot initialize query; Storage manager not set"));
   if (array_schema_ == nullptr)
-    return logger_->status(
-        Status::WriterError("Cannot initialize writer; Array schema not set"));
+    return logger_->status(Status_WriterError(
+        "Cannot initialize writer; Array schema not set"));
   if (buffers_.empty())
-    return logger_->status(
-        Status::WriterError("Cannot initialize writer; Buffers not set"));
+    return logger_->status(Status_WriterError(
+        "Cannot initialize writer; Buffers not set"));
   if (array_schema_->dense() &&
       (layout_ == Layout::ROW_MAJOR || layout_ == Layout::COL_MAJOR)) {
     for (const auto& b : buffers_) {
       if (array_schema_->is_dim(b.first)) {
-        return logger_->status(Status::WriterError(
+        return logger_->status(Status_WriterError(
             "Cannot initialize writer; Sparse coordinates "
             "for dense arrays cannot be provided "
             "if the query layout is ROW_MAJOR or COL_MAJOR"));
@@ -248,9 +248,9 @@ Status Writer::init() {
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    return logger_->status(
-        Status::WriterError("Cannot initialize writer; Unsupported offsets "
-                            "format in configuration"));
+    return logger_->status(Status_WriterError(
+        "Cannot initialize writer; Unsupported offsets "
+        "format in configuration"));
   }
   RETURN_NOT_OK(config_.get<bool>(
       "sm.var_offsets.extra_element", &offsets_extra_element_, &found));
@@ -258,9 +258,9 @@ Status Writer::init() {
   RETURN_NOT_OK(config_.get<uint32_t>(
       "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    return logger_->status(
-        Status::WriterError("Cannot initialize writer; Unsupported offsets "
-                            "bitsize in configuration"));
+    return logger_->status(Status_WriterError(
+        "Cannot initialize writer; Unsupported offsets "
+        "bitsize in configuration"));
   }
   assert(found);
 
@@ -352,7 +352,7 @@ Status Writer::check_buffer_sizes() const {
               "given for ";
         ss << "attribute '" << attr << "'";
         ss << " (" << expected_validity_num << " != " << cell_num << ")";
-        return logger_->status(Status::WriterError(ss.str()));
+        return logger_->status(Status_WriterError(ss.str()));
       }
     } else {
       if (expected_cell_num != cell_num) {
@@ -360,7 +360,7 @@ Status Writer::check_buffer_sizes() const {
         ss << "Buffer sizes check failed; Invalid number of cells given for ";
         ss << "attribute '" << attr << "'";
         ss << " (" << expected_cell_num << " != " << cell_num << ")";
-        return logger_->status(Status::WriterError(ss.str()));
+        return logger_->status(Status_WriterError(ss.str()));
       }
     }
   }
@@ -376,9 +376,8 @@ Status Writer::check_coord_dups(const std::vector<uint64_t>& cell_pos) const {
     return Status::Ok();
 
   if (!coords_info_.has_coords_) {
-    return logger_->status(
-        Status::WriterError("Cannot check for coordinate duplicates; "
-                            "Coordinates buffer not found"));
+    return logger_->status(Status_WriterError("Cannot check for coordinate duplicates; "
+                                   "Coordinates buffer not found"));
   }
 
   if (coords_info_.coords_num_ < 2)
@@ -453,7 +452,7 @@ Status Writer::check_coord_dups(const std::vector<uint64_t>& cell_pos) const {
           std::stringstream ss;
           ss << "Duplicate coordinates " << coords_to_str(cell_pos[i]);
           ss << " are not allowed";
-          return Status::WriterError(ss.str());
+          return Status_WriterError(ss.str());
         }
 
         return Status::Ok();
@@ -472,9 +471,8 @@ Status Writer::check_coord_dups() const {
     return Status::Ok();
 
   if (!coords_info_.has_coords_) {
-    return logger_->status(
-        Status::WriterError("Cannot check for coordinate duplicates; "
-                            "Coordinates buffer not found"));
+    return logger_->status(Status_WriterError("Cannot check for coordinate duplicates; "
+                                   "Coordinates buffer not found"));
   }
 
   if (coords_info_.coords_num_ < 2)
@@ -542,7 +540,7 @@ Status Writer::check_coord_dups() const {
           std::stringstream ss;
           ss << "Duplicate coordinates " << coords_to_str(i);
           ss << " are not allowed";
-          return Status::WriterError(ss.str());
+          return Status_WriterError(ss.str());
         }
 
         return Status::Ok();
@@ -640,7 +638,7 @@ Status Writer::check_global_order() const {
           ss << " in the global order";
           if (tile_cmp > 0)
             ss << " due to writes across tiles";
-          return Status::WriterError(ss.str());
+          return Status_WriterError(ss.str());
         }
         return Status::Ok();
       });
@@ -674,7 +672,7 @@ Status Writer::check_global_order_hilbert() const {
           ss << "Write failed; Coordinates " << coords_to_str(i);
           ss << " succeed " << coords_to_str(i + 1);
           ss << " in the global order";
-          return Status::WriterError(ss.str());
+          return Status_WriterError(ss.str());
         }
         return Status::Ok();
       });
@@ -686,8 +684,8 @@ Status Writer::check_global_order_hilbert() const {
 
 Status Writer::check_subarray() const {
   if (array_schema_ == nullptr)
-    return logger_->status(
-        Status::WriterError("Cannot check subarray; Array schema not set"));
+    return logger_->status(Status_WriterError(
+        "Cannot check subarray; Array schema not set"));
 
   if (array_schema_->dense()) {
     if (subarray_.range_num() != 1)
@@ -696,10 +694,10 @@ Status Writer::check_subarray() const {
                               "are not supported"));
 
     if (layout_ == Layout::GLOBAL_ORDER && !subarray_.coincides_with_tiles())
-      return logger_->status(
-          Status::WriterError("Cannot initialize query; In global writes for "
-                              "dense arrays, the subarray "
-                              "must coincide with the tile bounds"));
+      return logger_->status(Status_WriterError(
+          "Cannot initialize query; In global writes for "
+          "dense arrays, the subarray "
+          "must coincide with the tile bounds"));
   }
   return Status::Ok();
 }
@@ -763,9 +761,8 @@ Status Writer::compute_coord_dups(
   auto timer_se = stats_->start_timer("compute_coord_dups");
 
   if (!coords_info_.has_coords_) {
-    return logger_->status(
-        Status::WriterError("Cannot check for coordinate duplicates; "
-                            "Coordinates buffer not found"));
+    return logger_->status(Status_WriterError("Cannot check for coordinate duplicates; "
+                                   "Coordinates buffer not found"));
   }
 
   if (coords_info_.coords_num_ < 2)
@@ -854,9 +851,8 @@ Status Writer::compute_coord_dups(std::set<uint64_t>* coord_dups) const {
   auto timer_se = stats_->start_timer("compute_coord_dups");
 
   if (!coords_info_.has_coords_) {
-    return logger_->status(
-        Status::WriterError("Cannot check for coordinate duplicates; "
-                            "Coordinates buffer not found"));
+    return logger_->status(Status_WriterError("Cannot check for coordinate duplicates; "
+                                   "Coordinates buffer not found"));
   }
 
   if (coords_info_.coords_num_ < 2)
@@ -1121,7 +1117,7 @@ Status Writer::finalize_global_write_state() {
     const auto& name = it.first;
     if (global_write_state_->cells_written_[name] != cell_num) {
       clean_up(uri);
-      return logger_->status(Status::WriterError(
+      return logger_->status(Status_WriterError(
           "Failed to finalize global write state; Different "
           "number of cells written across attributes and coordinates"));
     }
@@ -1138,7 +1134,7 @@ Status Writer::finalize_global_write_state() {
          << "of cells written (" << cell_num
          << ") is different from the number of cells expected ("
          << expected_cell_num << ") for the query subarray";
-      return logger_->status(Status::WriterError(ss.str()));
+      return logger_->status(Status_WriterError(ss.str()));
     }
   }
 
@@ -1315,9 +1311,9 @@ bool Writer::all_last_tiles_empty() const {
 Status Writer::init_global_write_state() {
   // Create global array state object
   if (global_write_state_ != nullptr)
-    return logger_->status(
-        Status::WriterError("Cannot initialize global write state; State not "
-                            "properly finalized"));
+    return logger_->status(Status_WriterError(
+        "Cannot initialize global write state; State not "
+        "properly finalized"));
   global_write_state_.reset(new GlobalWriteState);
 
   // Create fragment
@@ -1496,7 +1492,7 @@ Status Writer::new_fragment_name(
   timestamp = (timestamp != 0) ? timestamp : utils::time::timestamp_now_ms();
 
   if (frag_uri == nullptr)
-    return Status::WriterError("Null fragment uri argument.");
+    return Status_WriterError("Null fragment uri argument.");
   std::string uuid;
   frag_uri->clear();
   RETURN_NOT_OK(uuid::generate_uuid(&uuid, false));
@@ -1540,7 +1536,7 @@ Status Writer::check_extra_element() {
         get_offset_buffer_element(buffer_off, num_offsets - 1);
 
     if (last_offset != max_offset)
-      return logger_->status(Status::WriterError(
+      return logger_->status(Status_WriterError(
           "Invalid offsets for attribute " + attr +
           "; the last offset: " + std::to_string(last_offset) +
           " is not equal to the size of the data buffer: " +
@@ -1597,7 +1593,7 @@ Status Writer::ordered_write() {
     case Datatype::TIME_AS:
       return ordered_write<int64_t>();
     default:
-      return logger_->status(Status::WriterError(
+      return logger_->status(Status_WriterError(
           "Cannot write in ordered layout; Unsupported domain type"));
   }
 
@@ -2353,7 +2349,7 @@ Status Writer::split_coords_buffer() {
     buff.buffer_ = tdb_malloc(coord_buffer_size);
     to_clean_.push_back(buff.buffer_);
     if (buff.buffer_ == nullptr)
-      RETURN_NOT_OK(Status::WriterError(
+      RETURN_NOT_OK(Status_WriterError(
           "Cannot split coordinate buffers; memory allocation failed"));
     buffers_[dim_name] = std::move(buff);
   }

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -693,7 +693,7 @@ Status Writer::check_subarray() const {
     if (subarray_.range_num() != 1)
       return LOG_STATUS(
           Status_WriterError("Multi-range dense writes "
-                              "are not supported"));
+                             "are not supported"));
 
     if (layout_ == Layout::GLOBAL_ORDER && !subarray_.coincides_with_tiles())
       return logger_->status(

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -264,7 +264,7 @@ Status Curl::init(
     std::mutex* const res_mtx) {
   if (config == nullptr)
     return LOG_STATUS(
-        Status::RestError("Error initializing libcurl; config is null."));
+        Status_RestError("Error initializing libcurl; config is null."));
 
   config_ = config;
   curl_.reset(curl_easy_init());
@@ -275,7 +275,7 @@ Status Curl::init(
   // See https://curl.haxx.se/libcurl/c/threadsafe.html
   CURLcode rc = curl_easy_setopt(curl_.get(), CURLOPT_NOSIGNAL, 1);
   if (rc != CURLE_OK)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error initializing libcurl; failed to set CURLOPT_NOSIGNAL"));
 
   // For human-readable error messages
@@ -284,19 +284,19 @@ Status Curl::init(
   rc = curl_easy_setopt(
       curl_.get(), CURLOPT_ERRORBUFFER, curl_error_buffer_.data());
   if (rc != CURLE_OK)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error initializing libcurl; failed to set CURLOPT_ERRORBUFFER"));
 
   rc = curl_easy_setopt(
       curl_.get(), CURLOPT_HEADERFUNCTION, write_header_callback);
   if (rc != CURLE_OK)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error initializing libcurl; failed to set CURLOPT_HEADERFUNCTION"));
 
   /* set url to fetch */
   rc = curl_easy_setopt(curl_.get(), CURLOPT_HEADERDATA, &headerData);
   if (rc != CURLE_OK)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error initializing libcurl; failed to set CURLOPT_HEADERDATA"));
 
   // Ignore ssl validation if the user has set rest.ignore_ssl_validation = true
@@ -357,7 +357,7 @@ Status Curl::set_headers(struct curl_slist** headers) const {
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
-        Status::RestError("Cannot set auth; curl instance is null."));
+        Status_RestError("Cannot set auth; curl instance is null."));
 
   const char* token = nullptr;
   RETURN_NOT_OK(config_->get("rest.token", &token));
@@ -366,7 +366,7 @@ Status Curl::set_headers(struct curl_slist** headers) const {
     *headers = curl_slist_append(
         *headers, (std::string("X-TILEDB-REST-API-Key: ") + token).c_str());
     if (*headers == nullptr)
-      return LOG_STATUS(Status::RestError(
+      return LOG_STATUS(Status_RestError(
           "Cannot set curl auth; curl_slist_append returned null."));
   } else {
     // Try username+password instead of token
@@ -378,7 +378,7 @@ Status Curl::set_headers(struct curl_slist** headers) const {
     // Check for no auth.
     if (username == nullptr || password == nullptr)
       return LOG_STATUS(
-          Status::RestError("Cannot set curl auth; either token or "
+          Status_RestError("Cannot set curl auth; either token or "
                             "username/password must be set."));
 
     std::string basic_auth = username + std::string(":") + password;
@@ -392,7 +392,7 @@ Status Curl::set_headers(struct curl_slist** headers) const {
     *headers = curl_slist_append(*headers, hdr.c_str());
     if (*headers == nullptr) {
       curl_slist_free_all(*headers);
-      return LOG_STATUS(Status::RestError(
+      return LOG_STATUS(Status_RestError(
           "Cannot set extra headers; curl_slist_append returned null."));
     }
   }
@@ -410,12 +410,12 @@ Status Curl::set_content_type(
       *headers = curl_slist_append(*headers, "Content-Type: application/capnp");
       break;
     default:
-      return LOG_STATUS(Status::RestError(
+      return LOG_STATUS(Status_RestError(
           "Cannot set content-type header; unknown serialization format."));
   }
 
   if (*headers == nullptr)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Cannot set content-type header; curl_slist_append returned null."));
 
   return Status::Ok();
@@ -456,7 +456,7 @@ Status Curl::make_curl_request_common(
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
-        Status::RestError("Cannot make curl request; curl instance is null."));
+        Status_RestError("Cannot make curl request; curl instance is null."));
 
   *curl_code = CURLE_OK;
   uint64_t retry_delay = retry_initial_delay_ms_;
@@ -540,7 +540,7 @@ Status Curl::make_curl_request_common(
       long http_code = 0;
       if (curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code) !=
           CURLE_OK)
-        return LOG_STATUS(Status::RestError(
+        return LOG_STATUS(Status_RestError(
             "Error checking curl error; could not get HTTP code."));
 
       global_logger().debug(
@@ -570,11 +570,11 @@ Status Curl::should_retry(bool* retry) const {
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
-        Status::RestError("Error checking curl error; curl instance is null."));
+        Status_RestError("Error checking curl error; curl instance is null."));
 
   long http_code = 0;
   if (curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code) != CURLE_OK)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error checking curl error; could not get HTTP code."));
 
   // Check http code for list of retries
@@ -595,11 +595,11 @@ Status Curl::check_curl_errors(
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
-        Status::RestError("Error checking curl error; curl instance is null."));
+        Status_RestError("Error checking curl error; curl instance is null."));
 
   long http_code = 0;
   if (curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code) != CURLE_OK)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error checking curl error; could not get HTTP code."));
 
   if (curl_code != CURLE_OK || http_code >= 400) {
@@ -620,7 +620,7 @@ Status Curl::check_curl_errors(
       }
     }
 
-    return LOG_STATUS(Status::RestError(msg.str()));
+    return LOG_STATUS(Status_RestError(msg.str()));
   }
 
   return Status::Ok();
@@ -694,13 +694,13 @@ Status Curl::post_data_common(
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
-        Status::RestError("Error posting data; curl instance is null."));
+        Status_RestError("Error posting data; curl instance is null."));
 
   // TODO: If you post more than 2GB, use CURLOPT_POSTFIELDSIZE_LARGE.
   const uint64_t post_size_limit = uint64_t(2) * 1024 * 1024 * 1024;
   if (data->total_size() > post_size_limit)
     return LOG_STATUS(
-        Status::RestError("Error posting data; buffer size > 2GB"));
+        Status_RestError("Error posting data; buffer size > 2GB"));
 
   // Set auth and content-type for request
   *headers = nullptr;
@@ -735,7 +735,7 @@ Status Curl::get_data(
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
-        Status::RestError("Error getting data; curl instance is null."));
+        Status_RestError("Error getting data; curl instance is null."));
 
   // Set auth and content-type for request
   struct curl_slist* headers = nullptr;
@@ -768,7 +768,7 @@ Status Curl::delete_data(
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
-        Status::RestError("Error deleting data; curl instance is null."));
+        Status_RestError("Error deleting data; curl instance is null."));
 
   // Set auth and content-type for request
   struct curl_slist* headers = nullptr;

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -379,7 +379,7 @@ Status Curl::set_headers(struct curl_slist** headers) const {
     if (username == nullptr || password == nullptr)
       return LOG_STATUS(
           Status_RestError("Cannot set curl auth; either token or "
-                            "username/password must be set."));
+                           "username/password must be set."));
 
     std::string basic_auth = username + std::string(":") + password;
     curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -81,7 +81,7 @@ Status RestClient::init(
     ThreadPool* compute_tp) {
   if (config == nullptr)
     return LOG_STATUS(
-        Status::RestError("Error initializing rest client; config is null."));
+        Status_RestError("Error initializing rest client; config is null."));
 
   stats_ = parent_stats->create_child("RestClient");
 
@@ -93,7 +93,7 @@ Status RestClient::init(
   if (c_str != nullptr)
     rest_server_ = std::string(c_str);
   if (rest_server_.empty())
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error initializing rest client; server address is empty."));
 
   RETURN_NOT_OK(config_->get("rest.server_serialization_format", &c_str));
@@ -130,7 +130,7 @@ Status RestClient::get_array_schema_from_rest(
   RETURN_NOT_OK(curlc.get_data(
       stats_, url, serialization_type_, &returned_data, cache_key));
   if (returned_data.data() == nullptr || returned_data.size() == 0)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error getting array schema from REST; server returned no data."));
 
   return serialization::array_schema_deserialize(
@@ -194,9 +194,9 @@ Status RestClient::get_array_non_empty_domain(
     Array* array, uint64_t timestamp_start, uint64_t timestamp_end) {
   if (array == nullptr)
     return LOG_STATUS(
-        Status::RestError("Cannot get array non-empty domain; array is null"));
+        Status_RestError("Cannot get array non-empty domain; array is null"));
   if (array->array_uri().to_string().empty())
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Cannot get array non-empty domain; array URI is empty"));
 
   // Init curl and form the URL
@@ -219,7 +219,7 @@ Status RestClient::get_array_non_empty_domain(
 
   if (returned_data.data() == nullptr || returned_data.size() == 0)
     return LOG_STATUS(
-        Status::RestError("Error getting array non-empty domain "
+        Status_RestError("Error getting array non-empty domain "
                           "from REST; server returned no data."));
 
   // Deserialize data returned
@@ -257,7 +257,7 @@ Status RestClient::get_array_max_buffer_sizes(
 
   if (returned_data.data() == nullptr || returned_data.size() == 0)
     return LOG_STATUS(
-        Status::RestError("Error getting array max buffer sizes "
+        Status_RestError("Error getting array max buffer sizes "
                           "from REST; server returned no data."));
 
   // Deserialize data returned
@@ -271,7 +271,7 @@ Status RestClient::get_array_metadata_from_rest(
     uint64_t timestamp_end,
     Array* array) {
   if (array == nullptr)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error getting array metadata from REST; array is null."));
 
   // Init curl and form the URL
@@ -292,7 +292,7 @@ Status RestClient::get_array_metadata_from_rest(
   RETURN_NOT_OK(curlc.get_data(
       stats_, url, serialization_type_, &returned_data, cache_key));
   if (returned_data.data() == nullptr || returned_data.size() == 0)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error getting array metadata from REST; server returned no data."));
 
   return serialization::array_metadata_deserialize(
@@ -305,7 +305,7 @@ Status RestClient::post_array_metadata_to_rest(
     uint64_t timestamp_end,
     Array* array) {
   if (array == nullptr)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error posting array metadata to REST; array is null."));
 
   Buffer buff;
@@ -355,7 +355,7 @@ Status RestClient::post_query_submit(
   const Array* array = query->array();
   if (array == nullptr) {
     return LOG_STATUS(
-        Status::RestError("Error submitting query to REST; null array."));
+        Status_RestError("Error submitting query to REST; null array."));
   }
 
   auto rest_scratch = query->rest_scratch();
@@ -410,7 +410,7 @@ Status RestClient::post_query_submit(
       cache_key);
 
   if (!st.ok() && copy_state->empty()) {
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error submitting query to REST; "
         "server returned no data. "
         "Curl error: " +
@@ -618,7 +618,7 @@ Status RestClient::finalize_query_to_rest(const URI& uri, Query* query) {
 
   if (returned_data.data() == nullptr || returned_data.size() == 0)
     return LOG_STATUS(
-        Status::RestError("Error finalizing query; server returned no data."));
+        Status_RestError("Error finalizing query; server returned no data."));
 
   // Deserialize data returned
   returned_data.reset_offset();
@@ -695,7 +695,7 @@ Status RestClient::subarray_to_str(
         ss << ((const double*)subarray)[i];
         break;
       default:
-        return LOG_STATUS(Status::RestError(
+        return LOG_STATUS(Status_RestError(
             "Error converting subarray to string; unhandled datatype."));
     }
 
@@ -730,13 +730,13 @@ Status RestClient::update_attribute_buffer_sizes(
 
 Status RestClient::get_query_est_result_sizes(const URI& uri, Query* query) {
   if (query == nullptr)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error getting query estimated result size from REST; Query is null."));
 
   // Get array
   const Array* array = query->array();
   if (array == nullptr) {
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error festing query estimated result size from REST; null array."));
   }
 
@@ -773,7 +773,7 @@ Status RestClient::get_query_est_result_sizes(const URI& uri, Query* query) {
       &returned_data,
       cache_key));
   if (returned_data.data() == nullptr || returned_data.size() == 0)
-    return LOG_STATUS(Status::RestError(
+    return LOG_STATUS(Status_RestError(
         "Error getting array metadata from REST; server returned no data."));
 
   return serialization::query_est_result_size_deserialize(
@@ -826,33 +826,33 @@ RestClient::RestClient() {
 }
 
 Status RestClient::init(stats::Stats*, const Config*, ThreadPool*) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::set_header(const std::string&, const std::string&) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_array_schema_from_rest(const URI&, ArraySchema**) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::post_array_schema_to_rest(const URI&, ArraySchema*) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::deregister_array_from_rest(const URI&) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_array_non_empty_domain(Array*, uint64_t, uint64_t) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_array_max_buffer_sizes(
@@ -860,41 +860,41 @@ Status RestClient::get_array_max_buffer_sizes(
     const ArraySchema*,
     const void*,
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_array_metadata_from_rest(
     const URI&, uint64_t, uint64_t, Array*) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::post_array_metadata_to_rest(
     const URI&, uint64_t, uint64_t, Array*) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::submit_query_to_rest(const URI&, Query*) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::finalize_query_to_rest(const URI&, Query*) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_query_est_result_sizes(const URI&, Query*) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::post_array_schema_evolution_to_rest(
     const URI&, ArraySchemaEvolution*) {
-  return LOG_STATUS(
-      Status::RestError("Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(Status_RestError(
+      "Cannot use rest client; serialization not enabled."));
 }
 
 #endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -220,7 +220,7 @@ Status RestClient::get_array_non_empty_domain(
   if (returned_data.data() == nullptr || returned_data.size() == 0)
     return LOG_STATUS(
         Status_RestError("Error getting array non-empty domain "
-                          "from REST; server returned no data."));
+                         "from REST; server returned no data."));
 
   // Deserialize data returned
   return serialization::nonempty_domain_deserialize(
@@ -258,7 +258,7 @@ Status RestClient::get_array_max_buffer_sizes(
   if (returned_data.data() == nullptr || returned_data.size() == 0)
     return LOG_STATUS(
         Status_RestError("Error getting array max buffer sizes "
-                          "from REST; server returned no data."));
+                         "from REST; server returned no data."));
 
   // Deserialize data returned
   return serialization::max_buffer_sizes_deserialize(
@@ -826,33 +826,33 @@ RestClient::RestClient() {
 }
 
 Status RestClient::init(stats::Stats*, const Config*, ThreadPool*) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::set_header(const std::string&, const std::string&) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_array_schema_from_rest(const URI&, ArraySchema**) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::post_array_schema_to_rest(const URI&, ArraySchema*) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::deregister_array_from_rest(const URI&) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_array_non_empty_domain(Array*, uint64_t, uint64_t) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_array_max_buffer_sizes(
@@ -860,41 +860,41 @@ Status RestClient::get_array_max_buffer_sizes(
     const ArraySchema*,
     const void*,
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_array_metadata_from_rest(
     const URI&, uint64_t, uint64_t, Array*) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::post_array_metadata_to_rest(
     const URI&, uint64_t, uint64_t, Array*) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::submit_query_to_rest(const URI&, Query*) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::finalize_query_to_rest(const URI&, Query*) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::get_query_est_result_sizes(const URI&, Query*) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 Status RestClient::post_array_schema_evolution_to_rest(
     const URI&, ArraySchemaEvolution*) {
-  return LOG_STATUS(Status_RestError(
-      "Cannot use rest client; serialization not enabled."));
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
 #endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -292,12 +292,11 @@ Status RTree::serialize(Buffer* buff) const {
 
 Status RTree::set_leaf(uint64_t leaf_id, const NDRange& mbr) {
   if (levels_.size() != 1)
-    return LOG_STATUS(Status::RTreeError(
+    return LOG_STATUS(Status_RTreeError(
         "Cannot set leaf; There are more than one levels in the tree"));
 
   if (leaf_id >= levels_[0].size())
-    return LOG_STATUS(
-        Status::RTreeError("Cannot set leaf; Invalid lead index"));
+    return LOG_STATUS(Status_RTreeError("Cannot set leaf; Invalid lead index"));
 
   levels_[0][leaf_id] = mbr;
 
@@ -317,9 +316,9 @@ Status RTree::set_leaf_num(uint64_t num) {
     levels_.resize(1);
 
   if (num < levels_[0].size())
-    return LOG_STATUS(
-        Status::RTreeError("Cannot set number of leaves; provided number "
-                           "cannot be smaller than the current leaf number"));
+    return LOG_STATUS(Status_RTreeError(
+        "Cannot set number of leaves; provided number "
+        "cannot be smaller than the current leaf number"));
 
   levels_[0].resize(num);
   return Status::Ok();

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -316,9 +316,9 @@ Status RTree::set_leaf_num(uint64_t num) {
     levels_.resize(1);
 
   if (num < levels_[0].size())
-    return LOG_STATUS(Status_RTreeError(
-        "Cannot set number of leaves; provided number "
-        "cannot be smaller than the current leaf number"));
+    return LOG_STATUS(
+        Status_RTreeError("Cannot set number of leaves; provided number "
+                          "cannot be smaller than the current leaf number"));
 
   levels_[0].resize(num);
   return Status::Ok();

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -66,7 +66,7 @@ Status filter_pipeline_to_capnp(
     const FilterPipeline* filter_pipeline,
     capnp::FilterPipeline::Builder* filter_pipeline_builder) {
   if (filter_pipeline == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing filter pipeline; filter pipeline is null."));
 
   const unsigned num_filters = filter_pipeline->size();
@@ -130,7 +130,7 @@ Status filter_pipeline_from_capnp(
     RETURN_NOT_OK(filter_type_enum(filter_reader.getType().cStr(), &type));
     tdb_unique_ptr<Filter> filter(FilterCreate::make(type));
     if (filter == nullptr)
-      return LOG_STATUS(Status::SerializationError(
+      return LOG_STATUS(Status_SerializationError(
           "Error deserializing filter pipeline; failed to create filter."));
 
     switch (filter->type()) {
@@ -173,7 +173,7 @@ Status filter_pipeline_from_capnp(
 Status attribute_to_capnp(
     const Attribute* attribute, capnp::Attribute::Builder* attribute_builder) {
   if (attribute == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing attribute; attribute is null."));
 
   attribute_builder->setName(attribute->name());
@@ -256,7 +256,7 @@ Status attribute_from_capnp(
 Status dimension_to_capnp(
     const Dimension* dimension, capnp::Dimension::Builder* dimension_builder) {
   if (dimension == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing dimension; dimension is null."));
 
   dimension_builder->setName(dimension->name());
@@ -386,7 +386,7 @@ Status dimension_from_capnp(
         break;
       }
       default:
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing dimension; unknown datatype."));
     }
   }
@@ -397,7 +397,7 @@ Status dimension_from_capnp(
 Status domain_to_capnp(
     const Domain* domain, capnp::Domain::Builder* domainBuilder) {
   if (domain == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing domain; domain is null."));
 
   domainBuilder->setType(datatype_str(domain->dimension(0)->type()));
@@ -436,7 +436,7 @@ Status array_schema_to_capnp(
     capnp::ArraySchema::Builder* array_schema_builder,
     const bool client_side) {
   if (array_schema == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing array schema; array schema is null."));
 
   // Only set the URI if client side
@@ -597,18 +597,18 @@ Status array_schema_serialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error serializing array schema; Unknown serialization type "
             "passed"));
       }
     }
 
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing array schema; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing array schema; exception " + std::string(e.what())));
   }
 
@@ -650,23 +650,23 @@ Status array_schema_deserialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing array schema; Unknown serialization type "
             "passed"));
       }
     }
 
     if (decoded_array_schema == nullptr)
-      return LOG_STATUS(Status::SerializationError(
+      return LOG_STATUS(Status_SerializationError(
           "Error serializing array schema; deserialized schema is null"));
 
     *array_schema = decoded_array_schema.release();
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing array schema; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing array schema; exception " +
         std::string(e.what())));
   }
@@ -681,7 +681,7 @@ Status nonempty_domain_serialize(
     SerializationType serialize_type,
     Buffer* serialized_buffer) {
   if (!is_empty && nonempty_domain == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; nonempty domain is null."));
 
   try {
@@ -721,18 +721,18 @@ Status nonempty_domain_serialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error serializing nonempty domain; Unknown serialization type "
             "passed"));
       }
     }
 
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; exception " +
         std::string(e.what())));
   }
@@ -747,7 +747,7 @@ Status nonempty_domain_deserialize(
     void* nonempty_domain,
     bool* is_empty) {
   if (nonempty_domain == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing nonempty domain; nonempty domain is null."));
 
   try {
@@ -794,17 +794,17 @@ Status nonempty_domain_deserialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing nonempty domain; Unknown serialization type "
             "passed"));
       }
     }
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing nonempty domain; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing nonempty domain; exception " +
         std::string(e.what())));
   }
@@ -819,12 +819,12 @@ Status nonempty_domain_serialize(
     SerializationType serialize_type,
     Buffer* serialized_buffer) {
   if (!is_empty && nonempty_domain == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; nonempty domain is null."));
 
   const auto* schema = array->array_schema_latest();
   if (schema == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; array schema is null."));
 
   try {
@@ -864,18 +864,18 @@ Status nonempty_domain_serialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error serializing nonempty domain; Unknown serialization type "
             "passed"));
       }
     }
 
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; exception " +
         std::string(e.what())));
   }
@@ -890,12 +890,12 @@ Status nonempty_domain_deserialize(
     void* nonempty_domain,
     bool* is_empty) {
   if (nonempty_domain == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing nonempty domain; nonempty domain is null."));
 
   const auto* schema = array->array_schema_latest();
   if (schema == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing nonempty domain; array schema is null."));
 
   try {
@@ -948,17 +948,17 @@ Status nonempty_domain_deserialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing nonempty domain; Unknown serialization type "
             "passed"));
       }
     }
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing nonempty domain; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing nonempty domain; exception " +
         std::string(e.what())));
   }
@@ -970,7 +970,7 @@ Status nonempty_domain_serialize(
     Array* array, SerializationType serialize_type, Buffer* serialized_buffer) {
   const auto* schema = array->array_schema_latest();
   if (schema == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; array schema is null."));
 
   try {
@@ -1005,18 +1005,18 @@ Status nonempty_domain_serialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error serializing nonempty domain; Unknown serialization type "
             "passed"));
       }
     }
 
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing nonempty domain; exception " +
         std::string(e.what())));
   }
@@ -1056,17 +1056,17 @@ Status nonempty_domain_deserialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing nonempty domain; Unknown serialization type "
             "passed"));
       }
     }
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing nonempty domain; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing nonempty domain; exception " +
         std::string(e.what())));
   }
@@ -1081,7 +1081,7 @@ Status max_buffer_sizes_serialize(
     Buffer* serialized_buffer) {
   const auto* schema = array->array_schema_latest();
   if (schema == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing max buffer sizes; array schema is null."));
 
   try {
@@ -1147,18 +1147,18 @@ Status max_buffer_sizes_serialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error serializing max buffer sizes; Unknown serialization type "
             "passed"));
       }
     }
 
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing max buffer sizes; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing max buffer sizes; exception " +
         std::string(e.what())));
   }
@@ -1173,7 +1173,7 @@ Status max_buffer_sizes_deserialize(
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*
         buffer_sizes) {
   if (schema == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing max buffer sizes; array schema is null."));
 
   try {
@@ -1232,17 +1232,17 @@ Status max_buffer_sizes_deserialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing max buffer sizes; Unknown serialization type "
             "passed"));
       }
     }
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing max buffer sizes; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing max buffer sizes; exception " +
         std::string(e.what())));
   }
@@ -1253,7 +1253,7 @@ Status max_buffer_sizes_deserialize(
 Status array_metadata_serialize(
     Array* array, SerializationType serialize_type, Buffer* serialized_buffer) {
   if (array == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing array metadata; array instance is null"));
 
   Metadata* metadata;
@@ -1261,7 +1261,7 @@ Status array_metadata_serialize(
   RETURN_NOT_OK(array->metadata(&metadata));
 
   if (metadata == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing array metadata; array metadata instance is null"));
 
   try {
@@ -1308,18 +1308,18 @@ Status array_metadata_serialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error serializing array metadata; Unknown serialization type "
             "passed"));
       }
     }
 
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing array metadata; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing array metadata; exception " +
         std::string(e.what())));
   }
@@ -1332,10 +1332,10 @@ Status array_metadata_deserialize(
     SerializationType serialize_type,
     const Buffer& serialized_buffer) {
   if (array == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing array metadata; null array instance given."));
   if (array->metadata() == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing array metadata; null metadata instance."));
 
   Metadata* metadata = array->metadata();
@@ -1364,7 +1364,7 @@ Status array_metadata_deserialize(
           auto value_ptr = entry_reader.getValue();
           const void* value = (void*)value_ptr.begin();
           if (value_ptr.size() != datatype_size(type) * value_num)
-            return LOG_STATUS(Status::SerializationError(
+            return LOG_STATUS(Status_SerializationError(
                 "Error deserializing array metadata; value size sanity check "
                 "failed."));
 
@@ -1398,7 +1398,7 @@ Status array_metadata_deserialize(
           auto value_ptr = entry_reader.getValue();
           const void* value = (void*)value_ptr.begin();
           if (value_ptr.size() != datatype_size(type) * value_num)
-            return LOG_STATUS(Status::SerializationError(
+            return LOG_STATUS(Status_SerializationError(
                 "Error deserializing array metadata; value size sanity check "
                 "failed."));
 
@@ -1412,17 +1412,17 @@ Status array_metadata_deserialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing array metadata; Unknown serialization type "
             "passed"));
       }
     }
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing array metadata; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing array metadata; exception " +
         std::string(e.what())));
   }
@@ -1434,41 +1434,41 @@ Status array_metadata_deserialize(
 
 Status array_schema_serialize(
     ArraySchema*, SerializationType, Buffer*, const bool) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status array_schema_deserialize(
     ArraySchema**, SerializationType, const Buffer&) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status nonempty_domain_serialize(Array*, SerializationType, Buffer*) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status nonempty_domain_deserialize(Array*, const Buffer&, SerializationType) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status nonempty_domain_serialize(
     const Array*, const void*, bool, SerializationType, Buffer*) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status nonempty_domain_deserialize(
     const Array*, const Buffer&, SerializationType, void*, bool*) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status max_buffer_sizes_serialize(
     Array*, const void*, SerializationType, Buffer*) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
@@ -1477,17 +1477,17 @@ Status max_buffer_sizes_deserialize(
     const Buffer&,
     SerializationType,
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status array_metadata_serialize(Array*, SerializationType, Buffer*) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status array_metadata_deserialize(Array*, SerializationType, const Buffer&) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -397,8 +397,8 @@ Status dimension_from_capnp(
 Status domain_to_capnp(
     const Domain* domain, capnp::Domain::Builder* domainBuilder) {
   if (domain == nullptr)
-    return LOG_STATUS(Status_SerializationError(
-        "Error serializing domain; domain is null."));
+    return LOG_STATUS(
+        Status_SerializationError("Error serializing domain; domain is null."));
 
   domainBuilder->setType(datatype_str(domain->dimension(0)->type()));
   domainBuilder->setTileOrder(layout_str(domain->tile_order()));

--- a/tiledb/sm/serialization/array_schema_evolution.cc
+++ b/tiledb/sm/serialization/array_schema_evolution.cc
@@ -69,7 +69,7 @@ Status array_schema_evolution_to_capnp(
   if (array_schema_evolution == nullptr)
     return LOG_STATUS(
         Status_SerializationError("Error serializing array schema evolution; "
-                                   "array schema evolution is null."));
+                                  "array schema evolution is null."));
 
   // Attributes to drop
   std::vector<std::string> attr_names_to_drop =
@@ -166,8 +166,8 @@ Status array_schema_evolution_serialize(
       default: {
         return LOG_STATUS(
             Status_SerializationError("Error serializing array schema "
-                                       "evolution; Unknown serialization type "
-                                       "passed"));
+                                      "evolution; Unknown serialization type "
+                                      "passed"));
       }
     }
 
@@ -222,8 +222,8 @@ Status array_schema_evolution_deserialize(
       default: {
         return LOG_STATUS(
             Status_SerializationError("Error deserializing array schema "
-                                       "evolution; Unknown serialization type "
-                                       "passed"));
+                                      "evolution; Unknown serialization type "
+                                      "passed"));
       }
     }
 

--- a/tiledb/sm/serialization/array_schema_evolution.cc
+++ b/tiledb/sm/serialization/array_schema_evolution.cc
@@ -68,7 +68,7 @@ Status array_schema_evolution_to_capnp(
     const bool client_side) {
   if (array_schema_evolution == nullptr)
     return LOG_STATUS(
-        Status::SerializationError("Error serializing array schema evolution; "
+        Status_SerializationError("Error serializing array schema evolution; "
                                    "array schema evolution is null."));
 
   // Attributes to drop
@@ -165,18 +165,18 @@ Status array_schema_evolution_serialize(
       }
       default: {
         return LOG_STATUS(
-            Status::SerializationError("Error serializing array schema "
+            Status_SerializationError("Error serializing array schema "
                                        "evolution; Unknown serialization type "
                                        "passed"));
       }
     }
 
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing array schema evolution; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing array schema evolution; exception " +
         std::string(e.what())));
   }
@@ -221,24 +221,24 @@ Status array_schema_evolution_deserialize(
       }
       default: {
         return LOG_STATUS(
-            Status::SerializationError("Error deserializing array schema "
+            Status_SerializationError("Error deserializing array schema "
                                        "evolution; Unknown serialization type "
                                        "passed"));
       }
     }
 
     if (decoded_array_schema_evolution == nullptr)
-      return LOG_STATUS(Status::SerializationError(
+      return LOG_STATUS(Status_SerializationError(
           "Error serializing array schema evolution; deserialized schema "
           "evolution is null"));
 
     *array_schema_evolution = decoded_array_schema_evolution.release();
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing array schema evolution; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing array schema evolution; exception " +
         std::string(e.what())));
   }
@@ -250,13 +250,13 @@ Status array_schema_evolution_deserialize(
 
 Status array_schema_evolution_serialize(
     ArraySchemaEvolution*, SerializationType, Buffer*, const bool) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status array_schema_evolution_deserialize(
     ArraySchemaEvolution**, SerializationType, const Buffer&) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -187,7 +187,7 @@ Status set_capnp_array_ptr(
       builder.setFloat64(kj::arrayPtr(static_cast<const double*>(ptr), size));
       break;
     default:
-      return Status::SerializationError(
+      return Status_SerializationError(
           "Cannot set capnp array pointer; unknown TileDB datatype.");
   }
 
@@ -262,7 +262,7 @@ Status set_capnp_scalar(
       builder.setFloat64(*static_cast<const double*>(value));
       break;
     default:
-      return Status::SerializationError(
+      return Status_SerializationError(
           "Cannot set capnp scalar; unknown TileDB datatype.");
   }
 
@@ -378,7 +378,7 @@ Status copy_capnp_list(
         RETURN_NOT_OK(copy_capnp_list<double>(reader.getFloat64(), buffer));
       break;
     default:
-      return Status::SerializationError(
+      return Status_SerializationError(
           "Cannot copy capnp list; unhandled TileDB datatype.");
   }
 
@@ -492,7 +492,7 @@ Status serialize_subarray(
     const auto coords_type = dimension->type();
 
     if (coords_type != first_dimension_datatype) {
-      return Status::SerializationError(
+      return Status_SerializationError(
           "Subarray dimension datatypes must be homogeneous");
     }
 
@@ -506,7 +506,7 @@ Status serialize_subarray(
       case tiledb::sm::Datatype::STRING_UCS4:
       case tiledb::sm::Datatype::ANY:
         // String dimensions not yet supported
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Cannot serialize subarray; unsupported domain type."));
       default:
         break;
@@ -537,7 +537,7 @@ Status deserialize_subarray(
     const auto coords_type = dimension->type();
 
     if (coords_type != first_dimension_datatype) {
-      return Status::SerializationError(
+      return Status_SerializationError(
           "Subarray dimension datatypes must be homogeneous");
     }
 
@@ -551,7 +551,7 @@ Status deserialize_subarray(
       case tiledb::sm::Datatype::STRING_UCS4:
       case tiledb::sm::Datatype::ANY:
         // String dimensions not yet supported
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Cannot deserialize subarray; unsupported domain type."));
       default:
         break;

--- a/tiledb/sm/serialization/config.cc
+++ b/tiledb/sm/serialization/config.cc
@@ -62,7 +62,7 @@ namespace serialization {
 Status config_to_capnp(
     const Config* config, capnp::Config::Builder* config_builder) {
   if (config == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing config; config is null."));
 
   auto entries = config_builder->initEntries(config->param_values().size());
@@ -141,18 +141,18 @@ Status config_serialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error serializing config; Unknown serialization type "
             "passed"));
       }
     }
 
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing config; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error serializing config; exception " + std::string(e.what())));
   }
 
@@ -190,23 +190,23 @@ Status config_deserialize(
         break;
       }
       default: {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing config; Unknown serialization type "
             "passed"));
       }
     }
 
     if (decoded_config == nullptr)
-      return LOG_STATUS(Status::SerializationError(
+      return LOG_STATUS(Status_SerializationError(
           "Error serializing config; deserialized config is null"));
 
     *config = decoded_config.release();
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing config; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing config; exception " + std::string(e.what())));
   }
 
@@ -216,12 +216,12 @@ Status config_deserialize(
 #else
 
 Status config_serialize(Config*, SerializationType, Buffer*, const bool) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status config_deserialize(Config**, SerializationType, const Buffer&) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot deserialize; serialization not enabled."));
 }
 

--- a/tiledb/sm/serialization/config.cc
+++ b/tiledb/sm/serialization/config.cc
@@ -62,8 +62,8 @@ namespace serialization {
 Status config_to_capnp(
     const Config* config, capnp::Config::Builder* config_builder) {
   if (config == nullptr)
-    return LOG_STATUS(Status_SerializationError(
-        "Error serializing config; config is null."));
+    return LOG_STATUS(
+        Status_SerializationError("Error serializing config; config is null."));
 
   auto entries = config_builder->initEntries(config->param_values().size());
   uint64_t i = 0;

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1051,7 +1051,7 @@ Status query_to_capnp(Query& query, capnp::Query::Builder* query_builder) {
   if (layout == Layout::GLOBAL_ORDER && query.type() == QueryType::WRITE)
     return LOG_STATUS(
         Status_SerializationError("Cannot serialize; global order "
-                                   "serialization not supported for writes."));
+                                  "serialization not supported for writes."));
 
   if (array == nullptr)
     return LOG_STATUS(
@@ -1238,13 +1238,13 @@ Status query_from_capnp(
 
   const auto* schema = query->array_schema();
   if (schema == nullptr)
-    return LOG_STATUS(Status_SerializationError(
-        "Cannot deserialize; array schema is null."));
+    return LOG_STATUS(
+        Status_SerializationError("Cannot deserialize; array schema is null."));
 
   const auto* domain = schema->domain();
   if (domain == nullptr)
-    return LOG_STATUS(Status_SerializationError(
-        "Cannot deserialize; array domain is null."));
+    return LOG_STATUS(
+        Status_SerializationError("Cannot deserialize; array domain is null."));
 
   if (array == nullptr)
     return LOG_STATUS(Status_SerializationError(
@@ -2285,8 +2285,8 @@ Status query_est_result_size_deserialize(
       default: {
         return LOG_STATUS(
             Status_SerializationError("Error deserializing query est result "
-                                       "size; Unknown serialization type "
-                                       "passed"));
+                                      "size; Unknown serialization type "
+                                      "passed"));
       }
     }
   } catch (kj::Exception& e) {

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1050,22 +1050,22 @@ Status query_to_capnp(Query& query, capnp::Query::Builder* query_builder) {
 
   if (layout == Layout::GLOBAL_ORDER && query.type() == QueryType::WRITE)
     return LOG_STATUS(
-        Status::SerializationError("Cannot serialize; global order "
+        Status_SerializationError("Cannot serialize; global order "
                                    "serialization not supported for writes."));
 
   if (array == nullptr)
     return LOG_STATUS(
-        Status::SerializationError("Cannot serialize; array is null."));
+        Status_SerializationError("Cannot serialize; array is null."));
 
   const auto* schema = query.array_schema();
   if (schema == nullptr)
     return LOG_STATUS(
-        Status::SerializationError("Cannot serialize; array schema is null."));
+        Status_SerializationError("Cannot serialize; array schema is null."));
 
   const auto* domain = schema->domain();
   if (domain == nullptr)
     return LOG_STATUS(
-        Status::SerializationError("Cannot serialize; array domain is null."));
+        Status_SerializationError("Cannot serialize; array domain is null."));
 
   // Serialize basic fields
   query_builder->setType(query_type_str(type));
@@ -1238,23 +1238,23 @@ Status query_from_capnp(
 
   const auto* schema = query->array_schema();
   if (schema == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; array schema is null."));
 
   const auto* domain = schema->domain();
   if (domain == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; array domain is null."));
 
   if (array == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; array pointer is null."));
 
   // Deserialize query type (sanity check).
   QueryType query_type = QueryType::READ;
   RETURN_NOT_OK(query_type_enum(query_reader.getType().cStr(), &query_type));
   if (query_type != type)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; Query opened for " + query_type_str(type) +
         " but got serialized type for " + query_reader.getType().cStr()));
 
@@ -1278,7 +1278,7 @@ Status query_from_capnp(
 
   // Deserialize and set attribute buffers.
   if (!query_reader.hasAttributeBufferHeaders())
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; no attribute buffer headers in message."));
 
   auto buffer_headers = query_reader.getAttributeBufferHeaders();
@@ -1430,7 +1430,7 @@ Status query_from_capnp(
           (var_size && offset_size_left >= fixedlen_size) || !var_size;
       const bool has_mem_for_validity = validity_size_left >= validitylen_size;
       if (!has_mem_for_data || !has_mem_for_offset || !has_mem_for_validity) {
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing read query; buffer too small for buffer "
             "'" +
             name + "'."));
@@ -1550,7 +1550,7 @@ Status query_from_capnp(
       // Always expect null buffers when deserializing.
       if (existing_buffer != nullptr || existing_offset_buffer != nullptr ||
           existing_validity_buffer != nullptr)
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Error deserializing read query; unexpected "
             "buffer set on server-side."));
 
@@ -1901,12 +1901,12 @@ Status query_serialize(
     bool clientside,
     BufferList* serialized_buffer) {
   if (serialize_type == SerializationType::JSON)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot serialize query; json format not supported."));
 
   const auto* array_schema = query->array_schema();
   if (array_schema == nullptr || query->array() == nullptr)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot serialize; array or array schema is null."));
 
   try {
@@ -1981,15 +1981,15 @@ Status query_serialize(
         break;
       }
       default:
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Cannot serialize; unknown serialization type"));
     }
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot serialize; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot serialize; exception: " + std::string(e.what())));
   }
 
@@ -2004,7 +2004,7 @@ Status do_query_deserialize(
     Query* query,
     ThreadPool* compute_tp) {
   if (serialize_type == SerializationType::JSON)
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize query; json format not supported."));
 
   try {
@@ -2025,7 +2025,7 @@ Status do_query_deserialize(
       case SerializationType::CAPNP: {
         // Capnp FlatArrayMessageReader requires 64-bit alignment.
         if (!utils::is_aligned<sizeof(uint64_t)>(serialized_buffer.cur_data()))
-          return LOG_STATUS(Status::SerializationError(
+          return LOG_STATUS(Status_SerializationError(
               "Could not deserialize query; buffer is not 8-byte aligned."));
 
         // Set traversal limit to 10GI (TODO: make this a config option)
@@ -2049,15 +2049,15 @@ Status do_query_deserialize(
             query_reader, context, buffer_start, copy_state, query, compute_tp);
       }
       default:
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Cannot deserialize; unknown serialization type."));
     }
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; exception: " + std::string(e.what())));
   }
   return Status::Ok();
@@ -2233,15 +2233,15 @@ Status query_est_result_size_serialize(
         break;
       }
       default:
-        return LOG_STATUS(Status::SerializationError(
+        return LOG_STATUS(Status_SerializationError(
             "Cannot serialize; unknown serialization type"));
     }
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot serialize; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Cannot serialize; exception: " + std::string(e.what())));
   }
 
@@ -2284,17 +2284,17 @@ Status query_est_result_size_deserialize(
       }
       default: {
         return LOG_STATUS(
-            Status::SerializationError("Error deserializing query est result "
+            Status_SerializationError("Error deserializing query est result "
                                        "size; Unknown serialization type "
                                        "passed"));
       }
     }
   } catch (kj::Exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing query est result size; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
-    return LOG_STATUS(Status::SerializationError(
+    return LOG_STATUS(Status_SerializationError(
         "Error deserializing query est result size; exception " +
         std::string(e.what())));
   }
@@ -2305,25 +2305,25 @@ Status query_est_result_size_deserialize(
 #else
 
 Status query_serialize(Query*, SerializationType, bool, BufferList*) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status query_deserialize(
     const Buffer&, SerializationType, bool, CopyState*, Query*, ThreadPool*) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot deserialize; serialization not enabled."));
 }
 
 Status query_est_result_size_serialize(
     Query*, SerializationType, bool, Buffer*) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot serialize; serialization not enabled."));
 }
 
 Status query_est_result_size_deserialize(
     Query*, SerializationType, bool, const Buffer&) {
-  return LOG_STATUS(Status::SerializationError(
+  return LOG_STATUS(Status_SerializationError(
       "Cannot deserialize; serialization not enabled."));
 }
 

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -906,9 +906,9 @@ Status Consolidator::set_config(const Config* config) {
         "Invalid configuration; Step size ratio config parameter must be in "
         "[0.0, 1.0]"));
   if (config_.amplification_ < 0)
-    return logger_->status(Status_ConsolidatorError(
-        "Invalid configuration; Amplification config "
-        "parameter must be non-negative"));
+    return logger_->status(
+        Status_ConsolidatorError("Invalid configuration; Amplification config "
+                                 "parameter must be non-negative"));
 
   return Status::Ok();
 }

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -92,7 +92,7 @@ Status Consolidator::consolidate(
     return consolidate_array_meta(
         array_name, encryption_type, encryption_key, key_length);
 
-  return logger_->status(Status::ConsolidatorError(
+  return logger_->status(Status_ConsolidatorError(
       "Cannot consolidate; Invalid consolidation mode"));
 }
 
@@ -882,7 +882,7 @@ Status Consolidator::set_config(const Config* config) {
   assert(found);
   const std::string mode = merged_config.get("sm.consolidation.mode", &found);
   if (!found)
-    return logger_->status(Status::ConsolidatorError(
+    return logger_->status(Status_ConsolidatorError(
         "Cannot consolidate; Consolidation mode cannot be null"));
   config_.mode_ = mode;
   RETURN_NOT_OK(merged_config.get<uint64_t>(
@@ -898,17 +898,17 @@ Status Consolidator::set_config(const Config* config) {
 
   // Sanity checks
   if (config_.min_frags_ > config_.max_frags_)
-    return logger_->status(Status::ConsolidatorError(
+    return logger_->status(Status_ConsolidatorError(
         "Invalid configuration; Minimum fragments config parameter is larger "
         "than the maximum"));
   if (config_.size_ratio_ > 1.0f || config_.size_ratio_ < 0.0f)
-    return logger_->status(Status::ConsolidatorError(
+    return logger_->status(Status_ConsolidatorError(
         "Invalid configuration; Step size ratio config parameter must be in "
         "[0.0, 1.0]"));
   if (config_.amplification_ < 0)
-    return logger_->status(
-        Status::ConsolidatorError("Invalid configuration; Amplification config "
-                                  "parameter must be non-negative"));
+    return logger_->status(Status_ConsolidatorError(
+        "Invalid configuration; Amplification config "
+        "parameter must be non-negative"));
 
   return Status::Ok();
 }

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -76,7 +76,7 @@ Status Context::init(Config* const config) {
   RETURN_NOT_OK(init_loggers(config));
 
   if (storage_manager_ != nullptr)
-    return logger_->status(Status::ContextError(
+    return logger_->status(Status_ContextError(
         "Cannot initialize context; Context already initialized"));
 
   // Initialize `compute_tp_` and `io_tp_`.
@@ -89,7 +89,7 @@ Status Context::init(Config* const config) {
   storage_manager_ = new (std::nothrow)
       tiledb::sm::StorageManager(&compute_tp_, &io_tp_, stats_.get(), logger_);
   if (storage_manager_ == nullptr)
-    return logger_->status(Status::ContextError(
+    return logger_->status(Status_ContextError(
         "Cannot initialize context Storage manager allocation failed"));
 
   // Initialize storage manager
@@ -145,7 +145,7 @@ Status Context::init_thread_pools(Config* const config) {
       "sm.num_async_threads", &num_async_threads, &found));
   if (found) {
     max_thread_count = std::max(max_thread_count, num_async_threads);
-    logger_->status(Status::StorageManagerError(
+    logger_->status(Status_StorageManagerError(
         "Config parameter \"sm.num_async_threads\" has been removed; use "
         "config parameter \"sm.compute_concurrency_level\"."));
   }
@@ -155,7 +155,7 @@ Status Context::init_thread_pools(Config* const config) {
       "sm.num_reader_threads", &num_reader_threads, &found));
   if (found) {
     max_thread_count = std::max(max_thread_count, num_reader_threads);
-    logger_->status(Status::StorageManagerError(
+    logger_->status(Status_StorageManagerError(
         "Config parameter \"sm.num_reader_threads\" has been removed; use "
         "config parameter \"sm.compute_concurrency_level\"."));
   }
@@ -165,7 +165,7 @@ Status Context::init_thread_pools(Config* const config) {
       "sm.num_writer_threads", &num_writer_threads, &found));
   if (found) {
     max_thread_count = std::max(max_thread_count, num_writer_threads);
-    logger_->status(Status::StorageManagerError(
+    logger_->status(Status_StorageManagerError(
         "Config parameter \"sm.num_writer_threads\" has been removed; use "
         "config parameter \"sm.compute_concurrency_level\"."));
   }
@@ -175,7 +175,7 @@ Status Context::init_thread_pools(Config* const config) {
       tmp_config.get<uint64_t>("sm.num_vfs_threads", &num_vfs_threads, &found));
   if (found) {
     max_thread_count = std::max(max_thread_count, num_vfs_threads);
-    logger_->status(Status::StorageManagerError(
+    logger_->status(Status_StorageManagerError(
         "Config parameter \"sm.num_vfs_threads\" has been removed; use "
         "config parameter \"sm.io_concurrency_level\"."));
   }
@@ -240,7 +240,7 @@ Status Context::init_loggers(Config* const config) {
       tmp_config.get<uint32_t>("config.logging_level", &level, &found));
   assert(found);
   if (level > static_cast<unsigned int>(Logger::Level::TRACE)) {
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot set logger level; Unsupported level:" + std::to_string(level) +
         "set in configuration"));
   }

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -528,8 +528,8 @@ Status StorageManager::array_consolidate(
   // Check array URI
   URI array_uri(array_name);
   if (array_uri.is_invalid()) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot consolidate array; Invalid URI"));
+    return logger_->status(
+        Status_StorageManagerError("Cannot consolidate array; Invalid URI"));
   }
 
   // Check if array exists
@@ -621,8 +621,8 @@ Status StorageManager::array_vacuum(
     RETURN_NOT_OK(
         array_vacuum_array_meta(array_name, timestamp_start, timestamp_end));
   else
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum array; Invalid vacuum mode"));
+    return logger_->status(
+        Status_StorageManagerError("Cannot vacuum array; Invalid vacuum mode"));
 
   return Status::Ok();
 }
@@ -815,8 +815,8 @@ Status StorageManager::array_create(
     const EncryptionKey& encryption_key) {
   // Check array schema
   if (array_schema == nullptr) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot create array; Empty array schema"));
+    return logger_->status(
+        Status_StorageManagerError("Cannot create array; Empty array schema"));
   }
 
   // Check if array exists
@@ -1120,8 +1120,7 @@ Status StorageManager::array_get_non_empty_domain_from_index(
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
     errmsg += array_domain->dimension(idx)->name();
     errmsg += "' is variable-sized";
-    return logger_->status(
-        Status_StorageManagerError(errmsg));
+    return logger_->status(Status_StorageManagerError(errmsg));
   }
 
   NDRange dom;
@@ -1153,8 +1152,7 @@ Status StorageManager::array_get_non_empty_domain_from_name(
       if (array_domain->dimension(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is variable-sized";
-        return logger_->status(
-            Status_StorageManagerError(errmsg));
+        return logger_->status(Status_StorageManagerError(errmsg));
       }
 
       if (!*is_empty)
@@ -1186,8 +1184,7 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_index(
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
     errmsg += array_domain->dimension(idx)->name();
     errmsg += "' is fixed-sized";
-    return logger_->status(
-        Status_StorageManagerError(errmsg));
+    return logger_->status(Status_StorageManagerError(errmsg));
   }
 
   NDRange dom;
@@ -1228,8 +1225,7 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_name(
       if (!array_domain->dimension(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is fixed-sized";
-        return logger_->status(
-            Status_StorageManagerError(errmsg));
+        return logger_->status(Status_StorageManagerError(errmsg));
       }
 
       if (*is_empty) {
@@ -1263,8 +1259,7 @@ Status StorageManager::array_get_non_empty_domain_var_from_index(
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
     errmsg += array_domain->dimension(idx)->name();
     errmsg += "' is fixed-sized";
-    return logger_->status(
-        Status_StorageManagerError(errmsg));
+    return logger_->status(Status_StorageManagerError(errmsg));
   }
 
   NDRange dom;
@@ -1299,8 +1294,7 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
       if (!array_domain->dimension(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is fixed-sized";
-        return logger_->status(
-            Status_StorageManagerError(errmsg));
+        return logger_->status(Status_StorageManagerError(errmsg));
       }
 
       if (!*is_empty) {
@@ -1883,7 +1877,8 @@ Status StorageManager::get_latest_array_schema_uri(
   }
   *uri = schema_uris.back();
   if (uri->is_invalid()) {
-    return logger_->status(Status_StorageManagerError("Could not find array schema URI"));
+    return logger_->status(
+        Status_StorageManagerError("Could not find array schema URI"));
   }
 
   return Status::Ok();
@@ -2495,8 +2490,8 @@ Status StorageManager::array_open_without_fragments(
   if (!vfs_->supports_uri_scheme(array_uri))
     return logger_->status(
         Status_StorageManagerError("Cannot open array; "
-                                           "URI scheme "
-                                           "unsupported."));
+                                   "URI scheme "
+                                   "unsupported."));
 
   // Lock mutexes
   {

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -110,7 +110,7 @@ StorageManager::~StorageManager() {
   if (vfs_ != nullptr) {
     const Status st = vfs_->terminate();
     if (!st.ok()) {
-      logger_->status(Status::StorageManagerError("Failed to terminate VFS."));
+      logger_->status(Status_StorageManagerError("Failed to terminate VFS."));
     }
 
     tdb_delete(vfs_);
@@ -307,7 +307,7 @@ std::tuple<
 StorageManager::array_open_for_writes(
     const URI& array_uri, const EncryptionKey& encryption_key) {
   if (!vfs_->supports_uri_scheme(array_uri))
-    return {logger_->status(Status::StorageManagerError(
+    return {logger_->status(Status_StorageManagerError(
                 "Cannot open array; URI scheme unsupported.")),
             std::nullopt,
             std::nullopt};
@@ -319,7 +319,7 @@ StorageManager::array_open_for_writes(
     return {st, std::nullopt, std::nullopt};
 
   if (obj_type != ObjectType::ARRAY) {
-    return {logger_->status(Status::StorageManagerError(
+    return {logger_->status(Status_StorageManagerError(
                 "Cannot open array; Array does not exist")),
             std::nullopt,
             std::nullopt};
@@ -377,7 +377,7 @@ StorageManager::array_open_for_writes(
     err << constants::format_version << ")";
     open_array->mtx_unlock();
     array_close_for_writes(array_uri, encryption_key, nullptr);
-    return {logger_->status(Status::StorageManagerError(err.str())),
+    return {logger_->status(Status_StorageManagerError(err.str())),
             std::nullopt,
             std::nullopt};
   }
@@ -405,7 +405,7 @@ Status StorageManager::array_load_fragments(
     // Find the open array entry
     auto it = open_arrays_for_reads_.find(array_uri.to_string());
     if (it == open_arrays_for_reads_.end()) {
-      return logger_->status(Status::StorageManagerError(
+      return logger_->status(Status_StorageManagerError(
           std::string("Cannot reopen array ") + array_uri.to_string() +
           "; Array not open"));
     }
@@ -459,7 +459,7 @@ StorageManager::array_reopen(
     // Find the open array entry
     auto it = open_arrays_for_reads_.find(array_uri.to_string());
     if (it == open_arrays_for_reads_.end()) {
-      return {logger_->status(Status::StorageManagerError(
+      return {logger_->status(Status_StorageManagerError(
                   std::string("Cannot reopen array ") + array_uri.to_string() +
                   "; Array not open")),
               std::nullopt,
@@ -528,8 +528,8 @@ Status StorageManager::array_consolidate(
   // Check array URI
   URI array_uri(array_name);
   if (array_uri.is_invalid()) {
-    return logger_->status(
-        Status::StorageManagerError("Cannot consolidate array; Invalid URI"));
+    return logger_->status(Status_StorageManagerError(
+        "Cannot consolidate array; Invalid URI"));
   }
 
   // Check if array exists
@@ -537,7 +537,7 @@ Status StorageManager::array_consolidate(
   RETURN_NOT_OK(object_type(array_uri, &obj_type));
 
   if (obj_type != ObjectType::ARRAY) {
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot consolidate array; Array does not exist"));
   }
 
@@ -610,7 +610,7 @@ Status StorageManager::array_vacuum(
   assert(found);
 
   if (mode == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot vacuum array; Vacuum mode cannot be null"));
   else if (std::string(mode) == "fragments")
     RETURN_NOT_OK(
@@ -621,7 +621,7 @@ Status StorageManager::array_vacuum(
     RETURN_NOT_OK(
         array_vacuum_array_meta(array_name, timestamp_start, timestamp_end));
   else
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot vacuum array; Invalid vacuum mode"));
 
   return Status::Ok();
@@ -630,7 +630,7 @@ Status StorageManager::array_vacuum(
 Status StorageManager::array_vacuum_fragments(
     const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end) {
   if (array_name == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot vacuum fragments; Array name cannot be null"));
 
   // Get all URIs in the array directory
@@ -675,7 +675,7 @@ Status StorageManager::array_vacuum_fragments(
 
 Status StorageManager::array_vacuum_fragment_meta(const char* array_name) {
   if (array_name == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot vacuum fragment metadata; Array name cannot be null"));
 
   // Get the consolidated fragment metadata URIs to be deleted
@@ -708,7 +708,7 @@ Status StorageManager::array_vacuum_fragment_meta(const char* array_name) {
 Status StorageManager::array_vacuum_array_meta(
     const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end) {
   if (array_name == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot vacuum array metadata; Array name cannot be null"));
 
   // Get all URIs in the array directory
@@ -752,7 +752,7 @@ Status StorageManager::array_metadata_consolidate(
   // Check array URI
   URI array_uri(array_name);
   if (array_uri.is_invalid()) {
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot consolidate array metadata; Invalid URI"));
   }
   // Check if array exists
@@ -760,7 +760,7 @@ Status StorageManager::array_metadata_consolidate(
   RETURN_NOT_OK(object_type(array_uri, &obj_type));
 
   if (obj_type != ObjectType::ARRAY) {
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot consolidate array metadata; Array does not exist"));
   }
 
@@ -815,15 +815,15 @@ Status StorageManager::array_create(
     const EncryptionKey& encryption_key) {
   // Check array schema
   if (array_schema == nullptr) {
-    return logger_->status(
-        Status::StorageManagerError("Cannot create array; Empty array schema"));
+    return logger_->status(Status_StorageManagerError(
+        "Cannot create array; Empty array schema"));
   }
 
   // Check if array exists
   bool exists = false;
   RETURN_NOT_OK(is_array(array_uri, &exists));
   if (exists)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         std::string("Cannot create array; Array '") + array_uri.c_str() +
         "' already exists"));
 
@@ -900,7 +900,7 @@ Status StorageManager::array_evolve_schema(
     const EncryptionKey& encryption_key) {
   // Check array schema
   if (schema_evolution == nullptr) {
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot evolve array; Empty schema evolution"));
   }
 
@@ -913,7 +913,7 @@ Status StorageManager::array_evolve_schema(
   bool exists = false;
   RETURN_NOT_OK(is_array(array_uri, &exists));
   if (!exists)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         std::string("Cannot evolve array; Array '") + array_uri.c_str() +
         "' not exists"));
 
@@ -929,8 +929,8 @@ Status StorageManager::array_evolve_schema(
   if (!st.ok()) {
     tdb_delete(array_schema_evolved);
     logger_->status(st);
-    return logger_->status(Status::StorageManagerError(
-        "Cannot evovle schema;  Not able to store evolved array schema."));
+    return logger_->status(Status_StorageManagerError(
+        "Cannot evolve schema;  Not able to store evolved array schema."));
   }
 
   tdb_delete(array_schema);
@@ -947,7 +947,7 @@ Status StorageManager::array_upgrade_version(
   bool exists = false;
   RETURN_NOT_OK(is_array(array_uri, &exists));
   if (!exists)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         std::string("Cannot upgrade array; Array '") + array_uri.c_str() +
         "' does not exist"));
 
@@ -1054,17 +1054,17 @@ OpenArrayMemoryTracker* StorageManager::array_memory_tracker(
 Status StorageManager::array_get_non_empty_domain(
     Array* array, NDRange* domain, bool* is_empty) {
   if (domain == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Domain object is null"));
 
   if (array == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array object is null"));
 
   if (!array->is_remote() &&
       open_arrays_for_reads_.find(array->array_uri().to_string()) ==
           open_arrays_for_reads_.end())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array not opened for reads"));
 
   *domain = array->non_empty_domain();
@@ -1076,16 +1076,16 @@ Status StorageManager::array_get_non_empty_domain(
 Status StorageManager::array_get_non_empty_domain(
     Array* array, void* domain, bool* is_empty) {
   if (array == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array object is null"));
 
   if (!array->array_schema_latest()->domain()->all_dims_same_type())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Function non-applicable to arrays with "
         "heterogenous dimensions"));
 
   if (!array->array_schema_latest()->domain()->all_dims_fixed())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Function non-applicable to arrays with "
         "variable-sized dimensions"));
 
@@ -1114,13 +1114,14 @@ Status StorageManager::array_get_non_empty_domain_from_index(
 
   // Sanity checks
   if (idx >= array_schema->dim_num())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension index"));
   if (array_domain->dimension(idx)->var_size()) {
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
     errmsg += array_domain->dimension(idx)->name();
     errmsg += "' is variable-sized";
-    return logger_->status(Status::StorageManagerError(errmsg));
+    return logger_->status(
+        Status_StorageManagerError(errmsg));
   }
 
   NDRange dom;
@@ -1136,7 +1137,7 @@ Status StorageManager::array_get_non_empty_domain_from_name(
     Array* array, const char* name, void* domain, bool* is_empty) {
   // Sanity check
   if (name == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension name"));
 
   NDRange dom;
@@ -1152,7 +1153,8 @@ Status StorageManager::array_get_non_empty_domain_from_name(
       if (array_domain->dimension(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is variable-sized";
-        return logger_->status(Status::StorageManagerError(errmsg));
+        return logger_->status(
+            Status_StorageManagerError(errmsg));
       }
 
       if (!*is_empty)
@@ -1161,7 +1163,7 @@ Status StorageManager::array_get_non_empty_domain_from_name(
     }
   }
 
-  return logger_->status(Status::StorageManagerError(
+  return logger_->status(Status_StorageManagerError(
       std::string("Cannot get non-empty domain; Dimension name '") + name +
       "' does not exist"));
 }
@@ -1178,13 +1180,14 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_index(
 
   // Sanity checks
   if (idx >= array_schema->dim_num())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension index"));
   if (!array_domain->dimension(idx)->var_size()) {
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
     errmsg += array_domain->dimension(idx)->name();
     errmsg += "' is fixed-sized";
-    return logger_->status(Status::StorageManagerError(errmsg));
+    return logger_->status(
+        Status_StorageManagerError(errmsg));
   }
 
   NDRange dom;
@@ -1209,7 +1212,7 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_name(
     bool* is_empty) {
   // Sanity check
   if (name == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension name"));
 
   NDRange dom;
@@ -1225,7 +1228,8 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_name(
       if (!array_domain->dimension(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is fixed-sized";
-        return logger_->status(Status::StorageManagerError(errmsg));
+        return logger_->status(
+            Status_StorageManagerError(errmsg));
       }
 
       if (*is_empty) {
@@ -1240,7 +1244,7 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_name(
     }
   }
 
-  return logger_->status(Status::StorageManagerError(
+  return logger_->status(Status_StorageManagerError(
       std::string("Cannot get non-empty domain; Dimension name '") + name +
       "' does not exist"));
 }
@@ -1253,13 +1257,14 @@ Status StorageManager::array_get_non_empty_domain_var_from_index(
 
   // Sanity checks
   if (idx >= array_schema->dim_num())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension index"));
   if (!array_domain->dimension(idx)->var_size()) {
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
     errmsg += array_domain->dimension(idx)->name();
     errmsg += "' is fixed-sized";
-    return logger_->status(Status::StorageManagerError(errmsg));
+    return logger_->status(
+        Status_StorageManagerError(errmsg));
   }
 
   NDRange dom;
@@ -1278,7 +1283,7 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
     Array* array, const char* name, void* start, void* end, bool* is_empty) {
   // Sanity check
   if (name == nullptr)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension name"));
 
   NDRange dom;
@@ -1294,7 +1299,8 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
       if (!array_domain->dimension(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is fixed-sized";
-        return logger_->status(Status::StorageManagerError(errmsg));
+        return logger_->status(
+            Status_StorageManagerError(errmsg));
       }
 
       if (!*is_empty) {
@@ -1306,7 +1312,7 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
     }
   }
 
-  return logger_->status(Status::StorageManagerError(
+  return logger_->status(Status_StorageManagerError(
       std::string("Cannot get non-empty domain; Dimension name '") + name +
       "' does not exist"));
 }
@@ -1316,7 +1322,7 @@ Status StorageManager::array_get_encryption(
   URI uri(array_uri);
 
   if (uri.is_invalid())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot get array encryption; Invalid array URI"));
 
   URI schema_uri;
@@ -1433,13 +1439,13 @@ void StorageManager::decrement_in_progress() {
 Status StorageManager::object_remove(const char* path) const {
   auto uri = URI(path);
   if (uri.is_invalid())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         std::string("Cannot remove object '") + path + "'; Invalid URI"));
 
   ObjectType obj_type;
   RETURN_NOT_OK(object_type(uri, &obj_type));
   if (obj_type == ObjectType::INVALID)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         std::string("Cannot remove object '") + path +
         "'; Invalid TileDB object"));
 
@@ -1450,18 +1456,18 @@ Status StorageManager::object_move(
     const char* old_path, const char* new_path) const {
   auto old_uri = URI(old_path);
   if (old_uri.is_invalid())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         std::string("Cannot move object '") + old_path + "'; Invalid URI"));
 
   auto new_uri = URI(new_path);
   if (new_uri.is_invalid())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         std::string("Cannot move object to '") + new_path + "'; Invalid URI"));
 
   ObjectType obj_type;
   RETURN_NOT_OK(object_type(old_uri, &obj_type));
   if (obj_type == ObjectType::INVALID)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         std::string("Cannot move object '") + old_path +
         "'; Invalid TileDB object"));
 
@@ -1682,14 +1688,14 @@ Status StorageManager::group_create(const std::string& group) {
   // Create group URI
   URI uri(group);
   if (uri.is_invalid())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot create group '" + group + "'; Invalid group URI"));
 
   // Check if group exists
   bool exists;
   RETURN_NOT_OK(is_group(uri, &exists));
   if (exists)
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         std::string("Cannot create group; Group '") + uri.c_str() +
         "' already exists"));
 
@@ -1858,7 +1864,7 @@ Status StorageManager::get_array_schema_uris(
 
   // Check if schema_uris is empty
   if (schema_uris->empty()) {
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Can not get the array schemas; No array schemas found."));
   }
 
@@ -1872,13 +1878,12 @@ Status StorageManager::get_latest_array_schema_uri(
   std::vector<URI> schema_uris;
   RETURN_NOT_OK(get_array_schema_uris(array_uri, &schema_uris));
   if (schema_uris.size() == 0) {
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Can not get the latest array schema; No array schemas found."));
   }
   *uri = schema_uris.back();
   if (uri->is_invalid()) {
-    return logger_->status(
-        Status::StorageManagerError("Could not find array schema URI"));
+    return logger_->status(Status_StorageManagerError("Could not find array schema URI"));
   }
 
   return Status::Ok();
@@ -1961,7 +1966,7 @@ Status StorageManager::load_array_schema(
   auto timer_se = stats_->start_timer("read_load_array_schema");
 
   if (array_uri.is_invalid())
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot load array schema; Invalid array URI"));
 
   URI schema_uri;
@@ -1981,7 +1986,7 @@ StorageManager::load_all_array_schemas(
   auto timer_se = stats_->start_timer("read_load_all_array_schemas");
 
   if (array_uri.is_invalid())
-    return {logger_->status(Status::StorageManagerError(
+    return {logger_->status(Status_StorageManagerError(
                 "Cannot load all array schemas; Invalid array URI")),
             std::nullopt};
 
@@ -1989,7 +1994,7 @@ StorageManager::load_all_array_schemas(
   RETURN_NOT_OK_TUPLE(get_array_schema_uris(array_uri, &schema_uris));
   if (schema_uris.empty()) {
     return {
-        logger_->status(Status::StorageManagerError(
+        logger_->status(Status_StorageManagerError(
             "Can not get the array schema vector; No array schemas found.")),
         std::nullopt};
   }
@@ -2113,7 +2118,7 @@ Status StorageManager::object_iter_begin(
   // Sanity check
   URI path_uri(path);
   if (path_uri.is_invalid()) {
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot create object iterator; Invalid input path"));
   }
 
@@ -2145,7 +2150,7 @@ Status StorageManager::object_iter_begin(
   // Sanity check
   URI path_uri(path);
   if (path_uri.is_invalid()) {
-    return logger_->status(Status::StorageManagerError(
+    return logger_->status(Status_StorageManagerError(
         "Cannot create object iterator; Invalid input path"));
   }
 
@@ -2489,9 +2494,9 @@ Status StorageManager::array_open_without_fragments(
   auto timer_se = stats_->start_timer("read_array_open_without_fragments");
   if (!vfs_->supports_uri_scheme(array_uri))
     return logger_->status(
-        Status::StorageManagerError("Cannot open array; "
-                                    "URI scheme "
-                                    "unsupported."));
+        Status_StorageManagerError("Cannot open array; "
+                                           "URI scheme "
+                                           "unsupported."));
 
   // Lock mutexes
   {

--- a/tiledb/sm/subarray/cell_slab_iter.cc
+++ b/tiledb/sm/subarray/cell_slab_iter.cc
@@ -275,7 +275,7 @@ Status CellSlabIter<T>::sanity_check() const {
   // Check layout
   auto layout = subarray_->layout();
   if (layout != Layout::ROW_MAJOR && layout != Layout::COL_MAJOR)
-    return LOG_STATUS(Status::CellSlabIterError(
+    return LOG_STATUS(Status_CellSlabIterError(
         "Unsupported subarray layout; the iterator supports only row-major and "
         "column-major layouts"));
 
@@ -338,7 +338,7 @@ Status CellSlabIter<T>::sanity_check() const {
   }
 
   if (error)
-    return LOG_STATUS(Status::CellSlabIterError(
+    return LOG_STATUS(Status_CellSlabIterError(
         "Datatype mismatch between cell slab iterator and subarray"));
 
   return Status::Ok();

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -152,7 +152,7 @@ Status Subarray::add_range(
     uint32_t dim_idx, Range&& range, const bool read_range_oob_error) {
   auto dim_num = array_->array_schema_latest()->dim_num();
   if (dim_idx >= dim_num)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot add range to dimension; Invalid dimension index"));
 
   // Must reset the result size and tile overlap
@@ -610,7 +610,7 @@ bool Subarray::empty() const {
 
 Status Subarray::get_query_type(QueryType* type) const {
   if (array_ == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get query type from array; Invalid array"));
 
   return array_->get_query_type(type);
@@ -620,13 +620,12 @@ Status Subarray::get_range(
     uint32_t dim_idx, uint64_t range_idx, const Range** range) const {
   auto dim_num = array_->array_schema_latest()->dim_num();
   if (dim_idx >= dim_num)
-    return logger_->status(
-        Status::SubarrayError("Cannot get range; Invalid dimension index"));
+    return logger_->status(Status_SubarrayError(
+        "Cannot get range; Invalid dimension index"));
 
   auto range_num = ranges_[dim_idx].size();
   if (range_idx >= range_num)
-    return logger_->status(
-        Status::SubarrayError("Cannot get range; Invalid range index"));
+    return logger_->status(Status_SubarrayError("Cannot get range; Invalid range index"));
 
   *range = &ranges_[dim_idx][range_idx];
 
@@ -640,13 +639,12 @@ Status Subarray::get_range(
     const void** end) const {
   auto dim_num = array_->array_schema_latest()->dim_num();
   if (dim_idx >= dim_num)
-    return logger_->status(
-        Status::SubarrayError("Cannot get range; Invalid dimension index"));
+    return logger_->status(Status_SubarrayError(
+        "Cannot get range; Invalid dimension index"));
 
   auto range_num = ranges_[dim_idx].size();
   if (range_idx >= range_num)
-    return logger_->status(
-        Status::SubarrayError("Cannot get range; Invalid range index"));
+    return logger_->status(Status_SubarrayError("Cannot get range; Invalid range index"));
 
   *start = ranges_[dim_idx][range_idx].start();
   *end = ranges_[dim_idx][range_idx].end();
@@ -662,18 +660,18 @@ Status Subarray::get_range_var_size(
   auto schema = array_->array_schema_latest();
   auto dim_num = schema->dim_num();
   if (dim_idx >= dim_num)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get var range size; Invalid dimension index"));
 
   auto dim = schema->domain()->dimension(dim_idx);
   if (!dim->var_size())
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get var range size; Dimension " + dim->name() +
         " is not var sized"));
 
   auto range_num = ranges_[dim_idx].size();
   if (range_idx >= range_num)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get var range size; Invalid range index"));
 
   *start = ranges_[dim_idx][range_idx].start_size();
@@ -689,7 +687,7 @@ Status Subarray::get_range_num(uint32_t dim_idx, uint64_t* range_num) const {
     msg << "Cannot get number of ranges for a dimension; "
            "Invalid dimension index "
         << dim_idx << " requested, " << dim_num - 1 << " max avail.";
-    return LOG_STATUS(Status::SubarrayError(msg.str()));
+    return LOG_STATUS(Status_SubarrayError(msg.str()));
   }
 
   QueryType array_query_type;
@@ -826,7 +824,7 @@ Status Subarray::set_coalesce_ranges(bool coalesce_ranges) {
 
 Status Subarray::to_byte_vec(std::vector<uint8_t>* byte_vec) const {
   if (range_num() != 1)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot export to byte vector; The subarray must be unary"));
 
   byte_vec->clear();
@@ -851,13 +849,13 @@ Status Subarray::get_est_result_size_internal(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute/Dimension name cannot be null"));
+    return logger_->status(Status_SubarrayError(
+        "Cannot get estimated result size; "
+        "Attribute/Dimension name cannot be null"));
 
   // Check size pointer
   if (size == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get estimated result size; Input size cannot be null"));
 
   // Check if name is attribute or dimension
@@ -867,21 +865,21 @@ Status Subarray::get_est_result_size_internal(
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         std::string("Cannot get estimated result size; Attribute/Dimension '") +
         name + "' does not exist"));
 
   // Check if the attribute/dimension is fixed-sized
   if (array_schema->var_size(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute/Dimension must be fixed-sized"));
+    return logger_->status(Status_SubarrayError(
+        "Cannot get estimated result size; "
+        "Attribute/Dimension must be fixed-sized"));
 
   // Check if attribute/dimension is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute/Dimension must not be nullable"));
+    return logger_->status(Status_SubarrayError(
+        "Cannot get estimated result size; "
+        "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
   RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
@@ -948,13 +946,13 @@ Status Subarray::get_est_result_size(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute/Dimension name cannot be null"));
+    return logger_->status(Status_SubarrayError(
+        "Cannot get estimated result size; "
+        "Attribute/Dimension name cannot be null"));
 
   // Check size pointer
   if (size_off == nullptr || size_val == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get estimated result size; Input sizes cannot be null"));
 
   // Check if name is attribute or dimension
@@ -964,21 +962,20 @@ Status Subarray::get_est_result_size(
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         std::string("Cannot get estimated result size; Attribute/Dimension '") +
         name + "' does not exist"));
 
   // Check if the attribute/dimension is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute/Dimension must be var-sized"));
+    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
+                                     "Attribute/Dimension must be var-sized"));
 
   // Check if attribute/dimension is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute/Dimension must not be nullable"));
+    return logger_->status(Status_SubarrayError(
+        "Cannot get estimated result size; "
+        "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
   RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
@@ -1013,13 +1010,12 @@ Status Subarray::get_est_result_size_nullable(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute name cannot be null"));
+    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
+                                     "Attribute name cannot be null"));
 
   // Check size pointer
   if (size == nullptr || size_validity == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get estimated result size; Input sizes cannot be null"));
 
   // Check if name is attribute
@@ -1028,21 +1024,19 @@ Status Subarray::get_est_result_size_nullable(
 
   // Check if attribute exists
   if (!is_attr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         std::string("Cannot get estimated result size; Attribute '") + name +
         "' does not exist"));
 
   // Check if the attribute is fixed-sized
   if (array_schema->var_size(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute must be fixed-sized"));
+    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
+                                     "Attribute must be fixed-sized"));
 
   // Check if attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute must be nullable"));
+    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
+                                     "Attribute must be nullable"));
 
   if (array_->is_remote() && !this->est_result_size_computed()) {
     return LOG_STATUS(Status::SubarrayError(
@@ -1076,13 +1070,12 @@ Status Subarray::get_est_result_size_nullable(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute name cannot be null"));
+    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
+                                     "Attribute name cannot be null"));
 
   // Check size pointer
   if (size_off == nullptr || size_val == nullptr || size_validity == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get estimated result size; Input sizes cannot be null"));
 
   // Check if name is attribute
@@ -1091,21 +1084,19 @@ Status Subarray::get_est_result_size_nullable(
 
   // Check if attribute exists
   if (!is_attr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         std::string("Cannot get estimated result size; Attribute '") + name +
         "' does not exist"));
 
   // Check if the attribute is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute must be var-sized"));
+    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
+                                     "Attribute must be var-sized"));
 
   // Check if attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute must be nullable"));
+    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
+                                     "Attribute must be nullable"));
 
   if (array_->is_remote() && !this->est_result_size_computed()) {
     return LOG_STATUS(Status::SubarrayError(
@@ -1152,12 +1143,12 @@ Status Subarray::get_max_memory_size(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Attribute/Dimension cannot be null"));
 
   // Check size pointer
   if (size == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Input size cannot be null"));
 
   // Check if name is attribute or dimension
@@ -1167,20 +1158,20 @@ Status Subarray::get_max_memory_size(
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         std::string("Cannot get max memory size; Attribute/Dimension '") +
         name + "' does not exist"));
 
   // Check if the attribute/dimension is fixed-sized
   if (name != constants::coords && array_schema->var_size(name))
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Attribute/Dimension must be fixed-sized"));
 
   // Check if attribute/dimension is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute/Dimension must not be nullable"));
+    return logger_->status(Status_SubarrayError(
+        "Cannot get estimated result size; "
+        "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);
@@ -1197,12 +1188,12 @@ Status Subarray::get_max_memory_size(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Attribute/Dimension cannot be null"));
 
   // Check size pointer
   if (size_off == nullptr || size_val == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Input sizes cannot be null"));
 
   // Check if name is attribute or dimension
@@ -1212,20 +1203,20 @@ Status Subarray::get_max_memory_size(
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         std::string("Cannot get max memory size; Attribute/Dimension '") +
         name + "' does not exist"));
 
   // Check if the attribute/dimension is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Attribute/Dimension must be var-sized"));
 
   // Check if attribute/dimension is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute/Dimension must not be nullable"));
+    return logger_->status(Status_SubarrayError(
+        "Cannot get estimated result size; "
+        "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);
@@ -1243,12 +1234,12 @@ Status Subarray::get_max_memory_size_nullable(
     ThreadPool* const compute_tp) {
   // Check attribute name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Attribute cannot be null"));
 
   // Check size pointer
   if (size == nullptr || size_validity == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Input sizes cannot be null"));
 
   // Check if name is attribute
@@ -1257,20 +1248,19 @@ Status Subarray::get_max_memory_size_nullable(
 
   // Check if attribute exists
   if (!is_attr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         std::string("Cannot get max memory size; Attribute '") + name +
         "' does not exist"));
 
   // Check if the attribute is fixed-sized
   if (array_schema->var_size(name))
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Attribute must be fixed-sized"));
 
   // Check if attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute must be nullable"));
+    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
+                                     "Attribute must be nullable"));
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);
@@ -1289,12 +1279,12 @@ Status Subarray::get_max_memory_size_nullable(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Attribute/Dimension cannot be null"));
 
   // Check size pointer
   if (size_off == nullptr || size_val == nullptr || size_validity == nullptr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Input sizes cannot be null"));
 
   // Check if name is attribute or dimension
@@ -1303,20 +1293,19 @@ Status Subarray::get_max_memory_size_nullable(
 
   // Check if attribute exists
   if (!is_attr)
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         std::string("Cannot get max memory size; Attribute '") + name +
         "' does not exist"));
 
   // Check if the attribute is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(Status::SubarrayError(
+    return logger_->status(Status_SubarrayError(
         "Cannot get max memory size; Attribute/Dimension must be var-sized"));
 
   // Check if attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(
-        Status::SubarrayError("Cannot get estimated result size; "
-                              "Attribute must be nullable"));
+    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
+                                     "Attribute must be nullable"));
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -203,12 +203,12 @@ Status Subarray::set_subarray(const void* subarray) {
   if (!array_->array_schema_latest()->domain()->all_dims_same_type())
     return LOG_STATUS(
         Status_SubarrayError("Cannot set subarray; Function not applicable to "
-                              "heterogeneous domains"));
+                             "heterogeneous domains"));
 
   if (!array_->array_schema_latest()->domain()->all_dims_fixed())
     return LOG_STATUS(
         Status_SubarrayError("Cannot set subarray; Function not applicable to "
-                              "domains with variable-sized dimensions"));
+                             "domains with variable-sized dimensions"));
 
   ranges_.clear();
   add_default_ranges();
@@ -245,7 +245,7 @@ Status Subarray::add_range(
     if (this->is_set(dim_idx))
       return LOG_STATUS(
           Status_SubarrayError("Cannot add range; Multi-range dense writes "
-                                "are not supported"));
+                               "are not supported"));
   }
 
   if (start == nullptr || end == nullptr)
@@ -302,8 +302,8 @@ Status Subarray::add_range_var(
     return LOG_STATUS(Status_SubarrayError("Cannot add range; Invalid range"));
 
   if (!array_->array_schema_latest()->domain()->dimension(dim_idx)->var_size())
-    return LOG_STATUS(Status_SubarrayError(
-        "Cannot add range; Range must be variable-sized"));
+    return LOG_STATUS(
+        Status_SubarrayError("Cannot add range; Range must be variable-sized"));
 
   QueryType array_query_type;
   RETURN_NOT_OK(array_->get_query_type(&array_query_type));
@@ -385,7 +385,7 @@ Status Subarray::get_range(
     if (!array_->array_schema_latest()->dense())
       return LOG_STATUS(
           Status_SubarrayError("Getting a range from a write query is not "
-                                "applicable to sparse arrays"));
+                               "applicable to sparse arrays"));
   }
 
   *stride = nullptr;
@@ -698,7 +698,7 @@ Status Subarray::get_range_num(uint32_t dim_idx, uint64_t* range_num) const {
       !array_->array_schema_latest()->dense()) {
     return LOG_STATUS(
         Status_SubarrayError("Getting the number of ranges from a write query "
-                              "is not applicable to sparse arrays"));
+                             "is not applicable to sparse arrays"));
   }
 
   *range_num = ranges_[dim_idx].size();
@@ -815,7 +815,7 @@ Status Subarray::set_coalesce_ranges(bool coalesce_ranges) {
   if (count_set_ranges())
     return LOG_STATUS(
         Status_SubarrayError("non-default ranges have been set, cannot change "
-                              "coalesce_ranges setting!"));
+                             "coalesce_ranges setting!"));
   // trying to mimic conditions at ctor()
   coalesce_ranges_ = coalesce_ranges;
   ranges_.clear();

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -620,12 +620,13 @@ Status Subarray::get_range(
     uint32_t dim_idx, uint64_t range_idx, const Range** range) const {
   auto dim_num = array_->array_schema_latest()->dim_num();
   if (dim_idx >= dim_num)
-    return logger_->status(Status_SubarrayError(
-        "Cannot get range; Invalid dimension index"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get range; Invalid dimension index"));
 
   auto range_num = ranges_[dim_idx].size();
   if (range_idx >= range_num)
-    return logger_->status(Status_SubarrayError("Cannot get range; Invalid range index"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get range; Invalid range index"));
 
   *range = &ranges_[dim_idx][range_idx];
 
@@ -639,12 +640,13 @@ Status Subarray::get_range(
     const void** end) const {
   auto dim_num = array_->array_schema_latest()->dim_num();
   if (dim_idx >= dim_num)
-    return logger_->status(Status_SubarrayError(
-        "Cannot get range; Invalid dimension index"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get range; Invalid dimension index"));
 
   auto range_num = ranges_[dim_idx].size();
   if (range_idx >= range_num)
-    return logger_->status(Status_SubarrayError("Cannot get range; Invalid range index"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get range; Invalid range index"));
 
   *start = ranges_[dim_idx][range_idx].start();
   *end = ranges_[dim_idx][range_idx].end();
@@ -671,8 +673,8 @@ Status Subarray::get_range_var_size(
 
   auto range_num = ranges_[dim_idx].size();
   if (range_idx >= range_num)
-    return logger_->status(Status_SubarrayError(
-        "Cannot get var range size; Invalid range index"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get var range size; Invalid range index"));
 
   *start = ranges_[dim_idx][range_idx].start_size();
   *end = ranges_[dim_idx][range_idx].end_size();
@@ -849,9 +851,9 @@ Status Subarray::get_est_result_size_internal(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status_SubarrayError(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension name cannot be null"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute/Dimension name cannot be null"));
 
   // Check size pointer
   if (size == nullptr)
@@ -871,15 +873,15 @@ Status Subarray::get_est_result_size_internal(
 
   // Check if the attribute/dimension is fixed-sized
   if (array_schema->var_size(name))
-    return logger_->status(Status_SubarrayError(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must be fixed-sized"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute/Dimension must be fixed-sized"));
 
   // Check if attribute/dimension is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(Status_SubarrayError(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must not be nullable"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
   RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
@@ -946,9 +948,9 @@ Status Subarray::get_est_result_size(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status_SubarrayError(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension name cannot be null"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute/Dimension name cannot be null"));
 
   // Check size pointer
   if (size_off == nullptr || size_val == nullptr)
@@ -968,14 +970,15 @@ Status Subarray::get_est_result_size(
 
   // Check if the attribute/dimension is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
-                                     "Attribute/Dimension must be var-sized"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute/Dimension must be var-sized"));
 
   // Check if attribute/dimension is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(Status_SubarrayError(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must not be nullable"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
   RETURN_NOT_OK(compute_est_result_size(config, compute_tp));
@@ -1010,8 +1013,9 @@ Status Subarray::get_est_result_size_nullable(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
-                                     "Attribute name cannot be null"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute name cannot be null"));
 
   // Check size pointer
   if (size == nullptr || size_validity == nullptr)
@@ -1030,13 +1034,15 @@ Status Subarray::get_est_result_size_nullable(
 
   // Check if the attribute is fixed-sized
   if (array_schema->var_size(name))
-    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
-                                     "Attribute must be fixed-sized"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute must be fixed-sized"));
 
   // Check if attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
-                                     "Attribute must be nullable"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute must be nullable"));
 
   if (array_->is_remote() && !this->est_result_size_computed()) {
     return LOG_STATUS(Status::SubarrayError(
@@ -1070,8 +1076,9 @@ Status Subarray::get_est_result_size_nullable(
     ThreadPool* const compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
-                                     "Attribute name cannot be null"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute name cannot be null"));
 
   // Check size pointer
   if (size_off == nullptr || size_val == nullptr || size_validity == nullptr)
@@ -1090,13 +1097,15 @@ Status Subarray::get_est_result_size_nullable(
 
   // Check if the attribute is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
-                                     "Attribute must be var-sized"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute must be var-sized"));
 
   // Check if attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
-                                     "Attribute must be nullable"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute must be nullable"));
 
   if (array_->is_remote() && !this->est_result_size_computed()) {
     return LOG_STATUS(Status::SubarrayError(
@@ -1169,9 +1178,9 @@ Status Subarray::get_max_memory_size(
 
   // Check if attribute/dimension is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(Status_SubarrayError(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must not be nullable"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);
@@ -1214,9 +1223,9 @@ Status Subarray::get_max_memory_size(
 
   // Check if attribute/dimension is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(Status_SubarrayError(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must not be nullable"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute/Dimension must not be nullable"));
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);
@@ -1259,8 +1268,9 @@ Status Subarray::get_max_memory_size_nullable(
 
   // Check if attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
-                                     "Attribute must be nullable"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute must be nullable"));
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);
@@ -1304,8 +1314,9 @@ Status Subarray::get_max_memory_size_nullable(
 
   // Check if attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status_SubarrayError("Cannot get estimated result size; "
-                                     "Attribute must be nullable"));
+    return logger_->status(
+        Status_SubarrayError("Cannot get estimated result size; "
+                             "Attribute must be nullable"));
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -150,12 +150,12 @@ Status SubarrayPartitioner::get_result_budget(
     const char* name, uint64_t* budget) const {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot get result budget; Attribute/Dimension name cannot be null"));
 
   // Check budget pointer
   if (budget == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot get result budget; Invalid budget input"));
 
   // For easy reference
@@ -165,26 +165,26 @@ Status SubarrayPartitioner::get_result_budget(
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Invalid attribute/dimension '") +
         name + "'"));
 
   // Check if the attribute/dimension is fixed-sized
   if (array_schema->var_size(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute/dimension '") +
         name + "' is var-sized"));
 
   // Check if the attribute is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute/dimension '") +
         name + "' is nullable"));
 
   // Check if budget has been set
   auto b_it = budget_.find(name);
   if (b_it == budget_.end())
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Budget not set for "
                     "attribute/dimension '") +
         name + "'"));
@@ -199,17 +199,17 @@ Status SubarrayPartitioner::get_result_budget(
     const char* name, uint64_t* budget_off, uint64_t* budget_val) const {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot get result budget; Attribute/Dimension name cannot be null"));
 
   // Check budget pointers
   if (budget_off == nullptr || budget_val == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot get result budget; Invalid budget input"));
 
   // Check zipped coordinates
   if (name == constants::coords)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot get result budget for zipped coordinates; Attribute/Dimension "
         "must be var-sized"));
 
@@ -220,26 +220,26 @@ Status SubarrayPartitioner::get_result_budget(
 
   // Check if attribute/dimension exists
   if (!is_dim && !is_attr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Invalid attribute/dimension '") +
         name + "'"));
 
   // Check if the attribute/dimension is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute/dimension '") +
         name + "' is fixed-sized"));
 
   // Check if the attribute is nullable
   if (array_schema->is_nullable(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute/dimension '") +
         name + "' is nullable"));
 
   // Check if budget has been set
   auto b_it = budget_.find(name);
   if (b_it == budget_.end())
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Budget not set for "
                     "attribute/dimension '") +
         name + "'"));
@@ -255,12 +255,12 @@ Status SubarrayPartitioner::get_result_budget_nullable(
     const char* name, uint64_t* budget, uint64_t* budget_validity) const {
   // Check attribute name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot get result budget; Attribute name cannot be null"));
 
   // Check budget pointers
   if (budget == nullptr || budget_validity == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot get result budget; Invalid budget input"));
 
   // For easy reference
@@ -269,26 +269,26 @@ Status SubarrayPartitioner::get_result_budget_nullable(
 
   // Check if attribute exists
   if (!is_attr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Invalid attribute '") + name +
         "'"));
 
   // Check if the attribute is fixed-sized
   if (array_schema->var_size(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute '") + name +
         "' is var-sized"));
 
   // Check if the attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute '") + name +
         "' is not nullable"));
 
   // Check if budget has been set
   auto b_it = budget_.find(name);
   if (b_it == budget_.end())
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Budget not set for "
                     "attribute '") +
         name + "'"));
@@ -307,13 +307,13 @@ Status SubarrayPartitioner::get_result_budget_nullable(
     uint64_t* budget_validity) const {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot get result budget; Attribute/Dimension name cannot be null"));
 
   // Check budget pointers
   if (budget_off == nullptr || budget_val == nullptr ||
       budget_validity == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot get result budget; Invalid budget input"));
 
   // For easy reference
@@ -322,26 +322,26 @@ Status SubarrayPartitioner::get_result_budget_nullable(
 
   // Check if attribute exists
   if (!is_attr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Invalid attribute '") + name +
         "'"));
 
   // Check if the attribute is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute '") + name +
         "' is fixed-sized"));
 
   // Check if the attribute is nullable
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute '") + name +
         "' is not nullable"));
 
   // Check if budget has been set
   auto b_it = budget_.find(name);
   if (b_it == budget_.end())
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Budget not set for "
                     "attribute '") +
         name + "'"));
@@ -415,7 +415,7 @@ Status SubarrayPartitioner::set_result_budget(
     const char* name, uint64_t budget) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot set result budget; Attribute/Dimension name cannot be null"));
 
   // For easy reference
@@ -425,21 +425,21 @@ Status SubarrayPartitioner::set_result_budget(
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Invalid attribute/dimension '") +
         name + "'"));
 
   // Check if the attribute/dimension is fixed-sized
   bool var_size = (name != constants::coords && array_schema->var_size(name));
   if (var_size)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute/dimension '") +
         name + "' is var-sized"));
 
   // Check if the attribute/dimension is nullable
   bool nullable = array_schema->is_nullable(name);
   if (nullable)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute/dimension '") +
         name + "' is nullable"));
 
@@ -452,11 +452,11 @@ Status SubarrayPartitioner::set_result_budget(
     const char* name, uint64_t budget_off, uint64_t budget_val) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot set result budget; Attribute/Dimension name cannot be null"));
 
   if (name == constants::coords)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot set result budget for zipped coordinates; Attribute/Dimension "
         "must be var-sized"));
 
@@ -467,20 +467,20 @@ Status SubarrayPartitioner::set_result_budget(
 
   // Check if attribute/dimension exists
   if (!is_dim && !is_attr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Invalid attribute/dimension '") +
         name + "'"));
 
   // Check if the attribute/dimension is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute/dimension '") +
         name + "' is fixed-sized"));
 
   // Check if the attribute/dimension is nullable
   bool nullable = array_schema->is_nullable(name);
   if (nullable)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute/dimension '") +
         name + "' is nullable"));
 
@@ -493,7 +493,7 @@ Status SubarrayPartitioner::set_result_budget_nullable(
     const char* name, uint64_t budget, uint64_t budget_validity) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot set result budget; Attribute name cannot be null"));
 
   // For easy reference
@@ -502,21 +502,21 @@ Status SubarrayPartitioner::set_result_budget_nullable(
 
   // Check if attribute exists
   if (!is_attr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Invalid attribute '") + name +
         "'"));
 
   // Check if the attribute is fixed-sized
   bool var_size = array_schema->var_size(name);
   if (var_size)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute '") + name +
         "' is var-sized"));
 
   // Check if the attribute is nullable
   bool nullable = array_schema->is_nullable(name);
   if (!nullable)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute '") + name +
         "' is not nullable"));
 
@@ -532,7 +532,7 @@ Status SubarrayPartitioner::set_result_budget_nullable(
     uint64_t budget_validity) {
   // Check attribute/dimension name
   if (name == nullptr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         "Cannot set result budget; Attribute name cannot be null"));
 
   // For easy reference
@@ -541,20 +541,20 @@ Status SubarrayPartitioner::set_result_budget_nullable(
 
   // Check if attribute exists
   if (!is_attr)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Invalid attribute '") + name +
         "'"));
 
   // Check if the attribute is var-sized
   if (!array_schema->var_size(name))
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute '") + name +
         "' is fixed-sized"));
 
   // Check if the attribute is nullable
   bool nullable = array_schema->is_nullable(name);
   if (!nullable)
-    return logger_->status(Status::SubarrayPartitionerError(
+    return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute '") + name +
         "' is not nullable"));
 

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -70,7 +70,7 @@ Status GenericTileIO::read_generic(
 
   if (encryption_key.encryption_type() !=
       (EncryptionType)header.encryption_type)
-    return LOG_STATUS(Status::TileIOError(
+    return LOG_STATUS(Status_TileIOError(
         "Error reading generic tile; tile is encrypted with " +
         encryption_type_str((EncryptionType)header.encryption_type) +
         " but given key is for " +
@@ -225,13 +225,13 @@ Status GenericTileIO::configure_encryption_filter(
     case EncryptionType::AES_256_GCM: {
       auto* f = header->filters.get_filter<EncryptionAES256GCMFilter>();
       if (f == nullptr)
-        return Status::TileIOError(
+        return Status_TileIOError(
             "Error getting generic tile; no encryption filter.");
       RETURN_NOT_OK(f->set_key(encryption_key));
       break;
     }
     default:
-      return Status::TileIOError(
+      return Status_TileIOError(
           "Error getting generic tile; invalid encryption type.");
   }
 

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -60,7 +60,8 @@ Status Tile::compute_chunk_size(
   chunk_size64 = chunk_size64 / dim_cell_size * dim_cell_size;
   chunk_size64 = std::max(chunk_size64, dim_cell_size);
   if (chunk_size64 > std::numeric_limits<uint32_t>::max()) {
-    return LOG_STATUS(Status::TileError("Chunk size exceeds uint32_t"));
+    return LOG_STATUS(
+        Status_TileError("Chunk size exceeds uint32_t"));
   }
 
   *chunk_size = chunk_size64;
@@ -182,8 +183,8 @@ Status Tile::init_unfiltered(
 
   buffer_ = tdb_new(Buffer);
   if (buffer_ == nullptr)
-    return LOG_STATUS(
-        Status::TileError("Cannot initialize tile; Buffer allocation failed"));
+    return LOG_STATUS(Status_TileError(
+        "Cannot initialize tile; Buffer allocation failed"));
 
   RETURN_NOT_OK(buffer_->realloc(tile_size));
 
@@ -207,8 +208,8 @@ Status Tile::init_filtered(
 
   buffer_ = tdb_new(Buffer);
   if (buffer_ == nullptr)
-    return LOG_STATUS(
-        Status::TileError("Cannot initialize tile; Buffer allocation failed"));
+    return LOG_STATUS(Status_TileError(
+        "Cannot initialize tile; Buffer allocation failed"));
 
   return Status::Ok();
 }

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -60,8 +60,7 @@ Status Tile::compute_chunk_size(
   chunk_size64 = chunk_size64 / dim_cell_size * dim_cell_size;
   chunk_size64 = std::max(chunk_size64, dim_cell_size);
   if (chunk_size64 > std::numeric_limits<uint32_t>::max()) {
-    return LOG_STATUS(
-        Status_TileError("Chunk size exceeds uint32_t"));
+    return LOG_STATUS(Status_TileError("Chunk size exceeds uint32_t"));
   }
 
   *chunk_size = chunk_size64;
@@ -183,8 +182,8 @@ Status Tile::init_unfiltered(
 
   buffer_ = tdb_new(Buffer);
   if (buffer_ == nullptr)
-    return LOG_STATUS(Status_TileError(
-        "Cannot initialize tile; Buffer allocation failed"));
+    return LOG_STATUS(
+        Status_TileError("Cannot initialize tile; Buffer allocation failed"));
 
   RETURN_NOT_OK(buffer_->realloc(tile_size));
 
@@ -208,8 +207,8 @@ Status Tile::init_filtered(
 
   buffer_ = tdb_new(Buffer);
   if (buffer_ == nullptr)
-    return LOG_STATUS(Status_TileError(
-        "Cannot initialize tile; Buffer allocation failed"));
+    return LOG_STATUS(
+        Status_TileError("Cannot initialize tile; Buffer allocation failed"));
 
   return Status::Ok();
 }


### PR DESCRIPTION
This is the "rip-the-bandage-off" part of a multipart rewrite of the `Status` class. `Status` is getting an overhaul in preparation for greater reliance on exceptions.

* The `StatusCode` enumeration has been moved to separate file in preparation for its transitional use in new code and eventual removal. All it's doing is acting as a placeholder for a string constant, so the end result will be to use string constants to construct `Status` objects.
* All the various error codes have had factories inside the single `Status` class. The end result will be to define error status where they're used and not centrally. They've got to come out of `Status` at some point. It's a really large text-change for a very simple idea.

---
TYPE: IMPROVEMENT
DESC: Move `Status::*Error` to `Status_*Error`
