### PR TITLE
Always load array schemas during opening

### DIFF
--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -217,7 +217,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema()->domain();
+  auto dom = array_->array_->array_schema_latest()->domain();
   create_result_space_tiles(
       dom,
       dom->domain(),
@@ -277,7 +277,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema()->domain();
+  auto dom = array_->array_->array_schema_latest()->domain();
   create_result_space_tiles(
       dom,
       dom->domain(),
@@ -340,7 +340,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds1, ds2};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema()->domain();
+  auto dom = array_->array_->array_schema_latest()->domain();
   create_result_space_tiles(
       dom,
       dom->domain(),
@@ -407,7 +407,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema()->domain();
+  auto dom = array_->array_->array_schema_latest()->domain();
   create_result_space_tiles(
       dom,
       dom->domain(),
@@ -630,7 +630,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema()->domain();
+  auto dom = array_->array_->array_schema_latest()->domain();
   create_result_space_tiles(
       dom,
       dom->domain(),
@@ -802,7 +802,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema()->domain();
+  auto dom = array_->array_->array_schema_latest()->domain();
   create_result_space_tiles(
       dom,
       dom->domain(),
@@ -987,7 +987,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema()->domain();
+  auto dom = array_->array_->array_schema_latest()->domain();
   create_result_space_tiles(
       dom,
       dom->domain(),
@@ -1218,7 +1218,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds1, ds2};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema()->domain();
+  auto dom = array_->array_->array_schema_latest()->domain();
   create_result_space_tiles(
       dom,
       dom->domain(),

--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -198,7 +198,6 @@ TEST_CASE(
       .set_data_buffer("a", a_read)
       .set_coordinates(coords_read);
   query_r.submit();
-  array.close();
 
   // Note: If you encounter a failure here, in particular with a_read[0] == 100
   // (instead of 1), be sure non_split_coords_v1_4_0 has not become 'corrupt',
@@ -207,6 +206,8 @@ TEST_CASE(
   // corrupt can refresh from repository to correct initial state.
   for (int i = 0; i < 4; i++)
     REQUIRE(a_read[i] == i + 1);
+
+  array.close();
 }
 
 TEST_CASE(

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -694,7 +694,8 @@ void SparseArrayFx::test_random_subarrays(
     int64_t domain_size_0,
     int64_t domain_size_1,
     int iter_num) {
-  // write array_schema cells with value = row id * columns + col id to disk
+  // write array_schema_latest cells with value = row id * columns + col id to
+  // disk
   write_sparse_array_unsorted_2D(array_name, domain_size_0, domain_size_1);
 
   // test random subarrays and check with corresponding value set by

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -80,6 +80,14 @@ namespace common {
     }                                \
   } while (false)
 
+#define RETURN_NOT_OK_TUPLE(s)   \
+  do {                           \
+    Status _s = (s);             \
+    if (!_s.ok()) {              \
+      return {_s, std::nullopt}; \
+    }                            \
+  } while (false)
+
 enum class StatusCode : char {
   Ok,
   Error,

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -64,7 +64,7 @@ namespace sm {
 /* ********************************* */
 
 Array::Array(const URI& array_uri, StorageManager* storage_manager)
-    : array_schema_(nullptr)
+    : array_schema_latest_(nullptr)
     , array_uri_(array_uri)
     , encryption_key_(tdb::make_shared<EncryptionKey>(HERE()))
     , is_open_(false)
@@ -78,7 +78,7 @@ Array::Array(const URI& array_uri, StorageManager* storage_manager)
     , non_empty_domain_computed_(false){};
 
 Array::Array(const Array& rhs)
-    : array_schema_(rhs.array_schema_)
+    : array_schema_latest_(rhs.array_schema_latest_)
     , array_uri_(rhs.array_uri_)
     , encryption_key_(rhs.encryption_key_)
     , fragment_metadata_(rhs.fragment_metadata_)
@@ -101,9 +101,9 @@ Array::Array(const Array& rhs)
 /*                API                */
 /* ********************************* */
 
-ArraySchema* Array::array_schema() const {
+ArraySchema* Array::array_schema_latest() const {
   std::unique_lock<std::mutex> lck(mtx_);
-  return array_schema_;
+  return array_schema_latest_;
 }
 
 const URI& Array::array_uri() const {
@@ -143,8 +143,8 @@ Status Array::open_without_fragments(
     if (rest_client == nullptr)
       return LOG_STATUS(Status::ArrayError(
           "Cannot open array; remote array with no REST client."));
-    RETURN_NOT_OK(
-        rest_client->get_array_schema_from_rest(array_uri_, &array_schema_));
+    RETURN_NOT_OK(rest_client->get_array_schema_from_rest(
+        array_uri_, &array_schema_latest_));
   } else {
     auto&& [st, array_schema, array_schemas] =
         storage_manager_->array_open_for_reads_without_fragments(
@@ -152,8 +152,8 @@ Status Array::open_without_fragments(
     if (!st.ok())
       return st;
 
-    array_schema_ = array_schema.value();
-    array_schemas_ = array_schemas.value();
+    array_schema_latest_ = array_schema.value();
+    array_schemas_all_ = array_schemas.value();
   }
 
   is_open_ = true;
@@ -259,8 +259,8 @@ Status Array::open(
     if (rest_client == nullptr)
       return LOG_STATUS(Status::ArrayError(
           "Cannot open array; remote array with no REST client."));
-    RETURN_NOT_OK(
-        rest_client->get_array_schema_from_rest(array_uri_, &array_schema_));
+    RETURN_NOT_OK(rest_client->get_array_schema_from_rest(
+        array_uri_, &array_schema_latest_));
   } else if (query_type == QueryType::READ) {
     auto&& [st, array_schema, array_schemas, fragment_metadata] =
         storage_manager_->array_open_for_reads(
@@ -271,8 +271,8 @@ Status Array::open(
     if (!st.ok())
       return st;
     // Set schemas
-    array_schema_ = array_schema.value();
-    array_schemas_ = array_schemas.value();
+    array_schema_latest_ = array_schema.value();
+    array_schemas_all_ = array_schemas.value();
     fragment_metadata_ = fragment_metadata.value();
   } else {
     auto&& [st, array_schema, array_schemas] =
@@ -280,8 +280,8 @@ Status Array::open(
     if (!st.ok())
       return st;
     // Set schemas
-    array_schema_ = array_schema.value();
-    array_schemas_ = array_schemas.value();
+    array_schema_latest_ = array_schema.value();
+    array_schemas_all_ = array_schemas.value();
 
     metadata_.reset(timestamp_end_opened_at_);
   }
@@ -320,10 +320,10 @@ Status Array::close() {
     }
 
     // Storage manager does not own the array schema for remote arrays.
-    tdb_delete(array_schema_);
-    array_schema_ = nullptr;
+    tdb_delete(array_schema_latest_);
+    array_schema_latest_ = nullptr;
   } else {
-    array_schema_ = nullptr;
+    array_schema_latest_ = nullptr;
     if (query_type_ == QueryType::READ) {
       RETURN_NOT_OK(storage_manager_->array_close_for_reads(array_uri_));
     } else {
@@ -365,7 +365,7 @@ Status Array::get_array_schema(ArraySchema** array_schema) const {
     return LOG_STATUS(
         Status::ArrayError("Cannot get array schema; Array is not open"));
 
-  *array_schema = array_schema_;
+  *array_schema = array_schema_latest_;
 
   return Status::Ok();
 }
@@ -403,20 +403,20 @@ Status Array::get_max_buffer_size(
         "Cannot get max buffer size; Attribute/Dimension name is null"));
 
   // Not applicable to heterogeneous domains
-  if (!array_schema_->domain()->all_dims_same_type())
+  if (!array_schema_latest_->domain()->all_dims_same_type())
     return LOG_STATUS(
         Status::ArrayError("Cannot get max buffer size; Function not "
                            "applicable to heterogeneous domains"));
 
   // Not applicable to variable-sized dimensions
-  if (!array_schema_->domain()->all_dims_fixed())
+  if (!array_schema_latest_->domain()->all_dims_fixed())
     return LOG_STATUS(Status::ArrayError(
         "Cannot get max buffer size; Function not "
         "applicable to domains with variable-sized dimensions"));
 
   // Check if name is attribute or dimension
-  bool is_dim = array_schema_->is_dim(name);
-  bool is_attr = array_schema_->is_attr(name);
+  bool is_dim = array_schema_latest_->is_dim(name);
+  bool is_attr = array_schema_latest_->is_attr(name);
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
@@ -425,7 +425,7 @@ Status Array::get_max_buffer_size(
         name + "' does not exist"));
 
   // Check if attribute/dimension is fixed sized
-  if (array_schema_->var_size(name))
+  if (array_schema_latest_->var_size(name))
     return LOG_STATUS(Status::ArrayError(
         std::string("Cannot get max buffer size; Attribute/Dimension '") +
         name + "' is var-sized"));
@@ -464,13 +464,13 @@ Status Array::get_max_buffer_size(
         "Cannot get max buffer size; Attribute/Dimension name is null"));
 
   // Not applicable to heterogeneous domains
-  if (!array_schema_->domain()->all_dims_same_type())
+  if (!array_schema_latest_->domain()->all_dims_same_type())
     return LOG_STATUS(
         Status::ArrayError("Cannot get max buffer size; Function not "
                            "applicable to heterogeneous domains"));
 
   // Not applicable to variable-sized dimensions
-  if (!array_schema_->domain()->all_dims_fixed())
+  if (!array_schema_latest_->domain()->all_dims_fixed())
     return LOG_STATUS(Status::ArrayError(
         "Cannot get max buffer size; Function not "
         "applicable to domains with variable-sized dimensions"));
@@ -485,7 +485,7 @@ Status Array::get_max_buffer_size(
         name + "' does not exist"));
 
   // Check if attribute/dimension is var-sized
-  if (!array_schema_->var_size(name))
+  if (!array_schema_latest_->var_size(name))
     return LOG_STATUS(Status::ArrayError(
         std::string("Cannot get max buffer size; Attribute/Dimension '") +
         name + "' is fixed-sized"));
@@ -557,8 +557,8 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   if (!st.ok())
     return st;
 
-  array_schema_ = array_schema.value();
-  array_schemas_ = array_schemas.value();
+  array_schema_latest_ = array_schema.value();
+  array_schemas_all_ = array_schemas.value();
   fragment_metadata_ = fragment_metadata.value();
 
   return Status::Ok();
@@ -804,14 +804,14 @@ void Array::clear_last_max_buffer_sizes() {
 
 Status Array::compute_max_buffer_sizes(const void* subarray) {
   // Applicable only to domains where all dimensions have the same type
-  if (!array_schema_->domain()->all_dims_same_type())
+  if (!array_schema_latest_->domain()->all_dims_same_type())
     return LOG_STATUS(
         Status::ArrayError("Cannot compute max buffer sizes; Inapplicable when "
                            "dimension domains have different types"));
 
   // Allocate space for max buffer sizes subarray
-  auto dim_num = array_schema_->dim_num();
-  auto coord_size = array_schema_->domain()->dimension(0)->coord_size();
+  auto dim_num = array_schema_latest_->dim_num();
+  auto coord_size = array_schema_latest_->domain()->dimension(0)->coord_size();
   auto subarray_size = 2 * dim_num * coord_size;
   last_max_buffer_sizes_subarray_.resize(subarray_size);
 
@@ -822,7 +822,7 @@ Status Array::compute_max_buffer_sizes(const void* subarray) {
     last_max_buffer_sizes_.clear();
 
     // Get all attributes and coordinates
-    auto attributes = array_schema_->attributes();
+    auto attributes = array_schema_latest_->attributes();
     last_max_buffer_sizes_.clear();
     for (const auto& attr : attributes)
       last_max_buffer_sizes_[attr->name()] =
@@ -830,8 +830,9 @@ Status Array::compute_max_buffer_sizes(const void* subarray) {
     last_max_buffer_sizes_[constants::coords] =
         std::pair<uint64_t, uint64_t>(0, 0);
     for (unsigned d = 0; d < dim_num; ++d)
-      last_max_buffer_sizes_[array_schema_->domain()->dimension(d)->name()] =
-          std::pair<uint64_t, uint64_t>(0, 0);
+      last_max_buffer_sizes_
+          [array_schema_latest_->domain()->dimension(d)->name()] =
+              std::pair<uint64_t, uint64_t>(0, 0);
 
     RETURN_NOT_OK(compute_max_buffer_sizes(subarray, &last_max_buffer_sizes_));
   }
@@ -852,7 +853,7 @@ Status Array::compute_max_buffer_sizes(
       return LOG_STATUS(Status::ArrayError(
           "Cannot get max buffer sizes; remote array with no REST client."));
     return rest_client->get_array_max_buffer_sizes(
-        array_uri_, array_schema_, subarray, buffer_sizes);
+        array_uri_, array_schema_latest_, subarray, buffer_sizes);
   }
 
   // Return if there are no metadata
@@ -867,46 +868,49 @@ Status Array::compute_max_buffer_sizes(
         meta->add_max_buffer_sizes(*encryption_key_, subarray, buffer_sizes));
 
   // Prepare an NDRange for the subarray
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_latest_->dim_num();
   NDRange sub(dim_num);
   auto sub_ptr = (const unsigned char*)subarray;
   uint64_t offset = 0;
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto r_size = 2 * array_schema_->dimension(d)->coord_size();
+    auto r_size = 2 * array_schema_latest_->dimension(d)->coord_size();
     sub[d] = Range(&sub_ptr[offset], r_size);
     offset += r_size;
   }
 
   // Rectify bound for dense arrays
-  if (array_schema_->dense()) {
-    auto cell_num = array_schema_->domain()->cell_num(sub);
+  if (array_schema_latest_->dense()) {
+    auto cell_num = array_schema_latest_->domain()->cell_num(sub);
     // `cell_num` becomes 0 when `subarray` is huge, leading to a
     // `uint64_t` overflow.
     if (cell_num != 0) {
       for (auto& it : *buffer_sizes) {
-        if (array_schema_->var_size(it.first)) {
+        if (array_schema_latest_->var_size(it.first)) {
           it.second.first = cell_num * constants::cell_var_offset_size;
           it.second.second +=
-              cell_num * datatype_size(array_schema_->type(it.first));
+              cell_num * datatype_size(array_schema_latest_->type(it.first));
         } else {
-          it.second.first = cell_num * array_schema_->cell_size(it.first);
+          it.second.first =
+              cell_num * array_schema_latest_->cell_size(it.first);
         }
       }
     }
   }
 
   // Rectify bound for sparse arrays with integer domain, without duplicates
-  if (!array_schema_->dense() && !array_schema_->allows_dups() &&
-      array_schema_->domain()->all_dims_int()) {
-    auto cell_num = array_schema_->domain()->cell_num(sub);
+  if (!array_schema_latest_->dense() && !array_schema_latest_->allows_dups() &&
+      array_schema_latest_->domain()->all_dims_int()) {
+    auto cell_num = array_schema_latest_->domain()->cell_num(sub);
     // `cell_num` becomes 0 when `subarray` is huge, leading to a
     // `uint64_t` overflow.
     if (cell_num != 0) {
       for (auto& it : *buffer_sizes) {
-        if (!array_schema_->var_size(it.first)) {
+        if (!array_schema_latest_->var_size(it.first)) {
           // Check for overflow
-          uint64_t new_size = cell_num * array_schema_->cell_size(it.first);
-          if (new_size / array_schema_->cell_size((it.first)) != cell_num)
+          uint64_t new_size =
+              cell_num * array_schema_latest_->cell_size(it.first);
+          if (new_size / array_schema_latest_->cell_size((it.first)) !=
+              cell_num)
             continue;
 
           // Potentially rectify size
@@ -970,7 +974,8 @@ Status Array::compute_non_empty_domain() {
       // corrupt for these cases we want to check to prevent any segfaults
       // later.
       if (!meta_dom.empty())
-        array_schema_->domain()->expand_ndrange(meta_dom, &non_empty_domain_);
+        array_schema_latest_->domain()->expand_ndrange(
+            meta_dom, &non_empty_domain_);
       else {
         // If the fragment's non-empty domain is indeed empty, lets log it so
         // the user gets a message warning that this fragment might be corrupt
@@ -984,11 +989,5 @@ Status Array::compute_non_empty_domain() {
   non_empty_domain_computed_ = true;
   return Status::Ok();
 }
-
-const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
-Array::array_schemas() const {
-  return array_schemas_;
-}
-
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -263,11 +263,11 @@ Status Array::open(
         rest_client->get_array_schema_from_rest(array_uri_, &array_schema_));
   } else if (query_type == QueryType::READ) {
     auto&& [st, array_schema, array_schemas, fragment_metadata] =
-        (storage_manager_->array_open_for_reads(
+        storage_manager_->array_open_for_reads(
             array_uri_,
             *encryption_key_,
             timestamp_start_,
-            timestamp_end_opened_at_));
+            timestamp_end_opened_at_);
     if (!st.ok())
       return st;
     // Set schemas
@@ -988,12 +988,6 @@ Status Array::compute_non_empty_domain() {
 const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
 Array::array_schemas() const {
   return array_schemas_;
-}
-
-void Array::set_array_schemas(
-    const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
-        array_schemas) {
-  array_schemas_ = array_schemas;
 }
 
 }  // namespace sm

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -83,11 +83,6 @@ class Array {
   const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
   array_schemas() const;
 
-  /** Set the array schemas map. */
-  void set_array_schemas(
-      const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
-          array_schemas);
-
   /** Returns the array URI. */
   const URI& array_uri() const;
 

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -79,6 +79,15 @@ class Array {
   /** Returns the array schema. */
   ArraySchema* array_schema() const;
 
+  /** Returns array schemas map. */
+  const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+  array_schemas() const;
+
+  /** Set the array schemas map. */
+  void set_array_schemas(
+      const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+          array_schemas);
+
   /** Returns the array URI. */
   const URI& array_uri() const;
 
@@ -341,8 +350,13 @@ class Array {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
-  /** The array schema. */
+  /** The latest array schema. */
   ArraySchema* array_schema_;
+
+  /**
+   * A map of all array_schemas
+   */
+  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>> array_schemas_;
 
   /** The array URI. */
   URI array_uri_;

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -76,12 +76,14 @@ class Array {
   /*                API                */
   /* ********************************* */
 
-  /** Returns the array schema. */
-  ArraySchema* array_schema() const;
+  /** Returns the latest array schema. */
+  ArraySchema* array_schema_latest() const;
 
   /** Returns array schemas map. */
-  const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
-  array_schemas() const;
+  inline const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+  array_schemas_all() const {
+    return array_schemas_all_;
+  }
 
   /** Returns the array URI. */
   const URI& array_uri() const;
@@ -325,9 +327,9 @@ class Array {
    * @note This is potentially an unsafe operation
    * it could have contention with locks from lazy loading of metadata.
    * This should only be used by the serialization class
-   * (tiledb/sm/serialization/array_schema.cc). In that class we need to fetch
-   * the underlying Metadata object to set the values we are loading from REST.
-   * A lock should already by taken before load_metadata is called.
+   * (tiledb/sm/serialization/array_schema_latest.cc). In that class we need to
+   * fetch the underlying Metadata object to set the values we are loading from
+   * REST. A lock should already by taken before load_metadata is called.
    */
   Metadata* metadata();
 
@@ -346,12 +348,13 @@ class Array {
   /* ********************************* */
 
   /** The latest array schema. */
-  ArraySchema* array_schema_;
+  ArraySchema* array_schema_latest_;
 
   /**
-   * A map of all array_schemas
+   * A map of all array_schemas_all
    */
-  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>> array_schemas_;
+  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>
+      array_schemas_all_;
 
   /** The array URI. */
   URI array_uri_;

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -93,7 +93,6 @@ ArraySchema::ArraySchema(const ArraySchema* array_schema) {
   allows_dups_ = array_schema->allows_dups_;
   array_uri_ = array_schema->array_uri_;
   uri_ = array_schema->uri_;
-  name_ = array_schema->name_;
   array_type_ = array_schema->array_type_;
   domain_ = nullptr;
   timestamp_range_ = array_schema->timestamp_range_;
@@ -111,6 +110,8 @@ ArraySchema::ArraySchema(const ArraySchema* array_schema) {
   attribute_map_.clear();
   for (auto attr : array_schema->attributes_)
     add_attribute(attr, false);
+
+  name_ = array_schema->name_;
 }
 
 ArraySchema::~ArraySchema() {

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -111,6 +111,8 @@ ArraySchema::ArraySchema(const ArraySchema* array_schema) {
   for (auto attr : array_schema->attributes_)
     add_attribute(attr, false);
 
+  // This has to be the last thing set because add_attribute sets the name
+  // TODO: This behavior needs to be changed
   name_ = array_schema->name_;
 }
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -2114,6 +2114,11 @@ Status FragmentMetadata::load_v1_v2(
   auto schema = array_schemas.find(array_schema_name_);
   if (schema != array_schemas.end()) {
     set_array_schema(schema->second.get());
+  } else {
+    return Status::FragmentMetadataError(
+        "Could not find schema" + array_schema_name_ +
+        " in map of schemas loaded.\n" +
+        "Consider reloading the array to check for new array schemas.");
   }
 
   // Deserialize
@@ -2175,6 +2180,11 @@ Status FragmentMetadata::load_footer(
     auto schema = array_schemas.find(array_schema_name_);
     if (schema != array_schemas.end()) {
       set_array_schema(schema->second.get());
+    } else {
+      return Status::FragmentMetadataError(
+          "Could not find schema" + array_schema_name_ +
+          " in map of schemas loaded.\n" +
+          "Consider reloading the array to check for new array schemas.");
     }
   } else {
     // Pre-v10 format fragments we need to set the schema and schema name to
@@ -2183,6 +2193,11 @@ Status FragmentMetadata::load_footer(
     auto schema = array_schemas.find(array_schema_name_);
     if (schema != array_schemas.end()) {
       set_array_schema(schema->second.get());
+    } else {
+      return Status::FragmentMetadataError(
+          "Could not find schema" + array_schema_name_ +
+          " in map of schemas loaded.\n" +
+          "Consider reloading the array to check for new array schemas.");
     }
   }
   RETURN_NOT_OK(load_dense(cbuff.get()));

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -58,7 +58,7 @@ DenseTiler<T>::DenseTiler(
     uint64_t offsets_bitsize,
     bool offsets_extra_element)
     : stats_(parent_stats->create_child("DenseTiler"))
-    , array_schema_(subarray->array()->array_schema())
+    , array_schema_(subarray->array()->array_schema_latest())
     , buffers_(buffers)
     , subarray_(subarray)
     , offsets_format_mode_(offsets_format_mode)

--- a/tiledb/sm/query/dense_tiler.h
+++ b/tiledb/sm/query/dense_tiler.h
@@ -140,7 +140,7 @@ class DenseTiler {
    * Constructor.
    *
    * @note It is assumed that `buffers` contains correct attributes
-   *     complying with the array_schema (which can be retrieved
+   *     complying with the array_schema_latest (which can be retrieved
    *     from `subarray`). Otherwise, an assertion is raised.
    */
   DenseTiler(

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -78,7 +78,7 @@ Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
     , fragment_uri_(fragment_uri) {
   if (array != nullptr) {
     assert(array->is_open());
-    array_schema_ = array->array_schema();
+    array_schema_ = array->array_schema_latest();
 
     auto st = array->get_query_type(&type_);
     assert(st.ok());

--- a/tiledb/sm/query/read_cell_slab_iter.cc
+++ b/tiledb/sm/query/read_cell_slab_iter.cc
@@ -61,7 +61,7 @@ ReadCellSlabIter<T>::ReadCellSlabIter(
     , result_coords_pos_(result_coords_pos)
     , init_result_coords_pos_(result_coords_pos) {
   domain_ = (subarray != nullptr) ?
-                subarray->array()->array_schema()->domain() :
+                subarray->array()->array_schema_latest()->domain() :
                 nullptr;
   layout_ = (subarray != nullptr) ? subarray->layout() : Layout::ROW_MAJOR;
   cell_slab_iter_ = CellSlabIter<T>(subarray);

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -64,7 +64,7 @@ StrategyBase::StrategyBase(
     , offsets_extra_element_(false)
     , offsets_bitsize_(constants::cell_var_offset_size * 8) {
   if (array != nullptr) {
-    array_schema_ = array->array_schema();
+    array_schema_ = array->array_schema_latest();
   }
 }
 

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -997,7 +997,9 @@ Status Writer::create_fragment(
   } else {
     std::string new_fragment_str;
     RETURN_NOT_OK(new_fragment_name(
-        timestamp, array_->array_schema()->write_version(), &new_fragment_str));
+        timestamp,
+        array_->array_schema_latest()->write_version(),
+        &new_fragment_str));
     uri = array_schema_->array_uri().join_path(new_fragment_str);
   }
   auto timestamp_range = std::pair<uint64_t, uint64_t>(timestamp, timestamp);

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -821,7 +821,7 @@ Status nonempty_domain_serialize(
     return LOG_STATUS(Status::SerializationError(
         "Error serializing nonempty domain; nonempty domain is null."));
 
-  const auto* schema = array->array_schema();
+  const auto* schema = array->array_schema_latest();
   if (schema == nullptr)
     return LOG_STATUS(Status::SerializationError(
         "Error serializing nonempty domain; array schema is null."));
@@ -892,7 +892,7 @@ Status nonempty_domain_deserialize(
     return LOG_STATUS(Status::SerializationError(
         "Error deserializing nonempty domain; nonempty domain is null."));
 
-  const auto* schema = array->array_schema();
+  const auto* schema = array->array_schema_latest();
   if (schema == nullptr)
     return LOG_STATUS(Status::SerializationError(
         "Error deserializing nonempty domain; array schema is null."));
@@ -967,7 +967,7 @@ Status nonempty_domain_deserialize(
 
 Status nonempty_domain_serialize(
     Array* array, SerializationType serialize_type, Buffer* serialized_buffer) {
-  const auto* schema = array->array_schema();
+  const auto* schema = array->array_schema_latest();
   if (schema == nullptr)
     return LOG_STATUS(Status::SerializationError(
         "Error serializing nonempty domain; array schema is null."));
@@ -1078,7 +1078,7 @@ Status max_buffer_sizes_serialize(
     const void* subarray,
     SerializationType serialize_type,
     Buffer* serialized_buffer) {
-  const auto* schema = array->array_schema();
+  const auto* schema = array->array_schema_latest();
   if (schema == nullptr)
     return LOG_STATUS(Status::SerializationError(
         "Error serializing max buffer sizes; array schema is null."));

--- a/tiledb/sm/serialization/array_schema_evolution.h
+++ b/tiledb/sm/serialization/array_schema_evolution.h
@@ -1,5 +1,5 @@
 /**
- * @file   array_schema.h
+ * @file   array_schema_evolution.h
  *
  * @section LICENSE
  *

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -398,7 +398,7 @@ Status serialize_non_empty_domain(CapnpT& builder, tiledb::sm::Array* array) {
 
   if (!nonEmptyDomain.empty()) {
     auto nonEmptyDomainListBuilder =
-        builder.initNonEmptyDomains(array->array_schema()->dim_num());
+        builder.initNonEmptyDomains(array->array_schema_latest()->dim_num());
 
     for (uint64_t dimIdx = 0; dimIdx < nonEmptyDomain.size(); ++dimIdx) {
       const auto& dimNonEmptyDomain = nonEmptyDomain[dimIdx];

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -380,7 +380,7 @@ Status subarray_partitioner_from_capnp(
 
   // Per-attr mem budgets
   if (reader.hasBudget()) {
-    const ArraySchema* schema = array->array_schema();
+    const ArraySchema* schema = array->array_schema_latest();
     auto mem_budgets_reader = reader.getBudget();
     auto num_attrs = mem_budgets_reader.size();
     for (size_t i = 0; i < num_attrs; i++) {

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -223,7 +223,7 @@ Status Consolidator::consolidate_fragments(
     // Find the next fragments to be consolidated
     NDRange union_non_empty_domains;
     st = compute_next_to_consolidate(
-        array_for_reads.array_schema(),
+        array_for_reads.array_schema_latest(),
         fragment_info,
         &to_consolidate,
         &union_non_empty_domains);
@@ -321,7 +321,7 @@ Status Consolidator::consolidate(
   }
 
   // Get schema
-  auto array_schema = array_for_reads.array_schema();
+  auto array_schema = array_for_reads.array_schema_latest();
 
   // Prepare buffers
   std::vector<ByteVec> buffers;
@@ -418,7 +418,7 @@ Status Consolidator::consolidate_fragment_meta(
   auto first = meta.front()->fragment_uri();
   auto last = meta.back()->fragment_uri();
   RETURN_NOT_OK(compute_new_fragment_uri(
-      first, last, array.array_schema()->write_version(), &uri));
+      first, last, array.array_schema_latest()->write_version(), &uri));
   uri = URI(uri.to_string() + constants::meta_file_suffix);
 
   // Get the consolidated fragment metadata version
@@ -580,7 +580,7 @@ Status Consolidator::create_queries(
 
   // Refactored reader optimizes for no subarray.
   if (!config_.use_refactored_reader_ ||
-      array_for_reads->array_schema()->dense())
+      array_for_reads->array_schema_latest()->dense())
     RETURN_NOT_OK((*query_r)->set_subarray_unsafe(subarray));
 
   // Get last fragment URI, which will be the URI of the consolidated fragment
@@ -590,7 +590,7 @@ Status Consolidator::create_queries(
   RETURN_NOT_OK(compute_new_fragment_uri(
       first,
       last,
-      array_for_reads->array_schema()->write_version(),
+      array_for_reads->array_schema_latest()->write_version(),
       new_fragment_uri));
 
   // Create write query
@@ -598,7 +598,7 @@ Status Consolidator::create_queries(
       tdb_new(Query, storage_manager_, array_for_writes, *new_fragment_uri);
   RETURN_NOT_OK((*query_w)->set_layout(Layout::GLOBAL_ORDER));
   RETURN_NOT_OK((*query_w)->disable_check_global_order());
-  if (array_for_reads->array_schema()->dense())
+  if (array_for_reads->array_schema_latest()->dense())
     RETURN_NOT_OK((*query_w)->set_subarray_unsafe(subarray));
 
   return Status::Ok();

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -68,9 +68,15 @@ ArraySchema* OpenArray::array_schema() const {
   return array_schema_;
 }
 
-std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
 OpenArray::array_schemas() {
   return array_schemas_;
+}
+
+void OpenArray::set_array_schemas(
+    const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+        array_schemas) {
+  array_schemas_ = array_schemas;
 }
 
 Status OpenArray::get_array_schema(

--- a/tiledb/sm/storage_manager/open_array.cc
+++ b/tiledb/sm/storage_manager/open_array.cc
@@ -50,13 +50,13 @@ namespace sm {
 OpenArray::OpenArray(const URI& array_uri, QueryType query_type)
     : array_uri_(array_uri)
     , query_type_(query_type) {
-  array_schema_ = nullptr;
+  array_schema_latest_ = nullptr;
   cnt_ = 0;
   filelock_ = INVALID_FILELOCK;
 }
 
 OpenArray::~OpenArray() {
-  tdb_delete(array_schema_);
+  tdb_delete(array_schema_latest_);
   fragment_metadata_.clear();
 }
 
@@ -64,26 +64,27 @@ OpenArray::~OpenArray() {
 /*               API              */
 /* ****************************** */
 
-ArraySchema* OpenArray::array_schema() const {
-  return array_schema_;
+ArraySchema* OpenArray::array_schema_latest() const {
+  return array_schema_latest_;
 }
 
 const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
-OpenArray::array_schemas() {
-  return array_schemas_;
+OpenArray::array_schemas_all() {
+  return array_schemas_all_;
 }
 
-void OpenArray::set_array_schemas(
+void OpenArray::set_array_schemas_all(
     const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
         array_schemas) {
-  array_schemas_ = array_schemas;
+  array_schemas_all_ = array_schemas;
 }
 
 Status OpenArray::get_array_schema(
     const std::string& schema_name, tdb_shared_ptr<ArraySchema>* array_schema) {
-  (*array_schema) = (array_schemas_.find(schema_name) == array_schemas_.end()) ?
-                        tdb_shared_ptr<ArraySchema>(nullptr) :
-                        array_schemas_[schema_name];
+  (*array_schema) =
+      (array_schemas_all_.find(schema_name) == array_schemas_all_.end()) ?
+          tdb_shared_ptr<ArraySchema>(nullptr) :
+          array_schemas_all_[schema_name];
   return Status::Ok();
 }
 
@@ -160,7 +161,7 @@ QueryType OpenArray::query_type() const {
 }
 
 void OpenArray::set_array_schema(ArraySchema* array_schema) {
-  array_schema_ = array_schema;
+  array_schema_latest_ = array_schema;
 }
 
 void OpenArray::insert_fragment_metadata(

--- a/tiledb/sm/storage_manager/open_array.h
+++ b/tiledb/sm/storage_manager/open_array.h
@@ -89,7 +89,13 @@ class OpenArray {
   ArraySchema* array_schema() const;
 
   /** Returns array schemas map. */
-  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>& array_schemas();
+  const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+  array_schemas();
+
+  /** Set the array schemas map. */
+  void set_array_schemas(
+      const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+          array_schemas);
 
   /** Gets the array schema given a array schema name. */
   Status get_array_schema(

--- a/tiledb/sm/storage_manager/open_array.h
+++ b/tiledb/sm/storage_manager/open_array.h
@@ -86,14 +86,14 @@ class OpenArray {
   /* ********************************* */
 
   /** Returns the array schema. */
-  ArraySchema* array_schema() const;
+  ArraySchema* array_schema_latest() const;
 
   /** Returns array schemas map. */
   const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
-  array_schemas();
+  array_schemas_all();
 
   /** Set the array schemas map. */
-  void set_array_schemas(
+  void set_array_schemas_all(
       const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
           array_schemas);
 
@@ -194,12 +194,13 @@ class OpenArray {
   /* ********************************* */
 
   /** The latest array schema. */
-  ArraySchema* array_schema_;
+  ArraySchema* array_schema_latest_;
 
   /**
-   * A map of all array_schemas
+   * A map of all array_schemas_all
    */
-  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>> array_schemas_;
+  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>
+      array_schemas_all_;
 
   /** The array URI. */
   URI array_uri_;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1537,6 +1537,9 @@ Status StorageManager::get_fragment_info(
           array_type == ArrayType::SPARSE ? timestamp_start : 0,
           timestamp_end);
 
+  if (!st.ok())
+    return st;
+
   // Return if array is empty
   if (fragment_metadata_opt.value().empty())
     return Status::Ok();
@@ -2018,7 +2021,6 @@ std::tuple<
 StorageManager::load_all_array_schemas(
     const URI& array_uri, const EncryptionKey& encryption_key) {
   auto timer_se = stats_->start_timer("read_load_all_array_schemas");
-  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>> array_schemas;
 
   if (array_uri.is_invalid())
     return {logger_->status(Status::StorageManagerError(
@@ -2049,6 +2051,7 @@ StorageManager::load_all_array_schemas(
       });
   RETURN_NOT_OK_TUPLE(status);
 
+  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>> array_schemas;
   for (const auto& array_schema : schema_vector) {
     array_schemas[array_schema->name()] =
         tdb_shared_ptr<ArraySchema>(array_schema);

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -167,6 +167,12 @@ class StorageManager {
    *     1970-01-01 00:00:00 +0000 (UTC).
    * @return tuple of Status, latest ArraySchema, map of all array schemas and
    * vector of FragmentMetadata
+   *        Status Ok on success, else error
+   *        ArraySchema The array schema to be retrieved after the
+   *           array is opened.
+   *        ArraySchemaMap Map of all array schemas found keyed by name
+   *        fragment_metadata The fragment metadata to be retrieved
+   *           after the array is opened.
    */
   std::tuple<
       Status,
@@ -186,6 +192,10 @@ class StorageManager {
    * @param array_uri The array URI.
    * @param enc_key The encryption key to use.
    * @return tuple of Status, latest ArraySchema and map of all array schemas
+   *        Status Ok on success, else error
+   *        ArraySchema The array schema to be retrieved after the
+   *          array is opened.
+   *        ArraySchemaMap Map of all array schemas found keyed by name
    */
   std::tuple<
       Status,
@@ -200,6 +210,10 @@ class StorageManager {
    * @param array_uri The array URI.
    * @param enc_key The encryption key.
    * @return tuple of Status, latest ArraySchema and map of all array schemas
+   *        Status Ok on success, else error
+   *        ArraySchema The array schema to be retrieved after the
+   *          array is opened.
+   *        ArraySchemaMap Map of all array schemas found keyed by name
    */
   std::tuple<
       Status,
@@ -214,7 +228,7 @@ class StorageManager {
    * @param array_uri The array URI.
    * @param enc_key The encryption key to use.
    * @param fragment_metadata The fragment metadata to be retrieved
-   *     after the array is opened.
+   *          after the array is opened.
    * @param fragment_info The list of fragment info.
    * @return Status
    */
@@ -231,10 +245,6 @@ class StorageManager {
    *
    * @param array_uri The array URI.
    * @param enc_key The encryption key to use.
-   * @param array_schema The array schema to be retrieved after the
-   *     array is opened.
-   * @param fragment_metadata The fragment metadata to be retrieved
-   *     after the array is opened.
    * @param timestamp_start The optional first timestamp between which the
    *     array will be opened.
    * @param timestamp_end The timestamp at which the array will be opened.
@@ -242,6 +252,12 @@ class StorageManager {
    *     1970-01-01 00:00:00 +0000 (UTC).
    * @return tuple of Status, latest ArraySchema, map of all array schemas and
    * vector of FragmentMetadata
+   *        Status Ok on success, else error
+   *        ArraySchema The array schema to be retrieved after the
+   *          array is opened.
+   *        ArraySchemaMap Map of all array schemas found keyed by name
+   *        FragmentMetadata The fragment metadata to be retrieved
+   *          after the array is opened.
    */
   std::tuple<
       Status,
@@ -759,6 +775,8 @@ class StorageManager {
    * @param encryption_key The encryption key to use.
    * @return tuple of Status and optional unordered map. If Status is an error
    * the unordered_map will be nullopt
+   *        Status Ok on success, else error
+   *        ArraySchemaMap Map of all array schemas found keyed by name
    */
   std::tuple<
       Status,

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -171,11 +171,15 @@ class StorageManager {
    *     1970-01-01 00:00:00 +0000 (UTC).
    * @return Status
    */
-  Status array_open_for_reads(
+  std::tuple<
+      Status,
+      std::optional<ArraySchema*>,
+      std::optional<
+          std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
+      std::optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+  array_open_for_reads(
       const URI& array_uri,
       const EncryptionKey& enc_key,
-      ArraySchema** array_schema,
-      std::vector<tdb_shared_ptr<FragmentMetadata>>* fragment_metadata,
       uint64_t timestamp_start,
       uint64_t timestamp_end);
 
@@ -197,11 +201,14 @@ class StorageManager {
    *
    * @param array_uri The array URI.
    * @param enc_key The encryption key.
-   * @param array_schema The array schema to be retrieved after the
-   *     array is opened.
-   * @return
+   * @return tuple of Status, latest ArraySchema and map of all array schemas
    */
-  Status array_open_for_writes(
+  std::tuple<
+      Status,
+      std::optional<ArraySchema*>,
+      std::optional<
+          std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+  array_open_for_writes(
       const URI& array_uri,
       const EncryptionKey& enc_key,
       ArraySchema** array_schema);
@@ -750,14 +757,15 @@ class StorageManager {
    *
    * @param array_uri The URI path of the array.
    * @param encryption_key The encryption key to use.
-   * @param array_schemas The array schema pointermap to be retrieved.
-   * @return Status
+   * @return tuple of Status and optional unordered map. If Status is an error
+   * the unordered_map will be nullopt
    */
-  Status load_all_array_schemas(
-      const URI& array_uri,
-      const EncryptionKey& encryption_key,
-      std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
-          array_schemas);
+  std::tuple<
+      Status,
+      std::optional<
+          std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+  load_all_array_schemas(
+      const URI& array_uri, const EncryptionKey& encryption_key);
 
   /**
    * Loads the array metadata from persistent storage that were created

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -160,16 +160,13 @@ class StorageManager {
    *
    * @param array_uri The array URI.
    * @param enc_key The encryption key to use.
-   * @param array_schema The array schema to be retrieved after the
-   *     array is opened.
-   * @param fragment_metadata The fragment metadata to be retrieved
-   *     after the array is opened.
    * @param timestamp_start The (optional) starting timestamp to open the array
    * between, starting at this timestamp and ending at `timestamp_end`.
    * @param timestamp_end The timestamp at which the array will be opened.
    *     In TileDB, timestamps are in ms elapsed since
    *     1970-01-01 00:00:00 +0000 (UTC).
-   * @return Status
+   * @return tuple of Status, latest ArraySchema, map of all array schemas and
+   * vector of FragmentMetadata
    */
   std::tuple<
       Status,
@@ -188,14 +185,15 @@ class StorageManager {
    *
    * @param array_uri The array URI.
    * @param enc_key The encryption key to use.
-   * @param array_schema The array schema to be retrieved after the
-   *     array is opened.
-   * @return Status
+   * @return tuple of Status, latest ArraySchema and map of all array schemas
    */
-  Status array_open_for_reads_without_fragments(
-      const URI& array_uri,
-      const EncryptionKey& enc_key,
-      ArraySchema** array_schema);
+  std::tuple<
+      Status,
+      std::optional<ArraySchema*>,
+      std::optional<
+          std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+  array_open_for_reads_without_fragments(
+      const URI& array_uri, const EncryptionKey& enc_key);
 
   /** Opens an array for writes.
    *
@@ -208,10 +206,7 @@ class StorageManager {
       std::optional<ArraySchema*>,
       std::optional<
           std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
-  array_open_for_writes(
-      const URI& array_uri,
-      const EncryptionKey& enc_key,
-      ArraySchema** array_schema);
+  array_open_for_writes(const URI& array_uri, const EncryptionKey& enc_key);
 
   /**
    * Load fragments for an already open array.
@@ -245,13 +240,18 @@ class StorageManager {
    * @param timestamp_end The timestamp at which the array will be opened.
    *     In TileDB, timestamps are in ms elapsed since
    *     1970-01-01 00:00:00 +0000 (UTC).
-   * @return Status
+   * @return tuple of Status, latest ArraySchema, map of all array schemas and
+   * vector of FragmentMetadata
    */
-  Status array_reopen(
+  std::tuple<
+      Status,
+      std::optional<ArraySchema*>,
+      std::optional<
+          std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
+      std::optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+  array_reopen(
       const URI& array_uri,
       const EncryptionKey& enc_key,
-      ArraySchema** array_schema,
-      std::vector<tdb_shared_ptr<FragmentMetadata>>* fragment_metadata,
       uint64_t timestamp_start,
       uint64_t timestamp_end);
 

--- a/tiledb/sm/subarray/cell_slab_iter.cc
+++ b/tiledb/sm/subarray/cell_slab_iter.cc
@@ -62,7 +62,7 @@ CellSlabIter<T>::CellSlabIter(const Subarray* subarray)
     : subarray_(subarray) {
   end_ = true;
   if (subarray != nullptr) {
-    auto array_schema = subarray->array()->array_schema();
+    auto array_schema = subarray->array()->array_schema_latest();
     auto dim_num = array_schema->dim_num();
     auto coord_size = array_schema->dimension(0)->coord_size();
     aux_tile_coords_.resize(dim_num);
@@ -245,7 +245,7 @@ template <class T>
 Status CellSlabIter<T>::init_ranges() {
   // For easy reference
   auto dim_num = subarray_->dim_num();
-  auto array_schema = subarray_->array()->array_schema();
+  auto array_schema = subarray_->array()->array_schema_latest();
   auto array_domain = array_schema->domain()->domain();
   uint64_t range_num;
   T tile_extent, dim_domain_start;
@@ -281,7 +281,7 @@ Status CellSlabIter<T>::sanity_check() const {
 
   // Check type
   bool error;
-  auto array_schema = subarray_->array()->array_schema();
+  auto array_schema = subarray_->array()->array_schema_latest();
   auto type = array_schema->domain()->dimension(0)->type();
   switch (type) {
     case Datatype::INT8:

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -1225,7 +1225,7 @@ class Subarray {
 
   /**
    * Constructs `add_or_coalesce_range_func_` for all dimensions
-   * in `array_->array_schema()`.
+   * in `array_->array_schema_latest()`.
    */
   void set_add_or_coalesce_range_func();
 

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -159,7 +159,7 @@ Status SubarrayPartitioner::get_result_budget(
         "Cannot get result budget; Invalid budget input"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   bool is_dim = array_schema->is_dim(name);
   bool is_attr = array_schema->is_attr(name);
 
@@ -214,7 +214,7 @@ Status SubarrayPartitioner::get_result_budget(
         "must be var-sized"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   bool is_dim = array_schema->is_dim(name);
   bool is_attr = array_schema->is_attr(name);
 
@@ -264,7 +264,7 @@ Status SubarrayPartitioner::get_result_budget_nullable(
         "Cannot get result budget; Invalid budget input"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   bool is_attr = array_schema->is_attr(name);
 
   // Check if attribute exists
@@ -317,7 +317,7 @@ Status SubarrayPartitioner::get_result_budget_nullable(
         "Cannot get result budget; Invalid budget input"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   bool is_attr = array_schema->is_attr(name);
 
   // Check if attribute exists
@@ -419,7 +419,7 @@ Status SubarrayPartitioner::set_result_budget(
         "Cannot set result budget; Attribute/Dimension name cannot be null"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   bool is_dim = array_schema->is_dim(name);
   bool is_attr = array_schema->is_attr(name);
 
@@ -461,7 +461,7 @@ Status SubarrayPartitioner::set_result_budget(
         "must be var-sized"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   bool is_dim = array_schema->is_dim(name);
   bool is_attr = array_schema->is_attr(name);
 
@@ -497,7 +497,7 @@ Status SubarrayPartitioner::set_result_budget_nullable(
         "Cannot set result budget; Attribute name cannot be null"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   bool is_attr = array_schema->is_attr(name);
 
   // Check if attribute exists
@@ -536,7 +536,7 @@ Status SubarrayPartitioner::set_result_budget_nullable(
         "Cannot set result budget; Attribute name cannot be null"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   bool is_attr = array_schema->is_attr(name);
 
   // Check if attribute exists
@@ -672,7 +672,7 @@ Status SubarrayPartitioner::calibrate_current_start_end(bool* must_split_slab) {
   }
 
   auto layout = subarray_.layout();
-  auto cell_order = subarray_.array()->array_schema()->cell_order();
+  auto cell_order = subarray_.array()->array_schema_latest()->cell_order();
   cell_order = (cell_order == Layout::HILBERT) ? Layout::ROW_MAJOR : cell_order;
   layout = (layout == Layout::UNORDERED) ? cell_order : layout;
   assert(layout == Layout::ROW_MAJOR || layout == Layout::COL_MAJOR);
@@ -880,13 +880,13 @@ void SubarrayPartitioner::compute_splitting_value_on_tiles(
   *unsplittable = true;
 
   // Inapplicable to Hilbert cell order
-  if (subarray_.array()->array_schema()->cell_order() == Layout::HILBERT)
+  if (subarray_.array()->array_schema_latest()->cell_order() == Layout::HILBERT)
     return;
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
-  auto dim_num = subarray_.array()->array_schema()->dim_num();
-  auto layout = subarray_.array()->array_schema()->tile_order();
+  auto array_schema = subarray_.array()->array_schema_latest();
+  auto dim_num = subarray_.array()->array_schema_latest()->dim_num();
+  auto layout = subarray_.array()->array_schema_latest()->tile_order();
   *splitting_dim = UINT32_MAX;
 
   std::vector<unsigned> dims;
@@ -938,7 +938,7 @@ void SubarrayPartitioner::compute_splitting_value_single_range(
   }
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   auto dim_num = array_schema->dim_num();
   auto cell_order = array_schema->cell_order();
   assert(!range.is_unary());
@@ -998,7 +998,7 @@ void SubarrayPartitioner::compute_splitting_value_single_range_hilbert(
     bool* normal_order,
     bool* unsplittable) {
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   auto dim_num = array_schema->dim_num();
   Hilbert h(dim_num);
 
@@ -1059,7 +1059,7 @@ Status SubarrayPartitioner::compute_splitting_value_multi_range(
 
   // Multi-range partition
   auto layout = subarray_.layout();
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   auto dim_num = array_schema->dim_num();
   auto cell_order = (array_schema->cell_order() == Layout::HILBERT) ?
                         Layout::ROW_MAJOR :
@@ -1105,7 +1105,7 @@ Status SubarrayPartitioner::compute_splitting_value_multi_range(
 }
 
 bool SubarrayPartitioner::must_split(Subarray* partition) {
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   bool must_split = false;
 
   uint64_t size_fixed;
@@ -1364,7 +1364,7 @@ void SubarrayPartitioner::compute_range_uint64(
     std::vector<std::array<uint64_t, 2>>* range_uint64,
     bool* unsplittable) const {
   // Initializations
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   auto dim_num = array_schema->dim_num();
   const Range* r;
   *unsplittable = true;
@@ -1409,7 +1409,7 @@ void SubarrayPartitioner::compute_splitting_dim_hilbert(
     const std::vector<std::array<uint64_t, 2>>& range_uint64,
     uint32_t* splitting_dim) const {
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   auto dim_num = array_schema->dim_num();
 
   // Prepare candidate splitting dimensions
@@ -1483,7 +1483,7 @@ void SubarrayPartitioner::compute_splitting_value_hilbert(
     const std::array<uint64_t, 2>& range_uint64,
     uint32_t splitting_dim,
     ByteVecValue* splitting_value) const {
-  auto array_schema = subarray_.array()->array_schema();
+  auto array_schema = subarray_.array()->array_schema_latest();
   auto dim_num = array_schema->dim_num();
   uint64_t splitting_value_uint64 = range_uint64[0];  // Splitting value
   if (range_uint64[0] + 1 != range_uint64[1]) {

--- a/tools/src/commands/info_command.cc
+++ b/tools/src/commands/info_command.cc
@@ -132,7 +132,7 @@ void InfoCommand::print_tile_sizes() const {
   EncryptionKey enc_key;
 
   // Compute and report mean persisted tile sizes over all attributes.
-  const auto* schema = array.array_schema();
+  const auto* schema = array.array_schema_latest();
   auto fragment_metadata = array.fragment_metadata();
   auto attributes = schema->attributes();
   uint64_t total_persisted_size = 0, total_in_memory_size = 0;
@@ -205,7 +205,7 @@ void InfoCommand::print_schema_info() const {
   THROW_NOT_OK(
       array.open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0));
 
-  array.array_schema()->dump(stdout);
+  array.array_schema_latest()->dump(stdout);
 
   // Close the array.
   THROW_NOT_OK(array.close());
@@ -223,7 +223,7 @@ void InfoCommand::write_svg_mbrs() const {
   THROW_NOT_OK(
       array.open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0));
 
-  const auto* schema = array.array_schema();
+  const auto* schema = array.array_schema_latest();
   auto dim_num = schema->dim_num();
   if (dim_num < 2) {
     THROW_NOT_OK(array.close());
@@ -300,7 +300,7 @@ void InfoCommand::write_text_mbrs() const {
       array.open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0));
 
   auto encryption_key = array.encryption_key();
-  const auto* schema = array.array_schema();
+  const auto* schema = array.array_schema_latest();
   auto dim_num = schema->dim_num();
   auto fragment_metadata = array.fragment_metadata();
   std::stringstream text;


### PR DESCRIPTION
When opening (or reopening) the array we want to always reload the schema. Fragments are always relisted, now with schema evolution we need to make sure we list out any new schemas too. Fragment listing is significantly slower than listing schemas and they happen in parallel so this is low impact.

This also modifies `Array` to keep a map of all array schemas (like `OpenArray`). The reason for this is the map of schemas is used in consolidation to read old fragments. The `Array` previously only kept the `latest` schema.

Further this PR also updates the code for opening arrays and getting schemas to match the new expected style of returning tuples of optional values instead of passing in values by pointers to modify.


---
TYPE: BUG
DESC: Always load array schemas during array open to find any new array schemas created from array schema evolution