### PR TITLE
Disable AVX2 on MSys2 builds (which are only for CRAN)

### DIFF
--- a/.github/workflows/mingw-w64-tiledb/PKGBUILD
+++ b/.github/workflows/mingw-w64-tiledb/PKGBUILD
@@ -35,6 +35,7 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DTILEDB_STATIC=ON \
     -DTILEDB_S3=ON \
+    -DCOMPILER_SUPPORTS_AVX2=OFF \
     ..
   make
   make -C tiledb


### PR DESCRIPTION
AVX2 instructions cause an error on the (arguably rather old, but beyond our control) Windows 2008 (aka Vista) build machine used by CRAN.   So we disable AVX2 in the YAML file for the CI providing the artifacts used by that build, and nowhere else.

---
TYPE: FEATURE
DESC: Disable AVX2 for MSys2 builds used by CRAN
