### PR TITLE
Fix missed rename of tiledb_shared_ptr to tdb_shared_ptr

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -2088,7 +2088,7 @@ Status FragmentMetadata::load_array_schema_name(ConstBuffer* buff) {
 
 Status FragmentMetadata::load_v1_v2(
     const EncryptionKey& encryption_key,
-    const std::unordered_map<std::string, tiledb_shared_ptr<ArraySchema>>&
+    const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
         array_schemas) {
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -928,7 +928,7 @@ class FragmentMetadata {
   /** Loads the basic metadata from storage (version 2 or before). */
   Status load_v1_v2(
       const EncryptionKey& encryption_key,
-      const std::unordered_map<std::string, tiledb_shared_ptr<ArraySchema>>&
+      const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
           array_schemas);
 
   /**


### PR DESCRIPTION
This fixes a single place I missed renaming tiledb_shared_ptr due to not rebasing the allocator change one last time before merging. Not putting a history file entry because this should have been included in #2542 . The problem code was introduced in #2611 

---
TYPE: NO_HISTORY
DESC: NO_HISTORY
