### PR TITLE
Fix logger creation on context to be threadsafe

### DIFF
--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -49,7 +49,8 @@ Context::Context()
     : last_error_(Status::Ok())
     , storage_manager_(nullptr)
     , stats_(tdb::make_shared<stats::Stats>(HERE(), "Context"))
-    , logger_(tdb::make_shared<Logger>(HERE(), "")) {
+    , logger_(tdb::make_shared<Logger>(
+          HERE(), "Context: " + std::to_string(++logger_id_))) {
 }
 
 Context::~Context() {
@@ -93,9 +94,6 @@ Status Context::init(Config* const config) {
 
   // Initialize storage manager
   auto sm = storage_manager_->init(config);
-
-  // Use the logger created for the storage manager
-  logger_ = storage_manager_->logger();
 
   return sm;
 }

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -111,6 +111,8 @@ class Context {
   /** The class logger. */
   tdb_shared_ptr<Logger> logger_;
 
+  inline static std::atomic<uint64_t> logger_id_ = 0;
+
   /* ********************************* */
   /*         PRIVATE METHODS           */
   /* ********************************* */

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -83,7 +83,7 @@ StorageManager::StorageManager(
     stats::Stats* const parent_stats,
     tdb_shared_ptr<Logger> logger)
     : stats_(parent_stats->create_child("StorageManager"))
-    , logger_(logger->clone("Context", ++logger_id_))
+    , logger_(logger)
     , cancellation_in_progress_(false)
     , queries_in_progress_(0)
     , compute_tp_(compute_tp)

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -1040,9 +1040,6 @@ class StorageManager {
   /** The class logger. */
   tdb_shared_ptr<Logger> logger_;
 
-  /** UID of the logger instance */
-  inline static std::atomic<uint64_t> logger_id_ = 0;
-
   /** Set to true when tasks are being cancelled. */
   bool cancellation_in_progress_;
 


### PR DESCRIPTION
Move base logger id creation from Storage Manager to Context constructor so that we don't create a temporary logger object with empty name. Such temporary logger objects are not thread safe, as there can be more than 1 created in parallel with the same dummy name ("") which is not allowed by spdlog.


---
TYPE: BUG
DESC: Fix logger creation on context to be threadsafe
