### PR TITLE
[Backport release-2.5]  Fix logger creation on context to be threadsafe

### DIFF
--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -47,7 +47,8 @@ Context::Context()
     : last_error_(Status::Ok())
     , storage_manager_(nullptr)
     , stats_(tdb_make_shared(stats::Stats, "Context"))
-    , logger_(tdb_make_shared(Logger, "")) {
+    , logger_(
+          tdb_make_shared(Logger, "Context: " + std::to_string(++logger_id_))) {
 }
 
 Context::~Context() {
@@ -91,9 +92,6 @@ Status Context::init(Config* const config) {
 
   // Initialize storage manager
   auto sm = storage_manager_->init(config);
-
-  // Use the logger created for the storage manager
-  logger_ = storage_manager_->logger();
 
   return sm;
 }

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -111,6 +111,8 @@ class Context {
   /** The class logger. */
   tdb_shared_ptr<Logger> logger_;
 
+  inline static std::atomic<uint64_t> logger_id_ = 0;
+
   /* ********************************* */
   /*         PRIVATE METHODS           */
   /* ********************************* */

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -81,7 +81,7 @@ StorageManager::StorageManager(
     stats::Stats* const parent_stats,
     tdb_shared_ptr<Logger> logger)
     : stats_(parent_stats->create_child("StorageManager"))
-    , logger_(logger->clone("Context", ++logger_id_))
+    , logger_(logger)
     , cancellation_in_progress_(false)
     , queries_in_progress_(0)
     , compute_tp_(compute_tp)

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -1040,9 +1040,6 @@ class StorageManager {
   /** The class logger. */
   tdb_shared_ptr<Logger> logger_;
 
-  /** UID of the logger instance */
-  inline static std::atomic<uint64_t> logger_id_ = 0;
-
   /** Set to true when tasks are being cancelled. */
   bool cancellation_in_progress_;
 


### PR DESCRIPTION
Backport a2a8cc15ced150c268f698e4937229c06a705707 from #2625

---
TYPE: NO_HISTORY
DESC: NO_HISTORY
