### PR TITLE
Added object libraries: baseline, buffer, thread_pool

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -38,6 +38,7 @@ cmake_policy(SET CMP0063 NEW)
 ############################################################
 
 add_subdirectory(common)
+add_subdirectory(sm)
 
 ############################################################
 # Source files

--- a/tiledb/common/CMakeLists.txt
+++ b/tiledb/common/CMakeLists.txt
@@ -25,6 +25,7 @@
 #
 
 include(common-root)
+include(common)
 
 add_subdirectory(thread_pool)
 add_subdirectory(dynamic_memory)
@@ -36,3 +37,21 @@ endif()
 
 get_gathered(COMMON_SOURCES)
 set(TILEDB_COMMON_SOURCES ${COMMON_SOURCES} PARENT_SCOPE)
+
+#
+# Object library for other units to depend upon
+#
+add_library(baseline OBJECT
+    logger.cc status.cc governor/governor.cc heap_profiler.cc heap_memory.cc
+)
+find_package(Spdlog_EP REQUIRED)
+target_link_libraries(baseline PUBLIC spdlog::spdlog)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_baseline EXCLUDE_FROM_ALL)
+target_link_libraries(compile_baseline PRIVATE baseline)
+target_sources(compile_baseline PRIVATE
+    test/compile_baseline_main.cc $<TARGET_OBJECTS:baseline>
+)

--- a/tiledb/common/test/compile_baseline_main.cc
+++ b/tiledb/common/test/compile_baseline_main.cc
@@ -1,3 +1,31 @@
+/**
+ * @file compile_baseline_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #include "../dynamic_memory/dynamic_memory.h"
 #include "../governor/governor.h"
 #include "../heap_memory.h"

--- a/tiledb/common/test/compile_baseline_main.cc
+++ b/tiledb/common/test/compile_baseline_main.cc
@@ -1,15 +1,15 @@
 #include "../dynamic_memory/dynamic_memory.h"
-#include "../logger.h"
-#include "../status.h"
 #include "../governor/governor.h"
 #include "../heap_memory.h"
 #include "../heap_profiler.h"
+#include "../logger.h"
+#include "../status.h"
 
 using namespace tiledb::common;
 
-int main()
-{
-  auto n = sizeof(Logger) + sizeof(Status) + sizeof(Governor) + sizeof(HeapProfiler);
+int main() {
+  auto n =
+      sizeof(Logger) + sizeof(Status) + sizeof(Governor) + sizeof(HeapProfiler);
   tdb_free(tdb_malloc(n));
   auto p = make_shared<int>(HERE(), n);
   return 0;

--- a/tiledb/common/test/compile_baseline_main.cc
+++ b/tiledb/common/test/compile_baseline_main.cc
@@ -1,0 +1,16 @@
+#include "../dynamic_memory/dynamic_memory.h"
+#include "../logger.h"
+#include "../status.h"
+#include "../governor/governor.h"
+#include "../heap_memory.h"
+#include "../heap_profiler.h"
+
+using namespace tiledb::common;
+
+int main()
+{
+  auto n = sizeof(Logger) + sizeof(Status) + sizeof(Governor) + sizeof(HeapProfiler);
+  tdb_free(tdb_malloc(n));
+  auto p = make_shared<int>(HERE(), n);
+  return 0;
+}

--- a/tiledb/common/thread_pool/CMakeLists.txt
+++ b/tiledb/common/thread_pool/CMakeLists.txt
@@ -31,27 +31,26 @@ list(APPEND SOURCES
 )
 gather_sources(${SOURCES})
 
-list(APPEND DEPENDENT_SOURCES
-    ../heap_memory.cc
-    ../heap_profiler.cc
-    ../logger.cc
-    ../status.cc
-    ../governor/governor.cc
+#
+# Object library for other units to depend upon
+#
+add_library(thread_pool OBJECT ${SOURCES})
+target_link_libraries(thread_pool PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_thread_pool EXCLUDE_FROM_ALL)
+target_link_libraries(compile_thread_pool PRIVATE thread_pool)
+target_sources(compile_thread_pool PRIVATE
+    test/compile_thread_pool_main.cc $<TARGET_OBJECTS:thread_pool>
 )
 
 if (TILEDB_TESTS)
-    find_package(Catch_EP REQUIRED)
-    find_package(Spdlog_EP REQUIRED)
-
     add_executable(unit_thread_pool EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_thread_pool PUBLIC thread_pool)
+    find_package(Catch_EP REQUIRED)
     target_link_libraries(unit_thread_pool PUBLIC Catch2::Catch2)
-    target_link_libraries(unit_thread_pool PUBLIC spdlog::spdlog)
-
-    # Sources for code under test
-    target_sources(unit_thread_pool PUBLIC ${SOURCES})
-
-    # Sources for code elsewhere required for tests
-    target_sources(unit_thread_pool PUBLIC ${DEPENDENT_SOURCES})
 
     # Sources for tests
     target_sources(unit_thread_pool PUBLIC

--- a/tiledb/common/thread_pool/test/compile_thread_pool_main.cc
+++ b/tiledb/common/thread_pool/test/compile_thread_pool_main.cc
@@ -1,0 +1,6 @@
+#include "../thread_pool.h"
+
+int main() {
+  (void) sizeof(tiledb::common::ThreadPool);
+  return 0;
+}

--- a/tiledb/common/thread_pool/test/compile_thread_pool_main.cc
+++ b/tiledb/common/thread_pool/test/compile_thread_pool_main.cc
@@ -1,3 +1,31 @@
+/**
+ * @file compile_thread_pool_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #include "../thread_pool.h"
 
 int main() {

--- a/tiledb/common/thread_pool/test/compile_thread_pool_main.cc
+++ b/tiledb/common/thread_pool/test/compile_thread_pool_main.cc
@@ -1,6 +1,6 @@
 #include "../thread_pool.h"
 
 int main() {
-  (void) sizeof(tiledb::common::ThreadPool);
+  (void)sizeof(tiledb::common::ThreadPool);
   return 0;
 }

--- a/tiledb/sm/CMakeLists.txt
+++ b/tiledb/sm/CMakeLists.txt
@@ -1,3 +1,29 @@
+#
+# tiledb/sm/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2021 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
 include(common-root)
 
 add_subdirectory(buffer)

--- a/tiledb/sm/CMakeLists.txt
+++ b/tiledb/sm/CMakeLists.txt
@@ -1,0 +1,4 @@
+include(common-root)
+
+add_subdirectory(buffer)
+#add_subdirectory(misc)

--- a/tiledb/sm/buffer/CMakeLists.txt
+++ b/tiledb/sm/buffer/CMakeLists.txt
@@ -1,0 +1,16 @@
+include(common NO_POLICY_SCOPE)
+
+#
+# Object library for other units to depend upon
+#
+add_library(buffer OBJECT buffer.cc)
+target_link_libraries(buffer PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_buffer EXCLUDE_FROM_ALL)
+target_link_libraries(compile_buffer PRIVATE buffer)
+target_sources(compile_buffer PRIVATE
+    test/compile_buffer_main.cc $<TARGET_OBJECTS:buffer>
+)

--- a/tiledb/sm/buffer/CMakeLists.txt
+++ b/tiledb/sm/buffer/CMakeLists.txt
@@ -1,3 +1,29 @@
+#
+# tiledb/sm/buffer/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2021 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
 include(common NO_POLICY_SCOPE)
 
 #

--- a/tiledb/sm/buffer/test/compile_buffer_main.cc
+++ b/tiledb/sm/buffer/test/compile_buffer_main.cc
@@ -1,0 +1,7 @@
+#include "../buffer.h"
+
+int main()
+{
+  (void) sizeof(tiledb::sm::Buffer);
+  return 0;
+}

--- a/tiledb/sm/buffer/test/compile_buffer_main.cc
+++ b/tiledb/sm/buffer/test/compile_buffer_main.cc
@@ -1,3 +1,31 @@
+/**
+ * @file compile_buffer_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #include "../buffer.h"
 
 int main() {

--- a/tiledb/sm/buffer/test/compile_buffer_main.cc
+++ b/tiledb/sm/buffer/test/compile_buffer_main.cc
@@ -1,7 +1,6 @@
 #include "../buffer.h"
 
-int main()
-{
-  (void) sizeof(tiledb::sm::Buffer);
+int main() {
+  (void)sizeof(tiledb::sm::Buffer);
   return 0;
 }


### PR DESCRIPTION
Taking advantage of CMake 3.21, this PR creates a few new units using object libraries. The small proof-of-concept success here is that the `thread_pool` unit test target is linked simply to the (new) `baseline` unit without any other explicit dependencies.

---
TYPE: IMPROVEMENT
DESC: Added object libraries: baseline, buffer, thread_pool