### PR TITLE
Pin cmake to 3.21.4 in example Dockerfile

### DIFF
--- a/.github/workflows/mingw-w64-tiledb/PKGBUILD
+++ b/.github/workflows/mingw-w64-tiledb/PKGBUILD
@@ -12,7 +12,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake=3.21"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-curl")
 options=("staticlibs" "strip")

--- a/examples/Dockerfile/Dockerfile
+++ b/examples/Dockerfile/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     && apt-get clean \
     && apt-get purge -y \
     && rm -rf /var/lib/apt/lists* \
-    && pip3 install cmake
+    && pip3 install cmake==3.21.4
 
 # Build and install TileDB.
 RUN cd /home/tiledb/TileDB \


### PR DESCRIPTION
This pins cmake to 3.21.4 because the current version of the AWS sdk we use does not work with cmake 3.22. Upgrading AWS sdk is a larger project that will happen in the near future.

---
TYPE: IMPROVEMENT
DESC: Pin cmake to 3.21.4 in example dockerfile to avoid issue with cmake 3.22 in AWS sdk
