### PR TITLE
Let error message getter check for null pointer

### DIFF
--- a/tiledb/sm/cpp_api/error.h
+++ b/tiledb/sm/cpp_api/error.h
@@ -90,7 +90,10 @@ class Error {
   const std::string error_message() {
     const char* msg = nullptr;
     tiledb_error_message(error_.get(), &msg);
-    return std::string(msg);
+    if (msg == nullptr)
+      return std::string("(empty error string returned from tiledb_error_message)");
+    else
+      return std::string(msg);
   }
 
  private:

--- a/tiledb/sm/cpp_api/error.h
+++ b/tiledb/sm/cpp_api/error.h
@@ -91,7 +91,8 @@ class Error {
     const char* msg = nullptr;
     tiledb_error_message(error_.get(), &msg);
     if (msg == nullptr)
-      return std::string("(empty error string returned from tiledb_error_message)");
+      return std::string(
+          "(empty error string returned from tiledb_error_message)");
     else
       return std::string(msg);
   }

--- a/tiledb/sm/cpp_api/error.h
+++ b/tiledb/sm/cpp_api/error.h
@@ -91,8 +91,7 @@ class Error {
     const char* msg = nullptr;
     tiledb_error_message(error_.get(), &msg);
     if (msg == nullptr)
-      return std::string(
-          "(empty error string returned from tiledb_error_message)");
+      return std::string();
     else
       return std::string(msg);
   }


### PR DESCRIPTION
The `char*` variable holding an error message is initialized to a `nullptr`. In case no error has been observed yet, this value is never updated so it is passed into a `std::string` object.  Adding an explicit 'no error yet' text clarifies this.

---
TYPE: IMPROVEMENT
DESC: Check error message variable for nullptr before further use
