### PR TITLE
Fix config check for consolidator.cc refactored reader path

### DIFF
--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -894,7 +894,7 @@ Status Consolidator::set_config(const Config* config) {
   std::string reader =
       merged_config.get("sm.query.sparse_global_order.reader", &found);
   assert(found);
-  config_.use_refactored_reader_ = reader.compare("reafctored") == 0;
+  config_.use_refactored_reader_ = reader.compare("refactored") == 0;
 
   // Sanity checks
   if (config_.min_frags_ > config_.max_frags_)


### PR DESCRIPTION
TYPE: NO_HISTORY

Fix config check for consolidator.cc refactored reader path
---
TYPE: NO_HISTORY
