### PR TITLE
Add patch for AWS SDK to support cmake 3.22

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -96,9 +96,11 @@ if (NOT AWSSDK_FOUND)
 
     if (WIN32)
       find_package(Git REQUIRED)
-      set(CONDITIONAL_PATCH cd ${CMAKE_SOURCE_DIR} && ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_awssdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch)
+      set(CONDITIONAL_PATCH cd ${CMAKE_SOURCE_DIR} && ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_awssdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch &&
+                                                      ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_awssdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsconfig_cmake_3.22.patch)
     else()
-      set(CONDITIONAL_PATCH patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch)
+      set(CONDITIONAL_PATCH patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch &&
+                            patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsconfig_cmake_3.22.patch)
     endif()
 
     ExternalProject_Add(ep_awssdk

--- a/cmake/inputs/patches/ep_awssdk/awsconfig_cmake_3.22.patch
+++ b/cmake/inputs/patches/ep_awssdk/awsconfig_cmake_3.22.patch
@@ -1,0 +1,23 @@
+diff --git a/cmake/AWSSDKConfig.cmake b/cmake/AWSSDKConfig.cmake
+index 83eac0b3b4..c1bf32066d 100644
+--- a/cmake/AWSSDKConfig.cmake
++++ b/cmake/AWSSDKConfig.cmake
+@@ -129,11 +129,13 @@ endif()
+ get_filename_component(TEMP_PATH "${AWSSDK_CORE_LIB_FILE}" PATH)
+ get_filename_component(TEMP_NAME "${TEMP_PATH}" NAME)
+ 
+-while (NOT TEMP_NAME STREQUAL ${LIB_SEARCH_PREFIX})
+-    set(TEMP_PLATFORM_PREFIX "${TEMP_NAME}/${TEMP_PLATFORM_PREFIX}")
+-    get_filename_component(TEMP_PATH "${TEMP_PATH}" PATH)
+-    get_filename_component(TEMP_NAME "${TEMP_PATH}" NAME)
+-endwhile()
++if(LIB_SEARCH_PREFIX)
++    while (NOT TEMP_NAME STREQUAL "${LIB_SEARCH_PREFIX}")
++        set(TEMP_PLATFORM_PREFIX "${TEMP_NAME}/${TEMP_PLATFORM_PREFIX}")
++        get_filename_component(TEMP_PATH "${TEMP_PATH}" PATH)
++        get_filename_component(TEMP_NAME "${TEMP_PATH}" NAME)
++    endwhile()
++endif()
+ 
+ set(AWSSDK_PLATFORM_PREFIX "${TEMP_PLATFORM_PREFIX}")
+ 


### PR DESCRIPTION
This is is backported from AWS SDK 1.9 series, inspired directly by msys2: https://github.com/msys2/MINGW-packages/pull/10134. Credit to Jeroen for the helpful msys2 hint.


---
TYPE: BUG
DESC: Patch AWS sdk for cmake 3.22 support
