### PR TITLE
Sparse refactored readers: better parallelization for tile bitmaps.

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1026,7 +1026,8 @@ Status Query::create_strategy() {
           &found));
       assert(found);
 
-      if (non_overlapping_ranges || !subarray_.is_set()) {
+      if (non_overlapping_ranges || !subarray_.is_set() ||
+          subarray_.range_num() == 1) {
         strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
             SparseUnorderedWithDupsReader<uint8_t>,
             stats_->create_child("Reader"),

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -231,6 +231,9 @@ class ResultTile {
    * Computes a result count for the input dimension for the coordinates that
    * fall in the input ranges and multiply with the previous count.
    *
+   * This only processes cells from min_cell to max_cell as we might
+   * parallelize on cells.
+   *
    * When called over multiple ranges, this follows the formula:
    * total_count = d1_count * d2_count ... dN_count.
    */
@@ -242,13 +245,18 @@ class ResultTile {
       const std::vector<uint64_t>* range_indexes,
       const uint64_t num_indexes,
       std::vector<BitmapType>* result_count,
-      const Layout& cell_order);
+      const Layout& cell_order,
+      const uint64_t min_cell,
+      const uint64_t max_cell);
 
   /**
    * Applicable only to sparse arrays.
    *
    * Computes a result count for the input string dimension for the coordinates
    * that fall in the input ranges and multiply with the previous count.
+   *
+   * This only processes cells from min_cell to max_cell as we might
+   * parallelize on cells.
    *
    * When called over multiple ranges, this follows the formula:
    * total_count = d1_count * d2_count ... dN_count.
@@ -261,7 +269,9 @@ class ResultTile {
       const std::vector<uint64_t>* range_indexes,
       const uint64_t num_indexes,
       std::vector<BitmapType>* result_count,
-      const Layout& cell_order);
+      const Layout& cell_order,
+      const uint64_t min_cell,
+      const uint64_t max_cell);
 
   /**
    * Applicable only to sparse tiles of dense arrays.
@@ -300,6 +310,9 @@ class ResultTile {
    * Computes a result count for the input dimension for the coordinates that
    * fall in the input ranges and multiply with the previous count.
    *
+   * This only processes cells from min_cell to max_cell as we might
+   * parallelize on cells.
+   *
    * When called over multiple ranges, this follows the formula:
    * total_count = d1_count * d2_count ... dN_count.
    */
@@ -310,7 +323,9 @@ class ResultTile {
       const std::vector<uint64_t>* range_indexes,
       const uint64_t num_indexes,
       std::vector<BitmapType>* result_count,
-      const Layout& cell_order) const;
+      const Layout& cell_order,
+      const uint64_t min_cell,
+      const uint64_t max_cell) const;
 
  private:
   /* ********************************* */
@@ -382,7 +397,9 @@ class ResultTile {
       const std::vector<uint64_t>*,
       const uint64_t,
       std::vector<uint64_t>*,
-      const Layout&)>>
+      const Layout&,
+      const uint64_t,
+      const uint64_t)>>
       compute_results_count_sparse_uint64_t_func_;
 
   /**
@@ -396,7 +413,9 @@ class ResultTile {
       const std::vector<uint64_t>*,
       const uint64_t,
       std::vector<uint8_t>*,
-      const Layout&)>>
+      const Layout&,
+      const uint64_t,
+      const uint64_t)>>
       compute_results_count_sparse_uint8_t_func_;
 
   /* ********************************* */

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -195,10 +195,10 @@ Status SparseGlobalOrderReader::dowork() {
       RETURN_NOT_OK(read_and_unfilter_coords(true, &tmp_result_tiles));
 
       // Compute the tile bitmaps.
-      RETURN_NOT_OK(compute_tile_bitmaps<uint8_t>(&result_tiles_));
+      RETURN_NOT_OK(compute_tile_bitmaps<uint8_t>(&tmp_result_tiles));
 
       // Apply query condition.
-      RETURN_NOT_OK(apply_query_condition<uint8_t>(&result_tiles_));
+      RETURN_NOT_OK(apply_query_condition<uint8_t>(&tmp_result_tiles));
 
       // Clear result tiles that are not necessary anymore.
       auto status = parallel_for(
@@ -216,7 +216,8 @@ Status SparseGlobalOrderReader::dowork() {
             }
 
             // Adjust tile ranges.
-            if (subarray_.is_set() && result_tiles_[f].empty()) {
+            if (subarray_.is_set() && result_tiles_[f].empty() &&
+                all_tiles_loaded_[f]) {
               while (!result_tile_ranges_[f].empty())
                 remove_result_tile_range(f);
             }


### PR DESCRIPTION
This updates the tile bitmap computation to parallelize on tiles first,
then tile ranges if there are less tiles than cores. This way we have
much better thread utilization in more scenarios.

Also fixing a small accounting issue where result tile ranges were not
accounted properly after query condition.

---
TYPE: IMPROVEMENT
DESC: Sparse refactored readers: better parallelization for tile bitmaps.
