### PR TITLE
Generalize linux build to current default plus a new no-avx2 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,13 +93,24 @@ stages:
      - job: linux_manylinux
        pool: { vmImage: 'ubuntu-20.04' }
        container: ${{ variables.MANYLINUX_IMAGE }}
-       variables:
-         CXX: g++
-         CFLAGS: "-lrt"
-         CXXFLAGS: "-lrt"
-         ARTIFACT_OS: 'linux'
-         ARTIFACT_ARCH: 'x86_64'
-         SUDO: ''
+       strategy:
+         matrix:
+           standard:
+             CXX: g++
+             CFLAGS: "-lrt"
+             CXXFLAGS: "-lrt"
+             ARTIFACT_OS: 'linux'
+             ARTIFACT_ARCH: "x86_64"
+             TILEDB_AVX2: ON
+             SUDO: ''
+           noavx2:
+             CXX: g++
+             CFLAGS: "-lrt"
+             CXXFLAGS: "-lrt"
+             ARTIFACT_OS: 'linux'
+             ARTIFACT_ARCH: "x86_64-noavx2"
+             TILEDB_AVX2: OFF
+             SUDO: ''
        steps:
        - template: scripts/azure-linux_mac-release.yml
      - job: Windows

--- a/scripts/azure-linux_mac-release.yml
+++ b/scripts/azure-linux_mac-release.yml
@@ -88,6 +88,10 @@ steps:
       # Add superbuild flag
       cmake_args="${cmake_args} -DTILEDB_WERROR=OFF";
     fi
+    if [[ "$TILEDB_AVX2" == "OFF" ]]; then
+      # Add superbuild flag
+      cmake_args="${cmake_args} -DCOMPILER_SUPPORTS_AVX2=OFF";
+    fi
 
     mkdir -p $BUILD_REPOSITORY_LOCALPATH/build
     cd $BUILD_REPOSITORY_LOCALPATH/build


### PR DESCRIPTION
Some systems using the Linux build-artifacts along with API bindings have been seen to be relying on older CPU chipsets requiring a fall-back build not deployng more modern CPU features such as AVX2.

---
TYPE: IMPROVEMENT 
DESC: Provide non-AVX2 build artifact on Linux
