### PR TITLE
Sparse refactored readers: disable filtered buffer tile cache.

### DIFF
--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -316,11 +316,13 @@ class ReaderBase : public StrategyBase {
    * @param names The attribute names.
    * @param result_tiles The retrieved tiles will be stored inside the
    *     `ResultTile` instances in this vector.
+   * @param disable_cache Disable the tile cache or not.
    * @return Status
    */
   Status read_attribute_tiles(
       const std::vector<std::string>* names,
-      const std::vector<ResultTile*>* result_tiles) const;
+      const std::vector<ResultTile*>* result_tiles,
+      const bool disable_cache = false) const;
 
   /**
    * Concurrently executes across each name in `names` and each result tile
@@ -332,11 +334,13 @@ class ReaderBase : public StrategyBase {
    * @param names The coordinate/dimension names.
    * @param result_tiles The retrieved tiles will be stored inside the
    *     `ResultTile` instances in this vector.
+   * @param disable_cache Disable the tile cache or not.
    * @return Status
    */
   Status read_coordinate_tiles(
       const std::vector<std::string>* names,
-      const std::vector<ResultTile*>* result_tiles) const;
+      const std::vector<ResultTile*>* result_tiles,
+      const bool disable_cache = false) const;
 
   /**
    * Retrieves the tiles on a list of attribute or dimension and stores it
@@ -348,11 +352,13 @@ class ReaderBase : public StrategyBase {
    * @param names The attribute/dimension names.
    * @param result_tiles The retrieved tiles will be stored inside the
    *     `ResultTile` instances in this vector.
+   * @param disable_cache Disable the tile cache or not.
    * @return Status
    */
   Status read_tiles(
       const std::vector<std::string>* names,
-      const std::vector<ResultTile*>* result_tiles) const;
+      const std::vector<ResultTile*>* result_tiles,
+      const bool disable_cache = false) const;
 
   /**
    * Filters the tiles on a particular attribute/dimension from all input
@@ -360,11 +366,13 @@ class ReaderBase : public StrategyBase {
    *
    * @param name Attribute/dimension whose tiles will be unfiltered.
    * @param result_tiles Vector containing the tiles to be unfiltered.
+   * @param disable_cache Disable the filtered buffers cache or not.
    * @return Status
    */
   Status unfilter_tiles(
       const std::string& name,
-      const std::vector<ResultTile*>* result_tiles) const;
+      const std::vector<ResultTile*>* result_tiles,
+      const bool disable_cache = false) const;
 
   /**
    * Runs the input fixed-sized tile for the input attribute or dimension
@@ -438,7 +446,8 @@ class ReaderBase : public StrategyBase {
       std::vector<ResultCellSlab>* result_cell_slabs,
       Subarray& subarray,
       uint64_t memory_budget = UINT64_MAX,
-      bool include_dim = false);
+      bool include_dim = false,
+      const bool disable_cache = false);
 
   /**
    * Copies the cells for the input **fixed-sized** attribute/dimension and
@@ -600,7 +609,8 @@ class ReaderBase : public StrategyBase {
    * @param subarray Specifies the current subarray.
    * @param stride The stride between cells, UINT64_MAX for contiguous.
    * @param memory_budget The memory budget, UINT64_MAX for unlimited.
-   * unloaded.
+   * @param disable_cache disable the filtered buffer cache.
+   * @return Status
    */
   Status process_tiles(
       const std::unordered_map<std::string, ProcessTileFlags>* names,
@@ -608,7 +618,8 @@ class ReaderBase : public StrategyBase {
       std::vector<ResultCellSlab>* result_cell_slabs,
       Subarray* subarray,
       uint64_t stride,
-      uint64_t memory_budget);
+      uint64_t memory_budget,
+      const bool disable_cache = false);
 
   /**
    * Get the size of an attribute tile.

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -332,7 +332,8 @@ Status SparseGlobalOrderReader::dowork() {
       &read_state_.result_cell_slabs_,
       subarray_,
       memory_budget_copy,
-      !coords_loaded_));
+      !coords_loaded_,
+      true));
 
   // copy_coordinates will only have an unrecoverable overflow if a single cell
   // is too big for the user's buffers.

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -296,24 +296,26 @@ Status SparseIndexReaderBase::read_and_unfilter_coords(
     // this will ignore fragments with a version >= 5.
     std::vector<std::string> zipped_coords_names = {constants::coords};
     RETURN_CANCEL_OR_ERROR(
-        read_coordinate_tiles(&zipped_coords_names, result_tiles));
-    RETURN_CANCEL_OR_ERROR(unfilter_tiles(constants::coords, result_tiles));
+        read_coordinate_tiles(&zipped_coords_names, result_tiles, true));
+    RETURN_CANCEL_OR_ERROR(
+        unfilter_tiles(constants::coords, result_tiles, true));
 
     // Read and unfilter unzipped coordinate tiles. Note that
     // this will ignore fragments with a version < 5.
-    RETURN_CANCEL_OR_ERROR(read_coordinate_tiles(&dim_names_, result_tiles));
+    RETURN_CANCEL_OR_ERROR(
+        read_coordinate_tiles(&dim_names_, result_tiles, true));
     for (const auto& dim_name : dim_names_) {
-      RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, result_tiles));
+      RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, result_tiles, true));
     }
   }
 
   if (!condition_.empty()) {
     // Read and unfilter tiles for querty condition.
     RETURN_CANCEL_OR_ERROR(
-        read_attribute_tiles(&qc_loaded_names_, result_tiles));
+        read_attribute_tiles(&qc_loaded_names_, result_tiles, true));
 
     for (const auto& name : qc_loaded_names_) {
-      RETURN_CANCEL_OR_ERROR(unfilter_tiles(name, result_tiles));
+      RETURN_CANCEL_OR_ERROR(unfilter_tiles(name, result_tiles, true));
     }
   }
 

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1026,10 +1026,10 @@ Status SparseUnorderedWithDupsReader<BitmapType>::read_and_unfilter_attributes(
   auto timer_se = stats_->start_timer("read_and_unfilter_attribute");
 
   // Read and unfilter tiles.
-  RETURN_NOT_OK(read_attribute_tiles(names, result_tiles));
+  RETURN_NOT_OK(read_attribute_tiles(names, result_tiles, true));
 
   for (auto& name : *names)
-    RETURN_NOT_OK(unfilter_tiles(name, result_tiles));
+    RETURN_NOT_OK(unfilter_tiles(name, result_tiles, true));
 
   return Status::Ok();
 }


### PR DESCRIPTION
From tests, it's been found that writing the cache for the filter
pipeline takes a significant amount of time for the tile unfiltering
operation. For example, 2.25 seconds with and 1.88 seconds without in
some cases. The cache improved performance before multi-range subarrays
were implemented, so dropping it is fine at least for the refactored
readers.

---
TYPE: IMPROVEMENT
DESC: Sparse refactored readers: disable filtered buffer tile cache.