### PR TITLE
Fixing str_coord_intersects to use std::basic_string_view.

### DIFF
--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -528,8 +528,8 @@ void Dimension::expand_range_var_v(const char* v, uint64_t v_size, Range* r) {
   assert(v != nullptr);
   assert(r != nullptr);
 
-  auto start = r->start_str();
-  auto end = r->end_str();
+  std::string start(r->start_str());
+  std::string end(r->end_str());
   auto v_str = std::string(v, v_size);
 
   r->set_str_range(
@@ -560,8 +560,8 @@ void Dimension::expand_range_var(const Range& r1, Range* r2) const {
   auto r2_start = r2->start_str();
   auto r2_end = r2->end_str();
 
-  auto min = (r1_start < r2_start) ? r1_start : r2_start;
-  auto max = (r1_end < r2_end) ? r2_end : r1_end;
+  std::string min((r1_start < r2_start) ? r1_start : r2_start);
+  std::string max((r1_end < r2_end) ? r2_end : r1_end);
 
   r2->set_str_range(min, max);
 }
@@ -841,8 +841,8 @@ void Dimension::split_range<char>(
 
   // First range
   auto min_string = std::string("\x0", 1);
-  auto new_r1_start = !r.start_str().empty() ? r.start_str() : min_string;
-  auto new_r1_end = v.rvalue_as<std::string>();
+  std::string new_r1_start(!r.start_str().empty() ? r.start_str() : min_string);
+  std::string new_r1_end(v.rvalue_as<std::string>());
   auto new_r1_end_size = (int)new_r1_end.size();
   int pos;
   for (pos = 0; pos < new_r1_end_size; ++pos) {
@@ -870,7 +870,7 @@ void Dimension::split_range<char>(
   new_r2_start.resize(pos + 1);
 
   auto max_string = std::string("\x7F", 1);
-  auto new_r2_end = !r.end_str().empty() ? r.end_str() : max_string;
+  std::string new_r2_end(!r.end_str().empty() ? r.end_str() : max_string);
 
   assert(new_r2_start > new_r1_end);
   assert(new_r2_start <= new_r2_end);
@@ -955,8 +955,9 @@ void Dimension::splitting_value<char>(
   uint8_t end_pref = end.empty() ? 127 : (uint8_t)end[pref_size];
   auto start_c = (start.size() == pref_size) ? 0 : start[pref_size];
   auto split_v = (end_pref - start_c) / 2;
-  auto split_str =
-      start.substr(0, pref_size) + (char)(start_c + split_v) + "\x80";
+  std::string split_str(start.substr(0, pref_size));
+  split_str += (char)(start_c + split_v);
+  split_str += "\x80";
   assert(split_str >= start);
 
   v->resize(split_str.size());
@@ -1357,7 +1358,6 @@ bool Dimension::smaller_than<char>(
 
   auto value_str = value.rvalue_as<std::string>();
   auto range_start_str = range.start_str();
-  auto range_end_str = range.end_str();
 
   // If the range start is empty, then it is essentially -inf
   if (range_start_str.empty())

--- a/tiledb/sm/fragment/single_fragment_info.h
+++ b/tiledb/sm/fragment/single_fragment_info.h
@@ -252,8 +252,8 @@ class SingleFragmentInfo {
              << ((int64_t*)non_empty_domain_[d].data())[1] << "]";
           break;
         case Datatype::STRING_ASCII:
-          ss << "[" << non_empty_domain_[d].start_str() << ", "
-             << non_empty_domain_[d].end_str() << "]";
+          ss << "[" << std::string(non_empty_domain_[d].start_str()) << ", "
+             << std::string(non_empty_domain_[d].end_str()) << "]";
           break;
         default:
           assert(false);

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -144,18 +144,14 @@ class Range {
     std::memcpy(&range_[0], start, fixed_size);
   }
 
-  /** Returns the start as a string. */
-  std::string start_str() const {
-    if (start_size() == 0)
-      return std::string();
-    return std::string((const char*)start(), start_size());
+  /** Returns the start as a string view. */
+  std::basic_string_view<char> start_str() const {
+    return std::basic_string_view<char>((const char*)start(), start_size());
   }
 
-  /** Returns the end as a string. */
-  std::string end_str() const {
-    if (end_size() == 0)
-      return std::string();
-    return std::string((const char*)end(), end_size());
+  /** Returns the end as a string view. */
+  std::basic_string_view<char> end_str() const {
+    return std::basic_string_view<char>((const char*)end(), end_size());
   }
 
   /**

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -452,7 +452,9 @@ std::string to_str(const void* value, Datatype type) {
   return ss.str();
 }
 
-uint64_t common_prefix_size(const std::string& a, const std::string& b) {
+uint64_t common_prefix_size(
+    const std::basic_string_view<char>& a,
+    const std::basic_string_view<char>& b) {
   auto size = std::min(a.size(), b.size());
   for (size_t i = 0; i < size; ++i) {
     if (a[i] != b[i])

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -185,7 +185,9 @@ std::string to_str(const T& value);
 std::string to_str(const void* value, Datatype type);
 
 /** Returns the size of the common prefix between `a` and `b`. */
-uint64_t common_prefix_size(const std::string& a, const std::string& b);
+uint64_t common_prefix_size(
+    const std::basic_string_view<char>& a,
+    const std::basic_string_view<char>& b);
 
 }  // namespace parse
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -440,51 +440,14 @@ void ResultTile::compute_results_dense(
   }
 }
 
-inline uint8_t ResultTile::str_coord_intersects(
+inline bool ResultTile::str_coord_intersects(
     const uint64_t c_offset,
     const uint64_t c_size,
     const char* const buff_str,
-    const std::string& range_start,
-    const std::string& range_end) {
-  // Test against start
-  bool geq_start = true;
-  bool all_chars_match = true;
-  uint64_t min_size = std::min<uint64_t>(c_size, range_start.size());
-  for (uint64_t i = 0; i < min_size; ++i) {
-    if (buff_str[c_offset + i] < range_start[i]) {
-      geq_start = false;
-      all_chars_match = false;
-      break;
-    } else if (buff_str[c_offset + i] > range_start[i]) {
-      all_chars_match = false;
-      break;
-    }  // Else characters match
-  }
-  if (geq_start && all_chars_match && c_size < range_start.size()) {
-    geq_start = false;
-  }
-
-  // Test against end
-  bool seq_end = false;
-  if (geq_start) {
-    seq_end = true;
-    all_chars_match = true;
-    min_size = std::min<uint64_t>(c_size, range_end.size());
-    for (uint64_t i = 0; i < min_size; ++i) {
-      if (buff_str[c_offset + i] > range_end[i]) {
-        geq_start = false;
-        break;
-      } else if (buff_str[c_offset + i] < range_end[i]) {
-        all_chars_match = false;
-        break;
-      }  // Else characters match
-    }
-    if (seq_end && all_chars_match && c_size > range_end.size()) {
-      seq_end = false;
-    }
-  }
-
-  return geq_start && seq_end;
+    const std::basic_string_view<char>& range_start,
+    const std::basic_string_view<char>& range_end) {
+  std::basic_string_view<char> str(buff_str + c_offset, c_size);
+  return str >= range_start && str <= range_end;
 }
 
 template <>

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -443,14 +443,14 @@ class ResultTile {
    *    at `c_offset`.
    * @param range_start The starting range value.
    * @param range_end The ending range value.
-   * @return uint8_t 0 for no intersection, 1 for instersection.
+   * @return false for no intersection, true for instersection.
    */
-  static uint8_t str_coord_intersects(
+  static bool str_coord_intersects(
       const uint64_t c_offset,
       const uint64_t c_size,
       const char* const buff_str,
-      const std::string& range_start,
-      const std::string& range_end);
+      const std::basic_string_view<char>& range_start,
+      const std::basic_string_view<char>& range_end);
 };
 
 }  // namespace sm

--- a/tools/src/commands/info_command.cc
+++ b/tools/src/commands/info_command.cc
@@ -502,8 +502,8 @@ std::vector<std::string> InfoCommand::mbr_to_string(
     auto type = domain->dimension(d)->type();
     switch (type) {
       case sm::Datatype::STRING_ASCII:
-        result.push_back(mbr[d].start_str());
-        result.push_back(mbr[d].end_str());
+        result.push_back(std::string(mbr[d].start_str()));
+        result.push_back(std::string(mbr[d].end_str()));
         break;
       case Datatype::INT8:
         r8 = (const int8_t*)mbr[d].data();


### PR DESCRIPTION
str_coord_intersects was trying to implement a character by character
comparison between a range and a cell but had some incorrect assumption.
Fixing it to use std::basic_string_view comparison.

Also switching Range::start_str() and Range::end_str() to return a
basic_string_view and not a string.

---
TYPE: IMPROVEMENT
DESC: Fixing str_coord_intersects to use std::basic_string_view.