### PR TITLE
Error out when setting multiple ranges for global layout

### DIFF
--- a/test/src/unit-capi-dense_array_2.cc
+++ b/test/src/unit-capi-dense_array_2.cc
@@ -488,19 +488,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_add_range(ctx_, query, 0, &start, &end, nullptr);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_add_range(ctx_, query, 0, &start, &end, nullptr);
-  CHECK(rc == TILEDB_OK);
-
-  // Set buffers
-  int a[10];
-  uint64_t a_size = sizeof(a);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a", a, &a_size);
-  CHECK(rc == TILEDB_OK);
-
-  // This should fail upon submit!
-  rc = tiledb_query_submit(ctx_, query);
   CHECK(rc == TILEDB_ERR);
 
   // Clean up
-  tiledb_query_free(&query);
   close_array(ctx_, array_);
 }

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -37,7 +37,6 @@
 #include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb;
-
 using namespace tiledb::test;
 
 TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
@@ -1005,6 +1004,47 @@ TEST_CASE(
   REQUIRE(result_num == 2);
   REQUIRE(data[0] == 'l');
   REQUIRE(data[1] == 'm');
+
+  // Close array.
+  array.close();
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+}
+
+TEST_CASE(
+    "C++ API: Test subarray - error on multi-range for global layout",
+    "[cppapi][subarray][error]") {
+  // parameterize over cell order and read layout
+  auto test_pair = GENERATE(
+      std::make_pair(TILEDB_HILBERT, TILEDB_GLOBAL_ORDER),
+      std::make_pair(TILEDB_ROW_MAJOR, TILEDB_GLOBAL_ORDER));
+
+  const std::string array_name = "cpp_unit_array";
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  // Create
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+      .add_dimension(Dimension::create<int>(ctx, "cols", {{0, 100}}, 101));
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain)
+      .set_order({{TILEDB_COL_MAJOR, test_pair.first}})
+      .set_capacity(10000);
+  schema.add_attribute(Attribute::create<char>(ctx, "a"));
+  Array::create(array_name, schema);
+
+  // Open array for reading
+  tiledb::Array array(ctx, array_name, TILEDB_READ);
+  tiledb::Query query(ctx, array);
+
+  query.set_layout(test_pair.second);
+  query.add_range(0, 0, 0);
+  CHECK_THROWS(query.add_range(0, 1, 1));
 
   // Close array.
   array.close();

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -164,6 +164,11 @@ Status Subarray::add_range(
   }
 
   // Correctness checks
+  if (layout_ == Layout::GLOBAL_ORDER && ranges_[dim_idx].size() > 0) {
+    return logger_->status(Status::SubarrayError(
+        "Cannot add more than one range per dimension to global order query"));
+  }
+
   auto dim = array_->array_schema()->dimension(dim_idx);
   if (!read_range_oob_error)
     RETURN_NOT_OK(dim->adjust_range_oob(&range));


### PR DESCRIPTION
Error out when setting multiple ranges for global layout

Add an error check when adding multiple ranges to global layout read query.
This is not supported and will cause assertion failure or segfault.

Fixes SC-11780

---
TYPE: IMPROVEMENT
DESC: Error out when setting multiple ranges for global layout
