### PR TITLE
Handle query condition causing incomplete query

### DIFF
--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -855,6 +855,15 @@ Status SparseUnorderedWithDupsReader::end_iteration() {
     RETURN_NOT_OK(remove_result_tile(last_f, result_tiles_.begin()));
   }
 
+  // Patch: if we have a query condition set, we might not clean up some reault
+  // tiles properly, clean them up here.
+  if (!condition_.empty() && read_state_.result_cell_slabs_.empty()) {
+    while (!result_tiles_.empty()) {
+      auto f = result_tiles_.begin()->frag_idx();
+      RETURN_NOT_OK(remove_result_tile(f, result_tiles_.begin()));
+    }
+  }
+
   auto uint64_t_max = std::numeric_limits<uint64_t>::max();
   copy_end_ = std::pair<uint64_t, uint64_t>(uint64_t_max, uint64_t_max);
 


### PR DESCRIPTION
If the query has a condition that filters out a tile, the tile needs to be removed from the query. The bug is when the tile remains but all cells have been filtered the query results in incomplete state since a tile remains but each submit skips the tile (since cell num is 0). This is only effects 2.5, `dev` has changed the code path and this no longer applies.

---
TYPE: BUG
DESC: Remove tiles that are empty through being filtered with a query condition
