### PR TITLE
[backport release-2.5] Error out when setting multiple ranges for global layout (#2658)

### DIFF
--- a/test/src/unit-capi-dense_array_2.cc
+++ b/test/src/unit-capi-dense_array_2.cc
@@ -488,19 +488,8 @@ TEST_CASE_METHOD(
   rc = tiledb_query_add_range(ctx_, query, 0, &start, &end, nullptr);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_add_range(ctx_, query, 0, &start, &end, nullptr);
-  CHECK(rc == TILEDB_OK);
-
-  // Set buffers
-  int a[10];
-  uint64_t a_size = sizeof(a);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a", a, &a_size);
-  CHECK(rc == TILEDB_OK);
-
-  // This should fail upon submit!
-  rc = tiledb_query_submit(ctx_, query);
   CHECK(rc == TILEDB_ERR);
 
   // Clean up
-  tiledb_query_free(&query);
   close_array(ctx_, array_);
 }

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -147,6 +147,11 @@ Status Subarray::add_range(
   }
 
   // Correctness checks
+  if (layout_ == Layout::GLOBAL_ORDER && ranges_[dim_idx].size() > 0) {
+    return logger_->status(Status::SubarrayError(
+        "Cannot add more than one range per dimension to global order query"));
+  }
+
   auto dim = array_->array_schema()->dimension(dim_idx);
   if (!read_range_oob_error)
     RETURN_NOT_OK(dim->adjust_range_oob(&range));


### PR DESCRIPTION
Backport 06f80a3c8b836b420877887cf9f4c6eff6dc222f from #2658

---
TYPE: IMPROVEMENT
DESC: Error out when setting multiple ranges for global layout
