### PR TITLE
[Backport release-2.6] Sparse unordered with dups reader: removing result cell slabs.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -258,20 +258,18 @@ void check_save_to_file() {
   ss << "sm.mem.reader.sparse_global_order.ratio_coords 0.5\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_query_condition 0.25\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_rcs 0.05\n";
-  ss << "sm.mem.reader.sparse_global_order.ratio_result_tiles 0.05\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_tile_ranges 0.1\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data 0.1\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_coords 0.5\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition "
         "0.25\n";
-  ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_rcs 0.05\n";
-  ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles 0.05\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges 0.1\n";
   ss << "sm.mem.total_budget 10737418240\n";
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.query.dense.reader legacy\n";
   ss << "sm.query.sparse_global_order.reader legacy\n";
+  ss << "sm.query.sparse_unordered_with_dups.non_overlapping_ranges false\n";
   ss << "sm.query.sparse_unordered_with_dups.reader refactored\n";
   ss << "sm.read_range_oob warn\n";
   ss << "sm.skip_checksum_validation false\n";
@@ -573,6 +571,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.query.dense.reader"] = "legacy";
   all_param_values["sm.query.sparse_global_order.reader"] = "legacy";
   all_param_values["sm.query.sparse_unordered_with_dups.reader"] = "refactored";
+  all_param_values
+      ["sm.query.sparse_unordered_with_dups.non_overlapping_ranges"] = "false";
   all_param_values["sm.mem.malloc_trim"] = "true";
   all_param_values["sm.mem.total_budget"] = "10737418240";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_coords"] = "0.5";
@@ -582,8 +582,6 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
       "0.1";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_array_data"] =
       "0.1";
-  all_param_values["sm.mem.reader.sparse_global_order.ratio_result_tiles"] =
-      "0.05";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_rcs"] = "0.05";
   all_param_values["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
       "0.5";
@@ -594,10 +592,6 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
       ["sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges"] = "0.1";
   all_param_values
       ["sm.mem.reader.sparse_unordered_with_dups.ratio_array_data"] = "0.1";
-  all_param_values
-      ["sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles"] = "0.05";
-  all_param_values["sm.mem.reader.sparse_unordered_with_dups.ratio_rcs"] =
-      "0.05";
   all_param_values["sm.enable_signal_handlers"] = "true";
   all_param_values["sm.compute_concurrency_level"] =
       std::to_string(std::thread::hardware_concurrency());

--- a/test/src/unit-capi-smoke-test.cc
+++ b/test/src/unit-capi-smoke-test.cc
@@ -207,6 +207,7 @@ class SmokeTestFx {
    * @param cell_order The cell order of the array.
    * @param tile_order The tile order of the array.
    * @param write_order The write layout.
+   * @param read_order The read layout.
    * @param encryption_type The encryption type.
    */
   void smoke_test(
@@ -217,6 +218,7 @@ class SmokeTestFx {
       tiledb_layout_t cell_order,
       tiledb_layout_t tile_order,
       tiledb_layout_t write_order,
+      tiledb_layout_t read_order,
       tiledb_encryption_type_t encryption_type);
 
  private:
@@ -282,6 +284,7 @@ class SmokeTestFx {
    * @param test_query_conditions The attribute conditions to filter on.
    * @param test_query_buffers The query buffers to read.
    * @param subarray The subarray to read.
+   * @param read_order The read layout.
    * @param encryption_type The encryption type of the array.
    */
   void read(
@@ -289,6 +292,7 @@ class SmokeTestFx {
       const vector<shared_ptr<test_query_condition_t>>& test_query_conditions,
       const vector<test_query_buffer_t>& test_query_buffers,
       const void* subarray,
+      tiledb_layout_t read_order,
       tiledb_encryption_type_t encryption_type);
 };
 
@@ -492,6 +496,9 @@ void SmokeTestFx::create_array(
     rc = tiledb_array_schema_add_attribute(ctx_, array_schema, attr);
     REQUIRE(rc == TILEDB_OK);
   }
+  if (array_type != TILEDB_DENSE) {
+    rc = tiledb_array_schema_set_allows_dups(ctx_, array_schema, true);
+  }
 
   // Check array schema
   rc = tiledb_array_schema_check(ctx_, array_schema);
@@ -673,6 +680,7 @@ void SmokeTestFx::read(
     const vector<shared_ptr<test_query_condition_t>>& test_query_conditions,
     const vector<test_query_buffer_t>& test_query_buffers,
     const void* subarray,
+    tiledb_layout_t read_order,
     tiledb_encryption_type_t encryption_type) {
   // Open the array for reading (with or without encryption).
   tiledb_array_t* array;
@@ -704,6 +712,10 @@ void SmokeTestFx::read(
   // Create the read query.
   tiledb_query_t* query;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set the layout.
+  rc = tiledb_query_set_layout(ctx_, query, read_order);
   REQUIRE(rc == TILEDB_OK);
 
   // Set the query buffers.
@@ -848,6 +860,7 @@ void SmokeTestFx::smoke_test(
     tiledb_layout_t cell_order,
     tiledb_layout_t tile_order,
     tiledb_layout_t write_order,
+    tiledb_layout_t read_order,
     tiledb_encryption_type_t encryption_type) {
   const string array_name = "smoke_test_array";
 
@@ -857,10 +870,11 @@ void SmokeTestFx::smoke_test(
     return;
   }
 
-  // Skip unordered writes for dense arrays.
-  if (array_type == TILEDB_DENSE && write_order == TILEDB_UNORDERED) {
-    return;
-  }
+  // Skip unordered writes/reads and global order reads for dense arrays.
+  if (array_type == TILEDB_DENSE)
+    if (write_order == TILEDB_UNORDERED || read_order == TILEDB_UNORDERED ||
+        read_order == TILEDB_GLOBAL_ORDER)
+      return;
 
   // String_ascii, float32, and float64 types can only be
   // written to sparse arrays.
@@ -1164,6 +1178,7 @@ void SmokeTestFx::smoke_test(
       test_query_conditions,
       read_query_buffers,
       subarray_full,
+      read_order,
       encryption_type);
 
   // Map each cell value to a bool that indicates whether or
@@ -1380,19 +1395,24 @@ TEST_CASE_METHOD(
                  {TILEDB_NO_ENCRYPTION, TILEDB_AES_256_GCM}) {
               for (const tiledb_layout_t write_order :
                    {TILEDB_ROW_MAJOR, TILEDB_UNORDERED}) {
-                vector<test_dim_t> test_dims;
-                for (const test_dim_t& dim : dims) {
-                  test_dims.emplace_back(dim);
+                for (const tiledb_layout_t read_order : {TILEDB_ROW_MAJOR,
+                                                         TILEDB_UNORDERED,
+                                                         TILEDB_GLOBAL_ORDER}) {
+                  vector<test_dim_t> test_dims;
+                  for (const test_dim_t& dim : dims) {
+                    test_dims.emplace_back(dim);
 
-                  smoke_test(
-                      test_attrs,
-                      query_conditions,
-                      test_dims,
-                      array_type,
-                      cell_order,
-                      tile_order,
-                      write_order,
-                      encryption_type);
+                    smoke_test(
+                        test_attrs,
+                        query_conditions,
+                        test_dims,
+                        array_type,
+                        cell_order,
+                        tile_order,
+                        write_order,
+                        read_order,
+                        encryption_type);
+                  }
                 }
               }
             }

--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -32,6 +32,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #include "tiledb/sm/cpp_api/tiledb"
 
 using namespace tiledb;
@@ -176,6 +177,12 @@ void partial_read_and_check_sparse_array(
     std::vector<int32_t>& exp_data_part2,
     std::vector<uint64_t>& exp_off_part2,
     tiledb_layout_t layout) {
+  // Sparse unordered with dups reader does not track cell progress meaning
+  // it only copies full tiles for now. Disable these cases until it does.
+  if (test::use_refactored_sparse_unordered_with_dups_reader() &&
+      layout == TILEDB_UNORDERED)
+    return;
+
   // The size of read buffers is smaller than the size
   // of all the data, so we'll do partial reads
   std::vector<int32_t> attr_val(exp_data_part1.size());

--- a/test/src/unit-duplicates.cc
+++ b/test/src/unit-duplicates.cc
@@ -182,8 +182,7 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(
-      ctx_, query, TILEDB_COORDS, coords_r, &coords_r_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -310,8 +309,7 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(
-      ctx_, query, TILEDB_COORDS, coords_r, &coords_r_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -361,8 +359,7 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(
-      ctx_, query, TILEDB_COORDS, coords_r, &coords_r_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -481,8 +478,7 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(
-      ctx_, query, TILEDB_COORDS, coords_r, &coords_r_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Set multi-range subarray to query
@@ -602,8 +598,7 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(
-      ctx_, query, TILEDB_COORDS, coords_r, &coords_r_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Set empty subarray to query
@@ -692,8 +687,7 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(
-      ctx_, query, TILEDB_COORDS, coords_r, &coords_r_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Set multi-range subarray to query

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -58,9 +58,7 @@ struct CSparseUnorderedWithDupsFx {
   std::string total_budget_;
   std::string ratio_tile_ranges_;
   std::string ratio_array_data_;
-  std::string ratio_result_tiles_;
   std::string ratio_coords_;
-  std::string ratio_rcs_;
   std::string ratio_query_condition_;
 
   void create_default_array_1d();
@@ -106,9 +104,7 @@ void CSparseUnorderedWithDupsFx::reset_config() {
   total_budget_ = "1048576";
   ratio_tile_ranges_ = "0.1";
   ratio_array_data_ = "0.1";
-  ratio_result_tiles_ = "0.05";
   ratio_coords_ = "0.5";
-  ratio_rcs_ = "0.05";
   ratio_query_condition_ = "0.25";
   update_config();
 }
@@ -158,24 +154,8 @@ void CSparseUnorderedWithDupsFx::update_config() {
   REQUIRE(
       tiledb_config_set(
           config,
-          "sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles",
-          ratio_result_tiles_.c_str(),
-          &error) == TILEDB_OK);
-  REQUIRE(error == nullptr);
-
-  REQUIRE(
-      tiledb_config_set(
-          config,
           "sm.mem.reader.sparse_unordered_with_dups.ratio_coords",
           ratio_coords_.c_str(),
-          &error) == TILEDB_OK);
-  REQUIRE(error == nullptr);
-
-  REQUIRE(
-      tiledb_config_set(
-          config,
-          "sm.mem.reader.sparse_unordered_with_dups.ratio_rcs",
-          ratio_rcs_.c_str(),
           &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
 
@@ -279,7 +259,7 @@ int32_t CSparseUnorderedWithDupsFx::read(
     tiledb_query_condition_t* query_condition = nullptr;
     rc = tiledb_query_condition_alloc(ctx_, &query_condition);
     CHECK(rc == TILEDB_OK);
-    int32_t val = 10;
+    int32_t val = 11;
     rc = tiledb_query_condition_init(
         ctx_, query_condition, "a", &val, sizeof(int32_t), TILEDB_LT);
     CHECK(rc == TILEDB_OK);
@@ -294,8 +274,7 @@ int32_t CSparseUnorderedWithDupsFx::read(
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(
-      ctx_, query, TILEDB_COORDS, coords, coords_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
   CHECK(rc == TILEDB_OK);
 
   // Submit query.
@@ -407,159 +386,6 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     CSparseUnorderedWithDupsFx,
-    "Sparse unordered with dups reader: result tiles budget forcing one tile "
-    "at a time",
-    "[sparse-unordered-with-dups][small-rt-budget]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  bool use_subarray = false;
-  SECTION("- No subarray") {
-    use_subarray = false;
-  }
-  SECTION("- Subarray") {
-    use_subarray = true;
-  }
-
-  // Write a fragment.
-  int coords[] = {1, 2, 3, 4, 5};
-  uint64_t coords_size = sizeof(coords);
-  int data[] = {1, 2, 3, 4, 5};
-  uint64_t data_size = sizeof(data);
-  write_1d_fragment(coords, &coords_size, data, &data_size);
-
-  // Two result tile (~880) will be bigger than the budget (500).
-  total_budget_ = "10000";
-  ratio_result_tiles_ = "0.05";
-  update_config();
-
-  tiledb_array_t* array = nullptr;
-  tiledb_query_t* query = nullptr;
-
-  // Try to read.
-  int coords_r[5];
-  int data_r[5];
-  uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-  auto rc = read(
-      use_subarray,
-      false,
-      coords_r,
-      &coords_r_size,
-      data_r,
-      &data_r_size,
-      &query,
-      &array);
-  CHECK(rc == TILEDB_OK);
-
-  // Check incomplete query status.
-  tiledb_query_status_t status;
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should only read one tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
-
-  int coords_c[] = {1, 2};
-  int data_c[] = {1, 2};
-  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check incomplete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should only read one more tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
-
-  int coords_c_2[] = {3, 4};
-  int data_c_2[] = {3, 4};
-  CHECK(!std::memcmp(coords_c_2, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_2, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check complete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_COMPLETED);
-
-  // Should read last tile (1 value).
-  CHECK(4 == data_r_size);
-  CHECK(4 == coords_r_size);
-
-  int coords_c_3[] = {5};
-  int data_c_3[] = {5};
-  CHECK(!std::memcmp(coords_c_3, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_3, data_r, data_r_size));
-
-  // Clean up.
-  rc = tiledb_array_close(ctx_, array);
-  CHECK(rc == TILEDB_OK);
-  tiledb_array_free(&array);
-  tiledb_query_free(&query);
-}
-
-TEST_CASE_METHOD(
-    CSparseUnorderedWithDupsFx,
-    "Sparse unordered with dups reader: result tiles budget too small",
-    "[sparse-unordered-with-dups][rt-budget][too-small]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  bool use_subarray = false;
-  SECTION("- No subarray") {
-    use_subarray = false;
-  }
-  SECTION("- Subarray") {
-    use_subarray = true;
-  }
-
-  // Write a fragment.
-  int coords[] = {1, 2, 3, 4, 5};
-  uint64_t coords_size = sizeof(coords);
-  int data[] = {1, 2, 3, 4, 5};
-  uint64_t data_size = sizeof(data);
-  write_1d_fragment(coords, &coords_size, data, &data_size);
-
-  // One result tile will be bigger than the budget (10).
-  total_budget_ = "10000";
-  ratio_result_tiles_ = "0.001";
-  update_config();
-
-  // Try to read.
-  int coords_r[5];
-  int data_r[5];
-  uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-  auto rc =
-      read(use_subarray, false, coords_r, &coords_r_size, data_r, &data_r_size);
-  CHECK(rc == TILEDB_ERR);
-
-  // Check we hit the correct error.
-  tiledb_error_t* error = NULL;
-  rc = tiledb_ctx_get_last_error(ctx_, &error);
-  CHECK(rc == TILEDB_OK);
-
-  const char* msg;
-  rc = tiledb_error_message(error, &msg);
-  CHECK(rc == TILEDB_OK);
-
-  std::string error_str(msg);
-  CHECK(error_str.find("Cannot load a single tile") != std::string::npos);
-}
-
-TEST_CASE_METHOD(
-    CSparseUnorderedWithDupsFx,
     "Sparse unordered with dups reader: coords budget forcing one tile at a "
     "time",
     "[sparse-unordered-with-dups][small-coords-budget]") {
@@ -568,91 +394,117 @@ TEST_CASE_METHOD(
   create_default_array_1d();
 
   bool use_subarray = false;
+  int num_frags = 0;
   SECTION("- No subarray") {
     use_subarray = false;
+    SECTION("- One fragment") {
+      num_frags = 1;
+    }
+    SECTION("- Two fragments") {
+      num_frags = 2;
+    }
   }
   SECTION("- Subarray") {
     use_subarray = true;
+    SECTION("- One fragment") {
+      num_frags = 1;
+    }
+    SECTION("- Two fragments") {
+      num_frags = 2;
+    }
   }
 
-  // Write a fragment.
-  int coords[] = {1, 2, 3, 4, 5};
-  uint64_t coords_size = sizeof(coords);
-  int data[] = {1, 2, 3, 4, 5};
-  uint64_t data_size = sizeof(data);
-  write_1d_fragment(coords, &coords_size, data, &data_size);
+  for (int i = 0; i < num_frags; i++) {
+    // Write a fragment.
+    int coords[] = {1 + i * 5, 2 + i * 5, 3 + i * 5, 4 + i * 5, 5 + i * 5};
+    uint64_t coords_size = sizeof(coords);
+    int data[] = {1 + i * 5, 2 + i * 5, 3 + i * 5, 4 + i * 5, 5 + i * 5};
+    uint64_t data_size = sizeof(data);
+    write_1d_fragment(coords, &coords_size, data, &data_size);
+  }
 
-  // Two result tile (2 * 8) will be bigger than the budget (10).
+  // Two result tile (2 * ~505) will be bigger than the budget (800).
   total_budget_ = "10000";
-  ratio_coords_ = "0.001";
+  ratio_coords_ = "0.08";
   update_config();
 
   tiledb_array_t* array = nullptr;
   tiledb_query_t* query = nullptr;
 
-  // Try to read.
-  int coords_r[5];
-  int data_r[5];
-  uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-  auto rc = read(
-      use_subarray,
-      false,
-      coords_r,
-      &coords_r_size,
-      data_r,
-      &data_r_size,
-      &query,
-      &array);
-  CHECK(rc == TILEDB_OK);
+  uint32_t rc;
+  uint64_t coords_r_size;
+  uint64_t data_r_size;
+  for (int i = 0; i < num_frags; i++) {
+    // Try to read.
+    int coords_r[5];
+    int data_r[5];
+    coords_r_size = sizeof(coords_r);
+    data_r_size = sizeof(data_r);
 
-  // Check incomplete query status.
-  tiledb_query_status_t status;
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
+    if (i == 0) {
+      rc = read(
+          use_subarray,
+          false,
+          coords_r,
+          &coords_r_size,
+          data_r,
+          &data_r_size,
+          &query,
+          &array);
+    } else {
+      rc = tiledb_query_submit(ctx_, query);
+    }
+    CHECK(rc == TILEDB_OK);
 
-  // Should only read one tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
+    // Check incomplete query status.
+    tiledb_query_status_t status;
+    tiledb_query_get_status(ctx_, query, &status);
+    CHECK(status == TILEDB_INCOMPLETE);
 
-  int coords_c[] = {1, 2};
-  int data_c[] = {1, 2};
-  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c, data_r, data_r_size));
+    // Should only read one tile (2 values).
+    CHECK(8 == data_r_size);
+    CHECK(8 == coords_r_size);
 
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
+    int coords_c[] = {1 + i * 5, 2 + i * 5};
+    int data_c[] = {1 + i * 5, 2 + i * 5};
+    CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
+    CHECK(!std::memcmp(data_c, data_r, data_r_size));
 
-  // Check incomplete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
+    // Read again.
+    rc = tiledb_query_submit(ctx_, query);
+    CHECK(rc == TILEDB_OK);
 
-  // Should only read one more tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
+    // Check incomplete query status.
+    tiledb_query_get_status(ctx_, query, &status);
+    CHECK(status == TILEDB_INCOMPLETE);
 
-  int coords_c_2[] = {3, 4};
-  int data_c_2[] = {3, 4};
-  CHECK(!std::memcmp(coords_c_2, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_2, data_r, data_r_size));
+    // Should only read one more tile (2 values).
+    CHECK(8 == data_r_size);
+    CHECK(8 == coords_r_size);
 
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
+    int coords_c_2[] = {3 + i * 5, 4 + i * 5};
+    int data_c_2[] = {3 + i * 5, 4 + i * 5};
+    CHECK(!std::memcmp(coords_c_2, coords_r, coords_r_size));
+    CHECK(!std::memcmp(data_c_2, data_r, data_r_size));
 
-  // Check complete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_COMPLETED);
+    // Read again.
+    rc = tiledb_query_submit(ctx_, query);
+    CHECK(rc == TILEDB_OK);
 
-  // Should read last tile (1 value).
-  CHECK(4 == data_r_size);
-  CHECK(4 == coords_r_size);
+    // Check complete query status.
+    tiledb_query_get_status(ctx_, query, &status);
+    CHECK(
+        status == (i == num_frags - 1 ? TILEDB_COMPLETED : TILEDB_INCOMPLETE));
 
-  int coords_c_3[] = {5};
-  int data_c_3[] = {5};
-  CHECK(!std::memcmp(coords_c_3, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_3, data_r, data_r_size));
+    // Should read last tile (1 value).
+    CHECK(4 == data_r_size);
+    CHECK(4 == coords_r_size);
+
+    int coords_c_3[] = {5 + i * 5};
+    int data_c_3[] = {5 + i * 5};
+    CHECK(!std::memcmp(coords_c_3, coords_r, coords_r_size));
+    CHECK(!std::memcmp(data_c_3, data_r, data_r_size));
+  }
 
   // Clean up.
   rc = tiledb_array_close(ctx_, array);
@@ -684,7 +536,7 @@ TEST_CASE_METHOD(
   uint64_t data_size = sizeof(data);
   write_1d_fragment(coords, &coords_size, data, &data_size);
 
-  // One result tile (8) will be bigger than the budget (5).
+  // One result tile (~505) will be bigger than the budget (5).
   total_budget_ = "10000";
   ratio_coords_ = "0.0005";
   update_config();
@@ -709,210 +561,6 @@ TEST_CASE_METHOD(
 
   std::string error_str(msg);
   CHECK(error_str.find("Cannot load a single tile") != std::string::npos);
-}
-
-TEST_CASE_METHOD(
-    CSparseUnorderedWithDupsFx,
-    "Sparse unordered with dups reader: rcs budget forcing one tile at a time",
-    "[sparse-unordered-with-dups][small-rcs-budget]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  bool use_subarray = false;
-  SECTION("- No subarray") {
-    use_subarray = false;
-  }
-  SECTION("- Subarray") {
-    use_subarray = true;
-  }
-
-  // Write a fragment.
-  int coords[] = {1, 2, 3, 4, 5};
-  uint64_t coords_size = sizeof(coords);
-  int data[] = {1, 2, 3, 4, 5};
-  uint64_t data_size = sizeof(data);
-  write_1d_fragment(coords, &coords_size, data, &data_size);
-
-  // One cell slab (24) will be bigger than the budget (10).
-  total_budget_ = "10000";
-  ratio_rcs_ = "0.001";
-  update_config();
-
-  tiledb_array_t* array = nullptr;
-  tiledb_query_t* query = nullptr;
-
-  // Try to read.
-  int coords_r[5];
-  int data_r[5];
-  uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-  auto rc = read(
-      use_subarray,
-      false,
-      coords_r,
-      &coords_r_size,
-      data_r,
-      &data_r_size,
-      &query,
-      &array);
-  CHECK(rc == TILEDB_OK);
-
-  // Check incomplete query status.
-  tiledb_query_status_t status;
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should only read one tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
-
-  int coords_c[] = {1, 2};
-  int data_c[] = {1, 2};
-  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check incomplete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should only read one more tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
-
-  int coords_c_2[] = {3, 4};
-  int data_c_2[] = {3, 4};
-  CHECK(!std::memcmp(coords_c_2, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_2, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check complete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_COMPLETED);
-
-  // Should read last tile (1 value).
-  CHECK(4 == data_r_size);
-  CHECK(4 == coords_r_size);
-
-  int coords_c_3[] = {5};
-  int data_c_3[] = {5};
-  CHECK(!std::memcmp(coords_c_3, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_3, data_r, data_r_size));
-
-  // Clean up.
-  rc = tiledb_array_close(ctx_, array);
-  CHECK(rc == TILEDB_OK);
-  tiledb_array_free(&array);
-  tiledb_query_free(&query);
-}
-
-TEST_CASE_METHOD(
-    CSparseUnorderedWithDupsFx,
-    "Sparse unordered with dups reader: qc budget forcing one tile at a time",
-    "[sparse-unordered-with-dups][small-qc-budget]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  bool use_subarray = false;
-  SECTION("- No subarray") {
-    use_subarray = false;
-  }
-  SECTION("- Subarray") {
-    use_subarray = true;
-  }
-
-  // Write a fragment.
-  int coords[] = {1, 2, 3, 4, 5};
-  uint64_t coords_size = sizeof(coords);
-  int data[] = {1, 2, 3, 4, 5};
-  uint64_t data_size = sizeof(data);
-  write_1d_fragment(coords, &coords_size, data, &data_size);
-
-  // Two qc tile (16) will be bigger than the budget (10).
-  total_budget_ = "10000";
-  ratio_query_condition_ = "0.001";
-  update_config();
-
-  tiledb_array_t* array = nullptr;
-  tiledb_query_t* query = nullptr;
-
-  // Try to read.
-  int coords_r[5];
-  int data_r[5];
-  uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-  auto rc = read(
-      use_subarray,
-      true,
-      coords_r,
-      &coords_r_size,
-      data_r,
-      &data_r_size,
-      &query,
-      &array);
-  CHECK(rc == TILEDB_OK);
-
-  // Check incomplete query status.
-  tiledb_query_status_t status;
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should only read one tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
-
-  int coords_c[] = {1, 2};
-  int data_c[] = {1, 2};
-  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check incomplete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should only read one more tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
-
-  int coords_c_2[] = {3, 4};
-  int data_c_2[] = {3, 4};
-  CHECK(!std::memcmp(coords_c_2, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_2, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check complete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_COMPLETED);
-
-  // Should read last tile (1 value).
-  CHECK(4 == data_r_size);
-  CHECK(4 == coords_r_size);
-
-  int coords_c_3[] = {5};
-  int data_c_3[] = {5};
-  CHECK(!std::memcmp(coords_c_3, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_3, data_r, data_r_size));
-
-  // Clean up.
-  rc = tiledb_array_close(ctx_, array);
-  CHECK(rc == TILEDB_OK);
-  tiledb_array_free(&array);
-  tiledb_query_free(&query);
 }
 
 TEST_CASE_METHOD(
@@ -963,4 +611,132 @@ TEST_CASE_METHOD(
 
   std::string error_str(msg);
   CHECK(error_str.find("Cannot load a single tile") != std::string::npos);
+}
+
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsFx,
+    "Sparse unordered with dups reader: qc budget forcing one tile at a time",
+    "[sparse-unordered-with-dups][small-qc-budget]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d();
+
+  bool use_subarray = false;
+  int num_frags = 0;
+  SECTION("- No subarray") {
+    use_subarray = false;
+    SECTION("- One fragment") {
+      num_frags = 1;
+    }
+    SECTION("- Two fragments") {
+      num_frags = 2;
+    }
+  }
+  SECTION("- Subarray") {
+    use_subarray = true;
+    SECTION("- One fragment") {
+      num_frags = 1;
+    }
+    SECTION("- Two fragments") {
+      num_frags = 2;
+    }
+  }
+
+  for (int i = 0; i < num_frags; i++) {
+    // Write a fragment.
+    int coords[] = {1 + i * 5, 2 + i * 5, 3 + i * 5, 4 + i * 5, 5 + i * 5};
+    uint64_t coords_size = sizeof(coords);
+    int data[] = {1 + i * 5, 2 + i * 5, 3 + i * 5, 4 + i * 5, 5 + i * 5};
+    uint64_t data_size = sizeof(data);
+    write_1d_fragment(coords, &coords_size, data, &data_size);
+  }
+
+  // Two qc tile (16) will be bigger than the budget (10).
+  total_budget_ = "10000";
+  ratio_query_condition_ = "0.001";
+  update_config();
+
+  tiledb_array_t* array = nullptr;
+  tiledb_query_t* query = nullptr;
+
+  uint32_t rc;
+  uint64_t coords_r_size;
+  uint64_t data_r_size;
+  for (int i = 0; i < num_frags; i++) {
+    // Try to read.
+    int coords_r[5];
+    int data_r[5];
+    coords_r_size = sizeof(coords_r);
+    data_r_size = sizeof(data_r);
+
+    if (i == 0) {
+      rc = read(
+          use_subarray,
+          true,
+          coords_r,
+          &coords_r_size,
+          data_r,
+          &data_r_size,
+          &query,
+          &array);
+    } else {
+      rc = tiledb_query_submit(ctx_, query);
+    }
+    CHECK(rc == TILEDB_OK);
+
+    // Check incomplete query status.
+    tiledb_query_status_t status;
+    tiledb_query_get_status(ctx_, query, &status);
+    CHECK(status == TILEDB_INCOMPLETE);
+
+    // Should only read one tile (2 values).
+    CHECK(8 == data_r_size);
+    CHECK(8 == coords_r_size);
+
+    int coords_c[] = {1 + i * 5, 2 + i * 5};
+    int data_c[] = {1 + i * 5, 2 + i * 5};
+    CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
+    CHECK(!std::memcmp(data_c, data_r, data_r_size));
+
+    // Read again.
+    rc = tiledb_query_submit(ctx_, query);
+    CHECK(rc == TILEDB_OK);
+
+    // Check incomplete query status.
+    tiledb_query_get_status(ctx_, query, &status);
+    CHECK(status == TILEDB_INCOMPLETE);
+
+    // Should only read one more tile (2 values).
+    CHECK(8 == data_r_size);
+    CHECK(8 == coords_r_size);
+
+    int coords_c_2[] = {3 + i * 5, 4 + i * 5};
+    int data_c_2[] = {3 + i * 5, 4 + i * 5};
+    CHECK(!std::memcmp(coords_c_2, coords_r, coords_r_size));
+    CHECK(!std::memcmp(data_c_2, data_r, data_r_size));
+
+    // Read again.
+    rc = tiledb_query_submit(ctx_, query);
+    CHECK(rc == TILEDB_OK);
+
+    // Check complete query status.
+    tiledb_query_get_status(ctx_, query, &status);
+    CHECK(
+        status == (i == num_frags - 1 ? TILEDB_COMPLETED : TILEDB_INCOMPLETE));
+
+    // Should read last tile (1 value).
+    CHECK(4 == data_r_size);
+    CHECK(4 == coords_r_size);
+
+    int coords_c_3[] = {5 + i * 5};
+    int data_c_3[] = {5 + i * 5};
+    CHECK(!std::memcmp(coords_c_3, coords_r, coords_r_size));
+    CHECK(!std::memcmp(data_c_3, data_r, data_r_size));
+  }
+
+  // Clean up.
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
 }

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1047,6 +1047,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Which reader to use for sparse unordered with dups queries.
  *    "refactored" or "legacy".<br>
  *    **Default**: refactored
+ * - `sm.query.sparse_unordered_with_dups.non_overlapping_ranges` <br>
+ *    Ensure ranges for sparse unordered with dups queries are not overlapping.
+ *    "true" or "false".<br>
+ *    **Default**: false
  * - `sm.mem.malloc_trim` <br>
  *    Should malloc_trim be called on context and query destruction? This might
  * reduce residual memory usage. <br>
@@ -1070,10 +1074,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Ratio of the budget allocated for array data in the sparse global
  *    order reader. <br>
  *    **Default**: 0.1
- * - `sm.mem.reader.sparse_global_order.ratio_result_tiles` <br>
- *    Ratio of the budget allocated for result tiles in the sparse global
- *    order reader. <br>
- *    **Default**: 0.05
  * - `sm.mem.reader.sparse_global_order.ratio_rcs` <br>
  *    Ratio of the budget allocated for result cell slabs in the sparse
  *    global order reader. <br>
@@ -1094,15 +1094,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Ratio of the budget allocated for array data in the sparse unordered
  *    with duplicates reader. <br>
  *    **Default**: 0.1
- * - `sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles` <br>
- *    Ratio of the budget allocated for result tiles in the sparse
- *    unordered with duplicates reader. <br>
- *    **Default**: 0.05
- * - `sm.mem.reader.sparse_unordered_with_dups.ratio_rcs` <br>
- *    Ratio of the budget allocated for result cell slabs in the sparse
- *    unordered with duplicates reader. <br>
- *    **Default**: 0.05
- * - `vfs.read_ahead_size` <br>
  *    The maximum byte size to read-ahead from the backend. <br>
  *    **Default**: 102400
  * -  `vfs.read_ahead_cache_size` <br>

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -156,6 +156,11 @@ class Config {
   /** Which reader to use for sparse unordered with dups queries. */
   static const std::string SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER;
 
+  /** Non overlapping ranges guaranteed for sparse unordered with dups queries.
+   */
+  static const std::string
+      SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_NON_OVERLAPPING_RANGES;
+
   /** Should malloc_trim be called on query/ctx destructors. */
   static const std::string SM_MEM_MALLOC_TRIM;
 
@@ -175,9 +180,6 @@ class Config {
 
   /** Ratio of the sparse global order reader budget used for array data. */
   static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA;
-
-  /** Ratio of the sparse global order reader budget used for result tiles. */
-  static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RESULT_TILES;
 
   /** Ratio of the sparse global order reader budget used for result cell slabs.
    */
@@ -204,18 +206,6 @@ class Config {
    * data.
    */
   static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_ARRAY_DATA;
-
-  /**
-   * Ratio of the sparse unordered with dups reader budget used for result
-   * tiles.
-   */
-  static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RESULT_TILES;
-
-  /**
-   * Ratio of the sparse unordered with dups reader budget used for result
-   * cell slabs.
-   */
-  static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_RCS;
 
   /** Whether or not the signal handlers are installed. */
   static const std::string SM_ENABLE_SIGNAL_HANDLERS;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -395,6 +395,10 @@ class Config {
    *    Which reader to use for sparse unordered with dups queries.
    *    "refactored" or "legacy".<br>
    *    **Default**: refactored
+   * - `sm.query.sparse_unordered_with_dups.non_overlapping_ranges` <br>
+   *    Ensure ranges for sparse unordered with dups queries are not
+   * overlapping. "true" or "false".<br>
+   *    **Default**: false
    * - `sm.mem.malloc_trim` <br>
    *    Should malloc_trim be called on context and query destruction? This
    *    might reduce residual memory usage. <br>
@@ -418,10 +422,6 @@ class Config {
    *    Ratio of the budget allocated for array data in the sparse global
    *    order reader. <br>
    *    **Default**: 0.1
-   * - `sm.mem.reader.sparse_global_order.ratio_result_tiles` <br>
-   *    Ratio of the budget allocated for result tiles in the sparse global
-   *    order reader. <br>
-   *    **Default**: 0.05
    * - `sm.mem.reader.sparse_global_order.ratio_rcs` <br>
    *    Ratio of the budget allocated for result cell slabs in the sparse
    *    global order reader. <br>
@@ -442,14 +442,6 @@ class Config {
    *    Ratio of the budget allocated for array data in the sparse unordered
    *    with duplicates reader. <br>
    *    **Default**: 0.1
-   * - `sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles` <br>
-   *    Ratio of the budget allocated for result tiles in the sparse
-   *    unordered with duplicates reader. <br>
-   *    **Default**: 0.05
-   * - `sm.mem.reader.sparse_unordered_with_dups.ratio_rcs` <br>
-   *    Ratio of the budget allocated for result cell slabs in the sparse
-   *    unordered with duplicates reader. <br>
-   * - `vfs.read_ahead_size` <br>
    *    The maximum byte size to read-ahead from the backend. <br>
    *    **Default**: 102400
    * -  `vfs.read_ahead_cache_size` <br>

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -397,7 +397,7 @@ class Config {
    *    **Default**: refactored
    * - `sm.query.sparse_unordered_with_dups.non_overlapping_ranges` <br>
    *    Ensure ranges for sparse unordered with dups queries are not
-   * overlapping. "true" or "false".<br>
+   *    overlapping. "true" or "false".<br>
    *    **Default**: false
    * - `sm.mem.malloc_trim` <br>
    *    Should malloc_trim be called on context and query destruction? This

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -218,14 +218,12 @@ class QueryCondition {
    * @param result_cell_slabs The cell slabs to filter. Mutated to remove cell
    *   slabs that do not meet the criteria in this query condition.
    * @param stride The stride between cells.
-   * @param memory_budget The memory_budget.
    * @return Status
    */
   Status apply(
       const ArraySchema* array_schema,
       std::vector<ResultCellSlab>* result_cell_slabs,
-      uint64_t stride,
-      uint64_t memory_budget = UINT64_MAX) const;
+      uint64_t stride) const;
 
   /**
    * Applies this query condition to a set of cells.
@@ -248,6 +246,22 @@ class QueryCondition {
       const uint64_t src_cell,
       const uint64_t stride,
       uint8_t* result_buffer);
+
+  /**
+   * Applies this query condition to a set of cells.
+   *
+   * @param array_schema The array schema.
+   * @param result_tile The result tile to get the cells from.
+   * @param result_bitmap The bitmap to use for results.
+   * @param cell_count The cell count after condition is applied.
+   * @return Status
+   */
+  template <typename T, typename BitmapType>
+  Status apply_sparse(
+      const ArraySchema* const array_schema,
+      ResultTile* result_tile,
+      BitmapType* result_bitmap,
+      uint64_t* cell_count);
 
   /**
    * Sets the clauses. This is internal state to only be used in
@@ -453,6 +467,63 @@ class QueryCondition {
       const uint8_t previous_result_bitmask,
       const uint8_t current_result_bitmask,
       uint8_t* result_buffer) const;
+
+  /**
+   * Applies a clause on a sparse result tile,
+   * templated for a query condition operator.
+   *
+   * @param clause The clause to apply.
+   * @param result_tile The result tile to get the cells from.
+   * @param var_size The attribute is var sized or not.
+   * @param nullable The attribute is nullable or not.
+   * @param result_bitmap The result bitmap.
+   * @param cell_count The cell count after condition is applied.
+   */
+  template <typename T, QueryConditionOp Op, typename BitmapType>
+  void apply_clause_sparse(
+      const QueryCondition::Clause& clause,
+      ResultTile* result_tile,
+      const bool var_size,
+      const bool nullable,
+      BitmapType* result_bitmap,
+      uint64_t* cell_count) const;
+
+  /**
+   * Applies a clause on a sparse result tile.
+   *
+   * @param clause The clause to apply.
+   * @param result_tile The result tile to get the cells from.
+   * @param var_size The attribute is var sized or not.
+   * @param nullable The attribute is nullable or not.
+   * @param result_bitmap The result bitmap.
+   * @param cell_count The cell count after condition is applied.
+   */
+  template <typename T, typename BitmapType>
+  Status apply_clause_sparse(
+      const Clause& clause,
+      ResultTile* result_tile,
+      const bool var_size,
+      const bool nullable,
+      BitmapType* result_bitmap,
+      uint64_t* cell_count) const;
+
+  /**
+   * Applies a clause to filter result cells from the input
+   * result tile.
+   *
+   * @param clause The clause to apply.
+   * @param array_schema The current array schema.
+   * @param result_tile The result tile to get the cells from.
+   * @param result_bitmap The result bitmap.
+   * @param cell_count The cell count after condition is applied.
+   */
+  template <typename BitmapType>
+  Status apply_clause_sparse(
+      const QueryCondition::Clause& clause,
+      const ArraySchema* const array_schema,
+      ResultTile* result_tile,
+      BitmapType* result_bitmap,
+      uint64_t* cell_count) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -248,6 +248,45 @@ void Reader::reset() {
 /*         PRIVATE METHODS        */
 /* ****************************** */
 
+Status Reader::apply_query_condition(
+    std::vector<ResultCellSlab>* const result_cell_slabs,
+    std::vector<ResultTile*>* result_tiles,
+    Subarray* subarray,
+    uint64_t stride) {
+  if (condition_.empty() || result_cell_slabs->empty())
+    return Status::Ok();
+
+  // To evaluate the query condition, we need to read tiles for the
+  // attributes used in the query condition. Build a map of attribute
+  // names to read.
+  const std::unordered_set<std::string>& condition_names =
+      condition_.field_names();
+  std::unordered_map<std::string, ProcessTileFlags> names;
+  for (const auto& condition_name : condition_names) {
+    names[condition_name] = ProcessTileFlag::READ;
+  }
+
+  // Each element in `names` has been flagged with `ProcessTileFlag::READ`.
+  // This will read the tiles, but will not copy them into the user buffers.
+  RETURN_NOT_OK(process_tiles(
+      &names,
+      result_tiles,
+      result_cell_slabs,
+      subarray,
+      stride,
+      std::numeric_limits<uint64_t>::max()));
+
+  // The `UINT64_MAX` is a sentinel value to indicate that we do not
+  // use a stride in the cell index calculation. To simplify our logic,
+  // assign this to `1`.
+  if (stride == UINT64_MAX)
+    stride = 1;
+
+  RETURN_NOT_OK(condition_.apply(array_schema_, result_cell_slabs, stride));
+
+  return Status::Ok();
+}
+
 Status Reader::compute_result_cell_slabs(
     const std::vector<ResultCoords>& result_coords,
     std::vector<ResultCellSlab>* result_cell_slabs) const {

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -222,6 +222,24 @@ class Reader : public ReaderBase, public IQueryStrategy {
   /* ********************************* */
 
   /**
+   * Applies the query condition, `condition_`, to filter cell indexes
+   * within `result_cell_slabs`. This mutates `result_cell_slabs`.
+   *
+   * @param result_cell_slabs The unfiltered cell slabs.
+   * @param result_tiles The result tiles that must contain values for
+   *   attributes within `condition_`.
+   * @param subarray Specifies the current subarray.
+   * @param stride The stride between cells, defaulting to UINT64_MAX
+   *   for contiguous cells.
+   * @return Status
+   */
+  Status apply_query_condition(
+      std::vector<ResultCellSlab>* result_cell_slabs,
+      std::vector<ResultTile*>* result_tiles,
+      Subarray* subarray,
+      uint64_t stride = UINT64_MAX);
+
+  /**
    * Compute the maximal cell slabs of contiguous sparse coordinates.
    *
    * @param coords The coordinates to compute the slabs from.

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -396,14 +396,14 @@ Status ReaderBase::init_tile_nullable(
 Status ReaderBase::read_attribute_tiles(
     const std::vector<std::string>* names,
     const std::vector<ResultTile*>* result_tiles) const {
-  auto timer_se = stats_->start_timer("attr_tiles");
+  auto timer_se = stats_->start_timer("read_attribute_tiles");
   return read_tiles(names, result_tiles);
 }
 
 Status ReaderBase::read_coordinate_tiles(
     const std::vector<std::string>* names,
     const std::vector<ResultTile*>* result_tiles) const {
-  auto timer_se = stats_->start_timer("coord_tiles");
+  auto timer_se = stats_->start_timer("read_coordinate_tiles");
   return read_tiles(names, result_tiles);
 }
 

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -961,8 +961,7 @@ Status ReaderBase::copy_attribute_values(
         result_cell_slabs,
         &subarray,
         stride,
-        memory_budget,
-        nullptr));
+        memory_budget));
   }
 
   return Status::Ok();
@@ -1529,8 +1528,7 @@ Status ReaderBase::process_tiles(
     std::vector<ResultCellSlab>* result_cell_slabs,
     Subarray* subarray,
     const uint64_t stride,
-    uint64_t memory_budget,
-    uint64_t* memory_used_for_tiles) {
+    uint64_t memory_budget) {
   // If a name needs to be read, we put it on `read_names` vector (it may
   // contain other flags). Otherwise, we put the name on the `copy_names`
   // vector if it needs to be copied back to the user buffer.
@@ -1538,18 +1536,14 @@ Status ReaderBase::process_tiles(
   // separately from `copy_names`.
   std::vector<std::string> read_names;
   std::vector<std::string> copy_names;
-  bool is_apply_query_condition = true;
   read_names.reserve(names->size());
   for (const auto& name_pair : *names) {
     const std::string name = name_pair.first;
     const ProcessTileFlags flags = name_pair.second;
     if (flags & ProcessTileFlag::READ) {
-      if (flags & ProcessTileFlag::COPY)
-        is_apply_query_condition = false;
       read_names.push_back(name);
     } else if (flags & ProcessTileFlag::COPY) {
       copy_names.push_back(name);
-      is_apply_query_condition = false;
     }
   }
 
@@ -1559,68 +1553,47 @@ Status ReaderBase::process_tiles(
 
   // Respect the memory budget if it is set.
   if (memory_budget != std::numeric_limits<uint64_t>::max()) {
-    // For query condition, make sure all tiles fit in memory budget.
-    if (is_apply_query_condition) {
-      for (const auto& name_pair : *names) {
-        const std::string name = name_pair.first;
-        assert(name_pair.second == ProcessTileFlag::READ);
-
-        for (const auto& rt : *result_tiles) {
-          uint64_t tile_size = 0;
-          RETURN_NOT_OK(get_attribute_tile_size(
-              name, rt->frag_idx(), rt->tile_idx(), &tile_size));
-          *memory_used_for_tiles += tile_size;
+    // Make sure that for each attribute, all tiles can fit in the budget.
+    uint64_t new_result_tile_size = result_tiles->size();
+    for (const auto& name_pair : *names) {
+      uint64_t mem_usage = 0;
+      for (uint64_t i = 0; i < result_tiles->size() && i < new_result_tile_size;
+           i++) {
+        const auto& rt = result_tiles->at(i);
+        uint64_t tile_size = 0;
+        RETURN_NOT_OK(get_attribute_tile_size(
+            name_pair.first, rt->frag_idx(), rt->tile_idx(), &tile_size));
+        if (mem_usage + tile_size > memory_budget) {
+          new_result_tile_size = i;
+          break;
         }
+        mem_usage += tile_size;
       }
+    }
 
-      if (*memory_used_for_tiles > memory_budget) {
-        return Status::ReaderError(
-            "Exceeded tile memory budget applying query condition");
-      }
-    } else {
-      // Make sure that for each attribute, all tiles can fit in the budget.
-      uint64_t new_result_tile_size = result_tiles->size();
-      for (const auto& name_pair : *names) {
-        uint64_t mem_usage = 0;
-        for (uint64_t i = 0;
-             i < result_tiles->size() && i < new_result_tile_size;
-             i++) {
-          const auto& rt = result_tiles->at(i);
-          uint64_t tile_size = 0;
-          RETURN_NOT_OK(get_attribute_tile_size(
-              name_pair.first, rt->frag_idx(), rt->tile_idx(), &tile_size));
-          if (mem_usage + tile_size > memory_budget) {
-            new_result_tile_size = i;
-            break;
+    if (new_result_tile_size != result_tiles->size()) {
+      // Erase tiles from result tiles.
+      result_tiles->erase(
+          result_tiles->begin() + new_result_tile_size - 1,
+          result_tiles->end());
+
+      // Find the result cell slab index to end the copy opeation.
+      auto& last_tile = result_tiles->back();
+      uint64_t last_idx = 0;
+      for (uint64_t i = 0; i < result_cell_slabs->size(); i++) {
+        if (result_cell_slabs->at(i).tile_ == last_tile) {
+          if (i == 0) {
+            return Status::ReaderError(
+                "Unable to copy one tile with current budget");
           }
-          mem_usage += tile_size;
+          last_idx = i;
         }
       }
 
-      if (new_result_tile_size != result_tiles->size()) {
-        // Erase tiles from result tiles.
-        result_tiles->erase(
-            result_tiles->begin() + new_result_tile_size - 1,
-            result_tiles->end());
-
-        // Find the result cell slab index to end the copy opeation.
-        auto& last_tile = result_tiles->back();
-        uint64_t last_idx = 0;
-        for (uint64_t i = 0; i < result_cell_slabs->size(); i++) {
-          if (result_cell_slabs->at(i).tile_ == last_tile) {
-            if (i == 0) {
-              return Status::ReaderError(
-                  "Unable to copy one tile with current budget");
-            }
-            last_idx = i;
-          }
-        }
-
-        // Adjust copy_end_
-        if (copy_end_.first > last_idx + 1) {
-          copy_end_.first = last_idx + 1;
-          copy_end_.second = result_cell_slabs->at(last_idx).length_;
-        }
+      // Adjust copy_end_
+      if (copy_end_.first > last_idx + 1) {
+        copy_end_.first = last_idx + 1;
+        copy_end_.second = result_cell_slabs->at(last_idx).length_;
       }
     }
   }
@@ -1708,76 +1681,6 @@ Status ReaderBase::process_tiles(
 
     idx += inner_names.size();
   }
-
-  return Status::Ok();
-}
-
-tdb_unique_ptr<ReaderBase::ResultCellSlabsIndex> ReaderBase::compute_rcs_index(
-    const std::vector<ResultCellSlab>* result_cell_slabs) const {
-  // Build an association from the result tile to the cell slab ranges
-  // that it contains.
-  tdb_unique_ptr<ReaderBase::ResultCellSlabsIndex> rcs_index =
-      tdb_unique_ptr<ReaderBase::ResultCellSlabsIndex>(
-          tdb_new(ResultCellSlabsIndex));
-
-  std::vector<ResultCellSlab>::const_iterator it = result_cell_slabs->cbegin();
-  while (it != result_cell_slabs->cend()) {
-    std::pair<uint64_t, uint64_t> range =
-        std::make_pair(it->start_, it->start_ + it->length_);
-    if (rcs_index->find(it->tile_) == rcs_index->end()) {
-      std::vector<std::pair<uint64_t, uint64_t>> ranges(1, std::move(range));
-      rcs_index->insert(std::make_pair(it->tile_, std::move(ranges)));
-    } else {
-      (*rcs_index)[it->tile_].emplace_back(std::move(range));
-    }
-    ++it;
-  }
-
-  return rcs_index;
-}
-
-Status ReaderBase::apply_query_condition(
-    std::vector<ResultCellSlab>* const result_cell_slabs,
-    std::vector<ResultTile*>* result_tiles,
-    Subarray* subarray,
-    uint64_t stride,
-    uint64_t memory_budget_rcs,
-    uint64_t memory_budget_tiles,
-    uint64_t* memory_used_for_tiles) {
-  if (condition_.empty() || result_cell_slabs->empty())
-    return Status::Ok();
-
-  // To evaluate the query condition, we need to read tiles for the
-  // attributes used in the query condition. Build a map of attribute
-  // names to read.
-  const std::unordered_set<std::string>& condition_names =
-      condition_.field_names();
-  std::unordered_map<std::string, ProcessTileFlags> names;
-  for (const auto& condition_name : condition_names) {
-    names[condition_name] = ProcessTileFlag::READ;
-  }
-
-  // Each element in `names` has been flagged with `ProcessTileFlag::READ`.
-  // This will read the tiles, but will not copy them into the user buffers.
-  RETURN_NOT_OK(process_tiles(
-      &names,
-      result_tiles,
-      result_cell_slabs,
-      subarray,
-      stride,
-      memory_budget_tiles,
-      memory_used_for_tiles));
-
-  // The `UINT64_MAX` is a sentinel value to indicate that we do not
-  // use a stride in the cell index calculation. To simplify our logic,
-  // assign this to `1`.
-  if (stride == UINT64_MAX)
-    stride = 1;
-
-  RETURN_NOT_OK(condition_.apply(
-      array_schema_, result_cell_slabs, stride, memory_budget_rcs));
-
-  logger_->debug("Done applying query condition");
 
   return Status::Ok();
 }
@@ -2080,44 +1983,37 @@ void ReaderBase::fill_dense_coords_col_slab(
 
 // Explicit template instantiations
 template void ReaderBase::compute_result_space_tiles<int8_t>(
-    const Subarray* subarray,
-    const Subarray* partitioner_subarray,
-    std::map<const int8_t*, ResultSpaceTile<int8_t>>* result_space_tiles) const;
+    const Subarray*,
+    const Subarray*,
+    std::map<const int8_t*, ResultSpaceTile<int8_t>>*) const;
 template void ReaderBase::compute_result_space_tiles<uint8_t>(
-    const Subarray* subarray,
-    const Subarray* partitioner_subarray,
-    std::map<const uint8_t*, ResultSpaceTile<uint8_t>>* result_space_tiles)
-    const;
+    const Subarray*,
+    const Subarray*,
+    std::map<const uint8_t*, ResultSpaceTile<uint8_t>>*) const;
 template void ReaderBase::compute_result_space_tiles<int16_t>(
-    const Subarray* subarray,
-    const Subarray* partitioner_subarray,
-    std::map<const int16_t*, ResultSpaceTile<int16_t>>* result_space_tiles)
-    const;
+    const Subarray*,
+    const Subarray*,
+    std::map<const int16_t*, ResultSpaceTile<int16_t>>*) const;
 template void ReaderBase::compute_result_space_tiles<uint16_t>(
-    const Subarray* subarray,
-    const Subarray* partitioner_subarray,
-    std::map<const uint16_t*, ResultSpaceTile<uint16_t>>* result_space_tiles)
-    const;
+    const Subarray*,
+    const Subarray*,
+    std::map<const uint16_t*, ResultSpaceTile<uint16_t>>*) const;
 template void ReaderBase::compute_result_space_tiles<int32_t>(
-    const Subarray* subarray,
-    const Subarray* partitioner_subarray,
-    std::map<const int32_t*, ResultSpaceTile<int32_t>>* result_space_tiles)
-    const;
+    const Subarray*,
+    const Subarray*,
+    std::map<const int32_t*, ResultSpaceTile<int32_t>>*) const;
 template void ReaderBase::compute_result_space_tiles<uint32_t>(
-    const Subarray* subarray,
-    const Subarray* partitioner_subarray,
-    std::map<const uint32_t*, ResultSpaceTile<uint32_t>>* result_space_tiles)
-    const;
+    const Subarray*,
+    const Subarray*,
+    std::map<const uint32_t*, ResultSpaceTile<uint32_t>>*) const;
 template void ReaderBase::compute_result_space_tiles<int64_t>(
-    const Subarray* subarray,
-    const Subarray* partitioner_subarray,
-    std::map<const int64_t*, ResultSpaceTile<int64_t>>* result_space_tiles)
-    const;
+    const Subarray*,
+    const Subarray*,
+    std::map<const int64_t*, ResultSpaceTile<int64_t>>*) const;
 template void ReaderBase::compute_result_space_tiles<uint64_t>(
-    const Subarray* subarray,
-    const Subarray* partitioner_subarray,
-    std::map<const uint64_t*, ResultSpaceTile<uint64_t>>* result_space_tiles)
-    const;
+    const Subarray*,
+    const Subarray*,
+    std::map<const uint64_t*, ResultSpaceTile<uint64_t>>*) const;
 
 template Status ReaderBase::fill_dense_coords<int8_t>(const Subarray&);
 template Status ReaderBase::fill_dense_coords<uint8_t>(const Subarray&);

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -623,7 +623,6 @@ class ReaderBase : public StrategyBase {
    * @param subarray Specifies the current subarray.
    * @param stride The stride between cells, UINT64_MAX for contiguous.
    * @param memory_budget The memory budget, UINT64_MAX for unlimited.
-   * @param memory_used_for_tiles The memory used for tiles that will not be
    * unloaded.
    */
   Status process_tiles(
@@ -632,42 +631,7 @@ class ReaderBase : public StrategyBase {
       std::vector<ResultCellSlab>* result_cell_slabs,
       Subarray* subarray,
       uint64_t stride,
-      uint64_t memory_budget,
-      uint64_t* memory_used_for_tiles);
-
-  /**
-   * Builds and returns an association from each tile in `result_cell_slabs`
-   * to the cell slabs it contains.
-   */
-  tdb_unique_ptr<ResultCellSlabsIndex> compute_rcs_index(
-      const std::vector<ResultCellSlab>* result_cell_slabs) const;
-
-  /**
-   * Applies the query condition, `condition_`, to filter cell indexes
-   * within `result_cell_slabs`. This mutates `result_cell_slabs`.
-   *
-   * @param result_cell_slabs The unfiltered cell slabs.
-   * @param result_tiles The result tiles that must contain values for
-   *   attributes within `condition_`.
-   * @param subarray Specifies the current subarray.
-   * @param stride The stride between cells, defaulting to UINT64_MAX
-   *   for contiguous cells.
-   * @param memory_budget_rcs The memory budget for tiles, defaulting
-   *   to UINT64_MAX for unlimited budget.
-   * @param memory_budget_tiles The memory budget for result cell slabs,
-   *   defaulting to UINT64_MAX for unlimited budget.
-   * @param memory_used_for_tiles The memory used for tiles that will
-   *   not be unloaded.
-   * @return Status
-   */
-  Status apply_query_condition(
-      std::vector<ResultCellSlab>* result_cell_slabs,
-      std::vector<ResultTile*>* result_tiles,
-      Subarray* subarray,
-      uint64_t stride = UINT64_MAX,
-      uint64_t memory_budget_rcs = UINT64_MAX,
-      uint64_t memory_budget_tiles = UINT64_MAX,
-      uint64_t* memory_used_for_tiles = nullptr);
+      uint64_t memory_budget);
 
   /**
    * Get the size of an attribute tile.

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -686,22 +686,18 @@ void ResultTile::compute_results_sparse(
   }
 }
 
-template <>
-void ResultTile::compute_results_count_sparse<char>(
+template <class BitmapType>
+void ResultTile::compute_results_count_sparse_string(
     const ResultTile* result_tile,
     unsigned dim_idx,
-    const Range& range,
-    std::vector<uint64_t>* result_count,
-    bool use_prev_dim_result_count,
-    std::vector<uint64_t>* prev_dim_result_count,
-    const Layout& cell_order,
-    std::mutex& mtx) {
+    const NDRange& ranges,
+    const std::vector<uint64_t>* range_indexes,
+    const uint64_t num_indexes,
+    std::vector<BitmapType>* result_count,
+    const Layout& cell_order) {
   auto coords_num = result_tile->cell_num();
   auto dim_num = result_tile->domain()->dim_num();
-  auto range_start = range.start_str();
-  auto range_end = range.end_str();
   auto& r_count = (*result_count);
-  auto& prev_dim_r_count = (*prev_dim_result_count);
 
   // Sanity check.
   assert(coords_num != 0);
@@ -780,25 +776,38 @@ void ResultTile::compute_results_count_sparse<char>(
       // string value.
       if (first_c_size == last_c_size &&
           strncmp(first_c_coord, second_coord, first_c_size) == 0) {
-        const uint8_t intersects = str_coord_intersects(
-            first_c_offset, first_c_size, buff_str, range_start, range_end);
-        if (intersects) {
-          std::unique_lock<std::mutex> ul(mtx);
+        uint64_t count = 0;
+        for (uint64_t i = 0; i < num_indexes; i++) {
+          auto& range = ranges[range_indexes->at(i)];
+          count += str_coord_intersects(
+              first_c_offset,
+              first_c_size,
+              buff_str,
+              range.start_str(),
+              range.end_str());
+        }
+
+        if (count != 0) {
           for (uint64_t pos = first_c_pos; pos < first_c_pos + c_partition_size;
                ++pos) {
-            r_count[pos]++;
+            r_count[pos] = count;
           }
         }
       } else {
         // Compute results
         uint64_t c_offset = 0, c_size = 0;
-        std::unique_lock<std::mutex> ul(mtx);
         for (uint64_t pos = first_c_pos; pos <= last_c_pos; ++pos) {
           c_offset = buff_off[pos];
           c_size = (pos < coords_num - 1) ? buff_off[pos + 1] - c_offset :
                                             buff_str_size - c_offset;
-          r_count[pos] += str_coord_intersects(
-              c_offset, c_size, buff_str, range_start, range_end);
+          uint64_t count = 0;
+          for (uint64_t i = 0; i < num_indexes; i++) {
+            auto& range = ranges[range_indexes->at(i)];
+            count += str_coord_intersects(
+                c_offset, c_size, buff_str, range.start_str(), range.end_str());
+          }
+
+          r_count[pos] = count;
         }
       }
     }
@@ -808,298 +817,74 @@ void ResultTile::compute_results_count_sparse<char>(
     return;
   }
 
-  // Here, we're computing on all other dimensions. After the first
-  // dimension, it is possible that coordinates have already been determined
-  // to not intersect with the range in an earlier dimension. For example,
-  // if `dim_idx` is 2 for a row-major cell order, we have already checked
-  // this coordinate for an intersection in dimension-0 and dimension-1. If
-  // either did not intersect a coordinate, its associated value in
-  // `prev_dim_r_count` will be zero. To optimize for the scenario where there
-  // are many contiguous zeroes, we can `memcmp` a large range of
-  // `prev_dim_r_count` values to avoid a comparison on each individual
-  // element.
+  // Here, we're computing on all other dimensions. After the first dimension,
+  // it is possible that coordinates have already been determined to not
+  // intersect with the range in an earlier dimension. For example, if
+  // `dim_idx` is 2 for a row-major cell order, we have already checked this
+  // coordinate for an intersection in dimension-0 and dimension-1. If either
+  // did not intersect a coordinate, its associated value in `r_count` will be
+  // zero. To optimize for the scenario where there are many contiguous zeroes,
+  //  we can `memcmp` a large range of `r_count` values to avoid a comparison
+  // on each individual element.
   //
-  // Often, a memory comparison for one byte is as quick as comparing
-  // 4 or 8 bytes. We will only get a benefit if we successfully
-  // find a `memcmp` on a much larger range.
+  // Often, a memory comparison for one byte is as quick as comparing 4 or 8
+  // bytes. We will only get a benefit if we successfully find a `memcmp` on a
+  // much larger range.
   const uint64_t zeroed_size = coords_num < 256 ? coords_num : 256;
   for (uint64_t i = 0; i < coords_num; i += zeroed_size) {
     const uint64_t partition_size =
         (i < coords_num - zeroed_size) ? zeroed_size : coords_num - i;
 
-    // Check if all `r_bitmap` values are zero between `i` and
+    // Check if all `r_count` values are zero between `i` and
     // `partition_size`.
-    if (use_prev_dim_result_count && prev_dim_r_count[i] == 0 &&
-        memcmp(
-            &prev_dim_r_count[i],
-            &prev_dim_r_count[i + 1],
-            (partition_size - 1) * sizeof(uint64_t)) == 0)
+    if (r_count[i] == 0 && memcmp(
+                               &r_count[i],
+                               &r_count[i + 1],
+                               (partition_size - 1) * sizeof(uint64_t)) == 0)
       continue;
 
     {
       // Here, we know that there is at least one `1` value within the
-      // `prev_dim_r_count` values within this partition. We must check
+      // `r_count` values within this partition. We must check
       // each value for an intersection.
       uint64_t c_offset = 0, c_size = 0;
-      std::unique_lock<std::mutex> ul(mtx);
       for (uint64_t pos = i; pos < i + partition_size; ++pos) {
-        if (use_prev_dim_result_count && prev_dim_r_count[pos] == 0)
+        if (r_count[pos] == 0)
           continue;
 
         c_offset = buff_off[pos];
         c_size = (pos < coords_num - 1) ? buff_off[pos + 1] - c_offset :
                                           buff_str_size - c_offset;
-        r_count[pos] += str_coord_intersects(
-            c_offset, c_size, buff_str, range_start, range_end);
+        uint64_t count = 0;
+        for (uint64_t i = 0; i < num_indexes; i++) {
+          auto& range = ranges[range_indexes->at(i)];
+          count += str_coord_intersects(
+              c_offset, c_size, buff_str, range.start_str(), range.end_str());
+        }
+
+        r_count[pos] *= count;
       }
     }
   }
 }
 
-template <class T>
+template <class BitmapType, class T>
 void ResultTile::compute_results_count_sparse(
     const ResultTile* result_tile,
     unsigned dim_idx,
-    const Range& range,
-    std::vector<uint64_t>* result_count,
-    bool use_prev_dim_result_count,
-    std::vector<uint64_t>* prev_dim_result_count,
-    const Layout& cell_order,
-    std::mutex& mtx) {
-  // We don't use cell_order or previous dimension data for this template type.
-  (void)cell_order;
-  (void)use_prev_dim_result_count;
-  (void)prev_dim_result_count;
-
-  // For easy reference.
-  auto coords_num = result_tile->cell_num();
-  auto r = (const T*)range.data();
-  auto stores_zipped_coords = result_tile->stores_zipped_coords();
-  auto dim_num = result_tile->domain()->dim_num();
-  auto& r_count = (*result_count);
-
-  // Variables for the loop over `coords_num`.
-  T c;
-  const T& r0 = r[0];
-  const T& r1 = r[1];
-
-  // Handle separate coordinate tiles
-  if (!stores_zipped_coords) {
-    const auto& coord_tile = std::get<0>(result_tile->coord_tile(dim_idx));
-    Buffer* const buffer = coord_tile.buffer();
-    const T* const coords = static_cast<const T*>(buffer->data());
-    {
-      std::unique_lock<std::mutex> ul(mtx);
-      for (uint64_t pos = 0; pos < coords_num; ++pos) {
-        c = coords[pos];
-        if (c >= r0 && c <= r1)
-          r_count[pos]++;
-      }
-    }
-
-    return;
-  }
-
-  // Handle zipped coordinates tile
-  assert(stores_zipped_coords);
-  const auto& coords_tile = result_tile->zipped_coords_tile();
-  Buffer* const buffer = coords_tile.buffer();
-  const T* const coords = static_cast<const T*>(buffer->data());
-  {
-    std::unique_lock<std::mutex> ul(mtx);
-    for (uint64_t pos = 0; pos < coords_num; ++pos) {
-      c = coords[pos * dim_num + dim_idx];
-      if (c >= r0 && c <= r1)
-        r_count[pos]++;
-    }
-  }
-}
-
-template <>
-void ResultTile::compute_results_bitmap_sparse<char>(
-    const ResultTile* result_tile,
-    unsigned dim_idx,
-    const Range& range,
-    bool has_previous_dim,
-    std::vector<uint8_t>* result_bitmap,
-    const Layout& cell_order) {
-  auto coords_num = result_tile->cell_num();
-  auto dim_num = result_tile->domain()->dim_num();
-  auto range_start = range.start_str();
-  auto range_end = range.end_str();
-  auto& r_bitmap = (*result_bitmap);
-
-  // Sanity check.
-  assert(coords_num != 0);
-  if (coords_num == 0)
-    return;
-
-  // Get coordinate tile
-  const auto& coord_tile = result_tile->coord_tile(dim_idx);
-
-  // Get offset buffer
-  const auto& coord_tile_off = std::get<0>(coord_tile);
-  auto buff_off = static_cast<const uint64_t*>(coord_tile_off.buffer()->data());
-
-  // Get string buffer
-  const auto& coord_tile_str = std::get<1>(coord_tile);
-  auto buff_str = static_cast<const char*>(coord_tile_str.buffer()->data());
-  auto buff_str_size = coord_tile_str.size();
-
-  // For row-major cell orders, the first dimension is sorted.
-  // For col-major cell orders, the last dimension is sorted.
-  // If the coordinate value at index 0 is equivalent to the
-  // coordinate value at index 100, we know that  all coordinates
-  // between them are also equivalent. In this scenario where
-  // coordinate value i=0 matches the coordinate value at i=100,
-  // we can calculate `r_bitmap[0]` and apply assign its value to
-  // `r_bitmap[i]` where i in the range [1, 100].
-  //
-  // Calculating `r_bitmap[i]` is expensive for strings because
-  // it invokes a string comparison. We partition the coordinates
-  // into a fixed number of ranges. For each partition, we will
-  // compare the start and ending coordinate values to see if
-  // they are equivalent. If so, we save the expense of computing
-  // `r_bitmap` for each corresponding coordinate. If they do
-  // not match, we must compare each coordinate in the partition.
-  static const uint64_t c_partition_num = 6;
-  // We calculate the size of each partition by dividing the total
-  // number of coordinates by the number of partitions. If this
-  // does not evenly divide, we will append the remaining coordinates
-  // onto the last partition.
-  const uint64_t c_partition_size_div = coords_num / c_partition_num;
-  const uint64_t c_partition_size_rem = coords_num % c_partition_num;
-  const bool is_sorted_dim =
-      ((cell_order == Layout::ROW_MAJOR && dim_idx == 0) ||
-       (cell_order == Layout::COL_MAJOR && dim_idx == dim_num - 1));
-  if (is_sorted_dim && c_partition_size_div > 1 &&
-      coords_num > c_partition_num) {
-    // Loop over each coordinate partition.
-    for (uint64_t p = 0; p < c_partition_num; ++p) {
-      // Calculate the size of this partition.
-      const uint64_t c_partition_size =
-          c_partition_size_div +
-          (p == (c_partition_num - 1) ? c_partition_size_rem : 0);
-
-      // Calculate the position of the first and last coordinates
-      // in this partition.
-      const uint64_t first_c_pos = p * c_partition_size_div;
-      const uint64_t last_c_pos = first_c_pos + c_partition_size - 1;
-      assert(first_c_pos < last_c_pos);
-
-      // The coordinate values are determined by their offset and size
-      // within `buff_str`. Calculate the offset and size for the
-      // first and last coordinates in this partition.
-      const uint64_t first_c_offset = buff_off[first_c_pos];
-      const uint64_t last_c_offset = buff_off[last_c_pos];
-      const uint64_t first_c_size = buff_off[first_c_pos + 1] - first_c_offset;
-      const uint64_t last_c_size = (last_c_pos == coords_num - 1) ?
-                                       buff_str_size - last_c_offset :
-                                       buff_off[last_c_pos + 1] - last_c_offset;
-
-      // Fetch the coordinate values for the first and last coordinates
-      // in this partition.
-      const char* const first_c_coord = &buff_str[first_c_offset];
-      const char* const second_coord = &buff_str[last_c_offset];
-
-      // Check if the first and last coordinates have an identical
-      // string value.
-      if (first_c_size == last_c_size &&
-          strncmp(first_c_coord, second_coord, first_c_size) == 0) {
-        const uint8_t intersects = str_coord_intersects(
-            first_c_offset, first_c_size, buff_str, range_start, range_end);
-        if (intersects) {
-          for (uint64_t pos = first_c_pos; pos < first_c_pos + c_partition_size;
-               ++pos) {
-            r_bitmap[pos] = 1;
-          }
-        }
-      } else {
-        // Compute results
-        uint64_t c_offset = 0, c_size = 0;
-        for (uint64_t pos = first_c_pos; pos <= last_c_pos; ++pos) {
-          c_offset = buff_off[pos];
-          c_size = (pos < coords_num - 1) ? buff_off[pos + 1] - c_offset :
-                                            buff_str_size - c_offset;
-          r_bitmap[pos] = str_coord_intersects(
-              c_offset, c_size, buff_str, range_start, range_end);
-        }
-      }
-    }
-
-    // We've calculated `r_bitmap` for all coordinate values in
-    // the sorted dimension.
-    return;
-  }
-
-  // Here, we're computing on all other dimensions. After the first
-  // dimension, it is possible that coordinates have already been determined
-  // to not intersect with the range in an earlier dimension. For example,
-  // if `has_previous_dim` is true, we have already checked this coordinate
-  // for an intersection in previous dimensions. If either did not intersect
-  // a coordinate, its associated value in `r_bitmap` will be zero. To optimize
-  // for the scenario where there are many contiguous zeroes, we can `memcmp`
-  // a large range of `r_bitmap` values to avoid a comparison on each
-  // individual element.
-  //
-  // Often, a memory comparison for one byte is as quick as comparing
-  // 4 or 8 bytes. We will only get a benefit if we successfully
-  // find a `memcmp` on a much larger range.
-  const uint64_t zeroed_size = coords_num < 256 ? coords_num : 256;
-  for (uint64_t i = 0; i < coords_num; i += zeroed_size) {
-    const uint64_t partition_size =
-        (i < coords_num - zeroed_size) ? zeroed_size : coords_num - i;
-
-    // Check if all `r_bitmap` values are zero between `i` and
-    // `partition_size`.
-    if (has_previous_dim && r_bitmap[i] == 0 &&
-        memcmp(
-            &r_bitmap[i],
-            &r_bitmap[i + 1],
-            (partition_size - 1) * sizeof(uint8_t)) == 0)
-      continue;
-
-    {
-      // Here, we know that there is at least one `1` value within the
-      // `prev_dim_r_count` values within this partition. We must check
-      // each value for an intersection.
-      uint64_t c_offset = 0, c_size = 0;
-      for (uint64_t pos = i; pos < i + partition_size; ++pos) {
-        if (has_previous_dim && r_bitmap[pos] == 0)
-          continue;
-
-        c_offset = buff_off[pos];
-        c_size = (pos < coords_num - 1) ? buff_off[pos + 1] - c_offset :
-                                          buff_str_size - c_offset;
-        r_bitmap[pos] = str_coord_intersects(
-            c_offset, c_size, buff_str, range_start, range_end);
-      }
-    }
-  }
-}
-
-template <class T>
-void ResultTile::compute_results_bitmap_sparse(
-    const ResultTile* result_tile,
-    unsigned dim_idx,
-    const Range& range,
-    bool has_previous_dim,
-    std::vector<uint8_t>* result_bitmap,
+    const NDRange& ranges,
+    const std::vector<uint64_t>* range_indexes,
+    const uint64_t num_indexes,
+    std::vector<BitmapType>* result_count,
     const Layout& cell_order) {
   // We don't use cell_order for this template type.
   (void)cell_order;
 
   // For easy reference.
   auto coords_num = result_tile->cell_num();
-  auto r = (const T*)range.data();
   auto stores_zipped_coords = result_tile->stores_zipped_coords();
   auto dim_num = result_tile->domain()->dim_num();
-  auto& r_bitmap = (*result_bitmap);
-
-  // Variables for the loop over `coords_num`.
-  T c;
-  const T& r0 = r[0];
-  const T& r1 = r[1];
+  auto& r_count = (*result_count);
 
   // Handle separate coordinate tiles
   if (!stores_zipped_coords) {
@@ -1107,19 +892,22 @@ void ResultTile::compute_results_bitmap_sparse(
     Buffer* const buffer = coord_tile.buffer();
     const T* const coords = static_cast<const T*>(buffer->data());
     {
-      if (has_previous_dim) {
-        for (uint64_t pos = 0; pos < coords_num; ++pos) {
-          c = coords[pos];
-          if (c >= r0 && c <= r1)
-            r_bitmap[pos] &= 1;
-          else
-            r_bitmap[pos] = 0;
-        }
-      } else {
-        for (uint64_t pos = 0; pos < coords_num; ++pos) {
-          c = coords[pos];
-          if (c >= r0 && c <= r1)
-            r_bitmap[pos] = 1;
+      // Iterate over all cells.
+      for (uint64_t pos = 0; pos < coords_num; ++pos) {
+        // We have a previous count.
+        if (r_count[pos]) {
+          T c = coords[pos];
+          uint64_t count = 0;
+
+          // Iterate through all ranges and compute the count for this dim.
+          for (uint64_t i = 0; i < num_indexes; i++) {
+            auto range = (const T*)ranges[range_indexes->at(i)].data();
+            if (c >= range[0] && c <= range[1])
+              count++;
+          }
+
+          // Multiply the past count by this dimension's count.
+          r_count[pos] *= count;
         }
       }
     }
@@ -1133,19 +921,16 @@ void ResultTile::compute_results_bitmap_sparse(
   Buffer* const buffer = coords_tile.buffer();
   const T* const coords = static_cast<const T*>(buffer->data());
   {
-    if (has_previous_dim) {
-      for (uint64_t pos = 0; pos < coords_num; ++pos) {
-        c = coords[pos * dim_num + dim_idx];
-        if (c >= r0 && c <= r1)
-          r_bitmap[pos] &= 1;
-        else
-          r_bitmap[pos] = 0;
-      }
-    } else {
-      for (uint64_t pos = 0; pos < coords_num; ++pos) {
-        c = coords[pos * dim_num + dim_idx];
-        if (c >= r0 && c <= r1)
-          r_bitmap[pos] = 1;
+    for (uint64_t pos = 0; pos < coords_num; ++pos) {
+      if (r_count[pos]) {
+        T c = coords[pos * dim_num + dim_idx];
+        uint64_t count = 0;
+        for (uint64_t i = 0; i < num_indexes; i++) {
+          auto range = (const T*)ranges[range_indexes->at(i)].data();
+          if (c >= range[0] && c <= range[1])
+            count++;
+        }
+        r_count[pos] *= count;
       }
     }
   }
@@ -1181,36 +966,43 @@ Status ResultTile::compute_results_sparse(
   return Status::Ok();
 }
 
-Status ResultTile::compute_results_count_sparse(
+template <>
+Status ResultTile::compute_results_count_sparse<uint8_t>(
     unsigned dim_idx,
-    const Range& range,
-    std::vector<uint64_t>* result_count,
-    bool use_prev_dim_result_count,
-    std::vector<uint64_t>* prev_dim_result_count,
-    const Layout& cell_order,
-    std::mutex& mtx) const {
-  assert(compute_results_count_sparse_func_[dim_idx] != nullptr);
-  compute_results_count_sparse_func_[dim_idx](
+    const NDRange& ranges,
+    const std::vector<uint64_t>* range_indexes,
+    const uint64_t num_indexes,
+    std::vector<uint8_t>* result_count,
+    const Layout& cell_order) const {
+  assert(compute_results_count_sparse_uint8_t_func_[dim_idx] != nullptr);
+  compute_results_count_sparse_uint8_t_func_[dim_idx](
       this,
       dim_idx,
-      range,
+      ranges,
+      range_indexes,
+      num_indexes,
       result_count,
-      use_prev_dim_result_count,
-      prev_dim_result_count,
-      cell_order,
-      mtx);
+      cell_order);
   return Status::Ok();
 }
 
-Status ResultTile::compute_results_bitmap_sparse(
+template <>
+Status ResultTile::compute_results_count_sparse<uint64_t>(
     unsigned dim_idx,
-    const Range& range,
-    bool has_previous_dim,
-    std::vector<uint8_t>* result_bitmap,
+    const NDRange& ranges,
+    const std::vector<uint64_t>* range_indexes,
+    const uint64_t num_indexes,
+    std::vector<uint64_t>* result_count,
     const Layout& cell_order) const {
-  assert(compute_results_bitmap_sparse_func_[dim_idx] != nullptr);
-  compute_results_bitmap_sparse_func_[dim_idx](
-      this, dim_idx, range, has_previous_dim, result_bitmap, cell_order);
+  assert(compute_results_count_sparse_uint64_t_func_[dim_idx] != nullptr);
+  compute_results_count_sparse_uint64_t_func_[dim_idx](
+      this,
+      dim_idx,
+      ranges,
+      range_indexes,
+      num_indexes,
+      result_count,
+      cell_order);
   return Status::Ok();
 }
 
@@ -1222,90 +1014,90 @@ void ResultTile::set_compute_results_func() {
   auto dim_num = domain_->dim_num();
   compute_results_dense_func_.resize(dim_num);
   compute_results_sparse_func_.resize(dim_num);
-  compute_results_count_sparse_func_.resize(dim_num);
-  compute_results_bitmap_sparse_func_.resize(dim_num);
+  compute_results_count_sparse_uint8_t_func_.resize(dim_num);
+  compute_results_count_sparse_uint64_t_func_.resize(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
     auto dim = domain_->dimension(d);
     switch (dim->type()) {
       case Datatype::INT32:
         compute_results_dense_func_[d] = compute_results_dense<int32_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<int32_t>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<int32_t>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<int32_t>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, int32_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, int32_t>;
         break;
       case Datatype::INT64:
         compute_results_dense_func_[d] = compute_results_dense<int64_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<int64_t>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<int64_t>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<int64_t>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, int64_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, int64_t>;
         break;
       case Datatype::INT8:
         compute_results_dense_func_[d] = compute_results_dense<int8_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<int8_t>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<int8_t>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<int8_t>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, int8_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, int8_t>;
         break;
       case Datatype::UINT8:
         compute_results_dense_func_[d] = compute_results_dense<uint8_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<uint8_t>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<uint8_t>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<uint8_t>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, uint8_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, uint8_t>;
         break;
       case Datatype::INT16:
         compute_results_dense_func_[d] = compute_results_dense<int16_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<int16_t>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<int16_t>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<int16_t>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, int16_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, int16_t>;
         break;
       case Datatype::UINT16:
         compute_results_dense_func_[d] = compute_results_dense<uint16_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<uint16_t>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<uint16_t>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<uint16_t>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, uint16_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, uint16_t>;
         break;
       case Datatype::UINT32:
         compute_results_dense_func_[d] = compute_results_dense<uint32_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<uint32_t>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<uint32_t>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<uint32_t>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, uint32_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, uint32_t>;
         break;
       case Datatype::UINT64:
         compute_results_dense_func_[d] = compute_results_dense<uint64_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<uint64_t>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<uint64_t>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<uint64_t>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, uint64_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, uint64_t>;
         break;
       case Datatype::FLOAT32:
         compute_results_dense_func_[d] = compute_results_dense<float>;
         compute_results_sparse_func_[d] = compute_results_sparse<float>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<float>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<float>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, float>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, float>;
         break;
       case Datatype::FLOAT64:
         compute_results_dense_func_[d] = compute_results_dense<double>;
         compute_results_sparse_func_[d] = compute_results_sparse<double>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<double>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<double>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, double>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, double>;
         break;
       case Datatype::DATETIME_YEAR:
       case Datatype::DATETIME_MONTH:
@@ -1331,24 +1123,24 @@ void ResultTile::set_compute_results_func() {
       case Datatype::TIME_AS:
         compute_results_dense_func_[d] = compute_results_dense<int64_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<int64_t>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<int64_t>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<int64_t>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse<uint8_t, int64_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse<uint64_t, int64_t>;
         break;
       case Datatype::STRING_ASCII:
         compute_results_dense_func_[d] = nullptr;
         compute_results_sparse_func_[d] = compute_results_sparse<char>;
-        compute_results_count_sparse_func_[d] =
-            compute_results_count_sparse<char>;
-        compute_results_bitmap_sparse_func_[d] =
-            compute_results_bitmap_sparse<char>;
+        compute_results_count_sparse_uint8_t_func_[d] =
+            compute_results_count_sparse_string<uint8_t>;
+        compute_results_count_sparse_uint64_t_func_[d] =
+            compute_results_count_sparse_string<uint64_t>;
         break;
       default:
         compute_results_dense_func_[d] = nullptr;
         compute_results_sparse_func_[d] = nullptr;
-        compute_results_count_sparse_func_[d] = nullptr;
-        compute_results_bitmap_sparse_func_[d] = nullptr;
+        compute_results_count_sparse_uint8_t_func_[d] = nullptr;
+        compute_results_count_sparse_uint64_t_func_[d] = nullptr;
         break;
     }
   }

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -604,7 +604,7 @@ void ResultTile::compute_results_sparse<char>(
   // to not intersect with the range in an earlier dimension. For example,
   // if `dim_idx` is 2 for a row-major cell order, we have already checked
   // this coordinate for an intersection in dimension-0 and dimension-1. If
-  // either did not intersect a coordindate, its associated value in
+  // either did not intersect a coordinate, its associated value in
   // `r_bitmap` will be zero. To optimize for the scenario where there are
   // many contiguous zeroes, we can `memcmp` a large range of `r_bitmap`
   // values to avoid a comparison on each individual element.
@@ -813,7 +813,7 @@ void ResultTile::compute_results_count_sparse<char>(
   // to not intersect with the range in an earlier dimension. For example,
   // if `dim_idx` is 2 for a row-major cell order, we have already checked
   // this coordinate for an intersection in dimension-0 and dimension-1. If
-  // either did not intersect a coordindate, its associated value in
+  // either did not intersect a coordinate, its associated value in
   // `prev_dim_r_count` will be zero. To optimize for the scenario where there
   // are many contiguous zeroes, we can `memcmp` a large range of
   // `prev_dim_r_count` values to avoid a comparison on each individual
@@ -866,8 +866,10 @@ void ResultTile::compute_results_count_sparse(
     std::vector<uint64_t>* prev_dim_result_count,
     const Layout& cell_order,
     std::mutex& mtx) {
-  // We do not use `cell_order` for this template type.
+  // We don't use cell_order or previous dimension data for this template type.
   (void)cell_order;
+  (void)use_prev_dim_result_count;
+  (void)prev_dim_result_count;
 
   // For easy reference.
   auto coords_num = result_tile->cell_num();
@@ -875,7 +877,6 @@ void ResultTile::compute_results_count_sparse(
   auto stores_zipped_coords = result_tile->stores_zipped_coords();
   auto dim_num = result_tile->domain()->dim_num();
   auto& r_count = (*result_count);
-  auto& prev_dim_r_count = (*prev_dim_result_count);
 
   // Variables for the loop over `coords_num`.
   T c;
@@ -891,9 +892,7 @@ void ResultTile::compute_results_count_sparse(
       std::unique_lock<std::mutex> ul(mtx);
       for (uint64_t pos = 0; pos < coords_num; ++pos) {
         c = coords[pos];
-        bool has_prev_res =
-            !use_prev_dim_result_count || prev_dim_r_count[pos] > 0;
-        if (has_prev_res && c >= r0 && c <= r1)
+        if (c >= r0 && c <= r1)
           r_count[pos]++;
       }
     }
@@ -910,10 +909,244 @@ void ResultTile::compute_results_count_sparse(
     std::unique_lock<std::mutex> ul(mtx);
     for (uint64_t pos = 0; pos < coords_num; ++pos) {
       c = coords[pos * dim_num + dim_idx];
-      bool has_prev_res =
-          !use_prev_dim_result_count || prev_dim_r_count[pos] > 0;
-      if (has_prev_res && c >= r0 && c <= r1)
+      if (c >= r0 && c <= r1)
         r_count[pos]++;
+    }
+  }
+}
+
+template <>
+void ResultTile::compute_results_bitmap_sparse<char>(
+    const ResultTile* result_tile,
+    unsigned dim_idx,
+    const Range& range,
+    bool has_previous_dim,
+    std::vector<uint8_t>* result_bitmap,
+    const Layout& cell_order) {
+  auto coords_num = result_tile->cell_num();
+  auto dim_num = result_tile->domain()->dim_num();
+  auto range_start = range.start_str();
+  auto range_end = range.end_str();
+  auto& r_bitmap = (*result_bitmap);
+
+  // Sanity check.
+  assert(coords_num != 0);
+  if (coords_num == 0)
+    return;
+
+  // Get coordinate tile
+  const auto& coord_tile = result_tile->coord_tile(dim_idx);
+
+  // Get offset buffer
+  const auto& coord_tile_off = std::get<0>(coord_tile);
+  auto buff_off = static_cast<const uint64_t*>(coord_tile_off.buffer()->data());
+
+  // Get string buffer
+  const auto& coord_tile_str = std::get<1>(coord_tile);
+  auto buff_str = static_cast<const char*>(coord_tile_str.buffer()->data());
+  auto buff_str_size = coord_tile_str.size();
+
+  // For row-major cell orders, the first dimension is sorted.
+  // For col-major cell orders, the last dimension is sorted.
+  // If the coordinate value at index 0 is equivalent to the
+  // coordinate value at index 100, we know that  all coordinates
+  // between them are also equivalent. In this scenario where
+  // coordinate value i=0 matches the coordinate value at i=100,
+  // we can calculate `r_bitmap[0]` and apply assign its value to
+  // `r_bitmap[i]` where i in the range [1, 100].
+  //
+  // Calculating `r_bitmap[i]` is expensive for strings because
+  // it invokes a string comparison. We partition the coordinates
+  // into a fixed number of ranges. For each partition, we will
+  // compare the start and ending coordinate values to see if
+  // they are equivalent. If so, we save the expense of computing
+  // `r_bitmap` for each corresponding coordinate. If they do
+  // not match, we must compare each coordinate in the partition.
+  static const uint64_t c_partition_num = 6;
+  // We calculate the size of each partition by dividing the total
+  // number of coordinates by the number of partitions. If this
+  // does not evenly divide, we will append the remaining coordinates
+  // onto the last partition.
+  const uint64_t c_partition_size_div = coords_num / c_partition_num;
+  const uint64_t c_partition_size_rem = coords_num % c_partition_num;
+  const bool is_sorted_dim =
+      ((cell_order == Layout::ROW_MAJOR && dim_idx == 0) ||
+       (cell_order == Layout::COL_MAJOR && dim_idx == dim_num - 1));
+  if (is_sorted_dim && c_partition_size_div > 1 &&
+      coords_num > c_partition_num) {
+    // Loop over each coordinate partition.
+    for (uint64_t p = 0; p < c_partition_num; ++p) {
+      // Calculate the size of this partition.
+      const uint64_t c_partition_size =
+          c_partition_size_div +
+          (p == (c_partition_num - 1) ? c_partition_size_rem : 0);
+
+      // Calculate the position of the first and last coordinates
+      // in this partition.
+      const uint64_t first_c_pos = p * c_partition_size_div;
+      const uint64_t last_c_pos = first_c_pos + c_partition_size - 1;
+      assert(first_c_pos < last_c_pos);
+
+      // The coordinate values are determined by their offset and size
+      // within `buff_str`. Calculate the offset and size for the
+      // first and last coordinates in this partition.
+      const uint64_t first_c_offset = buff_off[first_c_pos];
+      const uint64_t last_c_offset = buff_off[last_c_pos];
+      const uint64_t first_c_size = buff_off[first_c_pos + 1] - first_c_offset;
+      const uint64_t last_c_size = (last_c_pos == coords_num - 1) ?
+                                       buff_str_size - last_c_offset :
+                                       buff_off[last_c_pos + 1] - last_c_offset;
+
+      // Fetch the coordinate values for the first and last coordinates
+      // in this partition.
+      const char* const first_c_coord = &buff_str[first_c_offset];
+      const char* const second_coord = &buff_str[last_c_offset];
+
+      // Check if the first and last coordinates have an identical
+      // string value.
+      if (first_c_size == last_c_size &&
+          strncmp(first_c_coord, second_coord, first_c_size) == 0) {
+        const uint8_t intersects = str_coord_intersects(
+            first_c_offset, first_c_size, buff_str, range_start, range_end);
+        if (intersects) {
+          for (uint64_t pos = first_c_pos; pos < first_c_pos + c_partition_size;
+               ++pos) {
+            r_bitmap[pos] = 1;
+          }
+        }
+      } else {
+        // Compute results
+        uint64_t c_offset = 0, c_size = 0;
+        for (uint64_t pos = first_c_pos; pos <= last_c_pos; ++pos) {
+          c_offset = buff_off[pos];
+          c_size = (pos < coords_num - 1) ? buff_off[pos + 1] - c_offset :
+                                            buff_str_size - c_offset;
+          r_bitmap[pos] = str_coord_intersects(
+              c_offset, c_size, buff_str, range_start, range_end);
+        }
+      }
+    }
+
+    // We've calculated `r_bitmap` for all coordinate values in
+    // the sorted dimension.
+    return;
+  }
+
+  // Here, we're computing on all other dimensions. After the first
+  // dimension, it is possible that coordinates have already been determined
+  // to not intersect with the range in an earlier dimension. For example,
+  // if `has_previous_dim` is true, we have already checked this coordinate
+  // for an intersection in previous dimensions. If either did not intersect
+  // a coordinate, its associated value in `r_bitmap` will be zero. To optimize
+  // for the scenario where there are many contiguous zeroes, we can `memcmp`
+  // a large range of `r_bitmap` values to avoid a comparison on each
+  // individual element.
+  //
+  // Often, a memory comparison for one byte is as quick as comparing
+  // 4 or 8 bytes. We will only get a benefit if we successfully
+  // find a `memcmp` on a much larger range.
+  const uint64_t zeroed_size = coords_num < 256 ? coords_num : 256;
+  for (uint64_t i = 0; i < coords_num; i += zeroed_size) {
+    const uint64_t partition_size =
+        (i < coords_num - zeroed_size) ? zeroed_size : coords_num - i;
+
+    // Check if all `r_bitmap` values are zero between `i` and
+    // `partition_size`.
+    if (has_previous_dim && r_bitmap[i] == 0 &&
+        memcmp(
+            &r_bitmap[i],
+            &r_bitmap[i + 1],
+            (partition_size - 1) * sizeof(uint8_t)) == 0)
+      continue;
+
+    {
+      // Here, we know that there is at least one `1` value within the
+      // `prev_dim_r_count` values within this partition. We must check
+      // each value for an intersection.
+      uint64_t c_offset = 0, c_size = 0;
+      for (uint64_t pos = i; pos < i + partition_size; ++pos) {
+        if (has_previous_dim && r_bitmap[pos] == 0)
+          continue;
+
+        c_offset = buff_off[pos];
+        c_size = (pos < coords_num - 1) ? buff_off[pos + 1] - c_offset :
+                                          buff_str_size - c_offset;
+        r_bitmap[pos] = str_coord_intersects(
+            c_offset, c_size, buff_str, range_start, range_end);
+      }
+    }
+  }
+}
+
+template <class T>
+void ResultTile::compute_results_bitmap_sparse(
+    const ResultTile* result_tile,
+    unsigned dim_idx,
+    const Range& range,
+    bool has_previous_dim,
+    std::vector<uint8_t>* result_bitmap,
+    const Layout& cell_order) {
+  // We don't use cell_order for this template type.
+  (void)cell_order;
+
+  // For easy reference.
+  auto coords_num = result_tile->cell_num();
+  auto r = (const T*)range.data();
+  auto stores_zipped_coords = result_tile->stores_zipped_coords();
+  auto dim_num = result_tile->domain()->dim_num();
+  auto& r_bitmap = (*result_bitmap);
+
+  // Variables for the loop over `coords_num`.
+  T c;
+  const T& r0 = r[0];
+  const T& r1 = r[1];
+
+  // Handle separate coordinate tiles
+  if (!stores_zipped_coords) {
+    const auto& coord_tile = std::get<0>(result_tile->coord_tile(dim_idx));
+    Buffer* const buffer = coord_tile.buffer();
+    const T* const coords = static_cast<const T*>(buffer->data());
+    {
+      if (has_previous_dim) {
+        for (uint64_t pos = 0; pos < coords_num; ++pos) {
+          c = coords[pos];
+          if (c >= r0 && c <= r1)
+            r_bitmap[pos] &= 1;
+          else
+            r_bitmap[pos] = 0;
+        }
+      } else {
+        for (uint64_t pos = 0; pos < coords_num; ++pos) {
+          c = coords[pos];
+          if (c >= r0 && c <= r1)
+            r_bitmap[pos] = 1;
+        }
+      }
+    }
+
+    return;
+  }
+
+  // Handle zipped coordinates tile
+  assert(stores_zipped_coords);
+  const auto& coords_tile = result_tile->zipped_coords_tile();
+  Buffer* const buffer = coords_tile.buffer();
+  const T* const coords = static_cast<const T*>(buffer->data());
+  {
+    if (has_previous_dim) {
+      for (uint64_t pos = 0; pos < coords_num; ++pos) {
+        c = coords[pos * dim_num + dim_idx];
+        if (c >= r0 && c <= r1)
+          r_bitmap[pos] &= 1;
+        else
+          r_bitmap[pos] = 0;
+      }
+    } else {
+      for (uint64_t pos = 0; pos < coords_num; ++pos) {
+        c = coords[pos * dim_num + dim_idx];
+        if (c >= r0 && c <= r1)
+          r_bitmap[pos] = 1;
+      }
     }
   }
 }
@@ -969,6 +1202,18 @@ Status ResultTile::compute_results_count_sparse(
   return Status::Ok();
 }
 
+Status ResultTile::compute_results_bitmap_sparse(
+    unsigned dim_idx,
+    const Range& range,
+    bool has_previous_dim,
+    std::vector<uint8_t>* result_bitmap,
+    const Layout& cell_order) const {
+  assert(compute_results_bitmap_sparse_func_[dim_idx] != nullptr);
+  compute_results_bitmap_sparse_func_[dim_idx](
+      this, dim_idx, range, has_previous_dim, result_bitmap, cell_order);
+  return Status::Ok();
+}
+
 /* ****************************** */
 /*         PRIVATE METHODS        */
 /* ****************************** */
@@ -978,6 +1223,7 @@ void ResultTile::set_compute_results_func() {
   compute_results_dense_func_.resize(dim_num);
   compute_results_sparse_func_.resize(dim_num);
   compute_results_count_sparse_func_.resize(dim_num);
+  compute_results_bitmap_sparse_func_.resize(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
     auto dim = domain_->dimension(d);
     switch (dim->type()) {
@@ -986,60 +1232,80 @@ void ResultTile::set_compute_results_func() {
         compute_results_sparse_func_[d] = compute_results_sparse<int32_t>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<int32_t>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<int32_t>;
         break;
       case Datatype::INT64:
         compute_results_dense_func_[d] = compute_results_dense<int64_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<int64_t>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<int64_t>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<int64_t>;
         break;
       case Datatype::INT8:
         compute_results_dense_func_[d] = compute_results_dense<int8_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<int8_t>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<int8_t>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<int8_t>;
         break;
       case Datatype::UINT8:
         compute_results_dense_func_[d] = compute_results_dense<uint8_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<uint8_t>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<uint8_t>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<uint8_t>;
         break;
       case Datatype::INT16:
         compute_results_dense_func_[d] = compute_results_dense<int16_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<int16_t>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<int16_t>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<int16_t>;
         break;
       case Datatype::UINT16:
         compute_results_dense_func_[d] = compute_results_dense<uint16_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<uint16_t>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<uint16_t>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<uint16_t>;
         break;
       case Datatype::UINT32:
         compute_results_dense_func_[d] = compute_results_dense<uint32_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<uint32_t>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<uint32_t>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<uint32_t>;
         break;
       case Datatype::UINT64:
         compute_results_dense_func_[d] = compute_results_dense<uint64_t>;
         compute_results_sparse_func_[d] = compute_results_sparse<uint64_t>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<uint64_t>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<uint64_t>;
         break;
       case Datatype::FLOAT32:
         compute_results_dense_func_[d] = compute_results_dense<float>;
         compute_results_sparse_func_[d] = compute_results_sparse<float>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<float>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<float>;
         break;
       case Datatype::FLOAT64:
         compute_results_dense_func_[d] = compute_results_dense<double>;
         compute_results_sparse_func_[d] = compute_results_sparse<double>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<double>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<double>;
         break;
       case Datatype::DATETIME_YEAR:
       case Datatype::DATETIME_MONTH:
@@ -1067,17 +1333,22 @@ void ResultTile::set_compute_results_func() {
         compute_results_sparse_func_[d] = compute_results_sparse<int64_t>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<int64_t>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<int64_t>;
         break;
       case Datatype::STRING_ASCII:
         compute_results_dense_func_[d] = nullptr;
         compute_results_sparse_func_[d] = compute_results_sparse<char>;
         compute_results_count_sparse_func_[d] =
             compute_results_count_sparse<char>;
+        compute_results_bitmap_sparse_func_[d] =
+            compute_results_bitmap_sparse<char>;
         break;
       default:
         compute_results_dense_func_[d] = nullptr;
         compute_results_sparse_func_[d] = nullptr;
         compute_results_count_sparse_func_[d] = nullptr;
+        compute_results_bitmap_sparse_func_[d] = nullptr;
         break;
     }
   }

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -787,11 +787,9 @@ void ResultTile::compute_results_count_sparse_string(
               range.end_str());
         }
 
-        if (count != 0) {
-          for (uint64_t pos = first_c_pos; pos < first_c_pos + c_partition_size;
-               ++pos) {
-            r_count[pos] = count;
-          }
+        for (uint64_t pos = first_c_pos; pos < first_c_pos + c_partition_size;
+             ++pos) {
+          r_count[pos] = count;
         }
       } else {
         // Compute results

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -229,32 +229,38 @@ class ResultTile {
    * Applicable only to sparse arrays.
    *
    * Computes a result count for the input dimension for the coordinates that
-   * fall in the input range.
+   * fall in the input ranges and multiply with the previous count.
+   *
+   * When called over multiple ranges, this follows the formula:
+   * total_count = d1_count * d2_count ... dN_count.
    */
-  template <class T>
+  template <class BitmapType, class T>
   static void compute_results_count_sparse(
       const ResultTile* result_tile,
       unsigned dim_idx,
-      const Range& range,
-      std::vector<uint64_t>* result_count,
-      bool use_prev_dim_result_count,
-      std::vector<uint64_t>* prev_dim_result_count,
-      const Layout& cell_order,
-      std::mutex& mtx);
+      const NDRange& ranges,
+      const std::vector<uint64_t>* range_indexes,
+      const uint64_t num_indexes,
+      std::vector<BitmapType>* result_count,
+      const Layout& cell_order);
 
   /**
    * Applicable only to sparse arrays.
    *
-   * Computes a result bitmap for the input dimension for the coordinates that
-   * fall in the input range.
+   * Computes a result count for the input string dimension for the coordinates
+   * that fall in the input ranges and multiply with the previous count.
+   *
+   * When called over multiple ranges, this follows the formula:
+   * total_count = d1_count * d2_count ... dN_count.
    */
-  template <class T>
-  static void compute_results_bitmap_sparse(
+  template <class BitmapType>
+  static void compute_results_count_sparse_string(
       const ResultTile* result_tile,
       unsigned dim_idx,
-      const Range& range,
-      bool has_previous_dim,
-      std::vector<uint8_t>* result_bitmap,
+      const NDRange& ranges,
+      const std::vector<uint64_t>* range_indexes,
+      const uint64_t num_indexes,
+      std::vector<BitmapType>* result_count,
       const Layout& cell_order);
 
   /**
@@ -291,29 +297,19 @@ class ResultTile {
   /**
    * Applicable only to sparse arrays.
    *
-   * Accummulates to a result count for the coordinates that
-   * fall in the input range, checking only dimensions `dim_idx`.
+   * Computes a result count for the input dimension for the coordinates that
+   * fall in the input ranges and multiply with the previous count.
+   *
+   * When called over multiple ranges, this follows the formula:
+   * total_count = d1_count * d2_count ... dN_count.
    */
+  template <class BitmapType>
   Status compute_results_count_sparse(
       unsigned dim_idx,
-      const Range& range,
-      std::vector<uint64_t>* result_count,
-      bool use_prev_dim_result_count,
-      std::vector<uint64_t>* prev_dim_result_count,
-      const Layout& cell_order,
-      std::mutex& mtx) const;
-
-  /**
-   * Applicable only to sparse arrays.
-   *
-   * Accummulates to a result bitmap for the coordinates that
-   * fall in the input range, checking only dimensions `dim_idx`.
-   */
-  Status compute_results_bitmap_sparse(
-      unsigned dim_idx,
-      const Range& range,
-      bool has_previous_dim,
-      std::vector<uint8_t>* result_bitmap,
+      const NDRange& ranges,
+      const std::vector<uint64_t>* range_indexes,
+      const uint64_t num_indexes,
+      std::vector<BitmapType>* result_count,
       const Layout& cell_order) const;
 
  private:
@@ -382,26 +378,26 @@ class ResultTile {
   std::vector<std::function<void(
       const ResultTile*,
       unsigned,
-      const Range&,
+      const NDRange&,
+      const std::vector<uint64_t>*,
+      const uint64_t,
       std::vector<uint64_t>*,
-      bool,
-      std::vector<uint64_t>*,
-      const Layout&,
-      std::mutex&)>>
-      compute_results_count_sparse_func_;
+      const Layout&)>>
+      compute_results_count_sparse_uint64_t_func_;
 
   /**
-   * Stores the appropriate templated compute_results_bitmap_sparse() function
+   * Stores the appropriate templated compute_results_count_sparse() function
    * for each dimension, based on the dimension datatype.
    */
   std::vector<std::function<void(
       const ResultTile*,
       unsigned,
-      const Range&,
-      bool,
+      const NDRange&,
+      const std::vector<uint64_t>*,
+      const uint64_t,
       std::vector<uint8_t>*,
       const Layout&)>>
-      compute_results_bitmap_sparse_func_;
+      compute_results_count_sparse_uint8_t_func_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -243,6 +243,21 @@ class ResultTile {
       std::mutex& mtx);
 
   /**
+   * Applicable only to sparse arrays.
+   *
+   * Computes a result bitmap for the input dimension for the coordinates that
+   * fall in the input range.
+   */
+  template <class T>
+  static void compute_results_bitmap_sparse(
+      const ResultTile* result_tile,
+      unsigned dim_idx,
+      const Range& range,
+      bool has_previous_dim,
+      std::vector<uint8_t>* result_bitmap,
+      const Layout& cell_order);
+
+  /**
    * Applicable only to sparse tiles of dense arrays.
    *
    * Accummulates to a result bitmap for the coordinates that
@@ -287,6 +302,19 @@ class ResultTile {
       std::vector<uint64_t>* prev_dim_result_count,
       const Layout& cell_order,
       std::mutex& mtx) const;
+
+  /**
+   * Applicable only to sparse arrays.
+   *
+   * Accummulates to a result bitmap for the coordinates that
+   * fall in the input range, checking only dimensions `dim_idx`.
+   */
+  Status compute_results_bitmap_sparse(
+      unsigned dim_idx,
+      const Range& range,
+      bool has_previous_dim,
+      std::vector<uint8_t>* result_bitmap,
+      const Layout& cell_order) const;
 
  private:
   /* ********************************* */
@@ -349,7 +377,7 @@ class ResultTile {
 
   /**
    * Stores the appropriate templated compute_results_count_sparse() function
-   * based for each dimension, based on the dimension datatype.
+   * for each dimension, based on the dimension datatype.
    */
   std::vector<std::function<void(
       const ResultTile*,
@@ -361,6 +389,19 @@ class ResultTile {
       const Layout&,
       std::mutex&)>>
       compute_results_count_sparse_func_;
+
+  /**
+   * Stores the appropriate templated compute_results_bitmap_sparse() function
+   * for each dimension, based on the dimension datatype.
+   */
+  std::vector<std::function<void(
+      const ResultTile*,
+      unsigned,
+      const Range&,
+      bool,
+      std::vector<uint8_t>*,
+      const Layout&)>>
+      compute_results_bitmap_sparse_func_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -191,7 +191,7 @@ Status SparseGlobalOrderReader::dowork() {
         }
       }
 
-      // Compute the tile bitmaps.
+      // Read and unfilter coords.
       RETURN_NOT_OK(read_and_unfilter_coords(true, &tmp_result_tiles));
 
       // Compute the tile bitmaps.

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -125,7 +125,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
   /** The result tiles currently loaded. */
-  std::vector<std::list<ResultTile>> result_tiles_;
+  ResultTileListPerFragment<uint8_t> result_tiles_;
 
   /** Memory used for coordinates tiles per fragment. */
   std::vector<uint64_t> memory_used_for_coords_;
@@ -133,18 +133,30 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /** Memory budget per fragment. */
   double per_fragment_memory_;
 
+  /** Memory used for qc tiles per fragment. */
+  std::vector<uint64_t> memory_used_for_qc_tiles_;
+
+  /** Memory budget per fragment for qc tiles. */
+  double per_fragment_qc_memory_;
+
+  /** Memory used for result cell slabs. */
+  uint64_t memory_used_rcs_;
+
+  /** How much of the memory budget is reserved for result cell slabs. */
+  double memory_budget_ratio_rcs_;
+
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
 
-  /** Load a coordinate tile, making sure maximum budget is respected. */
+  /** Add a result tile to process, making sure maximum budget is respected. */
   Status add_result_tile(
-      unsigned dim_num,
-      uint64_t memory_budget_result_tiles,
-      uint64_t memory_budget_coords_tiles,
-      unsigned f,
-      uint64_t t,
-      const Domain* domain,
+      const unsigned dim_num,
+      const uint64_t memory_budget_coords_tiles,
+      const uint64_t memory_budget_qc_tiles,
+      const unsigned f,
+      const uint64_t t,
+      const Domain* const domain,
       bool* budget_exceeded);
 
   /** corrects memory usage after de-serialization. */
@@ -165,9 +177,9 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       bool subarray_set,
       unsigned int frag_idx,
       uint64_t cell_idx,
-      std::vector<std::list<ResultTile>::iterator>& result_tiles_it,
+      std::vector<std::list<ResultTileWithBitmap<uint8_t>>::iterator>&
+          result_tiles_it,
       std::vector<bool>& result_tile_used,
-      std::vector<std::vector<uint8_t>>& coord_tiles_result_bitmap,
       std::priority_queue<ResultCoords, std::vector<ResultCoords>, T>&
           tile_queue,
       std::mutex& tile_queue_mutex,
@@ -177,10 +189,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /** Computes a tile's Hilbert values, stores them in the comparator. */
   template <class T>
   Status calculate_hilbert_values(
-      bool subarray_set,
-      ResultTile* tile,
-      std::vector<std::vector<uint8_t>>& coord_tiles_result_bitmap,
-      T& cmp);
+      bool subarray_set, ResultTileWithBitmap<uint8_t>* tile, T& cmp);
 
   /** Compute the result cell slabs once tiles are loaded. */
   template <class T>
@@ -188,7 +197,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
 
   /** Remove a result tile from memory */
   Status remove_result_tile(
-      unsigned frag_idx, std::list<ResultTile>::iterator rt);
+      const unsigned frag_idx,
+      std::list<ResultTileWithBitmap<uint8_t>>::iterator rt);
 
   /** Clean up processed data after copying and get ready for the next
    * iteration. */

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -37,6 +37,8 @@
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/misc/resource_pool.h"
+#include "tiledb/sm/query/iquery_strategy.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/query/strategy_base.h"
 #include "tiledb/sm/storage_manager/open_array_memory_tracker.h"
@@ -73,16 +75,12 @@ SparseIndexReaderBase::SparseIndexReaderBase(
     , memory_budget_(0)
     , array_memory_tracker_(nullptr)
     , memory_used_for_coords_total_(0)
-    , memory_used_qc_tiles_(0)
-    , memory_used_rcs_(0)
-    , memory_used_result_tiles_(0)
+    , memory_used_qc_tiles_total_(0)
     , memory_used_result_tile_ranges_(0)
     , memory_budget_ratio_coords_(0.5)
     , memory_budget_ratio_query_condition_(0.25)
     , memory_budget_ratio_tile_ranges_(0.1)
     , memory_budget_ratio_array_data_(0.1)
-    , memory_budget_ratio_result_tiles_(0.05)
-    , memory_budget_ratio_rcs_(0.05)
     , coords_loaded_(true) {
   read_state_.done_adding_result_tiles_ = false;
 }
@@ -91,26 +89,98 @@ SparseIndexReaderBase::SparseIndexReaderBase(
 /*        PROTECTED METHODS       */
 /* ****************************** */
 
-const SparseIndexReaderBase::ReadState* SparseIndexReaderBase::read_state()
-    const {
+const typename SparseIndexReaderBase::ReadState*
+SparseIndexReaderBase::read_state() const {
   return &read_state_;
 }
 
-SparseIndexReaderBase::ReadState* SparseIndexReaderBase::read_state() {
+typename SparseIndexReaderBase::ReadState* SparseIndexReaderBase::read_state() {
   return &read_state_;
 }
 
+Status SparseIndexReaderBase::init() {
+  // Sanity checks
+  if (storage_manager_ == nullptr)
+    return logger_->status(Status::ReaderError(
+        "Cannot initialize sparse global order reader; Storage manager not "
+        "set"));
+  if (array_schema_ == nullptr)
+    return logger_->status(Status::ReaderError(
+        "Cannot initialize sparse global order reader; Array schema not set"));
+  if (buffers_.empty())
+    return logger_->status(Status::ReaderError(
+        "Cannot initialize sparse global order reader; Buffers not set"));
+
+  // Check subarray
+  RETURN_NOT_OK(check_subarray());
+
+  // Load offset configuration options.
+  bool found = false;
+  offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
+  assert(found);
+  if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
+    return logger_->status(
+        Status::ReaderError("Cannot initialize reader; Unsupported offsets "
+                            "format in configuration"));
+  }
+  elements_mode_ = offsets_format_mode_ == "elements";
+
+  RETURN_NOT_OK(config_.get<bool>(
+      "sm.var_offsets.extra_element", &offsets_extra_element_, &found));
+  assert(found);
+  RETURN_NOT_OK(config_.get<uint32_t>(
+      "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
+  if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
+    return logger_->status(
+        Status::ReaderError("Cannot initialize reader; "
+                            "Unsupported offsets bitsize in configuration"));
+  }
+
+  // Check the validity buffer sizes.
+  RETURN_NOT_OK(check_validity_buffer_sizes());
+
+  return Status::Ok();
+}
+
+template <class BitmapType>
 Status SparseIndexReaderBase::get_coord_tiles_size(
-    unsigned dim_num, unsigned f, uint64_t t, uint64_t* tiles_size) {
+    bool include_coords,
+    unsigned dim_num,
+    unsigned f,
+    uint64_t t,
+    uint64_t* tiles_size,
+    uint64_t* tiles_size_qc) {
   *tiles_size = 0;
-  for (unsigned d = 0; d < dim_num; d++) {
-    *tiles_size += fragment_metadata_[f]->tile_size(dim_names_[d], t);
 
-    if (is_dim_var_size_[d]) {
-      uint64_t temp = 0;
-      RETURN_NOT_OK(
-          fragment_metadata_[f]->tile_var_size(dim_names_[d], t, &temp));
-      *tiles_size += temp;
+  // Add the coordinate tiles size.
+  if (include_coords) {
+    for (unsigned d = 0; d < dim_num; d++) {
+      *tiles_size += fragment_metadata_[f]->tile_size(dim_names_[d], t);
+
+      if (is_dim_var_size_[d]) {
+        uint64_t temp = 0;
+        RETURN_NOT_OK(
+            fragment_metadata_[f]->tile_var_size(dim_names_[d], t, &temp));
+        *tiles_size += temp;
+      }
+    }
+  }
+
+  // Add the result tile structure size.
+  *tiles_size += sizeof(ResultTileWithBitmap<BitmapType>);
+
+  // Add the tile bitmap size if there is a subarray.
+  if (subarray_.is_set())
+    *tiles_size += fragment_metadata_[f]->cell_num(t) * sizeof(BitmapType);
+
+  // Compute query condition tile sizes.
+  *tiles_size_qc = 0;
+  if (!qc_loaded_names_.empty()) {
+    for (auto& name : qc_loaded_names_) {
+      // Calculate memory consumption for this tile.
+      uint64_t tile_size = 0;
+      RETURN_NOT_OK(get_attribute_tile_size(name, f, t, &tile_size));
+      *tiles_size_qc += tile_size;
     }
   }
 
@@ -123,6 +193,15 @@ Status SparseIndexReaderBase::load_initial_data() {
 
   auto timer_se = stats_->start_timer("load_initial_data");
   read_state_.done_adding_result_tiles_ = false;
+
+  // Make a list of dim/attr that will be loaded for query condition.
+  if (!initial_data_loaded_) {
+    if (!condition_.empty()) {
+      for (auto& name : condition_.field_names()) {
+        qc_loaded_names_.emplace_back(name);
+      }
+    }
+  }
 
   // For easy reference.
   auto fragment_num = fragment_metadata_.size();
@@ -181,67 +260,382 @@ Status SparseIndexReaderBase::load_initial_data() {
   }
   RETURN_CANCEL_OR_ERROR(load_tile_offsets(&subarray_, &dim_names_));
 
+  // Compute tile offsets to load and var size to load for attributes.
+  std::vector<std::string> attr_tile_offsets_to_load;
   for (auto& it : buffers_) {
     const auto& name = it.first;
     if (array_schema_->is_dim(name))
       continue;
 
+    attr_tile_offsets_to_load.emplace_back(name);
+
     if (array_schema_->var_size(name))
       var_size_to_load.emplace_back(name);
   }
+
+  // Load tile offsets and var sizes for attributes.
   RETURN_CANCEL_OR_ERROR(load_tile_var_sizes(&subarray_, &var_size_to_load));
+  RETURN_CANCEL_OR_ERROR(
+      load_tile_offsets(&subarray_, &attr_tile_offsets_to_load));
 
   logger_->debug("Initial data loaded");
   initial_data_loaded_ = true;
   return Status::Ok();
 }
 
-// Sort vector elements by second element of tuples.
-bool reverse_tuple_sort_by_second(
-    const tuple<uint64_t, uint64_t, uint64_t>& a,
-    const tuple<uint64_t, uint64_t, uint64_t>& b) {
-  return (std::get<1>(a) > std::get<1>(b));
-}
+Status SparseIndexReaderBase::read_and_unfilter_coords(
+    bool include_coords, const std::vector<ResultTile*>* result_tiles) {
+  auto timer_se = stats_->start_timer("read_and_unfilter_coords");
 
-Status SparseIndexReaderBase::compute_coord_tiles_result_bitmap(
-    ResultTile* tile,
-    uint64_t range_idx,
-    std::vector<uint8_t>* coord_tiles_result_bitmap) {
-  auto timer_se = stats_->start_timer("compute_coord_tiles_result_bitmap");
+  // Not including coords or no query condition, exit.
+  if (!include_coords && condition_.empty())
+    return Status::Ok();
 
-  // For easy reference.
-  auto dim_num = array_schema_->dim_num();
-  auto cell_order = array_schema_->cell_order();
-  auto range_coords = subarray_.get_range_coords(range_idx);
+  if (subarray_.is_set() || include_coords) {
+    // Read and unfilter zipped coordinate tiles. Note that
+    // this will ignore fragments with a version >= 5.
+    std::vector<std::string> zipped_coords_names = {constants::coords};
+    RETURN_CANCEL_OR_ERROR(
+        read_coordinate_tiles(&zipped_coords_names, result_tiles));
+    RETURN_CANCEL_OR_ERROR(unfilter_tiles(constants::coords, result_tiles));
 
-  // Compute result and overwritten bitmap per dimension
-  for (unsigned d = 0; d < dim_num; ++d) {
-    // For col-major cell ordering, iterate the dimensions
-    // in reverse.
-    const unsigned dim_idx =
-        cell_order == Layout::COL_MAJOR ? dim_num - d - 1 : d;
-    if (!subarray_.is_default(dim_idx)) {
-      const auto& ranges = subarray_.ranges_for_dim(dim_idx);
-      RETURN_NOT_OK(tile->compute_results_sparse(
-          dim_idx,
-          ranges[range_coords[dim_idx]],
-          coord_tiles_result_bitmap,
-          cell_order));
+    // Read and unfilter unzipped coordinate tiles. Note that
+    // this will ignore fragments with a version < 5.
+    RETURN_CANCEL_OR_ERROR(read_coordinate_tiles(&dim_names_, result_tiles));
+    for (const auto& dim_name : dim_names_) {
+      RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, result_tiles));
     }
   }
 
+  if (!condition_.empty()) {
+    // Read and unfilter tiles for querty condition.
+    RETURN_CANCEL_OR_ERROR(
+        read_attribute_tiles(&qc_loaded_names_, result_tiles));
+
+    for (const auto& name : qc_loaded_names_) {
+      RETURN_CANCEL_OR_ERROR(unfilter_tiles(name, result_tiles));
+    }
+  }
+
+  logger_->debug("Done reading and unfiltering coords tiles");
   return Status::Ok();
 }
 
-Status SparseIndexReaderBase::resize_output_buffers() {
-  // Count number of elements actually copied.
-  uint64_t cells_copied = 0;
-  for (uint64_t i = 0; i < copy_end_.first - 1; i++) {
-    cells_copied += read_state_.result_cell_slabs_[i].length_;
+/** Template specialisation for uint64_t which does result count. */
+template <>
+Status SparseIndexReaderBase::compute_tile_bitmaps<uint64_t>(
+    ResultTileListPerFragment<uint64_t>* result_tiles) {
+  auto timer_se = stats_->start_timer("compute_tile_bitmaps");
+
+  // For easy reference.
+  const auto domain = array_schema_->domain();
+  const auto dim_num = array_schema_->dim_num();
+  const auto cell_order = array_schema_->cell_order();
+
+  // No subarray set, return.
+  if (!subarray_.is_set()) {
+    return Status::Ok();
   }
 
-  cells_copied += copy_end_.second;
+  // Compute the number of non-default dimensions.
+  unsigned non_default_dims = 0;
+  for (unsigned d = 0; d < dim_num; d++) {
+    if (!subarray_.is_default(d))
+      non_default_dims++;
+  }
 
+  // If we have more than one non default dim, we'll need one temp bitmap per
+  // thread.
+  tdb_unique_ptr<ResourcePool<std::vector<uint64_t>>> bitmap_pool;
+  if (non_default_dims > 1) {
+    const auto num_threads =
+        storage_manager_->compute_tp()->concurrency_level();
+    bitmap_pool.reset(
+        tdb_new(ResourcePool<std::vector<uint64_t>>, num_threads));
+  }
+
+  // Process all tiles in parallel.
+  auto result_tiles_it = ResultTileIt(result_tiles);
+  auto status = parallel_for(
+      storage_manager_->compute_tp(), 0, result_tiles_it.size(), [&](uint64_t) {
+        // Take a result tile.
+        auto rt = result_tiles_it.get_next();
+
+        // Bitmap was already computed for this tile.
+        if (rt->bitmap_num_cells != std::numeric_limits<uint64_t>::max()) {
+          return Status::Ok();
+        }
+
+        // Make sure we have a bitmap available if there is more than one
+        // non default dimensions.
+        typedef ResourceGuard<std::vector<uint64_t>, ResourcePool>
+            Uint64VectorPool;
+        tdb_unique_ptr<Uint64VectorPool> guard = nullptr;
+        if (non_default_dims > 1)
+          guard.reset(tdb_new(Uint64VectorPool, *bitmap_pool.get()));
+
+        // Compute bitmaps one dimension at a time.
+        bool use_pool_buffer = false;
+        for (unsigned d = 0; d < dim_num; d++) {
+          bool tile_used = false;
+
+          // For col-major cell ordering, iterate the dimensions
+          // in reverse.
+          const unsigned dim_idx =
+              cell_order == Layout::COL_MAJOR ? dim_num - d - 1 : d;
+
+          // No need to compute bitmaps for default dimensions.
+          if (subarray_.is_default(dim_idx))
+            continue;
+
+          // Process all ranges at once.
+          // Note: this could be optimized. However, the result count is
+          // slowly going to get phased out so for now this code is going
+          // for simplicity.
+          rt->bitmap.resize(rt->cell_num());
+
+          // Make sure the pool buffer is ready for use.
+          if (use_pool_buffer) {
+            auto& pool_buffer = guard->get();
+            uint64_t memset_length =
+                std::min((uint64_t)pool_buffer.size(), rt->cell_num());
+            memset(pool_buffer.data(), 0, memset_length * sizeof(uint64_t));
+            pool_buffer.resize(rt->cell_num());
+          }
+
+          // Process all ranges in parallel.
+          const auto& ranges_for_dim = subarray_.ranges_for_dim(dim_idx);
+          std::mutex range_mtx;
+          auto status = parallel_for(
+              storage_manager_->compute_tp(),
+              0,
+              ranges_for_dim.size(),
+              [&](uint64_t r) {
+                // Figure out what to do with the tile.
+                bool full_overlap = false;
+                const auto& mbr =
+                    fragment_metadata_[rt->frag_idx()]->mbr(rt->tile_idx());
+                bool in_range = domain->dimension(dim_idx)->overlap(
+                    ranges_for_dim[r], mbr[dim_idx]);
+                if (in_range) {
+                  tile_used = true;
+                  full_overlap = domain->dimension(dim_idx)->covered(
+                      mbr[dim_idx], ranges_for_dim[r]);
+                } else {
+                  return Status::Ok();
+                }
+
+                if (!full_overlap) {
+                  // Calculate the bitmap for the cells.
+                  RETURN_NOT_OK(rt->compute_results_count_sparse(
+                      dim_idx,
+                      ranges_for_dim[r],
+                      use_pool_buffer ? &guard->get() : &rt->bitmap,
+                      use_pool_buffer,
+                      &rt->bitmap,
+                      cell_order,
+                      range_mtx));
+                } else {
+                  auto& buffer = use_pool_buffer ? guard->get() : rt->bitmap;
+                  std::unique_lock<std::mutex> ul(range_mtx);
+                  for (uint64_t c = 0; c < rt->cell_num(); ++c) {
+                    buffer[c]++;
+                  }
+                }
+
+                return Status::Ok();
+              });
+          RETURN_NOT_OK_ELSE(status, logger_->status(status));
+
+          if (!tile_used) {
+            return Status::Ok();
+          }
+
+          // Multiply the result of this dimension by the result of the last.
+          if (use_pool_buffer) {
+            auto& pool_buffer = guard->get();
+            for (uint64_t c = 0; c < rt->cell_num(); ++c) {
+              rt->bitmap[c] *= pool_buffer[c];
+            }
+          }
+
+          use_pool_buffer = true;
+        }
+
+        // Compute number of cells in this tile.
+        rt->bitmap_num_cells = 0;
+        for (uint64_t c = 0; c < rt->cell_num(); ++c) {
+          rt->bitmap_num_cells += rt->bitmap[c];
+        }
+
+        return Status::Ok();
+      });
+  RETURN_NOT_OK_ELSE(status, logger_->status(status));
+
+  logger_->debug("Done computing tile bitmaps");
+  return Status::Ok();
+}
+
+/** Template specialisation for uint8_t which does result bitmap. */
+template <>
+Status SparseIndexReaderBase::compute_tile_bitmaps<uint8_t>(
+    ResultTileListPerFragment<uint8_t>* result_tiles) {
+  auto timer_se = stats_->start_timer("compute_tile_bitmaps");
+
+  // For easy reference.
+  const auto domain = array_schema_->domain();
+  const auto dim_num = array_schema_->dim_num();
+  const auto cell_order = array_schema_->cell_order();
+
+  // No subarray set, return.
+  if (!subarray_.is_set()) {
+    return Status::Ok();
+  }
+
+  // Process all tiles in parallel.
+  auto result_tiles_it = ResultTileIt(result_tiles);
+  auto status = parallel_for(
+      storage_manager_->compute_tp(), 0, result_tiles_it.size(), [&](uint64_t) {
+        // Take a result tile.
+        auto rt = result_tiles_it.get_next();
+
+        // Bitmap was already computed for this tile.
+        if (rt->bitmap_num_cells != std::numeric_limits<uint64_t>::max()) {
+          return Status::Ok();
+        }
+
+        // Compute bitmaps one dimension at a time.
+        bool has_previous_dim = false;
+        for (unsigned d = 0; d < dim_num; d++) {
+          bool tile_used = false;
+
+          // For col-major cell ordering, iterate the dimensions
+          // in reverse.
+          const unsigned dim_idx =
+              cell_order == Layout::COL_MAJOR ? dim_num - d - 1 : d;
+
+          // No need to compute bitmaps for default dimensions.
+          if (subarray_.is_default(dim_idx))
+            continue;
+
+          // Process all ranges in parallel.
+          std::mutex bitmap_resize_mtx;
+          const auto& ranges_for_dim = subarray_.ranges_for_dim(dim_idx);
+          auto status = parallel_for(
+              storage_manager_->compute_tp(),
+              0,
+              ranges_for_dim.size(),
+              [&](uint64_t r) {
+                // Figure out what to do with the tile.
+                bool full_overlap = false;
+                const auto& mbr =
+                    fragment_metadata_[rt->frag_idx()]->mbr(rt->tile_idx());
+                bool in_range = domain->dimension(dim_idx)->overlap(
+                    ranges_for_dim[r], mbr[dim_idx]);
+                if (in_range) {
+                  tile_used = true;
+                  full_overlap = domain->dimension(dim_idx)->covered(
+                      mbr[dim_idx], ranges_for_dim[r]);
+                } else {
+                  return Status::Ok();
+                }
+
+                // If there is full overlap, no need to calculate anything for
+                // this dim, ranges are not overlapping so all other ranges will
+                // have no overlap, all previous results should stay the same.
+                if (!full_overlap) {
+                  {
+                    // Make sure the bitmap is ready.
+                    std::unique_lock<std::mutex> ul(bitmap_resize_mtx);
+                    rt->bitmap.resize(rt->cell_num());
+                  }
+
+                  // Calculate the bitmap for the cells.
+                  RETURN_NOT_OK(rt->compute_results_bitmap_sparse(
+                      dim_idx,
+                      ranges_for_dim[r],
+                      has_previous_dim,
+                      &rt->bitmap,
+                      cell_order));
+                }
+
+                return Status::Ok();
+              });
+          RETURN_NOT_OK_ELSE(status, logger_->status(status));
+
+          if (!tile_used) {
+            return Status::Ok();
+          }
+
+          // If there was full overlap, consider there is no previous dim.
+          has_previous_dim = rt->bitmap.size() != 0;
+        }
+
+        // Compute number of cells in this tile.
+        // If bitmap was not resized, we have full overlap.
+        if (rt->bitmap.size() == 0) {
+          rt->bitmap_num_cells = rt->cell_num();
+        } else {
+          rt->bitmap_num_cells = 0;
+          for (uint64_t c = 0; c < rt->cell_num(); ++c) {
+            rt->bitmap_num_cells += rt->bitmap[c];
+          }
+        }
+
+        return Status::Ok();
+      });
+  RETURN_NOT_OK_ELSE(status, logger_->status(status));
+
+  logger_->debug("Done computing tile bitmaps");
+  return Status::Ok();
+}
+
+template <class BitmapType>
+Status SparseIndexReaderBase::apply_query_condition(
+    ResultTileListPerFragment<BitmapType>* result_tiles) {
+  auto timer_se = stats_->start_timer("apply_query_condition");
+
+  if (!condition_.empty()) {
+    // Process all tiles in parallel.
+    auto result_tiles_it = ResultTileIt(result_tiles);
+    auto status = parallel_for(
+        storage_manager_->compute_tp(),
+        0,
+        result_tiles_it.size(),
+        [&](uint64_t) {
+          // Take a result tile.
+          auto rt = result_tiles_it.get_next();
+
+          // Set num_cells if no subarray as it's used to filter below.
+          if (!subarray_.is_set()) {
+            rt->bitmap_num_cells = rt->cell_num();
+          }
+
+          // Max bitmap_num_cells means the tile had no overlap, skip it.
+          if (!rt->qc_processed &&
+              rt->bitmap_num_cells != std::numeric_limits<uint64_t>::max()) {
+            // Full overlap in bitmap calculation, make a bitmap.
+            if (rt->bitmap.size() == 0) {
+              rt->bitmap.resize(rt->cell_num(), 1);
+              rt->bitmap_num_cells = rt->cell_num();
+            }
+
+            // Compute the result of the query condition for this tile.
+            RETURN_NOT_OK(condition_.apply_sparse<BitmapType>(
+                array_schema_, &*rt, rt->bitmap.data(), &rt->bitmap_num_cells));
+            rt->qc_processed = true;
+          }
+
+          return Status::Ok();
+        });
+    RETURN_NOT_OK_ELSE(status, logger_->status(status));
+  }
+
+  logger_->debug("Done applying query condition");
+  return Status::Ok();
+}
+
+Status SparseIndexReaderBase::resize_output_buffers(uint64_t cells_copied) {
   // Resize buffers if the result cell slabs was truncated.
   for (auto& it : buffers_) {
     const auto& name = it.first;
@@ -265,8 +659,17 @@ Status SparseIndexReaderBase::resize_output_buffers() {
 
         // Since the buffer is shrunk, there is an offset for the next element
         // loaded, use it.
-        *(it.second.buffer_var_size_) =
-            ((uint64_t*)it.second.buffer_)[cells_copied];
+        if (offsets_bitsize_ == 64) {
+          uint64_t offset_div =
+              elements_mode_ ? datatype_size(array_schema_->type(name)) : 1;
+          *it.second.buffer_var_size_ =
+              ((uint64_t*)it.second.buffer_)[cells_copied] * offset_div;
+        } else {
+          uint32_t offset_div =
+              elements_mode_ ? datatype_size(array_schema_->type(name)) : 1;
+          *it.second.buffer_var_size_ =
+              ((uint32_t*)it.second.buffer_)[cells_copied] * offset_div;
+        }
       }
     } else {
       // Always adjust the size for fixed size attributes.
@@ -320,6 +723,16 @@ void SparseIndexReaderBase::remove_result_tile_range(uint64_t f) {
     memory_used_result_tile_ranges_ -= sizeof(std::pair<uint64_t, uint64_t>);
   }
 }
+
+// Explicit template instantiations
+template Status SparseIndexReaderBase::get_coord_tiles_size<uint64_t>(
+    bool, unsigned, unsigned, uint64_t, uint64_t*, uint64_t*);
+template Status SparseIndexReaderBase::get_coord_tiles_size<uint8_t>(
+    bool, unsigned, unsigned, uint64_t, uint64_t*, uint64_t*);
+template Status SparseIndexReaderBase::apply_query_condition(
+    ResultTileListPerFragment<uint64_t>*);
+template Status SparseIndexReaderBase::apply_query_condition(
+    ResultTileListPerFragment<uint8_t>*);
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -51,12 +51,120 @@ class OpenArrayMemoryTracker;
 class StorageManager;
 class Subarray;
 
-constexpr uint64_t ceil_div(uint64_t a, uint64_t b) {
-  auto div = static_cast<float>(a) / static_cast<float>(b);
-  return (static_cast<float>(static_cast<int32_t>(div)) == div) ?
-             static_cast<int32_t>(div) :
-             static_cast<int32_t>(div) + ((div > 0) ? 1 : 0);
-}
+/** Result tile with bitmap. */
+template <class BitmapType>
+class ResultTileWithBitmap : public ResultTile {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+  ResultTileWithBitmap(
+      unsigned frag_idx, uint64_t tile_idx, const Domain* domain)
+      : ResultTile(frag_idx, tile_idx, domain)
+      , bitmap_num_cells(std::numeric_limits<uint64_t>::max())
+      , qc_processed(false) {
+  }
+
+  /* ********************************* */
+  /*         PUBLIC ATTRIBUTES         */
+  /* ********************************* */
+
+  /** Bitmap for this tile. */
+  std::vector<BitmapType> bitmap;
+
+  /** Number of cells in this bitmap. */
+  uint64_t bitmap_num_cells;
+
+  /** Was the query condition processed for this tile. */
+  bool qc_processed;
+};
+
+/**
+ * Result tile list per fragments. For sparse global order reader, this will
+ * be the list of tiles loaded per fragments. For the unordered with duplicates
+ * reader, all tiles will be in fragment 0.
+ */
+template <typename BitmapType>
+using ResultTileListPerFragment =
+    std::vector<std::list<ResultTileWithBitmap<BitmapType>>>;
+
+/**
+ * Iterates in a thread safe manner over a ResultTileListPerFragment. This will
+ * be used where we have parallel_for's the need to iterate over all tiles. As
+ * we have a vector of lists, we cannot retreive the ResultTile at a certain
+ * index easily so this helper gives us one ResultTile at a time until we are
+ * done.
+ */
+template <class BitmapType>
+class ResultTileIt {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+  ResultTileIt(ResultTileListPerFragment<BitmapType>* result_tiles)
+      : result_tiles_(result_tiles)
+      , it_(result_tiles->at(0).begin())
+      , f_(0) {
+  }
+
+  /* ********************************* */
+  /*          PUBLIC METHODS           */
+  /* ********************************* */
+
+  /** Returns the size. */
+  uint64_t size() {
+    uint64_t size = 0;
+    for (auto& rt_list : *result_tiles_)
+      size += rt_list.size();
+
+    return size;
+  }
+
+  /** Returns the next result tile iterator. */
+  typename std::list<ResultTileWithBitmap<BitmapType>>::iterator get_next() {
+    std::unique_lock<std::mutex> ul(mtx_);
+    ensure_not_end();
+    return it_++;
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE METHODS           */
+  /* ********************************* */
+
+  /**
+   * Make sure that we are not at the end of a fragment list by moving to the
+   * next fragment that still has tiles available.
+   */
+  void ensure_not_end() {
+    while (it_ == result_tiles_->at(f_).end()) {
+      if (f_ == result_tiles_->size() - 1) {
+        break;
+      }
+      f_++;
+      it_ = result_tiles_->at(f_).begin();
+    }
+  }
+
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /**
+   * List of tiles, per fragments. For unordered with dups reader, everything
+   * will be in fragment 0.
+   */
+  ResultTileListPerFragment<BitmapType>* result_tiles_;
+
+  /** Iterator to the current result tile. */
+  typename std::list<ResultTileWithBitmap<BitmapType>>::iterator it_;
+
+  /** Fragment index. */
+  unsigned f_;
+
+  /** Mutex to make the iterator thread safe. */
+  std::mutex mtx_;
+};
 
 /** Processes read queries. */
 class SparseIndexReaderBase : public ReaderBase {
@@ -103,15 +211,14 @@ class SparseIndexReaderBase : public ReaderBase {
   /** Returns the current read state. */
   const ReadState* read_state() const;
 
+  /** Initializes the reader. */
+  Status init();
+
+  /** Resize the output buffers to the correct size after copying. */
+  Status resize_output_buffers(uint64_t cells_copied);
+
   /** Returns the current read state. */
   ReadState* read_state();
-
-  /** Clears the result tiles. Used by serialization. */
-  virtual Status clear_result_tiles() = 0;
-
-  /** Add a result tile with no memory budget checks. Used by serialization. */
-  virtual ResultTile* add_result_tile_unsafe(
-      unsigned f, uint64_t t, const Domain* domain) = 0;
 
  protected:
   /* ********************************* */
@@ -150,13 +257,7 @@ class SparseIndexReaderBase : public ReaderBase {
   uint64_t memory_used_for_coords_total_;
 
   /** Memory used for query condition tiles. */
-  uint64_t memory_used_qc_tiles_;
-
-  /** Memory used for result cell slabs. */
-  uint64_t memory_used_rcs_;
-
-  /** Memory used for result tiles. */
-  uint64_t memory_used_result_tiles_;
+  uint64_t memory_used_qc_tiles_total_;
 
   /** Memory used for result tile ranges. */
   uint64_t memory_used_result_tile_ranges_;
@@ -173,34 +274,45 @@ class SparseIndexReaderBase : public ReaderBase {
   /** How much of the memory budget is reserved for array data. */
   double memory_budget_ratio_array_data_;
 
-  /** How much of the memory budget is reserved for result tiles. */
-  double memory_budget_ratio_result_tiles_;
-
-  /** How much of the memory budget is reserved for result cell slabs. */
-  double memory_budget_ratio_rcs_;
-
   /** Indicate if the coordinates are loaded for the result tiles. */
   bool coords_loaded_;
+
+  /** Are we in elements mode. */
+  bool elements_mode_;
+
+  /** Names of dim/attr loaded for query condition. */
+  std::vector<std::string> qc_loaded_names_;
 
   /* ********************************* */
   /*         PROTECTED METHODS         */
   /* ********************************* */
 
   /** Get the coordinate tiles size for a dimension. */
+  template <class BitmapType>
   Status get_coord_tiles_size(
-      unsigned dim_num, unsigned f, uint64_t t, uint64_t* tiles_size);
+      bool include_coords,
+      unsigned dim_num,
+      unsigned f,
+      uint64_t t,
+      uint64_t* tiles_size,
+      uint64_t* tiles_size_qc);
 
   /** Load tile offsets and result tile ranges. */
   Status load_initial_data();
 
-  /** Compute the result bitmap for a tile. */
-  Status compute_coord_tiles_result_bitmap(
-      ResultTile* tile,
-      uint64_t range_idx,
-      std::vector<uint8_t>* coord_tiles_result_bitmap);
+  /** Read and unfilter coord tiles. */
+  Status read_and_unfilter_coords(
+      bool include_coords, const std::vector<ResultTile*>* result_tiles);
 
-  /** Resize the output buffers to the correct size after copying. */
-  Status resize_output_buffers();
+  /** Compute tile bitmaps. */
+  template <class BitmapType>
+  Status compute_tile_bitmaps(
+      ResultTileListPerFragment<BitmapType>* result_tiles);
+
+  /** Apply query condition. */
+  template <class BitmapType>
+  Status apply_query_condition(
+      ResultTileListPerFragment<BitmapType>* result_tiles);
 
   /**
    * Adds an extra offset in the end of the offsets buffer indicating the

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -57,7 +57,8 @@ namespace sm {
 /*          CONSTRUCTORS          */
 /* ****************************** */
 
-SparseUnorderedWithDupsReader::SparseUnorderedWithDupsReader(
+template <class BitmapType>
+SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
     stats::Stats* stats,
     tdb_shared_ptr<Logger> logger,
     StorageManager* storage_manager,
@@ -88,97 +89,58 @@ SparseUnorderedWithDupsReader::SparseUnorderedWithDupsReader(
 /*               API              */
 /* ****************************** */
 
-bool SparseUnorderedWithDupsReader::incomplete() const {
-  return copy_overflowed_ || !read_state_.result_cell_slabs_.empty() ||
-         !read_state_.done_adding_result_tiles_ || !result_tiles_.empty();
+template <class BitmapType>
+bool SparseUnorderedWithDupsReader<BitmapType>::incomplete() const {
+  return this->copy_overflowed_ || !read_state_.result_cell_slabs_.empty() ||
+         !read_state_.done_adding_result_tiles_ || !result_tiles_[0].empty();
 }
 
-Status SparseUnorderedWithDupsReader::init() {
-  // Sanity checks
-  if (storage_manager_ == nullptr)
-    return logger_->status(Status::SparseUnorderedWithDupsReaderError(
-        "Cannot initialize sparse global order reader; Storage manager not "
-        "set"));
-  if (array_schema_ == nullptr)
-    return logger_->status(Status::SparseUnorderedWithDupsReaderError(
-        "Cannot initialize sparse global order reader; Array schema not set"));
-  if (buffers_.empty())
-    return logger_->status(Status::SparseUnorderedWithDupsReaderError(
-        "Cannot initialize sparse global order reader; Buffers not set"));
-
-  // Check subarray
-  RETURN_NOT_OK(check_subarray());
-
-  // Load offset configuration options.
-  bool found = false;
-  offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
-  assert(found);
-  if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    return logger_->status(
-        Status::ReaderError("Cannot initialize reader; Unsupported offsets "
-                            "format in configuration"));
-  }
-  RETURN_NOT_OK(config_.get<bool>(
-      "sm.var_offsets.extra_element", &offsets_extra_element_, &found));
-  assert(found);
-  RETURN_NOT_OK(config_.get<uint32_t>(
-      "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
-  if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    return logger_->status(Status::SparseUnorderedWithDupsReaderError(
-        "Cannot initialize reader; "
-        "Unsupported offsets bitsize in configuration"));
-  }
-  assert(found);
+template <class BitmapType>
+Status SparseUnorderedWithDupsReader<BitmapType>::init() {
+  RETURN_NOT_OK(SparseIndexReaderBase::init());
 
   // Initialize memory budget variables.
   RETURN_NOT_OK(initialize_memory_budget());
 
-  // Check the validity buffer sizes.
-  RETURN_NOT_OK(check_validity_buffer_sizes());
-
   return Status::Ok();
 }
 
-Status SparseUnorderedWithDupsReader::initialize_memory_budget() {
+template <class BitmapType>
+Status SparseUnorderedWithDupsReader<BitmapType>::initialize_memory_budget() {
   bool found = false;
   RETURN_NOT_OK(
       config_.get<uint64_t>("sm.mem.total_budget", &memory_budget_, &found));
   assert(found);
+
   RETURN_NOT_OK(config_.get<double>(
       "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data",
       &memory_budget_ratio_array_data_,
       &found));
   assert(found);
+
   RETURN_NOT_OK(config_.get<double>(
       "sm.mem.reader.sparse_unordered_with_dups.ratio_coords",
       &memory_budget_ratio_coords_,
       &found));
   assert(found);
+
   RETURN_NOT_OK(config_.get<double>(
       "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition",
       &memory_budget_ratio_query_condition_,
       &found));
   assert(found);
+
   RETURN_NOT_OK(config_.get<double>(
       "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges",
       &memory_budget_ratio_tile_ranges_,
-      &found));
-  assert(found);
-  RETURN_NOT_OK(config_.get<double>(
-      "sm.mem.reader.sparse_unordered_with_dups.ratio_result_tiles",
-      &memory_budget_ratio_result_tiles_,
-      &found));
-  assert(found);
-  RETURN_NOT_OK(config_.get<double>(
-      "sm.mem.reader.sparse_unordered_with_dups.ratio_rcs",
-      &memory_budget_ratio_rcs_,
       &found));
   assert(found);
 
   return Status::Ok();
 }
 
-Status SparseUnorderedWithDupsReader::dowork() {
+template <class BitmapType>
+Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
   auto timer_se = stats_->start_timer("dowork");
 
   // Check that the query condition is valid.
@@ -198,126 +160,67 @@ Status SparseUnorderedWithDupsReader::dowork() {
 
   reset_buffer_sizes();
 
+  // This reader only has one result tile list.
+  result_tiles_.resize(1);
+
   // Load initial data, if not loaded already.
   RETURN_NOT_OK(load_initial_data());
 
-  // Potentially fix memory usage after de-serialization.
-  RETURN_NOT_OK(fix_memory_usage_after_serialization());
-
-  // If the result cell slab is empty, populate it.
-  if (read_state_.result_cell_slabs_.empty())
-    RETURN_NOT_OK(compute_result_cell_slab());
+  // Create the result tiles we are going to process.
+  RETURN_NOT_OK(create_result_tiles());
 
   // No more tiles to process, done.
-  if (read_state_.result_cell_slabs_.empty()) {
-    read_state_.done_adding_result_tiles_ = true;
+  if (result_tiles_[0].empty()) {
+    assert(read_state_.done_adding_result_tiles_);
     zero_out_buffer_sizes();
     return Status::Ok();
   }
 
-  // First try to limit the maximum number of cells we copy using the size
-  // of the output buffers for fixed sized attributes. Later we will validate
-  // the memory budget. This is the first line of defence used to try to prevent
-  // overflows when copying data.
-  uint64_t num_cells = std::numeric_limits<uint64_t>::max();
-  for (const auto& it : buffers_) {
-    const auto& name = it.first;
-    const auto size = *it.second.buffer_size_;
-    if (array_schema_->var_size(name)) {
-      auto temp_num_cells = size / constants::cell_var_offset_size;
-
-      if (offsets_extra_element_ && temp_num_cells > 0)
-        temp_num_cells--;
-
-      num_cells = std::min(num_cells, temp_num_cells);
-    } else {
-      auto temp_num_cells = size / array_schema_->cell_size(name);
-      num_cells = std::min(num_cells, temp_num_cells);
-    }
-  }
-
-  // User gave us some empty buffers, exit.
-  if (num_cells == 0) {
-    zero_out_buffer_sizes();
-    return Status::Ok();
-  }
-
-  // Compute an initial boundary for the copy. Also generate a set of the
-  // ResultTile pointers to use later. Tiles in tmp_result_tiles should be
-  // unique and come in the same order as in the result cell slabs to work
-  // with copy_attribute_values.
-  auto it = read_state_.result_cell_slabs_.begin();
-  std::unordered_set<ResultTile*> result_tiles_set;
+  // Maintain a temporary vector with pointers to result tiles for calling
+  // read_and_unfilter_coords.
   std::vector<ResultTile*> tmp_result_tiles;
-  copy_end_.first = 0;
-  while (it != read_state_.result_cell_slabs_.end()) {
-    // Add the ResultTile* to our list if it's not in there already.
-    if (result_tiles_set.find(it->tile_) == result_tiles_set.end()) {
-      result_tiles_set.emplace(it->tile_);
-      tmp_result_tiles.push_back(it->tile_);
+  for (auto& rt_list : result_tiles_) {
+    for (auto& result_tile : rt_list) {
+      tmp_result_tiles.emplace_back(&result_tile);
     }
+  }
 
-    if (it->length_ > num_cells) {
-      copy_end_.first++;
-      copy_end_.second = num_cells;
-      break;
+  // Compute the tile bitmaps.
+  RETURN_NOT_OK(
+      read_and_unfilter_coords(subarray_.is_set(), &tmp_result_tiles));
+
+  // Compute the tile bitmaps.
+  RETURN_NOT_OK(compute_tile_bitmaps<BitmapType>(&result_tiles_));
+
+  // Apply query condition.
+  RETURN_NOT_OK(apply_query_condition<BitmapType>(&result_tiles_));
+
+  // Clear result tiles that are not necessary anymore.
+  auto it = result_tiles_[0].begin();
+  while (it != result_tiles_[0].end()) {
+    if (it->bitmap_num_cells == 0 ||
+        (subarray_.is_set() &&
+         it->bitmap_num_cells == std::numeric_limits<uint64_t>::max())) {
+      auto f = it->frag_idx();
+      RETURN_NOT_OK(remove_result_tile(f, it++));
     } else {
-      copy_end_.first++;
-      num_cells -= it->length_;
       it++;
     }
   }
 
-  if (it == read_state_.result_cell_slabs_.end()) {
-    auto& last_rcs = read_state_.result_cell_slabs_.back();
-    copy_end_.second = last_rcs.length_;
-  }
-
-  // No longer needed.
-  result_tiles_set.clear();
-
-  // TODO Whenever a buffer overflows in copy, move it to the front of the
-  //      list, this way we will prevent reading tiles we don't need on
-  //      future reads.
-
-  if (coords_loaded_) {
-    // Copy the coordinates data.
-    RETURN_NOT_OK(
-        copy_coordinates(&tmp_result_tiles, &read_state_.result_cell_slabs_));
-
-    // copy_coordinates will only have an unrecoverable overflow if a single
-    // cell is too big for the user's buffers.
-    if (copy_overflowed_) {
-      zero_out_buffer_sizes();
-      return Status::Ok();
-    }
-  }
-
-  // Calculate memory budget. For array data, copy_attribute_values might load
-  // more tile offsets so use the max budget.
-  uint64_t memory_budget_copy =
-      memory_budget_ - memory_used_qc_tiles_ - memory_used_rcs_ -
-      memory_used_result_tiles_ - memory_used_result_tile_ranges_ -
-      memory_budget_ratio_array_data_ * memory_budget_;
-
-  // Copy the attributes data.
-  RETURN_NOT_OK(copy_attribute_values(
-      UINT64_MAX,
-      &tmp_result_tiles,
-      &read_state_.result_cell_slabs_,
-      subarray_,
-      memory_budget_copy,
-      !coords_loaded_));
-
-  // copy_coordinates will only have an unrecoverable overflow if a single cell
-  // is too big for the user's buffers.
-  if (copy_overflowed_) {
+  // No more tiles to process, done.
+  if (result_tiles_[0].empty()) {
+    assert(read_state_.done_adding_result_tiles_);
     zero_out_buffer_sizes();
     return Status::Ok();
   }
 
-  // Fix the output buffer sizes.
-  RETURN_NOT_OK(resize_output_buffers());
+  // Copy tiles.
+  if (offsets_bitsize_ == 64) {
+    RETURN_NOT_OK(copy_tiles<uint64_t>());
+  } else {
+    RETURN_NOT_OK(copy_tiles<uint32_t>());
+  }
 
   // End the iteration.
   RETURN_NOT_OK(end_iteration());
@@ -325,136 +228,59 @@ Status SparseUnorderedWithDupsReader::dowork() {
   return Status::Ok();
 }
 
-void SparseUnorderedWithDupsReader::reset() {
+template <class BitmapType>
+void SparseUnorderedWithDupsReader<BitmapType>::reset() {
 }
 
-Status SparseUnorderedWithDupsReader::clear_result_tiles() {
-  while (!result_tiles_.empty()) {
-    auto f = result_tiles_.front().frag_idx();
-    RETURN_NOT_OK(remove_result_tile(f, result_tiles_.begin()));
-  }
-
-  coords_loaded_ = false;
-
-  return Status::Ok();
-}
-
-ResultTile* SparseUnorderedWithDupsReader::add_result_tile_unsafe(
-    unsigned f, uint64_t t, const Domain* domain) {
-  result_tiles_.emplace_back(f, t, domain);
-  return &result_tiles_.back();
-}
-
-Status SparseUnorderedWithDupsReader::add_result_tile(
-    unsigned dim_num,
-    uint64_t memory_budget_result_tiles,
-    uint64_t memory_budget_qc_tiles,
-    uint64_t memory_budget_coords_tiles,
-    unsigned f,
-    uint64_t t,
-    uint64_t last_t,
-    const Domain* domain,
+template <class BitmapType>
+Status SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
+    const unsigned dim_num,
+    const uint64_t memory_budget_qc_tiles,
+    const uint64_t memory_budget_coords_tiles,
+    const unsigned f,
+    const uint64_t t,
+    const uint64_t last_t,
+    const Domain* const domain,
     bool* budget_exceeded) {
   // Calculate memory consumption for this tile.
-  uint64_t tiles_size = 0;
-  RETURN_NOT_OK(get_coord_tiles_size(dim_num, f, t, &tiles_size));
+  uint64_t tiles_size = 0, tiles_size_qc = 0;
+  RETURN_NOT_OK(get_coord_tiles_size<BitmapType>(
+      subarray_.is_set(), dim_num, f, t, &tiles_size, &tiles_size_qc));
 
   // Don't load more tiles than the memory budget.
-  if (memory_used_for_coords_total_ + tiles_size > memory_budget_coords_tiles) {
+  if (memory_used_for_coords_total_ + tiles_size > memory_budget_coords_tiles ||
+      memory_used_qc_tiles_total_ + tiles_size_qc > memory_budget_qc_tiles) {
     *budget_exceeded = true;
     return Status::Ok();
   }
 
-  uint64_t tiles_size_qc = 0;
-  if (!condition_.empty()) {
-    for (auto& name : condition_.field_names()) {
-      // Calculate memory consumption for this tile.
-      uint64_t tile_size = 0;
-      RETURN_NOT_OK(get_attribute_tile_size(name, f, t, &tile_size));
-      tiles_size_qc += tile_size;
-    }
-
-    if (memory_used_qc_tiles_ + tiles_size_qc > memory_budget_qc_tiles) {
-      *budget_exceeded = true;
-      return Status::Ok();
-    }
-  }
-
-  if (memory_used_result_tiles_ + sizeof(ResultTile) >
-      memory_budget_result_tiles) {
-    *budget_exceeded = true;
-    return Status::Ok();
-  }
-
+  // Adjust memory usage.
   memory_used_for_coords_total_ += tiles_size;
-  memory_used_qc_tiles_ += tiles_size_qc;
-  memory_used_result_tiles_ += sizeof(ResultTile);
+  memory_used_qc_tiles_total_ += tiles_size_qc;
 
-  result_tiles_.emplace_back(f, t, domain);
+  // Add the result tile.
+  result_tiles_[0].emplace_back(f, t, domain);
+
+  // Are all tiles loaded for this fragment.
   if (t == last_t)
     all_tiles_loaded_[f] = true;
 
   return Status::Ok();
 }
 
-Status SparseUnorderedWithDupsReader::fix_memory_usage_after_serialization() {
-  // For easy reference.
-  auto dim_num = array_schema_->dim_num();
-
-  if (memory_used_result_tiles_ == 0) {
-    for (auto& rt : result_tiles_) {
-      auto f = rt.frag_idx();
-
-      // Calculate memory consumption for this tile.
-      uint64_t tiles_size = 0;
-      RETURN_NOT_OK(
-          get_coord_tiles_size(dim_num, f, rt.tile_idx(), &tiles_size));
-
-      memory_used_for_coords_total_ += tiles_size;
-      memory_used_result_tiles_ += sizeof(ResultTile);
-
-      if (!condition_.empty()) {
-        uint64_t tiles_size = 0;
-        for (auto& name : condition_.field_names()) {
-          // Calculate memory consumption for this tile.
-          uint64_t tile_size = 0;
-          RETURN_NOT_OK(
-              get_attribute_tile_size(name, f, rt.tile_idx(), &tile_size));
-          tiles_size += tile_size;
-        }
-
-        memory_used_qc_tiles_ += tiles_size;
-      }
-    }
-  }
-
-  return Status::Ok();
-}
-
-Status SparseUnorderedWithDupsReader::create_result_tiles() {
+template <class BitmapType>
+Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
   auto timer_se = stats_->start_timer("create_result_tiles");
 
   // For easy reference.
-  auto fragment_num = fragment_metadata_.size();
-  auto domain = array_schema_->domain();
-  auto dim_num = array_schema_->dim_num();
+  const auto fragment_num = fragment_metadata_.size();
+  const auto domain = array_schema_->domain();
+  const auto dim_num = array_schema_->dim_num();
 
-  if (!condition_.empty()) {
-    // To respect the memory budget, we only load as many tiles as we can
-    // process for the query condition. Load the tiles offsets first.
-    std::vector<std::string> names(condition_.field_names().size());
-    for (auto& name : condition_.field_names()) {
-      names.emplace_back(name);
-    }
-
-    RETURN_NOT_OK(load_tile_offsets(&subarray_, &names));
-  }
-
-  uint64_t memory_budget_result_tiles =
-      memory_budget_ * memory_budget_ratio_result_tiles_;
-  uint64_t memory_budget_qc_tiles =
+  const uint64_t memory_budget_qc_tiles =
       memory_budget_ * memory_budget_ratio_query_condition_;
-  uint64_t memory_budget_coords = memory_budget_ * memory_budget_ratio_coords_;
+  const uint64_t memory_budget_coords =
+      memory_budget_ * memory_budget_ratio_coords_;
 
   // Create result tiles.
   if (subarray_.is_set()) {
@@ -464,19 +290,21 @@ Status SparseUnorderedWithDupsReader::create_result_tiles() {
     while (f < fragment_num && !budget_exceeded) {
       if (!all_tiles_loaded_[f]) {
         auto range_it = result_tile_ranges_[f].rbegin();
+        all_tiles_loaded_[f] = range_it == result_tile_ranges_[f].rend();
         while (range_it != result_tile_ranges_[f].rend()) {
-          auto last_t = result_tile_ranges_[f].front().second;
+          const auto last_t = result_tile_ranges_[f].front().second;
 
           // Figure out the start index.
           auto start = range_it->first;
-          if (!result_tiles_.empty() && result_tiles_.back().frag_idx() == f) {
-            start = std::max(start, result_tiles_.back().tile_idx() + 1);
+          if (!result_tiles_[0].empty() &&
+              result_tiles_[0].back().frag_idx() == f) {
+            start = std::max(start, result_tiles_[0].back().tile_idx() + 1);
           }
 
+          // Add all tiles for this range.
           for (uint64_t t = start; t <= range_it->second; t++) {
             RETURN_NOT_OK(add_result_tile(
                 dim_num,
-                memory_budget_result_tiles,
                 memory_budget_qc_tiles,
                 memory_budget_coords,
                 f,
@@ -485,12 +313,13 @@ Status SparseUnorderedWithDupsReader::create_result_tiles() {
                 domain,
                 &budget_exceeded));
 
+            // Make sure we can add at least one tile.
             if (budget_exceeded) {
               logger_->debug(
                   "Budget exceeded adding result tiles, fragment {0}, tile {1}",
                   f,
                   t);
-              if (result_tiles_.empty())
+              if (result_tiles_[0].empty())
                 return logger_->status(
                     Status::SparseUnorderedWithDupsReaderError(
                         "Cannot load a single tile, increase memory budget"));
@@ -516,14 +345,15 @@ Status SparseUnorderedWithDupsReader::create_result_tiles() {
 
         // Figure out the start index.
         auto start = read_state_.frag_tile_idx_[f].first;
-        if (!result_tiles_.empty() && result_tiles_.back().frag_idx() == f) {
-          start = std::max(start, result_tiles_.back().tile_idx() + 1);
+        if (!result_tiles_[0].empty() &&
+            result_tiles_[0].back().frag_idx() == f) {
+          start = std::max(start, result_tiles_[0].back().tile_idx() + 1);
         }
 
+        // Add all tiles for this fragment.
         for (uint64_t t = start; t < tile_num; t++) {
           RETURN_NOT_OK(add_result_tile(
               dim_num,
-              memory_budget_result_tiles,
               memory_budget_qc_tiles,
               memory_budget_coords,
               f,
@@ -532,12 +362,13 @@ Status SparseUnorderedWithDupsReader::create_result_tiles() {
               domain,
               &budget_exceeded));
 
+          // Make sure we can add at least one tile.
           if (budget_exceeded) {
             logger_->debug(
                 "Budget exceeded adding result tiles, fragment {0}, tile {1}",
                 f,
                 t);
-            if (result_tiles_.empty())
+            if (result_tiles_[0].empty())
               return logger_->status(Status::SparseUnorderedWithDupsReaderError(
                   "Cannot load a single tile, increase memory budget"));
             break;
@@ -548,13 +379,15 @@ Status SparseUnorderedWithDupsReader::create_result_tiles() {
     }
   }
 
+  // Check if we are done adding result tiles.
   bool done_adding_result_tiles = true;
   for (unsigned int f = 0; f < fragment_num; f++) {
     done_adding_result_tiles &= all_tiles_loaded_[f];
   }
 
   logger_->debug(
-      "Done adding result tiles, num result tiles {0}", result_tiles_.size());
+      "Done adding result tiles, num result tiles {0}",
+      result_tiles_[0].size());
 
   if (done_adding_result_tiles) {
     logger_->debug("All result tiles loaded");
@@ -564,318 +397,694 @@ Status SparseUnorderedWithDupsReader::create_result_tiles() {
   return Status::Ok();
 }
 
-Status SparseUnorderedWithDupsReader::compute_result_cell_slab() {
-  auto timer_se = stats_->start_timer("compute_result_cell_slab");
+/** Copy offsets with a result count bitmap. */
+template <>
+template <class OffType>
+Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets(
+    const std::string& name,
+    ResultTileWithBitmap<uint64_t>* rt,
+    OffType* buffer,
+    const bool nullable,
+    uint8_t* val_buffer,
+    void** var_data,
+    const OffType div) {
+  // Get source buffers.
+  const auto tile_tuple = rt->tile_tuple(name);
+  const auto t = &std::get<0>(*tile_tuple);
+  const auto t_var = &std::get<1>(*tile_tuple);
+  const auto src_buff = (uint64_t*)t->buffer()->data();
+  const auto src_var_buff = (char*)t_var->buffer()->data();
+  const auto t_val = &std::get<2>(*tile_tuple);
+  const auto last_c = rt->cell_num() - 1;
 
-  // Create the result tiles we are going to process.
-  RETURN_NOT_OK(create_result_tiles());
-
-  // No tiles found, return.
-  if (result_tiles_.empty()) {
-    return Status::Ok();
+  // process all cells. Last cell is taken out for vectorization.
+  for (uint64_t c = 0; c < last_c; c++) {
+    for (uint64_t i = 0; i < rt->bitmap[c]; i++) {
+      *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / div;
+      buffer++;
+      *var_data = src_var_buff + src_buff[c];
+      var_data++;
+    }
   }
 
-  coords_loaded_ = true;
-
-  // Maintain a temporary vector with pointers to result tiles, so that
-  // `read_tiles`, `unfilter_tiles` can work without changes.
-  std::vector<ResultTile*> tmp_result_tiles;
-  for (auto& result_tile : result_tiles_)
-    tmp_result_tiles.push_back(&result_tile);
-
-  // Read and unfilter zipped coordinate tiles. Note that
-  // this will ignore fragments with a version >= 5.
-  std::vector<std::string> zipped_coords_names = {constants::coords};
-  RETURN_CANCEL_OR_ERROR(
-      read_coordinate_tiles(&zipped_coords_names, &tmp_result_tiles));
-  RETURN_CANCEL_OR_ERROR(unfilter_tiles(constants::coords, &tmp_result_tiles));
-
-  // Read and unfilter unzipped coordinate tiles. Note that
-  // this will ignore fragments with a version < 5.
-  RETURN_CANCEL_OR_ERROR(read_coordinate_tiles(&dim_names_, &tmp_result_tiles));
-  for (const auto& dim_name : dim_names_) {
-    RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, &tmp_result_tiles));
+  // Do last cell.
+  for (uint64_t i = 0; i < rt->bitmap[last_c]; i++) {
+    *buffer = (OffType)(t_var->size() - src_buff[last_c]) / div;
+    buffer++;
+    *var_data = src_var_buff + src_buff[last_c];
+    var_data++;
   }
 
-  // Compute the result cell slabs with the loaded coordinate tiles.
-  uint64_t memory_budget_rcs = memory_budget_ratio_rcs_ * memory_budget_;
-  RETURN_CANCEL_OR_ERROR(create_result_cell_slabs(memory_budget_rcs));
-
-  // TODO This can be moved before calculating result cell slabs.
-  // Finally apply the query condition.
-  uint64_t memory_used_tiles = 0;
-  RETURN_CANCEL_OR_ERROR(apply_query_condition(
-      &read_state_.result_cell_slabs_,
-      &tmp_result_tiles,
-      &subarray_,
-      std::numeric_limits<uint64_t>::max(),
-      memory_budget_rcs,
-      std::numeric_limits<uint64_t>::max() -
-          1,  // Memory budget already enforced.
-      &memory_used_tiles));
-  memory_used_rcs_ =
-      read_state_.result_cell_slabs_.size() * sizeof(ResultCellSlab);
+  // Copy nullable values.
+  if (nullable) {
+    const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+    for (uint64_t c = 0; c <= last_c; c++) {
+      for (uint64_t i = 0; i < rt->bitmap[c]; i++) {
+        *val_buffer = src_val_buff[c];
+        val_buffer++;
+      }
+    }
+  }
 
   return Status::Ok();
 }
 
-Status SparseUnorderedWithDupsReader::create_result_cell_slabs(
-    uint64_t memory_budget) {
-  auto timer_se = stats_->start_timer("create_result_cell_slabs");
+/** Copy offsets with a result bitmap. */
+template <>
+template <class OffType>
+Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets(
+    const std::string& name,
+    ResultTileWithBitmap<uint8_t>* rt,
+    OffType* buffer,
+    const bool nullable,
+    uint8_t* val_buffer,
+    void** var_data,
+    const OffType div) {
+  // Get source buffers.
+  const auto tile_tuple = rt->tile_tuple(name);
+  const auto t = &std::get<0>(*tile_tuple);
+  const auto t_var = &std::get<1>(*tile_tuple);
+  const auto src_buff = (uint64_t*)t->buffer()->data();
+  const auto src_var_buff = (char*)t_var->buffer()->data();
+  const auto t_val = &std::get<2>(*tile_tuple);
 
-  // For easy reference.
-  auto domain = array_schema_->domain();
-  auto dim_num = array_schema_->dim_num();
-  auto subarray_set = subarray_.is_set();
-  auto cell_order = array_schema_->cell_order();
-
-  // Vector per dimensions of counters for each cells.
-  std::vector<std::vector<uint64_t>> coord_tiles_result_counts(dim_num);
-  std::vector<std::atomic<uint64_t>> full_overlap_count(dim_num);
-
-  auto rt = result_tiles_.begin();
-  while (rt != result_tiles_.end()) {
-    bool tile_used = false;
-    // If no subarray is set, add all cells.
-    if (!subarray_set) {
-      read_state_.result_cell_slabs_.emplace_back(&*rt, 0, rt->cell_num());
-      memory_used_rcs_ += sizeof(ResultCellSlab);
-      tile_used = true;
-    } else {
-      unsigned prev_dim = 0;
-      bool use_prev_dim_result_count = false;
-      for (unsigned d = 0; d < dim_num; d++) {
-        // For col-major cell ordering, iterate the dimensions
-        // in reverse.
-        const unsigned dim_idx =
-            cell_order == Layout::COL_MAJOR ? dim_num - d - 1 : d;
-
-        // Get the bitmap data ready.
-        if (coord_tiles_result_counts[dim_idx].size() == 0) {
-          coord_tiles_result_counts[dim_idx].resize(rt->cell_num());
-        } else {
-          uint64_t memset_length = std::min(
-              (uint64_t)coord_tiles_result_counts[dim_idx].size(),
-              rt->cell_num());
-          memset(
-              coord_tiles_result_counts[dim_idx].data(),
-              0,
-              memset_length * sizeof(uint64_t));
-          coord_tiles_result_counts[dim_idx].resize(rt->cell_num());
-        }
-        full_overlap_count[dim_idx] = 0;
-
-        auto& ranges_for_dim = subarray_.ranges_for_dim(dim_idx);
-        std::mutex range_mtx;
-        auto status = parallel_for(
-            storage_manager_->compute_tp(),
-            0,
-            ranges_for_dim.size(),
-            [&](uint64_t r) {
-              // Figure out what to do with the tile.
-              bool full_overlap = subarray_.is_default(dim_idx);
-              if (!full_overlap) {
-                auto& mbr =
-                    fragment_metadata_[rt->frag_idx()]->mbr(rt->tile_idx());
-                bool in_range = domain->dimension(dim_idx)->overlap(
-                    ranges_for_dim[r], mbr[dim_idx]);
-                if (in_range) {
-                  full_overlap = domain->dimension(dim_idx)->covered(
-                      mbr[dim_idx], ranges_for_dim[r]);
-                } else {
-                  return Status::Ok();
-                }
-              }
-
-              if (!full_overlap) {
-                // Calculate the bitmap for the cells.
-                RETURN_NOT_OK(rt->compute_results_count_sparse(
-                    dim_idx,
-                    ranges_for_dim[r],
-                    &coord_tiles_result_counts[dim_idx],
-                    use_prev_dim_result_count,
-                    &coord_tiles_result_counts[prev_dim],
-                    cell_order,
-                    range_mtx));
-              } else {
-                full_overlap_count[dim_idx]++;
-              }
-
-              return Status::Ok();
-            });
-        RETURN_NOT_OK_ELSE(status, logger_->status(status));
-
-        use_prev_dim_result_count |= full_overlap_count[dim_idx] == 0;
-        prev_dim = dim_idx;
+  // 0 sized bitmap means full tile, full tile copy done below.
+  if (rt->bitmap.size() != 0) {
+    // process all cells. Last cell is taken out for vectorization.
+    const auto last_c = rt->cell_num() - 1;
+    for (uint64_t c = 0; c < last_c; c++) {
+      if (rt->bitmap[c]) {
+        *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / div;
+        buffer++;
+        *var_data = src_var_buff + src_buff[c];
+        var_data++;
       }
+    }
 
-      // Process all cells, when there is a "hole" in the cell
-      // contiguity, push a new cell slab.
-      uint64_t start = 0;
+    // Do last cell.
+    if (rt->bitmap[last_c]) {
+      *buffer = (OffType)(t_var->size() - src_buff[last_c]) / div;
+      *var_data = src_var_buff + src_buff[last_c];
+    }
+
+    // Copy nullable values.
+    if (nullable) {
+      const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+      for (uint64_t c = 0; c <= last_c; c++) {
+        if (rt->bitmap[c]) {
+          *val_buffer = src_val_buff[c];
+          val_buffer++;
+        }
+      }
+    }
+  } else {
+    // Copy full tile. Last cell is taken out for vectorization.
+    const auto last_c = rt->cell_num() - 1;
+    for (uint64_t c = 0; c < last_c; c++) {
+      *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / div;
+      buffer++;
+      *var_data = src_var_buff + src_buff[c];
+      var_data++;
+    }
+
+    // Copy last cell.
+    *buffer = (OffType)(t_var->size() - src_buff[last_c]) / div;
+    *var_data = src_var_buff + src_buff[last_c];
+
+    // Copy nullable values.
+    if (nullable) {
+      const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+      for (uint64_t c = 0; c <= last_c; c++) {
+        *val_buffer = src_val_buff[c];
+        val_buffer++;
+      }
+    }
+  }
+
+  return Status::Ok();
+}
+
+/** Copy fixed data with a result count bitmap. */
+template <>
+Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data(
+    const std::string& name,
+    ResultTileWithBitmap<uint64_t>* rt,
+    uint8_t* buffer,
+    const bool nullable,
+    uint8_t* val_buffer,
+    const uint64_t cell_size,
+    const bool is_dim,
+    const unsigned dim_idx) {
+  // Get source buffers.
+  const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
+  const auto tile_tuple = rt->tile_tuple(name);
+  const auto t = &std::get<0>(*tile_tuple);
+  const auto src_buff = (uint8_t*)t->buffer()->data();
+
+  // Copy values.
+  if (!stores_zipped_coords) {
+    for (uint64_t c = 0; c < rt->cell_num(); c++) {
+      for (uint64_t i = 0; i < rt->bitmap[c]; i++) {
+        memcpy(buffer, src_buff + c * cell_size, cell_size);
+        buffer += cell_size;
+      }
+    }
+  } else {  // Copy for zipped coords.
+    const auto dim_num = rt->domain()->dim_num();
+    for (uint64_t c = 0; c < rt->cell_num(); c++) {
+      for (uint64_t i = 0; i < rt->bitmap[c]; i++) {
+        auto pos = c * dim_num + dim_idx;
+        memcpy(buffer, src_buff + pos * cell_size, cell_size);
+        buffer += cell_size;
+      }
+    }
+  }
+
+  // Copy nullable values.
+  if (nullable) {
+    const auto t_val = &std::get<2>(*tile_tuple);
+    const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+    for (uint64_t c = 0; c < rt->cell_num(); c++) {
+      for (uint64_t i = 0; i < rt->bitmap[c]; i++) {
+        *val_buffer = src_val_buff[c];
+        val_buffer++;
+      }
+    }
+  }
+
+  return Status::Ok();
+}
+
+/** Copy fixed data with a result bitmap. */
+template <>
+Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data(
+    const std::string& name,
+    ResultTileWithBitmap<uint8_t>* rt,
+    uint8_t* buffer,
+    const bool nullable,
+    uint8_t* val_buffer,
+    const uint64_t cell_size,
+    const bool is_dim,
+    const unsigned dim_idx) {
+  // Get source buffers.
+  const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
+  const auto tile_tuple = rt->tile_tuple(name);
+  const auto t = &std::get<0>(*tile_tuple);
+  const auto src_buff = (uint8_t*)t->buffer()->data();
+  const auto t_val = &std::get<2>(*tile_tuple);
+
+  // 0 sized bitmap means full tile, full tile copy done below.
+  if (rt->bitmap.size() != 0) {
+    // Copy values.
+    if (!stores_zipped_coords) {
+      // Go through bitmap, when there is a hole in cell contiguity, do a
+      // memcpy.
       uint64_t length = 0;
-
-      uint64_t current_count = 1;
-      for (unsigned d = 0; d < dim_num; d++) {
-        current_count *=
-            full_overlap_count[d] + coord_tiles_result_counts[d][0];
-      }
-
+      uint64_t start = 0;
       for (uint64_t c = 0; c < rt->cell_num(); c++) {
-        uint64_t count = 1;
-        for (unsigned d = 0; d < dim_num; d++) {
-          count *= full_overlap_count[d] + coord_tiles_result_counts[d][c];
-        }
-
-        if (count == 0) {
+        if (rt->bitmap[c]) {
+          length++;
+        } else {
           if (length != 0) {
-            for (uint64_t i = 0; i < current_count; i++) {
-              read_state_.result_cell_slabs_.emplace_back(&*rt, start, length);
-              memory_used_rcs_ += sizeof(ResultCellSlab);
-            }
-            tile_used = true;
+            memcpy(buffer, src_buff + start * cell_size, length * cell_size);
+            buffer += length * cell_size;
             length = 0;
           }
 
           start = c + 1;
-        } else if (count != current_count) {
-          for (uint64_t i = 0; i < current_count; i++) {
-            read_state_.result_cell_slabs_.emplace_back(&*rt, start, length);
-            memory_used_rcs_ += sizeof(ResultCellSlab);
-          }
-          tile_used = true;
-          length = 1;
-          start = c;
-        } else {
-          length++;
         }
-
-        current_count = count;
       }
 
-      // Add the last cell slab.
+      // Do last memcpy.
       if (length != 0) {
-        for (uint64_t i = 0; i < current_count; i++) {
-          read_state_.result_cell_slabs_.emplace_back(&*rt, start, length);
-          memory_used_rcs_ += sizeof(ResultCellSlab);
+        memcpy(buffer, src_buff + start * cell_size, length * cell_size);
+        buffer += length * cell_size;
+      }
+    } else {  // Copy for zipped coords.
+      const auto dim_num = rt->domain()->dim_num();
+      for (uint64_t c = 0; c < rt->cell_num(); c++) {
+        if (rt->bitmap[c]) {
+          auto pos = c * dim_num + dim_idx;
+          memcpy(buffer, src_buff + pos * cell_size, cell_size);
+          buffer += cell_size;
         }
-        tile_used = true;
-      }
-
-      // Adjust result tile ranges.
-      auto& first_range = result_tile_ranges_[rt->frag_idx()].back();
-      if (first_range.second == rt->tile_idx()) {
-        remove_result_tile_range(rt->frag_idx());
-      } else {
-        first_range.first = rt->tile_idx() + 1;
       }
     }
 
-    read_state_.frag_tile_idx_[rt->frag_idx()] =
-        std::pair<uint64_t, uint64_t>(rt->tile_idx() + 1, 0);
+    // Copy nullable values.
+    if (nullable) {
+      // Go through bitmap, when there is a hole in cell contiguity, do a
+      // memcpy.
+      uint64_t length = 0;
+      uint64_t start = 0;
+      const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+      for (uint64_t c = 0; c < rt->cell_num(); c++) {
+        if (rt->bitmap[c]) {
+          length++;
+        } else {
+          if (length != 0) {
+            memcpy(val_buffer, src_val_buff + start, length);
+            val_buffer += length;
+            length = 0;
+          }
 
-    // Remove the tile from the list if it hasn't been used.
-    if (tile_used) {
-      ++rt;
-    } else {
-      auto f = rt->frag_idx();
-      remove_result_tile(f, rt++);
+          start = c + 1;
+        }
+      }
+
+      // Do last memcpy.
+      if (length != 0) {
+        memcpy(val_buffer, src_val_buff + start, length);
+        val_buffer += length;
+      }
     }
+  } else {  // Copy full tile.
+    memcpy(buffer, src_buff, cell_size * rt->cell_num());
 
-    // If we busted our memory budget, exit.
-    if (memory_used_rcs_ >= memory_budget) {
-      logger_->debug("Exceeded RCS memory budget");
-      break;
+    if (nullable) {
+      const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+      memcpy(val_buffer, src_val_buff, rt->cell_num());
     }
-  }
-
-  logger_->debug(
-      "Done creating result cell slabs, num slabs {0}",
-      read_state_.result_cell_slabs_.size());
-
-  return Status::Ok();
-};
-
-Status SparseUnorderedWithDupsReader::remove_result_tile(
-    unsigned frag_idx, std::list<ResultTile>::iterator rt) {
-  // Remove coord tile size from memory budget.
-  auto tile_idx = rt->tile_idx();
-  uint64_t tiles_size = 0;
-  RETURN_NOT_OK(get_coord_tiles_size(
-      array_schema_->dim_num(), frag_idx, tile_idx, &tiles_size));
-  memory_used_for_coords_total_ -= tiles_size;
-
-  for (const auto& name : condition_.field_names()) {
-    uint64_t tile_size = 0;
-    RETURN_NOT_OK(
-        get_attribute_tile_size(name, frag_idx, tile_idx, &tile_size));
-    memory_used_qc_tiles_ -= tile_size;
-  }
-
-  // Delete the tile.
-  result_tiles_.erase(rt);
-
-  {
-    std::unique_lock<std::mutex> lck(mem_budget_mtx_);
-    memory_used_result_tiles_ -= sizeof(ResultTile);
   }
 
   return Status::Ok();
 }
 
-Status SparseUnorderedWithDupsReader::end_iteration() {
-  // Remove the processed cell slabs.
-  auto& new_front = read_state_.result_cell_slabs_[copy_end_.first - 1];
+template <class BitmapType>
+Status SparseUnorderedWithDupsReader<BitmapType>::compute_initial_copy_bound(
+    uint64_t* max_rt_idx) {
+  *max_rt_idx = 0;
 
-  // If the last cell slab processed wasn't processed fully, split it.
-  if (new_front.length_ != copy_end_.second) {
-    new_front.start_ += copy_end_.second;
-    new_front.length_ -= copy_end_.second;
-    copy_end_.first--;
-  }
+  // First try to limit the maximum number of cells we copy using the size
+  // of the output buffers for fixed sized attributes. Later we will validate
+  // the memory budget. This is the first line of defence used to try to prevent
+  // overflows when copying data.
+  auto max_num_cells = std::numeric_limits<uint64_t>::max();
+  std::vector<std::string> names(buffers_.size());
+  for (const auto& it : buffers_) {
+    const auto& name = it.first;
+    const auto size = *it.second.buffer_size_;
+    if (array_schema_->var_size(name)) {
+      auto temp_num_cells = size / constants::cell_var_offset_size;
 
-  // Clear result tiles that are not necessary anymore.
-  while (result_tiles_.front().frag_idx() != new_front.tile_->frag_idx() ||
-         result_tiles_.front().tile_idx() != new_front.tile_->tile_idx()) {
-    auto f = result_tiles_.front().frag_idx();
-    RETURN_NOT_OK(remove_result_tile(f, result_tiles_.begin()));
-  }
+      if (offsets_extra_element_ && temp_num_cells > 0)
+        temp_num_cells--;
 
-  // Erase from the vector.
-  read_state_.result_cell_slabs_.erase(
-      read_state_.result_cell_slabs_.begin(),
-      read_state_.result_cell_slabs_.begin() + copy_end_.first);
-  memory_used_rcs_ -= copy_end_.first * sizeof(ResultCellSlab);
-
-  // If the result cell slabs are empty, check if we need to remove the last
-  // tile.
-  auto last_f = result_tiles_.front().frag_idx();
-  if (read_state_.result_cell_slabs_.empty() &&
-      result_tiles_.front().tile_idx() <
-          read_state_.frag_tile_idx_[last_f].first) {
-    RETURN_NOT_OK(remove_result_tile(last_f, result_tiles_.begin()));
-  }
-
-  // Patch: if we have a query condition set, we might not clean up some reault
-  // tiles properly, clean them up here.
-  if (!condition_.empty() && read_state_.result_cell_slabs_.empty()) {
-    while (!result_tiles_.empty()) {
-      auto f = result_tiles_.begin()->frag_idx();
-      RETURN_NOT_OK(remove_result_tile(f, result_tiles_.begin()));
+      max_num_cells = std::min(max_num_cells, temp_num_cells);
+    } else {
+      auto temp_num_cells = size / array_schema_->cell_size(name);
+      max_num_cells = std::min(max_num_cells, temp_num_cells);
     }
   }
 
-  auto uint64_t_max = std::numeric_limits<uint64_t>::max();
-  copy_end_ = std::pair<uint64_t, uint64_t>(uint64_t_max, uint64_t_max);
+  // User gave us some empty buffers, exit.
+  if (max_num_cells == 0) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  // Compute initial bound for result tiles by making sure all cells within
+  // a result tile can fit into the user's buffer. We use either the number
+  // of cells in the bitmap  when a subarray is set or the number of cells
+  // in the result tile to do so.
+  uint64_t rt_idx = 0;
+  uint64_t cell_offset = 0;
+  for (auto& rt : result_tiles_[0]) {
+    const auto cell_num =
+        subarray_.is_set() ? rt.bitmap_num_cells : rt.cell_num();
+    if (cell_offset + cell_num > max_num_cells)
+      break;
+
+    rt_idx++;
+  }
+
+  // Calculate memory budget.
+  uint64_t memory_budget_copy = memory_budget_ - memory_used_qc_tiles_total_ -
+                                memory_used_result_tile_ranges_ -
+                                array_memory_tracker_->get_memory_usage();
+
+  // Make sure we respect memory budget for copy operation by making sure that,
+  // for all attributes to be copied, the size of tiles in memory can fit into
+  // the budget.
+  std::mutex it_mtx;
+  auto buffers_it = buffers_.begin();
+  auto status = parallel_for(
+      storage_manager_->compute_tp(), 0, buffers_.size(), [&](uint64_t) {
+        // Get a tile from the list.
+        std::unordered_map<std::string, tiledb::sm::QueryBuffer>::iterator it;
+        {
+          std::unique_lock<std::mutex> ul(it_mtx);
+          it = buffers_it++;
+        }
+        const auto& name = it->first;
+        const auto var_sized = array_schema_->var_size(name);
+
+        // For dimensions, when we have a subarray, tiles are already all
+        // loaded in memory.
+        if (subarray_.is_set() && array_schema_->is_dim(name))
+          return Status::Ok();
+
+        // Get the size for this tile.
+        uint64_t mem_usage = 0;
+        auto rt = result_tiles_[0].begin();
+        uint64_t idx = 0;
+        while (rt != result_tiles_[0].end()) {
+          // Size of the tile in memory.
+          uint64_t tile_size = 0;
+          RETURN_NOT_OK(get_attribute_tile_size(
+              name, rt->frag_idx(), rt->tile_idx(), &tile_size));
+
+          // Account for the pointers to the var data that is created in
+          // copy_tiles for var sized attributes.
+          if (var_sized) {
+            auto cell_num =
+                subarray_.is_set() ? rt->bitmap_num_cells : rt->cell_num();
+            tile_size += sizeof(void*) * cell_num;
+          }
+
+          // Stop when we reach the budget.
+          if (mem_usage + tile_size > memory_budget_copy) {
+            break;
+          }
+
+          // Adjust memory usage and move to the next tile.
+          mem_usage += tile_size;
+          rt++;
+          idx++;
+        }
+
+        // Save the minimum result tile index that we saw for all attributes.
+        {
+          std::unique_lock<std::mutex> ul(it_mtx);
+          rt_idx = std::min(idx, rt_idx);
+        }
+
+        return Status::Ok();
+      });
+  RETURN_NOT_OK_ELSE(status, logger_->status(status));
+
+  if (rt_idx == 0)
+    return Status::SparseUnorderedWithDupsReaderError(
+        "Unable to copy one tile with current budget/buffers");
+
+  *max_rt_idx = rt_idx;
+
+  return Status::Ok();
+}
+
+template <class BitmapType>
+template <class OffType>
+Status SparseUnorderedWithDupsReader<BitmapType>::copy_tiles() {
+  auto timer_se = stats_->start_timer("copy_tiles");
+
+  // Calculating the maximum number of tiles to be copied from to the user
+  // buffers based on user's buffer size and on the memory budget.
+  uint64_t max_rt_idx = 0;
+  RETURN_NOT_OK(compute_initial_copy_bound(&max_rt_idx));
+
+  // Create the result tiles vector to use with read_tiles and unfilter_tiles.
+  std::vector<ResultTile*> tmp_result_tiles;
+  uint64_t i = 0;
+  for (auto it = result_tiles_[0].begin(); i < max_rt_idx; i++, it++) {
+    tmp_result_tiles.emplace_back(&*it);
+  }
+
+  // Copy tiles attribute by attribute.
+  // TODO load as many attributes as we can fit in memory so that we can
+  // parallelize here.
+  uint64_t num_cells_copied = std::numeric_limits<uint64_t>::max();
+  for (auto& it : buffers_) {
+    // For easy reference.
+    const auto& name = it.first;
+    const auto is_dim = array_schema_->is_dim(name);
+    const auto var_sized = array_schema_->var_size(name);
+    const auto nullable = array_schema_->is_nullable(name);
+    const auto cell_size = array_schema_->cell_size(name);
+
+    std::vector<std::string> names = {name};
+
+    // Get dim idx for zipped coords copy.
+    auto dim_idx = 0;
+    if (is_dim) {
+      const auto& dim_names = array_schema_->dim_names();
+      while (name != dim_names[dim_idx])
+        dim_idx++;
+    }
+
+    if (!subarray_.is_set() || !is_dim) {
+      // Read and unfilter tiles.
+      RETURN_NOT_OK(read_attribute_tiles(&names, &tmp_result_tiles));
+      RETURN_NOT_OK(unfilter_tiles(name, &tmp_result_tiles));
+    }
+
+    // Compute initial cells copied.
+    if (num_cells_copied == std::numeric_limits<uint64_t>::max()) {
+      num_cells_copied = 0;
+      i = 0;
+      for (auto it = result_tiles_[0].begin(); i < max_rt_idx; i++, it++) {
+        num_cells_copied +=
+            subarray_.is_set() ? it->bitmap_num_cells : it->cell_num();
+      }
+    }
+
+    // Pointers to var size data.
+    std::vector<void*> var_data;
+    if (var_sized) {
+      var_data.resize(num_cells_copied);
+    }
+
+    // Process all tiles in parallel.
+    OffType offset_div =
+        elements_mode_ ? datatype_size(array_schema_->type(name)) : 1;
+    uint64_t global_cell_offset = 0;
+    std::mutex it_mtx;
+    auto result_tiles_it = result_tiles_[0].begin();
+    auto status = parallel_for(
+        storage_manager_->compute_tp(), 0, max_rt_idx, [&](uint64_t) {
+          // Take a result tile in the list and calculate the cell offset for
+          // this tile. As the work is very simple and not parallelizable,
+          // using a mutex to prevent from allocating a vector for the cell
+          // offsets.
+          typename std::list<ResultTileWithBitmap<BitmapType>>::iterator rt;
+          uint64_t cell_offset = 0;
+          {
+            std::unique_lock<std::mutex> ul(it_mtx);
+            rt = result_tiles_it++;
+            cell_offset = global_cell_offset;
+            global_cell_offset +=
+                subarray_.is_set() ? rt->bitmap_num_cells : rt->cell_num();
+          }
+
+          // Copy the offsets or fixed size data.
+          if (var_sized) {
+            RETURN_NOT_OK(copy_offsets<OffType>(
+                name,
+                &*rt,
+                ((OffType*)it.second.buffer_) + cell_offset,
+                nullable,
+                it.second.validity_vector_.buffer() + cell_offset,
+                var_data.data() + cell_offset,
+                offset_div));
+          } else {
+            RETURN_NOT_OK(copy_fixed_data(
+                name,
+                &*rt,
+                (uint8_t*)it.second.buffer_ + cell_offset * cell_size,
+                nullable,
+                it.second.validity_vector_.buffer() + cell_offset,
+                cell_size,
+                is_dim,
+                dim_idx));
+          }
+
+          return Status::Ok();
+        });
+    RETURN_NOT_OK_ELSE(status, logger_->status(status));
+
+    OffType var_offset = 0;
+    if (var_sized) {
+      // Switch offsets buffer from cell size to offsets.
+      auto offsets_buff = (OffType*)it.second.buffer_;
+      for (uint64_t c = 0; c < global_cell_offset; c++) {
+        auto tmp = offsets_buff[c];
+        offsets_buff[c] = var_offset;
+        var_offset += tmp;
+      }
+
+      // Make sure var size buffer can fit the data.
+      while (*it.second.buffer_var_size_ < (uint64_t)var_offset) {
+        result_tiles_it--;
+        auto num_cells = subarray_.is_set() ?
+                             result_tiles_it->bitmap_num_cells :
+                             result_tiles_it->cell_num();
+        global_cell_offset -= num_cells;
+        var_offset = ((OffType*)it.second.buffer_)[global_cell_offset];
+        max_rt_idx--;
+      }
+
+      if (max_rt_idx == 0) {
+        return Status::SparseUnorderedWithDupsReaderError(
+            "Var size buffer cannot fit a full result tile for attribute " +
+            name);
+      }
+
+      // Now copy the var size data.
+      global_cell_offset = 0;
+      auto var_data_buff = (uint8_t*)it.second.buffer_var_;
+      auto result_tiles_it = result_tiles_[0].begin();
+      auto status = parallel_for(
+          storage_manager_->compute_tp(), 0, max_rt_idx, [&](uint64_t) {
+            // Take a result tile in the list and calculate the cell offset for
+            // this tile. As the work is very simple and not parallelizable,
+            // using a mutex to prevent from allocating a vector for the cell
+            // offsets.
+            typename std::list<ResultTileWithBitmap<BitmapType>>::iterator rt;
+            uint64_t cell_offset = 0;
+            bool last_t = false;
+            {
+              std::unique_lock<std::mutex> ul(it_mtx);
+              rt = result_tiles_it++;
+              cell_offset = global_cell_offset;
+              global_cell_offset +=
+                  subarray_.is_set() ? rt->bitmap_num_cells : rt->cell_num();
+              last_t = result_tiles_it == result_tiles_[0].end();
+            }
+
+            // Copy the data cells by cells. Last copy taken out for
+            // vectorization.
+            uint64_t num_cells =
+                subarray_.is_set() ? rt->bitmap_num_cells : rt->cell_num();
+            if (num_cells > 0) {
+              auto offsets_buff = ((OffType*)it.second.buffer_) + cell_offset;
+              auto max_cell = last_t ? num_cells - 1 : num_cells;
+              for (uint64_t c = 0; c < max_cell; c++) {
+                auto size =
+                    (offsets_buff[c + 1] - offsets_buff[c]) * offset_div;
+                memcpy(
+                    var_data_buff + offsets_buff[c] * offset_div,
+                    var_data[c + cell_offset],
+                    size);
+              }
+
+              // Last copy for last tile.
+              if (last_t) {
+                memcpy(
+                    var_data_buff + offsets_buff[num_cells - 1] * offset_div,
+                    var_data[num_cells - 1 + cell_offset],
+                    (var_offset - offsets_buff[num_cells - 1]) * offset_div);
+              }
+            }
+
+            return Status::Ok();
+          });
+      RETURN_NOT_OK_ELSE(status, logger_->status(status));
+    }
+
+    // Adjust tile index.
+    uint64_t i = 0;
+    for (auto it = result_tiles_[0].begin(); i < max_rt_idx; i++, it++) {
+      read_state_.frag_tile_idx_[it->frag_idx()].first = it->tile_idx() + 1;
+    }
+
+    // Adjust buffer sizes.
+    if (var_sized) {
+      *it.second.buffer_size_ = global_cell_offset * sizeof(OffType);
+
+      if (offsets_extra_element_)
+        (*it.second.buffer_size_) += sizeof(OffType);
+
+      *it.second.buffer_var_size_ = var_offset * offset_div;
+    } else {
+      *it.second.buffer_size_ = global_cell_offset * cell_size;
+    }
+
+    if (nullable)
+      *buffers_[name].validity_vector_.buffer_size() = global_cell_offset;
+
+    // Adjust number of cells copied.
+    num_cells_copied = std::min(num_cells_copied, global_cell_offset);
+
+    // Clear tiles from memory.
+    if (!subarray_.is_set() || !is_dim) {
+      clear_tiles(name, &tmp_result_tiles);
+    }
+  }
+
+  // Fix the output buffer sizes.
+  RETURN_NOT_OK(resize_output_buffers(num_cells_copied));
+
+  logger_->debug("Done copying tiles");
+  return Status::Ok();
+}
+
+template <class BitmapType>
+Status SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
+    const unsigned frag_idx,
+    typename std::list<ResultTileWithBitmap<BitmapType>>::iterator rt) {
+  // Remove coord tile size from memory budget.
+  const auto tile_idx = rt->tile_idx();
+  uint64_t tiles_size = 0, tiles_size_qc = 0;
+  RETURN_NOT_OK(get_coord_tiles_size<BitmapType>(
+      subarray_.is_set(),
+      array_schema_->dim_num(),
+      frag_idx,
+      tile_idx,
+      &tiles_size,
+      &tiles_size_qc));
+
+  {
+    std::unique_lock<std::mutex> lck(mem_budget_mtx_);
+    memory_used_for_coords_total_ -= tiles_size;
+    memory_used_qc_tiles_total_ -= tiles_size_qc;
+  }
+
+  // Delete the tile.
+  result_tiles_[0].erase(rt);
+
+  return Status::Ok();
+}
+
+template <class BitmapType>
+Status SparseUnorderedWithDupsReader<BitmapType>::end_iteration() {
+  if (subarray_.is_set()) {
+    // Adjust result tile ranges.
+    auto status = parallel_for(
+        storage_manager_->compute_tp(),
+        0,
+        fragment_metadata_.size(),
+        [&](uint64_t f) {
+          while (!result_tile_ranges_[f].empty() &&
+                 result_tile_ranges_[f].back().second <
+                     read_state_.frag_tile_idx_[f].first) {
+            remove_result_tile_range(f);
+          }
+
+          if (!result_tile_ranges_[f].empty()) {
+            result_tile_ranges_[f].back().first =
+                read_state_.frag_tile_idx_[f].first;
+          }
+
+          return Status::Ok();
+        });
+  }
+
+  // Clear result tiles that are not necessary anymore.
+  while (!result_tiles_[0].empty() &&
+         result_tiles_[0].front().tile_idx() <
+             read_state_.frag_tile_idx_[result_tiles_[0].front().frag_idx()]
+                 .first) {
+    const auto f = result_tiles_[0].front().frag_idx();
+    RETURN_NOT_OK(remove_result_tile(f, result_tiles_[0].begin()));
+  }
 
   if (offsets_extra_element_) {
     RETURN_NOT_OK(add_extra_offset());
   }
 
+  // Validate memory usage.
   if (!incomplete()) {
     assert(memory_used_for_coords_total_ == 0);
-    assert(memory_used_qc_tiles_ == 0);
-    assert(memory_used_rcs_ == 0);
-    assert(memory_used_result_tiles_ == 0);
+    assert(memory_used_qc_tiles_total_ == 0);
     /* This should be re-instated in a followup
      Currently there is a bug causing this assert to fail when
      sm.mem.total_budget is applied. These calculations are going to be
@@ -889,13 +1098,34 @@ Status SparseUnorderedWithDupsReader::end_iteration() {
   }
 
   logger_->debug(
-      "Done with iteration, num slabs {0}, num result tiles {1}",
-      read_state_.result_cell_slabs_.size(),
-      result_tiles_.size());
+      "Done with iteration, num result tiles {1}", result_tiles_[0].size());
 
+  const auto uint64_t_max = std::numeric_limits<uint64_t>::max();
   array_memory_tracker_->set_budget(uint64_t_max);
   return Status::Ok();
 }
+
+// Explicit template instantiations
+template SparseUnorderedWithDupsReader<uint8_t>::SparseUnorderedWithDupsReader(
+    stats::Stats*,
+    tdb_shared_ptr<Logger>,
+    StorageManager*,
+    Array*,
+    Config&,
+    std::unordered_map<std::string, QueryBuffer>&,
+    Subarray&,
+    Layout,
+    QueryCondition&);
+template SparseUnorderedWithDupsReader<uint64_t>::SparseUnorderedWithDupsReader(
+    stats::Stats*,
+    tdb_shared_ptr<Logger>,
+    StorageManager*,
+    Array*,
+    Config&,
+    std::unordered_map<std::string, QueryBuffer>&,
+    Subarray&,
+    Layout,
+    QueryCondition&);
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -212,12 +212,19 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       typename std::list<ResultTileWithBitmap<BitmapType>>::iterator*
           result_tiles_it);
 
-  /** Compute initial max rt index for the copy. */
-  Status compute_initial_copy_bound(uint64_t* max_rt_idx);
+  /**
+   * Compute initial max rt index for the copy and approximate memory usage
+   * per attribute.
+   */
+  Status compute_initial_copy_bound(
+      uint64_t memory_budget,
+      uint64_t* max_rt_idx,
+      std::vector<uint64_t>* total_mem_usage_per_attr);
 
-  /** Read and unfilter an attribute. */
-  Status read_and_unfilter_attribute(
-      const std::string& name, std::vector<ResultTile*>* result_tiles);
+  /** Read and unfilter attributes. */
+  Status read_and_unfilter_attributes(
+      const std::vector<std::string>* names,
+      std::vector<ResultTile*>* result_tiles);
 
   /** Copy tiles. */
   template <class OffType>

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -139,34 +139,89 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   /** Create the result tiles. */
   Status create_result_tiles();
 
-  /** Copy offsets. */
+  /** Copy offsets tile. */
   template <class OffType>
-  Status copy_offsets(
+  Status copy_offsets_tile(
       const std::string& name,
+      const bool nullable,
+      const OffType offset_div,
       ResultTileWithBitmap<BitmapType>* rt,
       OffType* buffer,
+      uint8_t* val_buffer,
+      void** var_data);
+
+  /** Copy offsets tiles. */
+  template <class OffType>
+  Status copy_offsets_tiles(
+      const std::string& name,
       const bool nullable,
+      const OffType offset_div,
+      const uint64_t max_rt_idx,
+      OffType* buffer,
       uint8_t* val_buffer,
       void** var_data,
-      const OffType div);
+      uint64_t* global_cell_offset,
+      typename std::list<ResultTileWithBitmap<BitmapType>>::iterator*
+          result_tiles_it);
 
-  /** Copy fixed size data. */
-  Status copy_fixed_data(
+  /** Copy var data tile. */
+  template <class OffType>
+  Status copy_var_data_tile(
+      const bool last_tile,
+      const uint64_t cell_offset,
+      const uint64_t offset_div,
+      const uint64_t last_offset,
+      const ResultTileWithBitmap<BitmapType>* rt,
+      const void** var_data,
+      const OffType* offsets_buffer,
+      uint8_t* var_data_buffer);
+
+  /** Copy var data tiles. */
+  template <class OffType>
+  Status copy_var_data_tiles(
+      const OffType offset_div,
+      const uint64_t last_offset,
+      const uint64_t max_rt_idx,
+      OffType* offsets_buffer,
+      uint8_t* var_data_buffer,
+      const void** var_data,
+      uint64_t* global_cell_offset);
+
+  /** Copy fixed size data tile. */
+  Status copy_fixed_data_tile(
       const std::string& name,
+      const bool is_dim,
+      const bool nullable,
+      const unsigned dim_idx,
+      const uint64_t cell_size,
       ResultTileWithBitmap<BitmapType>* rt,
       uint8_t* buffer,
-      const bool nullable,
-      uint8_t* val_buffer,
-      const uint64_t cell_size,
+      uint8_t* val_buffer);
+
+  /** Copy fixed size data tiles. */
+  Status copy_fixed_data_tiles(
+      const std::string& name,
       const bool is_dim,
-      const unsigned dim_idx);
+      const bool nullable,
+      const uint64_t dim_idx,
+      const uint64_t max_rt_idx,
+      const uint64_t cell_size,
+      uint8_t* buffer,
+      uint8_t* val_buffer,
+      uint64_t* global_cell_offset,
+      typename std::list<ResultTileWithBitmap<BitmapType>>::iterator*
+          result_tiles_it);
 
   /** Compute initial max rt index for the copy. */
   Status compute_initial_copy_bound(uint64_t* max_rt_idx);
 
+  /** Read and unfilter an attribute. */
+  Status read_and_unfilter_attribute(
+      const std::string& name, std::vector<ResultTile*>* result_tiles);
+
   /** Copy tiles. */
   template <class OffType>
-  Status copy_tiles();
+  Status process_tiles();
 
   /** Remove a result tile from memory */
   Status remove_result_tile(

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -588,33 +588,38 @@ Status index_read_state_from_capnp(
   read_state->done_adding_result_tiles_ =
       read_state_reader.getDoneAddingResultTiles();
 
-  assert(read_state_reader.hasResultCellSlab());
-  RETURN_NOT_OK(reader->clear_result_tiles());
-  read_state->result_cell_slabs_.clear();
+  // Only sparse global order reader has a result cell slab.
+  if (read_state_reader.hasResultCellSlab()) {
+    SparseGlobalOrderReader* sparse_global_order_reader =
+        (SparseGlobalOrderReader*)reader;
+    RETURN_NOT_OK(sparse_global_order_reader->clear_result_tiles());
+    read_state->result_cell_slabs_.clear();
 
-  std::unordered_map<
-      std::pair<unsigned, uint64_t>,
-      ResultTile*,
-      tiledb::sm::utils::hash::pair_hash>
-      result_tile_map;
-  for (const auto rcs : read_state_reader.getResultCellSlab()) {
-    auto start = rcs.getStart();
-    auto length = rcs.getLength();
-    auto frag_idx = rcs.getFragIdx();
-    auto tile_idx = rcs.getTileIdx();
+    std::unordered_map<
+        std::pair<unsigned, uint64_t>,
+        ResultTile*,
+        tiledb::sm::utils::hash::pair_hash>
+        result_tile_map;
+    for (const auto rcs : read_state_reader.getResultCellSlab()) {
+      auto start = rcs.getStart();
+      auto length = rcs.getLength();
+      auto frag_idx = rcs.getFragIdx();
+      auto tile_idx = rcs.getTileIdx();
 
-    ResultTile* rt = nullptr;
-    auto it =
-        result_tile_map.find(std::pair<unsigned, uint64_t>(frag_idx, tile_idx));
-    if (it != result_tile_map.end()) {
-      rt = it->second;
-    } else {
-      rt = reader->add_result_tile_unsafe(frag_idx, tile_idx, domain);
-      result_tile_map.emplace(
-          std::pair<unsigned, uint64_t>(frag_idx, tile_idx), rt);
+      ResultTile* rt = nullptr;
+      auto it = result_tile_map.find(
+          std::pair<unsigned, uint64_t>(frag_idx, tile_idx));
+      if (it != result_tile_map.end()) {
+        rt = it->second;
+      } else {
+        rt = sparse_global_order_reader->add_result_tile_unsafe(
+            frag_idx, tile_idx, domain);
+        result_tile_map.emplace(
+            std::pair<unsigned, uint64_t>(frag_idx, tile_idx), rt);
+      }
+
+      read_state->result_cell_slabs_.emplace_back(rt, start, length);
     }
-
-    read_state->result_cell_slabs_.emplace_back(rt, start, length);
   }
 
   assert(read_state_reader.hasFragTileIdx());
@@ -1120,13 +1125,33 @@ Status query_to_capnp(Query& query, capnp::Query::Builder* query_builder) {
         !schema->dense() && layout == Layout::UNORDERED &&
         schema->allows_dups()) {
       auto builder = query_builder->initReaderIndex();
-      auto reader = (SparseUnorderedWithDupsReader*)query.strategy();
 
-      query_builder->setVarOffsetsMode(reader->offsets_mode());
-      query_builder->setVarOffsetsAddExtraElement(
-          reader->offsets_extra_element());
-      query_builder->setVarOffsetsBitsize(reader->offsets_bitsize());
-      RETURN_NOT_OK(index_reader_to_capnp(query, *reader, &builder));
+      bool found = false;
+      bool non_overlapping_ranges = false;
+      RETURN_NOT_OK(query.config()->get<bool>(
+          "sm.query.sparse_unordered_with_dups.non_overlapping_ranges",
+          &non_overlapping_ranges,
+          &found));
+      assert(found);
+
+      if (non_overlapping_ranges) {
+        auto reader = (SparseUnorderedWithDupsReader<uint8_t>*)query.strategy();
+
+        query_builder->setVarOffsetsMode(reader->offsets_mode());
+        query_builder->setVarOffsetsAddExtraElement(
+            reader->offsets_extra_element());
+        query_builder->setVarOffsetsBitsize(reader->offsets_bitsize());
+        RETURN_NOT_OK(index_reader_to_capnp(query, *reader, &builder));
+      } else {
+        auto reader =
+            (SparseUnorderedWithDupsReader<uint64_t>*)query.strategy();
+
+        query_builder->setVarOffsetsMode(reader->offsets_mode());
+        query_builder->setVarOffsetsAddExtraElement(
+            reader->offsets_extra_element());
+        query_builder->setVarOffsetsBitsize(reader->offsets_bitsize());
+        RETURN_NOT_OK(index_reader_to_capnp(query, *reader, &builder));
+      }
     } else if (
         query.use_refactored_sparse_global_order_reader() && !schema->dense() &&
         (layout == Layout::GLOBAL_ORDER ||
@@ -1700,26 +1725,59 @@ Status query_from_capnp(
       query->clear_strategy();
       RETURN_NOT_OK(query->set_layout_unsafe(layout));
 
+      bool found = false;
+      bool non_overlapping_ranges = false;
+      RETURN_NOT_OK(query->config()->get<bool>(
+          "sm.query.sparse_unordered_with_dups.non_overlapping_ranges",
+          &non_overlapping_ranges,
+          &found));
+      assert(found);
+
       auto reader_reader = query_reader.getReaderIndex();
-      auto reader = (SparseUnorderedWithDupsReader*)query->strategy();
 
-      if (query_reader.hasVarOffsetsMode()) {
+      if (non_overlapping_ranges) {
+        auto reader =
+            (SparseUnorderedWithDupsReader<uint8_t>*)query->strategy();
+
+        if (query_reader.hasVarOffsetsMode()) {
+          RETURN_NOT_OK(
+              reader->set_offsets_mode(query_reader.getVarOffsetsMode()));
+        }
+
+        RETURN_NOT_OK(reader->set_offsets_extra_element(
+            query_reader.getVarOffsetsAddExtraElement()));
+
+        if (query_reader.getVarOffsetsBitsize() > 0) {
+          RETURN_NOT_OK(
+              reader->set_offsets_bitsize(query_reader.getVarOffsetsBitsize()));
+        }
+
+        RETURN_NOT_OK(reader->initialize_memory_budget());
+
         RETURN_NOT_OK(
-            reader->set_offsets_mode(query_reader.getVarOffsetsMode()));
-      }
+            index_reader_from_capnp(schema, reader_reader, query, reader));
+      } else {
+        auto reader =
+            (SparseUnorderedWithDupsReader<uint64_t>*)query->strategy();
 
-      RETURN_NOT_OK(reader->set_offsets_extra_element(
-          query_reader.getVarOffsetsAddExtraElement()));
+        if (query_reader.hasVarOffsetsMode()) {
+          RETURN_NOT_OK(
+              reader->set_offsets_mode(query_reader.getVarOffsetsMode()));
+        }
 
-      if (query_reader.getVarOffsetsBitsize() > 0) {
+        RETURN_NOT_OK(reader->set_offsets_extra_element(
+            query_reader.getVarOffsetsAddExtraElement()));
+
+        if (query_reader.getVarOffsetsBitsize() > 0) {
+          RETURN_NOT_OK(
+              reader->set_offsets_bitsize(query_reader.getVarOffsetsBitsize()));
+        }
+
+        RETURN_NOT_OK(reader->initialize_memory_budget());
+
         RETURN_NOT_OK(
-            reader->set_offsets_bitsize(query_reader.getVarOffsetsBitsize()));
+            index_reader_from_capnp(schema, reader_reader, query, reader));
       }
-
-      RETURN_NOT_OK(reader->initialize_memory_budget());
-
-      RETURN_NOT_OK(
-          index_reader_from_capnp(schema, reader_reader, query, reader));
     } else if (query_reader.hasDenseReader()) {
       // Strategy needs to be cleared here to create the correct reader.
       query->clear_strategy();

--- a/tiledb/sm/storage_manager/open_array_memory_tracker.h
+++ b/tiledb/sm/storage_manager/open_array_memory_tracker.h
@@ -89,6 +89,14 @@ class OpenArrayMemoryTracker {
     memory_budget_ = size;
   }
 
+  /**
+   * Get the memory usage.
+   */
+  uint64_t get_memory_usage() {
+    std::lock_guard<std::mutex> lg(mutex_);
+    return memory_usage_;
+  }
+
  private:
   /** Protects all member variables. */
   std::mutex mutex_;


### PR DESCRIPTION
Backport ba79cbb91d078ee091aa4aa5be1bafa2027b3379, 6044c13c3477a110daab03f8e1268e77e67ab757 and af0b461e7bab9e93da78b2d430ded816315762e6 from #2606

---
TYPE: IMPROVEMENT
DESC: Sparse unordered with dups reader: removing result cell slabs.