### PR TITLE
Fix handling checking config for refactored reader

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -2041,25 +2041,71 @@ tdb_shared_ptr<Buffer> Query::rest_scratch() const {
 }
 
 bool Query::use_refactored_dense_reader() {
+  bool use_refactored_readers = false;
   bool found = false;
-  std::string val = config_.get("sm.query.dense.reader", &found);
+  // First check for legacy option
+  config_.get<bool>(
+      "sm.use_refactored_readers", &use_refactored_readers, &found);
+  // If the legacy/deprecated option is set use it over the new parameters
+  // This facilitates backwards compatibility
+  if (found) {
+    logger_->warn(
+        "sm.use_refactored_readers config option is deprecated.\nPlease use "
+        "'sm.query.dense.reader' with value of 'refactored' or 'legacy'");
+    return use_refactored_readers;
+  }
+
+  const std::string& val = config_.get("sm.query.dense.reader", &found);
   assert(found);
-  return val.compare("refactored") == 0;
+
+  return val == "refactored";
 }
 
 bool Query::use_refactored_sparse_global_order_reader() {
+  bool use_refactored_readers = false;
   bool found = false;
-  std::string val = config_.get("sm.query.sparse_global_order.reader", &found);
+  // First check for legacy option
+  config_.get<bool>(
+      "sm.use_refactored_readers", &use_refactored_readers, &found);
+  // If the legacy/deprecated option is set use it over the new parameters
+  // This facilitates backwards compatibility
+  if (found) {
+    logger_->warn(
+        "sm.use_refactored_readers config option is deprecated.\nPlease use "
+        "'sm.query.sparse_global_order.reader' with value of 'refactored' or "
+        "'legacy'");
+    return use_refactored_readers;
+  }
+
+  const std::string& val =
+      config_.get("sm.query.sparse_global_order.reader", &found);
   assert(found);
-  return val.compare("refactored") == 0;
+
+  return val == "refactored";
 }
 
 bool Query::use_refactored_sparse_unordered_with_dups_reader() {
+  bool use_refactored_readers = false;
   bool found = false;
-  std::string val =
+
+  // First check for legacy option
+  config_.get<bool>(
+      "sm.use_refactored_readers", &use_refactored_readers, &found);
+  // If the legacy/deprecated option is set use it over the new parameters
+  // This facilitates backwards compatibility
+  if (found) {
+    logger_->warn(
+        "sm.use_refactored_readers config option is deprecated.\nPlease use "
+        "'sm.query.sparse_unordered_with_dups.reader' with value of "
+        "'refactored' or 'legacy'");
+    return use_refactored_readers;
+  }
+
+  const std::string& val =
       config_.get("sm.query.sparse_unordered_with_dups.reader", &found);
   assert(found);
-  return val.compare("refactored") == 0;
+
+  return val == "refactored";
 }
 
 /* ****************************** */


### PR DESCRIPTION
This supports the deprecated parameters for `"sm.use_refactored_readers"`, which is needed for serialization. If the client is pre 2.5, then they (in nearly all cases) want to use the legacy reader not the new refactored reader. This adjusts the check for refactored or not to account for the 2.4 config parameter which defaulted to false. The 2.4 config parameter was replaced by finer grained config settings in 2.5.


---
TYPE: BUG
DESC: Properly check and use legacy readers instead of refactored in serialized query.
