### PR TITLE
Sparse unordered w/ dups reader: tracking cell progress.

### DIFF
--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -177,12 +177,6 @@ void partial_read_and_check_sparse_array(
     std::vector<int32_t>& exp_data_part2,
     std::vector<uint64_t>& exp_off_part2,
     tiledb_layout_t layout) {
-  // Sparse unordered with dups reader does not track cell progress meaning
-  // it only copies full tiles for now. Disable these cases until it does.
-  if (test::use_refactored_sparse_unordered_with_dups_reader() &&
-      layout == TILEDB_UNORDERED)
-    return;
-
   // The size of read buffers is smaller than the size
   // of all the data, so we'll do partial reads
   std::vector<int32_t> attr_val(exp_data_part1.size());

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -61,8 +61,49 @@ class ResultTileWithBitmap : public ResultTile {
   ResultTileWithBitmap(
       unsigned frag_idx, uint64_t tile_idx, const Domain* domain)
       : ResultTile(frag_idx, tile_idx, domain)
-      , bitmap_num_cells(std::numeric_limits<uint64_t>::max())
-      , qc_processed(false) {
+      , bitmap_result_num_(std::numeric_limits<uint64_t>::max())
+      , qc_processed_(false) {
+  }
+
+  /* ********************************* */
+  /*          PUBLIC METHODS           */
+  /* ********************************* */
+
+  /**
+   * Returns the number of cells that are before a certain cell index in the
+   * bitmap.
+   */
+  uint64_t result_num_between_pos(uint64_t start_pos, uint64_t end_pos) const {
+    if (bitmap_.size() == 0)
+      return end_pos - start_pos;
+
+    uint64_t result_num = 0;
+    for (uint64_t c = start_pos; c < end_pos; c++)
+      result_num += bitmap_[c];
+
+    return result_num;
+  }
+
+  /**
+   * Returns cell index from a number of cells inside of the bitmap.
+   */
+  uint64_t pos_with_given_result_sum(uint64_t result_num) const {
+    assert(
+        bitmap_result_num_ != std::numeric_limits<uint64_t>::max() &&
+        result_num != 0);
+    if (bitmap_.size() == 0)
+      return result_num - 1;
+
+    uint64_t sum = 0;
+    for (uint64_t c = 0; c < bitmap_.size(); c++) {
+      sum += bitmap_[c];
+      if (sum == result_num) {
+        return c;
+      }
+    }
+
+    assert(false);
+    return std::numeric_limits<uint64_t>::max();
   }
 
   /* ********************************* */
@@ -70,13 +111,13 @@ class ResultTileWithBitmap : public ResultTile {
   /* ********************************* */
 
   /** Bitmap for this tile. */
-  std::vector<BitmapType> bitmap;
+  std::vector<BitmapType> bitmap_;
 
   /** Number of cells in this bitmap. */
-  uint64_t bitmap_num_cells;
+  uint64_t bitmap_result_num_;
 
   /** Was the query condition processed for this tile. */
-  bool qc_processed;
+  bool qc_processed_;
 };
 
 /**

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -83,6 +83,23 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   DISABLE_MOVE_AND_MOVE_ASSIGN(SparseUnorderedWithDupsReader);
 
   /* ********************************* */
+  /*          STATIC FUNCTIONS         */
+  /* ********************************* */
+
+  /**
+   * Compute the var size offsets and make sure all the data can fit in the
+   * user buffer.
+   */
+  template <class OffType>
+  static Status compute_var_size_offsets(
+      stats::Stats* stats,
+      const std::vector<ResultTile*>* result_tiles,
+      std::vector<uint64_t>* cell_offsets,
+      QueryBuffer* query_buffer,
+      uint64_t* new_result_tiles_size,
+      uint64_t* var_buffer_size);
+
+  /* ********************************* */
   /*                 API               */
   /* ********************************* */
 
@@ -139,6 +156,18 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   /** Create the result tiles. */
   Status create_result_tiles();
 
+  /** Compute parallelization parameters for a tile copy operation. */
+  void compute_parallelization_parameters(
+      const uint64_t range_thread_idx,
+      const uint64_t num_range_threads,
+      const uint64_t min_pos_tile,
+      const uint64_t max_pos_tile,
+      const ResultTileWithBitmap<BitmapType>* rt,
+      uint64_t* src_min_pos,
+      uint64_t* src_max_pos,
+      uint64_t* dest_cell_offset,
+      bool* skip_copy);
+
   /** Copy offsets tile. */
   template <class OffType>
   Status copy_offsets_tile(
@@ -146,6 +175,8 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const bool nullable,
       const OffType offset_div,
       ResultTileWithBitmap<BitmapType>* rt,
+      const uint64_t src_min_pos,
+      const uint64_t src_max_pos,
       OffType* buffer,
       uint8_t* val_buffer,
       void** var_data);
@@ -154,24 +185,23 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   template <class OffType>
   Status copy_offsets_tiles(
       const std::string& name,
+      const uint64_t num_range_threads,
       const bool nullable,
       const OffType offset_div,
-      const uint64_t max_rt_idx,
-      OffType* buffer,
-      uint8_t* val_buffer,
-      void** var_data,
-      uint64_t* global_cell_offset,
-      typename std::list<ResultTileWithBitmap<BitmapType>>::iterator*
-          result_tiles_it);
+      const std::vector<ResultTile*>* result_tiles,
+      const std::vector<uint64_t>* cell_offsets,
+      QueryBuffer* query_buffer,
+      void** var_data);
 
   /** Copy var data tile. */
   template <class OffType>
   Status copy_var_data_tile(
-      const bool last_tile,
+      const bool last_partition,
       const uint64_t cell_offset,
       const uint64_t offset_div,
-      const uint64_t last_offset,
-      const ResultTileWithBitmap<BitmapType>* rt,
+      const uint64_t var_buffer_size,
+      const uint64_t src_min_pos,
+      const uint64_t src_max_pos,
       const void** var_data,
       const OffType* offsets_buffer,
       uint8_t* var_data_buffer);
@@ -179,13 +209,14 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   /** Copy var data tiles. */
   template <class OffType>
   Status copy_var_data_tiles(
+      const uint64_t num_range_threads,
       const OffType offset_div,
-      const uint64_t last_offset,
-      const uint64_t max_rt_idx,
-      OffType* offsets_buffer,
-      uint8_t* var_data_buffer,
-      const void** var_data,
-      uint64_t* global_cell_offset);
+      const uint64_t var_buffer_size,
+      const uint64_t result_tiles_size,
+      const std::vector<ResultTile*>* result_tiles,
+      const std::vector<uint64_t>* cell_offsets,
+      QueryBuffer* query_buffer,
+      const void** var_data);
 
   /** Copy fixed size data tile. */
   Status copy_fixed_data_tile(
@@ -195,40 +226,59 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const unsigned dim_idx,
       const uint64_t cell_size,
       ResultTileWithBitmap<BitmapType>* rt,
+      const uint64_t src_min_pos,
+      const uint64_t src_max_pos,
       uint8_t* buffer,
       uint8_t* val_buffer);
 
   /** Copy fixed size data tiles. */
   Status copy_fixed_data_tiles(
       const std::string& name,
+      const uint64_t num_range_threads,
       const bool is_dim,
       const bool nullable,
       const uint64_t dim_idx,
-      const uint64_t max_rt_idx,
       const uint64_t cell_size,
-      uint8_t* buffer,
-      uint8_t* val_buffer,
-      uint64_t* global_cell_offset,
-      typename std::list<ResultTileWithBitmap<BitmapType>>::iterator*
-          result_tiles_it);
+      const std::vector<ResultTile*>* result_tiles,
+      const std::vector<uint64_t>* cell_offsets,
+      QueryBuffer* query_buffer);
 
   /**
-   * Compute initial max rt index for the copy and approximate memory usage
-   * per attribute.
+   * Compute the maximum vector of result tiles to process amd cell offsets for
+   * each tiles using the fixed size buffers from the user.
    */
-  Status compute_initial_copy_bound(
-      uint64_t memory_budget,
-      uint64_t* max_rt_idx,
+  Status compute_fixed_results_to_copy(
+      std::vector<ResultTile*>* result_tiles,
+      std::vector<uint64_t>* cell_offsets);
+
+  /**
+   * Make sure we respect memory budget for copy operation by making sure that,
+   * for all attributes to be copied, the size of tiles in memory can fit into
+   * the budget.
+   */
+  Status respect_copy_memory_budget(
+      const std::vector<std::string> names,
+      const uint64_t memory_budget,
+      const std::vector<uint64_t>* cell_offsets,
+      std::vector<ResultTile*>* result_tiles,
       std::vector<uint64_t>* total_mem_usage_per_attr);
 
-  /** Read and unfilter attributes. */
+  /**
+   * Read and unfilter as many attributes as can fit in the memory budget and
+   * return the names loaded in 'names_to_copy'. Also keep the 'buffer_idx'
+   * updated to keep track of progress.
+   */
   Status read_and_unfilter_attributes(
+      const uint64_t memory_budget,
       const std::vector<std::string>* names,
+      const std::vector<uint64_t>* mem_usage_per_attr,
+      uint64_t* buffer_idx,
+      std::vector<std::string>* names_to_copy,
       std::vector<ResultTile*>* result_tiles);
 
   /** Copy tiles. */
   template <class OffType>
-  Status process_tiles();
+  Status process_tiles(std::vector<ResultTile*>* result_tiles);
 
   /** Remove a result tile from memory */
   Status remove_result_tile(


### PR DESCRIPTION
This enables to track cell progress using the reader, meaning that
result tiles can be split to fit into the user's buffer. As part of this
work, every copy function has been modified to take a min cell/max cell
parameter. This made it very easy to better parallelize on tiles and
cells for the copy operation, so this PR also includes this work.

Also fixing how we track progress in result tile ranges by updating it
directly when a result tile is created.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups reader: tracking cell progress.