### PR TITLE
accommodate c++17 usage deprecation of std iterator

### DIFF
--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -49,10 +49,13 @@ class Config;  // Forward decl for impl classes
 
 namespace impl {
 
-class ConfigIter : public std::iterator<
-                       std::forward_iterator_tag,
-                       const std::pair<std::string, std::string>> {
+class ConfigIter {
  public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = const std::pair<std::string, std::string>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */

--- a/tiledb/sm/cpp_api/object_iter.h
+++ b/tiledb/sm/cpp_api/object_iter.h
@@ -155,7 +155,7 @@ class ObjectIter {
     using difference_type = std::ptrdiff_t;
     using pointer = value_type*;
     using reference = value_type&;
-   
+
     iterator()
         : cur_obj_(0) {
     }

--- a/tiledb/sm/cpp_api/object_iter.h
+++ b/tiledb/sm/cpp_api/object_iter.h
@@ -148,9 +148,14 @@ class ObjectIter {
   }
 
   /** The actual iterator implementation in this class. */
-  class iterator
-      : public std::iterator<std::forward_iterator_tag, const Object> {
+  class iterator {
    public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = const Object;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+   
     iterator()
         : cur_obj_(0) {
     }


### PR DESCRIPTION
eliminate usage of std::iterator due to c++17 deprecation

---
TYPE: DEPRECATION
DESC: eliminate usage of std::iterator due to c++17 deprecation
