### PR TITLE
[Backport release-2.5] Set the array uri for cap'n proto compatiblity (#2676)

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -64,6 +64,7 @@ namespace sm {
 Array::Array(const URI& array_uri, StorageManager* storage_manager)
     : array_schema_latest_(nullptr)
     , array_uri_(array_uri)
+    , array_uri_serialized_(array_uri)
     , encryption_key_(tdb_make_shared(EncryptionKey))
     , is_open_(false)
     , timestamp_start_(0)
@@ -78,6 +79,7 @@ Array::Array(const URI& array_uri, StorageManager* storage_manager)
 Array::Array(const Array& rhs)
     : array_schema_latest_(rhs.array_schema_latest_)
     , array_uri_(rhs.array_uri_)
+    , array_uri_serialized_(rhs.array_uri_serialized_)
     , encryption_key_(rhs.encryption_key_)
     , fragment_metadata_(rhs.fragment_metadata_)
     , is_open_(rhs.is_open_.load())
@@ -107,6 +109,11 @@ ArraySchema* Array::array_schema_latest() const {
 const URI& Array::array_uri() const {
   std::unique_lock<std::mutex> lck(mtx_);
   return array_uri_;
+}
+
+const URI& Array::array_uri_serialized() const {
+  std::unique_lock<std::mutex> lck(mtx_);
+  return array_uri_serialized_;
 }
 
 const EncryptionKey* Array::encryption_key() const {
@@ -601,6 +608,12 @@ Config Array::config() const {
 Status Array::set_uri(const std::string& uri) {
   std::unique_lock<std::mutex> lck(mtx_);
   array_uri_ = URI(uri);
+  return Status::Ok();
+}
+
+Status Array::set_uri_serialized(const std::string& uri) {
+  std::unique_lock<std::mutex> lck(mtx_);
+  array_uri_serialized_ = URI(uri);
   return Status::Ok();
 }
 

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -88,6 +88,10 @@ class Array {
   /** Returns the array URI. */
   const URI& array_uri() const;
 
+  /** Returns the serialized array URI, this is for backwards compatibility with
+   * serialization in pre TileDB 2.4 */
+  const URI& array_uri_serialized() const;
+
   /**
    * Opens the array for reading at a timestamp retrieved from the config
    * or for writing.
@@ -246,6 +250,10 @@ class Array {
   /** Directly set the array URI. */
   Status set_uri(const std::string& uri);
 
+  /** Directly set the array URI for serialized compatibility with pre
+   * TileDB 2.5 clients */
+  Status set_uri_serialized(const std::string& uri);
+
   /**
    * Deletes metadata from an array opened in WRITE mode.
    *
@@ -359,12 +367,20 @@ class Array {
   /** The array URI. */
   URI array_uri_;
 
+  /** This is a backwards compatible URI from serialization
+   *  In TileDB 2.5 we removed sending the URI but 2.4 and older were
+   * unconditionally setting the URI, so things got set to an empty stirng Now
+   * we store the serialized URI so we avoid the empty string with older
+   * clients.
+   */
+  URI array_uri_serialized_;
+
   /**
    * The private encryption key used to encrypt the array.
    *
-   * Note: This is the only place in TileDB where the user's private key bytes
-   * should be stored. Whenever a key is needed, a pointer to this memory region
-   * should be passed instead of a copy of the bytes.
+   * Note: This is the only place in TileDB where the user's private key
+   * bytes should be stored. Whenever a key is needed, a pointer to this
+   * memory region should be passed instead of a copy of the bytes.
    */
   tdb_shared_ptr<EncryptionKey> encryption_key_;
 

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -129,6 +129,13 @@ Status stats_from_capnp(
 
 Status array_to_capnp(
     const Array& array, capnp::Array::Builder* array_builder) {
+  // The serialized URI is set if it exists
+  // this is used for backwards compatibility with pre TileDB 2.5 clients that
+  // want to serialized a query object TileDB >= 2.5 no longer needs to send the
+  // array URI
+  if (!array.array_uri_serialized().to_string().empty()) {
+    array_builder->setUri(array.array_uri_serialized());
+  }
   array_builder->setStartTimestamp(array.timestamp_start());
   array_builder->setEndTimestamp(array.timestamp_end());
 
@@ -137,6 +144,13 @@ Status array_to_capnp(
 
 Status array_from_capnp(
     const capnp::Array::Reader& array_reader, Array* array) {
+  // The serialized URI is set if it exists
+  // this is used for backwards compatibility with pre TileDB 2.5 clients that
+  // want to serialized a query object TileDB >= 2.5 no longer needs to receive
+  // the array URI
+  if (array_reader.hasUri()) {
+    RETURN_NOT_OK(array->set_uri_serialized(array_reader.getUri().cStr()));
+  }
   RETURN_NOT_OK(array->set_timestamp_start(array_reader.getStartTimestamp()));
   RETURN_NOT_OK(array->set_timestamp_end(array_reader.getEndTimestamp()));
 


### PR DESCRIPTION
Backport 0e2184b22282407d3b55ca45b61f78fd80d158df from #2676

---
TYPE: BUG
DESC: Set array URI in cap'n proto object for compatibility with repeated opened array usage in TileDB 2.4 and older.