### PR TITLE
Adjust open_array_for_reads_mtx_ lock durations

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -429,10 +429,10 @@ Status StorageManager::array_load_fragments(
     }
     RETURN_NOT_OK(it->second->set_encryption_key(enc_key));
     open_array = it->second;
-
-    // Lock the array
-    open_array->mtx_lock();
   }
+
+  // Lock the array
+  open_array->mtx_lock();
 
   std::unordered_map<std::string, uint64_t> offsets;
 
@@ -489,10 +489,10 @@ StorageManager::array_reopen(
       return {st, std::nullopt, std::nullopt, std::nullopt};
 
     open_array = it->second;
-
-    // Lock the array
-    open_array->mtx_lock();
   }
+
+  // Lock the array
+  open_array->mtx_lock();
 
   // Determine which fragments to load
   std::vector<TimestampedURI> fragments_to_load;
@@ -2078,10 +2078,10 @@ Status StorageManager::load_array_metadata(
     auto it = open_arrays_for_reads_.find(array_uri.to_string());
     assert(it != open_arrays_for_reads_.end());
     open_array = it->second;
-
-    // Lock the array
-    open_array->mtx_lock();
   }
+
+  // Lock the array
+  open_array->mtx_lock();
 
   // Determine which array metadata to load
   std::vector<TimestampedURI> array_metadata_to_load;


### PR DESCRIPTION
Currently we hold lock on `open_array_for_reads_mtx_` in multiple places where we access or manipulate the `open_arrays_for_reads_` unordered_map. The scope often includes blocking on the open_array's open mutex. This has been show to cause a deadlock with VCF if we have have concurrent array opens and fragment info listings.

---
TYPE: IMPROVEMENT
DESC: Reduce scope of `open_array_for_reads_mtx_` locks