### PR TITLE
Remove `Array::set_uri`, which is not called.

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -607,12 +607,6 @@ Config Array::config() const {
   return config_;
 }
 
-Status Array::set_uri(const std::string& uri) {
-  std::unique_lock<std::mutex> lck(mtx_);
-  array_uri_ = URI(uri);
-  return Status::Ok();
-}
-
 Status Array::set_uri_serialized(const std::string& uri) {
   std::unique_lock<std::mutex> lck(mtx_);
   array_uri_serialized_ = URI(uri);

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -247,9 +247,6 @@ class Array {
   /** Retrieves a reference to the array config. */
   Config config() const;
 
-  /** Directly set the array URI. */
-  Status set_uri(const std::string& uri);
-
   /** Directly set the array URI for serialized compatibility with pre
    * TileDB 2.5 clients */
   Status set_uri_serialized(const std::string& uri);


### PR DESCRIPTION
Remove `Array::set_uri`, which is not called. Follow-on to #2679.

---
TYPE: NO_HISTORY
DESC: Remove `Array::set_uri`, which is not called.
