### PR TITLE
[Backport release-2.5]  Fix config check for consolidator.cc refactored reader path #2635 

### DIFF
--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -894,7 +894,7 @@ Status Consolidator::set_config(const Config* config) {
   std::string reader =
       merged_config.get("sm.query.sparse_global_order.reader", &found);
   assert(found);
-  config_.use_refactored_reader_ = reader.compare("reafctored") == 0;
+  config_.use_refactored_reader_ = reader.compare("refactored") == 0;
 
   // Sanity checks
   if (config_.min_frags_ > config_.max_frags_)


### PR DESCRIPTION
Backport 859bdf6c5d40352cdb4d0596a7ac3a2871551b73 from #2635

---
TYPE: NO_HISTORY
DESC: NO_HISTORY
