### PR TITLE
ZStd decompressor: allocate one context per thread and re-use.

### DIFF
--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -99,9 +99,9 @@ regex_unique_ptr = re.compile(r"unique_ptr<")
 unique_ptr_exceptions = {
     "*": ["tdb_unique_ptr", "tiledb_unique_ptr"],
     "zstd_compressor.cc": [
-        "std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx(",
-        "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx(",
-    ],
+        "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx("],
+    "zstd_compressor.h": [
+        "std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx("],
     "curl.h": ["std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>"],
 }
 

--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -100,8 +100,7 @@ unique_ptr_exceptions = {
     "*": ["tdb_unique_ptr", "tiledb_unique_ptr"],
     "zstd_compressor.cc": [
         "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx("],
-    "zstd_compressor.h": [
-        "std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx("],
+    "zstd_compressor.h": ["std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx_;"],
     "curl.h": ["std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>"],
 }
 

--- a/tiledb/sm/compressors/CMakeLists.txt
+++ b/tiledb/sm/compressors/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# tiledb/sm/CMakeLists.txt
+# tiledb/sm/compressors/CMakeLists.txt
+#
 #
 # The MIT License
 #
@@ -23,11 +24,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+include(common NO_POLICY_SCOPE)
 
-include(common-root)
+#
+# `compressors` object library
+#
+add_library(compressors OBJECT bzip_compressor.cc dd_compressor.cc gzip_compressor.cc lz4_compressor.cc rle_compressor.cc zstd_compressor.cc)
+target_link_libraries(compressors PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+target_link_libraries(compressors PUBLIC buffer $<TARGET_OBJECTS:buffer>)
 
-add_subdirectory(buffer)
-add_subdirectory(compressors)
-add_subdirectory(filter)
-add_subdirectory(misc)
-add_subdirectory(stats)
+find_package(Zstd_EP REQUIRED)
+target_link_libraries(compressors PUBLIC Zstd::Zstd)
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_compressors EXCLUDE_FROM_ALL)
+target_link_libraries(compile_compressors PRIVATE compressors)
+target_sources(compile_compressors PRIVATE
+        test/compile_compressors_main.cc $<TARGET_OBJECTS:compressors>
+)

--- a/tiledb/sm/compressors/test/compile_compressors_main.cc
+++ b/tiledb/sm/compressors/test/compile_compressors_main.cc
@@ -1,0 +1,44 @@
+/**
+ * @file compile_filter_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "../bzip_compressor.h"
+#include "../dd_compressor.h"
+#include "../gzip_compressor.h"
+#include "../lz4_compressor.h"
+#include "../rle_compressor.h"
+#include "../zstd_compressor.h"
+
+int main() {
+  (void)sizeof(tiledb::sm::BZip);
+  (void)sizeof(tiledb::sm::DoubleDelta);
+  (void)sizeof(tiledb::sm::GZip);
+  (void)sizeof(tiledb::sm::LZ4);
+  (void)sizeof(tiledb::sm::RLE);
+  (void)sizeof(tiledb::sm::ZStd);
+  return 0;
+}

--- a/tiledb/sm/compressors/zstd_compressor.cc
+++ b/tiledb/sm/compressors/zstd_compressor.cc
@@ -90,6 +90,11 @@ Status ZStd::decompress(
     return LOG_STATUS(Status::CompressionError(
         "Failed decompressing with ZStd; invalid buffer format"));
 
+  if (decompress_ctx_pool == nullptr) {
+    return LOG_STATUS(Status::CompressionError(
+        "Failed decompressing with ZStd; Resource pool not initialized"));
+  }
+
   ResourceGuard context_guard(*decompress_ctx_pool);
   auto& context = context_guard.get();
 

--- a/tiledb/sm/compressors/zstd_compressor.cc
+++ b/tiledb/sm/compressors/zstd_compressor.cc
@@ -30,7 +30,8 @@
  * This file implements the zstd compressor class.
  */
 
-#include "tiledb/sm/compressors/zstd_compressor.h"
+#include "zstd_compressor.h"
+
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 
@@ -80,22 +81,21 @@ Status ZStd::compress(
 }
 
 Status ZStd::decompress(
-    ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer) {
+    std::shared_ptr<ResourcePool<ZStd::ZSTD_Decompress_Context>>
+        decompress_ctx_pool,
+    ConstBuffer* input_buffer,
+    PreallocatedBuffer* output_buffer) {
   // Sanity check
   if (input_buffer->data() == nullptr || output_buffer->data() == nullptr)
     return LOG_STATUS(Status::CompressionError(
         "Failed decompressing with ZStd; invalid buffer format"));
 
-  // Create context
-  std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx(
-      ZSTD_createDCtx(), ZSTD_freeDCtx);
-  if (ctx.get() == nullptr)
-    return LOG_STATUS(Status::CompressionError(
-        std::string("ZStd decompression failed; could not allocate context.")));
+  ResourceGuard context_guard(*decompress_ctx_pool);
+  auto& context = context_guard.get();
 
   // Decompress
   uint64_t zstd_ret = ZSTD_decompressDCtx(
-      ctx.get(),
+      context.ptr(),
       output_buffer->cur_data(),
       output_buffer->free_space(),
       input_buffer->data(),

--- a/tiledb/sm/compressors/zstd_compressor.cc
+++ b/tiledb/sm/compressors/zstd_compressor.cc
@@ -35,7 +35,6 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 
-#include <zstd.h>
 #include <iostream>
 
 using namespace tiledb::common;

--- a/tiledb/sm/compressors/zstd_compressor.h
+++ b/tiledb/sm/compressors/zstd_compressor.h
@@ -51,7 +51,7 @@ class PreallocatedBuffer;
 /** Handles compression/decompression with the zstd library. */
 class ZStd {
  public:
-  /** wrapper around the decompress ZST context so that it can be used in a
+  /** wrapper around the decompress ZSTD context so that it can be used in a
    * resource pool */
   class ZSTD_Decompress_Context {
    public:

--- a/tiledb/sm/compressors/zstd_compressor.h
+++ b/tiledb/sm/compressors/zstd_compressor.h
@@ -35,6 +35,10 @@
 
 #include "tiledb/common/status.h"
 
+#include "tiledb/sm/misc/resource_pool.h"
+
+#include <zstd.h>
+
 using namespace tiledb::common;
 
 namespace tiledb {
@@ -47,6 +51,22 @@ class PreallocatedBuffer;
 /** Handles compression/decompression with the zstd library. */
 class ZStd {
  public:
+  /** wrapper around the decompress ZST context so that it can be used in a
+   * resource pool */
+  class ZSTD_Decompress_Context {
+   public:
+    ZSTD_Decompress_Context()
+        : ctx_(ZSTD_createDCtx(), ZSTD_freeDCtx) {
+    }
+
+    ZSTD_DCtx* ptr() {
+      return ctx_.get();
+    }
+
+   private:
+    std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx_;
+  };
+
   /**
    * Compression function.
    *
@@ -61,12 +81,17 @@ class ZStd {
   /**
    * Decompression function.
    *
+   * @param decompress_ctx_pool Resource pool to manage decompression context
+   * reuse
    * @param input_buffer Input buffer to read from.
    * @param output_buffer Output buffer to write the decompressed data to.
    * @return Status
    */
   static Status decompress(
-      ConstBuffer* input_buffer, PreallocatedBuffer* output_buffer);
+      std::shared_ptr<ResourcePool<ZStd::ZSTD_Decompress_Context>>
+          decompress_ctx_pool,
+      ConstBuffer* input_buffer,
+      PreallocatedBuffer* output_buffer);
 
   /** Returns the default compression level. */
   static int default_level() {

--- a/tiledb/sm/filter/CMakeLists.txt
+++ b/tiledb/sm/filter/CMakeLists.txt
@@ -32,6 +32,9 @@ include(common NO_POLICY_SCOPE)
 add_library(filter OBJECT filter.cc filter_buffer.cc filter_storage.cc)
 target_link_libraries(filter PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 target_link_libraries(filter PUBLIC buffer $<TARGET_OBJECTS:buffer>)
+
+find_package(Zstd_EP REQUIRED)
+target_link_libraries(filter PUBLIC Zstd::Zstd)
 #
 # Test-compile of object library ensures link-completeness
 #

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -432,7 +432,7 @@ Status CompressionFilter::deserialize_impl(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-void CompressionFilter::init_resource_pools(uint64_t size) {
+void CompressionFilter::init_resource_pool(uint64_t size) {
   if (zstd_decompress_ctx_pool_ == nullptr) {
     zstd_decompress_ctx_pool_ =
         tdb::make_shared<ResourcePool<ZStd::ZSTD_Decompress_Context>>(

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/sm/filter/compression_filter.h"
+#include "tiledb/common/common.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
@@ -53,16 +54,17 @@ namespace tiledb {
 namespace sm {
 
 CompressionFilter::CompressionFilter(FilterType compressor, int level)
-    : Filter(compressor) {
-  compressor_ = filter_to_compressor(compressor);
-  level_ = level;
+    : Filter(compressor)
+    , compressor_(filter_to_compressor(compressor))
+    , level_(level)
+    , zstd_decompress_ctx_pool_(nullptr) {
 }
 
 CompressionFilter::CompressionFilter(Compressor compressor, int level)
-    : Filter(FilterType::FILTER_NONE) {
-  compressor_ = compressor;
-  level_ = level;
-  type_ = compressor_to_filter(compressor);
+    : Filter(compressor_to_filter(compressor))
+    , compressor_(compressor)
+    , level_(level)
+    , zstd_decompress_ctx_pool_(nullptr) {
 }
 
 Compressor CompressionFilter::compressor() const {
@@ -366,7 +368,8 @@ Status CompressionFilter::decompress_part(
       st = GZip::decompress(&input_buffer, &output_buffer);
       break;
     case Compressor::ZSTD:
-      st = ZStd::decompress(&input_buffer, &output_buffer);
+      st = ZStd::decompress(
+          zstd_decompress_ctx_pool_, &input_buffer, &output_buffer);
       break;
     case Compressor::LZ4:
       st = LZ4::decompress(&input_buffer, &output_buffer);
@@ -427,6 +430,14 @@ Status CompressionFilter::deserialize_impl(ConstBuffer* buff) {
   RETURN_NOT_OK(buff->read(&level_, sizeof(int32_t)));
 
   return Status::Ok();
+}
+
+void CompressionFilter::init_resource_pools(uint64_t size) {
+  if (zstd_decompress_ctx_pool_ == nullptr) {
+    zstd_decompress_ctx_pool_ =
+        tdb::make_shared<ResourcePool<ZStd::ZSTD_Decompress_Context>>(
+            HERE(), size);
+  }
 }
 
 }  // namespace sm

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -34,7 +34,9 @@
 #define TILEDB_COMPRESSION_FILTER_H
 
 #include "tiledb/common/status.h"
+#include "tiledb/sm/compressors/zstd_compressor.h"
 #include "tiledb/sm/filter/filter.h"
+#include "tiledb/sm/misc/resource_pool.h"
 
 using namespace tiledb::common;
 
@@ -134,6 +136,11 @@ class CompressionFilter : public Filter {
   /** The compression level. */
   int level_;
 
+  /** A resource pool to be used in ZStd decompressor for improved performance
+   */
+  std::shared_ptr<ResourcePool<ZStd::ZSTD_Decompress_Context>>
+      zstd_decompress_ctx_pool_;
+
   /** Returns a new clone of this filter. */
   CompressionFilter* clone_impl() const override;
 
@@ -174,6 +181,9 @@ class CompressionFilter : public Filter {
 
   /** Serializes this filter's metadata to the given buffer. */
   Status serialize_impl(Buffer* buff) const override;
+
+  /** Initializes the compression filter resource pools */
+  void init_resource_pools(uint64_t size) override;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -182,8 +182,8 @@ class CompressionFilter : public Filter {
   /** Serializes this filter's metadata to the given buffer. */
   Status serialize_impl(Buffer* buff) const override;
 
-  /** Initializes the compression filter resource pools */
-  void init_resource_pools(uint64_t size) override;
+  /** Initializes the compression filter resource pool */
+  void init_resource_pool(uint64_t size) override;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/filter.cc
+++ b/tiledb/sm/filter/filter.cc
@@ -129,7 +129,7 @@ FilterType Filter::type() const {
   return type_;
 }
 
-void Filter::init_resource_pools(uint64_t size) {
+void Filter::init_resource_pool(uint64_t size) {
   (void)size;
 }
 

--- a/tiledb/sm/filter/filter.cc
+++ b/tiledb/sm/filter/filter.cc
@@ -129,5 +129,9 @@ FilterType Filter::type() const {
   return type_;
 }
 
+void Filter::init_resource_pools(uint64_t size) {
+  (void)size;
+}
+
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -129,6 +129,14 @@ class Filter {
       const Config& config) const = 0;
 
   /**
+   * Initializes the filter resource pools if any
+   *
+   * @param size the size of the resource pool to initiliaze
+   *
+   * */
+  virtual void init_resource_pools(uint64_t size);
+
+  /**
    * Sets an option on this filter.
    *
    * @param option Option whose value to get

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -129,12 +129,12 @@ class Filter {
       const Config& config) const = 0;
 
   /**
-   * Initializes the filter resource pools if any
+   * Initializes the filter resource pool if any
    *
    * @param size the size of the resource pool to initiliaze
    *
    * */
-  virtual void init_resource_pools(uint64_t size);
+  virtual void init_resource_pool(uint64_t size);
 
   /**
    * Sets an option on this filter.

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -307,7 +307,7 @@ Status FilterPipeline::filter_chunks_reverse(
             output_chunk_buffer, orig_chunk_len));
       }
 
-      f->init_resource_pools(compute_tp->concurrency_level());
+      f->init_resource_pool(compute_tp->concurrency_level());
 
       RETURN_NOT_OK(f->run_reverse(
           tile,

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -307,6 +307,8 @@ Status FilterPipeline::filter_chunks_reverse(
             output_chunk_buffer, orig_chunk_len));
       }
 
+      f->init_resource_pools(compute_tp->concurrency_level());
+
       RETURN_NOT_OK(f->run_reverse(
           tile,
           &input_metadata,

--- a/tiledb/sm/misc/resource_pool.h
+++ b/tiledb/sm/misc/resource_pool.h
@@ -34,6 +34,8 @@
 #ifndef RESOURCE_POOL_H
 #define RESOURCE_POOL_H
 
+#include <vector>
+
 namespace tiledb {
 namespace sm {
 


### PR DESCRIPTION
ZStd manual recommends for repetitive compression/decompression operations to allocate a context once per thread and re-use it for each successive compression operation for making workload friendlier for system's memory.

To do that, and benefit at the same time from the overall up to 10% performance gain in Reader work in certain scenarios, we are using in this PR our resource pool to allocate one context per thread for ZSTD decompression.

This can be extended to cover ZStd compression as well.

---
TYPE: IMPROVEMENT
DESC: ZStd compressor: allocate one context per thread and re-use.
