### PR TITLE
[Backport release-2.6] ZStd decompressor: allocate one context per thread and re-use. #2691

### DIFF
--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -128,9 +128,8 @@ regex_unique_ptr = re.compile(r"unique_ptr<")
 unique_ptr_exceptions = {
     "*": ["tdb_unique_ptr", "tiledb_unique_ptr"],
     "zstd_compressor.cc": [
-        "std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx(",
-        "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx(",
-    ],
+        "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx("],
+    "zstd_compressor.h": ["std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx_;"],
     "curl.h": ["std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>"],
 }
 

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -53,16 +53,17 @@ namespace tiledb {
 namespace sm {
 
 CompressionFilter::CompressionFilter(FilterType compressor, int level)
-    : Filter(compressor) {
-  compressor_ = filter_to_compressor(compressor);
-  level_ = level;
+    : Filter(compressor)
+    , compressor_(filter_to_compressor(compressor))
+    , level_(level)
+    , zstd_decompress_ctx_pool_(nullptr) {
 }
 
 CompressionFilter::CompressionFilter(Compressor compressor, int level)
-    : Filter(FilterType::FILTER_NONE) {
-  compressor_ = compressor;
-  level_ = level;
-  type_ = compressor_to_filter(compressor);
+    : Filter(compressor_to_filter(compressor))
+    , compressor_(compressor)
+    , level_(level)
+    , zstd_decompress_ctx_pool_(nullptr) {
 }
 
 Compressor CompressionFilter::compressor() const {
@@ -359,7 +360,8 @@ Status CompressionFilter::decompress_part(
       st = GZip::decompress(&input_buffer, &output_buffer);
       break;
     case Compressor::ZSTD:
-      st = ZStd::decompress(&input_buffer, &output_buffer);
+      st = ZStd::decompress(
+          zstd_decompress_ctx_pool_, &input_buffer, &output_buffer);
       break;
     case Compressor::LZ4:
       st = LZ4::decompress(&input_buffer, &output_buffer);
@@ -421,6 +423,13 @@ Status CompressionFilter::deserialize_impl(ConstBuffer* buff) {
   RETURN_NOT_OK(buff->read(&level_, sizeof(int32_t)));
 
   return Status::Ok();
+}
+
+void CompressionFilter::init_resource_pool(uint64_t size) {
+  if (zstd_decompress_ctx_pool_ == nullptr) {
+    zstd_decompress_ctx_pool_ =
+        tdb_make_shared(ResourcePool<ZStd::ZSTD_Decompress_Context>, size);
+  }
 }
 
 }  // namespace sm

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -34,7 +34,9 @@
 #define TILEDB_COMPRESSION_FILTER_H
 
 #include "tiledb/common/status.h"
+#include "tiledb/sm/compressors/zstd_compressor.h"
 #include "tiledb/sm/filter/filter.h"
+#include "tiledb/sm/misc/resource_pool.h"
 
 using namespace tiledb::common;
 
@@ -132,6 +134,11 @@ class CompressionFilter : public Filter {
   /** The compression level. */
   int level_;
 
+  /** A resource pool to be used in ZStd decompressor for improved performance
+   */
+  tdb_shared_ptr<ResourcePool<ZStd::ZSTD_Decompress_Context>>
+      zstd_decompress_ctx_pool_;
+
   /** Returns a new clone of this filter. */
   CompressionFilter* clone_impl() const override;
 
@@ -166,6 +173,9 @@ class CompressionFilter : public Filter {
 
   /** Serializes this filter's metadata to the given buffer. */
   Status serialize_impl(Buffer* buff) const override;
+
+  /** Initializes the compression filter resource pool */
+  void init_resource_pool(uint64_t size) override;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/filter.cc
+++ b/tiledb/sm/filter/filter.cc
@@ -189,5 +189,9 @@ FilterType Filter::type() const {
   return type_;
 }
 
+void Filter::init_resource_pool(uint64_t size) {
+  (void)size;
+}
+
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -143,6 +143,14 @@ class Filter {
       const Config& config) const = 0;
 
   /**
+   * Initializes the filter resource pool if any
+   *
+   * @param size the size of the resource pool to initiliaze
+   *
+   * */
+  virtual void init_resource_pool(uint64_t size);
+
+  /**
    * Sets an option on this filter.
    *
    * @param option Option whose value to get

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -311,6 +311,8 @@ Status FilterPipeline::filter_chunks_reverse(
             output_chunk_buffer, orig_chunk_len));
       }
 
+      f->init_resource_pool(compute_tp->concurrency_level());
+
       RETURN_NOT_OK(f->run_reverse(
           &input_metadata,
           &input_data,

--- a/tiledb/sm/misc/resource_pool.h
+++ b/tiledb/sm/misc/resource_pool.h
@@ -34,6 +34,8 @@
 #ifndef RESOURCE_POOL_H
 #define RESOURCE_POOL_H
 
+#include <vector>
+
 namespace tiledb {
 namespace sm {
 


### PR DESCRIPTION
Backport 2a470f457955e1c71a1c6f366229c471cb250148 from #2691

---
TYPE: IMPROVEMENT
DESC: ZStd compressor: allocate one context per thread and re-use.