### PR TITLE
[Backport release-2.6] Sparse refactored readers: better parallelization for tile bitmaps. #2643

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1026,7 +1026,8 @@ Status Query::create_strategy() {
           &found));
       assert(found);
 
-      if (non_overlapping_ranges || !subarray_.is_set()) {
+      if (non_overlapping_ranges || !subarray_.is_set() ||
+          subarray_.range_num() == 1) {
         strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
             SparseUnorderedWithDupsReader<uint8_t>,
             stats_->create_child("Reader"),

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -657,8 +657,11 @@ void ResultTile::compute_results_count_sparse_string(
     const std::vector<uint64_t>* range_indexes,
     const uint64_t num_indexes,
     std::vector<BitmapType>* result_count,
-    const Layout& cell_order) {
-  auto coords_num = result_tile->cell_num();
+    const Layout& cell_order,
+    const uint64_t min_cell,
+    const uint64_t max_cell) {
+  auto cell_num = result_tile->cell_num();
+  auto coords_num = max_cell - min_cell;
   auto dim_num = result_tile->domain()->dim_num();
   auto& r_count = (*result_count);
 
@@ -716,7 +719,7 @@ void ResultTile::compute_results_count_sparse_string(
 
       // Calculate the position of the first and last coordinates
       // in this partition.
-      const uint64_t first_c_pos = p * c_partition_size_div;
+      const uint64_t first_c_pos = min_cell + p * c_partition_size_div;
       const uint64_t last_c_pos = first_c_pos + c_partition_size - 1;
       assert(first_c_pos < last_c_pos);
 
@@ -726,7 +729,7 @@ void ResultTile::compute_results_count_sparse_string(
       const uint64_t first_c_offset = buff_off[first_c_pos];
       const uint64_t last_c_offset = buff_off[last_c_pos];
       const uint64_t first_c_size = buff_off[first_c_pos + 1] - first_c_offset;
-      const uint64_t last_c_size = (last_c_pos == coords_num - 1) ?
+      const uint64_t last_c_size = (last_c_pos == cell_num - 1) ?
                                        buff_str_size - last_c_offset :
                                        buff_off[last_c_pos + 1] - last_c_offset;
 
@@ -759,8 +762,8 @@ void ResultTile::compute_results_count_sparse_string(
         uint64_t c_offset = 0, c_size = 0;
         for (uint64_t pos = first_c_pos; pos <= last_c_pos; ++pos) {
           c_offset = buff_off[pos];
-          c_size = (pos < coords_num - 1) ? buff_off[pos + 1] - c_offset :
-                                            buff_str_size - c_offset;
+          c_size = (pos < cell_num - 1) ? buff_off[pos + 1] - c_offset :
+                                          buff_str_size - c_offset;
           uint64_t count = 0;
           for (uint64_t i = 0; i < num_indexes; i++) {
             auto& range = ranges[range_indexes->at(i)];
@@ -792,9 +795,9 @@ void ResultTile::compute_results_count_sparse_string(
   // bytes. We will only get a benefit if we successfully find a `memcmp` on a
   // much larger range.
   const uint64_t zeroed_size = coords_num < 256 ? coords_num : 256;
-  for (uint64_t i = 0; i < coords_num; i += zeroed_size) {
+  for (uint64_t i = min_cell; i < min_cell + coords_num; i += zeroed_size) {
     const uint64_t partition_size =
-        (i < coords_num - zeroed_size) ? zeroed_size : coords_num - i;
+        (i < cell_num - zeroed_size) ? zeroed_size : cell_num - i;
 
     // Check if all `r_count` values are zero between `i` and
     // `partition_size`.
@@ -814,8 +817,8 @@ void ResultTile::compute_results_count_sparse_string(
           continue;
 
         c_offset = buff_off[pos];
-        c_size = (pos < coords_num - 1) ? buff_off[pos + 1] - c_offset :
-                                          buff_str_size - c_offset;
+        c_size = (pos < cell_num - 1) ? buff_off[pos + 1] - c_offset :
+                                        buff_str_size - c_offset;
         uint64_t count = 0;
         for (uint64_t i = 0; i < num_indexes; i++) {
           auto& range = ranges[range_indexes->at(i)];
@@ -837,12 +840,13 @@ void ResultTile::compute_results_count_sparse(
     const std::vector<uint64_t>* range_indexes,
     const uint64_t num_indexes,
     std::vector<BitmapType>* result_count,
-    const Layout& cell_order) {
+    const Layout& cell_order,
+    const uint64_t min_cell,
+    const uint64_t max_cell) {
   // We don't use cell_order for this template type.
   (void)cell_order;
 
   // For easy reference.
-  auto coords_num = result_tile->cell_num();
   auto stores_zipped_coords = result_tile->stores_zipped_coords();
   auto dim_num = result_tile->domain()->dim_num();
   auto& r_count = (*result_count);
@@ -854,7 +858,7 @@ void ResultTile::compute_results_count_sparse(
     const T* const coords = static_cast<const T*>(buffer->data());
     {
       // Iterate over all cells.
-      for (uint64_t pos = 0; pos < coords_num; ++pos) {
+      for (uint64_t pos = min_cell; pos < max_cell; ++pos) {
         // We have a previous count.
         if (r_count[pos]) {
           T c = coords[pos];
@@ -882,7 +886,7 @@ void ResultTile::compute_results_count_sparse(
   Buffer* const buffer = coords_tile.buffer();
   const T* const coords = static_cast<const T*>(buffer->data());
   {
-    for (uint64_t pos = 0; pos < coords_num; ++pos) {
+    for (uint64_t pos = min_cell; pos < max_cell; ++pos) {
       if (r_count[pos]) {
         T c = coords[pos * dim_num + dim_idx];
         uint64_t count = 0;
@@ -934,7 +938,9 @@ Status ResultTile::compute_results_count_sparse<uint8_t>(
     const std::vector<uint64_t>* range_indexes,
     const uint64_t num_indexes,
     std::vector<uint8_t>* result_count,
-    const Layout& cell_order) const {
+    const Layout& cell_order,
+    const uint64_t min_cell,
+    const uint64_t max_cell) const {
   assert(compute_results_count_sparse_uint8_t_func_[dim_idx] != nullptr);
   compute_results_count_sparse_uint8_t_func_[dim_idx](
       this,
@@ -943,7 +949,9 @@ Status ResultTile::compute_results_count_sparse<uint8_t>(
       range_indexes,
       num_indexes,
       result_count,
-      cell_order);
+      cell_order,
+      min_cell,
+      max_cell);
   return Status::Ok();
 }
 
@@ -954,7 +962,9 @@ Status ResultTile::compute_results_count_sparse<uint64_t>(
     const std::vector<uint64_t>* range_indexes,
     const uint64_t num_indexes,
     std::vector<uint64_t>* result_count,
-    const Layout& cell_order) const {
+    const Layout& cell_order,
+    const uint64_t min_cell,
+    const uint64_t max_cell) const {
   assert(compute_results_count_sparse_uint64_t_func_[dim_idx] != nullptr);
   compute_results_count_sparse_uint64_t_func_[dim_idx](
       this,
@@ -963,7 +973,9 @@ Status ResultTile::compute_results_count_sparse<uint64_t>(
       range_indexes,
       num_indexes,
       result_count,
-      cell_order);
+      cell_order,
+      min_cell,
+      max_cell);
   return Status::Ok();
 }
 

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -231,6 +231,9 @@ class ResultTile {
    * Computes a result count for the input dimension for the coordinates that
    * fall in the input ranges and multiply with the previous count.
    *
+   * This only processes cells from min_cell to max_cell as we might
+   * parallelize on cells.
+   *
    * When called over multiple ranges, this follows the formula:
    * total_count = d1_count * d2_count ... dN_count.
    */
@@ -242,13 +245,18 @@ class ResultTile {
       const std::vector<uint64_t>* range_indexes,
       const uint64_t num_indexes,
       std::vector<BitmapType>* result_count,
-      const Layout& cell_order);
+      const Layout& cell_order,
+      const uint64_t min_cell,
+      const uint64_t max_cell);
 
   /**
    * Applicable only to sparse arrays.
    *
    * Computes a result count for the input string dimension for the coordinates
    * that fall in the input ranges and multiply with the previous count.
+   *
+   * This only processes cells from min_cell to max_cell as we might
+   * parallelize on cells.
    *
    * When called over multiple ranges, this follows the formula:
    * total_count = d1_count * d2_count ... dN_count.
@@ -261,7 +269,9 @@ class ResultTile {
       const std::vector<uint64_t>* range_indexes,
       const uint64_t num_indexes,
       std::vector<BitmapType>* result_count,
-      const Layout& cell_order);
+      const Layout& cell_order,
+      const uint64_t min_cell,
+      const uint64_t max_cell);
 
   /**
    * Applicable only to sparse tiles of dense arrays.
@@ -300,6 +310,9 @@ class ResultTile {
    * Computes a result count for the input dimension for the coordinates that
    * fall in the input ranges and multiply with the previous count.
    *
+   * This only processes cells from min_cell to max_cell as we might
+   * parallelize on cells.
+   *
    * When called over multiple ranges, this follows the formula:
    * total_count = d1_count * d2_count ... dN_count.
    */
@@ -310,7 +323,9 @@ class ResultTile {
       const std::vector<uint64_t>* range_indexes,
       const uint64_t num_indexes,
       std::vector<BitmapType>* result_count,
-      const Layout& cell_order) const;
+      const Layout& cell_order,
+      const uint64_t min_cell,
+      const uint64_t max_cell) const;
 
  private:
   /* ********************************* */
@@ -382,7 +397,9 @@ class ResultTile {
       const std::vector<uint64_t>*,
       const uint64_t,
       std::vector<uint64_t>*,
-      const Layout&)>>
+      const Layout&,
+      const uint64_t,
+      const uint64_t)>>
       compute_results_count_sparse_uint64_t_func_;
 
   /**
@@ -396,7 +413,9 @@ class ResultTile {
       const std::vector<uint64_t>*,
       const uint64_t,
       std::vector<uint8_t>*,
-      const Layout&)>>
+      const Layout&,
+      const uint64_t,
+      const uint64_t)>>
       compute_results_count_sparse_uint8_t_func_;
 
   /* ********************************* */

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -197,10 +197,10 @@ Status SparseGlobalOrderReader::dowork() {
       RETURN_NOT_OK(read_and_unfilter_coords(true, &tmp_result_tiles));
 
       // Compute the tile bitmaps.
-      RETURN_NOT_OK(compute_tile_bitmaps<uint8_t>(&result_tiles_));
+      RETURN_NOT_OK(compute_tile_bitmaps<uint8_t>(&tmp_result_tiles));
 
       // Apply query condition.
-      RETURN_NOT_OK(apply_query_condition<uint8_t>(&result_tiles_));
+      RETURN_NOT_OK(apply_query_condition<uint8_t>(&tmp_result_tiles));
 
       // Clear result tiles that are not necessary anymore.
       auto status = parallel_for(
@@ -218,7 +218,8 @@ Status SparseGlobalOrderReader::dowork() {
             }
 
             // Adjust tile ranges.
-            if (subarray_.is_set() && result_tiles_[f].empty()) {
+            if (subarray_.is_set() && result_tiles_[f].empty() &&
+                all_tiles_loaded_[f]) {
               while (!result_tile_ranges_[f].empty())
                 remove_result_tile_range(f);
             }


### PR DESCRIPTION
Backport ded8c26b2f2dcf6b48e70e2696a1d1863e7b81f5 from #2643


---
TYPE: IMPROVEMENT
DESC: Sparse refactored readers: better parallelization for tile bitmaps.