### PR TITLE
Query condition should use fragment's array schema

### DIFF
--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -554,7 +554,7 @@ Status DenseReader::apply_query_condition(
                       &start,
                       &end)) {
                 RETURN_NOT_OK(condition_.apply_dense<DimType>(
-                    array_schema_,
+                    fragment_metadata_[frag_domains[i].first]->array_schema(),
                     it->second.result_tile(frag_domains[i].first),
                     start,
                     end - start + 1,

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -599,7 +599,7 @@ Status SparseIndexReaderBase::apply_query_condition(
 
             // Compute the result of the query condition for this tile.
             RETURN_NOT_OK(condition_.apply_sparse<BitmapType>(
-                array_schema_,
+                fragment_metadata_[rt->frag_idx()]->array_schema(),
                 &*rt,
                 rt->bitmap_.data(),
                 &rt->bitmap_result_num_));


### PR DESCRIPTION
With schema evolution each fragment now carries a reference to its array schema. This is the schema that should be used when looping over the tile to apply query condition. This ensures that the schema matches the tile.

---
TYPE: BUG
DESC: Use fragment array schema for applying query condition to account for schema evolution