### PR TITLE
Guard ZStd resource pool to fix initialization race

### DIFF
--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -433,6 +433,7 @@ Status CompressionFilter::deserialize_impl(ConstBuffer* buff) {
 }
 
 void CompressionFilter::init_resource_pool(uint64_t size) {
+  std::lock_guard g(zstd_decompress_ctx_pool_mtx_);
   if (zstd_decompress_ctx_pool_ == nullptr) {
     zstd_decompress_ctx_pool_ =
         tdb::make_shared<ResourcePool<ZStd::ZSTD_Decompress_Context>>(

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -136,6 +136,9 @@ class CompressionFilter : public Filter {
   /** The compression level. */
   int level_;
 
+  /** Mutex guarding zstd_decompress_ctx_pool */
+  std::mutex zstd_decompress_ctx_pool_mtx_;
+
   /** A resource pool to be used in ZStd decompressor for improved performance
    */
   std::shared_ptr<ResourcePool<ZStd::ZSTD_Decompress_Context>>

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1491,6 +1491,9 @@ Status StorageManager::get_fragment_info(
           array_type == ArrayType::SPARSE ? timestamp_start : 0,
           timestamp_end);
 
+  (void)array_schemas_opt;
+  (void)array_schema_opt;  // -Wno-unused GCC 7.3
+
   if (!st.ok())
     return st;
 


### PR DESCRIPTION
Guard ZStd resource pool to fix initialization race

From my reading of the code and backtrace in sc-12665, this init call can be made from any thread. Therefore it must be guarded to avoid a race.

I've run the motivating test case 10 times with no segfault, whereas on dev it is segfaulting every 1/3-1/5 runs.

---
TYPE: BUG
DESC: Guard ZStd resource pool to fix initialization race
