### PR TITLE
ZStd Compressor: allocate one context per thread and re-use.

### DIFF
--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -98,9 +98,7 @@ regex_unique_ptr = re.compile(r"unique_ptr<")
 # Contains per-file exceptions to violations of "make_unique".
 unique_ptr_exceptions = {
     "*": ["tdb_unique_ptr", "tiledb_unique_ptr"],
-    "zstd_compressor.cc": [
-        "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx("],
-    "zstd_compressor.h": ["std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx_;"],
+    "zstd_compressor.h": ["std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx_;", "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx_;"],
     "curl.h": ["std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>"],
 }
 

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -136,8 +136,15 @@ class CompressionFilter : public Filter {
   /** The compression level. */
   int level_;
 
+  /** Mutex guarding zstd_compress_ctx_pool */
+  std::mutex zstd_compress_ctx_pool_mtx_;
+
   /** Mutex guarding zstd_decompress_ctx_pool */
   std::mutex zstd_decompress_ctx_pool_mtx_;
+
+  /** A resource pool to be used in ZStd compressor for improved performance */
+  std::shared_ptr<BlockingResourcePool<ZStd::ZSTD_Compress_Context>>
+      zstd_compress_ctx_pool_;
 
   /** A resource pool to be used in ZStd decompressor for improved performance
    */
@@ -185,8 +192,11 @@ class CompressionFilter : public Filter {
   /** Serializes this filter's metadata to the given buffer. */
   Status serialize_impl(Buffer* buff) const override;
 
-  /** Initializes the compression filter resource pool */
-  void init_resource_pool(uint64_t size) override;
+  /** Initializes the compression resource pool */
+  void init_compression_resource_pool(uint64_t size) override;
+
+  /** Initializes the decompression resource pool */
+  void init_decompression_resource_pool(uint64_t size) override;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/filter.cc
+++ b/tiledb/sm/filter/filter.cc
@@ -116,7 +116,11 @@ FilterType Filter::type() const {
   return type_;
 }
 
-void Filter::init_resource_pool(uint64_t size) {
+void Filter::init_compression_resource_pool(uint64_t size) {
+  (void)size;
+}
+
+void Filter::init_decompression_resource_pool(uint64_t size) {
   (void)size;
 }
 

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -129,12 +129,20 @@ class Filter {
       const Config& config) const = 0;
 
   /**
-   * Initializes the filter resource pool if any
+   * Initializes the filter compression resource pool if any
    *
    * @param size the size of the resource pool to initiliaze
    *
    * */
-  virtual void init_resource_pool(uint64_t size);
+  virtual void init_compression_resource_pool(uint64_t size);
+
+  /**
+   * Initializes the filter decompression resource pool if any
+   *
+   * @param size the size of the resource pool to initiliaze
+   *
+   * */
+  virtual void init_decompression_resource_pool(uint64_t size);
 
   /**
    * Sets an option on this filter.

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -137,6 +137,8 @@ Status FilterPipeline::filter_chunks_forward(
       output_data.clear();
       output_metadata.clear();
 
+      f->init_compression_resource_pool(compute_tp->concurrency_level());
+
       RETURN_NOT_OK(f->run_forward(
           tile, &input_metadata, &input_data, &output_metadata, &output_data));
 
@@ -308,7 +310,7 @@ Status FilterPipeline::filter_chunks_reverse(
             output_chunk_buffer, orig_chunk_len));
       }
 
-      f->init_resource_pool(compute_tp->concurrency_level());
+      f->init_decompression_resource_pool(compute_tp->concurrency_level());
 
       RETURN_NOT_OK(f->run_reverse(
           tile,


### PR DESCRIPTION
Applies context reuse for ZSTD to compression as well. Same logic as : #2691 

---
TYPE: IMPROVEMENT
DESC: ZStd Compressor: allocate one context per thread and re-use.
