### PR TITLE
Moving coord_string from returning a std::string to std::string_view.

### DIFF
--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -145,13 +145,13 @@ class Range {
   }
 
   /** Returns the start as a string view. */
-  std::basic_string_view<char> start_str() const {
-    return std::basic_string_view<char>((const char*)start(), start_size());
+  std::string_view start_str() const {
+    return std::string_view((const char*)start(), start_size());
   }
 
   /** Returns the end as a string view. */
-  std::basic_string_view<char> end_str() const {
-    return std::basic_string_view<char>((const char*)end(), end_size());
+  std::string_view end_str() const {
+    return std::string_view((const char*)end(), end_size());
   }
 
   /**

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -440,8 +440,7 @@ std::string to_str(const void* value, Datatype type) {
 }
 
 uint64_t common_prefix_size(
-    const std::basic_string_view<char>& a,
-    const std::basic_string_view<char>& b) {
+    const std::string_view& a, const std::string_view& b) {
   auto size = std::min(a.size(), b.size());
   for (size_t i = 0; i < size; ++i) {
     if (a[i] != b[i])

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -169,8 +169,7 @@ std::string to_str(const void* value, Datatype type);
 
 /** Returns the size of the common prefix between `a` and `b`. */
 uint64_t common_prefix_size(
-    const std::basic_string_view<char>& a,
-    const std::basic_string_view<char>& b);
+    const std::string_view& a, const std::string_view& b);
 
 }  // namespace parse
 

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -98,7 +98,7 @@ struct ResultCoords {
    * Returns a string coordinate. Applicable only to string
    * dimensions.
    */
-  std::string coord_string(unsigned dim_idx) const {
+  std::string_view coord_string(unsigned dim_idx) const {
     return tile_->coord_string(pos_, dim_idx);
   }
 

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -162,7 +162,8 @@ const void* ResultTile::zipped_coord(uint64_t pos, unsigned dim_idx) const {
   return ret;
 }
 
-std::string ResultTile::coord_string(uint64_t pos, unsigned dim_idx) const {
+std::string_view ResultTile::coord_string(
+    uint64_t pos, unsigned dim_idx) const {
   const auto& coord_tile_off = std::get<0>(coord_tiles_[dim_idx].second);
   const auto& coord_tile_val = std::get<1>(coord_tiles_[dim_idx].second);
   auto cell_num = coord_tile_off.cell_num();
@@ -185,7 +186,7 @@ std::string ResultTile::coord_string(uint64_t pos, unsigned dim_idx) const {
   auto size = next_offset - offset;
 
   auto* buffer = static_cast<char*>(coord_tile_val.buffer()->data()) + offset;
-  return std::string(buffer, size);
+  return std::string_view(buffer, size);
 }
 
 uint64_t ResultTile::coord_size(unsigned dim_idx) const {
@@ -444,9 +445,9 @@ inline bool ResultTile::str_coord_intersects(
     const uint64_t c_offset,
     const uint64_t c_size,
     const char* const buff_str,
-    const std::basic_string_view<char>& range_start,
-    const std::basic_string_view<char>& range_end) {
-  std::basic_string_view<char> str(buff_str + c_offset, c_size);
+    const std::string_view& range_start,
+    const std::string_view& range_end) {
+  std::string_view str(buff_str + c_offset, c_size);
   return str >= range_start && str <= range_end;
 }
 

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -149,7 +149,7 @@ class ResultTile {
    * Returns the string coordinate at position `pos` for
    * dimension `dim_idx`. Applicable only to string dimensions.
    */
-  std::string coord_string(uint64_t pos, unsigned dim_idx) const;
+  std::string_view coord_string(uint64_t pos, unsigned dim_idx) const;
 
   /** Returns the coordinate size on the input dimension. */
   uint64_t coord_size(unsigned dim_idx) const;
@@ -449,8 +449,8 @@ class ResultTile {
       const uint64_t c_offset,
       const uint64_t c_size,
       const char* const buff_str,
-      const std::basic_string_view<char>& range_start,
-      const std::basic_string_view<char>& range_end);
+      const std::string_view& range_start,
+      const std::string_view& range_end);
 };
 
 }  // namespace sm


### PR DESCRIPTION
The coord_string function is used in a lot of performance critical paths.
Moving it to return a basic_string_view as none of these paths benefit
from making a copy of the value.

---
TYPE: IMPROVEMENT
DESC: Moving coord_string from returning a std::string to std::basic_string_view.
