### PR TITLE
Dlh/ch12759 handle multiple mac core files

### DIFF
--- a/cmake/Modules/FindAzureSDK_EP.cmake
+++ b/cmake/Modules/FindAzureSDK_EP.cmake
@@ -125,7 +125,8 @@ if (NOT AZURESDK_FOUND)
           -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
         PATCH_COMMAND
           cd ${CMAKE_SOURCE_DIR} &&
-          ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_azuresdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0-patchset.patch
+          ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_azuresdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0-patchset.patch &&
+          ${CMAKE_COMMAND} -E copy ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0.CMakeLists.txt.md5mitigation ${TILEDB_EP_SOURCE_DIR}/ep_azuresdk/CMakeLists.txt
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE
@@ -152,6 +153,7 @@ if (NOT AZURESDK_FOUND)
         PATCH_COMMAND
           echo starting patching for azure &&
           ${PATCH} < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0-patchset.patch &&
+          ${CMAKE_COMMAND} -E copy ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0.CMakeLists.txt.md5mitigation ${TILEDB_EP_SOURCE_DIR}/ep_azuresdk/CMakeLists.txt &&
           echo done patches for azure
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE

--- a/cmake/Modules/FindGCSSDK_EP.cmake
+++ b/cmake/Modules/FindGCSSDK_EP.cmake
@@ -80,7 +80,11 @@ if (NOT GCSSDK_FOUND)
       PATCH_COMMAND
         patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/build.patch &&
         patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/disable_tests.patch &&
-        patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/disable_examples.patch
+        patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/disable_examples.patch &&
+        #The following patch is on top of a patch already done in build.patch above, application order is important!
+        #does add_compile_options() hoping for
+        #"These options are used when compiling targets from the current directory and below."
+        patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/v1.22.0.CMakelists.txt.openssl3md5deprecationmitigation.patch
       CONFIGURE_COMMAND
          ${CMAKE_COMMAND} -Hsuper -Bcmake-out
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/cmake/inputs/patches/ep_azuresdk/v0.3.0.CMakeLists.txt.md5mitigation
+++ b/cmake/inputs/patches/ep_azuresdk/v0.3.0.CMakeLists.txt.md5mitigation
@@ -1,0 +1,210 @@
+cmake_minimum_required(VERSION 3.6)
+
+project(azurestoragelite)
+set(CMAKE_CXX_STANDARD 11)
+
+option(BUILD_TESTS       "Build test codes"                  OFF)
+option(BUILD_SAMPLES     "Build sample codes"                OFF)
+option(BUILD_SHARED_LIBS "Request build of shared libraries" OFF)
+option(BUILD_ADLS        "Build ADLS Gen2 codes"             OFF)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+set(AZURE_STORAGE_LITE_HEADER
+  include/storage_EXPORTS.h
+
+  include/logging.h
+  include/base64.h
+  include/common.h
+  include/compare.h
+  include/constants.h
+  include/constants.dat
+  include/executor.h
+  include/hash.h
+  include/retry.h
+  include/utility.h
+  include/mstream.h
+
+  include/tinyxml2.h
+  include/xml_parser_base.h
+  include/tinyxml2_parser.h
+  include/xml_writer.h
+
+  include/json_parser_base.h
+
+  include/storage_account.h
+  include/storage_credential.h
+  include/storage_outcome.h
+  include/storage_stream.h
+  include/storage_url.h
+  include/storage_errno.h
+
+  include/storage_request_base.h
+  include/get_blob_request_base.h
+  include/put_blob_request_base.h
+  include/delete_blob_request_base.h
+  include/copy_blob_request_base.h
+  include/create_container_request_base.h
+  include/delete_container_request_base.h
+  include/set_container_metadata_request_base.h
+  include/list_containers_request_base.h
+  include/list_blobs_request_base.h
+  include/get_block_list_request_base.h
+  include/put_block_request_base.h
+  include/get_blob_property_request_base.h
+  include/set_blob_metadata_request_base.h
+  include/get_container_property_request_base.h
+  include/put_block_list_request_base.h
+  include/append_block_request_base.h
+  include/put_page_request_base.h
+  include/get_page_ranges_request_base.h
+
+  include/http_base.h
+  include/http/libcurl_http_client.h
+
+  include/blob/blob_client.h
+  include/blob/download_blob_request.h
+  include/blob/create_block_blob_request.h
+  include/blob/delete_blob_request.h
+  include/blob/copy_blob_request.h
+  include/blob/create_container_request.h
+  include/blob/delete_container_request.h
+  include/blob/set_container_metadata_request.h
+  include/blob/list_containers_request.h
+  include/blob/list_blobs_request.h
+  include/blob/get_blob_property_request.h
+  include/blob/set_blob_metadata_request.h
+  include/blob/get_container_property_request.h
+  include/blob/get_block_list_request.h
+  include/blob/put_block_request.h
+  include/blob/put_block_list_request.h
+  include/blob/append_block_request.h
+  include/blob/put_page_request.h
+  include/blob/get_page_ranges_request.h
+)
+
+set(AZURE_STORAGE_LITE_SOURCE
+  src/logging.cpp
+  src/base64.cpp
+  src/constants.cpp
+  src/hash.cpp
+  src/utility.cpp
+
+  src/tinyxml2.cpp
+  src/tinyxml2_parser.cpp
+
+  src/storage_account.cpp
+  src/storage_credential.cpp
+  src/storage_url.cpp
+
+  src/get_blob_request_base.cpp
+  src/put_blob_request_base.cpp
+  src/delete_blob_request_base.cpp
+  src/copy_blob_request_base.cpp
+  src/create_container_request_base.cpp
+  src/delete_container_request_base.cpp
+  src/set_container_metadata_request_base.cpp
+  src/list_containers_request_base.cpp
+  src/list_blobs_request_base.cpp
+  src/get_blob_property_request_base.cpp
+  src/set_blob_metadata_request_base.cpp
+  src/get_block_list_request_base.cpp
+  src/get_container_property_request_base.cpp
+  src/put_block_request_base.cpp
+  src/put_block_list_request_base.cpp
+  src/append_block_request_base.cpp
+  src/put_page_request_base.cpp
+  src/get_page_ranges_request_base.cpp
+
+  src/http/libcurl_http_client.cpp
+
+  src/blob/blob_client.cpp
+  src/blob/blob_client_wrapper.cpp
+)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_library(azure-storage-lite ${AZURE_STORAGE_LITE_HEADER} ${AZURE_STORAGE_LITE_SOURCE})
+
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+find_package(CURL REQUIRED)
+if (UNIX)
+  option(USE_OPENSSL "Use OpenSSL instead of GnuTLS" ON)
+  if(USE_OPENSSL)
+    target_compile_definitions(azure-storage-lite PRIVATE -DUSE_OPENSSL)
+    set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/local/opt/openssl)
+    find_package(OpenSSL REQUIRED)
+    list(APPEND EXTRA_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
+  else()
+    find_package(GnuTLS REQUIRED)
+    list(APPEND EXTRA_INCLUDE_DIRS ${GNUTLS_INCLUDE_DIR})
+    list(APPEND EXTRA_LIBRARIES ${GNUTLS_LIBRARIES})
+  endif()
+
+#  if(NOT APPLE)
+#    find_package(PkgConfig REQUIRED)
+#    pkg_check_modules(uuid REQUIRED IMPORTED_TARGET uuid)
+#    list(APPEND EXTRA_LIBRARIES PkgConfig::uuid)
+#  endif()
+elseif(WIN32)
+  list(APPEND EXTRA_LIBRARIES rpcrt4 bcrypt)
+  target_compile_definitions(azure-storage-lite PRIVATE azure_storage_lite_EXPORTS NOMINMAX)
+endif()
+
+#openssl3 md5 deprecation mitigation
+if(UNIX)
+  #sledge hammer approach
+  target_compile_options(azure-storage-lite PRIVATE "-Wno-deprecated-declarations")
+endif()
+if(MSVC)
+  #sledge hammer approach
+  target_compile_options(azure-storage-lite PRIVATE "/wd4996")
+endif()
+
+if(BUILD_TESTS)
+  find_package(Catch2)
+  if(NOT Catch2_FOUND)
+    find_path(SINGLE_HEADER_CATCH2_INCLUDE_DIR catch2/catch.hpp PATHS ${CATCH2_INCLUDE_DIR})
+    message("Found single-header Catch2: ${SINGLE_HEADER_CATCH2_INCLUDE_DIR}/catch2/catch.hpp")
+    add_library(Catch2::Catch2 INTERFACE IMPORTED)
+    set_target_properties(Catch2::Catch2 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${SINGLE_HEADER_CATCH2_INCLUDE_DIR})
+  endif()
+endif()
+
+target_include_directories(azure-storage-lite PUBLIC ${PROJECT_SOURCE_DIR}/include ${CURL_INCLUDE_DIRS} PRIVATE ${EXTRA_INCLUDE_DIRS})
+target_link_libraries(azure-storage-lite Threads::Threads ${CURL_LIBRARIES} ${EXTRA_LIBRARIES})
+
+if(MSVC)
+  target_compile_options(azure-storage-lite PRIVATE /W4 /WX /MP)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(azure-storage-lite PRIVATE -Wall -Wextra -Werror -pedantic)
+endif()
+
+if(BUILD_ADLS)
+  add_subdirectory(adls)
+endif()
+
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif()
+
+if(BUILD_SAMPLES)
+  add_subdirectory(sample)
+endif()
+
+# Set version numbers centralized
+set(AZURE_STORAGE_LITE_VERSION_MAJOR 0)
+set(AZURE_STORAGE_LITE_VERSION_MINOR 3)
+set(AZURE_STORAGE_LITE_VERSION_REVISION 0)
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS azure-storage-lite
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)

--- a/cmake/inputs/patches/ep_gcssdk/v1.22.0.CMakelists.txt.openssl3md5deprecationmitigation.patch
+++ b/cmake/inputs/patches/ep_gcssdk/v1.22.0.CMakelists.txt.openssl3md5deprecationmitigation.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 11327f7c..bdcef236 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,6 +23,10 @@ project(
+     VERSION 1.22.0
+     LANGUAGES CXX C)
+
++if(UNIX)
++add_compile_options("-Wno-deprecated-declarations")
++endif()
++
+ # Configure the Compiler options, we use C++11 features by default.
+ set(GOOGLE_CLOUD_CPP_CXX_STANDARD
+     ""

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -36,12 +36,12 @@ steps:
     ulimit -c unlimited     # Enable core dumps to be captured (must be in same run block)
     ulimit -c               # should output 'unlimited' now
     
-    if [[ -f $(which python3) ]]; then
+    if [[ -f $(which python) ]]; then
     #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
     #try for one
-    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3
+    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
     #try for two
-    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3
+    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
     else
       echo "unable to find python3!"
       exit 42

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -60,6 +60,9 @@ steps:
       echo "still nothing, missing /cores/areyoutherenow.txt"
     fi
     
+    sleep 100 &
+    killall -SIGSEGV sleep
+    
     if [[ -f $(which python) ]]; then
     #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
     #try for one

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -37,45 +37,45 @@ steps:
     ulimit -c               # should output 'unlimited' now
     
     #https://developer.apple.com/forums/thread/53023?answerId=158378022#158378022
-    sudo chmod 1775 /cores
+    #~ sudo chmod 1775 /cores
+    #~ sudo chown $(whoami) /cores
     
-    echo "bump 1 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"
-    touch /cores/areyouhere.txt
-    echo "some garbage" >> /cores/areyouthere.txt
-    if [[ -f /cores/areyouthere.txt ]]; then
-      cat /cores/areyouthere.txt
-    else
-      echo "why no /cores/areyouthere.txt?"
-    fi
-    ls -l /cores
-    ls -l /
+    #~ echo "bump 1 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"
+    #~ touch /cores/areyouhere.txt
+    #~ echo "some garbage" >> /cores/areyouthere.txt
+    #~ if [[ -f /cores/areyouthere.txt ]]; then
+      #~ cat /cores/areyouthere.txt
+    #~ else
+      #~ echo "why no /cores/areyouthere.txt?"
+    #~ fi
+    #~ ls -l /cores
+    #~ ls -l /
     
-    sudo chown $(whoami) /cores
-    ls -l /
+    #~ ls -l /
     
-    echo "more garbage" >> /cores/areyoutherenow.txt
-    if [[ -f /cores/areyoutherenow.txt ]]; then
-      cat /cores/areyoutherenow.txt
-    else
-      echo "still nothing, missing /cores/areyoutherenow.txt"
-    fi
+    #~ echo "more garbage" >> /cores/areyoutherenow.txt
+    #~ if [[ -f /cores/areyoutherenow.txt ]]; then
+      #~ cat /cores/areyoutherenow.txt
+    #~ else
+      #~ echo "still nothing, missing /cores/areyoutherenow.txt"
+    #~ fi
     
-    sleep 100 &
-    killall -SIGSEGV sleep
-    sleep 100 &
-    killall -SIGILL sleep
+    #~ sleep 100 &
+    #~ killall -SIGSEGV sleep
+    #~ sleep 100 &
+    #~ killall -SIGILL sleep
     
-    if [[ -f $(which python) ]]; then
-    #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
-    #try for one
-    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
-    #try for two
-    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
-    exit 41 #try this, core dumps alone apparently not enuf to stop mac build on azure pipelines
-    else
-      echo "unable to find python3!"
-      exit 42
-    fi
+    #~ if [[ -f $(which python) ]]; then
+    #~ #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
+    #~ #try for one
+    #~ echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
+    #~ #try for two
+    #~ echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
+    #~ exit 41 #try this, core dumps alone apparently not enuf to stop mac build on azure pipelines
+    #~ else
+      #~ echo "unable to find python3!"
+      #~ exit 42
+    #~ fi
     
     # Azure sets "SYSTEM=build" for unknown reasons, which breaks the OpenSSL configure script
     #   - openssl configure uses ENV{SYSTEM} if available:
@@ -184,6 +184,11 @@ steps:
     $BUILD_REPOSITORY_LOCALPATH/bootstrap $bootstrap_args
 
     make -j4
+    #vvvvvvvvvvvvvvvvv
+    #remove us
+    make -j4 -C tiledb tiledb_unit
+    ./tiledb/test/tiledb_unit -d yes --crash
+    #^^^^^^^^^^^^^^
     make examples -j4
     make -C tiledb install
 

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -40,13 +40,19 @@ steps:
     sysctl -a | grep core
     
     cat > abortprog.c <<EOF
+    #include <stdio.h>
     #include <stdlib.h>
     #include <sys/types.h>
     #include <unistd.h>
     #include <signal.h>
-    int main() {
+    int main(int argc, char *argv[]) {
+    int asigval = 4; //4==SIGILL
+    if(argc > 1){
+    asigval=atoi(argv[1]);
+    }
+    printf("doing kill(%d)\n",asigval);
     //no core dump... abort();
-    kill(getpid(), 4); //4==SIGILL
+    kill(getpid(), asigval); //4==SIGILL
     }
     EOF
     
@@ -57,8 +63,11 @@ steps:
     sudo chmod 1777 /cores
     sudo chown $(whoami) /cores
 
+    ps -A
+    ls -l /cores
     gcc ./abortprog.c
     ./a.out
+    ./a.out 9
     sudo ./a.out
     
     ls -l /cores

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -45,10 +45,11 @@ steps:
       echo "why no /cores/areyouthere.txt?"
     fi
     ls -l /cores
-    ls -d /*/
-    ls -d /*/cores/
+    ls -l /
     
     sudo chown $(whoami) /cores
+    ls -l /
+    
     echo "more garbage" >> /cores/areyoutherenow.txt
     if [[ -f /cores/areyoutherenow.txt ]]; then
       cat /cores/areyoutherenow.txt

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -46,12 +46,13 @@ steps:
     }
     EOF
     
+    #https://developer.apple.com/forums/thread/53023?answerId=158378022#158378022
+    sudo chmod 1775 /cores
+    sudo chown $(whoami) /cores
+
     gcc ./abortprog.c
     ./a.out
     
-    #https://developer.apple.com/forums/thread/53023?answerId=158378022#158378022
-    #~ sudo chmod 1775 /cores
-    #~ sudo chown $(whoami) /cores
     
     #~ echo "bump 1 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"
     #~ touch /cores/areyouhere.txt

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -63,6 +63,8 @@ steps:
     sudo chmod 1777 /cores
     sudo chown $(whoami) /cores
 
+    sudo ls -l /
+    
     ps -A
     ls -l /cores
     gcc ./abortprog.c

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -67,7 +67,8 @@ steps:
     ls -l /cores
     gcc ./abortprog.c
     ./a.out
-    ./a.out 9
+    ./a.out 9 //SIGKILL
+    ./a.out 11 //SIGSEGV
     sudo ./a.out
     
     ls -l /cores

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -62,6 +62,8 @@ steps:
     
     sleep 100 &
     killall -SIGSEGV sleep
+    sleep 100 &
+    killall -SIGILL sleep
     
     if [[ -f $(which python) ]]; then
     #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -41,8 +41,12 @@ steps:
     
     cat > abortprog.c <<EOF
     #include <stdlib.h>
+    #include <sys/types.h>
+    #include <unistd.h>
+    #include <signal.h>
     int main() {
-    abort();
+    //no core dump... abort();
+    kill(getpid(), 4); //4==SIGILL
     }
     EOF
     

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -42,6 +42,7 @@ steps:
     echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
     #try for two
     echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
+    exit 41 #try this, core dumps alone apparently not enuf to stop mac build on azure pipelines
     else
       echo "unable to find python3!"
       exit 42

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -51,12 +51,17 @@ steps:
     EOF
     
     #https://developer.apple.com/forums/thread/53023?answerId=158378022#158378022
-    sudo chmod 1775 /cores
+    #sudo chmod 1775 /cores
+    #https://developer.apple.com/forums/thread/127503?answerId=401103022#401103022
+    #so seems after change to 1777, the 'runner' attempt did core dump, while the sudo version did not...
+    sudo chmod 1777 /cores
     sudo chown $(whoami) /cores
 
     gcc ./abortprog.c
     ./a.out
     sudo ./a.out
+    
+    ls -l /cores
     
     
     #~ echo "bump 1 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"
@@ -84,17 +89,19 @@ steps:
     #~ sleep 100 &
     #~ killall -SIGILL sleep
     
-    #~ if [[ -f $(which python) ]]; then
-    #~ #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
-    #~ #try for one
-    #~ echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
-    #~ #try for two
-    #~ echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
-    #~ exit 41 #try this, core dumps alone apparently not enuf to stop mac build on azure pipelines
-    #~ else
-      #~ echo "unable to find python3!"
-      #~ exit 42
-    #~ fi
+    if [[ -f $(which python) ]]; then
+    #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
+    #try for one
+    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
+    #try for two
+    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
+    sleep 2s
+    ls -l /cores
+    exit 41 #try this, core dumps alone apparently not enuf to stop mac build on azure pipelines
+    else
+      echo "unable to find python3!"
+      exit 42
+    fi
     
     # Azure sets "SYSTEM=build" for unknown reasons, which breaks the OpenSSL configure script
     #   - openssl configure uses ENV{SYSTEM} if available:

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -56,6 +56,7 @@ steps:
 
     gcc ./abortprog.c
     ./a.out
+    sudo ./a.out
     
     
     #~ echo "bump 1 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -36,6 +36,25 @@ steps:
     ulimit -c unlimited     # Enable core dumps to be captured (must be in same run block)
     ulimit -c               # should output 'unlimited' now
     
+    touch /cores/areyouhere.txt
+    echo "some garbage" >> /cores/areyouthere.txt
+    if [[ -f /cores/areyouthere.txt) ]]; then
+      cat /cores/areyouthere.txt
+    else
+      echo "why no /cores/areyouthere.txt?"
+    fi
+    ls -l /cores
+    ls -d /*/
+    ls -d /*/cores/
+    
+    sudo chown $(whoami) /cores
+    echo "more garbage" >> /cores/areyoutherenow.txt
+    if [[ -f /cores/areyoutherenow.txt ]]; then
+      cat /cores/areyoutherenow.txt
+    else
+      echo "still nothing, missing /cores/areyoutherenow.txt"
+    fi
+    
     if [[ -f $(which python) ]]; then
     #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
     #try for one

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -36,6 +36,9 @@ steps:
     ulimit -c unlimited     # Enable core dumps to be captured (must be in same run block)
     ulimit -c               # should output 'unlimited' now
     
+    #https://developer.apple.com/forums/thread/53023?answerId=158378022#158378022
+    sudo chmod 1775 /cores
+    
     echo "bump 1 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"
     touch /cores/areyouhere.txt
     echo "some garbage" >> /cores/areyouthere.txt

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -69,6 +69,7 @@ steps:
     ls -l /cores
     gcc ./abortprog.c
     ./a.out
+    ./a.out 6 //SIGABRT
     ./a.out 9 //SIGKILL
     ./a.out 11 //SIGSEGV
     sudo ./a.out

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -36,6 +36,19 @@ steps:
     ulimit -c unlimited     # Enable core dumps to be captured (must be in same run block)
     ulimit -c               # should output 'unlimited' now
     
+    #https://stackoverflow.com/questions/65278351/no-core-dump-file-generated-after-segmentation-fault-in-macos-big-sur
+    sysctl -a | grep core
+    
+    cat > abortprog.c <<EOF
+    #include <stdlib.h>
+    int main() {
+    abort();
+    }
+    EOF
+    
+    gcc ./abortprog.c
+    ./a.out
+    
     #https://developer.apple.com/forums/thread/53023?answerId=158378022#158378022
     #~ sudo chmod 1775 /cores
     #~ sudo chown $(whoami) /cores

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -206,7 +206,7 @@ steps:
 
 - bash: |
     ls -la /cores
-    mkdir $BUILD_REPOSITORY_LOCALPATH/build/core
+    mkdir -p $BUILD_REPOSITORY_LOCALPATH/build/core
     mv /cores/core.* $BUILD_REPOSITORY_LOCALPATH/build/core/
     ls -la $BUILD_REPOSITORY_LOCALPATH/build/core
     #lldb -c $BUILD_REPOSITORY_LOCALPATH/build/core/core.1 --batch -o 'bt all' -o 'quit'

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -106,17 +106,17 @@ steps:
     #~ killall -SIGILL sleep
     
     if [[ -f $(which python) ]]; then
-    #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
-    #try for one
-    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
-    #try for two
-    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
-    sleep 2s
-    ls -l /cores
-    exit 41 #try this, core dumps alone apparently not enuf to stop mac build on azure pipelines
+      #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
+      #try for one
+      echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
+      #try for two
+      echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python
+      sleep 2s
+      ls -l /cores
+      #exit 41 #try this, core dumps alone apparently not enuf to stop mac build on azure pipelines
     else
-      echo "unable to find python3!"
-      exit 42
+      echo "unable to find python!"
+      #exit 42
     fi
   condition: and(true, eq(variables['Agent.OS'], 'Darwin'), startsWith(variables['imageName'], 'macOS-'))
   displayName: 'check macOS "runner" core dumps'
@@ -236,8 +236,8 @@ steps:
     make -j4
     #vvvvvvvvvvvvvvvvv
     #remove us
-    make -j4 -C tiledb tiledb_unit
-    ./tiledb/test/tiledb_unit -d yes --crash
+    #~ make -j4 -C tiledb tiledb_unit
+    #~ ./tiledb/test/tiledb_unit -d yes --crash
     #^^^^^^^^^^^^^^
     make examples -j4
     make -C tiledb install

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -38,7 +38,7 @@ steps:
     
     touch /cores/areyouhere.txt
     echo "some garbage" >> /cores/areyouthere.txt
-    if [[ -f /cores/areyouthere.txt) ]]; then
+    if [[ -f /cores/areyouthere.txt ]]; then
       cat /cores/areyouthere.txt
     else
       echo "why no /cores/areyouthere.txt?"

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -35,6 +35,18 @@ steps:
     ulimit -c               # should output 0 if disabled
     ulimit -c unlimited     # Enable core dumps to be captured (must be in same run block)
     ulimit -c               # should output 'unlimited' now
+    
+    if [[ -f $(which python3) ]]; then
+    #echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3          # Azure sets "SYSTEM=build" for unknown reasonas, which breaks the OpenSSL configure script
+    #try for one
+    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3
+    #try for two
+    echo -e "nl=\"\\\n\"\nprint('aborting...'+nl)\nimport resource as res\nimport time,threading\nprint(res.getrlimit(res.RLIMIT_CORE))\nprint(nl)\nres.setrlimit(res.RLIMIT_CORE,(res.RLIM_INFINITY,res.RLIM_INFINITY))\nprint(res.getrlimit(res.RLIMIT_CORE))\nt1=threading.Thread(name='thd1', target=lambda: time.sleep(5))\nt1.start()\nt2=threading.Thread(name='thd2', target=lambda: time.sleep(5))\nt2.start()\nimport sys\nsys.stdout.flush()\nsys.stderr.flush()\nimport os \nos.abort()" | python3
+    else
+      echo "unable to find python3!"
+      exit 42
+    fi
+    
     # Azure sets "SYSTEM=build" for unknown reasons, which breaks the OpenSSL configure script
     #   - openssl configure uses ENV{SYSTEM} if available:
     #     https://github.com/openssl/openssl/blob/6d745d740d37d680ff696486218b650512bbbbc6/config#L56

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -31,14 +31,29 @@ steps:
   displayName: 'Install system headers (OSX 10.14 only)'
 
 - bash: |
+    #https://stackoverflow.com/questions/65278351/no-core-dump-file-generated-after-segmentation-fault-in-macos-big-sur
+    sysctl -a | grep core
+    
+    #https://developer.apple.com/forums/thread/53023?answerId=158378022#158378022
+    #sudo chmod 1775 /cores
+    #https://developer.apple.com/forums/thread/127503?answerId=401103022#401103022
+    #so seems after change to 1777, the 'runner' attempt did core dump, while the sudo version did not...
+    sudo chmod 1777 /cores
+    sudo chown $(whoami) /cores
+
+    sudo ls -l /
+    
+    ps -A
+    ls -l /cores
+  condition: and(eq(variables['Agent.OS'], 'Darwin'), startsWith(variables['imageName'], 'macOS-'))
+  displayName: 'prep macOS for "runner" core dumps'
+
+- bash: |
     # enable core dumps
     ulimit -c               # should output 0 if disabled
     ulimit -c unlimited     # Enable core dumps to be captured (must be in same run block)
     ulimit -c               # should output 'unlimited' now
-    
-    #https://stackoverflow.com/questions/65278351/no-core-dump-file-generated-after-segmentation-fault-in-macos-big-sur
-    sysctl -a | grep core
-    
+
     cat > abortprog.c <<EOF
     #include <stdio.h>
     #include <stdlib.h>
@@ -55,18 +70,7 @@ steps:
     kill(getpid(), asigval); //4==SIGILL
     }
     EOF
-    
-    #https://developer.apple.com/forums/thread/53023?answerId=158378022#158378022
-    #sudo chmod 1775 /cores
-    #https://developer.apple.com/forums/thread/127503?answerId=401103022#401103022
-    #so seems after change to 1777, the 'runner' attempt did core dump, while the sudo version did not...
-    sudo chmod 1777 /cores
-    sudo chown $(whoami) /cores
 
-    sudo ls -l /
-    
-    ps -A
-    ls -l /cores
     gcc ./abortprog.c
     ./a.out
     ./a.out 6 #SIGABRT
@@ -75,7 +79,6 @@ steps:
     sudo ./a.out
     
     ls -l /cores
-    
     
     echo "bump 2 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"
     #~ touch /cores/areyouhere.txt
@@ -115,6 +118,14 @@ steps:
       echo "unable to find python3!"
       exit 42
     fi
+  condition: and(true, eq(variables['Agent.OS'], 'Darwin'), startsWith(variables['imageName'], 'macOS-'))
+  displayName: 'check macOS "runner" core dumps'
+
+- bash: |
+    # enable core dumps
+    ulimit -c               # should output 0 if disabled
+    ulimit -c unlimited     # Enable core dumps to be captured (must be in same run block)
+    ulimit -c               # should output 'unlimited' now
     
     # Azure sets "SYSTEM=build" for unknown reasons, which breaks the OpenSSL configure script
     #   - openssl configure uses ENV{SYSTEM} if available:

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -194,9 +194,14 @@ steps:
 - bash: |
     ls -la /cores
     mkdir $BUILD_REPOSITORY_LOCALPATH/build/core
-    mv /cores/core.* $BUILD_REPOSITORY_LOCALPATH/build/core/core.1
+    mv /cores/core.* $BUILD_REPOSITORY_LOCALPATH/build/core/
     ls -la $BUILD_REPOSITORY_LOCALPATH/build/core
-    lldb -c $BUILD_REPOSITORY_LOCALPATH/build/core/core.1 --batch -o 'bt all' -o 'quit'
+    #lldb -c $BUILD_REPOSITORY_LOCALPATH/build/core/core.1 --batch -o 'bt all' -o 'quit'
+    for f in $(find $BUILD_REPOSITORY_LOCALPATH/build/core -name 'core.*');
+      do
+        echo "stack trace for $f"
+        lldb -c $f --batch -o 'bt all' -o 'quit'
+      done;
   condition: and(failed(), eq(variables['Agent.OS'], 'Darwin')) # only run this job if the build step failed
   displayName: 'Print stack trace'
 

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -36,6 +36,7 @@ steps:
     ulimit -c unlimited     # Enable core dumps to be captured (must be in same run block)
     ulimit -c               # should output 'unlimited' now
     
+    echo "bump 1 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"
     touch /cores/areyouhere.txt
     echo "some garbage" >> /cores/areyouthere.txt
     if [[ -f /cores/areyouthere.txt ]]; then

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -77,7 +77,7 @@ steps:
     ls -l /cores
     
     
-    #~ echo "bump 1 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"
+    echo "bump 2 for azure pipelines status page 'An unexpected error has occurred within this region of the page'"
     #~ touch /cores/areyouhere.txt
     #~ echo "some garbage" >> /cores/areyouthere.txt
     #~ if [[ -f /cores/areyouthere.txt ]]; then

--- a/scripts/azure-linux_mac.yml
+++ b/scripts/azure-linux_mac.yml
@@ -69,9 +69,9 @@ steps:
     ls -l /cores
     gcc ./abortprog.c
     ./a.out
-    ./a.out 6 //SIGABRT
-    ./a.out 9 //SIGKILL
-    ./a.out 11 //SIGSEGV
+    ./a.out 6 #SIGABRT
+    ./a.out 9 #SIGKILL
+    ./a.out 11 #SIGSEGV
     sudo ./a.out
     
     ls -l /cores

--- a/test/src/unit.cc
+++ b/test/src/unit.cc
@@ -45,8 +45,9 @@ int main(const int argc, char** const argv) {
 
   // Add a '--vfs' command line argument to override the default VFS.
   std::string vfs;
+  bool doCrash = false;
   Catch::clara::Parser cli =
-      session.cli() |
+      session.cli() | Catch::clara::Opt(doCrash)["--crash"]("force crash") |
       Catch::clara::Opt(vfs, vfs_fs_oss.str())["--vfs"](
           "Override the VFS filesystem to use for generic tests");
 
@@ -56,6 +57,12 @@ int main(const int argc, char** const argv) {
   if (rc != 0)
     return rc;
 
+  if (doCrash) {
+    // compilation in mac environ prohibited use of direct "*(int *)0 = 0;"
+    int* ptr_to_null = nullptr;
+    *ptr_to_null = 0;
+    // should not reach here!
+  }
   // Validate and store the VFS command line argument.
   rc = store_g_vfs(std::move(vfs), std::move(vfs_fs));
   if (rc != 0)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -205,6 +205,13 @@ set(TILEDB_CORE_SOURCES
 )
 list(APPEND TILEDB_CORE_SOURCES ${TILEDB_COMMON_SOURCES})
 
+#openssl3 md5 deprecation mitigation
+if(MSVC)
+  set_source_files_properties(${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/crypto_openssl.cc PROPERTIES COMPILE_OPTIONS "/wd4996")
+else()
+  set_source_files_properties(${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/crypto_openssl.cc PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-declarations")
+endif()
+
 if (TILEDB_SERIALIZATION)
   list(APPEND TILEDB_CORE_SOURCES
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/rest/curl.cc


### PR DESCRIPTION
azure pipelines mac builds - avoid current core dump failure when more than 1 core file present and process all of them for stack traces and archiving, 

---
TYPE: BUG
DESC: Handle multiple core files for stack traces and archiving
