### PR TITLE
Sparse unordered w/ dups reader: fixing var size overflow adjustment.

### DIFF
--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -635,7 +635,7 @@ Status SparseIndexReaderBase::resize_output_buffers(uint64_t cells_copied) {
         // Offsets buffer is trivial.
         *(it.second.buffer_size_) =
             cells_copied * constants::cell_var_offset_size +
-            offsets_extra_element_;
+            offsets_extra_element_ * offsets_bytesize();
 
         // Since the buffer is shrunk, there is an offset for the next element
         // loaded, use it.

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1010,7 +1010,7 @@ template <class BitmapType>
 Status SparseUnorderedWithDupsReader<BitmapType>::compute_fixed_results_to_copy(
     std::vector<ResultTile*>* result_tiles,
     std::vector<uint64_t>* cell_offsets) {
-  auto timer_se = stats_->start_timer("compute_initial_copy_bound");
+  auto timer_se = stats_->start_timer("compute_fixed_results_to_copy");
 
   // First try to limit the maximum number of cells we copy using the size
   // of the output buffers for fixed sized attributes. Later we will validate
@@ -1194,7 +1194,10 @@ Status SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
 
       auto last_tile_num_cells = last_tile->cell_num();
       (*new_result_tiles_size)++;
-      cell_offsets->at(*new_result_tiles_size) = 0;
+      cell_offsets->at(*new_result_tiles_size) =
+          *new_result_tiles_size > 0 ?
+              cell_offsets->at(*new_result_tiles_size - 1) :
+              0;
 
       const bool has_bmp = last_tile->bitmap_.size() != 0;
       for (uint64_t c = 0; c < last_tile_num_cells - 1; c++) {
@@ -1501,7 +1504,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::end_iteration() {
   }
 
   logger_->debug(
-      "Done with iteration, num result tiles {1}", result_tiles_[0].size());
+      "Done with iteration, num result tiles {0}", result_tiles_[0].size());
 
   const auto uint64_t_max = std::numeric_limits<uint64_t>::max();
   array_memory_tracker_->set_budget(uint64_t_max);


### PR DESCRIPTION
When running into a case where the var size data cannot fit the user
buffers, we adjust how much data gets copied. This fixes a small logic
bug where the adjustment didn't take into consideration the offset from
the previous tiles.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups reader: fixing var size overflow adjustment.