### PR TITLE
openssl3 md5 deprecation mitigation

### DIFF
--- a/cmake/Modules/FindAzureSDK_EP.cmake
+++ b/cmake/Modules/FindAzureSDK_EP.cmake
@@ -125,7 +125,8 @@ if (NOT AZURESDK_FOUND)
           -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
         PATCH_COMMAND
           cd ${CMAKE_SOURCE_DIR} &&
-          ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_azuresdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0-patchset.patch
+          ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_azuresdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0-patchset.patch &&
+          ${CMAKE_COMMAND} -E copy ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0.CMakeLists.txt.md5mitigation ${TILEDB_EP_SOURCE_DIR}/ep_azuresdk/CMakeLists.txt
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE
         LOG_BUILD TRUE
@@ -152,6 +153,7 @@ if (NOT AZURESDK_FOUND)
         PATCH_COMMAND
           echo starting patching for azure &&
           ${PATCH} < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0-patchset.patch &&
+          ${CMAKE_COMMAND} -E copy ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_azuresdk/v0.3.0.CMakeLists.txt.md5mitigation ${TILEDB_EP_SOURCE_DIR}/ep_azuresdk/CMakeLists.txt &&
           echo done patches for azure
         LOG_DOWNLOAD TRUE
         LOG_CONFIGURE TRUE

--- a/cmake/Modules/FindGCSSDK_EP.cmake
+++ b/cmake/Modules/FindGCSSDK_EP.cmake
@@ -80,7 +80,11 @@ if (NOT GCSSDK_FOUND)
       PATCH_COMMAND
         patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/build.patch &&
         patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/disable_tests.patch &&
-        patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/disable_examples.patch
+        patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/disable_examples.patch &&
+        #The following patch is on top of a patch already done in build.patch above, application order is important!
+        #does add_compile_options() hoping for
+        #"These options are used when compiling targets from the current directory and below."
+        patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_gcssdk/v1.22.0.CMakelists.txt.openssl3md5deprecationmitigation.patch
       CONFIGURE_COMMAND
          ${CMAKE_COMMAND} -Hsuper -Bcmake-out
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/cmake/inputs/patches/ep_azuresdk/v0.3.0.CMakeLists.txt.md5mitigation
+++ b/cmake/inputs/patches/ep_azuresdk/v0.3.0.CMakeLists.txt.md5mitigation
@@ -1,0 +1,210 @@
+cmake_minimum_required(VERSION 3.6)
+
+project(azurestoragelite)
+set(CMAKE_CXX_STANDARD 11)
+
+option(BUILD_TESTS       "Build test codes"                  OFF)
+option(BUILD_SAMPLES     "Build sample codes"                OFF)
+option(BUILD_SHARED_LIBS "Request build of shared libraries" OFF)
+option(BUILD_ADLS        "Build ADLS Gen2 codes"             OFF)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+set(AZURE_STORAGE_LITE_HEADER
+  include/storage_EXPORTS.h
+
+  include/logging.h
+  include/base64.h
+  include/common.h
+  include/compare.h
+  include/constants.h
+  include/constants.dat
+  include/executor.h
+  include/hash.h
+  include/retry.h
+  include/utility.h
+  include/mstream.h
+
+  include/tinyxml2.h
+  include/xml_parser_base.h
+  include/tinyxml2_parser.h
+  include/xml_writer.h
+
+  include/json_parser_base.h
+
+  include/storage_account.h
+  include/storage_credential.h
+  include/storage_outcome.h
+  include/storage_stream.h
+  include/storage_url.h
+  include/storage_errno.h
+
+  include/storage_request_base.h
+  include/get_blob_request_base.h
+  include/put_blob_request_base.h
+  include/delete_blob_request_base.h
+  include/copy_blob_request_base.h
+  include/create_container_request_base.h
+  include/delete_container_request_base.h
+  include/set_container_metadata_request_base.h
+  include/list_containers_request_base.h
+  include/list_blobs_request_base.h
+  include/get_block_list_request_base.h
+  include/put_block_request_base.h
+  include/get_blob_property_request_base.h
+  include/set_blob_metadata_request_base.h
+  include/get_container_property_request_base.h
+  include/put_block_list_request_base.h
+  include/append_block_request_base.h
+  include/put_page_request_base.h
+  include/get_page_ranges_request_base.h
+
+  include/http_base.h
+  include/http/libcurl_http_client.h
+
+  include/blob/blob_client.h
+  include/blob/download_blob_request.h
+  include/blob/create_block_blob_request.h
+  include/blob/delete_blob_request.h
+  include/blob/copy_blob_request.h
+  include/blob/create_container_request.h
+  include/blob/delete_container_request.h
+  include/blob/set_container_metadata_request.h
+  include/blob/list_containers_request.h
+  include/blob/list_blobs_request.h
+  include/blob/get_blob_property_request.h
+  include/blob/set_blob_metadata_request.h
+  include/blob/get_container_property_request.h
+  include/blob/get_block_list_request.h
+  include/blob/put_block_request.h
+  include/blob/put_block_list_request.h
+  include/blob/append_block_request.h
+  include/blob/put_page_request.h
+  include/blob/get_page_ranges_request.h
+)
+
+set(AZURE_STORAGE_LITE_SOURCE
+  src/logging.cpp
+  src/base64.cpp
+  src/constants.cpp
+  src/hash.cpp
+  src/utility.cpp
+
+  src/tinyxml2.cpp
+  src/tinyxml2_parser.cpp
+
+  src/storage_account.cpp
+  src/storage_credential.cpp
+  src/storage_url.cpp
+
+  src/get_blob_request_base.cpp
+  src/put_blob_request_base.cpp
+  src/delete_blob_request_base.cpp
+  src/copy_blob_request_base.cpp
+  src/create_container_request_base.cpp
+  src/delete_container_request_base.cpp
+  src/set_container_metadata_request_base.cpp
+  src/list_containers_request_base.cpp
+  src/list_blobs_request_base.cpp
+  src/get_blob_property_request_base.cpp
+  src/set_blob_metadata_request_base.cpp
+  src/get_block_list_request_base.cpp
+  src/get_container_property_request_base.cpp
+  src/put_block_request_base.cpp
+  src/put_block_list_request_base.cpp
+  src/append_block_request_base.cpp
+  src/put_page_request_base.cpp
+  src/get_page_ranges_request_base.cpp
+
+  src/http/libcurl_http_client.cpp
+
+  src/blob/blob_client.cpp
+  src/blob/blob_client_wrapper.cpp
+)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_library(azure-storage-lite ${AZURE_STORAGE_LITE_HEADER} ${AZURE_STORAGE_LITE_SOURCE})
+
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+find_package(CURL REQUIRED)
+if (UNIX)
+  option(USE_OPENSSL "Use OpenSSL instead of GnuTLS" ON)
+  if(USE_OPENSSL)
+    target_compile_definitions(azure-storage-lite PRIVATE -DUSE_OPENSSL)
+    set(OPENSSL_ROOT_DIR ${OPENSSL_ROOT_DIR} /usr/local/opt/openssl)
+    find_package(OpenSSL REQUIRED)
+    list(APPEND EXTRA_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
+  else()
+    find_package(GnuTLS REQUIRED)
+    list(APPEND EXTRA_INCLUDE_DIRS ${GNUTLS_INCLUDE_DIR})
+    list(APPEND EXTRA_LIBRARIES ${GNUTLS_LIBRARIES})
+  endif()
+
+#  if(NOT APPLE)
+#    find_package(PkgConfig REQUIRED)
+#    pkg_check_modules(uuid REQUIRED IMPORTED_TARGET uuid)
+#    list(APPEND EXTRA_LIBRARIES PkgConfig::uuid)
+#  endif()
+elseif(WIN32)
+  list(APPEND EXTRA_LIBRARIES rpcrt4 bcrypt)
+  target_compile_definitions(azure-storage-lite PRIVATE azure_storage_lite_EXPORTS NOMINMAX)
+endif()
+
+#openssl3 md5 deprecation mitigation
+if(UNIX)
+  #sledge hammer approach
+  target_compile_options(azure-storage-lite PRIVATE "-Wno-deprecated-declarations")
+endif()
+if(MSVC)
+  #sledge hammer approach
+  target_compile_options(azure-storage-lite PRIVATE "/wd4996")
+endif()
+
+if(BUILD_TESTS)
+  find_package(Catch2)
+  if(NOT Catch2_FOUND)
+    find_path(SINGLE_HEADER_CATCH2_INCLUDE_DIR catch2/catch.hpp PATHS ${CATCH2_INCLUDE_DIR})
+    message("Found single-header Catch2: ${SINGLE_HEADER_CATCH2_INCLUDE_DIR}/catch2/catch.hpp")
+    add_library(Catch2::Catch2 INTERFACE IMPORTED)
+    set_target_properties(Catch2::Catch2 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${SINGLE_HEADER_CATCH2_INCLUDE_DIR})
+  endif()
+endif()
+
+target_include_directories(azure-storage-lite PUBLIC ${PROJECT_SOURCE_DIR}/include ${CURL_INCLUDE_DIRS} PRIVATE ${EXTRA_INCLUDE_DIRS})
+target_link_libraries(azure-storage-lite Threads::Threads ${CURL_LIBRARIES} ${EXTRA_LIBRARIES})
+
+if(MSVC)
+  target_compile_options(azure-storage-lite PRIVATE /W4 /WX /MP)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(azure-storage-lite PRIVATE -Wall -Wextra -Werror -pedantic)
+endif()
+
+if(BUILD_ADLS)
+  add_subdirectory(adls)
+endif()
+
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif()
+
+if(BUILD_SAMPLES)
+  add_subdirectory(sample)
+endif()
+
+# Set version numbers centralized
+set(AZURE_STORAGE_LITE_VERSION_MAJOR 0)
+set(AZURE_STORAGE_LITE_VERSION_MINOR 3)
+set(AZURE_STORAGE_LITE_VERSION_REVISION 0)
+
+install(DIRECTORY include/ DESTINATION include)
+install(TARGETS azure-storage-lite
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)

--- a/cmake/inputs/patches/ep_gcssdk/v1.22.0.CMakelists.txt.openssl3md5deprecationmitigation.patch
+++ b/cmake/inputs/patches/ep_gcssdk/v1.22.0.CMakelists.txt.openssl3md5deprecationmitigation.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 11327f7c..bdcef236 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,6 +23,10 @@ project(
+     VERSION 1.22.0
+     LANGUAGES CXX C)
+
++if(UNIX)
++add_compile_options("-Wno-deprecated-declarations")
++endif()
++
+ # Configure the Compiler options, we use C++11 features by default.
+ set(GOOGLE_CLOUD_CPP_CXX_STANDARD
+     ""

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -205,6 +205,13 @@ set(TILEDB_CORE_SOURCES
 )
 list(APPEND TILEDB_CORE_SOURCES ${TILEDB_COMMON_SOURCES})
 
+#openssl3 md5 deprecation mitigation
+if(MSVC)
+  set_source_files_properties(${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/crypto_openssl.cc PROPERTIES COMPILE_OPTIONS "/wd4996")
+else()
+  set_source_files_properties(${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/crypto_openssl.cc PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-declarations")
+endif()
+
 if (TILEDB_SERIALIZATION)
   list(APPEND TILEDB_CORE_SOURCES
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/rest/curl.cc


### PR DESCRIPTION
openssl3 has deprecated md5 resulting in compilation warnings that cause build failures.
Add -W-no-deprecated-declarations, /wd4996 to avoid those warnings, with broader effect that any other deprecations in these areas will also be masked.

---
TYPE: IMPROVEMENT
DESC: openssl3 md5 deprecation mitigation
