### PR TITLE
Sparse refactored reader: change all_tiles_loaded_ to vector of uint8_t.

### DIFF
--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -558,7 +558,7 @@ Status SparseGlobalOrderReader::create_result_tiles(bool* tiles_found) {
   uint64_t num_rt = 0;
   for (unsigned int f = 0; f < fragment_num; f++) {
     num_rt += result_tiles_[f].size();
-    done_adding_result_tiles &= all_tiles_loaded_[f];
+    done_adding_result_tiles &= all_tiles_loaded_[f] != 0;
   }
 
   logger_->debug("Done adding result tiles, num result tiles {0}", num_rt);

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -192,7 +192,7 @@ class SparseIndexReaderBase : public ReaderBase {
   ReadState read_state_;
 
   /** Have we loaded all thiles for this fragment. */
-  std::vector<bool> all_tiles_loaded_;
+  std::vector<uint8_t> all_tiles_loaded_;
 
   /** Dimension names. */
   std::vector<std::string> dim_names_;

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -381,7 +381,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
   // Check if we are done adding result tiles.
   bool done_adding_result_tiles = true;
   for (unsigned int f = 0; f < fragment_num; f++) {
-    done_adding_result_tiles &= all_tiles_loaded_[f];
+    done_adding_result_tiles &= all_tiles_loaded_[f] != 0;
   }
 
   logger_->debug(


### PR DESCRIPTION
Investigating random failures in unit tests for the sparse global order
reader, I found out the all_tiles_loaded_ was sometimes incorrect. This
was happening because the backing container was a vector of bools, which
internally gets converted to a bitset. As we use this member variable in
parallel for all fragments, it was sometimes leading to inpredictable
results. Switching to a vector of uint8_t ensures that a full byte is
used for all fragments and fixes the parallelisation issues.

---
TYPE: IMPROVEMENT
DESC: Sparse refactored reader: change all_tiles_loaded_ to vector of uint8_t.
