### PR TITLE
Add memory details when erroring on memory limit

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -944,7 +944,10 @@ Status FragmentMetadata::load_rtree(const EncryptionKey& encryption_key) {
   assert(memory_tracker);
   if (!memory_tracker->take_memory(buff.size())) {
     return LOG_STATUS(Status::FragmentMetadataError(
-        "Cannot load R-tree; Insufficient memory budget"));
+        "Cannot load R-tree; Insufficient memory budget; Needed " +
+        std::to_string(buff.size()) + " but only had " +
+        std::to_string(memory_tracker->get_memory_available()) +
+        " from budget " + std::to_string(memory_tracker->get_memory_budget())));
   }
 
   ConstBuffer cbuff(&buff);
@@ -1685,7 +1688,11 @@ Status FragmentMetadata::load_tile_offsets(ConstBuffer* buff) {
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
       return LOG_STATUS(Status::FragmentMetadataError(
-          "Cannot load tile offsets; Insufficient memory budget"));
+          "Cannot load tile offsets; Insufficient memory budget; Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker->get_memory_budget())));
     }
 
     // Get tile offsets
@@ -1722,7 +1729,11 @@ Status FragmentMetadata::load_tile_offsets(unsigned idx, ConstBuffer* buff) {
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
       return LOG_STATUS(Status::FragmentMetadataError(
-          "Cannot load tile offsets; Insufficient memory budget"));
+          "Cannot load tile offsets; Insufficient memory budget; Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker->get_memory_budget())));
     }
 
     tile_offsets_[idx].resize(tile_offsets_num);
@@ -1772,7 +1783,11 @@ Status FragmentMetadata::load_tile_var_offsets(ConstBuffer* buff) {
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
       return LOG_STATUS(Status::FragmentMetadataError(
-          "Cannot load tile var offsets; Insufficient memory budget"));
+          "Cannot load tile var offsets; Insufficient memory budget; Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker->get_memory_budget())));
     }
 
     // Get variable tile offsets
@@ -1813,7 +1828,11 @@ Status FragmentMetadata::load_tile_var_offsets(
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
       return LOG_STATUS(Status::FragmentMetadataError(
-          "Cannot load tile var offsets; Insufficient memory budget"));
+          "Cannot load tile var offsets; Insufficient memory budget; Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker->get_memory_budget())));
     }
 
     tile_var_offsets_[idx].resize(tile_var_offsets_num);
@@ -1862,7 +1881,11 @@ Status FragmentMetadata::load_tile_var_sizes(ConstBuffer* buff) {
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
       return LOG_STATUS(Status::FragmentMetadataError(
-          "Cannot load tile var sizes; Insufficient memory budget"));
+          "Cannot load tile var sizes; Insufficient memory budget; Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker->get_memory_budget())));
     }
 
     // Get variable tile sizes
@@ -1899,7 +1922,11 @@ Status FragmentMetadata::load_tile_var_sizes(unsigned idx, ConstBuffer* buff) {
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
       return LOG_STATUS(Status::FragmentMetadataError(
-          "Cannot load tile var sizes; Insufficient memory budget"));
+          "Cannot load tile var sizes; Insufficient memory budget; Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker->get_memory_budget())));
     }
 
     tile_var_sizes_[idx].resize(tile_var_sizes_num);
@@ -1935,7 +1962,12 @@ Status FragmentMetadata::load_tile_validity_offsets(
     assert(memory_tracker);
     if (!memory_tracker->take_memory(size)) {
       return LOG_STATUS(Status::FragmentMetadataError(
-          "Cannot load tile validity offsets; Insufficient memory budget"));
+          "Cannot load tile validity offsets; Insufficient memory budget; "
+          "Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker->get_memory_budget())));
     }
 
     tile_validity_offsets_[idx].resize(tile_validity_offsets_num);
@@ -2474,7 +2506,10 @@ Status FragmentMetadata::read_file_footer(
   assert(memory_tracker);
   if (!memory_tracker->take_memory(*footer_size)) {
     return LOG_STATUS(Status::FragmentMetadataError(
-        "Cannot load file footer; Insufficient memory budget"));
+        "Cannot load file footer; Insufficient memory budget; Needed " +
+        std::to_string(*footer_size) + " but only had " +
+        std::to_string(memory_tracker->get_memory_available()) +
+        " from budget " + std::to_string(memory_tracker->get_memory_budget())));
   }
 
   // Read footer

--- a/tiledb/sm/storage_manager/open_array_memory_tracker.h
+++ b/tiledb/sm/storage_manager/open_array_memory_tracker.h
@@ -97,6 +97,24 @@ class OpenArrayMemoryTracker {
     return memory_usage_;
   }
 
+  /**
+   * Get available room based on budget
+   * @return available amount left in budget
+   */
+  uint64_t get_memory_available() {
+    std::lock_guard<std::mutex> lg(mutex_);
+    return memory_budget_ - memory_usage_;
+  }
+
+  /**
+   * Get memory budget
+   * @return budget
+   */
+  uint64_t get_memory_budget() {
+    std::lock_guard<std::mutex> lg(mutex_);
+    return memory_budget_;
+  }
+
  private:
   /** Protects all member variables. */
   std::mutex mutex_;


### PR DESCRIPTION
This add some helpful debug details when erroring on not being able to run an operation due to memory budget constraints.

---
TYPE: IMPROVEMENT
DESC: Add helpful details to memory limit error strings.
