### PR TITLE
add missing function pointer compute_mbr_var_func_ 

### DIFF
--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -97,6 +97,7 @@ Dimension::Dimension(const Dimension* dim) {
   check_range_func_ = dim->check_range_func_;
   coincides_with_tiles_func_ = dim->coincides_with_tiles_func_;
   compute_mbr_func_ = dim->compute_mbr_func_;
+  compute_mbr_var_func_ = dim->compute_mbr_var_func_;
   crop_range_func_ = dim->crop_range_func_;
   domain_range_func_ = dim->domain_range_func_;
   expand_range_v_func_ = dim->expand_range_v_func_;


### PR DESCRIPTION
This PR added the missing function pointer compute_mbr_var_func_ in Dimension(const Dimension* dim) constructor function. This missing function pointer caused some problems in my another branch #2728.
 

---
TYPE:  BUG
DESC: Add the compute_mbr_var_func_pointer assignment in Dimension constructor 
