### PR TITLE
Add and use blocking resource pool

### DIFF
--- a/test/src/unit-resource-pool.cc
+++ b/test/src/unit-resource-pool.cc
@@ -115,9 +115,12 @@ TEST_CASE("Buffer: Test blocking resource pool", "[resource-pool]") {
   REQUIRE(r4.get() == 10);
 }
 
-TEST_CASE(
-    "Buffer: Test blocking resource pool possible deadlock",
-    "[resource-pool]") {
+/*
+ * Test disabled to avoid non-deterministic behaviour on CI, as flow-control is
+ * done unreliably using sleep_for. When `barrier` (C++20) will be available, it
+ * could be adapted and enabled.
+ */
+TEST_CASE("Buffer: Test blocking resource pool possible deadlock", "[.]") {
   std::thread t1, t2;
 
   BlockingResourcePool<int> pool(3);

--- a/tiledb/common/common.h
+++ b/tiledb/common/common.h
@@ -51,6 +51,7 @@ namespace tdb = tiledb::common;
  * Dynamic memory
  */
 #include "dynamic_memory/dynamic_memory.h"
+using std::shared_ptr;
 using tiledb::common::allocator;
 using tiledb::common::make_shared;
 // using tiledb::common::make_unique;

--- a/tiledb/sm/compressors/zstd_compressor.cc
+++ b/tiledb/sm/compressors/zstd_compressor.cc
@@ -80,7 +80,7 @@ Status ZStd::compress(
 }
 
 Status ZStd::decompress(
-    std::shared_ptr<ResourcePool<ZStd::ZSTD_Decompress_Context>>
+    shared_ptr<BlockingResourcePool<ZStd::ZSTD_Decompress_Context>>
         decompress_ctx_pool,
     ConstBuffer* input_buffer,
     PreallocatedBuffer* output_buffer) {

--- a/tiledb/sm/compressors/zstd_compressor.h
+++ b/tiledb/sm/compressors/zstd_compressor.h
@@ -88,7 +88,7 @@ class ZStd {
    * @return Status
    */
   static Status decompress(
-      std::shared_ptr<ResourcePool<ZStd::ZSTD_Decompress_Context>>
+      shared_ptr<BlockingResourcePool<ZStd::ZSTD_Decompress_Context>>
           decompress_ctx_pool,
       ConstBuffer* input_buffer,
       PreallocatedBuffer* output_buffer);

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -436,7 +436,7 @@ void CompressionFilter::init_resource_pool(uint64_t size) {
   std::lock_guard g(zstd_decompress_ctx_pool_mtx_);
   if (zstd_decompress_ctx_pool_ == nullptr) {
     zstd_decompress_ctx_pool_ =
-        tdb::make_shared<ResourcePool<ZStd::ZSTD_Decompress_Context>>(
+        tdb::make_shared<BlockingResourcePool<ZStd::ZSTD_Decompress_Context>>(
             HERE(), size);
   }
 }

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -141,7 +141,7 @@ class CompressionFilter : public Filter {
 
   /** A resource pool to be used in ZStd decompressor for improved performance
    */
-  std::shared_ptr<ResourcePool<ZStd::ZSTD_Decompress_Context>>
+  shared_ptr<BlockingResourcePool<ZStd::ZSTD_Decompress_Context>>
       zstd_decompress_ctx_pool_;
 
   /** Returns a new clone of this filter. */

--- a/tiledb/sm/misc/resource_pool.h
+++ b/tiledb/sm/misc/resource_pool.h
@@ -165,7 +165,7 @@ class BlockingResourcePool {
     while (resources_exhausted()) {
       // block until available again
       num_blocked_threads_++;
-      exhaustion_cv_.wait(lck, [this]() { return !resources_exhausted(); });
+      exhaustion_cv_.wait(lck);
       num_blocked_threads_--;
     }
     return {*this, unused_[unused_idx_--]};

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -2489,8 +2489,8 @@ Status Subarray::precompute_all_ranges_tile_overlap(
 
   // Each thread will use one bitmap per dimensions.
   const auto num_threads = compute_tp->concurrency_level();
-  ResourcePool<std::vector<std::vector<uint8_t>>> all_threads_tile_bitmaps(
-      num_threads);
+  BlockingResourcePool<std::vector<std::vector<uint8_t>>>
+      all_threads_tile_bitmaps(num_threads);
 
   // Run all fragments in parallel.
   auto status =


### PR DESCRIPTION
Currently when we run out of resources in a resource pool we throw an exception. However, it would be preferable to just wait a bit for resources to be freed instead.

This PR introduces a BlockingResourcePool class to do that and replaces all uses of ResourcePool in the code with this version.

---
TYPE: IMPROVEMENT
DESC: Add and use blocking resource pool
