### PR TITLE
[C API] Add bulk point-range setter tiledb_query_add_point_ranges

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3491,6 +3491,24 @@ int32_t tiledb_query_add_range(
       ctx, &query_subarray, dim_idx, start, end, stride);
 }
 
+int32_t tiledb_query_add_point_ranges(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    uint32_t dim_idx,
+    const void* start,
+    uint64_t count) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  tiledb_subarray_transient_local_t query_subarray(query);
+  tiledb_config_t local_cfg;
+  // Drop 'const'ness for local usage here
+  local_cfg.config_ = (tiledb::sm::Config*)query->query_->config();
+  tiledb_subarray_set_config(ctx, &query_subarray, &local_cfg);
+  return tiledb_subarray_add_point_ranges(
+      ctx, &query_subarray, dim_idx, start, count);
+}
+
 int32_t tiledb_query_add_range_by_name(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
@@ -3904,6 +3922,23 @@ int32_t tiledb_subarray_add_range(
 
   if (SAVE_ERROR_CATCH(
           ctx, subarray->subarray_->add_range(dim_idx, start, end, stride)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_subarray_add_point_ranges(
+    tiledb_ctx_t* ctx,
+    tiledb_subarray_t* subarray,
+    uint32_t dim_idx,
+    const void* start,
+    uint64_t count) {
+  if (sanity_check(ctx) == TILEDB_ERR ||
+      sanity_check(ctx, subarray) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx, subarray->subarray_->add_point_ranges(dim_idx, start, count)))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -171,6 +171,53 @@ TILEDB_EXPORT int32_t tiledb_array_evolve(
 TILEDB_EXPORT int32_t tiledb_array_upgrade_version(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config);
 
+/* ********************************* */
+/*               QUERY               */
+/* ********************************* */
+
+/**
+ * Adds point ranges to the given dimension index of the subarray
+ * Effectively `add_range(x_i, x_i)` for `count` points in the
+ * target array, but set in bulk to amortize expensive steps.
+ */
+TILEDB_EXPORT int32_t tiledb_subarray_add_point_ranges(
+    tiledb_ctx_t* ctx,
+    tiledb_subarray_t* subarray,
+    uint32_t dim_idx,
+    const void* start,
+    uint64_t count);
+
+/**
+ * Adds a set of point ranges along subarray dimension index. Each value
+ * in the target array is added as `add_range(x,x)` for count elements.
+ * The datatype of the range components must be the same as the type of
+ * the dimension of the array in the query.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint32_t dim_idx = 2;
+ * int64_t ranges[] = { 20, 21, 25, 31}
+ * tiledb_query_add_point_ranges(ctx, query, dim_idx, &ranges, 4);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The query to add the range to.
+ * @param dim_idx The index of the dimension to add the range to.
+ * @param start The start of the ranges array.
+ * @param count Number of ranges to add.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note The stride is currently unsupported. Use `nullptr` as the
+ *     stride argument.
+ */
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_query_add_point_ranges(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    uint32_t dim_idx,
+    const void* start,
+    uint64_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -275,6 +275,60 @@ Status Subarray::add_range(
       dim_idx, Range(&range[0], 2 * coord_size), err_on_range_oob_);
 }
 
+Status Subarray::add_point_ranges(
+    unsigned dim_idx, const void* start, uint64_t count) {
+  if (dim_idx >= this->array_->array_schema_latest()->dim_num())
+    return LOG_STATUS(
+        Status::SubarrayError("Cannot add range; Invalid dimension index"));
+
+  QueryType array_query_type;
+  RETURN_NOT_OK(array_->get_query_type(&array_query_type));
+  if (array_query_type == tiledb::sm::QueryType::WRITE) {
+    if (!array_->array_schema_latest()->dense()) {
+      return LOG_STATUS(Status::SubarrayError(
+          "Adding a subarray range to a write query is not "
+          "supported in sparse arrays"));
+    }
+    if (this->is_set(dim_idx))
+      return LOG_STATUS(
+          Status::SubarrayError("Cannot add range; Multi-range dense writes "
+                                "are not supported"));
+  }
+
+  if (start == nullptr)
+    return LOG_STATUS(
+        Status::SubarrayError("Cannot add ranges; Invalid start pointer"));
+
+  if (this->array_->array_schema_latest()
+          ->domain()
+          ->dimension(dim_idx)
+          ->var_size())
+    return LOG_STATUS(
+        Status::SubarrayError("Cannot add range; Range must be fixed-sized"));
+
+  // Prepare a temp range
+  std::vector<uint8_t> range;
+  uint8_t coord_size =
+      this->array_->array_schema_latest()->dimension(dim_idx)->coord_size();
+  range.resize(2 * coord_size);
+
+  ranges_[dim_idx].reserve(ranges_[dim_idx].size() + count);
+  for (size_t i = 0; i < count; i++) {
+    uint8_t* ptr = (uint8_t*)start + coord_size * i;
+    // point ranges
+    std::memcpy(&range[0], ptr, coord_size);
+    std::memcpy(&range[coord_size], ptr, coord_size);
+
+    // Add range
+    auto st = this->add_range(
+        dim_idx, Range(&range[0], 2 * coord_size), err_on_range_oob_);
+    if (!st.ok()) {
+      return LOG_STATUS(std::move(st));
+    }
+  }
+  return Status::Ok();
+}
+
 Status Subarray::add_range_by_name(
     const std::string& dim_name,
     const void* start,

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -255,6 +255,16 @@ class Subarray {
       unsigned dim_idx, const void* start, const void* end, const void* stride);
 
   /**
+   * @brief Set point ranges from an array
+   *
+   * @param dim_idx Dimension index
+   * @param start Pointer to start of the array
+   * @param count Number of elements to add
+   * @return Status
+   */
+  Status add_point_ranges(unsigned dim_idx, const void* start, uint64_t count);
+
+  /**
    * Adds a variable-sized range to the (read/write) query on the input
    * dimension by index, in the form of (start, end).
    */


### PR DESCRIPTION
This API allows bulk insertion of point-ranges (start==end) amortizing some
expensive parts of the initial path, to reduce overhead with large range
counts. For example, in a customer scenario with >300k point-ranges, this
API reduces insertion time from 7s to 0.05s.

This API is an experimental API and not in its final form. We are likely to adjust and change during the 2.7 development cycle to expand from point ranges to generic bulk range adding.

---
TYPE: C_API
DESC: Add bulk point-range setter tiledb_query_add_point_ranges
