### PR TITLE
Avoid setting config on transient subarray

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3487,10 +3487,6 @@ int32_t tiledb_query_add_range(
     return TILEDB_ERR;
 
   tiledb_subarray_transient_local_t query_subarray(query);
-  tiledb_config_t local_cfg;
-  // Drop 'const'ness for local usage here
-  local_cfg.config_ = (tiledb::sm::Config*)query->query_->config();
-  tiledb_subarray_set_config(ctx, &query_subarray, &local_cfg);
   return tiledb_subarray_add_range(
       ctx, &query_subarray, dim_idx, start, end, stride);
 }

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3512,6 +3512,10 @@ TILEDB_EXPORT int32_t tiledb_query_get_stats(
 /**
  * Set the query config
  *
+ * Setting the query config will also set the subarray configuration in order to
+ * maintain existing behavior. If you wish the subarray to have a different
+ * configuration than the query, set it after calling tiledb_query_set_config.
+ *
  * Setting the configuration with this function overrides the following
  * Query-level parameters only:
  *

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1133,6 +1133,10 @@ class Query {
   /**
    * Set the query config.
    *
+   * Setting the query config will also set the subarray configuration in order
+   * to maintain existing behavior. If you wish the subarray to have a different
+   * configuration than the query, set it after calling Query::set_config.
+   *
    * Setting configuration with this function overrides the following
    * Query-level parameters only:
    *

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -106,6 +106,9 @@ Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
   if (storage_manager != nullptr)
     config_ = storage_manager->config();
 
+  // Set initial subarray configuration
+  subarray_.set_config(config_);
+
   rest_scratch_ = make_shared<Buffer>(HERE());
 }
 
@@ -1184,9 +1187,14 @@ Status Query::check_set_fixed_buffer(const std::string& name) {
 Status Query::set_config(const Config& config) {
   config_ = config;
 
-  // Refresh memory budget configutation.
+  // Refresh memory budget configuration.
   if (strategy_ != nullptr)
     RETURN_NOT_OK(strategy_->initialize_memory_budget());
+
+  // Set subarray's config for backwards compatibility
+  // Users expect the query config to effect the subarray based on existing
+  // behavior before subarray was exposed directly
+  subarray_.set_config(config_);
 
   return Status::Ok();
 }


### PR DESCRIPTION
For the existing `tiledb_query_add_range` APIs there is a transient subarray object that is referenced. In one API the query config was also being set on this subarray. This is not required, and other variations of `tiledb_query_add_range` did not set the config. Removing this saves a few seconds of the WALL time when a user is setting hundreds of thousands of ranges.

The performance bottleneck comes in when the config is copied which is a full copy of the config map. This was being done once per range setting.

---
TYPE: IMPROVEMENT
DESC: Avoid copy and set of config in `tiledb_query_add_range` as a performance optimization from the new subarray APIs