### PR TITLE
Deprecate tiledb_char

### DIFF
--- a/test/src/unit-cppapi-type.cc
+++ b/test/src/unit-cppapi-type.cc
@@ -54,7 +54,7 @@ TEST_CASE("C++ API: Types", "[cppapi][types]") {
            value));
 
   CHECK_THROWS(impl::type_check<MyData>(TILEDB_INT8));
-  CHECK_NOTHROW(impl::type_check<MyData>(TILEDB_CHAR, sizeof(MyData)));
+  CHECK_NOTHROW(impl::type_check<MyData>(TILEDB_STRING_ASCII, sizeof(MyData)));
 
   // static char arrays are ok for tiledb string types as long as the static
   // lengths are equal
@@ -136,10 +136,10 @@ TEST_CASE("C++ API: Types", "[cppapi][types]") {
   CHECK(a1.type() == TILEDB_INT32);
   CHECK(a2.type() == TILEDB_FLOAT32);
   CHECK(a3.type() == TILEDB_FLOAT32);
-  CHECK(a4.type() == TILEDB_CHAR);
-  CHECK(a5.type() == TILEDB_CHAR);
-  CHECK(a6.type() == TILEDB_CHAR);
-  CHECK(a7.type() == TILEDB_CHAR);
+  CHECK(a4.type() == TILEDB_STRING_ASCII);
+  CHECK(a5.type() == TILEDB_STRING_ASCII);
+  CHECK(a6.type() == TILEDB_STRING_ASCII);
+  CHECK(a7.type() == TILEDB_STRING_ASCII);
   CHECK(a8.type() == TILEDB_FLOAT64);
   CHECK(a9.type() == TILEDB_FLOAT64);
 

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -119,6 +119,12 @@ typedef enum {
 #define TILEDB_DATATYPE_ENUM(id) TILEDB_##id
 #include "tiledb_enum.h"
 #undef TILEDB_DATATYPE_ENUM
+#ifdef TILEDB_CHAR
+#def TILEDB_CHAR_VAL TILEDB_CHAR
+#undef TILEDB_CHAR
+#define TILEDB_CHAR TILEDB_DEPRECATED TILEDB_CHAR_VAL
+#undef TILEDB_CHAR_VAL
+#endif
 } tiledb_datatype_t;
 
 /** Array type. */

--- a/tiledb/sm/cpp_api/exception.h
+++ b/tiledb/sm/cpp_api/exception.h
@@ -82,10 +82,12 @@ const T& identity(const T& t) {
 template <typename T, typename Handler = TypeHandler<T>>
 inline void type_check(tiledb_datatype_t type, unsigned num = 0) {
   if (tiledb_string_type(type)) {
-    if (Handler::tiledb_type != identity(TILEDB_CHAR)) {
+    if (Handler::tiledb_type != identity(TILEDB_STRING_ASCII) &&
+        Handler::tiledb_type != identity(TILEDB_CHAR)) {
       throw TypeError(
           "Static type (" + impl::type_to_str(Handler::tiledb_type) +
-          ") does not match expected container type CHAR for tiledb type (" +
+          ") does not match expected container type STRING_ASCII for tiledb "
+          "type (" +
           impl::type_to_str(type) + ")");
     }
   } else if (tiledb_datetime_type(type)) {

--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -80,7 +80,7 @@ template <typename T>
 struct type_to_tiledb {
   static_assert(IS_TRIVIALLY_COPYABLE(T), "Type must be trivially copyable.");
   using type = char;
-  static const tiledb_datatype_t tiledb_type = TILEDB_CHAR;
+  static const tiledb_datatype_t tiledb_type = TILEDB_STRING_ASCII;
   static constexpr const char* name = "Trivially Copyable (CHAR)";
 };
 


### PR DESCRIPTION
This PR deprecates the `TileDB_CHAR` datatype in the external API. There is a lot of confusion around `TILEDB_CHAR` and different users and applications use it in different ways. Some users use it for storing arbitrary bytes, others for single characters and still others for "strings". In this regard our goals is to introduce a byte datatype in #2721 and deprecate the use `TILEDB_CHAR` in this PR. Users are encouraged and expected to choose either `TILEDB_BYTE` or `TILEDB_STRING_ASCII` based on the data being stored and desired interpretation.

 [ch12395]

---
TYPE: DEPRECATION
DESC: Deprecate `TILEDB_CHAR` in favor of users using `TILEDB_BYTE` or `TILEDB_STRING_ASCII` for attribute datatypes.

TYPE: C_API
DESC: Deprecate `TILEDB_CHAR` in favor of users using `TILEDB_BYTE` or `TILEDB_STRING_ASCII` for attribute datatypes.


TYPE: CPP_API
DESC: Deprecate `TILEDB_CHAR` in favor of users using `TILEDB_BYTE` or `TILEDB_STRING_ASCII` for attribute datatypes.