### PR TITLE
[Backport release-2.6] Use correct frag index in tiles creation for compute_result_space_tiles #2741

### DIFF
--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -149,7 +149,7 @@ void ReadCellSlabIterFx::create_result_space_tiles(
   std::vector<TileDomain<T>> frag_tile_domains;
   for (size_t i = 0; i < domain_slices.size(); ++i) {
     frag_tile_domains.emplace_back(
-        (unsigned)(domain_slices.size() - i),
+        (unsigned)(domain_slices.size() - i - 1),
         domain,
         domain_slices[i],
         tile_extents,
@@ -246,8 +246,8 @@ TEST_CASE_METHOD(
   ReadCellSlabIter<uint64_t> iter(
       &subarray, &result_space_tiles, &result_coords);
   std::vector<std::vector<uint64_t>> c_result_cell_slabs = {
-      {1, 0, 4, 6},
-      {1, 1, 0, 5},
+      {0, 0, 4, 6},
+      {0, 1, 0, 5},
   };
   check_iter<uint64_t>(&iter, c_result_cell_slabs);
 
@@ -395,14 +395,14 @@ TEST_CASE_METHOD(
   ReadCellSlabIter<uint64_t> iter(
       &subarray, &result_space_tiles, &result_coords);
   std::vector<std::vector<uint64_t>> c_result_cell_slabs = {
-      {2, 0, 4, 6},
-      {2, 1, 0, 2},
-      {1, 1, 2, 3},
+      {1, 0, 4, 6},
+      {1, 1, 0, 2},
+      {0, 1, 2, 3},
       {UINT64_MAX, 0, 2, 1},
-      {1, 0, 3, 1},
-      {2, 0, 4, 1},
-      {2, 1, 0, 2},
-      {1, 1, 2, 2},
+      {0, 0, 3, 1},
+      {1, 0, 4, 1},
+      {1, 1, 0, 2},
+      {0, 1, 2, 2},
   };
   check_iter<uint64_t>(&iter, c_result_cell_slabs);
 
@@ -473,9 +473,9 @@ TEST_CASE_METHOD(
 
   // Create result coordinates
   std::vector<ResultCoords> result_coords;
-  ResultTile result_tile_2_0(2, 0, array_->array_->array_schema_latest());
-  ResultTile result_tile_3_0(3, 0, array_->array_->array_schema_latest());
-  ResultTile result_tile_3_1(3, 1, array_->array_->array_schema_latest());
+  ResultTile result_tile_2_0(1, 0, array_->array_->array_schema_latest());
+  ResultTile result_tile_3_0(2, 0, array_->array_->array_schema_latest());
+  ResultTile result_tile_3_1(2, 1, array_->array_->array_schema_latest());
 
   result_tile_2_0.init_coord_tile("d", 0);
   result_tile_3_0.init_coord_tile("d", 0);
@@ -514,17 +514,17 @@ TEST_CASE_METHOD(
   ReadCellSlabIter<uint64_t> iter(
       &subarray, &result_space_tiles, &result_coords);
   std::vector<std::vector<uint64_t>> c_result_cell_slabs = {
-      {2, 0, 1, 1},
+      {1, 0, 1, 1},
+      {0, 0, 3, 1},
       {1, 0, 3, 1},
-      {2, 0, 3, 1},
-      {1, 0, 5, 2},
-      {3, 0, 2, 1},
-      {1, 0, 8, 2},
-      {1, 1, 0, 1},
-      {3, 1, 1, 1},
+      {0, 0, 5, 2},
+      {2, 0, 2, 1},
+      {0, 0, 8, 2},
+      {0, 1, 0, 1},
+      {2, 1, 1, 1},
       {UINT64_MAX, 1, 2, 3},
       {UINT64_MAX, 1, 7, 1},
-      {3, 1, 2, 1},
+      {2, 1, 2, 1},
       {UINT64_MAX, 1, 9, 1},
   };
   check_iter<uint64_t>(&iter, c_result_cell_slabs);
@@ -549,10 +549,10 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::ROW_MAJOR;
     tile_domain_layout = Layout::ROW_MAJOR;
     c_result_cell_slabs = {
-        {1, 0, 4, 2},
-        {1, 1, 3, 3},
-        {1, 0, 7, 2},
-        {1, 1, 6, 3},
+        {0, 0, 4, 2},
+        {0, 1, 3, 3},
+        {0, 0, 7, 2},
+        {0, 1, 6, 3},
     };
   }
 
@@ -562,10 +562,10 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::ROW_MAJOR;
     tile_domain_layout = Layout::ROW_MAJOR;
     c_result_cell_slabs = {
-        {1, 0, 4, 2},
-        {1, 1, 1, 3},
-        {1, 0, 5, 2},
-        {1, 1, 2, 3},
+        {0, 0, 4, 2},
+        {0, 1, 1, 3},
+        {0, 0, 5, 2},
+        {0, 1, 2, 3},
     };
   }
 
@@ -575,10 +575,10 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::ROW_MAJOR;
     tile_domain_layout = Layout::COL_MAJOR;
     c_result_cell_slabs = {
-        {1, 0, 4, 2},
-        {1, 2, 3, 3},
-        {1, 0, 7, 2},
-        {1, 2, 6, 3},
+        {0, 0, 4, 2},
+        {0, 2, 3, 3},
+        {0, 0, 7, 2},
+        {0, 2, 6, 3},
     };
   }
 
@@ -588,10 +588,10 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::ROW_MAJOR;
     tile_domain_layout = Layout::COL_MAJOR;
     c_result_cell_slabs = {
-        {1, 0, 4, 2},
-        {1, 2, 1, 3},
-        {1, 0, 5, 2},
-        {1, 2, 2, 3},
+        {0, 0, 4, 2},
+        {0, 2, 1, 3},
+        {0, 0, 5, 2},
+        {0, 2, 2, 3},
     };
   }
 
@@ -601,11 +601,11 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::COL_MAJOR;
     tile_domain_layout = Layout::ROW_MAJOR;
     c_result_cell_slabs = {
-        {1, 0, 4, 2},
-        {1, 0, 5, 2},
-        {1, 1, 3, 2},
-        {1, 1, 4, 2},
-        {1, 1, 5, 2},
+        {0, 0, 4, 2},
+        {0, 0, 5, 2},
+        {0, 1, 3, 2},
+        {0, 1, 4, 2},
+        {0, 1, 5, 2},
     };
   }
 
@@ -615,11 +615,11 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::COL_MAJOR;
     tile_domain_layout = Layout::ROW_MAJOR;
     c_result_cell_slabs = {
-        {1, 0, 4, 2},
-        {1, 0, 7, 2},
-        {1, 1, 1, 2},
-        {1, 1, 4, 2},
-        {1, 1, 7, 2},
+        {0, 0, 4, 2},
+        {0, 0, 7, 2},
+        {0, 1, 1, 2},
+        {0, 1, 4, 2},
+        {0, 1, 7, 2},
     };
   }
 
@@ -629,11 +629,11 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::COL_MAJOR;
     tile_domain_layout = Layout::COL_MAJOR;
     c_result_cell_slabs = {
-        {1, 0, 4, 2},
-        {1, 0, 5, 2},
-        {1, 2, 3, 2},
-        {1, 2, 4, 2},
-        {1, 2, 5, 2},
+        {0, 0, 4, 2},
+        {0, 0, 5, 2},
+        {0, 2, 3, 2},
+        {0, 2, 4, 2},
+        {0, 2, 5, 2},
     };
   }
 
@@ -643,11 +643,11 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::COL_MAJOR;
     tile_domain_layout = Layout::COL_MAJOR;
     c_result_cell_slabs = {
-        {1, 0, 4, 2},
-        {1, 0, 7, 2},
-        {1, 2, 1, 2},
-        {1, 2, 4, 2},
-        {1, 2, 7, 2},
+        {0, 0, 4, 2},
+        {0, 0, 7, 2},
+        {0, 2, 1, 2},
+        {0, 2, 4, 2},
+        {0, 2, 7, 2},
     };
   }
 
@@ -922,7 +922,7 @@ TEST_CASE_METHOD(
         {UINT64_MAX, 1, 3, 3},
         {UINT64_MAX, 0, 7, 2},
         {UINT64_MAX, 1, 6, 1},
-        {1, 0, 7, 2},
+        {0, 0, 7, 2},
     };
   }
 
@@ -936,7 +936,7 @@ TEST_CASE_METHOD(
         {UINT64_MAX, 1, 1, 3},
         {UINT64_MAX, 0, 5, 2},
         {UINT64_MAX, 1, 2, 1},
-        {1, 0, 5, 2},
+        {0, 0, 5, 2},
     };
   }
 
@@ -950,7 +950,7 @@ TEST_CASE_METHOD(
         {UINT64_MAX, 2, 3, 3},
         {UINT64_MAX, 0, 7, 2},
         {UINT64_MAX, 2, 6, 1},
-        {1, 0, 7, 2},
+        {0, 0, 7, 2},
     };
   }
 
@@ -964,7 +964,7 @@ TEST_CASE_METHOD(
         {UINT64_MAX, 2, 1, 3},
         {UINT64_MAX, 0, 5, 2},
         {UINT64_MAX, 2, 2, 1},
-        {1, 0, 5, 2},
+        {0, 0, 5, 2},
     };
   }
 
@@ -978,9 +978,9 @@ TEST_CASE_METHOD(
         {UINT64_MAX, 0, 5, 2},
         {UINT64_MAX, 1, 3, 2},
         {UINT64_MAX, 1, 4, 1},
-        {1, 0, 7, 1},
+        {0, 0, 7, 1},
         {UINT64_MAX, 1, 5, 1},
-        {1, 0, 8, 1},
+        {0, 0, 8, 1},
     };
   }
 
@@ -994,9 +994,9 @@ TEST_CASE_METHOD(
         {UINT64_MAX, 0, 7, 2},
         {UINT64_MAX, 1, 1, 2},
         {UINT64_MAX, 1, 4, 1},
-        {1, 0, 5, 1},
+        {0, 0, 5, 1},
         {UINT64_MAX, 1, 7, 1},
-        {1, 0, 8, 1},
+        {0, 0, 8, 1},
     };
   }
 
@@ -1010,9 +1010,9 @@ TEST_CASE_METHOD(
         {UINT64_MAX, 0, 5, 2},
         {UINT64_MAX, 2, 3, 2},
         {UINT64_MAX, 2, 4, 1},
-        {1, 0, 7, 1},
+        {0, 0, 7, 1},
         {UINT64_MAX, 2, 5, 1},
-        {1, 0, 8, 1},
+        {0, 0, 8, 1},
     };
   }
 
@@ -1026,9 +1026,9 @@ TEST_CASE_METHOD(
         {UINT64_MAX, 0, 7, 2},
         {UINT64_MAX, 2, 1, 2},
         {UINT64_MAX, 2, 4, 1},
-        {1, 0, 5, 1},
+        {0, 0, 5, 1},
         {UINT64_MAX, 2, 7, 1},
-        {1, 0, 8, 1},
+        {0, 0, 8, 1},
     };
   }
 
@@ -1115,17 +1115,17 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::ROW_MAJOR;
     tile_domain_layout = Layout::ROW_MAJOR;
     c_result_cell_slabs = {
-        {2, 0, 7, 1},
-        {3, 0, 1, 1},
-        {2, 1, 6, 1},
-        {1, 1, 7, 2},
-        {2, 2, 1, 2},
-        {2, 3, 0, 1},
+        {1, 0, 7, 1},
+        {2, 0, 1, 1},
+        {1, 1, 6, 1},
+        {0, 1, 7, 2},
+        {1, 2, 1, 2},
+        {1, 3, 0, 1},
         {UINT64_MAX, 3, 1, 2},
-        {2, 2, 4, 2},
-        {2, 3, 3, 1},
-        {3, 1, 0, 1},
-        {3, 1, 2, 1},
+        {1, 2, 4, 2},
+        {1, 3, 3, 1},
+        {2, 1, 0, 1},
+        {2, 1, 2, 1},
     };
   }
 
@@ -1135,17 +1135,17 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::ROW_MAJOR;
     tile_domain_layout = Layout::ROW_MAJOR;
     c_result_cell_slabs = {
-        {2, 0, 5, 1},
-        {3, 0, 1, 1},
-        {2, 1, 2, 1},
-        {1, 1, 5, 2},
-        {2, 2, 3, 2},
-        {2, 3, 0, 1},
+        {1, 0, 5, 1},
+        {2, 0, 1, 1},
+        {1, 1, 2, 1},
+        {0, 1, 5, 2},
+        {1, 2, 3, 2},
+        {1, 3, 0, 1},
         {UINT64_MAX, 3, 3, 2},
-        {2, 2, 4, 2},
-        {2, 3, 1, 1},
-        {3, 1, 0, 1},
-        {3, 1, 2, 1},
+        {1, 2, 4, 2},
+        {1, 3, 1, 1},
+        {2, 1, 0, 1},
+        {2, 1, 2, 1},
     };
   }
 
@@ -1155,17 +1155,17 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::ROW_MAJOR;
     tile_domain_layout = Layout::COL_MAJOR;
     c_result_cell_slabs = {
-        {2, 0, 7, 1},
-        {3, 0, 1, 1},
-        {2, 2, 6, 1},
-        {1, 1, 7, 2},
-        {2, 1, 1, 2},
-        {2, 3, 0, 1},
+        {1, 0, 7, 1},
+        {2, 0, 1, 1},
+        {1, 2, 6, 1},
+        {0, 1, 7, 2},
+        {1, 1, 1, 2},
+        {1, 3, 0, 1},
         {UINT64_MAX, 3, 1, 2},
-        {2, 1, 4, 2},
-        {2, 3, 3, 1},
-        {3, 1, 0, 1},
-        {3, 1, 2, 1},
+        {1, 1, 4, 2},
+        {1, 3, 3, 1},
+        {2, 1, 0, 1},
+        {2, 1, 2, 1},
     };
   }
 
@@ -1175,17 +1175,17 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::ROW_MAJOR;
     tile_domain_layout = Layout::COL_MAJOR;
     c_result_cell_slabs = {
-        {2, 0, 5, 1},
-        {3, 0, 1, 1},
-        {2, 2, 2, 1},
-        {1, 1, 5, 2},
-        {2, 1, 3, 2},
-        {2, 3, 0, 1},
+        {1, 0, 5, 1},
+        {2, 0, 1, 1},
+        {1, 2, 2, 1},
+        {0, 1, 5, 2},
+        {1, 1, 3, 2},
+        {1, 3, 0, 1},
         {UINT64_MAX, 3, 3, 2},
-        {2, 1, 4, 2},
-        {2, 3, 1, 1},
-        {3, 1, 0, 1},
-        {3, 1, 2, 1},
+        {1, 1, 4, 2},
+        {1, 3, 1, 1},
+        {2, 1, 0, 1},
+        {2, 1, 2, 1},
     };
   }
 
@@ -1195,18 +1195,18 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::COL_MAJOR;
     tile_domain_layout = Layout::ROW_MAJOR;
     c_result_cell_slabs = {
-        {2, 0, 7, 1},
-        {2, 2, 1, 2},
-        {3, 0, 1, 1},
-        {2, 2, 2, 2},
-        {2, 1, 6, 1},
-        {2, 3, 0, 2},
-        {1, 1, 7, 1},
+        {1, 0, 7, 1},
+        {1, 2, 1, 2},
+        {2, 0, 1, 1},
+        {1, 2, 2, 2},
+        {1, 1, 6, 1},
+        {1, 3, 0, 2},
+        {0, 1, 7, 1},
         {UINT64_MAX, 3, 1, 1},
-        {3, 1, 0, 1},
-        {1, 1, 8, 1},
+        {2, 1, 0, 1},
+        {0, 1, 8, 1},
         {UINT64_MAX, 3, 2, 1},
-        {3, 1, 2, 1},
+        {2, 1, 2, 1},
     };
   }
 
@@ -1216,18 +1216,18 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::COL_MAJOR;
     tile_domain_layout = Layout::ROW_MAJOR;
     c_result_cell_slabs = {
-        {2, 0, 5, 1},
-        {2, 2, 3, 2},
-        {3, 0, 1, 1},
-        {2, 2, 6, 2},
-        {2, 1, 2, 1},
-        {2, 3, 0, 2},
-        {1, 1, 5, 1},
+        {1, 0, 5, 1},
+        {1, 2, 3, 2},
+        {2, 0, 1, 1},
+        {1, 2, 6, 2},
+        {1, 1, 2, 1},
+        {1, 3, 0, 2},
+        {0, 1, 5, 1},
         {UINT64_MAX, 3, 3, 1},
-        {3, 1, 0, 1},
-        {1, 1, 8, 1},
+        {2, 1, 0, 1},
+        {0, 1, 8, 1},
         {UINT64_MAX, 3, 6, 1},
-        {3, 1, 2, 1},
+        {2, 1, 2, 1},
     };
   }
 
@@ -1237,18 +1237,18 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::COL_MAJOR;
     tile_domain_layout = Layout::COL_MAJOR;
     c_result_cell_slabs = {
-        {2, 0, 7, 1},
-        {2, 1, 1, 2},
-        {3, 0, 1, 1},
-        {2, 1, 2, 2},
-        {2, 2, 6, 1},
-        {2, 3, 0, 2},
-        {1, 1, 7, 1},
+        {1, 0, 7, 1},
+        {1, 1, 1, 2},
+        {2, 0, 1, 1},
+        {1, 1, 2, 2},
+        {1, 2, 6, 1},
+        {1, 3, 0, 2},
+        {0, 1, 7, 1},
         {UINT64_MAX, 3, 1, 1},
-        {3, 1, 0, 1},
-        {1, 1, 8, 1},
+        {2, 1, 0, 1},
+        {0, 1, 8, 1},
         {UINT64_MAX, 3, 2, 1},
-        {3, 1, 2, 1},
+        {2, 1, 2, 1},
     };
   }
 
@@ -1258,18 +1258,18 @@ TEST_CASE_METHOD(
     subarray_layout = Layout::COL_MAJOR;
     tile_domain_layout = Layout::COL_MAJOR;
     c_result_cell_slabs = {
-        {2, 0, 5, 1},
-        {2, 1, 3, 2},
-        {3, 0, 1, 1},
-        {2, 1, 6, 2},
-        {2, 2, 2, 1},
-        {2, 3, 0, 2},
-        {1, 1, 5, 1},
+        {1, 0, 5, 1},
+        {1, 1, 3, 2},
+        {2, 0, 1, 1},
+        {1, 1, 6, 2},
+        {1, 2, 2, 1},
+        {1, 3, 0, 2},
+        {0, 1, 5, 1},
         {UINT64_MAX, 3, 3, 1},
-        {3, 1, 0, 1},
-        {1, 1, 8, 1},
+        {2, 1, 0, 1},
+        {0, 1, 8, 1},
         {UINT64_MAX, 3, 6, 1},
-        {3, 1, 2, 1},
+        {2, 1, 2, 1},
     };
   }
 
@@ -1334,8 +1334,8 @@ TEST_CASE_METHOD(
 
   // Create result coordinates
   std::vector<ResultCoords> result_coords;
-  ResultTile result_tile_3_0(3, 0, array_->array_->array_schema_latest());
-  ResultTile result_tile_3_1(3, 1, array_->array_->array_schema_latest());
+  ResultTile result_tile_3_0(2, 0, array_->array_->array_schema_latest());
+  ResultTile result_tile_3_1(2, 1, array_->array_->array_schema_latest());
 
   result_tile_3_0.init_coord_tile("d1", 0);
   result_tile_3_0.init_coord_tile("d2", 1);

--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -168,11 +168,11 @@ TEST_CASE_METHOD(
 
   std::vector<TileDomain<int32_t>> frag_tile_domains;
   frag_tile_domains.emplace_back(
-      TileDomain<int32_t>(3, domain, ds3, tile_extents, layout));
+      TileDomain<int32_t>(2, domain, ds3, tile_extents, layout));
   frag_tile_domains.emplace_back(
-      TileDomain<int32_t>(2, domain, ds2, tile_extents, layout));
+      TileDomain<int32_t>(1, domain, ds2, tile_extents, layout));
   frag_tile_domains.emplace_back(
-      TileDomain<int32_t>(1, domain, ds1, tile_extents, layout));
+      TileDomain<int32_t>(0, domain, ds1, tile_extents, layout));
   TileDomain<int32_t> array_tile_domain(
       UINT32_MAX, domain, dsd, tile_extents, layout);
 
@@ -210,38 +210,38 @@ TEST_CASE_METHOD(
       &result_space_tiles);
   CHECK(result_space_tiles.size() == 6);
 
+  // Result tiles for fragment #0
+  ResultTile result_tile_1_0_0(0, 0, &schema);
+  ResultTile result_tile_1_2_0(0, 2, &schema);
+
   // Result tiles for fragment #1
   ResultTile result_tile_1_0_1(1, 0, &schema);
-  ResultTile result_tile_1_2_1(1, 2, &schema);
 
   // Result tiles for fragment #2
-  ResultTile result_tile_1_0_2(2, 0, &schema);
-
-  // Result tiles for fragment #3
-  ResultTile result_tile_2_0_3(3, 0, &schema);
-  ResultTile result_tile_3_0_3(3, 2, &schema);
+  ResultTile result_tile_2_0_2(2, 0, &schema);
+  ResultTile result_tile_3_0_2(2, 2, &schema);
 
   // Initialize result_space_tiles
   ResultSpaceTile<int32_t> rst_1_0;
   rst_1_0.set_start_coords({3, 1});
-  rst_1_0.append_frag_domain(2, ds2);
-  rst_1_0.append_frag_domain(1, ds1);
+  rst_1_0.append_frag_domain(1, ds2);
+  rst_1_0.append_frag_domain(0, ds1);
+  rst_1_0.set_result_tile(0, result_tile_1_0_0);
   rst_1_0.set_result_tile(1, result_tile_1_0_1);
-  rst_1_0.set_result_tile(2, result_tile_1_0_2);
   ResultSpaceTile<int32_t> rst_1_2;
   rst_1_2.set_start_coords({3, 11});
-  rst_1_2.append_frag_domain(1, ds1);
-  rst_1_2.set_result_tile(1, result_tile_1_2_1);
+  rst_1_2.append_frag_domain(0, ds1);
+  rst_1_2.set_result_tile(0, result_tile_1_2_0);
   ResultSpaceTile<int32_t> rst_2_0;
   rst_2_0.set_start_coords({5, 1});
-  rst_2_0.append_frag_domain(3, ds3);
-  rst_2_0.set_result_tile(3, result_tile_2_0_3);
+  rst_2_0.append_frag_domain(2, ds3);
+  rst_2_0.set_result_tile(2, result_tile_2_0_2);
   ResultSpaceTile<int32_t> rst_2_2;
   rst_2_2.set_start_coords({5, 11});
   ResultSpaceTile<int32_t> rst_3_0;
   rst_3_0.set_start_coords({7, 1});
-  rst_3_0.append_frag_domain(3, ds3);
-  rst_3_0.set_result_tile(3, result_tile_3_0_3);
+  rst_3_0.append_frag_domain(2, ds3);
+  rst_3_0.set_result_tile(2, result_tile_3_0_2);
   ResultSpaceTile<int32_t> rst_3_2;
   rst_3_2.set_start_coords({7, 11});
 

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -132,7 +132,7 @@ void ReaderBase::compute_result_space_tiles(
       result_space_tile.append_frag_domain(frag_idx, frag_domain);
       auto tile_idx = frag_tile_domains[f].tile_pos(coords);
       ResultTile result_tile(
-          frag_idx, tile_idx, fragment_metadata[f]->array_schema());
+          frag_idx, tile_idx, fragment_metadata[frag_idx]->array_schema());
       result_space_tile.set_result_tile(frag_idx, result_tile);
     }
   }


### PR DESCRIPTION
Backport 5e85dfc1378f08aadbf7cd6d2fe6af1eca3fa08a from #2741

---
TYPE: IMPROVEMENT
DESC: Use correct frag index in tiles creation for compute_result_space_tiles.