### PR TITLE
[CPP] Backport Query::ctx and Query::array getters from 2.7

### DIFF
--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -2271,6 +2271,14 @@ class Query {
     return "";  // silence error
   }
 
+  const Context& ctx() const {
+    return ctx_.get();
+  }
+
+  const Array& array() const {
+    return array_.get();
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */


### PR DESCRIPTION
TYPE: CPP_API
DESC: Backport Query::ctx and Query::array getters from 2.7

Backport from https://github.com/TileDB-Inc/TileDB/pull/2214

---
TYPE: CPP_API
DESC: Backport Query::ctx and Query::array getters from 2.7
