### PR TITLE
[Backport release-2.6] Update github action CI jobs to macOS 11 (#2756)

### DIFF
--- a/.github/workflows/build-macOS11-GCS.yml
+++ b/.github/workflows/build-macOS11-GCS.yml
@@ -1,4 +1,4 @@
-name: build-macos-10.14-GCS
+name: build-macos-11-GCS
 on:
   push:
     branches:
@@ -16,7 +16,15 @@ env:
 
 jobs:
   build:
+<<<<<<< HEAD:.github/workflows/build-macOS10.14-GCS.yml
     runs-on: macos-10.14
+=======
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          -  macos-11
+>>>>>>> e120692b6 (Update github action CI jobs to macOS 11 (#2756)):.github/workflows/build-macOS11-GCS.yml
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
     timeout-minutes: 90
     name: Build - macos-10.14 - GCS

--- a/.github/workflows/build-macOS11-S3.yml
+++ b/.github/workflows/build-macOS11-S3.yml
@@ -1,4 +1,4 @@
-name: build-macos-10.14-S3
+name: build-macos-11-S3
 on:
   push:
     branches:
@@ -17,7 +17,15 @@ env:
 
 jobs:
   build:
+<<<<<<< HEAD:.github/workflows/build-macOS10.14-S3.yml
     runs-on: macos-10.14
+=======
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          -  macos-11
+>>>>>>> e120692b6 (Update github action CI jobs to macOS 11 (#2756)):.github/workflows/build-macOS11-S3.yml
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
     timeout-minutes: 90
     name: Build - macos-10.14 - S3


### PR DESCRIPTION
Backport e120692b6a53cf330dfb68be7f32428676859f72 from #2756

---
TYPE: NO_HISTORY
DESC: NO_HISTORY
