### PR TITLE
RFC Allow writing subset of attributes at a time

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3122,6 +3122,27 @@ int32_t tiledb_query_set_data_buffer(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_unset_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name) {  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(ctx, query->query_->unset_buffer(name)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_set_continuation(
+    tiledb_ctx_t* ctx, tiledb_query_t* query) {
+  if (SAVE_ERROR_CATCH(ctx, query->query_->set_continuation()))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_set_offsets_buffer(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
@@ -3759,6 +3780,17 @@ int32_t tiledb_query_get_fragment_uri(
     return TILEDB_ERR;
 
   if (SAVE_ERROR_CATCH(ctx, query->query_->get_written_fragment_uri(idx, uri)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_set_fragment_uri(
+    tiledb_ctx_t* ctx, const tiledb_query_t* query, const char* uri) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(ctx, query->query_->set_write_fragment_uri(uri)))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3847,6 +3847,14 @@ TILEDB_EXPORT int32_t tiledb_query_set_data_buffer(
     void* buffer,
     uint64_t* buffer_size);
 
+/* TODO */
+TILEDB_EXPORT int32_t tiledb_query_unset_buffer(
+    tiledb_ctx_t* ctx, tiledb_query_t* query, const char* name);
+
+/* TODO */
+TILEDB_EXPORT int32_t
+tiledb_query_set_continuation(tiledb_ctx_t* ctx, tiledb_query_t* query);
+
 /**
  * Sets the starting offsets of each cell value in the data buffer.
  *
@@ -4921,6 +4929,31 @@ TILEDB_EXPORT int32_t tiledb_query_get_fragment_uri(
     const tiledb_query_t* query,
     uint64_t idx,
     const char** uri);
+
+/**
+ * Retrieves the URI of the written fragment with the input index. Applicable
+ * only to WRITE queries.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * const char* uri;
+ * tiledb_query_get_fragment_uri(
+ *     ctx, query, 0, &uri);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param query The query.
+ * @param idx The index of the written fragment.
+ * @param uri The URI of the written fragment to be returned.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note Make sure to make a copy of `uri` after its retrieval, as the
+ *     constant pointer may be updated internally as new fragments
+ *     are being written.
+ */
+TILEDB_EXPORT int32_t tiledb_query_set_fragment_uri(
+    tiledb_ctx_t* ctx, const tiledb_query_t* query, const char* uri);
 
 /**
  * Retrieves the timestamp range of the written fragment with the input index.

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1000,6 +1000,21 @@ class Query {
   }
 
   /**
+   * Returns the URI of the written fragment with the input index. Applicable
+   * only to WRITE queries.
+   */
+  Query& set_fragment_uri(const std::string& uri) {
+    if (uri.empty()) {
+      throw TileDBError("Cannot set empty fragment URI");
+    }
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_query_set_fragment_uri(
+        ctx.ptr().get(), query_.get(), uri.c_str()));
+
+    return *this;
+  }
+
+  /**
    * Returns the timestamp range of the written fragment with the input index.
    * Applicable only to WRITE queries.
    */
@@ -1545,6 +1560,15 @@ class Query {
       impl::type_check<T>(schema_.domain().type());
 
     return set_data_buffer(name, buff, nelements, sizeof(T));
+  }
+
+  Query& unset_buffer(const std::string& name) {
+    auto ctx = ctx_.get();
+
+    ctx.handle_error(
+        tiledb_query_unset_buffer(ctx.ptr().get(), query_.get(), name.c_str()));
+
+    return *this;
   }
 
   /**

--- a/tiledb/sm/query/iquery_strategy.h
+++ b/tiledb/sm/query/iquery_strategy.h
@@ -55,6 +55,14 @@ class IQueryStrategy {
   /** Performs a query using its set members. */
   virtual Status dowork() = 0;
 
+  /** Enables continuation query (writes only) */
+  virtual void continuation(){};
+
+  /** TODO **/
+  virtual void set_fragment_uri(const std::string& uri) {
+    (void)uri;
+  };
+
   /** Finalizes the strategy. */
   virtual Status finalize() = 0;
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -332,6 +332,9 @@ class Query {
   /** Retrieves the URI of the written fragment with the input index. */
   Status get_written_fragment_uri(uint32_t idx, const char** uri) const;
 
+  /** Sets the URI of the written fragment with the input index. */
+  Status set_write_fragment_uri(const char* uri);
+
   /**
    * Retrieves the timestamp range [t1,t2] of the written fragment with the
    * input index.
@@ -581,6 +584,12 @@ class Query {
    * @return Status
    */
   Status set_coords_buffer(void* buffer, uint64_t* buffer_size);
+
+  /** TODO **/
+  Status unset_buffer(const std::string& name);
+
+  /** TODO **/
+  Status set_continuation();
 
   /**
    * Sets the data for a fixed/var-sized attribute/dimension.
@@ -978,6 +987,9 @@ class Query {
 
   /* Scratch space used for REST requests. */
   tdb_shared_ptr<Buffer> rest_scratch_;
+
+  /* TODO */
+  bool continuation_ = false;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -121,6 +121,9 @@ class Writer : public StrategyBase, public IQueryStrategy {
   /** Finalizes the writer. */
   Status finalize();
 
+  /** Enable write continuation. */
+  void continuation();
+
   /** Writer is never in an imcomplete state. */
   bool incomplete() const {
     return false;
@@ -171,6 +174,11 @@ class Writer : public StrategyBase, public IQueryStrategy {
    */
   bool disable_check_global_order_;
 
+  /**
+   * If `true`, it will not sort coordinates or check duplicates.
+   */
+  bool continuation_;
+
   /** Keeps track of the coords data. */
   Query::CoordsInfo& coords_info_;
 
@@ -220,6 +228,12 @@ class Writer : public StrategyBase, public IQueryStrategy {
 
   /** UID of the logger instance */
   inline static std::atomic<uint64_t> logger_id_ = 0;
+
+  /** TODO */
+  std::vector<uint64_t> cell_pos_;
+  std::set<uint64_t> coord_dups_;
+  void set_fragment_uri(const std::string& uri);
+  std::shared_ptr<FragmentMetadata> frag_meta_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */


### PR DESCRIPTION
- allow writing only a subset of attributes at a time
- provide API to set the exact fragment URI for write so that we can continue
  writing into an existing fragment folder
- provide API to "unset" a buffer to allow setting the next
  (different) attribute buffer
- provide API to signify that a query is a "continuation" write
  which will avoid various checks and preserve global write state
  until finalization
- move several variables to class level for reuse to allow appending into
  fragment metadata object; avoid recalculating cell position across
  runs; also avoid re-checking duplicates

There may be an implicit requirement that attributes are set in schema
order (that is how I did it in all cases, not sure if this is required
for correct fragment metadata).

---
TYPE: FEATURE
DESC: Allow writing subset of attributes at a time
