### PR TITLE
(release-2.6) [C API] Add bulk point-range setter tiledb_query_add_point_ranges

### DIFF
--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -33,6 +33,7 @@
 #include "catch.hpp"
 #include "test/src/helpers.h"
 #include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
 
 #include <climits>
 #include <cmath>
@@ -3057,6 +3058,73 @@ TEST_CASE_METHOD(
   CHECK(array == nullptr);
 
   tiledb_config_free(&config);
+
+  remove_array(array_name);
+}
+
+TEST_CASE_METHOD(
+    Query2Fx,
+    "C API: Test subarray, sparse, set bulk point ranges",
+    "[capi][query_2][sparse][bulk-ranges]") {
+  SECTION("- No serialization") {
+    serialize_ = false;
+  }
+  SECTION("- Serialization") {
+    serialize_ = true;
+  }
+  std::string array_name = "subarray_sparse_default_bulk_ranges";
+  remove_array(array_name);
+  create_sparse_array(array_name);
+
+  // Allocate subarray with an unopened array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+
+  // Open array
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query
+  tiledb_query_t* query = nullptr;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
+  CHECK(rc == TILEDB_OK);
+
+  // Add ranges
+  uint64_t ranges[] = {1, 3, 7, 10};
+  rc = tiledb_query_add_point_ranges(ctx_, query, 0, ranges, 4);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_add_point_ranges(ctx_, query, 1, ranges, 4);
+  CHECK(rc == TILEDB_OK);
+
+  // Check that there are four ranges
+  uint64_t range_num;
+  rc = tiledb_query_get_range_num(ctx_, query, 0, &range_num);
+  CHECK(rc == TILEDB_OK);
+  CHECK(range_num == 4);
+
+  // Check ranges
+  for (uint32_t dim_idx = 0; dim_idx < 1; dim_idx++) {
+    for (uint32_t idx = 0; idx < 4; idx++) {
+      const void *start, *end, *stride;
+      rc = tiledb_query_get_range(
+          ctx_, query, dim_idx, idx, &start, &end, &stride);
+      CHECK(rc == TILEDB_OK);
+      CHECK(*(uint64_t*)start == ranges[idx]);
+      CHECK(*(uint64_t*)end == ranges[idx]);
+      CHECK(stride == nullptr);
+    }
+  }
+
+  // Clean-up
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  CHECK(array == nullptr);
+  tiledb_query_free(&query);
+  CHECK(query == nullptr);
 
   remove_array(array_name);
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3451,6 +3451,22 @@ int32_t tiledb_query_add_range(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_add_point_ranges(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    uint32_t dim_idx,
+    const void* start,
+    uint64_t count) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx, query->query_->add_point_ranges(dim_idx, start, count)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_add_range_by_name(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -171,6 +171,41 @@ TILEDB_EXPORT int32_t tiledb_array_evolve(
 TILEDB_EXPORT int32_t tiledb_array_upgrade_version(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config);
 
+/* ********************************* */
+/*               QUERY               */
+/* ********************************* */
+
+/**
+ * Adds a set of point ranges along subarray dimension index. Each value
+ * in the target array is added as `add_range(x,x)` for count elements.
+ * The datatype of the range components must be the same as the type of
+ * the dimension of the array in the query.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint32_t dim_idx = 2;
+ * int64_t ranges[] = { 20, 21, 25, 31}
+ * tiledb_query_add_point_ranges(ctx, query, dim_idx, &ranges, 4);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The query to add the range to.
+ * @param dim_idx The index of the dimension to add the range to.
+ * @param start The start of the ranges array.
+ * @param count Number of ranges to add.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note The stride is currently unsupported. Use `nullptr` as the
+ *     stride argument.
+ */
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_query_add_point_ranges(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    uint32_t dim_idx,
+    const void* start,
+    uint64_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -160,6 +160,16 @@ class Query {
       unsigned dim_idx, const void* start, const void* end, const void* stride);
 
   /**
+   * @brief Set point ranges from an array
+   *
+   * @param dim_idx Dimension index
+   * @param start Pointer to start of the array
+   * @param count Number of elements to add
+   * @return Status
+   */
+  Status add_point_ranges(unsigned dim_idx, const void* start, uint64_t count);
+
+  /**
    * Adds a variable-sized range to the (read/write) query on the input
    * dimension by index, in the form of (start, end).
    */


### PR DESCRIPTION
This API allows bulk insertion of point-ranges (start==end) amortizing some
expensive parts of the initial path, to reduce overhead with large range
counts. For example, in a customer scenario with >300k point-ranges, this
API reduces insertion time from 7s to 0.05s.

(backport from https://github.com/TileDB-Inc/TileDB/pull/2738)

---
TYPE: C_API
DESC: Add bulk point-range setter tiledb_query_add_point_ranges
