### PR TITLE
Return error for nonempty_domain access regardless of local/remote status

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1061,9 +1061,8 @@ Status StorageManager::array_get_non_empty_domain(
     return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array object is null"));
 
-  if (!array->is_remote() &&
-      open_arrays_for_reads_.find(array->array_uri().to_string()) ==
-          open_arrays_for_reads_.end())
+  if (open_arrays_for_reads_.find(array->array_uri().to_string()) ==
+      open_arrays_for_reads_.end())
     return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array not opened for reads"));
 


### PR DESCRIPTION
This allows APIs to consistently propagate the error for local
or remote URIs.

---

TYPE: BUG
DESC: Return error for nonempty_domain access regardless of local/remote status