### PR TITLE
Add common base class for observability (logging, stats etc) - part 1

### DIFF
--- a/tiledb/common/logger.cc
+++ b/tiledb/common/logger.cc
@@ -58,7 +58,7 @@ Logger::Logger(const std::string& name, const Logger::Format format)
   }
   set_format(format);
   set_level(Logger::Level::ERR);
-  if (++instance_count == 1 && format == Logger::Format::JSON) {
+  if (++instance_count_ == 1 && format == Logger::Format::JSON) {
     // If this is the first logger created set up the opening brace and an
     // array named "log"
     logger_->set_pattern("{\n \"log\": [");
@@ -71,7 +71,7 @@ Logger::Logger(tdb_shared_ptr<spdlog::logger> logger) {
 }
 
 Logger::~Logger() {
-  if (--instance_count == 0 && fmt_ == Logger::Format::JSON) {
+  if (--instance_count_ == 0 && fmt_ == Logger::Format::JSON) {
     // If this is the last logger being destroyed, set the same log format,
     // without the "," at the end
     std::string last_log_pattern = {
@@ -87,6 +87,10 @@ Logger::~Logger() {
   }
   spdlog::drop(name_);
 }
+
+/* ********************************* */
+/*               API                 */
+/* ********************************* */
 
 void Logger::trace(const char* msg) {
   logger_->trace(msg);
@@ -244,17 +248,25 @@ void Logger::set_format(Logger::Format fmt) {
   fmt_ = fmt;
 }
 
-void Logger::set_name(const std::string& tags) {
-  name_ = tags;
-}
-
-tdb_shared_ptr<Logger> Logger::clone(const std::string& tag, uint64_t id) {
-  std::string new_tags = add_tag(tag, id);
+/*
+ * Constructs a new logger child by cloning the parent
+ */
+tdb_shared_ptr<Logger> Logger::clone(
+    const std::string& tag, uint64_t logger_id) {
+  std::string new_tags = add_tag(tag, ++logger_id);
   auto new_logger =
       tiledb::common::make_shared<Logger>(HERE(), logger_->clone(new_tags));
   new_logger->set_name(new_tags);
-  ++instance_count;
+  ++instance_count_;
   return new_logger;
+}
+
+/* ********************************* */
+/*          PRIVATE METHODS          */
+/* ********************************* */
+
+void Logger::set_name(const std::string& tags) {
+  name_ = tags;
 }
 
 std::string Logger::add_tag(const std::string& tag, uint64_t id) {

--- a/tiledb/common/logger.h
+++ b/tiledb/common/logger.h
@@ -66,6 +66,8 @@ class Logger {
  public:
   enum class Format : char;
   enum class Level : char;
+  template <typename T>
+  friend class LoggerDistinct;
 
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -285,6 +287,19 @@ class Logger {
   void critical(const std::stringstream& msg);
 
   /**
+   * A formatted critical statment.
+   *
+   * @param fmt A fmtlib format string, see http://fmtlib.net/latest/ for
+   *     details.
+   * @param arg positional argument to format.
+   * @param args optional additional positional arguments to format.
+   */
+  template <typename Arg1, typename... Args>
+  void critical(const char* fmt, const Arg1& arg1, const Args&... args) {
+    logger_->critical(fmt, arg1, args...);
+  }
+
+  /**
    * Log a message from a Status object and return
    * the same Status object
    *
@@ -314,7 +329,7 @@ class Logger {
   void fatal(const std::stringstream& msg);
 
   /**
-   * A formatted critical statment.
+   * A formatted fatal statment.
    *
    * @param fmt A fmtlib format string, see http://fmtlib.net/latest/ for
    *     details.
@@ -322,8 +337,9 @@ class Logger {
    * @param args optional additional positional arguments to format.
    */
   template <typename Arg1, typename... Args>
-  void critical(const char* fmt, const Arg1& arg1, const Args&... args) {
-    logger_->critical(fmt, arg1, args...);
+  void fatal(const char* fmt, const Arg1& arg1, const Args&... args) {
+    logger_->error(fmt, arg1, args...);
+    exit(1);
   }
 
   /**
@@ -341,6 +357,14 @@ class Logger {
    * logs in the default tiledb format
    */
   void set_format(Logger::Format fmt);
+
+  /**
+   * Set the logger name.
+   *
+   * @param tags The string to use as a name, usually a
+   * concatenation of [tag:id] strings
+   */
+  void set_name(const std::string& tags);
 
   /* ********************************* */
   /*          PUBLIC ATTRIBUTES        */
@@ -368,9 +392,9 @@ class Logger {
   /** The name of the global logger in json format */
   static inline constexpr char global_logger_json_name[] = "\"Global\":\"1\"";
 
- private:
+ protected:
   /* ********************************* */
-  /*         PRIVATE ATTRIBUTES        */
+  /*         PROTECTED ATTRIBUTES      */
   /* ********************************* */
 
   /** The logger object. */
@@ -383,19 +407,11 @@ class Logger {
   static inline Logger::Format fmt_ = Logger::Format::DEFAULT;
 
   /** A counter of logger class instances */
-  static inline std::atomic<uint64_t> instance_count = 0;
+  static inline std::atomic<uint64_t> instance_count_ = 0;
 
   /* ********************************* */
-  /*          PRIVATE METHODS          */
+  /*          PROTECTED METHODS        */
   /* ********************************* */
-
-  /**
-   * Set the logger name.
-   *
-   * @param tags The string to use as a name, usually a
-   * concatenation of [tag:id] strings
-   */
-  void set_name(const std::string& tags);
 
   /**
    * Create a new string by appending a [tag:id] to the current

--- a/tiledb/common/logger_distinct.h
+++ b/tiledb/common/logger_distinct.h
@@ -1,0 +1,134 @@
+/**
+ * @file   logger_distinct.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class LoggerDistinct to create uniquely identified loggers
+ * for classes
+ */
+
+#ifndef TILEDB_LOGGER_DISTINCT_H
+#define TILEDB_LOGGER_DISTINCT_H
+
+#include <atomic>
+
+#include "tiledb/common/common.h"
+
+#include "logger.h"
+
+namespace tiledb {
+
+namespace common {
+
+/**
+ * LoggerDistinct class uses CRTP pattern in order for each derived class to
+ * have its own static variable for counting instances.
+ */
+template <typename T>
+class LoggerDistinct : public Logger {
+ public:
+  /* ****************************** */
+  /*   CONSTRUCTORS & DESTRUCTORS   */
+  /* ****************************** */
+
+  /**
+   * Constructor.
+   * Constructs a new logger root
+   */
+  LoggerDistinct(const std::string& name)
+      : Logger(name + ": " + std::to_string(increment_instance_id())){};
+
+  /**
+   * Constructor.
+   * Constructs a new child logger from a parent
+   */
+  LoggerDistinct(
+      const std::string& new_tag, const shared_ptr<Logger>& parent_log)
+      : Logger(parent_log->logger_->clone(new_child_tags(
+            parent_log->name_, new_tag, increment_instance_id()))) {
+    set_name(tags_);
+    instance_count_++;
+  }
+
+  /** Destructor. */
+  ~LoggerDistinct() = default;
+
+  /** Copy constructor. */
+  DISABLE_COPY(LoggerDistinct);
+
+  /** Move constructor. */
+  DISABLE_MOVE(LoggerDistinct);
+
+  /* ****************************** */
+  /*           OPERATORS            */
+  /* ****************************** */
+
+  /** Copy-assignment. */
+  DISABLE_COPY_ASSIGN(LoggerDistinct);
+
+  /** Move-assignment. */
+  DISABLE_MOVE_ASSIGN(LoggerDistinct);
+
+  /* ****************************** */
+  /*              API               */
+  /* ****************************** */
+
+  static uint64_t increment_instance_id() {
+    return ++id_;
+  }
+
+ private:
+  /** UID of the logger instance */
+  static inline std::atomic<uint64_t> id_ = 0;
+
+  static inline std::string tags_;
+
+  /** Add a tag to the logger name */
+  std::string new_child_tags(
+      const std::string& old_tags,
+      const std::string& new_tag,
+      uint64_t tag_id) {
+    switch (fmt_) {
+      case Logger::Format::JSON: {
+        tags_ = old_tags.empty() ?
+                    fmt::format("\"{}\":\"{}\"", new_tag, tag_id) :
+                    fmt::format("{},\"{}\":\"{}\"", old_tags, new_tag, tag_id);
+        break;
+      }
+      default:
+        tags_ = old_tags.empty() ?
+                    fmt::format("{}: {}", new_tag, tag_id) :
+                    fmt::format("{}] [{}: {}", old_tags, new_tag, tag_id);
+    }
+    return tags_;
+  }
+};
+
+}  // namespace common
+}  // namespace tiledb
+
+#endif  // TILEDB_LOGGER_DISTINCT_H

--- a/tiledb/common/observable.h
+++ b/tiledb/common/observable.h
@@ -1,0 +1,115 @@
+/**
+ * @file   observable.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines base class Observable that centralizes observability tools
+ * (logging, metrics, tracing etc) for core classes.
+ */
+
+#ifndef TILEDB_OBSERVABLE_H
+#define TILEDB_OBSERVABLE_H
+
+#include <atomic>
+#include "logger_distinct.h"
+
+namespace tiledb {
+
+namespace common {
+
+/**
+ * To be extended by classes that want to use tools that enhance
+ * debuggability and visibility during runtime.
+ */
+template <typename T>
+class Observable {
+ public:
+  /* ****************************** */
+  /*   CONSTRUCTORS & DESTRUCTORS   */
+  /* ****************************** */
+
+  /** Constructor. */
+  Observable(const std::string& name)
+      : name_(name)
+      , log_(tdb::make_shared<LoggerDistinct<T>>(HERE(), name)) {
+  }
+
+  /** Constructor. */
+  Observable(const std::string& name, const shared_ptr<Logger>& parent_logger)
+      : name_(name)
+      , log_(tdb::make_shared<LoggerDistinct<T>>(HERE(), name, parent_logger)) {
+  }
+
+  /** Constructor. */
+  Observable(const shared_ptr<Logger>& log)
+      : log_(log) {
+  }
+
+  /** Destructor. */
+  ~Observable() = default;
+
+  /** Copy constructor. */
+  DISABLE_COPY(Observable);
+
+  /** Move constructor. */
+  DISABLE_MOVE(Observable);
+
+  /* ****************************** */
+  /*           OPERATORS            */
+  /* ****************************** */
+
+  /** Copy-assignment. */
+  DISABLE_COPY_ASSIGN(Observable);
+
+  /** Move-assignment. */
+  DISABLE_MOVE_ASSIGN(Observable);
+
+  /* ********************************* */
+  /*               API                 */
+  /* ********************************* */
+
+  /** Returns the internal logger object. */
+  shared_ptr<Logger> logger() const {
+    return log_;
+  }
+
+ protected:
+  /* ********************************* */
+  /*        PROTECTED ATTRIBUTES       */
+  /* ********************************* */
+
+  /** The name to use for observing this class */
+  const std::string name_;
+
+  /** The class logger. */
+  shared_ptr<Logger> log_;
+};
+
+}  // namespace common
+}  // namespace tiledb
+
+#endif  // TILEDB_OBSERVABLE_H

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -63,11 +63,11 @@ namespace sm {
 /* ****************************** */
 
 Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
-    : array_(array)
+    : Observable<Query>("Query", storage_manager->logger())
+    , array_(array)
     , layout_(Layout::ROW_MAJOR)
     , storage_manager_(storage_manager)
     , stats_(storage_manager_->stats()->create_child("Query"))
-    , logger_(storage_manager->logger()->clone("Query", ++logger_id_))
     , has_coords_buffer_(false)
     , has_zipped_coords_buffer_(false)
     , coord_buffer_is_set_(false)
@@ -85,9 +85,9 @@ Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
     assert(st.ok());
 
     if (type_ == QueryType::WRITE) {
-      subarray_ = Subarray(array, stats_, logger_);
+      subarray_ = Subarray(array, stats_, log_);
     } else {
-      subarray_ = Subarray(array, Layout::ROW_MAJOR, stats_, logger_);
+      subarray_ = Subarray(array, Layout::ROW_MAJOR, stats_, log_);
     }
 
     fragment_metadata_ = array->fragment_metadata();
@@ -130,19 +130,18 @@ Query::~Query() {
 Status Query::add_range(
     unsigned dim_idx, const void* start, const void* end, const void* stride) {
   if (dim_idx >= array_schema_->dim_num())
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot add range; Invalid dimension index"));
 
   if (start == nullptr || end == nullptr)
-    return logger_->status(
-        Status_QueryError("Cannot add range; Invalid range"));
+    return log_->status(Status_QueryError("Cannot add range; Invalid range"));
 
   if (stride != nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot add range; Setting range stride is currently unsupported"));
 
   if (array_schema_->domain()->dimension(dim_idx)->var_size())
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot add range; Range must be fixed-sized"));
 
   // Prepare a temp range
@@ -160,19 +159,19 @@ Status Query::add_range(
     assert(found);
 
     if (read_range_oob != "error" && read_range_oob != "warn")
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           "Invalid value " + read_range_oob +
           " for sm.read_range_obb. Acceptable values are 'error' or 'warn'."));
 
     read_range_oob_error = read_range_oob == "error";
   } else {
     if (!array_schema_->dense())
-      return logger_->status(
+      return log_->status(
           Status_QueryError("Adding a subarray range to a write query is not "
                             "supported in sparse arrays"));
 
     if (subarray_.is_set(dim_idx))
-      return logger_->status(
+      return log_->status(
           Status_QueryError("Cannot add range; Multi-range dense writes "
                             "are not supported"));
   }
@@ -189,20 +188,19 @@ Status Query::add_range_var(
     const void* end,
     uint64_t end_size) {
   if (dim_idx >= array_schema_->dim_num())
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot add range; Invalid dimension index"));
 
   if ((start == nullptr && start_size != 0) ||
       (end == nullptr && end_size != 0))
-    return logger_->status(
-        Status_QueryError("Cannot add range; Invalid range"));
+    return log_->status(Status_QueryError("Cannot add range; Invalid range"));
 
   if (!array_schema_->domain()->dimension(dim_idx)->var_size())
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot add range; Range must be variable-sized"));
 
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot add range; Function applicable only to reads"));
 
   // Get read_range_oob config setting
@@ -211,7 +209,7 @@ Status Query::add_range_var(
   assert(found);
 
   if (read_range_oob != "error" && read_range_oob != "warn")
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Invalid value " + read_range_oob +
         " for sm.read_range_obb. Acceptable values are 'error' or 'warn'."));
 
@@ -223,7 +221,7 @@ Status Query::add_range_var(
 
 Status Query::get_range_num(unsigned dim_idx, uint64_t* range_num) const {
   if (type_ == QueryType::WRITE && !array_schema_->dense())
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Getting the number of ranges from a write query "
                           "is not applicable to sparse arrays"));
 
@@ -237,7 +235,7 @@ Status Query::get_range(
     const void** end,
     const void** stride) const {
   if (type_ == QueryType::WRITE && !array_schema_->dense())
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Getting a range from a write query is not "
                           "applicable to sparse arrays"));
 
@@ -251,7 +249,7 @@ Status Query::get_range_var_size(
     uint64_t* start_size,
     uint64_t* end_size) const {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Getting a var range size from a write query is not applicable"));
 
   return subarray_.get_range_var_size(dim_idx, range_idx, start_size, end_size);
@@ -261,7 +259,7 @@ Status Query::get_range_var_size(
 Status Query::get_range_var(
     unsigned dim_idx, uint64_t range_idx, void* start, void* end) const {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Getting a var range from a write query is not applicable"));
 
   uint64_t start_size = 0;
@@ -353,27 +351,27 @@ Status Query::get_range_var_from_name(
 
 Status Query::get_est_result_size(const char* name, uint64_t* size) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
   if (name == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Name cannot be null"));
 
   if (name == constants::coords &&
       !array_schema_->domain()->all_dims_same_type())
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Not applicable to zipped "
         "coordinates in arrays with heterogeneous domain"));
 
   if (name == constants::coords && !array_schema_->domain()->all_dims_fixed())
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Not applicable to zipped "
         "coordinates in arrays with domains with variable-sized dimensions"));
 
   if (array_schema_->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string(
             "Cannot get estimated result size; Input attribute/dimension '") +
         name + "' is nullable"));
@@ -381,7 +379,7 @@ Status Query::get_est_result_size(const char* name, uint64_t* size) {
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(
+      return log_->status(
           Status_QueryError("Error in query estimate result size; remote "
                             "array with no rest client."));
 
@@ -398,12 +396,12 @@ Status Query::get_est_result_size(const char* name, uint64_t* size) {
 Status Query::get_est_result_size(
     const char* name, uint64_t* size_off, uint64_t* size_val) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
   if (array_schema_->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string(
             "Cannot get estimated result size; Input attribute/dimension '") +
         name + "' is nullable"));
@@ -411,7 +409,7 @@ Status Query::get_est_result_size(
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(
+      return log_->status(
           Status_QueryError("Error in query estimate result size; remote "
                             "array with no rest client."));
 
@@ -428,32 +426,32 @@ Status Query::get_est_result_size(
 Status Query::get_est_result_size_nullable(
     const char* name, uint64_t* size_val, uint64_t* size_validity) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
   if (name == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Name cannot be null"));
 
   if (!array_schema_->attribute(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Nullable API is only"
         "applicable to attributes"));
 
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get estimated result size; Input attribute '") +
         name + "' is not nullable"));
 
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(
+      return log_->status(
           Status_QueryError("Error in query estimate result size; remote "
                             "array with no rest client."));
 
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Error in query estimate result size; unimplemented "
                           "for nullable attributes in remote arrays."));
   }
@@ -468,28 +466,28 @@ Status Query::get_est_result_size_nullable(
     uint64_t* size_val,
     uint64_t* size_validity) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Operation currently "
         "unsupported for write queries"));
 
   if (!array_schema_->attribute(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get estimated result size; Nullable API is only"
         "applicable to attributes"));
 
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get estimated result size; Input attribute '") +
         name + "' is not nullable"));
 
   if (array_->is_remote() && !subarray_.est_result_size_computed()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(
+      return log_->status(
           Status_QueryError("Error in query estimate result size; remote "
                             "array with no rest client."));
 
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Error in query estimate result size; unimplemented "
                           "for nullable attributes in remote arrays."));
   }
@@ -517,7 +515,7 @@ Query::get_max_mem_size_map() {
 
 Status Query::get_written_fragment_num(uint32_t* num) const {
   if (type_ != QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get number of fragments; Applicable only to WRITE mode"));
 
   *num = (uint32_t)written_fragment_info_.size();
@@ -527,12 +525,12 @@ Status Query::get_written_fragment_num(uint32_t* num) const {
 
 Status Query::get_written_fragment_uri(uint32_t idx, const char** uri) const {
   if (type_ != QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get fragment URI; Applicable only to WRITE mode"));
 
   auto num = (uint32_t)written_fragment_info_.size();
   if (idx >= num)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot get fragment URI; Invalid fragment index"));
 
   *uri = written_fragment_info_[idx].uri_.c_str();
@@ -543,12 +541,12 @@ Status Query::get_written_fragment_uri(uint32_t idx, const char** uri) const {
 Status Query::get_written_fragment_timestamp_range(
     uint32_t idx, uint64_t* t1, uint64_t* t2) const {
   if (type_ != QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get fragment timestamp range; Applicable only to WRITE mode"));
 
   auto num = (uint32_t)written_fragment_info_.size();
   if (idx >= num)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot get fragment timestamp range; Invalid fragment index"));
 
   *t1 = written_fragment_info_[idx].timestamp_range_.first;
@@ -611,7 +609,7 @@ Status Query::finalize() {
   if (array_->is_remote()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           "Error in query finalize; remote array with no rest client."));
 
     array_schema_->set_array_uri(array_->array_uri());
@@ -631,12 +629,12 @@ Status Query::get_buffer(
   if (name != constants::coords) {
     if (array_schema->attribute(name) == nullptr &&
         array_schema->dimension(name) == nullptr)
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           std::string("Cannot get buffer; Invalid attribute/dimension name '") +
           name + "'"));
   }
   if (array_schema->var_size(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is var-sized"));
 
   return get_data_buffer(name, buffer, buffer_size);
@@ -651,16 +649,16 @@ Status Query::get_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (name == constants::coords) {
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot get buffer; Coordinates are not var-sized"));
   }
   if (array_schema->attribute(name) == nullptr &&
       array_schema->dimension(name) == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute/dimension name '") +
         name + "'"));
   if (!array_schema->var_size(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
 
   // Attribute or dimension
@@ -687,16 +685,16 @@ Status Query::get_offsets_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (name == constants::coords) {
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot get buffer; Coordinates are not var-sized"));
   }
   if (array_schema->attribute(name) == nullptr &&
       array_schema->dimension(name) == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute/dimension name '") +
         name + "'"));
   if (!array_schema->var_size(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
 
   // Attribute or dimension
@@ -721,7 +719,7 @@ Status Query::get_data_buffer(
   if (name != constants::coords) {
     if (array_schema->attribute(name) == nullptr &&
         array_schema->dimension(name) == nullptr)
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           std::string("Cannot get buffer; Invalid attribute/dimension name '") +
           name + "'"));
   }
@@ -760,7 +758,7 @@ Status Query::get_validity_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
   // Attribute or dimension
@@ -819,14 +817,14 @@ Status Query::get_buffer(
   // Check nullable attribute
   auto array_schema = this->array_schema();
   if (array_schema->attribute(name) == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute name '") + name +
         "'"));
   if (array_schema->var_size(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is var-sized"));
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
   // Attribute or dimension
@@ -856,14 +854,14 @@ Status Query::get_buffer(
   // Check attribute
   auto array_schema = this->array_schema();
   if (array_schema->attribute(name) == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute name '") + name +
         "'"));
   if (!array_schema->var_size(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
   if (!array_schema->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
   // Attribute or dimension
@@ -909,7 +907,7 @@ Status Query::init() {
   if (status_ == QueryStatus::UNINITIALIZED) {
     // Check if the array got closed
     if (array_ == nullptr || !array_->is_open())
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           "Cannot init query; The associated array is not open"));
 
     // Check if the array got re-opened with a different query type
@@ -921,7 +919,7 @@ Status Query::init() {
              << "Associated array query type does not match query type: "
              << "(" << query_type_str(array_query_type)
              << " != " << query_type_str(type_) << ")";
-      return logger_->status(Status_QueryError(errmsg.str()));
+      return log_->status(Status_QueryError(errmsg.str()));
     }
 
     RETURN_NOT_OK(check_buffer_names());
@@ -963,7 +961,7 @@ Status Query::cancel() {
 
 Status Query::process() {
   if (status_ == QueryStatus::UNINITIALIZED)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot process query; Query is not initialized"));
   status_ = QueryStatus::INPROGRESS;
 
@@ -1004,7 +1002,7 @@ Status Query::create_strategy() {
     strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
         Writer,
         stats_->create_child("Writer"),
-        logger_,
+        log_,
         storage_manager_,
         array_,
         config_,
@@ -1035,7 +1033,7 @@ Status Query::create_strategy() {
         strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
             SparseUnorderedWithDupsReader<uint8_t>,
             stats_->create_child("Reader"),
-            logger_,
+            log_,
             storage_manager_,
             array_,
             config_,
@@ -1047,7 +1045,7 @@ Status Query::create_strategy() {
         strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
             SparseUnorderedWithDupsReader<uint64_t>,
             stats_->create_child("Reader"),
-            logger_,
+            log_,
             storage_manager_,
             array_,
             config_,
@@ -1066,7 +1064,7 @@ Status Query::create_strategy() {
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
           SparseGlobalOrderReader,
           stats_->create_child("Reader"),
-          logger_,
+          log_,
           storage_manager_,
           array_,
           config_,
@@ -1084,7 +1082,7 @@ Status Query::create_strategy() {
         strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
             DenseReader,
             stats_->create_child("Reader"),
-            logger_,
+            log_,
             storage_manager_,
             array_,
             config_,
@@ -1099,7 +1097,7 @@ Status Query::create_strategy() {
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
           Reader,
           stats_->create_child("Reader"),
-          logger_,
+          log_,
           storage_manager_,
           array_,
           config_,
@@ -1111,7 +1109,7 @@ Status Query::create_strategy() {
   }
 
   if (strategy_ == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot create strategy; allocation failed"));
 
   return Status::Ok();
@@ -1130,11 +1128,11 @@ void Query::clear_strategy() {
 
 Status Query::disable_check_global_order() {
   if (status_ != QueryStatus::UNINITIALIZED)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot disable checking global order after initialization"));
 
   if (type_ == QueryType::READ)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot disable checking global order; Applicable only to writes"));
 
   disable_check_global_order_ = true;
@@ -1145,13 +1143,13 @@ Status Query::check_buffer_names() {
   if (type_ == QueryType::WRITE) {
     // If the array is sparse, the coordinates must be provided
     if (!array_schema_->dense() && !coords_info_.has_coords_)
-      return logger_->status(Status_WriterError(
+      return log_->status(Status_WriterError(
           "Sparse array writes expect the coordinates of the "
           "cells to be written"));
 
     // If the layout is unordered, the coordinates must be provided
     if (layout_ == Layout::UNORDERED && !coords_info_.has_coords_)
-      return logger_->status(
+      return log_->status(
           Status_WriterError("Unordered writes expect the coordinates of the "
                              "cells to be written"));
 
@@ -1162,7 +1160,7 @@ Status Query::check_buffer_names() {
                         array_schema_->dim_num() :
                         0;
     if (buffers_.size() != expected_num)
-      return logger_->status(
+      return log_->status(
           Status_WriterError("Writes expect all attributes (and coordinates in "
                              "the sparse/unordered case) to be set"));
   }
@@ -1173,12 +1171,12 @@ Status Query::check_buffer_names() {
 Status Query::check_set_fixed_buffer(const std::string& name) {
   if (name == constants::coords &&
       !array_schema_->domain()->all_dims_same_type())
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; Setting a buffer for zipped coordinates is not "
         "applicable to heterogeneous domains"));
 
   if (name == constants::coords && !array_schema_->domain()->all_dims_fixed())
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; Setting a buffer for zipped coordinates is not "
         "applicable to domains with variable-sized dimensions"));
 
@@ -1218,17 +1216,17 @@ Status Query::set_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
@@ -1237,13 +1235,13 @@ Status Query::set_buffer(
 
   // Check that attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
         "'"));
 
   // Must not be nullable
   if (array_schema_->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is nullable"));
 
@@ -1251,21 +1249,21 @@ Status Query::set_buffer(
   const bool var_size =
       (name != constants::coords && array_schema_->var_size(name));
   if (var_size)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is var-sized"));
 
   // Check if zipped coordinates coexist with separate coordinate buffers
   if ((is_dim && has_zipped_coords_buffer_) ||
       (name == constants::coords && has_coords_buffer_))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set separate coordinate buffers and "
                     "a zipped coordinate buffer in the same query")));
 
   // Error if setting a new attribute/dimension after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
@@ -1281,7 +1279,7 @@ Status Query::set_buffer(
     // Check number of coordinates
     uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
     if (coord_buffer_is_set_ && coords_num != coords_info_.coords_num_)
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           std::string("Cannot set buffer; Input buffer for dimension '") +
           name +
           "' has a different number of coordinates than previously "
@@ -1310,17 +1308,17 @@ Status Query::set_data_buffer(
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
     if (type_ != QueryType::WRITE || *buffer_size != 0)
-      return logger_->status(
+      return log_->status(
           Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
@@ -1329,26 +1327,26 @@ Status Query::set_data_buffer(
 
   // Check that attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
         "'"));
 
   if (array_schema_->dense() && type_ == QueryType::WRITE && !is_attr) {
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Dense write queries cannot set dimension buffers")));
   }
 
   // Check if zipped coordinates coexist with separate coordinate buffers
   if ((is_dim && has_zipped_coords_buffer_) ||
       (name == constants::coords && has_coords_buffer_))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set separate coordinate buffers and "
                     "a zipped coordinate buffer in the same query")));
 
   // Error if setting a new attribute/dimension after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
@@ -1365,7 +1363,7 @@ Status Query::set_data_buffer(
     uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
     if (coord_data_buffer_is_set_ && coords_num != coords_info_.coords_num_ &&
         name == data_buffer_name_)
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           std::string("Cannot set buffer; Input buffer for dimension '") +
           name +
           "' has a different number of coordinates than previously "
@@ -1399,17 +1397,17 @@ Status Query::set_offsets_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer_offsets == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_offsets_size == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
@@ -1418,20 +1416,20 @@ Status Query::set_offsets_buffer(
 
   // Neither a dimension nor an attribute
   if (!is_dim && !is_attr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Invalid buffer name '") + name +
         "' (it should be an attribute or dimension)"));
 
   // Error if it is fixed-sized
   if (!array_schema_->var_size(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is fixed-sized"));
 
   // Error if setting a new attribute/dimension after initialization
   bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
@@ -1441,7 +1439,7 @@ Status Query::set_offsets_buffer(
         *buffer_offsets_size / constants::cell_var_offset_size;
     if (coord_offsets_buffer_is_set_ &&
         coords_num != coords_info_.coords_num_ && name == offsets_buffer_name_)
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           std::string("Cannot set buffer; Input buffer for dimension '") +
           name +
           "' has a different number of coordinates than previously "
@@ -1473,35 +1471,35 @@ Status Query::set_validity_buffer(
       buffer_validity_bytemap, buffer_validity_bytemap_size));
   // Check validity buffer
   if (check_null_buffers && validity_vector.buffer() == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer is null"));
 
   // Check validity buffer size
   if (check_null_buffers && validity_vector.buffer_size() == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Buffer name '") + name +
         "' is not an attribute"));
 
   // Must be nullable
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is not nullable"));
 
   // Error if setting a new attribute after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute '") + name +
         "' after initialization"));
 
@@ -1521,27 +1519,27 @@ Status Query::set_buffer(
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
     if (type_ != QueryType::WRITE || *buffer_val_size != 0)
-      return logger_->status(
+      return log_->status(
           Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_val_size == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Check offset buffer
   if (check_null_buffers && buffer_off == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " offset buffer is null"));
 
   // Check offset buffer size
   if (check_null_buffers && buffer_off_size == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " offset buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
@@ -1550,26 +1548,26 @@ Status Query::set_buffer(
 
   // Check that attribute/dimension exists
   if (!is_dim && !is_attr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
         "'"));
 
   // Must not be nullable
   if (array_schema_->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is nullable"));
 
   // Check that attribute/dimension is var-sized
   if (!array_schema_->var_size(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is fixed-sized"));
 
   // Error if setting a new attribute/dimension after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
@@ -1577,7 +1575,7 @@ Status Query::set_buffer(
     // Check number of coordinates
     uint64_t coords_num = *buffer_off_size / constants::cell_var_offset_size;
     if (coord_buffer_is_set_ && coords_num != coords_info_.coords_num_)
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           std::string("Cannot set buffer; Input buffer for dimension '") +
           name +
           "' has a different number of coordinates than previously "
@@ -1645,51 +1643,51 @@ Status Query::set_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_size == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Check validity buffer offset
   if (check_null_buffers && validity_vector.buffer() == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer is null"));
 
   // Check validity buffer size
   if (check_null_buffers && validity_vector.buffer_size() == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Buffer name '") + name +
         "' is not an attribute"));
 
   // Must be fixed-size
   if (array_schema_->var_size(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is var-sized"));
 
   // Must be nullable
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is not nullable"));
 
   // Error if setting a new attribute/dimension after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute '") + name +
         "' after initialization"));
 
@@ -1711,62 +1709,62 @@ Status Query::set_buffer(
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
     if (type_ != QueryType::WRITE || *buffer_val_size != 0)
-      return logger_->status(
+      return log_->status(
           Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
   // Check buffer size
   if (check_null_buffers && buffer_val_size == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
   // Check buffer offset
   if (check_null_buffers && buffer_off == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " offset buffer is null"));
 
   // Check buffer offset size
   if (check_null_buffers && buffer_off_size == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " offset buffer size is null"));
   ;
 
   // Check validity buffer offset
   if (check_null_buffers && validity_vector.buffer() == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer is null"));
 
   // Check validity buffer size
   if (check_null_buffers && validity_vector.buffer_size() == nullptr)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
 
   // Array schema must exist
   if (array_schema_ == nullptr)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Buffer name '") + name +
         "' is not an attribute"));
 
   // Must be var-size
   if (!array_schema_->var_size(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is fixed-sized"));
 
   // Must be nullable
   if (!array_schema_->is_nullable(name))
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer; Input attribute '") + name +
         "' is not nullable"));
 
   // Error if setting a new attribute after initialization
   const bool exists = buffers_.find(name) != buffers_.end();
   if (status_ != QueryStatus::UNINITIALIZED && !exists)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         std::string("Cannot set buffer for new attribute '") + name +
         "' after initialization"));
 
@@ -1782,7 +1780,7 @@ Status Query::set_est_result_size(
     std::unordered_map<std::string, Subarray::ResultSize>& est_result_size,
     std::unordered_map<std::string, Subarray::MemorySize>& max_mem_size) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set estimated result size; Operation currently "
         "unsupported for write queries"));
   return subarray_.set_est_result_size(est_result_size, max_mem_size);
@@ -1796,16 +1794,16 @@ Status Query::set_layout_unsafe(Layout layout) {
 
 Status Query::set_layout(Layout layout) {
   if (type_ == QueryType::READ && status_ != QueryStatus::UNINITIALIZED)
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set layout after initialization"));
 
   if (layout == Layout::HILBERT)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set layout; Hilbert order is not applicable to queries"));
 
   if (type_ == QueryType::WRITE && array_schema_->dense() &&
       layout == Layout::UNORDERED) {
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Unordered writes are only possible for sparse arrays"));
   }
 
@@ -1816,7 +1814,7 @@ Status Query::set_layout(Layout layout) {
 
 Status Query::set_condition(const QueryCondition& condition) {
   if (type_ == QueryType::WRITE)
-    return logger_->status(Status_QueryError(
+    return log_->status(Status_QueryError(
         "Cannot set query condition; Operation only applicable "
         "to read queries"));
 
@@ -1830,17 +1828,17 @@ void Query::set_status(QueryStatus status) {
 
 Status Query::set_subarray(const void* subarray) {
   if (!array_schema_->domain()->all_dims_same_type())
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set subarray; Function not applicable to "
                           "heterogeneous domains"));
 
   if (!array_schema_->domain()->all_dims_fixed())
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Cannot set subarray; Function not applicable to "
                           "domains with variable-sized dimensions"));
 
   // Prepare a subarray object
-  Subarray sub(array_, layout_, stats_, logger_);
+  Subarray sub(array_, layout_, stats_, log_);
   if (subarray != nullptr) {
     auto dim_num = array_schema_->dim_num();
     auto s_ptr = (const unsigned char*)subarray;
@@ -1854,7 +1852,7 @@ Status Query::set_subarray(const void* subarray) {
           config()->get("sm.read_range_oob", &found);
       assert(found);
       if (read_range_oob_str != "error" && read_range_oob_str != "warn")
-        return logger_->status(Status_QueryError(
+        return log_->status(Status_QueryError(
             "Invalid value " + read_range_oob_str +
             " for sm.read_range_obb. Acceptable values are 'error' or "
             "'warn'."));
@@ -1872,12 +1870,12 @@ Status Query::set_subarray(const void* subarray) {
   if (type_ == QueryType::WRITE) {
     // Not applicable to sparse arrays
     if (!array_schema_->dense())
-      return logger_->status(Status_WriterError(
+      return log_->status(Status_WriterError(
           "Setting a subarray is not supported in sparse writes"));
 
     // Subarray must be unary for dense writes
     if (sub.range_num() != 1)
-      return logger_->status(
+      return log_->status(
           Status_WriterError("Cannot set subarray; Multi-range dense writes "
                              "are not supported"));
     if (strategy_ != nullptr)
@@ -1927,7 +1925,7 @@ Status Query::set_subarray(const tiledb::sm::Subarray& subarray) {
 
 Status Query::set_subarray_unsafe(const NDRange& subarray) {
   // Prepare a subarray object
-  Subarray sub(array_, layout_, stats_, logger_);
+  Subarray sub(array_, layout_, stats_, log_);
   if (!subarray.empty()) {
     auto dim_num = array_schema_->dim_num();
     for (unsigned d = 0; d < dim_num; ++d)
@@ -1949,28 +1947,28 @@ Status Query::check_buffers_correctness() {
       // Check for data buffer under buffer_var and offsets buffer under buffer
       if (type_ == QueryType::READ) {
         if (buffer(attr).buffer_var_ == nullptr) {
-          return logger_->status(Status_QueryError(
+          return log_->status(Status_QueryError(
               std::string("Var-Sized input attribute/dimension '") + attr +
               "' is not set correctly. \nVar size buffer is not set."));
         }
       } else {
         if (buffer(attr).buffer_var_ == nullptr &&
             *buffer(attr).buffer_var_size_ != 0) {
-          return logger_->status(Status_QueryError(
+          return log_->status(Status_QueryError(
               std::string("Var-Sized input attribute/dimension '") + attr +
               "' is not set correctly. \nVar size buffer is not set and buffer "
               "size if not 0."));
         }
       }
       if (buffer(attr).buffer_ == nullptr) {
-        return logger_->status(Status_QueryError(
+        return log_->status(Status_QueryError(
             std::string("Var-Sized input attribute/dimension '") + attr +
             "' is not set correctly. \nOffsets buffer is not set."));
       }
     } else {
       // Fixed sized
       if (buffer(attr).buffer_ == nullptr) {
-        return logger_->status(Status_QueryError(
+        return log_->status(Status_QueryError(
             std::string("Fix-Sized input attribute/dimension '") + attr +
             "' is not set correctly. \nData buffer is not set."));
       }
@@ -1978,7 +1976,7 @@ Status Query::check_buffers_correctness() {
     if (array_schema_->is_nullable(attr)) {
       bool exists_validity = buffer(attr).validity_vector_.buffer() != nullptr;
       if (!exists_validity) {
-        return logger_->status(Status_QueryError(
+        return log_->status(Status_QueryError(
             std::string("Nullable input attribute/dimension '") + attr +
             "' is not set correctly \nValidity buffer is not set"));
       }
@@ -1999,7 +1997,7 @@ Status Query::submit() {
   if (array_->is_remote()) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      return logger_->status(Status_QueryError(
+      return log_->status(Status_QueryError(
           "Error in query submission; remote array with no rest client."));
 
     array_schema_->set_array_uri(array_->array_uri());
@@ -2020,7 +2018,7 @@ Status Query::submit_async(
   }
   RETURN_NOT_OK(init());
   if (array_->is_remote())
-    return logger_->status(
+    return log_->status(
         Status_QueryError("Error in async query submission; async queries not "
                           "supported for remote arrays."));
 
@@ -2058,7 +2056,7 @@ bool Query::use_refactored_dense_reader() {
   // If the legacy/deprecated option is set use it over the new parameters
   // This facilitates backwards compatibility
   if (found) {
-    logger_->warn(
+    log_->warn(
         "sm.use_refactored_readers config option is deprecated.\nPlease use "
         "'sm.query.dense.reader' with value of 'refactored' or 'legacy'");
     return use_refactored_readers;
@@ -2079,7 +2077,7 @@ bool Query::use_refactored_sparse_global_order_reader() {
   // If the legacy/deprecated option is set use it over the new parameters
   // This facilitates backwards compatibility
   if (found) {
-    logger_->warn(
+    log_->warn(
         "sm.use_refactored_readers config option is deprecated.\nPlease use "
         "'sm.query.sparse_global_order.reader' with value of 'refactored' or "
         "'legacy'");
@@ -2103,7 +2101,7 @@ bool Query::use_refactored_sparse_unordered_with_dups_reader() {
   // If the legacy/deprecated option is set use it over the new parameters
   // This facilitates backwards compatibility
   if (found) {
-    logger_->warn(
+    log_->warn(
         "sm.use_refactored_readers config option is deprecated.\nPlease use "
         "'sm.query.sparse_unordered_with_dups.reader' with value of "
         "'refactored' or 'legacy'");

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -39,7 +39,7 @@
 #include <utility>
 #include <vector>
 
-#include "tiledb/common/logger_public.h"
+#include "tiledb/common/observable.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -63,7 +63,7 @@ enum class QueryStatus : uint8_t;
 enum class QueryType : uint8_t;
 
 /** Processes a (read/write) query. */
-class Query {
+class Query : public Observable<Query> {
  public:
   /* ********************************* */
   /*          PUBLIC DATATYPES         */
@@ -917,12 +917,6 @@ class Query {
 
   /** The class stats. */
   stats::Stats* stats_;
-
-  /** The class logger. */
-  tdb_shared_ptr<Logger> logger_;
-
-  /** UID of the logger instance */
-  inline static std::atomic<uint64_t> logger_id_ = 0;
 
   /**
    * Maps attribute/dimension names to their buffers.

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_CONTEXT_H
 #define TILEDB_CONTEXT_H
 
+#include "tiledb/common/observable.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
@@ -48,7 +49,7 @@ namespace sm {
  * This class manages the context for the C API, wrapping a
  * storage manager object.
  * */
-class Context {
+class Context : public Observable<Context> {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -107,11 +108,6 @@ class Context {
 
   /** The class stats. */
   tdb_shared_ptr<stats::Stats> stats_;
-
-  /** The class logger. */
-  tdb_shared_ptr<Logger> logger_;
-
-  inline static std::atomic<uint64_t> logger_id_ = 0;
 
   /* ********************************* */
   /*         PRIVATE METHODS           */

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -82,9 +82,9 @@ StorageManager::StorageManager(
     ThreadPool* const compute_tp,
     ThreadPool* const io_tp,
     stats::Stats* const parent_stats,
-    tdb_shared_ptr<Logger> logger)
-    : stats_(parent_stats->create_child("StorageManager"))
-    , logger_(logger)
+    shared_ptr<Logger> logger)
+    : Observable<StorageManager>(logger)
+    , stats_(parent_stats->create_child("StorageManager"))
     , cancellation_in_progress_(false)
     , queries_in_progress_(0)
     , compute_tp_(compute_tp)
@@ -110,7 +110,7 @@ StorageManager::~StorageManager() {
   if (vfs_ != nullptr) {
     const Status st = vfs_->terminate();
     if (!st.ok()) {
-      logger_->status(Status_StorageManagerError("Failed to terminate VFS."));
+      log_->status(Status_StorageManagerError("Failed to terminate VFS."));
     }
 
     tdb_delete(vfs_);
@@ -307,7 +307,7 @@ std::tuple<
 StorageManager::array_open_for_writes(
     const URI& array_uri, const EncryptionKey& encryption_key) {
   if (!vfs_->supports_uri_scheme(array_uri))
-    return {logger_->status(Status_StorageManagerError(
+    return {log_->status(Status_StorageManagerError(
                 "Cannot open array; URI scheme unsupported.")),
             std::nullopt,
             std::nullopt};
@@ -319,7 +319,7 @@ StorageManager::array_open_for_writes(
     return {st, std::nullopt, std::nullopt};
 
   if (obj_type != ObjectType::ARRAY) {
-    return {logger_->status(Status_StorageManagerError(
+    return {log_->status(Status_StorageManagerError(
                 "Cannot open array; Array does not exist")),
             std::nullopt,
             std::nullopt};
@@ -377,7 +377,7 @@ StorageManager::array_open_for_writes(
     err << constants::format_version << ")";
     open_array->mtx_unlock();
     array_close_for_writes(array_uri, encryption_key, nullptr);
-    return {logger_->status(Status_StorageManagerError(err.str())),
+    return {log_->status(Status_StorageManagerError(err.str())),
             std::nullopt,
             std::nullopt};
   }
@@ -405,7 +405,7 @@ Status StorageManager::array_load_fragments(
     // Find the open array entry
     auto it = open_arrays_for_reads_.find(array_uri.to_string());
     if (it == open_arrays_for_reads_.end()) {
-      return logger_->status(Status_StorageManagerError(
+      return log_->status(Status_StorageManagerError(
           std::string("Cannot reopen array ") + array_uri.to_string() +
           "; Array not open"));
     }
@@ -459,7 +459,7 @@ StorageManager::array_reopen(
     // Find the open array entry
     auto it = open_arrays_for_reads_.find(array_uri.to_string());
     if (it == open_arrays_for_reads_.end()) {
-      return {logger_->status(Status_StorageManagerError(
+      return {log_->status(Status_StorageManagerError(
                   std::string("Cannot reopen array ") + array_uri.to_string() +
                   "; Array not open")),
               std::nullopt,
@@ -528,7 +528,7 @@ Status StorageManager::array_consolidate(
   // Check array URI
   URI array_uri(array_name);
   if (array_uri.is_invalid()) {
-    return logger_->status(
+    return log_->status(
         Status_StorageManagerError("Cannot consolidate array; Invalid URI"));
   }
 
@@ -537,7 +537,7 @@ Status StorageManager::array_consolidate(
   RETURN_NOT_OK(object_type(array_uri, &obj_type));
 
   if (obj_type != ObjectType::ARRAY) {
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot consolidate array; Array does not exist"));
   }
 
@@ -610,7 +610,7 @@ Status StorageManager::array_vacuum(
   assert(found);
 
   if (mode == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot vacuum array; Vacuum mode cannot be null"));
   else if (std::string(mode) == "fragments")
     RETURN_NOT_OK(
@@ -621,7 +621,7 @@ Status StorageManager::array_vacuum(
     RETURN_NOT_OK(
         array_vacuum_array_meta(array_name, timestamp_start, timestamp_end));
   else
-    return logger_->status(
+    return log_->status(
         Status_StorageManagerError("Cannot vacuum array; Invalid vacuum mode"));
 
   return Status::Ok();
@@ -630,7 +630,7 @@ Status StorageManager::array_vacuum(
 Status StorageManager::array_vacuum_fragments(
     const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end) {
   if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot vacuum fragments; Array name cannot be null"));
 
   // Get all URIs in the array directory
@@ -675,7 +675,7 @@ Status StorageManager::array_vacuum_fragments(
 
 Status StorageManager::array_vacuum_fragment_meta(const char* array_name) {
   if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot vacuum fragment metadata; Array name cannot be null"));
 
   // Get the consolidated fragment metadata URIs to be deleted
@@ -708,7 +708,7 @@ Status StorageManager::array_vacuum_fragment_meta(const char* array_name) {
 Status StorageManager::array_vacuum_array_meta(
     const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end) {
   if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot vacuum array metadata; Array name cannot be null"));
 
   // Get all URIs in the array directory
@@ -752,7 +752,7 @@ Status StorageManager::array_metadata_consolidate(
   // Check array URI
   URI array_uri(array_name);
   if (array_uri.is_invalid()) {
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot consolidate array metadata; Invalid URI"));
   }
   // Check if array exists
@@ -760,7 +760,7 @@ Status StorageManager::array_metadata_consolidate(
   RETURN_NOT_OK(object_type(array_uri, &obj_type));
 
   if (obj_type != ObjectType::ARRAY) {
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot consolidate array metadata; Array does not exist"));
   }
 
@@ -815,7 +815,7 @@ Status StorageManager::array_create(
     const EncryptionKey& encryption_key) {
   // Check array schema
   if (array_schema == nullptr) {
-    return logger_->status(
+    return log_->status(
         Status_StorageManagerError("Cannot create array; Empty array schema"));
   }
 
@@ -823,7 +823,7 @@ Status StorageManager::array_create(
   bool exists = false;
   RETURN_NOT_OK(is_array(array_uri, &exists));
   if (exists)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         std::string("Cannot create array; Array '") + array_uri.c_str() +
         "' already exists"));
 
@@ -900,7 +900,7 @@ Status StorageManager::array_evolve_schema(
     const EncryptionKey& encryption_key) {
   // Check array schema
   if (schema_evolution == nullptr) {
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot evolve array; Empty schema evolution"));
   }
 
@@ -913,7 +913,7 @@ Status StorageManager::array_evolve_schema(
   bool exists = false;
   RETURN_NOT_OK(is_array(array_uri, &exists));
   if (!exists)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         std::string("Cannot evolve array; Array '") + array_uri.c_str() +
         "' not exists"));
 
@@ -928,8 +928,8 @@ Status StorageManager::array_evolve_schema(
   Status st = store_array_schema(array_schema_evolved, encryption_key);
   if (!st.ok()) {
     tdb_delete(array_schema_evolved);
-    logger_->status(st);
-    return logger_->status(Status_StorageManagerError(
+    log_->status(st);
+    return log_->status(Status_StorageManagerError(
         "Cannot evolve schema;  Not able to store evolved array schema."));
   }
 
@@ -947,7 +947,7 @@ Status StorageManager::array_upgrade_version(
   bool exists = false;
   RETURN_NOT_OK(is_array(array_uri, &exists));
   if (!exists)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         std::string("Cannot upgrade array; Array '") + array_uri.c_str() +
         "' does not exist"));
 
@@ -997,7 +997,7 @@ Status StorageManager::array_upgrade_version(
   if (array_schema->version() < constants::format_version) {
     Status st = array_schema->generate_uri();
     if (!st.ok()) {
-      logger_->status(st);
+      log_->status(st);
       // Clean up
       tdb_delete(array_schema);
       return st;
@@ -1009,7 +1009,7 @@ Status StorageManager::array_upgrade_version(
         array_uri.join_path(constants::array_schema_folder_name);
     st = vfs_->create_dir(array_schema_folder_uri);
     if (!st.ok()) {
-      logger_->status(st);
+      log_->status(st);
       // Clean up
       tdb_delete(array_schema);
       return st;
@@ -1017,7 +1017,7 @@ Status StorageManager::array_upgrade_version(
 
     st = store_array_schema(array_schema, encryption_key_cfg);
     if (!st.ok()) {
-      logger_->status(st);
+      log_->status(st);
       // Clean up
       tdb_delete(array_schema);
       return st;
@@ -1054,17 +1054,17 @@ OpenArrayMemoryTracker* StorageManager::array_memory_tracker(
 Status StorageManager::array_get_non_empty_domain(
     Array* array, NDRange* domain, bool* is_empty) {
   if (domain == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Domain object is null"));
 
   if (array == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array object is null"));
 
   if (!array->is_remote() &&
       open_arrays_for_reads_.find(array->array_uri().to_string()) ==
           open_arrays_for_reads_.end())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array not opened for reads"));
 
   *domain = array->non_empty_domain();
@@ -1076,16 +1076,16 @@ Status StorageManager::array_get_non_empty_domain(
 Status StorageManager::array_get_non_empty_domain(
     Array* array, void* domain, bool* is_empty) {
   if (array == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array object is null"));
 
   if (!array->array_schema_latest()->domain()->all_dims_same_type())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Function non-applicable to arrays with "
         "heterogenous dimensions"));
 
   if (!array->array_schema_latest()->domain()->all_dims_fixed())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Function non-applicable to arrays with "
         "variable-sized dimensions"));
 
@@ -1114,13 +1114,13 @@ Status StorageManager::array_get_non_empty_domain_from_index(
 
   // Sanity checks
   if (idx >= array_schema->dim_num())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension index"));
   if (array_domain->dimension(idx)->var_size()) {
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
     errmsg += array_domain->dimension(idx)->name();
     errmsg += "' is variable-sized";
-    return logger_->status(Status_StorageManagerError(errmsg));
+    return log_->status(Status_StorageManagerError(errmsg));
   }
 
   NDRange dom;
@@ -1136,7 +1136,7 @@ Status StorageManager::array_get_non_empty_domain_from_name(
     Array* array, const char* name, void* domain, bool* is_empty) {
   // Sanity check
   if (name == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension name"));
 
   NDRange dom;
@@ -1152,7 +1152,7 @@ Status StorageManager::array_get_non_empty_domain_from_name(
       if (array_domain->dimension(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is variable-sized";
-        return logger_->status(Status_StorageManagerError(errmsg));
+        return log_->status(Status_StorageManagerError(errmsg));
       }
 
       if (!*is_empty)
@@ -1161,7 +1161,7 @@ Status StorageManager::array_get_non_empty_domain_from_name(
     }
   }
 
-  return logger_->status(Status_StorageManagerError(
+  return log_->status(Status_StorageManagerError(
       std::string("Cannot get non-empty domain; Dimension name '") + name +
       "' does not exist"));
 }
@@ -1178,13 +1178,13 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_index(
 
   // Sanity checks
   if (idx >= array_schema->dim_num())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension index"));
   if (!array_domain->dimension(idx)->var_size()) {
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
     errmsg += array_domain->dimension(idx)->name();
     errmsg += "' is fixed-sized";
-    return logger_->status(Status_StorageManagerError(errmsg));
+    return log_->status(Status_StorageManagerError(errmsg));
   }
 
   NDRange dom;
@@ -1209,7 +1209,7 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_name(
     bool* is_empty) {
   // Sanity check
   if (name == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension name"));
 
   NDRange dom;
@@ -1225,7 +1225,7 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_name(
       if (!array_domain->dimension(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is fixed-sized";
-        return logger_->status(Status_StorageManagerError(errmsg));
+        return log_->status(Status_StorageManagerError(errmsg));
       }
 
       if (*is_empty) {
@@ -1240,7 +1240,7 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_name(
     }
   }
 
-  return logger_->status(Status_StorageManagerError(
+  return log_->status(Status_StorageManagerError(
       std::string("Cannot get non-empty domain; Dimension name '") + name +
       "' does not exist"));
 }
@@ -1253,13 +1253,13 @@ Status StorageManager::array_get_non_empty_domain_var_from_index(
 
   // Sanity checks
   if (idx >= array_schema->dim_num())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension index"));
   if (!array_domain->dimension(idx)->var_size()) {
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
     errmsg += array_domain->dimension(idx)->name();
     errmsg += "' is fixed-sized";
-    return logger_->status(Status_StorageManagerError(errmsg));
+    return log_->status(Status_StorageManagerError(errmsg));
   }
 
   NDRange dom;
@@ -1278,7 +1278,7 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
     Array* array, const char* name, void* start, void* end, bool* is_empty) {
   // Sanity check
   if (name == nullptr)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension name"));
 
   NDRange dom;
@@ -1294,7 +1294,7 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
       if (!array_domain->dimension(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is fixed-sized";
-        return logger_->status(Status_StorageManagerError(errmsg));
+        return log_->status(Status_StorageManagerError(errmsg));
       }
 
       if (!*is_empty) {
@@ -1306,7 +1306,7 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
     }
   }
 
-  return logger_->status(Status_StorageManagerError(
+  return log_->status(Status_StorageManagerError(
       std::string("Cannot get non-empty domain; Dimension name '") + name +
       "' does not exist"));
 }
@@ -1316,7 +1316,7 @@ Status StorageManager::array_get_encryption(
   URI uri(array_uri);
 
   if (uri.is_invalid())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot get array encryption; Invalid array URI"));
 
   URI schema_uri;
@@ -1359,7 +1359,7 @@ Status StorageManager::async_push_query(Query* query) {
         // Process query.
         Status st = query_submit(query);
         if (!st.ok())
-          logger_->status(st);
+          log_->status(st);
         return st;
       },
       [query]() {
@@ -1433,13 +1433,13 @@ void StorageManager::decrement_in_progress() {
 Status StorageManager::object_remove(const char* path) const {
   auto uri = URI(path);
   if (uri.is_invalid())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         std::string("Cannot remove object '") + path + "'; Invalid URI"));
 
   ObjectType obj_type;
   RETURN_NOT_OK(object_type(uri, &obj_type));
   if (obj_type == ObjectType::INVALID)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         std::string("Cannot remove object '") + path +
         "'; Invalid TileDB object"));
 
@@ -1450,18 +1450,18 @@ Status StorageManager::object_move(
     const char* old_path, const char* new_path) const {
   auto old_uri = URI(old_path);
   if (old_uri.is_invalid())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         std::string("Cannot move object '") + old_path + "'; Invalid URI"));
 
   auto new_uri = URI(new_path);
   if (new_uri.is_invalid())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         std::string("Cannot move object to '") + new_path + "'; Invalid URI"));
 
   ObjectType obj_type;
   RETURN_NOT_OK(object_type(old_uri, &obj_type));
   if (obj_type == ObjectType::INVALID)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         std::string("Cannot move object '") + old_path +
         "'; Invalid TileDB object"));
 
@@ -1682,14 +1682,14 @@ Status StorageManager::group_create(const std::string& group) {
   // Create group URI
   URI uri(group);
   if (uri.is_invalid())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot create group '" + group + "'; Invalid group URI"));
 
   // Check if group exists
   bool exists;
   RETURN_NOT_OK(is_group(uri, &exists));
   if (exists)
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         std::string("Cannot create group; Group '") + uri.c_str() +
         "' already exists"));
 
@@ -1858,7 +1858,7 @@ Status StorageManager::get_array_schema_uris(
 
   // Check if schema_uris is empty
   if (schema_uris->empty()) {
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Can not get the array schemas; No array schemas found."));
   }
 
@@ -1872,12 +1872,12 @@ Status StorageManager::get_latest_array_schema_uri(
   std::vector<URI> schema_uris;
   RETURN_NOT_OK(get_array_schema_uris(array_uri, &schema_uris));
   if (schema_uris.size() == 0) {
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Can not get the latest array schema; No array schemas found."));
   }
   *uri = schema_uris.back();
   if (uri->is_invalid()) {
-    return logger_->status(
+    return log_->status(
         Status_StorageManagerError("Could not find array schema URI"));
   }
 
@@ -1961,7 +1961,7 @@ Status StorageManager::load_array_schema(
   auto timer_se = stats_->start_timer("read_load_array_schema");
 
   if (array_uri.is_invalid())
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot load array schema; Invalid array URI"));
 
   URI schema_uri;
@@ -1981,7 +1981,7 @@ StorageManager::load_all_array_schemas(
   auto timer_se = stats_->start_timer("read_load_all_array_schemas");
 
   if (array_uri.is_invalid())
-    return {logger_->status(Status_StorageManagerError(
+    return {log_->status(Status_StorageManagerError(
                 "Cannot load all array schemas; Invalid array URI")),
             std::nullopt};
 
@@ -1989,7 +1989,7 @@ StorageManager::load_all_array_schemas(
   RETURN_NOT_OK_TUPLE(get_array_schema_uris(array_uri, &schema_uris));
   if (schema_uris.empty()) {
     return {
-        logger_->status(Status_StorageManagerError(
+        log_->status(Status_StorageManagerError(
             "Can not get the array schema vector; No array schemas found.")),
         std::nullopt};
   }
@@ -2113,7 +2113,7 @@ Status StorageManager::object_iter_begin(
   // Sanity check
   URI path_uri(path);
   if (path_uri.is_invalid()) {
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot create object iterator; Invalid input path"));
   }
 
@@ -2145,7 +2145,7 @@ Status StorageManager::object_iter_begin(
   // Sanity check
   URI path_uri(path);
   if (path_uri.is_invalid()) {
-    return logger_->status(Status_StorageManagerError(
+    return log_->status(Status_StorageManagerError(
         "Cannot create object iterator; Invalid input path"));
   }
 
@@ -2474,10 +2474,6 @@ stats::Stats* StorageManager::stats() {
   return stats_;
 }
 
-tdb_shared_ptr<Logger> StorageManager::logger() const {
-  return logger_;
-}
-
 /* ****************************** */
 /*         PRIVATE METHODS        */
 /* ****************************** */
@@ -2488,7 +2484,7 @@ Status StorageManager::array_open_without_fragments(
     OpenArray** open_array) {
   auto timer_se = stats_->start_timer("read_array_open_without_fragments");
   if (!vfs_->supports_uri_scheme(array_uri))
-    return logger_->status(
+    return log_->status(
         Status_StorageManagerError("Cannot open array; "
                                    "URI scheme "
                                    "unsupported."));

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -46,7 +46,7 @@
 #include <unordered_map>
 
 #include "tiledb/common/heap_memory.h"
-#include "tiledb/common/logger_public.h"
+#include "tiledb/common/observable.h"
 #include "tiledb/common/status.h"
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/config/config.h"
@@ -81,7 +81,7 @@ enum class EncryptionType : uint8_t;
 enum class ObjectType : uint8_t;
 
 /** The storage manager that manages pretty much everything in TileDB. */
-class StorageManager {
+class StorageManager : public Observable<StorageManager> {
  public:
   /* ********************************* */
   /*          TYPE DEFINITIONS         */
@@ -116,7 +116,7 @@ class StorageManager {
       ThreadPool* compute_tp,
       ThreadPool* io_tp,
       stats::Stats* parent_stats,
-      tdb_shared_ptr<Logger> logger);
+      shared_ptr<Logger> logger);
 
   /** Destructor. */
   ~StorageManager();
@@ -1024,9 +1024,6 @@ class StorageManager {
   /** Returns `stats_`. */
   stats::Stats* stats();
 
-  /** Returns the internal logger object. */
-  tdb_shared_ptr<Logger> logger() const;
-
  private:
   /* ********************************* */
   /*        PRIVATE DATATYPES          */
@@ -1061,9 +1058,6 @@ class StorageManager {
 
   /** The class stats. */
   stats::Stats* stats_;
-
-  /** The class logger. */
-  tdb_shared_ptr<Logger> logger_;
 
   /** Set to true when tasks are being cancelled. */
   bool cancellation_in_progress_;


### PR DESCRIPTION
This is part 1 of the effort to create a base class that offers all observability tools in Core, such as logging, stats, tracing in the future etc. This base class will make it easier to add tools such as logging to a class and will remove boilerplate repetitive logic from current Core classes.

This first PR is adding the Observable base class that classes will need to extend in order to have access to the toolbox, as well as the base class for logging which is the first available tool in Observable class.

It also uses this new class in Context, StorageManager and Query to display its usage and ensure it's working correctly.

Future PRs will cover:
- Subclass the new class in every class in the code that currently defines its own logger
- Add `stats` tool in `Observable` and adapt all classes.
- Add logging in Filters and resource pool

---
TYPE: IMPROVEMENT
DESC: Add common base class for observability - part1
