### PR TITLE
Add experimental query status details API

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -7114,7 +7114,6 @@ int32_t tiledb_fragment_info_dump(
 /*          EXPERIMENTAL APIs        */
 /* ********************************* */
 
-/** TODO */
 TILEDB_EXPORT int32_t tiledb_query_get_status_details(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
@@ -7124,10 +7123,10 @@ TILEDB_EXPORT int32_t tiledb_query_get_status_details(
     return TILEDB_ERR;
 
   // Currently only one detailed reason. Retrieve it and set to user struct.
-  tiledb_query_status_details_reason_t reason =
+  tiledb_query_status_details_reason_t incomplete_reason =
       (tiledb_query_status_details_reason_t)
-          query->query_->status_details_reason();
-  status->reason = reason;
+          query->query_->status_incomplete_reason();
+  status->incomplete_reason = incomplete_reason;
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -7109,3 +7109,25 @@ int32_t tiledb_fragment_info_dump(
   fragment_info->fragment_info_->dump(out);
   return TILEDB_OK;
 }
+
+/* ********************************* */
+/*          EXPERIMENTAL APIs        */
+/* ********************************* */
+
+/** TODO */
+TILEDB_EXPORT int32_t tiledb_query_get_status_details(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    tiledb_query_status_details_t* status) {
+  // Sanity check
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Currently only one detailed reason. Retrieve it and set to user struct.
+  tiledb_query_status_details_reason_t reason =
+      (tiledb_query_status_details_reason_t)
+          query->query_->status_details_reason();
+  status->reason = reason;
+
+  return TILEDB_OK;
+}

--- a/tiledb/sm/c_api/tiledb_enum.h
+++ b/tiledb/sm/c_api/tiledb_enum.h
@@ -218,6 +218,14 @@
     TILEDB_QUERY_STATUS_ENUM(UNINITIALIZED) = 4,
 #endif
 
+#ifdef TILEDB_QUERY_STATUS_DETAILS_ENUM
+    TILEDB_QUERY_STATUS_DETAILS_ENUM(REASON_NONE) = 0,
+    /** User buffers are too small */
+    TILEDB_QUERY_STATUS_DETAILS_ENUM(REASON_USER_BUFFER_SIZE) = 1,
+    /** Exceeded memory budget: can resubmit without resize */
+    TILEDB_QUERY_STATUS_DETAILS_ENUM(REASON_MEMORY_BUDGET) = 2,
+#endif
+
 #ifdef TILEDB_QUERY_CONDITION_OP_ENUM
     /** Less-than operator */
     TILEDB_QUERY_CONDITION_OP_ENUM(LT) = 0,

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -218,6 +218,51 @@ TILEDB_DEPRECATED_EXPORT int32_t tiledb_query_add_point_ranges(
     const void* start,
     uint64_t count);
 
+/* ********************************* */
+/*        QUERY STATUS DETAILS       */
+/* ********************************* */
+
+/** This should move to c_api/tiledb.h when stabilized */
+typedef struct tiledb_query_status_details_t tiledb_query_status_details_t;
+
+/** TileDB query status details type. */
+typedef enum {
+/** Helper macro for defining status details type enums. */
+#define TILEDB_QUERY_STATUS_DETAILS_ENUM(id) TILEDB_##id
+#include "tiledb_enum.h"
+#undef TILEDB_QUERY_STATUS_DETAILS_ENUM
+} tiledb_query_status_details_reason_t;
+
+/** This should move to c_api/tiledb_struct_defs.h when stabilized */
+struct tiledb_query_status_details_t {
+  tiledb_query_status_details_reason_t reason;
+};
+
+/**
+ * Get extended query status details.
+ *
+ * The contained enumeration tiledb_query_status_details_reason_t
+ * indicates extended information about a returned query status
+ * in order to allow improved client-side handling of buffers and
+ * potential resubmissions.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_query_status_details_t status_details;
+ * tiledb_query_get_status_details(ctx, query, &status_details);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The query from which to retrieve status details.
+ * @param status_details The tiledb_query_status_details_t struct.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_status_details(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    tiledb_query_status_details_t* status);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -235,7 +235,7 @@ typedef enum {
 
 /** This should move to c_api/tiledb_struct_defs.h when stabilized */
 struct tiledb_query_status_details_t {
-  tiledb_query_status_details_reason_t reason;
+  tiledb_query_status_details_reason_t incomplete_reason;
 };
 
 /**

--- a/tiledb/sm/enums/query_status_details.h
+++ b/tiledb/sm/enums/query_status_details.h
@@ -1,0 +1,53 @@
+/**
+ * @file query_status.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This defines the tiledb QueryStatus enum that maps to tiledb_query_status_t
+ * C-api enum.
+ */
+
+#ifndef TILEDB_QUERY_STATUS_DETAILS_H
+#define TILEDB_QUERY_STATUS_DETAILS_H
+
+#include "tiledb/common/status.h"
+#include "tiledb/sm/misc/constants.h"
+
+namespace tiledb {
+namespace sm {
+
+/** Defines the query statuses. */
+enum class QueryStatusDetailsReason : uint8_t {
+#define TILEDB_QUERY_STATUS_DETAILS_ENUM(id) id
+#include "tiledb/sm/c_api/tiledb_enum.h"
+#undef TILEDB_QUERY_STATUS_DETAILS_ENUM
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_QUERY_STATUS_DETAILS_H

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -88,7 +88,7 @@ bool DenseReader::incomplete() const {
   return read_state_.overflowed_ || !read_state_.done();
 }
 
-QueryStatusDetailsReason DenseReader::status_details_reason() const {
+QueryStatusDetailsReason DenseReader::status_incomplete_reason() const {
   return incomplete() ? QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE :
                         QueryStatusDetailsReason::REASON_NONE;
 }

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -88,6 +88,11 @@ bool DenseReader::incomplete() const {
   return read_state_.overflowed_ || !read_state_.done();
 }
 
+QueryStatusDetailsReason DenseReader::status_details_reason() const {
+  return incomplete() ? QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE :
+                        QueryStatusDetailsReason::REASON_NONE;
+}
+
 Status DenseReader::init() {
   // Sanity checks.
   if (storage_manager_ == nullptr)

--- a/tiledb/sm/query/dense_reader.h
+++ b/tiledb/sm/query/dense_reader.h
@@ -93,7 +93,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
   bool incomplete() const;
 
   /** Returns the status details reason. */
-  QueryStatusDetailsReason status_details_reason() const;
+  QueryStatusDetailsReason status_incomplete_reason() const;
 
   /** Initializes the reader. */
   Status init();

--- a/tiledb/sm/query/dense_reader.h
+++ b/tiledb/sm/query/dense_reader.h
@@ -92,6 +92,9 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
    */
   bool incomplete() const;
 
+  /** Returns the status details reason. */
+  QueryStatusDetailsReason status_details_reason() const;
+
   /** Initializes the reader. */
   Status init();
 

--- a/tiledb/sm/query/iquery_strategy.h
+++ b/tiledb/sm/query/iquery_strategy.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/common/status.h"
 #include "tiledb/sm/enums/layout.h"
+#include "tiledb/sm/enums/query_status_details.h"
 
 using namespace tiledb::common;
 
@@ -58,8 +59,11 @@ class IQueryStrategy {
   /** Finalizes the strategy. */
   virtual Status finalize() = 0;
 
-  /** Returns of the query is incomplete. */
+  /** Returns if the query is incomplete. */
   virtual bool incomplete() const = 0;
+
+  /** Returns the status details reason. */
+  virtual QueryStatusDetailsReason status_details_reason() const = 0;
 
   /** Resets the object */
   virtual void reset() = 0;

--- a/tiledb/sm/query/iquery_strategy.h
+++ b/tiledb/sm/query/iquery_strategy.h
@@ -63,7 +63,7 @@ class IQueryStrategy {
   virtual bool incomplete() const = 0;
 
   /** Returns the status details reason. */
-  virtual QueryStatusDetailsReason status_details_reason() const = 0;
+  virtual QueryStatusDetailsReason status_incomplete_reason() const = 0;
 
   /** Resets the object */
   virtual void reset() = 0;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -2033,9 +2033,9 @@ QueryStatus Query::status() const {
   return status_;
 }
 
-QueryStatusDetailsReason Query::status_details_reason() const {
+QueryStatusDetailsReason Query::status_incomplete_reason() const {
   if (strategy_ != nullptr)
-    return strategy_->status_details_reason();
+    return strategy_->status_incomplete_reason();
 
   return QueryStatusDetailsReason::REASON_NONE;
 }

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -2034,7 +2034,10 @@ QueryStatus Query::status() const {
 }
 
 QueryStatusDetailsReason Query::status_details_reason() const {
-  return QueryStatusDetailsReason::REASON_NONE;  // TODO
+  if (strategy_ != nullptr)
+    return strategy_->status_details_reason();
+
+  return QueryStatusDetailsReason::REASON_NONE;
 }
 
 QueryType Query::type() const {

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -2033,6 +2033,10 @@ QueryStatus Query::status() const {
   return status_;
 }
 
+QueryStatusDetailsReason Query::status_details_reason() const {
+  return QueryStatusDetailsReason::REASON_NONE;  // TODO
+}
+
 QueryType Query::type() const {
   return type_;
 }

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -860,8 +860,8 @@ class Query {
   /** Returns the query status. */
   QueryStatus status() const;
 
-  /** Returns the query status details reason. */
-  QueryStatusDetailsReason status_details_reason() const;
+  /** Returns the query status incomplete reason. */
+  QueryStatusDetailsReason status_incomplete_reason() const;
 
   /** Returns the query type. */
   QueryType type() const;

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -44,6 +44,7 @@
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
+#include "tiledb/sm/enums/query_status_details.h"
 #include "tiledb/sm/fragment/written_fragment_info.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/iquery_strategy.h"
@@ -858,6 +859,9 @@ class Query {
 
   /** Returns the query status. */
   QueryStatus status() const;
+
+  /** Returns the query status details reason. */
+  QueryStatusDetailsReason status_details_reason() const;
 
   /** Returns the query type. */
   QueryType type() const;

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -127,7 +127,7 @@ bool Reader::incomplete() const {
   return read_state_.overflowed_ || !read_state_.done();
 }
 
-QueryStatusDetailsReason Reader::status_details_reason() const {
+QueryStatusDetailsReason Reader::status_incomplete_reason() const {
   return incomplete() ? QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE :
                         QueryStatusDetailsReason::REASON_NONE;
 }

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -127,6 +127,11 @@ bool Reader::incomplete() const {
   return read_state_.overflowed_ || !read_state_.done();
 }
 
+QueryStatusDetailsReason Reader::status_details_reason() const {
+  return incomplete() ? QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE :
+                        QueryStatusDetailsReason::REASON_NONE;
+}
+
 Status Reader::init() {
   // Sanity checks
   if (storage_manager_ == nullptr)

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -95,6 +95,9 @@ class Reader : public ReaderBase, public IQueryStrategy {
    */
   bool incomplete() const;
 
+  /** Returns the status details reason. */
+  QueryStatusDetailsReason status_details_reason() const;
+
   /** Initializes the reader. */
   Status init();
 

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -96,7 +96,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
   bool incomplete() const;
 
   /** Returns the status details reason. */
-  QueryStatusDetailsReason status_details_reason() const;
+  QueryStatusDetailsReason status_incomplete_reason() const;
 
   /** Initializes the reader. */
   Status init();

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -98,7 +98,7 @@ bool SparseGlobalOrderReader::incomplete() const {
          !read_state_.done_adding_result_tiles_ || !empty_result_tiles_;
 }
 
-QueryStatusDetailsReason SparseGlobalOrderReader::status_details_reason()
+QueryStatusDetailsReason SparseGlobalOrderReader::status_incomplete_reason()
     const {
   return incomplete() ? QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE :
                         QueryStatusDetailsReason::REASON_NONE;

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -98,6 +98,12 @@ bool SparseGlobalOrderReader::incomplete() const {
          !read_state_.done_adding_result_tiles_ || !empty_result_tiles_;
 }
 
+QueryStatusDetailsReason SparseGlobalOrderReader::status_details_reason()
+    const {
+  return incomplete() ? QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE :
+                        QueryStatusDetailsReason::REASON_NONE;
+}
+
 Status SparseGlobalOrderReader::init() {
   RETURN_NOT_OK(SparseIndexReaderBase::init());
 

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -94,7 +94,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   bool incomplete() const;
 
   /** Returns the status details reason. */
-  QueryStatusDetailsReason status_details_reason() const;
+  QueryStatusDetailsReason status_incomplete_reason() const;
 
   /** Initializes the reader. */
   Status init();

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -90,12 +90,11 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
     return Status::Ok();
   }
 
-  /**
-   * Returns `true` if the query was incomplete, i.e., if all subarray
-   * partitions in the read state have not been processed or there
-   * was some buffer overflow.
-   */
+  /** Returns `true` if the query was incomplete. */
   bool incomplete() const;
+
+  /** Returns the status details reason. */
+  QueryStatusDetailsReason status_details_reason() const;
 
   /** Initializes the reader. */
   Status init();

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -96,7 +96,7 @@ bool SparseUnorderedWithDupsReader<BitmapType>::incomplete() const {
 
 template <class BitmapType>
 QueryStatusDetailsReason
-SparseUnorderedWithDupsReader<BitmapType>::status_details_reason() const {
+SparseUnorderedWithDupsReader<BitmapType>::status_incomplete_reason() const {
   if (!incomplete())
     return QueryStatusDetailsReason::REASON_NONE;
 

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -95,6 +95,17 @@ bool SparseUnorderedWithDupsReader<BitmapType>::incomplete() const {
 }
 
 template <class BitmapType>
+QueryStatusDetailsReason
+SparseUnorderedWithDupsReader<BitmapType>::status_details_reason() const {
+  if (!incomplete())
+    return QueryStatusDetailsReason::REASON_NONE;
+
+  return result_tiles_[0].empty() ?
+             QueryStatusDetailsReason::REASON_MEMORY_BUDGET :
+             QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE;
+}
+
+template <class BitmapType>
 Status SparseUnorderedWithDupsReader<BitmapType>::init() {
   RETURN_NOT_OK(SparseIndexReaderBase::init());
 

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -108,12 +108,11 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
     return Status::Ok();
   }
 
-  /**
-   * Returns `true` if the query was incomplete, i.e., if all subarray
-   * partitions in the read state have not been processed or there
-   * was some buffer overflow.
-   */
+  /** Returns `true` if the query was incomplete. */
   bool incomplete() const;
+
+  /** Returns the status details reason. */
+  QueryStatusDetailsReason status_details_reason() const;
 
   /** Initializes the reader. */
   Status init();

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -112,7 +112,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   bool incomplete() const;
 
   /** Returns the status details reason. */
-  QueryStatusDetailsReason status_details_reason() const;
+  QueryStatusDetailsReason status_incomplete_reason() const;
 
   /** Initializes the reader. */
   Status init();

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -127,7 +127,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
   }
 
   /** Writer is never in an imcomplete state. */
-  QueryStatusDetailsReason status_details_reason() const {
+  QueryStatusDetailsReason status_incomplete_reason() const {
     return QueryStatusDetailsReason::REASON_NONE;
   }
 

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -126,6 +126,11 @@ class Writer : public StrategyBase, public IQueryStrategy {
     return false;
   }
 
+  /** Writer is never in an imcomplete state. */
+  QueryStatusDetailsReason status_details_reason() const {
+    return QueryStatusDetailsReason::REASON_NONE;
+  }
+
   /** Returns current setting of check_coord_dups_ */
   bool get_check_coord_dups() const;
 


### PR DESCRIPTION
Add a C API for libtiledb clients to retrieve extended query status information. This will allow improved handling of user buffers and resizing during incomplete query resubmission.

Currently two status detail reasons are implemented:

- `TILEDB_REASON_USER_BUFFER_SIZE`: indicates that the query returned incomplete because the user buffers were full or not large enough to fill results.
- `TILEDB_REASON_MEMORY_BUDGET`: indicates that the query returned incomplete because an internal memory budget was exceeded. The client may choose to resubmit the query without resizing buffers.

Fixes [sc-13108]

---

TYPE: C_API
DESC: Add experimental query status details API
