### PR TITLE
Don't try to read config from uninitialized storage manager

### DIFF
--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -464,7 +464,13 @@ Status Config::get(const std::string& param, T* value, bool* found) const {
     return Status::Ok();
 
   // Parameter found, retrieve value
-  return utils::parse::convert(val, value);
+  auto status = utils::parse::convert(val, value);
+  if (!status.ok()) {
+    return Status_ConfigError(
+        std::string("Failed to parse config value '") + std::string(val) +
+        std::string("' for key '") + param + "' due to: " + status.to_string());
+  }
+  return Status::Ok();
 }
 
 /*

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -56,10 +56,13 @@ Context::Context()
 Context::~Context() {
   bool found = false;
   bool use_malloc_trim = false;
-  const Status& st = storage_manager_->config().get<bool>(
-      "sm.mem.malloc_trim", &use_malloc_trim, &found);
-  if (st.ok() && found && use_malloc_trim) {
-    tdb_malloc_trim();
+
+  if (storage_manager_ != nullptr) {
+    const Status& st = storage_manager_->config().get<bool>(
+        "sm.mem.malloc_trim", &use_malloc_trim, &found);
+    if (st.ok() && found && use_malloc_trim) {
+      tdb_malloc_trim();
+    }
   }
 
   // Delete the `storage_manager_` to ensure it is destructed


### PR DESCRIPTION
- Don't try to read config from uninitialized storage manager: this causes a segfault if config parameter is invalid (eg when specified as an environment variable)
- Improve error message for config parse failure

---

TYPE: BUG
DESC: Don't try to read config from uninitialize storage manager