### PR TITLE
Fix concurrency level for macOS-11 jobs

### DIFF
--- a/.github/workflows/build-macOS11-GCS.yml
+++ b/.github/workflows/build-macOS11-GCS.yml
@@ -10,7 +10,7 @@ on:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build-macOS11-S3.yml
+++ b/.github/workflows/build-macOS11-S3.yml
@@ -10,7 +10,7 @@ on:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
The current specification always cancels the second job to start.
Instead, change the grouping to use workflow and github.ref as per this
discussion:

    - https://github.community/t/concurrecy-not-work-for-push/183068/
---

`perl -i -p -e 's/  group: \${{ github.head_ref }}/  group: \${{ github.workflow }}-\${{ github.event.pull_request.number || github.ref }}/g' *.yml`

---
TYPE: NO_HISTORY
