### PR TITLE
Splitting up #2769 to diagnose CI issues [WIP]

### DIFF
--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -76,7 +76,9 @@ class Add1InPlace : public tiledb::sm::Filter {
   void dump(FILE* out) const override {
     (void)out;
   }
-  // ...
+  void dump_ss(std::stringstream& ss) const override {
+    (void)ss;
+  }
 
   Status run_forward(
       const Tile&,
@@ -145,6 +147,9 @@ class Add1OutOfPlace : public tiledb::sm::Filter {
 
   void dump(FILE* out) const override {
     (void)out;
+  }
+  void dump_ss(std::stringstream& ss) const override {
+    (void)ss;
   }
 
   Status run_forward(
@@ -237,6 +242,9 @@ class AddNInPlace : public tiledb::sm::Filter {
   void dump(FILE* out) const override {
     (void)out;
   }
+  void dump_ss(std::stringstream& ss) const override {
+    (void)ss;
+  }
 
   Status run_forward(
       const Tile&,
@@ -317,6 +325,9 @@ class PseudoChecksumFilter : public tiledb::sm::Filter {
 
   void dump(FILE* out) const override {
     (void)out;
+  }
+  void dump_ss(std::stringstream& ss) const override {
+    (void)ss;
   }
 
   Status run_forward(
@@ -406,6 +417,9 @@ class Add1IncludingMetadataFilter : public tiledb::sm::Filter {
 
   void dump(FILE* out) const override {
     (void)out;
+  }
+  void dump_ss(std::stringstream& ss) const override {
+    (void)ss;
   }
 
   Status run_forward(

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -76,6 +76,7 @@ class Add1InPlace : public tiledb::sm::Filter {
   void dump(FILE* out) const override {
     (void)out;
   }
+  // ...
 
   Status run_forward(
       const Tile&,

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -222,23 +222,29 @@ const Range& Dimension::domain() const {
 void Dimension::dump(FILE* out) const {
   if (out == nullptr)
     out = stdout;
+  std::stringstream ss;
+  dump_ss(ss);
+  fprintf(out, "%s", ss.str().c_str());
+}
+
+void Dimension::dump_ss(std::stringstream& ss) const {
   // Retrieve domain and tile extent strings
   std::string domain_s = domain_str();
   std::string tile_extent_s = tile_extent_str();
 
   // Dump
-  fprintf(out, "### Dimension ###\n");
-  fprintf(out, "- Name: %s\n", name_.c_str());
-  fprintf(out, "- Type: %s\n", datatype_str(type_).c_str());
+  ss << "### Dimension ###\n";
+  ss << "- Name: " << name_ << "\n";
+  ss << "- Type: " << datatype_str(type_) << "\n";
   if (!var_size())
-    fprintf(out, "- Cell val num: %u\n", cell_val_num_);
+    ss << "- Cell val num: " << cell_val_num_ << "\n";
   else
-    fprintf(out, "- Cell val num: var\n");
-  fprintf(out, "- Domain: %s\n", domain_s.c_str());
-  fprintf(out, "- Tile extent: %s\n", tile_extent_s.c_str());
-  fprintf(out, "- Filters: %u", (unsigned)filters_.size());
-  filters_.dump(out);
-  fprintf(out, "\n");
+    ss << "- Cell val num: var\n";
+  ss << "- Domain: " << domain_s << "\n";
+  ss << "- Tile extent: " << tile_extent_s << "\n";
+  ss << "- Filters: " << (unsigned)filters_.size();
+  filters_.dump_ss(ss);
+  ss << "\n";
 }
 
 const FilterPipeline& Dimension::filters() const {

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -130,6 +130,7 @@ class Dimension {
 
   /** Dumps the dimension contents in ASCII form in the selected output. */
   void dump(FILE* out) const;
+  void dump_ss(std::stringstream& ss) const;
 
   /** Returns the filter pipeline of this dimension. */
   const FilterPipeline& filters() const;

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -354,10 +354,15 @@ const Dimension* Domain::dimension(const std::string& name) const {
 void Domain::dump(FILE* out) const {
   if (out == nullptr)
     out = stdout;
+  std::stringstream ss;
+  dump_ss(ss);
+  fprintf(out, "%s", ss.str().c_str());
+}
 
+void Domain::dump_ss(std::stringstream& ss) const {
   for (const auto& dim : dimensions_) {
-    fprintf(out, "\n");
-    dim->dump(out);
+    ss << "\n";
+    dim->dump_ss(ss);
   }
 }
 

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -224,6 +224,7 @@ class Domain {
 
   /** Dumps the domain in ASCII format in the selected output. */
   void dump(FILE* out) const;
+  void dump_ss(std::stringstream& ss) const;
 
   /** Expands ND range `r2` using ND range `r1`. */
   void expand_ndrange(const NDRange& r1, NDRange* r2) const;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2647,6 +2647,15 @@ int32_t tiledb_array_schema_dump(
   return TILEDB_OK;
 }
 
+int32_t tiledb_array_schema_dump_str(
+    tiledb_ctx_t* ctx, const tiledb_array_schema_t* array_schema, char** out) {
+  if (sanity_check(ctx) == TILEDB_ERR ||
+      sanity_check(ctx, array_schema) == TILEDB_ERR)
+    return TILEDB_ERR;
+  array_schema->array_schema_->dump_str(out);
+  return TILEDB_OK;
+}
+
 int32_t tiledb_array_schema_get_attribute_from_index(
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3477,23 +3477,6 @@ TILEDB_EXPORT int32_t tiledb_array_schema_dump(
 TILEDB_EXPORT int32_t tiledb_array_schema_dump_str(
     tiledb_ctx_t* ctx, const tiledb_array_schema_t* array_schema, char** out);
 
-/**
- * Dumps the array schema in ASCII format as a string.
- *
- * **Example:**
- *
- * @code{.c}
- * char *stats_str;
- * tiledb_stats_raw_dump_str(&stats_str);
- * // ...
- * tiledb_stats_raw_free_str(&stats_str);
- * @endcode
- *
- * @param out Will be set to point to an allocated string containing the stats.
- * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
- */
-TILEDB_EXPORT int32_t tiledb_stats_raw_dump_str(char** out);
-
 /* ********************************* */
 /*               QUERY               */
 /* ********************************* */

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3443,7 +3443,7 @@ TILEDB_EXPORT int32_t tiledb_array_schema_has_attribute(
  *
  * **Example:**
  *
- * The following prints the array schema dump in standard output.
+ * The following prints the array-schema dump to standard output.
  *
  * @code{.c}
  * tiledb_array_schema_dump(ctx, array_schema, stdout);
@@ -3456,6 +3456,43 @@ TILEDB_EXPORT int32_t tiledb_array_schema_has_attribute(
  */
 TILEDB_EXPORT int32_t tiledb_array_schema_dump(
     tiledb_ctx_t* ctx, const tiledb_array_schema_t* array_schema, FILE* out);
+
+/**
+ * Returns the array schema in ASCII format as a string.
+ *
+ * **Example:**
+ *
+ * The following retrieves the array-schema dump as a string.
+ *
+ * @code{.c}
+ * char* txt;
+ * tiledb_array_schema_dump_str(ctx, array_schema, &txt);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_schema The array schema.
+ * @param out Returns the output string. Maybe be passed in as nullptr.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_schema_dump_str(
+    tiledb_ctx_t* ctx, const tiledb_array_schema_t* array_schema, char** out);
+
+/**
+ * Dumps the array schema in ASCII format as a string.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * char *stats_str;
+ * tiledb_stats_raw_dump_str(&stats_str);
+ * // ...
+ * tiledb_stats_raw_free_str(&stats_str);
+ * @endcode
+ *
+ * @param out Will be set to point to an allocated string containing the stats.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_stats_raw_dump_str(char** out);
 
 /* ********************************* */
 /*               QUERY               */

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -92,6 +92,10 @@ void BitWidthReductionFilter::dump(FILE* out) const {
   fprintf(out, "BitWidthReduction: BIT_WIDTH_MAX_WINDOW=%u", max_window_size_);
 }
 
+void BitWidthReductionFilter::dump_ss(std::stringstream& ss) const {
+  ss << "BitWidthReduction: BIT_WIDTH_MAX_WINDOW=" << max_window_size_;
+}
+
 Status BitWidthReductionFilter::run_forward(
     const Tile& tile,
     FilterBuffer* input_metadata,

--- a/tiledb/sm/filter/bit_width_reduction_filter.h
+++ b/tiledb/sm/filter/bit_width_reduction_filter.h
@@ -87,6 +87,7 @@ class BitWidthReductionFilter : public Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   void dump(FILE* out) const override;
+  void dump_ss(std::stringstream& ss) const override;
 
   /** Return the max window size used by the filter. */
   uint32_t max_window_size() const;

--- a/tiledb/sm/filter/bitshuffle_filter.cc
+++ b/tiledb/sm/filter/bitshuffle_filter.cc
@@ -58,6 +58,10 @@ void BitshuffleFilter::dump(FILE* out) const {
   fprintf(out, "BitShuffle");
 }
 
+void BitshuffleFilter::dump_ss(std::stringstream& ss) const {
+  ss << "BitShuffle";
+}
+
 Status BitshuffleFilter::run_forward(
     const Tile& tile,
     FilterBuffer* input_metadata,

--- a/tiledb/sm/filter/bitshuffle_filter.h
+++ b/tiledb/sm/filter/bitshuffle_filter.h
@@ -81,6 +81,7 @@ class BitshuffleFilter : public Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   void dump(FILE* out) const override;
+  void dump_ss(std::stringstream& ss) const override;
 
   /**
    * Shuffle the bits of the input data into the output data buffer.

--- a/tiledb/sm/filter/byteshuffle_filter.cc
+++ b/tiledb/sm/filter/byteshuffle_filter.cc
@@ -58,6 +58,10 @@ void ByteshuffleFilter::dump(FILE* out) const {
   fprintf(out, "ByteShuffle");
 }
 
+void ByteshuffleFilter::dump_ss(std::stringstream& ss) const {
+  ss << "ByteShuffle";
+}
+
 Status ByteshuffleFilter::run_forward(
     const Tile& tile,
     FilterBuffer* input_metadata,

--- a/tiledb/sm/filter/byteshuffle_filter.h
+++ b/tiledb/sm/filter/byteshuffle_filter.h
@@ -73,6 +73,7 @@ class ByteshuffleFilter : public Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   void dump(FILE* out) const override;
+  void dump_ss(std::stringstream& ss) const override;
 
   /**
    * Shuffle the bytes of the input data into the output data buffer.

--- a/tiledb/sm/filter/checksum_md5_filter.cc
+++ b/tiledb/sm/filter/checksum_md5_filter.cc
@@ -60,6 +60,10 @@ void ChecksumMD5Filter::dump(FILE* out) const {
   fprintf(out, "ChecksumMD5");
 }
 
+void ChecksumMD5Filter::dump_ss(std::stringstream& ss) const {
+  ss << "ChecksumMD5";
+}
+
 Status ChecksumMD5Filter::run_forward(
     const Tile&,
     FilterBuffer* input_metadata,

--- a/tiledb/sm/filter/checksum_md5_filter.h
+++ b/tiledb/sm/filter/checksum_md5_filter.h
@@ -79,6 +79,7 @@ class ChecksumMD5Filter : public Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   void dump(FILE* out) const override;
+  void dump_ss(std::stringstream& ss) const override;
 
   /**
    * Encrypt the bytes of the input data into the output data buffer.

--- a/tiledb/sm/filter/checksum_sha256_filter.cc
+++ b/tiledb/sm/filter/checksum_sha256_filter.cc
@@ -60,6 +60,10 @@ void ChecksumSHA256Filter::dump(FILE* out) const {
   fprintf(out, "ChecksumSHA256");
 }
 
+void ChecksumSHA256Filter::dump_ss(std::stringstream& ss) const {
+  ss << "ChecksumSHA256";
+}
+
 Status ChecksumSHA256Filter::run_forward(
     const Tile&,
     FilterBuffer* input_metadata,

--- a/tiledb/sm/filter/checksum_sha256_filter.h
+++ b/tiledb/sm/filter/checksum_sha256_filter.h
@@ -79,6 +79,7 @@ class ChecksumSHA256Filter : public Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   void dump(FILE* out) const override;
+  void dump_ss(std::stringstream& ss) const override;
 
   /**
    * Encrypt the bytes of the input data into the output data buffer.

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -80,35 +80,39 @@ int CompressionFilter::compression_level() const {
 void CompressionFilter::dump(FILE* out) const {
   if (out == nullptr)
     out = stdout;
+  std::stringstream ss;
+  dump_ss(ss);
+  fprintf(out, "%s", ss.str().c_str());
+}
 
-  std::string compressor_str;
+void CompressionFilter::dump_ss(std::stringstream& ss) const {
   switch (compressor_) {
     case Compressor::NO_COMPRESSION:
-      compressor_str = "NO_COMPRESSION";
+      ss << "NO_COMPRESSION";
       break;
     case Compressor::GZIP:
-      compressor_str = "GZIP";
+      ss << "GZIP";
       break;
     case Compressor::ZSTD:
-      compressor_str = "ZSTD";
+      ss << "ZSTD";
       break;
     case Compressor::LZ4:
-      compressor_str = "LZ4";
+      ss << "LZ4";
       break;
     case Compressor::RLE:
-      compressor_str = "RLE";
+      ss << "RLE";
       break;
     case Compressor::BZIP2:
-      compressor_str = "BZIP2";
+      ss << "BZIP2";
       break;
     case Compressor::DOUBLE_DELTA:
-      compressor_str = "DOUBLE_DELTA";
+      ss << "DOUBLE_DELTA";
       break;
     default:
-      compressor_str = "NO_COMPRESSION";
+      ss << "NO_COMPRESSION";
   }
 
-  fprintf(out, "%s: COMPRESSION_LEVEL=%i", compressor_str.c_str(), level_);
+  ss << ": COMPRESSION_LEVEL=" << level_;
 }
 
 CompressionFilter* CompressionFilter::clone_impl() const {

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -101,6 +101,7 @@ class CompressionFilter : public Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   void dump(FILE* out) const override;
+  void dump_ss(std::stringstream& ss) const override;
 
   /**
    * Compress the given input into the given output.

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.cc
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.cc
@@ -70,6 +70,10 @@ void EncryptionAES256GCMFilter::dump(FILE* out) const {
   fprintf(out, "EncryptionAES256GCM");
 }
 
+void EncryptionAES256GCMFilter::dump_ss(std::stringstream& ss) const {
+  ss << "EncryptionAES256GCM";
+}
+
 Status EncryptionAES256GCMFilter::run_forward(
     const Tile&,
     FilterBuffer* input_metadata,

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.h
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.h
@@ -92,6 +92,7 @@ class EncryptionAES256GCMFilter : public Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   void dump(FILE* out) const override;
+  void dump_ss(std::stringstream& ss) const override;
 
   /**
    * Encrypt the bytes of the input data into the output data buffer.

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -72,6 +72,7 @@ class Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   virtual void dump(FILE* out) const = 0;
+  virtual void dump_ss(std::stringstream& ss) const = 0;
 
   /**
    * Gets an option from this filter.

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -511,10 +511,15 @@ Status FilterPipeline::deserialize(ConstBuffer* buff) {
 void FilterPipeline::dump(FILE* out) const {
   if (out == nullptr)
     out = stdout;
+  std::stringstream ss;
+  dump_ss(ss);
+  fprintf(out, "%s", ss.str().c_str());
+}
 
+void FilterPipeline::dump_ss(std::stringstream& ss) const {
   for (const auto& filter : filters_) {
-    fprintf(out, "\n  > ");
-    filter->dump(out);
+    ss << "\n  > ";
+    filter->dump_ss(ss);
   }
 }
 

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -97,10 +97,16 @@ class FilterPipeline {
   Status deserialize(ConstBuffer* buff);
 
   /**
-   * Dumps the filter pipeline details in ASCII format in the selected
-   * output.
+   * Dumps the filter pipeline details in ASCII format to the selected
+   * output file.
    */
   void dump(FILE* out) const;
+
+  /**
+   * Dumps the filter pipeline details in ASCII format to the selected
+   * output stringstream.
+   */
+  void dump_ss(std::stringstream& ss) const;
 
   /**
    * Returns pointer to the first instance of a filter in the pipeline with the

--- a/tiledb/sm/filter/noop_filter.cc
+++ b/tiledb/sm/filter/noop_filter.cc
@@ -55,6 +55,10 @@ void NoopFilter::dump(FILE* out) const {
   fprintf(out, "NoOp");
 }
 
+void NoopFilter::dump_ss(std::stringstream& ss) const {
+  ss << "NoOp";
+}
+
 Status NoopFilter::run_forward(
     const Tile&,
     FilterBuffer* input_metadata,

--- a/tiledb/sm/filter/noop_filter.h
+++ b/tiledb/sm/filter/noop_filter.h
@@ -53,6 +53,7 @@ class NoopFilter : public Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   void dump(FILE* out) const override;
+  void dump_ss(std::stringstream& ss) const override;
 
   /**
    * Run forward.

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -55,6 +55,10 @@ void PositiveDeltaFilter::dump(FILE* out) const {
   fprintf(out, "PositiveDelta: POSITIVE_DELTA_MAX_WINDOW=%u", max_window_size_);
 }
 
+void PositiveDeltaFilter::dump_ss(std::stringstream& ss) const {
+  ss << "PositiveDelta: POSITIVE_DELTA_MAX_WINDOW=" << max_window_size_;
+}
+
 Status PositiveDeltaFilter::run_forward(
     const Tile& tile,
     FilterBuffer* input_metadata,

--- a/tiledb/sm/filter/positive_delta_filter.h
+++ b/tiledb/sm/filter/positive_delta_filter.h
@@ -81,6 +81,7 @@ class PositiveDeltaFilter : public Filter {
 
   /** Dumps the filter details in ASCII format in the selected output. */
   void dump(FILE* out) const override;
+  void dump_ss(std::stringstream& ss) const override;
 
   /**
    * Perform positive-delta encoding of the given input into the given output.


### PR DESCRIPTION
The array-schema dump method writes to `stdout` which is fine for many uses. In notebook contexts, though, it isn't fine -- `stdout` does not route to anything the notebook user can see. Notebook display of `arr.schema` works for Python because the Python library works around this by rolling its own array-schema dumper in its `__repr__` method for `ArraySchema` [here](https://github.com/TileDB-Inc/TileDB-Py/blob/dev/tiledb/libtiledb.pyx#L3939). Notebook display of `schema(arr)` does not work for R because the R library, in its `show` generic for `ArraySchema`, directly invokes the core function which prints to stdout [here](https://github.com/TileDB-Inc/TileDB-R/blob/master/R/ArraySchema.R#L148). Rather than taking the roll-another-of-our-own approach in `TileDB-R` (which could be done), on this PR we address the issue at the core level.

On #2769 I am getting too many CI errors for me to understand. Here I'm starting the commits bottom-up: filters, then dimensions, then domains, then attributes, then array schema at `c_api`/`cpp_api`, then array schema at top `sm` level.

---
TYPE: IMPROVEMENT
DESC: Create array-schema-to-string methods in support of notebook display of array schemas
