### PR TITLE
Sparse unordered w/ dups: var buffer overflow on tile continuation fix.

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1193,6 +1193,7 @@ TEST_CASE(
               uint64_t>(
               &tiledb::test::g_helper_stats,
               &result_tiles,
+              0,
               &cell_offsets,
               &query_buffer,
               &new_result_tiles_size,
@@ -1245,6 +1246,7 @@ TEST_CASE(
               uint64_t>(
               &tiledb::test::g_helper_stats,
               &result_tiles,
+              0,
               &cell_offsets,
               &query_buffer,
               &new_result_tiles_size,

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -94,6 +94,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   static Status compute_var_size_offsets(
       stats::Stats* stats,
       const std::vector<ResultTile*>* result_tiles,
+      const uint64_t first_tile_min_pos,
       std::vector<uint64_t>* cell_offsets,
       QueryBuffer* query_buffer,
       uint64_t* new_result_tiles_size,


### PR DESCRIPTION
In the sparse unordered with duplicates reader, when we continue a query
on a partially processed tile and we hit an overflow of the var sized
buffer, we didn't take into account the minimum cell position when
resolving the overflow, which caused undefined behavior.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups: var buffer overflow on tile continuation fix.
