### PR TITLE
Sparse unordered w/ dups reader: remove invalid assert.

### DIFF
--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -216,7 +216,6 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
 
   // No more tiles to process, done.
   if (result_tiles_[0].empty()) {
-    assert(read_state_.done_adding_result_tiles_);
     zero_out_buffer_sizes();
     return Status::Ok();
   }


### PR DESCRIPTION
After we are done processing tile bitmaps and query condition, we remove
tiles that didn't make the cut. It's totally possible that every tiles
that fit into memory for a call to dowork all get filtered out, so this
assert needs to be removed as it is invalid.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups reader: remove invalid assert.
