### PR TITLE
Determine non overlapping ranges automatically.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -269,7 +269,6 @@ void check_save_to_file() {
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.query.dense.reader legacy\n";
   ss << "sm.query.sparse_global_order.reader legacy\n";
-  ss << "sm.query.sparse_unordered_with_dups.non_overlapping_ranges false\n";
   ss << "sm.query.sparse_unordered_with_dups.reader refactored\n";
   ss << "sm.read_range_oob warn\n";
   ss << "sm.skip_checksum_validation false\n";
@@ -570,8 +569,6 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.query.dense.reader"] = "legacy";
   all_param_values["sm.query.sparse_global_order.reader"] = "legacy";
   all_param_values["sm.query.sparse_unordered_with_dups.reader"] = "refactored";
-  all_param_values
-      ["sm.query.sparse_unordered_with_dups.non_overlapping_ranges"] = "false";
   all_param_values["sm.mem.malloc_trim"] = "true";
   all_param_values["sm.mem.total_budget"] = "10737418240";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_coords"] = "0.5";

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -81,12 +81,12 @@ namespace common {
     }                                \
   } while (false)
 
-#define RETURN_NOT_OK_TUPLE(s)   \
-  do {                           \
-    Status _s = (s);             \
-    if (!_s.ok()) {              \
-      return {_s, std::nullopt}; \
-    }                            \
+#define RETURN_NOT_OK_TUPLE(s, ...) \
+  do {                              \
+    Status _s = (s);                \
+    if (!_s.ok()) {                 \
+      return {_s, __VA_ARGS__};     \
+    }                               \
   } while (false)
 
 class Status {

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1061,10 +1061,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Which reader to use for sparse unordered with dups queries.
  *    "refactored" or "legacy".<br>
  *    **Default**: refactored
- * - `sm.query.sparse_unordered_with_dups.non_overlapping_ranges` <br>
- *    Ensure ranges for sparse unordered with dups queries are not overlapping.
- *    "true" or "false".<br>
- *    **Default**: false
  * - `sm.mem.malloc_trim` <br>
  *    Should malloc_trim be called on context and query destruction? This might
  * reduce residual memory usage. <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -79,9 +79,6 @@ const std::string Config::SM_QUERY_DENSE_READER = "legacy";
 const std::string Config::SM_QUERY_SPARSE_GLOBAL_ORDER_READER = "legacy";
 const std::string Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER =
     "refactored";
-const std::string
-    Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_NON_OVERLAPPING_RANGES =
-        "false";
 const std::string Config::SM_MEM_MALLOC_TRIM = "true";
 const std::string Config::SM_MEM_TOTAL_BUDGET = "10737418240";  // 10GB;
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS = "0.5";
@@ -240,8 +237,6 @@ Config::Config() {
       SM_QUERY_SPARSE_GLOBAL_ORDER_READER;
   param_values_["sm.query.sparse_unordered_with_dups.reader"] =
       SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER;
-  param_values_["sm.query.sparse_unordered_with_dups.non_overlapping_ranges"] =
-      SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_NON_OVERLAPPING_RANGES;
   param_values_["sm.mem.malloc_trim"] = SM_MEM_MALLOC_TRIM;
   param_values_["sm.mem.total_budget"] = SM_MEM_TOTAL_BUDGET;
   param_values_["sm.mem.reader.sparse_global_order.ratio_coords"] =
@@ -542,11 +537,6 @@ Status Config::unset(const std::string& param) {
   } else if (param == "sm.query.sparse_unordered_with_dups.reader") {
     param_values_["sm.query.sparse_unordered_with_dups.reader"] =
         SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER;
-  } else if (
-      param == "sm.query.sparse_unordered_with_dups.non_overlapping_ranges") {
-    param_values_
-        ["sm.query.sparse_unordered_with_dups.non_overlapping_ranges"] =
-            SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_NON_OVERLAPPING_RANGES;
   } else if (param == "sm.mem.malloc_trim") {
     param_values_["sm.mem.malloc_trim"] = SM_MEM_MALLOC_TRIM;
   } else if (param == "sm.mem.total_budget") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -155,11 +155,6 @@ class Config {
   /** Which reader to use for sparse unordered with dups queries. */
   static const std::string SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER;
 
-  /** Non overlapping ranges guaranteed for sparse unordered with dups queries.
-   */
-  static const std::string
-      SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_NON_OVERLAPPING_RANGES;
-
   /** Should malloc_trim be called on query/ctx destructors. */
   static const std::string SM_MEM_MALLOC_TRIM;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -398,10 +398,6 @@ class Config {
    *    Which reader to use for sparse unordered with dups queries.
    *    "refactored" or "legacy".<br>
    *    **Default**: refactored
-   * - `sm.query.sparse_unordered_with_dups.non_overlapping_ranges` <br>
-   *    Ensure ranges for sparse unordered with dups queries are not
-   *    overlapping. "true" or "false".<br>
-   *    **Default**: false
    * - `sm.mem.malloc_trim` <br>
    *    Should malloc_trim be called on context and query destruction? This
    *    might reduce residual memory usage. <br>

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1022,13 +1022,8 @@ Status Query::create_strategy() {
         array_schema_->allows_dups()) {
       use_default = false;
 
-      bool found = false;
-      bool non_overlapping_ranges = false;
-      RETURN_NOT_OK(config_.get<bool>(
-          "sm.query.sparse_unordered_with_dups.non_overlapping_ranges",
-          &non_overlapping_ranges,
-          &found));
-      assert(found);
+      auto&& [st, non_overlapping_ranges]{Query::non_overlapping_ranges()};
+      RETURN_NOT_OK(st);
 
       if (non_overlapping_ranges || !subarray_.is_set() ||
           subarray_.range_num() == 1) {
@@ -2115,6 +2110,10 @@ bool Query::use_refactored_sparse_unordered_with_dups_reader() {
   assert(found);
 
   return val == "refactored";
+}
+
+std::tuple<Status, bool> Query::non_overlapping_ranges() {
+  return subarray_.non_overlapping_ranges(storage_manager_->compute_tp());
 }
 
 /* ****************************** */

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -877,6 +877,9 @@ class Query {
   /** Use the refactored sparse unordered with dups reader or not. */
   bool use_refactored_sparse_unordered_with_dups_reader();
 
+  /** Returns if all ranges for this query are non overlapping. */
+  std::tuple<Status, bool> non_overlapping_ranges();
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -150,8 +150,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
   // This reader only has one result tile list.
   result_tiles_.resize(1);
 
-  // This reader benefits from sorting ranges.
-  RETURN_NOT_OK(subarray_.sort_ranges(storage_manager_->compute_tp()));
+  // This reader assumes ranges are sorted.
+  assert(subarray_.ranges_sorted());
 
   // Handle empty array.
   if (fragment_metadata_.empty()) {

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1140,13 +1140,8 @@ Status query_to_capnp(Query& query, capnp::Query::Builder* query_builder) {
         schema->allows_dups()) {
       auto builder = query_builder->initReaderIndex();
 
-      bool found = false;
-      bool non_overlapping_ranges = false;
-      RETURN_NOT_OK(query.config()->get<bool>(
-          "sm.query.sparse_unordered_with_dups.non_overlapping_ranges",
-          &non_overlapping_ranges,
-          &found));
-      assert(found);
+      auto&& [st, non_overlapping_ranges]{query.non_overlapping_ranges()};
+      RETURN_NOT_OK(st);
 
       if (non_overlapping_ranges) {
         auto reader = (SparseUnorderedWithDupsReader<uint8_t>*)query.strategy();
@@ -1739,13 +1734,8 @@ Status query_from_capnp(
       query->clear_strategy();
       RETURN_NOT_OK(query->set_layout_unsafe(layout));
 
-      bool found = false;
-      bool non_overlapping_ranges = false;
-      RETURN_NOT_OK(query->config()->get<bool>(
-          "sm.query.sparse_unordered_with_dups.non_overlapping_ranges",
-          &non_overlapping_ranges,
-          &found));
-      assert(found);
+      auto&& [st, non_overlapping_ranges]{query->non_overlapping_ranges()};
+      RETURN_NOT_OK(st);
 
       auto reader_reader = query_reader.getReaderIndex();
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1986,7 +1986,8 @@ StorageManager::load_all_array_schemas(
             std::nullopt};
 
   std::vector<URI> schema_uris;
-  RETURN_NOT_OK_TUPLE(get_array_schema_uris(array_uri, &schema_uris));
+  RETURN_NOT_OK_TUPLE(
+      get_array_schema_uris(array_uri, &schema_uris), std::nullopt);
   if (schema_uris.empty()) {
     return {
         logger_->status(Status_StorageManagerError(
@@ -2007,7 +2008,7 @@ StorageManager::load_all_array_schemas(
         schema_vector[schema_ith] = array_schema;
         return Status::Ok();
       });
-  RETURN_NOT_OK_TUPLE(status);
+  RETURN_NOT_OK_TUPLE(status, std::nullopt);
 
   std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>> array_schemas;
   for (const auto& array_schema : schema_vector) {

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -2022,6 +2022,25 @@ Status Subarray::sort_ranges(ThreadPool* const compute_tp) {
   return Status::Ok();
 }
 
+std::tuple<Status, bool> Subarray::non_overlapping_ranges(
+    ThreadPool* const compute_tp) {
+  RETURN_NOT_OK_TUPLE(sort_ranges(compute_tp), false);
+
+  std::atomic<bool> non_overlapping_ranges = true;
+  auto st = parallel_for(
+      compute_tp,
+      0,
+      array_->array_schema_latest()->dim_num(),
+      [&](uint64_t dim_idx) {
+        auto&& [status, nor]{non_overlapping_ranges_for_dim(dim_idx)};
+        non_overlapping_ranges = nor;
+        return status;
+      });
+  RETURN_NOT_OK_TUPLE(st, false);
+
+  return {Status::Ok(), non_overlapping_ranges};
+}
+
 /* ****************************** */
 /*          PRIVATE METHODS       */
 /* ****************************** */
@@ -3217,6 +3236,89 @@ Status Subarray::sort_ranges_for_dim(
       return sort_ranges_for_dim<int64_t>(compute_tp, dim_idx);
   }
   return Status::Ok();
+}
+
+template <typename T>
+std::tuple<Status, bool> Subarray::non_overlapping_ranges_for_dim(
+    const uint64_t dim_idx) {
+  const auto& ranges = ranges_[dim_idx];
+  const Dimension* const dim =
+      array_->array_schema_latest()->dimension(dim_idx);
+
+  if (ranges.size() > 1) {
+    for (uint64_t r = 0; r < ranges.size() - 1; r++) {
+      if (dim->overlap<T>(ranges[r], ranges[r + 1]))
+        return {Status::Ok(), false};
+    }
+  }
+
+  return {Status::Ok(), true};
+}
+
+std::tuple<Status, bool> Subarray::non_overlapping_ranges_for_dim(
+    const uint64_t dim_idx) {
+  const Datatype& datatype =
+      array_->array_schema_latest()->dimension(dim_idx)->type();
+  switch (datatype) {
+    case Datatype::INT8:
+      return non_overlapping_ranges_for_dim<int8_t>(dim_idx);
+    case Datatype::UINT8:
+      return non_overlapping_ranges_for_dim<uint8_t>(dim_idx);
+    case Datatype::INT16:
+      return non_overlapping_ranges_for_dim<int16_t>(dim_idx);
+    case Datatype::UINT16:
+      return non_overlapping_ranges_for_dim<uint16_t>(dim_idx);
+    case Datatype::INT32:
+      return non_overlapping_ranges_for_dim<int32_t>(dim_idx);
+    case Datatype::UINT32:
+      return non_overlapping_ranges_for_dim<uint32_t>(dim_idx);
+    case Datatype::INT64:
+      return non_overlapping_ranges_for_dim<int64_t>(dim_idx);
+    case Datatype::UINT64:
+      return non_overlapping_ranges_for_dim<uint64_t>(dim_idx);
+    case Datatype::FLOAT32:
+      return non_overlapping_ranges_for_dim<float>(dim_idx);
+    case Datatype::FLOAT64:
+      return non_overlapping_ranges_for_dim<double>(dim_idx);
+    case Datatype::STRING_ASCII:
+      return non_overlapping_ranges_for_dim<char>(dim_idx);
+    case Datatype::CHAR:
+    case Datatype::STRING_UTF8:
+    case Datatype::STRING_UTF16:
+    case Datatype::STRING_UTF32:
+    case Datatype::STRING_UCS2:
+    case Datatype::STRING_UCS4:
+    case Datatype::ANY:
+      return {
+          LOG_STATUS(Status_SubarrayError(
+              "Invalid datatype " + datatype_str(datatype) + " for sorting")),
+          false};
+    case Datatype::DATETIME_YEAR:
+    case Datatype::DATETIME_MONTH:
+    case Datatype::DATETIME_WEEK:
+    case Datatype::DATETIME_DAY:
+    case Datatype::DATETIME_HR:
+    case Datatype::DATETIME_MIN:
+    case Datatype::DATETIME_SEC:
+    case Datatype::DATETIME_MS:
+    case Datatype::DATETIME_US:
+    case Datatype::DATETIME_NS:
+    case Datatype::DATETIME_PS:
+    case Datatype::DATETIME_FS:
+    case Datatype::DATETIME_AS:
+    case Datatype::TIME_HR:
+    case Datatype::TIME_MIN:
+    case Datatype::TIME_SEC:
+    case Datatype::TIME_MS:
+    case Datatype::TIME_US:
+    case Datatype::TIME_NS:
+    case Datatype::TIME_PS:
+    case Datatype::TIME_FS:
+    case Datatype::TIME_AS:
+      return non_overlapping_ranges_for_dim<int64_t>(dim_idx);
+  }
+  return {Status::Ok(), false};
+  ;
 }
 
 // Explicit instantiations

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -935,6 +935,11 @@ class Subarray {
   /** Stores a vector of 1D ranges per dimension. */
   std::vector<std::vector<uint64_t>> original_range_idx_;
 
+  /** Returns if ranges are sorted. */
+  bool ranges_sorted() {
+    return ranges_sorted_;
+  }
+
   /** Sort ranges per dimension. */
   Status sort_ranges(ThreadPool* const compute_tp);
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -935,7 +935,11 @@ class Subarray {
   /** Stores a vector of 1D ranges per dimension. */
   std::vector<std::vector<uint64_t>> original_range_idx_;
 
+  /** Sort ranges per dimension. */
   Status sort_ranges(ThreadPool* const compute_tp);
+
+  /** Returns if all ranges for this subarray are non overlapping. */
+  std::tuple<Status, bool> non_overlapping_ranges(ThreadPool* const compute_tp);
 
  private:
   /* ********************************* */
@@ -1286,6 +1290,25 @@ class Subarray {
    */
   Status sort_ranges_for_dim(
       ThreadPool* const compute_tp, const uint64_t& dim_idx);
+
+  /**
+   * Determine if ranges for a dimension are non overlapping.
+   *
+   * @param dim_idx dimension index.
+   * @return true if the ranges are non overlapping, false otherwise.
+   */
+  template <typename T>
+  std::tuple<Status, bool> non_overlapping_ranges_for_dim(
+      const uint64_t dim_idx);
+
+  /**
+   * Determine if ranges for a dimension are non overlapping.
+   *
+   * @param dim_idx dimension index.
+   * @return true if the ranges are non overlapping, false otherwise.
+   */
+  std::tuple<Status, bool> non_overlapping_ranges_for_dim(
+      const uint64_t dim_idx);
 };
 
 }  // namespace sm


### PR DESCRIPTION
As we now sort ranges for the sparse unordered with dups reader,
determining if ranges are not overlapping is very cheap to perform. This
change removes the existing config option and determines the value
automatically.

---
TYPE: IMPROVEMENT
DESC: Determine non overlapping ranges automatically.
