### PR TITLE
Improve object type detection performance

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -2085,23 +2085,26 @@ Status StorageManager::object_type(const URI& uri, ObjectType* type) const {
     }
   }
 
-  std::vector<URI> child_uris;
-  RETURN_NOT_OK(vfs_->ls(dir_uri, &child_uris));
+  bool exists = false;
+  RETURN_NOT_OK(vfs_->is_dir(
+      dir_uri.join_path(constants::array_schema_folder_name), &exists));
+  if (exists) {
+    *type = ObjectType::ARRAY;
+    return Status::Ok();
+  }
 
-  for (const auto& child_uri : child_uris) {
-    auto uri_str = child_uri.to_string();
-    if (utils::parse::ends_with(uri_str, constants::group_filename)) {
-      *type = ObjectType::GROUP;
-      return Status::Ok();
-    } else if (utils::parse::ends_with(
-                   uri_str, constants::array_schema_filename)) {
-      *type = ObjectType::ARRAY;
-      return Status::Ok();
-    } else if (utils::parse::ends_with(
-                   uri_str, constants::array_schema_folder_name)) {
-      *type = ObjectType::ARRAY;
-      return Status::Ok();
-    }
+  RETURN_NOT_OK(vfs_->is_file(
+      dir_uri.join_path(constants::array_schema_filename), &exists));
+  if (exists) {
+    *type = ObjectType::ARRAY;
+    return Status::Ok();
+  }
+
+  RETURN_NOT_OK(
+      vfs_->is_file(dir_uri.join_path(constants::group_filename), &exists));
+  if (exists) {
+    *type = ObjectType::GROUP;
+    return Status::Ok();
   }
 
   *type = ObjectType::INVALID;


### PR DESCRIPTION
This improves the object APIs performance for detecting types by switching from listing all items in the URI to checking only for the existence of the group indicator, array schema file or array schema folder. We also switch the order to check for the array schema folder first, since it is most likely to exist based on the assumption that there are more arrays than there are groups.

x-ref: https://forum.tiledb.com/t/s3-first-access-very-slow-with-3d-tiled-dense-array/416

---
TYPE: IMPROVEMENT
DESC: Improve object type detection performance