### PR TITLE
Return early with nullable QueryConditions

### DIFF
--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1571,6 +1571,7 @@ Status QueryCondition::apply_clause_sparse(
           result_bitmap[c] *= buffer_validity[c] == 0;
         }
       }
+      return Status::Ok();
     } else {
       // Turn off bitmap values for null cells.
       for (uint64_t c = 0; c < result_tile.cell_num(); c++) {


### PR DESCRIPTION
This solves a segfault when the comparison was attempted on a null condition.

---
TYPE: BUG
DESC: Fix segfault in new sparse null `QueryCondition` code
