### PR TITLE
Query condition: differentiate between nullptr and empty string.

### DIFF
--- a/test/src/unit-QueryCondition.cc
+++ b/test/src/unit-QueryCondition.cc
@@ -856,14 +856,19 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "QueryCondition: Test empty string", "[QueryCondition][empty_string]") {
+    "QueryCondition: Test empty/null strings",
+    "[QueryCondition][empty_string][null_string]") {
   const std::string field_name = "foo";
   const uint64_t cells = 10;
   const char* fill_value = "ac";
   const Datatype type = Datatype::STRING_ASCII;
   bool var_size = true;
   bool nullable = GENERATE(true, false);
+  bool null_cmp = GENERATE(true, false);
   QueryConditionOp op = GENERATE(QueryConditionOp::NE, QueryConditionOp::EQ);
+
+  if (!nullable && null_cmp)
+    return;
 
   // Initialize the array schema.
   ArraySchema array_schema;
@@ -960,12 +965,11 @@ TEST_CASE(
     free(validity);
   }
 
-  // Empty string as condition value
-  const char* cmp_value = "";
+  // Empty string or null string as condition value
+  const char* cmp_value = null_cmp ? nullptr : "";
 
   QueryCondition query_condition;
-  REQUIRE(
-      query_condition.init(std::string(field_name), &cmp_value, 0, op).ok());
+  REQUIRE(query_condition.init(std::string(field_name), cmp_value, 0, op).ok());
 
   // Run Check
   REQUIRE(query_condition.check(&array_schema).ok());
@@ -976,20 +980,24 @@ TEST_CASE(
   for (uint64_t i = 0; i < cells; ++i) {
     switch (op) {
       case QueryConditionOp::EQ:
-        if ((nullable && (i % 2 == 0)) || (i >= 8)) {
-          expected_cell_idx_vec.emplace_back(i);
-        } else if (
-            std::string(&static_cast<char*>(values)[2 * i], 2) ==
-            std::string(cmp_value)) {
+        if (null_cmp) {
+          if (i % 2 == 0)
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (nullable) {
+          if ((i % 2 != 0) && (i >= 8))
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (i >= 8) {
           expected_cell_idx_vec.emplace_back(i);
         }
         break;
       case QueryConditionOp::NE:
-        if ((nullable && (i % 2 == 0)) || (i >= 8)) {
-          continue;
-        } else if (
-            std::string(&static_cast<char*>(values)[2 * i], 2) !=
-            std::string(cmp_value)) {
+        if (null_cmp) {
+          if (i % 2 != 0)
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (nullable) {
+          if ((i % 2 != 0) && (i < 8))
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (i < 8) {
           expected_cell_idx_vec.emplace_back(i);
         }
         break;
@@ -1010,6 +1018,1525 @@ TEST_CASE(
     for (uint64_t cell_idx = result_cell_slab.start_;
          cell_idx < (result_cell_slab.start_ + result_cell_slab.length_);
          ++cell_idx) {
+      REQUIRE(*expected_iter == cell_idx);
+      ++expected_iter;
+    }
+  }
+
+  free(values);
+}
+
+/**
+ * Tests a comparison operator on all cells in a tile.
+ *
+ * @param op The relational query condition operator.
+ * @param field_name The attribute name in the tile.
+ * @param cells The number of cells in the tile.
+ * @param result_tile The result tile.
+ * @param values The values written to the tile.
+ */
+template <typename T>
+void test_apply_cells_dense(
+    const QueryConditionOp op,
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values);
+
+/**
+ * C-string template-specialization for `test_apply_cells_dense`.
+ */
+template <>
+void test_apply_cells_dense<char*>(
+    const QueryConditionOp op,
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values) {
+  const char* const cmp_value = "ae";
+  QueryCondition query_condition;
+  REQUIRE(query_condition
+              .init(std::string(field_name), cmp_value, 2 * sizeof(char), op)
+              .ok());
+  // Run Check
+  REQUIRE(query_condition.check(array_schema).ok());
+
+  bool nullable = array_schema->attribute(field_name)->nullable();
+
+  // Build expected indexes of cells that meet the query condition
+  // criteria.
+  std::vector<uint64_t> expected_cell_idx_vec;
+  for (uint64_t i = 0; i < cells; ++i) {
+    if (nullable && (i % 2 == 0))
+      continue;
+
+    switch (op) {
+      case QueryConditionOp::LT:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) <
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::LE:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) <=
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::GT:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) >
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::GE:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) >=
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::EQ:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) ==
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::NE:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) !=
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      default:
+        REQUIRE(false);
+    }
+  }
+
+  // Apply the query condition.
+  std::vector<uint8_t> result_bitmap(cells, 1);
+  REQUIRE(query_condition
+              .apply_dense(
+                  array_schema, result_tile, 0, 10, 0, 1, result_bitmap.data())
+              .ok());
+
+  // Verify the result bitmap contain the expected cells.
+  auto expected_iter = expected_cell_idx_vec.begin();
+  for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+    if (result_bitmap[cell_idx]) {
+      REQUIRE(*expected_iter == cell_idx);
+      ++expected_iter;
+    }
+  }
+
+  if (nullable) {
+    if (op == QueryConditionOp::EQ || op == QueryConditionOp::NE) {
+      const uint64_t eq = op == QueryConditionOp::EQ ? 0 : 1;
+      QueryCondition query_condition_eq_null;
+      REQUIRE(
+          query_condition_eq_null.init(std::string(field_name), nullptr, 0, op)
+              .ok());
+      // Run Check
+      REQUIRE(query_condition_eq_null.check(array_schema).ok());
+
+      // Apply the query condition.
+      std::vector<uint8_t> result_bitmap_eq_null(cells, 1);
+      REQUIRE(query_condition_eq_null
+                  .apply_dense(
+                      array_schema,
+                      result_tile,
+                      0,
+                      10,
+                      0,
+                      1,
+                      result_bitmap_eq_null.data())
+                  .ok());
+
+      // Verify the result bitmap contain the expected cells.
+      for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+        REQUIRE(result_bitmap_eq_null[cell_idx] == (cell_idx + eq + 1) % 2);
+      }
+    }
+
+    return;
+  }
+}
+
+/**
+ * Non-specialized template type for `test_apply_cells_dense`.
+ */
+template <typename T>
+void test_apply_cells_dense(
+    const QueryConditionOp op,
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values) {
+  const T cmp_value = 5;
+  QueryCondition query_condition;
+  REQUIRE(
+      query_condition.init(std::string(field_name), &cmp_value, sizeof(T), op)
+          .ok());
+  // Run Check
+  REQUIRE(query_condition.check(array_schema).ok());
+
+  // Build expected indexes of cells that meet the query condition
+  // criteria.
+  std::vector<uint64_t> expected_cell_idx_vec;
+  for (uint64_t i = 0; i < cells; ++i) {
+    switch (op) {
+      case QueryConditionOp::LT:
+        if (static_cast<T*>(values)[i] < cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::LE:
+        if (static_cast<T*>(values)[i] <= cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::GT:
+        if (static_cast<T*>(values)[i] > cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::GE:
+        if (static_cast<T*>(values)[i] >= cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::EQ:
+        if (static_cast<T*>(values)[i] == cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::NE:
+        if (static_cast<T*>(values)[i] != cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      default:
+        REQUIRE(false);
+    }
+  }
+
+  // Apply the query condition.
+  std::vector<uint8_t> result_bitmap(cells, 1);
+  REQUIRE(query_condition
+              .apply_dense(
+                  array_schema, result_tile, 0, 10, 0, 1, result_bitmap.data())
+              .ok());
+
+  // Verify the result bitmap contain the expected cells.
+  auto expected_iter = expected_cell_idx_vec.begin();
+  for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+    if (result_bitmap[cell_idx]) {
+      REQUIRE(*expected_iter == cell_idx);
+      ++expected_iter;
+    }
+  }
+}
+
+/**
+ * Tests each comparison operator on all cells in a tile.
+ *
+ * @param field_name The attribute name in the tile.
+ * @param cells The number of cells in the tile.
+ * @param result_tile The result tile.
+ * @param values The values written to the tile.
+ */
+template <typename T>
+void test_apply_operators_dense(
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values) {
+  test_apply_cells_dense<T>(
+      QueryConditionOp::LT,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_dense<T>(
+      QueryConditionOp::LE,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_dense<T>(
+      QueryConditionOp::GT,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_dense<T>(
+      QueryConditionOp::GE,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_dense<T>(
+      QueryConditionOp::EQ,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_dense<T>(
+      QueryConditionOp::NE,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+}
+
+/**
+ * Populates a tile and tests query condition comparisons against
+ * each cell.
+ *
+ * @param field_name The attribute name in the tile.
+ * @param cells The number of cells in the tile.
+ * @param type The TILEDB data type of the attribute.
+ * @param array_schema The array schema.
+ * @param result_tile The result tile.
+ */
+template <typename T>
+void test_apply_tile_dense(
+    const std::string& field_name,
+    uint64_t cells,
+    Datatype type,
+    ArraySchema* array_schema,
+    ResultTile* result_tile);
+
+/**
+ * C-string template-specialization for `test_apply_tile_dense`.
+ */
+template <>
+void test_apply_tile_dense<char*>(
+    const std::string& field_name,
+    const uint64_t cells,
+    const Datatype type,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile) {
+  ResultTile::TileTuple* const tile_tuple = result_tile->tile_tuple(field_name);
+
+  bool var_size = array_schema->attribute(field_name)->var_size();
+  bool nullable = array_schema->attribute(field_name)->nullable();
+  Tile* const tile =
+      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+
+  REQUIRE(tile->init_unfiltered(
+                  constants::format_version,
+                  type,
+                  2 * cells * sizeof(char),
+                  2 * sizeof(char),
+                  0)
+              .ok());
+
+  char* values = static_cast<char*>(malloc(sizeof(char) * 2 * cells));
+  for (uint64_t i = 0; i < cells; ++i) {
+    values[i * 2] = 'a';
+    values[(i * 2) + 1] = 'a' + static_cast<char>(i);
+  }
+  REQUIRE(tile->write(values, 2 * cells * sizeof(char)).ok());
+
+  if (var_size) {
+    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    REQUIRE(tile_offsets
+                ->init_unfiltered(
+                    constants::format_version,
+                    constants::cell_var_offset_type,
+                    10 * constants::cell_var_offset_size,
+                    constants::cell_var_offset_size,
+                    0)
+                .ok());
+
+    uint64_t* offsets =
+        static_cast<uint64_t*>(malloc(sizeof(uint64_t) * cells));
+    uint64_t offset = 0;
+    for (uint64_t i = 0; i < cells; ++i) {
+      offsets[i] = offset;
+      offset += 2;
+    }
+    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+  }
+
+  if (nullable) {
+    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    REQUIRE(tile_validity
+                ->init_unfiltered(
+                    constants::format_version,
+                    constants::cell_validity_type,
+                    10 * constants::cell_validity_size,
+                    constants::cell_validity_size,
+                    0)
+                .ok());
+
+    uint8_t* validity = static_cast<uint8_t*>(malloc(sizeof(uint8_t) * cells));
+    for (uint64_t i = 0; i < cells; ++i) {
+      validity[i] = i % 2;
+    }
+    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+  }
+
+  test_apply_operators_dense<char*>(
+      field_name, cells, array_schema, result_tile, values);
+
+  free(values);
+}
+
+/**
+ * Non-specialized template type for `test_apply_tile_dense`.
+ */
+template <typename T>
+void test_apply_tile_dense(
+    const std::string& field_name,
+    const uint64_t cells,
+    const Datatype type,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile) {
+  ResultTile::TileTuple* const tile_tuple = result_tile->tile_tuple(field_name);
+  Tile* const tile = &std::get<0>(*tile_tuple);
+
+  REQUIRE(
+      tile->init_unfiltered(
+              constants::format_version, type, cells * sizeof(T), sizeof(T), 0)
+          .ok());
+  T* values = static_cast<T*>(malloc(sizeof(T) * cells));
+  for (uint64_t i = 0; i < cells; ++i) {
+    values[i] = static_cast<T>(i);
+  }
+  REQUIRE(tile->write(values, cells * sizeof(T)).ok());
+
+  test_apply_operators_dense<T>(
+      field_name, cells, array_schema, result_tile, values);
+
+  free(values);
+}
+
+/**
+ * Constructs a tile and tests query condition comparisons against
+ * each cell.
+ *
+ * @param type The TILEDB data type of the attribute.
+ * @param var_size Run the test with variable size attribute.
+ * @param nullable Run the test with nullable attribute.
+ */
+template <typename T>
+void test_apply_dense(
+    const Datatype type, bool var_size = false, bool nullable = false);
+
+/**
+ * C-string template-specialization for `test_apply_dense`.
+ */
+template <>
+void test_apply_dense<char*>(
+    const Datatype type, bool var_size, bool nullable) {
+  REQUIRE(type == Datatype::STRING_ASCII);
+
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const char* fill_value = "ac";
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(attr.set_nullable(nullable).ok());
+  REQUIRE(attr.set_cell_val_num(var_size ? constants::var_num : 2).ok());
+
+  if (!nullable) {
+    REQUIRE(attr.set_fill_value(fill_value, 2 * sizeof(char)).ok());
+  }
+
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &array_schema);
+  result_tile.init_attr_tile(field_name);
+
+  test_apply_tile_dense<char*>(
+      field_name, cells, type, &array_schema, &result_tile);
+}
+
+/**
+ * Non-specialized template type for `test_apply_dense`.
+ */
+template <typename T>
+void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
+  (void)var_size;
+  (void)nullable;
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const T fill_value = 3;
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(attr.set_cell_val_num(1).ok());
+  REQUIRE(attr.set_fill_value(&fill_value, sizeof(T)).ok());
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &array_schema);
+  result_tile.init_attr_tile(field_name);
+
+  test_apply_tile_dense<T>(
+      field_name, cells, type, &array_schema, &result_tile);
+}
+
+TEST_CASE(
+    "QueryCondition: Test apply dense", "[QueryCondition][apply][dense]") {
+  test_apply_dense<int8_t>(Datatype::INT8);
+  test_apply_dense<uint8_t>(Datatype::UINT8);
+  test_apply_dense<int16_t>(Datatype::INT16);
+  test_apply_dense<uint16_t>(Datatype::UINT16);
+  test_apply_dense<int32_t>(Datatype::INT32);
+  test_apply_dense<uint32_t>(Datatype::UINT32);
+  test_apply_dense<int64_t>(Datatype::INT64);
+  test_apply_dense<uint64_t>(Datatype::UINT64);
+  test_apply_dense<float>(Datatype::FLOAT32);
+  test_apply_dense<double>(Datatype::FLOAT64);
+  test_apply_dense<char>(Datatype::CHAR);
+  test_apply_dense<int64_t>(Datatype::DATETIME_YEAR);
+  test_apply_dense<int64_t>(Datatype::DATETIME_MONTH);
+  test_apply_dense<int64_t>(Datatype::DATETIME_WEEK);
+  test_apply_dense<int64_t>(Datatype::DATETIME_DAY);
+  test_apply_dense<int64_t>(Datatype::DATETIME_HR);
+  test_apply_dense<int64_t>(Datatype::DATETIME_MIN);
+  test_apply_dense<int64_t>(Datatype::DATETIME_SEC);
+  test_apply_dense<int64_t>(Datatype::DATETIME_MS);
+  test_apply_dense<int64_t>(Datatype::DATETIME_US);
+  test_apply_dense<int64_t>(Datatype::DATETIME_NS);
+  test_apply_dense<int64_t>(Datatype::DATETIME_PS);
+  test_apply_dense<int64_t>(Datatype::DATETIME_FS);
+  test_apply_dense<int64_t>(Datatype::DATETIME_AS);
+  test_apply_dense<char*>(Datatype::STRING_ASCII);
+  test_apply_dense<char*>(Datatype::STRING_ASCII, true);
+  test_apply_dense<char*>(Datatype::STRING_ASCII, false, true);
+}
+
+TEST_CASE(
+    "QueryCondition: Test combinations dense",
+    "[QueryCondition][combinations][dense]") {
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const Datatype type = Datatype::UINT64;
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &array_schema);
+  result_tile.init_attr_tile(field_name);
+  ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
+  Tile* const tile = &std::get<0>(*tile_tuple);
+
+  // Initialize and populate the data tile.
+  REQUIRE(tile->init_unfiltered(
+                  constants::format_version,
+                  type,
+                  cells * sizeof(uint64_t),
+                  sizeof(uint64_t),
+                  0)
+              .ok());
+  uint64_t* values = static_cast<uint64_t*>(malloc(sizeof(uint64_t) * cells));
+  for (uint64_t i = 0; i < cells; ++i) {
+    values[i] = i;
+  }
+  REQUIRE(tile->write(values, cells * sizeof(uint64_t)).ok());
+
+  // Build a combined query for `> 3 AND <= 6`.
+  uint64_t cmp_value_1 = 3;
+  QueryCondition query_condition_1;
+  REQUIRE(query_condition_1
+              .init(
+                  std::string(field_name),
+                  &cmp_value_1,
+                  sizeof(uint64_t),
+                  QueryConditionOp::GT)
+              .ok());
+  // Run Check
+  REQUIRE(query_condition_1.check(&array_schema).ok());
+  uint64_t cmp_value_2 = 6;
+  QueryCondition query_condition_2;
+  REQUIRE(query_condition_2
+              .init(
+                  std::string(field_name),
+                  &cmp_value_2,
+                  sizeof(uint64_t),
+                  QueryConditionOp::LE)
+              .ok());
+  // Run Check
+  REQUIRE(query_condition_2.check(&array_schema).ok());
+  QueryCondition query_condition_3;
+  REQUIRE(query_condition_1
+              .combine(
+                  query_condition_2,
+                  QueryConditionCombinationOp::AND,
+                  &query_condition_3)
+              .ok());
+
+  // Apply the query condition.
+  std::vector<uint8_t> result_bitmap(cells, 1);
+  REQUIRE(
+      query_condition_3
+          .apply_dense(
+              &array_schema, &result_tile, 0, 10, 0, 1, result_bitmap.data())
+          .ok());
+
+  // Check that the cell slab now contains cell indexes 4, 5, and 6.
+  for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+    REQUIRE(
+        result_bitmap[cell_idx] == (cell_idx >= 4 && cell_idx <= 6 ? 1 : 0));
+  }
+
+  free(values);
+}
+
+TEST_CASE(
+    "QueryCondition: Test empty/null strings dense",
+    "[QueryCondition][empty_string][null_string][dense]") {
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const char* fill_value = "ac";
+  const Datatype type = Datatype::STRING_ASCII;
+  bool var_size = true;
+  bool nullable = GENERATE(true, false);
+  bool null_cmp = GENERATE(true, false);
+  QueryConditionOp op = GENERATE(QueryConditionOp::NE, QueryConditionOp::EQ);
+
+  if (!nullable && null_cmp)
+    return;
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(attr.set_nullable(nullable).ok());
+  REQUIRE(attr.set_cell_val_num(var_size ? constants::var_num : 2).ok());
+
+  if (!nullable) {
+    REQUIRE(attr.set_fill_value(fill_value, 2 * sizeof(char)).ok());
+  }
+
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &array_schema);
+  result_tile.init_attr_tile(field_name);
+
+  ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
+
+  var_size = array_schema.attribute(field_name)->var_size();
+  nullable = array_schema.attribute(field_name)->nullable();
+  Tile* const tile =
+      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+
+  REQUIRE(tile->init_unfiltered(
+                  constants::format_version,
+                  type,
+                  2 * (cells - 2) * sizeof(char),
+                  2 * sizeof(char),
+                  0)
+              .ok());
+
+  char* values = static_cast<char*>(malloc(
+      sizeof(char) * 2 *
+      (cells - 2)));  // static_cast<char*>(malloc(sizeof(char) * 2 * cells));
+
+  // Empty strings are at idx 8 and 9
+  for (uint64_t i = 0; i < (cells - 2); ++i) {
+    values[i * 2] = 'a';
+    values[(i * 2) + 1] = 'a' + static_cast<char>(i);
+  }
+
+  REQUIRE(tile->write(values, 2 * (cells - 2) * sizeof(char)).ok());
+
+  if (var_size) {
+    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    REQUIRE(tile_offsets
+                ->init_unfiltered(
+                    constants::format_version,
+                    constants::cell_var_offset_type,
+                    10 * constants::cell_var_offset_size,
+                    constants::cell_var_offset_size,
+                    0)
+                .ok());
+
+    uint64_t* offsets =
+        static_cast<uint64_t*>(malloc(sizeof(uint64_t) * cells));
+    uint64_t offset = 0;
+    for (uint64_t i = 0; i < cells - 2; ++i) {
+      offsets[i] = offset;
+      offset += 2;
+    }
+    offsets[cells - 2] = offset;
+    offsets[cells - 1] = offset;
+    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+
+    free(offsets);
+  }
+
+  if (nullable) {
+    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    REQUIRE(tile_validity
+                ->init_unfiltered(
+                    constants::format_version,
+                    constants::cell_validity_type,
+                    10 * constants::cell_validity_size,
+                    constants::cell_validity_size,
+                    0)
+                .ok());
+
+    uint8_t* validity = static_cast<uint8_t*>(malloc(sizeof(uint8_t) * cells));
+    for (uint64_t i = 0; i < cells; ++i) {
+      validity[i] = i % 2;
+    }
+    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+
+    free(validity);
+  }
+
+  // Empty string or null string as condition value
+  const char* cmp_value = null_cmp ? nullptr : "";
+
+  QueryCondition query_condition;
+  REQUIRE(query_condition.init(std::string(field_name), cmp_value, 0, op).ok());
+
+  // Run Check
+  REQUIRE(query_condition.check(&array_schema).ok());
+
+  // Build expected indexes of cells that meet the query condition
+  // criteria.
+  std::vector<uint64_t> expected_cell_idx_vec;
+  for (uint64_t i = 0; i < cells; ++i) {
+    switch (op) {
+      case QueryConditionOp::EQ:
+        if (null_cmp) {
+          if (i % 2 == 0)
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (nullable) {
+          if ((i % 2 != 0) && (i >= 8))
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (i >= 8) {
+          expected_cell_idx_vec.emplace_back(i);
+        }
+        break;
+      case QueryConditionOp::NE:
+        if (null_cmp) {
+          if (i % 2 != 0)
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (nullable) {
+          if ((i % 2 != 0) && (i < 8))
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (i < 8) {
+          expected_cell_idx_vec.emplace_back(i);
+        }
+        break;
+      default:
+        REQUIRE(false);
+    }
+  }
+
+  // Apply the query condition.
+  std::vector<uint8_t> result_bitmap(cells, 1);
+  REQUIRE(
+      query_condition
+          .apply_dense(
+              &array_schema, &result_tile, 0, 10, 0, 1, result_bitmap.data())
+          .ok());
+
+  // Verify the result bitmap contain the expected cells.
+  auto expected_iter = expected_cell_idx_vec.begin();
+  for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+    if (result_bitmap[cell_idx]) {
+      REQUIRE(*expected_iter == cell_idx);
+      ++expected_iter;
+    }
+  }
+
+  free(values);
+}
+
+/**
+ * Tests a comparison operator on all cells in a tile.
+ *
+ * @param op The relational query condition operator.
+ * @param field_name The attribute name in the tile.
+ * @param cells The number of cells in the tile.
+ * @param result_tile The result tile.
+ * @param values The values written to the tile.
+ */
+template <typename T>
+void test_apply_cells_sparse(
+    const QueryConditionOp op,
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values);
+
+/**
+ * C-string template-specialization for `test_apply_cells_sparse`.
+ */
+template <>
+void test_apply_cells_sparse<char*>(
+    const QueryConditionOp op,
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values) {
+  const char* const cmp_value = "ae";
+  QueryCondition query_condition;
+  REQUIRE(query_condition
+              .init(std::string(field_name), cmp_value, 2 * sizeof(char), op)
+              .ok());
+  // Run Check
+  REQUIRE(query_condition.check(array_schema).ok());
+
+  bool nullable = array_schema->attribute(field_name)->nullable();
+
+  // Build expected indexes of cells that meet the query condition
+  // criteria.
+  std::vector<uint64_t> expected_cell_idx_vec;
+  for (uint64_t i = 0; i < cells; ++i) {
+    if (nullable && (i % 2 == 0))
+      continue;
+
+    switch (op) {
+      case QueryConditionOp::LT:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) <
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::LE:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) <=
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::GT:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) >
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::GE:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) >=
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::EQ:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) ==
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::NE:
+        if (std::string(&static_cast<char*>(values)[2 * i], 2) !=
+            std::string(cmp_value, 2))
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      default:
+        REQUIRE(false);
+    }
+  }
+
+  // Apply the query condition.
+  uint64_t cell_count = 0;
+  std::vector<uint8_t> result_bitmap(cells, 1);
+  REQUIRE(query_condition
+              .apply_sparse<uint8_t>(
+                  array_schema, *result_tile, result_bitmap, &cell_count)
+              .ok());
+
+  // Verify the result bitmap contain the expected cells.
+  REQUIRE(cell_count == expected_cell_idx_vec.size());
+  auto expected_iter = expected_cell_idx_vec.begin();
+  for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+    if (result_bitmap[cell_idx]) {
+      REQUIRE(*expected_iter == cell_idx);
+      ++expected_iter;
+    }
+  }
+
+  if (nullable) {
+    if (op == QueryConditionOp::EQ || op == QueryConditionOp::NE) {
+      const uint64_t eq = op == QueryConditionOp::EQ ? 0 : 1;
+      QueryCondition query_condition_eq_null;
+      REQUIRE(
+          query_condition_eq_null.init(std::string(field_name), nullptr, 0, op)
+              .ok());
+      // Run Check
+      REQUIRE(query_condition_eq_null.check(array_schema).ok());
+
+      // Apply the query condition.
+      uint64_t cell_count_eq_null = 0;
+      std::vector<uint8_t> result_bitmap_eq_null(cells, 1);
+      REQUIRE(query_condition_eq_null
+                  .apply_sparse<uint8_t>(
+                      array_schema,
+                      *result_tile,
+                      result_bitmap_eq_null,
+                      &cell_count_eq_null)
+                  .ok());
+
+      // Verify the result bitmap contain the expected cells.
+      REQUIRE(cell_count_eq_null == 5);
+      for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+        REQUIRE(result_bitmap_eq_null[cell_idx] == (cell_idx + eq + 1) % 2);
+      }
+    }
+
+    return;
+  }
+}
+
+/**
+ * Non-specialized template type for `test_apply_cells_sparse`.
+ */
+template <typename T>
+void test_apply_cells_sparse(
+    const QueryConditionOp op,
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values) {
+  const T cmp_value = 5;
+  QueryCondition query_condition;
+  REQUIRE(
+      query_condition.init(std::string(field_name), &cmp_value, sizeof(T), op)
+          .ok());
+  // Run Check
+  REQUIRE(query_condition.check(array_schema).ok());
+
+  // Build expected indexes of cells that meet the query condition
+  // criteria.
+  std::vector<uint64_t> expected_cell_idx_vec;
+  for (uint64_t i = 0; i < cells; ++i) {
+    switch (op) {
+      case QueryConditionOp::LT:
+        if (static_cast<T*>(values)[i] < cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::LE:
+        if (static_cast<T*>(values)[i] <= cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::GT:
+        if (static_cast<T*>(values)[i] > cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::GE:
+        if (static_cast<T*>(values)[i] >= cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::EQ:
+        if (static_cast<T*>(values)[i] == cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      case QueryConditionOp::NE:
+        if (static_cast<T*>(values)[i] != cmp_value)
+          expected_cell_idx_vec.emplace_back(i);
+        break;
+      default:
+        REQUIRE(false);
+    }
+  }
+
+  // Apply the query condition.
+  uint64_t cell_count = 0;
+  std::vector<uint8_t> result_bitmap(cells, 1);
+  REQUIRE(query_condition
+              .apply_sparse<uint8_t>(
+                  array_schema, *result_tile, result_bitmap, &cell_count)
+              .ok());
+
+  // Verify the result bitmap contain the expected cells.
+  REQUIRE(cell_count == expected_cell_idx_vec.size());
+  auto expected_iter = expected_cell_idx_vec.begin();
+  for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+    if (result_bitmap[cell_idx]) {
+      REQUIRE(*expected_iter == cell_idx);
+      ++expected_iter;
+    }
+  }
+}
+
+/**
+ * Tests each comparison operator on all cells in a tile.
+ *
+ * @param field_name The attribute name in the tile.
+ * @param cells The number of cells in the tile.
+ * @param result_tile The result tile.
+ * @param values The values written to the tile.
+ */
+template <typename T>
+void test_apply_operators_sparse(
+    const std::string& field_name,
+    const uint64_t cells,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile,
+    void* values) {
+  test_apply_cells_sparse<T>(
+      QueryConditionOp::LT,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_sparse<T>(
+      QueryConditionOp::LE,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_sparse<T>(
+      QueryConditionOp::GT,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_sparse<T>(
+      QueryConditionOp::GE,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_sparse<T>(
+      QueryConditionOp::EQ,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+  test_apply_cells_sparse<T>(
+      QueryConditionOp::NE,
+      field_name,
+      cells,
+      array_schema,
+      result_tile,
+      values);
+}
+
+/**
+ * Populates a tile and tests query condition comparisons against
+ * each cell.
+ *
+ * @param field_name The attribute name in the tile.
+ * @param cells The number of cells in the tile.
+ * @param type The TILEDB data type of the attribute.
+ * @param array_schema The array schema.
+ * @param result_tile The result tile.
+ */
+template <typename T>
+void test_apply_tile_sparse(
+    const std::string& field_name,
+    uint64_t cells,
+    Datatype type,
+    ArraySchema* array_schema,
+    ResultTile* result_tile);
+
+/**
+ * C-string template-specialization for `test_apply_tile_sparse`.
+ */
+template <>
+void test_apply_tile_sparse<char*>(
+    const std::string& field_name,
+    const uint64_t cells,
+    const Datatype type,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile) {
+  ResultTile::TileTuple* const tile_tuple = result_tile->tile_tuple(field_name);
+
+  bool var_size = array_schema->attribute(field_name)->var_size();
+  bool nullable = array_schema->attribute(field_name)->nullable();
+  Tile* const tile =
+      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+
+  REQUIRE(tile->init_unfiltered(
+                  constants::format_version,
+                  type,
+                  2 * cells * sizeof(char),
+                  2 * sizeof(char),
+                  0)
+              .ok());
+
+  char* values = static_cast<char*>(malloc(sizeof(char) * 2 * cells));
+  for (uint64_t i = 0; i < cells; ++i) {
+    values[i * 2] = 'a';
+    values[(i * 2) + 1] = 'a' + static_cast<char>(i);
+  }
+  REQUIRE(tile->write(values, 2 * cells * sizeof(char)).ok());
+
+  if (var_size) {
+    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    REQUIRE(tile_offsets
+                ->init_unfiltered(
+                    constants::format_version,
+                    constants::cell_var_offset_type,
+                    10 * constants::cell_var_offset_size,
+                    constants::cell_var_offset_size,
+                    0)
+                .ok());
+
+    uint64_t* offsets =
+        static_cast<uint64_t*>(malloc(sizeof(uint64_t) * cells));
+    uint64_t offset = 0;
+    for (uint64_t i = 0; i < cells; ++i) {
+      offsets[i] = offset;
+      offset += 2;
+    }
+    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+  }
+
+  if (nullable) {
+    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    REQUIRE(tile_validity
+                ->init_unfiltered(
+                    constants::format_version,
+                    constants::cell_validity_type,
+                    10 * constants::cell_validity_size,
+                    constants::cell_validity_size,
+                    0)
+                .ok());
+
+    uint8_t* validity = static_cast<uint8_t*>(malloc(sizeof(uint8_t) * cells));
+    for (uint64_t i = 0; i < cells; ++i) {
+      validity[i] = i % 2;
+    }
+    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+  }
+
+  test_apply_operators_sparse<char*>(
+      field_name, cells, array_schema, result_tile, values);
+
+  free(values);
+}
+
+/**
+ * Non-specialized template type for `test_apply_tile_sparse`.
+ */
+template <typename T>
+void test_apply_tile_sparse(
+    const std::string& field_name,
+    const uint64_t cells,
+    const Datatype type,
+    ArraySchema* const array_schema,
+    ResultTile* const result_tile) {
+  ResultTile::TileTuple* const tile_tuple = result_tile->tile_tuple(field_name);
+  Tile* const tile = &std::get<0>(*tile_tuple);
+
+  REQUIRE(
+      tile->init_unfiltered(
+              constants::format_version, type, cells * sizeof(T), sizeof(T), 0)
+          .ok());
+  T* values = static_cast<T*>(malloc(sizeof(T) * cells));
+  for (uint64_t i = 0; i < cells; ++i) {
+    values[i] = static_cast<T>(i);
+  }
+  REQUIRE(tile->write(values, cells * sizeof(T)).ok());
+
+  test_apply_operators_sparse<T>(
+      field_name, cells, array_schema, result_tile, values);
+
+  free(values);
+}
+
+/**
+ * Constructs a tile and tests query condition comparisons against
+ * each cell.
+ *
+ * @param type The TILEDB data type of the attribute.
+ * @param var_size Run the test with variable size attribute.
+ * @param nullable Run the test with nullable attribute.
+ */
+template <typename T>
+void test_apply_sparse(
+    const Datatype type, bool var_size = false, bool nullable = false);
+
+/**
+ * C-string template-specialization for `test_apply_sparse`.
+ */
+template <>
+void test_apply_sparse<char*>(
+    const Datatype type, bool var_size, bool nullable) {
+  REQUIRE(type == Datatype::STRING_ASCII);
+
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const char* fill_value = "ac";
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(attr.set_nullable(nullable).ok());
+  REQUIRE(attr.set_cell_val_num(var_size ? constants::var_num : 2).ok());
+
+  if (!nullable) {
+    REQUIRE(attr.set_fill_value(fill_value, 2 * sizeof(char)).ok());
+  }
+
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &array_schema);
+  result_tile.init_attr_tile(field_name);
+
+  test_apply_tile_sparse<char*>(
+      field_name, cells, type, &array_schema, &result_tile);
+}
+
+/**
+ * Non-specialized template type for `test_apply_sparse`.
+ */
+template <typename T>
+void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
+  (void)var_size;
+  (void)nullable;
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const T fill_value = 3;
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(attr.set_cell_val_num(1).ok());
+  REQUIRE(attr.set_fill_value(&fill_value, sizeof(T)).ok());
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &array_schema);
+  result_tile.init_attr_tile(field_name);
+
+  test_apply_tile_sparse<T>(
+      field_name, cells, type, &array_schema, &result_tile);
+}
+
+TEST_CASE(
+    "QueryCondition: Test apply sparse", "[QueryCondition][apply][sparse]") {
+  test_apply_sparse<int8_t>(Datatype::INT8);
+  test_apply_sparse<uint8_t>(Datatype::UINT8);
+  test_apply_sparse<int16_t>(Datatype::INT16);
+  test_apply_sparse<uint16_t>(Datatype::UINT16);
+  test_apply_sparse<int32_t>(Datatype::INT32);
+  test_apply_sparse<uint32_t>(Datatype::UINT32);
+  test_apply_sparse<int64_t>(Datatype::INT64);
+  test_apply_sparse<uint64_t>(Datatype::UINT64);
+  test_apply_sparse<float>(Datatype::FLOAT32);
+  test_apply_sparse<double>(Datatype::FLOAT64);
+  test_apply_sparse<char>(Datatype::CHAR);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_YEAR);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_MONTH);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_WEEK);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_DAY);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_HR);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_MIN);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_SEC);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_MS);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_US);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_NS);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_PS);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_FS);
+  test_apply_sparse<int64_t>(Datatype::DATETIME_AS);
+  test_apply_sparse<char*>(Datatype::STRING_ASCII);
+  test_apply_sparse<char*>(Datatype::STRING_ASCII, true);
+  test_apply_sparse<char*>(Datatype::STRING_ASCII, false, true);
+}
+
+TEST_CASE(
+    "QueryCondition: Test combinations sparse",
+    "[QueryCondition][combinations][sparse]") {
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const Datatype type = Datatype::UINT64;
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &array_schema);
+  result_tile.init_attr_tile(field_name);
+  ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
+  Tile* const tile = &std::get<0>(*tile_tuple);
+
+  // Initialize and populate the data tile.
+  REQUIRE(tile->init_unfiltered(
+                  constants::format_version,
+                  type,
+                  cells * sizeof(uint64_t),
+                  sizeof(uint64_t),
+                  0)
+              .ok());
+  uint64_t* values = static_cast<uint64_t*>(malloc(sizeof(uint64_t) * cells));
+  for (uint64_t i = 0; i < cells; ++i) {
+    values[i] = i;
+  }
+  REQUIRE(tile->write(values, cells * sizeof(uint64_t)).ok());
+
+  // Build a combined query for `> 3 AND <= 6`.
+  uint64_t cmp_value_1 = 3;
+  QueryCondition query_condition_1;
+  REQUIRE(query_condition_1
+              .init(
+                  std::string(field_name),
+                  &cmp_value_1,
+                  sizeof(uint64_t),
+                  QueryConditionOp::GT)
+              .ok());
+  // Run Check
+  REQUIRE(query_condition_1.check(&array_schema).ok());
+  uint64_t cmp_value_2 = 6;
+  QueryCondition query_condition_2;
+  REQUIRE(query_condition_2
+              .init(
+                  std::string(field_name),
+                  &cmp_value_2,
+                  sizeof(uint64_t),
+                  QueryConditionOp::LE)
+              .ok());
+  // Run Check
+  REQUIRE(query_condition_2.check(&array_schema).ok());
+  QueryCondition query_condition_3;
+  REQUIRE(query_condition_1
+              .combine(
+                  query_condition_2,
+                  QueryConditionCombinationOp::AND,
+                  &query_condition_3)
+              .ok());
+
+  // Apply the query condition.
+  uint64_t cell_count = 0;
+  std::vector<uint8_t> result_bitmap(cells, 1);
+  REQUIRE(query_condition_3
+              .apply_sparse<uint8_t>(
+                  &array_schema, result_tile, result_bitmap, &cell_count)
+              .ok());
+
+  // Check that the cell slab now contains cell indexes 4, 5, and 6.
+  REQUIRE(cell_count == 3);
+  for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+    REQUIRE(
+        result_bitmap[cell_idx] == (cell_idx >= 4 && cell_idx <= 6 ? 1 : 0));
+  }
+
+  free(values);
+}
+
+TEST_CASE(
+    "QueryCondition: Test empty/null strings sparse",
+    "[QueryCondition][empty_string][null_string][sparse]") {
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const char* fill_value = "ac";
+  const Datatype type = Datatype::STRING_ASCII;
+  bool var_size = true;
+  bool nullable = GENERATE(true, false);
+  bool null_cmp = GENERATE(true, false);
+  QueryConditionOp op = GENERATE(QueryConditionOp::NE, QueryConditionOp::EQ);
+
+  if (!nullable && null_cmp)
+    return;
+
+  // Initialize the array schema.
+  ArraySchema array_schema;
+  Attribute attr(field_name, type);
+  REQUIRE(attr.set_nullable(nullable).ok());
+  REQUIRE(attr.set_cell_val_num(var_size ? constants::var_num : 2).ok());
+
+  if (!nullable) {
+    REQUIRE(attr.set_fill_value(fill_value, 2 * sizeof(char)).ok());
+  }
+
+  REQUIRE(array_schema.add_attribute(&attr).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(&dim).ok());
+  REQUIRE(array_schema.set_domain(&domain).ok());
+
+  // Initialize the result tile.
+  ResultTile result_tile(0, 0, &array_schema);
+  result_tile.init_attr_tile(field_name);
+
+  ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
+
+  var_size = array_schema.attribute(field_name)->var_size();
+  nullable = array_schema.attribute(field_name)->nullable();
+  Tile* const tile =
+      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+
+  REQUIRE(tile->init_unfiltered(
+                  constants::format_version,
+                  type,
+                  2 * (cells - 2) * sizeof(char),
+                  2 * sizeof(char),
+                  0)
+              .ok());
+
+  char* values = static_cast<char*>(malloc(
+      sizeof(char) * 2 *
+      (cells - 2)));  // static_cast<char*>(malloc(sizeof(char) * 2 * cells));
+
+  // Empty strings are at idx 8 and 9
+  for (uint64_t i = 0; i < (cells - 2); ++i) {
+    values[i * 2] = 'a';
+    values[(i * 2) + 1] = 'a' + static_cast<char>(i);
+  }
+
+  REQUIRE(tile->write(values, 2 * (cells - 2) * sizeof(char)).ok());
+
+  if (var_size) {
+    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    REQUIRE(tile_offsets
+                ->init_unfiltered(
+                    constants::format_version,
+                    constants::cell_var_offset_type,
+                    10 * constants::cell_var_offset_size,
+                    constants::cell_var_offset_size,
+                    0)
+                .ok());
+
+    uint64_t* offsets =
+        static_cast<uint64_t*>(malloc(sizeof(uint64_t) * cells));
+    uint64_t offset = 0;
+    for (uint64_t i = 0; i < cells - 2; ++i) {
+      offsets[i] = offset;
+      offset += 2;
+    }
+    offsets[cells - 2] = offset;
+    offsets[cells - 1] = offset;
+    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+
+    free(offsets);
+  }
+
+  if (nullable) {
+    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    REQUIRE(tile_validity
+                ->init_unfiltered(
+                    constants::format_version,
+                    constants::cell_validity_type,
+                    10 * constants::cell_validity_size,
+                    constants::cell_validity_size,
+                    0)
+                .ok());
+
+    uint8_t* validity = static_cast<uint8_t*>(malloc(sizeof(uint8_t) * cells));
+    for (uint64_t i = 0; i < cells; ++i) {
+      validity[i] = i % 2;
+    }
+    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+
+    free(validity);
+  }
+
+  // Empty string or null string as condition value
+  const char* cmp_value = null_cmp ? nullptr : "";
+
+  QueryCondition query_condition;
+  REQUIRE(query_condition.init(std::string(field_name), cmp_value, 0, op).ok());
+
+  // Run Check
+  REQUIRE(query_condition.check(&array_schema).ok());
+
+  // Build expected indexes of cells that meet the query condition
+  // criteria.
+  std::vector<uint64_t> expected_cell_idx_vec;
+  for (uint64_t i = 0; i < cells; ++i) {
+    switch (op) {
+      case QueryConditionOp::EQ:
+        if (null_cmp) {
+          if (i % 2 == 0)
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (nullable) {
+          if ((i % 2 != 0) && (i >= 8))
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (i >= 8) {
+          expected_cell_idx_vec.emplace_back(i);
+        }
+        break;
+      case QueryConditionOp::NE:
+        if (null_cmp) {
+          if (i % 2 != 0)
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (nullable) {
+          if ((i % 2 != 0) && (i < 8))
+            expected_cell_idx_vec.emplace_back(i);
+        } else if (i < 8) {
+          expected_cell_idx_vec.emplace_back(i);
+        }
+        break;
+      default:
+        REQUIRE(false);
+    }
+  }
+
+  // Apply the query condition.
+  uint64_t cell_count = 0;
+  std::vector<uint8_t> result_bitmap(cells, 1);
+  REQUIRE(query_condition
+              .apply_sparse<uint8_t>(
+                  &array_schema, result_tile, result_bitmap, &cell_count)
+              .ok());
+
+  // Verify the result bitmap contain the expected cells.
+  REQUIRE(cell_count == expected_cell_idx_vec.size());
+  auto expected_iter = expected_cell_idx_vec.begin();
+  for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
+    if (result_bitmap[cell_idx]) {
       REQUIRE(*expected_iter == cell_idx);
       ++expected_iter;
     }

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -503,7 +503,7 @@ Status DenseReader::apply_query_condition(
 
     // Initialize the result buffer.
     qc_result->resize(cell_num);
-    memset(qc_result->data(), 0xFF, cell_num);
+    memset(qc_result->data(), 1, cell_num);
 
     // Process all tiles in parallel.
     auto status = parallel_for(
@@ -559,7 +559,7 @@ Status DenseReader::apply_query_condition(
                       cell_slab.length_,
                       &start,
                       &end)) {
-                RETURN_NOT_OK(condition_.apply_dense<DimType>(
+                RETURN_NOT_OK(condition_.apply_dense(
                     fragment_metadata_[frag_domains[i].first]->array_schema(),
                     it->second.result_tile(frag_domains[i].first),
                     start,

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -65,9 +65,14 @@ class QueryCondition {
         : field_name_(std::move(field_name))
         , op_(op) {
       condition_value_data_.resize(condition_value_size);
-      condition_value_ =
-          condition_value == nullptr ? nullptr : condition_value_data_.data();
+      condition_value_ = nullptr;
+
       if (condition_value != nullptr) {
+        // Using an empty string litteral for empty string as vector::resize(0)
+        // doesn't guarantee an allocation.
+        condition_value_ = condition_value_size == 0 ?
+                               (void*)"" :
+                               condition_value_data_.data();
         memcpy(
             condition_value_data_.data(),
             condition_value,
@@ -237,7 +242,6 @@ class QueryCondition {
    * @param result_buffer The buffer to use for results.
    * @return Status
    */
-  template <typename T>
   Status apply_dense(
       const ArraySchema* const array_schema,
       ResultTile* result_tile,
@@ -256,7 +260,7 @@ class QueryCondition {
    * @param cell_count The cell count after condition is applied.
    * @return Status
    */
-  template <typename T, typename BitmapType>
+  template <typename BitmapType>
   Status apply_sparse(
       const ArraySchema* const array_schema,
       ResultTile& result_tile,
@@ -404,9 +408,7 @@ class QueryCondition {
    * @param src_cell The cell offset in the source tile.
    * @param stride The stride between cells.
    * @param var_size The attribute is var sized or not.
-   * @param nullable The attribute is nullable or not.
-   * @param previous_result_bitmask The bitmask to get the previous result.
-   * @param current_result_bitmask The bitmask to set the current result.
+
    * @param result_buffer The result buffer.
    */
   template <typename T, QueryConditionOp Op>
@@ -418,9 +420,6 @@ class QueryCondition {
       const uint64_t src_cell,
       const uint64_t stride,
       const bool var_size,
-      const bool nullable,
-      const uint8_t previous_result_bitmask,
-      const uint8_t current_result_bitmask,
       uint8_t* result_buffer) const;
 
   /**
@@ -433,9 +432,6 @@ class QueryCondition {
    * @param src_cell The cell offset in the source tile.
    * @param stride The stride between cells.
    * @param var_size The attribute is var sized or not.
-   * @param nullable The attribute is nullable or not.
-   * @param previous_result_bitmask The bitmask to get the previous result.
-   * @param current_result_bitmask The bitmask to set the current result.
    * @param result_buffer The result buffer.
    */
   template <typename T>
@@ -447,9 +443,6 @@ class QueryCondition {
       const uint64_t src_cell,
       const uint64_t stride,
       const bool var_size,
-      const bool nullable,
-      const uint8_t previous_result_bitmask,
-      const uint8_t current_result_bitmask,
       uint8_t* result_buffer) const;
 
   /**
@@ -463,8 +456,6 @@ class QueryCondition {
    * @param length The number of cells to process.
    * @param src_cell The cell offset in the source tile.
    * @param stride The stride between cells.
-   * @param previous_result_bitmask The bitmask to get the previous result.
-   * @param current_result_bitmask The bitmask to set the current result.
    * @param result_buffer The result buffer.
    */
   Status apply_clause_dense(
@@ -475,8 +466,6 @@ class QueryCondition {
       const uint64_t length,
       const uint64_t src_cell,
       const uint64_t stride,
-      const uint8_t previous_result_bitmask,
-      const uint8_t current_result_bitmask,
       uint8_t* result_buffer) const;
 
   /**


### PR DESCRIPTION
While porting the existing tests for query condition to the refactored
readers, I found out that empty string and nullptr were treated the same
when initializing a query condition, as initializing a vector to size 0
doesn't guarantee an allocation, and differentiation was done on the
vector::data() member.

Also included in this change:
- Better vectorization for the refactored dense reader.
- Ported existing query condition tests to the refactored dense and sparse readers.
- Some code cleanup.

---
TYPE: IMPROVEMENT
DESC: Query condition: differentiate between nullptr and empty string.
