### PR TITLE
Deprecate TILEDB_ANY

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -125,6 +125,12 @@ typedef enum {
 #define TILEDB_CHAR TILEDB_DEPRECATED TILEDB_CHAR_VAL
 #undef TILEDB_CHAR_VAL
 #endif
+#ifdef TILEDB_ANY
+#def TILEDB_ANY_VAL TILEDB_ANY
+#undef TILEDB_ANY
+#define TILEDB_ANY TILEDB_DEPRECATED TILEDB_ANY_VAL
+#undef TILEDB_ANY_VAL
+#endif
 } tiledb_datatype_t;
 
 /** Array type. */


### PR DESCRIPTION
Deprecate the datatype `TILEDB_ANY`
[ch13246]

---
TYPE: DEPRECATION
DESC: Deprecate `TILEDB_ANY` datatype

TYPE: C_API
DESC: Deprecate `TILEDB_ANY` datatype

TYPE: CPP_API
DESC: Deprecate `TILEDB_ANY` datatype