### PR TITLE
Sparse unordered w/ dups reader: off by one error in query continuation.

### DIFF
--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1214,7 +1214,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
               0;
 
       const bool has_bmp = last_tile->bitmap_.size() != 0;
-      const auto min_pos = *new_result_tiles_size == 0 ? first_tile_min_pos : 0;
+      const auto min_pos = *new_result_tiles_size == 1 ? first_tile_min_pos : 0;
       for (uint64_t c = min_pos; c < last_tile_num_cells - 1; c++) {
         auto cell_count = has_bmp ? last_tile->bitmap_[c] : 1;
         auto new_size = ((OffType*)query_buffer->buffer_)


### PR DESCRIPTION
This fixes an off by one error when resuming a query that only partially
processed a tile.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups reader: off by one error in query continuation.
