### PR TITLE
Sparse global order reader: merge smaller cell slabs.

### DIFF
--- a/test/src/unit-QueryCondition.cc
+++ b/test/src/unit-QueryCondition.cc
@@ -53,7 +53,7 @@ TEST_CASE(
 
   ArraySchema array_schema;
   std::vector<ResultCellSlab> result_cell_slabs;
-  REQUIRE(query_condition.apply(&array_schema, &result_cell_slabs, 1).ok());
+  REQUIRE(query_condition.apply(&array_schema, result_cell_slabs, 1).ok());
 }
 
 TEST_CASE("QueryCondition: Test init", "[QueryCondition][value_constructor]") {
@@ -241,7 +241,7 @@ void test_apply_cells<char*>(
   ResultCellSlab result_cell_slab(result_tile, 0, cells);
   std::vector<ResultCellSlab> result_cell_slabs;
   result_cell_slabs.emplace_back(std::move(result_cell_slab));
-  REQUIRE(query_condition.apply(array_schema, &result_cell_slabs, 1).ok());
+  REQUIRE(query_condition.apply(array_schema, result_cell_slabs, 1).ok());
 
   // Verify the result cell slabs contain the expected cells.
   auto expected_iter = expected_cell_idx_vec.begin();
@@ -269,7 +269,7 @@ void test_apply_cells<char*>(
       result_cell_slabs_eq_null.emplace_back(
           std::move(result_cell_slab_eq_null));
       REQUIRE(query_condition_eq_null
-                  .apply(array_schema, &result_cell_slabs_eq_null, 1)
+                  .apply(array_schema, result_cell_slabs_eq_null, 1)
                   .ok());
 
       REQUIRE(result_cell_slabs_eq_null.size() == (cells / 2));
@@ -334,7 +334,7 @@ void test_apply_cells<char*>(
   ResultCellSlab fill_result_cell_slab(nullptr, 0, cells);
   std::vector<ResultCellSlab> fill_result_cell_slabs;
   fill_result_cell_slabs.emplace_back(std::move(fill_result_cell_slab));
-  REQUIRE(query_condition.apply(array_schema, &fill_result_cell_slabs, 1).ok());
+  REQUIRE(query_condition.apply(array_schema, fill_result_cell_slabs, 1).ok());
 
   // Verify the fill result cell slabs contain the expected cells.
   auto fill_expected_iter = fill_expected_cell_idx_vec.begin();
@@ -406,7 +406,7 @@ void test_apply_cells(
   ResultCellSlab result_cell_slab(result_tile, 0, cells);
   std::vector<ResultCellSlab> result_cell_slabs;
   result_cell_slabs.emplace_back(std::move(result_cell_slab));
-  REQUIRE(query_condition.apply(array_schema, &result_cell_slabs, 1).ok());
+  REQUIRE(query_condition.apply(array_schema, result_cell_slabs, 1).ok());
 
   // Verify the result cell slabs contain the expected cells.
   auto expected_iter = expected_cell_idx_vec.begin();
@@ -464,7 +464,7 @@ void test_apply_cells(
   ResultCellSlab fill_result_cell_slab(nullptr, 0, cells);
   std::vector<ResultCellSlab> fill_result_cell_slabs;
   fill_result_cell_slabs.emplace_back(std::move(fill_result_cell_slab));
-  REQUIRE(query_condition.apply(array_schema, &fill_result_cell_slabs, 1).ok());
+  REQUIRE(query_condition.apply(array_schema, fill_result_cell_slabs, 1).ok());
 
   // Verify the fill result cell slabs contain the expected cells.
   auto fill_expected_iter = fill_expected_cell_idx_vec.begin();
@@ -845,7 +845,7 @@ TEST_CASE(
   std::vector<ResultCellSlab> result_cell_slabs;
   result_cell_slabs.emplace_back(std::move(result_cell_slab));
 
-  REQUIRE(query_condition_3.apply(&array_schema, &result_cell_slabs, 1).ok());
+  REQUIRE(query_condition_3.apply(&array_schema, result_cell_slabs, 1).ok());
 
   // Check that the cell slab now contains cell indexes 4, 5, and 6.
   REQUIRE(result_cell_slabs.size() == 1);
@@ -1010,7 +1010,7 @@ TEST_CASE(
   ResultCellSlab result_cell_slab(&result_tile, 0, cells);
   std::vector<ResultCellSlab> result_cell_slabs;
   result_cell_slabs.emplace_back(std::move(result_cell_slab));
-  REQUIRE(query_condition.apply(&array_schema, &result_cell_slabs, 1).ok());
+  REQUIRE(query_condition.apply(&array_schema, result_cell_slabs, 1).ok());
 
   // Verify the result cell slabs contain the expected cells.
   auto expected_iter = expected_cell_idx_vec.begin();

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -77,7 +77,7 @@ struct ReadCellSlabIterFx {
       Layout layout,
       const std::vector<NDRange>& domain_slices,
       const std::vector<std::vector<uint8_t>>& tile_coords,
-      std::map<const T*, ResultSpaceTile<T>>* result_space_tiles);
+      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles);
 };
 
 ReadCellSlabIterFx::ReadCellSlabIterFx()
@@ -142,7 +142,7 @@ void ReadCellSlabIterFx::create_result_space_tiles(
     Layout layout,
     const std::vector<NDRange>& domain_slices,
     const std::vector<std::vector<uint8_t>>& tile_coords,
-    std::map<const T*, ResultSpaceTile<T>>* result_space_tiles) {
+    std::map<const T*, ResultSpaceTile<T>>& result_space_tiles) {
   auto domain = dom->domain();
   const auto& tile_extents = dom->tile_extents();
   std::vector<TileDomain<T>> frag_tile_domains;
@@ -239,7 +239,7 @@ TEST_CASE_METHOD(
       subarray_layout,
       domain_slices,
       tile_coords,
-      &result_space_tiles);
+      result_space_tiles);
 
   // Check iterator
   std::vector<ResultCoords> result_coords;
@@ -312,7 +312,7 @@ TEST_CASE_METHOD(
       subarray_layout,
       domain_slices,
       tile_coords,
-      &result_space_tiles);
+      result_space_tiles);
 
   // Check iterator
   std::vector<ResultCoords> result_coords;
@@ -390,7 +390,7 @@ TEST_CASE_METHOD(
       subarray_layout,
       domain_slices,
       tile_coords,
-      &result_space_tiles);
+      result_space_tiles);
 
   // Check iterator
   std::vector<ResultCoords> result_coords;
@@ -472,7 +472,7 @@ TEST_CASE_METHOD(
       subarray_layout,
       domain_slices,
       tile_coords,
-      &result_space_tiles);
+      result_space_tiles);
 
   // Create result coordinates
   std::vector<ResultCoords> result_coords;
@@ -708,7 +708,7 @@ TEST_CASE_METHOD(
       tile_domain_layout,
       domain_slices,
       tile_coords,
-      &result_space_tiles);
+      result_space_tiles);
 
   // Create result coordinates
   std::vector<ResultCoords> result_coords;
@@ -893,7 +893,7 @@ TEST_CASE_METHOD(
       tile_domain_layout,
       domain_slices,
       tile_coords,
-      &result_space_tiles);
+      result_space_tiles);
 
   // Create result coordinates
   std::vector<ResultCoords> result_coords;
@@ -1091,7 +1091,7 @@ TEST_CASE_METHOD(
       tile_domain_layout,
       domain_slices,
       tile_coords,
-      &result_space_tiles);
+      result_space_tiles);
 
   // Create result coordinates
   std::vector<ResultCoords> result_coords;
@@ -1337,7 +1337,7 @@ TEST_CASE_METHOD(
       tile_domain_layout,
       domain_slices,
       tile_coords,
-      &result_space_tiles);
+      result_space_tiles);
 
   // Create result coordinates
   std::vector<ResultCoords> result_coords;

--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -209,7 +209,7 @@ TEST_CASE_METHOD(
       tile_coords,
       array_tile_domain,
       frag_tile_domains,
-      &result_space_tiles);
+      result_space_tiles);
   CHECK(result_space_tiles.size() == 6);
 
   // Result tiles for fragment #1

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -257,7 +257,6 @@ void check_save_to_file() {
   ss << "sm.mem.reader.sparse_global_order.ratio_array_data 0.1\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_coords 0.5\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_query_condition 0.25\n";
-  ss << "sm.mem.reader.sparse_global_order.ratio_rcs 0.05\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_tile_ranges 0.1\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data 0.1\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_coords 0.5\n";
@@ -578,7 +577,6 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
       "0.1";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_array_data"] =
       "0.1";
-  all_param_values["sm.mem.reader.sparse_global_order.ratio_rcs"] = "0.05";
   all_param_values["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
       "0.5";
   all_param_values

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -500,14 +500,17 @@ TEST_CASE(
 
   // Allocate buffers large enough to hold 2 cells at a time.
   std::vector<char> data(2, '\0');
-  std::vector<int> coords(4);
-  query.set_coordinates(coords).set_data_buffer("a", data);
+  std::vector<int> rows(2);
+  std::vector<int> cols(2);
+  query.set_data_buffer("rows", rows)
+      .set_data_buffer("cols", cols)
+      .set_data_buffer("a", data);
 
   // Submit query
   auto st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
-  auto result_num = result_elts[TILEDB_COORDS].second / 2;
+  auto result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
   REQUIRE(data[0] == 'a');
   REQUIRE(data[1] == 'l');
@@ -516,7 +519,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
   REQUIRE(data[0] == 'b');
   REQUIRE(data[1] == 'm');
@@ -525,7 +528,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'c');
@@ -539,7 +542,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
 
   if (test::use_refactored_sparse_global_order_reader()) {
@@ -554,7 +557,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'f');
@@ -568,7 +571,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'h');
@@ -586,7 +589,7 @@ TEST_CASE(
     REQUIRE(st == Query::Status::INCOMPLETE);
   }
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
 
   if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
@@ -601,7 +604,7 @@ TEST_CASE(
     st = query.submit();
     REQUIRE(st == Query::Status::INCOMPLETE);
     result_elts = query.result_buffer_elements();
-    result_num = result_elts[TILEDB_COORDS].second / 2;
+    result_num = result_elts["rows"].second;
     REQUIRE(result_num == 1);
     REQUIRE(data[0] == 'i');
 
@@ -609,7 +612,7 @@ TEST_CASE(
     st = query.submit();
     REQUIRE(st == Query::Status::COMPLETE);
     result_elts = query.result_buffer_elements();
-    result_num = result_elts[TILEDB_COORDS].second / 2;
+    result_num = result_elts["rows"].second;
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'j');
     REQUIRE(data[1] == 'k');
@@ -691,8 +694,11 @@ TEST_CASE(
 
   // Allocate buffers large enough to hold 2 cells at a time.
   std::vector<char> data(2, '\0');
-  std::vector<int> coords(4);
-  query.set_coordinates(coords).set_buffer("a", data);
+  std::vector<int> rows(2);
+  std::vector<int> cols(2);
+  query.set_data_buffer("rows", rows)
+      .set_data_buffer("cols", cols)
+      .set_data_buffer("a", data);
 
   {
     tiledb::Query query(ctx, array);
@@ -723,7 +729,7 @@ TEST_CASE(
   auto st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
-  auto result_num = result_elts[TILEDB_COORDS].second / 2;
+  auto result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
   REQUIRE(data[0] == 'a');
   REQUIRE(data[1] == 'l');
@@ -742,7 +748,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
   REQUIRE(data[0] == 'b');
   REQUIRE(data[1] == 'm');
@@ -752,7 +758,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'c');
@@ -767,7 +773,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
   if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(data[0] == 'd');
@@ -782,7 +788,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'f');
@@ -797,7 +803,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'h');
@@ -816,7 +822,7 @@ TEST_CASE(
     REQUIRE(st == Query::Status::INCOMPLETE);
   }
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'j');
@@ -830,7 +836,7 @@ TEST_CASE(
     st = query.submit();
     REQUIRE(st == Query::Status::INCOMPLETE);
     result_elts = query.result_buffer_elements();
-    result_num = result_elts[TILEDB_COORDS].second / 2;
+    result_num = result_elts["rows"].second;
     REQUIRE(result_num == 1);
     REQUIRE(data[0] == 'i');
 
@@ -838,7 +844,7 @@ TEST_CASE(
     st = query.submit();
     REQUIRE(st == Query::Status::COMPLETE);
     result_elts = query.result_buffer_elements();
-    result_num = result_elts[TILEDB_COORDS].second / 2;
+    result_num = result_elts["rows"].second;
     REQUIRE(result_num == 2);
     REQUIRE(data[0] == 'j');
     REQUIRE(data[1] == 'k');
@@ -903,21 +909,24 @@ TEST_CASE(
 
   // Allocate buffers large enough to hold 2 cells at a time.
   std::vector<char> data(2, '\0');
-  std::vector<int> coords(4);
-  query.set_coordinates(coords).set_data_buffer("a", data);
+  std::vector<int> rows(2);
+  std::vector<int> cols(2);
+  query.set_data_buffer("rows", rows)
+      .set_data_buffer("cols", cols)
+      .set_data_buffer("a", data);
 
   // Submit query
   auto st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
-  auto result_num = result_elts[TILEDB_COORDS].second / 2;
+  auto result_num = result_elts["rows"].second;
   REQUIRE(result_num == 1);
   REQUIRE(data[0] == 'l');
 
   st = query.submit();
   REQUIRE(st == Query::Status::COMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
   REQUIRE(data[0] == 'l');
   REQUIRE(data[1] == 'm');
@@ -984,15 +993,18 @@ TEST_CASE(
 
   // Allocate buffers large enough to hold 2 cells at a time.
   std::vector<char> data(2, '\0');
-  std::vector<int> coords(4);
-  query.set_coordinates(coords).set_buffer("a", data);
+  std::vector<int> rows(2);
+  std::vector<int> cols(2);
+  query.set_data_buffer("rows", rows)
+      .set_data_buffer("cols", cols)
+      .set_data_buffer("a", data);
 
   // Submit query
   query.set_subarray(subarray);
   auto st = query.submit();
   REQUIRE(st == Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
-  auto result_num = result_elts[TILEDB_COORDS].second / 2;
+  auto result_num = result_elts["rows"].second;
   REQUIRE(result_num == 1);
   REQUIRE(data[0] == 'l');
 
@@ -1000,7 +1012,7 @@ TEST_CASE(
   st = query.submit();
   REQUIRE(st == Query::Status::COMPLETE);
   result_elts = query.result_buffer_elements();
-  result_num = result_elts[TILEDB_COORDS].second / 2;
+  result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
   REQUIRE(data[0] == 'l');
   REQUIRE(data[1] == 'm');

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -32,6 +32,8 @@
 
 #include "test/src/helpers.h"
 #include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/query/sparse_global_order_reader.h"
 
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
@@ -59,7 +61,6 @@ struct CSparseGlobalOrderFx {
   std::string ratio_tile_ranges_;
   std::string ratio_array_data_;
   std::string ratio_coords_;
-  std::string ratio_rcs_;
   std::string ratio_query_condition_;
 
   void create_default_array_1d();
@@ -106,7 +107,6 @@ void CSparseGlobalOrderFx::reset_config() {
   ratio_tile_ranges_ = "0.1";
   ratio_array_data_ = "0.1";
   ratio_coords_ = "0.5";
-  ratio_rcs_ = "0.05";
   ratio_query_condition_ = "0.25";
   update_config();
 }
@@ -158,14 +158,6 @@ void CSparseGlobalOrderFx::update_config() {
           config,
           "sm.mem.reader.sparse_global_order.ratio_coords",
           ratio_coords_.c_str(),
-          &error) == TILEDB_OK);
-  REQUIRE(error == nullptr);
-
-  REQUIRE(
-      tiledb_config_set(
-          config,
-          "sm.mem.reader.sparse_global_order.ratio_rcs",
-          ratio_rcs_.c_str(),
           &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
 
@@ -440,8 +432,8 @@ TEST_CASE_METHOD(
   uint32_t rc;
 
   // Try to read.
-  int coords_r[5];
-  int data_r[5];
+  int coords_r[10];
+  int data_r[10];
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
 
@@ -456,87 +448,28 @@ TEST_CASE_METHOD(
       &array);
   CHECK(rc == TILEDB_OK);
 
+  // Check the internal loop count against expected value.
+  auto stats = ((SparseGlobalOrderReader*)query->query_->strategy())->stats();
+  REQUIRE(stats != nullptr);
+  auto counters = stats->counters();
+  REQUIRE(counters != nullptr);
+  auto loop_num =
+      counters->find("Context.StorageManager.Query.Reader.loop_num");
+  CHECK(5 == loop_num->second);
+
   // Check incomplete query status.
   tiledb_query_status_t status;
   tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should only read one tile (2 values).
-  CHECK(12 == data_r_size);
-  CHECK(12 == coords_r_size);
-
-  int coords_c[] = {1, 2, 3};
-  int data_c[] = {1, 2, 3};
-  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check incomplete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should only read one more tile (2 values).
-  CHECK(4 == data_r_size);
-  CHECK(4 == coords_r_size);
-
-  int coords_c_2[] = {4};
-  int data_c_2[] = {4};
-  CHECK(!std::memcmp(coords_c_2, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_2, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check complete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should read last tile (1 value).
-  CHECK(12 == data_r_size);
-  CHECK(12 == coords_r_size);
-
-  int coords_c_3[] = {5, 6, 7};
-  int data_c_3[] = {5, 6, 7};
-  CHECK(!std::memcmp(coords_c_3, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_3, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check complete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should read last tile (1 value).
-  CHECK(4 == data_r_size);
-  CHECK(4 == coords_r_size);
-
-  int coords_c_4[] = {8};
-  int data_c_4[] = {8};
-  CHECK(!std::memcmp(coords_c_4, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_4, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check complete query status.
-  tiledb_query_get_status(ctx_, query, &status);
   CHECK(status == TILEDB_COMPLETED);
 
-  // Should read last tile (1 value).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
+  // Should only read one tile (2 values).
+  CHECK(40 == data_r_size);
+  CHECK(40 == coords_r_size);
 
-  int coords_c_5[] = {9, 10};
-  int data_c_5[] = {9, 10};
-  CHECK(!std::memcmp(coords_c_5, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_5, data_r, data_r_size));
+  int coords_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  int data_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
+  CHECK(!std::memcmp(data_c, data_r, data_r_size));
 
   // Clean up.
   rc = tiledb_array_close(ctx_, array);
@@ -593,95 +526,6 @@ TEST_CASE_METHOD(
 
   std::string error_str(msg);
   CHECK(error_str.find("Cannot load a single tile") != std::string::npos);
-}
-
-TEST_CASE_METHOD(
-    CSparseGlobalOrderFx,
-    "Sparse global order reader: rcs budget forcing one tile at a time",
-    "[sparse-global-order][small-rcs-budget]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  bool use_subarray = false;
-  SECTION("- No subarray") {
-    use_subarray = false;
-  }
-  SECTION("- Subarray") {
-    use_subarray = true;
-  }
-
-  int num_frags = 2;
-  for (int i = 1; i < num_frags + 1; i++) {
-    // Write a fragment.
-    int coords[] = {i,
-                    num_frags + i,
-                    2 * num_frags + i,
-                    3 * num_frags + i,
-                    4 * num_frags + i};
-    uint64_t coords_size = sizeof(coords);
-    int data[] = {i,
-                  num_frags + i,
-                  2 * num_frags + i,
-                  3 * num_frags + i,
-                  4 * num_frags + i};
-    uint64_t data_size = sizeof(data);
-    write_1d_fragment(coords, &coords_size, data, &data_size);
-  }
-
-  // One cell slab (24) will be bigger than the budget (10).
-  total_budget_ = "10000";
-  ratio_rcs_ = "0.001";
-  update_config();
-
-  tiledb_array_t* array = nullptr;
-  tiledb_query_t* query = nullptr;
-
-  uint32_t rc;
-  uint64_t coords_r_size;
-  uint64_t data_r_size;
-  for (int i = 0; i < 10; i++) {
-    // Try to read.
-    int coords_r[5];
-    int data_r[5];
-    coords_r_size = sizeof(coords_r);
-    data_r_size = sizeof(data_r);
-
-    if (i == 0) {
-      rc = read(
-          use_subarray,
-          false,
-          coords_r,
-          &coords_r_size,
-          data_r,
-          &data_r_size,
-          &query,
-          &array);
-    } else {
-      rc = tiledb_query_submit(ctx_, query);
-    }
-    CHECK(rc == TILEDB_OK);
-
-    // Check query status.
-    tiledb_query_status_t status;
-    tiledb_query_get_status(ctx_, query, &status);
-    CHECK(status == (i == 9 ? TILEDB_COMPLETED : TILEDB_INCOMPLETE));
-
-    // Should only read one value.
-    CHECK(4 == data_r_size);
-    CHECK(4 == coords_r_size);
-
-    int coords_c[] = {i + 1};
-    int data_c[] = {i + 1};
-    CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
-    CHECK(!std::memcmp(data_c, data_r, data_r_size));
-  }
-
-  // Clean up.
-  rc = tiledb_array_close(ctx_, array);
-  CHECK(rc == TILEDB_OK);
-  tiledb_array_free(&array);
-  tiledb_query_free(&query);
 }
 
 TEST_CASE_METHOD(
@@ -782,8 +626,8 @@ TEST_CASE_METHOD(
   uint64_t data_r_size;
 
   // Try to read.
-  int coords_r[5];
-  int data_r[5];
+  int coords_r[10];
+  int data_r[10];
   coords_r_size = sizeof(coords_r);
   data_r_size = sizeof(data_r);
 
@@ -798,86 +642,28 @@ TEST_CASE_METHOD(
       &array);
   CHECK(rc == TILEDB_OK);
 
+  // Check the internal loop count against expected value.
+  auto stats = ((SparseGlobalOrderReader*)query->query_->strategy())->stats();
+  REQUIRE(stats != nullptr);
+  auto counters = stats->counters();
+  REQUIRE(counters != nullptr);
+  auto loop_num =
+      counters->find("Context.StorageManager.Query.Reader.loop_num");
+  CHECK(2 + (uint64_t)num_frags == loop_num->second);
+
   // Check incomplete query status.
   tiledb_query_status_t status;
   tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
+  CHECK(status == TILEDB_COMPLETED);
 
   // Should only read one tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
+  CHECK(uint64_t(num_frags * 20) == data_r_size);
+  CHECK(uint64_t(num_frags * 20) == coords_r_size);
 
-  int coords_c[] = {1, 2};
-  int data_c[] = {1, 2};
+  int coords_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  int data_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
   CHECK(!std::memcmp(data_c, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Check incomplete query status.
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_INCOMPLETE);
-
-  // Should only read one more tile (2 values).
-  CHECK(8 == data_r_size);
-  CHECK(8 == coords_r_size);
-
-  int coords_c_2[] = {3, 4};
-  int data_c_2[] = {3, 4};
-  CHECK(!std::memcmp(coords_c_2, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c_2, data_r, data_r_size));
-
-  // Read again.
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  if (num_frags == 1) {
-    // Check complete query status.
-    tiledb_query_get_status(ctx_, query, &status);
-    CHECK(status == TILEDB_COMPLETED);
-
-    // Should read last tile (1 value).
-    CHECK(4 == data_r_size);
-    CHECK(4 == coords_r_size);
-
-    int coords_c_3[] = {5};
-    int data_c_3[] = {5};
-    CHECK(!std::memcmp(coords_c_3, coords_r, coords_r_size));
-    CHECK(!std::memcmp(data_c_3, data_r, data_r_size));
-  } else {
-    // Check complete query status.
-    tiledb_query_get_status(ctx_, query, &status);
-    CHECK(status == TILEDB_INCOMPLETE);
-
-    // Should read last tile and first tile of second fragment (3 value).
-    CHECK(12 == data_r_size);
-    CHECK(12 == coords_r_size);
-
-    int coords_c_3[] = {5, 6, 7};
-    int data_c_3[] = {5, 6, 7};
-    CHECK(!std::memcmp(coords_c_3, coords_r, coords_r_size));
-    CHECK(!std::memcmp(data_c_3, data_r, data_r_size));
-
-    // Read again. Here per fragment budget is bigger so everything should
-    // be read.
-    rc = tiledb_query_submit(ctx_, query);
-    CHECK(rc == TILEDB_OK);
-
-    // Check incomplete query status.
-    tiledb_query_get_status(ctx_, query, &status);
-    CHECK(status == TILEDB_COMPLETED);
-
-    // Expecting 3 values.
-    CHECK(12 == data_r_size);
-    CHECK(12 == coords_r_size);
-
-    int coords_c_4[] = {8, 9, 10};
-    int data_c_4[] = {8, 9, 10};
-    CHECK(!std::memcmp(coords_c_4, coords_r, coords_r_size));
-    CHECK(!std::memcmp(data_c_4, data_r, data_r_size));
-  }
 
   // Clean up.
   rc = tiledb_array_close(ctx_, array);

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1122,7 +1122,7 @@ TEST_CASE(
   query_buffer.original_buffer_var_size_ = 6;
 
   // Call the function.
-  auto&& [var_buffer_size, result_tiles_size] =
+  auto&& [buffers_full, var_buffer_size, result_tiles_size] =
       SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
           uint64_t>(
           &tiledb::test::g_helper_stats,
@@ -1132,6 +1132,7 @@ TEST_CASE(
           query_buffer);
 
   // Validate results.
+  CHECK(buffers_full == true);
   CHECK(cell_offsets[1] == 3);
   CHECK(result_tiles_size == 1);
   CHECK(var_buffer_size == 6);
@@ -1172,7 +1173,7 @@ TEST_CASE(
   query_buffer.original_buffer_var_size_ = 6;
 
   // Call the function.
-  auto&& [var_buffer_size, result_tiles_size] =
+  auto&& [buffers_full, var_buffer_size, result_tiles_size] =
       SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
           uint64_t>(
           &tiledb::test::g_helper_stats,
@@ -1182,6 +1183,7 @@ TEST_CASE(
           query_buffer);
 
   // Validate results.
+  CHECK(buffers_full == true);
   CHECK(cell_offsets[1] == 3);
   CHECK(result_tiles_size == 1);
   CHECK(var_buffer_size == 6);
@@ -1227,7 +1229,7 @@ TEST_CASE(
   query_buffer.original_buffer_var_size_ = 5;
 
   // Call the function.
-  auto&& [var_buffer_size, result_tiles_size] =
+  auto&& [buffers_full, var_buffer_size, result_tiles_size] =
       SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
           uint64_t>(
           &tiledb::test::g_helper_stats,
@@ -1237,6 +1239,7 @@ TEST_CASE(
           query_buffer);
 
   // Validate results.
+  CHECK(buffers_full == true);
   CHECK(cell_offsets[1] == 2);
   CHECK(result_tiles_size == 1);
   CHECK(var_buffer_size == 4);

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -857,13 +857,16 @@ void Dimension::relevant_ranges(
     const NDRange& ranges,
     const Range& mbr,
     std::vector<uint64_t>& relevant_ranges) {
-  const auto d2 = (const T*)mbr.start();
-  const auto d2_0 = d2[0];
-  const auto d2_1 = d2[1];
+  const auto mbr_data = (const T*)mbr.start();
+  const auto mbr_start = mbr_data[0];
+  const auto mbr_end = mbr_data[1];
 
-  // Find lower bound
+  // Binary search to find the first range containing the start mbr.
   auto it = std::lower_bound(
-      ranges.begin(), ranges.end(), d2_0, [&](const Range& a, const T value) {
+      ranges.begin(),
+      ranges.end(),
+      mbr_start,
+      [&](const Range& a, const T value) {
         return ((const T*)a.start())[1] < value;
       });
 
@@ -875,7 +878,7 @@ void Dimension::relevant_ranges(
   // Find upper bound to end comparisons. Finding this early allows avoiding the
   // conditional exit in the for loop below
   auto it2 = std::lower_bound(
-      it, ranges.end(), d2_1, [&](const Range& a, const T value) {
+      it, ranges.end(), mbr_end, [&](const Range& a, const T value) {
         return ((const T*)a.start())[0] < value;
       });
 
@@ -889,7 +892,7 @@ void Dimension::relevant_ranges(
   for (uint64_t r = start_range; r < end_range; ++r) {
     const auto d1 = (const T*)ranges[r].start();
 
-    if ((d1[0] <= d2_1 && d1[1] >= d2_0))
+    if ((d1[0] <= mbr_end && d1[1] >= mbr_start))
       relevant_ranges.emplace_back(r);
   }
 }

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1110,10 +1110,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    Ratio of the budget allocated for array data in the sparse global
  *    order reader. <br>
  *    **Default**: 0.1
- * - `sm.mem.reader.sparse_global_order.ratio_rcs` <br>
- *    Ratio of the budget allocated for result cell slabs in the sparse
- *    global order reader. <br>
- *    **Default**: 0.05
  * - `sm.mem.reader.sparse_unordered_with_dups.ratio_coords` <br>
  *    Ratio of the budget allocated for coordinates in the sparse unordered
  *    with duplicates reader. <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -86,7 +86,6 @@ const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION =
     "0.25";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES = "0.1";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA = "0.1";
-const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RCS = "0.05";
 const std::string Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS =
     "0.5";
 const std::string
@@ -247,8 +246,6 @@ Config::Config() {
       SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES;
   param_values_["sm.mem.reader.sparse_global_order.ratio_array_data"] =
       SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA;
-  param_values_["sm.mem.reader.sparse_global_order.ratio_rcs"] =
-      SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RCS;
   param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
       SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS;
   param_values_
@@ -560,9 +557,6 @@ Status Config::unset(const std::string& param) {
   } else if (param == "sm.mem.reader.sparse_global_order.ratio_array_data") {
     param_values_["sm.mem.reader.sparse_global_order.ratio_array_data"] =
         SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA;
-  } else if (param == "sm.mem.reader.sparse_global_order.ratio_rcs") {
-    param_values_["sm.mem.reader.sparse_global_order.ratio_rcs"] =
-        SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RCS;
   } else if (param == "sm.mem.reader.sparse_unordered_with_dups.ratio_coords") {
     param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
         SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS;

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -175,10 +175,6 @@ class Config {
   /** Ratio of the sparse global order reader budget used for array data. */
   static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA;
 
-  /** Ratio of the sparse global order reader budget used for result cell slabs.
-   */
-  static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_RCS;
-
   /** Ratio of the sparse unordered with dups reader budget used for coords. */
   static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -421,10 +421,6 @@ class Config {
    *    Ratio of the budget allocated for array data in the sparse global
    *    order reader. <br>
    *    **Default**: 0.1
-   * - `sm.mem.reader.sparse_global_order.ratio_rcs` <br>
-   *    Ratio of the budget allocated for result cell slabs in the sparse
-   *    global order reader. <br>
-   *    **Default**: 0.05
    * - `sm.mem.reader.sparse_unordered_with_dups.ratio_coords` <br>
    *    Ratio of the budget allocated for coordinates in the sparse unordered
    *    with duplicates reader. <br>

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -250,7 +250,7 @@ Status DenseReader::dense_read() {
   // relevant result tiles of the dense fragments.
   std::map<const DimType*, ResultSpaceTile<DimType>> result_space_tiles;
   compute_result_space_tiles<DimType>(
-      &subarray, read_state_.partitioner_.subarray(), &result_space_tiles);
+      subarray, read_state_.partitioner_.subarray(), result_space_tiles);
 
   std::vector<ResultTile*> result_tiles;
   for (const auto& result_space_tile : result_space_tiles) {
@@ -328,13 +328,13 @@ Status DenseReader::dense_read() {
   // Pre-load all attribute offsets into memory for attributes
   // in query condition to be read.
   RETURN_CANCEL_OR_ERROR(
-      load_tile_offsets(read_state_.partitioner_.subarray(), &names));
+      load_tile_offsets(read_state_.partitioner_.subarray(), names));
 
   // Read and unfilter tiles.
-  RETURN_CANCEL_OR_ERROR(read_attribute_tiles(&names, &result_tiles));
+  RETURN_CANCEL_OR_ERROR(read_attribute_tiles(names, result_tiles));
 
   for (const auto& name : names) {
-    RETURN_CANCEL_OR_ERROR(unfilter_tiles(name, &result_tiles));
+    RETURN_CANCEL_OR_ERROR(unfilter_tiles(name, result_tiles));
   }
 
   // Compute the result of the query condition.
@@ -372,8 +372,9 @@ Status DenseReader::dense_read() {
 
   // Fill coordinates if the user requested them.
   if (!read_state_.overflowed_ && has_coords()) {
-    RETURN_CANCEL_OR_ERROR(fill_dense_coords<DimType>(subarray));
-    read_state_.overflowed_ = copy_overflowed_;
+    auto&& [st, overflowed] = fill_dense_coords<DimType>(subarray);
+    RETURN_CANCEL_OR_ERROR(st);
+    read_state_.overflowed_ = *overflowed;
   }
 
   return Status::Ok();
@@ -472,7 +473,6 @@ Status DenseReader::init_read_state() {
 
   read_state_.unsplittable_ = false;
   read_state_.overflowed_ = false;
-  copy_overflowed_ = false;
   read_state_.initialized_ = true;
 
   return Status::Ok();

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -409,12 +409,12 @@ uint64_t create_new_result_slab(
     uint64_t stride,
     uint64_t current,
     ResultTile* const result_tile,
-    std::vector<ResultCellSlab>* const out_result_cell_slabs) {
+    std::vector<ResultCellSlab>& result_cell_slabs) {
   // Create a result cell slab if there are pending cells.
   if (pending_start != start + current) {
     const uint64_t rcs_start = start + ((pending_start - start) * stride);
     const uint64_t rcs_length = current - (pending_start - start);
-    out_result_cell_slabs->emplace_back(result_tile, rcs_start, rcs_length);
+    result_cell_slabs.emplace_back(result_tile, rcs_start, rcs_length);
   }
 
   // Return the new start of the pending result cell slab.
@@ -422,14 +422,14 @@ uint64_t create_new_result_slab(
 }
 
 template <typename T, QueryConditionOp Op>
-void QueryCondition::apply_clause(
+std::vector<ResultCellSlab> QueryCondition::apply_clause(
     const QueryCondition::Clause& clause,
     const uint64_t stride,
     const bool var_size,
     const bool nullable,
     const ByteVecValue& fill_value,
-    const std::vector<ResultCellSlab>& result_cell_slabs,
-    std::vector<ResultCellSlab>* const out_result_cell_slabs) const {
+    const std::vector<ResultCellSlab>& result_cell_slabs) const {
+  std::vector<ResultCellSlab> ret;
   const std::string& field_name = clause.field_name_;
 
   for (const auto& rcs : result_cell_slabs) {
@@ -445,7 +445,7 @@ void QueryCondition::apply_clause(
           clause.condition_value_,
           clause.condition_value_data_.size());
       if (cmp) {
-        out_result_cell_slabs->emplace_back(result_tile, start, length);
+        ret.emplace_back(result_tile, start, length);
       }
     } else {
       const auto tile_tuple = result_tile->tile_tuple(field_name);
@@ -496,12 +496,7 @@ void QueryCondition::apply_clause(
               clause.condition_value_data_.size());
           if (!cmp) {
             pending_start = create_new_result_slab(
-                start,
-                pending_start,
-                stride,
-                c,
-                result_tile,
-                out_result_cell_slabs);
+                start, pending_start, stride, c, result_tile, ret);
           }
 
           ++c;
@@ -531,12 +526,7 @@ void QueryCondition::apply_clause(
               clause.condition_value_data_.size());
           if (!cmp) {
             pending_start = create_new_result_slab(
-                start,
-                pending_start,
-                stride,
-                c,
-                result_tile,
-                out_result_cell_slabs);
+                start, pending_start, stride, c, result_tile, ret);
           }
 
           ++c;
@@ -544,102 +534,70 @@ void QueryCondition::apply_clause(
       }
 
       // Create the final result cell slab if there are pending cells.
-      create_new_result_slab(
-          start, pending_start, stride, c, result_tile, out_result_cell_slabs);
+      create_new_result_slab(start, pending_start, stride, c, result_tile, ret);
     }
   }
+
+  return ret;
 }
 
 template <typename T>
-Status QueryCondition::apply_clause(
+std::tuple<Status, std::optional<std::vector<ResultCellSlab>>>
+QueryCondition::apply_clause(
     const Clause& clause,
     const uint64_t stride,
     const bool var_size,
     const bool nullable,
     const ByteVecValue& fill_value,
-    const std::vector<ResultCellSlab>& result_cell_slabs,
-    std::vector<ResultCellSlab>* const out_result_cell_slabs) const {
+    const std::vector<ResultCellSlab>& result_cell_slabs) const {
+  std::vector<ResultCellSlab> ret;
   switch (clause.op_) {
     case QueryConditionOp::LT:
-      apply_clause<T, QueryConditionOp::LT>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+      ret = apply_clause<T, QueryConditionOp::LT>(
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
       break;
     case QueryConditionOp::LE:
-      apply_clause<T, QueryConditionOp::LE>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+      ret = apply_clause<T, QueryConditionOp::LE>(
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
       break;
     case QueryConditionOp::GT:
-      apply_clause<T, QueryConditionOp::GT>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+      ret = apply_clause<T, QueryConditionOp::GT>(
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
       break;
     case QueryConditionOp::GE:
-      apply_clause<T, QueryConditionOp::GE>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+      ret = apply_clause<T, QueryConditionOp::GE>(
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
       break;
     case QueryConditionOp::EQ:
-      apply_clause<T, QueryConditionOp::EQ>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+      ret = apply_clause<T, QueryConditionOp::EQ>(
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
       break;
     case QueryConditionOp::NE:
-      apply_clause<T, QueryConditionOp::NE>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+      ret = apply_clause<T, QueryConditionOp::NE>(
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
       break;
     default:
-      return Status_QueryConditionError(
-          "Cannot perform query comparison; Unknown query "
-          "condition operator");
+      return {Status_QueryConditionError(
+                  "Cannot perform query comparison; Unknown query "
+                  "condition operator"),
+              std::nullopt};
   }
 
-  return Status::Ok();
+  return {Status::Ok(), std::move(ret)};
 }
 
-Status QueryCondition::apply_clause(
+std::tuple<Status, std::optional<std::vector<ResultCellSlab>>>
+QueryCondition::apply_clause(
     const QueryCondition::Clause& clause,
     const ArraySchema* const array_schema,
     const uint64_t stride,
-    const std::vector<ResultCellSlab>& result_cell_slabs,
-    std::vector<ResultCellSlab>* const out_result_cell_slabs) const {
+    const std::vector<ResultCellSlab>& result_cell_slabs) const {
   const Attribute* const attribute =
       array_schema->attribute(clause.field_name_);
   if (!attribute) {
-    return Status_QueryConditionError(
-        "Unknown attribute " + clause.field_name_);
+    return {
+        Status_QueryConditionError("Unknown attribute " + clause.field_name_),
+        std::nullopt};
   }
 
   const ByteVecValue fill_value = attribute->fill_value();
@@ -648,112 +606,40 @@ Status QueryCondition::apply_clause(
   switch (attribute->type()) {
     case Datatype::INT8:
       return apply_clause<int8_t>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::UINT8:
       return apply_clause<uint8_t>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::INT16:
       return apply_clause<int16_t>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::UINT16:
       return apply_clause<uint16_t>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::INT32:
       return apply_clause<int32_t>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::UINT32:
       return apply_clause<uint32_t>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::INT64:
       return apply_clause<int64_t>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::UINT64:
       return apply_clause<uint64_t>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::FLOAT32:
       return apply_clause<float>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::FLOAT64:
       return apply_clause<double>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::STRING_ASCII:
       return apply_clause<char*>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::CHAR:
       return apply_clause<char>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::DATETIME_YEAR:
     case Datatype::DATETIME_MONTH:
     case Datatype::DATETIME_WEEK:
@@ -768,13 +654,7 @@ Status QueryCondition::apply_clause(
     case Datatype::DATETIME_FS:
     case Datatype::DATETIME_AS:
       return apply_clause<int64_t>(
-          clause,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          out_result_cell_slabs);
+          clause, stride, var_size, nullable, fill_value, result_cell_slabs);
     case Datatype::ANY:
     case Datatype::BLOB:
     case Datatype::STRING_UTF8:
@@ -783,18 +663,19 @@ Status QueryCondition::apply_clause(
     case Datatype::STRING_UCS2:
     case Datatype::STRING_UCS4:
     default:
-      return Status_QueryConditionError(
-          "Cannot perform query comparison; Unsupported query "
-          "conditional type on " +
-          clause.field_name_);
+      return {Status_QueryConditionError(
+                  "Cannot perform query comparison; Unsupported query "
+                  "conditional type on " +
+                  clause.field_name_),
+              std::nullopt};
   }
 
-  return Status::Ok();
+  return {Status::Ok(), std::nullopt};
 }
 
 Status QueryCondition::apply(
     const ArraySchema* const array_schema,
-    std::vector<ResultCellSlab>* const result_cell_slabs,
+    std::vector<ResultCellSlab>& result_cell_slabs,
     const uint64_t stride) const {
   if (clauses_.empty()) {
     return Status::Ok();
@@ -805,14 +686,10 @@ Status QueryCondition::apply(
   // clauses. This assumes all clauses are combined with a
   // logical "AND".
   for (const auto& clause : clauses_) {
-    std::vector<ResultCellSlab> tmp_result_cell_slabs;
-    RETURN_NOT_OK(apply_clause(
-        clause,
-        array_schema,
-        stride,
-        *result_cell_slabs,
-        &tmp_result_cell_slabs));
-    *result_cell_slabs = tmp_result_cell_slabs;
+    auto&& [st, tmp_result_cell_slabs] =
+        apply_clause(clause, array_schema, stride, result_cell_slabs);
+    RETURN_NOT_OK(st);
+    result_cell_slabs = std::move(*tmp_result_cell_slabs);
   }
 
   return Status::Ok();

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -227,7 +227,7 @@ class QueryCondition {
    */
   Status apply(
       const ArraySchema* array_schema,
-      std::vector<ResultCellSlab>* result_cell_slabs,
+      std::vector<ResultCellSlab>& result_cell_slabs,
       uint64_t stride) const;
 
   /**
@@ -347,17 +347,16 @@ class QueryCondition {
    * @param nullable The attribute is nullable or not.
    * @param fill_value The fill value for the cells.
    * @param result_cell_slabs The input cell slabs.
-   * @param out_result_cell_slabs The filtered cell slabs.
+   * @return The filtered cell slabs.
    */
   template <typename T, QueryConditionOp Op>
-  void apply_clause(
+  std::vector<ResultCellSlab> apply_clause(
       const Clause& clause,
       uint64_t stride,
       const bool var_size,
       const bool nullable,
       const ByteVecValue& fill_value,
-      const std::vector<ResultCellSlab>& result_cell_slabs,
-      std::vector<ResultCellSlab>* out_result_cell_slabs) const;
+      const std::vector<ResultCellSlab>& result_cell_slabs) const;
 
   /**
    * Applies a clause on primitive-typed result cell slabs.
@@ -368,17 +367,16 @@ class QueryCondition {
    * @param nullable The attribute is nullable or not.
    * @param fill_value The fill value for the cells.
    * @param result_cell_slabs The input cell slabs.
-   * @param out_result_cell_slabs The filtered cell slabs.
+   * @return Status, filtered cell slabs.
    */
   template <typename T>
-  Status apply_clause(
+  std::tuple<Status, std::optional<std::vector<ResultCellSlab>>> apply_clause(
       const Clause& clause,
       uint64_t stride,
       const bool var_size,
       const bool nullable,
       const ByteVecValue& fill_value,
-      const std::vector<ResultCellSlab>& result_cell_slabs,
-      std::vector<ResultCellSlab>* out_result_cell_slabs) const;
+      const std::vector<ResultCellSlab>& result_cell_slabs) const;
 
   /**
    * Applies a clause to filter result cells from the input
@@ -388,14 +386,13 @@ class QueryCondition {
    * @param array_schema The current array schema.
    * @param stride The stride between cells.
    * @param result_cell_slabs The input cell slabs.
-   * @param out_result_cell_slabs The filtered cell slabs.
+   * @return Status, filtered cell slabs.
    */
-  Status apply_clause(
+  std::tuple<Status, std::optional<std::vector<ResultCellSlab>>> apply_clause(
       const QueryCondition::Clause& clause,
       const ArraySchema* const array_schema,
       uint64_t stride,
-      const std::vector<ResultCellSlab>& result_cell_slabs,
-      std::vector<ResultCellSlab>* out_result_cell_slabs) const;
+      const std::vector<ResultCellSlab>& result_cell_slabs) const;
 
   /**
    * Applies a clause on a dense result tile,
@@ -408,7 +405,6 @@ class QueryCondition {
    * @param src_cell The cell offset in the source tile.
    * @param stride The stride between cells.
    * @param var_size The attribute is var sized or not.
-
    * @param result_buffer The result buffer.
    */
   template <typename T, QueryConditionOp Op>
@@ -433,6 +429,7 @@ class QueryCondition {
    * @param stride The stride between cells.
    * @param var_size The attribute is var sized or not.
    * @param result_buffer The result buffer.
+   * @return Status.
    */
   template <typename T>
   Status apply_clause_dense(
@@ -457,6 +454,7 @@ class QueryCondition {
    * @param src_cell The cell offset in the source tile.
    * @param stride The stride between cells.
    * @param result_buffer The result buffer.
+   * @return Status.
    */
   Status apply_clause_dense(
       const QueryCondition::Clause& clause,
@@ -491,6 +489,7 @@ class QueryCondition {
    * @param result_tile The result tile to get the cells from.
    * @param var_size The attribute is var sized or not.
    * @param result_bitmap The result bitmap.
+   * @return Status.
    */
   template <typename T, typename BitmapType>
   Status apply_clause_sparse(
@@ -507,6 +506,7 @@ class QueryCondition {
    * @param array_schema The current array schema.
    * @param result_tile The result tile to get the cells from.
    * @param result_bitmap The result bitmap.
+   * @return Status.
    */
   template <typename BitmapType>
   Status apply_clause_sparse(

--- a/tiledb/sm/query/query_macros.h
+++ b/tiledb/sm/query/query_macros.h
@@ -54,6 +54,22 @@ namespace sm {
   } while (false)
 #endif
 
+#ifndef RETURN_CANCEL_OR_ERROR_TUPLE
+/**
+ * Returns an error status if the given Status is not Status::Ok, or
+ * if the StorageManager that owns this Query has requested cancellation.
+ */
+#define RETURN_CANCEL_OR_ERROR_TUPLE(s)                             \
+  do {                                                              \
+    Status _s = (s);                                                \
+    if (!_s.ok()) {                                                 \
+      return {_s, std::nullopt};                                    \
+    } else if (storage_manager_->cancellation_in_progress()) {      \
+      return {Status_QueryError("Query cancelled."), std::nullopt}; \
+    }                                                               \
+  } while (false)
+#endif
+
 #ifndef RETURN_CANCEL_OR_ERROR_ELSE
 /**
  * Returns an error status if the given Status is not Status::Ok, or

--- a/tiledb/sm/query/read_cell_slab_iter.cc
+++ b/tiledb/sm/query/read_cell_slab_iter.cc
@@ -331,7 +331,7 @@ void ReadCellSlabIter<T>::compute_result_cell_slabs_dense(
 
   // Append temporary results for empty cell slabs
   compute_result_cell_slabs_empty(
-      *result_space_tile, to_process, &result_cell_slabs);
+      *result_space_tile, to_process, result_cell_slabs);
 
   // Sort the temporary result cell slabs on starting position
   std::sort(result_cell_slabs.begin(), result_cell_slabs.end());
@@ -347,7 +347,7 @@ template <class T>
 void ReadCellSlabIter<T>::compute_result_cell_slabs_empty(
     const ResultSpaceTile<T>& result_space_tile,
     const std::list<CellSlab<T>>& to_process,
-    std::vector<ResultCellSlab>* result_cell_slabs) {
+    std::vector<ResultCellSlab>& result_cell_slabs) {
   // Nothing to process
   if (to_process.empty())
     return;
@@ -357,7 +357,7 @@ void ReadCellSlabIter<T>::compute_result_cell_slabs_empty(
   for (auto pit = to_process.begin(); pit != to_process.end(); ++pit) {
     compute_cell_slab_start(
         &pit->coords_[0], result_space_tile.start_coords(), &start);
-    result_cell_slabs->emplace_back(nullptr, start, pit->length_);
+    result_cell_slabs.emplace_back(nullptr, start, pit->length_);
   }
 }
 

--- a/tiledb/sm/query/read_cell_slab_iter.h
+++ b/tiledb/sm/query/read_cell_slab_iter.h
@@ -263,7 +263,7 @@ class ReadCellSlabIter {
   void compute_result_cell_slabs_empty(
       const ResultSpaceTile<T>& result_space_tile,
       const std::list<CellSlab<T>>& to_process,
-      std::vector<ResultCellSlab>* result_cell_slabs);
+      std::vector<ResultCellSlab>& result_cell_slabs);
 
   /**
    * Splits the input cell slab into up to two new cell slabs based on the

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -206,7 +206,6 @@ Status Reader::dowork() {
     stats_->add_counter("loop_num", 1);
 
     read_state_.overflowed_ = false;
-    copy_overflowed_ = false;
     reset_buffer_sizes();
 
     // Perform read
@@ -255,11 +254,11 @@ void Reader::reset() {
 /* ****************************** */
 
 Status Reader::apply_query_condition(
-    std::vector<ResultCellSlab>* const result_cell_slabs,
-    std::vector<ResultTile*>* result_tiles,
-    Subarray* subarray,
+    std::vector<ResultCellSlab>& result_cell_slabs,
+    std::vector<ResultTile*>& result_tiles,
+    Subarray& subarray,
     uint64_t stride) {
-  if (condition_.empty() || result_cell_slabs->empty())
+  if (condition_.empty() || result_cell_slabs.empty())
     return Status::Ok();
 
   // To evaluate the query condition, we need to read tiles for the
@@ -272,13 +271,8 @@ Status Reader::apply_query_condition(
 
   // Each element in `names` has been flagged with `ProcessTileFlag::READ`.
   // This will read the tiles, but will not copy them into the user buffers.
-  RETURN_NOT_OK(process_tiles(
-      &names,
-      result_tiles,
-      result_cell_slabs,
-      subarray,
-      stride,
-      std::numeric_limits<uint64_t>::max()));
+  RETURN_NOT_OK(
+      process_tiles(names, result_tiles, result_cell_slabs, subarray, stride));
 
   // The `UINT64_MAX` is a sentinel value to indicate that we do not
   // use a stride in the cell index calculation. To simplify our logic,
@@ -293,7 +287,7 @@ Status Reader::apply_query_condition(
 
 Status Reader::compute_result_cell_slabs(
     const std::vector<ResultCoords>& result_coords,
-    std::vector<ResultCellSlab>* result_cell_slabs) const {
+    std::vector<ResultCellSlab>& result_cell_slabs) const {
   auto timer_se =
       stats_->start_timer("compute_sparse_result_cell_slabs_sparse");
 
@@ -320,7 +314,7 @@ Status Reader::compute_result_cell_slabs(
       end_pos = it->pos_;
     } else {
       // New range - append previous range
-      result_cell_slabs->emplace_back(tile, start_pos, end_pos - start_pos + 1);
+      result_cell_slabs.emplace_back(tile, start_pos, end_pos - start_pos + 1);
       start_pos = it->pos_;
       end_pos = start_pos;
       tile = it->tile_;
@@ -329,21 +323,21 @@ Status Reader::compute_result_cell_slabs(
   }
 
   // Append the last range
-  result_cell_slabs->emplace_back(tile, start_pos, end_pos - start_pos + 1);
+  result_cell_slabs.emplace_back(tile, start_pos, end_pos - start_pos + 1);
 
   return Status::Ok();
 }
 
 Status Reader::compute_range_result_coords(
-    Subarray* subarray,
+    Subarray& subarray,
     unsigned frag_idx,
     ResultTile* tile,
     uint64_t range_idx,
-    std::vector<ResultCoords>* result_coords) {
+    std::vector<ResultCoords>& result_coords) {
   auto coords_num = tile->cell_num();
   auto dim_num = array_schema_->dim_num();
   auto cell_order = array_schema_->cell_order();
-  auto range_coords = subarray->get_range_coords(range_idx);
+  auto range_coords = subarray.get_range_coords(range_idx);
 
   if (array_schema_->dense()) {
     std::vector<uint8_t> result_bitmap(coords_num, 1);
@@ -351,7 +345,7 @@ Status Reader::compute_range_result_coords(
 
     // Compute result and overwritten bitmap per dimension
     for (unsigned d = 0; d < dim_num; ++d) {
-      const auto& ranges = subarray->ranges_for_dim(d);
+      const auto& ranges = subarray.ranges_for_dim(d);
       RETURN_NOT_OK(tile->compute_results_dense(
           d,
           ranges[range_coords[d]],
@@ -364,7 +358,7 @@ Status Reader::compute_range_result_coords(
     // Gather results
     for (uint64_t pos = 0; pos < coords_num; ++pos) {
       if (result_bitmap[pos] && !overwritten_bitmap[pos])
-        result_coords->emplace_back(tile, pos);
+        result_coords.emplace_back(tile, pos);
     }
   } else {  // Sparse
     std::vector<uint8_t> result_bitmap(coords_num, 1);
@@ -375,8 +369,8 @@ Status Reader::compute_range_result_coords(
       // in reverse.
       const unsigned dim_idx =
           cell_order == Layout::COL_MAJOR ? dim_num - d - 1 : d;
-      if (!subarray->is_default(dim_idx)) {
-        const auto& ranges = subarray->ranges_for_dim(dim_idx);
+      if (!subarray.is_default(dim_idx)) {
+        const auto& ranges = subarray.ranges_for_dim(dim_idx);
         RETURN_NOT_OK(tile->compute_results_sparse(
             dim_idx,
             ranges[range_coords[dim_idx]],
@@ -388,7 +382,7 @@ Status Reader::compute_range_result_coords(
     // Gather results
     for (uint64_t pos = 0; pos < coords_num; ++pos) {
       if (result_bitmap[pos])
-        result_coords->emplace_back(tile, pos);
+        result_coords.emplace_back(tile, pos);
     }
   }
 
@@ -396,15 +390,15 @@ Status Reader::compute_range_result_coords(
 }
 
 Status Reader::compute_range_result_coords(
-    Subarray* subarray,
+    Subarray& subarray,
     const std::vector<bool>& single_fragment,
     const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
-    std::vector<ResultTile>* result_tiles,
-    std::vector<std::vector<ResultCoords>>* range_result_coords) {
+    std::vector<ResultTile>& result_tiles,
+    std::vector<std::vector<ResultCoords>>& range_result_coords) {
   auto timer_se = stats_->start_timer("compute_range_result_coords");
 
-  auto range_num = subarray->range_num();
-  range_result_coords->resize(range_num);
+  auto range_num = subarray.range_num();
+  range_result_coords.resize(range_num);
   auto cell_order = array_schema_->cell_order();
   auto allows_dups = array_schema_->allows_dups();
 
@@ -428,18 +422,17 @@ Status Reader::compute_range_result_coords(
             r,
             result_tile_map,
             result_tiles,
-            &((*range_result_coords)[r])));
+            range_result_coords[r]));
 
         // Dedup unless there is a single fragment or array schema allows
         // duplicates
         if (!single_fragment[r] && !allows_dups) {
           RETURN_CANCEL_OR_ERROR(sort_result_coords(
-              ((*range_result_coords)[r]).begin(),
-              ((*range_result_coords)[r]).end(),
-              ((*range_result_coords)[r]).size(),
+              range_result_coords[r].begin(),
+              range_result_coords[r].end(),
+              range_result_coords[r].size(),
               sort_layout));
-          RETURN_CANCEL_OR_ERROR(
-              dedup_result_coords(&((*range_result_coords)[r])));
+          RETURN_CANCEL_OR_ERROR(dedup_result_coords(range_result_coords[r]));
         }
 
         return Status::Ok();
@@ -451,22 +444,22 @@ Status Reader::compute_range_result_coords(
 }
 
 Status Reader::compute_range_result_coords(
-    Subarray* subarray,
+    Subarray& subarray,
     uint64_t range_idx,
     uint32_t fragment_idx,
     const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
-    std::vector<ResultTile>* result_tiles,
-    std::vector<ResultCoords>* range_result_coords) {
+    std::vector<ResultTile>& result_tiles,
+    std::vector<ResultCoords>& range_result_coords) {
   // Skip dense fragments
   if (fragment_metadata_[fragment_idx]->dense())
     return Status::Ok();
 
   auto tr =
-      subarray->tile_overlap(fragment_idx, range_idx)->tile_ranges_.begin();
+      subarray.tile_overlap(fragment_idx, range_idx)->tile_ranges_.begin();
   auto tr_end =
-      subarray->tile_overlap(fragment_idx, range_idx)->tile_ranges_.end();
-  auto t = subarray->tile_overlap(fragment_idx, range_idx)->tiles_.begin();
-  auto t_end = subarray->tile_overlap(fragment_idx, range_idx)->tiles_.end();
+      subarray.tile_overlap(fragment_idx, range_idx)->tile_ranges_.end();
+  auto t = subarray.tile_overlap(fragment_idx, range_idx)->tiles_.begin();
+  auto t_end = subarray.tile_overlap(fragment_idx, range_idx)->tiles_.end();
 
   while (tr != tr_end || t != t_end) {
     // Handle tile range
@@ -476,7 +469,7 @@ Status Reader::compute_range_result_coords(
         auto tile_it = result_tile_map.find(pair);
         assert(tile_it != result_tile_map.end());
         auto tile_idx = tile_it->second;
-        auto& tile = (*result_tiles)[tile_idx];
+        auto& tile = result_tiles[tile_idx];
 
         // Add results only if the sparse tile MBR is not fully
         // covered by a more recent fragment's non-empty domain
@@ -490,7 +483,7 @@ Status Reader::compute_range_result_coords(
       auto tile_it = result_tile_map.find(pair);
       assert(tile_it != result_tile_map.end());
       auto tile_idx = tile_it->second;
-      auto& tile = (*result_tiles)[tile_idx];
+      auto& tile = result_tiles[tile_idx];
       if (t->second == 1.0) {  // Full overlap
         // Add results only if the sparse tile MBR is not fully
         // covered by a more recent fragment's non-empty domain
@@ -508,11 +501,11 @@ Status Reader::compute_range_result_coords(
 }
 
 Status Reader::compute_range_result_coords(
-    Subarray* subarray,
+    Subarray& subarray,
     uint64_t range_idx,
     const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
-    std::vector<ResultTile>* result_tiles,
-    std::vector<ResultCoords>* range_result_coords) {
+    std::vector<ResultTile>& result_tiles,
+    std::vector<ResultCoords>& range_result_coords) {
   // Gather result range coordinates per fragment
   auto fragment_num = fragment_metadata_.size();
   std::vector<std::vector<ResultCoords>> range_result_coords_vec(fragment_num);
@@ -524,32 +517,32 @@ Status Reader::compute_range_result_coords(
             f,
             result_tile_map,
             result_tiles,
-            &range_result_coords_vec[f]);
+            range_result_coords_vec[f]);
       });
   RETURN_NOT_OK(status);
 
   // Consolidate the result coordinates in the single result vector
   for (const auto& vec : range_result_coords_vec) {
     for (const auto& r : vec)
-      range_result_coords->emplace_back(r);
+      range_result_coords.emplace_back(r);
   }
 
   return Status::Ok();
 }
 
 Status Reader::compute_subarray_coords(
-    std::vector<std::vector<ResultCoords>>* range_result_coords,
-    std::vector<ResultCoords>* result_coords) {
+    std::vector<std::vector<ResultCoords>>& range_result_coords,
+    std::vector<ResultCoords>& result_coords) {
   auto timer_se = stats_->start_timer("compute_subarray_coords");
   // The input 'result_coords' is already sorted. Save the current size
   // before inserting new elements.
-  const size_t result_coords_size = result_coords->size();
+  const size_t result_coords_size = result_coords.size();
 
   // Add all valid ``range_result_coords`` to ``result_coords``
-  for (const auto& rv : *range_result_coords) {
+  for (const auto& rv : range_result_coords) {
     for (const auto& c : rv) {
       if (c.valid())
-        result_coords->emplace_back(c.tile_, c.pos_);
+        result_coords.emplace_back(c.tile_, c.pos_);
     }
   }
 
@@ -565,20 +558,20 @@ Status Reader::compute_subarray_coords(
   auto dim_num = array_schema_->dim_num();
   bool must_sort = true;
   auto allows_dups = array_schema_->allows_dups();
-  auto single_range = (range_result_coords->size() == 1);
+  auto single_range = (range_result_coords.size() == 1);
   if (layout_ == Layout::GLOBAL_ORDER || dim_num == 1) {
     must_sort = !belong_to_single_fragment(
-        result_coords->begin() + result_coords_size, result_coords->end());
+        result_coords.begin() + result_coords_size, result_coords.end());
   } else if (single_range && !allows_dups) {
     must_sort = belong_to_single_fragment(
-        result_coords->begin() + result_coords_size, result_coords->end());
+        result_coords.begin() + result_coords_size, result_coords.end());
   }
 
   if (must_sort) {
     RETURN_NOT_OK(sort_result_coords(
-        result_coords->begin() + result_coords_size,
-        result_coords->end(),
-        result_coords->size() - result_coords_size,
+        result_coords.begin() + result_coords_size,
+        result_coords.end(),
+        result_coords.size() - result_coords_size,
         layout_));
   }
 
@@ -586,7 +579,7 @@ Status Reader::compute_subarray_coords(
 }
 
 Status Reader::compute_sparse_result_tiles(
-    std::vector<ResultTile>* result_tiles,
+    std::vector<ResultTile>& result_tiles,
     std::map<std::pair<unsigned, uint64_t>, size_t>* result_tile_map,
     std::vector<bool>* single_fragment) {
   auto timer_se = stats_->start_timer("compute_sparse_result_tiles");
@@ -605,7 +598,7 @@ Status Reader::compute_sparse_result_tiles(
   for (uint64_t i = 0; i < range_num; ++i)
     (*single_fragment)[i] = true;
 
-  result_tiles->clear();
+  result_tiles.clear();
   for (unsigned f = 0; f < fragment_num; ++f) {
     // Skip dense fragments
     if (fragment_metadata_[f]->dense())
@@ -619,9 +612,9 @@ Status Reader::compute_sparse_result_tiles(
           auto pair = std::pair<unsigned, uint64_t>(f, t);
           // Add tile only if it does not already exist
           if (result_tile_map->find(pair) == result_tile_map->end()) {
-            result_tiles->emplace_back(
+            result_tiles.emplace_back(
                 f, t, fragment_metadata_[f]->array_schema());
-            (*result_tile_map)[pair] = result_tiles->size() - 1;
+            (*result_tile_map)[pair] = result_tiles.size() - 1;
           }
           // Always check range for multiple fragments
           if (f > first_fragment[r])
@@ -638,9 +631,9 @@ Status Reader::compute_sparse_result_tiles(
         auto pair = std::pair<unsigned, uint64_t>(f, t);
         // Add tile only if it does not already exist
         if (result_tile_map->find(pair) == result_tile_map->end()) {
-          result_tiles->emplace_back(
+          result_tiles.emplace_back(
               f, t, fragment_metadata_[f]->array_schema());
-          (*result_tile_map)[pair] = result_tiles->size() - 1;
+          (*result_tile_map)[pair] = result_tiles.size() - 1;
         }
         // Always check range for multiple fragments
         if (f > first_fragment[r])
@@ -654,13 +647,751 @@ Status Reader::compute_sparse_result_tiles(
   return Status::Ok();
 }
 
+Status Reader::copy_coordinates(
+    const std::vector<ResultTile*>& result_tiles,
+    std::vector<ResultCellSlab>& result_cell_slabs) {
+  auto timer_se = stats_->start_timer("copy_coordinates");
+
+  if (result_cell_slabs.empty() && result_tiles.empty()) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  const uint64_t stride = UINT64_MAX;
+
+  // Build a list of coordinate names to copy, separating them by
+  // whether they are of fixed or variable length. The motivation
+  // is that copying fixed and variable cells require two different
+  // cell slab partitions. Processing them separately allows us to
+  // reduce memory use.
+  std::vector<std::string> fixed_names;
+  std::vector<std::string> var_names;
+
+  for (const auto& it : buffers_) {
+    const auto& name = it.first;
+    if (read_state_.overflowed_)
+      break;
+    if (!(name == constants::coords || array_schema_->is_dim(name)))
+      continue;
+
+    if (array_schema_->var_size(name))
+      var_names.emplace_back(name);
+    else
+      fixed_names.emplace_back(name);
+  }
+
+  // Copy result cells for fixed-sized coordinates.
+  if (!fixed_names.empty()) {
+    std::vector<size_t> fixed_cs_partitions;
+    compute_fixed_cs_partitions(result_cell_slabs, &fixed_cs_partitions);
+
+    for (const auto& name : fixed_names) {
+      RETURN_CANCEL_OR_ERROR(copy_fixed_cells(
+          name, stride, result_cell_slabs, &fixed_cs_partitions));
+      clear_tiles(name, result_tiles);
+    }
+  }
+
+  // Copy result cells for var-sized coordinates.
+  if (!var_names.empty()) {
+    std::vector<std::pair<size_t, size_t>> var_cs_partitions;
+    size_t total_var_cs_length;
+    compute_var_cs_partitions(
+        result_cell_slabs, &var_cs_partitions, &total_var_cs_length);
+
+    for (const auto& name : var_names) {
+      RETURN_CANCEL_OR_ERROR(copy_var_cells(
+          name,
+          stride,
+          result_cell_slabs,
+          &var_cs_partitions,
+          total_var_cs_length));
+      clear_tiles(name, result_tiles);
+    }
+  }
+
+  return Status::Ok();
+}
+
+Status Reader::copy_attribute_values(
+    const uint64_t stride,
+    std::vector<ResultTile*>& result_tiles,
+    std::vector<ResultCellSlab>& result_cell_slabs,
+    Subarray& subarray) {
+  auto timer_se = stats_->start_timer("copy_attr_values");
+
+  if (result_cell_slabs.empty() && result_tiles.empty()) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  // Build a set of attribute names to process.
+  std::unordered_map<std::string, ProcessTileFlags> names;
+  for (const auto& it : buffers_) {
+    const auto& name = it.first;
+
+    if (read_state_.overflowed_) {
+      break;
+    }
+
+    if (name == constants::coords || array_schema_->is_dim(name)) {
+      continue;
+    }
+
+    // If the query condition has a clause for `name`, we will only
+    // flag it to copy because we have already preloaded the offsets
+    // and read the tiles in `apply_query_condition`.
+    ProcessTileFlags flags = ProcessTileFlag::COPY;
+    if (condition_.field_names().count(name) == 0) {
+      flags |= ProcessTileFlag::READ;
+    }
+
+    names[name] = flags;
+  }
+
+  if (!names.empty()) {
+    RETURN_NOT_OK(process_tiles(
+        names, result_tiles, result_cell_slabs, subarray, stride));
+  }
+
+  return Status::Ok();
+}
+
+Status Reader::copy_fixed_cells(
+    const std::string& name,
+    uint64_t stride,
+    const std::vector<ResultCellSlab>& result_cell_slabs,
+    std::vector<size_t>* fixed_cs_partitions) {
+  auto stat_type = (array_schema_->is_attr(name)) ? "copy_fixed_attr_values" :
+                                                    "copy_fixed_coords";
+  auto timer_se = stats_->start_timer(stat_type);
+
+  if (result_cell_slabs.empty()) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  auto it = buffers_.find(name);
+  auto buffer_size = it->second.buffer_size_;
+  auto cell_size = array_schema_->cell_size(name);
+
+  // Precompute the cell range destination offsets in the buffer.
+  uint64_t buffer_offset = 0;
+  std::vector<uint64_t> cs_offsets(result_cell_slabs.size());
+  for (uint64_t i = 0; i < cs_offsets.size(); i++) {
+    const auto& cs = result_cell_slabs[i];
+    auto cs_length = cs.length_;
+
+    auto bytes_to_copy = cs_length * cell_size;
+    cs_offsets[i] = buffer_offset;
+    buffer_offset += bytes_to_copy;
+  }
+
+  // Handle overflow.
+  if (buffer_offset > *buffer_size) {
+    read_state_.overflowed_ = true;
+    return Status::Ok();
+  }
+
+  // Copy result cell slabs in parallel.
+  std::function<Status(size_t)> copy_fn = std::bind(
+      &Reader::copy_partitioned_fixed_cells,
+      this,
+      std::placeholders::_1,
+      &name,
+      stride,
+      result_cell_slabs,
+      &cs_offsets,
+      fixed_cs_partitions);
+  auto status = parallel_for(
+      storage_manager_->compute_tp(),
+      0,
+      fixed_cs_partitions->size(),
+      std::move(copy_fn));
+
+  RETURN_NOT_OK(status);
+
+  // Update buffer offsets
+  *(buffers_[name].buffer_size_) = buffer_offset;
+  if (array_schema_->is_nullable(name)) {
+    *(buffers_[name].validity_vector_.buffer_size()) =
+        (buffer_offset / cell_size) * constants::cell_validity_size;
+  }
+
+  return Status::Ok();
+}
+
+void Reader::compute_fixed_cs_partitions(
+    const std::vector<ResultCellSlab>& result_cell_slabs,
+    std::vector<size_t>* fixed_cs_partitions) {
+  if (result_cell_slabs.empty()) {
+    return;
+  }
+
+  const int num_copy_threads =
+      storage_manager_->compute_tp()->concurrency_level();
+
+  // Calculate the partition sizes.
+  auto num_cs = result_cell_slabs.size();
+  const uint64_t num_cs_partitions =
+      std::min<uint64_t>(num_copy_threads, num_cs);
+  const uint64_t cs_per_partition = num_cs / num_cs_partitions;
+  const uint64_t cs_per_partition_carry = num_cs % num_cs_partitions;
+
+  // Calculate the partition offsets.
+  uint64_t num_cs_partitioned = 0;
+  fixed_cs_partitions->reserve(num_cs_partitions);
+  for (uint64_t i = 0; i < num_cs_partitions; ++i) {
+    const uint64_t num_cs_in_partition =
+        cs_per_partition + ((i < cs_per_partition_carry) ? 1 : 0);
+    num_cs_partitioned += num_cs_in_partition;
+    fixed_cs_partitions->emplace_back(num_cs_partitioned);
+  }
+}
+
+uint64_t ReaderBase::offsets_bytesize() const {
+  assert(offsets_bitsize_ == 32 || offsets_bitsize_ == 64);
+  return offsets_bitsize_ == 32 ? sizeof(uint32_t) :
+                                  constants::cell_var_offset_size;
+}
+
+Status Reader::copy_partitioned_fixed_cells(
+    const size_t partition_idx,
+    const std::string* const name,
+    const uint64_t stride,
+    const std::vector<ResultCellSlab>& result_cell_slabs,
+    const std::vector<uint64_t>* cs_offsets,
+    const std::vector<size_t>* cs_partitions) {
+  assert(name);
+
+  // For easy reference.
+  auto nullable = array_schema_->is_nullable(*name);
+  auto it = buffers_.find(*name);
+  auto buffer = (unsigned char*)it->second.buffer_;
+  auto buffer_validity = (unsigned char*)it->second.validity_vector_.buffer();
+  auto cell_size = array_schema_->cell_size(*name);
+  ByteVecValue fill_value;
+  uint8_t fill_value_validity = 0;
+  if (array_schema_->is_attr(*name)) {
+    fill_value = array_schema_->attribute(*name)->fill_value();
+    fill_value_validity =
+        array_schema_->attribute(*name)->fill_value_validity();
+  }
+  uint64_t fill_value_size = (uint64_t)fill_value.size();
+
+  // Calculate the partition to operate on.
+  const uint64_t cs_idx_start =
+      partition_idx == 0 ? 0 : cs_partitions->at(partition_idx - 1);
+  const uint64_t cs_idx_end = cs_partitions->at(partition_idx);
+
+  // Copy the cells.
+  for (uint64_t cs_idx = cs_idx_start; cs_idx < cs_idx_end; ++cs_idx) {
+    const auto& cs = result_cell_slabs[cs_idx];
+    uint64_t offset = cs_offsets->at(cs_idx);
+    auto cs_length = cs.length_;
+
+    // Copy
+
+    // First we check if this is an older (pre TileDB 2.0) array with zipped
+    // coordinates and the user has requested split buffer if so we should
+    // proceed to copying the tile If not, and there is no tile or the tile is
+    // empty for the field then this is a read of an older fragment in schema
+    // evolution. In that case we want to set the field to fill values for this
+    // for this tile.
+    const bool split_buffer_for_zipped_coords =
+        array_schema_->is_dim(*name) && cs.tile_->stores_zipped_coords();
+    if ((cs.tile_ == nullptr || cs.tile_->tile_tuple(*name) == nullptr) &&
+        !split_buffer_for_zipped_coords) {  // Empty range or attributed added
+                                            // in schema evolution
+      auto bytes_to_copy = cs_length * cell_size;
+      auto fill_num = bytes_to_copy / fill_value_size;
+      for (uint64_t j = 0; j < fill_num; ++j) {
+        std::memcpy(buffer + offset, fill_value.data(), fill_value_size);
+        if (nullable) {
+          std::memset(
+              buffer_validity +
+                  (offset / cell_size * constants::cell_validity_size),
+              fill_value_validity,
+              constants::cell_validity_size);
+        }
+        offset += fill_value_size;
+      }
+    } else {  // Non-empty range
+      if (stride == UINT64_MAX) {
+        if (!nullable)
+          RETURN_NOT_OK(
+              cs.tile_->read(*name, buffer, offset, cs.start_, cs_length));
+        else
+          RETURN_NOT_OK(cs.tile_->read_nullable(
+              *name, buffer, offset, cs.start_, cs_length, buffer_validity));
+      } else {
+        auto cell_offset = offset;
+        auto start = cs.start_;
+        for (uint64_t j = 0; j < cs_length; ++j) {
+          if (!nullable)
+            RETURN_NOT_OK(cs.tile_->read(*name, buffer, cell_offset, start, 1));
+          else
+            RETURN_NOT_OK(cs.tile_->read_nullable(
+                *name, buffer, cell_offset, start, 1, buffer_validity));
+          cell_offset += cell_size;
+          start += stride;
+        }
+      }
+    }
+  }
+
+  return Status::Ok();
+}
+
+Status Reader::copy_var_cells(
+    const std::string& name,
+    const uint64_t stride,
+    std::vector<ResultCellSlab>& result_cell_slabs,
+    std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
+    size_t total_cs_length) {
+  auto stat_type = (array_schema_->is_attr(name)) ? "copy_var_attr_values" :
+                                                    "copy_var_coords";
+  auto timer_se = stats_->start_timer(stat_type);
+
+  if (result_cell_slabs.empty()) {
+    zero_out_buffer_sizes();
+    return Status::Ok();
+  }
+
+  std::vector<uint64_t> offset_offsets_per_cs(total_cs_length);
+  std::vector<uint64_t> var_offsets_per_cs(total_cs_length);
+
+  // Compute the destinations of offsets and var-len data in the buffers.
+  uint64_t total_offset_size, total_var_size, total_validity_size;
+  RETURN_NOT_OK(compute_var_cell_destinations(
+      name,
+      stride,
+      result_cell_slabs,
+      &offset_offsets_per_cs,
+      &var_offsets_per_cs,
+      &total_offset_size,
+      &total_var_size,
+      &total_validity_size));
+
+  // Check for overflow and return early (without copying) in that case.
+  if (read_state_.overflowed_) {
+    return Status::Ok();
+  }
+
+  // Copy result cell slabs in parallel
+  std::function<Status(size_t)> copy_fn = std::bind(
+      &Reader::copy_partitioned_var_cells,
+      this,
+      std::placeholders::_1,
+      &name,
+      stride,
+      result_cell_slabs,
+      &offset_offsets_per_cs,
+      &var_offsets_per_cs,
+      var_cs_partitions);
+  auto status = parallel_for(
+      storage_manager_->compute_tp(), 0, var_cs_partitions->size(), copy_fn);
+
+  RETURN_NOT_OK(status);
+
+  // Update buffer offsets
+  *(buffers_[name].buffer_size_) = total_offset_size;
+  *(buffers_[name].buffer_var_size_) = total_var_size;
+  if (array_schema_->is_nullable(name))
+    *(buffers_[name].validity_vector_.buffer_size()) = total_validity_size;
+
+  return Status::Ok();
+}
+
+void Reader::compute_var_cs_partitions(
+    const std::vector<ResultCellSlab>& result_cell_slabs,
+    std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
+    size_t* total_var_cs_length) {
+  if (result_cell_slabs.empty()) {
+    return;
+  }
+
+  const int num_copy_threads =
+      storage_manager_->compute_tp()->concurrency_level();
+
+  // Calculate the partition range.
+  const uint64_t num_cs = result_cell_slabs.size();
+  const uint64_t num_cs_partitions =
+      std::min<uint64_t>(num_copy_threads, num_cs);
+  const uint64_t cs_per_partition = num_cs / num_cs_partitions;
+  const uint64_t cs_per_partition_carry = num_cs % num_cs_partitions;
+
+  // Compute the boundary between each partition. Each boundary
+  // is represented by an `std::pair` that contains the total
+  // length of each cell slab in the leading partition and an
+  // exclusive cell slab index that ends the partition.
+  uint64_t next_partition_idx = cs_per_partition;
+  if (cs_per_partition_carry > 0)
+    ++next_partition_idx;
+
+  *total_var_cs_length = 0;
+  var_cs_partitions->reserve(num_cs_partitions);
+  for (uint64_t cs_idx = 0; cs_idx < num_cs; cs_idx++) {
+    if (cs_idx == next_partition_idx) {
+      var_cs_partitions->emplace_back(*total_var_cs_length, cs_idx);
+
+      // The final partition may contain extra cell slabs that did
+      // not evenly divide into the partition range. Set the
+      // `next_partition_idx` to zero and build the last boundary
+      // after this for-loop.
+      if (var_cs_partitions->size() == num_cs_partitions) {
+        next_partition_idx = 0;
+      } else {
+        next_partition_idx += cs_per_partition;
+        if (cs_idx < (cs_per_partition_carry - 1))
+          ++next_partition_idx;
+      }
+    }
+
+    *total_var_cs_length += result_cell_slabs[cs_idx].length_;
+  }
+
+  // Store the final boundary.
+  var_cs_partitions->emplace_back(*total_var_cs_length, num_cs);
+}
+
+Status Reader::compute_var_cell_destinations(
+    const std::string& name,
+    uint64_t stride,
+    std::vector<ResultCellSlab>& result_cell_slabs,
+    std::vector<uint64_t>* offset_offsets_per_cs,
+    std::vector<uint64_t>* var_offsets_per_cs,
+    uint64_t* total_offset_size,
+    uint64_t* total_var_size,
+    uint64_t* total_validity_size) {
+  // For easy reference
+  auto nullable = array_schema_->is_nullable(name);
+  auto num_cs = result_cell_slabs.size();
+  auto offset_size = offsets_bytesize();
+  ByteVecValue fill_value;
+  if (array_schema_->is_attr(name))
+    fill_value = array_schema_->attribute(name)->fill_value();
+  auto fill_value_size = (uint64_t)fill_value.size();
+
+  auto it = buffers_.find(name);
+  auto buffer_size = *it->second.buffer_size_;
+  auto buffer_var_size = *it->second.buffer_var_size_;
+  auto buffer_validity_size = it->second.validity_vector_.buffer_size();
+
+  if (offsets_extra_element_)
+    buffer_size -= offset_size;
+
+  // Compute the destinations for all result cell slabs
+  *total_offset_size = 0;
+  *total_var_size = 0;
+  *total_validity_size = 0;
+  size_t total_cs_length = 0;
+  for (uint64_t cs_idx = 0; cs_idx < num_cs; cs_idx++) {
+    const auto& cs = result_cell_slabs.at(cs_idx);
+    auto cs_length = cs.length_;
+
+    // Get tile information, if the range is nonempty.
+    uint64_t* tile_offsets = nullptr;
+    uint64_t tile_cell_num = 0;
+    uint64_t tile_var_size = 0;
+    if (cs.tile_ != nullptr && cs.tile_->tile_tuple(name) != nullptr) {
+      const auto tile_tuple = cs.tile_->tile_tuple(name);
+      const auto& tile = std::get<0>(*tile_tuple);
+      const auto& tile_var = std::get<1>(*tile_tuple);
+
+      // Get the internal buffer to the offset values.
+      Buffer* const buffer = tile.buffer();
+
+      tile_offsets = (uint64_t*)buffer->data();
+      tile_cell_num = tile.cell_num();
+      tile_var_size = tile_var.size();
+    }
+
+    // Compute the destinations for each cell in the range.
+    uint64_t dest_vec_idx = 0;
+    stride = (stride == UINT64_MAX) ? 1 : stride;
+
+    for (auto cell_idx = cs.start_; dest_vec_idx < cs_length;
+         cell_idx += stride, dest_vec_idx++) {
+      // Get size of variable-sized cell
+      uint64_t cell_var_size = 0;
+      if (cs.tile_ == nullptr || cs.tile_->tile_tuple(name) == nullptr) {
+        cell_var_size = fill_value_size;
+      } else {
+        cell_var_size =
+            (cell_idx != tile_cell_num - 1) ?
+                tile_offsets[cell_idx + 1] - tile_offsets[cell_idx] :
+                tile_var_size - (tile_offsets[cell_idx] - tile_offsets[0]);
+      }
+
+      if (*total_offset_size + offset_size > buffer_size ||
+          *total_var_size + cell_var_size > buffer_var_size ||
+          (buffer_validity_size &&
+           *total_validity_size + constants::cell_validity_size >
+               *buffer_validity_size)) {
+        read_state_.overflowed_ = true;
+
+        // In case an extra offset is configured, we need to account memory for
+        // it on each read
+        *total_offset_size += offsets_extra_element_ ? offset_size : 0;
+
+        return Status::Ok();
+      }
+
+      // Record destination offsets.
+      (*offset_offsets_per_cs)[total_cs_length + dest_vec_idx] =
+          *total_offset_size;
+      (*var_offsets_per_cs)[total_cs_length + dest_vec_idx] = *total_var_size;
+      *total_offset_size += offset_size;
+      *total_var_size += cell_var_size;
+      if (nullable)
+        *total_validity_size += constants::cell_validity_size;
+    }
+
+    total_cs_length += cs_length;
+  }
+
+  // In case an extra offset is configured, we need to account memory for it on
+  // each read
+  *total_offset_size += offsets_extra_element_ ? offset_size : 0;
+
+  return Status::Ok();
+}
+
+Status Reader::copy_partitioned_var_cells(
+    const size_t partition_idx,
+    const std::string* const name,
+    uint64_t stride,
+    const std::vector<ResultCellSlab>& result_cell_slabs,
+    const std::vector<uint64_t>* const offset_offsets_per_cs,
+    const std::vector<uint64_t>* const var_offsets_per_cs,
+    const std::vector<std::pair<size_t, size_t>>* const cs_partitions) {
+  assert(name);
+
+  auto it = buffers_.find(*name);
+  auto nullable = array_schema_->is_nullable(*name);
+  auto buffer = (unsigned char*)it->second.buffer_;
+  auto buffer_var = (unsigned char*)it->second.buffer_var_;
+  auto buffer_validity = (unsigned char*)it->second.validity_vector_.buffer();
+  auto offset_size = offsets_bytesize();
+  ByteVecValue fill_value;
+  uint8_t fill_value_validity = 0;
+  if (array_schema_->is_attr(*name)) {
+    fill_value = array_schema_->attribute(*name)->fill_value();
+    fill_value_validity =
+        array_schema_->attribute(*name)->fill_value_validity();
+  }
+  auto fill_value_size = (uint64_t)fill_value.size();
+  auto attr_datatype_size = datatype_size(array_schema_->type(*name));
+
+  // Fetch the starting array offset into both `offset_offsets_per_cs`
+  // and `var_offsets_per_cs`.
+  size_t arr_offset =
+      partition_idx == 0 ? 0 : (*cs_partitions)[partition_idx - 1].first;
+
+  // Fetch the inclusive starting cell slab index and the exclusive ending
+  // cell slab index.
+  const size_t start_cs_idx =
+      partition_idx == 0 ? 0 : (*cs_partitions)[partition_idx - 1].second;
+  const size_t end_cs_idx = (*cs_partitions)[partition_idx].second;
+
+  // Copy all cells within the range of cell slabs.
+  for (uint64_t cs_idx = start_cs_idx; cs_idx < end_cs_idx; ++cs_idx) {
+    const auto& cs = result_cell_slabs[cs_idx];
+    auto cs_length = cs.length_;
+
+    // Get tile information, if the range is nonempty.
+    uint64_t* tile_offsets = nullptr;
+    Tile* tile_var = nullptr;
+    Tile* tile_validity = nullptr;
+    uint64_t tile_cell_num = 0;
+    if (cs.tile_ != nullptr && cs.tile_->tile_tuple(*name) != nullptr) {
+      const auto tile_tuple = cs.tile_->tile_tuple(*name);
+      Tile* const tile = &std::get<0>(*tile_tuple);
+      tile_var = &std::get<1>(*tile_tuple);
+      tile_validity = &std::get<2>(*tile_tuple);
+
+      // Get the internal buffer to the offset values.
+      Buffer* const buffer = tile->buffer();
+
+      tile_offsets = (uint64_t*)buffer->data();
+      tile_cell_num = tile->cell_num();
+    }
+
+    // Copy each cell in the range
+    uint64_t dest_vec_idx = 0;
+    stride = (stride == UINT64_MAX) ? 1 : stride;
+    for (auto cell_idx = cs.start_; dest_vec_idx < cs_length;
+         cell_idx += stride, dest_vec_idx++) {
+      auto offset_offsets = (*offset_offsets_per_cs)[arr_offset + dest_vec_idx];
+      auto offset_dest = buffer + offset_offsets;
+      auto var_offset = (*var_offsets_per_cs)[arr_offset + dest_vec_idx];
+      auto var_dest = buffer_var + var_offset;
+      auto validity_dest = buffer_validity + (offset_offsets / offset_size);
+
+      if (offsets_format_mode_ == "elements") {
+        var_offset = var_offset / attr_datatype_size;
+      }
+
+      // Copy offset
+      std::memcpy(offset_dest, &var_offset, offset_size);
+
+      // Copy variable-sized value
+      if (cs.tile_ == nullptr || cs.tile_->tile_tuple(*name) == nullptr) {
+        std::memcpy(var_dest, fill_value.data(), fill_value_size);
+        if (nullable)
+          std::memset(
+              validity_dest,
+              fill_value_validity,
+              constants::cell_validity_size);
+      } else {
+        const uint64_t cell_var_size =
+            (cell_idx != tile_cell_num - 1) ?
+                tile_offsets[cell_idx + 1] - tile_offsets[cell_idx] :
+                tile_var->size() - (tile_offsets[cell_idx] - tile_offsets[0]);
+        const uint64_t tile_var_offset =
+            tile_offsets[cell_idx] - tile_offsets[0];
+
+        RETURN_NOT_OK(tile_var->read(var_dest, cell_var_size, tile_var_offset));
+
+        if (nullable)
+          RETURN_NOT_OK(tile_validity->read(
+              validity_dest, constants::cell_validity_size, cell_idx));
+      }
+    }
+
+    arr_offset += cs_length;
+  }
+
+  return Status::Ok();
+}
+
+Status Reader::process_tiles(
+    const std::unordered_map<std::string, ProcessTileFlags>& names,
+    std::vector<ResultTile*>& result_tiles,
+    std::vector<ResultCellSlab>& result_cell_slabs,
+    Subarray& subarray,
+    const uint64_t stride) {
+  // If a name needs to be read, we put it on `read_names` vector (it may
+  // contain other flags). Otherwise, we put the name on the `copy_names`
+  // vector if it needs to be copied back to the user buffer.
+  // We can benefit from concurrent reads by processing `read_names`
+  // separately from `copy_names`.
+  std::vector<std::string> read_names;
+  std::vector<std::string> copy_names;
+  std::vector<std::string> var_size_read_names;
+  read_names.reserve(names.size());
+  for (const auto& name_pair : names) {
+    const std::string name = name_pair.first;
+    const ProcessTileFlags flags = name_pair.second;
+    if (flags & ProcessTileFlag::READ) {
+      read_names.push_back(name);
+      if (array_schema_->var_size(name))
+        var_size_read_names.emplace_back(name);
+    } else if (flags & ProcessTileFlag::COPY) {
+      copy_names.push_back(name);
+    }
+  }
+
+  // Pre-load all attribute offsets into memory for attributes
+  // to be read.
+  RETURN_NOT_OK(load_tile_offsets(subarray, read_names));
+
+  // Pre-load all var attribute var tile sizes into memory for attributes
+  // to be read.
+  RETURN_NOT_OK(load_tile_var_sizes(subarray, var_size_read_names));
+
+  // Get the maximum number of attributes to read and unfilter in parallel.
+  // Each attribute requires additional memory to buffer reads into
+  // before copying them back into `buffers_`. Cells must be copied
+  // before moving onto the next set of concurrent reads to prevent
+  // bloating memory. Additionally, the copy cells paths are performed
+  // in serial, which will bottleneck the read concurrency. Increasing
+  // this number will have diminishing returns on performance.
+  const uint64_t concurrent_reads = constants::concurrent_attr_reads;
+
+  // Instantiate partitions for copying fixed and variable cells.
+  std::vector<size_t> fixed_cs_partitions;
+  compute_fixed_cs_partitions(result_cell_slabs, &fixed_cs_partitions);
+
+  std::vector<std::pair<size_t, size_t>> var_cs_partitions;
+  size_t total_var_cs_length;
+  compute_var_cs_partitions(
+      result_cell_slabs, &var_cs_partitions, &total_var_cs_length);
+
+  // Handle attribute/dimensions that need to be copied but do
+  // not need to be read.
+  for (const auto& copy_name : copy_names) {
+    if (!array_schema_->var_size(copy_name))
+      RETURN_CANCEL_OR_ERROR(copy_fixed_cells(
+          copy_name, stride, result_cell_slabs, &fixed_cs_partitions));
+    else
+      RETURN_CANCEL_OR_ERROR(copy_var_cells(
+          copy_name,
+          stride,
+          result_cell_slabs,
+          &var_cs_partitions,
+          total_var_cs_length));
+    clear_tiles(copy_name, result_tiles);
+  }
+
+  // Iterate through all of the attribute names. This loop
+  // will read, unfilter, and copy tiles back into the `buffers_`.
+  uint64_t idx = 0;
+  tdb_unique_ptr<ResultCellSlabsIndex> rcs_index = nullptr;
+  while (idx < read_names.size()) {
+    // We will perform `concurrent_reads` unless we have a smaller
+    // number of remaining attributes to process.
+    const uint64_t num_reads =
+        std::min(concurrent_reads, read_names.size() - idx);
+
+    // Build a vector of the attribute names to process.
+    std::vector<std::string> inner_names(
+        read_names.begin() + idx, read_names.begin() + idx + num_reads);
+
+    // Read the tiles for the names in `inner_names`. Each attribute
+    // name will be read concurrently.
+    RETURN_CANCEL_OR_ERROR(
+        read_attribute_tiles(inner_names, result_tiles, false));
+
+    // Copy the cells into the associated `buffers_`, and then clear the cells
+    // from the tiles. The cell copies are not thread safe. Clearing tiles are
+    // thread safe, but quick enough that they do not justify scheduling on
+    // separate threads.
+    for (const auto& inner_name : inner_names) {
+      const ProcessTileFlags flags = names.at(inner_name);
+
+      RETURN_CANCEL_OR_ERROR(unfilter_tiles(inner_name, result_tiles, false));
+
+      if (flags & ProcessTileFlag::COPY) {
+        if (!array_schema_->var_size(inner_name)) {
+          RETURN_CANCEL_OR_ERROR(copy_fixed_cells(
+              inner_name, stride, result_cell_slabs, &fixed_cs_partitions));
+        } else {
+          RETURN_CANCEL_OR_ERROR(copy_var_cells(
+              inner_name,
+              stride,
+              result_cell_slabs,
+              &var_cs_partitions,
+              total_var_cs_length));
+        }
+        clear_tiles(inner_name, result_tiles);
+      }
+    }
+
+    idx += inner_names.size();
+  }
+
+  return Status::Ok();
+}
+
 template <class T>
 Status Reader::compute_result_cell_slabs(
     const Subarray& subarray,
-    std::map<const T*, ResultSpaceTile<T>>* result_space_tiles,
-    std::vector<ResultCoords>* result_coords,
-    std::vector<ResultTile*>* result_tiles,
-    std::vector<ResultCellSlab>* result_cell_slabs) const {
+    std::map<const T*, ResultSpaceTile<T>>& result_space_tiles,
+    std::vector<ResultCoords>& result_coords,
+    std::vector<ResultTile*>& result_tiles,
+    std::vector<ResultCellSlab>& result_cell_slabs) const {
   auto timer_se = stats_->start_timer("compute_sparse_result_cell_slabs_dense");
 
   auto layout = subarray.layout();
@@ -673,7 +1404,7 @@ Status Reader::compute_result_cell_slabs(
         result_coords,
         &result_coords_pos,
         result_tiles,
-        &frag_tile_set,
+        frag_tile_set,
         result_cell_slabs);
   } else if (layout == Layout::GLOBAL_ORDER) {
     return compute_result_cell_slabs_global<T>(
@@ -692,36 +1423,36 @@ Status Reader::compute_result_cell_slabs(
 template <class T>
 Status Reader::compute_result_cell_slabs_row_col(
     const Subarray& subarray,
-    std::map<const T*, ResultSpaceTile<T>>* result_space_tiles,
-    std::vector<ResultCoords>* result_coords,
+    std::map<const T*, ResultSpaceTile<T>>& result_space_tiles,
+    std::vector<ResultCoords>& result_coords,
     uint64_t* result_coords_pos,
-    std::vector<ResultTile*>* result_tiles,
-    std::set<std::pair<unsigned, uint64_t>>* frag_tile_set,
-    std::vector<ResultCellSlab>* result_cell_slabs) const {
+    std::vector<ResultTile*>& result_tiles,
+    std::set<std::pair<unsigned, uint64_t>>& frag_tile_set,
+    std::vector<ResultCellSlab>& result_cell_slabs) const {
   // Compute result space tiles. The result space tiles hold all the
   // relevant result tiles of the dense fragments
   compute_result_space_tiles<T>(
-      &subarray, read_state_.partitioner_.subarray(), result_space_tiles);
+      subarray, read_state_.partitioner_.subarray(), result_space_tiles);
 
   // Gather result cell slabs and pointers to result tiles
   // `result_tiles` holds pointers to tiles that store actual results,
   // which can be stored either in `sparse_result_tiles` (sparse)
   // or in `result_space_tiles` (dense).
   auto rcs_it = ReadCellSlabIter<T>(
-      &subarray, result_space_tiles, result_coords, *result_coords_pos);
+      &subarray, &result_space_tiles, &result_coords, *result_coords_pos);
   for (rcs_it.begin(); !rcs_it.end(); ++rcs_it) {
     // Add result cell slab
     auto result_cell_slab = rcs_it.result_cell_slab();
-    result_cell_slabs->push_back(result_cell_slab);
+    result_cell_slabs.push_back(result_cell_slab);
     // Add result tile
     if (result_cell_slab.tile_ != nullptr) {
       auto frag_idx = result_cell_slab.tile_->frag_idx();
       auto tile_idx = result_cell_slab.tile_->tile_idx();
       auto frag_tile_tuple = std::pair<unsigned, uint64_t>(frag_idx, tile_idx);
-      auto it = frag_tile_set->find(frag_tile_tuple);
-      if (it == frag_tile_set->end()) {
-        frag_tile_set->insert(frag_tile_tuple);
-        result_tiles->push_back(result_cell_slab.tile_);
+      auto it = frag_tile_set.find(frag_tile_tuple);
+      if (it == frag_tile_set.end()) {
+        frag_tile_set.insert(frag_tile_tuple);
+        result_tiles.push_back(result_cell_slab.tile_);
       }
     }
   }
@@ -733,10 +1464,10 @@ Status Reader::compute_result_cell_slabs_row_col(
 template <class T>
 Status Reader::compute_result_cell_slabs_global(
     const Subarray& subarray,
-    std::map<const T*, ResultSpaceTile<T>>* result_space_tiles,
-    std::vector<ResultCoords>* result_coords,
-    std::vector<ResultTile*>* result_tiles,
-    std::vector<ResultCellSlab>* result_cell_slabs) const {
+    std::map<const T*, ResultSpaceTile<T>>& result_space_tiles,
+    std::vector<ResultCoords>& result_coords,
+    std::vector<ResultTile*>& result_tiles,
+    std::vector<ResultCellSlab>& result_cell_slabs) const {
   const auto& tile_coords = subarray.tile_coords();
   auto cell_order = array_schema_->cell_order();
   std::vector<Subarray> tile_subarrays;
@@ -756,7 +1487,7 @@ Status Reader::compute_result_cell_slabs_global(
         result_coords,
         &result_coords_pos,
         result_tiles,
-        &frag_tile_set,
+        frag_tile_set,
         result_cell_slabs));
   }
 
@@ -764,8 +1495,8 @@ Status Reader::compute_result_cell_slabs_global(
 }
 
 Status Reader::compute_result_coords(
-    std::vector<ResultTile>* result_tiles,
-    std::vector<ResultCoords>* result_coords) {
+    std::vector<ResultTile>& result_tiles,
+    std::vector<ResultCoords>& result_coords) {
   auto timer_se = stats_->start_timer("compute_result_coords");
 
   // Get overlapping tile indexes
@@ -776,13 +1507,13 @@ Status Reader::compute_result_coords(
   RETURN_CANCEL_OR_ERROR(compute_sparse_result_tiles(
       result_tiles, &result_tile_map, &single_fragment));
 
-  if (result_tiles->empty())
+  if (result_tiles.empty())
     return Status::Ok();
 
   // Create temporary vector with pointers to result tiles, so that
   // `read_tiles`, `unfilter_tiles` below can work without changes
   std::vector<ResultTile*> tmp_result_tiles;
-  for (auto& result_tile : *result_tiles)
+  for (auto& result_tile : result_tiles)
     tmp_result_tiles.push_back(&result_tile);
 
   // Preload zipped coordinate tile offsets. Note that this will
@@ -790,7 +1521,7 @@ Status Reader::compute_result_coords(
   auto& subarray = read_state_.partitioner_.current();
   std::vector<std::string> zipped_coords_names = {constants::coords};
   RETURN_CANCEL_OR_ERROR(load_tile_offsets(
-      read_state_.partitioner_.subarray(), &zipped_coords_names));
+      read_state_.partitioner_.subarray(), zipped_coords_names));
 
   // Preload unzipped coordinate tile offsets. Note that this will
   // ignore fragments with a version < 5.
@@ -805,45 +1536,45 @@ Status Reader::compute_result_coords(
       var_size_dim_names.emplace_back(name);
   }
   RETURN_CANCEL_OR_ERROR(
-      load_tile_offsets(read_state_.partitioner_.subarray(), &dim_names));
+      load_tile_offsets(read_state_.partitioner_.subarray(), dim_names));
   RETURN_CANCEL_OR_ERROR(load_tile_var_sizes(
-      read_state_.partitioner_.subarray(), &var_size_dim_names));
+      read_state_.partitioner_.subarray(), var_size_dim_names));
 
   // Read and unfilter zipped coordinate tiles. Note that
   // this will ignore fragments with a version >= 5.
   RETURN_CANCEL_OR_ERROR(
-      read_coordinate_tiles(&zipped_coords_names, &tmp_result_tiles));
-  RETURN_CANCEL_OR_ERROR(unfilter_tiles(constants::coords, &tmp_result_tiles));
+      read_coordinate_tiles(zipped_coords_names, tmp_result_tiles));
+  RETURN_CANCEL_OR_ERROR(unfilter_tiles(constants::coords, tmp_result_tiles));
 
   // Read and unfilter unzipped coordinate tiles. Note that
   // this will ignore fragments with a version < 5.
-  RETURN_CANCEL_OR_ERROR(read_coordinate_tiles(&dim_names, &tmp_result_tiles));
+  RETURN_CANCEL_OR_ERROR(read_coordinate_tiles(dim_names, tmp_result_tiles));
   for (const auto& dim_name : dim_names) {
-    RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, &tmp_result_tiles));
+    RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, tmp_result_tiles));
   }
 
   // Compute the read coordinates for all fragments for each subarray range.
   std::vector<std::vector<ResultCoords>> range_result_coords;
   RETURN_CANCEL_OR_ERROR(compute_range_result_coords(
-      &subarray,
+      subarray,
       single_fragment,
       result_tile_map,
       result_tiles,
-      &range_result_coords));
+      range_result_coords));
   result_tile_map.clear();
 
   // Compute final coords (sorted in the result layout) of the whole subarray.
   RETURN_CANCEL_OR_ERROR(
-      compute_subarray_coords(&range_result_coords, result_coords));
+      compute_subarray_coords(range_result_coords, result_coords));
   range_result_coords.clear();
 
   return Status::Ok();
 }
 
 Status Reader::dedup_result_coords(
-    std::vector<ResultCoords>* result_coords) const {
-  auto coords_end = result_coords->end();
-  auto it = skip_invalid_elements(result_coords->begin(), coords_end);
+    std::vector<ResultCoords>& result_coords) const {
+  auto coords_end = result_coords.end();
+  auto it = skip_invalid_elements(result_coords.begin(), coords_end);
   while (it != coords_end) {
     auto next_it = skip_invalid_elements(std::next(it), coords_end);
     if (next_it != coords_end && it->same_coords(*next_it)) {
@@ -920,7 +1651,7 @@ Status Reader::dense_read() {
   // sparse fragments
   std::vector<ResultCoords> result_coords;
   std::vector<ResultTile> sparse_result_tiles;
-  RETURN_NOT_OK(compute_result_coords(&sparse_result_tiles, &result_coords));
+  RETURN_NOT_OK(compute_result_coords(sparse_result_tiles, result_coords));
 
   // Compute result cell slabs.
   // `result_space_tiles` will hold all the relevant result tiles of
@@ -934,15 +1665,15 @@ Status Reader::dense_read() {
   RETURN_NOT_OK(subarray.compute_tile_coords<T>());
   RETURN_NOT_OK(compute_result_cell_slabs<T>(
       subarray,
-      &result_space_tiles,
-      &result_coords,
-      &result_tiles,
-      &result_cell_slabs));
+      result_space_tiles,
+      result_coords,
+      result_tiles,
+      result_cell_slabs));
 
   auto stride = array_schema_->domain()->stride<T>(subarray.layout());
   RETURN_NOT_OK(apply_query_condition(
-      &result_cell_slabs,
-      &result_tiles,
+      result_cell_slabs,
+      result_tiles,
       read_state_.partitioner_.subarray(),
       stride));
 
@@ -950,29 +1681,30 @@ Status Reader::dense_read() {
   get_result_cell_stats(result_cell_slabs);
 
   // Clear sparse coordinate tiles (not needed any more)
-  erase_coord_tiles(&sparse_result_tiles);
+  erase_coord_tiles(sparse_result_tiles);
 
   // Needed when copying the cells
   RETURN_NOT_OK(copy_attribute_values(
       stride,
-      &result_tiles,
-      &result_cell_slabs,
-      *read_state_.partitioner_.subarray()));
-  read_state_.overflowed_ = copy_overflowed_;
+      result_tiles,
+      result_cell_slabs,
+      read_state_.partitioner_.subarray()));
 
   // Fill coordinates if the user requested them
-  if (!read_state_.overflowed_ && has_coords())
-    RETURN_CANCEL_OR_ERROR(fill_dense_coords<T>(subarray));
-  read_state_.overflowed_ = copy_overflowed_;
+  if (!read_state_.overflowed_ && has_coords()) {
+    auto&& [st, overflowed] = fill_dense_coords<T>(subarray);
+    RETURN_CANCEL_OR_ERROR(st);
+    read_state_.overflowed_ = *overflowed;
+  }
 
   return Status::Ok();
 }
 
 Status Reader::get_all_result_coords(
-    ResultTile* tile, std::vector<ResultCoords>* result_coords) const {
+    ResultTile* tile, std::vector<ResultCoords>& result_coords) const {
   auto coords_num = tile->cell_num();
   for (uint64_t i = 0; i < coords_num; ++i)
-    result_coords->emplace_back(tile, i);
+    result_coords.emplace_back(tile, i);
 
   return Status::Ok();
 }
@@ -1074,7 +1806,6 @@ Status Reader::init_read_state() {
 
   read_state_.unsplittable_ = false;
   read_state_.overflowed_ = false;
-  copy_overflowed_ = false;
   read_state_.initialized_ = true;
 
   return Status::Ok();
@@ -1125,7 +1856,7 @@ Status Reader::sparse_read() {
   std::vector<ResultCoords> result_coords;
   std::vector<ResultTile> sparse_result_tiles;
 
-  RETURN_NOT_OK(compute_result_coords(&sparse_result_tiles, &result_coords));
+  RETURN_NOT_OK(compute_result_coords(sparse_result_tiles, result_coords));
   std::vector<ResultTile*> result_tiles;
   for (auto& srt : sparse_result_tiles)
     result_tiles.push_back(&srt);
@@ -1133,21 +1864,20 @@ Status Reader::sparse_read() {
   // Compute result cell slabs
   std::vector<ResultCellSlab> result_cell_slabs;
   RETURN_CANCEL_OR_ERROR(
-      compute_result_cell_slabs(result_coords, &result_cell_slabs));
+      compute_result_cell_slabs(result_coords, result_cell_slabs));
   result_coords.clear();
 
   apply_query_condition(
-      &result_cell_slabs, &result_tiles, read_state_.partitioner_.subarray());
+      result_cell_slabs, result_tiles, read_state_.partitioner_.subarray());
   get_result_tile_stats(result_tiles);
   get_result_cell_stats(result_cell_slabs);
 
-  RETURN_NOT_OK(copy_coordinates(&result_tiles, &result_cell_slabs));
+  RETURN_NOT_OK(copy_coordinates(result_tiles, result_cell_slabs));
   RETURN_NOT_OK(copy_attribute_values(
       UINT64_MAX,
-      &result_tiles,
-      &result_cell_slabs,
-      *read_state_.partitioner_.subarray()));
-  read_state_.overflowed_ = copy_overflowed_;
+      result_tiles,
+      result_cell_slabs,
+      read_state_.partitioner_.subarray()));
 
   return Status::Ok();
 }
@@ -1204,8 +1934,8 @@ bool Reader::sparse_tile_overwritten(
   return false;
 }
 
-void Reader::erase_coord_tiles(std::vector<ResultTile>* result_tiles) const {
-  for (auto& tile : *result_tiles) {
+void Reader::erase_coord_tiles(std::vector<ResultTile>& result_tiles) const {
+  for (auto& tile : result_tiles) {
     auto dim_num = array_schema_->dim_num();
     for (unsigned d = 0; d < dim_num; ++d)
       tile.erase_tile(array_schema_->dimension(d)->name());

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -138,10 +138,10 @@ class Reader : public ReaderBase, public IQueryStrategy {
   template <class T>
   Status compute_result_cell_slabs(
       const Subarray& subarray,
-      std::map<const T*, ResultSpaceTile<T>>* result_space_tiles,
-      std::vector<ResultCoords>* result_coords,
-      std::vector<ResultTile*>* result_tiles,
-      std::vector<ResultCellSlab>* result_cell_slabs) const;
+      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles,
+      std::vector<ResultCoords>& result_coords,
+      std::vector<ResultTile*>& result_tiles,
+      std::vector<ResultCellSlab>& result_cell_slabs) const;
 
   /**
    * Computes the result cell slabs for the input subarray, given the
@@ -174,12 +174,12 @@ class Reader : public ReaderBase, public IQueryStrategy {
   template <class T>
   Status compute_result_cell_slabs_row_col(
       const Subarray& subarray,
-      std::map<const T*, ResultSpaceTile<T>>* result_space_tiles,
-      std::vector<ResultCoords>* result_coords,
+      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles,
+      std::vector<ResultCoords>& result_coords,
       uint64_t* result_coords_pos,
-      std::vector<ResultTile*>* result_tiles,
-      std::set<std::pair<unsigned, uint64_t>>* frag_tile_set,
-      std::vector<ResultCellSlab>* result_cell_slabs) const;
+      std::vector<ResultTile*>& result_tiles,
+      std::set<std::pair<unsigned, uint64_t>>& frag_tile_set,
+      std::vector<ResultCellSlab>& result_cell_slabs) const;
 
   /**
    * Computes the result cell slabs for the input subarray, given the
@@ -204,10 +204,10 @@ class Reader : public ReaderBase, public IQueryStrategy {
   template <class T>
   Status compute_result_cell_slabs_global(
       const Subarray& subarray,
-      std::map<const T*, ResultSpaceTile<T>>* result_space_tiles,
-      std::vector<ResultCoords>* result_coords,
-      std::vector<ResultTile*>* result_tiles,
-      std::vector<ResultCellSlab>* result_cell_slabs) const;
+      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles,
+      std::vector<ResultCoords>& result_coords,
+      std::vector<ResultTile*>& result_tiles,
+      std::vector<ResultCellSlab>& result_cell_slabs) const;
 
  private:
   /* ********************************* */
@@ -219,6 +219,20 @@ class Reader : public ReaderBase, public IQueryStrategy {
 
   /** Read state. */
   ReadState read_state_;
+
+  /* ********************************* */
+  /*         PRIVATE DATATYPES         */
+  /* ********************************* */
+
+  /** Bitflags for individual dimension/attributes in `process_tiles()`. */
+  typedef uint8_t ProcessTileFlags;
+
+  /** Bitflag values applicable to `ProcessTileFlags`. */
+  enum ProcessTileFlag { READ = 1, COPY = 2 };
+
+  typedef std::
+      unordered_map<ResultTile*, std::vector<std::pair<uint64_t, uint64_t>>>
+          ResultCellSlabsIndex;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */
@@ -237,9 +251,9 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @return Status
    */
   Status apply_query_condition(
-      std::vector<ResultCellSlab>* result_cell_slabs,
-      std::vector<ResultTile*>* result_tiles,
-      Subarray* subarray,
+      std::vector<ResultCellSlab>& result_cell_slabs,
+      std::vector<ResultTile*>& result_tiles,
+      Subarray& subarray,
       uint64_t stride = UINT64_MAX);
 
   /**
@@ -251,7 +265,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
    */
   Status compute_result_cell_slabs(
       const std::vector<ResultCoords>& result_coords,
-      std::vector<ResultCellSlab>* result_cell_slabs) const;
+      std::vector<ResultCellSlab>& result_cell_slabs) const;
 
   /**
    * Retrieves the coordinates that overlap the input N-dimensional range
@@ -265,11 +279,11 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @return Status
    */
   Status compute_range_result_coords(
-      Subarray* subarray,
+      Subarray& subarray,
       unsigned frag_idx,
       ResultTile* tile,
       uint64_t range_idx,
-      std::vector<ResultCoords>* result_coords);
+      std::vector<ResultCoords>& result_coords);
 
   /**
    * Computes the result coordinates for each range of the query
@@ -286,11 +300,11 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @return Status
    */
   Status compute_range_result_coords(
-      Subarray* subarray,
+      Subarray& subarray,
       const std::vector<bool>& single_fragment,
       const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
-      std::vector<ResultTile>* result_tiles,
-      std::vector<std::vector<ResultCoords>>* range_result_coords);
+      std::vector<ResultTile>& result_tiles,
+      std::vector<std::vector<ResultCoords>>& range_result_coords);
 
   /**
    * Computes the result coordinates of a given range of the query
@@ -306,11 +320,11 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @return Status
    */
   Status compute_range_result_coords(
-      Subarray* subarray,
+      Subarray& subarray,
       uint64_t range_idx,
       const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
-      std::vector<ResultTile>* result_tiles,
-      std::vector<ResultCoords>* range_result_coords);
+      std::vector<ResultTile>& result_tiles,
+      std::vector<ResultCoords>& range_result_coords);
 
   /**
    * Computes the result coordinates of a given range of the query
@@ -327,12 +341,12 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @return Status
    */
   Status compute_range_result_coords(
-      Subarray* subarray,
+      Subarray& subarray,
       uint64_t range_idx,
       uint32_t fragment_idx,
       const std::map<std::pair<unsigned, uint64_t>, size_t>& result_tile_map,
-      std::vector<ResultTile>* result_tiles,
-      std::vector<ResultCoords>* range_result_coords);
+      std::vector<ResultTile>& result_tiles,
+      std::vector<ResultCoords>& range_result_coords);
 
   /**
    * Computes the final subarray result coordinates, which will be
@@ -347,8 +361,8 @@ class Reader : public ReaderBase, public IQueryStrategy {
    *     as it is done processing its elements to quickly reclaim memory.
    */
   Status compute_subarray_coords(
-      std::vector<std::vector<ResultCoords>>* range_result_coords,
-      std::vector<ResultCoords>* result_coords);
+      std::vector<std::vector<ResultCoords>>& range_result_coords,
+      std::vector<ResultCoords>& result_coords);
 
   /**
    * Computes info about the sparse result tiles, such as which fragment they
@@ -366,9 +380,190 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @return Status
    */
   Status compute_sparse_result_tiles(
-      std::vector<ResultTile>* result_tiles,
+      std::vector<ResultTile>& result_tiles,
       std::map<std::pair<unsigned, uint64_t>, size_t>* result_tile_map,
       std::vector<bool>* single_fragment);
+
+  /**
+   * Copies the result coordinates to the user buffers.
+   * It also appropriately cleans up the used result tiles.
+   */
+  Status copy_coordinates(
+      const std::vector<ResultTile*>& result_tiles,
+      std::vector<ResultCellSlab>& result_cell_slabs);
+
+  /**
+   * Copies the result attribute values to the user buffers.
+   * It also appropriately cleans up the used result tiles.
+   */
+  Status copy_attribute_values(
+      uint64_t stride,
+      std::vector<ResultTile*>& result_tiles,
+      std::vector<ResultCellSlab>& result_cell_slabs,
+      Subarray& subarray);
+
+  /**
+   * Copies the cells for the input **fixed-sized** attribute/dimension and
+   * result cell slabs into the corresponding result buffers.
+   *
+   * @param name The targeted attribute/dimension.
+   * @param stride If it is `UINT64_MAX`, then the cells in the result
+   *     cell slabs are all contiguous. Otherwise, each cell in the
+   *     result cell slabs are `stride` cells apart from each other.
+   * @param result_cell_slabs The result cell slabs to copy cells for.
+   * @param fixed_cs_partitions The cell slab partitions.
+   * @return Status
+   */
+  Status copy_fixed_cells(
+      const std::string& name,
+      uint64_t stride,
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      std::vector<size_t>* fixed_cs_partitions);
+
+  /**
+   * Compute cs partitions for fixed-sized cell copying.
+   *
+   * @param result_cell_slabs The result cell slabs to copy cells for.
+   * @param fixed_cs_partitions The output partitions.
+   */
+  void compute_fixed_cs_partitions(
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      std::vector<size_t>* fixed_cs_partitions);
+
+  /**
+   * Copies the cells for the input **fixed-sized** attribute/dimension and
+   * result cell slabs into the corresponding result buffers for the
+   * partition in `ctx_cache` at index `partition_idx`.
+   *
+   * @param name The partition index.
+   * @param name The targeted attribute/dimension.
+   * @param stride If it is `UINT64_MAX`, then the cells in the result
+   *     cell slabs are all contiguous. Otherwise, each cell in the
+   *     result cell slabs are `stride` cells apart from each other.
+   * @param result_cell_slabs The result cell slabs to copy cells for.
+   * @param cs_offsets The cell slab offsets.
+   * @param cs_partitions The cell slab partitions to operate on.
+   * @return Status
+   */
+  Status copy_partitioned_fixed_cells(
+      size_t partition_idx,
+      const std::string* name,
+      uint64_t stride,
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      const std::vector<uint64_t>* cs_offsets,
+      const std::vector<size_t>* cs_partitions);
+
+  /**
+   * Copies the cells for the input **var-sized** attribute/dimension and result
+   * cell slabs into the corresponding result buffers.
+   *
+   * @param name The targeted attribute/dimension.
+   * @param stride If it is `UINT64_MAX`, then the cells in the result
+   *     cell slabs are all contiguous. Otherwise, each cell in the
+   *     result cell slabs are `stride` cells apart from each other.
+   * @param result_cell_slabs The result cell slabs to copy cells for.
+   * @param var_cs_partitions The cell slab partitions.
+   * @param total_cs_length The total cell slab length.
+   * @return Status
+   */
+  Status copy_var_cells(
+      const std::string& name,
+      uint64_t stride,
+      std::vector<ResultCellSlab>& result_cell_slabs,
+      std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
+      size_t total_var_cs_length);
+
+  /**
+   * Compute cs partitions for var-sized cell copying.
+   *
+   * @param result_cell_slabs The result cell slabs to copy cells for.
+   * @param var_cs_partitions The output partitions.
+   * @param total_var_cs_length The total cell slab length.
+   */
+  void compute_var_cs_partitions(
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
+      size_t* total_var_cs_length);
+
+  /**
+   * Computes offsets into destination buffers for the given
+   * attribute/dimensions's offset and variable-length data, for the given list
+   * of result cell slabs.
+   *
+   * @param name The variable-length attribute/dimension.
+   * @param stride If it is `UINT64_MAX`, then the cells in the result
+   *     cell slabs are all contiguous. Otherwise, each cell in the
+   *     result cell slabs are `stride` cells apart from each other.
+   * @param result_cell_slabs The result cell slabs to compute destinations for.
+   * @param offset_offsets_per_cs Output to hold one vector per result cell
+   *    slab, and one element per cell in the slab. The elements are the
+   *    destination offsets for the attribute's offsets.
+   * @param var_offsets_per_cs Output to hold one vector per result cell slab,
+   *    and one element per cell in the slab. The elements are the destination
+   *    offsets for the attribute's variable-length data.
+   * @param total_offset_size Output set to the total size in bytes of the
+   *    offsets in the given list of result cell slabs.
+   * @param total_var_size Output set to the total size in bytes of the
+   *    attribute's variable-length in the given list of result cell slabs.
+   * @param total_validity_size Output set to the total size in bytes of the
+   *    attribute's validity vector in the given list of result cell slabs.
+   * @return Status
+   */
+  Status compute_var_cell_destinations(
+      const std::string& name,
+      uint64_t stride,
+      std::vector<ResultCellSlab>& result_cell_slabs,
+      std::vector<uint64_t>* offset_offsets_per_cs,
+      std::vector<uint64_t>* var_offsets_per_cs,
+      uint64_t* total_offset_size,
+      uint64_t* total_var_size,
+      uint64_t* total_validity_size);
+
+  /**
+   * Copies the cells for the input **var-sized** attribute/dimension and result
+   * cell slabs into the corresponding result buffers for the
+   * partition in `cs_partitions` at index `partition_idx`.
+   *
+   * @param name The partition index.
+   * @param name The targeted attribute/dimension.
+   * @param stride If it is `UINT64_MAX`, then the cells in the result
+   *     cell slabs are all contiguous. Otherwise, each cell in the
+   *     result cell slabs are `stride` cells apart from each other.
+   * @param result_cell_slabs The result cell slabs to copy cells for.
+   * @param offset_offsets_per_cs Maps each cell slab to its offset
+   *     for its attribute offsets.
+   * @param var_offsets_per_cs Maps each cell slab to its offset
+   *     for its variable-length data.
+   * @param cs_partitions The cell slab partitions to operate on.
+   * @return Status
+   */
+  Status copy_partitioned_var_cells(
+      size_t partition_idx,
+      const std::string* name,
+      uint64_t stride,
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      const std::vector<uint64_t>* offset_offsets_per_cs,
+      const std::vector<uint64_t>* var_offsets_per_cs,
+      const std::vector<std::pair<size_t, size_t>>* cs_partitions);
+
+  /**
+   * For each dimension/attribute in `names`, performs the actions
+   * defined in the `ProcessTileFlags`.
+   *
+   * @param names The dimension/attribute names to process.
+   * @param result_tiles The retrieved tiles will be stored inside the
+   *   `ResultTile` instances in this vector.
+   * @param result_cell_slabs The cell slabs to process.
+   * @param subarray Specifies the current subarray.
+   * @param stride The stride between cells, UINT64_MAX for contiguous.
+   * @return Status
+   */
+  Status process_tiles(
+      const std::unordered_map<std::string, ProcessTileFlags>& names,
+      std::vector<ResultTile*>& result_tiles,
+      std::vector<ResultCellSlab>& result_cell_slabs,
+      Subarray& subarray,
+      uint64_t stride);
 
   /**
    * Computes the result coordinates from the sparse fragments.
@@ -377,8 +572,8 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @param result_coords This will store the result coordinates.
    */
   Status compute_result_coords(
-      std::vector<ResultTile>* result_tiles,
-      std::vector<ResultCoords>* result_coords);
+      std::vector<ResultTile>& result_tiles,
+      std::vector<ResultCoords>& result_coords);
 
   /**
    * Deduplicates the input result coordinates, breaking ties giving preference
@@ -387,7 +582,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @param result_coords The result coordinates to dedup.
    * @return Status
    */
-  Status dedup_result_coords(std::vector<ResultCoords>* result_coords) const;
+  Status dedup_result_coords(std::vector<ResultCoords>& result_coords) const;
 
   /** Performs a read on a dense array. */
   Status dense_read();
@@ -409,7 +604,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @return Status
    */
   Status get_all_result_coords(
-      ResultTile* tile, std::vector<ResultCoords>* result_coords) const;
+      ResultTile* tile, std::vector<ResultCoords>& result_coords) const;
 
   /**
    * Returns `true` if a coordinate buffer for a separate dimension
@@ -454,7 +649,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * Erases the coordinate tiles (zipped or separate) from the input result
    * tiles.
    */
-  void erase_coord_tiles(std::vector<ResultTile>* result_tiles) const;
+  void erase_coord_tiles(std::vector<ResultTile>& result_tiles) const;
 
   /** Gets statistics about the result cells. */
   void get_result_cell_stats(

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -149,23 +149,9 @@ class ReaderBase : public StrategyBase {
       const std::vector<std::vector<uint8_t>>& tile_coords,
       const TileDomain<T>& array_tile_domain,
       const std::vector<TileDomain<T>>& frag_tile_domains,
-      std::map<const T*, ResultSpaceTile<T>>* result_space_tiles);
+      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles);
 
  protected:
-  /* ********************************* */
-  /*        PROTECTED DATATYPES        */
-  /* ********************************* */
-
-  /** Bitflags for individual dimension/attributes in `process_tiles()`. */
-  typedef uint8_t ProcessTileFlags;
-
-  /** Bitflag values applicable to `ProcessTileFlags`. */
-  enum ProcessTileFlag { READ = 1, COPY = 2 };
-
-  typedef std::
-      unordered_map<ResultTile*, std::vector<std::pair<uint64_t, uint64_t>>>
-          ResultCellSlabsIndex;
-
   /* ********************************* */
   /*       PROTECTED ATTRIBUTES        */
   /* ********************************* */
@@ -175,25 +161,6 @@ class ReaderBase : public StrategyBase {
 
   /** The fragment metadata that the reader will focus on. */
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragment_metadata_;
-
-  /** Protects result tiles. */
-  mutable std::mutex result_tiles_mutex_;
-
-  /** Try to fix overflows on var sized copies. */
-  bool fix_var_sized_overflows_;
-
-  /** Clear the coordinates tiles after copies. */
-  bool clear_coords_tiles_on_copy_;
-
-  /** Was there an overflow during copying tiles. */
-  bool copy_overflowed_;
-
-  /**
-   * Used to specify where in the result cell slabs to end the copy
-   * operations. First is the size of the result cell slabs, second is
-   * the length of the last result cell slab.
-   */
-  std::pair<uint64_t, uint64_t> copy_end_;
 
   /* ********************************* */
   /*         PROTECTED METHODS         */
@@ -235,7 +202,7 @@ class ReaderBase : public StrategyBase {
    * @return Status
    */
   Status load_tile_offsets(
-      Subarray* subarray, const std::vector<std::string>* names);
+      Subarray& subarray, const std::vector<std::string>& names);
 
   /**
    * Loads tile var sizes for each attribute/dimension name into
@@ -246,7 +213,7 @@ class ReaderBase : public StrategyBase {
    * @return Status
    */
   Status load_tile_var_sizes(
-      Subarray* subarray, const std::vector<std::string>* names);
+      Subarray& subarray, const std::vector<std::string>& names);
 
   /**
    * Initializes a fixed-sized tile.
@@ -320,8 +287,8 @@ class ReaderBase : public StrategyBase {
    * @return Status
    */
   Status read_attribute_tiles(
-      const std::vector<std::string>* names,
-      const std::vector<ResultTile*>* result_tiles,
+      const std::vector<std::string>& names,
+      const std::vector<ResultTile*>& result_tiles,
       const bool disable_cache = false) const;
 
   /**
@@ -338,8 +305,8 @@ class ReaderBase : public StrategyBase {
    * @return Status
    */
   Status read_coordinate_tiles(
-      const std::vector<std::string>* names,
-      const std::vector<ResultTile*>* result_tiles,
+      const std::vector<std::string>& names,
+      const std::vector<ResultTile*>& result_tiles,
       const bool disable_cache = false) const;
 
   /**
@@ -356,8 +323,8 @@ class ReaderBase : public StrategyBase {
    * @return Status
    */
   Status read_tiles(
-      const std::vector<std::string>* names,
-      const std::vector<ResultTile*>* result_tiles,
+      const std::vector<std::string>& names,
+      const std::vector<ResultTile*>& result_tiles,
       const bool disable_cache = false) const;
 
   /**
@@ -371,7 +338,7 @@ class ReaderBase : public StrategyBase {
    */
   Status unfilter_tiles(
       const std::string& name,
-      const std::vector<ResultTile*>* result_tiles,
+      const std::vector<ResultTile*>& result_tiles,
       const bool disable_cache = false) const;
 
   /**
@@ -429,197 +396,9 @@ class ReaderBase : public StrategyBase {
       Tile* tile_validity) const;
 
   /**
-   * Copies the result coordinates to the user buffers.
-   * It also appropriately cleans up the used result tiles.
-   */
-  Status copy_coordinates(
-      const std::vector<ResultTile*>* result_tiles,
-      std::vector<ResultCellSlab>* result_cell_slabs);
-
-  /**
-   * Copies the result attribute values to the user buffers.
-   * It also appropriately cleans up the used result tiles.
-   */
-  Status copy_attribute_values(
-      uint64_t stride,
-      std::vector<ResultTile*>* result_tiles,
-      std::vector<ResultCellSlab>* result_cell_slabs,
-      Subarray& subarray,
-      uint64_t memory_budget = UINT64_MAX,
-      bool include_dim = false,
-      const bool disable_cache = false);
-
-  /**
-   * Copies the cells for the input **fixed-sized** attribute/dimension and
-   * result cell slabs into the corresponding result buffers.
-   *
-   * @param name The targeted attribute/dimension.
-   * @param stride If it is `UINT64_MAX`, then the cells in the result
-   *     cell slabs are all contiguous. Otherwise, each cell in the
-   *     result cell slabs are `stride` cells apart from each other.
-   * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param fixed_cs_partitions The cell slab partitions.
-   * @return Status
-   */
-  Status copy_fixed_cells(
-      const std::string& name,
-      uint64_t stride,
-      const std::vector<ResultCellSlab>* result_cell_slabs,
-      std::vector<size_t>* fixed_cs_partitions);
-
-  /**
-   * Compute cs partitions for fixed-sized cell copying.
-   *
-   * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param fixed_cs_partitions The output partitions.
-   */
-  void compute_fixed_cs_partitions(
-      const std::vector<ResultCellSlab>* result_cell_slabs,
-      std::vector<size_t>* fixed_cs_partitions);
-
-  /**
    * Returns the configured bytesize for var-sized attribute offsets
    */
   uint64_t offsets_bytesize() const;
-
-  /**
-   * Copies the cells for the input **fixed-sized** attribute/dimension and
-   * result cell slabs into the corresponding result buffers for the
-   * partition in `ctx_cache` at index `partition_idx`.
-   *
-   * @param name The partition index.
-   * @param name The targeted attribute/dimension.
-   * @param stride If it is `UINT64_MAX`, then the cells in the result
-   *     cell slabs are all contiguous. Otherwise, each cell in the
-   *     result cell slabs are `stride` cells apart from each other.
-   * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param cs_offsets The cell slab offsets.
-   * @param cs_partitions The cell slab partitions to operate on.
-   * @return Status
-   */
-  Status copy_partitioned_fixed_cells(
-      size_t partition_idx,
-      const std::string* name,
-      uint64_t stride,
-      const std::vector<ResultCellSlab>* result_cell_slabs,
-      const std::vector<uint64_t>* cs_offsets,
-      const std::vector<size_t>* cs_partitions);
-
-  /**
-   * Copies the cells for the input **var-sized** attribute/dimension and result
-   * cell slabs into the corresponding result buffers.
-   *
-   * @param name The targeted attribute/dimension.
-   * @param stride If it is `UINT64_MAX`, then the cells in the result
-   *     cell slabs are all contiguous. Otherwise, each cell in the
-   *     result cell slabs are `stride` cells apart from each other.
-   * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param var_cs_partitions The cell slab partitions.
-   * @param total_cs_length The total cell slab length.
-   * @return Status
-   */
-  Status copy_var_cells(
-      const std::string& name,
-      uint64_t stride,
-      std::vector<ResultCellSlab>* result_cell_slabs,
-      std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
-      size_t total_var_cs_length);
-
-  /**
-   * Compute cs partitions for var-sized cell copying.
-   *
-   * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param var_cs_partitions The output partitions.
-   * @param total_var_cs_length The total cell slab length.
-   */
-  void compute_var_cs_partitions(
-      const std::vector<ResultCellSlab>* result_cell_slabs,
-      std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
-      size_t* total_var_cs_length);
-
-  /**
-   * Computes offsets into destination buffers for the given
-   * attribute/dimensions's offset and variable-length data, for the given list
-   * of result cell slabs.
-   *
-   * @param name The variable-length attribute/dimension.
-   * @param stride If it is `UINT64_MAX`, then the cells in the result
-   *     cell slabs are all contiguous. Otherwise, each cell in the
-   *     result cell slabs are `stride` cells apart from each other.
-   * @param result_cell_slabs The result cell slabs to compute destinations for.
-   * @param offset_offsets_per_cs Output to hold one vector per result cell
-   *    slab, and one element per cell in the slab. The elements are the
-   *    destination offsets for the attribute's offsets.
-   * @param var_offsets_per_cs Output to hold one vector per result cell slab,
-   *    and one element per cell in the slab. The elements are the destination
-   *    offsets for the attribute's variable-length data.
-   * @param total_offset_size Output set to the total size in bytes of the
-   *    offsets in the given list of result cell slabs.
-   * @param total_var_size Output set to the total size in bytes of the
-   *    attribute's variable-length in the given list of result cell slabs.
-   * @param total_validity_size Output set to the total size in bytes of the
-   *    attribute's validity vector in the given list of result cell slabs.
-   * @return Status
-   */
-  Status compute_var_cell_destinations(
-      const std::string& name,
-      uint64_t stride,
-      std::vector<ResultCellSlab>* result_cell_slabs,
-      std::vector<uint64_t>* offset_offsets_per_cs,
-      std::vector<uint64_t>* var_offsets_per_cs,
-      uint64_t* total_offset_size,
-      uint64_t* total_var_size,
-      uint64_t* total_validity_size);
-
-  /**
-   * Copies the cells for the input **var-sized** attribute/dimension and result
-   * cell slabs into the corresponding result buffers for the
-   * partition in `cs_partitions` at index `partition_idx`.
-   *
-   * @param name The partition index.
-   * @param name The targeted attribute/dimension.
-   * @param stride If it is `UINT64_MAX`, then the cells in the result
-   *     cell slabs are all contiguous. Otherwise, each cell in the
-   *     result cell slabs are `stride` cells apart from each other.
-   * @param result_cell_slabs The result cell slabs to copy cells for.
-   * @param offset_offsets_per_cs Maps each cell slab to its offset
-   *     for its attribute offsets.
-   * @param var_offsets_per_cs Maps each cell slab to its offset
-   *     for its variable-length data.
-   * @param cs_partitions The cell slab partitions to operate on.
-   * @return Status
-   */
-  Status copy_partitioned_var_cells(
-      size_t partition_idx,
-      const std::string* name,
-      uint64_t stride,
-      const std::vector<ResultCellSlab>* result_cell_slabs,
-      const std::vector<uint64_t>* offset_offsets_per_cs,
-      const std::vector<uint64_t>* var_offsets_per_cs,
-      const std::vector<std::pair<size_t, size_t>>* cs_partitions);
-
-  /**
-   * For each dimension/attribute in `names`, performs the actions
-   * defined in the `ProcessTileFlags`.
-   *
-   * @param names The dimension/attribute names to process.
-   * @param result_tiles The retrieved tiles will be stored inside the
-   *   `ResultTile` instances in this vector.
-   * @param result_cell_slabs The cell slabs to process.
-   * @param subarray Specifies the current subarray.
-   * @param stride The stride between cells, UINT64_MAX for contiguous.
-   * @param memory_budget The memory budget, UINT64_MAX for unlimited.
-   * @param disable_cache disable the filtered buffer cache.
-   * @return Status
-   */
-  Status process_tiles(
-      const std::unordered_map<std::string, ProcessTileFlags>* names,
-      std::vector<ResultTile*>* result_tiles,
-      std::vector<ResultCellSlab>* result_cell_slabs,
-      Subarray* subarray,
-      uint64_t stride,
-      uint64_t memory_budget,
-      const bool disable_cache = false);
 
   /**
    * Get the size of an attribute tile.
@@ -642,9 +421,9 @@ class ReaderBase : public StrategyBase {
    */
   template <class T>
   void compute_result_space_tiles(
-      const Subarray* subarray,
-      const Subarray* partitioner_subarray,
-      std::map<const T*, ResultSpaceTile<T>>* result_space_tiles) const;
+      const Subarray& subarray,
+      const Subarray& partitioner_subarray,
+      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles) const;
 
   /** Returns `true` if the coordinates are included in the attributes. */
   bool has_coords() const;
@@ -656,10 +435,12 @@ class ReaderBase : public StrategyBase {
    *
    * @tparam T The domain type.
    * @param subarray The input subarray.
-   * @return Status
+   * @param overflowed Returns true if the method overflowed.
+   * @return Status, overflowed
    */
   template <class T>
-  Status fill_dense_coords(const Subarray& subarray);
+  std::tuple<Status, std::optional<bool>> fill_dense_coords(
+      const Subarray& subarray);
 
   /**
    * Fills the coordinate buffers with coordinates. Applicable only to dense
@@ -677,14 +458,14 @@ class ReaderBase : public StrategyBase {
    * @param offsets The offsets that will be used eventually to update
    *     the buffer sizes, determining the useful results written in
    *     the buffers.
-   * @return Status
+   * @return Status, overflowed.
    */
   template <class T>
-  Status fill_dense_coords_global(
+  std::tuple<Status, std::optional<bool>> fill_dense_coords_global(
       const Subarray& subarray,
       const std::vector<unsigned>& dim_idx,
       const std::vector<QueryBuffer*>& buffers,
-      std::vector<uint64_t>* offsets);
+      std::vector<uint64_t>& offsets);
 
   /**
    * Fills the coordinate buffers with coordinates. Applicable only to dense
@@ -702,14 +483,14 @@ class ReaderBase : public StrategyBase {
    * @param offsets The offsets that will be used eventually to update
    *     the buffer sizes, determining the useful results written in
    *     the buffers.
-   * @return Status
+   * @return Status, overflowed.
    */
   template <class T>
-  Status fill_dense_coords_row_col(
+  std::tuple<Status, std::optional<bool>> fill_dense_coords_row_col(
       const Subarray& subarray,
       const std::vector<unsigned>& dim_idx,
       const std::vector<QueryBuffer*>& buffers,
-      std::vector<uint64_t>* offsets);
+      std::vector<uint64_t>& offsets);
 
   /**
    * Fills coordinates in the input buffers for a particular cell slab,
@@ -737,7 +518,7 @@ class ReaderBase : public StrategyBase {
       uint64_t num,
       const std::vector<unsigned>& dim_idx,
       const std::vector<QueryBuffer*>& buffers,
-      std::vector<uint64_t>* offsets) const;
+      std::vector<uint64_t>& offsets) const;
 
   /**
    * Fills coordinates in the input buffers for a particular cell slab,
@@ -765,7 +546,7 @@ class ReaderBase : public StrategyBase {
       uint64_t num,
       const std::vector<unsigned>& dim_idx,
       const std::vector<QueryBuffer*>& buffers,
-      std::vector<uint64_t>* offsets) const;
+      std::vector<uint64_t>& offsets) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -85,35 +85,52 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /*                 API               */
   /* ********************************* */
 
-  /** Finalizes the reader. */
+  /**
+   * Finalizes the reader.
+   *
+   * @return Status.
+   */
   Status finalize() {
     return Status::Ok();
   }
 
-  /** Returns `true` if the query was incomplete. */
+  /**
+   * Returns `true` if the query was incomplete.
+   *
+   * @return The query status.
+   */
   bool incomplete() const;
 
-  /** Returns the status details reason. */
+  /**
+   * Returns `true` if the query was incomplete.
+   *
+   * @return The query status.
+   */
   QueryStatusDetailsReason status_incomplete_reason() const;
 
-  /** Initializes the reader. */
+  /**
+   * Initializes the reader.
+   *
+   * @return Status.
+   */
   Status init();
 
-  /** Initialize the memory budget variables. */
+  /**
+   * Initialize the memory budget variables.
+   *
+   * @return Status.
+   */
   Status initialize_memory_budget();
 
-  /** Performs a read query using its set members. */
+  /**
+   * Performs a read query using its set members.
+   *
+   * @return Status.
+   */
   Status dowork();
 
   /** Resets the reader object. */
   void reset();
-
-  /** Clears the result tiles. Used by serialization. */
-  Status clear_result_tiles();
-
-  /** Add a result tile with no memory budget checks. Used by serialization. */
-  ResultTile* add_result_tile_unsafe(
-      unsigned f, uint64_t t, const ArraySchema* array_schema);
 
  private:
   /* ********************************* */
@@ -125,9 +142,6 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
 
   /** The result tiles currently loaded. */
   ResultTileListPerFragment<uint8_t> result_tiles_;
-
-  /** Is the result tile list empty. */
-  bool empty_result_tiles_;
 
   /** Memory used for coordinates tiles per fragment. */
   std::vector<uint64_t> memory_used_for_coords_;
@@ -141,69 +155,249 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /** Memory budget per fragment for qc tiles. */
   double per_fragment_qc_memory_;
 
-  /** Memory used for result cell slabs. */
-  uint64_t memory_used_rcs_;
-
-  /** How much of the memory budget is reserved for result cell slabs. */
-  double memory_budget_ratio_rcs_;
-
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
 
-  /** Add a result tile to process, making sure maximum budget is respected. */
-  Status add_result_tile(
+  /**
+   * Add a result tile to process, making sure maximum budget is respected.
+   *
+   * @param dim_num Number of dimensions.
+   * @param memory_budget_coords_tiles Memory budget for coordinate tiles.
+   * @param memory_budget_qc_tiles Memory budget for query condition tiles.
+   * @param f Fragment index.
+   * @param t Tile index.
+   * @param array_schema Array schema.
+   *
+   * @return buffers_full, new_var_buffer_size, new_result_tiles_size.
+   */
+  std::tuple<Status, std::optional<bool>> add_result_tile(
       const unsigned dim_num,
       const uint64_t memory_budget_coords_tiles,
       const uint64_t memory_budget_qc_tiles,
       const unsigned f,
       const uint64_t t,
-      const ArraySchema* const array_schema,
-      bool* budget_exceeded);
+      const ArraySchema* const array_schema);
 
-  /** corrects memory usage after de-serialization. */
-  Status fix_memory_usage_after_serialization();
+  /**
+   * Create the result tiles.
+   *
+   * @return Status, tiles_found.
+   */
+  std::tuple<Status, std::optional<bool>> create_result_tiles();
 
-  /** Create the result tiles. */
-  Status create_result_tiles(bool* tiles_found);
-
-  /** Populate a result cell slab to process. */
-  Status compute_result_cell_slab();
+  /**
+   * Populate a result cell slab to process.
+   *
+   * @return Status, result_cell_slab.
+   */
+  std::tuple<Status, std::optional<std::vector<ResultCellSlab>>>
+  compute_result_cell_slab();
 
   /**
    * Add a new tile to the queue of tiles currently being processed
-   *  for a specific fragment.
+   * for a specific fragment.
+   *
+   * @param frag_idx Fragment index.
+   * @param cell_idx Cell index.
+   * @param result_tiles_it Iterator, per frag, in the list of retult tiles.
+   * @param result_tile_used Boolean, per frag, to know if a tile was used.
+   * @param tile_queue Queue of one result coords, per fragment, sorted.
+   * @param tile_queue_mutex Protects tile_queue.
+   *
+   * @return Status, more_tiles.
    */
   template <class T>
-  Status add_next_tile_to_queue(
-      bool subarray_set,
+  std::tuple<Status, std::optional<bool>> add_next_tile_to_queue(
       unsigned int frag_idx,
       uint64_t cell_idx,
       std::vector<std::list<ResultTileWithBitmap<uint8_t>>::iterator>&
           result_tiles_it,
-      std::vector<bool>& result_tile_used,
+      std::vector<uint8_t>& result_tile_used,
       std::priority_queue<ResultCoords, std::vector<ResultCoords>, T>&
           tile_queue,
-      std::mutex& tile_queue_mutex,
-      T& cmp,
-      bool* need_more_tiles);
+      std::mutex& tile_queue_mutex);
 
-  /** Computes a tile's Hilbert values, stores them in the comparator. */
+  /**
+   * Computes a tile's Hilbert values for a tile.
+   *
+   * @param result_tiles Result tiles to process.
+   *
+   * @return Status.
+   */
+  Status compute_hilbert_values(std::vector<ResultTile*>& result_tiles);
+
+  /**
+   * Compute the result cell slabs once tiles are loaded.
+   *
+   * @param num_cells Number of cells that can be copied in the user buffer.
+   * @param cmp Comparator used to merge cells.
+   *
+   * @return Status, result_cell_slabs.
+   */
   template <class T>
-  Status calculate_hilbert_values(
-      bool subarray_set, ResultTileWithBitmap<uint8_t>* tile, T& cmp);
+  std::tuple<Status, std::optional<std::vector<ResultCellSlab>>>
+  merge_result_cell_slabs(uint64_t num_cells, T cmp);
 
-  /** Compute the result cell slabs once tiles are loaded. */
-  template <class T>
-  Status merge_result_cell_slabs(uint64_t memory_budget, T cmp);
+  /**
+   * Compute parallelization parameters for a tile copy operation.
+   *
+   * @param range_thread_idx Current range thread index.
+   * @param num_range_threads Total number of range threads.
+   * @param start Start cell position to process.
+   * @param lenth Number of cells to process.
+   * @param cell_offsets Cell offset per result tile.
+   *
+   * @return min_pos, max_pos, dest_cell_offset, skip_copy.
+   */
+  std::tuple<uint64_t, uint64_t, uint64_t, bool>
+  compute_parallelization_parameters(
+      const uint64_t range_thread_idx,
+      const uint64_t num_range_threads,
+      const uint64_t start,
+      const uint64_t length,
+      const uint64_t cell_offset);
 
-  /** Remove a result tile from memory */
+  /**
+   * Copy offsets tiles.
+   *
+   * @param name Name of the dimension/attribute.
+   * @param num_range_threads Total number of range threads.
+   * @param nullable Is this field nullable.
+   * @param offset_div Divisor used to convert offsets into element mode.
+   * @param result_cell_slabs Result cell slabs to process.
+   * @param cell_offsets Cell offset per result tile.
+   * @param query_buffer Query buffer to operate on.
+   * @param var_data Stores pointers to var data cell values.
+   *
+   * @return Status.
+   */
+  template <class OffType>
+  Status copy_offsets_tiles(
+      const std::string& name,
+      const uint64_t num_range_threads,
+      const bool nullable,
+      const OffType offset_div,
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      const std::vector<uint64_t>& cell_offsets,
+      QueryBuffer& query_buffer,
+      std::vector<void*>& var_data);
+
+  /**
+   * Copy var data tiles.
+   *
+   * @param num_range_threads Total number of range threads.
+   * @param offset_div Divisor used to convert offsets into element mode.
+   * @param var_buffer_size Size of the var data buffer.
+   * @param result_cell_slabs Result cell slabs to process.
+   * @param cell_offsets Cell offset per result tile.
+   * @param query_buffer Query buffer to operate on.
+   * @param var_data Stores pointers to var data cell values.
+   *
+   * @return Status.
+   */
+  template <class OffType>
+  Status copy_var_data_tiles(
+      const uint64_t num_range_threads,
+      const OffType offset_div,
+      const uint64_t var_buffer_size,
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      const std::vector<uint64_t>& cell_offsets,
+      QueryBuffer& query_buffer,
+      const std::vector<void*>& var_data);
+
+  /**
+   * Copy fixed size data tiles.
+   *
+   * @param name Name of the dimension/attribute.
+   * @param num_range_threads Total number of range threads.
+   * @param is_dim Is this field a dimension.
+   * @param nullable Is this field nullable.
+   * @param dim_idx Dimention index, used for zipped coords.
+   * @param cell_size Cell size.
+   * @param result_cell_slabs Result cell slabs to process.
+   * @param cell_offsets Cell offset per result tile.
+   * @param query_buffer Query buffer to operate on.
+   *
+   * @return Status.
+   */
+  Status copy_fixed_data_tiles(
+      const std::string& name,
+      const uint64_t num_range_threads,
+      const bool is_dim,
+      const bool nullable,
+      const unsigned dim_idx,
+      const uint64_t cell_size,
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      const std::vector<uint64_t>& cell_offsets,
+      QueryBuffer& query_buffer);
+
+  /**
+   * Make sure we respect memory budget for copy operation by making sure that,
+   * for all attributes to be copied, the size of tiles in memory can fit into
+   * the budget.
+   *
+   * @param names Attribute/dimensions to compute for.
+   * @param memory_budget Memory budget allowed for copy operation.
+   * @param result_cell_slabs Result cell slabs to process, might be truncated.
+   *
+   * @return Status, total_mem_usage_per_attr.
+   */
+  std::tuple<Status, std::optional<std::vector<uint64_t>>>
+  respect_copy_memory_budget(
+      const std::vector<std::string>& names,
+      const uint64_t memory_budget,
+      std::vector<ResultCellSlab>& result_cell_slabs);
+
+  /**
+   * Compute the var size offsets and make sure all the data can fit in the
+   * user buffer.
+   *
+   * @param stats Stats.
+   * @param result_cell_slabs Result cell slabs to process, might be truncated.
+   * @param cell_offsets Cell offset per result tile.
+   * @param query_buffer Query buffer to operate on.
+   *
+   * @return new_var_buffer_size.
+   */
+  template <class OffType>
+  uint64_t compute_var_size_offsets(
+      stats::Stats* stats,
+      std::vector<ResultCellSlab>& result_cell_slabs,
+      std::vector<uint64_t>& cell_offsets,
+      QueryBuffer& query_buffer);
+
+  /**
+   * Copy cell slabs.
+   *
+   * @param names Attribute/dimensions to compute for.
+   * @param result_cell_slabs The result cell slabs to process.
+   *
+   * @return Status.
+   */
+  template <class OffType>
+  Status process_slabs(
+      std::vector<std::string>& names,
+      std::vector<ResultCellSlab>& result_cell_slabs);
+
+  /**
+   * Remove a result tile from memory
+   *
+   * @param frag_idx Fragment index.
+   * @param rt Iterator to the result tile to remove.
+   *
+   * @return Status.
+   */
   Status remove_result_tile(
       const unsigned frag_idx,
       std::list<ResultTileWithBitmap<uint8_t>>::iterator rt);
 
-  /** Clean up processed data after copying and get ready for the next
-   * iteration. */
+  /**
+   * Clean up processed data after copying and get ready for the next
+   * iteration.
+   *
+   * @return Status.
+   */
   Status end_iteration();
 };
 

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -278,7 +278,7 @@ Status subarray_partitioner_to_capnp(
   // Subarray
   auto subarray_builder = builder->initSubarray();
   RETURN_NOT_OK(
-      subarray_to_capnp(schema, partitioner.subarray(), &subarray_builder));
+      subarray_to_capnp(schema, &partitioner.subarray(), &subarray_builder));
 
   // Per-attr/dim mem budgets
   const auto* budgets = partitioner.get_result_budgets();
@@ -523,17 +523,6 @@ Status index_read_state_to_capnp(
   read_state_builder.setDoneAddingResultTiles(
       read_state->done_adding_result_tiles_);
 
-  auto rcs_builder = read_state_builder.initResultCellSlab(
-      read_state->result_cell_slabs_.size());
-  for (size_t i = 0; i < read_state->result_cell_slabs_.size(); ++i) {
-    rcs_builder[i].setFragIdx(
-        read_state->result_cell_slabs_[i].tile_->frag_idx());
-    rcs_builder[i].setTileIdx(
-        read_state->result_cell_slabs_[i].tile_->tile_idx());
-    rcs_builder[i].setStart(read_state->result_cell_slabs_[i].start_);
-    rcs_builder[i].setLength(read_state->result_cell_slabs_[i].length_);
-  }
-
   auto frag_tile_idx_builder =
       read_state_builder.initFragTileIdx(read_state->frag_tile_idx_.size());
   for (size_t i = 0; i < read_state->frag_tile_idx_.size(); ++i) {
@@ -601,40 +590,6 @@ Status index_read_state_from_capnp(
 
   read_state->done_adding_result_tiles_ =
       read_state_reader.getDoneAddingResultTiles();
-
-  // Only sparse global order reader has a result cell slab.
-  if (read_state_reader.hasResultCellSlab()) {
-    SparseGlobalOrderReader* sparse_global_order_reader =
-        (SparseGlobalOrderReader*)reader;
-    RETURN_NOT_OK(sparse_global_order_reader->clear_result_tiles());
-    read_state->result_cell_slabs_.clear();
-
-    std::unordered_map<
-        std::pair<unsigned, uint64_t>,
-        ResultTile*,
-        tiledb::sm::utils::hash::pair_hash>
-        result_tile_map;
-    for (const auto rcs : read_state_reader.getResultCellSlab()) {
-      auto start = rcs.getStart();
-      auto length = rcs.getLength();
-      auto frag_idx = rcs.getFragIdx();
-      auto tile_idx = rcs.getTileIdx();
-
-      ResultTile* rt = nullptr;
-      auto it = result_tile_map.find(
-          std::pair<unsigned, uint64_t>(frag_idx, tile_idx));
-      if (it != result_tile_map.end()) {
-        rt = it->second;
-      } else {
-        rt = sparse_global_order_reader->add_result_tile_unsafe(
-            frag_idx, tile_idx, schema);
-        result_tile_map.emplace(
-            std::pair<unsigned, uint64_t>(frag_idx, tile_idx), rt);
-      }
-
-      read_state->result_cell_slabs_.emplace_back(rt, start, length);
-    }
-  }
 
   assert(read_state_reader.hasFragTileIdx());
   read_state->frag_tile_idx_.clear();

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -2036,6 +2036,7 @@ std::tuple<Status, std::optional<bool>> Subarray::non_overlapping_ranges(
       [&](uint64_t dim_idx) {
         auto&& [status, nor]{non_overlapping_ranges_for_dim(dim_idx)};
         non_overlapping_ranges = *nor;
+
         return status;
       });
   RETURN_NOT_OK_TUPLE(st);

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -635,12 +635,12 @@ SubarrayPartitioner::State* SubarrayPartitioner::state() {
   return &state_;
 }
 
-const Subarray* SubarrayPartitioner::subarray() const {
-  return &subarray_;
+const Subarray& SubarrayPartitioner::subarray() const {
+  return subarray_;
 }
 
-Subarray* SubarrayPartitioner::subarray() {
-  return &subarray_;
+Subarray& SubarrayPartitioner::subarray() {
+  return subarray_;
 }
 
 stats::Stats* SubarrayPartitioner::stats() const {

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -326,10 +326,10 @@ class SubarrayPartitioner {
   State* state();
 
   /** Returns the subarray. */
-  const Subarray* subarray() const;
+  const Subarray& subarray() const;
 
   /** Returns the subarray. */
-  Subarray* subarray();
+  Subarray& subarray();
 
   /** Returns `stats_`. */
   stats::Stats* stats() const;


### PR DESCRIPTION
Switches the sparse global order reader to only merge cell slabs that
can be copied to the users buffers. That way, the reader becomes more
stateless. It also now loops, like the sparse unordered with duplicates
reader until users buffer are filled in case of a memory budget
incomplete.

More, this change is separating the copy code for the legacy reader and
the sparse global order reader. This way, the copy code for the legacy
reader doesn't include any memory budgeting code from the refactored
reader and we can now move the copy code for the refactored global order
reader forward without risking to break the legacy one.

A small bug fix to not reprocess already loaded coordinate tiles is also
included.

Finally, this includes a lot of code cleanup to move some code to the
new coding standard and having more consistency by using references
instead of pointers for std containers.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: merge smaller cell slabs.
