### PR TITLE
Read tiles: no buffer pre-allocation for no-opt filter.

### DIFF
--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -34,6 +34,8 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/enums/encryption_type.h"
+#include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/parallel_functions.h"
@@ -415,6 +417,7 @@ Status ReaderBase::read_tiles(
     const std::vector<ResultTile*>* result_tiles,
     const bool disable_cache) const {
   auto timer_se = stats_->start_timer("read_tiles");
+  auto enc_type = array_->get_encryption_key().encryption_type();
 
   // Shortcut for empty tile vec
   if (result_tiles->empty())
@@ -517,7 +520,17 @@ Status ReaderBase::read_tiles(
         t->filtered_buffer()->set_size(tile_persisted_size);
         t->filtered_buffer()->reset_offset();
 
-        RETURN_NOT_OK(t->buffer()->realloc(tile_size));
+        // Pre-allocate the unfiltered buffer unless we are using the no-op
+        // filter with no encryption as the no-op filter will reuse the
+        // filtered buffer.
+        const auto& filters =
+            var_size ? fragment->array_schema()->cell_var_offsets_filters() :
+                       fragment->array_schema()->filters(name);
+        if (filters.size() != 1 ||
+            filters.get_filter(0)->type() != FilterType::FILTER_NONE ||
+            enc_type != EncryptionType::NO_ENCRYPTION) {
+          RETURN_NOT_OK(t->buffer()->realloc(tile_size));
+        }
       }
 
       if (var_size) {
@@ -550,7 +563,15 @@ Status ReaderBase::read_tiles(
           t_var->filtered_buffer()->set_size(tile_var_persisted_size);
           t_var->filtered_buffer()->reset_offset();
 
-          RETURN_NOT_OK(t_var->buffer()->realloc(tile_var_size));
+          // Pre-allocate the unfiltered buffer unless we are using the no-op
+          // filter with no encryption as the no-op filter will reuse the
+          // filtered buffer.
+          const auto& filters = fragment->array_schema()->filters(name);
+          if (filters.size() != 1 ||
+              filters.get_filter(0)->type() != FilterType::FILTER_NONE ||
+              enc_type != EncryptionType::NO_ENCRYPTION) {
+            RETURN_NOT_OK(t_var->buffer()->realloc(tile_var_size));
+          }
         }
       }
 
@@ -586,7 +607,16 @@ Status ReaderBase::read_tiles(
           t_validity->filtered_buffer()->set_size(tile_validity_persisted_size);
           t_validity->filtered_buffer()->reset_offset();
 
-          RETURN_NOT_OK(t_validity->buffer()->realloc(tile_validity_size));
+          // Pre-allocate the unfiltered buffer unless we are using the no-op
+          // filter with no encryption as the no-op filter will reuse the
+          // filtered buffer.
+          const auto& filters =
+              fragment->array_schema()->cell_validity_filters();
+          if (filters.size() != 1 ||
+              filters.get_filter(0)->type() != FilterType::FILTER_NONE ||
+              enc_type != EncryptionType::NO_ENCRYPTION) {
+            RETURN_NOT_OK(t_validity->buffer()->realloc(tile_validity_size));
+          }
         }
       }
     }


### PR DESCRIPTION
As the no-opt filter moves the input buffer to the output buffer, there's
no need to preallocate a buffer for this filter.

---
TYPE: IMPROVEMENT
DESC: Read tiles: no buffer pre-allocation for no-opt filter.
