### PR TITLE
Support storing integral cells in a chunk.

### DIFF
--- a/format_spec/FORMAT_SPEC.md
+++ b/format_spec/FORMAT_SPEC.md
@@ -2,7 +2,7 @@
 
 
 :information_source: **Notes:**  
-- The current TileDB format version number is **10** (`uint32_t`).
+- The current TileDB format version number is **11** (`uint32_t`).
 - All data written by TileDB and referenced in this document is **little-endian**. 
 
 ## Table of Contents

--- a/format_spec/filter_pipeline.md
+++ b/format_spec/filter_pipeline.md
@@ -12,6 +12,11 @@ The filter pipeline has internal format:
 | … | … | … |
 | Filter N | [Filter](#filter) | Nth filter |
 
+For var size data, the filter pipeline tries to fit integral cells in a chunk. It uses the following heuristic if the cell doesn't fit:
+  - If the chunk is not yet at 50% capacity, add the cell to the current chunk.
+  - If the chunk is over 50% capacity and adding the cell would make it less than 150% of the maximum chunk size, add it to this chunk.
+  - Else, start a new chunk.
+
 ## Filter
 
 The filter has internal format:

--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -1321,22 +1321,24 @@ TEST_CASE("C API: Test fragment info, dump", "[capi][fragment_info][dump]") {
   CHECK(tiledb_vfs_remove_file(ctx, vfs, "frag3_schema.txt") == TILEDB_OK);
 
   // Check dump
+  const auto ver = std::to_string(tiledb::sm::constants::format_version);
   std::string dump_str =
       std::string("- Fragment num: 3\n") +
       "- Unconsolidated metadata num: 3\n" + "- To vacuum num: 0\n" +
       "- Fragment #1:\n" + "  > URI: " + written_frag_uri_1 + "\n" +
       "  > Type: dense\n" + "  > Non-empty domain: [1, 6]\n" +
       "  > Size: 1662\n" + "  > Cell num: 10\n" +
-      "  > Timestamp range: [1, 1]\n" + "  > Format version: 10\n" +
+      "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n" + "- Fragment #2:\n" +
       "  > URI: " + written_frag_uri_2 + "\n" + "  > Type: dense\n" +
       "  > Non-empty domain: [1, 4]\n" + "  > Size: 1619\n" +
       "  > Cell num: 5\n" + "  > Timestamp range: [2, 2]\n" +
-      "  > Format version: 10\n" + "  > Has consolidated metadata: no\n" +
-      "- Fragment #3:\n" + "  > URI: " + written_frag_uri_3 + "\n" +
-      "  > Type: dense\n" + "  > Non-empty domain: [5, 6]\n" +
-      "  > Size: 1662\n" + "  > Cell num: 10\n" +
-      "  > Timestamp range: [3, 3]\n" + "  > Format version: 10\n" +
+      "  > Format version: " + ver + "\n" +
+      "  > Has consolidated metadata: no\n" + "- Fragment #3:\n" +
+      "  > URI: " + written_frag_uri_3 + "\n" + "  > Type: dense\n" +
+      "  > Non-empty domain: [5, 6]\n" + "  > Size: 1662\n" +
+      "  > Cell num: 10\n" + "  > Timestamp range: [3, 3]\n" +
+      "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";
   FILE* gold_fout = fopen("gold_fout.txt", "w");
   const char* dump = dump_str.c_str();
@@ -1458,6 +1460,7 @@ TEST_CASE(
   CHECK(rc == TILEDB_OK);
 
   // Check dump
+  const auto ver = std::to_string(tiledb::sm::constants::format_version);
   std::string dump_str =
       std::string("- Fragment num: 1\n") +
       "- Unconsolidated metadata num: 1\n" + "- To vacuum num: 3\n" +
@@ -1466,7 +1469,8 @@ TEST_CASE(
       "- Fragment #1:\n" + "  > URI: " + uri + "\n" + "  > Type: dense\n" +
       "  > Non-empty domain: [1, 10]\n" + "  > Size: 1662\n" +
       "  > Cell num: 10\n" + "  > Timestamp range: [1, 3]\n" +
-      "  > Format version: 10\n" + "  > Has consolidated metadata: no\n";
+      "  > Format version: " + ver + "\n" +
+      "  > Has consolidated metadata: no\n";
   FILE* gold_fout = fopen("gold_fout.txt", "w");
   const char* dump = dump_str.c_str();
   fwrite(dump, sizeof(char), strlen(dump), gold_fout);
@@ -1541,13 +1545,14 @@ TEST_CASE(
   CHECK(rc == TILEDB_OK);
 
   // Check dump
+  const auto ver = std::to_string(tiledb::sm::constants::format_version);
   std::string dump_str =
       std::string("- Fragment num: 1\n") +
       "- Unconsolidated metadata num: 1\n" + "- To vacuum num: 0\n" +
       "- Fragment #1:\n" + "  > URI: " + written_frag_uri + "\n" +
       "  > Type: sparse\n" + "  > Non-empty domain: [a, ddd]\n" +
       "  > Size: 1903\n" + "  > Cell num: 4\n" +
-      "  > Timestamp range: [1, 1]\n" + "  > Format version: 10\n" +
+      "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";
   FILE* gold_fout = fopen("gold_fout.txt", "w");
   const char* dump = dump_str.c_str();

--- a/test/src/unit-cppapi-fragment_info.cc
+++ b/test/src/unit-cppapi-fragment_info.cc
@@ -834,22 +834,24 @@ TEST_CASE(
     CHECK(frag1_schema_str == frag3_schema_str);
 
     // Check dump
+    const auto ver = std::to_string(tiledb::sm::constants::format_version);
     std::string dump_str =
         std::string("- Fragment num: 3\n") +
         "- Unconsolidated metadata num: 3\n" + "- To vacuum num: 0\n" +
         "- Fragment #1:\n" + "  > URI: " + written_frag_uri_1 + "\n" +
         "  > Type: dense\n" + "  > Non-empty domain: [1, 6]\n" +
         "  > Size: 1662\n" + "  > Cell num: 10\n" +
-        "  > Timestamp range: [1, 1]\n" + "  > Format version: 10\n" +
+        "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n" + "- Fragment #2:\n" +
         "  > URI: " + written_frag_uri_2 + "\n" + "  > Type: dense\n" +
         "  > Non-empty domain: [1, 4]\n" + "  > Size: 1619\n" +
         "  > Cell num: 5\n" + "  > Timestamp range: [2, 2]\n" +
-        "  > Format version: 10\n" + "  > Has consolidated metadata: no\n" +
-        "- Fragment #3:\n" + "  > URI: " + written_frag_uri_3 + "\n" +
-        "  > Type: dense\n" + "  > Non-empty domain: [5, 6]\n" +
-        "  > Size: 1662\n" + "  > Cell num: 10\n" +
-        "  > Timestamp range: [3, 3]\n" + "  > Format version: 10\n" +
+        "  > Format version: " + ver + "\n" +
+        "  > Has consolidated metadata: no\n" + "- Fragment #3:\n" +
+        "  > URI: " + written_frag_uri_3 + "\n" + "  > Type: dense\n" +
+        "  > Non-empty domain: [5, 6]\n" + "  > Size: 1662\n" +
+        "  > Cell num: 10\n" + "  > Timestamp range: [3, 3]\n" +
+        "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n";
     FILE* gold_fout = fopen("gold_fout.txt", "w");
     const char* dump = dump_str.c_str();

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -93,16 +93,23 @@ Status FilterPipeline::filter_chunks_forward(
     const Tile& tile,
     const Buffer& input,
     uint32_t chunk_size,
+    std::vector<uint64_t>& chunk_offsets,
     Buffer* const output,
     ThreadPool* const compute_tp) const {
   assert(output);
 
-  uint64_t nchunks = input.size() / chunk_size;
-  uint64_t last_buffer_size = input.size() % chunk_size;
-  if (last_buffer_size != 0) {
-    nchunks++;
-  } else {
-    last_buffer_size = chunk_size;
+  bool var_sizes = chunk_offsets.size() > 0;
+  uint64_t nchunks =
+      var_sizes ? chunk_offsets.size() : input.size() / chunk_size;
+  uint64_t last_buffer_size = var_sizes ?
+                                  input.size() - chunk_offsets[nchunks - 1] :
+                                  input.size() % chunk_size;
+  if (!var_sizes) {
+    if (last_buffer_size != 0) {
+      nchunks++;
+    } else {
+      last_buffer_size = chunk_size;
+    }
   }
 
   // Vector storing the input and output of the final pipeline stage for each
@@ -119,9 +126,12 @@ Status FilterPipeline::filter_chunks_forward(
     FilterBuffer input_metadata(&storage), output_metadata(&storage);
 
     // First filter's input is the original chunk.
-    void* chunk_buffer = static_cast<char*>(input.data()) + i * chunk_size;
+    uint64_t offset = var_sizes ? chunk_offsets[i] : i * chunk_size;
+    void* chunk_buffer = static_cast<char*>(input.data()) + offset;
     uint32_t chunk_buffer_size =
-        i == nchunks - 1 ? last_buffer_size : chunk_size;
+        i == nchunks - 1 ?
+            last_buffer_size :
+            var_sizes ? chunk_offsets[i + 1] - chunk_offsets[i] : chunk_size;
     RETURN_NOT_OK(input_data.init(chunk_buffer, chunk_buffer_size));
 
     // Apply the filters sequentially.
@@ -206,7 +216,9 @@ Status FilterPipeline::filter_chunks_forward(
     auto& final_stage_output_data = final_stage_io[i].first.second;
     auto filtered_size = (uint32_t)final_stage_output_data.size();
     uint32_t orig_chunk_size =
-        i == final_stage_io.size() - 1 ? last_buffer_size : chunk_size;
+        i == final_stage_io.size() - 1 ?
+            last_buffer_size :
+            var_sizes ? chunk_offsets[i + 1] - chunk_offsets[i] : chunk_size;
     auto metadata_size = (uint32_t)final_stage_output_metadata.size();
     void* dest = output->data(offsets[i]);
     uint64_t dest_offset = 0;
@@ -357,6 +369,7 @@ uint32_t FilterPipeline::max_chunk_size() const {
 Status FilterPipeline::run_forward(
     stats::Stats* const writer_stats,
     Tile* const tile,
+    Tile* const offsets_tile,
     ThreadPool* const compute_tp) const {
   RETURN_NOT_OK(
       tile ? Status::Ok() : Status_Error("invalid argument: null Tile*"));
@@ -367,6 +380,60 @@ Status FilterPipeline::run_forward(
   RETURN_NOT_OK(Tile::compute_chunk_size(
       tile->size(), tile->dim_num(), tile->cell_size(), &chunk_size));
 
+  // Figure out chunk sizes so that integral cells are within a chunk.
+  // Heuristic is the following when determining to add a cell:
+  //   - If the cell fits in the buffer, add it.
+  //   - If it doesn't fit and new size < 150% capacity, add it.
+  //   - If it doesn't fit and current size < 50% capacity, add it.
+  std::vector<uint64_t> chunk_offsets;
+  if (offsets_tile != nullptr) {
+    uint64_t num_offsets =
+        offsets_tile->buffer()->size() / constants::cell_var_offset_size;
+    auto offsets = (uint64_t*)offsets_tile->buffer()->data();
+
+    uint64_t current_size = 0;
+    uint64_t min_size = chunk_size / 2;
+    uint64_t max_size = chunk_size + chunk_size / 2;
+    chunk_offsets.emplace_back(0);
+    for (uint64_t c = 0; c < num_offsets; c++) {
+      auto cell_size = c == num_offsets - 1 ?
+                           tile->buffer()->size() - offsets[c] :
+                           offsets[c + 1] - offsets[c];
+
+      // Time for a new chunk?
+      auto new_size = current_size + cell_size;
+      if (new_size > chunk_size) {
+        // Do we add this cell to this fragment?
+        if (current_size <= min_size || new_size <= max_size) {
+          if (new_size > std::numeric_limits<uint32_t>::max()) {
+            return LOG_STATUS(Status_TileError("Chunk size exceeds uint32_t"));
+          }
+          chunk_offsets.emplace_back(offsets[c] + cell_size);
+          current_size = 0;
+        } else {  // Start a new chunk.
+          chunk_offsets.emplace_back(offsets[c]);
+          current_size = 0;
+
+          // This cell belong in its own chunk.
+          if (cell_size > chunk_size) {
+            if (cell_size > std::numeric_limits<uint32_t>::max()) {
+              return LOG_STATUS(
+                  Status_TileError("Chunk size exceeds uint32_t"));
+            }
+
+            if (c != num_offsets - 1)
+              chunk_offsets.emplace_back(offsets[c] + cell_size);
+            current_size = 0;
+          } else {  // Start a new chunk.
+            current_size = cell_size;
+          }
+        }
+      } else {
+        current_size += cell_size;
+      }
+    }
+  }
+
   // Run the filters over all the chunks and store the result in
   // 'filtered_buffer'.
   RETURN_NOT_OK_ELSE(
@@ -374,6 +441,7 @@ Status FilterPipeline::run_forward(
           *tile,
           *tile->buffer(),
           chunk_size,
+          chunk_offsets,
           tile->filtered_buffer(),
           compute_tp),
       tile->filtered_buffer()->clear());

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -265,6 +265,23 @@ class FilterPipeline {
   uint32_t max_chunk_size_;
 
   /**
+   * Get the chunk offsets for a var sized tile so that integral cells are
+   * within a chunk.
+   *
+   * Heuristic is the following when determining to add a cell:
+   *   - If the cell fits in the buffer, add it.
+   *   - If it doesn't fit and new size < 150% capacity, add it.
+   *   - If it doesn't fit and current size < 50% capacity, add it.
+   *
+   * @param chunk_size Target chunk size.
+   * @param tile Var tile.
+   * @param offsets_tile Offsets tile.
+   * @return Status, chunk offsets vector.
+   */
+  std::tuple<Status, std::optional<std::vector<uint64_t>>> get_var_chunk_sizes(
+      uint32_t chunk_size, Tile* const tile, Tile* const offsets_tile) const;
+
+  /**
    * Run the given buffer forward through the pipeline.
    *
    * @param tile Current tile on which the filter pipeline is being run

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -171,11 +171,15 @@ class FilterPipeline {
    * data.
    *
    * @param tile Tile to filter.
+   * @param offsets_tile Offets tile for tile to filter.
    * @param compute_tp The thread pool for compute-bound tasks.
    * @return Status
    */
   Status run_forward(
-      stats::Stats* writer_stats, Tile* tile, ThreadPool* compute_tp) const;
+      stats::Stats* writer_stats,
+      Tile* tile,
+      Tile* offsets_tile,
+      ThreadPool* compute_tp) const;
 
   /**
    * Runs the pipeline in reverse on the given filtered tile. This is used
@@ -266,6 +270,7 @@ class FilterPipeline {
    * @param tile Current tile on which the filter pipeline is being run
    * @param input buffer to process.
    * @param chunk_size chunk size.
+   * @param chunk_offsets chunk offsets computed for var sized attributes.
    * @param output buffer where output of the last stage
    *    will be written.
    * @param compute_tp The thread pool for compute-bound tasks.
@@ -275,6 +280,7 @@ class FilterPipeline {
       const Tile& tile,
       const Buffer& input,
       uint32_t chunk_size,
+      std::vector<uint64_t>& chunk_offsets,
       Buffer* const output,
       ThreadPool* const compute_tp) const;
 

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -528,7 +528,7 @@ const int32_t library_version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
 /** The TileDB serialization format version number. */
-const uint32_t format_version = 10;
+const uint32_t format_version = 11;
 
 /** The lowest version supported for back compat writes. */
 const uint32_t back_compat_writes_min_format_version = 7;

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -1004,7 +1004,7 @@ Status DenseReader::copy_fixed_tiles(
           const Tile* const tile = &std::get<0>(*tile_tuple);
           const Tile* const tile_nullable = &std::get<2>(*tile_tuple);
 
-          auto src_offset = (src_cell + start);
+          auto src_offset = src_cell + start;
 
           // If the subarray and tile are in the same order, copy the whole
           // slab.

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -1040,16 +1040,20 @@ Status Writer::filter_tiles(const std::string& name, std::vector<Tile>* tiles) {
   // Filter all tiles
   auto tile_num = tiles->size();
 
-  std::vector<std::tuple<Tile*, bool, bool>> args;
+  std::vector<std::tuple<Tile*, Tile*, bool, bool>> args;
   args.reserve(tile_num);
 
   size_t i = 0;
   while (i < tile_num) {
-    args.emplace_back(&(*tiles)[i++], var_size, false);
-    if (var_size)
-      args.emplace_back(&(*tiles)[i++], false, false);
-    if (nullable)
-      args.emplace_back(&(*tiles)[i++], false, true);
+    args.emplace_back(&(*tiles)[i++], nullptr, var_size, false);
+    if (var_size) {
+      args.emplace_back(&(*tiles)[i], &(*tiles)[i - 1], false, false);
+      ++i;
+    }
+
+    if (nullable) {
+      args.emplace_back(&(*tiles)[i++], nullptr, false, true);
+    }
   }
 
   auto status = parallel_for(
@@ -1058,7 +1062,8 @@ Status Writer::filter_tiles(const std::string& name, std::vector<Tile>* tiles) {
             name,
             std::get<0>(args[i]),
             std::get<1>(args[i]),
-            std::get<2>(args[i])));
+            std::get<2>(args[i]),
+            std::get<3>(args[i])));
         return Status::Ok();
       });
 
@@ -1070,6 +1075,7 @@ Status Writer::filter_tiles(const std::string& name, std::vector<Tile>* tiles) {
 Status Writer::filter_tile(
     const std::string& name,
     Tile* const tile,
+    Tile* const offsets_tile,
     const bool offsets,
     const bool nullable) {
   auto timer_se = stats_->start_timer("filter_tile");
@@ -1092,8 +1098,8 @@ Status Writer::filter_tile(
       &filters, array_->get_encryption_key()));
 
   assert(!tile->filtered());
-  RETURN_NOT_OK(
-      filters.run_forward(stats_, tile, storage_manager_->compute_tp()));
+  RETURN_NOT_OK(filters.run_forward(
+      stats_, tile, offsets_tile, storage_manager_->compute_tp()));
   assert(tile->filtered());
 
   tile->set_pre_filtered_size(orig_size);
@@ -2796,22 +2802,24 @@ Status Writer::prepare_filter_and_write_tiles(
           if (!var) {
             RETURN_NOT_OK(dense_tiler->get_tile(
                 frag_tile_id + i, name, &tiles[tiles_id]));
-            RETURN_NOT_OK(filter_tile(name, &tiles[tiles_id], false, false));
+            RETURN_NOT_OK(
+                filter_tile(name, &tiles[tiles_id], nullptr, false, false));
           } else {
             RETURN_NOT_OK(dense_tiler->get_tile_var(
                 frag_tile_id + i,
                 name,
                 &tiles[tiles_id],
                 &tiles[tiles_id + 1]));
-            RETURN_NOT_OK(filter_tile(name, &tiles[tiles_id], true, false));
             RETURN_NOT_OK(
-                filter_tile(name, &tiles[tiles_id + 1], false, false));
+                filter_tile(name, &tiles[tiles_id], nullptr, true, false));
+            RETURN_NOT_OK(filter_tile(
+                name, &tiles[tiles_id + 1], &tiles[tiles_id], false, false));
           }
           if (nullable) {
             RETURN_NOT_OK(dense_tiler->get_tile_null(
                 frag_tile_id + i, name, &tiles[tiles_id + 1 + var]));
-            RETURN_NOT_OK(
-                filter_tile(name, &tiles[tiles_id + 1 + var], false, true));
+            RETURN_NOT_OK(filter_tile(
+                name, &tiles[tiles_id + 1 + var], nullptr, false, true));
           }
           return Status::Ok();
         });

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -1036,34 +1036,39 @@ Status Writer::filter_tiles(
 Status Writer::filter_tiles(const std::string& name, std::vector<Tile>* tiles) {
   const bool var_size = array_schema_->var_size(name);
   const bool nullable = array_schema_->is_nullable(name);
+  const size_t tile_step = 1 + nullable + var_size;
 
   // Filter all tiles
   auto tile_num = tiles->size();
 
+  // Make sure we have the correct number of tiles.
+  if (tile_num % tile_step != 0) {
+    return logger_->status(
+        Status_WriterError("Incorrect number of tiles in filter_tiles"));
+  }
+
   std::vector<std::tuple<Tile*, Tile*, bool, bool>> args;
   args.reserve(tile_num);
 
-  size_t i = 0;
-  while (i < tile_num) {
-    args.emplace_back(&(*tiles)[i++], nullptr, var_size, false);
+  for (size_t tile_idx = 0; tile_idx < tile_num; tile_idx += tile_step) {
+    args.emplace_back(&(*tiles)[tile_idx], nullptr, var_size, false);
     if (var_size) {
-      args.emplace_back(&(*tiles)[i], &(*tiles)[i - 1], false, false);
-      ++i;
+      args.emplace_back(
+          &(*tiles)[tile_idx + 1], &(*tiles)[tile_idx], false, false);
     }
 
     if (nullable) {
-      args.emplace_back(&(*tiles)[i++], nullptr, false, true);
+      args.emplace_back(
+          &(*tiles)[tile_idx + var_size + 1], nullptr, false, true);
     }
   }
 
   auto status = parallel_for(
       storage_manager_->compute_tp(), 0, tile_num, [&](uint64_t i) {
+        const auto& [tile, offset_tile, contains_offsets, is_nullable] =
+            args[i];
         RETURN_NOT_OK(filter_tile(
-            name,
-            std::get<0>(args[i]),
-            std::get<1>(args[i]),
-            std::get<2>(args[i]),
-            std::get<3>(args[i])));
+            name, tile, offset_tile, contains_offsets, is_nullable));
         return Status::Ok();
       });
 

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -384,13 +384,18 @@ class Writer : public StrategyBase, public IQueryStrategy {
    *
    * @param name The attribute/dimension the tile belong to.
    * @param tile The tile to be filtered.
+   * @param offsets_tile The offsets tile in case of a var tile, or null.
    * @param offsets True if the tile to be filtered contains offsets for a
    *    var-sized attribute/dimension.
    * @param offsets True if the tile to be filtered contains validity values.
    * @return Status
    */
   Status filter_tile(
-      const std::string& name, Tile* tile, bool offsets, bool nullable);
+      const std::string& name,
+      Tile* tile,
+      Tile* offsets_tile,
+      bool offsets,
+      bool nullable);
 
   /** Finalizes the global write state. */
   Status finalize_global_write_state();

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -163,7 +163,10 @@ Status GenericTileIO::write_generic(
   // Filter tile
   assert(!tile->filtered());
   RETURN_NOT_OK(header.filters.run_forward(
-      storage_manager_->stats(), tile, storage_manager_->compute_tp()));
+      storage_manager_->stats(),
+      tile,
+      nullptr,
+      storage_manager_->compute_tp()));
   header.persisted_size = tile->filtered_buffer()->size();
   assert(tile->filtered());
 

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -43,6 +43,11 @@ namespace tiledb {
 namespace sm {
 
 /* ****************************** */
+/*           STATIC INIT          */
+/* ****************************** */
+uint64_t Tile::max_tile_chunk_size_ = constants::max_tile_chunk_size;
+
+/* ****************************** */
 /*           STATIC API           */
 /* ****************************** */
 
@@ -55,8 +60,7 @@ Status Tile::compute_chunk_size(
   const uint64_t dim_tile_size = tile_size / dim_num;
   const uint64_t dim_cell_size = tile_cell_size / dim_num;
 
-  uint64_t chunk_size64 =
-      std::min(constants::max_tile_chunk_size, dim_tile_size);
+  uint64_t chunk_size64 = std::min(max_tile_chunk_size_, dim_tile_size);
   chunk_size64 = chunk_size64 / dim_cell_size * dim_cell_size;
   chunk_size64 = std::max(chunk_size64, dim_cell_size);
   if (chunk_size64 > std::numeric_limits<uint32_t>::max()) {
@@ -65,6 +69,10 @@ Status Tile::compute_chunk_size(
 
   *chunk_size = chunk_size64;
   return Status::Ok();
+}
+
+void Tile::set_max_tile_chunk_size(uint64_t max_tile_chunk_size) {
+  max_tile_chunk_size_ = max_tile_chunk_size;
 }
 
 /* ****************************** */

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -67,6 +67,13 @@ class Tile {
       const uint64_t tile_cell_size,
       uint32_t* const chunk_size);
 
+  /**
+   * Override max_tile_chunk_size_. Used in tests only.
+   *
+   * @param max_tile_chunk_size The maximum chunk size.
+   */
+  static void set_max_tile_chunk_size(uint64_t max_tile_chunk_size);
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -365,6 +372,12 @@ class Tile {
    * public API, all other public API routines operate on 'buffer_'.
    */
   Buffer filtered_buffer_;
+
+  /**
+   * Static variable to store constants::max_tile_chunk_size. This will be used
+   * to override the value in tests.
+   */
+  static uint64_t max_tile_chunk_size_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */


### PR DESCRIPTION
Currently chunks are broken up at 64kib boundary for unfiltered data.
This means that potentially we'll have a single cells value split across
two chunks. This is not ideal as we then have to included multiple
chunks to access a single cell.

This change makes sure cells are never split. The heuristic is the
following when determining to add a cell to a chunk:
 - If the cell fits in the buffer, add it.
 - If it doesn't fit and new size < 150% capacity, add it.
 - If it doesn't fit and current size < 50% capacity, add it.

---
TYPE: IMPROVEMENT
DESC: Support storing integral cells in a chunk.
