### PR TITLE
Switching TUPLE macros to be variadic.

### DIFF
--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -81,21 +81,21 @@ namespace common {
     }                                \
   } while (false)
 
-#define RETURN_NOT_OK_TUPLE(s)   \
-  do {                           \
-    Status _s = (s);             \
-    if (!_s.ok()) {              \
-      return {_s, std::nullopt}; \
-    }                            \
+#define RETURN_NOT_OK_TUPLE(s, ...) \
+  do {                              \
+    Status _s = (s);                \
+    if (!_s.ok()) {                 \
+      return {_s, __VA_ARGS__};     \
+    }                               \
   } while (false)
 
-#define RETURN_NOT_OK_ELSE_TUPLE(s, else_) \
-  do {                                     \
-    Status _s = (s);                       \
-    if (!_s.ok()) {                        \
-      else_;                               \
-      return {_s, std::nullopt};           \
-    }                                      \
+#define RETURN_NOT_OK_ELSE_TUPLE(s, else_, ...) \
+  do {                                          \
+    Status _s = (s);                            \
+    if (!_s.ok()) {                             \
+      else_;                                    \
+      return {_s, __VA_ARGS__};                 \
+    }                                           \
   } while (false)
 
 class Status {

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -113,21 +113,23 @@ std::tuple<Status, std::optional<Attribute>> Attribute::deserialize(
     ConstBuffer* buff, const uint32_t version) {
   // Load attribute name
   uint32_t attribute_name_size;
-  RETURN_NOT_OK_TUPLE(buff->read(&attribute_name_size, sizeof(uint32_t)));
+  RETURN_NOT_OK_TUPLE(
+      buff->read(&attribute_name_size, sizeof(uint32_t)), std::nullopt);
 
   std::string name;
   name.resize(attribute_name_size);
-  RETURN_NOT_OK_TUPLE(buff->read(&name[0], attribute_name_size));
+  RETURN_NOT_OK_TUPLE(buff->read(&name[0], attribute_name_size), std::nullopt);
 
   // Load type
   uint8_t type;
-  RETURN_NOT_OK_TUPLE(buff->read(&type, sizeof(uint8_t)));
+  RETURN_NOT_OK_TUPLE(buff->read(&type, sizeof(uint8_t)), std::nullopt);
 
   Datatype datatype = static_cast<Datatype>(type);
 
   // Load cell_val_num
   uint32_t cell_val_num;
-  RETURN_NOT_OK_TUPLE(buff->read(&cell_val_num, sizeof(uint32_t)));
+  RETURN_NOT_OK_TUPLE(
+      buff->read(&cell_val_num, sizeof(uint32_t)), std::nullopt);
 
   // Load filter pipeline
   FilterPipeline filter_pipeline;
@@ -137,11 +139,13 @@ std::tuple<Status, std::optional<Attribute>> Attribute::deserialize(
   uint64_t fill_value_size = 0;
   ByteVecValue fill_value;
   if (version >= 6) {
-    RETURN_NOT_OK_TUPLE(buff->read(&fill_value_size, sizeof(uint64_t)));
+    RETURN_NOT_OK_TUPLE(
+        buff->read(&fill_value_size, sizeof(uint64_t)), std::nullopt);
     assert(fill_value_size > 0);
     fill_value.resize(fill_value_size);
     fill_value.shrink_to_fit();
-    RETURN_NOT_OK_TUPLE(buff->read(fill_value.data(), fill_value_size));
+    RETURN_NOT_OK_TUPLE(
+        buff->read(fill_value.data(), fill_value_size), std::nullopt);
   } else {
     fill_value = default_fill_value(datatype, cell_val_num);
   }
@@ -149,13 +153,14 @@ std::tuple<Status, std::optional<Attribute>> Attribute::deserialize(
   // Load nullable flag
   bool nullable = false;
   if (version >= 7) {
-    RETURN_NOT_OK_TUPLE(buff->read(&nullable, sizeof(bool)));
+    RETURN_NOT_OK_TUPLE(buff->read(&nullable, sizeof(bool)), std::nullopt);
   }
 
   // Load validity fill value
   uint8_t fill_value_validity = 0;
   if (version >= 7) {
-    RETURN_NOT_OK_TUPLE(buff->read(&fill_value_validity, sizeof(uint8_t)));
+    RETURN_NOT_OK_TUPLE(
+        buff->read(&fill_value_validity, sizeof(uint8_t)), std::nullopt);
   }
 
   return {Status::Ok(),

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -827,7 +827,8 @@ std::tuple<Status, std::optional<uint64_t>> ReaderBase::get_attribute_tile_size(
 
   if (array_schema_->var_size(name)) {
     uint64_t temp = 0;
-    RETURN_NOT_OK_TUPLE(fragment_metadata_[f]->tile_var_size(name, t, &temp));
+    RETURN_NOT_OK_TUPLE(
+        fragment_metadata_[f]->tile_var_size(name, t, &temp), std::nullopt);
     tile_size += temp;
   }
 
@@ -944,13 +945,13 @@ std::tuple<Status, std::optional<bool>> ReaderBase::fill_dense_coords(
   if (layout_ == Layout::GLOBAL_ORDER) {
     auto&& [st, of] =
         fill_dense_coords_global<T>(subarray, dim_idx, buffers, offsets);
-    RETURN_NOT_OK_TUPLE(st);
+    RETURN_NOT_OK_TUPLE(st, std::nullopt);
     overflowed = *of;
   } else {
     assert(layout_ == Layout::ROW_MAJOR || layout_ == Layout::COL_MAJOR);
     auto&& [st, of] =
         fill_dense_coords_row_col<T>(subarray, dim_idx, buffers, offsets);
-    RETURN_NOT_OK_TUPLE(st);
+    RETURN_NOT_OK_TUPLE(st, std::nullopt);
     overflowed = *of;
   }
 
@@ -975,7 +976,7 @@ std::tuple<Status, std::optional<bool>> ReaderBase::fill_dense_coords_global(
     auto tile_subarray = subarray.crop_to_tile((const T*)&tc[0], cell_order);
     auto&& [st, of] =
         fill_dense_coords_row_col<T>(tile_subarray, dim_idx, buffers, offsets);
-    RETURN_NOT_OK_TUPLE(st);
+    RETURN_NOT_OK_TUPLE(st, std::nullopt);
     overflowed |= *of;
   }
 

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -269,7 +269,7 @@ SparseGlobalOrderReader::add_result_tile(
     const ArraySchema* const array_schema) {
   // Calculate memory consumption for this tile.
   auto&& [st, tiles_sizes] = get_coord_tiles_size<uint8_t>(true, dim_num, f, t);
-  RETURN_NOT_OK_TUPLE(st);
+  RETURN_NOT_OK_TUPLE(st, std::nullopt);
   auto tiles_size = tiles_sizes->first;
   auto tiles_size_qc = tiles_sizes->second;
 
@@ -364,7 +364,7 @@ SparseGlobalOrderReader::create_result_tiles() {
           all_tiles_loaded_[f] = true;
           return Status::Ok();
         });
-    RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status));
+    RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status), std::nullopt);
   } else {
     // Load as many tiles as the memory budget allows.
     auto status = parallel_for(
@@ -406,7 +406,7 @@ SparseGlobalOrderReader::create_result_tiles() {
           all_tiles_loaded_[f] = true;
           return Status::Ok();
         });
-    RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status));
+    RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status), std::nullopt);
   }
 
   bool done_adding_result_tiles = true;
@@ -634,7 +634,7 @@ SparseGlobalOrderReader::merge_result_cell_slabs(uint64_t num_cells, T cmp) {
 
         return Status::Ok();
       });
-  RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status));
+  RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status), std::nullopt);
 
   // Process all elements.
   while (!tile_queue.empty() && !need_more_tiles && num_cells > 0) {
@@ -673,7 +673,7 @@ SparseGlobalOrderReader::merge_result_cell_slabs(uint64_t num_cells, T cmp) {
             result_tile_used,
             tile_queue,
             tile_queue_mutex);
-        RETURN_NOT_OK_TUPLE(st);
+        RETURN_NOT_OK_TUPLE(st, std::nullopt);
         need_more_tiles = *more_tiles;
       } else {
         tile_queue.emplace(std::move(next_tile));
@@ -780,7 +780,7 @@ SparseGlobalOrderReader::merge_result_cell_slabs(uint64_t num_cells, T cmp) {
           result_tile_used,
           tile_queue,
           tile_queue_mutex);
-      RETURN_NOT_OK_TUPLE(st);
+      RETURN_NOT_OK_TUPLE(st, std::nullopt);
       need_more_tiles = *more_tiles;
     } else {
       // Put the next cell on the queue to be resorted.
@@ -1129,7 +1129,7 @@ SparseGlobalOrderReader::respect_copy_memory_budget(
 
         return Status::Ok();
       });
-  RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status));
+  RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status), std::nullopt);
 
   if (max_cs_idx == 0)
     return {Status_SparseUnorderedWithDupsReaderError(

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -172,7 +172,8 @@ SparseIndexReaderBase::get_coord_tiles_size(
       if (is_dim_var_size_[d]) {
         uint64_t temp = 0;
         RETURN_NOT_OK_TUPLE(
-            fragment_metadata_[f]->tile_var_size(dim_names_[d], t, &temp));
+            fragment_metadata_[f]->tile_var_size(dim_names_[d], t, &temp),
+            std::nullopt);
         tiles_size += temp;
       }
     }
@@ -191,7 +192,7 @@ SparseIndexReaderBase::get_coord_tiles_size(
     for (auto& name : qc_loaded_names_) {
       // Calculate memory consumption for this tile.
       auto&& [st, tile_size] = get_attribute_tile_size(name, f, t);
-      RETURN_NOT_OK_TUPLE(st);
+      RETURN_NOT_OK_TUPLE(st, std::nullopt);
       tiles_size_qc += *tile_size;
     }
   }
@@ -605,10 +606,11 @@ SparseIndexReaderBase::read_and_unfilter_attributes(
   }
 
   // Read and unfilter tiles.
-  RETURN_NOT_OK_TUPLE(read_attribute_tiles(names_to_read, result_tiles, true));
+  RETURN_NOT_OK_TUPLE(
+      read_attribute_tiles(names_to_read, result_tiles, true), std::nullopt);
 
   for (auto& name : names_to_read)
-    RETURN_NOT_OK_TUPLE(unfilter_tiles(name, result_tiles, true));
+    RETURN_NOT_OK_TUPLE(unfilter_tiles(name, result_tiles, true), std::nullopt);
 
   return {Status::Ok(), std::move(index_to_copy)};
 }

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -290,7 +290,7 @@ SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
   // Calculate memory consumption for this tile.
   auto&& [st, tiles_sizes] =
       get_coord_tiles_size<BitmapType>(subarray_.is_set(), dim_num, f, t);
-  RETURN_NOT_OK_TUPLE(st);
+  RETURN_NOT_OK_TUPLE(st, std::nullopt);
   auto tiles_size = tiles_sizes->first;
   auto tiles_size_qc = tiles_sizes->second;
 
@@ -1180,7 +1180,7 @@ SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
 
         return Status::Ok();
       });
-  RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status));
+  RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status), std::nullopt);
 
   if (max_rt_idx == 0)
     return {Status_SparseUnorderedWithDupsReaderError(

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1985,7 +1985,8 @@ StorageManager::load_all_array_schemas(
             std::nullopt};
 
   std::vector<URI> schema_uris;
-  RETURN_NOT_OK_TUPLE(get_array_schema_uris(array_uri, &schema_uris));
+  RETURN_NOT_OK_TUPLE(
+      get_array_schema_uris(array_uri, &schema_uris), std::nullopt);
   if (schema_uris.empty()) {
     return {
         logger_->status(Status_StorageManagerError(
@@ -2006,7 +2007,7 @@ StorageManager::load_all_array_schemas(
         schema_vector[schema_ith] = array_schema;
         return Status::Ok();
       });
-  RETURN_NOT_OK_TUPLE(status);
+  RETURN_NOT_OK_TUPLE(status, std::nullopt);
 
   std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>> array_schemas;
   for (const auto& array_schema : schema_vector) {

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -2026,7 +2026,7 @@ Status Subarray::sort_ranges(ThreadPool* const compute_tp) {
 
 std::tuple<Status, std::optional<bool>> Subarray::non_overlapping_ranges(
     ThreadPool* const compute_tp) {
-  RETURN_NOT_OK_TUPLE(sort_ranges(compute_tp));
+  RETURN_NOT_OK_TUPLE(sort_ranges(compute_tp), std::nullopt);
 
   std::atomic<bool> non_overlapping_ranges = true;
   auto st = parallel_for(
@@ -2039,7 +2039,7 @@ std::tuple<Status, std::optional<bool>> Subarray::non_overlapping_ranges(
 
         return status;
       });
-  RETURN_NOT_OK_TUPLE(st);
+  RETURN_NOT_OK_TUPLE(st, std::nullopt);
 
   return {Status::Ok(), non_overlapping_ranges};
 }


### PR DESCRIPTION
Switching RETURN_NOT_OK_TUPLE and RETURN_NOT_OK_ELSE_TUPLE to be variadic. These should go away once proper exception handling is implemented.

---
TYPE: IMPROVEMENT
DESC: Switching TUPLE macros to be variadic.