### PR TITLE
tiledb::Array destructor no longer calls ::close for non-owned C ptr

### DIFF
--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -340,6 +340,7 @@ class Array {
     tiledb_array_schema_t* array_schema;
     ctx.handle_error(tiledb_array_get_schema(c_ctx, carray, &array_schema));
     schema_ = ArraySchema(ctx, array_schema);
+    owns_c_ptr_ = own;
 
     array_ = std::shared_ptr<tiledb_array_t>(carray, [own](tiledb_array_t* p) {
       if (own) {
@@ -355,7 +356,9 @@ class Array {
 
   /** Destructor; calls `close()`. */
   ~Array() {
-    close();
+    if (owns_c_ptr_) {
+      close();
+    }
   }
 
   /** Checks if the array is open. */
@@ -701,7 +704,8 @@ class Array {
   }
 
   /**
-   * Closes the array. The destructor calls this automatically.
+   * Closes the array. The destructor calls this automatically
+   * if the underlying pointer is owned.
    *
    * **Example:**
    * @code{.cpp}
@@ -1511,6 +1515,9 @@ class Array {
 
   /** Pointer to the TileDB C array object. */
   std::shared_ptr<tiledb_array_t> array_;
+
+  /** Flag indicating ownership of the TileDB C array object */
+  bool owns_c_ptr_ = true;
 
   /** The array schema. */
   ArraySchema schema_;

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -942,6 +942,7 @@ Status SparseGlobalOrderReader::copy_var_data_tiles(
                 0,
                 rcs.length_,
                 cell_offsets[i]);
+        (void)dest_cell_offset;
         if (skip_copy) {
           return Status::Ok();
         }

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -402,7 +402,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
               t,
               tile_num - 1,
               fragment_metadata_[f]->array_schema());
-
+          (void)st;
           // Make sure we can add at least one tile.
           if (*exceeded) {
             logger_->debug(
@@ -1456,6 +1456,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
   const auto tile_idx = rt->tile_idx();
   auto&& [st, tiles_sizes] = get_coord_tiles_size<BitmapType>(
       subarray_.is_set(), array_schema_->dim_num(), frag_idx, tile_idx);
+  (void)st;
   auto tiles_size = tiles_sizes->first;
   auto tiles_size_qc = tiles_sizes->second;
 


### PR DESCRIPTION
TYPE: CPP_API
DESC: tiledb::Array destructor no longer calls ::close for non-owned C ptr