### PR TITLE
[Backport release-2.6] [C++ API] tiledb::Array destructor no longer c…

### DIFF
--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -340,6 +340,7 @@ class Array {
     tiledb_array_schema_t* array_schema;
     ctx.handle_error(tiledb_array_get_schema(c_ctx, carray, &array_schema));
     schema_ = ArraySchema(ctx, array_schema);
+    owns_c_ptr_ = own;
 
     array_ = std::shared_ptr<tiledb_array_t>(carray, [own](tiledb_array_t* p) {
       if (own) {
@@ -355,7 +356,9 @@ class Array {
 
   /** Destructor; calls `close()`. */
   ~Array() {
-    close();
+    if (owns_c_ptr_) {
+      close();
+    }
   }
 
   /** Checks if the array is open. */
@@ -701,7 +704,8 @@ class Array {
   }
 
   /**
-   * Closes the array. The destructor calls this automatically.
+   * Closes the array. The destructor calls this automatically
+   * if the underlying pointer is owned.
    *
    * **Example:**
    * @code{.cpp}
@@ -1511,6 +1515,9 @@ class Array {
 
   /** Pointer to the TileDB C array object. */
   std::shared_ptr<tiledb_array_t> array_;
+
+  /** Flag indicating ownership of the TileDB C array object */
+  bool owns_c_ptr_ = true;
 
   /** The array schema. */
   ArraySchema schema_;


### PR DESCRIPTION
…alls ::close for non-owned C ptr (#2823)

(cherry-picked from 8e636c2ec68a0dc56c38e30769412ec10924626e)

---
TYPE: CPP_API
DESC: tiledb::Array destructor no longer calls ::close for non-owned C ptr
