### PR TITLE
[Backport release-2.6]  Sparse unordered w dups reader: fixing query continuation with subarray

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1110,6 +1110,78 @@ TEST_CASE_METHOD(
 }
 
 TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsFx,
+    "Sparse unordered with dups reader: single tile query continuation",
+    "[sparse-unordered-with-dups][single-tile][continuation]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d();
+
+  // Write a fragment.
+  int coords[] = {1, 2};
+  uint64_t coords_size = sizeof(coords);
+  int data[] = {1, 2};
+  uint64_t data_size = sizeof(data);
+  write_1d_fragment(coords, &coords_size, data, &data_size);
+
+  tiledb_array_t* array = nullptr;
+  tiledb_query_t* query = nullptr;
+
+  // Try to read.
+  int coords_r[1];  // only room for one cell.
+  int data_r[1];
+  uint64_t coords_r_size = sizeof(coords_r);
+  uint64_t data_r_size = sizeof(data_r);
+  auto rc = read(
+      false,
+      false,
+      coords_r,
+      &coords_r_size,
+      data_r,
+      &data_r_size,
+      &query,
+      &array);
+  CHECK(rc == TILEDB_OK);
+
+  // Check incomplete query status.
+  tiledb_query_status_t status;
+  tiledb_query_get_status(ctx_, query, &status);
+  CHECK(status == TILEDB_INCOMPLETE);
+
+  // Should only read one cell (1 values).
+  CHECK(4 == data_r_size);
+  CHECK(4 == coords_r_size);
+
+  int coords_c_1[] = {1};
+  int data_c_1[] = {1};
+  CHECK(!std::memcmp(coords_c_1, coords_r, coords_r_size));
+  CHECK(!std::memcmp(data_c_1, data_r, data_r_size));
+
+  // Read again.
+  rc = tiledb_query_submit(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Check incomplete query status.
+  tiledb_query_get_status(ctx_, query, &status);
+  CHECK(status == TILEDB_COMPLETED);
+
+  // Should read last cell (1 values).
+  CHECK(4 == data_r_size);
+  CHECK(4 == coords_r_size);
+
+  int coords_c_2[] = {2};
+  int data_c_2[] = {2};
+  CHECK(!std::memcmp(coords_c_2, coords_r, coords_r_size));
+  CHECK(!std::memcmp(data_c_2, data_r, data_r_size));
+
+  // Clean up.
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+TEST_CASE_METHOD(
     CSparseUnorderedWithDupsVarDataFx,
     "Sparse unordered with dups reader: results shrinked due to data buffer",
     "[sparse-unordered-with-dups][data-buffer-overflow]") {

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1442,12 +1442,18 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
   auto last_tile_cells_copied = cell_offsets[result_tiles->size()] -
                                 cell_offsets[result_tiles->size() - 1];
   if (frag_tile_idx.first == last_tile->tile_idx()) {
-    last_tile_cells_copied += frag_tile_idx.second;
+    if (last_tile->bitmap_result_num_ != std::numeric_limits<uint64_t>::max()) {
+      last_tile_cells_copied +=
+          last_tile->result_num_between_pos(0, frag_tile_idx.second);
+    } else {
+      last_tile_cells_copied += frag_tile_idx.second;
+    }
   }
 
   // Adjust tile index.
   for (auto rt : *result_tiles) {
-    read_state_.frag_tile_idx_[rt->frag_idx()].first = rt->tile_idx() + 1;
+    read_state_.frag_tile_idx_[rt->frag_idx()] =
+        std::make_pair(rt->tile_idx() + 1, 0);
   }
 
   // If the last tile is not fully copied, save the cell index.


### PR DESCRIPTION
Backport 69e79a59db817ebe98a83583d504d8c2f7a3462f from #2824

---
TYPE: NO_HISTORY
DESC: NO_HISTORY
