### PR TITLE
Adding min/max/sum/null count to fragment info.

### DIFF
--- a/format_spec/fragment.md
+++ b/format_spec/fragment.md
@@ -142,6 +142,18 @@ The footer is a simple blob \(i.e., _not a generic tile_\) with the following in
 | Tile validity offset for attribute/dimension 1 | `uint64_t` | The offset to the generic tile storing the tile validity offsets for attribute/dimension 1. |
 | … | … | … |
 | Tile validity offset for attribute/dimension N | `uint64_t` | The offset to the generic tile storing the tile validity offsets for attribute/dimension N |
+| Tile mins offset for attribute/dimension 1 | `uint64_t` | The offset to the generic tile storing the tile mins for attribute/dimension 1. |
+| … | … | … |
+| Tile mins offset for attribute/dimension N | `uint64_t` | The offset to the generic tile storing the tile mins for attribute/dimension N |
+| Tile maxs offset for attribute/dimension 1 | `uint64_t` | The offset to the generic tile storing the tile maxs for attribute/dimension 1. |
+| … | … | … |
+| Tile maxs offset for attribute/dimension N | `uint64_t` | The offset to the generic tile storing the tile maxs for attribute/dimension N |
+| Tile sums offset for attribute/dimension 1 | `uint64_t` | The offset to the generic tile storing the tile sums for attribute/dimension 1. |
+| … | … | … |
+| Tile sums offset for attribute/dimension N | `uint64_t` | The offset to the generic tile storing the tile sums for attribute/dimension N |
+| Tile null counts offset for attribute/dimension 1 | `uint64_t` | The offset to the generic tile storing the tile null counts for attribute/dimension 1. |
+| … | … | … |
+| Tile null counts offset for attribute/dimension N | `uint64_t` | The offset to the generic tile storing the tile null counts for attribute/dimension N |
 | Array schema name size | `uint64_t` | The total number of characters of the array schema name. |
 | Array schema name character 1 | `char` | The first character of the array schema name. |
 | … | … | … |

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -155,6 +155,8 @@ set(TILEDB_TEST_SOURCES
   src/unit-hdfs-filesystem.cc
   src/unit-hilbert.cc
   src/unit-lru_cache.cc
+  src/unit-tile-metadata.cc
+  src/unit-tile-metadata-generator.cc
   src/unit-QueryCondition.cc
   src/unit-ReadCellSlabIter.cc
   src/unit-Reader.cc

--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -1236,6 +1236,21 @@ int32_t num_fragments(const std::string& array_name) {
   return ret;
 }
 
+std::string random_string(const uint64_t l) {
+  static const char char_set[] =
+      "0123456789"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "abcdefghijklmnopqrstuvwxyz";
+  std::string s;
+  s.reserve(l);
+
+  for (uint64_t i = 0; i < l; ++i) {
+    s += char_set[rand() % (sizeof(char_set) - 1)];
+  }
+
+  return s;
+}
+
 template void check_subarray<int8_t>(
     tiledb::sm::Subarray& subarray, const SubarrayRanges<int8_t>& ranges);
 template void check_subarray<uint8_t>(

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -676,6 +676,11 @@ void read_array(
  */
 int32_t num_fragments(const std::string& array_name);
 
+/**
+ * Creates a random string of length l.
+ */
+std::string random_string(const uint64_t l);
+
 }  // End of namespace test
 
 }  // End of namespace tiledb

--- a/test/src/unit-Tile.cc
+++ b/test/src/unit-Tile.cc
@@ -188,7 +188,6 @@ TEST_CASE("Tile: Test copy constructor", "[Tile][copy_constructor]") {
   CHECK(tile2.format_version() == tile1.format_version());
   CHECK(tile2.full() == tile1.full());
   CHECK(tile2.offset() == tile1.offset());
-  CHECK(tile2.pre_filtered_size() == tile1.pre_filtered_size());
   CHECK(tile2.size() == tile1.size());
   CHECK(tile2.stores_coords() == tile1.stores_coords());
   CHECK(tile2.type() == tile1.type());
@@ -251,7 +250,6 @@ TEST_CASE("Tile: Test move constructor", "[Tile][move_constructor]") {
   CHECK(tile3.format_version() == tile2.format_version());
   CHECK(tile3.full() == tile2.full());
   CHECK(tile3.offset() == tile2.offset());
-  CHECK(tile3.pre_filtered_size() == tile2.pre_filtered_size());
   CHECK(tile3.size() == tile2.size());
   CHECK(tile3.stores_coords() == tile2.stores_coords());
   CHECK(tile3.type() == tile2.type());
@@ -304,7 +302,6 @@ TEST_CASE("Tile: Test assignment", "[Tile][assignment]") {
   CHECK(tile2.format_version() == tile1.format_version());
   CHECK(tile2.full() == tile1.full());
   CHECK(tile2.offset() == tile1.offset());
-  CHECK(tile2.pre_filtered_size() == tile1.pre_filtered_size());
   CHECK(tile2.size() == tile1.size());
   CHECK(tile2.stores_coords() == tile1.stores_coords());
   CHECK(tile2.type() == tile1.type());
@@ -367,7 +364,6 @@ TEST_CASE("Tile: Test move-assignment", "[Tile][move_assignment]") {
   CHECK(tile3.format_version() == tile2.format_version());
   CHECK(tile3.full() == tile2.full());
   CHECK(tile3.offset() == tile2.offset());
-  CHECK(tile3.pre_filtered_size() == tile2.pre_filtered_size());
   CHECK(tile3.size() == tile2.size());
   CHECK(tile3.stores_coords() == tile2.stores_coords());
   CHECK(tile3.type() == tile2.type());

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -5209,7 +5209,7 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
   rc = tiledb_config_set(
-      config, "sm.consolidation.step_size_ratio", "0.78", &error);
+      config, "sm.consolidation.step_size_ratio", "0.82", &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
 

--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -272,7 +272,7 @@ TEST_CASE(
   uint64_t size;
   rc = tiledb_fragment_info_get_fragment_size(ctx, fragment_info, 1, &size);
   CHECK(rc == TILEDB_OK);
-  CHECK(size == 1662);
+  CHECK(size == 2960);
 
   // Get dense / sparse
   int32_t dense;
@@ -504,7 +504,7 @@ TEST_CASE(
   uint64_t size;
   rc = tiledb_fragment_info_get_fragment_size(ctx, fragment_info, 1, &size);
   CHECK(rc == TILEDB_OK);
-  CHECK(size == 2855);
+  CHECK(size == 5173);
 
   // Get dense / sparse
   int32_t dense;
@@ -1339,16 +1339,16 @@ TEST_CASE("C API: Test fragment info, dump", "[capi][fragment_info][dump]") {
       "- Unconsolidated metadata num: 3\n" + "- To vacuum num: 0\n" +
       "- Fragment #1:\n" + "  > URI: " + written_frag_uri_1 + "\n" +
       "  > Type: dense\n" + "  > Non-empty domain: [1, 6]\n" +
-      "  > Size: 1662\n" + "  > Cell num: 10\n" +
+      "  > Size: 2960\n" + "  > Cell num: 10\n" +
       "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n" + "- Fragment #2:\n" +
       "  > URI: " + written_frag_uri_2 + "\n" + "  > Type: dense\n" +
-      "  > Non-empty domain: [1, 4]\n" + "  > Size: 1619\n" +
+      "  > Non-empty domain: [1, 4]\n" + "  > Size: 2909\n" +
       "  > Cell num: 5\n" + "  > Timestamp range: [2, 2]\n" +
       "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n" + "- Fragment #3:\n" +
       "  > URI: " + written_frag_uri_3 + "\n" + "  > Type: dense\n" +
-      "  > Non-empty domain: [5, 6]\n" + "  > Size: 1662\n" +
+      "  > Non-empty domain: [5, 6]\n" + "  > Size: 2957\n" +
       "  > Cell num: 10\n" + "  > Timestamp range: [3, 3]\n" +
       "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";
@@ -1479,7 +1479,7 @@ TEST_CASE(
       "- To vacuum URIs:\n" + "  > " + written_frag_uri_1 + "\n  > " +
       written_frag_uri_2 + "\n  > " + written_frag_uri_3 + "\n" +
       "- Fragment #1:\n" + "  > URI: " + uri + "\n" + "  > Type: dense\n" +
-      "  > Non-empty domain: [1, 10]\n" + "  > Size: 1662\n" +
+      "  > Non-empty domain: [1, 10]\n" + "  > Size: 2966\n" +
       "  > Cell num: 10\n" + "  > Timestamp range: [1, 3]\n" +
       "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";
@@ -1563,7 +1563,7 @@ TEST_CASE(
       "- Unconsolidated metadata num: 1\n" + "- To vacuum num: 0\n" +
       "- Fragment #1:\n" + "  > URI: " + written_frag_uri + "\n" +
       "  > Type: sparse\n" + "  > Non-empty domain: [a, ddd]\n" +
-      "  > Size: 1903\n" + "  > Cell num: 4\n" +
+      "  > Size: 3204\n" + "  > Cell num: 4\n" +
       "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";
   FILE* gold_fout = fopen("gold_fout.txt", "w");

--- a/test/src/unit-cppapi-fragment_info.cc
+++ b/test/src/unit-cppapi-fragment_info.cc
@@ -220,7 +220,7 @@ TEST_CASE(
 
     // Get fragment size
     auto size = fragment_info.fragment_size(1);
-    CHECK(size == 1662);
+    CHECK(size == 2960);
 
     // Get dense / sparse
     auto dense = fragment_info.dense(0);
@@ -841,16 +841,16 @@ TEST_CASE(
         "- Unconsolidated metadata num: 3\n" + "- To vacuum num: 0\n" +
         "- Fragment #1:\n" + "  > URI: " + written_frag_uri_1 + "\n" +
         "  > Type: dense\n" + "  > Non-empty domain: [1, 6]\n" +
-        "  > Size: 1662\n" + "  > Cell num: 10\n" +
+        "  > Size: 2960\n" + "  > Cell num: 10\n" +
         "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n" + "- Fragment #2:\n" +
         "  > URI: " + written_frag_uri_2 + "\n" + "  > Type: dense\n" +
-        "  > Non-empty domain: [1, 4]\n" + "  > Size: 1619\n" +
+        "  > Non-empty domain: [1, 4]\n" + "  > Size: 2909\n" +
         "  > Cell num: 5\n" + "  > Timestamp range: [2, 2]\n" +
         "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n" + "- Fragment #3:\n" +
         "  > URI: " + written_frag_uri_3 + "\n" + "  > Type: dense\n" +
-        "  > Non-empty domain: [5, 6]\n" + "  > Size: 1662\n" +
+        "  > Non-empty domain: [5, 6]\n" + "  > Size: 2957\n" +
         "  > Cell num: 10\n" + "  > Timestamp range: [3, 3]\n" +
         "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n";

--- a/test/src/unit-tile-metadata-generator.cc
+++ b/test/src/unit-tile-metadata-generator.cc
@@ -1,0 +1,472 @@
+/**
+ * @file   unit-tile-metadata-generator.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the TileMetadataGenerator class.
+ */
+
+#include <catch.hpp>
+
+#include "catch.hpp"
+#include "helpers.h"
+#include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/tile/tile_metadata_generator.h"
+
+using namespace tiledb::sm;
+
+typedef tuple<
+    char,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    float,
+    double>
+    FixedTypesUnderTest;
+TEMPLATE_LIST_TEST_CASE(
+    "TileMetadataGenerator: fixed data type tile",
+    "[tile-metadata-generator][fixed-data]",
+    FixedTypesUnderTest) {
+  std::default_random_engine random_engine;
+  typedef TestType T;
+  auto type = tiledb::impl::type_to_tiledb<T>();
+  std::string test =
+      GENERATE("non nullable", "nullable", "all null", "empty tile");
+
+  bool nullable = test == "nullable" || test == "all null";
+  bool all_null = test == "all null";
+  bool empty_tile = test == "empty tile";
+
+  uint64_t cell_val_num = std::is_same<T, char>::value ? 10 : 1;
+
+  // Generate the array schema.
+  ArraySchema schema;
+  Attribute a("a", (Datatype)type.tiledb_type);
+  a.set_cell_val_num(cell_val_num);
+  schema.add_attribute(&a);
+
+  // Generate random, sorted strings for the string ascii type.
+  std::vector<std::string> string_ascii;
+  string_ascii.reserve(256);
+  if constexpr (std::is_same<T, char>::value) {
+    for (uint64_t i = 0; i < 256; i++) {
+      string_ascii.emplace_back(tiledb::test::random_string(10));
+    }
+    std::sort(string_ascii.begin(), string_ascii.end());
+  }
+
+  // Initialize a new tile.
+  uint64_t num_cells = empty_tile ? 0 : 1000;
+  Tile tile;
+  tile.init_unfiltered(
+      0,
+      (Datatype)type.tiledb_type,
+      num_cells * cell_val_num * sizeof(T),
+      cell_val_num * sizeof(T),
+      0,
+      true);
+  auto tile_buff = (T*)tile.buffer()->data();
+
+  // Initialize a new nullable tile.
+  Tile tile_nullable;
+  uint8_t* nullable_buff = nullptr;
+  if (nullable) {
+    tile_nullable.init_unfiltered(0, Datatype::UINT8, num_cells, 1, 0, true);
+    nullable_buff = (uint8_t*)tile_nullable.buffer()->data();
+  }
+
+  // Compute correct values as the tile is filled with data.
+  T correct_min = std::numeric_limits<T>::max();
+  T correct_max = std::numeric_limits<T>::lowest();
+  int64_t correct_sum_int = 0;
+  double correct_sum_double = 0;
+  uint64_t correct_null_count = 0;
+
+  // Fill the tiles with data.
+  for (uint64_t i = 0; i < num_cells; i++) {
+    // Generate a random value depending on the data type.
+    T val;
+    uint8_t validity_val = all_null ? 0 : (nullable ? rand() % 2 : 1);
+    if constexpr (std::is_integral_v<T>) {
+      if constexpr (std::is_signed_v<TestType>) {
+        if constexpr (std::is_same<TestType, int64_t>::value) {
+          std::uniform_int_distribution<int64_t> dist(
+              std::numeric_limits<int32_t>::lowest(),
+              std::numeric_limits<int32_t>::max());
+          val = dist(random_engine);
+        } else {
+          std::uniform_int_distribution<int64_t> dist(
+              std::numeric_limits<TestType>::lowest(),
+              std::numeric_limits<TestType>::max());
+          val = (TestType)dist(random_engine);
+        }
+      } else {
+        if constexpr (std::is_same<TestType, uint64_t>::value) {
+          std::uniform_int_distribution<uint64_t> dist(
+              std::numeric_limits<uint32_t>::lowest(),
+              std::numeric_limits<uint32_t>::max());
+          val = dist(random_engine);
+        } else {
+          std::uniform_int_distribution<uint64_t> dist(
+              std::numeric_limits<TestType>::lowest(),
+              std::numeric_limits<TestType>::max());
+          val = (TestType)dist(random_engine);
+        }
+      }
+
+      if constexpr (!std::is_same<T, char>::value) {
+        if (validity_val == 1) {
+          correct_sum_int += (int64_t)val;
+        }
+      }
+
+      correct_sum_double = 0;
+    } else {
+      std::uniform_real_distribution<T> dist(-10000, 10000);
+      val = dist(random_engine);
+      if (validity_val == 1) {
+        correct_sum_double += (double)val;
+      }
+
+      correct_sum_int = 0;
+    }
+
+    if (nullable) {
+      nullable_buff[i] = validity_val;
+    }
+
+    if (validity_val == 1) {
+      correct_min = std::min(correct_min, val);
+      correct_max = std::max(correct_max, val);
+    }
+    correct_null_count += uint64_t(validity_val == 0);
+
+    if constexpr (std::is_same<T, char>::value) {
+      int64_t idx = (int64_t)val - (int64_t)std::numeric_limits<char>::min();
+      memcpy(
+          &tile_buff[i * cell_val_num],
+          string_ascii[idx].c_str(),
+          cell_val_num);
+    } else {
+      tile_buff[i] = val;
+    }
+  }
+
+  // Call the tile metadata generator.
+  TileMetadataGenerator md_generator(
+      static_cast<Datatype>(type.tiledb_type),
+      false,
+      false,
+      cell_val_num * sizeof(T),
+      cell_val_num);
+  md_generator.process_tile(
+      &tile, nullptr, nullable ? &tile_nullable : nullptr);
+
+  // Compare the metadata to what's expected.
+  auto&& [min, min_size, max, max_size, sum, nc] = md_generator.metadata();
+
+  if constexpr (std::is_same<T, char>::value) {
+    if (all_null || empty_tile) {
+      CHECK(min == nullptr);
+      CHECK(max == nullptr);
+    } else {
+      int64_t idx_min =
+          (int64_t)correct_min - (int64_t)std::numeric_limits<char>::min();
+      int64_t idx_max =
+          (int64_t)correct_max - (int64_t)std::numeric_limits<char>::min();
+      CHECK(
+          0 ==
+          strncmp(
+              (const char*)min, string_ascii[idx_min].c_str(), cell_val_num));
+      CHECK(
+          0 ==
+          strncmp(
+              (const char*)max, string_ascii[idx_max].c_str(), cell_val_num));
+    }
+  } else {
+    CHECK(*(T*)min == correct_min);
+    CHECK(*(T*)max == correct_max);
+  }
+  CHECK(min_size == sizeof(T) * cell_val_num);
+  CHECK(max_size == sizeof(T) * cell_val_num);
+
+  if constexpr (std::is_integral_v<T>) {
+    CHECK(*(int64_t*)sum->data() == correct_sum_int);
+  } else {
+    CHECK(*(double*)sum->data() == correct_sum_double);
+  }
+  CHECK(nc == correct_null_count);
+}
+
+typedef tuple<uint64_t, int64_t, double> FixedTypesUnderTestOverflow;
+TEMPLATE_LIST_TEST_CASE(
+    "TileMetadataGenerator: fixed data type tile overflow",
+    "[tile-metadata-generator][sum-overflow]",
+    FixedTypesUnderTestOverflow) {
+  typedef TestType T;
+  auto type = tiledb::impl::type_to_tiledb<T>();
+
+  // Generate the array schema.
+  ArraySchema schema;
+  Attribute a("a", (Datatype)type.tiledb_type);
+  schema.add_attribute(&a);
+
+  // Initialize a new tile.
+  uint64_t num_cells = 4;
+  Tile tile;
+  tile.init_unfiltered(
+      0, (Datatype)type.tiledb_type, num_cells * sizeof(T), sizeof(T), 0, true);
+  auto tile_buff = (T*)tile.buffer()->data();
+
+  // Once an overflow happens, the computation should abort, try to add a few
+  // min values after the overflow to confirm.
+  tile_buff[0] = std::numeric_limits<T>::max();
+  tile_buff[1] = std::numeric_limits<T>::max();
+  tile_buff[2] = std::numeric_limits<T>::lowest();
+  tile_buff[3] = std::numeric_limits<T>::lowest();
+
+  // Call the tile metadata generator.
+  TileMetadataGenerator md_generator(
+      static_cast<Datatype>(type.tiledb_type), false, false, sizeof(T), 1);
+  md_generator.process_tile(&tile, nullptr, nullptr);
+
+  // Compare the metadata to what's expected.
+  auto&& [min, min_size, max, max_size, sum, nc] = md_generator.metadata();
+  if constexpr (std::is_integral_v<T>) {
+    CHECK(*(T*)sum->data() == std::numeric_limits<T>::max());
+  } else {
+    CHECK(*(double*)sum->data() == std::numeric_limits<T>::max());
+  }
+
+  // Test negative overflow.
+  if constexpr (std::is_signed_v<T>) {
+    // Initialize a new tile.
+    uint64_t num_cells = 4;
+    Tile tile;
+    tile.init_unfiltered(
+        0,
+        (Datatype)type.tiledb_type,
+        num_cells * sizeof(T),
+        sizeof(T),
+        0,
+        true);
+    auto tile_buff = (T*)tile.buffer()->data();
+
+    // Once an overflow happens, the computation should abort, try to add a few
+    // max values after the overflow to confirm.
+    tile_buff[0] = std::numeric_limits<T>::lowest();
+    tile_buff[1] = std::numeric_limits<T>::lowest();
+    tile_buff[2] = std::numeric_limits<T>::max();
+    tile_buff[3] = std::numeric_limits<T>::max();
+
+    // Call the tile metadata generator.
+    TileMetadataGenerator md_generator(
+        static_cast<Datatype>(type.tiledb_type), false, false, sizeof(T), 1);
+    md_generator.process_tile(&tile, nullptr, nullptr);
+
+    // Compare the metadata to what's expected.
+    auto&& [min, min_size, max, max_size, sum, nc] = md_generator.metadata();
+    if constexpr (std::is_integral_v<T>) {
+      CHECK(*(int64_t*)sum->data() == std::numeric_limits<T>::min());
+    } else {
+      CHECK(*(double*)sum->data() == std::numeric_limits<T>::lowest());
+    }
+  }
+}
+
+TEST_CASE(
+    "TileMetadataGenerator: var data tiles",
+    "[tile-metadata-generator][var-data]") {
+  std::string test =
+      GENERATE("nullable", "all null", "non nullable", "empty tile");
+
+  bool nullable = test == "nullable" || test == "all null";
+  bool all_null = test == "all null";
+  bool empty_tile = test == "empty tile";
+
+  uint64_t max_string_size = 100;
+  uint64_t num_strings = 2000;
+
+  // Generate the array schema.
+  ArraySchema schema;
+  Attribute a("a", Datatype::STRING_ASCII);
+  a.set_cell_val_num(constants::var_num);
+  schema.add_attribute(&a);
+
+  // Generate random, sorted strings for the string ascii type.
+  std::vector<std::string> strings;
+  strings.reserve(num_strings);
+  for (uint64_t i = 0; i < num_strings; i++) {
+    strings.emplace_back(tiledb::test::random_string(rand() % max_string_size));
+  }
+  std::sort(strings.begin(), strings.end());
+
+  // Choose strings randomly.
+  uint64_t num_cells = empty_tile ? 0 : 20;
+  std::vector<int> values;
+  values.reserve(num_cells);
+  uint64_t var_size = 0;
+  for (uint64_t i = 0; i < num_cells; i++) {
+    values.emplace_back(rand() % num_strings);
+    var_size += strings[values.back()].size();
+  }
+
+  // Initialize offsets tile.
+  Tile offsets_tile;
+  offsets_tile.init_unfiltered(
+      0,
+      Datatype::UINT64,
+      num_cells * sizeof(uint64_t),
+      sizeof(uint64_t),
+      0,
+      true);
+  auto offsets_tile_buff = (uint64_t*)offsets_tile.buffer()->data();
+
+  // Initialize var tile.
+  Tile var_tile;
+  var_tile.init_unfiltered(
+      0, Datatype::CHAR, var_size, constants::var_num, 0, true);
+  auto var_tile_buff = (char*)var_tile.buffer()->data();
+
+  // Initialize a new nullable tile.
+  Tile tile_nullable;
+  uint8_t* nullable_buff = nullptr;
+  if (nullable) {
+    tile_nullable.init_unfiltered(0, Datatype::UINT8, num_cells, 1, 0, true);
+    nullable_buff = (uint8_t*)tile_nullable.buffer()->data();
+  }
+
+  // Compute correct values as the tile is filled with data.
+  int correct_min = num_strings;
+  int correct_max = 0;
+  uint64_t correct_null_count = 0;
+
+  // Fill the tiles with data.
+  uint64_t offset = 0;
+  for (uint64_t i = 0; i < num_cells; i++) {
+    uint8_t validity_val = all_null ? 0 : (nullable ? rand() % 2 : 1);
+
+    if (nullable) {
+      nullable_buff[i] = validity_val;
+    }
+
+    if (validity_val == 1) {
+      correct_min = std::min(correct_min, values[i]);
+      correct_max = std::max(correct_max, values[i]);
+    }
+    correct_null_count += uint64_t(validity_val == 0);
+
+    *offsets_tile_buff = offset;
+    auto& val = strings[values[i]];
+    memcpy(&var_tile_buff[offset], val.c_str(), val.size());
+
+    offset += val.size();
+    offsets_tile_buff++;
+  }
+
+  // Call the tile metadata generator.
+  TileMetadataGenerator md_generator(
+      Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
+  md_generator.process_tile(
+      &offsets_tile, &var_tile, nullable ? &tile_nullable : nullptr);
+
+  // Compare the metadata to what's expected.
+  auto&& [min, min_size, max, max_size, sum, nc] = md_generator.metadata();
+
+  if (all_null || empty_tile) {
+    CHECK(min == nullptr);
+    CHECK(max == nullptr);
+    CHECK(min_size == 0);
+    CHECK(max_size == 0);
+  } else {
+    CHECK(
+        0 == strncmp(
+                 (const char*)min,
+                 strings[correct_min].c_str(),
+                 strings[correct_min].size()));
+    CHECK(
+        0 == strncmp(
+                 (const char*)max,
+                 strings[correct_max].c_str(),
+                 strings[correct_max].size()));
+    CHECK(min_size == strings[correct_min].size());
+    CHECK(max_size == strings[correct_max].size());
+  }
+
+  CHECK(*(int64_t*)sum->data() == 0);
+  CHECK(nc == correct_null_count);
+}
+
+TEST_CASE(
+    "TileMetadataGenerator: var data tiles same string, different lengths",
+    "[tile-metadata-generator][var-data][same-length]") {
+  // Generate the array schema.
+  ArraySchema schema;
+  Attribute a("a", Datatype::CHAR);
+  a.set_cell_val_num(constants::var_num);
+  schema.add_attribute(&a);
+
+  // Store '123' and '12'
+  // Initialize offsets tile.
+  Tile offsets_tile;
+  offsets_tile.init_unfiltered(
+      0, Datatype::UINT64, 2 * sizeof(uint64_t), sizeof(uint64_t), 0, true);
+  auto offsets_tile_buff = (uint64_t*)offsets_tile.buffer()->data();
+  offsets_tile_buff[0] = 0;
+  offsets_tile_buff[1] = 3;
+
+  // Initialize var tile.
+  Tile var_tile;
+  var_tile.init_unfiltered(0, Datatype::CHAR, 5, constants::var_num, 0, true);
+  auto var_tile_buff = (char*)var_tile.buffer()->data();
+  var_tile_buff[0] = '1';
+  var_tile_buff[1] = '2';
+  var_tile_buff[2] = '3';
+  var_tile_buff[3] = '1';
+  var_tile_buff[4] = '2';
+
+  // Call the tile metadata generator.
+  TileMetadataGenerator md_generator(
+      Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
+  md_generator.process_tile(&offsets_tile, &var_tile, nullptr);
+
+  // Compare the metadata to what's expected.
+  auto&& [min, min_size, max, max_size, sum, nc] = md_generator.metadata();
+
+  CHECK(0 == strncmp((const char*)min, "12", 2));
+  CHECK(0 == strncmp((const char*)max, "123", 3));
+  CHECK(min_size == 2);
+  CHECK(max_size == 3);
+
+  CHECK(*(int64_t*)sum->data() == 0);
+  CHECK(nc == 0);
+}

--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -1,0 +1,737 @@
+/**
+ * @file   unit-tile-metadata.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the min/max/sum/null count values written to disk by using the
+ * load_tile_*_values and get_tile_* apis of fragment metadata.
+ */
+
+#include <catch.hpp>
+
+#include "catch.hpp"
+#include "helpers.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/tile/tile_metadata_generator.h"
+
+using namespace tiledb;
+
+template <typename TestType>
+struct CPPFixedTileMetadataFx {
+  CPPFixedTileMetadataFx()
+      : vfs_(ctx_) {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  ~CPPFixedTileMetadataFx() {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  void create_array(
+      tiledb_layout_t layout, bool nullable, uint64_t cell_val_num) {
+    Domain domain(ctx_);
+    auto d = Dimension::create<uint32_t>(ctx_, "d", {{0, 999}}, tile_extent_);
+    domain.add_dimension(d);
+
+    auto a = Attribute::create<TestType>(ctx_, "a");
+    a.set_nullable(nullable);
+    a.set_cell_val_num(cell_val_num);
+
+    ArraySchema schema(
+        ctx_, layout == TILEDB_ROW_MAJOR ? TILEDB_DENSE : TILEDB_SPARSE);
+    schema.set_domain(domain);
+    schema.add_attribute(a);
+
+    if (layout != TILEDB_ROW_MAJOR) {
+      schema.set_capacity(tile_extent_);
+    }
+
+    Array::create(ARRAY_NAME, schema);
+  }
+
+  void write_fragment(
+      tiledb_layout_t layout,
+      bool nullable,
+      bool all_null,
+      uint64_t cell_val_num) {
+    std::default_random_engine random_engine;
+
+    // Generate random, sorted strings for the string ascii type.
+    string_ascii_.clear();
+    string_ascii_.reserve(256);
+    if constexpr (std::is_same<TestType, char>::value) {
+      for (uint64_t i = 0; i < 256; i++) {
+        string_ascii_.emplace_back(tiledb::test::random_string(10));
+      }
+      std::sort(string_ascii_.begin(), string_ascii_.end());
+    }
+
+    // Compute correct values as the tile is filled with data.
+    correct_mins_.clear();
+    correct_maxs_.clear();
+    correct_sums_int_.clear();
+    correct_sums_double_.clear();
+    correct_null_counts_.clear();
+    correct_mins_.resize(num_tiles_, std::numeric_limits<TestType>::max());
+    correct_maxs_.resize(num_tiles_, std::numeric_limits<TestType>::lowest());
+    correct_sums_int_.resize(num_tiles_, 0);
+    correct_sums_double_.resize(num_tiles_, 0);
+    correct_null_counts_.resize(num_tiles_, 0);
+
+    // Fill the tiles with data.
+    std::vector<uint32_t> d(num_cells_);
+    std::vector<TestType> a(num_cells_ * cell_val_num);
+    std::vector<uint8_t> a_val(num_cells_);
+    for (uint64_t i = 0; i < num_cells_; i++) {
+      auto tile_idx = i / tile_extent_;
+
+      // Generate a random value depending on the data type, also compute
+      // correct sums as we go.
+      TestType val;
+      a_val[i] =
+          all_null ? 0 : (nullable && (i % tile_extent_ != 0) ? rand() % 2 : 1);
+      if constexpr (std::is_integral_v<TestType>) {
+        if constexpr (std::is_signed_v<TestType>) {
+          if constexpr (std::is_same<TestType, int64_t>::value) {
+            std::uniform_int_distribution<int64_t> dist(
+                std::numeric_limits<int32_t>::lowest(),
+                std::numeric_limits<int32_t>::max());
+            val = dist(random_engine);
+          } else {
+            std::uniform_int_distribution<int64_t> dist(
+                std::numeric_limits<TestType>::lowest(),
+                std::numeric_limits<TestType>::max());
+            val = (TestType)dist(random_engine);
+          }
+        } else {
+          if constexpr (std::is_same<TestType, uint64_t>::value) {
+            std::uniform_int_distribution<uint64_t> dist(
+                std::numeric_limits<uint32_t>::lowest(),
+                std::numeric_limits<uint32_t>::max());
+            val = dist(random_engine);
+          } else {
+            std::uniform_int_distribution<uint64_t> dist(
+                std::numeric_limits<TestType>::lowest(),
+                std::numeric_limits<TestType>::max());
+            val = (TestType)dist(random_engine);
+          }
+        }
+
+        if constexpr (!std::is_same<TestType, char>::value) {
+          if (a_val[i] == 1) {
+            correct_sums_int_[tile_idx] += (int64_t)val;
+          }
+        }
+      } else {
+        std::uniform_real_distribution<TestType> dist(-10000, 10000);
+        val = dist(random_engine);
+        if (a_val[i] == 1) {
+          correct_sums_double_[tile_idx] += (double)val;
+        }
+      }
+
+      // Compute correct min/max.
+      if (a_val[i] == 1) {
+        correct_mins_[tile_idx] = std::min(correct_mins_[tile_idx], val);
+        correct_maxs_[tile_idx] = std::max(correct_maxs_[tile_idx], val);
+      }
+
+      // Compute correct null count.
+      correct_null_counts_[tile_idx] += uint64_t(a_val[i] == 0);
+
+      // Set the value.
+      if constexpr (std::is_same<TestType, char>::value) {
+        // For strings, the index is stored in a signed value, switch to
+        // the index to unsigned.
+        int64_t idx = (int64_t)val - (int64_t)std::numeric_limits<char>::min();
+
+        // Copy the string.
+        memcpy(&a[i * cell_val_num], string_ascii_[idx].c_str(), cell_val_num);
+      } else {
+        a[i] = val;
+      }
+
+      // Set the coordinate value.
+      d[i] = i;
+    }
+
+    // Write to the array.
+    auto array = tiledb::Array(ctx_, ARRAY_NAME, TILEDB_WRITE);
+    auto query = tiledb::Query(ctx_, array, TILEDB_WRITE);
+
+    query.set_layout(layout);
+
+    if (layout != TILEDB_ROW_MAJOR) {
+      query.set_data_buffer("d", d);
+    }
+    query.set_data_buffer("a", a);
+
+    if (nullable) {
+      query.set_validity_buffer("a", a_val);
+    }
+
+    query.submit();
+    query.finalize();
+    array.close();
+  }
+
+  void check_metadata(
+      tiledb_layout_t layout,
+      bool nullable,
+      bool all_null,
+      uint64_t cell_val_num) {
+    // Open array.
+    tiledb_ctx_t* ctx;
+    tiledb_ctx_alloc(NULL, &ctx);
+    tiledb_array_t* array;
+    int rc = tiledb_array_alloc(ctx, ARRAY_NAME, &array);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_array_open(ctx, array, TILEDB_READ);
+    CHECK(rc == TILEDB_OK);
+
+    // Load the metadata and validate coords netadata.
+    auto frag_meta = array->array_->fragment_metadata();
+    auto& enc_key = array->array_->get_encryption_key();
+    bool has_coords = layout != TILEDB_ROW_MAJOR;
+    if (has_coords) {
+      std::vector<std::string> names_min{"d"};
+      auto st =
+          frag_meta[0]->load_tile_min_values(enc_key, std::move(names_min));
+      CHECK(st.ok());
+
+      std::vector<std::string> names_max{"d"};
+      st = frag_meta[0]->load_tile_max_values(enc_key, std::move(names_max));
+      CHECK(st.ok());
+
+      std::vector<std::string> names_sum{"d"};
+      st = frag_meta[0]->load_tile_sum_values(enc_key, std::move(names_sum));
+      CHECK(st.ok());
+
+      std::vector<std::string> names_null_count{"d"};
+      st = frag_meta[0]->load_tile_null_count_values(
+          enc_key, std::move(names_null_count));
+      CHECK(st.ok());
+
+      // Validation.
+      // Min/max/sum for all null tile are invalid.
+      if (!all_null) {
+        for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
+          uint32_t correct_min = tile_idx * tile_extent_;
+          uint32_t correct_max = tile_idx * tile_extent_ + tile_extent_ - 1;
+          int64_t correct_sum =
+              (tile_extent_) * (correct_min + correct_max) / 2;
+
+          // Validate min.
+          auto&& [st_min, min, min_size] =
+              frag_meta[0]->get_tile_min("d", tile_idx);
+          CHECK(!st_min.ok());
+          CHECK(!min.has_value());
+          CHECK(!min_size.has_value());
+
+          // Validate max.
+          auto&& [st_max, max, max_size] =
+              frag_meta[0]->get_tile_max("d", tile_idx);
+          CHECK(!st_max.ok());
+          CHECK(!max.has_value());
+          CHECK(!max_size.has_value());
+
+          // Validate sum.
+          auto&& [st_sum, sum] = frag_meta[0]->get_tile_sum("d", tile_idx);
+          CHECK(st_sum.ok());
+          if (st_sum.ok()) {
+            CHECK(*(int64_t*)*sum == correct_sum);
+          }
+        }
+      }
+    }
+
+    // Load attribute metadata.
+    std::vector<std::string> names_min{"a"};
+    auto st = frag_meta[0]->load_tile_min_values(enc_key, std::move(names_min));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_max{"a"};
+    st = frag_meta[0]->load_tile_max_values(enc_key, std::move(names_max));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_sum{"a"};
+    st = frag_meta[0]->load_tile_sum_values(enc_key, std::move(names_sum));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_null_count{"a"};
+    st = frag_meta[0]->load_tile_null_count_values(
+        enc_key, std::move(names_null_count));
+    CHECK(st.ok());
+
+    // Validate attribute metadta.
+    // Min/max/sum for all null tile are invalid.
+    if (!all_null) {
+      if constexpr (std::is_same<TestType, char>::value) {
+        for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
+          // Validate min.
+          auto&& [st_min, min, min_size] =
+              frag_meta[0]->get_tile_min("a", tile_idx);
+          CHECK(st_min.ok());
+          if (st_min.ok()) {
+            CHECK(*min_size == cell_val_num);
+
+            // For strings, the index is stored in a signed value, switch to
+            // the index to unsigned.
+            int64_t idx = (int64_t)correct_mins_[tile_idx] -
+                          (int64_t)std::numeric_limits<char>::min();
+            CHECK(
+                0 == strncmp(
+                         (const char*)*min,
+                         string_ascii_[idx].c_str(),
+                         cell_val_num));
+          }
+
+          // Validate max.
+          auto&& [st_max, max, max_size] =
+              frag_meta[0]->get_tile_max("a", tile_idx);
+          CHECK(st_max.ok());
+          if (st_max.ok()) {
+            CHECK(*max_size == cell_val_num);
+
+            // For strings, the index is stored in a signed value, switch to
+            // the index to unsigned.
+            int64_t idx = (int64_t)correct_maxs_[tile_idx] -
+                          (int64_t)std::numeric_limits<char>::min();
+            CHECK(
+                0 == strncmp(
+                         (const char*)*max,
+                         string_ascii_[idx].c_str(),
+                         cell_val_num));
+          }
+
+          // Validate no sum.
+          auto&& [st_sum, sum] = frag_meta[0]->get_tile_sum("a", tile_idx);
+          CHECK(!st_sum.ok());
+        }
+      } else {
+        (void)cell_val_num;
+        for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
+          // Validate min.
+          auto&& [st_min, min, min_size] =
+              frag_meta[0]->get_tile_min("a", tile_idx);
+          CHECK(st_min.ok());
+          if (st_min.ok()) {
+            CHECK(*min_size == sizeof(TestType));
+            CHECK(0 == memcmp(*min, &correct_mins_[tile_idx], *min_size));
+          }
+
+          // Validate max.
+          auto&& [st_max, max, max_size] =
+              frag_meta[0]->get_tile_max("a", tile_idx);
+          CHECK(st_max.ok());
+          if (st_max.ok()) {
+            CHECK(*max_size == sizeof(TestType));
+            CHECK(0 == memcmp(*max, &correct_maxs_[tile_idx], *max_size));
+          }
+
+          // Validate sum.
+          auto&& [st_sum, sum] = frag_meta[0]->get_tile_sum("a", tile_idx);
+          CHECK(st_sum.ok());
+          if (st_sum.ok()) {
+            if constexpr (std::is_integral_v<TestType>) {
+              CHECK(*(int64_t*)*sum == correct_sums_int_[tile_idx]);
+            } else {
+              CHECK(*(double*)*sum == correct_sums_double_[tile_idx]);
+            }
+          }
+        }
+      }
+    }
+
+    // Check null count.
+    for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
+      // Null count.
+      auto&& [st_nc, nc] = frag_meta[0]->get_tile_null_count("a", tile_idx);
+      CHECK(st_nc.ok() == nullable);
+      if (st_nc.ok()) {
+        CHECK(*nc == correct_null_counts_[tile_idx]);
+      }
+    }
+
+    // Close array.
+    rc = tiledb_array_close(ctx, array);
+    CHECK(rc == TILEDB_OK);
+
+    // Clean up.
+    tiledb_array_free(&array);
+    tiledb_ctx_free(&ctx);
+  }
+
+  std::vector<TestType> correct_mins_;
+  std::vector<TestType> correct_maxs_;
+  std::vector<int64_t> correct_sums_int_;
+  std::vector<double> correct_sums_double_;
+  std::vector<uint64_t> correct_null_counts_;
+  std::vector<std::string> string_ascii_;
+
+  const char* ARRAY_NAME = "tile_metadata_unit_array";
+  const uint64_t tile_extent_ = 100;
+  const uint64_t num_cells_ = 1000;
+  const uint64_t num_tiles_ = num_cells_ / tile_extent_;
+  Context ctx_;
+  VFS vfs_;
+};
+
+typedef tuple<
+    char,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    float,
+    double>
+    FixedTypesUnderTest;
+TEMPLATE_LIST_TEST_CASE_METHOD(
+    CPPFixedTileMetadataFx,
+    "TileMetadata: fixed data type tile",
+    "[tile-metadata][fixed-data]",
+    FixedTypesUnderTest) {
+  typedef TestType T;
+  std::string test = GENERATE("nullable", "all null", "non nullable");
+
+  tiledb_layout_t layout =
+      GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER, TILEDB_ROW_MAJOR);
+
+  bool nullable = test == "nullable" || test == "all null";
+  bool all_null = test == "all null";
+
+  uint64_t cell_val_num = std::is_same<T, char>::value ? 10 : 1;
+
+  // Create the array.
+  CPPFixedTileMetadataFx<T>::create_array(layout, nullable, cell_val_num);
+
+  // Write a fragment.
+  CPPFixedTileMetadataFx<T>::write_fragment(
+      layout, nullable, all_null, cell_val_num);
+
+  // Check metadata.
+  CPPFixedTileMetadataFx<T>::check_metadata(
+      layout, nullable, all_null, cell_val_num);
+}
+
+struct CPPVarTileMetadataFx {
+  CPPVarTileMetadataFx()
+      : vfs_(ctx_) {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  ~CPPVarTileMetadataFx() {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  void create_array(tiledb_layout_t layout, bool nullable) {
+    Domain domain(ctx_);
+    auto d = Dimension::create<uint32_t>(ctx_, "d", {{0, 999}}, tile_extent_);
+    domain.add_dimension(d);
+
+    auto a = Attribute::create<std::string>(ctx_, "a");
+    a.set_nullable(nullable);
+    a.set_cell_val_num(TILEDB_VAR_NUM);
+
+    ArraySchema schema(
+        ctx_, layout == TILEDB_ROW_MAJOR ? TILEDB_DENSE : TILEDB_SPARSE);
+    schema.set_domain(domain);
+    schema.add_attribute(a);
+
+    if (layout != TILEDB_ROW_MAJOR) {
+      schema.set_capacity(tile_extent_);
+    }
+
+    Array::create(ARRAY_NAME, schema);
+  }
+
+  void write_fragment(tiledb_layout_t layout, bool nullable, bool all_null) {
+    std::default_random_engine random_engine;
+
+    uint64_t max_string_size = 100;
+    uint64_t num_strings = 2000;
+
+    // Generate random, sorted strings for the string ascii type.
+    strings_.reserve(num_strings);
+    for (uint64_t i = 0; i < num_strings; i++) {
+      strings_.emplace_back(
+          tiledb::test::random_string(rand() % max_string_size));
+    }
+    std::sort(strings_.begin(), strings_.end());
+
+    // Choose strings randomly.
+    std::vector<int> values;
+    values.reserve(num_cells_);
+    uint64_t var_size = 0;
+    for (uint64_t i = 0; i < num_cells_; i++) {
+      values.emplace_back(rand() % num_strings);
+      var_size += strings_[values.back()].size();
+    }
+
+    // Compute correct values as the tile is filled with data.
+    correct_mins_.clear();
+    correct_maxs_.clear();
+    correct_null_counts_.clear();
+    correct_mins_.resize(num_tiles_, std::numeric_limits<int>::max());
+    correct_maxs_.resize(num_tiles_, std::numeric_limits<int>::lowest());
+    correct_null_counts_.resize(num_tiles_, 0);
+
+    // Fill the tiles with data.
+    uint64_t offset = 0;
+    std::vector<uint32_t> d(num_cells_);
+    std::vector<uint64_t> a_offsets(num_cells_);
+    std::vector<char> a_var(var_size);
+    std::vector<uint8_t> a_val(num_cells_);
+    for (uint64_t i = 0; i < num_cells_; i++) {
+      auto tile_idx = i / tile_extent_;
+
+      a_val[i] =
+          all_null ? 0 : (nullable && (i % tile_extent_ != 0) ? rand() % 2 : 1);
+
+      // Compute correct min/max.
+      if (a_val[i] == 1) {
+        correct_mins_[tile_idx] = std::min(correct_mins_[tile_idx], values[i]);
+        correct_maxs_[tile_idx] = std::max(correct_maxs_[tile_idx], values[i]);
+      }
+
+      // Compute correct null count.
+      correct_null_counts_[tile_idx] += uint64_t(a_val[i] == 0);
+
+      // Copy the string.
+      a_offsets[i] = offset;
+      auto idx = values[i];
+      memcpy(&a_var[offset], strings_[idx].c_str(), strings_[idx].size());
+      offset += strings_[idx].size();
+
+      // Set the coordinate value.
+      d[i] = i;
+    }
+
+    // Write to the array.
+    auto array = tiledb::Array(ctx_, ARRAY_NAME, TILEDB_WRITE);
+    auto query = tiledb::Query(ctx_, array, TILEDB_WRITE);
+
+    query.set_layout(layout);
+
+    if (layout != TILEDB_ROW_MAJOR) {
+      query.set_data_buffer("d", d);
+    }
+    query.set_offsets_buffer("a", a_offsets);
+    query.set_buffer("a", a_var);
+
+    if (nullable) {
+      query.set_validity_buffer("a", a_val);
+    }
+
+    query.submit();
+    query.finalize();
+    array.close();
+  }
+
+  void check_metadata(tiledb_layout_t layout, bool nullable, bool all_null) {
+    // Open array.
+    tiledb_ctx_t* ctx;
+    tiledb_ctx_alloc(NULL, &ctx);
+    tiledb_array_t* array;
+    int rc = tiledb_array_alloc(ctx, ARRAY_NAME, &array);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_array_open(ctx, array, TILEDB_READ);
+    CHECK(rc == TILEDB_OK);
+
+    // Load the metadata and validate coords netadata.
+    auto frag_meta = array->array_->fragment_metadata();
+    auto& enc_key = array->array_->get_encryption_key();
+    bool has_coords = layout != TILEDB_ROW_MAJOR;
+    if (has_coords) {
+      std::vector<std::string> names_min{"d"};
+      auto st =
+          frag_meta[0]->load_tile_min_values(enc_key, std::move(names_min));
+      CHECK(st.ok());
+
+      std::vector<std::string> names_max{"d"};
+      st = frag_meta[0]->load_tile_max_values(enc_key, std::move(names_max));
+      CHECK(st.ok());
+
+      std::vector<std::string> names_sum{"d"};
+      st = frag_meta[0]->load_tile_sum_values(enc_key, std::move(names_sum));
+      CHECK(st.ok());
+
+      std::vector<std::string> names_null_count{"d"};
+      st = frag_meta[0]->load_tile_null_count_values(
+          enc_key, std::move(names_null_count));
+      CHECK(st.ok());
+
+      // Validation.
+      // Min/max/sum for all null tile are invalid.
+      if (!all_null) {
+        for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
+          uint32_t correct_min = tile_idx * tile_extent_;
+          uint32_t correct_max = tile_idx * tile_extent_ + tile_extent_ - 1;
+          int64_t correct_sum =
+              (tile_extent_) * (correct_min + correct_max) / 2;
+
+          // Validate no min.
+          auto&& [st_min, min, min_size] =
+              frag_meta[0]->get_tile_min("d", tile_idx);
+          CHECK(!min.has_value());
+          CHECK(!min_size.has_value());
+
+          // Validate no max.
+          auto&& [st_max, max, max_size] =
+              frag_meta[0]->get_tile_max("d", tile_idx);
+          CHECK(!st_max.ok());
+          CHECK(!max.has_value());
+          CHECK(!max_size.has_value());
+
+          // Validate sum.
+          auto&& [st_sum, sum] = frag_meta[0]->get_tile_sum("d", tile_idx);
+          CHECK(st_sum.ok());
+          if (st_sum.ok()) {
+            CHECK(*(int64_t*)*sum == correct_sum);
+          }
+        }
+      }
+    }
+
+    // Load attribute metadata.
+    std::vector<std::string> names_min{"a"};
+    auto st = frag_meta[0]->load_tile_min_values(enc_key, std::move(names_min));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_max{"a"};
+    st = frag_meta[0]->load_tile_max_values(enc_key, std::move(names_max));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_sum{"a"};
+    st = frag_meta[0]->load_tile_sum_values(enc_key, std::move(names_sum));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_null_count{"a"};
+    st = frag_meta[0]->load_tile_null_count_values(
+        enc_key, std::move(names_null_count));
+    CHECK(st.ok());
+
+    // Validate attribute metadata.
+    // Min/max/sum for all null tile are invalid.
+    if (!all_null) {
+      for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
+        // Validate min.
+        auto&& [st_min, min, min_size] =
+            frag_meta[0]->get_tile_min("a", tile_idx);
+        CHECK(st_min.ok());
+        if (st_min.ok()) {
+          int idx = correct_mins_[tile_idx];
+          CHECK(*min_size == strings_[idx].size());
+          CHECK(
+              0 == strncmp(
+                       (const char*)*min,
+                       strings_[idx].c_str(),
+                       strings_[idx].size()));
+        }
+
+        // Validate max.
+        auto&& [st_max, max, max_size] =
+            frag_meta[0]->get_tile_max("a", tile_idx);
+        CHECK(st_max.ok());
+        if (st_max.ok()) {
+          int idx = correct_maxs_[tile_idx];
+          CHECK(*max_size == strings_[idx].size());
+          CHECK(
+              0 == strncmp(
+                       (const char*)*max,
+                       strings_[idx].c_str(),
+                       strings_[idx].size()));
+        }
+
+        // Validate no sum.
+        auto&& [st_sum, sum] = frag_meta[0]->get_tile_sum("a", tile_idx);
+        CHECK(!st_sum.ok());
+      }
+    }
+
+    // Check null count.
+    for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
+      // Null count.
+      auto&& [st_nc, nc] = frag_meta[0]->get_tile_null_count("a", tile_idx);
+      CHECK(st_nc.ok() == nullable);
+      if (st_nc.ok()) {
+        CHECK(*nc == correct_null_counts_[tile_idx]);
+      }
+    }
+
+    // Close array.
+    rc = tiledb_array_close(ctx, array);
+    CHECK(rc == TILEDB_OK);
+
+    // Clean up.
+    tiledb_array_free(&array);
+    tiledb_ctx_free(&ctx);
+  }
+
+  std::vector<int> correct_mins_;
+  std::vector<int> correct_maxs_;
+  std::vector<uint64_t> correct_null_counts_;
+  std::vector<std::string> strings_;
+
+  const char* ARRAY_NAME = "tile_metadata_unit_array";
+  const uint64_t tile_extent_ = 10;
+  const uint64_t num_cells_ = 1000;
+  const uint64_t num_tiles_ = num_cells_ / tile_extent_;
+  Context ctx_;
+  VFS vfs_;
+};
+
+TEST_CASE_METHOD(
+    CPPVarTileMetadataFx,
+    "TileMetadata: var data type tile",
+    "[tile-metadata][var-data]") {
+  std::string test = GENERATE("nullable", "all null", "non nullable");
+
+  tiledb_layout_t layout =
+      GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER, TILEDB_ROW_MAJOR);
+
+  bool nullable = test == "nullable" || test == "all null";
+  bool all_null = test == "all null";
+
+  // Create the array.
+  CPPVarTileMetadataFx::create_array(layout, nullable);
+
+  // Write a fragment.
+  CPPVarTileMetadataFx::write_fragment(layout, nullable, all_null);
+
+  // Check metadata.
+  CPPVarTileMetadataFx::check_metadata(layout, nullable, all_null);
+}

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -208,6 +208,8 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray_tile_overlap.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/generic_tile_io.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile_metadata_generator.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/writer_tile.cc
 )
 list(APPEND TILEDB_CORE_SOURCES ${TILEDB_COMMON_SOURCES})
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -49,6 +49,7 @@
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile.h"
+#include "tiledb/sm/tile/tile_metadata_generator.h"
 
 #include <cassert>
 #include <iostream>
@@ -74,20 +75,20 @@ FragmentMetadata::FragmentMetadata(
     , memory_tracker_(memory_tracker)
     , array_schema_(array_schema)
     , dense_(dense)
+    , footer_size_(0)
+    , footer_offset_(0)
     , fragment_uri_(fragment_uri)
-    , timestamp_range_(timestamp_range) {
-  has_consolidated_footer_ = false;
-  rtree_ = RTree(array_schema_->domain(), constants::rtree_fanout);
-  meta_file_size_ = 0;
-  version_ = array_schema_->write_version();
-  tile_index_base_ = 0;
-  sparse_tile_num_ = 0;
-  footer_size_ = 0;
-  footer_offset_ = 0;
-
+    , has_consolidated_footer_(false)
+    , last_tile_cell_num_(0)
+    , sparse_tile_num_(0)
+    , meta_file_size_(0)
+    , rtree_(RTree(array_schema_->domain(), constants::rtree_fanout))
+    , tile_index_base_(0)
+    , version_(array_schema_->write_version())
+    , timestamp_range_(timestamp_range)
+    , array_uri_(array_schema_->array_uri()) {
   build_idx_map();
   array_schema_->get_name(&array_schema_name_);
-  array_uri_ = array_schema_->array_uri();
 }
 
 FragmentMetadata::~FragmentMetadata() = default;
@@ -189,6 +190,146 @@ void FragmentMetadata::set_tile_validity_offset(
   assert(tid < tile_validity_offsets_[idx].size());
   tile_validity_offsets_[idx][tid] = file_validity_sizes_[idx];
   file_validity_sizes_[idx] += step;
+}
+
+void FragmentMetadata::set_tile_min(
+    const std::string& name, uint64_t tid, const void* min, uint64_t size) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  tid += tile_index_base_;
+  auto buff_offset = tid * size;
+  assert(tid < tile_min_buffer_[idx].size() / size);
+  memcpy(&tile_min_buffer_[idx][buff_offset], min, size);
+}
+
+void FragmentMetadata::set_tile_min_var_size(
+    const std::string& name, uint64_t tid, uint64_t size) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  tid += tile_index_base_;
+  auto buff_offset = tid * sizeof(uint64_t);
+  assert(tid < tile_min_buffer_[idx].size() / sizeof(uint64_t));
+
+  auto offset = (uint64_t*)&tile_min_buffer_[idx][buff_offset];
+  *offset = size;
+}
+
+void FragmentMetadata::set_tile_min_var(
+    const std::string& name, uint64_t tid, const void* min) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  tid += tile_index_base_;
+  auto buff_offset = tid * sizeof(uint64_t);
+  assert(tid < tile_min_buffer_[idx].size() / sizeof(uint64_t));
+
+  auto offset = (uint64_t*)&tile_min_buffer_[idx][buff_offset];
+  auto size = buff_offset != tile_min_buffer_[idx].size() - sizeof(uint64_t) ?
+                  offset[1] - offset[0] :
+                  tile_min_var_buffer_[idx].size() - offset[0];
+
+  // Copy var data
+  memcpy(&tile_min_var_buffer_[idx][offset[0]], min, size);
+}
+
+void FragmentMetadata::set_tile_max(
+    const std::string& name, uint64_t tid, const void* max, uint64_t size) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  tid += tile_index_base_;
+  auto buff_offset = tid * size;
+  assert(tid < tile_max_buffer_[idx].size() / size);
+  memcpy(&tile_max_buffer_[idx][buff_offset], max, size);
+}
+
+void FragmentMetadata::set_tile_max_var_size(
+    const std::string& name, uint64_t tid, uint64_t size) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  tid += tile_index_base_;
+  auto buff_offset = tid * sizeof(uint64_t);
+  assert(tid < tile_max_buffer_[idx].size() / sizeof(uint64_t));
+
+  auto offset = (uint64_t*)&tile_max_buffer_[idx][buff_offset];
+  *offset = size;
+}
+
+void FragmentMetadata::set_tile_max_var(
+    const std::string& name, uint64_t tid, const void* max) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  tid += tile_index_base_;
+  auto buff_offset = tid * sizeof(uint64_t);
+  assert(tid < tile_max_buffer_[idx].size() / sizeof(uint64_t));
+
+  auto offset = (uint64_t*)&tile_max_buffer_[idx][buff_offset];
+  auto size = buff_offset != tile_max_buffer_[idx].size() - sizeof(uint64_t) ?
+                  offset[1] - offset[0] :
+                  tile_max_var_buffer_[idx].size() - offset[0];
+
+  // Copy var data
+  memcpy(&tile_max_var_buffer_[idx][offset[0]], max, size);
+}
+
+void FragmentMetadata::convert_tile_min_max_var_sizes_to_offsets(
+    const std::string& name) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+
+  // Fix the min offsets.
+  uint64_t offset = 0;
+  auto offsets = (uint64_t*)tile_min_buffer_[idx].data();
+  for (uint64_t i = 0; i < tile_min_buffer_[idx].size() / sizeof(uint64_t);
+       i++) {
+    auto size = *offsets;
+    *offsets = offset;
+    offsets++;
+    offset += size;
+  }
+
+  // Allocate min var data buffer.
+  tile_min_var_buffer_[idx].resize(offset);
+
+  // Fix the max offsets.
+  offset = 0;
+  offsets = (uint64_t*)tile_max_buffer_[idx].data();
+  for (uint64_t i = 0; i < tile_max_buffer_[idx].size() / sizeof(uint64_t);
+       i++) {
+    auto size = *offsets;
+    *offsets = offset;
+    offsets++;
+    offset += size;
+  }
+
+  // Allocate min var data buffer.
+  tile_max_var_buffer_[idx].resize(offset);
+}
+
+void FragmentMetadata::set_tile_sum(
+    const std::string& name, uint64_t tid, const ByteVec* sum) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  tid += tile_index_base_;
+  assert(tid * sizeof(uint64_t) < tile_sums_[idx].size());
+  memcpy(
+      &tile_sums_[idx][tid * sizeof(uint64_t)], sum->data(), sizeof(uint64_t));
+}
+
+void FragmentMetadata::set_tile_null_count(
+    const std::string& name, uint64_t tid, uint64_t null_count) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  tid += tile_index_base_;
+  assert(tid < tile_null_counts_[idx].size());
+  tile_null_counts_[idx][tid] = null_count;
 }
 
 void FragmentMetadata::set_array_schema(ArraySchema* array_schema) {
@@ -330,7 +471,6 @@ Status FragmentMetadata::add_max_buffer_sizes_dense(
         buffer_sizes) {
   // Calculate the ids of all tiles overlapping with subarray
   auto tids = compute_overlapping_tile_ids(subarray);
-  uint64_t size = 0;
 
   // Compute buffer sizes
   for (auto& tid : tids) {
@@ -338,8 +478,9 @@ Status FragmentMetadata::add_max_buffer_sizes_dense(
       if (array_schema_->var_size(it.first)) {
         auto cell_num = this->cell_num(tid);
         it.second.first += cell_num * constants::cell_var_offset_size;
-        RETURN_NOT_OK(tile_var_size(it.first, tid, &size));
-        it.second.second += size;
+        auto&& [st, size] = tile_var_size(it.first, tid);
+        RETURN_NOT_OK(st);
+        it.second.second += *size;
       } else {
         it.second.first += cell_num(tid) * array_schema_->cell_size(it.first);
       }
@@ -358,7 +499,6 @@ Status FragmentMetadata::add_max_buffer_sizes_sparse(
 
   // Get tile overlap
   auto tile_overlap = rtree_.get_tile_overlap(subarray);
-  uint64_t size = 0;
 
   // Handle tile ranges
   for (const auto& tr : tile_overlap.tile_ranges_) {
@@ -367,8 +507,9 @@ Status FragmentMetadata::add_max_buffer_sizes_sparse(
         if (array_schema_->var_size(it.first)) {
           auto cell_num = this->cell_num(tid);
           it.second.first += cell_num * constants::cell_var_offset_size;
-          RETURN_NOT_OK(tile_var_size(it.first, tid, &size));
-          it.second.second += size;
+          auto&& [st, size] = tile_var_size(it.first, tid);
+          RETURN_NOT_OK(st);
+          it.second.second += *size;
         } else {
           it.second.first += cell_num(tid) * array_schema_->cell_size(it.first);
         }
@@ -383,8 +524,9 @@ Status FragmentMetadata::add_max_buffer_sizes_sparse(
       if (array_schema_->var_size(it.first)) {
         auto cell_num = this->cell_num(tid);
         it.second.first += cell_num * constants::cell_var_offset_size;
-        RETURN_NOT_OK(tile_var_size(it.first, tid, &size));
-        it.second.second += size;
+        auto&& [st, size] = tile_var_size(it.first, tid);
+        it.second.second += *size;
+        RETURN_NOT_OK(st);
       } else {
         it.second.first += cell_num(tid) * array_schema_->cell_size(it.first);
       }
@@ -513,6 +655,14 @@ Status FragmentMetadata::init(const NDRange& non_empty_domain) {
   for (unsigned int i = 0; i < num; ++i)
     file_validity_sizes_[i] = 0;
 
+  // Initialize tile min/max/sum/null count
+  tile_min_buffer_.resize(num);
+  tile_min_var_buffer_.resize(num);
+  tile_max_buffer_.resize(num);
+  tile_max_var_buffer_.resize(num);
+  tile_sums_.resize(num);
+  tile_null_counts_.resize(num);
+
   return Status::Ok();
 }
 
@@ -556,6 +706,20 @@ Status FragmentMetadata::store(const EncryptionKey& encryption_key) {
   auto timer_se =
       storage_manager_->stats()->start_timer("write_store_frag_meta");
 
+  assert(version_ >= 7);
+  if (version_ <= 10)
+    return store_v7_v10(encryption_key);
+  else
+    return store_v11_or_higher(encryption_key);
+
+  assert(false);
+  return Status::Ok();
+}
+
+Status FragmentMetadata::store_v7_v10(const EncryptionKey& encryption_key) {
+  auto timer_se =
+      storage_manager_->stats()->start_timer("write_store_frag_meta");
+
   auto fragment_metadata_uri =
       fragment_uri_.join_path(constants::fragment_metadata_filename);
   auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
@@ -594,14 +758,103 @@ Status FragmentMetadata::store(const EncryptionKey& encryption_key) {
   }
 
   // Store validity tile offsets
-  if (version_ >= 7) {
-    gt_offsets_.tile_validity_offsets_.resize(num);
-    for (unsigned int i = 0; i < num; ++i) {
-      gt_offsets_.tile_validity_offsets_[i] = offset;
-      RETURN_NOT_OK_ELSE(
-          store_tile_validity_offsets(i, encryption_key, &nbytes), clean_up());
-      offset += nbytes;
-    }
+  gt_offsets_.tile_validity_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_validity_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_validity_offsets(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store footer
+  RETURN_NOT_OK_ELSE(store_footer(encryption_key), clean_up());
+
+  // Close file
+  return storage_manager_->close_file(fragment_metadata_uri);
+}
+
+Status FragmentMetadata::store_v11_or_higher(
+    const EncryptionKey& encryption_key) {
+  auto timer_se =
+      storage_manager_->stats()->start_timer("write_store_frag_meta");
+
+  auto fragment_metadata_uri =
+      fragment_uri_.join_path(constants::fragment_metadata_filename);
+  auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
+  uint64_t offset = 0, nbytes;
+
+  // Store R-Tree
+  gt_offsets_.rtree_ = offset;
+  RETURN_NOT_OK_ELSE(store_rtree(encryption_key, &nbytes), clean_up());
+  offset += nbytes;
+
+  // Store tile offsets
+  gt_offsets_.tile_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_offsets(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store tile var offsets
+  gt_offsets_.tile_var_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_var_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_var_offsets(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store tile var sizes
+  gt_offsets_.tile_var_sizes_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_var_sizes_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_var_sizes(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store validity tile offsets
+  gt_offsets_.tile_validity_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_validity_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_validity_offsets(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store mins
+  gt_offsets_.tile_min_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_min_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(store_tile_mins(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store maxs
+  gt_offsets_.tile_max_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_max_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(store_tile_maxs(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store sums
+  gt_offsets_.tile_sum_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_sum_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(store_tile_sums(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store null counts
+  gt_offsets_.tile_null_count_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_null_count_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_null_counts(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
   }
 
   // Store footer
@@ -616,14 +869,41 @@ const NDRange& FragmentMetadata::non_empty_domain() {
 }
 
 Status FragmentMetadata::set_num_tiles(uint64_t num_tiles) {
-  auto num = array_schema_->attribute_num() + 1 + array_schema_->dim_num();
-
-  for (unsigned i = 0; i < num; i++) {
+  for (auto& it : idx_map_) {
+    auto i = it.second;
     assert(num_tiles >= tile_offsets_[i].size());
+
+    // Get the fixed cell size
+    const auto is_dim = array_schema_->is_dim(it.first);
+    const auto var_size = array_schema_->var_size(it.first);
+    const auto cell_size = var_size ? constants::cell_var_offset_size :
+                                      array_schema_->cell_size(it.first);
+
     tile_offsets_[i].resize(num_tiles, 0);
     tile_var_offsets_[i].resize(num_tiles, 0);
     tile_var_sizes_[i].resize(num_tiles, 0);
     tile_validity_offsets_[i].resize(num_tiles, 0);
+
+    // No metadata for dense coords
+    if (!array_schema_->dense() || !is_dim) {
+      const auto type = array_schema_->type(it.first);
+      const auto cell_val_num = array_schema_->cell_val_num(it.first);
+
+      if (TileMetadataGenerator::has_min_max_metadata(
+              type, is_dim, var_size, cell_val_num)) {
+        tile_min_buffer_[i].resize(num_tiles * cell_size, 0);
+        tile_max_buffer_[i].resize(num_tiles * cell_size, 0);
+      }
+
+      if (TileMetadataGenerator::has_sum_metadata(
+              type, var_size, cell_val_num)) {
+        if (!var_size)
+          tile_sums_[i].resize(num_tiles * sizeof(uint64_t), 0);
+      }
+
+      if (array_schema_->is_nullable(it.first))
+        tile_null_counts_[i].resize(num_tiles, 0);
+    }
   }
 
   if (!dense_) {
@@ -778,6 +1058,94 @@ Status FragmentMetadata::load_tile_offsets(
   return Status::Ok();
 }
 
+Status FragmentMetadata::load_tile_min_values(
+    const EncryptionKey& encryption_key, std::vector<std::string>&& names) {
+  // Sort 'names' in ascending order of their index. The
+  // motivation is to load the offsets in order of their
+  // layout for sequential reads to the file.
+  std::sort(
+      names.begin(),
+      names.end(),
+      [&](const std::string& lhs, const std::string& rhs) {
+        assert(idx_map_.count(lhs) > 0);
+        assert(idx_map_.count(rhs) > 0);
+        return idx_map_[lhs] < idx_map_[rhs];
+      });
+
+  // Load all the min values.
+  for (const auto& name : names) {
+    RETURN_NOT_OK(load_tile_min_values(encryption_key, idx_map_[name]));
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_tile_max_values(
+    const EncryptionKey& encryption_key, std::vector<std::string>&& names) {
+  // Sort 'names' in ascending order of their index. The
+  // motivation is to load the offsets in order of their
+  // layout for sequential reads to the file.
+  std::sort(
+      names.begin(),
+      names.end(),
+      [&](const std::string& lhs, const std::string& rhs) {
+        assert(idx_map_.count(lhs) > 0);
+        assert(idx_map_.count(rhs) > 0);
+        return idx_map_[lhs] < idx_map_[rhs];
+      });
+
+  // Load all the max values.
+  for (const auto& name : names) {
+    RETURN_NOT_OK(load_tile_max_values(encryption_key, idx_map_[name]));
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_tile_sum_values(
+    const EncryptionKey& encryption_key, std::vector<std::string>&& names) {
+  // Sort 'names' in ascending order of their index. The
+  // motivation is to load the offsets in order of their
+  // layout for sequential reads to the file.
+  std::sort(
+      names.begin(),
+      names.end(),
+      [&](const std::string& lhs, const std::string& rhs) {
+        assert(idx_map_.count(lhs) > 0);
+        assert(idx_map_.count(rhs) > 0);
+        return idx_map_[lhs] < idx_map_[rhs];
+      });
+
+  // Load all the sum values.
+  for (const auto& name : names) {
+    RETURN_NOT_OK(load_tile_sum_values(encryption_key, idx_map_[name]));
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_tile_null_count_values(
+    const EncryptionKey& encryption_key, std::vector<std::string>&& names) {
+  // Sort 'names' in ascending order of their index. The
+  // motivation is to load the offsets in order of their
+  // layout for sequential reads to the file.
+  std::sort(
+      names.begin(),
+      names.end(),
+      [&](const std::string& lhs, const std::string& rhs) {
+        assert(idx_map_.count(lhs) > 0);
+        assert(idx_map_.count(rhs) > 0);
+        return idx_map_[lhs] < idx_map_[rhs];
+      });
+
+  // Load all the null count values.
+  for (const auto& name : names) {
+    RETURN_NOT_OK(load_tile_null_count_values(encryption_key, idx_map_[name]));
+  }
+
+  return Status::Ok();
+}
+
 Status FragmentMetadata::file_offset(
     const std::string& name, uint64_t tile_idx, uint64_t* offset) {
   auto it = idx_map_.find(name);
@@ -825,63 +1193,69 @@ const std::vector<NDRange>& FragmentMetadata::mbrs() const {
   return rtree_.leaves();
 }
 
-Status FragmentMetadata::persisted_tile_size(
-    const std::string& name, uint64_t tile_idx, uint64_t* tile_size) {
+std::tuple<Status, std::optional<uint64_t>>
+FragmentMetadata::persisted_tile_size(
+    const std::string& name, uint64_t tile_idx) {
   auto it = idx_map_.find(name);
   assert(it != idx_map_.end());
   auto idx = it->second;
   if (!loaded_metadata_.tile_offsets_[idx])
-    return LOG_STATUS(Status_FragmentMetadataError(
-        "Trying to access metadata that's not loaded"));
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            std::nullopt};
 
   auto tile_num = this->tile_num();
 
-  *tile_size =
+  auto tile_size =
       (tile_idx != tile_num - 1) ?
           tile_offsets_[idx][tile_idx + 1] - tile_offsets_[idx][tile_idx] :
           file_sizes_[idx] - tile_offsets_[idx][tile_idx];
 
-  return Status::Ok();
+  return {Status::Ok(), tile_size};
 }
 
-Status FragmentMetadata::persisted_tile_var_size(
-    const std::string& name, uint64_t tile_idx, uint64_t* tile_size) {
+std::tuple<Status, std::optional<uint64_t>>
+FragmentMetadata::persisted_tile_var_size(
+    const std::string& name, uint64_t tile_idx) {
   auto it = idx_map_.find(name);
   assert(it != idx_map_.end());
   auto idx = it->second;
 
   if (!loaded_metadata_.tile_var_offsets_[idx])
-    return LOG_STATUS(Status_FragmentMetadataError(
-        "Trying to access metadata that's not loaded"));
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            std::nullopt};
 
   auto tile_num = this->tile_num();
 
-  *tile_size = (tile_idx != tile_num - 1) ?
-                   tile_var_offsets_[idx][tile_idx + 1] -
-                       tile_var_offsets_[idx][tile_idx] :
-                   file_var_sizes_[idx] - tile_var_offsets_[idx][tile_idx];
+  auto tile_size = (tile_idx != tile_num - 1) ?
+                       tile_var_offsets_[idx][tile_idx + 1] -
+                           tile_var_offsets_[idx][tile_idx] :
+                       file_var_sizes_[idx] - tile_var_offsets_[idx][tile_idx];
 
-  return Status::Ok();
+  return {Status::Ok(), tile_size};
 }
 
-Status FragmentMetadata::persisted_tile_validity_size(
-    const std::string& name, uint64_t tile_idx, uint64_t* tile_size) {
+std::tuple<Status, std::optional<uint64_t>>
+FragmentMetadata::persisted_tile_validity_size(
+    const std::string& name, uint64_t tile_idx) {
   auto it = idx_map_.find(name);
   assert(it != idx_map_.end());
   auto idx = it->second;
   if (!loaded_metadata_.tile_validity_offsets_[idx])
-    return LOG_STATUS(Status_FragmentMetadataError(
-        "Trying to access metadata that's not loaded"));
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            std::nullopt};
 
   auto tile_num = this->tile_num();
 
-  *tile_size =
+  auto tile_size =
       (tile_idx != tile_num - 1) ?
           tile_validity_offsets_[idx][tile_idx + 1] -
               tile_validity_offsets_[idx][tile_idx] :
           file_validity_sizes_[idx] - tile_validity_offsets_[idx][tile_idx];
 
-  return Status::Ok();
+  return {Status::Ok(), tile_size};
 }
 
 uint64_t FragmentMetadata::tile_size(
@@ -892,17 +1266,137 @@ uint64_t FragmentMetadata::tile_size(
                       cell_num * array_schema_->cell_size(name);
 }
 
-Status FragmentMetadata::tile_var_size(
-    const std::string& name, uint64_t tile_idx, uint64_t* tile_size) {
+std::tuple<Status, std::optional<uint64_t>> FragmentMetadata::tile_var_size(
+    const std::string& name, uint64_t tile_idx) {
   auto it = idx_map_.find(name);
   assert(it != idx_map_.end());
   auto idx = it->second;
   if (!loaded_metadata_.tile_var_sizes_[idx])
-    return LOG_STATUS(Status_FragmentMetadataError(
-        "Trying to access metadata that's not loaded"));
-  *tile_size = tile_var_sizes_[idx][tile_idx];
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            std::nullopt};
+  auto tile_size = tile_var_sizes_[idx][tile_idx];
 
-  return Status::Ok();
+  return {Status::Ok(), tile_size};
+}
+
+std::tuple<Status, std::optional<void*>, std::optional<uint64_t>>
+FragmentMetadata::get_tile_min(const std::string& name, uint64_t tile_idx) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  if (!loaded_metadata_.tile_min_[idx])
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            std::nullopt,
+            std::nullopt};
+
+  const auto type = array_schema_->type(name);
+  const auto is_dim = array_schema_->is_dim(name);
+  const auto var_size = array_schema_->var_size(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+  if (!TileMetadataGenerator::has_min_max_metadata(
+          type, is_dim, var_size, cell_val_num))
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not present")),
+            std::nullopt,
+            std::nullopt};
+
+  if (var_size) {
+    auto tile_num = this->tile_num();
+    auto offsets = (uint64_t*)tile_min_buffer_[idx].data();
+    auto min_offset = offsets[tile_idx];
+    auto size = tile_idx == tile_num - 1 ?
+                    tile_min_var_buffer_[idx].size() - min_offset :
+                    offsets[tile_idx + 1] - min_offset;
+    void* min = &tile_min_var_buffer_[idx][min_offset];
+    return {Status::Ok(), min, size};
+  } else {
+    auto size = array_schema_->cell_size(name);
+    void* min = &tile_min_buffer_[idx][tile_idx * size];
+    return {Status::Ok(), min, size};
+  }
+}
+
+std::tuple<Status, std::optional<void*>, std::optional<uint64_t>>
+FragmentMetadata::get_tile_max(const std::string& name, uint64_t tile_idx) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  if (!loaded_metadata_.tile_max_[idx])
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            std::nullopt,
+            std::nullopt};
+
+  const auto type = array_schema_->type(name);
+  const auto is_dim = array_schema_->is_dim(name);
+  const auto var_size = array_schema_->var_size(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+  if (!TileMetadataGenerator::has_min_max_metadata(
+          type, is_dim, var_size, cell_val_num))
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not present")),
+            std::nullopt,
+            std::nullopt};
+
+  if (var_size) {
+    auto tile_num = this->tile_num();
+    auto offsets = (uint64_t*)tile_max_buffer_[idx].data();
+    auto max_offset = offsets[tile_idx];
+    auto size = tile_idx == tile_num - 1 ?
+                    tile_max_var_buffer_[idx].size() - max_offset :
+                    offsets[tile_idx + 1] - max_offset;
+    void* max = &tile_max_var_buffer_[idx][max_offset];
+    return {Status::Ok(), max, size};
+  } else {
+    auto size = array_schema_->cell_size(name);
+    void* max = &tile_max_buffer_[idx][tile_idx * size];
+    return {Status::Ok(), max, size};
+  }
+}
+
+std::tuple<Status, std::optional<void*>> FragmentMetadata::get_tile_sum(
+    const std::string& name, uint64_t tile_idx) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  if (!loaded_metadata_.tile_sum_[idx])
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            std::nullopt};
+
+  auto type = array_schema_->type(name);
+  auto var_size = array_schema_->var_size(name);
+  auto cell_val_num = array_schema_->cell_val_num(name);
+  if (!TileMetadataGenerator::has_sum_metadata(type, var_size, cell_val_num))
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not present")),
+            std::nullopt};
+
+  void* sum = &tile_sums_[idx][tile_idx * sizeof(uint64_t)];
+  return {Status::Ok(), sum};
+}
+
+std::tuple<Status, std::optional<uint64_t>>
+FragmentMetadata::get_tile_null_count(
+    const std::string& name, uint64_t tile_idx) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  if (!loaded_metadata_.tile_null_count_[idx])
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            std::nullopt};
+
+  if (!array_schema_->is_nullable(name)) {
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not present")),
+            std::nullopt};
+  }
+
+  uint64_t null_count = tile_null_counts_[idx][tile_idx];
+  return {Status::Ok(), null_count};
 }
 
 uint64_t FragmentMetadata::first_timestamp() const {
@@ -997,8 +1491,10 @@ Status FragmentMetadata::get_footer_size(
     *size = footer_size_v3_v4();
   } else if (version < 4) {
     *size = footer_size_v5_v6();
+  } else if (version < 11) {
+    *size = footer_size_v7_v10();
   } else {
-    *size = footer_size_v7_or_higher();
+    *size = footer_size_v11_or_higher();
   }
 
   return Status::Ok();
@@ -1097,7 +1593,7 @@ uint64_t FragmentMetadata::footer_size_v5_v6() const {
   return size;
 }
 
-uint64_t FragmentMetadata::footer_size_v7_or_higher() const {
+uint64_t FragmentMetadata::footer_size_v7_v10() const {
   auto dim_num = array_schema_->dim_num();
   auto num = array_schema_->attribute_num() + dim_num + 1;
   uint64_t domain_size = 0;
@@ -1135,6 +1631,52 @@ uint64_t FragmentMetadata::footer_size_v7_or_higher() const {
   size += num * sizeof(uint64_t);  // tile var offsets
   size += num * sizeof(uint64_t);  // tile var sizes
   size += num * sizeof(uint64_t);  // tile validity sizes
+
+  return size;
+}
+
+uint64_t FragmentMetadata::footer_size_v11_or_higher() const {
+  auto dim_num = array_schema_->dim_num();
+  auto num = array_schema_->attribute_num() + dim_num + 1;
+  uint64_t domain_size = 0;
+
+  if (non_empty_domain_.empty()) {
+    // For var-sized dimensions, this function would be called only upon
+    // writing the footer to storage, in which case the non-empty domain
+    // would not be empty. For reading the footer from storage, the footer
+    // size is explicitly stored to and retrieved from storage, so this
+    // function is not called then.
+    assert(array_schema_->domain()->all_dims_fixed());
+    for (unsigned d = 0; d < dim_num; ++d)
+      domain_size += 2 * array_schema_->domain()->dimension(d)->coord_size();
+  } else {
+    for (unsigned d = 0; d < dim_num; ++d) {
+      domain_size += non_empty_domain_[d].size();
+      if (array_schema_->dimension(d)->var_size())
+        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized
+    }
+  }
+
+  // Get footer size
+  uint64_t size = 0;
+  size += sizeof(uint32_t);        // version
+  size += sizeof(char);            // dense
+  size += sizeof(char);            // null non-empty domain
+  size += domain_size;             // non-empty domain
+  size += sizeof(uint64_t);        // sparse tile num
+  size += sizeof(uint64_t);        // last tile cell num
+  size += num * sizeof(uint64_t);  // file sizes
+  size += num * sizeof(uint64_t);  // file var sizes
+  size += num * sizeof(uint64_t);  // file validity sizes
+  size += sizeof(uint64_t);        // R-Tree offset
+  size += num * sizeof(uint64_t);  // tile offsets
+  size += num * sizeof(uint64_t);  // tile var offsets
+  size += num * sizeof(uint64_t);  // tile var sizes
+  size += num * sizeof(uint64_t);  // tile validity sizes
+  size += num * sizeof(uint64_t);  // tile mins sizes
+  size += num * sizeof(uint64_t);  // tile maxs sizes
+  size += num * sizeof(uint64_t);  // tile sums sizes
+  size += num * sizeof(uint64_t);  // tile null count sizes
 
   return size;
 }
@@ -1386,6 +1928,103 @@ Status FragmentMetadata::load_tile_validity_offsets(
   RETURN_NOT_OK(load_tile_validity_offsets(idx, &cbuff));
 
   loaded_metadata_.tile_validity_offsets_[idx] = true;
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_tile_min_values(
+    const EncryptionKey& encryption_key, unsigned idx) {
+  if (version_ <= 10)
+    return Status::Ok();
+
+  std::lock_guard<std::mutex> lock(mtx_);
+
+  if (loaded_metadata_.tile_min_[idx])
+    return Status::Ok();
+
+  Buffer buff;
+  RETURN_NOT_OK(read_generic_tile_from_file(
+      encryption_key, gt_offsets_.tile_min_offsets_[idx], &buff));
+
+  storage_manager_->stats()->add_counter("read_tile_min_size", buff.size());
+
+  ConstBuffer cbuff(&buff);
+  RETURN_NOT_OK(load_tile_min_values(idx, &cbuff));
+
+  loaded_metadata_.tile_min_[idx] = true;
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_tile_max_values(
+    const EncryptionKey& encryption_key, unsigned idx) {
+  if (version_ <= 10)
+    return Status::Ok();
+
+  std::lock_guard<std::mutex> lock(mtx_);
+
+  if (loaded_metadata_.tile_max_[idx])
+    return Status::Ok();
+
+  Buffer buff;
+  RETURN_NOT_OK(read_generic_tile_from_file(
+      encryption_key, gt_offsets_.tile_max_offsets_[idx], &buff));
+
+  storage_manager_->stats()->add_counter("read_tile_max_size", buff.size());
+
+  ConstBuffer cbuff(&buff);
+  RETURN_NOT_OK(load_tile_max_values(idx, &cbuff));
+
+  loaded_metadata_.tile_max_[idx] = true;
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_tile_sum_values(
+    const EncryptionKey& encryption_key, unsigned idx) {
+  if (version_ <= 10)
+    return Status::Ok();
+
+  std::lock_guard<std::mutex> lock(mtx_);
+
+  if (loaded_metadata_.tile_sum_[idx])
+    return Status::Ok();
+
+  Buffer buff;
+  RETURN_NOT_OK(read_generic_tile_from_file(
+      encryption_key, gt_offsets_.tile_sum_offsets_[idx], &buff));
+
+  storage_manager_->stats()->add_counter("read_tile_sum_size", buff.size());
+
+  ConstBuffer cbuff(&buff);
+  RETURN_NOT_OK(load_tile_sum_values(idx, &cbuff));
+
+  loaded_metadata_.tile_sum_[idx] = true;
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_tile_null_count_values(
+    const EncryptionKey& encryption_key, unsigned idx) {
+  if (version_ <= 10)
+    return Status::Ok();
+
+  std::lock_guard<std::mutex> lock(mtx_);
+
+  if (loaded_metadata_.tile_null_count_[idx])
+    return Status::Ok();
+
+  Buffer buff;
+  RETURN_NOT_OK(read_generic_tile_from_file(
+      encryption_key, gt_offsets_.tile_null_count_offsets_[idx], &buff));
+
+  storage_manager_->stats()->add_counter(
+      "read_tile_null_count_size", buff.size());
+
+  ConstBuffer cbuff(&buff);
+  RETURN_NOT_OK(load_tile_null_count_values(idx, &cbuff));
+
+  loaded_metadata_.tile_null_count_[idx] = true;
 
   return Status::Ok();
 }
@@ -1980,6 +2619,212 @@ Status FragmentMetadata::load_tile_validity_offsets(
   return Status::Ok();
 }
 
+// ===== FORMAT =====
+// tile_min_values#0_size_buffer (uint64_t)
+// tile_min_values#0_size_buffer_var (uint64_t)
+// tile_min_values#0_buffer
+// tile_min_values#0_buffer_var
+// ...
+// tile_min_values#<attribute_num-1>_size_buffer (uint64_t)
+// tile_min_values#<attribute_num-1>_size_buffer_var (uint64_t)
+// tile_min_values#<attribute_num-1>_buffer
+// tile_min_values#<attribute_num-1>_buffer_var
+Status FragmentMetadata::load_tile_min_values(unsigned idx, ConstBuffer* buff) {
+  Status st;
+  uint64_t buffer_size = 0;
+  uint64_t var_buffer_size = 0;
+
+  // Get buffer size
+  st = buff->read(&buffer_size, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(Status_FragmentMetadataError(
+        "Cannot load fragment metadata; Reading tile min buffer size failed"));
+  }
+
+  // Get var buffer size
+  st = buff->read(&var_buffer_size, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot load fragment metadata; Reading "
+                                     "tile min buffer var size failed"));
+  }
+
+  // Get tile mins
+  if (buffer_size != 0) {
+    auto size = buffer_size + var_buffer_size;
+    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load min values; Insufficient memory budget; Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker_->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker_->get_memory_budget())));
+    }
+
+    tile_min_buffer_[idx].resize(buffer_size);
+    st = buff->read(&tile_min_buffer_[idx][0], buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load fragment metadata; Reading tile min buffer failed"));
+    }
+
+    tile_min_var_buffer_[idx].resize(var_buffer_size);
+    st = buff->read(&tile_min_var_buffer_[idx][0], var_buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load fragment metadata; Reading tile min buffer failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
+// ===== FORMAT =====
+// tile_max_values#0_size_buffer (uint64_t)
+// tile_max_values#0_size_buffer_var (uint64_t)
+// tile_max_values#0_buffer
+// tile_max_values#0_buffer_var
+// ...
+// tile_max_values#<attribute_num-1>_size_buffer (uint64_t)
+// tile_max_values#<attribute_num-1>_size_buffer_var (uint64_t)
+// tile_max_values#<attribute_num-1>_buffer
+// tile_max_values#<attribute_num-1>_buffer_var
+Status FragmentMetadata::load_tile_max_values(unsigned idx, ConstBuffer* buff) {
+  Status st;
+  uint64_t buffer_size = 0;
+  uint64_t var_buffer_size = 0;
+
+  // Get buffer size
+  st = buff->read(&buffer_size, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(Status_FragmentMetadataError(
+        "Cannot load fragment metadata; Reading tile max buffer size failed"));
+  }
+
+  // Get var buffer size
+  st = buff->read(&var_buffer_size, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot load fragment metadata; Reading "
+                                     "tile max var buffer size failed"));
+  }
+
+  // Get tile maxs
+  if (buffer_size != 0) {
+    auto size = buffer_size + var_buffer_size;
+    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load max values; Insufficient memory budget; Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker_->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker_->get_memory_budget())));
+    }
+
+    tile_max_buffer_[idx].resize(buffer_size);
+    st = buff->read(&tile_max_buffer_[idx][0], buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load fragment metadata; Reading tile max buffer failed"));
+    }
+
+    tile_max_var_buffer_[idx].resize(var_buffer_size);
+    st = buff->read(&tile_max_var_buffer_[idx][0], var_buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load fragment metadata; Reading tile max var buffer failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
+// ===== FORMAT =====
+// tile_sum_values_attr#0_num (uint64_t)
+// tile_sum_value_attr#0_#1 (uint64_t) tile_sum_value_attr#0_#2 (uint64_t) ...
+// ...
+// tile_sum_values_attr#<attribute_num-1>_num (uint64_t)
+// tile_sum_value_attr#<attribute_num-1>_#1 (uint64_t)
+//     tile_sum_value_attr#<attribute_num-1>_#2 (uint64_t) ...
+Status FragmentMetadata::load_tile_sum_values(unsigned idx, ConstBuffer* buff) {
+  Status st;
+  uint64_t tile_sum_num = 0;
+
+  // Get number of tile sums
+  st = buff->read(&tile_sum_num, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(Status_FragmentMetadataError(
+        "Cannot load fragment metadata; Reading number of tile sum failed"));
+  }
+
+  // Get tile sums
+  if (tile_sum_num != 0) {
+    auto size = tile_sum_num * sizeof(uint64_t);
+    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load sum values; Insufficient memory budget; Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker_->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker_->get_memory_budget())));
+    }
+
+    tile_sums_[idx].resize(size);
+    st = buff->read(tile_sums_[idx].data(), size);
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load fragment metadata; Reading tile sums failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
+// ===== FORMAT =====
+// tile_nc_values_attr#0_num (uint64_t)
+// tile_nc_value_attr#0_#1 (uint64_t) tile_nc_value_attr#0_#2 (uint64_t) ...
+// ...
+// tile_nc_values_attr#<attribute_num-1>_num (uint64_t)
+// tile_nc_value_attr#<attribute_num-1>_#1 (uint64_t)
+//     tile_nc_value_attr#<attribute_num-1>_#2 (uint64_t) ...
+Status FragmentMetadata::load_tile_null_count_values(
+    unsigned idx, ConstBuffer* buff) {
+  Status st;
+  uint64_t tile_null_count_num = 0;
+
+  // Get number of tile null counts
+  st = buff->read(&tile_null_count_num, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot load fragment metadata; Reading "
+                                     "number of tile null_count failed"));
+  }
+
+  // Get tile null count
+  if (tile_null_count_num != 0) {
+    auto size = tile_null_count_num * sizeof(uint64_t);
+    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load null count values; Insufficient memory budget; "
+          "Needed " +
+          std::to_string(size) + " but only had " +
+          std::to_string(memory_tracker_->get_memory_available()) +
+          " from budget " +
+          std::to_string(memory_tracker_->get_memory_budget())));
+    }
+
+    tile_null_counts_[idx].resize(tile_null_count_num);
+    st = buff->read(&tile_null_counts_[idx][0], size);
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot load fragment metadata; Reading "
+                                       "tile null_counts failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
 Status FragmentMetadata::load_version(ConstBuffer* buff) {
   RETURN_NOT_OK(buff->read(&version_, sizeof(uint32_t)));
   return Status::Ok();
@@ -2000,8 +2845,10 @@ Status FragmentMetadata::load_generic_tile_offsets(ConstBuffer* buff) {
     return load_generic_tile_offsets_v3_v4(buff);
   else if (version_ >= 5 && version_ < 7)
     return load_generic_tile_offsets_v5_v6(buff);
-  else if (version_ >= 7)
-    return load_generic_tile_offsets_v7_or_higher(buff);
+  else if (version_ >= 7 && version_ < 11)
+    return load_generic_tile_offsets_v7_v10(buff);
+  else
+    return load_generic_tile_offsets_v11_or_higher(buff);
 
   assert(false);
   return Status::Ok();
@@ -2063,7 +2910,42 @@ Status FragmentMetadata::load_generic_tile_offsets_v5_v6(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-Status FragmentMetadata::load_generic_tile_offsets_v7_or_higher(
+Status FragmentMetadata::load_generic_tile_offsets_v7_v10(ConstBuffer* buff) {
+  // Load R-Tree offset
+  RETURN_NOT_OK(buff->read(&gt_offsets_.rtree_, sizeof(uint64_t)));
+
+  // Load offsets for tile offsets
+  auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
+  gt_offsets_.tile_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(buff->read(&gt_offsets_.tile_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile var offsets
+  gt_offsets_.tile_var_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_var_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile var sizes
+  gt_offsets_.tile_var_sizes_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_var_sizes_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile validity offsets
+  gt_offsets_.tile_validity_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_validity_offsets_[i], sizeof(uint64_t)));
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_generic_tile_offsets_v11_or_higher(
     ConstBuffer* buff) {
   // Load R-Tree offset
   RETURN_NOT_OK(buff->read(&gt_offsets_.rtree_, sizeof(uint64_t)));
@@ -2090,12 +2972,38 @@ Status FragmentMetadata::load_generic_tile_offsets_v7_or_higher(
   }
 
   // Load offsets for tile validity offsets
-  if (version_ >= 7) {
-    gt_offsets_.tile_validity_offsets_.resize(num);
-    for (unsigned i = 0; i < num; ++i) {
-      RETURN_NOT_OK(
-          buff->read(&gt_offsets_.tile_validity_offsets_[i], sizeof(uint64_t)));
-    }
+  gt_offsets_.tile_validity_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_validity_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile min offsets
+  gt_offsets_.tile_min_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_min_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile max offsets
+  gt_offsets_.tile_max_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_max_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile sum offsets
+  gt_offsets_.tile_sum_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_sum_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile null count offsets
+  gt_offsets_.tile_null_count_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_null_count_offsets_[i], sizeof(uint64_t)));
   }
 
   return Status::Ok();
@@ -2246,11 +3154,21 @@ Status FragmentMetadata::load_footer(
   tile_var_offsets_mtx_.resize(num);
   tile_var_sizes_.resize(num);
   tile_validity_offsets_.resize(num);
+  tile_min_buffer_.resize(num);
+  tile_min_var_buffer_.resize(num);
+  tile_max_buffer_.resize(num);
+  tile_max_var_buffer_.resize(num);
+  tile_sums_.resize(num);
+  tile_null_counts_.resize(num);
 
   loaded_metadata_.tile_offsets_.resize(num, false);
   loaded_metadata_.tile_var_offsets_.resize(num, false);
   loaded_metadata_.tile_var_sizes_.resize(num, false);
   loaded_metadata_.tile_validity_offsets_.resize(num, false);
+  loaded_metadata_.tile_min_.resize(num, false);
+  loaded_metadata_.tile_max_.resize(num, false);
+  loaded_metadata_.tile_sum_.resize(num, false);
+  loaded_metadata_.tile_null_count_.resize(num, false);
 
   RETURN_NOT_OK(load_generic_tile_offsets(cbuff.get()));
 
@@ -2369,6 +3287,52 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
       if (!st.ok()) {
         return LOG_STATUS(Status_FragmentMetadataError(
             "Cannot serialize fragment metadata; Writing tile offsets failed"));
+      }
+    }
+  }
+
+  // Write tile min offsets
+  if (version_ >= 11) {
+    for (unsigned i = 0; i < num; ++i) {
+      st = buff->write(&gt_offsets_.tile_min_offsets_[i], sizeof(uint64_t));
+      if (!st.ok()) {
+        return LOG_STATUS(Status_FragmentMetadataError(
+            "Cannot serialize fragment metadata; Writing tile mins failed"));
+      }
+    }
+  }
+
+  // Write tile max offsets
+  if (version_ >= 11) {
+    for (unsigned i = 0; i < num; ++i) {
+      st = buff->write(&gt_offsets_.tile_max_offsets_[i], sizeof(uint64_t));
+      if (!st.ok()) {
+        return LOG_STATUS(Status_FragmentMetadataError(
+            "Cannot serialize fragment metadata; Writing tile maxs failed"));
+      }
+    }
+  }
+
+  // Write tile sum offsets
+  if (version_ >= 11) {
+    for (unsigned i = 0; i < num; ++i) {
+      st = buff->write(&gt_offsets_.tile_sum_offsets_[i], sizeof(uint64_t));
+      if (!st.ok()) {
+        return LOG_STATUS(Status_FragmentMetadataError(
+            "Cannot serialize fragment metadata; Writing tile sums failed"));
+      }
+    }
+  }
+
+  // Write tile null count offsets
+  if (version_ >= 11) {
+    for (unsigned i = 0; i < num; ++i) {
+      st = buff->write(
+          &gt_offsets_.tile_null_count_offsets_[i], sizeof(uint64_t));
+      if (!st.ok()) {
+        return LOG_STATUS(Status_FragmentMetadataError(
+            "Cannot serialize fragment metadata; Writing tile null counts "
+            "failed"));
       }
     }
   }
@@ -2700,6 +3664,197 @@ Status FragmentMetadata::write_tile_validity_offsets(
     if (!st.ok()) {
       return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot serialize fragment metadata; Writing tile offsets failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::store_tile_mins(
+    unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
+  Buffer buff;
+  RETURN_NOT_OK(write_tile_mins(idx, &buff));
+  RETURN_NOT_OK(
+      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+
+  storage_manager_->stats()->add_counter("write_mins_size", *nbytes);
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::write_tile_mins(unsigned idx, Buffer* buff) {
+  Status st;
+
+  // Write size of buffer
+  uint64_t tile_mins_buffer_size = tile_min_buffer_[idx].size();
+  st = buff->write(&tile_mins_buffer_size, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                     "Writing size of tile mins buffer "
+                                     "failed"));
+  }
+
+  // Write size of buffer var
+  uint64_t tile_mins_var_buffer_size = tile_min_var_buffer_[idx].size();
+  st = buff->write(&tile_mins_var_buffer_size, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                     "Writing size of tile mins var buffer "
+                                     "failed"));
+  }
+
+  // Write tile buffer
+  if (tile_mins_buffer_size != 0) {
+    st = buff->write(&tile_min_buffer_[idx][0], tile_mins_buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing tile min buffer failed"));
+    }
+  }
+
+  // Write tile var buffer
+  if (tile_mins_var_buffer_size != 0) {
+    st = buff->write(&tile_min_var_buffer_[idx][0], tile_mins_var_buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot serialize fragment metadata; Writing tile min var buffer"
+          " failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::store_tile_maxs(
+    unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
+  Buffer buff;
+  RETURN_NOT_OK(write_tile_maxs(idx, &buff));
+  RETURN_NOT_OK(
+      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+
+  storage_manager_->stats()->add_counter("write_maxs_size", *nbytes);
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::write_tile_maxs(unsigned idx, Buffer* buff) {
+  Status st;
+
+  // Write size of buffer
+  uint64_t tile_maxs_buffer_size = tile_max_buffer_[idx].size();
+  st = buff->write(&tile_maxs_buffer_size, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                     "Writing size of tile maxs buffer "
+                                     "failed"));
+  }
+
+  // Write size of buffer var
+  uint64_t tile_maxs_var_buffer_size = tile_max_var_buffer_[idx].size();
+  st = buff->write(&tile_maxs_var_buffer_size, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                     "Writing size of tile maxs var buffer "
+                                     "failed"));
+  }
+
+  // Write tile buffer
+  if (tile_maxs_buffer_size != 0) {
+    st = buff->write(&tile_max_buffer_[idx][0], tile_maxs_buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing tile max buffer failed"));
+    }
+  }
+
+  // Write tile var buffer
+  if (tile_maxs_var_buffer_size != 0) {
+    st = buff->write(&tile_max_var_buffer_[idx][0], tile_maxs_var_buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot serialize fragment metadata; Writing tile max var buffer"
+          " failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::store_tile_sums(
+    unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
+  Buffer buff;
+  RETURN_NOT_OK(write_tile_sums(idx, &buff));
+  RETURN_NOT_OK(
+      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+
+  storage_manager_->stats()->add_counter("write_sums_size", *nbytes);
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::write_tile_sums(unsigned idx, Buffer* buff) {
+  Status st;
+
+  // Write number of tile sums
+  uint64_t tile_sums_num = tile_sums_[idx].size() / sizeof(uint64_t);
+  st = buff->write(&tile_sums_num, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                     "Writing number of tile sums failed"));
+  }
+
+  // Write tile sums
+  if (tile_sums_num != 0) {
+    st = buff->write(tile_sums_[idx].data(), tile_sums_num * sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot serialize fragment metadata; Writing tile sums failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::store_tile_null_counts(
+    unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
+  Buffer buff;
+  RETURN_NOT_OK(write_tile_null_counts(idx, &buff));
+  RETURN_NOT_OK(
+      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+
+  storage_manager_->stats()->add_counter("write_null_counts_size", *nbytes);
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::write_tile_null_counts(unsigned idx, Buffer* buff) {
+  Status st;
+
+  // Write number of tile null counts
+  uint64_t tile_null_counts_num = tile_null_counts_[idx].size();
+  st = buff->write(&tile_null_counts_num, sizeof(uint64_t));
+  if (!st.ok()) {
+    return LOG_STATUS(
+        Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                     "Writing number of tile null counts "
+                                     "failed"));
+  }
+
+  // Write tile null counts
+  if (tile_null_counts_num != 0) {
+    st = buff->write(
+        &tile_null_counts_[idx][0], tile_null_counts_num * sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot serialize fragment metadata; Writing tile null counts "
+          "failed"));
     }
   }
 

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -262,6 +262,20 @@ class FragmentMetadata {
   /** Stores all the metadata to storage. */
   Status store(const EncryptionKey& encryption_key);
 
+  /**
+   * Stores all the metadata to storage.
+   *
+   * Applicable to format versions 7 to 10.
+   */
+  Status store_v7_v10(const EncryptionKey& encryption_key);
+
+  /**
+   * Stores all the metadata to storage.
+   *
+   * Applicable to format versions 11 or higher.
+   */
+  Status store_v11_or_higher(const EncryptionKey& encryption_key);
+
   /** Returns the non-empty domain in which the fragment is constrained. */
   const NDRange& non_empty_domain();
 
@@ -350,6 +364,101 @@ class FragmentMetadata {
       const std::string& name, uint64_t tid, uint64_t step);
 
   /**
+   * Sets a tile min for the fixed input attribute.
+   *
+   * @param name The attribute for which the min is set.
+   * @param tid The index of the tile for which the min is set.
+   * @param min The minimum.
+   * @param size The size.
+   * @return void
+   */
+  void set_tile_min(
+      const std::string& name, uint64_t tid, const void* min, uint64_t size);
+
+  /**
+   * Sets a tile min size for the var input attribute.
+   *
+   * @param name The attribute for which the min size is set.
+   * @param tid The index of the tile for which the min is set.
+   * @param size The size.
+   * @return void
+   */
+  void set_tile_min_var_size(
+      const std::string& name, uint64_t tid, uint64_t size);
+
+  /**
+   * Sets a tile min for the var input attribute.
+   *
+   * @param name The attribute for which the min is set.
+   * @param tid The index of the tile for which the min is set.
+   * @param min The minimum.
+   * @return void
+   */
+  void set_tile_min_var(const std::string& name, uint64_t tid, const void* min);
+
+  /**
+   * Sets a tile max for the input attribute.
+   *
+   * @param name The attribute for which the max is set.
+   * @param tid The index of the tile for which the max is set.
+   * @param max The maximum.
+   * @param size The size.
+   * @return void
+   */
+  void set_tile_max(
+      const std::string& name, uint64_t tid, const void* max, uint64_t size);
+
+  /**
+   * Sets a tile max for the var input attribute.
+   *
+   * @param name The attribute for which the min size is set.
+   * @param tid The index of the tile for which the min is set.
+   * @param size The size.
+   * @return void
+   */
+  void set_tile_max_var_size(
+      const std::string& name, uint64_t tid, uint64_t size);
+
+  /**
+   * Sets a tile max for the var input attribute.
+   *
+   * @param name The attribute for which the min is set.
+   * @param tid The index of the tile for which the min is set.
+   * @param max The maximum.
+   * @return void
+   */
+  void set_tile_max_var(const std::string& name, uint64_t tid, const void* max);
+
+  /**
+   * Converts min/max sizes to offsets.
+   *
+   * @param name The attribute for which the offsets are converted
+   * @return void
+   */
+  void convert_tile_min_max_var_sizes_to_offsets(const std::string& name);
+
+  /**
+   * Sets a tile sum for the input attribute.
+   *
+   * @param name The attribute for which the sum is set.
+   * @param tid The index of the tile for which the sum is set.
+   * @param sum The sum.
+   * @return void
+   */
+  void set_tile_sum(const std::string& name, uint64_t tid, const ByteVec* sum);
+
+  /**
+   * Sets a tile null count for the input attribute.
+   *
+   * @param name The attribute for which the null count is set.
+   * @param tid The index of the tile for which the null count is set.
+   * @param sum The null count.
+   * @return void
+   */
+  void set_tile_null_count(
+      const std::string& name, uint64_t tid, uint64_t null_count);
+
+  /**
    * Sets array schema pointer.
    *
    * @param array_schema The schema pointer.
@@ -434,11 +543,10 @@ class FragmentMetadata {
    *
    * @param name The input attribute/dimension.
    * @param tile_idx The index of the tile in the metadata.
-   * @param tile_size The tile size to be retrieved.
-   * @return Status
+   * @return Status, size
    */
-  Status persisted_tile_size(
-      const std::string& name, uint64_t tile_idx, uint64_t* tile_size);
+  std::tuple<Status, std::optional<uint64_t>> persisted_tile_size(
+      const std::string& name, uint64_t tile_idx);
 
   /**
    * Retrieves the size of the tile when it is persisted (e.g. the size of the
@@ -447,11 +555,10 @@ class FragmentMetadata {
    *
    * @param name The input attribute/dimension.
    * @param tile_idx The index of the tile in the metadata.
-   * @param tile_size The tile size to be retrieved.
-   * @return Status
+   * @return Status, size
    */
-  Status persisted_tile_var_size(
-      const std::string& name, uint64_t tile_idx, uint64_t* tile_size);
+  std::tuple<Status, std::optional<uint64_t>> persisted_tile_var_size(
+      const std::string& name, uint64_t tile_idx);
 
   /**
    * Retrieves the size of the validity tile when it is persisted (e.g. the size
@@ -459,11 +566,10 @@ class FragmentMetadata {
    *
    * @param name The input attribute.
    * @param tile_idx The index of the tile in the metadata.
-   * @param tile_size The tile size to be retrieved.
-   * @return Status
+   * @return Status, size
    */
-  Status persisted_tile_validity_size(
-      const std::string& name, uint64_t tile_idx, uint64_t* tile_size);
+  std::tuple<Status, std::optional<uint64_t>> persisted_tile_validity_size(
+      const std::string& name, uint64_t tile_idx);
 
   /**
    * Returns the (uncompressed) tile size for a given attribute or dimension
@@ -482,11 +588,54 @@ class FragmentMetadata {
    *
    * @param name The input attribute/dimension.
    * @param tile_idx The index of the tile in the metadata.
-   * @param tile_size The tile size to be retrieved.
-   * @return Status
+   * @return Status, size.
    */
-  Status tile_var_size(
-      const std::string& name, uint64_t tile_idx, uint64_t* tile_size);
+  std::tuple<Status, std::optional<uint64_t>> tile_var_size(
+      const std::string& name, uint64_t tile_idx);
+
+  /**
+   * Retrieves the tile min value for a given attribute or dimension and tile
+   * index.
+   *
+   * @param name The input attribute/dimension.
+   * @param tile_idx The index of the tile in the metadata.
+   * @return Status, value, size.
+   */
+  std::tuple<Status, std::optional<void*>, std::optional<uint64_t>>
+  get_tile_min(const std::string& name, uint64_t tile_idx);
+
+  /**
+   * Retrieves the tile max value for a given attribute or dimension and tile
+   * index.
+   *
+   * @param name The input attribute/dimension.
+   * @param tile_idx The index of the tile in the metadata.
+   * @return Status, value, size.
+   */
+  std::tuple<Status, std::optional<void*>, std::optional<uint64_t>>
+  get_tile_max(const std::string& name, uint64_t tile_idx);
+
+  /**
+   * Retrieves the tile sum value for a given attribute or dimension and tile
+   * index.
+   *
+   * @param name The input attribute/dimension.
+   * @param tile_idx The index of the tile in the metadata.
+   * @return Status, sum.
+   */
+  std::tuple<Status, std::optional<void*>> get_tile_sum(
+      const std::string& name, uint64_t tile_idx);
+
+  /**
+   * Retrieves the tile null count value for a given attribute or dimension
+   * and tile index.
+   *
+   * @param name The input attribute/dimension.
+   * @param tile_idx The index of the tile in the metadata.
+   * @return Status, count.
+   */
+  std::tuple<Status, std::optional<uint64_t>> get_tile_null_count(
+      const std::string& name, uint64_t tile_idx);
 
   /** Returns the first timestamp of the fragment timestamp range. */
   uint64_t first_timestamp() const;
@@ -527,13 +676,43 @@ class FragmentMetadata {
       const EncryptionKey& encryption_key, std::vector<std::string>&& names);
 
   /**
-   * Loads validity tile offsets for the attribute names.
+   * Loads min values for the attribute names.
    *
    * @param encryption_key The key the array got opened with.
    * @param names The attribute names.
    * @return Status
    */
-  Status load_tile_validity_offsets(
+  Status load_tile_min_values(
+      const EncryptionKey& encryption_key, std::vector<std::string>&& names);
+
+  /**
+   * Loads max values for the attribute names.
+   *
+   * @param encryption_key The key the array got opened with.
+   * @param names The attribute names.
+   * @return Status
+   */
+  Status load_tile_max_values(
+      const EncryptionKey& encryption_key, std::vector<std::string>&& names);
+
+  /**
+   * Loads sum values for the attribute names.
+   *
+   * @param encryption_key The key the array got opened with.
+   * @param names The attribute names.
+   * @return Status
+   */
+  Status load_tile_sum_values(
+      const EncryptionKey& encryption_key, std::vector<std::string>&& names);
+
+  /**
+   * Loads null count values for the attribute names.
+   *
+   * @param encryption_key The key the array got opened with.
+   * @param names The attribute names.
+   * @return Status
+   */
+  Status load_tile_null_count_values(
       const EncryptionKey& encryption_key, std::vector<std::string>&& names);
 
   /**
@@ -559,6 +738,10 @@ class FragmentMetadata {
     std::vector<uint64_t> tile_var_offsets_;
     std::vector<uint64_t> tile_var_sizes_;
     std::vector<uint64_t> tile_validity_offsets_;
+    std::vector<uint64_t> tile_min_offsets_;
+    std::vector<uint64_t> tile_max_offsets_;
+    std::vector<uint64_t> tile_sum_offsets_;
+    std::vector<uint64_t> tile_null_count_offsets_;
   };
 
   /** Keeps track of which metadata is loaded. */
@@ -569,6 +752,10 @@ class FragmentMetadata {
     std::vector<bool> tile_var_offsets_;
     std::vector<bool> tile_var_sizes_;
     std::vector<bool> tile_validity_offsets_;
+    std::vector<bool> tile_min_;
+    std::vector<bool> tile_max_;
+    std::vector<bool> tile_sum_;
+    std::vector<bool> tile_null_count_;
   };
 
   /* ********************************* */
@@ -688,6 +875,39 @@ class FragmentMetadata {
    */
   std::vector<std::vector<uint64_t>> tile_validity_offsets_;
 
+  /**
+   * The tile min buffers, for variable attributes/dimensions, this will store
+   * offsets.
+   */
+  std::vector<std::vector<uint8_t>> tile_min_buffer_;
+
+  /**
+   * The tile min buffers variable length data.
+   */
+  std::vector<std::vector<uint8_t>> tile_min_var_buffer_;
+
+  /**
+   * The tile max buffers, for variable attributes/dimensions, this will store
+   * offsets.
+   */
+  std::vector<std::vector<uint8_t>> tile_max_buffer_;
+
+  /**
+   * The tile max buffers variable length data.
+   */
+  std::vector<std::vector<uint8_t>> tile_max_var_buffer_;
+
+  /**
+   * The tile sum values, ignored for var sized attributes/dimensions.
+   */
+  std::vector<std::vector<uint8_t>> tile_sums_;
+
+  /**
+   * The tile null count values ignored for non nullable attributes or
+   * dimensions.
+   */
+  std::vector<std::vector<uint64_t>> tile_null_counts_;
+
   /** The format version of this metadata. */
   uint32_t version_;
 
@@ -730,9 +950,17 @@ class FragmentMetadata {
    * Returns the size of the fragment metadata footer
    * (which contains the generic tile offsets) along with its size.
    *
-   * Applicable to format version 7 or higher.
+   * Applicable to format version 7 to 10.
    */
-  uint64_t footer_size_v7_or_higher() const;
+  uint64_t footer_size_v7_v10() const;
+
+  /**
+   * Returns the size of the fragment metadata footer
+   * (which contains the generic tile offsets) along with its size.
+   *
+   * Applicable to format version 11 or higher.
+   */
+  uint64_t footer_size_v11_or_higher() const;
 
   /**
    * Returns the ids (positions) of the tiles overlapping `subarray`.
@@ -778,10 +1006,33 @@ class FragmentMetadata {
   Status load_tile_var_sizes(const EncryptionKey& encryption_key, unsigned idx);
 
   /**
-   * Loads the validity tile offsets for the input attribute idx
-   * from storage.
+   * Loads the validity tile offsets for the input attribute idx from storage.
    */
   Status load_tile_validity_offsets(
+      const EncryptionKey& encryption_key, unsigned idx);
+
+  /**
+   * Loads the min values for the input attribute idx from storage.
+   */
+  Status load_tile_min_values(
+      const EncryptionKey& encryption_key, unsigned idx);
+
+  /**
+   * Loads the max values for the input attribute idx from storage.
+   */
+  Status load_tile_max_values(
+      const EncryptionKey& encryption_key, unsigned idx);
+
+  /**
+   * Loads the sum values for the input attribute idx from storage.
+   */
+  Status load_tile_sum_values(
+      const EncryptionKey& encryption_key, unsigned idx);
+
+  /**
+   * Loads the null count values for the input attribute idx from storage.
+   */
+  Status load_tile_null_count_values(
       const EncryptionKey& encryption_key, unsigned idx);
 
   /** Loads the generic tile offsets from the buffer. */
@@ -789,7 +1040,7 @@ class FragmentMetadata {
 
   /**
    * Loads the generic tile offsets from the buffer. Applicable to
-   * versions 4 and 5.
+   * versions 3 and 4.
    */
   Status load_generic_tile_offsets_v3_v4(ConstBuffer* buff);
 
@@ -801,9 +1052,15 @@ class FragmentMetadata {
 
   /**
    * Loads the generic tile offsets from the buffer. Applicable to
-   * versions 7 or higher.
+   * versions 7 to 10.
    */
-  Status load_generic_tile_offsets_v7_or_higher(ConstBuffer* buff);
+  Status load_generic_tile_offsets_v7_v10(ConstBuffer* buff);
+
+  /**
+   * Loads the generic tile offsets from the buffer. Applicable to
+   * versions 11 or higher.
+   */
+  Status load_generic_tile_offsets_v11_or_higher(ConstBuffer* buff);
 
   /**
    * Loads the array schema name.
@@ -929,6 +1186,27 @@ class FragmentMetadata {
    * input buffer.
    */
   Status load_tile_validity_offsets(unsigned idx, ConstBuffer* buff);
+
+  /**
+   * Loads the min values for the input attribute from the input buffer.
+   */
+  Status load_tile_min_values(unsigned idx, ConstBuffer* buff);
+
+  /**
+   * Loads the max values for the input attribute from the input buffer.
+   */
+  Status load_tile_max_values(unsigned idx, ConstBuffer* buff);
+
+  /**
+   * Loads the sum values for the input attribute from the input buffer.
+   */
+  Status load_tile_sum_values(unsigned idx, ConstBuffer* buff);
+
+  /**
+   * Loads the null count values for the input attribute from the input
+   * buffer.
+   */
+  Status load_tile_null_count_values(unsigned idx, ConstBuffer* buff);
 
   /** Loads the format version from the buffer. */
   Status load_version(ConstBuffer* buff);
@@ -1077,6 +1355,70 @@ class FragmentMetadata {
    * input buffer.
    */
   Status write_tile_validity_offsets(unsigned idx, Buffer* buff);
+
+  /**
+   * Writes the mins of the input attribute to storage.
+   *
+   * @param idx The index of the attribute.
+   * @param encryption_key The encryption key.
+   * @param nbytes The total number of bytes written for the mins.
+   * @return Status
+   */
+  Status store_tile_mins(
+      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+
+  /**
+   * Writes the mins of the input attribute idx to the input buffer.
+   */
+  Status write_tile_mins(unsigned idx, Buffer* buff);
+
+  /**
+   * Writes the maxs of the input attribute to storage.
+   *
+   * @param idx The index of the attribute.
+   * @param encryption_key The encryption key.
+   * @param nbytes The total number of bytes written for the maxs.
+   * @return Status
+   */
+  Status store_tile_maxs(
+      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+
+  /**
+   * Writes the maxs of the input attribute idx to the input buffer.
+   */
+  Status write_tile_maxs(unsigned idx, Buffer* buff);
+
+  /**
+   * Writes the sums of the input attribute to storage.
+   *
+   * @param idx The index of the attribute.
+   * @param encryption_key The encryption key.
+   * @param nbytes The total number of bytes written for the sums.
+   * @return Status
+   */
+  Status store_tile_sums(
+      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+
+  /**
+   * Writes the sums of the input attribute idx to the input buffer.
+   */
+  Status write_tile_sums(unsigned idx, Buffer* buff);
+
+  /**
+   * Writes the null counts of the input attribute to storage.
+   *
+   * @param idx The index of the attribute.
+   * @param encryption_key The encryption key.
+   * @param nbytes The total number of bytes written for the null counts.
+   * @return Status
+   */
+  Status store_tile_null_counts(
+      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+
+  /**
+   * Writes the null counts of the input attribute idx to the input buffer.
+   */
+  Status write_tile_null_counts(unsigned idx, Buffer* buff);
 
   /** Writes the format version to the buffer. */
   Status write_version(Buffer* buff) const;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -47,6 +47,7 @@
 #include "tiledb/sm/query/writer.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
+#include "tiledb/sm/tile/writer_tile.h"
 
 #include <cassert>
 #include <iostream>

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -170,11 +170,10 @@ SparseIndexReaderBase::get_coord_tiles_size(
       tiles_size += fragment_metadata_[f]->tile_size(dim_names_[d], t);
 
       if (is_dim_var_size_[d]) {
-        uint64_t temp = 0;
-        RETURN_NOT_OK_TUPLE(
-            fragment_metadata_[f]->tile_var_size(dim_names_[d], t, &temp),
-            std::nullopt);
-        tiles_size += temp;
+        auto&& [st, temp] =
+            fragment_metadata_[f]->tile_var_size(dim_names_[d], t);
+        RETURN_NOT_OK_TUPLE(st, std::nullopt);
+        tiles_size += *temp;
       }
     }
   }

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -51,6 +51,8 @@
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
+#include "tiledb/sm/tile/tile_metadata_generator.h"
+#include "tiledb/sm/tile/writer_tile.h"
 
 using namespace tiledb;
 using namespace tiledb::common;
@@ -938,7 +940,7 @@ Status Writer::compute_coord_dups(std::set<uint64_t>* coord_dups) const {
 }
 
 Status Writer::compute_coords_metadata(
-    const std::unordered_map<std::string, std::vector<Tile>>& tiles,
+    const std::unordered_map<std::string, std::vector<WriterTile>>& tiles,
     tdb_shared_ptr<FragmentMetadata> meta) const {
   auto timer_se = stats_->start_timer("compute_coord_meta");
 
@@ -991,6 +993,70 @@ Status Writer::compute_coords_metadata(
   return Status::Ok();
 }
 
+Status Writer::compute_tiles_metadata(
+    uint64_t tile_num,
+    std::unordered_map<std::string, std::vector<WriterTile>>& tiles) const {
+  auto attr_num = buffers_.size();
+  auto compute_tp = storage_manager_->compute_tp();
+
+  // Parallelize over attributes?
+  if (attr_num > tile_num) {
+    auto st = parallel_for(compute_tp, 0, attr_num, [&](uint64_t i) {
+      auto buff_it = buffers_.begin();
+      std::advance(buff_it, i);
+      const auto& attr = buff_it->first;
+      auto& attr_tiles = tiles[attr];
+      const auto type = array_schema_->type(attr);
+      const auto is_dim = array_schema_->is_dim(attr);
+      const auto var_size = array_schema_->var_size(attr);
+      const auto nullable = array_schema_->is_nullable(attr);
+      const auto cell_size = array_schema_->cell_size(attr);
+      const auto cell_val_num = array_schema_->cell_val_num(attr);
+      const uint64_t tile_num_mult = 1 + var_size + nullable;
+      TileMetadataGenerator md_generator(
+          type, is_dim, var_size, cell_size, cell_val_num);
+      for (uint64_t t = 0; t < tile_num; t++) {
+        auto tile = &attr_tiles[t * tile_num_mult];
+        md_generator.process_tile(
+            tile,
+            var_size ? &attr_tiles[t * tile_num_mult + 1] : nullptr,
+            nullable ? &attr_tiles[t * tile_num_mult + var_size + 1] : nullptr);
+        tile->set_metadata(md_generator.metadata());
+      }
+
+      return Status::Ok();
+    });
+    RETURN_NOT_OK(st);
+  } else {  // Parallelize over tiles
+    for (const auto& buff : buffers_) {
+      const auto& attr = buff.first;
+      auto& attr_tiles = tiles[attr];
+      const auto type = array_schema_->type(attr);
+      const auto is_dim = array_schema_->is_dim(attr);
+      const auto var_size = array_schema_->var_size(attr);
+      const auto nullable = array_schema_->is_nullable(attr);
+      const auto cell_size = array_schema_->cell_size(attr);
+      const auto cell_val_num = array_schema_->cell_val_num(attr);
+      const uint64_t tile_num_mult = 1 + var_size + nullable;
+      auto st = parallel_for(compute_tp, 0, tile_num, [&](uint64_t t) {
+        TileMetadataGenerator md_generator(
+            type, is_dim, var_size, cell_size, cell_val_num);
+        auto tile = &attr_tiles[t * tile_num_mult];
+        md_generator.process_tile(
+            tile,
+            var_size ? &attr_tiles[t * tile_num_mult + 1] : nullptr,
+            nullable ? &attr_tiles[t * tile_num_mult + var_size + 1] : nullptr);
+        tile->set_metadata(md_generator.metadata());
+
+        return Status::Ok();
+      });
+      RETURN_NOT_OK(st);
+    }
+  }
+
+  return Status::Ok();
+}
+
 Status Writer::create_fragment(
     bool dense, tdb_shared_ptr<FragmentMetadata>& frag_meta) const {
   URI uri;
@@ -1020,7 +1086,7 @@ Status Writer::create_fragment(
 }
 
 Status Writer::filter_tiles(
-    std::unordered_map<std::string, std::vector<Tile>>* tiles) {
+    std::unordered_map<std::string, std::vector<WriterTile>>* tiles) {
   auto timer_se = stats_->start_timer("filter_tiles");
 
   // Coordinates
@@ -1039,7 +1105,8 @@ Status Writer::filter_tiles(
   return Status::Ok();
 }
 
-Status Writer::filter_tiles(const std::string& name, std::vector<Tile>* tiles) {
+Status Writer::filter_tiles(
+    const std::string& name, std::vector<WriterTile>* tiles) {
   const bool var_size = array_schema_->var_size(name);
   const bool nullable = array_schema_->is_nullable(name);
   const size_t tile_step = 1 + nullable + var_size;
@@ -1053,7 +1120,7 @@ Status Writer::filter_tiles(const std::string& name, std::vector<Tile>* tiles) {
         Status_WriterError("Incorrect number of tiles in filter_tiles"));
   }
 
-  std::vector<std::tuple<Tile*, Tile*, bool, bool>> args;
+  std::vector<std::tuple<WriterTile*, WriterTile*, bool, bool>> args;
   args.reserve(tile_num);
 
   for (size_t tile_idx = 0; tile_idx < tile_num; tile_idx += tile_step) {
@@ -1085,8 +1152,8 @@ Status Writer::filter_tiles(const std::string& name, std::vector<Tile>* tiles) {
 
 Status Writer::filter_tile(
     const std::string& name,
-    Tile* const tile,
-    Tile* const offsets_tile,
+    WriterTile* const tile,
+    WriterTile* const offsets_tile,
     const bool offsets,
     const bool nullable) {
   auto timer_se = stats_->start_timer("filter_tile");
@@ -1201,7 +1268,7 @@ Status Writer::global_write() {
   if (dedup_coords_)
     RETURN_CANCEL_OR_ERROR(compute_coord_dups(&coord_dups));
 
-  std::unordered_map<std::string, std::vector<Tile>> tiles;
+  std::unordered_map<std::string, std::vector<WriterTile>> tiles;
   RETURN_CANCEL_OR_ERROR_ELSE(
       prepare_full_tiles(coord_dups, &tiles), clean_up(uri));
 
@@ -1236,6 +1303,10 @@ Status Writer::global_write() {
   RETURN_CANCEL_OR_ERROR_ELSE(
       compute_coords_metadata(tiles, frag_meta), clean_up(uri));
 
+  // Compute tile metadata.
+  RETURN_CANCEL_OR_ERROR_ELSE(
+      compute_tiles_metadata(tile_num, tiles), clean_up(uri));
+
   // Filter all tiles
   RETURN_CANCEL_OR_ERROR_ELSE(filter_tiles(&tiles), clean_up(uri));
 
@@ -1259,7 +1330,7 @@ Status Writer::global_write_handle_last_tile() {
   const auto& uri = global_write_state_->frag_meta_->fragment_uri();
 
   // Filter last tiles
-  std::unordered_map<std::string, std::vector<Tile>> tiles;
+  std::unordered_map<std::string, std::vector<WriterTile>> tiles;
   RETURN_CANCEL_OR_ERROR_ELSE(filter_last_tiles(&tiles), clean_up(uri));
 
   // Write the last tiles
@@ -1272,10 +1343,10 @@ Status Writer::global_write_handle_last_tile() {
 }
 
 Status Writer::filter_last_tiles(
-    std::unordered_map<std::string, std::vector<Tile>>* tiles) {
+    std::unordered_map<std::string, std::vector<WriterTile>>* tiles) {
   // Initialize attribute and coordinate tiles
   for (const auto& it : buffers_)
-    (*tiles)[it.first] = std::vector<Tile>();
+    (*tiles)[it.first] = std::vector<WriterTile>();
 
   // Prepare the tiles first
   uint64_t num = buffers_.size();
@@ -1292,7 +1363,7 @@ Status Writer::filter_last_tiles(
             std::get<2>(global_write_state_->last_tiles_[*name]);
 
         if (!last_tile.empty()) {
-          std::vector<Tile>& tiles_ref = (*tiles)[*name];
+          std::vector<WriterTile>& tiles_ref = (*tiles)[*name];
           // Note making shallow clones here, as it's not necessary to copy the
           // underlying tile Buffers.
           tiles_ref.push_back(last_tile.clone(false));
@@ -1309,6 +1380,9 @@ Status Writer::filter_last_tiles(
   // Compute coordinates metadata
   auto meta = global_write_state_->frag_meta_;
   RETURN_NOT_OK(compute_coords_metadata(*tiles, meta));
+
+  // Compute tile metadata.
+  RETURN_NOT_OK(compute_tiles_metadata(1, *tiles));
 
   // Gather stats
   stats_->add_counter("cell_num", tiles->begin()->second[0].cell_num());
@@ -1350,8 +1424,11 @@ Status Writer::init_global_write_state() {
   for (const auto& it : buffers_) {
     // Initialize last tiles
     const auto& name = it.first;
-    auto last_tile_tuple = std::pair<std::string, std::tuple<Tile, Tile, Tile>>(
-        name, std::tuple<Tile, Tile, Tile>(Tile(), Tile(), Tile()));
+    auto last_tile_tuple =
+        std::pair<std::string, std::tuple<WriterTile, WriterTile, WriterTile>>(
+            name,
+            std::tuple<WriterTile, WriterTile, WriterTile>(
+                WriterTile(), WriterTile(), WriterTile()));
     auto it_ret = global_write_state_->last_tiles_.emplace(last_tile_tuple);
 
     if (!array_schema_->var_size(name)) {
@@ -1386,7 +1463,7 @@ Status Writer::init_global_write_state() {
   return Status::Ok();
 }
 
-Status Writer::init_tile(const std::string& name, Tile* tile) const {
+Status Writer::init_tile(const std::string& name, WriterTile* tile) const {
   // For easy reference
   auto cell_size = array_schema_->cell_size(name);
   auto type = array_schema_->type(name);
@@ -1404,7 +1481,7 @@ Status Writer::init_tile(const std::string& name, Tile* tile) const {
 }
 
 Status Writer::init_tile(
-    const std::string& name, Tile* tile, Tile* tile_var) const {
+    const std::string& name, WriterTile* tile, WriterTile* tile_var) const {
   // For easy reference
   auto type = array_schema_->type(name);
   auto domain = array_schema_->domain();
@@ -1426,7 +1503,9 @@ Status Writer::init_tile(
 }
 
 Status Writer::init_tile_nullable(
-    const std::string& name, Tile* tile, Tile* tile_validity) const {
+    const std::string& name,
+    WriterTile* tile,
+    WriterTile* tile_validity) const {
   // For easy reference
   auto cell_size = array_schema_->cell_size(name);
   auto type = array_schema_->type(name);
@@ -1451,9 +1530,9 @@ Status Writer::init_tile_nullable(
 
 Status Writer::init_tile_nullable(
     const std::string& name,
-    Tile* tile,
-    Tile* tile_var,
-    Tile* tile_validity) const {
+    WriterTile* tile,
+    WriterTile* tile_var,
+    WriterTile* tile_validity) const {
   // For easy reference
   auto type = array_schema_->type(name);
   auto domain = array_schema_->domain();
@@ -1484,7 +1563,7 @@ Status Writer::init_tile_nullable(
 Status Writer::init_tiles(
     const std::string& name,
     uint64_t tile_num,
-    std::vector<Tile>* tiles) const {
+    std::vector<WriterTile>* tiles) const {
   // Initialize tiles
   const bool var_size = array_schema_->var_size(name);
   const bool nullable = array_schema_->is_nullable(name);
@@ -1650,24 +1729,78 @@ Status Writer::ordered_write() {
   auto attr_num = buffers_.size();
   auto compute_tp = storage_manager_->compute_tp();
   auto thread_num = compute_tp->concurrency_level();
+  std::unordered_map<std::string, std::vector<std::vector<WriterTile>>> tiles;
   if (attr_num > tile_num) {  // Parallelize over attributes
     auto st = parallel_for(compute_tp, 0, attr_num, [&](uint64_t i) {
       auto buff_it = buffers_.begin();
       std::advance(buff_it, i);
       const auto& attr = buff_it->first;
+      auto res = tiles.emplace(attr, std::vector<std::vector<WriterTile>>());
+      auto& attr_tile_batches = res.first->second;
       return prepare_filter_and_write_tiles<T>(
-          attr, frag_meta, &dense_tiler, 1);
+          attr, attr_tile_batches, frag_meta, &dense_tiler, 1);
     });
     RETURN_NOT_OK_ELSE(st, storage_manager_->vfs()->remove_dir(uri));
   } else {  // Parallelize over tiles
-    size_t i = 0;
     for (const auto& buff : buffers_) {
       const auto& attr = buff.first;
+      auto&& res = tiles.emplace(attr, std::vector<std::vector<WriterTile>>());
+      auto& attr_tile_batches = res.first->second;
       RETURN_NOT_OK_ELSE(
           prepare_filter_and_write_tiles<T>(
-              attr, frag_meta, &dense_tiler, thread_num),
+              attr, attr_tile_batches, frag_meta, &dense_tiler, thread_num),
           storage_manager_->vfs()->remove_dir(uri));
-      ++i;
+    }
+  }
+
+  // Fix the tile metadata for var size attributes.
+  if (attr_num > tile_num) {  // Parallelize over attributes
+    auto st = parallel_for(compute_tp, 0, attr_num, [&](uint64_t i) {
+      auto buff_it = buffers_.begin();
+      std::advance(buff_it, i);
+      const auto& attr = buff_it->first;
+      const auto var_size = array_schema_->var_size(attr);
+      if (has_min_max_metadata(attr, var_size) &&
+          array_schema_->var_size(attr)) {
+        auto& attr_tile_batches = tiles[attr];
+        const uint64_t tile_num_mult =
+            1 + (var_size ? 1 : 0) + (array_schema_->is_nullable(attr) ? 1 : 0);
+        frag_meta->convert_tile_min_max_var_sizes_to_offsets(attr);
+        for (auto& batch : attr_tile_batches) {
+          for (uint64_t i = 0; i < batch.size(); i += tile_num_mult) {
+            auto idx = i / tile_num_mult;
+            frag_meta->set_tile_min_var(attr, idx, batch[i].min());
+            frag_meta->set_tile_max_var(attr, idx, batch[i].max());
+          }
+        }
+      }
+      return Status::Ok();
+    });
+    RETURN_NOT_OK_ELSE(st, storage_manager_->vfs()->remove_dir(uri));
+  } else {  // Parallelize over tiles
+    for (const auto& buff : buffers_) {
+      const auto& attr = buff.first;
+      auto& attr_tile_batches = tiles[attr];
+      const auto var_size = array_schema_->var_size(attr);
+      if (has_min_max_metadata(attr, var_size) &&
+          array_schema_->var_size(attr)) {
+        frag_meta->convert_tile_min_max_var_sizes_to_offsets(attr);
+        auto st = parallel_for(
+            compute_tp, 0, attr_tile_batches.size(), [&](uint64_t b) {
+              const auto& attr = buff.first;
+              auto& batch = tiles[attr][b];
+              const uint64_t tile_num_mult =
+                  1 + (var_size ? 1 : 0) +
+                  (array_schema_->is_nullable(attr) ? 1 : 0);
+              for (uint64_t i = 0; i < batch.size(); i += tile_num_mult) {
+                auto idx = b * thread_num + i / tile_num_mult;
+                frag_meta->set_tile_min_var(attr, idx, batch[i].min());
+                frag_meta->set_tile_max_var(attr, idx, batch[i].max());
+              }
+              return Status::Ok();
+            });
+        RETURN_NOT_OK_ELSE(st, storage_manager_->vfs()->remove_dir(uri));
+      }
     }
   }
 
@@ -1692,12 +1825,12 @@ Status Writer::ordered_write() {
 
 Status Writer::prepare_full_tiles(
     const std::set<uint64_t>& coord_dups,
-    std::unordered_map<std::string, std::vector<Tile>>* tiles) const {
+    std::unordered_map<std::string, std::vector<WriterTile>>* tiles) const {
   auto timer_se = stats_->start_timer("prepare_tiles");
 
   // Initialize attribute and coordinate tiles
   for (const auto& it : buffers_)
-    (*tiles)[it.first] = std::vector<Tile>();
+    (*tiles)[it.first] = std::vector<WriterTile>();
 
   auto num = buffers_.size();
   auto status =
@@ -1718,7 +1851,7 @@ Status Writer::prepare_full_tiles(
 Status Writer::prepare_full_tiles(
     const std::string& name,
     const std::set<uint64_t>& coord_dups,
-    std::vector<Tile>* tiles) const {
+    std::vector<WriterTile>* tiles) const {
   return array_schema_->var_size(name) ?
              prepare_full_tiles_var(name, coord_dups, tiles) :
              prepare_full_tiles_fixed(name, coord_dups, tiles);
@@ -1727,7 +1860,7 @@ Status Writer::prepare_full_tiles(
 Status Writer::prepare_full_tiles_fixed(
     const std::string& name,
     const std::set<uint64_t>& coord_dups,
-    std::vector<Tile>* tiles) const {
+    std::vector<WriterTile>* tiles) const {
   // For easy reference
   auto nullable = array_schema_->is_nullable(name);
   auto it = buffers_.find(name);
@@ -1816,8 +1949,9 @@ Status Writer::prepare_full_tiles_fixed(
         if ((*tiles)[tile_idx].full())
           tile_idx += t;
 
-        RETURN_NOT_OK((*tiles)[tile_idx].write(
-            buffer + cell_idx * cell_size, cell_size * cell_num_per_tile));
+        auto val = buffer + cell_idx * cell_size;
+        RETURN_NOT_OK(
+            (*tiles)[tile_idx].write(val, cell_size * cell_num_per_tile));
 
         if (nullable) {
           RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
@@ -1880,7 +2014,7 @@ Status Writer::prepare_full_tiles_fixed(
 Status Writer::prepare_full_tiles_var(
     const std::string& name,
     const std::set<uint64_t>& coord_dups,
-    std::vector<Tile>* tiles) const {
+    std::vector<WriterTile>* tiles) const {
   // For easy reference
   auto it = buffers_.find(name);
   auto nullable = array_schema_->is_nullable(name);
@@ -2109,13 +2243,13 @@ Status Writer::prepare_full_tiles_var(
 Status Writer::prepare_tiles(
     const std::vector<uint64_t>& cell_pos,
     const std::set<uint64_t>& coord_dups,
-    std::unordered_map<std::string, std::vector<Tile>>* tiles) const {
+    std::unordered_map<std::string, std::vector<WriterTile>>* tiles) const {
   auto timer_se = stats_->start_timer("prepare_tiles");
 
   // Initialize attribute tiles
   tiles->clear();
   for (const auto& it : buffers_)
-    (*tiles)[it.first] = std::vector<Tile>();
+    (*tiles)[it.first] = std::vector<WriterTile>();
 
   // Prepare tiles for all attributes and coordinates
   auto buffer_num = buffers_.size();
@@ -2138,7 +2272,7 @@ Status Writer::prepare_tiles(
     const std::string& name,
     const std::vector<uint64_t>& cell_pos,
     const std::set<uint64_t>& coord_dups,
-    std::vector<Tile>* tiles) const {
+    std::vector<WriterTile>* tiles) const {
   return array_schema_->var_size(name) ?
              prepare_tiles_var(name, cell_pos, coord_dups, tiles) :
              prepare_tiles_fixed(name, cell_pos, coord_dups, tiles);
@@ -2148,7 +2282,7 @@ Status Writer::prepare_tiles_fixed(
     const std::string& name,
     const std::vector<uint64_t>& cell_pos,
     const std::set<uint64_t>& coord_dups,
-    std::vector<Tile>* tiles) const {
+    std::vector<WriterTile>* tiles) const {
   // Trivial case
   if (cell_pos.empty())
     return Status::Ok();
@@ -2212,7 +2346,7 @@ Status Writer::prepare_tiles_var(
     const std::string& name,
     const std::vector<uint64_t>& cell_pos,
     const std::set<uint64_t>& coord_dups,
-    std::vector<Tile>* tiles) const {
+    std::vector<WriterTile>* tiles) const {
   // For easy reference
   auto it = buffers_.find(name);
   auto nullable = array_schema_->is_nullable(name);
@@ -2417,7 +2551,7 @@ Status Writer::unordered_write() {
   const auto& uri = frag_meta->fragment_uri();
 
   // Prepare tiles
-  std::unordered_map<std::string, std::vector<Tile>> tiles;
+  std::unordered_map<std::string, std::vector<WriterTile>> tiles;
   RETURN_CANCEL_OR_ERROR_ELSE(
       prepare_tiles(cell_pos, coord_dups, &tiles), clean_up(uri));
 
@@ -2442,6 +2576,10 @@ Status Writer::unordered_write() {
   // Compute coordinates metadata
   RETURN_CANCEL_OR_ERROR_ELSE(
       compute_coords_metadata(tiles, frag_meta), clean_up(uri));
+
+  // Compute tile metadata.
+  RETURN_CANCEL_OR_ERROR_ELSE(
+      compute_tiles_metadata(tile_num, tiles), clean_up(uri));
 
   // Filter all tiles
   RETURN_CANCEL_OR_ERROR_ELSE(filter_tiles(&tiles), clean_up(uri));
@@ -2468,7 +2606,7 @@ Status Writer::unordered_write() {
 Status Writer::write_empty_cell_range_to_tile(
     const uint64_t cell_num,
     const uint32_t cell_val_num,
-    Tile* const tile) const {
+    WriterTile* const tile) const {
   auto type = tile->type();
   auto fill_size = datatype_size(type);
   auto fill_value = constants::fill_value(type);
@@ -2486,8 +2624,8 @@ Status Writer::write_empty_cell_range_to_tile(
 Status Writer::write_empty_cell_range_to_tile_nullable(
     const uint64_t cell_num,
     const uint32_t cell_val_num,
-    Tile* const tile,
-    Tile* const tile_validity) const {
+    WriterTile* const tile,
+    WriterTile* const tile_validity) const {
   auto type = tile->type();
   auto fill_size = datatype_size(type);
   auto fill_value = constants::fill_value(type);
@@ -2508,7 +2646,7 @@ Status Writer::write_empty_cell_range_to_tile_nullable(
 }
 
 Status Writer::write_empty_cell_range_to_tile_var(
-    uint64_t num, Tile* tile, Tile* tile_var) const {
+    uint64_t num, WriterTile* tile, WriterTile* tile_var) const {
   auto type = tile_var->type();
   auto fill_size = datatype_size(type);
   auto fill_value = constants::fill_value(type);
@@ -2527,7 +2665,10 @@ Status Writer::write_empty_cell_range_to_tile_var(
 }
 
 Status Writer::write_empty_cell_range_to_tile_var_nullable(
-    uint64_t num, Tile* tile, Tile* tile_var, Tile* tile_validity) const {
+    uint64_t num,
+    WriterTile* tile,
+    WriterTile* tile_var,
+    WriterTile* tile_validity) const {
   auto type = tile_var->type();
   auto fill_size = datatype_size(type);
   auto fill_value = constants::fill_value(type);
@@ -2551,7 +2692,7 @@ Status Writer::write_empty_cell_range_to_tile_var_nullable(
 }
 
 Status Writer::write_cell_range_to_tile(
-    ConstBuffer* buff, uint64_t start, uint64_t end, Tile* tile) const {
+    ConstBuffer* buff, uint64_t start, uint64_t end, WriterTile* tile) const {
   auto fixed_cell_size = tile->cell_size();
   buff->set_offset(start * fixed_cell_size);
   return tile->write(buff, (end - start + 1) * fixed_cell_size);
@@ -2562,8 +2703,8 @@ Status Writer::write_cell_range_to_tile_nullable(
     ConstBuffer* buff_validity,
     uint64_t start,
     uint64_t end,
-    Tile* tile,
-    Tile* tile_validity) const {
+    WriterTile* tile,
+    WriterTile* tile_validity) const {
   auto fixed_cell_size = tile->cell_size();
   buff->set_offset(start * fixed_cell_size);
   RETURN_NOT_OK(tile->write(buff, (end - start + 1) * fixed_cell_size));
@@ -2582,8 +2723,8 @@ Status Writer::write_cell_range_to_tile_var(
     uint64_t start,
     uint64_t end,
     uint64_t attr_datatype_size,
-    Tile* tile,
-    Tile* tile_var) const {
+    WriterTile* tile,
+    WriterTile* tile_var) const {
   auto buff_cell_num = buff->size() / sizeof(uint64_t);
 
   for (auto i = start; i <= end; ++i) {
@@ -2613,9 +2754,9 @@ Status Writer::write_cell_range_to_tile_var_nullable(
     uint64_t start,
     uint64_t end,
     uint64_t attr_datatype_size,
-    Tile* tile,
-    Tile* tile_var,
-    Tile* tile_validity) const {
+    WriterTile* tile,
+    WriterTile* tile_var,
+    WriterTile* tile_validity) const {
   auto buff_cell_num = buff->size() / sizeof(uint64_t);
 
   for (auto i = start; i <= end; ++i) {
@@ -2645,7 +2786,7 @@ Status Writer::write_cell_range_to_tile_var_nullable(
 
 Status Writer::write_all_tiles(
     tdb_shared_ptr<FragmentMetadata> frag_meta,
-    std::unordered_map<std::string, std::vector<Tile>>* const tiles) {
+    std::unordered_map<std::string, std::vector<WriterTile>>* const tiles) {
   auto timer_se = stats_->start_timer("tiles");
 
   assert(!tiles->empty());
@@ -2653,7 +2794,24 @@ Status Writer::write_all_tiles(
   std::vector<ThreadPool::Task> tasks;
   for (auto& it : *tiles) {
     tasks.push_back(storage_manager_->io_tp()->execute([&, this]() {
-      RETURN_CANCEL_OR_ERROR(write_tiles(it.first, frag_meta, 0, &it.second));
+      auto& attr = it.first;
+      auto& tiles = it.second;
+      RETURN_CANCEL_OR_ERROR(write_tiles(attr, frag_meta, 0, &tiles));
+
+      // Fix var size attributes metadata.
+      const auto var_size = array_schema_->var_size(attr);
+      if (has_min_max_metadata(attr, var_size) &&
+          array_schema_->var_size(attr)) {
+        frag_meta->convert_tile_min_max_var_sizes_to_offsets(attr);
+
+        const auto nullable = array_schema_->is_nullable(attr);
+        const uint64_t tile_num_mult = 1 + var_size + nullable;
+        for (uint64_t i = 0; i < tiles.size(); i += tile_num_mult) {
+          auto tile_idx = i / tile_num_mult;
+          frag_meta->set_tile_min_var(attr, tile_idx, tiles[i].min());
+          frag_meta->set_tile_max_var(attr, tile_idx, tiles[i].max());
+        }
+      }
       return Status::Ok();
     }));
   }
@@ -2670,7 +2828,7 @@ Status Writer::write_tiles(
     const std::string& name,
     tdb_shared_ptr<FragmentMetadata> frag_meta,
     uint64_t start_tile_id,
-    std::vector<Tile>* const tiles,
+    std::vector<WriterTile>* const tiles,
     bool close_files) {
   auto timer_se = stats_->start_timer("tiles");
 
@@ -2685,13 +2843,18 @@ Status Writer::write_tiles(
   const auto& var_uri = var_size ? frag_meta->var_uri(name) : URI("");
   const auto& validity_uri = nullable ? frag_meta->validity_uri(name) : URI("");
 
-  // Write tiles
+  // Compute and set var buffer sizes for the min/max metadata
+  const auto has_min_max_md = has_min_max_metadata(name, var_size);
+  const auto has_sum_md = has_sum_metadata(name, var_size);
   auto tile_num = tiles->size();
+
+  // Write tiles
   for (size_t i = 0, tile_id = start_tile_id; i < tile_num; ++i, ++tile_id) {
-    Tile* tile = &(*tiles)[i];
+    auto tile = &(*tiles)[i];
     RETURN_NOT_OK(storage_manager_->write(uri, tile->filtered_buffer()));
     frag_meta->set_tile_offset(name, tile_id, tile->filtered_buffer()->size());
 
+    auto&& [min, min_size, max, max_size, sum, null_count] = tile->metadata();
     if (var_size) {
       ++i;
 
@@ -2700,6 +2863,19 @@ Status Writer::write_tiles(
       frag_meta->set_tile_var_offset(
           name, tile_id, tile->filtered_buffer()->size());
       frag_meta->set_tile_var_size(name, tile_id, tile->pre_filtered_size());
+      if (has_min_max_md && null_count != frag_meta->cell_num(tile_id)) {
+        frag_meta->set_tile_min_var_size(name, tile_id, min_size);
+        frag_meta->set_tile_max_var_size(name, tile_id, max_size);
+      }
+    } else {
+      if (has_min_max_md && null_count != frag_meta->cell_num(tile_id)) {
+        frag_meta->set_tile_min(name, tile_id, min, min_size);
+        frag_meta->set_tile_max(name, tile_id, max, max_size);
+      }
+
+      if (has_sum_md) {
+        frag_meta->set_tile_sum(name, tile_id, sum);
+      }
     }
 
     if (nullable) {
@@ -2710,6 +2886,7 @@ Status Writer::write_tiles(
           storage_manager_->write(validity_uri, tile->filtered_buffer()));
       frag_meta->set_tile_validity_offset(
           name, tile_id, tile->filtered_buffer()->size());
+      frag_meta->set_tile_null_count(name, tile_id, null_count);
     }
   }
 
@@ -2724,6 +2901,21 @@ Status Writer::write_tiles(
   }
 
   return Status::Ok();
+}
+
+bool Writer::has_min_max_metadata(
+    const std::string& name, const bool var_size) {
+  const auto type = array_schema_->type(name);
+  const auto is_dim = array_schema_->is_dim(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+  return TileMetadataGenerator::has_min_max_metadata(
+      type, is_dim, var_size, cell_val_num);
+}
+
+bool Writer::has_sum_metadata(const std::string& name, const bool var_size) {
+  const auto type = array_schema_->type(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+  return TileMetadataGenerator::has_sum_metadata(type, var_size, cell_val_num);
 }
 
 std::string Writer::coords_to_str(uint64_t i) const {
@@ -2782,13 +2974,18 @@ Status Writer::calculate_hilbert_values(
 template <class T>
 Status Writer::prepare_filter_and_write_tiles(
     const std::string& name,
+    std::vector<std::vector<WriterTile>>& tile_batches,
     tdb_shared_ptr<FragmentMetadata> frag_meta,
     DenseTiler<T>* dense_tiler,
     uint64_t thread_num) {
   auto timer_se = stats_->start_timer("prepare_filter_and_write_tiles");
 
   // For easy reference
+  const auto type = array_schema_->type(name);
+  const auto is_dim = array_schema_->is_dim(name);
   const bool var = array_schema_->var_size(name);
+  const auto cell_size = array_schema_->cell_size(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
   const bool nullable = array_schema_->is_nullable(name);
 
   // Initialization
@@ -2802,35 +2999,43 @@ Status Writer::prepare_filter_and_write_tiles(
   // Process batches
   uint64_t frag_tile_id = 0;
   bool close_files = false;
+  tile_batches.resize(batch_num);
   for (uint64_t b = 0; b < batch_num; ++b) {
     auto batch_size = (b == batch_num - 1) ? last_batch_size : thread_num;
     assert(batch_size > 0);
-    std::vector<Tile> tiles(batch_size * (1 + var + nullable));
+    tile_batches[b].resize(batch_size * (1 + var + nullable));
+    std::vector<WriterTile> tiles(batch_size * (1 + var + nullable));
     auto st = parallel_for(
         storage_manager_->compute_tp(), 0, batch_size, [&](uint64_t i) {
           // Prepare and filter tiles
+          TileMetadataGenerator md_generator(
+              type, is_dim, var, cell_size, cell_val_num);
           auto tiles_id = i * (1 + var + nullable);
+
+          auto tile = &tile_batches[b][tiles_id];
+          auto tile_val =
+              nullable ? &tile_batches[b][tiles_id + 1 + var] : nullptr;
+          if (nullable) {
+            RETURN_NOT_OK(
+                dense_tiler->get_tile_null(frag_tile_id + i, name, tile_val));
+          }
+
           if (!var) {
-            RETURN_NOT_OK(dense_tiler->get_tile(
-                frag_tile_id + i, name, &tiles[tiles_id]));
-            RETURN_NOT_OK(
-                filter_tile(name, &tiles[tiles_id], nullptr, false, false));
+            RETURN_NOT_OK(dense_tiler->get_tile(frag_tile_id + i, name, tile));
+            md_generator.process_tile(tile, nullptr, tile_val);
+            tile->set_metadata(md_generator.metadata());
+            RETURN_NOT_OK(filter_tile(name, tile, nullptr, false, false));
           } else {
+            auto tile_var = &tile_batches[b][tiles_id + 1];
             RETURN_NOT_OK(dense_tiler->get_tile_var(
-                frag_tile_id + i,
-                name,
-                &tiles[tiles_id],
-                &tiles[tiles_id + 1]));
-            RETURN_NOT_OK(
-                filter_tile(name, &tiles[tiles_id], nullptr, true, false));
-            RETURN_NOT_OK(filter_tile(
-                name, &tiles[tiles_id + 1], &tiles[tiles_id], false, false));
+                frag_tile_id + i, name, tile, tile_var));
+            md_generator.process_tile(tile, tile_var, tile_val);
+            tile->set_metadata(md_generator.metadata());
+            RETURN_NOT_OK(filter_tile(name, tile, nullptr, true, false));
+            RETURN_NOT_OK(filter_tile(name, tile_var, tile, false, false));
           }
           if (nullable) {
-            RETURN_NOT_OK(dense_tiler->get_tile_null(
-                frag_tile_id + i, name, &tiles[tiles_id + 1 + var]));
-            RETURN_NOT_OK(filter_tile(
-                name, &tiles[tiles_id + 1 + var], nullptr, false, true));
+            RETURN_NOT_OK(filter_tile(name, tile_val, nullptr, false, true));
           }
           return Status::Ok();
         });
@@ -2838,8 +3043,8 @@ Status Writer::prepare_filter_and_write_tiles(
 
     // Write tiles
     close_files = (b == batch_num - 1);
-    RETURN_NOT_OK(
-        write_tiles(name, frag_meta, frag_tile_id, &tiles, close_files));
+    RETURN_NOT_OK(write_tiles(
+        name, frag_meta, frag_tile_id, &tile_batches[b], close_files));
 
     frag_tile_id += batch_size;
   }

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -44,7 +44,7 @@
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/strategy_base.h"
 #include "tiledb/sm/stats/stats.h"
-#include "tiledb/sm/tile/tile.h"
+#include "tiledb/sm/tile/writer_tile.h"
 
 using namespace tiledb::common;
 
@@ -53,6 +53,7 @@ namespace sm {
 
 class Array;
 class FragmentMetadata;
+class TileMetadataGenerator;
 class StorageManager;
 
 /** Processes write queries. */
@@ -74,7 +75,10 @@ class Writer : public StrategyBase, public IQueryStrategy {
      * offsets tile, whereas the second tile is the values tile. In both cases,
      * the third tile stores a validity tile for nullable attributes.
      */
-    std::unordered_map<std::string, std::tuple<Tile, Tile, Tile>> last_tiles_;
+    std::unordered_map<
+        std::string,
+        std::tuple<WriterTile, WriterTile, WriterTile>>
+        last_tiles_;
 
     /**
      * Stores the number of cells written for each attribute/dimension across
@@ -334,13 +338,25 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * Computes the coordinates metadata (e.g., MBRs).
    *
    * @param tiles The tiles to calculate the coords metadata from. It is
-   *     a vector of vectors, one vector of tiles per dimension.
+   *     a map of vectors, one vector of tiles per dimension.
    * @param meta The fragment metadata that will store the coords metadata.
    * @return Status
    */
   Status compute_coords_metadata(
-      const std::unordered_map<std::string, std::vector<Tile>>& tiles,
+      const std::unordered_map<std::string, std::vector<WriterTile>>& tiles,
       tdb_shared_ptr<FragmentMetadata> meta) const;
+
+  /**
+   * Computes the tiles metadata (min/max/sum/null count).
+   *
+   * @param tile_num The number of tiles.
+   * @param tiles The tiles to calculate the tile metadata from. It is
+   *     a map of vectors, one vector of tiles per dimension.
+   * @return Status
+   */
+  Status compute_tiles_metadata(
+      uint64_t tile_num,
+      std::unordered_map<std::string, std::vector<WriterTile>>& tiles) const;
 
   /**
    * Creates a new fragment.
@@ -358,14 +374,14 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * of the pipeline.
    */
   Status filter_tiles(
-      std::unordered_map<std::string, std::vector<Tile>>* tiles);
+      std::unordered_map<std::string, std::vector<WriterTile>>* tiles);
 
   /**
    * Applicable only to global writes. Filters the last attribute and
    * coordinate tiles.
    */
   Status filter_last_tiles(
-      std::unordered_map<std::string, std::vector<Tile>>* tiles);
+      std::unordered_map<std::string, std::vector<WriterTile>>* tiles);
 
   /**
    * Runs the input tiles for the input attribute through the filter pipeline.
@@ -375,7 +391,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * @param tile The tiles to be filtered.
    * @return Status
    */
-  Status filter_tiles(const std::string& name, std::vector<Tile>* tiles);
+  Status filter_tiles(const std::string& name, std::vector<WriterTile>* tiles);
 
   /**
    * Runs the input tile for the input attribute/dimension through the filter
@@ -392,8 +408,8 @@ class Writer : public StrategyBase, public IQueryStrategy {
    */
   Status filter_tile(
       const std::string& name,
-      Tile* tile,
-      Tile* offsets_tile,
+      WriterTile* tile,
+      WriterTile* offsets_tile,
       bool offsets,
       bool nullable);
 
@@ -425,7 +441,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * @param tile The tile to be initialized.
    * @return Status
    */
-  Status init_tile(const std::string& name, Tile* tile) const;
+  Status init_tile(const std::string& name, WriterTile* tile) const;
 
   /**
    * Initializes a var-sized tile.
@@ -435,7 +451,8 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * @param tile_var The var-sized data tile to be initialized.
    * @return Status
    */
-  Status init_tile(const std::string& name, Tile* tile, Tile* tile_var) const;
+  Status init_tile(
+      const std::string& name, WriterTile* tile, WriterTile* tile_var) const;
 
   /**
    * Initializes a fixed-sized, nullable tile.
@@ -446,7 +463,9 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * @return Status
    */
   Status init_tile_nullable(
-      const std::string& name, Tile* tile, Tile* tile_validity) const;
+      const std::string& name,
+      WriterTile* tile,
+      WriterTile* tile_validity) const;
 
   /**
    * Initializes a var-sized, nullable tile.
@@ -459,9 +478,9 @@ class Writer : public StrategyBase, public IQueryStrategy {
    */
   Status init_tile_nullable(
       const std::string& name,
-      Tile* tile,
-      Tile* tile_var,
-      Tile* tile_validity) const;
+      WriterTile* tile,
+      WriterTile* tile_var,
+      WriterTile* tile_validity) const;
 
   /**
    * Initializes the tiles for writing for the input attribute/dimension.
@@ -475,7 +494,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
   Status init_tiles(
       const std::string& name,
       uint64_t tile_num,
-      std::vector<Tile>* tiles) const;
+      std::vector<WriterTile>* tiles) const;
 
   /**
    * Generates a new fragment name, which is in the form: <br>
@@ -563,7 +582,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
    */
   Status prepare_full_tiles(
       const std::set<uint64_t>& coord_dups,
-      std::unordered_map<std::string, std::vector<Tile>>* tiles) const;
+      std::unordered_map<std::string, std::vector<WriterTile>>* tiles) const;
 
   /**
    * Applicable only to write in global order. It prepares only full
@@ -582,7 +601,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
   Status prepare_full_tiles(
       const std::string& name,
       const std::set<uint64_t>& coord_dups,
-      std::vector<Tile>* tiles) const;
+      std::vector<WriterTile>* tiles) const;
 
   /**
    * Applicable only to write in global order. It prepares only full
@@ -601,7 +620,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
   Status prepare_full_tiles_fixed(
       const std::string& name,
       const std::set<uint64_t>& coord_dups,
-      std::vector<Tile>* tiles) const;
+      std::vector<WriterTile>* tiles) const;
 
   /**
    * Applicable only to write in global order. It prepares only full
@@ -620,7 +639,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
   Status prepare_full_tiles_var(
       const std::string& name,
       const std::set<uint64_t>& coord_dups,
-      std::vector<Tile>* tiles) const;
+      std::vector<WriterTile>* tiles) const;
 
   /**
    * It prepares the attribute and coordinate tiles, re-organizing the cells
@@ -638,7 +657,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
   Status prepare_tiles(
       const std::vector<uint64_t>& cell_pos,
       const std::set<uint64_t>& coord_dups,
-      std::unordered_map<std::string, std::vector<Tile>>* tiles) const;
+      std::unordered_map<std::string, std::vector<WriterTile>>* tiles) const;
 
   /**
    * It prepares the tiles for the input attribute or dimension, re-organizing
@@ -656,7 +675,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
       const std::string& name,
       const std::vector<uint64_t>& cell_pos,
       const std::set<uint64_t>& coord_dups,
-      std::vector<Tile>* tiles) const;
+      std::vector<WriterTile>* tiles) const;
 
   /**
    * It prepares the tiles for the input attribute or dimension, re-organizing
@@ -675,7 +694,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
       const std::string& name,
       const std::vector<uint64_t>& cell_pos,
       const std::set<uint64_t>& coord_dups,
-      std::vector<Tile>* tiles) const;
+      std::vector<WriterTile>* tiles) const;
 
   /**
    * It prepares the tiles for the input attribute or dimension, re-organizing
@@ -694,7 +713,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
       const std::string& name,
       const std::vector<uint64_t>& cell_pos,
       const std::set<uint64_t>& coord_dups,
-      std::vector<Tile>* tiles) const;
+      std::vector<WriterTile>* tiles) const;
 
   /** Resets the writer object, rendering it incomplete. */
   void reset();
@@ -733,7 +752,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * @return Status
    */
   Status write_empty_cell_range_to_tile(
-      uint64_t num, uint32_t cell_val_num, Tile* tile) const;
+      uint64_t num, uint32_t cell_val_num, WriterTile* tile) const;
 
   /**
    * Writes an empty cell range to the input tile.
@@ -748,8 +767,8 @@ class Writer : public StrategyBase, public IQueryStrategy {
   Status write_empty_cell_range_to_tile_nullable(
       uint64_t num,
       uint32_t cell_val_num,
-      Tile* tile,
-      Tile* tile_validity) const;
+      WriterTile* tile,
+      WriterTile* tile_validity) const;
 
   /**
    * Writes an empty cell range to the input tile.
@@ -761,7 +780,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * @return Status
    */
   Status write_empty_cell_range_to_tile_var(
-      uint64_t num, Tile* tile, Tile* tile_var) const;
+      uint64_t num, WriterTile* tile, WriterTile* tile_var) const;
 
   /**
    * Writes an empty cell range to the input tile.
@@ -774,7 +793,10 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * @return Status
    */
   Status write_empty_cell_range_to_tile_var_nullable(
-      uint64_t num, Tile* tile, Tile* tile_var, Tile* tile_validity) const;
+      uint64_t num,
+      WriterTile* tile,
+      WriterTile* tile_var,
+      WriterTile* tile_validity) const;
 
   /**
    * Writes the input cell range to the input tile, for a particular
@@ -787,7 +809,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * @return Status
    */
   Status write_cell_range_to_tile(
-      ConstBuffer* buff, uint64_t start, uint64_t end, Tile* tile) const;
+      ConstBuffer* buff, uint64_t start, uint64_t end, WriterTile* tile) const;
 
   /**
    * Writes the input cell range to the input tile, for a particular
@@ -807,8 +829,8 @@ class Writer : public StrategyBase, public IQueryStrategy {
       ConstBuffer* buff_validity,
       uint64_t start,
       uint64_t end,
-      Tile* tile,
-      Tile* tile_validity) const;
+      WriterTile* tile,
+      WriterTile* tile_validity) const;
 
   /**
    * Writes the input cell range to the input tile, for a particular
@@ -829,8 +851,8 @@ class Writer : public StrategyBase, public IQueryStrategy {
       uint64_t start,
       uint64_t end,
       uint64_t attr_datatype_size,
-      Tile* tile,
-      Tile* tile_var) const;
+      WriterTile* tile,
+      WriterTile* tile_var) const;
 
   /**
    * Writes the input cell range to the input tile, for a particular
@@ -855,9 +877,9 @@ class Writer : public StrategyBase, public IQueryStrategy {
       uint64_t start,
       uint64_t end,
       uint64_t attr_datatype_size,
-      Tile* tile,
-      Tile* tile_var,
-      Tile* tile_validity) const;
+      WriterTile* tile,
+      WriterTile* tile_var,
+      WriterTile* tile_validity) const;
 
   /**
    * Writes all the input tiles to storage.
@@ -869,7 +891,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
    */
   Status write_all_tiles(
       tdb_shared_ptr<FragmentMetadata> frag_meta,
-      std::unordered_map<std::string, std::vector<Tile>>* tiles);
+      std::unordered_map<std::string, std::vector<WriterTile>>* tiles);
 
   /**
    * Writes the input tiles for the input attribute/dimension to storage.
@@ -887,8 +909,26 @@ class Writer : public StrategyBase, public IQueryStrategy {
       const std::string& name,
       tdb_shared_ptr<FragmentMetadata> frag_meta,
       uint64_t start_tile_id,
-      std::vector<Tile>* tiles,
+      std::vector<WriterTile>* tiles,
       bool close_files = true);
+
+  /**
+   * Determines if an attribute has min max metadata.
+   *
+   * @param name Attribute/dimension name.
+   * @param var_size Is the attribute/dimension var size.
+   * @return true if the atribute has min max metadata.
+   */
+  bool has_min_max_metadata(const std::string& name, const bool var_size);
+
+  /**
+   * Determines if an attribute has sum metadata.
+   *
+   * @param name Attribute/dimension name.
+   * @param var_size Is the attribute/dimension var size.
+   * @return true if the atribute has sum metadata.
+   */
+  bool has_sum_metadata(const std::string& name, const bool var_size);
 
   /**
    * Returns the i-th coordinates in the coordinate buffers in string
@@ -918,6 +958,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
    *
    * @tparam T The array domain datatype.
    * @param name The attribute name.
+   * @param tile_batches The attribute tile batches.
    * @param frag_meta The metadata of the new fragment.
    * @param dense_tiler The dense tiler that will prepare the tiles.
    * @param thread_num The number of threads to be used for the function.
@@ -926,6 +967,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
   template <class T>
   Status prepare_filter_and_write_tiles(
       const std::string& name,
+      std::vector<std::vector<WriterTile>>& tile_batches,
       tdb_shared_ptr<FragmentMetadata> frag_meta,
       DenseTiler<T>* dense_tiler,
       uint64_t thread_num);

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1741,7 +1741,6 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
     ms.resize(names.size(), {0, 0, 0});
   std::unordered_set<std::pair<unsigned, uint64_t>, utils::hash::pair_hash>
       all_frag_tiles;
-  uint64_t tile_size, tile_var_size;
   for (uint64_t r = 0; r < range_num; ++r) {
     auto& mem_vec = (*mem_sizes)[r];
     for (const auto& ft : frag_tiles[r]) {
@@ -1755,7 +1754,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
             continue;
           }
 
-          tile_size = meta->tile_size(names[i], ft.second);
+          auto tile_size = meta->tile_size(names[i], ft.second);
           auto cell_size = array_schema->cell_size(names[i]);
           if (!var_sizes[i]) {
             mem_vec[i].size_fixed_ += tile_size;
@@ -1763,13 +1762,14 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
               mem_vec[i].size_validity_ +=
                   tile_size / cell_size * constants::cell_validity_size;
           } else {
-            RETURN_NOT_OK(
-                meta->tile_var_size(names[i], ft.second, &tile_var_size));
+            auto&& [st, tile_var_size] =
+                meta->tile_var_size(names[i], ft.second);
+            RETURN_NOT_OK(st);
             mem_vec[i].size_fixed_ += tile_size;
-            mem_vec[i].size_var_ += tile_var_size;
+            mem_vec[i].size_var_ += *tile_var_size;
             if (nullable[i])
               mem_vec[i].size_validity_ +=
-                  tile_var_size / cell_size * constants::cell_validity_size;
+                  *tile_var_size / cell_size * constants::cell_validity_size;
           }
         }
       }
@@ -2229,7 +2229,6 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
     auto meta = fragment_meta[f];
 
     // Parse tile ranges
-    uint64_t tile_size = 0, tile_var_size = 0;
     for (const auto& tr : overlap->tile_ranges_) {
       for (uint64_t tid = tr.first; tid <= tr.second; ++tid) {
         for (size_t n = 0; n < names.size(); ++n) {
@@ -2244,7 +2243,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
           }
 
           frag_tiles->insert(std::pair<unsigned, uint64_t>(f, tid));
-          tile_size = meta->tile_size(names[n], tid);
+          auto tile_size = meta->tile_size(names[n], tid);
           auto attr_datatype_size = datatype_size(array_schema->type(names[n]));
           if (!var_sizes[n]) {
             (*result_sizes)[n].size_fixed_ += tile_size;
@@ -2254,11 +2253,12 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
                   constants::cell_validity_size;
           } else {
             (*result_sizes)[n].size_fixed_ += tile_size;
-            RETURN_NOT_OK(meta->tile_var_size(names[n], tid, &tile_var_size));
-            (*result_sizes)[n].size_var_ += tile_var_size;
+            auto&& [st, tile_var_size] = meta->tile_var_size(names[n], tid);
+            RETURN_NOT_OK(st);
+            (*result_sizes)[n].size_var_ += *tile_var_size;
             if (nullable[n])
               (*result_sizes)[n].size_validity_ +=
-                  tile_var_size / attr_datatype_size *
+                  *tile_var_size / attr_datatype_size *
                   constants::cell_validity_size;
           }
         }
@@ -2281,7 +2281,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
         }
 
         frag_tiles->insert(std::pair<unsigned, uint64_t>(f, tid));
-        tile_size = meta->tile_size(names[n], tid);
+        auto tile_size = meta->tile_size(names[n], tid);
         auto attr_datatype_size = datatype_size(array_schema->type(names[n]));
         if (!var_sizes[n]) {
           (*result_sizes)[n].size_fixed_ += tile_size * ratio;
@@ -2293,11 +2293,12 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
 
         } else {
           (*result_sizes)[n].size_fixed_ += tile_size * ratio;
-          RETURN_NOT_OK(meta->tile_var_size(names[n], tid, &tile_var_size));
-          (*result_sizes)[n].size_var_ += tile_var_size * ratio;
+          auto&& [st, tile_var_size] = meta->tile_var_size(names[n], tid);
+          RETURN_NOT_OK(st);
+          (*result_sizes)[n].size_var_ += *tile_var_size * ratio;
           if (nullable[n])
             (*result_sizes)[n].size_validity_ +=
-                (tile_var_size / attr_datatype_size *
+                (*tile_var_size / attr_datatype_size *
                  constants::cell_validity_size) *
                 ratio;
         }

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -84,7 +84,6 @@ Tile::Tile() {
   cell_size_ = 0;
   dim_num_ = 0;
   owns_buffer_ = true;
-  pre_filtered_size_ = 0;
   format_version_ = 0;
   type_ = Datatype::INT32;
 }
@@ -100,7 +99,6 @@ Tile::Tile(
     , dim_num_(dim_num)
     , format_version_(0)
     , owns_buffer_(owns_buff)
-    , pre_filtered_size_(0)
     , type_(type) {
   buffer->reset_offset();
 }
@@ -117,7 +115,6 @@ Tile::Tile(
     , dim_num_(dim_num)
     , format_version_(format_version)
     , owns_buffer_(owns_buff)
-    , pre_filtered_size_(0)
     , type_(type) {
 }
 
@@ -230,7 +227,6 @@ Tile Tile::clone(bool deep_copy) const {
   clone.cell_size_ = cell_size_;
   clone.dim_num_ = dim_num_;
   clone.format_version_ = format_version_;
-  clone.pre_filtered_size_ = pre_filtered_size_;
   clone.type_ = type_;
   clone.filtered_buffer_ = filtered_buffer_;
 
@@ -273,10 +269,6 @@ uint64_t Tile::offset() const {
   return buffer_->offset();
 }
 
-uint64_t Tile::pre_filtered_size() const {
-  return pre_filtered_size_;
-}
-
 Status Tile::read(void* buffer, uint64_t nbytes) {
   assert(!filtered());
   RETURN_NOT_OK(buffer_->read(buffer, nbytes));
@@ -306,10 +298,6 @@ void Tile::reset_size() {
 
 void Tile::set_offset(uint64_t offset) {
   buffer_->set_offset(offset);
-}
-
-void Tile::set_pre_filtered_size(uint64_t pre_filtered_size) {
-  pre_filtered_size_ = pre_filtered_size;
 }
 
 Status Tile::write(ConstBuffer* buf) {
@@ -384,7 +372,6 @@ void Tile::swap(Tile& tile) {
   std::swap(dim_num_, tile.dim_num_);
   std::swap(format_version_, tile.format_version_);
   std::swap(owns_buffer_, tile.owns_buffer_);
-  std::swap(pre_filtered_size_, tile.pre_filtered_size_);
   std::swap(type_, tile.type_);
 }
 

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -257,15 +257,6 @@ class Tile {
   /** The current offset in the tile. */
   uint64_t offset() const;
 
-  /**
-   * Returns the pre-filtered size of the tile data in the buffer.
-   *
-   * On writes, the pre-filtered size is the uncompressed size.
-   *
-   * On reads, the pre-filtered size is the persisted (compressed) size.
-   */
-  uint64_t pre_filtered_size() const;
-
   /** Reads from the tile into the input buffer *nbytes*. */
   Status read(void* buffer, uint64_t nbytes);
 
@@ -287,9 +278,6 @@ class Tile {
 
   /** Sets the tile offset. */
   void set_offset(uint64_t offset);
-
-  /** Sets the pre-filtered size value to the given value. */
-  void set_pre_filtered_size(uint64_t pre_filtered_size);
 
   /** Returns the tile size. */
   inline uint64_t size() const {
@@ -333,9 +321,9 @@ class Tile {
    */
   Status zip_coordinates();
 
- private:
+ protected:
   /* ********************************* */
-  /*         PRIVATE ATTRIBUTES        */
+  /*        PROTECTED ATTRIBUTES       */
   /* ********************************* */
 
   /** The buffer backing the tile data. */
@@ -358,9 +346,6 @@ class Tile {
    * it will not delete it.
    */
   bool owns_buffer_;
-
-  /** The size in bytes of the tile data before it has been filtered. */
-  uint64_t pre_filtered_size_;
 
   /** The tile data type. */
   Datatype type_;

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -1,0 +1,662 @@
+/**
+ * @file   tile_metadata_generator.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class TileMetadataGenerator.
+ */
+
+#include "tiledb/sm/tile/tile_metadata_generator.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*    STRUCTURED BINDINGS APIS    */
+/* ****************************** */
+
+template <typename T>
+ByteVec Sum<T, int64_t>::sum(Tile* tile) {
+  assert(tile != nullptr);
+
+  // Zero sum.
+  ByteVec ret(8, 0);
+
+  // Get pointers to the data and cell num.
+  auto values = static_cast<T*>(tile->buffer()->data());
+  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto sum_data = reinterpret_cast<int64_t*>(ret.data());
+
+  // Process cell by cell, swallowing overflow exception.
+  for (uint64_t c = 0; c < cell_num; c++) {
+    auto value = static_cast<int64_t>(*static_cast<T*>(&values[c]));
+    if (*sum_data > 0 && value > 0 &&
+        (*sum_data > std::numeric_limits<int64_t>::max() - value)) {
+      *sum_data = std::numeric_limits<int64_t>::max();
+      break;
+    }
+
+    if (*sum_data < 0 && value < 0 &&
+        (*sum_data < std::numeric_limits<int64_t>::min() - value)) {
+      *sum_data = std::numeric_limits<int64_t>::min();
+      break;
+    }
+
+    *sum_data += value;
+  }
+
+  return ret;
+}
+
+template <typename T>
+ByteVec Sum<T, uint64_t>::sum(Tile* tile) {
+  assert(tile != nullptr);
+
+  // Zero sum.
+  ByteVec ret(8, 0);
+
+  // Get pointers to the data and cell num.
+  auto values = static_cast<T*>(tile->buffer()->data());
+  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto sum_data = reinterpret_cast<uint64_t*>(ret.data());
+
+  // Process cell by cell, swallowing overflow exception.
+  for (uint64_t c = 0; c < cell_num; c++) {
+    auto value = static_cast<uint64_t>(*static_cast<T*>(&values[c]));
+    if (*sum_data > std::numeric_limits<uint64_t>::max() - value) {
+      *sum_data = std::numeric_limits<uint64_t>::max();
+      break;
+    }
+
+    *sum_data += value;
+  }
+
+  return ret;
+}
+
+template <typename T>
+ByteVec Sum<T, double>::sum(Tile* tile) {
+  assert(tile != nullptr);
+
+  // Zero sum.
+  ByteVec ret(8, 0);
+
+  // Get pointers to the data and cell num.
+  auto values = static_cast<T*>(tile->buffer()->data());
+  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto sum_data = reinterpret_cast<double*>(ret.data());
+
+  // Process cell by cell, swallowing overflow exception.
+  for (uint64_t c = 0; c < cell_num; c++) {
+    auto value = static_cast<double>(*static_cast<T*>(&values[c]));
+    if ((*sum_data < 0.0) == (value < 0.0) &&
+        std::abs(*sum_data) >
+            std::numeric_limits<double>::max() - std::abs(value)) {
+      *sum_data = *sum_data < 0.0 ? std::numeric_limits<double>::lowest() :
+                                    std::numeric_limits<double>::max();
+      break;
+    }
+
+    *sum_data += value;
+  }
+
+  return ret;
+}
+
+template <typename T>
+ByteVec Sum<T, int64_t>::sum_nullable(Tile* tile, Tile* tile_validity) {
+  assert(tile != nullptr);
+
+  // Zero sum.
+  ByteVec ret(8, 0);
+
+  // Get pointers to the data and cell num.
+  auto values = static_cast<T*>(tile->buffer()->data());
+  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
+  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto sum_data = reinterpret_cast<int64_t*>(ret.data());
+
+  // Process cell by cell, swallowing overflow exception.
+  for (uint64_t c = 0; c < cell_num; c++) {
+    if (validity_values[c] != 0) {
+      auto value = static_cast<int64_t>(*static_cast<T*>(&values[c]));
+      if (*sum_data > 0 && value > 0 &&
+          (*sum_data > std::numeric_limits<int64_t>::max() - value)) {
+        *sum_data = std::numeric_limits<int64_t>::max();
+        break;
+      }
+
+      if (*sum_data < 0 && value < 0 &&
+          (*sum_data < std::numeric_limits<int64_t>::min() - value)) {
+        *sum_data = std::numeric_limits<int64_t>::min();
+        break;
+      }
+
+      *sum_data += value;
+    }
+  }
+
+  return ret;
+}
+
+template <typename T>
+ByteVec Sum<T, uint64_t>::sum_nullable(Tile* tile, Tile* tile_validity) {
+  assert(tile != nullptr);
+
+  // Zero sum.
+  ByteVec ret(8, 0);
+
+  // Get pointers to the data and cell num.
+  auto values = static_cast<T*>(tile->buffer()->data());
+  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
+  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto sum_data = reinterpret_cast<uint64_t*>(ret.data());
+
+  // Process cell by cell, swallowing overflow exception.
+  for (uint64_t c = 0; c < cell_num; c++) {
+    if (validity_values[c] != 0) {
+      auto value = static_cast<uint64_t>(*static_cast<T*>(&values[c]));
+      if (*sum_data > std::numeric_limits<uint64_t>::max() - value) {
+        *sum_data = std::numeric_limits<uint64_t>::max();
+        break;
+      }
+
+      *sum_data += value;
+    }
+  }
+
+  return ret;
+}
+
+template <typename T>
+ByteVec Sum<T, double>::sum_nullable(Tile* tile, Tile* tile_validity) {
+  assert(tile != nullptr);
+
+  // Zero sum.
+  ByteVec ret(8, 0);
+
+  // Get pointers to the data and cell num.
+  auto values = static_cast<T*>(tile->buffer()->data());
+  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
+  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto sum_data = reinterpret_cast<double*>(ret.data());
+
+  // Process cell by cell, swallowing overflow exception.
+  for (uint64_t c = 0; c < cell_num; c++) {
+    if (validity_values[c] != 0) {
+      auto value = static_cast<double>(*static_cast<T*>(&values[c]));
+      if ((*sum_data < 0.0) == (value < 0.0) &&
+          std::abs(*sum_data) >
+              std::numeric_limits<double>::max() - std::abs(value)) {
+        *sum_data = *sum_data < 0.0 ? std::numeric_limits<double>::lowest() :
+                                      std::numeric_limits<double>::max();
+        break;
+      }
+
+      *sum_data += value;
+    }
+  }
+
+  return ret;
+}
+
+/* ****************************** */
+/*           STATIC API           */
+/* ****************************** */
+
+bool TileMetadataGenerator::has_min_max_metadata(
+    const Datatype type,
+    const bool is_dim,
+    const bool var_size,
+    const uint64_t cell_val_num) {
+  // No mix max for dims, we have rtrees.
+  if (is_dim) {
+    return false;
+  }
+
+  // No min max for var size data other than strings.
+  if (var_size && type != Datatype::CHAR && type != Datatype::STRING_ASCII) {
+    return false;
+  }
+
+  // No min max for fixed cells with more than one value other than strings.
+  if (cell_val_num != 1 && type != Datatype::CHAR &&
+      type != Datatype::STRING_ASCII) {
+    return false;
+  }
+
+  // No min max for any, blob, or non ascii strings.
+  switch (type) {
+    case Datatype::ANY:
+    case Datatype::BLOB:
+    case Datatype::STRING_UTF8:
+    case Datatype::STRING_UTF16:
+    case Datatype::STRING_UTF32:
+    case Datatype::STRING_UCS2:
+    case Datatype::STRING_UCS4:
+      return false;
+
+    default:
+      return true;
+  }
+}
+
+bool TileMetadataGenerator::has_sum_metadata(
+    const Datatype type, const bool var_size, const uint64_t cell_val_num) {
+  // No sum for var sized attributes or cells with more than one value.
+  if (var_size || cell_val_num != 1)
+    return false;
+
+  // No sum for any, blob, or non ascii strings.
+  switch (type) {
+    case Datatype::ANY:
+    case Datatype::BLOB:
+    case Datatype::STRING_UTF8:
+    case Datatype::STRING_UTF16:
+    case Datatype::STRING_UTF32:
+    case Datatype::STRING_UCS2:
+    case Datatype::STRING_UCS4:
+    case Datatype::STRING_ASCII:
+      return false;
+
+    default:
+      return true;
+  }
+}
+
+template <class T>
+const std::tuple<void*, void*> TileMetadataGenerator::min_max(
+    const Tile* tile, const uint64_t cell_size) {
+  assert(tile != nullptr);
+
+  // Initialize defaults.
+  void* min = (void*)&metadata_generator_type_data<T>::min;
+  void* max = (void*)&metadata_generator_type_data<T>::max;
+
+  // Get pointer to the data and cell num.
+  auto values = static_cast<T*>(tile->buffer()->data());
+  auto cell_num = tile->buffer()->size() / cell_size;
+
+  // Process cell by cell.
+  for (uint64_t c = 0; c < cell_num; c++) {
+    min = *static_cast<T*>(min) < values[c] ? min : &values[c];
+    max = *static_cast<T*>(max) > values[c] ? max : &values[c];
+  }
+
+  return {min, max};
+}
+
+template <>
+const std::tuple<void*, void*> TileMetadataGenerator::min_max<char>(
+    const Tile* tile, const uint64_t cell_size) {
+  assert(tile != nullptr);
+
+  // For strings, return null for empty tiles.
+  auto size = tile->buffer()->size();
+  if (size == 0)
+    return {nullptr, nullptr};
+
+  // Get pointer to the data, set the min max to the first value.
+  auto data = (char*)tile->buffer()->data();
+  void* min = data;
+  void* max = data;
+
+  // Process all cells, starting at the second value.
+  auto value = data + cell_size;
+  auto cell_num = size / cell_size;
+  for (uint64_t c = 1; c < cell_num; c++) {
+    min = strncmp((const char*)min, (const char*)value, size) > 0 ? value : min;
+    max = strncmp((const char*)max, (const char*)value, size) < 0 ? value : max;
+    value += cell_size;
+  }
+
+  return {min, max};
+}
+
+template <class T>
+const std::tuple<void*, void*, uint64_t>
+TileMetadataGenerator::min_max_nullable(
+    const Tile* tile, const Tile* tile_validity, const uint64_t cell_size) {
+  assert(tile != nullptr);
+
+  // Initialize defaults.
+  void* min = (void*)&metadata_generator_type_data<T>::min;
+  void* max = (void*)&metadata_generator_type_data<T>::max;
+  uint64_t null_count = 0;
+
+  // Get pointers to the data and cell num.
+  auto values = static_cast<T*>(tile->buffer()->data());
+  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
+  auto cell_num = tile->buffer()->size() / cell_size;
+
+  // Process cell by cell.
+  for (uint64_t c = 0; c < cell_num; c++) {
+    const bool is_null = validity_values[c] == 0;
+    min = (is_null || (*static_cast<T*>(min) < values[c])) ? min : &values[c];
+    max = (is_null || (*static_cast<T*>(max) > values[c])) ? max : &values[c];
+    null_count += is_null;
+  }
+
+  return {min, max, null_count};
+}
+
+template <>
+const std::tuple<void*, void*, uint64_t>
+TileMetadataGenerator::min_max_nullable<char>(
+    const Tile* tile, const Tile* tile_validity, const uint64_t cell_size) {
+  assert(tile != nullptr);
+
+  // Initialize to null.
+  void* min = nullptr;
+  void* max = nullptr;
+  uint64_t null_count = 0;
+
+  // Get pointers to the data and cell num.
+  auto value = (char*)tile->buffer()->data();
+  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
+  auto cell_num = tile->buffer()->size() / cell_size;
+
+  // Process cell by cell.
+  for (uint64_t c = 0; c < cell_num; c++) {
+    const bool is_null = validity_values[c] == 0;
+    min =
+        !is_null &&
+                (min == nullptr ||
+                 strncmp((const char*)min, (const char*)value, cell_size) > 0) ?
+            value :
+            min;
+    max =
+        !is_null &&
+                (max == nullptr ||
+                 strncmp((const char*)max, (const char*)value, cell_size) < 0) ?
+            value :
+            max;
+    value += cell_size;
+    null_count += is_null;
+  }
+
+  return {min, max, null_count};
+}
+
+/* ****************************** */
+/*   CONSTRUCTORS & DESTRUCTORS   */
+/* ****************************** */
+
+TileMetadataGenerator::TileMetadataGenerator(
+    const Datatype type,
+    const bool is_dim,
+    const bool var_size,
+    const uint64_t cell_size,
+    const uint64_t cell_val_num)
+    : type_(type)
+    , min_(nullptr)
+    , min_size_(0)
+    , max_(nullptr)
+    , max_size_(0)
+    , null_count_(0)
+    , cell_size_(cell_size) {
+  has_min_max_ = has_min_max_metadata(type, is_dim, var_size, cell_val_num);
+  has_sum_ = has_sum_metadata(type, var_size, cell_val_num);
+
+  sum_.resize(sizeof(uint64_t));
+}
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+std::tuple<
+    const void*,
+    uint64_t,
+    const void*,
+    uint64_t,
+    const ByteVec*,
+    uint64_t>
+TileMetadataGenerator::metadata() const {
+  return {min_, min_size_, max_, max_size_, &sum_, null_count_};
+}
+
+void TileMetadataGenerator::process_tile(
+    Tile* tile, Tile* tile_var, Tile* tile_validity) {
+  min_ = nullptr;
+  min_size_ = 0;
+  max_ = nullptr;
+  max_size_ = 0;
+  null_count_ = 0;
+
+  if (tile_var == nullptr) {
+    // Switch depending on datatype.
+    switch (type_) {
+      case Datatype::INT8:
+        process_tile<int8_t>(tile, tile_validity);
+        break;
+      case Datatype::INT16:
+        process_tile<int16_t>(tile, tile_validity);
+        break;
+      case Datatype::INT32:
+        process_tile<int32_t>(tile, tile_validity);
+        break;
+      case Datatype::INT64:
+        process_tile<int64_t>(tile, tile_validity);
+        break;
+      case Datatype::UINT8:
+        process_tile<uint8_t>(tile, tile_validity);
+        break;
+      case Datatype::UINT16:
+        process_tile<uint16_t>(tile, tile_validity);
+        break;
+      case Datatype::UINT32:
+        process_tile<uint32_t>(tile, tile_validity);
+        break;
+      case Datatype::UINT64:
+        process_tile<uint64_t>(tile, tile_validity);
+        break;
+      case Datatype::FLOAT32:
+        process_tile<float>(tile, tile_validity);
+        break;
+      case Datatype::FLOAT64:
+        process_tile<double>(tile, tile_validity);
+        break;
+      case Datatype::DATETIME_YEAR:
+      case Datatype::DATETIME_MONTH:
+      case Datatype::DATETIME_WEEK:
+      case Datatype::DATETIME_DAY:
+      case Datatype::DATETIME_HR:
+      case Datatype::DATETIME_MIN:
+      case Datatype::DATETIME_SEC:
+      case Datatype::DATETIME_MS:
+      case Datatype::DATETIME_US:
+      case Datatype::DATETIME_NS:
+      case Datatype::DATETIME_PS:
+      case Datatype::DATETIME_FS:
+      case Datatype::DATETIME_AS:
+      case Datatype::TIME_HR:
+      case Datatype::TIME_MIN:
+      case Datatype::TIME_SEC:
+      case Datatype::TIME_MS:
+      case Datatype::TIME_US:
+      case Datatype::TIME_NS:
+      case Datatype::TIME_PS:
+      case Datatype::TIME_FS:
+      case Datatype::TIME_AS:
+        process_tile<int64_t>(tile, tile_validity);
+        break;
+      case Datatype::STRING_ASCII:
+        process_tile<char>(tile, tile_validity);
+        break;
+      default:
+        break;
+    }
+  } else {
+    process_tile_var(tile, tile_var, tile_validity);
+  }
+}
+
+/* ****************************** */
+/*        PRIVATE METHODS         */
+/* ****************************** */
+
+template <class T>
+void TileMetadataGenerator::process_tile(Tile* tile, Tile* tile_validity) {
+  assert(tile != nullptr);
+  min_size_ = max_size_ = cell_size_;
+
+  // Fixed size attribute, non nullable
+  if (tile_validity == nullptr) {
+    if (has_min_max_) {
+      auto&& [min, max] = min_max<T>(tile, cell_size_);
+      min_ = min;
+      max_ = max;
+    }
+
+    if (has_sum_) {
+      sum_ =
+          Sum<T, typename metadata_generator_type_data<T>::sum_type>::sum(tile);
+    }
+  } else {  // Fixed size attribute, nullable.
+    auto validity_value =
+        static_cast<uint8_t*>(tile_validity->buffer()->data());
+    if (has_min_max_) {
+      auto&& [min, max, nc] =
+          min_max_nullable<T>(tile, tile_validity, cell_size_);
+      min_ = min;
+      max_ = max;
+      null_count_ = nc;
+    } else {
+      auto cell_num = tile->buffer()->size() / cell_size_;
+      for (uint64_t c = 0; c < cell_num; c++) {
+        auto is_null = *validity_value == 0;
+        null_count_ += (uint64_t)is_null;
+        validity_value++;
+      }
+    }
+
+    if (has_sum_) {
+      sum_ = Sum<T, typename metadata_generator_type_data<T>::sum_type>::
+          sum_nullable(tile, tile_validity);
+    }
+  }
+}
+
+void TileMetadataGenerator::process_tile_var(
+    Tile* tile, Tile* tile_var, Tile* tile_validity) {
+  assert(tile != nullptr);
+  assert(tile_var != nullptr);
+
+  // Handle empty tile.
+  if (!has_min_max_ || tile->buffer()->size() == 0) {
+    return;
+  }
+
+  // Get pointers to the data and cell num.
+  auto offset_value = static_cast<uint64_t*>(tile->buffer()->data());
+  auto var_data = static_cast<char*>(tile_var->buffer()->data());
+  auto cell_num = tile->buffer()->size() / constants::cell_var_offset_size;
+
+  // Var size attribute, non nullable.
+  if (tile_validity == nullptr) {
+    offset_value++;
+    min_ = var_data;
+    max_ = var_data;
+    min_size_ = max_size_ =
+        cell_num == 1 ? tile_var->buffer()->size() : *offset_value;
+
+    for (uint64_t c = 1; c < cell_num; c++) {
+      auto value = var_data + *offset_value;
+      auto size = c == cell_num - 1 ?
+                      tile_var->buffer()->size() - *offset_value :
+                      offset_value[1] - *offset_value;
+      min_max_var(value, size);
+      offset_value++;
+    }
+  } else {  // Var size attribute, nullable.
+    auto validity_value =
+        static_cast<uint8_t*>(tile_validity->buffer()->data());
+
+    for (uint64_t c = 0; c < cell_num; c++) {
+      auto is_null = *validity_value == 0;
+      if (!is_null) {
+        auto value = var_data + *offset_value;
+        auto size = c == cell_num - 1 ?
+                        tile_var->buffer()->size() - *offset_value :
+                        offset_value[1] - *offset_value;
+        if (min_ == nullptr && max_ == nullptr) {
+          min_ = value;
+          max_ = value;
+          min_size_ = size;
+          max_size_ = size;
+        } else {
+          min_max_var(value, size);
+        }
+      }
+      offset_value++;
+
+      null_count_ += (uint64_t)is_null;
+      validity_value++;
+    }
+  }
+}
+
+inline void TileMetadataGenerator::min_max_var(
+    const char* value, const uint64_t size) {
+  assert(value != nullptr);
+
+  // Process min.
+  size_t min_size = std::min<size_t>(min_size_, size);
+  int cmp = strncmp(static_cast<const char*>(min_), value, min_size);
+  if (cmp != 0) {
+    if (cmp > 0) {
+      min_ = value;
+      min_size_ = size;
+    }
+  } else {
+    if (size < min_size_) {
+      min_ = value;
+      min_size_ = size;
+    }
+  }
+
+  // Process max.
+  min_size = std::min<size_t>(max_size_, size);
+  cmp = strncmp(static_cast<const char*>(max_), value, min_size);
+  if (cmp != 0) {
+    if (cmp < 0) {
+      max_ = value;
+      max_size_ = size;
+    }
+  } else {
+    if (size > max_size_) {
+      max_ = value;
+      max_size_ = size;
+    }
+  }
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/tile/tile_metadata_generator.h
+++ b/tiledb/sm/tile/tile_metadata_generator.h
@@ -1,0 +1,303 @@
+/**
+ * @file   tile_metadata_generator.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class TileMetadataGenerator.
+ */
+
+#ifndef TILEDB_TILE_METADATA_GENERATOR_H
+#define TILEDB_TILE_METADATA_GENERATOR_H
+
+#include "tiledb/sm/tile/tile.h"
+
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/misc/types.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * Sum structure used to bind a type and sum type to a sum and sum_nullable
+ * functions.
+ */
+template <typename T, typename SUM_T>
+struct Sum {
+  /**
+   * Compute the sum of a tile.
+   *
+   * @param tile Fixed data tile.
+   */
+  static ByteVec sum(Tile* tile);
+
+  /**
+   * Compute the sum of a nullable tile.
+   *
+   * @param tile Fixed data tile.
+   * @param tile_validity Validity tile.
+   */
+  static ByteVec sum_nullable(Tile* tile, Tile* tile_validity);
+
+  constexpr static T min = std::numeric_limits<T>::max();
+  constexpr static T max = std::numeric_limits<T>::lowest();
+};
+
+/**
+ * Specialization of the sum struct for int64_t sums.
+ */
+template <typename T>
+struct Sum<T, int64_t> {
+  static ByteVec sum(Tile* tile);
+  static ByteVec sum_nullable(Tile* tile, Tile* tile_validity);
+};
+
+/**
+ * Specialization of the sum struct for uint64_t sums.
+ */
+template <typename T>
+struct Sum<T, uint64_t> {
+  static ByteVec sum(Tile* tile);
+  static ByteVec sum_nullable(Tile* tile, Tile* tile_validity);
+};
+
+/**
+ * Specialization of the sum struct for double sums.
+ */
+template <typename T>
+struct Sum<T, double> {
+  static ByteVec sum(Tile* tile);
+  static ByteVec sum_nullable(Tile* tile, Tile* tile_validity);
+};
+
+// Declare static values to point to min/max default values.
+#define METADATA_GENERATOR_TYPE_DATA(T, SUM_T)                 \
+  template <>                                                  \
+  struct metadata_generator_type_data<T> {                     \
+    using type = T;                                            \
+    typedef SUM_T sum_type;                                    \
+    constexpr static T min = std::numeric_limits<T>::max();    \
+    constexpr static T max = std::numeric_limits<T>::lowest(); \
+  };
+
+/** Convert tiledb_datatype_t to a type. **/
+template <typename T>
+struct metadata_generator_type_data;
+
+METADATA_GENERATOR_TYPE_DATA(char, int64_t);
+METADATA_GENERATOR_TYPE_DATA(int8_t, int64_t);
+METADATA_GENERATOR_TYPE_DATA(uint8_t, uint64_t);
+METADATA_GENERATOR_TYPE_DATA(int16_t, int64_t);
+METADATA_GENERATOR_TYPE_DATA(uint16_t, uint64_t);
+METADATA_GENERATOR_TYPE_DATA(int32_t, int64_t);
+METADATA_GENERATOR_TYPE_DATA(uint32_t, uint64_t);
+METADATA_GENERATOR_TYPE_DATA(int64_t, int64_t);
+METADATA_GENERATOR_TYPE_DATA(uint64_t, uint64_t);
+METADATA_GENERATOR_TYPE_DATA(float, double);
+METADATA_GENERATOR_TYPE_DATA(double, double);
+
+/**
+ * Generate metadata for a tile using the tile, tile var, and tile validity.
+ */
+class TileMetadataGenerator {
+ public:
+  /* ****************************** */
+  /*           STATIC API           */
+  /* ****************************** */
+
+  /**
+   * Does this datatype have min/max metadata.
+   *
+   * @param type Data type.
+   * @param is_dim Is it a dimension.
+   * @param var_size Is the attribute var size.
+   * @param cell_val_num Number of values per cell.
+   * @return bool.
+   */
+  static bool has_min_max_metadata(
+      const Datatype type,
+      const bool is_dim,
+      const bool var_size,
+      const uint64_t cell_val_num);
+
+  /**
+   * Does this datatype have sum metadata.
+   *
+   * @param type Data type.
+   * @param var_size Is the attribute/dimension var size?
+   * @param cell_val_num Number of values per cell.
+   *
+   * @return bool.
+   */
+  static bool has_sum_metadata(
+      const Datatype type, const bool var_size, const uint64_t cell_val_num);
+
+  /**
+   * Returns the min and max of a fixed data tile.
+   *
+   * @param type_data Type data struct.
+   * @param tile Tile to process.
+   * @param cell_size Cell size.
+   *
+   * @return minimum, maximum.
+   */
+  template <class T>
+  static const std::tuple<void*, void*> min_max(
+      const Tile* tile, const uint64_t cell_size);
+
+  /**
+   * Returns the min and max of a fixed data tile with nullable values.
+   *
+   * @param type_data Type data struct.
+   * @param tile Tile to process.
+   * @param tile_validity Validity tile.
+   * @param cell_size Cell size.
+   *
+   * @return minimum, maximum, null count.
+   */
+  template <class T>
+  static const std::tuple<void*, void*, uint64_t> min_max_nullable(
+      const Tile* tile, const Tile* tile_validity, const uint64_t cell_size);
+
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * @param type Data type.
+   * @param is_dim Is it a dimension.
+   * @param var_size Is the attribute/dimension var size?
+   * @param cell_size Cell size.
+   * @param cell_val_num Number of values per cell.
+   */
+  TileMetadataGenerator(
+      const Datatype type,
+      const bool is_dim,
+      const bool var_size,
+      const uint64_t cell_size,
+      const uint64_t cell_val_num);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Returns the metadata.
+   *
+   * @return min, min_size, max, max_size, sum, null count.
+   */
+  std::tuple<
+      const void*,
+      uint64_t,
+      const void*,
+      uint64_t,
+      const ByteVec*,
+      uint64_t>
+  metadata() const;
+
+  /**
+   * Compute metatada.
+   *
+   * @param tile The fixed size tile.
+   * @param tile_var The var size tile.
+   * @param tile_validity The validity tile.
+   */
+  void process_tile(Tile* tile, Tile* tile_var, Tile* tile_validity);
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The data type. */
+  Datatype type_;
+
+  /** Minimum value for this tile. */
+  const void* min_;
+
+  /** Minimum value size for this tile. */
+  uint64_t min_size_;
+
+  /** Maximum value for this tile. */
+  const void* max_;
+
+  /** Maximum value size for this tile. */
+  uint64_t max_size_;
+
+  /** Sum of values. */
+  ByteVec sum_;
+
+  /** Count of null values. */
+  uint64_t null_count_;
+
+  /** Cell size. */
+  uint64_t cell_size_;
+
+  /** This metadata stores sums. */
+  bool has_min_max_;
+
+  /** This metadata stores sums. */
+  bool has_sum_;
+
+  /* ********************************* */
+  /*          PRIVATE METHODS          */
+  /* ********************************* */
+
+  /**
+   * Process var size attribute.
+   *
+   * @param tile The fixed size tile.
+   * @param tile_var The var size tile.
+   * @param tile_validity The validity tile.
+   */
+
+  void process_tile_var(Tile* tile, Tile* tile_var, Tile* tile_validity);
+
+  /**
+   * Process fixed size attribute.
+   *
+   * @param tile The fixed size tile.
+   * @param tile_validity The validity tile.
+   */
+  template <class T>
+  void process_tile(Tile* tile, Tile* tile_validity);
+
+  /**
+   * Min max function for var sized attributes.
+   *
+   * @param value Value to compare current min against.
+   * @param size Value size.
+   */
+  void min_max_var(const char* value, const uint64_t size);
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_TILE_METADATA_GENERATOR_H

--- a/tiledb/sm/tile/writer_tile.cc
+++ b/tiledb/sm/tile/writer_tile.cc
@@ -1,0 +1,140 @@
+/**
+ * @file   writer_tile.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class WriterTile.
+ */
+
+#include "tiledb/sm/tile/writer_tile.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*   CONSTRUCTORS & DESTRUCTORS   */
+/* ****************************** */
+
+WriterTile::WriterTile()
+    : Tile()
+    , pre_filtered_size_(0)
+    , min_size_(0)
+    , max_size_(0)
+    , null_count_(0) {
+}
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+uint64_t WriterTile::pre_filtered_size() const {
+  return pre_filtered_size_;
+}
+
+void WriterTile::set_pre_filtered_size(uint64_t pre_filtered_size) {
+  pre_filtered_size_ = pre_filtered_size;
+}
+
+void* WriterTile::min() const {
+  return (void*)min_.data();
+}
+
+void* WriterTile::max() const {
+  return (void*)max_.data();
+}
+
+std::tuple<
+    const void*,
+    uint64_t,
+    const void*,
+    uint64_t,
+    const ByteVec*,
+    uint64_t>
+WriterTile::metadata() const {
+  return {min_.data(), min_size_, max_.data(), max_size_, &sum_, null_count_};
+}
+
+void WriterTile::set_metadata(const std::tuple<
+                              const void*,
+                              uint64_t,
+                              const void*,
+                              uint64_t,
+                              const ByteVec*,
+                              uint64_t>& md) {
+  const auto& [min, min_size, max, max_size, sum, null_count] = md;
+  assert(sum != nullptr);
+
+  min_.resize(min_size);
+  min_size_ = min_size;
+  if (min != nullptr) {
+    memcpy(min_.data(), min, min_size);
+  }
+
+  max_.resize(max_size);
+  max_size_ = max_size;
+  if (max != nullptr) {
+    memcpy(max_.data(), max, max_size);
+  }
+
+  sum_ = *sum;
+  null_count_ = null_count;
+}
+
+WriterTile WriterTile::clone(bool deep_copy) const {
+  WriterTile clone;
+  clone.pre_filtered_size_ = pre_filtered_size_;
+  clone.min_ = min_;
+  clone.max_ = max_;
+  clone.sum_ = sum_;
+  clone.null_count_ = null_count_;
+  clone.cell_size_ = cell_size_;
+  clone.dim_num_ = dim_num_;
+  clone.format_version_ = format_version_;
+  clone.type_ = type_;
+  clone.filtered_buffer_ = filtered_buffer_;
+
+  if (deep_copy) {
+    clone.owns_buffer_ = owns_buffer_;
+    if (owns_buffer_ && buffer_ != nullptr) {
+      clone.buffer_ = tdb_new(Buffer);
+      // Calls Buffer copy-assign, which performs a deep copy.
+      *clone.buffer_ = *buffer_;
+    } else {
+      clone.buffer_ = buffer_;
+    }
+  } else {
+    clone.owns_buffer_ = false;
+    clone.buffer_ = buffer_;
+  }
+
+  return clone;
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/tile/writer_tile.h
+++ b/tiledb/sm/tile/writer_tile.h
@@ -1,0 +1,154 @@
+/**
+ * @file   writer_tile.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class WriterTile.
+ */
+
+#ifndef TILEDB_WRITER_TILE_H
+#define TILEDB_WRITER_TILE_H
+
+#include "tiledb/sm/tile/tile.h"
+#include "tiledb/sm/tile/tile_metadata_generator.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * Handles tile information, with added data used by writer.
+ */
+class WriterTile : public Tile {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  WriterTile();
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Returns the pre-filtered size of the tile data in the buffer.
+   *
+   * @return Pre-filtered size.
+   */
+  uint64_t pre_filtered_size() const;
+
+  /**
+   * Sets the pre-filtered size value to the given value.
+   *
+   * @param pre_filtered_size Pre-filtered size.
+   */
+  void set_pre_filtered_size(uint64_t pre_filtered_size);
+
+  /**
+   * Returns the tile minimum value.
+   *
+   * @return tile minimum value.
+   */
+  void* min() const;
+
+  /**
+   * Returns the tile maximum value.
+   *
+   * @return tile maximum value.
+   * */
+  void* max() const;
+
+  /**
+   * Returns the tile metadata.
+   *
+   * @return minimum, minimum size, maximum, maximum size, sum, null count.
+   */
+  std::tuple<
+      const void*,
+      uint64_t,
+      const void*,
+      uint64_t,
+      const ByteVec*,
+      uint64_t>
+  metadata() const;
+
+  /**
+   * Sets the tile metadata.
+   *
+   * @param md minimum, minimum size, maximum, maximum size, sum, null count.
+   */
+  void set_metadata(const std::tuple<
+                    const void*,
+                    uint64_t,
+                    const void*,
+                    uint64_t,
+                    const ByteVec*,
+                    uint64_t>& md);
+
+  /**
+   * Returns a shallow or deep copy of this WriterTile.
+   *
+   * @param deep_copy If true, a deep copy is performed, including potentially
+   *    memcpying the underlying Buffer. If false, a shallow copy is performed,
+   *    which sets the clone's Buffer equal to WriterTile's buffer pointer.
+   * @return New WriterTile
+   */
+  WriterTile clone(bool deep_copy) const;
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The size in bytes of the tile data before it has been filtered. */
+  uint64_t pre_filtered_size_;
+
+  /** Minimum value for this tile. */
+  ByteVec min_;
+
+  /** Minimum value size for this tile. */
+  uint64_t min_size_;
+
+  /** Maximum value for this tile. */
+  ByteVec max_;
+
+  /** Maximum value size for this tile. */
+  uint64_t max_size_;
+
+  /** Sum of values. */
+  ByteVec sum_;
+
+  /** Count of null values. */
+  uint64_t null_count_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_WRITER_TILE_H

--- a/tools/src/commands/info_command.cc
+++ b/tools/src/commands/info_command.cc
@@ -148,16 +148,19 @@ void InfoCommand::print_tile_sizes() const {
       THROW_NOT_OK(f->load_tile_offsets(enc_key, std::move(names)));
       THROW_NOT_OK(f->load_tile_var_sizes(enc_key, name));
       for (uint64_t tile_idx = 0; tile_idx < tile_num; tile_idx++) {
-        uint64_t tile_size = 0;
-        THROW_NOT_OK(f->persisted_tile_size(name, tile_idx, &tile_size));
-        persisted_tile_size += tile_size;
+        auto&& [st, tile_size] = f->persisted_tile_size(name, tile_idx);
+        THROW_NOT_OK(st);
+        persisted_tile_size += *tile_size;
         in_memory_tile_size += f->tile_size(name, tile_idx);
         num_tiles++;
         if (var_size) {
-          THROW_NOT_OK(f->persisted_tile_var_size(name, tile_idx, &tile_size));
-          persisted_tile_size += tile_size;
-          THROW_NOT_OK(f->tile_var_size(name, tile_idx, &tile_size));
-          in_memory_tile_size += tile_size;
+          auto&& [st_var_persisted, tile_size_var_persisted] =
+              f->persisted_tile_var_size(name, tile_idx);
+          THROW_NOT_OK(st_var_persisted);
+          persisted_tile_size += *tile_size_var_persisted;
+          auto&& [st_var, tile_size_var] = f->tile_var_size(name, tile_idx);
+          THROW_NOT_OK(st_var);
+          in_memory_tile_size += *tile_size_var;
           num_tiles++;
         }
       }


### PR DESCRIPTION
This adds the min/max/sum/null count information to the written fragment
info. It also adds the reader side functionality to load and read the
min/max/sum/null count for a specific attribute. This will later enable
query condition to do faster filtering on the data and enable
aggregate functionalities.

The processing of the min/max/sum/null count for a tile is done by the
TileMetadataGenerator class, which is easily unit testable.

Implementing this change, a new WriterTile class was implemented on top
of the existing Tile class. This is so that the added per tile metadata
by the Writer doesn't affect the size of the Tile objects for the
readers. One of the existing member, pre_filtered_size_, was moved to
this new class as it's only used by the writer.

---
TYPE: IMPROVEMENT
DESC: Adding min/max/sum/null count to fragment info.
