### PR TITLE
Fixing Subarray::crop_to_tile to crop default dimensions.

### DIFF
--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -630,21 +630,19 @@ Subarray Subarray::crop_to_tile(const T* tile_coords, Layout layout) const {
     auto r_size = 2 * array_schema->dimension(d)->coord_size();
     uint64_t i = 0;
     for (size_t r = 0; r < ranges_[d].size(); ++r) {
-      if (!is_default_[d]) {
-        const auto& range = ranges_[d][r];
-        utils::geometry::overlap(
-            (const T*)range.data(),
-            &tile_subarray[2 * d],
-            1,
-            new_range,
-            &overlaps);
+      const auto& range = ranges_[d][r];
+      utils::geometry::overlap(
+          (const T*)range.data(),
+          &tile_subarray[2 * d],
+          1,
+          new_range,
+          &overlaps);
 
-        if (overlaps) {
-          ret.add_range_unsafe(d, Range(new_range, r_size));
-          ret.original_range_idx_.resize(dim_num());
-          ret.original_range_idx_[d].resize(i + 1);
-          ret.original_range_idx_[d][i++] = r;
-        }
+      if (overlaps) {
+        ret.add_range_unsafe(d, Range(new_range, r_size));
+        ret.original_range_idx_.resize(dim_num());
+        ret.original_range_idx_[d].resize(i + 1);
+        ret.original_range_idx_[d][i++] = r;
       }
     }
   }


### PR DESCRIPTION
The refactored reader is using Subarray::crop_to_tile to process every
tiles independently. When setting a range on only one dimension for a
2D array, this API wouldn't crop the other dimension as it is a default
one. This caused the refactored dense reader to try to copy data that is
outside of the tile currently processed, causing an out of bound read
for a tile. Since this API is only available to fixed data types, all
calls will have the default range filled in, so it doesn't need to skip
default dimensions when processing.

---
TYPE: IMPROVEMENT
DESC: Fixing Subarray::crop_to_tile to crop default dimensions.