### PR TITLE
Refactored dense reader: resetting the unsplittable flag on completion.

### DIFF
--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -176,6 +176,7 @@ Status DenseReader::dowork() {
         return complete_read_loop();
       }
     } else {
+      read_state_.unsplittable_ = false;
       return complete_read_loop();
     }
   } while (true);


### PR DESCRIPTION
When initially refactoring the dense reader, I got rid of this flag
reset as I didn't see how it was possible to hit the condition. The
python tests now have a case that hits this, so the flag reset needs to
be put back in. When processing partitions, the partitioner will try to
fit the data into the users buffer, and forcing the refactored dense
reader to partition until unary ranges worked fine. However, the
partitioner will also try to respect the set sm.memory_budget and when
the range is unary and still cannot fit into this budget, the reader
will try to process the data, but the unsplittable will be set. To allow
the query to continue, this is for now reset.

Moving forward, we might not want to continue this behavior of
processing the query when this condition occurs. This is tracked in
shortcut story #10286.

---
TYPE: IMPROVEMENT
DESC: Refactored dense reader: resetting the unsplittable flag on completion.
