### PR TITLE
When query is submitted don't recreate query strategy

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1998,8 +1998,10 @@ Status Query::submit() {
           "Error in query submission; remote array with no rest client."));
 
     array_schema_->set_array_uri(array_->array_uri());
-    RETURN_NOT_OK(create_strategy());
-    RETURN_NOT_OK(strategy_->init());
+    if (status_ == QueryStatus::UNINITIALIZED) {
+      RETURN_NOT_OK(create_strategy());
+      RETURN_NOT_OK(strategy_->init());
+    }
     return rest_client->submit_query_to_rest(array_->array_uri(), this);
   }
   RETURN_NOT_OK(init());


### PR DESCRIPTION
This is a minor bug that effected REST requests. Currently the behavior of init just setup memory budgets and basic parameters so this did not cause active problems. However the general idea of the query initialization should not be called multiple times.

---
TYPE: BUG
DESC: Only initialize REST query strategies once