### PR TITLE
Sparse unordered w dups reader: fixing max pos calculation in tile copy.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -162,6 +162,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-rtree.cc
   src/unit-s3-no-multipart.cc
   src/unit-s3.cc
+  src/unit-sparse-index-reader-base.cc
   src/unit-sparse-global-order-reader.cc
   src/unit-sparse-unordered-with-dups-reader.cc
   src/unit-status.cc

--- a/test/src/unit-sparse-index-reader-base.cc
+++ b/test/src/unit-sparse-index-reader-base.cc
@@ -1,0 +1,106 @@
+/**
+ * @file unit-sparse-index-reader-base.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for the sparse index reader base class.
+ */
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+
+#include "test/src/helpers.h"
+#include "tiledb/sm/query/sparse_index_reader_base.h"
+
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
+#include <catch.hpp>
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+/* ********************************* */
+/*                TESTS              */
+/* ********************************* */
+
+TEST_CASE(
+    "ResultTileWithBitmap: result_num_between_pos and "
+    "pos_with_given_result_sum test",
+    "[resulttilewithbitmap][pos_with_given_result_sum][pos_with_given_result_"
+    "sum]") {
+  tiledb_ctx_t* ctx = nullptr;
+  REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
+
+  tiledb_array_schema_t* array_schema;
+  int rc = tiledb_array_schema_alloc(ctx, TILEDB_SPARSE, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create dimensions and domain
+  tiledb_domain_t* domain;
+  rc = tiledb_domain_alloc(ctx, &domain);
+  REQUIRE(rc == TILEDB_OK);
+
+  int dim_domain[] = {1, 4};
+  int tile_extent = 2;
+  tiledb_dimension_t* d;
+  rc = tiledb_dimension_alloc(
+      ctx, "d", TILEDB_INT32, &dim_domain[0], &tile_extent, &d);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx, domain, d);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_dimension_free(&d);
+
+  // Set domain to schema
+  rc = tiledb_array_schema_set_domain(ctx, array_schema, domain);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_domain_free(&domain);
+
+  ResultTileWithBitmap<uint8_t> tile(0, 0, array_schema->array_schema_);
+  tile.bitmap_result_num_ = 100;
+
+  // Check the function with an empty bitmap.
+  CHECK(tile.result_num_between_pos(2, 10) == 8);
+  CHECK(tile.pos_with_given_result_sum(2, 8) == 9);
+
+  // Check the functions with a bitmap.
+  tile.bitmap_.resize(100, 1);
+  CHECK(tile.result_num_between_pos(2, 10) == 8);
+  CHECK(tile.pos_with_given_result_sum(2, 8) == 9);
+
+  tile.bitmap_result_num_ = 99;
+  tile.bitmap_[6] = 0;
+  CHECK(tile.result_num_between_pos(2, 10) == 7);
+  CHECK(tile.pos_with_given_result_sum(2, 8) == 10);
+
+  rc = tiledb_array_schema_check(ctx, array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_ctx_free(&ctx);
+}

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1046,6 +1046,14 @@ TEST_CASE_METHOD(
     CSparseUnorderedWithDupsFx,
     "Sparse unordered with dups reader: single tile query continuation",
     "[sparse-unordered-with-dups][single-tile][continuation]") {
+  bool use_subarray = false;
+  SECTION("- No subarray") {
+    use_subarray = false;
+  }
+  SECTION("- Subarray") {
+    use_subarray = true;
+  }
+
   // Create default array.
   reset_config();
   create_default_array_1d();
@@ -1066,7 +1074,7 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
   auto rc = read(
-      false,
+      use_subarray,
       false,
       coords_r,
       &coords_r_size,

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -102,7 +102,7 @@ class ResultTileWithBitmap : public ResultTile {
         bitmap_result_num_ != std::numeric_limits<uint64_t>::max() &&
         result_num != 0);
     if (bitmap_.size() == 0)
-      return result_num - 1;
+      return start_pos + result_num - 1;
 
     uint64_t sum = 0;
     for (uint64_t c = start_pos; c < bitmap_.size(); c++) {

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -657,13 +657,13 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
         if (i == result_tiles.size() - 1) {
           auto to_copy = cell_offsets[i + 1] - cell_offsets[i];
 
-          // No bitmap, just use the cell offsets. Otherwise, we need to count
-          // cells if the tile is not fully copied.
+          // No bitmap, just use the cell offsets. Otherwise, we need to check
+          // the bitmap to determine the max.
           if (rt->bitmap_result_num_ == std::numeric_limits<uint64_t>::max()) {
             max_pos_tile = min_pos_tile + to_copy;
-          } else if (rt->bitmap_result_num_ != min_pos_tile + to_copy) {
+          } else {
             max_pos_tile =
-                rt->pos_with_given_result_sum(0, min_pos_tile + to_copy) + 1;
+                rt->pos_with_given_result_sum(min_pos_tile, to_copy) + 1;
           }
         }
 
@@ -988,13 +988,13 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
         if (i == result_tiles.size() - 1) {
           auto to_copy = cell_offsets[i + 1] - cell_offsets[i];
 
-          // No bitmap, just use the cell offsets. Otherwise, we need to count
-          // cells if the tile is not fully copied.
+          // No bitmap, just use the cell offsets. Otherwise, we need to check
+          // the bitmap to determine the max.
           if (rt->bitmap_result_num_ == std::numeric_limits<uint64_t>::max()) {
             max_pos_tile = min_pos_tile + to_copy;
-          } else if (rt->bitmap_result_num_ != min_pos_tile + to_copy) {
+          } else {
             max_pos_tile =
-                rt->pos_with_given_result_sum(0, min_pos_tile + to_copy) + 1;
+                rt->pos_with_given_result_sum(min_pos_tile, to_copy) + 1;
           }
         }
 

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -94,6 +94,10 @@ bool SparseUnorderedWithDupsReader<BitmapType>::incomplete() const {
 template <class BitmapType>
 QueryStatusDetailsReason
 SparseUnorderedWithDupsReader<BitmapType>::status_incomplete_reason() const {
+  // Returning early for deserialized incomplete queries.
+  if (result_tiles_.empty())
+    return QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE;
+
   if (!incomplete())
     return QueryStatusDetailsReason::REASON_NONE;
 


### PR DESCRIPTION
Continuing on #2824, there was still an issue with the calculation for
tile continuation in copy tiles. In dev, this was masked because
pos_with_given_result_sum was changed to allow asking for a  result sum
that was out of bound and return the max position of the tile.

Also in dev, there is still a bug for the following corner case: a
query ends on the last tile, but cannot copy it. Continuation goes and
the last partial tile still cannot fit in the user buffers and needs to
be split again. This will give incorrect results.

In 2.6, this would return max uint64 for the position and would crash.

Finally, this also fixes the deserialized query on the client size, coming
back from the server, the query doesn't have any result tiles so 
status_incomplete_reason would segfault trying to call result_tiles_[0].

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w dups reader: fixing max pos calculation in tile copy.
