### PR TITLE
Propagate errors from compute_non_empty_domain

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -787,12 +787,12 @@ Status Array::metadata(Metadata** metadata) {
   return Status::Ok();
 }
 
-const NDRange& Array::non_empty_domain() {
+std::tuple<Status, std::optional<const NDRange>> Array::non_empty_domain() {
   if (!non_empty_domain_computed_) {
     // Compute non-empty domain
-    compute_non_empty_domain();
+    RETURN_NOT_OK_TUPLE(compute_non_empty_domain(), std::nullopt);
   }
-  return non_empty_domain_;
+  return {Status::Ok(), non_empty_domain_};
 }
 
 void Array::set_non_empty_domain(const NDRange& non_empty_domain) {

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -342,7 +342,7 @@ class Array {
    *  If the non_empty_domain has not been computed or loaded
    *  it will be loaded first
    * */
-  const NDRange& non_empty_domain();
+  std::tuple<Status, std::optional<const NDRange>> non_empty_domain();
 
   /** Returns the non-empty domain of the opened array. */
   void set_non_empty_domain(const NDRange& non_empty_domain);

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1066,8 +1066,12 @@ Status StorageManager::array_get_non_empty_domain(
     return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array not opened for reads"));
 
-  *domain = array->non_empty_domain();
-  *is_empty = domain->empty();
+  auto&& [st, domain_opt] = array->non_empty_domain();
+  RETURN_NOT_OK(st);
+  if (domain_opt.has_value()) {
+    *domain = domain_opt.value();
+    *is_empty = domain->empty();
+  }
 
   return Status::Ok();
 }


### PR DESCRIPTION
This adjust the calls for `Array::non_empty_domain()` to handle catching any errors that come from `Array::compute_non_empty_domain()`. This is a followup from #2766 

---
TYPE: IMPROVEMENT
DESC: Improve error handling for Array non empty domain calls.
