### PR TITLE
Don't assert on rest.ignore_ssl_validation config

### DIFF
--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -304,7 +304,6 @@ Status Curl::init(
   bool found;
   RETURN_NOT_OK(config_->get<bool>(
       "rest.ignore_ssl_validation", &ignore_ssl_validation, &found));
-  assert(found);
 
   if (ignore_ssl_validation) {
     curl_easy_setopt(curl_.get(), CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
This configuration is optional and if its not set, we assume a default of false. This was the existing behavior from before PR #2703 in which the assert was added.

---
TYPE: NO_HISTORY
DESC: NO_HISTORY
