### PR TITLE
Remove windows VS2017 infavor of 2019 in CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2016]
+        os: [windows-2019]
         #considering https://stackoverflow.com/questions/65035256/how-to-access-matrix-variables-in-github-actions
         environ: [azure, s3, serialization]
         include:
@@ -107,13 +107,7 @@ jobs:
           cd $env:BUILD_BUILDDIRECTORY
 
           $VSCategory = "Enterprise" # alternate 'Community'
-          if ($env:TILEDB_GA_IMAGE_NAME -eq "windows-2016") {
-            if (!(Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2017\${VSCategory}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin")) {
-              Write-Host "ERROR***: Missing C:\Program Files (x86)\Microsoft Visual Studio\2017\${VSCategory}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-              exit $LastExitCode
-            }
-            $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\${VSCategory}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-          } elseif ($env:TILEDB_GA_IMAGE_NAME -eq "windows-2019") {
+          if ($env:TILEDB_GA_IMAGE_NAME -eq "windows-2019") {
             if (!(Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\${VSCategory}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin")) {
               Write-Host "ERROR***: Missing C:\Program Files (x86)\Microsoft Visual Studio\2019\${VSCategory}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
               exit $LastExitCode

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,8 +116,8 @@ stages:
      - job: Windows
        strategy:
          matrix:
-           VS2017:
-             imageName: 'vs2017-win2016'
+           VS2019:
+             imageName: 'windows-2019'
              # Only S3 variable is currently supported in boostrap powershell
              TILEDB_GCS: OFF
              TILEDB_HDFS: OFF

--- a/scripts/azure-windows-release.yml
+++ b/scripts/azure-windows-release.yml
@@ -12,11 +12,16 @@ steps:
     mkdir $env:AGENT_BUILDDIRECTORY\build
     cd $env:AGENT_BUILDDIRECTORY\build
 
-    if ($env:imageName -eq "vs2017-win2016") {
-      $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+    if ($env:imageName -eq "windows-2019") {
+      $VSCategory = "Enterprise" # alternate 'Community'
+      if (!(Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\${VSCategory}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin")) {
+        Write-Host "ERROR***: Missing C:\Program Files (x86)\Microsoft Visual Studio\2019\${VSCategory}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+        $host.SetShouldExit(2)
+      }
+      $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\${VSCategory}\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
     } else {
       Write-Host "Unknown image name: '$($env:imageName)'"
-      $host.SetShouldExit(1)
+      $host.SetShouldExit(3)
     }
 
     $bootstrapOptions = "-EnableVerbose -EnableStaticTileDB -EnableBuildDeps"


### PR DESCRIPTION
This affects CI testing and release artifact building.


---
TYPE: DEPRECATION
DESC: Drop support for Visual Studio 2017 compiler
