### PR TITLE
Global writes: writting bad validity values when coordinates are dups.

### DIFF
--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -1861,13 +1861,14 @@ Status Writer::prepare_full_tiles_fixed(
     }
   } else {
     for (; cell_idx < cell_num; ++cell_idx) {
-      if (coord_dups.find(cell_idx) == coord_dups.end())
+      if (coord_dups.find(cell_idx) == coord_dups.end()) {
         RETURN_NOT_OK(
             last_tile.write(buffer + cell_idx * cell_size, cell_size));
-      if (nullable) {
-        RETURN_NOT_OK(last_tile_validity.write(
-            buffer_validity + cell_idx * constants::cell_validity_size,
-            constants::cell_validity_size));
+        if (nullable) {
+          RETURN_NOT_OK(last_tile_validity.write(
+              buffer_validity + cell_idx * constants::cell_validity_size,
+              constants::cell_validity_size));
+        }
       }
     }
   }


### PR DESCRIPTION
While working on another PR, I noticed an if statement with no brackets
is causing a bug in the writer. This will write invalid validity tiles
when there are duplicates coordinates and we are writting in global
order by the validity cell of duplicate coordinates when it shouldn't.
It will only happen on fixed size attributes.

---
TYPE: IMPROVEMENT
DESC: Global writes: writting bad validity values when coordinates are dups.
