### PR TITLE
Avoid std::future in S3 multipart upload

### DIFF
--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -436,20 +436,36 @@ class S3 {
    */
   struct MakeUploadPartCtx {
     /** Constructor. */
+    MakeUploadPartCtx()
+        : upload_part_num(0){};
     MakeUploadPartCtx(
-        Aws::S3::Model::UploadPartOutcomeCallable&&
-            in_upload_part_outcome_callable,
+        Aws::S3::Model::UploadPartOutcome&& in_upload_part_outcome,
         const int in_upload_part_num)
-        : upload_part_outcome_callable(
-              std::move(in_upload_part_outcome_callable))
+        : upload_part_outcome(std::move(in_upload_part_outcome))
         , upload_part_num(in_upload_part_num) {
     }
 
+    /** Move Constructor */
+    MakeUploadPartCtx(MakeUploadPartCtx&& other) noexcept {
+      this->upload_part_outcome = std::move(other.upload_part_outcome);
+      this->upload_part_num = other.upload_part_num;
+    }
+
+    /** Move assignment operator */
+    MakeUploadPartCtx& operator=(MakeUploadPartCtx&& other) {
+      this->upload_part_outcome = std::move(other.upload_part_outcome);
+      this->upload_part_num = other.upload_part_num;
+      return *this;
+    }
+
+    /** Copy Constructor **/
+    MakeUploadPartCtx(const MakeUploadPartCtx& other) = delete;
+
     /** The AWS future to wait on for a pending upload part request. */
-    Aws::S3::Model::UploadPartOutcomeCallable upload_part_outcome_callable;
+    Aws::S3::Model::UploadPartOutcome upload_part_outcome;
 
     /** The part number of the pending upload part request. */
-    const int upload_part_num;
+    int upload_part_num;
   };
 
   /** Contains all state associated with a multipart upload transaction. */


### PR DESCRIPTION
This solves a deadlock that can occur when all cores get blocked on waiting for the std::future get() call leading to thread starvation.

---
TYPE: BUG
DESC: Avoid thread starvation by removing std::future usage in S3 multipart upload