### PR TITLE
Removing Buffer from Tile.

### DIFF
--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -100,6 +100,7 @@ unique_ptr_exceptions = {
     "*": ["tdb_unique_ptr", "tiledb_unique_ptr"],
     "zstd_compressor.h": ["std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx_;", "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx_;"],
     "curl.h": ["std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>"],
+    "tile.h": ["std::unique_ptr<char, void (*)(void*)> data_;"],
 }
 
 

--- a/test/src/unit-DenseTiler.cc
+++ b/test/src/unit-DenseTiler.cc
@@ -174,7 +174,7 @@ template <class T>
 bool DenseTilerFx::check_tile(Tile* tile, const std::vector<T>& data) {
   std::vector<T> tile_data(data.size());
   CHECK(tile->size() == data.size() * sizeof(T));
-  CHECK(tile->read(&tile_data[0], data.size() * sizeof(T)).ok());
+  CHECK(tile->read(&tile_data[0], 0, data.size() * sizeof(T)).ok());
   CHECK(tile_data == data);
   return tile_data == data;
 }
@@ -390,7 +390,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
+  WriterTile tile1_0;
   CHECK(!tiler1.get_tile(0, "foo", &tile1_0).ok());
   CHECK(!tiler1.get_tile(10, "a", &tile1_0).ok());
   CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
@@ -398,7 +398,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
+  WriterTile tile1_1;
   CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
   std::vector<int32_t> c_data1_1 = {
       4, fill_value, fill_value, fill_value, fill_value};
@@ -419,7 +419,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2;
+  WriterTile tile2;
   CHECK(tiler2.get_tile(0, "a", &tile2).ok());
   std::vector<int32_t> c_data2 = {fill_value, 1, 2, 3, 4};
   CHECK(check_tile<int32_t>(&tile2, c_data2));
@@ -439,7 +439,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3;
+  WriterTile tile3;
   CHECK(tiler3.get_tile(0, "a", &tile3).ok());
   std::vector<int32_t> c_data3 = {fill_value, 1, 2, 3, 4};
   CHECK(check_tile<int32_t>(&tile3, c_data3));
@@ -484,7 +484,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
+  WriterTile tile1_0;
   CHECK(!tiler1.get_tile(0, "foo", &tile1_0).ok());
   CHECK(!tiler1.get_tile(10, "a", &tile1_0).ok());
   CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
@@ -492,7 +492,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
+  WriterTile tile1_1;
   CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
   std::vector<int32_t> c_data1_1 = {
       4, fill_value, fill_value, fill_value, fill_value};
@@ -538,7 +538,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
+  WriterTile tile1_0;
   CHECK(!tiler1.get_tile(0, "foo", &tile1_0).ok());
   CHECK(!tiler1.get_tile(10, "a", &tile1_0).ok());
   CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
@@ -546,7 +546,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
+  WriterTile tile1_1;
   CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
   std::vector<int32_t> c_data1_1 = {
       4, fill_value, fill_value, fill_value, fill_value};
@@ -1365,7 +1365,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
+  WriterTile tile1_0;
   CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
   std::vector<int32_t> c_data1_0(50);
   for (int i = 0; i <= 36; ++i)
@@ -1379,7 +1379,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
+  WriterTile tile1_1;
   CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
   std::vector<int32_t> c_data1_1(50);
   for (int i = 0; i <= 29; ++i)
@@ -1395,7 +1395,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
 
   // Test get tile 2
-  Tile tile1_2;
+  WriterTile tile1_2;
   CHECK(tiler1.get_tile(2, "a", &tile1_2).ok());
   std::vector<int32_t> c_data1_2(50);
   for (int i = 0; i <= 6; ++i)
@@ -1407,7 +1407,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_2, c_data1_2));
 
   // Test get tile 3
-  Tile tile1_3;
+  WriterTile tile1_3;
   CHECK(tiler1.get_tile(3, "a", &tile1_3).ok());
   std::vector<int32_t> c_data1_3(50);
   for (int i = 0; i <= 1; ++i)
@@ -1435,7 +1435,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0;
+  WriterTile tile2_0;
   CHECK(tiler2.get_tile(0, "a", &tile2_0).ok());
   std::vector<int32_t> c_data2_0(50);
   for (int i = 0; i <= 21; ++i)
@@ -1473,7 +1473,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3_0;
+  WriterTile tile3_0;
   CHECK(tiler3.get_tile(0, "a", &tile3_0).ok());
   std::vector<int32_t> c_data3_0(50);
   for (int i = 0; i <= 36; ++i)
@@ -1487,7 +1487,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile3_0, c_data3_0));
 
   // Test get tile 1
-  Tile tile3_1;
+  WriterTile tile3_1;
   CHECK(tiler3.get_tile(1, "a", &tile3_1).ok());
   std::vector<int32_t> c_data3_1(50);
   for (int i = 0; i <= 29; ++i)
@@ -1503,7 +1503,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile3_1, c_data3_1));
 
   // Test get tile 2
-  Tile tile3_2;
+  WriterTile tile3_2;
   CHECK(tiler3.get_tile(2, "a", &tile3_2).ok());
   std::vector<int32_t> c_data3_2(50);
   for (int i = 0; i <= 6; ++i)
@@ -1515,7 +1515,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile3_2, c_data3_2));
 
   // Test get tile 3
-  Tile tile3_3;
+  WriterTile tile3_3;
   CHECK(tiler3.get_tile(3, "a", &tile3_3).ok());
   std::vector<int32_t> c_data3_3(50);
   for (int i = 0; i <= 1; ++i)
@@ -1543,7 +1543,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile4_0;
+  WriterTile tile4_0;
   CHECK(tiler4.get_tile(0, "a", &tile4_0).ok());
   std::vector<int32_t> c_data4_0(50);
   for (int i = 0; i <= 21; ++i)
@@ -1607,7 +1607,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
+  WriterTile tile1_0;
   CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
   std::vector<int32_t> c_data1_0(50);
   for (int i = 0; i <= 37; ++i)
@@ -1625,7 +1625,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
+  WriterTile tile1_1;
   CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
   std::vector<int32_t> c_data1_1(50);
   for (int i = 0; i <= 34; ++i)
@@ -1642,7 +1642,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
 
   // Test get tile 2
-  Tile tile1_2;
+  WriterTile tile1_2;
   CHECK(tiler1.get_tile(2, "a", &tile1_2).ok());
   std::vector<int32_t> c_data1_2(50);
   for (int i = 0; i <= 2; ++i)
@@ -1658,7 +1658,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_2, c_data1_2));
 
   // Test get tile 3
-  Tile tile1_3;
+  WriterTile tile1_3;
   CHECK(tiler1.get_tile(3, "a", &tile1_3).ok());
   std::vector<int32_t> c_data1_3(50);
   c_data1_3[0] = 14;
@@ -1688,7 +1688,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0;
+  WriterTile tile2_0;
   CHECK(tiler2.get_tile(0, "a", &tile2_0).ok());
   std::vector<int32_t> c_data2_0(50);
   for (int i = 0; i <= 11; ++i)
@@ -1744,7 +1744,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3_0;
+  WriterTile tile3_0;
   CHECK(tiler3.get_tile(0, "a", &tile3_0).ok());
   std::vector<int32_t> c_data3_0(50);
   for (int i = 0; i <= 37; ++i)
@@ -1762,7 +1762,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile3_0, c_data3_0));
 
   // Test get tile 1
-  Tile tile3_1;
+  WriterTile tile3_1;
   CHECK(tiler3.get_tile(1, "a", &tile3_1).ok());
   std::vector<int32_t> c_data3_1(50);
   for (int i = 0; i <= 34; ++i)
@@ -1779,7 +1779,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile3_1, c_data3_1));
 
   // Test get tile 2
-  Tile tile3_2;
+  WriterTile tile3_2;
   CHECK(tiler3.get_tile(2, "a", &tile3_2).ok());
   std::vector<int32_t> c_data3_2(50);
   for (int i = 0; i <= 2; ++i)
@@ -1795,7 +1795,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile3_2, c_data3_2));
 
   // Test get tile 3
-  Tile tile3_3;
+  WriterTile tile3_3;
   CHECK(tiler3.get_tile(3, "a", &tile3_3).ok());
   std::vector<int32_t> c_data3_3(50);
   c_data3_3[0] = 14;
@@ -1825,7 +1825,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile4_0;
+  WriterTile tile4_0;
   CHECK(tiler4.get_tile(0, "a", &tile4_0).ok());
   std::vector<int32_t> c_data4_0(50);
   for (int i = 0; i <= 11; ++i)
@@ -1910,7 +1910,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
+  WriterTile tile1_0;
   CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
   std::vector<int32_t> c_data1_0(50);
   for (int i = 0; i <= 29; ++i)
@@ -1920,7 +1920,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
+  WriterTile tile1_1;
   CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
   std::vector<int32_t> c_data1_1(50);
   for (int i = 0; i <= 39; ++i)
@@ -1975,7 +1975,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
+  WriterTile tile1_0;
   CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
   std::vector<int32_t> c_data1_0(50);
   for (int i = 0; i <= 34; ++i)
@@ -1985,7 +1985,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
+  WriterTile tile1_1;
   CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
   std::vector<int32_t> c_data1_1(50);
   for (int i = 0; i <= 9; ++i)
@@ -2034,14 +2034,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
+  WriterTile tile1_0;
   CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
   std::vector<int32_t> c_data1_0 = {
       fill_value, fill_value, fill_value, fill_value, 1, 11, 2, 22, 3, 33};
   CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
+  WriterTile tile1_1;
   CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
   std::vector<int32_t> c_data1_1 = {4,
                                     44,
@@ -2070,7 +2070,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2;
+  WriterTile tile2;
   CHECK(tiler2.get_tile(0, "a", &tile2).ok());
   std::vector<int32_t> c_data2 = {
       fill_value, fill_value, 1, 11, 2, 22, 3, 33, 4, 44};
@@ -2091,7 +2091,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3;
+  WriterTile tile3;
   CHECK(tiler3.get_tile(0, "a", &tile3).ok());
   std::vector<int32_t> c_data3 = {
       fill_value, fill_value, 1, 11, 2, 22, 3, 33, 4, 44};
@@ -2140,23 +2140,23 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0_a1;
+  WriterTile tile1_0_a1;
   CHECK(tiler1.get_tile(0, "a1", &tile1_0_a1).ok());
   std::vector<int32_t> c_data1_0_a1 = {fill_value, fill_value, 1, 2, 3};
   CHECK(check_tile<int32_t>(&tile1_0_a1, c_data1_0_a1));
-  Tile tile1_0_a2;
+  WriterTile tile1_0_a2;
   CHECK(tiler1.get_tile(0, "a2", &tile1_0_a2).ok());
   std::vector<double> c_data1_0_a2 = {
       double(fill_value), double(fill_value), 1.1, 2.2, 3.3};
   CHECK(check_tile<double>(&tile1_0_a2, c_data1_0_a2));
 
   // Test get tile 1
-  Tile tile1_1_a1;
+  WriterTile tile1_1_a1;
   CHECK(tiler1.get_tile(1, "a1", &tile1_1_a1).ok());
   std::vector<int32_t> c_data1_1_a1 = {
       4, fill_value, fill_value, fill_value, fill_value};
   CHECK(check_tile<int32_t>(&tile1_1_a1, c_data1_1_a1));
-  Tile tile1_1_a2;
+  WriterTile tile1_1_a2;
   CHECK(tiler1.get_tile(1, "a2", &tile1_1_a2).ok());
   std::vector<double> c_data1_1_a2 = {4.4,
                                       double(fill_value),
@@ -2180,11 +2180,11 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_a1;
+  WriterTile tile2_a1;
   CHECK(tiler2.get_tile(0, "a1", &tile2_a1).ok());
   std::vector<int32_t> c_data2_a1 = {fill_value, 1, 2, 3, 4};
   CHECK(check_tile<int32_t>(&tile2_a1, c_data2_a1));
-  Tile tile2_a2;
+  WriterTile tile2_a2;
   CHECK(tiler2.get_tile(0, "a2", &tile2_a2).ok());
   std::vector<double> c_data2_a2 = {double(fill_value), 1.1, 2.2, 3.3, 4.4};
   CHECK(check_tile<double>(&tile2_a2, c_data2_a2));
@@ -2204,11 +2204,11 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3_a1;
+  WriterTile tile3_a1;
   CHECK(tiler3.get_tile(0, "a1", &tile3_a1).ok());
   std::vector<int32_t> c_data3_a1 = {fill_value, 1, 2, 3, 4};
   CHECK(check_tile<int32_t>(&tile3_a1, c_data3_a1));
-  Tile tile3_a2;
+  WriterTile tile3_a2;
   CHECK(tiler3.get_tile(0, "a2", &tile3_a2).ok());
   std::vector<double> c_data3_a2 = {double(fill_value), 1.1, 2.2, 3.3, 4.4};
   CHECK(check_tile<double>(&tile3_a2, c_data3_a2));
@@ -2265,7 +2265,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
+  WriterTile tile1_0;
   CHECK(tiler1.get_tile_null(0, "a", &tile1_0).ok());
   std::vector<uint8_t> c_data1_0(50);
   for (int i = 0; i <= 36; ++i)
@@ -2281,7 +2281,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(&tile1_0, c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
+  WriterTile tile1_1;
   CHECK(tiler1.get_tile_null(1, "a", &tile1_1).ok());
   std::vector<uint8_t> c_data1_1(50);
   for (int i = 0; i <= 29; ++i)
@@ -2297,7 +2297,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(&tile1_1, c_data1_1));
 
   // Test get tile 2
-  Tile tile1_2;
+  WriterTile tile1_2;
   CHECK(tiler1.get_tile_null(2, "a", &tile1_2).ok());
   std::vector<uint8_t> c_data1_2(50);
   for (int i = 0; i <= 6; ++i)
@@ -2310,7 +2310,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(&tile1_2, c_data1_2));
 
   // Test get tile 3
-  Tile tile1_3;
+  WriterTile tile1_3;
   CHECK(tiler1.get_tile_null(3, "a", &tile1_3).ok());
   std::vector<uint8_t> c_data1_3(50);
   c_data1_3[0] = 0;
@@ -2345,7 +2345,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0;
+  WriterTile tile2_0;
   CHECK(tiler2.get_tile_null(0, "a", &tile2_0).ok());
   std::vector<uint8_t> c_data2_0(50);
   for (int i = 0; i <= 21; ++i)
@@ -2402,7 +2402,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3_0;
+  WriterTile tile3_0;
   CHECK(tiler3.get_tile_null(0, "a", &tile3_0).ok());
   std::vector<uint8_t> c_data3_0(50);
   for (int i = 0; i <= 36; ++i)
@@ -2418,7 +2418,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(&tile3_0, c_data3_0));
 
   // Test get tile 1
-  Tile tile3_1;
+  WriterTile tile3_1;
   CHECK(tiler3.get_tile_null(1, "a", &tile3_1).ok());
   std::vector<uint8_t> c_data3_1(50);
   for (int i = 0; i <= 29; ++i)
@@ -2434,7 +2434,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(&tile3_1, c_data3_1));
 
   // Test get tile 2
-  Tile tile3_2;
+  WriterTile tile3_2;
   CHECK(tiler3.get_tile_null(2, "a", &tile3_2).ok());
   std::vector<uint8_t> c_data3_2(50);
   for (int i = 0; i <= 6; ++i)
@@ -2447,7 +2447,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(&tile3_2, c_data3_2));
 
   // Test get tile 3
-  Tile tile3_3;
+  WriterTile tile3_3;
   CHECK(tiler3.get_tile_null(3, "a", &tile3_3).ok());
   std::vector<uint8_t> c_data3_3(50);
   c_data3_3[0] = 1;
@@ -2482,7 +2482,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile4_0;
+  WriterTile tile4_0;
   CHECK(tiler4.get_tile_null(0, "a", &tile4_0).ok());
   std::vector<uint8_t> c_data4_0(50);
   for (int i = 0; i <= 21; ++i)
@@ -2564,7 +2564,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
+  WriterTile tile1_0_off, tile1_0_val;
   CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
@@ -2598,7 +2598,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(&tile1_0_val, c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
+  WriterTile tile1_1_off, tile1_1_val;
   CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
@@ -2640,7 +2640,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(&tile1_1_val, c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
+  WriterTile tile1_2_off, tile1_2_val;
   CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
@@ -2665,7 +2665,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(&tile1_2_val, c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
+  WriterTile tile1_3_off, tile1_3_val;
   CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
@@ -2712,7 +2712,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
+  WriterTile tile2_0_off, tile2_0_val;
   CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)
@@ -2868,7 +2868,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
+  WriterTile tile1_0_off, tile1_0_val;
   CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
@@ -2902,7 +2902,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0_val, c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
+  WriterTile tile1_1_off, tile1_1_val;
   CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
@@ -2944,7 +2944,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_1_val, c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
+  WriterTile tile1_2_off, tile1_2_val;
   CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
@@ -2969,7 +2969,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_2_val, c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
+  WriterTile tile1_3_off, tile1_3_val;
   CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
@@ -3035,7 +3035,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
+  WriterTile tile2_0_off, tile2_0_val;
   CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)
@@ -3193,7 +3193,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray1, &test::g_helper_stats, "bytes", 64, true);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
+  WriterTile tile1_0_off, tile1_0_val;
   CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
@@ -3227,7 +3227,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0_val, c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
+  WriterTile tile1_1_off, tile1_1_val;
   CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
@@ -3269,7 +3269,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_1_val, c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
+  WriterTile tile1_2_off, tile1_2_val;
   CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
@@ -3294,7 +3294,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_2_val, c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
+  WriterTile tile1_3_off, tile1_3_val;
   CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
@@ -3362,7 +3362,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray2, &test::g_helper_stats, "bytes", 64, true);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
+  WriterTile tile2_0_off, tile2_0_val;
   CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)
@@ -3506,7 +3506,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray1, &test::g_helper_stats, "elements", 64, false);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
+  WriterTile tile1_0_off, tile1_0_val;
   CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
@@ -3540,7 +3540,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0_val, c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
+  WriterTile tile1_1_off, tile1_1_val;
   CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
@@ -3582,7 +3582,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_1_val, c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
+  WriterTile tile1_2_off, tile1_2_val;
   CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
@@ -3607,7 +3607,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_2_val, c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
+  WriterTile tile1_3_off, tile1_3_val;
   CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
@@ -3658,7 +3658,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray2, &test::g_helper_stats, "elements", 64, false);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
+  WriterTile tile2_0_off, tile2_0_val;
   CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)
@@ -3802,7 +3802,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray1, &test::g_helper_stats, "elements", 32, false);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
+  WriterTile tile1_0_off, tile1_0_val;
   CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
@@ -3836,7 +3836,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_0_val, c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
+  WriterTile tile1_1_off, tile1_1_val;
   CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
@@ -3878,7 +3878,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_1_val, c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
+  WriterTile tile1_2_off, tile1_2_val;
   CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
@@ -3903,7 +3903,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(&tile1_2_val, c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
+  WriterTile tile1_3_off, tile1_3_val;
   CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
@@ -3954,7 +3954,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray2, &test::g_helper_stats, "elements", 32, false);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
+  WriterTile tile2_0_off, tile2_0_val;
   CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)

--- a/test/src/unit-QueryCondition.cc
+++ b/test/src/unit-QueryCondition.cc
@@ -603,7 +603,7 @@ void test_apply_tile<char*>(
     values[i * 2] = 'a';
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
-  REQUIRE(tile->write(values, 2 * cells * sizeof(char)).ok());
+  REQUIRE(tile->write(values, 0, 2 * cells * sizeof(char)).ok());
 
   if (var_size) {
     Tile* const tile_offsets = &std::get<0>(*tile_tuple);
@@ -623,7 +623,7 @@ void test_apply_tile<char*>(
       offsets[i] = offset;
       offset += 2;
     }
-    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+    REQUIRE(tile_offsets->write(offsets, 0, cells * sizeof(uint64_t)).ok());
   }
 
   if (nullable) {
@@ -641,7 +641,7 @@ void test_apply_tile<char*>(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+    REQUIRE(tile_validity->write(validity, 0, cells * sizeof(uint8_t)).ok());
   }
 
   test_apply_operators<char*>(
@@ -671,7 +671,7 @@ void test_apply_tile(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = static_cast<T>(i);
   }
-  REQUIRE(tile->write(values, cells * sizeof(T)).ok());
+  REQUIRE(tile->write(values, 0, cells * sizeof(T)).ok());
 
   test_apply_operators<T>(field_name, cells, array_schema, result_tile, values);
 
@@ -825,7 +825,7 @@ TEST_CASE(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = i;
   }
-  REQUIRE(tile->write(values, cells * sizeof(uint64_t)).ok());
+  REQUIRE(tile->write(values, 0, cells * sizeof(uint64_t)).ok());
 
   // Build a combined query for `> 3 AND <= 6`.
   uint64_t cmp_value_1 = 3;
@@ -935,7 +935,7 @@ TEST_CASE(
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
 
-  REQUIRE(tile->write(values, 2 * (cells - 2) * sizeof(char)).ok());
+  REQUIRE(tile->write(values, 0, 2 * (cells - 2) * sizeof(char)).ok());
 
   if (var_size) {
     Tile* const tile_offsets = &std::get<0>(*tile_tuple);
@@ -957,7 +957,7 @@ TEST_CASE(
     }
     offsets[cells - 2] = offset;
     offsets[cells - 1] = offset;
-    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+    REQUIRE(tile_offsets->write(offsets, 0, cells * sizeof(uint64_t)).ok());
 
     free(offsets);
   }
@@ -977,7 +977,7 @@ TEST_CASE(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+    REQUIRE(tile_validity->write(validity, 0, cells * sizeof(uint8_t)).ok());
 
     free(validity);
   }
@@ -1351,7 +1351,7 @@ void test_apply_tile_dense<char*>(
     values[i * 2] = 'a';
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
-  REQUIRE(tile->write(values, 2 * cells * sizeof(char)).ok());
+  REQUIRE(tile->write(values, 0, 2 * cells * sizeof(char)).ok());
 
   if (var_size) {
     Tile* const tile_offsets = &std::get<0>(*tile_tuple);
@@ -1371,7 +1371,7 @@ void test_apply_tile_dense<char*>(
       offsets[i] = offset;
       offset += 2;
     }
-    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+    REQUIRE(tile_offsets->write(offsets, 0, cells * sizeof(uint64_t)).ok());
   }
 
   if (nullable) {
@@ -1389,7 +1389,7 @@ void test_apply_tile_dense<char*>(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+    REQUIRE(tile_validity->write(validity, 0, cells * sizeof(uint8_t)).ok());
   }
 
   test_apply_operators_dense<char*>(
@@ -1419,7 +1419,7 @@ void test_apply_tile_dense(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = static_cast<T>(i);
   }
-  REQUIRE(tile->write(values, cells * sizeof(T)).ok());
+  REQUIRE(tile->write(values, 0, cells * sizeof(T)).ok());
 
   test_apply_operators_dense<T>(
       field_name, cells, array_schema, result_tile, values);
@@ -1579,7 +1579,7 @@ TEST_CASE(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = i;
   }
-  REQUIRE(tile->write(values, cells * sizeof(uint64_t)).ok());
+  REQUIRE(tile->write(values, 0, cells * sizeof(uint64_t)).ok());
 
   // Build a combined query for `> 3 AND <= 6`.
   uint64_t cmp_value_1 = 3;
@@ -1692,7 +1692,7 @@ TEST_CASE(
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
 
-  REQUIRE(tile->write(values, 2 * (cells - 2) * sizeof(char)).ok());
+  REQUIRE(tile->write(values, 0, 2 * (cells - 2) * sizeof(char)).ok());
 
   if (var_size) {
     Tile* const tile_offsets = &std::get<0>(*tile_tuple);
@@ -1714,7 +1714,7 @@ TEST_CASE(
     }
     offsets[cells - 2] = offset;
     offsets[cells - 1] = offset;
-    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+    REQUIRE(tile_offsets->write(offsets, 0, cells * sizeof(uint64_t)).ok());
 
     free(offsets);
   }
@@ -1734,7 +1734,7 @@ TEST_CASE(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+    REQUIRE(tile_validity->write(validity, 0, cells * sizeof(uint8_t)).ok());
 
     free(validity);
   }
@@ -2111,7 +2111,7 @@ void test_apply_tile_sparse<char*>(
     values[i * 2] = 'a';
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
-  REQUIRE(tile->write(values, 2 * cells * sizeof(char)).ok());
+  REQUIRE(tile->write(values, 0, 2 * cells * sizeof(char)).ok());
 
   if (var_size) {
     Tile* const tile_offsets = &std::get<0>(*tile_tuple);
@@ -2131,7 +2131,7 @@ void test_apply_tile_sparse<char*>(
       offsets[i] = offset;
       offset += 2;
     }
-    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+    REQUIRE(tile_offsets->write(offsets, 0, cells * sizeof(uint64_t)).ok());
   }
 
   if (nullable) {
@@ -2149,7 +2149,7 @@ void test_apply_tile_sparse<char*>(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+    REQUIRE(tile_validity->write(validity, 0, cells * sizeof(uint8_t)).ok());
   }
 
   test_apply_operators_sparse<char*>(
@@ -2179,7 +2179,7 @@ void test_apply_tile_sparse(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = static_cast<T>(i);
   }
-  REQUIRE(tile->write(values, cells * sizeof(T)).ok());
+  REQUIRE(tile->write(values, 0, cells * sizeof(T)).ok());
 
   test_apply_operators_sparse<T>(
       field_name, cells, array_schema, result_tile, values);
@@ -2339,7 +2339,7 @@ TEST_CASE(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = i;
   }
-  REQUIRE(tile->write(values, cells * sizeof(uint64_t)).ok());
+  REQUIRE(tile->write(values, 0, cells * sizeof(uint64_t)).ok());
 
   // Build a combined query for `> 3 AND <= 6`.
   uint64_t cmp_value_1 = 3;
@@ -2453,7 +2453,7 @@ TEST_CASE(
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
 
-  REQUIRE(tile->write(values, 2 * (cells - 2) * sizeof(char)).ok());
+  REQUIRE(tile->write(values, 0, 2 * (cells - 2) * sizeof(char)).ok());
 
   if (var_size) {
     Tile* const tile_offsets = &std::get<0>(*tile_tuple);
@@ -2475,7 +2475,7 @@ TEST_CASE(
     }
     offsets[cells - 2] = offset;
     offsets[cells - 1] = offset;
-    REQUIRE(tile_offsets->write(offsets, cells * sizeof(uint64_t)).ok());
+    REQUIRE(tile_offsets->write(offsets, 0, cells * sizeof(uint64_t)).ok());
 
     free(offsets);
   }
@@ -2495,7 +2495,7 @@ TEST_CASE(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(tile_validity->write(validity, cells * sizeof(uint8_t)).ok());
+    REQUIRE(tile_validity->write(validity, 0, cells * sizeof(uint8_t)).ok());
 
     free(validity);
   }

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -488,23 +488,36 @@ TEST_CASE_METHOD(
   result_tile_3_0.init_coord_tile("d", 0);
   result_tile_3_1.init_coord_tile("d", 0);
 
-  std::vector<uint64_t> vec_2_0 = {1000, 3, 1000, 5};
-  Buffer buff_2_0(&vec_2_0[0], vec_2_0.size() * sizeof(uint64_t));
-  Tile tile_2_0(Datatype::UINT64, sizeof(uint64_t), 0, &buff_2_0, false);
+  uint64_t* data =
+      reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
+  data[0] = 1000;
+  data[1] = 3;
+  data[2] = 1000;
+  data[3] = 5;
+  Tile tile_2_0(
+      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
   auto tile_tuple = result_tile_2_0.tile_tuple("d");
   REQUIRE(tile_tuple != nullptr);
   std::get<0>(*tile_tuple) = tile_2_0;
 
-  std::vector<uint64_t> vec_3_0 = {1000, 1000, 8, 9};
-  Buffer buff_3_0(&vec_3_0[0], vec_3_0.size() * sizeof(uint64_t));
-  Tile tile_3_0(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_0, false);
+  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
+  data[0] = 1000;
+  data[1] = 1000;
+  data[2] = 8;
+  data[3] = 9;
+  Tile tile_3_0(
+      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
   tile_tuple = result_tile_3_0.tile_tuple("d");
   REQUIRE(tile_tuple != nullptr);
   std::get<0>(*tile_tuple) = tile_3_0;
 
-  std::vector<uint64_t> vec_3_1 = {1000, 12, 19, 1000};
-  Buffer buff_3_1(&vec_3_1[0], vec_3_1.size() * sizeof(uint64_t));
-  Tile tile_3_1(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_1, false);
+  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
+  data[0] = 1000;
+  data[1] = 12;
+  data[2] = 19;
+  data[3] = 1000;
+  Tile tile_3_1(
+      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
   tile_tuple = result_tile_3_1.tile_tuple("d");
   REQUIRE(tile_tuple != nullptr);
   std::get<0>(*tile_tuple) = tile_3_1;
@@ -1357,30 +1370,47 @@ TEST_CASE_METHOD(
   result_tile_3_1.init_coord_tile("d1", 0);
   result_tile_3_1.init_coord_tile("d2", 1);
 
-  std::vector<uint64_t> vec_3_0_d1 = {1000, 3, 1000, 1000};
-  Buffer buff_3_0_d1(&vec_3_0_d1[0], vec_3_0_d1.size() * sizeof(uint64_t));
-  Tile tile_3_0_d1(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_0_d1, false);
+  uint64_t* data =
+      reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
+  data[0] = 1000;
+  data[1] = 3;
+  data[2] = 1000;
+  data[3] = 1000;
+  Tile tile_3_0_d1(
+      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
   auto tile_tuple = result_tile_3_0.tile_tuple("d1");
   REQUIRE(tile_tuple != nullptr);
   std::get<0>(*tile_tuple) = tile_3_0_d1;
 
-  std::vector<uint64_t> vec_3_0_d2 = {1000, 3, 1000, 1000};
-  Buffer buff_3_0_d2(&vec_3_0_d2[0], vec_3_0_d2.size() * sizeof(uint64_t));
-  Tile tile_3_0_d2(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_0_d2, false);
+  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
+  data[0] = 1000;
+  data[1] = 3;
+  data[2] = 1000;
+  data[3] = 1000;
+  Tile tile_3_0_d2(
+      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
   tile_tuple = result_tile_3_0.tile_tuple("d2");
   REQUIRE(tile_tuple != nullptr);
   std::get<0>(*tile_tuple) = tile_3_0_d2;
 
-  std::vector<uint64_t> vec_3_1_d1 = {5, 1000, 5, 1000};
-  Buffer buff_3_1_d1(&vec_3_1_d1[0], vec_3_1_d1.size() * sizeof(uint64_t));
-  Tile tile_3_1_d1(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_1_d1, false);
+  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
+  data[0] = 5;
+  data[1] = 1000;
+  data[2] = 5;
+  data[3] = 1000;
+  Tile tile_3_1_d1(
+      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
   tile_tuple = result_tile_3_1.tile_tuple("d1");
   REQUIRE(tile_tuple != nullptr);
   std::get<0>(*tile_tuple) = tile_3_1_d1;
 
-  std::vector<uint64_t> vec_3_1_d2 = {5, 1000, 6, 1000};
-  Buffer buff_3_1_d2(&vec_3_1_d2[0], vec_3_1_d2.size() * sizeof(uint64_t));
-  Tile tile_3_1_d2(Datatype::UINT64, sizeof(uint64_t), 0, &buff_3_1_d2, false);
+  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
+  data[0] = 5;
+  data[1] = 1000;
+  data[2] = 6;
+  data[3] = 1000;
+  Tile tile_3_1_d2(
+      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
   tile_tuple = result_tile_3_1.tile_tuple("d2");
   REQUIRE(tile_tuple != nullptr);
   std::get<0>(*tile_tuple) = tile_3_1_d2;

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -164,6 +164,26 @@ void ReadCellSlabIterFx::create_result_space_tiles(
       result_space_tiles);
 }
 
+void set_result_tile_dim(
+    ResultTile& result_tile,
+    std::string dim,
+    uint64_t dim_idx,
+    std::vector<uint64_t> v) {
+  result_tile.init_coord_tile(dim, dim_idx);
+
+  uint64_t* data =
+      static_cast<uint64_t*>(tdb_malloc(v.size() * sizeof(uint64_t)));
+  for (uint64_t i = 0; i < v.size(); i++) {
+    data[i] = v[i];
+  }
+
+  Tile tile(
+      Datatype::UINT64, sizeof(uint64_t), 0, data, v.size() * sizeof(uint64_t));
+  auto tile_tuple = result_tile.tile_tuple(dim);
+  REQUIRE(tile_tuple != nullptr);
+  std::get<0>(*tile_tuple) = std::move(tile);
+}
+
 /* ********************************* */
 /*                TESTS              */
 /* ********************************* */
@@ -484,43 +504,9 @@ TEST_CASE_METHOD(
   ResultTile result_tile_3_0(2, 0, array_->array_->array_schema_latest());
   ResultTile result_tile_3_1(2, 1, array_->array_->array_schema_latest());
 
-  result_tile_2_0.init_coord_tile("d", 0);
-  result_tile_3_0.init_coord_tile("d", 0);
-  result_tile_3_1.init_coord_tile("d", 0);
-
-  uint64_t* data =
-      reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
-  data[0] = 1000;
-  data[1] = 3;
-  data[2] = 1000;
-  data[3] = 5;
-  Tile tile_2_0(
-      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
-  auto tile_tuple = result_tile_2_0.tile_tuple("d");
-  REQUIRE(tile_tuple != nullptr);
-  std::get<0>(*tile_tuple) = tile_2_0;
-
-  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
-  data[0] = 1000;
-  data[1] = 1000;
-  data[2] = 8;
-  data[3] = 9;
-  Tile tile_3_0(
-      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
-  tile_tuple = result_tile_3_0.tile_tuple("d");
-  REQUIRE(tile_tuple != nullptr);
-  std::get<0>(*tile_tuple) = tile_3_0;
-
-  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
-  data[0] = 1000;
-  data[1] = 12;
-  data[2] = 19;
-  data[3] = 1000;
-  Tile tile_3_1(
-      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
-  tile_tuple = result_tile_3_1.tile_tuple("d");
-  REQUIRE(tile_tuple != nullptr);
-  std::get<0>(*tile_tuple) = tile_3_1;
+  set_result_tile_dim(result_tile_2_0, "d", 0, {{1000, 3, 1000, 5}});
+  set_result_tile_dim(result_tile_3_0, "d", 0, {{1000, 1000, 8, 9}});
+  set_result_tile_dim(result_tile_3_1, "d", 0, {{1000, 12, 19, 1000}});
 
   result_coords.emplace_back(&result_tile_2_0, 1);
   result_coords.emplace_back(&result_tile_2_0, 3);
@@ -1365,55 +1351,10 @@ TEST_CASE_METHOD(
   ResultTile result_tile_3_0(2, 0, array_->array_->array_schema_latest());
   ResultTile result_tile_3_1(2, 1, array_->array_->array_schema_latest());
 
-  result_tile_3_0.init_coord_tile("d1", 0);
-  result_tile_3_0.init_coord_tile("d2", 1);
-  result_tile_3_1.init_coord_tile("d1", 0);
-  result_tile_3_1.init_coord_tile("d2", 1);
-
-  uint64_t* data =
-      reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
-  data[0] = 1000;
-  data[1] = 3;
-  data[2] = 1000;
-  data[3] = 1000;
-  Tile tile_3_0_d1(
-      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
-  auto tile_tuple = result_tile_3_0.tile_tuple("d1");
-  REQUIRE(tile_tuple != nullptr);
-  std::get<0>(*tile_tuple) = tile_3_0_d1;
-
-  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
-  data[0] = 1000;
-  data[1] = 3;
-  data[2] = 1000;
-  data[3] = 1000;
-  Tile tile_3_0_d2(
-      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
-  tile_tuple = result_tile_3_0.tile_tuple("d2");
-  REQUIRE(tile_tuple != nullptr);
-  std::get<0>(*tile_tuple) = tile_3_0_d2;
-
-  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
-  data[0] = 5;
-  data[1] = 1000;
-  data[2] = 5;
-  data[3] = 1000;
-  Tile tile_3_1_d1(
-      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
-  tile_tuple = result_tile_3_1.tile_tuple("d1");
-  REQUIRE(tile_tuple != nullptr);
-  std::get<0>(*tile_tuple) = tile_3_1_d1;
-
-  data = reinterpret_cast<uint64_t*>(tdb_malloc(4 * sizeof(uint64_t)));
-  data[0] = 5;
-  data[1] = 1000;
-  data[2] = 6;
-  data[3] = 1000;
-  Tile tile_3_1_d2(
-      Datatype::UINT64, sizeof(uint64_t), 0, data, 4 * sizeof(uint64_t));
-  tile_tuple = result_tile_3_1.tile_tuple("d2");
-  REQUIRE(tile_tuple != nullptr);
-  std::get<0>(*tile_tuple) = tile_3_1_d2;
+  set_result_tile_dim(result_tile_3_0, "d1", 0, {{1000, 3, 1000, 1000}});
+  set_result_tile_dim(result_tile_3_0, "d2", 1, {{1000, 3, 1000, 1000}});
+  set_result_tile_dim(result_tile_3_1, "d1", 0, {{5, 1000, 5, 1000}});
+  set_result_tile_dim(result_tile_3_1, "d2", 1, {{5, 1000, 6, 1000}});
 
   result_coords.emplace_back(&result_tile_3_0, 1);
   result_coords.emplace_back(&result_tile_3_1, 0);

--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -248,15 +248,11 @@ TEST_CASE_METHOD(
   ResultSpaceTile<int32_t> rst_3_2;
   rst_3_2.set_start_coords({7, 11});
 
-  // Prepare correct space tiles map
-  std::map<const int32_t*, ResultSpaceTile<int32_t>> c_result_space_tiles;
-  c_result_space_tiles[(const int32_t*)&(tile_coords[0][0])] = rst_1_0;
-  c_result_space_tiles[(const int32_t*)&(tile_coords[1][0])] = rst_1_2;
-  c_result_space_tiles[(const int32_t*)&(tile_coords[2][0])] = rst_2_0;
-  c_result_space_tiles[(const int32_t*)&(tile_coords[3][0])] = rst_2_2;
-  c_result_space_tiles[(const int32_t*)&(tile_coords[4][0])] = rst_3_0;
-  c_result_space_tiles[(const int32_t*)&(tile_coords[5][0])] = rst_3_2;
-
   // Check correctness
-  CHECK(result_space_tiles == c_result_space_tiles);
+  CHECK(result_space_tiles[(const int32_t*)&(tile_coords[0][0])] == rst_1_0);
+  CHECK(result_space_tiles[(const int32_t*)&(tile_coords[1][0])] == rst_1_2);
+  CHECK(result_space_tiles[(const int32_t*)&(tile_coords[2][0])] == rst_2_0);
+  CHECK(result_space_tiles[(const int32_t*)&(tile_coords[3][0])] == rst_2_2);
+  CHECK(result_space_tiles[(const int32_t*)&(tile_coords[4][0])] == rst_3_0);
+  CHECK(result_space_tiles[(const int32_t*)&(tile_coords[5][0])] == rst_3_2);
 }

--- a/test/src/unit-Tile.cc
+++ b/test/src/unit-Tile.cc
@@ -42,7 +42,6 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
   // Instantiate the test Tile.
   Tile tile;
   CHECK(tile.empty());
-  CHECK(!tile.full());
   CHECK(tile.size() == 0);
 
   // Initialize the test Tile.
@@ -54,11 +53,7 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
   CHECK(tile.init_unfiltered(
                 format_version, data_type, tile_size, cell_size, dim_num)
             .ok());
-  CHECK(tile.empty());
-  CHECK(!tile.full());
-  CHECK(tile.size() == 0);
-  CHECK(tile.buffer()->alloced_size() == tile_size);
-  CHECK(tile.owns_buff());
+  CHECK(tile.size() == tile_size);
 
   // Create a buffer to write to the test Tile.
   uint32_t* const write_buffer = static_cast<uint32_t*>(malloc(tile_size));
@@ -68,66 +63,44 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
   }
 
   // Write the buffer to the test Tile.
-  CHECK(tile.offset() == 0);
-  CHECK(tile.write(write_buffer, tile_size).ok());
-  CHECK(tile.offset() == tile_size);
+  CHECK(tile.write(write_buffer, 0, tile_size).ok());
   CHECK(!tile.empty());
-  CHECK(tile.full());
   CHECK(tile.size() == tile_size);
 
   // Ensure the internal data was deep-copied:
-  void* tile_chunk_0 = tile.buffer()->data();
+  void* tile_chunk_0 = tile.data();
   CHECK(tile_chunk_0 != static_cast<void*>(write_buffer));
 
   // Test a partial read at offset 8, which should be a uint32_t with
   // a value of two.
   uint32_t two = 0;
-  CHECK(tile.read(&two, sizeof(uint32_t), 8).ok());
+  CHECK(tile.read(&two, 8, sizeof(uint32_t)).ok());
   CHECK(two == 2);
-
-  // The last read should have not changed the internal offset.
-  CHECK(tile.offset() == tile_size);
-
-  // Perform a read at the current offset and verify we read 'two'
-  // again and that the offset has changed.
-  tile.set_offset(8);
-  two = 0;
-  CHECK(tile.read(&two, sizeof(uint32_t)).ok());
-  CHECK(two == 2);
-  CHECK(tile.offset() == 12);
 
   // Test a full read.
   uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
   memset(read_buffer, 0, tile_size);
   uint64_t read_offset = 0;
-  CHECK(tile.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(tile.read(read_buffer, read_offset, tile_size).ok());
   CHECK(memcmp(read_buffer, write_buffer, tile_size) == 0);
 
-  // Verify the internal offset did not change.
-  CHECK(tile.offset() == 12);
-
   // Test a write at a non-zero offset. Overwrite the two at offset 8.
-  tile.reset_offset();
-  tile.advance_offset(8);
   uint32_t magic = 5234549;
-  CHECK(tile.write(&magic, sizeof(uint32_t)).ok());
-  CHECK(tile.offset() == 12);
+  CHECK(tile.write(&magic, 8, sizeof(uint32_t)).ok());
 
   // Read the magic number to ensure the '2' value was overwritten.
   two = 0;
-  CHECK(tile.read(&two, sizeof(uint32_t), 8).ok());
+  CHECK(tile.read(&two, 8, sizeof(uint32_t)).ok());
   CHECK(two == magic);
 
   // Restore the state without the magic number.
-  tile.set_offset(8);
   two = 2;
-  CHECK(tile.write(&two, sizeof(uint32_t)).ok());
-  CHECK(tile.offset() == 12);
+  CHECK(tile.write(&two, 8, sizeof(uint32_t)).ok());
 
   // Test a read at an out-of-bounds offset.
   memset(read_buffer, 0, tile_size);
   read_offset = tile_size;
-  CHECK(!tile.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(!tile.read(read_buffer, read_offset, tile_size).ok());
 
   // Test a read at a valid offset but with a size that
   // exceeds the written buffer size.
@@ -136,7 +109,7 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
       static_cast<uint32_t*>(malloc(large_buffer_size));
   memset(large_read_buffer, 0, large_buffer_size);
   read_offset = 0;
-  CHECK(!tile.read(large_read_buffer, large_buffer_size, read_offset).ok());
+  CHECK(!tile.read(large_read_buffer, read_offset, large_buffer_size).ok());
 
   // Free the write buffer to ensure that it was deep-copied
   // within the initial write.
@@ -145,7 +118,7 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
   free(write_buffer);
   memset(read_buffer, 0, tile_size);
   read_offset = 0;
-  CHECK(tile.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(tile.read(read_buffer, read_offset, tile_size).ok());
   CHECK(memcmp(read_buffer, write_buffer_copy, tile_size) == 0);
 
   free(read_buffer);
@@ -174,7 +147,7 @@ TEST_CASE("Tile: Test copy constructor", "[Tile][copy_constructor]") {
   }
 
   // Write the buffer to the first test Tile.
-  CHECK(tile1.write(buffer, tile_size).ok());
+  CHECK(tile1.write(buffer, 0, tile_size).ok());
 
   // Instantiate a second test tile with the copy constructor.
   Tile tile2(tile1);
@@ -186,26 +159,23 @@ TEST_CASE("Tile: Test copy constructor", "[Tile][copy_constructor]") {
   CHECK(tile2.empty() == tile1.empty());
   CHECK(tile2.filtered() == tile1.filtered());
   CHECK(tile2.format_version() == tile1.format_version());
-  CHECK(tile2.full() == tile1.full());
-  CHECK(tile2.offset() == tile1.offset());
   CHECK(tile2.size() == tile1.size());
   CHECK(tile2.stores_coords() == tile1.stores_coords());
   CHECK(tile2.type() == tile1.type());
-  CHECK(tile2.owns_buff() == tile1.owns_buff());
 
   // Read the second test tile to verify it contains the data
   // written to the first test tile.
   uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
   memset(read_buffer, 0, tile_size);
   uint64_t read_offset = 0;
-  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(tile2.read(read_buffer, read_offset, tile_size).ok());
   CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
 
   // Ensure the internal data was deep-copied:
-  CHECK(tile1.buffer());
-  CHECK(tile2.buffer());
-  void* tile1_chunk_0 = tile1.buffer()->data();
-  void* tile2_chunk_0 = tile2.buffer()->data();
+  CHECK(tile1.data());
+  CHECK(tile2.data());
+  void* tile1_chunk_0 = tile1.data();
+  void* tile2_chunk_0 = tile2.data();
   CHECK(tile1_chunk_0 != tile2_chunk_0);
 
   free(buffer);
@@ -233,7 +203,7 @@ TEST_CASE("Tile: Test move constructor", "[Tile][move_constructor]") {
   }
 
   // Write the buffer to the first test Tile.
-  CHECK(tile1.write(buffer, tile_size).ok());
+  CHECK(tile1.write(buffer, 0, tile_size).ok());
 
   // Instantiate a second test tile with the copy constructor.
   Tile tile2(tile1);
@@ -248,19 +218,16 @@ TEST_CASE("Tile: Test move constructor", "[Tile][move_constructor]") {
   CHECK(tile3.empty() == tile2.empty());
   CHECK(tile3.filtered() == tile2.filtered());
   CHECK(tile3.format_version() == tile2.format_version());
-  CHECK(tile3.full() == tile2.full());
-  CHECK(tile3.offset() == tile2.offset());
   CHECK(tile3.size() == tile2.size());
   CHECK(tile3.stores_coords() == tile2.stores_coords());
   CHECK(tile3.type() == tile2.type());
-  CHECK(tile3.owns_buff() == tile2.owns_buff());
 
   // Read the second test tile to verify it contains the data
   // written to the first test tile.
   uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
   memset(read_buffer, 0, tile_size);
   uint64_t read_offset = 0;
-  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(tile2.read(read_buffer, read_offset, tile_size).ok());
   CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
 
   free(buffer);
@@ -288,7 +255,7 @@ TEST_CASE("Tile: Test assignment", "[Tile][assignment]") {
   }
 
   // Write the buffer to the first test Tile.
-  CHECK(tile1.write(buffer, tile_size).ok());
+  CHECK(tile1.write(buffer, 0, tile_size).ok());
 
   // Assign the first test Tile to a second test Tile.
   Tile tile2 = tile1;
@@ -300,26 +267,23 @@ TEST_CASE("Tile: Test assignment", "[Tile][assignment]") {
   CHECK(tile2.empty() == tile1.empty());
   CHECK(tile2.filtered() == tile1.filtered());
   CHECK(tile2.format_version() == tile1.format_version());
-  CHECK(tile2.full() == tile1.full());
-  CHECK(tile2.offset() == tile1.offset());
   CHECK(tile2.size() == tile1.size());
   CHECK(tile2.stores_coords() == tile1.stores_coords());
   CHECK(tile2.type() == tile1.type());
-  CHECK(tile2.owns_buff() == tile1.owns_buff());
 
   // Read the second test tile to verify it contains the data
   // written to the first test tile.
   uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
   memset(read_buffer, 0, tile_size);
   uint64_t read_offset = 0;
-  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(tile2.read(read_buffer, read_offset, tile_size).ok());
   CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
 
   // Ensure the internal data was deep-copied:
-  CHECK(tile1.buffer());
-  CHECK(tile2.buffer());
-  void* tile1_chunk_0 = tile1.buffer()->data();
-  void* tile2_chunk_0 = tile2.buffer()->data();
+  CHECK(tile1.data());
+  CHECK(tile2.data());
+  void* tile1_chunk_0 = tile1.data();
+  void* tile2_chunk_0 = tile2.data();
   CHECK(tile1_chunk_0 != tile2_chunk_0);
 
   free(buffer);
@@ -347,7 +311,7 @@ TEST_CASE("Tile: Test move-assignment", "[Tile][move_assignment]") {
   }
 
   // Write the buffer to the first test Tile.
-  CHECK(tile1.write(buffer, tile_size).ok());
+  CHECK(tile1.write(buffer, 0, tile_size).ok());
 
   // Instantiate a second test tile with the copy constructor.
   Tile tile2(tile1);
@@ -362,89 +326,18 @@ TEST_CASE("Tile: Test move-assignment", "[Tile][move_assignment]") {
   CHECK(tile3.empty() == tile2.empty());
   CHECK(tile3.filtered() == tile2.filtered());
   CHECK(tile3.format_version() == tile2.format_version());
-  CHECK(tile3.full() == tile2.full());
-  CHECK(tile3.offset() == tile2.offset());
   CHECK(tile3.size() == tile2.size());
   CHECK(tile3.stores_coords() == tile2.stores_coords());
   CHECK(tile3.type() == tile2.type());
-  CHECK(tile3.owns_buff() == tile2.owns_buff());
 
   // Read the second test tile to verify it contains the data
   // written to the first test tile.
   uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
   memset(read_buffer, 0, tile_size);
   uint64_t read_offset = 0;
-  CHECK(tile2.read(read_buffer, tile_size, read_offset).ok());
+  CHECK(tile2.read(read_buffer, read_offset, tile_size).ok());
   CHECK(memcmp(read_buffer, buffer, tile_size) == 0);
 
   free(buffer);
-  free(read_buffer);
-}
-
-TEST_CASE(
-    "Tile: Test buffer chunks value constructor",
-    "[Tile][buffer_chunks_value_constructor]") {
-  // Define test tile attributes.
-  const Datatype data_type = Datatype::UINT32;
-  const uint64_t tile_size = 1024 * 1024;
-  const uint64_t cell_size = sizeof(uint32_t);
-  const unsigned int dim_num = 1;
-
-  // Instantiate a Buffer instance. We will use this to test
-  // ownership and non-ownership from a Tile value constructor.
-  Buffer buffer;
-  const uint32_t buffer_len = tile_size / sizeof(uint32_t);
-  for (uint32_t i = 0; i < buffer_len; ++i) {
-    buffer.write(&i, sizeof(uint32_t));
-  }
-  CHECK(buffer.size() == tile_size);
-
-  // Instantiate the first test tile that does NOT own 'buffer'.
-  bool owns_buff = false;
-  std::unique_ptr<Tile> tile1(
-      new Tile(data_type, cell_size, dim_num, &buffer, owns_buff));
-  CHECK(tile1);
-  CHECK(tile1->size() == tile_size);
-  CHECK(!tile1->full());
-  CHECK(tile1->buffer()->size() == tile_size);
-  CHECK(!tile1->owns_buff());
-
-  // Test a full read.
-  uint32_t* const read_buffer = static_cast<uint32_t*>(malloc(tile_size));
-  memset(read_buffer, 0, tile_size);
-  uint64_t read_offset = 0;
-  CHECK(tile1->read(read_buffer, tile_size, read_offset).ok());
-  CHECK(memcmp(read_buffer, buffer.data(), tile_size) == 0);
-
-  // Free tile1 and ensure that buffer is still valid.
-  uint32_t* const buffer_copy = static_cast<uint32_t*>(malloc(tile_size));
-  memcpy(buffer_copy, buffer.data(), tile_size);
-  tile1.reset();
-  CHECK(memcmp(buffer_copy, buffer.data(), tile_size) == 0);
-
-  Buffer* const alloced_buffer = tdb_new(Buffer);
-  alloced_buffer->swap(buffer);
-
-  // Instantiate the second test tile that does own 'buffer'.
-  owns_buff = true;
-  std::unique_ptr<Tile> tile2(
-      new Tile(data_type, cell_size, dim_num, alloced_buffer, owns_buff));
-  CHECK(tile2);
-  CHECK(!tile2->empty());
-  CHECK(!tile2->full());
-  CHECK(tile2->size() == tile_size);
-  CHECK(tile2->owns_buff());
-
-  // Test a full read.
-  memset(read_buffer, 0, tile_size);
-  read_offset = 0;
-  CHECK(tile2->read(read_buffer, tile_size, read_offset).ok());
-  CHECK(memcmp(read_buffer, alloced_buffer->data(), tile_size) == 0);
-
-  // Disown 'buffer' because the destructor of 'tile2' will delete it.
-  alloced_buffer->disown_data();
-  tile2.reset();
-
-  free(buffer_copy);
   free(read_buffer);
 }

--- a/test/src/unit-lru_cache.cc
+++ b/test/src/unit-lru_cache.cc
@@ -65,24 +65,19 @@ struct BufferLRUCacheFx {
 TEST_CASE_METHOD(
     BufferLRUCacheFx, "Unit-test class BufferLRUCache", "[lru_cache]") {
   // Insert an object larger than CACHE_SIZE
-  FilteredBuffer v;
-  v.resize(CACHE_SIZE + 1);
+  FilteredBuffer v(CACHE_SIZE + 1);
   bool success;
   Status st = lru_cache_->insert("key", std::move(v));
   CHECK(st.ok());
-  FilteredBuffer v_buf;
-  v_buf.resize(3 * sizeof(int));
+  FilteredBuffer v_buf(3 * sizeof(int));
   st = lru_cache_->read("key", v_buf, 0, sizeof(int), &success);
   CHECK(st.ok());
   CHECK(!success);
 
   // Prepare some vectors
-  FilteredBuffer v1;
-  FilteredBuffer v2;
-  FilteredBuffer v3;
-  v1.resize(sizeof(int) * 3);
-  v2.resize(sizeof(int) * 3);
-  v3.resize(sizeof(int) * 3);
+  FilteredBuffer v1(sizeof(int) * 3);
+  FilteredBuffer v2(sizeof(int) * 3);
+  FilteredBuffer v3(sizeof(int) * 3);
 
   for (int i = 0; i < 3; ++i) {
     reinterpret_cast<int*>(v1.data())[i] = i;
@@ -134,8 +129,7 @@ TEST_CASE_METHOD(
   CHECK(!st.ok());
 
   // Test eviction
-  FilteredBuffer v4;
-  v4.resize(sizeof(int) * 5);
+  FilteredBuffer v4(sizeof(int) * 5);
   st = lru_cache_->insert("v4", std::move(v4));
   CHECK(st.ok());
 
@@ -151,14 +145,10 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     BufferLRUCacheFx, "BufferLRUCache item invalidation", "[lru_cache]") {
-  FilteredBuffer v1;
-  FilteredBuffer v2;
-  FilteredBuffer v3;
-  FilteredBuffer v4;
-  v1.resize(sizeof(int) * 3);
-  v2.resize(sizeof(int) * 3);
-  v3.resize(sizeof(int) * 3);
-  v4.resize(sizeof(int) * 4);
+  FilteredBuffer v1(sizeof(int) * 3);
+  FilteredBuffer v2(sizeof(int) * 3);
+  FilteredBuffer v3(sizeof(int) * 3);
+  FilteredBuffer v4(sizeof(int) * 4);
   for (int i = 0; i < 3; ++i) {
     reinterpret_cast<int*>(v1.data())[i] = i + 1;
     reinterpret_cast<int*>(v2.data())[i] = 3 + i + 1;
@@ -227,13 +217,12 @@ TEST_CASE("BufferLRUCache of 0 capacity", "[lru_cache]") {
   CHECK(it == it_end);
 
   // Test insert
-  FilteredBuffer v;
-  v.resize(CACHE_ZERO_SIZE + 1);
+  FilteredBuffer v(CACHE_ZERO_SIZE + 1);
   Status st = lru_cache->insert("key", std::move(v));
   CHECK(st.ok());
 
   // Test read
-  FilteredBuffer v_buf;
+  FilteredBuffer v_buf(0);
   bool success;
   st = lru_cache->read("key", v_buf, 0, sizeof(int), &success);
   CHECK(st.ok());

--- a/test/src/unit-lru_cache.cc
+++ b/test/src/unit-lru_cache.cc
@@ -80,9 +80,9 @@ TEST_CASE_METHOD(
   FilteredBuffer v3(sizeof(int) * 3);
 
   for (int i = 0; i < 3; ++i) {
-    reinterpret_cast<int*>(v1.data())[i] = i;
-    reinterpret_cast<int*>(v2.data())[i] = 3 + i;
-    reinterpret_cast<int*>(v3.data())[i] = 6 + i;
+    v1.data_as<int>()[i] = i;
+    v1.data_as<int>()[i] = 3 + i;
+    v1.data_as<int>()[i] = 6 + i;
   }
 
   // Insert 3 items in the cache

--- a/test/src/unit-lru_cache.cc
+++ b/test/src/unit-lru_cache.cc
@@ -33,6 +33,7 @@
 #include "catch.hpp"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/cache/buffer_lru_cache.h"
+#include "tiledb/sm/tile/filtered_buffer.h"
 
 using namespace tiledb::common;
 using namespace tiledb::sm;
@@ -64,41 +65,39 @@ struct BufferLRUCacheFx {
 TEST_CASE_METHOD(
     BufferLRUCacheFx, "Unit-test class BufferLRUCache", "[lru_cache]") {
   // Insert an object larger than CACHE_SIZE
-  Buffer v;
-  CHECK(v.realloc(CACHE_SIZE + 1).ok());
+  FilteredBuffer v;
+  v.resize(CACHE_SIZE + 1);
   bool success;
   Status st = lru_cache_->insert("key", std::move(v));
   CHECK(st.ok());
-  Buffer v_buf;
-  st = lru_cache_->read("key", &v_buf, 0, sizeof(int), &success);
+  FilteredBuffer v_buf;
+  v_buf.resize(3 * sizeof(int));
+  st = lru_cache_->read("key", v_buf, 0, sizeof(int), &success);
   CHECK(st.ok());
   CHECK(!success);
 
   // Prepare some vectors
-  Buffer v1;
-  Buffer v2;
-  Buffer v3;
-  CHECK(v1.realloc(sizeof(int) * 3).ok());
-  CHECK(v2.realloc(sizeof(int) * 3).ok());
-  CHECK(v3.realloc(sizeof(int) * 3).ok());
-  v1.set_size(v1.alloced_size());
-  v2.set_size(v2.alloced_size());
-  v3.set_size(v3.alloced_size());
+  FilteredBuffer v1;
+  FilteredBuffer v2;
+  FilteredBuffer v3;
+  v1.resize(sizeof(int) * 3);
+  v2.resize(sizeof(int) * 3);
+  v3.resize(sizeof(int) * 3);
 
   for (int i = 0; i < 3; ++i) {
-    static_cast<int*>(v1.data())[i] = i;
-    static_cast<int*>(v2.data())[i] = 3 + i;
-    static_cast<int*>(v3.data())[i] = 6 + i;
+    reinterpret_cast<int*>(v1.data())[i] = i;
+    reinterpret_cast<int*>(v2.data())[i] = 3 + i;
+    reinterpret_cast<int*>(v3.data())[i] = 6 + i;
   }
 
   // Insert 3 items in the cache
-  Buffer v1_cp(v1);
+  FilteredBuffer v1_cp(v1);
   st = lru_cache_->insert("v1", std::move(v1_cp));
   CHECK(st.ok());
-  Buffer v2_cp(v2);
+  FilteredBuffer v2_cp(v2);
   st = lru_cache_->insert("v2", std::move(v2_cp));
   CHECK(st.ok());
-  Buffer v3_cp(v3);
+  FilteredBuffer v3_cp(v3);
   st = lru_cache_->insert("v3", std::move(v3_cp));
   CHECK(st.ok());
 
@@ -106,14 +105,12 @@ TEST_CASE_METHOD(
   CHECK(check_key_order("v1v2v3"));
 
   // Read non-existent item
-  v_buf.reset_offset();
-  st = lru_cache_->read("v", &v_buf, 0, sizeof(int), &success);
+  st = lru_cache_->read("v", v_buf, 0, sizeof(int), &success);
   CHECK(st.ok());
   CHECK(!success);
 
   // Read full v3
-  v_buf.reset_offset();
-  st = lru_cache_->read("v3", &v_buf, 0, 3 * sizeof(int), &success);
+  st = lru_cache_->read("v3", v_buf, 0, 3 * sizeof(int), &success);
   CHECK(st.ok());
   CHECK(success);
   CHECK(!memcmp(v_buf.data(), v3.data(), 3 * sizeof(int)));
@@ -122,23 +119,23 @@ TEST_CASE_METHOD(
   CHECK(check_key_order("v1v2v3"));
 
   // Read partial v2
-  v_buf.reset_offset();
-  st = lru_cache_->read("v2", &v_buf, sizeof(int), sizeof(int), &success);
+  st = lru_cache_->read("v2", v_buf, sizeof(int), sizeof(int), &success);
   CHECK(st.ok());
   CHECK(success);
-  CHECK(v_buf.value<int>(0) == v2.value<int>(1 * sizeof(int)));
+  CHECK(
+      *reinterpret_cast<int*>(v_buf.data()) ==
+      *reinterpret_cast<int*>(&v2.data()[sizeof(int)]));
 
   // Check that the order in the linked list is v1-v3-v2
   CHECK(check_key_order("v1v3v2"));
 
   // Read out of bounds
-  v_buf.reset_offset();
-  st = lru_cache_->read("v2", &v_buf, sizeof(int), 4 * sizeof(int), &success);
+  st = lru_cache_->read("v2", v_buf, sizeof(int), 4 * sizeof(int), &success);
   CHECK(!st.ok());
 
   // Test eviction
-  Buffer v4;
-  CHECK(v4.realloc(sizeof(int) * 5).ok());
+  FilteredBuffer v4;
+  v4.resize(sizeof(int) * 5);
   st = lru_cache_->insert("v4", std::move(v4));
   CHECK(st.ok());
 
@@ -154,29 +151,25 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     BufferLRUCacheFx, "BufferLRUCache item invalidation", "[lru_cache]") {
-  Buffer v1;
-  Buffer v2;
-  Buffer v3;
-  Buffer v4;
-  CHECK(v1.realloc(sizeof(int) * 3).ok());
-  CHECK(v2.realloc(sizeof(int) * 3).ok());
-  CHECK(v3.realloc(sizeof(int) * 3).ok());
-  CHECK(v4.realloc(sizeof(int) * 4).ok());
-  v1.set_size(v1.alloced_size());
-  v2.set_size(v2.alloced_size());
-  v3.set_size(v3.alloced_size());
-  v4.set_size(v4.alloced_size());
+  FilteredBuffer v1;
+  FilteredBuffer v2;
+  FilteredBuffer v3;
+  FilteredBuffer v4;
+  v1.resize(sizeof(int) * 3);
+  v2.resize(sizeof(int) * 3);
+  v3.resize(sizeof(int) * 3);
+  v4.resize(sizeof(int) * 4);
   for (int i = 0; i < 3; ++i) {
-    static_cast<int*>(v1.data())[i] = i + 1;
-    static_cast<int*>(v2.data())[i] = 3 + i + 1;
-    static_cast<int*>(v3.data())[i] = 6 + i + 1;
-    static_cast<int*>(v4.data())[i] = 9 + i + 1;
+    reinterpret_cast<int*>(v1.data())[i] = i + 1;
+    reinterpret_cast<int*>(v2.data())[i] = 3 + i + 1;
+    reinterpret_cast<int*>(v3.data())[i] = 6 + i + 1;
+    reinterpret_cast<int*>(v4.data())[i] = 9 + i + 1;
   }
 
-  Buffer v1_cp(v1);
+  FilteredBuffer v1_cp(v1);
   Status st = lru_cache_->insert("v1", std::move(v1_cp));
   CHECK(st.ok());
-  Buffer v2_cp(v2);
+  FilteredBuffer v2_cp(v2);
   st = lru_cache_->insert("v2", std::move(v2_cp));
   CHECK(st.ok());
 
@@ -197,10 +190,10 @@ TEST_CASE_METHOD(
   CHECK(!success);
   CHECK(check_key_order("v2"));
 
-  Buffer v3_cp(v3);
+  FilteredBuffer v3_cp(v3);
   st = lru_cache_->insert("v3", std::move(v3_cp));
   CHECK(st.ok());
-  Buffer v4_cp(v4);
+  FilteredBuffer v4_cp(v4);
   st = lru_cache_->insert("v4", std::move(v4_cp));
   CHECK(st.ok());
   CHECK(check_key_order("v2v3v4"));
@@ -234,15 +227,15 @@ TEST_CASE("BufferLRUCache of 0 capacity", "[lru_cache]") {
   CHECK(it == it_end);
 
   // Test insert
-  Buffer v;
-  CHECK(v.realloc(CACHE_ZERO_SIZE + 1).ok());
+  FilteredBuffer v;
+  v.resize(CACHE_ZERO_SIZE + 1);
   Status st = lru_cache->insert("key", std::move(v));
   CHECK(st.ok());
 
   // Test read
-  Buffer v_buf;
+  FilteredBuffer v_buf;
   bool success;
-  st = lru_cache->read("key", &v_buf, 0, sizeof(int), &success);
+  st = lru_cache->read("key", v_buf, 0, sizeof(int), &success);
   CHECK(st.ok());
   CHECK(!success);
 

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1166,7 +1166,9 @@ TEST_CASE(
     "Sparse unordered with dups reader: test compute_var_size_offsets",
     "[sparse-unordered-with-dups][compute_var_size_offsets]") {
   // Make a vector of tiles.
-  std::vector<ResultTileWithBitmap<uint64_t>> rt = {make_tile(5)};
+  auto tile = make_tile(5);
+  std::vector<ResultTileWithBitmap<uint64_t>> rt;
+  rt.push_back(std::move(tile));
 
   SECTION("- No bitmap") {
   }
@@ -1223,7 +1225,9 @@ TEST_CASE(
     "bitmap",
     "[sparse-unordered-with-dups][compute_var_size_offsets][count-bitmap]") {
   // Make a vector of tiles.
-  std::vector<ResultTileWithBitmap<uint64_t>> rt = {make_tile(5)};
+  auto tile = make_tile(5);
+  std::vector<ResultTileWithBitmap<uint64_t>> rt;
+  rt.push_back(std::move(tile));
   rt[0].bitmap_.resize(5);
   rt[0].bitmap_ = {0, 1, 2, 0, 2};
 
@@ -1274,7 +1278,9 @@ TEST_CASE(
     "continuation",
     "[sparse-unordered-with-dups][compute_var_size_offsets][continuation]") {
   // Make a vector of tiles.
-  std::vector<ResultTileWithBitmap<uint64_t>> rt = {make_tile(5)};
+  auto tile = make_tile(5);
+  std::vector<ResultTileWithBitmap<uint64_t>> rt;
+  rt.push_back(std::move(tile));
 
   SECTION("- No bitmap") {
   }

--- a/test/src/unit-tile-metadata-generator.cc
+++ b/test/src/unit-tile-metadata-generator.cc
@@ -94,14 +94,14 @@ TEMPLATE_LIST_TEST_CASE(
       cell_val_num * sizeof(T),
       0,
       true);
-  auto tile_buff = (T*)tile.buffer()->data();
+  auto tile_buff = (T*)tile.data();
 
   // Initialize a new nullable tile.
   Tile tile_nullable;
   uint8_t* nullable_buff = nullptr;
   if (nullable) {
     tile_nullable.init_unfiltered(0, Datatype::UINT8, num_cells, 1, 0, true);
-    nullable_buff = (uint8_t*)tile_nullable.buffer()->data();
+    nullable_buff = (uint8_t*)tile_nullable.data();
   }
 
   // Compute correct values as the tile is filled with data.
@@ -245,7 +245,7 @@ TEMPLATE_LIST_TEST_CASE(
   Tile tile;
   tile.init_unfiltered(
       0, (Datatype)type.tiledb_type, num_cells * sizeof(T), sizeof(T), 0, true);
-  auto tile_buff = (T*)tile.buffer()->data();
+  auto tile_buff = (T*)tile.data();
 
   // Once an overflow happens, the computation should abort, try to add a few
   // min values after the overflow to confirm.
@@ -279,7 +279,7 @@ TEMPLATE_LIST_TEST_CASE(
         sizeof(T),
         0,
         true);
-    auto tile_buff = (T*)tile.buffer()->data();
+    auto tile_buff = (T*)tile.data();
 
     // Once an overflow happens, the computation should abort, try to add a few
     // max values after the overflow to confirm.
@@ -349,20 +349,20 @@ TEST_CASE(
       sizeof(uint64_t),
       0,
       true);
-  auto offsets_tile_buff = (uint64_t*)offsets_tile.buffer()->data();
+  auto offsets_tile_buff = (uint64_t*)offsets_tile.data();
 
   // Initialize var tile.
   Tile var_tile;
   var_tile.init_unfiltered(
       0, Datatype::CHAR, var_size, constants::var_num, 0, true);
-  auto var_tile_buff = (char*)var_tile.buffer()->data();
+  auto var_tile_buff = (char*)var_tile.data();
 
   // Initialize a new nullable tile.
   Tile tile_nullable;
   uint8_t* nullable_buff = nullptr;
   if (nullable) {
     tile_nullable.init_unfiltered(0, Datatype::UINT8, num_cells, 1, 0, true);
-    nullable_buff = (uint8_t*)tile_nullable.buffer()->data();
+    nullable_buff = (uint8_t*)tile_nullable.data();
   }
 
   // Compute correct values as the tile is filled with data.
@@ -440,14 +440,14 @@ TEST_CASE(
   Tile offsets_tile;
   offsets_tile.init_unfiltered(
       0, Datatype::UINT64, 2 * sizeof(uint64_t), sizeof(uint64_t), 0, true);
-  auto offsets_tile_buff = (uint64_t*)offsets_tile.buffer()->data();
+  auto offsets_tile_buff = (uint64_t*)offsets_tile.data();
   offsets_tile_buff[0] = 0;
   offsets_tile_buff[1] = 3;
 
   // Initialize var tile.
   Tile var_tile;
   var_tile.init_unfiltered(0, Datatype::CHAR, 5, constants::var_num, 0, true);
-  auto var_tile_buff = (char*)var_tile.buffer()->data();
+  auto var_tile_buff = (char*)var_tile.data();
   var_tile_buff[0] = '1';
   var_tile_buff[1] = '2';
   var_tile_buff[2] = '3';

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -83,9 +83,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     REQUIRE(io_tp.wait_all(tasks).ok());
     tasks.clear();
     for (unsigned i = 0; i < nelts; i++)
-      REQUIRE(
-          reinterpret_cast<uint32_t*>(tile[0].filtered_buffer().data())[i] ==
-          i);
+      REQUIRE(tile[0].filtered_buffer().data_as<uint32_t>()[i] == i);
 
     // Check reading first and last element: 1 reads due to the default
     // batch size.
@@ -98,11 +96,8 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     REQUIRE(vfs->read_all(testfile, batches, &io_tp, &tasks).ok());
     REQUIRE(io_tp.wait_all(tasks).ok());
     tasks.clear();
-    REQUIRE(
-        reinterpret_cast<uint32_t*>(tile[0].filtered_buffer().data())[0] == 0);
-    REQUIRE(
-        reinterpret_cast<uint32_t*>(tile[1].filtered_buffer().data())[0] ==
-        nelts - 1);
+    REQUIRE(tile[0].filtered_buffer().data_as<uint32_t>()[0] == 0);
+    REQUIRE(tile[1].filtered_buffer().data_as<uint32_t>()[0] == nelts - 1);
 
     // Check each element as a different region: single read because there is no
     // amplification required (all work is useful).
@@ -116,9 +111,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     REQUIRE(io_tp.wait_all(tasks).ok());
     tasks.clear();
     for (unsigned i = 0; i < nelts; i++) {
-      REQUIRE(
-          reinterpret_cast<uint32_t*>(tile[i].filtered_buffer().data())[0] ==
-          i);
+      REQUIRE(tile[i].filtered_buffer().data_as<uint32_t>()[0] == i);
     }
     REQUIRE(vfs->terminate().ok());
   }
@@ -143,9 +136,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     REQUIRE(io_tp.wait_all(tasks).ok());
     tasks.clear();
     for (unsigned i = 0; i < nelts; i++) {
-      REQUIRE(
-          reinterpret_cast<uint32_t*>(tile[0].filtered_buffer().data())[i] ==
-          i);
+      REQUIRE(tile[0].filtered_buffer().data_as<uint32_t>()[i] == i);
     }
 
     // Check each element as a different region (results in several read
@@ -161,9 +152,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     REQUIRE(io_tp.wait_all(tasks).ok());
     tasks.clear();
     for (unsigned i = 0; i < nelts / 2; i++) {
-      REQUIRE(
-          reinterpret_cast<uint32_t*>(tile[i].filtered_buffer().data())[0] ==
-          2 * i);
+      REQUIRE(tile[i].filtered_buffer().data_as<uint32_t>()[0] == 2 * i);
     }
 
     // Check reading first and last element (results in 2 reads because the
@@ -177,11 +166,8 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     REQUIRE(vfs->read_all(testfile, batches, &io_tp, &tasks).ok());
     REQUIRE(io_tp.wait_all(tasks).ok());
     tasks.clear();
-    REQUIRE(
-        reinterpret_cast<uint32_t*>(tile[0].filtered_buffer().data())[0] == 0);
-    REQUIRE(
-        reinterpret_cast<uint32_t*>(tile[1].filtered_buffer().data())[0] ==
-        nelts - 1);
+    REQUIRE(tile[0].filtered_buffer().data_as<uint32_t>()[0] == 0);
+    REQUIRE(tile[1].filtered_buffer().data_as<uint32_t>()[0] == nelts - 1);
     REQUIRE(vfs->terminate().ok());
   }
 
@@ -208,9 +194,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     REQUIRE(io_tp.wait_all(tasks).ok());
     tasks.clear();
     for (unsigned i = 0; i < nelts; i++) {
-      REQUIRE(
-          reinterpret_cast<uint32_t*>(tile[i].filtered_buffer().data())[0] ==
-          i);
+      REQUIRE(tile[i].filtered_buffer().data_as<uint32_t>()[0] == i);
     }
     REQUIRE(vfs->terminate().ok());
   }
@@ -238,9 +222,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
     REQUIRE(io_tp.wait_all(tasks).ok());
     tasks.clear();
     for (unsigned i = 0; i < nelts; i++) {
-      REQUIRE(
-          reinterpret_cast<uint32_t*>(tile[i].filtered_buffer().data())[0] ==
-          i);
+      REQUIRE(tile[i].filtered_buffer().data_as<uint32_t>()[0] == i);
     }
     REQUIRE(vfs->terminate().ok());
   }

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -67,7 +67,7 @@ TEST_CASE("VFS: Test read batching", "[vfs]") {
 
   Tile tile[nelts];
   for (uint64_t i = 0; i < nelts; i++) {
-    tile[i].filtered_buffer().resize(nelts * sizeof(uint32_t));
+    tile[i].filtered_buffer().expand(nelts * sizeof(uint32_t));
   }
 
   std::vector<std::tuple<uint64_t, Tile*, uint64_t>> batches;

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -371,7 +371,7 @@ Status Dimension::compute_mbr(const Tile& tile, Range* mbr) {
   auto cell_num = tile.cell_num();
   assert(cell_num > 0);
 
-  void* tile_buffer = tile.buffer()->data();
+  void* tile_buffer = tile.data();
   assert(tile_buffer != nullptr);
 
   // Initialize MBR with the first tile values
@@ -399,10 +399,10 @@ Status Dimension::compute_mbr_var<char>(
   auto cell_num = tile_off.cell_num();
   assert(cell_num > 0);
 
-  void* tile_buffer_off = tile_off.buffer()->data();
+  void* tile_buffer_off = tile_off.data();
   assert(tile_buffer_off != nullptr);
 
-  void* tile_buffer_val = tile_val.buffer()->data();
+  void* tile_buffer_val = tile_val.data();
   assert(tile_buffer_val != nullptr);
 
   uint64_t* const d_off = static_cast<uint64_t*>(tile_buffer_off);

--- a/tiledb/sm/cache/buffer_lru_cache.h
+++ b/tiledb/sm/cache/buffer_lru_cache.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/common/status.h"
 #include "tiledb/sm/cache/lru_cache.h"
+#include "tiledb/sm/tile/filtered_buffer.h"
 
 #include <list>
 #include <map>
@@ -48,14 +49,14 @@ namespace sm {
 class Buffer;
 
 /**
- * Provides a least-recently used cache for `Buffer` objects
+ * Provides a least-recently used cache for `FilteredBuffer` objects
  * mapped by a `std::string` key. The maximum capacity of the
  * cache is defined as a total allocated byte size among all
- * `Buffer` objects.
+ * `FilteredBuffer` objects.
  *
  * This class is thread-safe.
  */
-class BufferLRUCache : public LRUCache<std::string, Buffer> {
+class BufferLRUCache : public LRUCache<std::string, FilteredBuffer> {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -85,7 +86,8 @@ class BufferLRUCache : public LRUCache<std::string, Buffer> {
    *     overwritten. Otherwise, the new object will be deleted.
    * @return Status
    */
-  Status insert(const std::string& key, Buffer&& buffer, bool overwrite = true);
+  Status insert(
+      const std::string& key, FilteredBuffer&& buffer, bool overwrite = true);
 
   /**
    * Reads a portion of the object labeled by `key`.
@@ -100,7 +102,7 @@ class BufferLRUCache : public LRUCache<std::string, Buffer> {
    */
   Status read(
       const std::string& key,
-      Buffer* buffer,
+      FilteredBuffer& buffer,
       uint64_t offset,
       uint64_t nbytes,
       bool* success);

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -1450,7 +1450,7 @@ Status VFS::read_all(
           for (uint64_t i = 0; i < batch_copy.regions.size(); i++) {
             const auto& region = batch_copy.regions[i];
             uint64_t offset = std::get<0>(region);
-            void* dest = std::get<1>(region)->filtered_buffer()->data();
+            void* dest = std::get<1>(region)->filtered_buffer().data();
             uint64_t nbytes = std::get<2>(region);
             std::memcpy(dest, buffer.data(offset - batch_copy.offset), nbytes);
           }

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -258,7 +258,7 @@ Status FilterPipeline::filter_chunks_forward(
 
   // Allocate enough space in 'output' to store the leading uint64_t
   // prefix containing the number of chunks and the 'total_processed_size'.
-  output.resize(sizeof(uint64_t) + total_processed_size);
+  output.expand(sizeof(uint64_t) + total_processed_size);
 
   // Write the leading prefix that contains the number of chunks.
   memcpy(output.data(), &nchunks, sizeof(uint64_t));
@@ -455,8 +455,6 @@ Status FilterPipeline::run_reverse_chunk_range(
     const uint64_t max_chunk_index,
     uint64_t concurrency_level,
     const Config& config) const {
-  assert(tile->data());
-
   // Run each chunk through the entire pipeline.
   for (size_t i = min_chunk_index; i < max_chunk_index; i++) {
     auto& chunk = chunk_data.filtered_chunks_[i];

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -95,17 +95,16 @@ FilterPipeline::get_var_chunk_sizes(
   std::vector<uint64_t> chunk_offsets;
   if (offsets_tile != nullptr) {
     uint64_t num_offsets =
-        offsets_tile->buffer()->size() / constants::cell_var_offset_size;
-    auto offsets = (uint64_t*)offsets_tile->buffer()->data();
+        offsets_tile->size() / constants::cell_var_offset_size;
+    auto offsets = (uint64_t*)offsets_tile->data();
 
     uint64_t current_size = 0;
     uint64_t min_size = chunk_size / 2;
     uint64_t max_size = chunk_size + chunk_size / 2;
     chunk_offsets.emplace_back(0);
     for (uint64_t c = 0; c < num_offsets; c++) {
-      auto cell_size = c == num_offsets - 1 ?
-                           tile->buffer()->size() - offsets[c] :
-                           offsets[c + 1] - offsets[c];
+      auto cell_size = c == num_offsets - 1 ? tile->size() - offsets[c] :
+                                              offsets[c + 1] - offsets[c];
 
       // Time for a new chunk?
       auto new_size = current_size + cell_size;
@@ -148,19 +147,16 @@ FilterPipeline::get_var_chunk_sizes(
 
 Status FilterPipeline::filter_chunks_forward(
     const Tile& tile,
-    const Buffer& input,
     uint32_t chunk_size,
     std::vector<uint64_t>& chunk_offsets,
-    Buffer* const output,
+    FilteredBuffer& output,
     ThreadPool* const compute_tp) const {
-  assert(output);
-
   bool var_sizes = chunk_offsets.size() > 0;
   uint64_t nchunks =
-      var_sizes ? chunk_offsets.size() : input.size() / chunk_size;
+      var_sizes ? chunk_offsets.size() : tile.size() / chunk_size;
   uint64_t last_buffer_size = var_sizes ?
-                                  input.size() - chunk_offsets[nchunks - 1] :
-                                  input.size() % chunk_size;
+                                  tile.size() - chunk_offsets[nchunks - 1] :
+                                  tile.size() % chunk_size;
   if (!var_sizes) {
     if (last_buffer_size != 0) {
       nchunks++;
@@ -184,7 +180,7 @@ Status FilterPipeline::filter_chunks_forward(
 
     // First filter's input is the original chunk.
     uint64_t offset = var_sizes ? chunk_offsets[i] : i * chunk_size;
-    void* chunk_buffer = static_cast<char*>(input.data()) + offset;
+    void* chunk_buffer = static_cast<char*>(tile.data()) + offset;
     uint32_t chunk_buffer_size =
         i == nchunks - 1 ?
             last_buffer_size :
@@ -262,10 +258,10 @@ Status FilterPipeline::filter_chunks_forward(
 
   // Allocate enough space in 'output' to store the leading uint64_t
   // prefix containing the number of chunks and the 'total_processed_size'.
-  RETURN_NOT_OK(output->realloc(sizeof(uint64_t) + total_processed_size));
+  output.resize(sizeof(uint64_t) + total_processed_size);
 
   // Write the leading prefix that contains the number of chunks.
-  RETURN_NOT_OK(output->write(&nchunks, sizeof(uint64_t)));
+  memcpy(output.data(), &nchunks, sizeof(uint64_t));
 
   // Concatenate all processed chunks into the final output buffer.
   status = parallel_for(compute_tp, 0, final_stage_io.size(), [&](uint64_t i) {
@@ -277,7 +273,7 @@ Status FilterPipeline::filter_chunks_forward(
             last_buffer_size :
             var_sizes ? chunk_offsets[i + 1] - chunk_offsets[i] : chunk_size;
     auto metadata_size = (uint32_t)final_stage_output_metadata.size();
-    void* dest = output->data(offsets[i]);
+    void* dest = output.data() + offsets[i];
     uint64_t dest_offset = 0;
 
     // Write the original (unfiltered) chunk size
@@ -300,17 +296,12 @@ Status FilterPipeline::filter_chunks_forward(
 
   RETURN_NOT_OK(status);
 
-  // Ensure the final size is set to the concatenated size.
-  output->advance_offset(total_processed_size);
-  output->advance_size(total_processed_size);
-
   return Status::Ok();
 }
 
 Status FilterPipeline::filter_chunks_reverse(
-    const Tile& tile,
+    Tile& tile,
     const std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>>& input,
-    Buffer* const output,
     ThreadPool* const compute_tp,
     const Config& config) const {
   if (input.empty()) {
@@ -325,8 +316,10 @@ Status FilterPipeline::filter_chunks_reverse(
     total_size += std::get<2>(input[i]);
   }
 
-  if (total_size != output->alloced_size())
-    RETURN_NOT_OK(output->realloc(total_size));
+  if (total_size != tile.size()) {
+    return LOG_STATUS(
+        Status_FilterError("Error incorrect unfiltered tile size allocated."));
+  }
 
   // Run each chunk through the entire pipeline.
   auto status = parallel_for(compute_tp, 0, input.size(), [&](uint64_t i) {
@@ -351,7 +344,7 @@ Status FilterPipeline::filter_chunks_reverse(
     // If the pipeline is empty, just copy input to output.
     if (filters_.empty()) {
       void* output_chunk_buffer =
-          static_cast<char*>(output->data()) + chunk_offsets[i];
+          static_cast<char*>(tile.data()) + chunk_offsets[i];
       RETURN_NOT_OK(input_data.copy_to(output_chunk_buffer));
       return Status::Ok();
     }
@@ -374,7 +367,7 @@ Status FilterPipeline::filter_chunks_reverse(
       bool last_filter = filter_idx == 0;
       if (last_filter) {
         void* output_chunk_buffer =
-            static_cast<char*>(output->data()) + chunk_offsets[i];
+            static_cast<char*>(tile.data()) + chunk_offsets[i];
         RETURN_NOT_OK(output_data.set_fixed_allocation(
             output_chunk_buffer, orig_chunk_len));
       }
@@ -402,11 +395,6 @@ Status FilterPipeline::filter_chunks_reverse(
   });
 
   RETURN_NOT_OK(status);
-
-  // Since we did not use the 'write' interface above, the 'output' size
-  // will still be 0. We wrote the entire capacity of the output buffer,
-  // set it here.
-  output->set_size(total_size);
 
   return Status::Ok();
 }
@@ -439,23 +427,22 @@ Status FilterPipeline::run_forward(
   // Get the chunk sizes for var size attributes.
   auto&& [st, chunk_offsets] =
       get_var_chunk_sizes(chunk_size, tile, offsets_tile);
-  RETURN_NOT_OK_ELSE(st, tile->filtered_buffer()->clear());
+  RETURN_NOT_OK_ELSE(st, tile->filtered_buffer().clear());
 
   // Run the filters over all the chunks and store the result in
   // 'filtered_buffer'.
   RETURN_NOT_OK_ELSE(
       filter_chunks_forward(
           *tile,
-          *tile->buffer(),
           chunk_size,
           *chunk_offsets,
           tile->filtered_buffer(),
           compute_tp),
-      tile->filtered_buffer()->clear());
+      tile->filtered_buffer().clear());
 
   // The contents of 'buffer' have been filtered and stored
   // in 'filtered_buffer'. We can safely free 'buffer'.
-  tile->buffer()->clear();
+  tile->clear_data();
 
   return Status::Ok();
 }
@@ -468,8 +455,7 @@ Status FilterPipeline::run_reverse_chunk_range(
     const uint64_t max_chunk_index,
     uint64_t concurrency_level,
     const Config& config) const {
-  assert(tile->buffer()->data());
-  assert(tile->filtered_buffer());
+  assert(tile->data());
 
   // Run each chunk through the entire pipeline.
   for (size_t i = min_chunk_index; i < max_chunk_index; i++) {
@@ -486,8 +472,8 @@ Status FilterPipeline::run_reverse_chunk_range(
 
     // If the pipeline is empty, just copy input to output.
     if (filters_.empty()) {
-      void* output_chunk_buffer = static_cast<char*>(tile->buffer()->data()) +
-                                  chunk_data.chunk_offsets_[i];
+      void* output_chunk_buffer =
+          static_cast<char*>(tile->data()) + chunk_data.chunk_offsets_[i];
       RETURN_NOT_OK(input_data.copy_to(output_chunk_buffer));
       return Status::Ok();
     }
@@ -509,8 +495,8 @@ Status FilterPipeline::run_reverse_chunk_range(
       // Final filter: output directly into the shared output buffer.
       bool last_filter = filter_idx == 0;
       if (last_filter) {
-        void* output_chunk_buffer = static_cast<char*>(tile->buffer()->data()) +
-                                    chunk_data.chunk_offsets_[i];
+        void* output_chunk_buffer =
+            static_cast<char*>(tile->data()) + chunk_data.chunk_offsets_[i];
         RETURN_NOT_OK(output_data.set_fixed_allocation(
             output_chunk_buffer, chunk.unfiltered_data_size_));
         reader_stats->add_counter(
@@ -556,54 +542,46 @@ Status FilterPipeline::run_reverse_internal(
     Tile* tile,
     ThreadPool* const compute_tp,
     const Config& config) const {
-  Buffer* const filtered_buffer = tile->filtered_buffer();
-  if (filtered_buffer == nullptr)
-    return LOG_STATUS(
-        Status_FilterError("Filter error; tile has null buffer."));
-
-  assert(tile->buffer());
-  assert(tile->buffer()->size() == 0);
-  if (tile->buffer()->size() > 0)
-    return LOG_STATUS(Status_FilterError(
-        "Filter error; tile has allocated uncompressed chunk buffers."));
+  auto filtered_buffer_data = tile->filtered_buffer().data();
 
   // First make a pass over the tile to get the chunk information.
-  filtered_buffer->reset_offset();
   uint64_t num_chunks;
-  RETURN_NOT_OK(filtered_buffer->read(&num_chunks, sizeof(uint64_t)));
+  memcpy(&num_chunks, filtered_buffer_data, sizeof(uint64_t));
+  filtered_buffer_data += sizeof(uint64_t);
   std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>> filtered_chunks(
       num_chunks);
   uint64_t total_orig_size = 0;
   for (uint64_t i = 0; i < num_chunks; i++) {
     uint32_t filtered_chunk_size, orig_chunk_size, metadata_size;
-    RETURN_NOT_OK(filtered_buffer->read(&orig_chunk_size, sizeof(uint32_t)));
-    RETURN_NOT_OK(
-        filtered_buffer->read(&filtered_chunk_size, sizeof(uint32_t)));
-    RETURN_NOT_OK(filtered_buffer->read(&metadata_size, sizeof(uint32_t)));
+    memcpy(&orig_chunk_size, filtered_buffer_data, sizeof(uint32_t));
+    filtered_buffer_data += sizeof(uint32_t);
+    memcpy(&filtered_chunk_size, filtered_buffer_data, sizeof(uint32_t));
+    filtered_buffer_data += sizeof(uint32_t);
+    memcpy(&metadata_size, filtered_buffer_data, sizeof(uint32_t));
+    filtered_buffer_data += sizeof(uint32_t);
 
     total_orig_size += orig_chunk_size;
 
     filtered_chunks[i] = std::make_tuple(
-        filtered_buffer->cur_data(),
+        filtered_buffer_data,
         filtered_chunk_size,
         orig_chunk_size,
         metadata_size);
-    filtered_buffer->advance_offset(metadata_size + filtered_chunk_size);
+    filtered_buffer_data += metadata_size + filtered_chunk_size;
   }
-  assert(filtered_buffer->offset() == filtered_buffer->size());
 
   reader_stats->add_counter("read_unfiltered_byte_num", total_orig_size);
 
-  const Status st = filter_chunks_reverse(
-      *tile, filtered_chunks, tile->buffer(), compute_tp, config);
+  const Status st =
+      filter_chunks_reverse(*tile, filtered_chunks, compute_tp, config);
   if (!st.ok()) {
-    tile->buffer()->clear();
+    tile->clear_data();
     return st;
   }
 
   // Clear the filtered buffer now that we have reverse-filtered it into
   // 'tile->buffer()'.
-  filtered_buffer->clear();
+  tile->filtered_buffer().clear();
 
   // Zip the coords.
   if (tile->stores_coords()) {

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -43,6 +43,7 @@
 #include "tiledb/sm/filter/filter_buffer.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/stats/stats.h"
+#include "tiledb/sm/tile/filtered_buffer.h"
 
 using namespace tiledb::common;
 
@@ -317,10 +318,9 @@ class FilterPipeline {
    */
   Status filter_chunks_forward(
       const Tile& tile,
-      const Buffer& input,
       uint32_t chunk_size,
       std::vector<uint64_t>& chunk_offsets,
-      Buffer* const output,
+      FilteredBuffer& output,
       ThreadPool* const compute_tp) const;
 
   /**
@@ -335,9 +335,8 @@ class FilterPipeline {
    * @return Status
    */
   Status filter_chunks_reverse(
-      const Tile& tile,
+      Tile& tile,
       const std::vector<std::tuple<void*, uint32_t, uint32_t, uint32_t>>& input,
-      Buffer* const output,
       ThreadPool* const compute_tp,
       const Config& config) const;
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -3035,12 +3035,10 @@ Status FragmentMetadata::load_v1_v2(
   RETURN_NOT_OK(tile_io.read_generic(
       &tile, 0, encryption_key, storage_manager_->config()));
 
-  auto buffer = tile->buffer();
   Buffer buff;
-  RETURN_NOT_OK_ELSE(buff.realloc(buffer->size()), tdb_delete(tile));
-  buff.set_size(buffer->size());
-  buffer->reset_offset();
-  RETURN_NOT_OK_ELSE(buffer->read(buff.data(), buff.size()), tdb_delete(tile));
+  RETURN_NOT_OK_ELSE(buff.realloc(tile->size()), tdb_delete(tile));
+  buff.set_size(tile->size());
+  RETURN_NOT_OK_ELSE(tile->read(buff.data(), 0, buff.size()), tdb_delete(tile));
   tdb_delete(tile);
 
   storage_manager_->stats()->add_counter("read_frag_meta_size", buff.size());
@@ -3375,8 +3373,7 @@ Status FragmentMetadata::store_rtree(
   Buffer buff;
   RETURN_NOT_OK(write_rtree(&buff));
 
-  RETURN_NOT_OK(
-      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
   storage_manager_->stats()->add_counter("write_rtree_size", *nbytes);
 
   return Status::Ok();
@@ -3442,12 +3439,10 @@ Status FragmentMetadata::read_generic_tile_from_file(
   RETURN_NOT_OK(tile_io.read_generic(
       &tile, offset, encryption_key, storage_manager_->config()));
 
-  const auto buffer = tile->buffer();
-  buff->realloc(buffer->size());
-  buff->set_size(buffer->size());
-  buffer->reset_offset();
+  buff->realloc(tile->size());
+  buff->set_size(tile->size());
   RETURN_NOT_OK_ELSE(
-      buffer->read(buff->data(), buff->size()), tdb_delete(tile));
+      tile->read(buff->data(), 0, buff->size()), tdb_delete(tile));
   tdb_delete(tile);
 
   return Status::Ok();
@@ -3479,21 +3474,17 @@ Status FragmentMetadata::read_file_footer(
 }
 
 Status FragmentMetadata::write_generic_tile_to_file(
-    const EncryptionKey& encryption_key,
-    Buffer&& buff,
-    uint64_t* nbytes) const {
+    const EncryptionKey& encryption_key, Buffer& buff, uint64_t* nbytes) const {
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
-
-  Buffer* const buffer = tdb_new(Buffer);
-  buffer->swap(buff);
 
   Tile tile(
       constants::generic_tile_datatype,
       constants::generic_tile_cell_size,
       0,
-      buffer,
-      true);
+      buff.data(),
+      buff.size());
+  buff.disown_data();
 
   GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
   RETURN_NOT_OK(tile_io.write_generic(&tile, encryption_key, nbytes));
@@ -3519,8 +3510,7 @@ Status FragmentMetadata::store_tile_offsets(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_offsets(idx, &buff));
-  RETURN_NOT_OK(
-      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
 
   storage_manager_->stats()->add_counter("write_tile_offsets_size", *nbytes);
 
@@ -3556,8 +3546,7 @@ Status FragmentMetadata::store_tile_var_offsets(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_var_offsets(idx, &buff));
-  RETURN_NOT_OK(
-      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
 
   storage_manager_->stats()->add_counter(
       "write_tile_var_offsets_size", *nbytes);
@@ -3596,8 +3585,7 @@ Status FragmentMetadata::store_tile_var_sizes(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_var_sizes(idx, &buff));
-  RETURN_NOT_OK(
-      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
 
   storage_manager_->stats()->add_counter("write_tile_var_sizes_size", *nbytes);
 
@@ -3633,8 +3621,7 @@ Status FragmentMetadata::store_tile_validity_offsets(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_validity_offsets(idx, &buff));
-  RETURN_NOT_OK(
-      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
 
   storage_manager_->stats()->add_counter(
       "write_tile_validity_offsets_size", *nbytes);
@@ -3674,8 +3661,7 @@ Status FragmentMetadata::store_tile_mins(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_mins(idx, &buff));
-  RETURN_NOT_OK(
-      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
 
   storage_manager_->stats()->add_counter("write_mins_size", *nbytes);
 
@@ -3732,8 +3718,7 @@ Status FragmentMetadata::store_tile_maxs(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_maxs(idx, &buff));
-  RETURN_NOT_OK(
-      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
 
   storage_manager_->stats()->add_counter("write_maxs_size", *nbytes);
 
@@ -3790,8 +3775,7 @@ Status FragmentMetadata::store_tile_sums(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_sums(idx, &buff));
-  RETURN_NOT_OK(
-      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
 
   storage_manager_->stats()->add_counter("write_sums_size", *nbytes);
 
@@ -3826,8 +3810,7 @@ Status FragmentMetadata::store_tile_null_counts(
     unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Buffer buff;
   RETURN_NOT_OK(write_tile_null_counts(idx, &buff));
-  RETURN_NOT_OK(
-      write_generic_tile_to_file(encryption_key, std::move(buff), nbytes));
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
 
   storage_manager_->stats()->add_counter("write_null_counts_size", *nbytes);
 

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1454,7 +1454,7 @@ class FragmentMetadata {
    */
   Status write_generic_tile_to_file(
       const EncryptionKey& encryption_key,
-      Buffer&& buff,
+      Buffer& buff,
       uint64_t* nbytes) const;
 
   /**

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -983,21 +983,22 @@ Status DenseReader::copy_fixed_tiles(
           if (stride == 1) {
             std::memcpy(
                 dest_ptr + cell_size * start,
-                (char*)tile->data() + cell_size * src_offset,
+                tile->data_as<char>() + cell_size * src_offset,
                 cell_size * (end - start + 1));
 
             if (attributes[n]->nullable()) {
               std::memcpy(
                   dest_validity_ptr + start,
-                  (char*)tile_nullable->data() + src_offset,
+                  tile_nullable->data_as<char>() + src_offset,
                   (end - start + 1));
             }
           } else {
             // Go cell by cell.
             const auto nullable = attributes[n]->nullable();
-            auto src = (char*)tile->data() + cell_size * src_offset;
+            auto src = tile->data_as<char>() + cell_size * src_offset;
             auto src_validity =
-                nullable ? (char*)tile_nullable->data() + src_offset : nullptr;
+                nullable ? tile_nullable->data_as<char>() + src_offset :
+                           nullptr;
             auto dest = dest_ptr + cell_size * start;
             auto dest_validity = dest_validity_ptr + start;
             for (uint64_t i = 0; i < end - start + 1; ++i) {
@@ -1193,7 +1194,7 @@ Status DenseReader::copy_offset_tiles(
           for (; i < end - start; ++i) {
             auto i_src = i * stride;
             dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
-            var_data_buff[i + start] = (char*)t_var->data() + src_buff[i_src];
+            var_data_buff[i + start] = t_var->data_as<char>() + src_buff[i_src];
           }
 
           if (attributes[n]->nullable()) {
@@ -1212,7 +1213,7 @@ Status DenseReader::copy_offset_tiles(
             dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
           }
           var_data_buff[i + start] =
-              (char*)t_var->data() + src_buff[i * stride];
+              t_var->data_as<char>() + src_buff[i * stride];
 
           if (attributes[n]->nullable())
             dest_validity_ptr[start + i] = src_buff_validity[i * stride];

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -983,22 +983,21 @@ Status DenseReader::copy_fixed_tiles(
           if (stride == 1) {
             std::memcpy(
                 dest_ptr + cell_size * start,
-                (char*)tile->buffer()->data() + cell_size * src_offset,
+                (char*)tile->data() + cell_size * src_offset,
                 cell_size * (end - start + 1));
 
             if (attributes[n]->nullable()) {
               std::memcpy(
                   dest_validity_ptr + start,
-                  (char*)tile_nullable->buffer()->data() + src_offset,
+                  (char*)tile_nullable->data() + src_offset,
                   (end - start + 1));
             }
           } else {
             // Go cell by cell.
             const auto nullable = attributes[n]->nullable();
-            auto src = (char*)tile->buffer()->data() + cell_size * src_offset;
+            auto src = (char*)tile->data() + cell_size * src_offset;
             auto src_validity =
-                nullable ? (char*)tile_nullable->buffer()->data() + src_offset :
-                           nullptr;
+                nullable ? (char*)tile_nullable->data() + src_offset : nullptr;
             auto dest = dest_ptr + cell_size * start;
             auto dest_validity = dest_validity_ptr + start;
             for (uint64_t i = 0; i < end - start + 1; ++i) {
@@ -1179,12 +1178,11 @@ Status DenseReader::copy_offset_tiles(
           const Tile* const t_var = &std::get<1>(*tile_tuple);
 
           // Setup variables for the copy.
-          auto src_buff = (uint64_t*)std::get<0>(*tile_tuple).buffer()->data() +
+          auto src_buff = (uint64_t*)std::get<0>(*tile_tuple).data() +
                           start * stride + src_cell;
           auto src_buff_validity =
               attributes[n]->nullable() ?
-                  (uint8_t*)std::get<2>(*tile_tuple).buffer()->data() + start +
-                      src_cell :
+                  (uint8_t*)std::get<2>(*tile_tuple).data() + start + src_cell :
                   nullptr;
           auto div = elements_mode_ ? data_type_sizes[n] : 1;
           auto dest = (OffType*)dest_ptr + start;
@@ -1195,8 +1193,7 @@ Status DenseReader::copy_offset_tiles(
           for (; i < end - start; ++i) {
             auto i_src = i * stride;
             dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
-            var_data_buff[i + start] =
-                (char*)t_var->buffer()->data() + src_buff[i_src];
+            var_data_buff[i + start] = (char*)t_var->data() + src_buff[i_src];
           }
 
           if (attributes[n]->nullable()) {
@@ -1209,13 +1206,13 @@ Status DenseReader::copy_offset_tiles(
           // Copy the last value.
           if (start + src_cell + (end - start) * stride >=
               cell_num_per_tile - 1) {
-            dest[i] = (t_var->buffer()->size() - src_buff[i * stride]) / div;
+            dest[i] = (t_var->size() - src_buff[i * stride]) / div;
           } else {
             auto i_src = i * stride;
             dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
           }
           var_data_buff[i + start] =
-              (char*)t_var->buffer()->data() + src_buff[i * stride];
+              (char*)t_var->data() + src_buff[i * stride];
 
           if (attributes[n]->nullable())
             dest_validity_ptr[start + i] = src_buff_validity[i * stride];

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -38,7 +38,7 @@
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
-#include "tiledb/sm/tile/tile.h"
+#include "tiledb/sm/tile/writer_tile.h"
 
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;
@@ -188,7 +188,7 @@ const typename DenseTiler<T>::CopyPlan DenseTiler<T>::copy_plan(
 
 template <class T>
 Status DenseTiler<T>::get_tile(
-    uint64_t id, const std::string& name, Tile* tile) {
+    uint64_t id, const std::string& name, WriterTile* tile) {
   auto timer_se = stats_->start_timer("get_tile");
 
   // Checks
@@ -215,7 +215,6 @@ Status DenseTiler<T>::get_tile(
   // Initialize tile
   RETURN_NOT_OK(tile->init_unfiltered(
       constants::format_version, type, tile_size, cell_size, 0, true));
-  tile->reset_offset();
 
   // Copy tile from buffer
   RETURN_NOT_OK(copy_tile(id, cell_size, buff, tile));
@@ -225,7 +224,7 @@ Status DenseTiler<T>::get_tile(
 
 template <class T>
 Status DenseTiler<T>::get_tile_null(
-    uint64_t id, const std::string& name, Tile* tile) const {
+    uint64_t id, const std::string& name, WriterTile* tile) const {
   // Checks
   if (id >= tile_num_)
     return LOG_STATUS(
@@ -250,8 +249,6 @@ Status DenseTiler<T>::get_tile_null(
   // Initialize tile
   RETURN_NOT_OK(tile->init_unfiltered(
       constants::format_version, type, tile_size, cell_size, 0, true));
-  tile->reset_offset();
-  assert(tile->size() == tile_size);
 
   // Copy tile from buffer
   return copy_tile(id, cell_size, buff, tile);
@@ -261,8 +258,8 @@ template <class T>
 Status DenseTiler<T>::get_tile_var(
     uint64_t id,
     const std::string& name,
-    Tile* tile_off,
-    Tile* tile_val) const {
+    WriterTile* tile_off,
+    WriterTile* tile_val) const {
   // Checks
   if (id >= tile_num_)
     return LOG_STATUS(
@@ -290,7 +287,7 @@ Status DenseTiler<T>::get_tile_var(
   std::vector<uint8_t> fill_var(sizeof(uint64_t), 0);
 
   // Initialize position tile
-  Tile tile_pos;
+  WriterTile tile_pos;
   RETURN_NOT_OK(tile_pos.init_unfiltered(
       constants::format_version,
       constants::cell_var_offset_type,
@@ -301,10 +298,9 @@ Status DenseTiler<T>::get_tile_var(
   // Fill entire tile with MAX_UINT64
   std::vector<uint64_t> to_write(
       cell_num_in_tile, std::numeric_limits<uint64_t>::max());
-  tile_pos.write(to_write.data(), tile_off_size);
+  RETURN_NOT_OK(tile_pos.write(to_write.data(), 0, tile_off_size));
   to_write.clear();
   to_write.shrink_to_fit();
-  tile_pos.reset_offset();
 
   // Get position tile
   auto cell_num_in_buff =  // TODO: fix
@@ -331,15 +327,16 @@ Status DenseTiler<T>::get_tile_var(
       0));
 
   // Copy real offsets and values to the corresponding tiles
-  void* tile_pos_buff_tmp = tile_pos.buffer()->data();
+  void* tile_pos_buff_tmp = tile_pos.data();
   auto tile_pos_buff = (uint64_t*)tile_pos_buff_tmp;
-  uint64_t offset = 0, val_offset, val_size, pos;
+  uint64_t tile_off_offset = 0, offset = 0, val_offset, val_size, pos;
   auto mul = (offsets_format_mode_ == "bytes") ? 1 : cell_size;
   for (uint64_t i = 0; i < cell_num_in_tile; ++i) {
     pos = tile_pos_buff[i];
-    tile_off->write(&offset, sizeof(offset));
+    RETURN_NOT_OK(tile_off->write(&offset, tile_off_offset, sizeof(offset)));
+    tile_off_offset += sizeof(offset);
     if (pos == std::numeric_limits<uint64_t>::max()) {  // Empty
-      tile_val->write(&fill_var[0], cell_size);
+      RETURN_NOT_OK(tile_val->write_var(&fill_var[0], offset, cell_size));
       offset += cell_size;
     } else {  // Non-empty
       val_offset = ((offsets_bytesize_ == 8) ?
@@ -353,14 +350,13 @@ Status DenseTiler<T>::get_tile_var(
                           mul -
                       val_offset) :
                      buff_var_size - val_offset;
-      tile_val->write(&buff_var[val_offset], val_size);
+      RETURN_NOT_OK(
+          tile_val->write_var(&buff_var[val_offset], offset, val_size));
       offset += val_size;
     }
   }
 
-  // Reset tile offsets
-  tile_off->reset_offset();
-  tile_val->reset_offset();
+  tile_val->final_size(offset);
 
   return Status::Ok();
 }
@@ -561,7 +557,7 @@ std::vector<std::array<T, 2>> DenseTiler<T>::tile_subarray(uint64_t id) const {
 
 template <class T>
 Status DenseTiler<T>::copy_tile(
-    uint64_t id, uint64_t cell_size, uint8_t* buff, Tile* tile) const {
+    uint64_t id, uint64_t cell_size, uint8_t* buff, WriterTile* tile) const {
   // Calculate copy plan
   const CopyPlan copy_plan = this->copy_plan(id);
 
@@ -622,9 +618,6 @@ Status DenseTiler<T>::copy_tile(
       sub_offsets[i] = sub_offsets[i - 1];
     }
   }
-
-  // Reset the tile offset to the beginning of the tile
-  tile->reset_offset();
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/dense_tiler.h
+++ b/tiledb/sm/query/dense_tiler.h
@@ -43,6 +43,7 @@
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/subarray/subarray.h"
+#include "tiledb/sm/tile/writer_tile.h"
 
 using namespace tiledb::common;
 
@@ -172,7 +173,7 @@ class DenseTiler {
    *     be preallocated and initialized before passed to the function.
    * @return Status
    */
-  Status get_tile(uint64_t id, const std::string& name, Tile* tile);
+  Status get_tile(uint64_t id, const std::string& name, WriterTile* tile);
 
   /**
    * Retrieves the validity tile with the input id and for the input
@@ -185,7 +186,8 @@ class DenseTiler {
    *     be preallocated and initialized before passed to the function.
    * @return Status
    */
-  Status get_tile_null(uint64_t id, const std::string& name, Tile* tile) const;
+  Status get_tile_null(
+      uint64_t id, const std::string& name, WriterTile* tile) const;
 
   /**
    * Retrieves the var-sized tile with the input id and for the input
@@ -203,8 +205,8 @@ class DenseTiler {
   Status get_tile_var(
       uint64_t id,
       const std::string& name,
-      Tile* tile_off,
-      Tile* tile_var) const;
+      WriterTile* tile_off,
+      WriterTile* tile_var) const;
 
   /**
    * Returns the number of tiles to be created. This is equal
@@ -349,7 +351,7 @@ class DenseTiler {
    * @return Status
    */
   Status copy_tile(
-      uint64_t id, uint64_t cell_size, uint8_t* buff, Tile* tile) const;
+      uint64_t id, uint64_t cell_size, uint8_t* buff, WriterTile* tile) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -455,7 +455,7 @@ std::vector<ResultCellSlab> QueryCondition::apply_clause(
 
       if (nullable) {
         const auto& tile_validity = std::get<2>(*tile_tuple);
-        buffer_validity = static_cast<uint8_t*>(tile_validity.buffer()->data());
+        buffer_validity = static_cast<uint8_t*>(tile_validity.data());
       }
 
       // Start the pending result cell slab at the start position
@@ -465,12 +465,12 @@ std::vector<ResultCellSlab> QueryCondition::apply_clause(
 
       if (var_size) {
         const auto& tile = std::get<1>(*tile_tuple);
-        const char* buffer = static_cast<char*>(tile.buffer()->data());
+        const char* buffer = static_cast<char*>(tile.data());
         const uint64_t buffer_size = tile.size();
 
         const auto& tile_offsets = std::get<0>(*tile_tuple);
         const uint64_t* buffer_offsets =
-            static_cast<uint64_t*>(tile_offsets.buffer()->data());
+            static_cast<uint64_t*>(tile_offsets.data());
         const uint64_t buffer_offsets_el =
             tile_offsets.size() / constants::cell_var_offset_size;
 
@@ -505,7 +505,7 @@ std::vector<ResultCellSlab> QueryCondition::apply_clause(
         }
       } else {
         const auto& tile = std::get<0>(*tile_tuple);
-        const char* buffer = static_cast<char*>(tile.buffer()->data());
+        const char* buffer = static_cast<char*>(tile.data());
         const uint64_t cell_size = tile.cell_size();
         uint64_t buffer_offset = start * cell_size;
         const uint64_t buffer_offset_inc = stride * cell_size;
@@ -719,12 +719,12 @@ void QueryCondition::apply_clause_dense(
   if (var_size) {
     // Get var data buffer and tile offsets buffer.
     const auto& tile = std::get<1>(*tile_tuple);
-    const char* buffer = static_cast<char*>(tile.buffer()->data());
+    const char* buffer = static_cast<char*>(tile.data());
     const uint64_t buffer_size = tile.size();
 
     const auto& tile_offsets = std::get<0>(*tile_tuple);
     const uint64_t* buffer_offsets =
-        static_cast<uint64_t*>(tile_offsets.buffer()->data()) + src_cell;
+        static_cast<uint64_t*>(tile_offsets.data()) + src_cell;
     const uint64_t buffer_offsets_el =
         tile_offsets.size() / constants::cell_var_offset_size;
 
@@ -758,7 +758,7 @@ void QueryCondition::apply_clause_dense(
   } else {
     // Get the fixed size data buffers.
     const auto& tile = std::get<0>(*tile_tuple);
-    const char* buffer = static_cast<char*>(tile.buffer()->data());
+    const char* buffer = static_cast<char*>(tile.data());
     const uint64_t cell_size = tile.cell_size();
     uint64_t buffer_offset = (start + src_cell) * cell_size;
     const uint64_t buffer_offset_inc = stride * cell_size;
@@ -892,7 +892,7 @@ Status QueryCondition::apply_clause_dense(
     const auto tile_tuple = result_tile->tile_tuple(clause.field_name_);
     const auto& tile_validity = std::get<2>(*tile_tuple);
     const auto buffer_validity =
-        static_cast<uint8_t*>(tile_validity.buffer()->data()) + src_cell;
+        static_cast<uint8_t*>(tile_validity.data()) + src_cell;
     ;
 
     // Null values can only be specified for equality operators.
@@ -1266,12 +1266,12 @@ void QueryCondition::apply_clause_sparse(
   if (var_size) {
     // Get var data buffer and tile offsets buffer.
     const auto& tile = std::get<1>(*tile_tuple);
-    const char* buffer = static_cast<char*>(tile.buffer()->data());
+    const char* buffer = static_cast<char*>(tile.data());
     const uint64_t buffer_size = tile.size();
 
     const auto& tile_offsets = std::get<0>(*tile_tuple);
     const uint64_t* buffer_offsets =
-        static_cast<uint64_t*>(tile_offsets.buffer()->data());
+        static_cast<uint64_t*>(tile_offsets.data());
     const uint64_t buffer_offsets_el =
         tile_offsets.size() / constants::cell_var_offset_size;
 
@@ -1303,7 +1303,7 @@ void QueryCondition::apply_clause_sparse(
   } else {
     // Get the fixed size data buffers.
     const auto& tile = std::get<0>(*tile_tuple);
-    const char* buffer = static_cast<char*>(tile.buffer()->data());
+    const char* buffer = static_cast<char*>(tile.data());
     const uint64_t cell_size = tile.cell_size();
     const uint64_t buffer_el = tile.size() / cell_size;
 
@@ -1387,8 +1387,7 @@ Status QueryCondition::apply_clause_sparse(
   if (nullable) {
     const auto tile_tuple = result_tile.tile_tuple(clause.field_name_);
     const auto& tile_validity = std::get<2>(*tile_tuple);
-    const auto buffer_validity =
-        static_cast<uint8_t*>(tile_validity.buffer()->data());
+    const auto buffer_validity = static_cast<uint8_t*>(tile_validity.data());
 
     // Null values can only be specified for equality operators.
     if (clause.condition_value_ == nullptr) {

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -1100,9 +1100,7 @@ Status Reader::compute_var_cell_destinations(
       const auto& tile_var = std::get<1>(*tile_tuple);
 
       // Get the internal buffer to the offset values.
-      Buffer* const buffer = tile.buffer();
-
-      tile_offsets = (uint64_t*)buffer->data();
+      tile_offsets = (uint64_t*)tile.data();
       tile_cell_num = tile.cell_num();
       tile_var_size = tile_var.size();
     }
@@ -1212,9 +1210,7 @@ Status Reader::copy_partitioned_var_cells(
       tile_validity = &std::get<2>(*tile_tuple);
 
       // Get the internal buffer to the offset values.
-      Buffer* const buffer = tile->buffer();
-
-      tile_offsets = (uint64_t*)buffer->data();
+      tile_offsets = (uint64_t*)tile->data();
       tile_cell_num = tile->cell_num();
     }
 
@@ -1252,11 +1248,11 @@ Status Reader::copy_partitioned_var_cells(
         const uint64_t tile_var_offset =
             tile_offsets[cell_idx] - tile_offsets[0];
 
-        RETURN_NOT_OK(tile_var->read(var_dest, cell_var_size, tile_var_offset));
+        RETURN_NOT_OK(tile_var->read(var_dest, tile_var_offset, cell_var_size));
 
         if (nullable)
           RETURN_NOT_OK(tile_validity->read(
-              validity_dest, constants::cell_validity_size, cell_idx));
+              validity_dest, cell_idx, constants::cell_validity_size));
       }
     }
 

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -510,7 +510,7 @@ Status ReaderBase::read_tiles(
         all_regions[tile_attr_uri].emplace_back(
             tile_attr_offset, t, *tile_persisted_size);
 
-        t->filtered_buffer().resize(*tile_persisted_size);
+        t->filtered_buffer().expand(*tile_persisted_size);
       }
 
       // Pre-allocate the unfiltered buffer.
@@ -541,7 +541,7 @@ Status ReaderBase::read_tiles(
           all_regions[tile_attr_var_uri].emplace_back(
               tile_attr_var_offset, t_var, *tile_var_persisted_size);
 
-          t_var->filtered_buffer().resize(*tile_var_persisted_size);
+          t_var->filtered_buffer().expand(*tile_var_persisted_size);
         }
 
         // Pre-allocate the unfiltered buffer.
@@ -575,7 +575,7 @@ Status ReaderBase::read_tiles(
               t_validity,
               *tile_validity_persisted_size);
 
-          t_validity->filtered_buffer().resize(*tile_validity_persisted_size);
+          t_validity->filtered_buffer().expand(*tile_validity_persisted_size);
         }
 
         // Pre-allocate the unfiltered buffer.
@@ -614,7 +614,6 @@ std::tuple<Status, std::optional<uint64_t>> ReaderBase::load_chunk_data(
   assert(tile);
   assert(unfiltered_tile);
   assert(tile->filtered());
-  assert(tile->data());
 
   Status st = Status::Ok();
   auto filtered_buffer_data = tile->filtered_buffer().data();

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -772,10 +772,7 @@ class ReaderBase : public StrategyBase {
       const std::string& name,
       ResultTile* const tile,
       const bool var_size,
-      const bool nullable,
-      const uint64_t unfiltered_tile_size,
-      const uint64_t unfiltered_tile_var_size,
-      const uint64_t unfiltered_tile_validity_size) const;
+      const bool nullable) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/result_space_tile.h
+++ b/tiledb/sm/query/result_space_tile.h
@@ -100,9 +100,9 @@ class ResultSpaceTile {
   }
 
   /** Sets the input result tile for the given fragment. */
-  void set_result_tile(unsigned frag_idx, const ResultTile& result_tile) {
+  void set_result_tile(unsigned frag_idx, ResultTile& result_tile) {
     assert(result_tiles_.count(frag_idx) == 0);
-    result_tiles_[frag_idx] = result_tile;
+    result_tiles_[frag_idx] = std::move(result_tile);
   }
 
   /** Returns the result tile for the input fragment. */

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -69,6 +69,20 @@ ResultTile::ResultTile(
   coord_func_ = &ResultTile::zipped_coord;
 }
 
+/** Move constructor. */
+ResultTile::ResultTile(ResultTile&& other) {
+  // Swap with the argument
+  swap(other);
+}
+
+/** Move-assign operator. */
+ResultTile& ResultTile::operator=(ResultTile&& other) {
+  // Swap with the argument
+  swap(other);
+
+  return *this;
+}
+
 /* ****************************** */
 /*               API              */
 /* ****************************** */
@@ -277,7 +291,7 @@ Status ResultTile::read(
     auto buff_offset = 0;
     for (uint64_t c = 0; c < len; ++c) {
       for (unsigned d = 0; d < dim_num; ++d) {
-        auto coord_tile = std::get<0>(coord_tiles_[d].second);
+        auto& coord_tile = std::get<0>(coord_tiles_[d].second);
         auto cell_size = coord_tile.cell_size();
         auto tile_offset = (pos + c) * cell_size;
         RETURN_NOT_OK(
@@ -1018,6 +1032,24 @@ Status ResultTile::compute_results_count_sparse<uint64_t>(
       min_cell,
       max_cell);
   return Status::Ok();
+}
+
+void ResultTile::swap(ResultTile& tile) {
+  std::swap(domain_, tile.domain_);
+  std::swap(frag_idx_, tile.frag_idx_);
+  std::swap(tile_idx_, tile.tile_idx_);
+  std::swap(attr_tiles_, tile.attr_tiles_);
+  std::swap(coords_tile_, tile.coords_tile_);
+  std::swap(coord_tiles_, tile.coord_tiles_);
+  std::swap(compute_results_dense_func_, tile.compute_results_dense_func_);
+  std::swap(coord_func_, tile.coord_func_);
+  std::swap(compute_results_sparse_func_, tile.compute_results_sparse_func_);
+  std::swap(
+      compute_results_count_sparse_uint64_t_func_,
+      tile.compute_results_count_sparse_uint64_t_func_);
+  std::swap(
+      compute_results_count_sparse_uint8_t_func_,
+      tile.compute_results_count_sparse_uint8_t_func_);
 }
 
 /* ****************************** */

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -83,6 +83,24 @@ ResultTile& ResultTile::operator=(ResultTile&& other) {
   return *this;
 }
 
+void ResultTile::swap(ResultTile& tile) {
+  std::swap(domain_, tile.domain_);
+  std::swap(frag_idx_, tile.frag_idx_);
+  std::swap(tile_idx_, tile.tile_idx_);
+  std::swap(attr_tiles_, tile.attr_tiles_);
+  std::swap(coords_tile_, tile.coords_tile_);
+  std::swap(coord_tiles_, tile.coord_tiles_);
+  std::swap(compute_results_dense_func_, tile.compute_results_dense_func_);
+  std::swap(coord_func_, tile.coord_func_);
+  std::swap(compute_results_sparse_func_, tile.compute_results_sparse_func_);
+  std::swap(
+      compute_results_count_sparse_uint64_t_func_,
+      tile.compute_results_count_sparse_uint64_t_func_);
+  std::swap(
+      compute_results_count_sparse_uint8_t_func_,
+      tile.compute_results_count_sparse_uint8_t_func_);
+}
+
 /* ****************************** */
 /*               API              */
 /* ****************************** */
@@ -1032,24 +1050,6 @@ Status ResultTile::compute_results_count_sparse<uint64_t>(
       min_cell,
       max_cell);
   return Status::Ok();
-}
-
-void ResultTile::swap(ResultTile& tile) {
-  std::swap(domain_, tile.domain_);
-  std::swap(frag_idx_, tile.frag_idx_);
-  std::swap(tile_idx_, tile.tile_idx_);
-  std::swap(attr_tiles_, tile.attr_tiles_);
-  std::swap(coords_tile_, tile.coords_tile_);
-  std::swap(coord_tiles_, tile.coord_tiles_);
-  std::swap(compute_results_dense_func_, tile.compute_results_dense_func_);
-  std::swap(coord_func_, tile.coord_func_);
-  std::swap(compute_results_sparse_func_, tile.compute_results_sparse_func_);
-  std::swap(
-      compute_results_count_sparse_uint64_t_func_,
-      tile.compute_results_count_sparse_uint64_t_func_);
-  std::swap(
-      compute_results_count_sparse_uint8_t_func_,
-      tile.compute_results_count_sparse_uint8_t_func_);
 }
 
 /* ****************************** */

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -91,12 +91,15 @@ class ResultTile {
   /** Move constructor. */
   ResultTile(ResultTile&& tile);
 
+  /** Move-assign operator. */
+  ResultTile& operator=(ResultTile&& tile);
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(ResultTile& tile);
+
   /* ********************************* */
   /*                API                */
   /* ********************************* */
-
-  /** Move-assign operator. */
-  ResultTile& operator=(ResultTile&& tile);
 
   /** Equality operator (mainly for debugging purposes). */
   bool operator==(const ResultTile& rt) const;
@@ -320,9 +323,6 @@ class ResultTile {
       const Layout& cell_order,
       const uint64_t min_cell,
       const uint64_t max_cell) const;
-
-  /** Swaps the contents (all field values) of this tile with the given tile. */
-  void swap(ResultTile& tile);
 
  private:
   /* ********************************* */

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -83,24 +83,20 @@ class ResultTile {
    */
   ResultTile(unsigned frag_idx, uint64_t tile_idx, const ArraySchema* schema);
 
+  DISABLE_COPY_AND_COPY_ASSIGN(ResultTile);
+
   /** Default destructor. */
   ~ResultTile() = default;
 
-  /** Default copy constructor. */
-  ResultTile(const ResultTile&) = default;
-
-  /** Default move constructor. */
-  ResultTile(ResultTile&&) = default;
+  /** Move constructor. */
+  ResultTile(ResultTile&& tile);
 
   /* ********************************* */
   /*                API                */
   /* ********************************* */
 
-  /** Default copy-assign operator. */
-  ResultTile& operator=(const ResultTile&) = default;
-
-  /** Default move-assign operator. */
-  ResultTile& operator=(ResultTile&&) = default;
+  /** Move-assign operator. */
+  ResultTile& operator=(ResultTile&& tile);
 
   /** Equality operator (mainly for debugging purposes). */
   bool operator==(const ResultTile& rt) const;
@@ -324,6 +320,9 @@ class ResultTile {
       const Layout& cell_order,
       const uint64_t min_cell,
       const uint64_t max_cell) const;
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(ResultTile& tile);
 
  private:
   /* ********************************* */

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -848,8 +848,8 @@ Status SparseGlobalOrderReader::copy_offsets_tiles(
         const auto tile_tuple = rt->tile_tuple(name);
         const auto t = &std::get<0>(*tile_tuple);
         const auto t_var = &std::get<1>(*tile_tuple);
-        const auto src_buff = (uint64_t*)t->data();
-        const auto src_var_buff = (char*)t_var->data();
+        const auto src_buff = t->data_as<uint64_t>();
+        const auto src_var_buff = t_var->data_as<char>();
         const auto t_val = &std::get<2>(*tile_tuple);
         const auto cell_num =
             fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
@@ -890,7 +890,7 @@ Status SparseGlobalOrderReader::copy_offsets_tiles(
 
         // Copy nullable values.
         if (nullable) {
-          const auto src_val_buff = (uint8_t*)t_val->data();
+          const auto src_val_buff = t_val->data_as<uint8_t>();
           for (uint64_t c = min_pos; c < max_pos; c++) {
             *val_buffer = src_val_buff[c];
             val_buffer++;
@@ -1007,7 +1007,7 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
         const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
         const auto tile_tuple = rt->tile_tuple(name);
         const auto t = &std::get<0>(*tile_tuple);
-        const auto src_buff = (uint8_t*)t->data();
+        const auto src_buff = t->data_as<uint8_t>();
         const auto t_val = &std::get<2>(*tile_tuple);
 
         // Compute parallelization parameters.
@@ -1044,7 +1044,7 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
         }
 
         if (nullable) {
-          const auto src_val_buff = (uint8_t*)t_val->data();
+          const auto src_val_buff = t_val->data_as<uint8_t>();
           memcpy(val_buffer, src_val_buff + min_pos, max_pos - min_pos);
         }
 

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -79,8 +79,10 @@ SparseGlobalOrderReader::SparseGlobalOrderReader(
           buffers,
           subarray,
           layout,
-          condition) {
-  array_memory_tracker_ = array->memory_tracker();
+          condition)
+    , result_tiles_(array->fragment_metadata().size())
+    , memory_used_for_coords_(array->fragment_metadata().size())
+    , memory_used_for_qc_tiles_(array->fragment_metadata().size()) {
 }
 
 /* ****************************** */
@@ -155,11 +157,6 @@ Status SparseGlobalOrderReader::dowork() {
     read_state_.done_adding_result_tiles_ = true;
     return Status::Ok();
   }
-
-  // Make sure we have enough space for tiles data.
-  memory_used_for_coords_.resize(fragment_num);
-  memory_used_for_qc_tiles_.resize(fragment_num);
-  result_tiles_.resize(fragment_num);
 
   // Load initial data, if not loaded already.
   RETURN_NOT_OK(load_initial_data());

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -851,8 +851,8 @@ Status SparseGlobalOrderReader::copy_offsets_tiles(
         const auto tile_tuple = rt->tile_tuple(name);
         const auto t = &std::get<0>(*tile_tuple);
         const auto t_var = &std::get<1>(*tile_tuple);
-        const auto src_buff = (uint64_t*)t->buffer()->data();
-        const auto src_var_buff = (char*)t_var->buffer()->data();
+        const auto src_buff = (uint64_t*)t->data();
+        const auto src_var_buff = (char*)t_var->data();
         const auto t_val = &std::get<2>(*tile_tuple);
         const auto cell_num =
             fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
@@ -893,7 +893,7 @@ Status SparseGlobalOrderReader::copy_offsets_tiles(
 
         // Copy nullable values.
         if (nullable) {
-          const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+          const auto src_val_buff = (uint8_t*)t_val->data();
           for (uint64_t c = min_pos; c < max_pos; c++) {
             *val_buffer = src_val_buff[c];
             val_buffer++;
@@ -1010,7 +1010,7 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
         const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
         const auto tile_tuple = rt->tile_tuple(name);
         const auto t = &std::get<0>(*tile_tuple);
-        const auto src_buff = (uint8_t*)t->buffer()->data();
+        const auto src_buff = (uint8_t*)t->data();
         const auto t_val = &std::get<2>(*tile_tuple);
 
         // Compute parallelization parameters.
@@ -1047,7 +1047,7 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
         }
 
         if (nullable) {
-          const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+          const auto src_val_buff = (uint8_t*)t_val->data();
           memcpy(val_buffer, src_val_buff + min_pos, max_pos - min_pos);
         }
 

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -75,7 +75,7 @@ SparseIndexReaderBase::SparseIndexReaderBase(
           condition)
     , initial_data_loaded_(false)
     , memory_budget_(0)
-    , array_memory_tracker_(nullptr)
+    , array_memory_tracker_(array->memory_tracker())
     , memory_used_for_coords_total_(0)
     , memory_used_qc_tiles_total_(0)
     , memory_used_result_tile_ranges_(0)

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -64,6 +64,23 @@ class ResultTileWithBitmap : public ResultTile {
       , coords_loaded_(false) {
   }
 
+  /** Move constructor. */
+  ResultTileWithBitmap(ResultTileWithBitmap<BitmapType>&& other) noexcept {
+    // Swap with the argument
+    swap(other);
+  }
+
+  /** Move-assign operator. */
+  ResultTileWithBitmap<BitmapType>& operator=(
+      ResultTileWithBitmap<BitmapType>&& other) {
+    // Swap with the argument
+    swap(other);
+
+    return *this;
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(ResultTileWithBitmap);
+
   /* ********************************* */
   /*          PUBLIC METHODS           */
   /* ********************************* */
@@ -113,6 +130,15 @@ class ResultTileWithBitmap : public ResultTile {
     }
 
     return bitmap_.size() - 1;
+  }
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(ResultTileWithBitmap<BitmapType>& tile) {
+    ResultTile::swap(tile);
+    std::swap(bitmap_, tile.bitmap_);
+    std::swap(bitmap_result_num_, tile.bitmap_result_num_);
+    std::swap(coords_loaded_, tile.coords_loaded_);
+    std::swap(hilbert_values_, tile.hilbert_values_);
   }
 
   /* ********************************* */

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -490,8 +490,8 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
   const auto tile_tuple = rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
   const auto t_var = &std::get<1>(*tile_tuple);
-  const auto src_buff = (uint64_t*)t->data();
-  const auto src_var_buff = (char*)t_var->data();
+  const auto src_buff = t->data_as<uint64_t>();
+  const auto src_var_buff = t_var->data_as<char>();
   const auto t_val = &std::get<2>(*tile_tuple);
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
@@ -520,7 +520,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
 
   // Copy nullable values.
   if (nullable) {
-    const auto src_val_buff = (uint8_t*)t_val->data();
+    const auto src_val_buff = t_val->data_as<uint8_t>();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
       for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
         *val_buffer = src_val_buff[c];
@@ -549,8 +549,8 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
   const auto tile_tuple = rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
   const auto t_var = &std::get<1>(*tile_tuple);
-  const auto src_buff = (uint64_t*)t->data();
-  const auto src_var_buff = (char*)t_var->data();
+  const auto src_buff = t->data_as<uint64_t>();
+  const auto src_var_buff = t_var->data_as<char>();
   const auto t_val = &std::get<2>(*tile_tuple);
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
@@ -577,7 +577,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
 
     // Copy nullable values.
     if (nullable) {
-      const auto src_val_buff = (uint8_t*)t_val->data();
+      const auto src_val_buff = t_val->data_as<uint8_t>();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
         if (rt->bitmap_[c]) {
           *val_buffer = src_val_buff[c];
@@ -604,7 +604,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
 
     // Copy nullable values.
     if (nullable) {
-      const auto src_val_buff = (uint8_t*)t_val->data();
+      const auto src_val_buff = t_val->data_as<uint8_t>();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
         *val_buffer = src_val_buff[c];
         val_buffer++;
@@ -810,7 +810,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
   const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
   const auto tile_tuple = rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
-  const auto src_buff = (uint8_t*)t->data();
+  const auto src_buff = t->data_as<uint8_t>();
 
   // Copy values.
   if (!stores_zipped_coords) {
@@ -834,7 +834,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
   // Copy nullable values.
   if (nullable) {
     const auto t_val = &std::get<2>(*tile_tuple);
-    const auto src_val_buff = (uint8_t*)t_val->data();
+    const auto src_val_buff = t_val->data_as<uint8_t>();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
       for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
         *val_buffer = src_val_buff[c];
@@ -863,7 +863,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
   const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
   const auto tile_tuple = rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
-  const auto src_buff = (uint8_t*)t->data();
+  const auto src_buff = t->data_as<uint8_t>();
   const auto t_val = &std::get<2>(*tile_tuple);
 
   // 0 sized bitmap means full tile, full tile copy done below.
@@ -910,7 +910,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
       // memcpy.
       uint64_t length = 0;
       uint64_t start = src_min_pos;
-      const auto src_val_buff = (uint8_t*)t_val->data();
+      const auto src_val_buff = t_val->data_as<uint8_t>();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
         if (rt->bitmap_[c]) {
           length++;
@@ -938,7 +938,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
         (src_max_pos - src_min_pos) * cell_size);
 
     if (nullable) {
-      const auto src_val_buff = (uint8_t*)t_val->data();
+      const auto src_val_buff = t_val->data_as<uint8_t>();
       memcpy(val_buffer, src_val_buff + src_min_pos, src_max_pos - src_min_pos);
     }
   }

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -493,8 +493,8 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
   const auto tile_tuple = rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
   const auto t_var = &std::get<1>(*tile_tuple);
-  const auto src_buff = (uint64_t*)t->buffer()->data();
-  const auto src_var_buff = (char*)t_var->buffer()->data();
+  const auto src_buff = (uint64_t*)t->data();
+  const auto src_var_buff = (char*)t_var->data();
   const auto t_val = &std::get<2>(*tile_tuple);
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
@@ -523,7 +523,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
 
   // Copy nullable values.
   if (nullable) {
-    const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+    const auto src_val_buff = (uint8_t*)t_val->data();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
       for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
         *val_buffer = src_val_buff[c];
@@ -552,8 +552,8 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
   const auto tile_tuple = rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
   const auto t_var = &std::get<1>(*tile_tuple);
-  const auto src_buff = (uint64_t*)t->buffer()->data();
-  const auto src_var_buff = (char*)t_var->buffer()->data();
+  const auto src_buff = (uint64_t*)t->data();
+  const auto src_var_buff = (char*)t_var->data();
   const auto t_val = &std::get<2>(*tile_tuple);
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
@@ -580,7 +580,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
 
     // Copy nullable values.
     if (nullable) {
-      const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+      const auto src_val_buff = (uint8_t*)t_val->data();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
         if (rt->bitmap_[c]) {
           *val_buffer = src_val_buff[c];
@@ -607,7 +607,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
 
     // Copy nullable values.
     if (nullable) {
-      const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+      const auto src_val_buff = (uint8_t*)t_val->data();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
         *val_buffer = src_val_buff[c];
         val_buffer++;
@@ -813,7 +813,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
   const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
   const auto tile_tuple = rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
-  const auto src_buff = (uint8_t*)t->buffer()->data();
+  const auto src_buff = (uint8_t*)t->data();
 
   // Copy values.
   if (!stores_zipped_coords) {
@@ -837,7 +837,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
   // Copy nullable values.
   if (nullable) {
     const auto t_val = &std::get<2>(*tile_tuple);
-    const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+    const auto src_val_buff = (uint8_t*)t_val->data();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
       for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
         *val_buffer = src_val_buff[c];
@@ -866,7 +866,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
   const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
   const auto tile_tuple = rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
-  const auto src_buff = (uint8_t*)t->buffer()->data();
+  const auto src_buff = (uint8_t*)t->data();
   const auto t_val = &std::get<2>(*tile_tuple);
 
   // 0 sized bitmap means full tile, full tile copy done below.
@@ -913,7 +913,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
       // memcpy.
       uint64_t length = 0;
       uint64_t start = src_min_pos;
-      const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+      const auto src_val_buff = (uint8_t*)t_val->data();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
         if (rt->bitmap_[c]) {
           length++;
@@ -941,7 +941,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
         (src_max_pos - src_min_pos) * cell_size);
 
     if (nullable) {
-      const auto src_val_buff = (uint8_t*)t_val->buffer()->data();
+      const auto src_val_buff = (uint8_t*)t_val->data();
       memcpy(val_buffer, src_val_buff + src_min_pos, src_max_pos - src_min_pos);
     }
   }

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -77,8 +77,8 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
           buffers,
           subarray,
           layout,
-          condition) {
-  array_memory_tracker_ = array->memory_tracker();
+          condition)
+    , result_tiles_(1) {
 }
 
 /* ****************************** */
@@ -157,9 +157,6 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
   RETURN_NOT_OK(condition_.check(array_schema_));
 
   get_dim_attr_stats();
-
-  // This reader only has one result tile list.
-  result_tiles_.resize(1);
 
   // This reader assumes ranges are sorted.
   assert(subarray_.ranges_sorted());
@@ -1464,7 +1461,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
   const auto tile_idx = rt->tile_idx();
   auto&& [st, tiles_sizes] = get_coord_tiles_size<BitmapType>(
       subarray_.is_set(), array_schema_->dim_num(), frag_idx, tile_idx);
-  (void)st;
+  RETURN_NOT_OK(st);
   auto tiles_size = tiles_sizes->first;
   auto tiles_size_qc = tiles_sizes->second;
 
@@ -1488,6 +1485,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::end_iteration() {
              read_state_.frag_tile_idx_[result_tiles_[0].front().frag_idx()]
                  .first) {
     const auto f = result_tiles_[0].front().frag_idx();
+
     RETURN_NOT_OK(remove_result_tile(f, result_tiles_[0].begin()));
   }
 

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -172,7 +172,7 @@ Status Writer::check_var_attr_offsets() const {
     const uint64_t buffer_off_size =
         get_offset_buffer_size(*it.second.buffer_size_);
     const uint64_t* buffer_val_size = it.second.buffer_var_size_;
-    auto num_offsets = buffer_off_size / sizeof(uint64_t);
+    auto num_offsets = buffer_off_size / constants::cell_var_offset_size;
     if (num_offsets == 0)
       return Status::Ok();
 
@@ -1184,7 +1184,7 @@ Status Writer::filter_tile(
     const bool nullable) {
   auto timer_se = stats_->start_timer("filter_tile");
 
-  const auto orig_size = tile->buffer()->size();
+  const auto orig_size = tile->size();
 
   // Get a copy of the appropriate filter pipeline.
   FilterPipeline filters;
@@ -1347,7 +1347,14 @@ Status Writer::global_write() {
 }
 
 Status Writer::global_write_handle_last_tile() {
-  if (all_last_tiles_empty())
+  auto capacity = array_schema_->capacity();
+  auto domain = array_schema_->domain();
+  auto cell_num_per_tile =
+      coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
+  auto cell_num_last_tiles =
+      global_write_state_->cells_written_[buffers_.begin()->first] %
+      cell_num_per_tile;
+  if (cell_num_last_tiles == 0)
     return Status::Ok();
 
   // Reserve space for the last tile in the fragment metadata
@@ -1356,11 +1363,12 @@ Status Writer::global_write_handle_last_tile() {
   const auto& uri = global_write_state_->frag_meta_->fragment_uri();
 
   // Filter last tiles
-  std::unordered_map<std::string, std::vector<WriterTile>> tiles;
-  RETURN_CANCEL_OR_ERROR_ELSE(filter_last_tiles(&tiles), clean_up(uri));
+  RETURN_CANCEL_OR_ERROR_ELSE(
+      filter_last_tiles(cell_num_last_tiles), clean_up(uri));
 
   // Write the last tiles
-  RETURN_CANCEL_OR_ERROR(write_all_tiles(meta, &tiles));
+  RETURN_CANCEL_OR_ERROR(
+      write_all_tiles(meta, &global_write_state_->last_tiles_));
 
   // Increment the tile index base.
   meta->set_tile_index_base(meta->tile_index_base() + 1);
@@ -1368,68 +1376,44 @@ Status Writer::global_write_handle_last_tile() {
   return Status::Ok();
 }
 
-Status Writer::filter_last_tiles(
-    std::unordered_map<std::string, std::vector<WriterTile>>* tiles) {
-  // Initialize attribute and coordinate tiles
-  for (const auto& it : buffers_)
-    (*tiles)[it.first] = std::vector<WriterTile>();
+Status Writer::filter_last_tiles(uint64_t cell_num) {
+  // Adjust cell num
+  for (auto& last_tiles : global_write_state_->last_tiles_) {
+    const auto var_size = array_schema_->var_size(last_tiles.first);
+    const auto nullable = array_schema_->is_nullable(last_tiles.first);
 
-  // Prepare the tiles first
-  uint64_t num = buffers_.size();
-  auto status =
-      parallel_for(storage_manager_->compute_tp(), 0, num, [&](uint64_t i) {
-        auto buff_it = buffers_.begin();
-        std::advance(buff_it, i);
-        const auto& name = &(buff_it->first);
+    if (var_size) {
+      last_tiles.second[0].final_size(
+          cell_num * constants::cell_var_offset_size);
+    } else {
+      auto cell_size = array_schema_->cell_size(last_tiles.first);
+      last_tiles.second[0].final_size(cell_num * cell_size);
+    }
 
-        auto& last_tile = std::get<0>(global_write_state_->last_tiles_[*name]);
-        auto& last_tile_var =
-            std::get<1>(global_write_state_->last_tiles_[*name]);
-        auto& last_tile_validity =
-            std::get<2>(global_write_state_->last_tiles_[*name]);
-
-        if (!last_tile.empty()) {
-          std::vector<WriterTile>& tiles_ref = (*tiles)[*name];
-          // Note making shallow clones here, as it's not necessary to copy the
-          // underlying tile Buffers.
-          tiles_ref.push_back(last_tile.clone(false));
-          if (array_schema_->var_size(*name))
-            tiles_ref.push_back(last_tile_var.clone(false));
-          if (array_schema_->is_nullable(*name))
-            tiles_ref.push_back(last_tile_validity.clone(false));
-        }
-        return Status::Ok();
-      });
-
-  RETURN_NOT_OK(status);
+    if (nullable) {
+      last_tiles.second[var_size + 1].final_size(
+          cell_num * constants::cell_validity_size);
+    }
+  }
 
   // Compute coordinates metadata
   auto meta = global_write_state_->frag_meta_;
-  RETURN_NOT_OK(compute_coords_metadata(*tiles, meta));
+  RETURN_NOT_OK(
+      compute_coords_metadata(global_write_state_->last_tiles_, meta));
 
   // Compute tile metadata.
-  RETURN_NOT_OK(compute_tiles_metadata(1, *tiles));
+  RETURN_NOT_OK(compute_tiles_metadata(1, global_write_state_->last_tiles_));
 
   // Gather stats
-  stats_->add_counter("cell_num", tiles->begin()->second[0].cell_num());
+  stats_->add_counter(
+      "cell_num",
+      global_write_state_->last_tiles_.begin()->second[0].cell_num());
   stats_->add_counter("tile_num", 1);
 
   // Filter tiles
-  RETURN_NOT_OK(filter_tiles(tiles));
+  RETURN_NOT_OK(filter_tiles(&global_write_state_->last_tiles_));
 
   return Status::Ok();
-}
-
-bool Writer::all_last_tiles_empty() const {
-  // See if any last attribute/coordinate tiles are nonempty
-  for (const auto& it : buffers_) {
-    const auto& name = it.first;
-    auto& last_tile = std::get<0>(global_write_state_->last_tiles_[name]);
-    if (!last_tile.empty())
-      return false;
-  }
-
-  return true;
 }
 
 Status Writer::init_global_write_state() {
@@ -1450,31 +1434,31 @@ Status Writer::init_global_write_state() {
   for (const auto& it : buffers_) {
     // Initialize last tiles
     const auto& name = it.first;
-    auto last_tile_tuple =
-        std::pair<std::string, std::tuple<WriterTile, WriterTile, WriterTile>>(
-            name,
-            std::tuple<WriterTile, WriterTile, WriterTile>(
-                WriterTile(), WriterTile(), WriterTile()));
-    auto it_ret = global_write_state_->last_tiles_.emplace(last_tile_tuple);
+    const auto var_size = array_schema_->var_size(name);
+    const auto nullable = array_schema_->is_nullable(name);
+    uint64_t num = 1 + var_size + nullable;
+    auto last_tile_vector = std::pair<std::string, std::vector<WriterTile>>(
+        name, std::vector<WriterTile>(num));
+    auto it_ret = global_write_state_->last_tiles_.emplace(last_tile_vector);
 
-    if (!array_schema_->var_size(name)) {
-      auto& last_tile = std::get<0>(it_ret.first->second);
+    if (!var_size) {
+      auto& last_tile = it_ret.first->second[0];
       if (!array_schema_->is_nullable(name)) {
         RETURN_NOT_OK_ELSE(init_tile(name, &last_tile), clean_up(uri));
       } else {
-        auto& last_tile_validity = std::get<2>(it_ret.first->second);
+        auto& last_tile_validity = it_ret.first->second[1];
         RETURN_NOT_OK_ELSE(
             init_tile_nullable(name, &last_tile, &last_tile_validity),
             clean_up(uri));
       }
     } else {
-      auto& last_tile = std::get<0>(it_ret.first->second);
-      auto& last_tile_var = std::get<1>(it_ret.first->second);
+      auto& last_tile = it_ret.first->second[0];
+      auto& last_tile_var = it_ret.first->second[1];
       if (!array_schema_->is_nullable(name)) {
         RETURN_NOT_OK_ELSE(
             init_tile(name, &last_tile, &last_tile_var), clean_up(uri));
       } else {
-        auto& last_tile_validity = std::get<2>(it_ret.first->second);
+        auto& last_tile_validity = it_ret.first->second[2];
         RETURN_NOT_OK_ELSE(
             init_tile_nullable(
                 name, &last_tile, &last_tile_var, &last_tile_validity),
@@ -1539,15 +1523,18 @@ Status Writer::init_tile_nullable(
   auto capacity = array_schema_->capacity();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
-  auto tile_size = cell_num_per_tile * cell_size;
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      array_schema_->write_version(), type, tile_size, cell_size, 0));
+      array_schema_->write_version(),
+      type,
+      cell_num_per_tile * cell_size,
+      cell_size,
+      0));
   RETURN_NOT_OK(tile_validity->init_unfiltered(
       array_schema_->write_version(),
       constants::cell_validity_type,
-      tile_size,
+      cell_num_per_tile * constants::cell_validity_size,
       constants::cell_validity_size,
       0));
 
@@ -1579,7 +1566,7 @@ Status Writer::init_tile_nullable(
   RETURN_NOT_OK(tile_validity->init_unfiltered(
       array_schema_->write_version(),
       constants::cell_validity_type,
-      tile_size,
+      cell_num_per_tile * constants::cell_validity_size,
       constants::cell_validity_size,
       0));
 
@@ -1907,43 +1894,53 @@ Status Writer::prepare_full_tiles_fixed(
     return Status::Ok();
 
   // First fill the last tile
-  auto& last_tile = std::get<0>(global_write_state_->last_tiles_[name]);
-  auto& last_tile_validity =
-      std::get<2>(global_write_state_->last_tiles_[name]);
+  auto& last_tile = global_write_state_->last_tiles_[name][0];
+  auto& last_tile_validity = global_write_state_->last_tiles_[name][1];
   uint64_t cell_idx = 0;
-  if (!last_tile.empty()) {
+  uint64_t last_tile_cell_idx =
+      global_write_state_->cells_written_[name] % cell_num_per_tile;
+  if (last_tile_cell_idx != 0) {
     if (coord_dups.empty()) {
       do {
-        RETURN_NOT_OK(
-            last_tile.write(buffer + cell_idx * cell_size, cell_size));
+        RETURN_NOT_OK(last_tile.write(
+            buffer + cell_idx * cell_size,
+            last_tile_cell_idx * cell_size,
+            cell_size));
         if (nullable) {
           RETURN_NOT_OK(last_tile_validity.write(
               buffer_validity + cell_idx * constants::cell_validity_size,
+              last_tile_cell_idx * constants::cell_validity_size,
               constants::cell_validity_size));
         }
         ++cell_idx;
-      } while (!last_tile.full() && cell_idx != cell_num);
+        ++last_tile_cell_idx;
+      } while (last_tile_cell_idx != cell_num_per_tile && cell_idx != cell_num);
     } else {
       do {
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
-          RETURN_NOT_OK(
-              last_tile.write(buffer + cell_idx * cell_size, cell_size));
+          RETURN_NOT_OK(last_tile.write(
+              buffer + cell_idx * cell_size,
+              last_tile_cell_idx * cell_size,
+              cell_size));
           if (nullable) {
             RETURN_NOT_OK(last_tile_validity.write(
                 buffer_validity + cell_idx * constants::cell_validity_size,
+                last_tile_cell_idx * constants::cell_validity_size,
                 constants::cell_validity_size));
           }
+          ++last_tile_cell_idx;
         }
         ++cell_idx;
-      } while (!last_tile.full() && cell_idx != cell_num);
+      } while (last_tile_cell_idx != cell_num_per_tile && cell_idx != cell_num);
     }
   }
 
   // Initialize full tiles and set previous last tile as first tile
-  auto full_tile_num =
-      (cell_num - cell_idx) / cell_num_per_tile + (int)last_tile.full();
+  auto full_tile_num = (cell_num - cell_idx) / cell_num_per_tile +
+                       (int)(last_tile_cell_idx == cell_num_per_tile);
   auto cell_num_to_write =
-      (full_tile_num - last_tile.full()) * cell_num_per_tile;
+      (full_tile_num - (last_tile_cell_idx == cell_num_per_tile)) *
+      cell_num_per_tile;
 
   if (full_tile_num > 0) {
     const uint64_t t = 1 + (nullable ? 1 : 0);
@@ -1957,52 +1954,49 @@ Status Writer::prepare_full_tiles_fixed(
             init_tile_nullable(name, &((*tiles)[i]), &((*tiles)[i + 1])));
 
     // Handle last tile (it must be either full or empty)
-    if (last_tile.full()) {
+    if (last_tile_cell_idx == cell_num_per_tile) {
       (*tiles)[0] = last_tile;
-      last_tile.reset();
       if (nullable) {
         (*tiles)[1] = last_tile_validity;
-        last_tile_validity.reset();
       }
     } else {
-      assert(last_tile.empty());
-      if (nullable) {
-        assert(last_tile_validity.empty());
-      }
+      assert(last_tile_cell_idx == 0);
     }
 
     // Write all remaining cells one by one
     if (coord_dups.empty()) {
       for (uint64_t tile_idx = 0, i = 0; i < cell_num_to_write;) {
-        if ((*tiles)[tile_idx].full())
-          tile_idx += t;
-
-        auto val = buffer + cell_idx * cell_size;
-        RETURN_NOT_OK(
-            (*tiles)[tile_idx].write(val, cell_size * cell_num_per_tile));
+        RETURN_NOT_OK((*tiles)[tile_idx].write(
+            buffer + cell_idx * cell_size, 0, cell_size * cell_num_per_tile));
 
         if (nullable) {
           RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
               buffer_validity + cell_idx * constants::cell_validity_size,
+              0,
               constants::cell_validity_size * cell_num_per_tile));
         }
 
         cell_idx += cell_num_per_tile;
         i += cell_num_per_tile;
+        tile_idx += t;
       }
     } else {
+      uint64_t current_tile_cell_idx = 0;
       for (uint64_t tile_idx = 0, i = 0; i < cell_num_to_write;
            ++cell_idx, ++i) {
-        if (coord_dups.find(cell_idx) == coord_dups.end()) {
-          if ((*tiles)[tile_idx].full())
-            tile_idx += t;
+        if (current_tile_cell_idx == cell_num_per_tile) {
+          tile_idx += t;
+          current_tile_cell_idx = 0;
+        }
 
+        if (coord_dups.find(cell_idx) == coord_dups.end()) {
           RETURN_NOT_OK((*tiles)[tile_idx].write(
-              buffer + cell_idx * cell_size, cell_size));
+              buffer + cell_idx * cell_size, cell_idx * cell_size, cell_size));
 
           if (nullable) {
             RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
                 buffer_validity + cell_idx * constants::cell_validity_size,
+                cell_idx * constants::cell_validity_size,
                 constants::cell_validity_size));
           }
         }
@@ -2011,26 +2005,34 @@ Status Writer::prepare_full_tiles_fixed(
   }
 
   // Potentially fill the last tile
-  assert(cell_num - cell_idx < cell_num_per_tile - last_tile.cell_num());
+  last_tile_cell_idx = 0;
   if (coord_dups.empty()) {
-    for (; cell_idx < cell_num; ++cell_idx) {
-      RETURN_NOT_OK(last_tile.write(buffer + cell_idx * cell_size, cell_size));
+    for (; cell_idx < cell_num; ++cell_idx, ++last_tile_cell_idx) {
+      RETURN_NOT_OK(last_tile.write(
+          buffer + cell_idx * cell_size,
+          last_tile_cell_idx * cell_size,
+          cell_size));
       if (nullable) {
         RETURN_NOT_OK(last_tile_validity.write(
             buffer_validity + cell_idx * constants::cell_validity_size,
+            last_tile_cell_idx * constants::cell_validity_size,
             constants::cell_validity_size));
       }
     }
   } else {
     for (; cell_idx < cell_num; ++cell_idx) {
       if (coord_dups.find(cell_idx) == coord_dups.end()) {
-        RETURN_NOT_OK(
-            last_tile.write(buffer + cell_idx * cell_size, cell_size));
+        RETURN_NOT_OK(last_tile.write(
+            buffer + cell_idx * cell_size,
+            last_tile_cell_idx * cell_size,
+            cell_size));
         if (nullable) {
           RETURN_NOT_OK(last_tile_validity.write(
               buffer_validity + cell_idx * constants::cell_validity_size,
+              last_tile_cell_idx * constants::cell_validity_size,
               constants::cell_validity_size));
         }
+        ++last_tile_cell_idx;
       }
     }
   }
@@ -2058,77 +2060,95 @@ Status Writer::prepare_full_tiles_var(
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto attr_datatype_size = datatype_size(array_schema_->type(name));
-  uint64_t offset, var_size;
 
   // Do nothing if there are no cells to write
   if (cell_num == 0)
     return Status::Ok();
 
   // First fill the last tile
-  auto& last_tile_tuple = global_write_state_->last_tiles_[name];
-  auto& last_tile = std::get<0>(last_tile_tuple);
-  auto& last_tile_var = std::get<1>(last_tile_tuple);
-  auto& last_tile_validity = std::get<2>(last_tile_tuple);
-
+  auto& last_tile_vector = global_write_state_->last_tiles_[name];
+  auto& last_tile = last_tile_vector[0];
+  auto& last_tile_var = last_tile_vector[1];
+  auto& last_tile_validity = last_tile_vector[2];
+  auto& last_var_offset = global_write_state_->last_var_offsets_[name];
   uint64_t cell_idx = 0;
-  if (!last_tile.empty()) {
+  uint64_t last_tile_cell_idx =
+      global_write_state_->cells_written_[name] % cell_num_per_tile;
+  if (last_tile_cell_idx != 0) {
     if (coord_dups.empty()) {
       do {
         // Write offset.
-        offset = last_tile_var.size();
-        RETURN_NOT_OK(last_tile.write(&offset, sizeof(offset)));
+        RETURN_NOT_OK(last_tile.write(
+            &last_var_offset,
+            last_tile_cell_idx * sizeof(last_var_offset),
+            sizeof(last_var_offset)));
 
         // Write var-sized value(s).
         auto buff_offset =
             prepare_buffer_offset(buffer, cell_idx, attr_datatype_size);
-        var_size = (cell_idx == cell_num - 1) ?
-                       *buffer_var_size - buff_offset :
-                       prepare_buffer_offset(
-                           buffer, cell_idx + 1, attr_datatype_size) -
-                           buff_offset;
-        RETURN_NOT_OK(last_tile_var.write(buffer_var + buff_offset, var_size));
+        uint64_t var_size = (cell_idx == cell_num - 1) ?
+                                *buffer_var_size - buff_offset :
+                                prepare_buffer_offset(
+                                    buffer, cell_idx + 1, attr_datatype_size) -
+                                    buff_offset;
+        RETURN_NOT_OK(last_tile_var.write_var(
+            buffer_var + buff_offset, last_var_offset, var_size));
+        last_var_offset += var_size;
 
         // Write validity value(s).
         if (nullable)
           RETURN_NOT_OK(last_tile_validity.write(
-              buffer_validity + cell_idx, constants::cell_validity_size));
+              buffer_validity + cell_idx,
+              last_tile_cell_idx * constants::cell_validity_size,
+              constants::cell_validity_size));
 
         ++cell_idx;
-      } while (!last_tile.full() && cell_idx != cell_num);
+        ++last_tile_cell_idx;
+      } while (last_tile_cell_idx != cell_num_per_tile && cell_idx != cell_num);
     } else {
       do {
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
           // Write offset.
-          offset = last_tile_var.size();
-          RETURN_NOT_OK(last_tile.write(&offset, sizeof(offset)));
+          RETURN_NOT_OK(last_tile.write(
+              &last_var_offset,
+              last_tile_cell_idx * sizeof(last_var_offset),
+              sizeof(last_var_offset)));
 
           // Write var-sized value(s).
           auto buff_offset =
               prepare_buffer_offset(buffer, cell_idx, attr_datatype_size);
-          var_size = (cell_idx == cell_num - 1) ?
-                         *buffer_var_size - buff_offset :
-                         prepare_buffer_offset(
-                             buffer, cell_idx + 1, attr_datatype_size) -
-                             buff_offset;
-          RETURN_NOT_OK(
-              last_tile_var.write(buffer_var + buff_offset, var_size));
+          uint64_t var_size =
+              (cell_idx == cell_num - 1) ?
+                  *buffer_var_size - buff_offset :
+                  prepare_buffer_offset(
+                      buffer, cell_idx + 1, attr_datatype_size) -
+                      buff_offset;
+          RETURN_NOT_OK(last_tile_var.write_var(
+              buffer_var + buff_offset, last_var_offset, var_size));
+          last_var_offset += var_size;
 
           // Write validity value(s).
           if (nullable)
             RETURN_NOT_OK(last_tile_validity.write(
-                buffer_validity + cell_idx, constants::cell_validity_size));
+                buffer_validity + cell_idx,
+                last_tile_cell_idx * constants::cell_validity_size,
+                constants::cell_validity_size));
+          ++last_tile_cell_idx;
         }
 
         ++cell_idx;
-      } while (!last_tile.full() && cell_idx != cell_num);
+      } while (last_tile_cell_idx != cell_num_per_tile && cell_idx != cell_num);
     }
+
+    last_tile_var.final_size(last_var_offset);
   }
 
   // Initialize full tiles and set previous last tile as first tile
-  auto full_tile_num =
-      (cell_num - cell_idx) / cell_num_per_tile + last_tile.full();
+  auto full_tile_num = (cell_num - cell_idx) / cell_num_per_tile +
+                       (last_tile_cell_idx == cell_num_per_tile);
   auto cell_num_to_write =
-      (full_tile_num - last_tile.full()) * cell_num_per_tile;
+      (full_tile_num - (last_tile_cell_idx == cell_num_per_tile)) *
+      cell_num_per_tile;
 
   if (full_tile_num > 0) {
     const uint64_t t = 2 + (nullable ? 1 : 0);
@@ -2142,127 +2162,163 @@ Status Writer::prepare_full_tiles_var(
             name, &((*tiles)[i]), &((*tiles)[i + 1]), &((*tiles)[i + 2])));
 
     // Handle last tile (it must be either full or empty)
-    if (last_tile.full()) {
+    if (last_tile_cell_idx == cell_num_per_tile) {
+      last_var_offset = 0;
       (*tiles)[0] = last_tile;
-      last_tile.reset();
       (*tiles)[1] = last_tile_var;
-      last_tile_var.reset();
       if (nullable) {
         (*tiles)[2] = last_tile_validity;
-        last_tile_validity.reset();
       }
     } else {
-      assert(last_tile.empty());
-      assert(last_tile_var.empty());
-      if (nullable)
-        assert(last_tile_validity.empty());
+      assert(last_tile_cell_idx == 0);
     }
 
     // Write all remaining cells one by one
+    uint64_t current_tile_cell_idx = 0;
+    uint64_t tile_idx = 0;
     if (coord_dups.empty()) {
-      for (uint64_t tile_idx = 0, i = 0; i < cell_num_to_write;
-           ++cell_idx, ++i) {
-        if ((*tiles)[tile_idx].full())
+      for (uint64_t i = 0; i < cell_num_to_write;
+           ++cell_idx, ++i, ++current_tile_cell_idx) {
+        if (current_tile_cell_idx == cell_num_per_tile) {
+          (*tiles)[tile_idx + 1].final_size(last_var_offset);
+          current_tile_cell_idx = 0;
+          last_var_offset = 0;
           tile_idx += t;
+        }
 
         // Write offset.
-        offset = (*tiles)[tile_idx + 1].size();
-        RETURN_NOT_OK((*tiles)[tile_idx].write(&offset, sizeof(offset)));
+        RETURN_NOT_OK((*tiles)[tile_idx].write(
+            &last_var_offset,
+            current_tile_cell_idx * sizeof(last_var_offset),
+            sizeof(last_var_offset)));
 
         // Write var-sized value(s).
         auto buff_offset =
             prepare_buffer_offset(buffer, cell_idx, attr_datatype_size);
-        var_size = (cell_idx == cell_num - 1) ?
-                       *buffer_var_size - buff_offset :
-                       prepare_buffer_offset(
-                           buffer, cell_idx + 1, attr_datatype_size) -
-                           buff_offset;
-        RETURN_NOT_OK(
-            (*tiles)[tile_idx + 1].write(buffer_var + buff_offset, var_size));
+        uint64_t var_size = (cell_idx == cell_num - 1) ?
+                                *buffer_var_size - buff_offset :
+                                prepare_buffer_offset(
+                                    buffer, cell_idx + 1, attr_datatype_size) -
+                                    buff_offset;
+        RETURN_NOT_OK((*tiles)[tile_idx + 1].write_var(
+            buffer_var + buff_offset, last_var_offset, var_size));
+        last_var_offset += var_size;
 
         // Write validity value(s).
         if (nullable)
           RETURN_NOT_OK((*tiles)[tile_idx + 2].write(
-              buffer_validity + cell_idx, constants::cell_validity_size));
+              buffer_validity + cell_idx,
+              current_tile_cell_idx * constants::cell_validity_size,
+              constants::cell_validity_size));
       }
     } else {
-      for (uint64_t tile_idx = 0, i = 0; i < cell_num_to_write;
-           ++cell_idx, ++i) {
+      for (uint64_t i = 0; i < cell_num_to_write; ++cell_idx, ++i) {
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
-          if ((*tiles)[tile_idx].full())
+          if (current_tile_cell_idx == cell_num_per_tile) {
+            (*tiles)[tile_idx + 1].final_size(last_var_offset);
+            current_tile_cell_idx = 0;
+            last_var_offset = 0;
             tile_idx += t;
+          }
 
           // Write offset.
-          offset = (*tiles)[tile_idx + 1].size();
-          RETURN_NOT_OK((*tiles)[tile_idx].write(&offset, sizeof(offset)));
+          RETURN_NOT_OK((*tiles)[tile_idx].write(
+              &last_var_offset,
+              current_tile_cell_idx * sizeof(last_var_offset),
+              sizeof(last_var_offset)));
 
           // Write var-sized value(s).
           auto buff_offset =
               prepare_buffer_offset(buffer, cell_idx, attr_datatype_size);
-          var_size = (cell_idx == cell_num - 1) ?
-                         *buffer_var_size - buff_offset :
-                         prepare_buffer_offset(
-                             buffer, cell_idx + 1, attr_datatype_size) -
-                             buff_offset;
-          RETURN_NOT_OK(
-              (*tiles)[tile_idx + 1].write(buffer_var + buff_offset, var_size));
+          uint64_t var_size =
+              (cell_idx == cell_num - 1) ?
+                  *buffer_var_size - buff_offset :
+                  prepare_buffer_offset(
+                      buffer, cell_idx + 1, attr_datatype_size) -
+                      buff_offset;
+          RETURN_NOT_OK((*tiles)[tile_idx + 1].write_var(
+              buffer_var + buff_offset, last_var_offset, var_size));
+          last_var_offset += var_size;
 
           // Write validity value(s).
           if (nullable)
             RETURN_NOT_OK((*tiles)[tile_idx + 2].write(
-                buffer_validity + cell_idx, constants::cell_validity_size));
+                buffer_validity + cell_idx,
+                current_tile_cell_idx * constants::cell_validity_size,
+                constants::cell_validity_size));
+
+          ++current_tile_cell_idx;
         }
       }
     }
+
+    (*tiles)[tile_idx + 1].final_size(last_var_offset);
   }
 
   // Potentially fill the last tile
-  assert(cell_num - cell_idx < cell_num_per_tile - last_tile.cell_num());
+  last_tile_cell_idx = 0;
+  last_var_offset = 0;
   if (coord_dups.empty()) {
-    for (; cell_idx < cell_num; ++cell_idx) {
+    for (; cell_idx < cell_num; ++cell_idx, ++last_tile_cell_idx) {
       // Write offset.
-      offset = last_tile_var.size();
-      RETURN_NOT_OK(last_tile.write(&offset, sizeof(offset)));
+      RETURN_NOT_OK(last_tile.write(
+          &last_var_offset,
+          last_tile_cell_idx * sizeof(last_var_offset),
+          sizeof(last_var_offset)));
 
       // Write var-sized value(s).
       auto buff_offset =
           prepare_buffer_offset(buffer, cell_idx, attr_datatype_size);
-      var_size =
+      uint64_t var_size =
           (cell_idx == cell_num - 1) ?
               *buffer_var_size - buff_offset :
               prepare_buffer_offset(buffer, cell_idx + 1, attr_datatype_size) -
                   buff_offset;
-      RETURN_NOT_OK(last_tile_var.write(buffer_var + buff_offset, var_size));
+      RETURN_NOT_OK(last_tile_var.write_var(
+          buffer_var + buff_offset, last_var_offset, var_size));
+      last_var_offset += var_size;
 
       // Write validity value(s).
       if (nullable)
         RETURN_NOT_OK(last_tile_validity.write(
-            buffer_validity + cell_idx, constants::cell_validity_size));
+            buffer_validity + cell_idx,
+            last_tile_cell_idx * constants::cell_validity_size,
+            constants::cell_validity_size));
     }
   } else {
     for (; cell_idx < cell_num; ++cell_idx) {
       if (coord_dups.find(cell_idx) == coord_dups.end()) {
         // Write offset.
-        offset = last_tile_var.size();
-        RETURN_NOT_OK(last_tile.write(&offset, sizeof(offset)));
+        RETURN_NOT_OK(last_tile.write(
+            &last_var_offset,
+            last_tile_cell_idx * sizeof(last_var_offset),
+            sizeof(last_var_offset)));
 
         // Write var-sized value(s).
         auto buff_offset =
             prepare_buffer_offset(buffer, cell_idx, attr_datatype_size);
-        var_size = (cell_idx == cell_num - 1) ?
-                       *buffer_var_size - buff_offset :
-                       prepare_buffer_offset(
-                           buffer, cell_idx + 1, attr_datatype_size) -
-                           buff_offset;
-        RETURN_NOT_OK(last_tile_var.write(buffer_var + buff_offset, var_size));
+        uint64_t var_size = (cell_idx == cell_num - 1) ?
+                                *buffer_var_size - buff_offset :
+                                prepare_buffer_offset(
+                                    buffer, cell_idx + 1, attr_datatype_size) -
+                                    buff_offset;
+        RETURN_NOT_OK(last_tile_var.write_var(
+            buffer_var + buff_offset, last_var_offset, var_size));
+        last_var_offset += var_size;
 
         // Write validity value(s).
         if (nullable)
           RETURN_NOT_OK(last_tile_validity.write(
-              buffer_validity + cell_idx, constants::cell_validity_size));
+              buffer_validity + cell_idx,
+              last_tile_cell_idx * constants::cell_validity_size,
+              constants::cell_validity_size));
+
+        ++last_tile_cell_idx;
       }
     }
   }
+
+  last_tile_var.final_size(last_var_offset);
 
   global_write_state_->cells_written_[name] += cell_num;
 
@@ -2326,6 +2382,9 @@ Status Writer::prepare_tiles_fixed(
   auto capacity = array_schema_->capacity();
   auto dups_num = coord_dups.size();
   auto tile_num = utils::math::ceil(cell_num - dups_num, capacity);
+  auto domain = array_schema_->domain();
+  auto cell_num_per_tile =
+      coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
 
   // Initialize tiles
   const uint64_t t = 1 + (nullable ? 1 : 0);
@@ -2339,32 +2398,51 @@ Status Writer::prepare_tiles_fixed(
   }
 
   // Write all cells one by one
+  uint64_t cell_idx = 0;
+  uint64_t tile_idx = 0;
   if (dups_num == 0) {
-    for (uint64_t i = 0, tile_idx = 0; i < cell_num; ++i) {
-      if ((*tiles)[tile_idx].full())
+    for (uint64_t i = 0; i < cell_num; ++i, ++cell_idx) {
+      if (cell_idx == cell_num_per_tile) {
         tile_idx += t;
+        cell_idx = 0;
+      }
 
       RETURN_NOT_OK((*tiles)[tile_idx].write(
-          buffer + cell_pos[i] * cell_size, cell_size));
+          buffer + cell_pos[i] * cell_size, cell_idx * cell_size, cell_size));
       if (nullable)
         RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
             buffer_validity + cell_pos[i] * constants::cell_validity_size,
+            cell_idx * constants::cell_validity_size,
             constants::cell_validity_size));
     }
   } else {
-    for (uint64_t i = 0, tile_idx = 0; i < cell_num; ++i) {
+    for (uint64_t i = 0; i < cell_num; ++i) {
       if (coord_dups.find(cell_pos[i]) != coord_dups.end())
         continue;
 
-      if ((*tiles)[tile_idx].full())
+      if (cell_idx == cell_num_per_tile) {
         tile_idx += t;
+        cell_idx = 0;
+      }
 
       RETURN_NOT_OK((*tiles)[tile_idx].write(
-          buffer + cell_pos[i] * cell_size, cell_size));
+          buffer + cell_pos[i] * cell_size, cell_idx * cell_size, cell_size));
       if (nullable)
         RETURN_NOT_OK((*tiles)[tile_idx + 1].write(
             buffer_validity + cell_pos[i] * constants::cell_validity_size,
+            cell_idx * constants::cell_validity_size,
             constants::cell_validity_size));
+      ++cell_idx;
+    }
+  }
+
+  uint64_t last_tile_cell_num = (cell_num - dups_num) % capacity;
+  if (last_tile_cell_num != 0) {
+    (*tiles)[tile_idx].final_size(last_tile_cell_num * cell_size);
+
+    if (nullable) {
+      (*tiles)[tile_idx + 1].final_size(
+          last_tile_cell_num * constants::cell_validity_size);
     }
   }
 
@@ -2388,8 +2466,9 @@ Status Writer::prepare_tiles_var(
   auto dups_num = coord_dups.size();
   auto tile_num = utils::math::ceil(cell_num - dups_num, capacity);
   auto attr_datatype_size = datatype_size(array_schema_->type(name));
-  uint64_t offset;
-  uint64_t var_size;
+  auto domain = array_schema_->domain();
+  auto cell_num_per_tile =
+      coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
 
   // Initialize tiles
   const uint64_t t = 2 + (nullable ? 1 : 0);
@@ -2404,60 +2483,92 @@ Status Writer::prepare_tiles_var(
   }
 
   // Write all cells one by one
+  uint64_t cell_idx = 0;
+  uint64_t tile_idx = 0;
+  uint64_t offset = 0;
   if (dups_num == 0) {
-    for (uint64_t i = 0, tile_idx = 0; i < cell_num; ++i) {
-      if ((*tiles)[tile_idx].full())
+    for (uint64_t i = 0; i < cell_num; ++i, ++cell_idx) {
+      if (cell_idx == cell_num_per_tile) {
+        (*tiles)[tile_idx + 1].final_size(offset);
+        cell_idx = 0;
+        offset = 0;
         tile_idx += t;
+      }
 
       // Write offset.
-      offset = (*tiles)[tile_idx + 1].size();
-      RETURN_NOT_OK((*tiles)[tile_idx].write(&offset, sizeof(offset)));
+      RETURN_NOT_OK((*tiles)[tile_idx].write(
+          &offset, cell_idx * sizeof(offset), sizeof(offset)));
 
       // Write var-sized value(s).
       auto buff_offset =
           prepare_buffer_offset(buffer, cell_pos[i], attr_datatype_size);
-      var_size = (cell_pos[i] == cell_num - 1) ?
-                     *buffer_var_size - buff_offset :
-                     prepare_buffer_offset(
-                         buffer, cell_pos[i] + 1, attr_datatype_size) -
-                         buff_offset;
-      RETURN_NOT_OK(
-          (*tiles)[tile_idx + 1].write(buffer_var + buff_offset, var_size));
+      uint64_t var_size = (cell_pos[i] == cell_num - 1) ?
+                              *buffer_var_size - buff_offset :
+                              prepare_buffer_offset(
+                                  buffer, cell_pos[i] + 1, attr_datatype_size) -
+                                  buff_offset;
+      RETURN_NOT_OK((*tiles)[tile_idx + 1].write_var(
+          buffer_var + buff_offset, offset, var_size));
+      offset += var_size;
 
       // Write validity value(s).
       if (nullable) {
         RETURN_NOT_OK((*tiles)[tile_idx + 2].write(
-            buffer_validity + cell_pos[i], constants::cell_validity_size));
+            buffer_validity + cell_pos[i],
+            cell_idx * constants::cell_validity_size,
+            constants::cell_validity_size));
       }
     }
   } else {
-    for (uint64_t i = 0, tile_idx = 0; i < cell_num; ++i) {
+    for (uint64_t i = 0; i < cell_num; ++i) {
       if (coord_dups.find(cell_pos[i]) != coord_dups.end())
         continue;
 
-      if ((*tiles)[tile_idx].full())
+      if (cell_idx == cell_num_per_tile) {
+        (*tiles)[tile_idx + 1].final_size(offset);
+        cell_idx = 0;
+        offset = 0;
         tile_idx += t;
+      }
 
       // Write offset.
-      offset = (*tiles)[tile_idx + 1].size();
-      RETURN_NOT_OK((*tiles)[tile_idx].write(&offset, sizeof(offset)));
+      RETURN_NOT_OK((*tiles)[tile_idx].write(
+          &offset, cell_idx * sizeof(offset), sizeof(offset)));
 
       // Write var-sized value(s).
       auto buff_offset =
           prepare_buffer_offset(buffer, cell_pos[i], attr_datatype_size);
-      var_size = (cell_pos[i] == cell_num - 1) ?
-                     *buffer_var_size - buff_offset :
-                     prepare_buffer_offset(
-                         buffer, cell_pos[i] + 1, attr_datatype_size) -
-                         buff_offset;
-      RETURN_NOT_OK(
-          (*tiles)[tile_idx + 1].write(buffer_var + buff_offset, var_size));
+      uint64_t var_size = (cell_pos[i] == cell_num - 1) ?
+                              *buffer_var_size - buff_offset :
+                              prepare_buffer_offset(
+                                  buffer, cell_pos[i] + 1, attr_datatype_size) -
+                                  buff_offset;
+      RETURN_NOT_OK((*tiles)[tile_idx + 1].write_var(
+          buffer_var + buff_offset, offset, var_size));
+      offset += var_size;
 
       // Write validity value(s).
       if (nullable) {
         RETURN_NOT_OK((*tiles)[tile_idx + 2].write(
-            buffer_validity + cell_pos[i], constants::cell_validity_size));
+            buffer_validity + cell_pos[i],
+            cell_idx * constants::cell_validity_size,
+            constants::cell_validity_size));
       }
+
+      ++cell_idx;
+    }
+  }
+
+  (*tiles)[tile_idx + 1].final_size(offset);
+
+  uint64_t last_tile_cell_num = (cell_num - dups_num) % capacity;
+  if (last_tile_cell_num != 0) {
+    (*tiles)[tile_idx].final_size(
+        last_tile_cell_num * constants::cell_var_offset_size);
+
+    if (nullable) {
+      (*tiles)[tile_idx + 2].final_size(
+          last_tile_cell_num * constants::cell_validity_size);
     }
   }
 
@@ -2632,187 +2743,6 @@ Status Writer::unordered_write() {
   return Status::Ok();
 }
 
-Status Writer::write_empty_cell_range_to_tile(
-    const uint64_t cell_num,
-    const uint32_t cell_val_num,
-    WriterTile* const tile) const {
-  auto type = tile->type();
-  auto fill_size = datatype_size(type);
-  auto fill_value = constants::fill_value(type);
-  assert(fill_value != nullptr);
-
-  for (uint64_t i = 0; i < cell_num; ++i) {
-    for (uint64_t j = 0; j < cell_val_num; ++j) {
-      RETURN_NOT_OK(tile->write(fill_value, fill_size));
-    }
-  }
-
-  return Status::Ok();
-}
-
-Status Writer::write_empty_cell_range_to_tile_nullable(
-    const uint64_t cell_num,
-    const uint32_t cell_val_num,
-    WriterTile* const tile,
-    WriterTile* const tile_validity) const {
-  auto type = tile->type();
-  auto fill_size = datatype_size(type);
-  auto fill_value = constants::fill_value(type);
-  assert(fill_value != nullptr);
-
-  for (uint64_t i = 0; i < cell_num; ++i) {
-    for (uint64_t j = 0; j < cell_val_num; ++j) {
-      RETURN_NOT_OK(tile->write(fill_value, fill_size));
-    }
-
-    // Write validity empty value, one per cell.
-    uint8_t empty_validity_value = 0;
-    RETURN_NOT_OK(tile_validity->write(
-        &empty_validity_value, constants::cell_validity_size));
-  }
-
-  return Status::Ok();
-}
-
-Status Writer::write_empty_cell_range_to_tile_var(
-    uint64_t num, WriterTile* tile, WriterTile* tile_var) const {
-  auto type = tile_var->type();
-  auto fill_size = datatype_size(type);
-  auto fill_value = constants::fill_value(type);
-  assert(fill_value != nullptr);
-
-  for (uint64_t i = 0; i < num; ++i) {
-    // Write next offset
-    uint64_t next_offset = tile_var->size();
-    RETURN_NOT_OK(tile->write(&next_offset, sizeof(uint64_t)));
-
-    // Write variable-sized empty value
-    RETURN_NOT_OK(tile_var->write(fill_value, fill_size));
-  }
-
-  return Status::Ok();
-}
-
-Status Writer::write_empty_cell_range_to_tile_var_nullable(
-    uint64_t num,
-    WriterTile* tile,
-    WriterTile* tile_var,
-    WriterTile* tile_validity) const {
-  auto type = tile_var->type();
-  auto fill_size = datatype_size(type);
-  auto fill_value = constants::fill_value(type);
-  assert(fill_value != nullptr);
-
-  for (uint64_t i = 0; i < num; ++i) {
-    // Write next offset
-    const uint64_t next_offset = tile_var->size();
-    RETURN_NOT_OK(tile->write(&next_offset, sizeof(uint64_t)));
-
-    // Write variable-sized empty value
-    RETURN_NOT_OK(tile_var->write(fill_value, fill_size));
-
-    // Write validity empty value
-    uint8_t empty_validity_value = 0;
-    RETURN_NOT_OK(tile_validity->write(
-        &empty_validity_value, constants::cell_validity_size));
-  }
-
-  return Status::Ok();
-}
-
-Status Writer::write_cell_range_to_tile(
-    ConstBuffer* buff, uint64_t start, uint64_t end, WriterTile* tile) const {
-  auto fixed_cell_size = tile->cell_size();
-  buff->set_offset(start * fixed_cell_size);
-  return tile->write(buff, (end - start + 1) * fixed_cell_size);
-}
-
-Status Writer::write_cell_range_to_tile_nullable(
-    ConstBuffer* buff,
-    ConstBuffer* buff_validity,
-    uint64_t start,
-    uint64_t end,
-    WriterTile* tile,
-    WriterTile* tile_validity) const {
-  auto fixed_cell_size = tile->cell_size();
-  buff->set_offset(start * fixed_cell_size);
-  RETURN_NOT_OK(tile->write(buff, (end - start + 1) * fixed_cell_size));
-
-  auto validity_cell_size = constants::cell_validity_size;
-  buff_validity->set_offset(start * validity_cell_size);
-  RETURN_NOT_OK(tile_validity->write(
-      buff_validity, (end - start + 1) * validity_cell_size));
-
-  return Status::Ok();
-}
-
-Status Writer::write_cell_range_to_tile_var(
-    ConstBuffer* buff,
-    ConstBuffer* buff_var,
-    uint64_t start,
-    uint64_t end,
-    uint64_t attr_datatype_size,
-    WriterTile* tile,
-    WriterTile* tile_var) const {
-  auto buff_cell_num = buff->size() / sizeof(uint64_t);
-
-  for (auto i = start; i <= end; ++i) {
-    // Write next offset
-    uint64_t next_offset = tile_var->size();
-    RETURN_NOT_OK(tile->write(&next_offset, sizeof(uint64_t)));
-
-    // Write variable-sized value
-    auto last_cell = (i == buff_cell_num - 1);
-    auto start_offset =
-        prepare_buffer_offset(buff->data(), i, attr_datatype_size);
-    auto end_offset = last_cell ? buff_var->size() :
-                                  prepare_buffer_offset(
-                                      buff->data(), i + 1, attr_datatype_size);
-    auto cell_var_size = end_offset - start_offset;
-    buff_var->set_offset(start_offset);
-    RETURN_NOT_OK(tile_var->write(buff_var, cell_var_size));
-  }
-
-  return Status::Ok();
-}
-
-Status Writer::write_cell_range_to_tile_var_nullable(
-    ConstBuffer* buff,
-    ConstBuffer* buff_var,
-    ConstBuffer* buff_validity,
-    uint64_t start,
-    uint64_t end,
-    uint64_t attr_datatype_size,
-    WriterTile* tile,
-    WriterTile* tile_var,
-    WriterTile* tile_validity) const {
-  auto buff_cell_num = buff->size() / sizeof(uint64_t);
-
-  for (auto i = start; i <= end; ++i) {
-    // Write next offset.
-    uint64_t next_offset = tile_var->size();
-    RETURN_NOT_OK(tile->write(&next_offset, sizeof(uint64_t)));
-
-    // Write variable-sized value(s).
-    auto last_cell = (i == buff_cell_num - 1);
-    auto start_offset =
-        prepare_buffer_offset(buff->data(), i, attr_datatype_size);
-    auto end_offset = last_cell ? buff_var->size() :
-                                  prepare_buffer_offset(
-                                      buff->data(), i + 1, attr_datatype_size);
-    auto cell_var_size = end_offset - start_offset;
-    buff_var->set_offset(start_offset);
-    RETURN_NOT_OK(tile_var->write(buff_var, cell_var_size));
-
-    // Write the validity value(s).
-    buff_validity->set_offset(i * constants::cell_validity_size);
-    RETURN_NOT_OK(
-        tile_validity->write(buff_validity, constants::cell_validity_size));
-  }
-
-  return Status::Ok();
-}
-
 Status Writer::write_all_tiles(
     tdb_shared_ptr<FragmentMetadata> frag_meta,
     std::unordered_map<std::string, std::vector<WriterTile>>* const tiles) {
@@ -2879,18 +2809,22 @@ Status Writer::write_tiles(
 
   // Write tiles
   for (size_t i = 0, tile_id = start_tile_id; i < tile_num; ++i, ++tile_id) {
-    auto tile = &(*tiles)[i];
-    RETURN_NOT_OK(storage_manager_->write(uri, tile->filtered_buffer()));
-    frag_meta->set_tile_offset(name, tile_id, tile->filtered_buffer()->size());
+    WriterTile* tile = &(*tiles)[i];
+    RETURN_NOT_OK(storage_manager_->write(
+        uri, tile->filtered_buffer().data(), tile->filtered_buffer().size()));
+    frag_meta->set_tile_offset(name, tile_id, tile->filtered_buffer().size());
 
     auto&& [min, min_size, max, max_size, sum, null_count] = tile->metadata();
     if (var_size) {
       ++i;
 
       tile = &(*tiles)[i];
-      RETURN_NOT_OK(storage_manager_->write(var_uri, tile->filtered_buffer()));
+      RETURN_NOT_OK(storage_manager_->write(
+          var_uri,
+          tile->filtered_buffer().data(),
+          tile->filtered_buffer().size()));
       frag_meta->set_tile_var_offset(
-          name, tile_id, tile->filtered_buffer()->size());
+          name, tile_id, tile->filtered_buffer().size());
       frag_meta->set_tile_var_size(name, tile_id, tile->pre_filtered_size());
       if (has_min_max_md && null_count != frag_meta->cell_num(tile_id)) {
         frag_meta->set_tile_min_var_size(name, tile_id, min_size);
@@ -2911,10 +2845,12 @@ Status Writer::write_tiles(
       ++i;
 
       tile = &(*tiles)[i];
-      RETURN_NOT_OK(
-          storage_manager_->write(validity_uri, tile->filtered_buffer()));
+      RETURN_NOT_OK(storage_manager_->write(
+          validity_uri,
+          tile->filtered_buffer().data(),
+          tile->filtered_buffer().size()));
       frag_meta->set_tile_validity_offset(
-          name, tile_id, tile->filtered_buffer()->size());
+          name, tile_id, tile->filtered_buffer().size());
       frag_meta->set_tile_null_count(name, tile_id, null_count);
     }
   }

--- a/tiledb/sm/query/writer.cc
+++ b/tiledb/sm/query/writer.cc
@@ -1439,7 +1439,8 @@ Status Writer::init_global_write_state() {
     uint64_t num = 1 + var_size + nullable;
     auto last_tile_vector = std::pair<std::string, std::vector<WriterTile>>(
         name, std::vector<WriterTile>(num));
-    auto it_ret = global_write_state_->last_tiles_.emplace(last_tile_vector);
+    auto it_ret =
+        global_write_state_->last_tiles_.emplace(std::move(last_tile_vector));
 
     if (!var_size) {
       auto& last_tile = it_ret.first->second[0];
@@ -1955,9 +1956,9 @@ Status Writer::prepare_full_tiles_fixed(
 
     // Handle last tile (it must be either full or empty)
     if (last_tile_cell_idx == cell_num_per_tile) {
-      (*tiles)[0] = last_tile;
+      (*tiles)[0].swap(last_tile);
       if (nullable) {
-        (*tiles)[1] = last_tile_validity;
+        (*tiles)[1].swap(last_tile_validity);
       }
     } else {
       assert(last_tile_cell_idx == 0);
@@ -2164,10 +2165,10 @@ Status Writer::prepare_full_tiles_var(
     // Handle last tile (it must be either full or empty)
     if (last_tile_cell_idx == cell_num_per_tile) {
       last_var_offset = 0;
-      (*tiles)[0] = last_tile;
-      (*tiles)[1] = last_tile_var;
+      (*tiles)[0].swap(last_tile);
+      (*tiles)[1].swap(last_tile_var);
       if (nullable) {
-        (*tiles)[2] = last_tile_validity;
+        (*tiles)[2].swap(last_tile_validity);
       }
     } else {
       assert(last_tile_cell_idx == 0);

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -70,13 +70,21 @@ class Writer : public StrategyBase, public IQueryStrategy {
   struct GlobalWriteState {
     /**
      * Stores the last tile of each attribute/dimension for each write
-     * operation. For fixed-sized attributes/dimensions, the second tile is
-     * ignored. For var-sized attributes/dimensions, the first tile is the
-     * offsets tile, whereas the second tile is the values tile. In both cases,
-     * the third tile stores a validity tile for nullable attributes.
+     * operation. The key is the attribute/dimension name. For fixed-sized
+     * attributes/dimensions, the second tile is ignored. For var-sized
+     * attributes/dimensions, the first tile is the offsets tile, whereas the
+     * second tile is the values tile. In both cases, the third tile stores a
+     * validity tile for nullable attributes.
      */
     std::unordered_map<std::string, std::vector<WriterTile>> last_tiles_;
 
+    /**
+     * Stores the last offset into the var size tile buffer for var size
+     * dimensions/attributes. The key is the attribute/dimension name.
+     *
+     * Note: Once tiles are created with the correct size from the beginning,
+     * this variable can go awaty.
+     */
     std::unordered_map<std::string, uint64_t> last_var_offsets_;
 
     /**

--- a/tiledb/sm/query/writer.h
+++ b/tiledb/sm/query/writer.h
@@ -75,10 +75,9 @@ class Writer : public StrategyBase, public IQueryStrategy {
      * offsets tile, whereas the second tile is the values tile. In both cases,
      * the third tile stores a validity tile for nullable attributes.
      */
-    std::unordered_map<
-        std::string,
-        std::tuple<WriterTile, WriterTile, WriterTile>>
-        last_tiles_;
+    std::unordered_map<std::string, std::vector<WriterTile>> last_tiles_;
+
+    std::unordered_map<std::string, uint64_t> last_var_offsets_;
 
     /**
      * Stores the number of cells written for each attribute/dimension across
@@ -380,8 +379,7 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * Applicable only to global writes. Filters the last attribute and
    * coordinate tiles.
    */
-  Status filter_last_tiles(
-      std::unordered_map<std::string, std::vector<WriterTile>>* tiles);
+  Status filter_last_tiles(uint64_t cell_num);
 
   /**
    * Runs the input tiles for the input attribute through the filter pipeline.
@@ -743,145 +741,6 @@ class Writer : public StrategyBase, public IQueryStrategy {
   Status unordered_write();
 
   /**
-   * Writes an empty cell range to the input tile.
-   * Applicable to **fixed-sized** attributes.
-   *
-   * @param cell_num Number of empty cells to write.
-   * @param cell_val_num Number of values per cell.
-   * @param tile The tile to write to.
-   * @return Status
-   */
-  Status write_empty_cell_range_to_tile(
-      uint64_t num, uint32_t cell_val_num, WriterTile* tile) const;
-
-  /**
-   * Writes an empty cell range to the input tile.
-   * Applicable to **fixed-sized** attributes.
-   *
-   * @param cell_num Number of empty cells to write.
-   * @param cell_val_num Number of values per cell.
-   * @param tile The tile to write to.
-   * @param tile_validity The tile with the validity cells to write to.
-   * @return Status
-   */
-  Status write_empty_cell_range_to_tile_nullable(
-      uint64_t num,
-      uint32_t cell_val_num,
-      WriterTile* tile,
-      WriterTile* tile_validity) const;
-
-  /**
-   * Writes an empty cell range to the input tile.
-   * Applicable to **variable-sized** attributes.
-   *
-   * @param num Number of empty values to write.
-   * @param tile The tile offsets to write to.
-   * @param tile_var The tile with the var-sized cells to write to.
-   * @return Status
-   */
-  Status write_empty_cell_range_to_tile_var(
-      uint64_t num, WriterTile* tile, WriterTile* tile_var) const;
-
-  /**
-   * Writes an empty cell range to the input tile.
-   * Applicable to **variable-sized** attributes.
-   *
-   * @param num Number of empty values to write.
-   * @param tile The tile offsets to write to.
-   * @param tile_var The tile with the var-sized cells to write to.
-   * @param tile_validity The tile with the validity cells to write to.
-   * @return Status
-   */
-  Status write_empty_cell_range_to_tile_var_nullable(
-      uint64_t num,
-      WriterTile* tile,
-      WriterTile* tile_var,
-      WriterTile* tile_validity) const;
-
-  /**
-   * Writes the input cell range to the input tile, for a particular
-   * buffer. Applicable to **fixed-sized** attributes.
-   *
-   * @param buff The write buffer where the cells will be copied from.
-   * @param start The start element in the write buffer.
-   * @param end The end element in the write buffer.
-   * @param tile The tile to write to.
-   * @return Status
-   */
-  Status write_cell_range_to_tile(
-      ConstBuffer* buff, uint64_t start, uint64_t end, WriterTile* tile) const;
-
-  /**
-   * Writes the input cell range to the input tile, for a particular
-   * buffer. Applicable to **fixed-sized** attributes.
-   *
-   * @param buff The write buffer where the cells will be copied from.
-   * @param buff_validity The write buffer where the validity cell values will
-   * be copied from.
-   * @param start The start element in the write buffer.
-   * @param end The end element in the write buffer.
-   * @param tile The tile to write to.
-   * @param tile_validity The validity tile to be initialized.
-   * @return Status
-   */
-  Status write_cell_range_to_tile_nullable(
-      ConstBuffer* buff,
-      ConstBuffer* buff_validity,
-      uint64_t start,
-      uint64_t end,
-      WriterTile* tile,
-      WriterTile* tile_validity) const;
-
-  /**
-   * Writes the input cell range to the input tile, for a particular
-   * buffer. Applicable to **variable-sized** attributes.
-   *
-   * @param buff The write buffer where the cell offsets will be copied from.
-   * @param buff_var The write buffer where the cell values will be copied from.
-   * @param start The start element in the write buffer.
-   * @param end The end element in the write buffer.
-   * @param attr_datatype_size The size of each attribute value in `buff_var`.
-   * @param tile The tile offsets to write to.
-   * @param tile_var The tile with the var-sized cells to write to.
-   * @return Status
-   */
-  Status write_cell_range_to_tile_var(
-      ConstBuffer* buff,
-      ConstBuffer* buff_var,
-      uint64_t start,
-      uint64_t end,
-      uint64_t attr_datatype_size,
-      WriterTile* tile,
-      WriterTile* tile_var) const;
-
-  /**
-   * Writes the input cell range to the input tile, for a particular
-   * buffer. Applicable to **variable-sized**, nullable attributes.
-   *
-   * @param buff The write buffer where the cell offsets will be copied from.
-   * @param buff_var The write buffer where the cell values will be copied from.
-   * @param buff_validity The write buffer where the validity cell values will
-   * be copied from.
-   * @param start The start element in the write buffer.
-   * @param end The end element in the write buffer.
-   * @param attr_datatype_size The size of each attribute value in `buff_var`.
-   * @param tile The tile offsets to write to.
-   * @param tile_var The tile with the var-sized cells to write to.
-   * @param tile_validity The validity tile to be initialized.
-   * @return Status
-   */
-  Status write_cell_range_to_tile_var_nullable(
-      ConstBuffer* buff,
-      ConstBuffer* buff_var,
-      ConstBuffer* buff_validity,
-      uint64_t start,
-      uint64_t end,
-      uint64_t attr_datatype_size,
-      WriterTile* tile,
-      WriterTile* tile_var,
-      WriterTile* tile_validity) const;
-
-  /**
    * Writes all the input tiles to storage.
    *
    * @param tiles Attribute/Coordinate tiles to be written, one element per
@@ -941,12 +800,6 @@ class Writer : public StrategyBase, public IQueryStrategy {
    * resets the global write state.
    */
   void clean_up(const URI& uri);
-
-  /**
-   * Applicable only to global writes. Returns true if all last tiles stored
-   * in the global write state are empty.
-   */
-  bool all_last_tiles_empty() const;
 
   /** Calculates the hilbert values of the input coordinate buffers. */
   Status calculate_hilbert_values(

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -480,13 +480,12 @@ Status Consolidator::consolidate_fragment_meta(
   // Write to file
   EncryptionKey enc_key;
   RETURN_NOT_OK(enc_key.set_key(encryption_type, encryption_key, key_length));
-  buff.reset_offset();
   Tile tile(
       constants::generic_tile_datatype,
       constants::generic_tile_cell_size,
       0,
-      &buff,
-      false);
+      buff.data(),
+      buff.size());
   buff.disown_data();
   GenericTileIO tile_io(storage_manager_, uri);
   uint64_t nbytes = 0;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -2006,7 +2006,7 @@ Status StorageManager::read_from_cache(
     bool* in_cache) const {
   std::stringstream key;
   key << uri.to_string() << "+" << offset;
-  buffer.resize(nbytes);
+  buffer.expand(nbytes);
   RETURN_NOT_OK(tile_cache_->read(key.str(), buffer, 0, nbytes, in_cache));
 
   return Status::Ok();

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -55,6 +55,7 @@
 #include "tiledb/sm/misc/cancelable_tasks.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/tile/filtered_buffer.h"
 
 using namespace tiledb::common;
 
@@ -895,7 +896,7 @@ class StorageManager {
   Status read_from_cache(
       const URI& uri,
       uint64_t offset,
-      Buffer* buffer,
+      FilteredBuffer& buffer,
       uint64_t nbytes,
       bool* in_cache) const;
 
@@ -979,7 +980,8 @@ class StorageManager {
    * @param buffer The buffer whose contents will be cached.
    * @return Status.
    */
-  Status write_to_cache(const URI& uri, uint64_t offset, Buffer* buffer) const;
+  Status write_to_cache(
+      const URI& uri, uint64_t offset, const FilteredBuffer& buffer) const;
 
   /**
    * Writes the contents of a buffer into a URI file.

--- a/tiledb/sm/tile/filtered_buffer.h
+++ b/tiledb/sm/tile/filtered_buffer.h
@@ -93,13 +93,19 @@ class FilteredBuffer {
   }
 
   /** Returns the data. */
-  inline uint8_t* data() {
+  inline char* data() {
     return filtered_buffer_.data();
   }
 
   /** Returns the data. */
-  inline const uint8_t* data() const {
+  inline const char* data() const {
     return filtered_buffer_.data();
+  }
+
+  /** Returns the data casted as a type. */
+  template <class T>
+  inline T* data_as() {
+    return static_cast<T*>(static_cast<void*>(filtered_buffer_.data()));
   }
 
   /** Expands the size of the underlying container. */
@@ -127,7 +133,7 @@ class FilteredBuffer {
   /* ********************************* */
 
   /** Storing container for the filtered buffer. */
-  std::vector<uint8_t> filtered_buffer_;
+  std::vector<char> filtered_buffer_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/tile/filtered_buffer.h
+++ b/tiledb/sm/tile/filtered_buffer.h
@@ -51,7 +51,37 @@ class FilteredBuffer {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  FilteredBuffer() = default;
+  FilteredBuffer(uint64_t size) {
+    if (size != 0) {
+      filtered_buffer_.resize(size);
+    }
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * Only used in the tile cache. Should be removed when the tile cache is
+   * removed.
+   */
+  FilteredBuffer(const FilteredBuffer& other) {
+    filtered_buffer_ = other.filtered_buffer_;
+  }
+
+  /** Move constructor. */
+  FilteredBuffer(FilteredBuffer&& other) {
+    // Swap with the argument
+    swap(other);
+  }
+
+  /** Move-assign operator. */
+  FilteredBuffer& operator=(FilteredBuffer&& other) {
+    // Swap with the argument
+    swap(other);
+
+    return *this;
+  }
+
+  DISABLE_COPY_ASSIGN(FilteredBuffer);
 
   /* ********************************* */
   /*                API                */
@@ -72,14 +102,23 @@ class FilteredBuffer {
     return filtered_buffer_.data();
   }
 
-  /** Resizes the underlying container. */
-  inline void resize(size_t size) {
+  /** Expands the size of the underlying container. */
+  inline void expand(size_t size) {
+    assert(size >= filtered_buffer_.size());
     filtered_buffer_.resize(size);
   }
 
   /** Clears the data. */
   inline void clear() {
     filtered_buffer_.clear();
+  }
+
+  /**
+   * Swaps the contents (all field values) of this filtered buffer with the
+   * given filtered buffer.
+   */
+  void swap(FilteredBuffer& other) {
+    std::swap(filtered_buffer_, other.filtered_buffer_);
   }
 
  private:

--- a/tiledb/sm/tile/filtered_buffer.h
+++ b/tiledb/sm/tile/filtered_buffer.h
@@ -108,6 +108,14 @@ class FilteredBuffer {
     return static_cast<T*>(static_cast<void*>(filtered_buffer_.data()));
   }
 
+  /** Converts the data at an offset to a specific type. */
+  template <class T>
+  inline T value_at_as(uint64_t offset) const {
+    assert(offset + sizeof(T) <= filtered_buffer_.size());
+    return *static_cast<const T*>(
+        static_cast<const void*>(&filtered_buffer_.data()[offset]));
+  }
+
   /** Expands the size of the underlying container. */
   inline void expand(size_t size) {
     assert(size >= filtered_buffer_.size());

--- a/tiledb/sm/tile/filtered_buffer.h
+++ b/tiledb/sm/tile/filtered_buffer.h
@@ -1,0 +1,97 @@
+/**
+ * @file   filtered_buffer.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class FilteredBuffer.
+ */
+
+#ifndef TILEDB_FILTERED_BUFFER_H
+#define TILEDB_FILTERED_BUFFER_H
+
+#include <vector>
+
+#include "tiledb/common/status.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * Handles filtered buffer information.
+ */
+class FilteredBuffer {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  FilteredBuffer() = default;
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Returns the size. */
+  inline size_t size() const {
+    return filtered_buffer_.size();
+  }
+
+  /** Returns the data. */
+  inline uint8_t* data() {
+    return filtered_buffer_.data();
+  }
+
+  /** Returns the data. */
+  inline const uint8_t* data() const {
+    return filtered_buffer_.data();
+  }
+
+  /** Resizes the underlying container. */
+  inline void resize(size_t size) {
+    filtered_buffer_.resize(size);
+  }
+
+  /** Clears the data. */
+  inline void clear() {
+    filtered_buffer_.clear();
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** Storing container for the filtered buffer. */
+  std::vector<uint8_t> filtered_buffer_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_FILTERED_BUFFER_H

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -86,7 +86,7 @@ Status GenericTileIO::read_generic(
       header.version_number, (Datatype)header.datatype, header.cell_size, 0));
 
   // Read the tile.
-  ret->filtered_buffer().resize(header.persisted_size);
+  ret->filtered_buffer().expand(header.persisted_size);
   RETURN_NOT_OK(ret->alloc_data(header.tile_size));
   RETURN_NOT_OK(storage_manager_->read(
       uri_,

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -64,6 +64,7 @@ Status GenericTileIO::read_generic(
     uint64_t file_offset,
     const EncryptionKey& encryption_key,
     const Config& config) {
+  tdb_unique_ptr<Tile> ret(tdb_new(Tile));
   GenericTileHeader header;
   RETURN_NOT_OK(
       read_generic_tile_header(storage_manager_, uri_, file_offset, &header));
@@ -81,39 +82,28 @@ Status GenericTileIO::read_generic(
   const auto tile_data_offset =
       GenericTileHeader::BASE_SIZE + header.filter_pipeline_size;
 
-  assert(tile);
-  *tile = tdb_new(Tile);
-  RETURN_NOT_OK_ELSE(
-      (*tile)->init_filtered(
-          header.version_number,
-          (Datatype)header.datatype,
-          header.cell_size,
-          0),
-      tdb_delete(*tile));
+  RETURN_NOT_OK(ret->init_filtered(
+      header.version_number, (Datatype)header.datatype, header.cell_size, 0));
 
   // Read the tile.
-  RETURN_NOT_OK_ELSE(
-      (*tile)->filtered_buffer()->realloc(header.persisted_size),
-      tdb_delete(*tile));
-  RETURN_NOT_OK_ELSE(
-      storage_manager_->read(
-          uri_,
-          file_offset + tile_data_offset,
-          (*tile)->filtered_buffer(),
-          header.persisted_size),
-      tdb_delete(*tile));
+  ret->filtered_buffer().resize(header.persisted_size);
+  RETURN_NOT_OK(ret->alloc_data(header.tile_size));
+  RETURN_NOT_OK(storage_manager_->read(
+      uri_,
+      file_offset + tile_data_offset,
+      ret->filtered_buffer().data(),
+      header.persisted_size));
 
   // Unfilter
-  assert((*tile)->filtered());
-  RETURN_NOT_OK_ELSE(
-      header.filters.run_reverse(
-          storage_manager_->stats(),
-          *tile,
-          storage_manager_->compute_tp(),
-          config),
-      tdb_delete(*tile));
-  assert(!(*tile)->filtered());
+  assert(ret->filtered());
+  RETURN_NOT_OK(header.filters.run_reverse(
+      storage_manager_->stats(),
+      ret.get(),
+      storage_manager_->compute_tp(),
+      config));
+  assert(!ret->filtered());
 
+  *tile = ret.release();
   return Status::Ok();
 }
 
@@ -153,9 +143,6 @@ Status GenericTileIO::read_generic_tile_header(
 
 Status GenericTileIO::write_generic(
     Tile* tile, const EncryptionKey& encryption_key, uint64_t* nbytes) {
-  // Reset the tile and buffer offset
-  tile->reset_offset();
-
   // Create a header
   GenericTileHeader header;
   RETURN_NOT_OK(init_generic_tile_header(tile, &header, encryption_key));
@@ -167,11 +154,13 @@ Status GenericTileIO::write_generic(
       tile,
       nullptr,
       storage_manager_->compute_tp()));
-  header.persisted_size = tile->filtered_buffer()->size();
+  header.persisted_size = tile->filtered_buffer().size();
   assert(tile->filtered());
 
   RETURN_NOT_OK(write_generic_tile_header(&header));
-  RETURN_NOT_OK(storage_manager_->write(uri_, tile->filtered_buffer()));
+
+  RETURN_NOT_OK(storage_manager_->write(
+      uri_, tile->filtered_buffer().data(), tile->filtered_buffer().size()));
 
   *nbytes = GenericTileIO::GenericTileHeader::BASE_SIZE +
             header.filter_pipeline_size + header.persisted_size;

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -138,7 +138,7 @@ ByteVec Sum<T, int64_t>::sum_nullable(Tile* tile, Tile* tile_validity) {
 
   // Get pointers to the data and cell num.
   auto values = tile->data_as<T>();
-  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto validity_values = tile_validity->data_as<uint8_t>();
   auto cell_num = tile->size_as<T>();
   auto sum_data = reinterpret_cast<int64_t*>(ret.data());
 
@@ -174,7 +174,7 @@ ByteVec Sum<T, uint64_t>::sum_nullable(Tile* tile, Tile* tile_validity) {
 
   // Get pointers to the data and cell num.
   auto values = tile->data_as<T>();
-  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto validity_values = tile_validity->data_as<uint8_t>();
   auto cell_num = tile->size_as<T>();
   auto sum_data = reinterpret_cast<uint64_t*>(ret.data());
 
@@ -203,7 +203,7 @@ ByteVec Sum<T, double>::sum_nullable(Tile* tile, Tile* tile_validity) {
 
   // Get pointers to the data and cell num.
   auto values = tile->data_as<T>();
-  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto validity_values = tile_validity->data_as<uint8_t>();
   auto cell_num = tile->size_as<T>();
   auto sum_data = reinterpret_cast<double*>(ret.data());
 
@@ -323,7 +323,7 @@ const std::tuple<void*, void*> TileMetadataGenerator::min_max<char>(
     return {nullptr, nullptr};
 
   // Get pointer to the data, set the min max to the first value.
-  auto data = (char*)tile->data();
+  auto data = tile->data_as<char>();
   void* min = data;
   void* max = data;
 
@@ -352,7 +352,7 @@ TileMetadataGenerator::min_max_nullable(
 
   // Get pointers to the data and cell num.
   auto values = tile->data_as<T>();
-  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto validity_values = tile_validity->data_as<uint8_t>();
   auto cell_num = tile->size() / cell_size;
 
   // Process cell by cell.
@@ -378,8 +378,8 @@ TileMetadataGenerator::min_max_nullable<char>(
   uint64_t null_count = 0;
 
   // Get pointers to the data and cell num.
-  auto value = (char*)tile->data();
-  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto value = tile->data_as<char>();
+  auto validity_values = tile_validity->data_as<uint8_t>();
   auto cell_num = tile->size() / cell_size;
 
   // Process cell by cell.
@@ -540,7 +540,7 @@ void TileMetadataGenerator::process_tile(Tile* tile, Tile* tile_validity) {
           Sum<T, typename metadata_generator_type_data<T>::sum_type>::sum(tile);
     }
   } else {  // Fixed size attribute, nullable.
-    auto validity_value = static_cast<uint8_t*>(tile_validity->data());
+    auto validity_value = tile_validity->data_as<uint8_t>();
     if (has_min_max_) {
       auto&& [min, max, nc] =
           min_max_nullable<T>(tile, tile_validity, cell_size_);
@@ -574,8 +574,8 @@ void TileMetadataGenerator::process_tile_var(
   }
 
   // Get pointers to the data and cell num.
-  auto offset_value = static_cast<uint64_t*>(tile->data());
-  auto var_data = static_cast<char*>(tile_var->data());
+  auto offset_value = tile->data_as<uint64_t>();
+  auto var_data = tile_var->data_as<char>();
   auto cell_num = tile->size() / constants::cell_var_offset_size;
 
   // Var size attribute, non nullable.
@@ -593,7 +593,7 @@ void TileMetadataGenerator::process_tile_var(
       offset_value++;
     }
   } else {  // Var size attribute, nullable.
-    auto validity_value = static_cast<uint8_t*>(tile_validity->data());
+    auto validity_value = tile_validity->data_as<uint8_t>();
 
     for (uint64_t c = 0; c < cell_num; c++) {
       auto is_null = *validity_value == 0;

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -49,8 +49,8 @@ ByteVec Sum<T, int64_t>::sum(Tile* tile) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->buffer()->data());
-  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto values = static_cast<T*>(tile->data());
+  auto cell_num = tile->size() / sizeof(T);
   auto sum_data = reinterpret_cast<int64_t*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -82,8 +82,8 @@ ByteVec Sum<T, uint64_t>::sum(Tile* tile) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->buffer()->data());
-  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto values = static_cast<T*>(tile->data());
+  auto cell_num = tile->size() / sizeof(T);
   auto sum_data = reinterpret_cast<uint64_t*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -108,8 +108,8 @@ ByteVec Sum<T, double>::sum(Tile* tile) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->buffer()->data());
-  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto values = static_cast<T*>(tile->data());
+  auto cell_num = tile->size() / sizeof(T);
   auto sum_data = reinterpret_cast<double*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -137,9 +137,9 @@ ByteVec Sum<T, int64_t>::sum_nullable(Tile* tile, Tile* tile_validity) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->buffer()->data());
-  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
-  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto values = static_cast<T*>(tile->data());
+  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto cell_num = tile->size() / sizeof(T);
   auto sum_data = reinterpret_cast<int64_t*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -173,9 +173,9 @@ ByteVec Sum<T, uint64_t>::sum_nullable(Tile* tile, Tile* tile_validity) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->buffer()->data());
-  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
-  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto values = static_cast<T*>(tile->data());
+  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto cell_num = tile->size() / sizeof(T);
   auto sum_data = reinterpret_cast<uint64_t*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -202,9 +202,9 @@ ByteVec Sum<T, double>::sum_nullable(Tile* tile, Tile* tile_validity) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->buffer()->data());
-  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
-  auto cell_num = tile->buffer()->size() / sizeof(T);
+  auto values = static_cast<T*>(tile->data());
+  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto cell_num = tile->size() / sizeof(T);
   auto sum_data = reinterpret_cast<double*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -300,8 +300,8 @@ const std::tuple<void*, void*> TileMetadataGenerator::min_max(
   void* max = (void*)&metadata_generator_type_data<T>::max;
 
   // Get pointer to the data and cell num.
-  auto values = static_cast<T*>(tile->buffer()->data());
-  auto cell_num = tile->buffer()->size() / cell_size;
+  auto values = static_cast<T*>(tile->data());
+  auto cell_num = tile->size() / cell_size;
 
   // Process cell by cell.
   for (uint64_t c = 0; c < cell_num; c++) {
@@ -318,12 +318,12 @@ const std::tuple<void*, void*> TileMetadataGenerator::min_max<char>(
   assert(tile != nullptr);
 
   // For strings, return null for empty tiles.
-  auto size = tile->buffer()->size();
+  auto size = tile->size();
   if (size == 0)
     return {nullptr, nullptr};
 
   // Get pointer to the data, set the min max to the first value.
-  auto data = (char*)tile->buffer()->data();
+  auto data = (char*)tile->data();
   void* min = data;
   void* max = data;
 
@@ -351,9 +351,9 @@ TileMetadataGenerator::min_max_nullable(
   uint64_t null_count = 0;
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->buffer()->data());
-  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
-  auto cell_num = tile->buffer()->size() / cell_size;
+  auto values = static_cast<T*>(tile->data());
+  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto cell_num = tile->size() / cell_size;
 
   // Process cell by cell.
   for (uint64_t c = 0; c < cell_num; c++) {
@@ -378,9 +378,9 @@ TileMetadataGenerator::min_max_nullable<char>(
   uint64_t null_count = 0;
 
   // Get pointers to the data and cell num.
-  auto value = (char*)tile->buffer()->data();
-  auto validity_values = static_cast<uint8_t*>(tile_validity->buffer()->data());
-  auto cell_num = tile->buffer()->size() / cell_size;
+  auto value = (char*)tile->data();
+  auto validity_values = static_cast<uint8_t*>(tile_validity->data());
+  auto cell_num = tile->size() / cell_size;
 
   // Process cell by cell.
   for (uint64_t c = 0; c < cell_num; c++) {
@@ -540,8 +540,7 @@ void TileMetadataGenerator::process_tile(Tile* tile, Tile* tile_validity) {
           Sum<T, typename metadata_generator_type_data<T>::sum_type>::sum(tile);
     }
   } else {  // Fixed size attribute, nullable.
-    auto validity_value =
-        static_cast<uint8_t*>(tile_validity->buffer()->data());
+    auto validity_value = static_cast<uint8_t*>(tile_validity->data());
     if (has_min_max_) {
       auto&& [min, max, nc] =
           min_max_nullable<T>(tile, tile_validity, cell_size_);
@@ -549,7 +548,7 @@ void TileMetadataGenerator::process_tile(Tile* tile, Tile* tile_validity) {
       max_ = max;
       null_count_ = nc;
     } else {
-      auto cell_num = tile->buffer()->size() / cell_size_;
+      auto cell_num = tile->size() / cell_size_;
       for (uint64_t c = 0; c < cell_num; c++) {
         auto is_null = *validity_value == 0;
         null_count_ += (uint64_t)is_null;
@@ -570,42 +569,38 @@ void TileMetadataGenerator::process_tile_var(
   assert(tile_var != nullptr);
 
   // Handle empty tile.
-  if (!has_min_max_ || tile->buffer()->size() == 0) {
+  if (!has_min_max_ || tile->size() == 0) {
     return;
   }
 
   // Get pointers to the data and cell num.
-  auto offset_value = static_cast<uint64_t*>(tile->buffer()->data());
-  auto var_data = static_cast<char*>(tile_var->buffer()->data());
-  auto cell_num = tile->buffer()->size() / constants::cell_var_offset_size;
+  auto offset_value = static_cast<uint64_t*>(tile->data());
+  auto var_data = static_cast<char*>(tile_var->data());
+  auto cell_num = tile->size() / constants::cell_var_offset_size;
 
   // Var size attribute, non nullable.
   if (tile_validity == nullptr) {
     offset_value++;
     min_ = var_data;
     max_ = var_data;
-    min_size_ = max_size_ =
-        cell_num == 1 ? tile_var->buffer()->size() : *offset_value;
+    min_size_ = max_size_ = cell_num == 1 ? tile_var->size() : *offset_value;
 
     for (uint64_t c = 1; c < cell_num; c++) {
       auto value = var_data + *offset_value;
-      auto size = c == cell_num - 1 ?
-                      tile_var->buffer()->size() - *offset_value :
-                      offset_value[1] - *offset_value;
+      auto size = c == cell_num - 1 ? tile_var->size() - *offset_value :
+                                      offset_value[1] - *offset_value;
       min_max_var(value, size);
       offset_value++;
     }
   } else {  // Var size attribute, nullable.
-    auto validity_value =
-        static_cast<uint8_t*>(tile_validity->buffer()->data());
+    auto validity_value = static_cast<uint8_t*>(tile_validity->data());
 
     for (uint64_t c = 0; c < cell_num; c++) {
       auto is_null = *validity_value == 0;
       if (!is_null) {
         auto value = var_data + *offset_value;
-        auto size = c == cell_num - 1 ?
-                        tile_var->buffer()->size() - *offset_value :
-                        offset_value[1] - *offset_value;
+        auto size = c == cell_num - 1 ? tile_var->size() - *offset_value :
+                                        offset_value[1] - *offset_value;
         if (min_ == nullptr && max_ == nullptr) {
           min_ = value;
           max_ = value;

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -49,8 +49,8 @@ ByteVec Sum<T, int64_t>::sum(Tile* tile) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->data());
-  auto cell_num = tile->size() / sizeof(T);
+  auto values = tile->data_as<T>();
+  auto cell_num = tile->size_as<T>();
   auto sum_data = reinterpret_cast<int64_t*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -82,8 +82,8 @@ ByteVec Sum<T, uint64_t>::sum(Tile* tile) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->data());
-  auto cell_num = tile->size() / sizeof(T);
+  auto values = tile->data_as<T>();
+  auto cell_num = tile->size_as<T>();
   auto sum_data = reinterpret_cast<uint64_t*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -108,8 +108,8 @@ ByteVec Sum<T, double>::sum(Tile* tile) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->data());
-  auto cell_num = tile->size() / sizeof(T);
+  auto values = tile->data_as<T>();
+  auto cell_num = tile->size_as<T>();
   auto sum_data = reinterpret_cast<double*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -137,9 +137,9 @@ ByteVec Sum<T, int64_t>::sum_nullable(Tile* tile, Tile* tile_validity) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->data());
+  auto values = tile->data_as<T>();
   auto validity_values = static_cast<uint8_t*>(tile_validity->data());
-  auto cell_num = tile->size() / sizeof(T);
+  auto cell_num = tile->size_as<T>();
   auto sum_data = reinterpret_cast<int64_t*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -173,9 +173,9 @@ ByteVec Sum<T, uint64_t>::sum_nullable(Tile* tile, Tile* tile_validity) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->data());
+  auto values = tile->data_as<T>();
   auto validity_values = static_cast<uint8_t*>(tile_validity->data());
-  auto cell_num = tile->size() / sizeof(T);
+  auto cell_num = tile->size_as<T>();
   auto sum_data = reinterpret_cast<uint64_t*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -202,9 +202,9 @@ ByteVec Sum<T, double>::sum_nullable(Tile* tile, Tile* tile_validity) {
   ByteVec ret(8, 0);
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->data());
+  auto values = tile->data_as<T>();
   auto validity_values = static_cast<uint8_t*>(tile_validity->data());
-  auto cell_num = tile->size() / sizeof(T);
+  auto cell_num = tile->size_as<T>();
   auto sum_data = reinterpret_cast<double*>(ret.data());
 
   // Process cell by cell, swallowing overflow exception.
@@ -300,7 +300,7 @@ const std::tuple<void*, void*> TileMetadataGenerator::min_max(
   void* max = (void*)&metadata_generator_type_data<T>::max;
 
   // Get pointer to the data and cell num.
-  auto values = static_cast<T*>(tile->data());
+  auto values = tile->data_as<T>();
   auto cell_num = tile->size() / cell_size;
 
   // Process cell by cell.
@@ -351,7 +351,7 @@ TileMetadataGenerator::min_max_nullable(
   uint64_t null_count = 0;
 
   // Get pointers to the data and cell num.
-  auto values = static_cast<T*>(tile->data());
+  auto values = tile->data_as<T>();
   auto validity_values = static_cast<uint8_t*>(tile_validity->data());
   auto cell_num = tile->size() / cell_size;
 

--- a/tiledb/sm/tile/writer_tile.h
+++ b/tiledb/sm/tile/writer_tile.h
@@ -52,6 +52,14 @@ class WriterTile : public Tile {
 
   WriterTile();
 
+  /** Move constructor. */
+  WriterTile(WriterTile&& tile);
+
+  /** Move-assign operator. */
+  WriterTile& operator=(WriterTile&& tile);
+
+  DISABLE_COPY_AND_COPY_ASSIGN(WriterTile);
+
   /* ********************************* */
   /*                API                */
   /* ********************************* */
@@ -121,13 +129,6 @@ class WriterTile : public Tile {
   Status write_var(const void* data, uint64_t offset, uint64_t nbytes);
 
   /**
-   * Returns a shallow or deep copy of this WriterTile.
-   *
-   * @return New WriterTile
-   */
-  WriterTile clone() const;
-
-  /**
    * Sets the final size of a written tile.
    *
    * @param size Final size.
@@ -135,6 +136,9 @@ class WriterTile : public Tile {
   inline void final_size(uint64_t size) {
     size_ = size;
   }
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(WriterTile& tile);
 
  private:
   /* ********************************* */

--- a/tiledb/sm/tile/writer_tile.h
+++ b/tiledb/sm/tile/writer_tile.h
@@ -110,16 +110,31 @@ class WriterTile : public Tile {
                     uint64_t,
                     const ByteVec*,
                     uint64_t>& md);
+  /**
+   * Write method used for var data. Resizes the internal buffer if needed.
+   *
+   * @param data Pointer to the data to write.
+   * @param offset Offset to write into the tile buffer.
+   * @param nbytes Number of bytes to write.
+   * @return Status.
+   */
+  Status write_var(const void* data, uint64_t offset, uint64_t nbytes);
 
   /**
    * Returns a shallow or deep copy of this WriterTile.
    *
-   * @param deep_copy If true, a deep copy is performed, including potentially
-   *    memcpying the underlying Buffer. If false, a shallow copy is performed,
-   *    which sets the clone's Buffer equal to WriterTile's buffer pointer.
    * @return New WriterTile
    */
-  WriterTile clone(bool deep_copy) const;
+  WriterTile clone() const;
+
+  /**
+   * Sets the final size of a written tile.
+   *
+   * @param size Final size.
+   */
+  inline void final_size(uint64_t size) {
+    size_ = size;
+  }
 
  private:
   /* ********************************* */


### PR DESCRIPTION
The Buffer class is used everywhere in the system, and because of that,
it's trying to do too much. This is a first step to remove some of those
uses by removing Buffer entirely from Tile. Tile should be a simple
container that manages a unfiltered and filtered buffer.

Also, the ultimate goals of tiles is that they are allocated with a size
and that will not be changed. For the reader, it's very simple to know
up front what the size of a tile is. So for the read path in this
change, the unfiltered size of tiles are all defined in 'read_tiles'
through the use of 'alloc_data'. Filtered sizes are also defined in
'read_tiles'. This will allow soon to make it so that tiles are
constructed from the get go with a size.

For the writer, it's a little more challenging, but still achievable.
This change is a step in the right direction, fixed size attributes are
allocated and not changed. Var size attributes will take some work. For
now, 'WriterTile' exposes a write_var method that does realloc when the
size of the buffer is exceeded. In the future this will need to change
to compute sizes of var sized tiles first.

So, the change also cleans up a lot of the tile usage. The tile no
longer manages an offset and so every read/writes now specifies which
offset the operation is happening on.

---
TYPE: IMPROVEMENT
DESC: Removing Buffer from Tile.
