### PR TITLE
Writer: processing var tiles before offset tiles.

### DIFF
--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -113,8 +113,9 @@ FilterPipeline::get_var_chunk_sizes(
         // Do we add this cell to this chunk?
         if (current_size <= min_size || new_size <= max_size) {
           if (new_size > std::numeric_limits<uint32_t>::max()) {
-            return {LOG_STATUS(Status_TileError("Chunk size exceeds uint32_t")),
-                    std::nullopt};
+            return {
+                LOG_STATUS(Status_FilterError("Chunk size exceeds uint32_t")),
+                std::nullopt};
           }
           chunk_offsets.emplace_back(offsets[c] + cell_size);
           current_size = 0;
@@ -125,7 +126,7 @@ FilterPipeline::get_var_chunk_sizes(
           if (cell_size > chunk_size) {
             if (cell_size > std::numeric_limits<uint32_t>::max()) {
               return {
-                  LOG_STATUS(Status_TileError("Chunk size exceeds uint32_t")),
+                  LOG_STATUS(Status_FilterError("Chunk size exceeds uint32_t")),
                   std::nullopt};
             }
 


### PR DESCRIPTION
To store integral cells in a tile, the filter pipeline needs the offsets
tile while processing the var tile. As the filter pipeline frees the
data buffer of a processed tile, this introduced an issue where in some
cases, the offsets buffer would be freed as the var tile is being
processed. This would be a strong case for using a smart pointer, but
unfortunately, this change is quite extensive. This change just makes
sure that var tiles are always processed before offset tiles.

---
TYPE: IMPROVEMENT
DESC: Writer: processing var tiles before offset tiles.
