### PR TITLE
Dense reader: removing unnecessary loop around read_attributes.

### DIFF
--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -347,27 +347,20 @@ Status DenseReader::dense_read() {
       result_space_tiles);
   RETURN_CANCEL_OR_ERROR(st);
 
-  // Process each attributes one at a time.
-  for (const auto& name : names) {
-    if (name == constants::coords || array_schema_->is_dim(name)) {
-      continue;
-    }
+  // Copy attribute data to users buffers.
+  status = read_attributes<DimType, OffType>(
+      fixed_names,
+      var_names,
+      subarray,
+      tile_subarrays,
+      tile_offsets,
+      range_offsets,
+      result_space_tiles,
+      *qc_result);
+  RETURN_CANCEL_OR_ERROR(status);
 
-    // Copy attribute data to users buffers.
-    auto status = read_attributes<DimType, OffType>(
-        fixed_names,
-        var_names,
-        subarray,
-        tile_subarrays,
-        tile_offsets,
-        range_offsets,
-        result_space_tiles,
-        *qc_result);
-    RETURN_CANCEL_OR_ERROR(status);
-
-    if (read_state_.overflowed_)
-      break;
-  }
+  if (read_state_.overflowed_)
+    Status::Ok();
 
   // Fill coordinates if the user requested them.
   if (!read_state_.overflowed_ && has_coords()) {


### PR DESCRIPTION
While refactoring the dense reader, the first version of read_attributes
would process only one attribute. Later, it was changed to process all
attributes at once. Unfortunately, the loop going through  all
attributes was never removed so this would cause unnecessary calls to
read_attributes.

---
TYPE: IMPROVEMENT
DESC: Dense reader: removing unnecessary loop around read_attributes.