### PR TITLE
Object libraries part 7

### DIFF
--- a/test/src/unit-domain.cc
+++ b/test/src/unit-domain.cc
@@ -32,8 +32,11 @@
  * Tests the  `Domain` class.
  */
 
+#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
+#include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/layout.h"
 
 #include <catch.hpp>
 

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,7 @@
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/path_win.h"
 #endif
+#include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;
 using namespace tiledb::sm;

--- a/tiledb/common/dynamic_memory/dynamic_memory.h
+++ b/tiledb/common/dynamic_memory/dynamic_memory.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2021-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -147,6 +147,20 @@ using TiledbTracedAllocator = typename std::conditional<
  */
 template <class T>
 using allocator = GovernedAllocator<T, TiledbTracedAllocator, Governor>;
+
+/**
+ * Predicate class for use with std::enable_if
+ *
+ * The required template is ignored. If weren't an argument, there couldn't be a
+ * substitution for an argument and SFINAE would never apply.
+ */
+template <class>
+struct is_tracing_enabled {
+  constexpr static bool value = detail::global_tracing<void>::enabled::value;
+};
+
+template <class T = void>
+constexpr bool is_tracing_enabled_v = is_tracing_enabled<T>::value;
 
 namespace /* anonymous */ {
 

--- a/tiledb/common/tag.h
+++ b/tiledb/common/tag.h
@@ -1,0 +1,84 @@
+/**
+ * @file tiledb/sm/array_schema/domain_typed_data_view.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a class Tag useful for template argument deduction.
+ */
+
+#ifndef TILEDB_COMMON_TAG_H
+#define TILEDB_COMMON_TAG_H
+
+#include <type_traits>
+
+namespace tiledb ::common {
+/**
+ * State-free class that carries a type.
+ *
+ * This class support template argument deduction for constructors. C++ syntax
+ * does not allow direct specification of template arguments in a template
+ * constructor (for example `T<class_arguments><constructor_arguments>` is not
+ * a thing). Instead, a template constructor must infer its arguments from
+ * an argument list. This class has no state, but does have a type that can
+ * be matched.
+ *
+ * @example
+ * ```
+ * class Example {
+ *   template<class P> Example(Tag<P>, int);
+ * };
+ *
+ * struct Policy {
+ *   P() = default;
+ *   static void behavior();
+ * };
+ *
+ * void foo() {
+ *   Example x{Tag<Policy>{}, 0};  // May treat 0 with varying behavior
+ * }
+ *```
+ *
+ * @tparam T The type carried by the tag
+ */
+template <class T>
+struct Tag {
+  using type = T;
+  Tag() = default;
+  Tag(const Tag&) = delete;
+  Tag& operator=(const Tag&) = delete;
+  Tag(Tag&&) = delete;
+  Tag& operator=(Tag&&) = delete;
+};
+
+static_assert(std::is_default_constructible_v<Tag<void>>);
+static_assert(!std::is_copy_constructible_v<Tag<void>>);
+static_assert(!std::is_copy_assignable_v<Tag<void>>);
+static_assert(!std::is_move_constructible_v<Tag<void>>);
+static_assert(!std::is_move_assignable_v<Tag<void>>);
+}  // namespace tiledb::common
+
+#endif  // TILEDB_COMMON_TAG_H

--- a/tiledb/common/types/dynamic_typed_datum.h
+++ b/tiledb/common/types/dynamic_typed_datum.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2021-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -70,6 +70,10 @@ class DynamicTypedDatumView {
   }
   [[nodiscard]] inline tiledb::sm::Datatype type() const {
     return type_;
+  }
+  template <class T>
+  [[nodiscard]] inline const T& value_as() const {
+    return *static_cast<const T*>(datum_.content());
   }
 };
 }  // namespace tiledb::common

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@
 #include "tiledb/common/memory_tracker.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array/array_directory.h"
+#include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/crypto/encryption_key.h"
 #include "tiledb/sm/fragment/fragment_info.h"
 #include "tiledb/sm/metadata/metadata.h"

--- a/tiledb/sm/array_schema/CMakeLists.txt
+++ b/tiledb/sm/array_schema/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2021 TileDB, Inc.
+# Copyright (c) 2021-2022 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -56,17 +56,28 @@ add_executable(compile_dimension EXCLUDE_FROM_ALL)
 target_link_libraries(compile_dimension PRIVATE dimension)
 target_sources(compile_dimension PRIVATE test/compile_dimension_main.cc)
 
+#
+# `domain` object library
+#
+add_library(domain OBJECT domain.cc)
+target_link_libraries(domain PUBLIC datum $<TARGET_OBJECTS:datum>)
+target_link_libraries(domain PUBLIC dimension $<TARGET_OBJECTS:dimension>)
+target_link_libraries(domain PUBLIC math $<TARGET_OBJECTS:math>)
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_domain EXCLUDE_FROM_ALL)
+target_link_libraries(compile_domain PRIVATE domain)
+target_sources(compile_domain PRIVATE test/compile_domain_main.cc)
 
 if (TILEDB_TESTS)
     add_executable(unit_array_schema EXCLUDE_FROM_ALL)
-    target_link_libraries(unit_array_schema PRIVATE attribute dimension)
+    target_link_libraries(unit_array_schema PRIVATE attribute domain)
     find_package(Catch_EP REQUIRED)
     target_link_libraries(unit_array_schema PUBLIC Catch2::Catch2)
 
     # Sources for tests
-    target_sources(unit_array_schema PUBLIC test/main.cc 
-      test/unit_dimension.cc
-      )
+    target_sources(unit_array_schema PUBLIC test/main.cc test/unit_dimension.cc test/unit_domain_data.cc)
 
     add_test(
         NAME "unit_array_schema"

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,11 +30,13 @@
  * This file implements class Domain.
  */
 
-#include "tiledb/sm/array_schema/domain.h"
+#include "domain.h"
+#include "dimension.h"
+#include "domain_data_ref.h"
+#include "domain_typed_data_view.h"
 #include "tiledb/common/blank.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
-#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/math.h"
@@ -43,12 +45,11 @@
 #include <cassert>
 #include <iostream>
 #include <limits>
-#include <sstream>
+#include <stdexcept>
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -188,30 +189,16 @@ uint64_t Domain::cell_num_per_tile() const {
 }
 
 template <>
-int Domain::cell_order_cmp<char>(
-    const Dimension* dim, const QueryBuffer* buff, uint64_t a, uint64_t b) {
+int Domain::cell_order_cmp_impl<char>(
+    const Dimension* dim, const UntypedDatumView a, const UntypedDatumView b) {
   // Must be var-sized
   assert(dim->var_size());
   (void)dim;
 
-  auto offs = (const uint64_t*)buff->buffer_;
-  auto offs_size = *(buff->buffer_size_);
-  auto var_size = *(buff->buffer_var_size_);
-  auto off_a = offs[a];
-  auto off_b = offs[b];
-  auto var_a = &((const char*)buff->buffer_var_)[off_a];
-  auto var_b = &((const char*)buff->buffer_var_)[off_b];
-
-  // If coordinates are last, the next offset is the size of the variable buffer
-  // Otherwisse, it is just the next offset in the fixed buffer
-  auto next_off_a = ((a + 1) * constants::cell_var_offset_size == offs_size) ?
-                        var_size :
-                        offs[a + 1];
-  auto next_off_b = ((b + 1) * constants::cell_var_offset_size == offs_size) ?
-                        var_size :
-                        offs[b + 1];
-  auto size_a = next_off_a - off_a;
-  auto size_b = next_off_b - off_b;
+  auto var_a{a.value_as<const char[]>()};
+  auto var_b{b.value_as<const char[]>()};
+  auto size_a{a.size()};
+  auto size_b{b.size()};
   auto size = std::min(size_a, size_b);
 
   // Check common prefix of size `size`
@@ -231,14 +218,13 @@ int Domain::cell_order_cmp<char>(
 }
 
 template <class T>
-int Domain::cell_order_cmp(
-    const Dimension* dim, const QueryBuffer* buff, uint64_t a, uint64_t b) {
-  // Must be fixed-sized
+int Domain::cell_order_cmp_impl(
+    const Dimension* dim, const UntypedDatumView a, const UntypedDatumView b) {
   assert(!dim->var_size());
   (void)dim;
 
-  auto ca = ((const T*)buff->buffer_)[a];
-  auto cb = ((const T*)buff->buffer_)[b];
+  auto ca = a.template value_as<T>();
+  auto cb = b.template value_as<T>();
   if (ca < cb)
     return -1;
   if (ca > cb)
@@ -247,11 +233,11 @@ int Domain::cell_order_cmp(
 }
 
 int Domain::cell_order_cmp(
-    unsigned dim_idx, const ResultCoords& a, const ResultCoords& b) const {
+    unsigned dim_idx, UntypedDatumView a, UntypedDatumView b) const {
   // Handle variable-sized dimensions
   if (dimensions_[dim_idx]->var_size()) {
-    auto s_a = a.coord_string(dim_idx);
-    auto s_b = b.coord_string(dim_idx);
+    std::string_view s_a{static_cast<const char*>(a.content()), a.size()};
+    std::string_view s_b{static_cast<const char*>(b.content()), b.size()};
 
     if (s_a == s_b)
       return 0;
@@ -260,10 +246,11 @@ int Domain::cell_order_cmp(
     return 1;
   }
 
-  assert(cell_order_cmp_func_2_[dim_idx] != nullptr);
-  auto coord_a = a.coord(dim_idx);
-  auto coord_b = b.coord(dim_idx);
-  return cell_order_cmp_func_2_[dim_idx](coord_a, coord_b);
+  if (cell_order_cmp_func_2_[dim_idx] == nullptr) {
+    assert(cell_order_cmp_func_2_[dim_idx] != nullptr);
+    throw std::logic_error("comparison function not initialized");
+  }
+  return cell_order_cmp_func_2_[dim_idx](a.content(), b.content());
 }
 
 template <class T>
@@ -278,13 +265,14 @@ int Domain::cell_order_cmp_2(const void* coord_a, const void* coord_b) {
 }
 
 int Domain::cell_order_cmp(
-    const std::vector<const QueryBuffer*>& coord_buffs,
-    uint64_t a,
-    uint64_t b) const {
+    const type::DomainDataRef& left, const type::DomainDataRef& right) const {
   if (cell_order_ == Layout::ROW_MAJOR) {
     for (unsigned d = 0; d < dim_num_; ++d) {
       auto dim = dimension(d);
-      auto res = cell_order_cmp_func_[d](dim.get(), coord_buffs[d], a, b);
+      auto res = cell_order_cmp_func_[d](
+          dim.get(),
+          left.dimension_datum_view(d),
+          right.dimension_datum_view(d));
 
       if (res == 1 || res == -1)
         return res;
@@ -293,7 +281,10 @@ int Domain::cell_order_cmp(
   } else {  // COL_MAJOR
     for (unsigned d = dim_num_ - 1;; --d) {
       auto dim = dimension(d);
-      auto res = cell_order_cmp_func_[d](dim.get(), coord_buffs[d], a, b);
+      auto res = cell_order_cmp_func_[d](
+          dim.get(),
+          left.dimension_datum_view(d),
+          right.dimension_datum_view(d));
 
       if (res == 1 || res == -1)
         return res;
@@ -344,10 +335,6 @@ tuple<Status, optional<shared_ptr<Domain>>> Domain::deserialize(
   return {Status::Ok(),
           tiledb::common::make_shared<Domain>(
               HERE(), cell_order, dimensions, tile_order)};
-}
-
-unsigned int Domain::dim_num() const {
-  return dim_num_;
 }
 
 const Range& Domain::domain(unsigned i) const {
@@ -713,7 +700,7 @@ double Domain::overlap_ratio(
 }
 
 template <class T>
-int Domain::tile_order_cmp(
+int Domain::tile_order_cmp_impl(
     const Dimension* dim, const void* coord_a, const void* coord_b) {
   if (!dim->tile_extent())
     return 0;
@@ -732,9 +719,7 @@ int Domain::tile_order_cmp(
 }
 
 int Domain::tile_order_cmp(
-    const std::vector<const QueryBuffer*>& coord_buffs,
-    uint64_t a,
-    uint64_t b) const {
+    const type::DomainDataRef& left, const type::DomainDataRef& right) const {
   if (tile_order_ == Layout::ROW_MAJOR) {
     for (unsigned d = 0; d < dim_num_; ++d) {
       auto dim = dimension(d);
@@ -743,10 +728,10 @@ int Domain::tile_order_cmp(
       if (dim->var_size() || !dim->tile_extent())
         continue;
 
-      auto coord_size = dim->coord_size();
-      auto ca = &(((unsigned char*)coord_buffs[d]->buffer_)[a * coord_size]);
-      auto cb = &(((unsigned char*)coord_buffs[d]->buffer_)[b * coord_size]);
-      auto res = tile_order_cmp_func_[d](dim.get(), ca, cb);
+      auto res = tile_order_cmp_func_[d](
+          dim.get(),
+          left.dimension_datum_view(d).content(),
+          right.dimension_datum_view(d).content());
 
       if (res == 1 || res == -1)
         return res;
@@ -758,10 +743,10 @@ int Domain::tile_order_cmp(
 
       // Inapplicable to var-sized dimensions or absent tile extents
       if (!dim->var_size() && dim->tile_extent()) {
-        auto coord_size = dim->coord_size();
-        auto ca = &(((unsigned char*)coord_buffs[d]->buffer_)[a * coord_size]);
-        auto cb = &(((unsigned char*)coord_buffs[d]->buffer_)[b * coord_size]);
-        auto res = tile_order_cmp_func_[d](dim.get(), ca, cb);
+        auto res = tile_order_cmp_func_[d](
+            dim.get(),
+            left.dimension_datum_view(d).content(),
+            right.dimension_datum_view(d).content());
 
         if (res == 1 || res == -1)
           return res;
@@ -873,43 +858,43 @@ void Domain::set_tile_cell_order_cmp_funcs() {
     auto type = dimensions_[d]->type();
     switch (type) {
       case Datatype::INT32:
-        tile_order_cmp_func_[d] = tile_order_cmp<int32_t>;
-        cell_order_cmp_func_[d] = cell_order_cmp<int32_t>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<int32_t>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<int32_t>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<int32_t>;
         break;
       case Datatype::INT64:
-        tile_order_cmp_func_[d] = tile_order_cmp<int64_t>;
-        cell_order_cmp_func_[d] = cell_order_cmp<int64_t>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<int64_t>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<int64_t>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<int64_t>;
         break;
       case Datatype::INT8:
-        tile_order_cmp_func_[d] = tile_order_cmp<int8_t>;
-        cell_order_cmp_func_[d] = cell_order_cmp<int8_t>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<int8_t>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<int8_t>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<int8_t>;
         break;
       case Datatype::UINT8:
-        tile_order_cmp_func_[d] = tile_order_cmp<uint8_t>;
-        cell_order_cmp_func_[d] = cell_order_cmp<uint8_t>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<uint8_t>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<uint8_t>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<uint8_t>;
         break;
       case Datatype::INT16:
-        tile_order_cmp_func_[d] = tile_order_cmp<int16_t>;
-        cell_order_cmp_func_[d] = cell_order_cmp<int16_t>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<int16_t>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<int16_t>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<int16_t>;
         break;
       case Datatype::UINT16:
-        tile_order_cmp_func_[d] = tile_order_cmp<uint16_t>;
-        cell_order_cmp_func_[d] = cell_order_cmp<uint16_t>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<uint16_t>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<uint16_t>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<uint16_t>;
         break;
       case Datatype::UINT32:
-        tile_order_cmp_func_[d] = tile_order_cmp<uint32_t>;
-        cell_order_cmp_func_[d] = cell_order_cmp<uint32_t>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<uint32_t>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<uint32_t>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<uint32_t>;
         break;
       case Datatype::UINT64:
-        tile_order_cmp_func_[d] = tile_order_cmp<uint64_t>;
-        cell_order_cmp_func_[d] = cell_order_cmp<uint64_t>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<uint64_t>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<uint64_t>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<uint64_t>;
         break;
       case Datatype::DATETIME_YEAR:
@@ -934,23 +919,23 @@ void Domain::set_tile_cell_order_cmp_funcs() {
       case Datatype::TIME_PS:
       case Datatype::TIME_FS:
       case Datatype::TIME_AS:
-        tile_order_cmp_func_[d] = tile_order_cmp<int64_t>;
-        cell_order_cmp_func_[d] = cell_order_cmp<int64_t>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<int64_t>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<int64_t>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<int64_t>;
         break;
       case Datatype::FLOAT32:
-        tile_order_cmp_func_[d] = tile_order_cmp<float>;
-        cell_order_cmp_func_[d] = cell_order_cmp<float>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<float>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<float>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<float>;
         break;
       case Datatype::FLOAT64:
-        tile_order_cmp_func_[d] = tile_order_cmp<double>;
-        cell_order_cmp_func_[d] = cell_order_cmp<double>;
+        tile_order_cmp_func_[d] = tile_order_cmp_impl<double>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<double>;
         cell_order_cmp_func_2_[d] = cell_order_cmp_2<double>;
         break;
       case Datatype::STRING_ASCII:
         tile_order_cmp_func_[d] = nullptr;
-        cell_order_cmp_func_[d] = cell_order_cmp<char>;
+        cell_order_cmp_func_[d] = cell_order_cmp_impl<char>;
         cell_order_cmp_func_2_[d] = nullptr;
         break;
       case Datatype::BLOB:
@@ -1252,5 +1237,4 @@ template uint64_t Domain::stride<uint64_t>(Layout subarray_layout) const;
 template uint64_t Domain::stride<float>(Layout subarray_layout) const;
 template uint64_t Domain::stride<double>(Layout subarray_layout) const;
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,21 +36,23 @@
 #include "tiledb/common/common.h"
 #include "tiledb/common/macros.h"
 #include "tiledb/common/status.h"
+#include "tiledb/common/types/dynamic_typed_datum.h"
+#include "tiledb/common/types/untyped_datum.h"
 #include "tiledb/sm/misc/types.h"
-#include "tiledb/sm/query/query_buffer.h"
-#include "tiledb/sm/query/result_coords.h"
 
 #include <vector>
 
 using namespace tiledb::common;
+namespace tiledb::type {
+class DomainDataRef;
+};
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Buffer;
 class ConstBuffer;
 class Dimension;
-
+class DomainTypedDataView;
 enum class Datatype : uint8_t;
 enum class Layout : uint8_t;
 
@@ -131,7 +133,6 @@ class Domain {
    * of a regular tile grid, this function assumes that the cells are in the
    * same regular tile.
    *
-   * @tparam T The coordinates type.
    * @param dim_idx The dimension to compare the coordinates on.
    * @param a The first input coordinates.
    * @param b The second input coordinates.
@@ -141,7 +142,9 @@ class Domain {
    *    - +1 if the first coordinate succeeds the second
    */
   int cell_order_cmp(
-      unsigned dim_idx, const ResultCoords& a, const ResultCoords& b) const;
+      unsigned dim_idx,
+      const UntypedDatumView a,
+      const UntypedDatumView b) const;
 
   /**
    * Checks the cell order of the input coordinates. Since the coordinates
@@ -159,40 +162,17 @@ class Domain {
   static int cell_order_cmp_2(const void* coord_a, const void* coord_b);
 
   /**
-   * Checks the cell order of the input coordinates. Since the coordinates
-   * are given for a single dimension, this function simply checks which
-   * coordinate is larger.
-   *
-   * @param dim The dimension to check the coordinates on.
-   * @param buff The buffer that stores all coordinates.
-   * @param a The position of the first coordinate in the buffer to check.
-   * @param b The position of the second coordinate in the buffer to check.
-   * @return One of the following:
-   *    - -1 if the first coordinate is smaller than the second
-   *    -  0 if the two coordinates have the same cell order
-   *    - +1 if the first coordinate is larger than the second
-   */
-  template <class T>
-  static int cell_order_cmp(
-      const Dimension* dim, const QueryBuffer* buff, uint64_t a, uint64_t b);
-
-  /**
    * Checks the cell order of the input coordinates.
    *
-   * @param coord_buffs The input coordinates, given n separate buffers,
-   *     one per dimension. The buffers are sorted in the same order of the
-   *     dimensions as defined in the array schema.
-   * @param a The position of the first coordinate tuple across all buffers.
-   * @param b The position of the second coordinate tuple across all buffers.
+   * @param left Left operand
+   * @param right Right operand
    * @return One of the following:
-   *    - -1 if the first coordinates precede the second on the cell order
+   *    - -1 if the left coordinates precede the right on the cell order
    *    -  0 if the two coordinates have the same cell order
-   *    - +1 if the first coordinates succeed the second on the cell order
+   *    - +1 if the left coordinates succeed the right on the cell order
    */
   int cell_order_cmp(
-      const std::vector<const QueryBuffer*>& coord_buffs,
-      uint64_t a,
-      uint64_t b) const;
+      const type::DomainDataRef& left, const type::DomainDataRef& right) const;
 
   /**
    * Populates the object members from the data in the input binary buffer.
@@ -219,7 +199,9 @@ class Domain {
   Layout tile_order() const;
 
   /** Returns the number of dimensions. */
-  unsigned int dim_num() const;
+  inline unsigned int dim_num() const {
+    return dim_num_;
+  }
 
   /** Returns the domain along the i-th dimension. */
   const Range& domain(unsigned i) const;
@@ -445,37 +427,18 @@ class Domain {
       const NDRange& r2) const;
 
   /**
-   * Checks the tile order of the input coordinates on the given dimension.
-   *
-   * @param The dimension to compare on.
-   * @param coord_a The first coordinate.
-   * @param coord_b The second coordinate.
-   * @return One of the following:
-   *    - -1 if the first coordinate precedes the second on the tile order
-   *    -  0 if the two coordinates have the same tile order
-   *    - +1 if the first coordinate succeeds the second on the tile order
-   */
-  template <class T>
-  static int tile_order_cmp(
-      const Dimension* dim, const void* coord_a, const void* coord_b);
-
-  /**
    * Checks the tile order of the input coordinates.
    *
-   * @param coord_buffs The input coordinates, given n separate buffers,
-   *     one per dimension. The buffers are sorted in the same order of the
-   *     dimensions as defined in the array schema.
-   * @param a The position of the first coordinate tuple across all buffers.
-   * @param b The position of the second coordinate tuple across all buffers.
+   * @param left
+   * @param right
    * @return One of the following:
    *    - -1 if the first coordinates precede the second on the tile order
    *    -  0 if the two coordinates have the same tile order
    *    - +1 if the first coordinates succeed the second on the tile order
    */
   int tile_order_cmp(
-      const std::vector<const QueryBuffer*>& coord_buffs,
-      uint64_t a,
-      uint64_t b) const;
+      const tiledb::type::DomainDataRef& left,
+      const tiledb::type::DomainDataRef& right) const;
 
   /**
    * Checks the tile order of the input coordinates for a given dimension.
@@ -520,7 +483,7 @@ class Domain {
    * - a, b: The positions of the two coordinates in the buffer to compare.
    */
   std::vector<int (*)(
-      const Dimension* dim, const QueryBuffer* buff, uint64_t a, uint64_t b)>
+      const Dimension* dim, const UntypedDatumView a, const UntypedDatumView b)>
       cell_order_cmp_func_;
 
   /**
@@ -546,6 +509,38 @@ class Domain {
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
+
+  /**
+   * Checks the cell order of the input coordinates. Since the coordinates
+   * are given for a single dimension, this function simply checks which
+   * coordinate is larger.
+   *
+   * @param dim The dimension to check the coordinates on.
+   * @param a The position of the first coordinate in the buffer to check.
+   * @param b The position of the second coordinate in the buffer to check.
+   * @return One of the following:
+   *    - -1 if the first coordinate is smaller than the second
+   *    -  0 if the two coordinates have the same cell order
+   *    - +1 if the first coordinate is larger than the second
+   */
+  template <class T>
+  static int cell_order_cmp_impl(
+      const Dimension* dim, UntypedDatumView a, UntypedDatumView b);
+
+  /**
+   * Checks the tile order of the input coordinates on the given dimension.
+   *
+   * @param dim The dimension to compare on.
+   * @param coord_a The first coordinate.
+   * @param coord_b The second coordinate.
+   * @return One of the following:
+   *    - -1 if the first coordinate precedes the second on the tile order
+   *    -  0 if the two coordinates have the same tile order
+   *    - +1 if the first coordinate succeeds the second on the tile order
+   */
+  template <class T>
+  static int tile_order_cmp_impl(
+      const Dimension* dim, const void* coord_a, const void* coord_b);
 
   /** Compute the number of cells per tile. */
   void compute_cell_num_per_tile();
@@ -655,7 +650,6 @@ class Domain {
   uint64_t get_tile_pos_row(const T* domain, const T* tile_coords) const;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_DOMAIN_H

--- a/tiledb/sm/array_schema/domain_data_ref.h
+++ b/tiledb/sm/array_schema/domain_data_ref.h
@@ -1,0 +1,76 @@
+/**
+ * @file tiledb/sm/array_schema/domain_data_ref.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines an abstract base class for reference to domain data.
+ */
+
+#ifndef TILEDB_ARRAYSCHEMA_DOMAIN_DATA_REF_H
+#define TILEDB_ARRAYSCHEMA_DOMAIN_DATA_REF_H
+
+#include "tiledb/common/types/untyped_datum.h"
+
+namespace tiledb::type {
+
+/**
+ * An abstract base class for a reference to domain data.
+ *
+ * This class is transitional. In the new type system, it's a reference to a
+ * product type of (in general) dynamic types, so it's three levels removed
+ * from a primitive type. There's no practical way not have a transition type
+ * here while the type infrastructure remains a work in progress.
+ */
+class DomainDataRef {
+ protected:
+  /**
+   * Default constructor is only for subclasses.
+   *
+   * The default constructor must be the only constructor because this is an
+   * abstract base class.
+   */
+  DomainDataRef() = default;
+
+ public:
+  /**
+   * Returns a datum for the dimension at a given index.
+   *
+   * Each `DomainDataRef` must be created with reference to some specific
+   * domain. This base class does not specify anything about how that reference
+   * is obtained or held.
+   *
+   * Note: `unsigned int` is the _de facto_ type for the number of dimensions
+   * in a domain.
+   *
+   * anonymous-param The index of the dimension within the domain.
+   * @return
+   */
+  virtual UntypedDatumView dimension_datum_view(unsigned int) const = 0;
+};
+
+}  // namespace tiledb::type
+#endif  // TILEDB_ARRAYSCHEMA_DOMAIN_DATA_REF_H

--- a/tiledb/sm/array_schema/domain_typed_data_view.h
+++ b/tiledb/sm/array_schema/domain_typed_data_view.h
@@ -1,0 +1,221 @@
+/**
+ * @file tiledb/sm/array_schema/domain_typed_data_view.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a data-view class for Domain
+ */
+
+#ifndef TILEDB_ARRAYSCHEMA_DOMAIN_TYPED_DATUM_VIEW_H
+#define TILEDB_ARRAYSCHEMA_DOMAIN_TYPED_DATUM_VIEW_H
+
+#include <utility>
+#include "dynamic_array.h"
+#include "tiledb/common/common.h"
+#include "tiledb/common/types/untyped_datum.h"
+#include "tiledb/sm/array_schema/domain.h"
+
+namespace tiledb::sm {
+
+/**
+ * A datum-view class for values within a domain.
+ *
+ * This class must be contextually associated with a Domain object; it has no
+ * class member that explicitly links a datum instance with a Domain. This
+ * is a design choice that promotes efficiency by not repeating a Domain
+ * reference that can be obtained without going through this class.
+ *
+ * A consequence of this choice is that values of this class are not typed
+ * within the class itself. These values are "domain-typed" from a user's point
+ * of view, but implemented as untyped, that is, only as storage. Along these
+ * lines, the size of the Domain is not stored within this class.
+ *
+ * This class is not publicly constructible by design, in order to maintain
+ * adherence to principle of C.41. It's only available through factory functions
+ * in friend classes that do not expose an object until after it has been fully
+ * initialized. Strictly speaking, this class in isolation is not compliant with
+ * C.41, but the combination of it with its factory friends is compliant.
+ */
+class DomainTypedDataView {
+  /**
+   * Friends with its whitebox testing class
+   */
+  friend class WhiteboxDomainTypedDataView;
+  /**
+   * Friends with DomainBuffersView for its factory.
+   */
+  friend class DomainBuffersView;
+
+ public:
+  /**
+   * The type of the element for each dimension
+   */
+  using view_type = tdb::UntypedDatumView;
+
+  /*
+   * The destructor of this class does not call destructors of the data view
+   * objects it holds. This is acceptable only if the data view class is
+   * trivially destructible.
+   */
+  static_assert(std::is_trivially_destructible_v<view_type>);
+
+ private:
+  /**
+   * Storage for each of the dimension values.
+   *
+   * The container used at present stores its size (the number of dimension)
+   * in each element, in order that it be able to deallocate memory on
+   * destruction. The size of such object doesn't change for elements within
+   * a specific dimension, so there's opportunity to optimize for memory use.
+   * Doing this would require a container class that was able to obtain its size
+   * outside of storing it in each instance. This is a rather more difficult
+   * task than it might seem at first glance. The present container is used
+   * as a matter of expediency over this issue.
+   *
+   * Invariant: array_ is non-null.
+   *
+   * Note on the invariant: This class represents a domain, one value for each
+   * dimension. It does *not* introduce anything like a nil value to the domain,
+   * since that would add a (single) new value to what's specified by the
+   * cartesian product of the dimension types. If a consumer needs a nil value,
+   * then `optional<DomainTypedDataView>` should be used.
+   */
+  DynamicArray<view_type> array_;
+
+  /**
+   * Constructor for use with factory functions.
+   *
+   * Each factory function must supply its own initialization policy class and
+   * additional arguments for the initialize function. `DynamicArray` supplies
+   * its arguments (an address and an index). This constructor supplies a
+   * `Domain` argument.
+   *
+   * @tparam I Initialization policy class for DynamicArray
+   * @param domain Domain with which to associate values
+   */
+  template <class I, class... Args>
+  DomainTypedDataView(const Domain& domain, Tag<I>, Args&&... args)
+      : array_(MakeDynamicArray<view_type, I>(
+            HERE(),
+            domain.dim_num(),
+            Tag<I>{},
+            domain,
+            std::forward<Args>(args)...)) {
+  }
+
+ public:
+  /**
+   * Default constructor is prohibited.
+   *
+   * We don't require the allocator of this class to be default-constructible.
+   * Nor do we require it to be constructible with any default argument we might
+   * supply. As a result, without being given an allocator object, we can't
+   * construct this one.
+   */
+  DomainTypedDataView() = delete;
+
+  /**
+   * Default destructor does not call destructors on its contents.
+   */
+  ~DomainTypedDataView() = default;
+
+  /**
+   * Move construction has transfer semantics.
+   */
+  DomainTypedDataView(DomainTypedDataView&& x) noexcept
+      : array_(move(x.array_)) {
+  }
+
+  /**
+   * Move assignment has exchange semantics.
+   */
+  DomainTypedDataView& operator=(DomainTypedDataView&& x) noexcept {
+    swap(x);
+    return *this;
+  }
+
+  /// Swap
+  inline void swap(DomainTypedDataView& x) noexcept {
+    std::swap(array_, x.array_);
+  }
+
+  /**
+   * Size of this object as a container. Same as the number of dimensions in the
+   * associated domain.
+   *
+   * @return The number of data objects in this container.
+   */
+  [[nodiscard]] inline size_t size() const noexcept {
+    return array_.size();
+  }
+
+  /**
+   * Pointer to the internal container as an array of view objects.
+   *
+   * @return Pointer to the first element in the container
+   */
+  [[nodiscard]] inline const view_type* data() const noexcept {
+    return array_.data();
+  }
+
+  /**
+   * Indexed accessor, non-constant version.
+   *
+   * @param k Index into this container
+   * @return A datum
+   */
+  [[nodiscard]] inline view_type& operator[](size_t k) noexcept {
+    return array_.data()[k];
+  }
+
+  /**
+   * Indexed accessor, constant version.
+   *
+   * @param k Index into this container
+   * @return A datum
+   */
+  [[nodiscard]] inline const view_type& operator[](size_t k) const noexcept {
+    return array_.data()[k];
+  }
+};
+
+/**
+ * Non-member swap.
+ */
+inline void swap(DomainTypedDataView& a, DomainTypedDataView& b) {
+  a.swap(b);
+}
+
+static_assert(!std::is_default_constructible_v<DomainTypedDataView>);
+static_assert(!std::is_copy_constructible_v<DomainTypedDataView>);
+static_assert(!std::is_copy_assignable_v<DomainTypedDataView>);
+static_assert(std::is_move_constructible_v<DomainTypedDataView>);
+static_assert(std::is_move_assignable_v<DomainTypedDataView>);
+static_assert(std::is_swappable_v<DomainTypedDataView>);
+
+}  // namespace tiledb::sm
+#endif  // TILEDB_ARRAYSCHEMA_DOMAIN_TYPED_DATUM_VIEW_H

--- a/tiledb/sm/array_schema/dynamic_array.h
+++ b/tiledb/sm/array_schema/dynamic_array.h
@@ -1,0 +1,369 @@
+/**
+ * @file tiledb/sm/array_schema/dynamic_array.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a dynamic array container
+ */
+
+#ifndef TILEDB_DYNAMIC_ARRAY_H
+#define TILEDB_DYNAMIC_ARRAY_H
+
+#include <stdexcept>
+#include "tiledb/common/dynamic_memory/dynamic_memory.h"
+#include "tiledb/common/tag.h"
+
+namespace tiledb::sm {
+/**
+ * Allocated storage for arrays of varying size.
+ *
+ * This class sits between the gap between standard library classes `array`
+ * and `vector`. `array` only allocates fixed-length sequences, since the
+ * length is given as a template argument. `vector` allocates variable-length
+ * sequences, but allows them to be resized. This class allocates storage for
+ * a variable- length sequence which is thereafter fixed; it can't be resized.
+ *
+ * This class does not fill the gap exactly, however. Filling the gap would
+ * require that the array elements be default-constructed in place, as `array`
+ * does. This class does not require that its content type be
+ * default-constructible, since that would make it ineligible for use with a
+ * C.41-compliant class without a default constructor. This class is more
+ * general, allowing non-default constructible content types.
+ *
+ * This class, therefore, fills the gap as a special case by allowing
+ * default-construction of its contents even as it does not mandate
+ * default-construction. Responsibility for initialization with its user. This
+ * class is a combination of (1) uninitialized storage and (2) policy-based
+ * initialization at construction time.
+ *
+ * In addition, this class does not require its allocator to be
+ * default-constructible. This means that users of the class might have
+ * difficulty using swap to implement move-construction, since there may be no
+ * natural way to make a nonce object to swap with.
+ *
+ * @tparam T The type of the element used in the array
+ * @tpara Alloc Allocator for storage. Defaults to the library allocator.
+ */
+template <class T, class Alloc = tiledb::common::allocator<T>>
+class DynamicArray {
+  /**
+   * Allocator instance for type T
+   */
+  Alloc a_;
+
+  /**
+   * The number of allocated objects.
+   *
+   * The allocated size in bytes is `size_*sizeof(T)`.
+   */
+  size_t size_;
+
+  /**
+   * `data_` is an allocated pointer to hold a sequence of `T` whose length is
+   * equal to `size`. It's allocated with the class template argument `Alloc`.
+   *
+   * There's no invariant that `data_` not be null. There is only one case,
+   * however, when it might be null, which is during move construction, when
+   * it's assigned null to achieve transfer semantics.
+   */
+  T* data_;
+
+ public:
+  /**
+   * Size type [container.requirements.general]
+   */
+  using size_type = size_t;
+
+  /**
+   * The null initializer does no initialization, but does compile as a tagged
+   * template argument for the constructor.
+   *
+   * @param item Pointer to uninitialized memory in which to construct an object
+   * @param index Index in the array of this item
+   */
+  class NullInitializer {
+   public:
+    inline static void initialize(
+        [[maybe_unused]] T* item, [[maybe_unused]] size_t index){
+        // Arguments ignored; named only to document policy concept
+    };
+  };
+
+  /**
+   * Default initializer policy.
+   *
+   * @param item Address at which to construct an object.
+   */
+  class DefaultInitializer {
+   public:
+    inline static void initialize(T* item, size_t) {
+      new (item) T();
+    };
+  };
+
+  /**
+   * Constructor with no initialization of contained elements.
+   *
+   * The allocator is not called if the size is not positive.
+   *
+   * @tparam SizeT Type of number-of-elements argument.
+   * @param n The number of elements in the sequence to allocate
+   * @param a Allocates memory for the array
+   *
+   * Postcondition: data_ is non-null.
+   */
+  template <class SizeT>
+  DynamicArray(SizeT n, const Alloc& a)
+      : a_(a)
+      , size_(n)
+      , data_(
+            n > 0 ? a_.allocate(size_) :
+                    throw std::logic_error(
+                        "zero-length dynamic array not permitted")) {
+  }
+
+  /**
+   * Constructor with policy initialization of contained elements.
+   *
+   * @tparam SizeT Type of number-of-elements argument.
+   * @tparam I Initialization policy
+   * @param n The number of elements in the sequence to allocate
+   * @param a Allocates memory for the array
+   * @param
+   * @param args Arguments forwarded to the initialization function
+   *
+   * Postcondition: data_ is non-null.
+   */
+  template <class SizeT, class I, class... Args>
+  DynamicArray(SizeT n, const Alloc& a, tiledb::common::Tag<I>, Args&&... args)
+      : DynamicArray(n, a) {
+    for (SizeT i = 0; i < n; ++i) {
+      I::initialize(&data_[i], i, std::forward<Args>(args)...);
+    }
+  }
+
+  /**
+   * Constructor with default construction of contained elements.
+   *
+   * Arguably, it would be better to have use a named marker class to specify
+   * default-initialization as the initialization policy, but using a
+   * void specialization on the Tag introduces no new symbols.
+   *
+   * @tparam SizeT Type of number-of-elements argument.
+   * @param n The number of elements in the sequence to allocate
+   * @param a Allocates memory for the array
+   *
+   * Postcondition: data_ is non-null.
+   */
+  template <class SizeT>
+  DynamicArray(SizeT n, const Alloc& a, tiledb::common::Tag<void>)
+      : DynamicArray(n, a, tiledb::common::Tag<DefaultInitializer>{}) {
+  }
+
+  /**
+   * Swap
+   */
+  inline void swap(DynamicArray& x) noexcept {
+    std::swap(a_, x.a_);
+    std::swap(size_, x.size_);
+    std::swap(data_, x.data_);
+  }
+
+  /**
+   * Default construction is prohibited.
+   *
+   * The size of the container is fixed at construction time. The only sensible
+   * length for a default object is zero, which would mean a forever-empty
+   * container.
+   *
+   * Default construction would also complicate and enlarge the class. There's
+   * no requirement that the allocator be default-constructible, and it needs to
+   * store a copy of its allocator for use in the destructor. Default
+   * construction would mean storing an optional allocator or equivalent.
+   *
+   * The design decision is that it's not worth having default construction.
+   */
+  DynamicArray() = delete;
+
+  /**
+   * Copy construction is prohibited.
+   *
+   * This container allocates only-possibly initialized memory. Depending on
+   * the constructor it's either non-initialized or initialized by external
+   * policy. This class can't know what the semantics of a copy operation
+   * should be. A user of this class that wants to make a copy of an object
+   * must create and initialize the copy. It's up to the user to ensure the
+   * validity of the copy.
+   */
+  DynamicArray(const DynamicArray&) = delete;
+
+  /**
+   * Copy assignment is prohibited. See the copy constructor for rationale.
+   */
+  DynamicArray& operator=(const DynamicArray&) = delete;
+
+  /**
+   * Move construction has transfer semantics.
+   */
+  DynamicArray(DynamicArray&& x) noexcept
+      : a_(x.a_)
+      , size_(x.size_)
+      , data_(x.data_) {
+    x.data_ = nullptr;
+  }
+
+  /**
+   * Move assignment has swap semantics.
+   */
+  DynamicArray& operator=(DynamicArray&& x) noexcept {
+    swap(x);
+    return *this;
+  }
+
+  /**
+   * The destructor deallocates, but does not call destructors on its
+   * contents. The user of this class has the responsibility for ensuring that
+   * any required destructors are called.
+   */
+  ~DynamicArray() {
+    if (data_ != nullptr) {
+      a_.deallocate(data_, size_);
+    }
+  }
+
+  /**
+   * Size [container.requirements.general]
+   *
+   * @return Size of the array in bytes.
+   */
+  [[nodiscard]] inline size_t size() const {
+    return size_;
+  }
+
+  /**
+   * Accessor to the start of the contiguous container, non-constant.
+   *
+   * @return Pointer to the first element of the container.
+   */
+  [[nodiscard]] inline T* data() {
+    return data_;
+  }
+
+  /**
+   * Accessor to the start of the contiguous container, constant.
+   *
+   * @return Pointer to the first element of the container.
+   */
+  [[nodiscard]] inline const T* data() const {
+    return data_;
+  }
+
+  /**
+   * Non-constant unchecked-index accessor [sequence.reqmts]
+   */
+  inline T& operator[](size_t pos) {
+    return data_[pos];
+  }
+
+  /**
+   * Constant unchecked-index accessor [sequence.reqmts]
+   */
+  inline const T& operator[](size_t pos) const {
+    return data_[pos];
+  }
+};
+
+/**
+ * Non-member swap.
+ */
+template <class T, class A>
+inline void swap(DynamicArray<T, A>& a, DynamicArray<T, A>& b) {
+  a.swap(b);
+}
+
+/**
+ * Factory for DynamicArrayStorage, tracing label
+ *
+ * @tparam T The type of object to allocate
+ * @tparam I Initialization policy
+ * @param origin Label for tracing provenance of allocations
+ * @param n The number of elements in the array
+ */
+template <class T, class I, class SizeT, class... Args>
+inline DynamicArray<T, tiledb::common::allocator<T>> MakeDynamicArray(
+    tiledb::common::TracingLabel origin,
+    SizeT n,
+    tiledb::common::Tag<I>,
+    Args&&... args) {
+  if constexpr (tiledb::common::is_tracing_enabled_v<>) {
+    return DynamicArray<T, tiledb::common::allocator<T>>{
+        n,
+        tiledb::common::allocator<T>{origin},
+        tiledb::common::Tag<I>{},
+        std::forward<Args>(args)...};
+  } else {
+    return DynamicArray<T, tiledb::common::allocator<T>>{
+        n,
+        tiledb::common::allocator<T>{},
+        tiledb::common::Tag<I>{},
+        std::forward<Args>(args)...};
+  }
+}
+
+/**
+ * Factory for DynamicArray, string constant
+ *
+ * @tparam T The type of object to allocate
+ * @tparam I Initialization policy
+ * @param origin Label for tracing provenance of allocations
+ * @param n The number of elements in the array
+ */
+template <class T, class I, class SizeT, int m, class... Args>
+inline DynamicArray<T, tiledb::common::allocator<T>> MakeDynamicArray(
+    [[maybe_unused]] const char (&origin)[m],
+    SizeT n,
+    tiledb::common::Tag<I>,
+    Args&&... args) {
+  if constexpr (tiledb::common::is_tracing_enabled_v<>) {
+    return DynamicArray<T, tiledb::common::allocator<T>>{
+        n,
+        tiledb::common::allocator<T>{
+            tiledb::common::TracingLabel{std::string_view(origin, m - 1)}},
+        tiledb::common::Tag<I>{},
+        std::forward<Args>(args)...};
+  } else {
+    return DynamicArray<T, tiledb::common::allocator<T>>{
+        n,
+        tiledb::common::allocator<T>{},
+        tiledb::common::Tag<I>{},
+        std::forward<Args>(args)...};
+  }
+}
+
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_DYNAMIC_ARRAY_H

--- a/tiledb/sm/array_schema/test/compile_domain_main.cc
+++ b/tiledb/sm/array_schema/test/compile_domain_main.cc
@@ -1,5 +1,5 @@
 /**
- * @file untyped_datum.h
+ * @file compile_domain_main.cc
  *
  * @section LICENSE
  *
@@ -26,35 +26,9 @@
  * THE SOFTWARE.
  */
 
-#ifndef TILEDB_COMMON_UNTYPED_DATUM_H
-#define TILEDB_COMMON_UNTYPED_DATUM_H
+#include "../domain.h"
 
-#include <ostream>
-
-namespace tiledb::common {
-
-/**
- * A non-owning view of a datum of any type.
- */
-class UntypedDatumView {
-  const void* datum_content_;
-  size_t datum_size_;
-
- public:
-  UntypedDatumView(const void* content, size_t size)
-      : datum_content_(content)
-      , datum_size_(size) {
-  }
-  [[nodiscard]] inline const void* content() const {
-    return datum_content_;
-  }
-  [[nodiscard]] inline size_t size() const {
-    return datum_size_;
-  }
-  template <class T>
-  [[nodiscard]] inline const T& value_as() const {
-    return *static_cast<const T*>(datum_content_);
-  }
-};
-}  // namespace tiledb::common
-#endif  // TILEDB_COMMON_UNTYPED_DATUM_H
+int main() {
+  (void)sizeof(tiledb::sm::Domain);
+  return 0;
+}

--- a/tiledb/sm/array_schema/test/unit_domain_data.cc
+++ b/tiledb/sm/array_schema/test/unit_domain_data.cc
@@ -1,0 +1,147 @@
+/**
+ * @file tiledb/sm/array_schema/test/unit_domain_data.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`
+ */
+
+#include <catch.hpp>
+#include "../domain_typed_data_view.h"
+#include "../dynamic_array.h"
+/*
+ * Instantiating the class `Domain` requires a full definition of `Dimension` so
+ * that its destructor is visible. The need to include this header indicates
+ * some kind of trouble with definition order that needs to be fixed.
+ */
+#include "tiledb/sm/array_schema/dimension.h"
+
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+/**
+ * Null initializer takes any argument, so it's suitable for both
+ * DynamicArrayStorage and for DomainTypedDataView.
+ */
+struct NullInitializer {
+  template <class... Args>
+  inline static void initialize(Args&&...) {
+  }
+};
+
+TEST_CASE("DynamicArray::DynamicArray, no initializer") {
+  DynamicArray<int> x{3, tdb::allocator<int>{}};
+}
+
+TEST_CASE("DynamicArray::DynamicArray, null initializer") {
+  DynamicArray<int> x{3, tdb::allocator<int>{}, Tag<NullInitializer>{}};
+}
+
+struct X1 {
+  static int counter;
+  X1() {
+    ++counter;
+  }
+};
+int X1::counter{0};
+TEST_CASE("DynamicArray::DynamicArray, default initializer") {
+  X1::counter = 0;
+  DynamicArray<X1> x{3, tdb::allocator<X1>{}, Tag<void>{}};
+  CHECK(X1::counter == 3);
+}
+
+TEST_CASE("DynamicArray::DynamicArray, simple initializer") {
+  struct X {
+    int x_;
+    X() = delete;
+    X(int x)
+        : x_(x) {
+    }
+  };
+  struct Initializer {
+    static inline void initialize(X* item, int i) {
+      new (item) X{i};
+    }
+  };
+  DynamicArray<X> x{3, tdb::allocator<X>{}, Tag<Initializer>{}};
+  CHECK(x[0].x_ == 0);
+  CHECK(x[1].x_ == 1);
+  CHECK(x[2].x_ == 2);
+}
+
+namespace tiledb::sm {
+class WhiteboxDomainTypedDataView : public DomainTypedDataView {
+ public:
+  template <class I, class... Args>
+  WhiteboxDomainTypedDataView(const Domain& domain, Tag<I>, Args&&... args)
+      : DomainTypedDataView(domain, Tag<I>{}, std::forward<Args>(args)...) {
+  }
+};
+
+struct TestNullInitializer {
+  inline static void initialize(
+      UntypedDatumView*, unsigned int, const Domain&) {
+  }
+};
+
+TEST_CASE("DomainTypedDataView::DomainTypedDataView, null initializer") {
+  Domain d{};
+  //  tiledb::sm::Dimension dim{"", tiledb::sm::Datatype::INT32};
+  auto dim{make_shared<tiledb::sm::Dimension>(
+      HERE(), "", tiledb::sm::Datatype::INT32)};
+  d.add_dimension(dim);
+  d.add_dimension(dim);
+  d.add_dimension(dim);
+  WhiteboxDomainTypedDataView x{d, Tag<TestNullInitializer>{}};
+  CHECK(x.size() == 3);
+}
+
+TEST_CASE("DomainTypedDataView::DomainTypedDataView, simple initializer") {
+  /*
+   * To verify that the initializer runs, we use only the size element.
+   */
+  struct Initializer {
+    static inline void initialize(
+        UntypedDatumView* item, unsigned int i, const Domain&) {
+      new (item) UntypedDatumView{nullptr, i};
+    }
+  };
+
+  Domain d{};
+  auto dim{make_shared<tiledb::sm::Dimension>(
+      HERE(), "", tiledb::sm::Datatype::INT32)};
+  d.add_dimension(dim);
+  d.add_dimension(dim);
+  d.add_dimension(dim);
+  WhiteboxDomainTypedDataView x{d, Tag<Initializer>{}};
+  CHECK(x.size() == 3);
+  CHECK(x[0].size() == 0);
+  CHECK(x[1].size() == 1);
+  CHECK(x[2].size() == 2);
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -34,6 +34,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -34,6 +34,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/time.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/global_stats.h"

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -34,10 +34,12 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
+#include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;
 

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2020-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array/array_directory.h"
+#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/misc/parallel_functions.h"

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -34,6 +34,7 @@
 #ifndef TILEDB_FRAGMENT_METADATA_H
 #define TILEDB_FRAGMENT_METADATA_H
 
+#include <deque>
 #include <mutex>
 #include <unordered_map>
 #include <vector>

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -134,5 +134,5 @@ TEST_CASE(
   meta.value()->get("key3", &type, &v_num, (const void**)(&v_3));
   CHECK(type == Datatype::STRING_ASCII);
   CHECK(v_num == value_3_size);
-  CHECK(std::string(v_3) == value_3);
+  CHECK(std::string(v_3, value_3_size) == value_3);
 }

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -40,21 +40,43 @@
 
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/enums/layout.h"
+#include "tiledb/sm/query/domain_buffer.h"
 #include "tiledb/sm/query/result_coords.h"
 #include "tiledb/sm/query/sparse_index_reader_base.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
-/** Wrapper of comparison function for sorting coords on row-major order. */
-class RowCmp {
+class CellCmpBase {
+ protected:
+  /** The domain. */
+  const Domain& domain_;
+
+  /** The number of dimensions. */
+  unsigned dim_num_;
+
  public:
-  /** Constructor. */
-  RowCmp(const Domain& domain)
+  explicit CellCmpBase(const Domain& domain)
       : domain_(domain)
       , dim_num_(domain.dim_num()) {
+  }
+
+  [[nodiscard]] int cell_order_cmp_RC(
+      unsigned int d, const ResultCoords& a, const ResultCoords& b) const {
+    const auto& dim{*(domain_.dimension(d))};
+    auto v1{a.dimension_datum(dim, d)};
+    auto v2{b.dimension_datum(dim, d)};
+    return domain_.cell_order_cmp(d, v1, v2);
+  }
+};
+
+/** Wrapper of comparison function for sorting coords on row-major order. */
+class RowCmp : CellCmpBase {
+ public:
+  /** Constructor. */
+  explicit RowCmp(const Domain& domain)
+      : CellCmpBase(domain) {
   }
 
   /**
@@ -66,7 +88,7 @@ class RowCmp {
    */
   bool operator()(const ResultCoords& a, const ResultCoords& b) const {
     for (unsigned int d = 0; d < dim_num_; ++d) {
-      auto res = domain_.cell_order_cmp(d, a, b);
+      auto res = cell_order_cmp_RC(d, a, b);
 
       if (res == -1)
         return true;
@@ -77,21 +99,14 @@ class RowCmp {
 
     return false;
   }
-
- private:
-  /** The domain. */
-  const Domain& domain_;
-  /** The number of dimensions. */
-  unsigned dim_num_;
 };
 
 /** Wrapper of comparison function for sorting coords on col-major order. */
-class ColCmp {
+class ColCmp : CellCmpBase {
  public:
   /** Constructor. */
-  ColCmp(const Domain& domain)
-      : domain_(domain)
-      , dim_num_(domain.dim_num()) {
+  explicit ColCmp(const Domain& domain)
+      : CellCmpBase(domain) {
   }
 
   /**
@@ -103,7 +118,7 @@ class ColCmp {
    */
   bool operator()(const ResultCoords& a, const ResultCoords& b) const {
     for (unsigned int d = dim_num_ - 1;; --d) {
-      auto res = domain_.cell_order_cmp(d, a, b);
+      auto res = cell_order_cmp_RC(d, a, b);
 
       if (res == -1)
         return true;
@@ -117,94 +132,14 @@ class ColCmp {
 
     return false;
   }
-
- private:
-  /** The domain. */
-  const Domain& domain_;
-  /** The number of dimensions. */
-  unsigned dim_num_;
 };
 
 /** Wrapper of comparison function for sorting coords on Hilbert values. */
-class HilbertCmp {
+class HilbertCmp : protected CellCmpBase {
  public:
   /** Constructor. */
-  HilbertCmp(
-      const Domain& domain,
-      const std::vector<const QueryBuffer*>* buffs,
-      const std::vector<uint64_t>* hilbert_values)
-      : buffs_(buffs)
-      , domain_(domain)
-      , hilbert_values_(hilbert_values) {
-    dim_num_ = domain.dim_num();
-  }
-
-  /** Constructor. */
-  HilbertCmp(
-      const Domain& domain, std::vector<ResultCoords>::iterator iter_begin)
-      : domain_(domain)
-      , iter_begin_(iter_begin) {
-    dim_num_ = domain.dim_num();
-  }
-
-  /** Constructor. */
   HilbertCmp(const Domain& domain)
-      : domain_(domain) {
-    dim_num_ = domain.dim_num();
-  }
-
-  /**
-   * Positional comparison operator.
-   *
-   * @param a The first cell position.
-   * @param b The second cell position.
-   * @return `true` if cell at `a` precedes
-   *     cell at `b` on the hilbert value, and `false` otherwise.
-   */
-  bool operator()(uint64_t a, uint64_t b) const {
-    assert(hilbert_values_ != nullptr);
-    if ((*hilbert_values_)[a] < (*hilbert_values_)[b])
-      return true;
-    else if ((*hilbert_values_)[a] > (*hilbert_values_)[b])
-      return false;
-    // else the hilbert values are equal
-
-    // Compare cell order
-    auto cell_cmp = domain_.cell_order_cmp(*buffs_, a, b);
-    return cell_cmp == -1;
-  }
-
-  /**
-   * (Hilbert, iterator offset) comparison operator.
-   *
-   * @param a The first (Hilbert, iterator offset).
-   * @param b The second (Hilbert, iterator offset).
-   * @return `true` if cell represented by `a` across precedes
-   *     cell at `b` on the hilbert value, and `false` otherwise.
-   */
-  bool operator()(
-      const std::pair<uint64_t, uint64_t>& a,
-      const std::pair<uint64_t, uint64_t>& b) const {
-    assert(hilbert_values_ != nullptr);
-    if (a.first < b.first)
-      return true;
-    else if (a.first > b.first)
-      return false;
-    // else the hilbert values are equal
-
-    // Compare cell order on row-major to break the tie
-    const auto& a_coord = *(iter_begin_ + a.second);
-    const auto& b_coord = *(iter_begin_ + b.second);
-    for (unsigned d = 0; d < dim_num_; ++d) {
-      auto res = domain_.cell_order_cmp(d, a_coord, b_coord);
-      if (res == -1)
-        return true;
-      if (res == 1)
-        return false;
-      // else same tile on dimension d --> continue
-    }
-
-    return false;
+      : CellCmpBase(domain) {
   }
 
   /**
@@ -227,7 +162,7 @@ class HilbertCmp {
 
     // Compare cell order on row-major to break the tie
     for (unsigned d = 0; d < dim_num_; ++d) {
-      auto res = domain_.cell_order_cmp(d, a, b);
+      auto res = cell_order_cmp_RC(d, a, b);
       if (res == -1)
         return true;
       if (res == 1)
@@ -237,21 +172,6 @@ class HilbertCmp {
 
     return false;
   }
-
- private:
-  /**
-   * The coordinate buffers, one per dimension, sorted in the order the
-   * dimensions are defined in the array schema.
-   */
-  const std::vector<const QueryBuffer*>* buffs_;
-  /** The array domain. */
-  const Domain& domain_;
-  /** The number of dimensions. */
-  unsigned dim_num_;
-  /** Start iterator of result coords vector. */
-  std::vector<ResultCoords>::iterator iter_begin_;
-  /** The Hilbert values vector. */
-  const std::vector<uint64_t>* hilbert_values_;
 };
 
 /**
@@ -286,10 +206,62 @@ class HilbertCmpReverse {
 };
 
 /**
+ * (Hilbert) comparison (Cmp) function class on domain values retrieved with a
+ * `ResultCoords` iterator (RCI).
+ */
+class HilbertCmpRCI : protected CellCmpBase {
+  /**
+   * Start iterator of result coords vector.
+   */
+  const std::vector<ResultCoords>::iterator& iter_begin_;
+
+ public:
+  /** Constructor. */
+  HilbertCmpRCI(
+      const Domain& domain,
+      const std::vector<ResultCoords>::iterator& iter_begin)
+      : CellCmpBase(domain)
+      , iter_begin_(iter_begin) {
+  }
+
+  /**
+   * (Hilbert, iterator offset) comparison operator.
+   *
+   * @param a The first (Hilbert, iterator offset).
+   * @param b The second (Hilbert, iterator offset).
+   * @return `true` if cell represented by `a` across precedes
+   *     cell at `b` on the hilbert value, and `false` otherwise.
+   */
+  bool operator()(
+      const std::pair<uint64_t, uint64_t>& a,
+      const std::pair<uint64_t, uint64_t>& b) const {
+    if (a.first < b.first)
+      return true;
+    else if (a.first > b.first)
+      return false;
+    // else the hilbert values are equal
+
+    // Compare cell order on row-major to break the tie
+    const auto& a_coord = *(iter_begin_ + a.second);
+    const auto& b_coord = *(iter_begin_ + b.second);
+    for (unsigned d = 0; d < dim_num_; ++d) {
+      auto res = cell_order_cmp_RC(d, a_coord, b_coord);
+      if (res == -1)
+        return true;
+      if (res == 1)
+        return false;
+      // else same tile on dimension d --> continue
+    }
+
+    return false;
+  }
+};
+
+/**
  * Wrapper of comparison function for sorting coords on the global order
  * of some domain.
  */
-class GlobalCmp {
+class GlobalCmp : protected CellCmpBase {
  public:
   /**
    * Constructor.
@@ -298,23 +270,10 @@ class GlobalCmp {
    * @param buff The buffer containing the actual values, used
    *     in positional comparisons.
    */
-  GlobalCmp(const Domain& domain)
-      : domain_(domain) {
-    dim_num_ = domain.dim_num();
+  explicit GlobalCmp(const Domain& domain)
+      : CellCmpBase(domain) {
     tile_order_ = domain.tile_order();
     cell_order_ = domain.cell_order();
-    buffs_ = nullptr;
-  }
-
-  /**
-   * Constructor.
-   *
-   * @param domain The array domain.
-   * @param buffs The coordinate query buffers, one per dimension.
-   */
-  GlobalCmp(const Domain& domain, const std::vector<const QueryBuffer*>* buffs)
-      : domain_(domain)
-      , buffs_(buffs) {
   }
 
   /**
@@ -362,7 +321,7 @@ class GlobalCmp {
     // Compare cell order
     if (cell_order_ == Layout::ROW_MAJOR) {
       for (unsigned d = 0; d < dim_num_; ++d) {
-        auto res = domain_.cell_order_cmp(d, a, b);
+        auto res = cell_order_cmp_RC(d, a, b);
 
         if (res == -1)
           return true;
@@ -373,7 +332,7 @@ class GlobalCmp {
     } else {  // COL_MAJOR
       assert(cell_order_ == Layout::COL_MAJOR);
       for (unsigned d = dim_num_ - 1;; --d) {
-        auto res = domain_.cell_order_cmp(d, a, b);
+        auto res = cell_order_cmp_RC(d, a, b);
 
         if (res == -1)
           return true;
@@ -389,43 +348,11 @@ class GlobalCmp {
     return false;
   }
 
-  /**
-   * Positional comparison operator.
-   *
-   * @param a The first cell position.
-   * @param b The second cell position.
-   * @return `true` if cell at `a` across all coordinate buffers precedes
-   *     cell at `b`, and `false` otherwise.
-   */
-  bool operator()(uint64_t a, uint64_t b) const {
-    assert(buffs_ != nullptr);
-    auto tile_cmp = domain_.tile_order_cmp(*buffs_, a, b);
-
-    if (tile_cmp == -1)
-      return true;
-    if (tile_cmp == 1)
-      return false;
-    // else tile_cmp == 0 --> continue
-
-    // Compare cell order
-    auto cell_cmp = domain_.cell_order_cmp(*buffs_, a, b);
-    return cell_cmp == -1;
-  }
-
  private:
-  /** The domain. */
-  const Domain& domain_;
-  /** The number of dimensions. */
-  unsigned dim_num_;
   /** The tile order. */
   Layout tile_order_;
   /** The cell order. */
   Layout cell_order_;
-  /**
-   * The coordinate buffers, one per dimension, sorted in the order the
-   * dimensions are defined in the array schema.
-   */
-  const std::vector<const QueryBuffer*>* buffs_;
 };
 
 /**
@@ -441,7 +368,7 @@ class GlobalCmpReverse {
    * @param buff The buffer containing the actual values, used
    *     in positional comparisons.
    */
-  GlobalCmpReverse(const Domain& domain)
+  explicit GlobalCmpReverse(const Domain& domain)
       : cmp_(domain) {
   }
 
@@ -461,7 +388,131 @@ class GlobalCmpReverse {
   GlobalCmp cmp_;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+/**
+ * Base class for comparison function classes whose operands are domain values
+ * residing in QueryBuffer objects.
+ */
+class DomainValueCmpBaseQB {
+ protected:
+  /**
+   * The type of a domain, currently accessed through Domain object.
+   */
+  const Domain& domain_;
+
+  /**
+   * A view into a set of buffers for the domain.
+   */
+  const DomainBuffersView& db_;
+
+  /**
+   * Constructor.
+   *
+   * @param domain A domain of an array
+   * @param buffs Coordinate query buffers, one per dimension of the array.
+   */
+  DomainValueCmpBaseQB(const Domain& domain, const DomainBuffersView& db)
+      : domain_(domain)
+      , db_(db) {
+  }
+
+  [[nodiscard]] DomainBufferDataRef domain_ref_at(size_t k) const {
+    return db_.domain_ref_at(domain_, k);
+  }
+};
+
+/**
+ * (Global) Comparsion (Cmp) function class that operates on values that
+ * reside in QueryBuffers (QB) for a domain.
+ */
+class GlobalCmpQB : protected DomainValueCmpBaseQB {
+ public:
+  /// Default constructor is prohibited.
+  GlobalCmpQB() = delete;
+
+  /**
+   * Constructor.
+   *
+   * @param domain The array domain.
+   * @param buffs The coordinate query buffers, one per dimension.
+   */
+  GlobalCmpQB(const Domain& domain, const DomainBuffersView& db)
+      : DomainValueCmpBaseQB(domain, db) {
+  }
+
+  /**
+   * Positional comparison operator.
+   *
+   * @param a The first cell position.
+   * @param b The second cell position.
+   * @return `true` if cell at `a` across all coordinate buffers precedes
+   *     cell at `b`, and `false` otherwise.
+   */
+  bool operator()(uint64_t a, uint64_t b) const {
+    auto left{domain_ref_at(a)};
+    auto right{domain_ref_at(b)};
+    auto tile_cmp = domain_.tile_order_cmp(left, right);
+
+    if (tile_cmp == -1)
+      return true;
+    if (tile_cmp == 1)
+      return false;
+    // else tile_cmp == 0 --> continue
+
+    // Compare cell order
+    auto cell_cmp = domain_.cell_order_cmp(left, right);
+    return cell_cmp == -1;
+  }
+};
+
+/**
+ * (Hilbert) Comparsion (Cmp) function class that operates on values that
+ * reside in QueryBuffers (QB) for a domain.
+ */
+class HilbertCmpQB : protected DomainValueCmpBaseQB {
+  /**
+   * The Hilbert values vector.
+   */
+  const std::vector<uint64_t>& hilbert_values_;
+
+ public:
+  /// Default constructor is prohibited.
+  HilbertCmpQB() = delete;
+
+  /**
+   * Constructor.
+   */
+  HilbertCmpQB(
+      const Domain& domain,
+      const DomainBuffersView& domain_buffers,
+      const std::vector<uint64_t>& hilbert_values)
+      : DomainValueCmpBaseQB(domain, domain_buffers)
+      , hilbert_values_(hilbert_values) {
+  }
+
+  /**
+   * Positional comparison operator.
+   *
+   * @param a The first cell position.
+   * @param b The second cell position.
+   * @return `true` if cell at `a` precedes
+   *     cell at `b` on the hilbert value, and `false` otherwise.
+   */
+  bool operator()(uint64_t a, uint64_t b) const {
+    if (hilbert_values_[a] < hilbert_values_[b]) {
+      return true;
+    } else if (hilbert_values_[a] > hilbert_values_[b]) {
+      return false;
+    }
+    // Assert: The hilbert values are equal
+
+    // Compare cell order
+    auto left{domain_ref_at(a)};
+    auto right{domain_ref_at(b)};
+    auto cell_cmp = domain_.cell_order_cmp(left, right);
+    return cell_cmp == -1;
+  }
+};
+
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_COMPARATORS_H

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2021-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,6 +35,7 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
+#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"

--- a/tiledb/sm/query/domain_buffer.h
+++ b/tiledb/sm/query/domain_buffer.h
@@ -1,0 +1,233 @@
+/**
+ * @file tiledb/sm/query/domain_buffer.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a data-view class for Domain buffers
+ */
+#ifndef TILEDB_QUERY_DOMAIN_BUFFER_H
+#define TILEDB_QUERY_DOMAIN_BUFFER_H
+
+#include <new>
+#include "query_buffer.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/array_schema/domain.h"
+#include "tiledb/sm/array_schema/domain_data_ref.h"
+#include "tiledb/sm/array_schema/domain_typed_data_view.h"
+
+namespace tiledb::sm {
+
+namespace detail {
+class DomainBuffersTypes {
+ public:
+  /**
+   * Buffer type for an individual dimension.
+   *
+   * The pointer declaration here is central to the "view" aspect of this class.
+   * The lifespan of the `QueryBuffer` objects is determined externally to this
+   * class.
+   */
+  using per_dimension_type = const QueryBuffer*;
+
+  /**
+   * The storage type for the list of buffers.
+   *
+   * TODO: Convert this to use `DynamicArray`
+   */
+  using storage_type = std::vector<per_dimension_type>;
+
+  /**
+   * The type of the sizes and indices of the storage type
+   */
+  using size_type = storage_type::size_type;
+};
+}  // namespace detail
+
+/**
+ * A reference to a domain-typed datum. Roughly equivalent to a reference to
+ * a DomainTypedDataView.
+ */
+class DomainBufferDataRef : public detail::DomainBuffersTypes,
+                            public type::DomainDataRef {
+  /**
+   * Friends with DomainBuffersView for its factory.
+   */
+  friend class DomainBuffersView;
+
+  const Domain& domain_;
+
+  /**
+   * The list of buffers, one for each dimension for some domain.
+   */
+  const storage_type& qb_;
+
+  /**
+   * The index into the buffers that this object refers to.
+   */
+  size_type k_;
+
+ public:
+  explicit DomainBufferDataRef(
+      const Domain& domain, const storage_type& qb, size_type k)
+      : domain_(domain)
+      , qb_(qb)
+      , k_(k) {
+  }
+
+  UntypedDatumView dimension_datum_view(unsigned int i) const override {
+    return {qb_[i]->dimension_datum_at(*domain_.dimension(i), k_).datum()};
+  }
+
+  DomainBufferDataRef(const Domain& domain) = delete;
+};
+
+/**
+ * A non-owning sequence of QueryBuffer pointers, one per dimension of the
+ * domain of an open array.
+ *
+ * This class at present is hardly optimal. It began as a thin rewrite of
+ * legacy code and still retains its flavor. It remains a relatively thin
+ * wrapper around its storage type.
+ */
+class DomainBuffersView : public detail::DomainBuffersTypes {
+  /**
+   * The list of buffers, one for each dimension for some domain.
+   */
+  storage_type qb_;
+
+ public:
+  /**
+   * Default constructor is prohibited. An object in a view class is senseless
+   * if there's nothing to view.
+   */
+  DomainBuffersView() = delete;
+
+  /**
+   * Constructor
+   *
+   * TODO: Change argument from `ArraySchema` to `Domain`. The current type is
+   * the result of code refactoring.
+   *
+   * @param schema the schema of an open array
+   * @param buffers a buffer map for each dimension of the domain
+   */
+  DomainBuffersView(
+      const ArraySchema& schema,
+      const std::unordered_map<std::string, QueryBuffer>& buffers)
+      : qb_(schema.dim_num()) {
+    auto n_dimensions{schema.dim_num()};
+    for (decltype(n_dimensions) i = 0; i < n_dimensions; ++i) {
+      const auto& name = schema.dimension(i)->name();
+      qb_[i] = &buffers.at(name);
+    }
+  }
+
+  /**
+   * Accessor to wrapped container.
+   */
+  [[nodiscard]] inline const storage_type& buffers() const {
+    return qb_;
+  }
+
+  /**
+   * Accessor to an individual element of the container.
+   *
+   * @param k Dimension index within the domain
+   */
+  [[nodiscard]] inline per_dimension_type operator[](size_t k) const {
+    return qb_[k];
+  }
+
+  /**
+   * Accessor to an individual element of the container.
+   *
+   * @param k Dimension index within the domain
+   */
+  [[nodiscard]] inline per_dimension_type at(size_t k) const {
+    return qb_.at(k);
+  }
+
+  /**
+   * Initializer (Initializer) policy class for DynamicArray for values drawn
+   * from a list of QueryBuffer (QB) pointers.
+   */
+  class InitializerQB {
+   public:
+    /**
+     * Constructs a dimension value drawn from a QueryBuffer that's associated
+     * with a domain.
+     *
+     * Argument `qb` is initialized with member variable `qb_`.
+     *
+     * @param item Location in which to place a new value as UntypedDatumView
+     * @param i Index of item in container; same as dimension index
+     * @param domain Domain associated with the value
+     * @param qb Container of pointers to query buffers, one per dimension
+     * @param k Dimension index with the domain
+     */
+    inline static void initialize(
+        UntypedDatumView* item,
+        unsigned int i,
+        const Domain& domain,
+        const storage_type& qb,
+        size_t k) {
+      // Construct datum in place with placement-new
+      new (item) UntypedDatumView{
+          qb[i]->dimension_datum_at(*domain.dimension(i), k).datum()};
+    }
+  };
+
+  /**
+   * Factory method for DomainTypedDataView. Extracts data at the index from
+   * the QueryBuffer for each dimension.
+   *
+   * @param k Dimension index within the domain
+   * @return Domain value at index `k` drawn from the QueryBuffer map given at
+   * construction
+   */
+  [[nodiscard]] DomainTypedDataView domain_data_at(
+      const Domain& domain, size_t k) const {
+    return {domain, tdb::Tag<InitializerQB>{}, qb_, k};
+  }
+
+  /**
+   * Factory method for DomainTypedDataRef. Creates a reference to data drawn
+   * from the QueryBuffer for each dimension, each at the given index.
+   *
+   * @param k Dimension index within the domain
+   * @return Domain value at index `k` drawn from the QueryBuffer map given at
+   * construction
+   */
+  [[nodiscard]] DomainBufferDataRef domain_ref_at(
+      const Domain& domain, size_t k) const {
+    return DomainBufferDataRef{domain, qb_, k};
+  }
+};
+
+}  // namespace tiledb::sm
+#endif  // TILEDB_QUERY_DOMAIN_BUFFER_H

--- a/tiledb/sm/query/hilbert_order.cc
+++ b/tiledb/sm/query/hilbert_order.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2021-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,8 +52,7 @@ uint64_t map_to_uint64(
     int bits,
     uint64_t max_bucket_val) {
   auto d{coord.dimension_datum(dim, dim_idx)};
-  return dim.map_to_uint64(
-      d.datum().content(), d.datum().size(), bits, max_bucket_val);
+  return dim.map_to_uint64(d.content(), d.size(), bits, max_bucket_val);
 }
 
 }  // namespace tiledb::sm::hilbert_order

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -47,6 +47,7 @@
 #include "tiledb/sm/enums/query_status_details.h"
 #include "tiledb/sm/fragment/written_fragment_info.h"
 #include "tiledb/sm/query/iquery_strategy.h"
+#include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/query_condition.h"
 #include "tiledb/sm/query/validity_vector.h"
 #include "tiledb/sm/subarray/subarray.h"

--- a/tiledb/sm/query/query_buffer.h
+++ b/tiledb/sm/query/query_buffer.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2020-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -257,8 +257,7 @@ class QueryBuffer {
    * retrieve the datum at sequence position `index`.
    *
    * @param index The index into a sequence of data of varying sizes.
-   * @return tuple<1> A pointer to the retrieved datum. tuple<2> The size of the
-   * retrieved datum.
+   * @return a view of the datum at the given index
    */
   tdb::UntypedDatumView varying_size_datum_at(size_t index) const {
     using buffer_type = uint64_t;

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1824,7 +1824,7 @@ Status Reader::sort_result_coords(
           storage_manager_->compute_tp(),
           hilbert_values.begin(),
           hilbert_values.end(),
-          HilbertCmp(domain, iter_begin));
+          HilbertCmpRCI(domain, iter_begin));
       RETURN_NOT_OK(reorganize_result_coords(iter_begin, &hilbert_values));
     } else {
       parallel_sort(

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@
 #include "tiledb/sm/filter/compression_filter.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/query/strategy_base.h"
 #include "tiledb/sm/subarray/cell_slab_iter.h"

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,7 @@
 #include <vector>
 
 #include "tiledb/common/types/dynamic_typed_datum.h"
+#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/query/result_tile.h"
 
 using namespace tiledb::common;
@@ -114,16 +115,13 @@ struct ResultCoords {
     return tile_->coord(pos_, dim_idx);
   }
 
-  inline DynamicTypedDatumView dimension_datum(
+  inline UntypedDatumView dimension_datum(
       const Dimension& dim, unsigned dim_idx) const {
-    auto type = dim.type();
     if (dim.var_size()) {
       auto x{tile_->coord_string(pos_, dim_idx)};
-      return tdb::DynamicTypedDatumView{UntypedDatumView{x.data(), x.size()},
-                                        type};
+      return tdb::UntypedDatumView{x.data(), x.size()};
     } else {
-      return tdb::DynamicTypedDatumView{
-          UntypedDatumView{coord(dim_idx), dim.coord_size()}, type};
+      return tdb::UntypedDatumView{coord(dim_idx), dim.coord_size()};
     }
   }
 

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/resource_pool.h"
 #include "tiledb/sm/query/iquery_strategy.h"
+#include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/query/strategy_base.h"
 #include "tiledb/sm/subarray/subarray.h"

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,6 +35,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/query/query_buffer.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tiledb/sm/query/unordered_writer.cc
+++ b/tiledb/sm/query/unordered_writer.cc
@@ -574,41 +574,32 @@ Status UnorderedWriter::prepare_tiles_var(
   return Status::Ok();
 }
 
-Status UnorderedWriter::sort_coords(std::vector<uint64_t>* cell_pos) const {
+Status UnorderedWriter::sort_coords(std::vector<uint64_t>& cell_pos) const {
   auto timer_se = stats_->start_timer("sort_coords");
 
-  // For easy reference
-  auto& domain{array_schema_.domain()};
-  auto cell_order = array_schema_.cell_order();
-
-  // Prepare auxiliary vector for better performance
-  auto dim_num = array_schema_.dim_num();
-  std::vector<const QueryBuffer*> buffs(dim_num);
-  for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_.dimension(d)->name();
-    buffs[d] = &(buffers_.find(dim_name)->second);
-  }
-
   // Populate cell_pos
-  cell_pos->resize(coords_info_.coords_num_);
+  cell_pos.resize(coords_info_.coords_num_);
   for (uint64_t i = 0; i < coords_info_.coords_num_; ++i)
-    (*cell_pos)[i] = i;
+    cell_pos[i] = i;
 
   // Sort the coordinates in global order
+  auto cell_order = array_schema_.cell_order();
+  const Domain& domain = array_schema_.domain();
+  DomainBuffersView domain_buffs{array_schema_, buffers_};
   if (cell_order != Layout::HILBERT) {  // Row- or col-major
     parallel_sort(
         storage_manager_->compute_tp(),
-        cell_pos->begin(),
-        cell_pos->end(),
-        GlobalCmp(domain, &buffs));
+        cell_pos.begin(),
+        cell_pos.end(),
+        GlobalCmpQB(domain, domain_buffs));
   } else {  // Hilbert order
     std::vector<uint64_t> hilbert_values(coords_info_.coords_num_);
-    RETURN_NOT_OK(calculate_hilbert_values(buffs, &hilbert_values));
+    RETURN_NOT_OK(calculate_hilbert_values(domain_buffs, hilbert_values));
     parallel_sort(
         storage_manager_->compute_tp(),
-        cell_pos->begin(),
-        cell_pos->end(),
-        HilbertCmp(domain, &buffs, &hilbert_values));
+        cell_pos.begin(),
+        cell_pos.end(),
+        HilbertCmpQB(domain, domain_buffs, hilbert_values));
   }
 
   return Status::Ok();
@@ -621,7 +612,7 @@ Status UnorderedWriter::unordered_write() {
 
   // Sort coordinates first
   std::vector<uint64_t> cell_pos;
-  RETURN_CANCEL_OR_ERROR(sort_coords(&cell_pos));
+  RETURN_CANCEL_OR_ERROR(sort_coords(cell_pos));
 
   // Check for coordinate duplicates
   RETURN_CANCEL_OR_ERROR(check_coord_dups(cell_pos));

--- a/tiledb/sm/query/unordered_writer.h
+++ b/tiledb/sm/query/unordered_writer.h
@@ -206,7 +206,7 @@ class UnorderedWriter : public WriterBase {
    * @param cell_pos The sorted cell positions to be created.
    * @return Status
    */
-  Status sort_coords(std::vector<uint64_t>* cell_pos) const;
+  Status sort_coords(std::vector<uint64_t>& cell_pos) const;
 
   /**
    * Writes in unordered layout. Applicable to both dense and sparse arrays.

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,6 +55,7 @@
 #include "tiledb/sm/misc/endian.h"
 #include "tiledb/sm/misc/parse_argument.h"
 #include "tiledb/sm/query/query.h"
+#include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/serialization/array_schema.h"
 


### PR DESCRIPTION
Object library: domain
Removed compile dependency of `Domain` on both `ResultCoords` and `QueryBuffer`. The obstacle was value-comparison functions such as `cell_order_cmp` (in various versions) which took access-specifiers to data as their arguments rather than actual data. New arguments are of type `UntypedDatumView` or `DomainTypedDatumView` as appropriate.
Added an accessor to `ResultCoords` that returns `UntypedDatumView`.
New class `DomainTypedDataView` to hold data interpreted as a domain element. It holds one `UntypedDatumView` instance for each dimension within the domain. New class `DomainBuffersView` to encapsulate a sequence of `QueryBuffer` that hold domain data. This class contains a factory method for `DomainTypedDataView`. The factory method allows `DomainTypedDataView` to be C.41 compliant.
New class `DynamicArrayStorage` container class. It sits between `std::array` (fixed size by template argument) and `std::vector` (dynamic size) as having fixed size given by a constructor argument. It differs from those two container in that it does not defualt-construct objects; it delegates responsibility for element initialization to its user.
Added `is_tracing_enabled<T>` to allow selective constructor instantiation with `enable_if`. Used in `DynamicArrayStorage`.
Rewrote comparison classes in `misc/comparators.h` to use new comparison function signatures in `domain.h`. Added a common base class for existing comparison functions. Split `HilbertCmp` into three classes, one each for the three kinds of comparisons it was doing. Analogously, split `GlobalCmp` into two classes.
Adjusted headers in other sources that had been relying on transitive inclusions through `domain.h`.

---
TYPE: NO_HISTORY
DESC: <short description>

---

[IHN] closes https://github.com/TileDB-Inc/TileDB/pull/2858