### PR TITLE
Support new open array call on REST

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -225,9 +225,9 @@ void check_save_to_file() {
 #else
   ss << "config.logging_level 0\n";
 #endif
+  ss << "experimental.rest.optimized_array_open false\n";
   ss << "filestore.buffer_size 104857600\n";
   ss << "rest.curl.verbose false\n";
-  ss << "experimental.rest.optimized_array_open false\n";
   ss << "rest.http_compressor any\n";
   ss << "rest.retry_count 25\n";
   ss << "rest.retry_delay_factor 1.25\n";

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -227,6 +227,7 @@ void check_save_to_file() {
 #endif
   ss << "filestore.buffer_size 104857600\n";
   ss << "rest.curl.verbose false\n";
+  ss << "experimental.rest.optimized_array_open false\n";
   ss << "rest.http_compressor any\n";
   ss << "rest.retry_count 25\n";
   ss << "rest.retry_delay_factor 1.25\n";
@@ -551,6 +552,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["config.logging_level"] = "2";
   all_param_values["config.logging_format"] = "JSON";
   all_param_values["filestore.buffer_size"] = "104857600";
+  all_param_values["experimental.rest.optimized_array_open"] = "false";
   all_param_values["rest.server_address"] = "https://api.tiledb.com";
   all_param_values["rest.server_serialization_format"] = "CAPNP";
   all_param_values["rest.http_compressor"] = "any";

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -148,10 +148,23 @@ Status Array::open_without_fragments(
     if (rest_client == nullptr)
       return LOG_STATUS(Status_ArrayError(
           "Cannot open array; remote array with no REST client."));
-    auto&& [st, array_schema_latest] =
-        rest_client->get_array_schema_from_rest(array_uri_);
-    RETURN_NOT_OK(st);
-    array_schema_latest_ = array_schema_latest.value();
+
+    bool optimized_array_open = false;
+    bool found = false;
+    RETURN_NOT_OK(config_.get<bool>(
+        "experimental.rest.optimized_array_open",
+        &optimized_array_open,
+        &found));
+    assert(found);
+
+    if (optimized_array_open) {
+      RETURN_NOT_OK(rest_client->post_array_to_rest(array_uri_, this));
+    } else {
+      auto&& [st, array_schema_latest] =
+          rest_client->get_array_schema_from_rest(array_uri_);
+      RETURN_NOT_OK(st);
+      array_schema_latest_ = array_schema_latest.value();
+    }
   } else {
     try {
       array_dir_ = ArrayDirectory(
@@ -284,10 +297,23 @@ Status Array::open(
     if (rest_client == nullptr)
       return LOG_STATUS(Status_ArrayError(
           "Cannot open array; remote array with no REST client."));
-    auto&& [st, array_schema_latest] =
-        rest_client->get_array_schema_from_rest(array_uri_);
-    RETURN_NOT_OK(st);
-    array_schema_latest_ = array_schema_latest.value();
+
+    bool optimized_array_open = false;
+    bool found = false;
+    RETURN_NOT_OK(config_.get<bool>(
+        "experimental.rest.optimized_array_open",
+        &optimized_array_open,
+        &found));
+    assert(found);
+
+    if (optimized_array_open) {
+      RETURN_NOT_OK(rest_client->post_array_to_rest(array_uri_, this));
+    } else {
+      auto&& [st, array_schema_latest] =
+          rest_client->get_array_schema_from_rest(array_uri_);
+      RETURN_NOT_OK(st);
+      array_schema_latest_ = array_schema_latest.value();
+    }
   } else if (query_type == QueryType::READ) {
     try {
       array_dir_ = ArrayDirectory(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1427,6 +1427,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `config.logging_format` <br>
  *    The logging format configured (DEFAULT or JSON)
  *    **Default**: "DEFAULT"
+ * - `experimental.rest.optimized_array_open` <br>
+ *    Switch to open array with or without optimization. <br>
+ *    **Default**: "false"
  * - `rest.server_address` <br>
  *    URL for REST server to use for remote arrays. <br>
  *    **Default**: "https://api.tiledb.com"

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -56,6 +56,7 @@ const std::string Config::CONFIG_LOGGING_LEVEL = "1";
 const std::string Config::CONFIG_LOGGING_LEVEL = "0";
 #endif
 const std::string Config::CONFIG_LOGGING_DEFAULT_FORMAT = "DEFAULT";
+const std::string Config::EXPERIMENTAL_REST_OPTIMIZED_ARRAY_OPEN = "false";
 const std::string Config::REST_SERVER_DEFAULT_ADDRESS =
     "https://api.tiledb.com";
 const std::string Config::REST_SERIALIZATION_DEFAULT_FORMAT = "CAPNP";
@@ -213,6 +214,8 @@ const std::set<std::string> Config::unserialized_params_ = {
 
 Config::Config() {
   // Set config values
+  param_values_["experimental.rest.optimized_array_open"] =
+      EXPERIMENTAL_REST_OPTIMIZED_ARRAY_OPEN;
   param_values_["rest.server_address"] = REST_SERVER_DEFAULT_ADDRESS;
   param_values_["rest.server_serialization_format"] =
       REST_SERIALIZATION_DEFAULT_FORMAT;
@@ -499,7 +502,10 @@ const std::set<std::string>& Config::set_params() const {
 
 Status Config::unset(const std::string& param) {
   // Set back to default
-  if (param == "rest.server_address") {
+  if (param == "experimental.rest.optimized_array_open") {
+    param_values_["experimental.rest.optimized_array_open"] =
+        EXPERIMENTAL_REST_OPTIMIZED_ARRAY_OPEN;
+  } else if (param == "rest.server_address") {
     param_values_["rest.server_address"] = REST_SERVER_DEFAULT_ADDRESS;
   } else if (param == "rest.server_serialization_format") {
     param_values_["rest.server_serialization_format"] =

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -56,6 +56,9 @@ class Config {
   /*        CONFIG DEFAULTS         */
   /* ****************************** */
 
+  /** The default switch for opening an array with or without optimization. */
+  static const std::string EXPERIMENTAL_REST_OPTIMIZED_ARRAY_OPEN;
+
   /** The default address for rest server. */
   static const std::string REST_SERVER_DEFAULT_ADDRESS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -660,6 +660,9 @@ class Config {
    * - `config.logging_format` <br>
    *    The logging format configured (DEFAULT or JSON)
    *    **Default**: "DEFAULT"
+   * - `experimental.rest.optimized_array_open` <br>
+   *    Switch to open array with or without optimization. <br>
+   *    **Default**: "false"
    * - `rest.server_address` <br>
    *    URL for REST server to use for remote arrays. <br>
    *    **Default**: "https://api.tiledb.com"

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -265,6 +265,45 @@ Status RestClient::post_array_schema_to_rest(
   return sc;
 }
 
+Status RestClient::post_array_to_rest(const URI& uri, Array* array) {
+  Buffer buff;
+  BufferList serialized;
+  Config config = array->config();
+
+  RETURN_NOT_OK(serialization::config_serialize(
+      &config, serialization_type_, &buff, false));
+  RETURN_NOT_OK(serialized.add_buffer(std::move(buff)));
+
+  uint64_t timestamp_start = array->timestamp_start();
+  uint64_t timestamp_end = array->timestamp_end();
+
+  // Init curl and form the URL
+  Curl curlc;
+  std::string array_ns, array_uri;
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  const std::string cache_key = array_ns + ":" + array_uri;
+  RETURN_NOT_OK(
+      curlc.init(&config, extra_headers_, &redirect_meta_, &redirect_mtx_));
+  auto deduced_url = redirect_uri(cache_key) + "/v2/arrays/" + array_ns + "/" +
+                     curlc.url_escape(array_uri) +
+                     "?start_timestamp=" + std::to_string(timestamp_start) +
+                     "&end_timestamp=" + std::to_string(timestamp_end);
+  Buffer returned_data;
+  RETURN_NOT_OK(curlc.post_data(
+      stats_,
+      deduced_url,
+      serialization_type_,
+      &serialized,
+      &returned_data,
+      cache_key));
+  if (returned_data.data() == nullptr || returned_data.size() == 0)
+    return LOG_STATUS(Status_RestError(
+        "Error getting array from REST; server returned no data."));
+
+  return serialization::array_deserialize(
+      array, serialization_type_, returned_data);
+}
+
 Status RestClient::deregister_array_from_rest(const URI& uri) {
   // Init curl and form the URL
   Curl curlc(logger_);
@@ -1125,6 +1164,11 @@ RestClient::get_array_schema_from_rest(const URI&) {
 }
 
 Status RestClient::post_array_schema_to_rest(const URI&, const ArraySchema&) {
+  return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
+}
+
+Status RestClient::post_array_to_rest(const URI&, Array*) {
   return LOG_STATUS(
       Status_RestError("Cannot use rest client; serialization not enabled."));
 }

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -278,7 +278,7 @@ Status RestClient::post_array_to_rest(const URI& uri, Array* array) {
   uint64_t timestamp_end = array->timestamp_end();
 
   // Init curl and form the URL
-  Curl curlc;
+  Curl curlc(logger_);
   std::string array_ns, array_uri;
   RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
   const std::string cache_key = array_ns + ":" + array_uri;

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -109,6 +109,15 @@ class RestClient {
       const URI& uri, const ArraySchema& array_schema);
 
   /**
+   * Post a data array to rest server
+   *
+   * @param uri of array being created
+   * @param array array to load into
+   * @return Status Ok() on success Error() on failures
+   */
+  Status post_array_to_rest(const URI& uri, Array* array);
+
+  /**
    * Deregisters an array at the given URI from the REST server.
    *
    * @param uri Array URI to deregister


### PR DESCRIPTION
Support for a new array object with high level serialization has been added. This next step will allow for REST support of the new array object with use of a configuration parameter. [ch14052]

---
TYPE: IMPROVEMENT
DESC: Support serialized arrays on REST
