### PR TITLE
Adds function for deserializing default subarray ranges

### DIFF
--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -833,10 +833,6 @@ bool Subarray::is_unary(uint64_t range_idx) const {
   return true;
 }
 
-void Subarray::set_is_default(uint32_t dim_index, bool is_default) {
-  is_default_[dim_index] = is_default;
-}
-
 void Subarray::set_layout(Layout layout) {
   layout_ = layout;
 }
@@ -1527,6 +1523,16 @@ const std::vector<Range>& Subarray::ranges_for_dim(uint32_t dim_idx) const {
   return ranges_[dim_idx];
 }
 
+Status Subarray::set_default_range(uint32_t dim_idx, const Range& range) {
+  // Set range value.
+  ranges_.resize(dim_idx + 1, std::vector<Range>());
+  ranges_[dim_idx].clear();
+  ranges_[dim_idx].emplace_back(range);
+  // Set the range as default.
+  is_default_[dim_idx] = true;
+  return Status::Ok();
+}
+
 Status Subarray::set_ranges_for_dim(
     uint32_t dim_idx, const std::vector<Range>& ranges) {
   ranges_.resize(dim_idx + 1, std::vector<Range>());
@@ -1537,6 +1543,8 @@ Status Subarray::set_ranges_for_dim(
   for (const auto& range : ranges)
     add_or_coalesce_range_func_[dim_idx](this, dim_idx, range);
 
+  // Set the range as not default.
+  is_default_[dim_idx] = false;
   return Status::Ok();
 }
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -716,13 +716,6 @@ class Subarray {
    */
   Subarray get_subarray(uint64_t start, uint64_t end) const;
 
-  /**
-   * Set default indicator for dimension subarray. Used by serialization only
-   * @param dim_index
-   * @param is_default
-   */
-  void set_is_default(uint32_t dim_index, bool is_default);
-
   /** Sets the subarray layout. */
   void set_layout(Layout layout);
 
@@ -771,6 +764,18 @@ class Subarray {
    * @note Intended for serialization only
    */
   const std::vector<Range>& ranges_for_dim(uint32_t dim_idx) const;
+
+  /**
+   * Directly sets the `Range` vector for the given dimension index, making a
+   * deep copy, and marking it as default.
+   *
+   * @param dim_idx Index of dimension to set
+   * @param ranges `Range` vector that will be copied and set
+   * @return Status
+   *
+   * @note Intended for serialization only
+   */
+  Status set_default_range(uint32_t dim_idx, const Range& range);
 
   /**
    * Directly sets the `Range` vector for the given dimension index, making


### PR DESCRIPTION
Ranges were being set as default or not default using a setter method after setting ranges with no check for multiple ranges in a range marked default. This adds a separate deserialization function for default ranges that takes exactly one range.

---
TYPE:  IMPROVEMENT
DESC: Adds separate functions for setting default subarray ranges and non-default subarray ranges
