### PR TITLE
Update prepare release script to fall back to latest common ancestor between base and head

### DIFF
--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -69,8 +69,6 @@ def find_prs(gh: Github, head: str, base: Optional[str] = None) -> Dict[int, str
             assert comparison.behind_by == 0, comparison.behind_by
         else:
             sys.exit(f"Aborting: head is {comparison.behind_by} commits behind base")
-    if comparison.ahead_by == 0:
-        raise ValueError("Head is not ahead of base")
     logging.info(f"Head is {comparison.ahead_by} commits ahead of base")
 
     prs = {}

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -59,7 +59,16 @@ def find_prs(gh: Github, head: str, base: Optional[str] = None) -> Dict[int, str
 
     comparison = repo.compare(base_sha, head_sha)
     if comparison.behind_by != 0:
-        raise ValueError(f"Head is {comparison.behind_by} commits behind base")
+        find_common_ancestor = input(
+            f"Head is {comparison.behind_by} commits behind base: do you want to use the "
+            f"latest common ancestor of {base} and {head} as base? [y/n] "
+        )
+        if find_common_ancestor.lower() == "y":
+            base_sha = comparison.merge_base_commit.sha
+            comparison = repo.compare(base_sha, head_sha)
+            assert comparison.behind_by == 0, comparison.behind_by
+        else:
+            sys.exit(f"Aborting: head is {comparison.behind_by} commits behind base")
     if comparison.ahead_by == 0:
         raise ValueError("Head is not ahead of base")
     logging.info(f"Head is {comparison.ahead_by} commits ahead of base")


### PR DESCRIPTION
`prepare_release.py` required that the `base` commit is an ancestor of `head`. Update it so that if this is not the case, the user can choose (interactively) whether to use the latest common ancestor of `base` and `head` as the new base, or exit the script without making any changes.

---
TYPE: NO_HISTORY
DESC: NO_HISTORY