### PR TITLE
Tile metadata test: reducing amount of spew in verbose mode.

### DIFF
--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -260,14 +260,14 @@ struct CPPFixedTileMetadataFx {
           int64_t correct_sum =
               (tile_extent_) * (correct_min + correct_max) / 2;
 
-          // Validate min.
+          // Validate no min.
           auto&& [st_min, min, min_size] =
               frag_meta[f]->get_tile_min("d", tile_idx);
           CHECK(!st_min.ok());
           CHECK(!min.has_value());
           CHECK(!min_size.has_value());
 
-          // Validate max.
+          // Validate no max.
           auto&& [st_max, max, max_size] =
               frag_meta[f]->get_tile_max("d", tile_idx);
           CHECK(!st_max.ok());
@@ -635,6 +635,7 @@ struct CPPVarTileMetadataFx {
           // Validate no min.
           auto&& [st_min, min, min_size] =
               frag_meta[f]->get_tile_min("d", tile_idx);
+          CHECK(!st_min.ok());
           CHECK(!min.has_value());
           CHECK(!min_size.has_value());
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1301,8 +1301,8 @@ FragmentMetadata::get_tile_min(const std::string& name, uint64_t tile_idx) {
   const auto cell_val_num = array_schema_->cell_val_num(name);
   if (!TileMetadataGenerator::has_min_max_metadata(
           type, is_dim, var_size, cell_val_num))
-    return {LOG_STATUS(Status_FragmentMetadataError(
-                "Trying to access metadata that's not present")),
+    return {Status_FragmentMetadataError(
+                "Trying to access metadata that's not present"),
             std::nullopt,
             std::nullopt};
 
@@ -1339,8 +1339,8 @@ FragmentMetadata::get_tile_max(const std::string& name, uint64_t tile_idx) {
   const auto cell_val_num = array_schema_->cell_val_num(name);
   if (!TileMetadataGenerator::has_min_max_metadata(
           type, is_dim, var_size, cell_val_num))
-    return {LOG_STATUS(Status_FragmentMetadataError(
-                "Trying to access metadata that's not present")),
+    return {Status_FragmentMetadataError(
+                "Trying to access metadata that's not present"),
             std::nullopt,
             std::nullopt};
 
@@ -1374,8 +1374,8 @@ std::tuple<Status, std::optional<void*>> FragmentMetadata::get_tile_sum(
   auto var_size = array_schema_->var_size(name);
   auto cell_val_num = array_schema_->cell_val_num(name);
   if (!TileMetadataGenerator::has_sum_metadata(type, var_size, cell_val_num))
-    return {LOG_STATUS(Status_FragmentMetadataError(
-                "Trying to access metadata that's not present")),
+    return {Status_FragmentMetadataError(
+                "Trying to access metadata that's not present"),
             std::nullopt};
 
   void* sum = &tile_sums_[idx][tile_idx * sizeof(uint64_t)];
@@ -1394,8 +1394,8 @@ FragmentMetadata::get_tile_null_count(
             std::nullopt};
 
   if (!array_schema_->is_nullable(name)) {
-    return {LOG_STATUS(Status_FragmentMetadataError(
-                "Trying to access metadata that's not present")),
+    return {Status_FragmentMetadataError(
+                "Trying to access metadata that's not present"),
             std::nullopt};
   }
 


### PR DESCRIPTION
There has been several CI failures on the tile metadata tests with no
crash dump. The test is asking for a lot of metadata that is not present
on purpose to test that this codepath works and since it's doing so on
a lot of variations, this causes a lot of spew when running in verbose
mode. Looking more closely at the logs, I noticed the following clue:

awk: cmd. line:1: (FILENAME=- FNR=8894) fatal: print to "standard output" failed (Resource temporarily unavailable)

This could hint that something is unstable in the standard output when
running tests in github actions, so reducing the amount of spew seems
like a valid attempt to reduce the amount of CI failures so this change
does just that.

---
TYPE: IMPROVEMENT
DESC: Tile metadata test: reducing amount of spew in verbose mode.
