### PR TITLE
[C++ API] Add missing cstddef include to fix compile w/ GCC 7

### DIFF
--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -37,6 +37,7 @@
 
 #include "tiledb.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <iterator>


### PR DESCRIPTION
Fixes `error: no member named 'byte' in namespace 'std'` build error with GCC 7.3.

---

TYPE: CPP_API
DESC: Add missing cstddef include to fix compile w/ GCC 7
