### PR TITLE
Fixes missing pthread link and replaces with Threads::Threads

### DIFF
--- a/external/blosc/CMakeLists.txt
+++ b/external/blosc/CMakeLists.txt
@@ -61,12 +61,6 @@ endif()
 # in case something else has a pthread dependency.
 #
 find_package(Threads REQUIRED)
-message(DEBUG "Threads_FOUND=${Threads_FOUND}")
-message(DEBUG "CMAKE_THREAD_LIBS_INIT=${CMAKE_THREAD_LIBS_INIT}")
-message(DEBUG "CMAKE_USE_WIN32_THREADS_INIT=${CMAKE_USE_WIN32_THREADS_INIT}")
-message(DEBUG "CMAKE_USE_PTHREADS_INIT=${CMAKE_USE_PTHREADS_INIT}")
-message(DEBUG "CMAKE_HP_PTHREADS_INIT=${CMAKE_HP_PTHREADS_INIT}")
-message(DEBUG "CMAKE_HAVE_PTHREAD_H=${CMAKE_HAVE_PTHREAD_H}")
 
 if (CMAKE_USE_PTHREADS_INIT)
   message(DEBUG "Using system-provided pthread")

--- a/external/blosc/CMakeLists.txt
+++ b/external/blosc/CMakeLists.txt
@@ -54,14 +54,11 @@ if(SSE2_DETECTED)
     )
 endif()
 
-#
-# Blosc requires a pthread library. There's a substitute one available for
-# Windows for use with Visual C++, which doesn't have it. Other compilers do,
-# however, and we use it if it's available. This avoids duplicate link symbols
-# in case something else has a pthread dependency.
-#
-find_package(Threads REQUIRED)
 
+# Blosc requires a pthread library. There's a substitute one available for Windows for
+# use with Visual C++, which doesn't have it. The following checks if pthreads is
+# already enable, and adds the substitute Windows pthread library for Visual C++.
+# Variables used for checking are set by CMake FindThreads module.
 if (CMAKE_USE_PTHREADS_INIT)
   message(DEBUG "Using system-provided pthread")
 elseif(CMAKE_USE_WIN32_THREADS_INIT)
@@ -119,4 +116,3 @@ set(TileDB_blosc_SOURCES ${SOURCES} PARENT_SCOPE)
 set(TileDB_blosc_INCLUDE_DIRS ${SOURCE_DIR}/include PARENT_SCOPE)
 set(TileDB_blosc_COMPILE_OPTIONS ${TILEDB_BLOSC_COMPILE_OPTIONS} PARENT_SCOPE)
 set(TileDB_blosc_LINK_OPTIONS ${CMAKE_THREAD_LIBS_INIT} PARENT_SCOPE)
-

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -545,10 +545,15 @@ if(APPLE)
   endif()
 endif()
 
-# On Linux, must explicitly link -lpthread -ldl in order for static linking
-# to libzstd.
+# Enable threading library for systems where it is not automatically enable.
+find_package(Threads REQUIRED)
+if (CMAKE_THREAD_LIBS_INIT)
+  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE Threads::Threads)
+endif()
+
+# On Linux, must explicitly link -ldl for static linking to libzstd.
 if (NOT WIN32)
-  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE pthread dl)
+  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE dl)
 endif()
 
 # Copy over dependency info (e.g. include directories) to the core objects.

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -545,8 +545,16 @@ if(APPLE)
   endif()
 endif()
 
-# Enable threading library for systems where it is not automatically enable.
+# Require support for thread functions. FindThreads defines the following:
+#  * Threads_FOUND - If a supported thread library was found.
+#  * CMAKE_THREAD_LIBS_INIT - The thread library to use. This is empty if the thread
+#    functions are provided by the system libraries and no special flags are needed to
+#    use them.
+#  * CMAKE_USE_WIN32_THREADS_INIT - If the found thread library is the win32 one.
+#  * CMAKE_USE_PTHREADS_INIT - If the found thread library is pthread compatible.
+#  * CMAKE_HP_PTHREADS_INIT - If the found thread library is the HP thread library.
 find_package(Threads REQUIRED)
+# Link to Threads::Threads if library or flag needed to enable threading.
 if (CMAKE_THREAD_LIBS_INIT)
   target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE Threads::Threads)
 endif()

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -34,6 +34,20 @@
 cmake_policy(SET CMP0063 NEW)
 
 ############################################################
+# Find packages needed for object libraries
+############################################################
+
+# FindThreads defines the following:
+#  * Threads_FOUND - If a supported thread library was found.
+#  * CMAKE_THREAD_LIBS_INIT - The thread library to use. This is empty if the thread
+#    functions are provided by the system libraries and no special flags are needed to
+#    use them.
+#  * CMAKE_USE_WIN32_THREADS_INIT - If the found thread library is the win32 one.
+#  * CMAKE_USE_PTHREADS_INIT - If the found thread library is pthread compatible.
+#  * CMAKE_HP_PTHREADS_INIT - If the found thread library is the HP thread library.
+find_package(Threads REQUIRED)
+
+############################################################
 # Subdirectories
 ############################################################
 
@@ -545,15 +559,6 @@ if(APPLE)
   endif()
 endif()
 
-# Require support for thread functions. FindThreads defines the following:
-#  * Threads_FOUND - If a supported thread library was found.
-#  * CMAKE_THREAD_LIBS_INIT - The thread library to use. This is empty if the thread
-#    functions are provided by the system libraries and no special flags are needed to
-#    use them.
-#  * CMAKE_USE_WIN32_THREADS_INIT - If the found thread library is the win32 one.
-#  * CMAKE_USE_PTHREADS_INIT - If the found thread library is pthread compatible.
-#  * CMAKE_HP_PTHREADS_INIT - If the found thread library is the HP thread library.
-find_package(Threads REQUIRED)
 # Link to Threads::Threads if library or flag needed to enable threading.
 if (CMAKE_THREAD_LIBS_INIT)
   target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE Threads::Threads)

--- a/tiledb/common/dynamic_memory/CMakeLists.txt
+++ b/tiledb/common/dynamic_memory/CMakeLists.txt
@@ -43,7 +43,16 @@ if (TILEDB_TESTS)
     target_link_libraries(unit_dynamic_memory PUBLIC Catch2::Catch2)
     # The heap_profiler dependency requires threads. The dependency should be
     # moved to heap_profiler if/when it is added to its own object library.
+    # FindThreads defines the following:
+    #  * Threads_FOUND - If a supported thread library was found.
+    #  * CMAKE_THREAD_LIBS_INIT - The thread library to use. This is empty if the thread
+    #    functions are provided by the system libraries and no special flags are needed to
+    #    use them.
+    #  * CMAKE_USE_WIN32_THREADS_INIT - If the found thread library is the win32 one.
+    #  * CMAKE_USE_PTHREADS_INIT - If the found thread library is pthread compatible.
+    #  * CMAKE_HP_PTHREADS_INIT - If the found thread library is the HP thread library.
     find_package(Threads REQUIRED)
+    # Link to Threads::Threads if library or flag needed to enable threading.
     if (CMAKE_THREAD_LIBS_INIT)
         target_link_libraries(unit_dynamic_memory PUBLIC Threads::Threads)
     endif()

--- a/tiledb/common/dynamic_memory/CMakeLists.txt
+++ b/tiledb/common/dynamic_memory/CMakeLists.txt
@@ -41,14 +41,11 @@ if (TILEDB_TESTS)
 
     add_executable(unit_dynamic_memory EXCLUDE_FROM_ALL)
     target_link_libraries(unit_dynamic_memory PUBLIC Catch2::Catch2)
-    #
-    # The heap_profiler dependency is as loose files rather than as a library
-    # of some sort. The pthread requirement below should ideally be carried
-    # on a library interface rather than specified directly.
-    #
-    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        # Apparently gcc requires pthread to be linked for <thread> definitions
-        target_link_libraries(unit_dynamic_memory PUBLIC pthread)
+    # The heap_profiler dependency requires threads. The dependency should be
+    # moved to heap_profiler if/when it is added to its own object library.
+    find_package(Threads REQUIRED)
+    if (CMAKE_THREAD_LIBS_INIT)
+        target_link_libraries(unit_dynamic_memory PUBLIC Threads::Threads)
     endif()
 
     # Sources for code under test

--- a/tiledb/common/dynamic_memory/CMakeLists.txt
+++ b/tiledb/common/dynamic_memory/CMakeLists.txt
@@ -41,18 +41,9 @@ if (TILEDB_TESTS)
 
     add_executable(unit_dynamic_memory EXCLUDE_FROM_ALL)
     target_link_libraries(unit_dynamic_memory PUBLIC Catch2::Catch2)
+    # Link to Threads::Threads if library or flag needed to enable threading.
     # The heap_profiler dependency requires threads. The dependency should be
     # moved to heap_profiler if/when it is added to its own object library.
-    # FindThreads defines the following:
-    #  * Threads_FOUND - If a supported thread library was found.
-    #  * CMAKE_THREAD_LIBS_INIT - The thread library to use. This is empty if the thread
-    #    functions are provided by the system libraries and no special flags are needed to
-    #    use them.
-    #  * CMAKE_USE_WIN32_THREADS_INIT - If the found thread library is the win32 one.
-    #  * CMAKE_USE_PTHREADS_INIT - If the found thread library is pthread compatible.
-    #  * CMAKE_HP_PTHREADS_INIT - If the found thread library is the HP thread library.
-    find_package(Threads REQUIRED)
-    # Link to Threads::Threads if library or flag needed to enable threading.
     if (CMAKE_THREAD_LIBS_INIT)
         target_link_libraries(unit_dynamic_memory PUBLIC Threads::Threads)
     endif()


### PR DESCRIPTION
* Replaces hard-coded link to pthread with link to Threads::Threads library using built-in CMake module FindThreads.
* Adds missing link to Threads::Threads for `unit_dynamic_memory`.


---
TYPE: BUG
DESC: Adds missing pthreads link to dynamic memory unit test
