### PR TITLE
Adds RangeSubset for handling ranges in Subarray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ option(TILEDB_SKIP_S3AWSSDK_DIR_LENGTH_CHECK "If true, skip check needed path le
 
 set(TILEDB_INSTALL_LIBDIR "" CACHE STRING "If non-empty, install TileDB library to this directory instead of CMAKE_INSTALL_LIBDIR.")
 
-# early WIN32 audit of path length for aws sdk build where 
+# early WIN32 audit of path length for aws sdk build where
 # insufficient available path length causes sdk build failure.
 if (WIN32 AND NOT TILEDB_SKIP_S3AWSSDK_DIR_LENGTH_CHECK)
   if (TILEDB_SUPERBUILD)
@@ -270,6 +270,7 @@ if (TILEDB_TESTS)
   add_dependencies(tests unit_interval unit_datum unit_dynamic_memory unit_thread_pool)
   add_dependencies(tests unit_filter unit_array_schema)
   add_dependencies(tests unit_compressors)
+  add_dependencies(tests unit_range_subset)
 endif()
 
 # Build tools

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -222,6 +222,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/consolidator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/storage_manager.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/cell_slab_iter.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/range_subset.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray_partitioner.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray_tile_overlap.cc

--- a/tiledb/sm/subarray/CMakeLists.txt
+++ b/tiledb/sm/subarray/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# tiledb/sm/CMakeLists.txt
+# tiledb/sm/subarray/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2021 TileDB, Inc.
+# Copyright (c) 2022 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,18 +24,24 @@
 # THE SOFTWARE.
 #
 
-include(common-root)
+include(common NO_POLICY_SCOPE)
 
-add_subdirectory(array_schema)
-add_subdirectory(buffer)
-add_subdirectory(compressors)
-add_subdirectory(config)
-add_subdirectory(crypto)
-add_subdirectory(filesystem)
-add_subdirectory(filter)
-add_subdirectory(metadata)
-add_subdirectory(misc)
-add_subdirectory(query)
-add_subdirectory(stats)
-add_subdirectory(subarray)
-add_subdirectory(tile)
+#
+# `range_subset` object library
+#
+add_library(range_subset OBJECT range_subset.cc)
+target_link_libraries(range_subset PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+target_link_libraries(range_subset PUBLIC misc_types $<TARGET_OBJECTS:misc_types>)
+target_link_libraries(range_subset PUBLIC constants $<TARGET_OBJECTS:constants>)
+target_link_libraries(range_subset PUBLIC thread_pool $<TARGET_OBJECTS:thread_pool>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_range_subset EXCLUDE_FROM_ALL)
+target_link_libraries(compile_range_subset PRIVATE range_subset)
+target_sources(compile_range_subset PRIVATE test/compile_range_subset_main.cc)
+
+if (TILEDB_TESTS)
+    add_subdirectory(test)
+endif()

--- a/tiledb/sm/subarray/range_subset.cc
+++ b/tiledb/sm/subarray/range_subset.cc
@@ -1,0 +1,130 @@
+/**
+ * @file   range_subset.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the class RangeSetAndSuperset.
+ */
+
+#include "tiledb/sm/subarray/range_subset.h"
+
+#include <iostream>
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+template <typename T>
+tdb_shared_ptr<detail::RangeSetAndSupersetInternals>
+create_range_subset_internals(bool coalesce_ranges) {
+  if (coalesce_ranges) {
+    return make_shared<detail::RangeSetAndSupersetInternalsImpl<T, true>>(
+        HERE());
+  }
+  return make_shared<detail::RangeSetAndSupersetInternalsImpl<T, false>>(
+      HERE());
+};
+
+tdb_shared_ptr<detail::RangeSetAndSupersetInternals> range_subset_internals(
+    Datatype datatype, bool coalesce_ranges) {
+  switch (datatype) {
+    case Datatype::INT8:
+      return create_range_subset_internals<int8_t>(coalesce_ranges);
+    case Datatype::UINT8:
+      return create_range_subset_internals<uint8_t>(coalesce_ranges);
+    case Datatype::INT16:
+      return create_range_subset_internals<int16_t>(coalesce_ranges);
+    case Datatype::UINT16:
+      return create_range_subset_internals<uint16_t>(coalesce_ranges);
+    case Datatype::INT32:
+      return create_range_subset_internals<int32_t>(coalesce_ranges);
+    case Datatype::UINT32:
+      return create_range_subset_internals<uint32_t>(coalesce_ranges);
+    case Datatype::INT64:
+      return create_range_subset_internals<int64_t>(coalesce_ranges);
+    case Datatype::UINT64:
+      return create_range_subset_internals<uint64_t>(coalesce_ranges);
+    case Datatype::FLOAT32:
+      return create_range_subset_internals<float>(coalesce_ranges);
+    case Datatype::FLOAT64:
+      return create_range_subset_internals<double>(coalesce_ranges);
+    case Datatype::DATETIME_YEAR:
+    case Datatype::DATETIME_MONTH:
+    case Datatype::DATETIME_WEEK:
+    case Datatype::DATETIME_DAY:
+    case Datatype::DATETIME_HR:
+    case Datatype::DATETIME_MIN:
+    case Datatype::DATETIME_SEC:
+    case Datatype::DATETIME_MS:
+    case Datatype::DATETIME_US:
+    case Datatype::DATETIME_NS:
+    case Datatype::DATETIME_PS:
+    case Datatype::DATETIME_FS:
+    case Datatype::DATETIME_AS:
+    case Datatype::TIME_HR:
+    case Datatype::TIME_MIN:
+    case Datatype::TIME_SEC:
+    case Datatype::TIME_MS:
+    case Datatype::TIME_US:
+    case Datatype::TIME_NS:
+    case Datatype::TIME_PS:
+    case Datatype::TIME_FS:
+    case Datatype::TIME_AS:
+      return create_range_subset_internals<int64_t>(coalesce_ranges);
+    case Datatype::STRING_ASCII:
+      return create_range_subset_internals<std::string>(coalesce_ranges);
+    default:
+      LOG_ERROR("Unexpected dimension datatype " + datatype_str(datatype));
+      return nullptr;
+  }
+}
+
+RangeSetAndSuperset::RangeSetAndSuperset(
+    Datatype datatype,
+    const Range& superset,
+    bool implicitly_initialize,
+    bool coalesce_ranges)
+    : impl_(range_subset_internals(datatype, coalesce_ranges))
+    , superset_(superset)
+    , is_implicitly_initialized_(implicitly_initialize) {
+  if (implicitly_initialize)
+    ranges_.emplace_back(superset);
+}
+
+Status RangeSetAndSuperset::sort_ranges(ThreadPool* const compute_tp) {
+  return impl_->sort_ranges(compute_tp, ranges_);
+}
+
+Status RangeSetAndSuperset::add_range_unrestricted(const Range& range) {
+  if (is_implicitly_initialized_) {
+    ranges_.clear();
+    is_implicitly_initialized_ = false;
+  }
+  return impl_->add_range(ranges_, range);
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/subarray/range_subset.h
+++ b/tiledb/sm/subarray/range_subset.h
@@ -1,0 +1,322 @@
+/**
+ * @file   range_subset.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the class RangeSetAndSuperset.
+ */
+
+#ifndef TILEDB_RANGE_SUBSET_H
+#define TILEDB_RANGE_SUBSET_H
+
+#include "tiledb/common/heap_memory.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/misc/types.h"
+
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+namespace detail {
+
+/** Default add strategy: simple add. */
+template <typename T, bool Coalesce, typename Enable = T>
+struct AddStrategy {
+  static Status add_range(std::vector<Range>& ranges, const Range& new_range) {
+    ranges.emplace_back(new_range);
+    return Status::Ok();
+  };
+};
+
+/** Specialization for coalescing integer-type ranges. */
+template <typename T>
+struct AddStrategy<
+    T,
+    true,
+    typename std::enable_if<std::is_integral<T>::value, T>::type> {
+  static Status add_range(std::vector<Range>& ranges, const Range& new_range) {
+    if (ranges.empty()) {
+      ranges.emplace_back(new_range);
+      return Status::Ok();
+    }
+
+    // If the start index of `range` immediately follows the end of the
+    // last range on `ranges`, they are contiguous and will be coalesced.
+    Range& last_range = ranges.back();
+    const bool contiguous_after =
+        *static_cast<const T*>(last_range.end()) !=
+            std::numeric_limits<T>::max() &&
+        *static_cast<const T*>(last_range.end()) + 1 ==
+            *static_cast<const T*>(new_range.start());
+
+    // Coalesce `range` with `last_range` if they are contiguous.
+    if (contiguous_after) {
+      last_range.set_end(new_range.end());
+    } else {
+      ranges.emplace_back(new_range);
+    }
+    return Status::Ok();
+  };
+};
+
+/**
+ * Sort algorithm for ranges.
+ *
+ * Default behavior: sorting is not enable.
+ */
+template <typename T, typename Enable = T>
+struct SortStrategy {
+  static Status sort(ThreadPool* const, std::vector<Range>&);
+};
+
+/**
+ * Sort algorithm for ranges.
+ *
+ * Sorting for numeric types.
+ */
+template <typename T>
+struct SortStrategy<
+    T,
+    typename std::enable_if<std::is_arithmetic<T>::value, T>::type> {
+  static Status sort(ThreadPool* const compute_tp, std::vector<Range>& ranges) {
+    parallel_sort(
+        compute_tp,
+        ranges.begin(),
+        ranges.end(),
+        [&](const Range& a, const Range& b) {
+          const T* a_data = static_cast<const T*>(a.start());
+          const T* b_data = static_cast<const T*>(b.start());
+          return a_data[0] < b_data[0] ||
+                 (a_data[0] == b_data[0] && a_data[1] < b_data[1]);
+        });
+    return Status::Ok();
+  };
+};
+
+/**
+ * Sort algorithm for ranges.
+ *
+ * Sort for ASCII strings.
+ */
+template <>
+struct SortStrategy<std::string, std::string> {
+  static Status sort(ThreadPool* const compute_tp, std::vector<Range>& ranges) {
+    parallel_sort(
+        compute_tp,
+        ranges.begin(),
+        ranges.end(),
+        [&](const Range& a, const Range& b) {
+          return a.start_str() < b.start_str() ||
+                 (a.start_str() == b.start_str() && a.end_str() < b.end_str());
+        });
+    return Status::Ok();
+  };
+};
+
+class RangeSetAndSupersetInternals {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Destructor. */
+  virtual ~RangeSetAndSupersetInternals() = default;
+
+  /**
+   * Adds a range to the range manager without performing any checkes. If a
+   * default strategy is set, then first update the range strategy.
+   *
+   * @param ranges The current ranges in the subarray (remove after
+   refactor).
+   * @param new_range The range to add.
+   */
+  virtual Status add_range(std::vector<Range>& ranges, const Range& range) = 0;
+
+  /**
+   * Sorts the ranges in the range manager.
+   *
+   * @param compute_tp The compute thread pool.
+   */
+  virtual Status sort_ranges(
+      ThreadPool* const compute_tp, std::vector<Range>& ranges) = 0;
+};
+
+template <typename T, bool CoalesceAdds>
+class RangeSetAndSupersetInternalsImpl : public RangeSetAndSupersetInternals {
+ public:
+  Status add_range(
+      std::vector<Range>& ranges, const Range& new_range) override {
+    return AddStrategy<T, CoalesceAdds>::add_range(ranges, new_range);
+  };
+
+  Status sort_ranges(
+      ThreadPool* const compute_tp, std::vector<Range>& ranges) override {
+    return SortStrategy<T>::sort(compute_tp, ranges);
+  };
+};
+
+}  // namespace detail
+
+/**
+ * A RangeSetAndSuperset object is a collection of possibly overlapping or
+ * duplicate Ranges that are assumed to be subsets of a given superset with a
+ * defined TileDB datatype.
+ *
+ * If constructed with the ``implicitly_initialize`` flag set to ``true``, the
+ * superset will be added to the Ranges in the set until any additional ranages
+ * are added.
+ *
+ * Current state of the RangeSetAndSuperset:
+ *
+ *  * The only way to add Ranges is with an "unrestricted" method that does not
+ *  check the range is in fact a subset of the superset.
+ *
+ * Planned updates:
+ *
+ *  * When adding a new range, this will verify that Range is a subset of the
+ *  RangeSetAndSuperset by using ``is_subset`` and ``intersection`` methods.
+ *
+ */
+class RangeSetAndSuperset {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Default constructor. */
+  RangeSetAndSuperset() = default;
+
+  /** General constructor
+   *
+   * @param datatype The TileDB datatype of of the ranges.
+   * @param implicitly_initialize If ``true``, set the ranges to contain the
+   * full superset until a new range is explicitly added.
+   * @param coalesce_ranges If ``true``, when adding a new range, attempt to
+   * combine with the first left-adjacent range found.
+   **/
+  RangeSetAndSuperset(
+      Datatype datatype,
+      const Range& superset,
+      bool implicitly_initialize,
+      bool coalesce_ranges);
+
+  /** Destructor. */
+  ~RangeSetAndSuperset() = default;
+
+  /**
+   * Access specified element.
+   *
+   * @param range_index Index of the range to access.
+   */
+  inline const Range& operator[](const uint64_t range_index) const {
+    return ranges_[range_index];
+  };
+
+  /**
+   * Adds a range to the range manager without performing any checkes.
+   *
+   * If the ranges are currently implicitly initialized, then they will be
+   * cleared before the new range is added.
+   *
+   * @param range The range to add.
+   */
+  Status add_range_unrestricted(const Range& range);
+
+  /** Returns a const reference to the stored ranges. */
+  inline const std::vector<Range>& ranges() const {
+    return ranges_;
+  };
+
+  /**
+   * Returns ``true`` if the current range is implicitly set to the full subset.
+   **/
+  inline bool is_implicitly_initialized() const {
+    return is_implicitly_initialized_;
+  };
+
+  /** Returns ``true`` if the range subset is the empty set. */
+  inline bool is_empty() const {
+    return ranges_.empty();
+  };
+
+  /**
+   * Returns ``false`` if the subset contains a range other than the default
+   * range.
+   *
+   * IMPORTANT: This method is different from the `is_set` method of the
+   * Subarray. The Subarray class only checks if any ranges are not default
+   * whereas this method considers the RangeSetAndSuperset to be unset if it is
+   * cleared.
+   **/
+  inline bool is_explicitly_initialized() const {
+    return !is_implicitly_initialized_ && !ranges_.empty();
+  };
+
+  /**
+   * Returns ``true`` if there is exactly one ranage with one element in the
+   * subset.
+   */
+  inline bool has_single_element() const {
+    return (ranges_.size() == 1) && ranges_[0].unary();
+  };
+
+  /** Returns the number of distinct ranges stored in the range manager. */
+  inline uint64_t num_ranges() const {
+    return ranges_.size();
+  };
+
+  /**
+   * Sorts the stored ranges.
+   *
+   * @param compute_tp The compute thread pool.
+   */
+  Status sort_ranges(ThreadPool* const compute_tp);
+
+ private:
+  tdb_shared_ptr<detail::RangeSetAndSupersetInternals> impl_ = nullptr;
+  /** Maximum possible range. */
+  Range superset_ = Range();
+
+  /**
+   * If ``true``, the range contains the full domain for the dimension (the
+   * default value for a subarray before any other values is set. Otherwise,
+   * some values has been explicitly set to the range.
+   */
+  bool is_implicitly_initialized_ = true;
+
+  /** Stored ranges. */
+  std::vector<Range> ranges_{};
+};
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -44,6 +44,7 @@
 #include "tiledb/sm/misc/tile_overlap.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/stats/stats.h"
+#include "tiledb/sm/subarray/range_subset.h"
 #include "tiledb/sm/subarray/subarray_tile_overlap.h"
 
 #include <cmath>
@@ -1046,12 +1047,16 @@ class Subarray {
    */
   Layout cell_order_;
 
-  /** Stores a vector of 1D ranges per dimension. */
-  std::vector<std::vector<Range>> ranges_;
+  /**
+   * Stores a vector of RangeSetAndSuperset objects, one per dimension, for
+   * handling operations on ranges.
+   */
+  std::vector<RangeSetAndSuperset> range_subset_;
 
   /**
-   * One value per dimension indicating whether the (single) range set in
-   * `ranges_` is the default range.
+   * Flag storing if each dimension is a default value or not.
+   *
+   * TODO: Remove this variable and store `is_default` directly with NDRange.
    */
   std::vector<bool> is_default_;
 
@@ -1080,16 +1085,6 @@ class Subarray {
    * ``True`` if ranges should attempt to be coalesced as they are added.
    */
   bool coalesce_ranges_;
-
-  /**
-   * Each element on the vector contains a template-bound variant of
-   * `add_or_coalesce_range()` for the respective dimension's data
-   * type. Dimensions with data types that we do not attempt to
-   * coalesce (e.g. floats and var-sized data types), this will be
-   * bound to `add_range_without_coalesce` as an optimization.
-   */
-  std::vector<std::function<void(Subarray*, uint32_t, const Range&)>>
-      add_or_coalesce_range_func_;
 
   /**
    * The tile coordinates that the subarray overlaps with. Note that
@@ -1253,30 +1248,6 @@ class Subarray {
    */
   Status load_relevant_fragment_tile_var_sizes(
       const std::vector<std::string>& names, ThreadPool* compute_tp) const;
-
-  /**
-   * Constructs `add_or_coalesce_range_func_` for all dimensions
-   * in `array_->array_schema_latest()`.
-   */
-  void set_add_or_coalesce_range_func();
-
-  /**
-   * Appends `range` onto `ranges_[dim_idx]` without attempting to
-   * coalesce `range` with any existing ranges.
-   */
-  void add_range_without_coalesce(uint32_t dim_idx, const Range& range);
-
-  /**
-   * Coalesces `range` with the last element on `ranges_[dim_idx]`
-   * if they are contiguous. Otherwise, `range` will be appended to
-   * `ranges_[dim_idx]`.
-   *
-   * @tparam T The range data type.
-   * @param dim_idx The dimension index into `ranges_`.
-   * @param range The range to add or coalesce.
-   */
-  template <class T>
-  void add_or_coalesce_range(uint32_t dim_idx, const Range& range);
 
   /**
    * Sort ranges for a particular dimension

--- a/tiledb/sm/subarray/test/CMakeLists.txt
+++ b/tiledb/sm/subarray/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+find_package(Catch_EP REQUIRED)
+
+add_executable(unit_range_subset EXCLUDE_FROM_ALL)
+target_link_libraries(unit_range_subset
+    PRIVATE range_subset
+    PUBLIC Catch2::Catch2
+)
+target_sources(unit_range_subset PUBLIC main.cc unit_range_subset.cc)
+
+add_test(
+    NAME "unit_range_subset"
+    COMMAND $<TARGET_FILE:unit_range_subset>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/tiledb/sm/subarray/test/compile_range_subset_main.cc
+++ b/tiledb/sm/subarray/test/compile_range_subset_main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file compile_range_subset_main.cc
+ *
+ * @section license
+ *
+ * the mit license
+ *
+ * @copyright copyright (c) 2022 tiledb, inc.
+ *
+ * permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "software"), to deal
+ * in the software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * the above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the software.
+ *
+ * the software is provided "as is", without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose and noninfringement. in no event shall the
+ * authors or copyright holders be liable for any claim, damages or other
+ * liability, whether in an action of contract, tort or otherwise, arising from,
+ * out of or in connection with the software or the use or other dealings in
+ * the software.
+ */
+
+#include "../range_subset.h"
+
+int main() {
+  (void)sizeof(tiledb::sm::RangeSubsetBase);
+  return 0;
+}

--- a/tiledb/sm/subarray/test/main.cc
+++ b/tiledb/sm/subarray/test/main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file tiledb/sm/subarray/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>

--- a/tiledb/sm/subarray/test/unit_range_subset.cc
+++ b/tiledb/sm/subarray/test/unit_range_subset.cc
@@ -1,0 +1,166 @@
+/**
+ * @file tiledb/sm/subarray/unit_range_subset.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines unit tests for the RangeSetAndSuperset classes.
+ */
+
+#include <catch.hpp>
+#include "../range_subset.h"
+#include "tiledb/common/thread_pool.h"
+#include "tiledb/sm/misc/types.h"
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+// TODO: Generalize for all types
+TEST_CASE("CreateDefaultRangeSetAndSuperset") {
+  uint64_t bounds[2] = {0, 10};
+  Range range{bounds, 2 * sizeof(uint64_t)};
+  RangeSetAndSuperset range_subset{Datatype::UINT64, range, true, false};
+  CHECK(range_subset.num_ranges() == 1);
+  Range default_range = range_subset[0];
+  CHECK(!default_range.empty());
+  const uint64_t* start = (uint64_t*)default_range.start();
+  const uint64_t* end = (uint64_t*)default_range.end();
+  CHECK(*start == 0);
+  CHECK(*end == 10);
+}
+
+// TODO: Generalize for all coalescing types
+TEST_CASE("RangeSetAndSuperset::RangeSetAndSuperset") {
+  uint64_t bounds[2] = {0, 10};
+  Range range{bounds, 2 * sizeof(uint64_t)};
+  RangeSetAndSuperset range_subset{Datatype::UINT64, range, false, true};
+  CHECK(range_subset.num_ranges() == 0);
+  SECTION("Add 2 Overlapping Ranges") {
+    uint64_t data1[2] = {1, 3};
+    uint64_t data2[2] = {4, 5};
+    Range r1{data1, 2 * sizeof(uint64_t)};
+    Range r2{data2, 2 * sizeof(uint64_t)};
+    range_subset.add_range_unrestricted(r1);
+    range_subset.add_range_unrestricted(r2);
+    CHECK(range_subset.num_ranges() == 1);
+    auto combined_range = range_subset[0];
+    const uint64_t* start = (uint64_t*)combined_range.start();
+    const uint64_t* end = (uint64_t*)combined_range.end();
+    CHECK(*start == 1);
+    CHECK(*end == 5);
+  }
+}
+
+// TODO: Generalize for all non-coalescing types
+TEST_CASE("RangeSetAndSuperset::add_range - coalesce float") {
+  float bounds[2] = {-1.0, 1.0};
+  Range range{bounds, 2 * sizeof(float)};
+  RangeSetAndSuperset range_subset{Datatype::FLOAT32, range, false, true};
+  CHECK(range_subset.num_ranges() == 0);
+  SECTION("Add 2 Overlapping Ranges") {
+    float data1[2] = {-0.5, 0.5};
+    float data2[2] = {0.5, 0.75};
+    Range r1{data1, 2 * sizeof(float)};
+    Range r2{data2, 2 * sizeof(float)};
+    range_subset.add_range_unrestricted(r1);
+    range_subset.add_range_unrestricted(r2);
+    CHECK(range_subset.num_ranges() == 2);
+  }
+}
+
+// TODO: Generatize for all numeric sortable types.
+TEST_CASE(
+    "RangeSetAndSuperset: Test numeric sort", "[range-manager][threadpool]") {
+  uint64_t bounds[2] = {0, 10};
+  Range range{bounds, 2 * sizeof(uint64_t)};
+  RangeSetAndSuperset range_subset{Datatype::UINT64, range, false, true};
+  SECTION("Sort 2 reverse ordered ranges") {
+    // Add ranges.
+    uint64_t data1[2] = {4, 5};
+    uint64_t data2[2] = {1, 2};
+    Range r1{data1, 2 * sizeof(uint64_t)};
+    Range r2{data2, 2 * sizeof(uint64_t)};
+    range_subset.add_range_unrestricted(r1);
+    range_subset.add_range_unrestricted(r2);
+    CHECK(range_subset.num_ranges() == 2);
+    // Create ThreadPool.
+    ThreadPool pool;
+    REQUIRE(pool.init(2).ok());
+    //  Sort ranges.
+    auto sort_status = range_subset.sort_ranges(&pool);
+    CHECK(sort_status.ok());
+    // Check the numner of ranges.
+    CHECK(range_subset.num_ranges() == 2);
+    // Check the first range.
+    auto result_range = range_subset[0];
+    const uint64_t* start = (uint64_t*)result_range.start();
+    const uint64_t* end = (uint64_t*)result_range.end();
+    CHECK(*start == 1);
+    CHECK(*end == 2);
+    // Check the second range.
+    result_range = range_subset[1];
+    start = (uint64_t*)result_range.start();
+    end = (uint64_t*)result_range.end();
+    CHECK(*start == 4);
+    CHECK(*end == 5);
+  }
+}
+
+TEST_CASE("RangeSetAndSuperset::sort - STRING_ASCII") {
+  Range range{};
+  RangeSetAndSuperset range_subset{Datatype::STRING_ASCII, range, false, false};
+  SECTION("Sort 2 reverse ordered non-overlapping ranges") {
+    // Set ranges.
+    const std::string d1{"cat"};
+    const std::string d2{"dog"};
+    const std::string d3{"ax"};
+    const std::string d4{"bird"};
+    Range r1{};
+    r1.set_str_range(d1, d2);
+    range_subset.add_range_unrestricted(r1);
+    Range r2{};
+    r2.set_str_range(d3, d4);
+    range_subset.add_range_unrestricted(r2);
+    CHECK(range_subset.num_ranges() == 2);
+    // Create ThreadPool.
+    ThreadPool pool;
+    REQUIRE(pool.init(2).ok());
+    // Sort ranges.
+    auto sort_status = range_subset.sort_ranges(&pool);
+    CHECK(sort_status.ok());
+    // Check the number of ranges.
+    CHECK(range_subset.num_ranges() == 2);
+    // Check the first range.
+    auto result_range = range_subset[0];
+    auto start = result_range.start_str();
+    auto end = result_range.end_str();
+    CHECK(start == d3);
+    CHECK(end == d4);
+    // Check the second range.
+    result_range = range_subset[1];
+  }
+}


### PR DESCRIPTION
This is an internal refactor that adds in a single place to manage all range data/operations for the subarray. It will help with removing unnecessary dependencies on the Dimension class, which in turn will make handling DimensionLabels in subarrays much easier.

Since this was a pretty big change in and of itself, the goal for this PR is mainly just to do the first big refactor. Future smaller PRs will remove the Dimension dependencies.

---
TYPE: NO_HISTORY
DESC:
