### PR TITLE
[CI] Fix sc-14860, gcs emulator failure, by pinning python itsdangerous pkg

### DIFF
--- a/scripts/install-gcs-emu.sh
+++ b/scripts/install-gcs-emu.sh
@@ -42,6 +42,7 @@ install_gcs(){
     #patch git+git:// ==> git+https://
     #sed -i fails on GA CI macos...
     sed 's/git+git:/git+https:/' /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt > /tmp/tdbpatchedrequirements.txt
+    echo 'itsdangerous==2.0.1' >> /tmp/tdbpatchedrequirements.txt
     cp -f /tmp/tdbpatchedrequirements.txt /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt
     pip3 install -r /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt
 }

--- a/scripts/run-gcs-emu.sh
+++ b/scripts/run-gcs-emu.sh
@@ -27,7 +27,7 @@
 # Starts a GCS Emulator Server and exports credentials to the environment
 # ('source' this script instead of executing).
 # This script should be sourced from tiledb/build folder
-
+set -xe
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
GCS CI jobs are currently failing because the emulator does not start, due to upstream changes to a python dependency which lead to an import failure.

- fix GCS emulator by pinning the `itsdangerous` package
- add `set -xe` to the `run-gcs-emu.sh` script
---
TYPE: NO_HISTORY