### PR TITLE
Eliminate LOG_FATAL use from codebase

### DIFF
--- a/tiledb/common/logger.cc
+++ b/tiledb/common/logger.cc
@@ -316,12 +316,6 @@ Status LOG_STATUS(const Status& st) {
   return st;
 }
 
-/** Logs an error and exits with a non-zero status. */
-void LOG_FATAL(const std::string& msg) {
-  global_logger().error(msg);
-  exit(1);
-}
-
 /** Logs a trace. */
 void LOG_TRACE(const std::stringstream& msg) {
   global_logger().trace(msg);
@@ -345,12 +339,6 @@ void LOG_WARN(const std::stringstream& msg) {
 /** Logs an error. */
 void LOG_ERROR(const std::stringstream& msg) {
   global_logger().error(msg);
-}
-
-/** Logs an error and exits with a non-zero status. */
-void LOG_FATAL(const std::stringstream& msg) {
-  global_logger().error(msg);
-  exit(1);
 }
 
 }  // namespace tiledb::common

--- a/tiledb/common/logger_public.h
+++ b/tiledb/common/logger_public.h
@@ -61,9 +61,6 @@ void LOG_ERROR(const std::string& msg);
 /** Logs a status. */
 Status LOG_STATUS(const Status& st);
 
-/** Logs an error and exits with a non-zero status. */
-void LOG_FATAL(const std::string& msg);
-
 /** Logs trace. */
 void LOG_TRACE(const std::stringstream& msg);
 
@@ -79,9 +76,6 @@ void LOG_WARN(const std::stringstream& msg);
 /** Logs an error. */
 void LOG_ERROR(const std::stringstream& msg);
 
-/** Logs an error and exits with a non-zero status. */
-void LOG_FATAL(const std::stringstream& msg);
-
 }  // namespace common
 
 /*
@@ -89,7 +83,6 @@ void LOG_FATAL(const std::stringstream& msg);
  */
 using common::LOG_DEBUG;
 using common::LOG_ERROR;
-using common::LOG_FATAL;
 using common::LOG_INFO;
 using common::LOG_STATUS;
 using common::LOG_TRACE;

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -980,11 +980,9 @@ tuple<Status, optional<std::string>> FragmentMetadata::encode_name(
 
   assert(version_ > 8);
   const auto iter = idx_map_.find(name);
-  if (iter == idx_map_.end()) {
-    auto err = "Name " + name + " not in idx_map_";
-    LOG_ERROR(err);
-    return {Status_FragmentMetadataError(err), std::nullopt};
-  }
+  if (iter == idx_map_.end())
+    return {Status_FragmentMetadataError("Name " + name + " not in idx_map_"),
+            std::nullopt};
 
   const unsigned idx = iter->second;
 
@@ -1010,7 +1008,6 @@ tuple<Status, optional<std::string>> FragmentMetadata::encode_name(
   }
 
   auto err = "Unable to locate dimension/attribute " + name;
-  LOG_ERROR(err);
   return {Status_FragmentMetadataError(err), std::nullopt};
 }
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -933,9 +933,10 @@ uint64_t FragmentMetadata::tile_num() const {
   return sparse_tile_num_;
 }
 
-std::string FragmentMetadata::encode_name(const std::string& name) const {
+tuple<Status, optional<std::string>> FragmentMetadata::encode_name(
+    const std::string& name) const {
   if (version_ <= 7)
-    return name;
+    return {Status::Ok(), name};
 
   if (version_ == 8) {
     static const std::unordered_map<char, std::string> percent_encoding{
@@ -974,13 +975,17 @@ std::string FragmentMetadata::encode_name(const std::string& name) const {
         percent_encoded_name << percent_encoding.at(c);
     }
 
-    return percent_encoded_name.str();
+    return {Status::Ok(), percent_encoded_name.str()};
   }
 
   assert(version_ > 8);
   const auto iter = idx_map_.find(name);
-  if (iter == idx_map_.end())
-    LOG_FATAL("Name " + name + " not in idx_map_");
+  if (iter == idx_map_.end()) {
+    auto err = "Name " + name + " not in idx_map_";
+    LOG_ERROR(err);
+    return {Status_FragmentMetadataError(err), std::nullopt};
+  }
+
   const unsigned idx = iter->second;
 
   const std::vector<tiledb::sm::Attribute*> attributes =
@@ -988,7 +993,7 @@ std::string FragmentMetadata::encode_name(const std::string& name) const {
   for (unsigned i = 0; i < attributes.size(); ++i) {
     const std::string attr_name = attributes[i]->name();
     if (attr_name == name) {
-      return "a" + std::to_string(idx);
+      return {Status::Ok(), "a" + std::to_string(idx)};
     }
   }
 
@@ -996,30 +1001,48 @@ std::string FragmentMetadata::encode_name(const std::string& name) const {
     const std::string dim_name = array_schema_->dimension(i)->name();
     if (dim_name == name) {
       const unsigned dim_idx = idx - array_schema_->attribute_num() - 1;
-      return "d" + std::to_string(dim_idx);
+      return {Status::Ok(), "d" + std::to_string(dim_idx)};
     }
   }
 
   if (name == constants::coords) {
-    return name;
+    return {Status::Ok(), name};
   }
 
-  LOG_FATAL("Unable to locate dimension/attribute " + name);
-  return "";
+  auto err = "Unable to locate dimension/attribute " + name;
+  LOG_ERROR(err);
+  return {Status_FragmentMetadataError(err), std::nullopt};
 }
 
-URI FragmentMetadata::uri(const std::string& name) const {
-  return fragment_uri_.join_path(encode_name(name) + constants::file_suffix);
+tuple<Status, optional<URI>> FragmentMetadata::uri(
+    const std::string& name) const {
+  auto&& [st, encoded_name] = encode_name(name);
+  if (!st.ok())
+    return {st, std::nullopt};
+
+  return {st, fragment_uri_.join_path(*encoded_name + constants::file_suffix)};
 }
 
-URI FragmentMetadata::var_uri(const std::string& name) const {
-  return fragment_uri_.join_path(
-      encode_name(name) + "_var" + constants::file_suffix);
+tuple<Status, optional<URI>> FragmentMetadata::var_uri(
+    const std::string& name) const {
+  auto&& [st, encoded_name] = encode_name(name);
+  if (!st.ok())
+    return {st, std::nullopt};
+
+  return {
+      st,
+      fragment_uri_.join_path(*encoded_name + "_var" + constants::file_suffix)};
 }
 
-URI FragmentMetadata::validity_uri(const std::string& name) const {
-  return fragment_uri_.join_path(
-      encode_name(name) + "_validity" + constants::file_suffix);
+tuple<Status, optional<URI>> FragmentMetadata::validity_uri(
+    const std::string& name) const {
+  auto&& [st, encoded_name] = encode_name(name);
+  if (!st.ok())
+    return {st, std::nullopt};
+
+  return {st,
+          fragment_uri_.join_path(
+              *encoded_name + "_validity" + constants::file_suffix)};
 }
 
 const std::string& FragmentMetadata::array_schema_name() {

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -481,13 +481,13 @@ class FragmentMetadata {
   uint64_t tile_num() const;
 
   /** Returns the URI of the input attribute/dimension. */
-  URI uri(const std::string& name) const;
+  tuple<Status, optional<URI>> uri(const std::string& name) const;
 
   /** Returns the URI of the input variable-sized attribute/dimension. */
-  URI var_uri(const std::string& name) const;
+  tuple<Status, optional<URI>> var_uri(const std::string& name) const;
 
   /** Returns the validity URI of the input nullable attribute. */
-  URI validity_uri(const std::string& name) const;
+  tuple<Status, optional<URI>> validity_uri(const std::string& name) const;
 
   /** Return the array schema name. */
   const std::string& array_schema_name();
@@ -1484,9 +1484,10 @@ class FragmentMetadata {
    * motiviation is to encode illegal/reserved file name characters.
    *
    * @param name The dimension/attribute name.
-   * return std::string The encoded dimension/attribute name.
+   * return Status, the encoded dimension/attribute name.
    */
-  std::string encode_name(const std::string& name) const;
+  tuple<Status, optional<std::string>> encode_name(
+      const std::string& name) const;
 
   /**
    * This builds the index mapping for attribute/dimension name to id.

--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -138,8 +138,11 @@ class Range {
 
   /** Copies 'start' into this range's start bytes for fixed-size ranges. */
   void set_start(const void* const start) {
-    if (var_size_)
-      LOG_FATAL("Unexpected var-sized range; cannot set end range.");
+    if (var_size_) {
+      LOG_ERROR("Unexpected var-sized range; cannot set start range.");
+      return;
+    }
+
     const size_t fixed_size = range_.size() / 2;
     std::memcpy(range_.data(), start, fixed_size);
   }
@@ -180,8 +183,10 @@ class Range {
 
   /** Copies 'end' into this range's end bytes for fixed-size ranges. */
   void set_end(const void* const end) {
-    if (var_size_)
-      LOG_FATAL("Unexpected var-sized range; cannot set end range.");
+    if (var_size_) {
+      LOG_ERROR("Unexpected var-sized range; cannot set end range.");
+      return;
+    }
     const size_t fixed_size = range_.size() / 2;
     std::memcpy(&range_[fixed_size], end, fixed_size);
   }

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -485,7 +485,9 @@ Status ReaderBase::read_tiles(
       }
 
       // Get information about the tile in its fragment
-      auto tile_attr_uri = fragment->uri(name);
+      auto&& [status, tile_attr_uri] = fragment->uri(name);
+      RETURN_NOT_OK(status);
+
       auto tile_idx = tile->tile_idx();
       uint64_t tile_attr_offset;
       RETURN_NOT_OK(fragment->file_offset(name, tile_idx, &tile_attr_offset));
@@ -498,7 +500,7 @@ Status ReaderBase::read_tiles(
       bool cache_hit = false;
       if (!disable_cache) {
         RETURN_NOT_OK(storage_manager_->read_from_cache(
-            tile_attr_uri,
+            *tile_attr_uri,
             tile_attr_offset,
             t->filtered_buffer(),
             *tile_persisted_size,
@@ -507,7 +509,7 @@ Status ReaderBase::read_tiles(
 
       if (!cache_hit) {
         // Add the region of the fragment to be read.
-        all_regions[tile_attr_uri].emplace_back(
+        all_regions[*tile_attr_uri].emplace_back(
             tile_attr_offset, t, *tile_persisted_size);
 
         t->filtered_buffer().expand(*tile_persisted_size);
@@ -517,7 +519,9 @@ Status ReaderBase::read_tiles(
       RETURN_NOT_OK(t->alloc_data(tile_size));
 
       if (var_size) {
-        auto tile_attr_var_uri = fragment->var_uri(name);
+        auto&& [status, tile_attr_var_uri] = fragment->var_uri(name);
+        RETURN_NOT_OK(status);
+
         uint64_t tile_attr_var_offset;
         RETURN_NOT_OK(
             fragment->file_var_offset(name, tile_idx, &tile_attr_var_offset));
@@ -529,7 +533,7 @@ Status ReaderBase::read_tiles(
 
         if (!disable_cache) {
           RETURN_NOT_OK(storage_manager_->read_from_cache(
-              tile_attr_var_uri,
+              *tile_attr_var_uri,
               tile_attr_var_offset,
               t_var->filtered_buffer(),
               *tile_var_persisted_size,
@@ -538,7 +542,7 @@ Status ReaderBase::read_tiles(
 
         if (!cache_hit) {
           // Add the region of the fragment to be read.
-          all_regions[tile_attr_var_uri].emplace_back(
+          all_regions[*tile_attr_var_uri].emplace_back(
               tile_attr_var_offset, t_var, *tile_var_persisted_size);
 
           t_var->filtered_buffer().expand(*tile_var_persisted_size);
@@ -549,7 +553,9 @@ Status ReaderBase::read_tiles(
       }
 
       if (nullable) {
-        auto tile_validity_attr_uri = fragment->validity_uri(name);
+        auto&& [status, tile_validity_attr_uri] = fragment->validity_uri(name);
+        RETURN_NOT_OK(status);
+
         uint64_t tile_attr_validity_offset;
         RETURN_NOT_OK(fragment->file_validity_offset(
             name, tile_idx, &tile_attr_validity_offset));
@@ -561,7 +567,7 @@ Status ReaderBase::read_tiles(
 
         if (!disable_cache) {
           RETURN_NOT_OK(storage_manager_->read_from_cache(
-              tile_validity_attr_uri,
+              *tile_validity_attr_uri,
               tile_attr_validity_offset,
               t_validity->filtered_buffer(),
               *tile_validity_persisted_size,
@@ -570,7 +576,7 @@ Status ReaderBase::read_tiles(
 
         if (!cache_hit) {
           // Add the region of the fragment to be read.
-          all_regions[tile_validity_attr_uri].emplace_back(
+          all_regions[*tile_validity_attr_uri].emplace_back(
               tile_attr_validity_offset,
               t_validity,
               *tile_validity_persisted_size);
@@ -1210,7 +1216,9 @@ Status ReaderBase::unfilter_tiles(
 
           logger_->info("using cache");
           // Get information about the tile in its fragment.
-          auto tile_attr_uri = fragment->uri(name);
+          auto&& [status, tile_attr_uri] = fragment->uri(name);
+          RETURN_NOT_OK(status);
+
           auto tile_idx = tile->tile_idx();
           uint64_t tile_attr_offset;
           RETURN_NOT_OK(
@@ -1220,33 +1228,38 @@ Status ReaderBase::unfilter_tiles(
           if (t.filtered()) {
             // Store the filtered buffer in the tile cache.
             RETURN_NOT_OK(storage_manager_->write_to_cache(
-                tile_attr_uri, tile_attr_offset, t.filtered_buffer()));
+                *tile_attr_uri, tile_attr_offset, t.filtered_buffer()));
           }
 
           // Cache 't_var'.
           if (var_size && t_var.filtered()) {
-            auto tile_attr_var_uri = fragment->var_uri(name);
+            auto&& [status, tile_attr_var_uri] = fragment->var_uri(name);
+            RETURN_NOT_OK(status);
+
             uint64_t tile_attr_var_offset;
             RETURN_NOT_OK(fragment->file_var_offset(
                 name, tile_idx, &tile_attr_var_offset));
 
             // Store the filtered buffer in the tile cache.
             RETURN_NOT_OK(storage_manager_->write_to_cache(
-                tile_attr_var_uri,
+                *tile_attr_var_uri,
                 tile_attr_var_offset,
                 t_var.filtered_buffer()));
           }
 
           // Cache 't_validity'.
           if (nullable && t_validity.filtered()) {
-            auto tile_attr_validity_uri = fragment->validity_uri(name);
+            auto&& [status, tile_attr_validity_uri] =
+                fragment->validity_uri(name);
+            RETURN_NOT_OK(status);
+
             uint64_t tile_attr_validity_offset;
             RETURN_NOT_OK(fragment->file_validity_offset(
                 name, tile_idx, &tile_attr_validity_offset));
 
             // Store the filtered buffer in the tile cache.
             RETURN_NOT_OK(storage_manager_->write_to_cache(
-                tile_attr_validity_uri,
+                *tile_attr_validity_uri,
                 tile_attr_validity_offset,
                 t_validity.filtered_buffer()));
           }

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -42,6 +42,7 @@
 #endif
 // clang-format on
 
+#include "tiledb/sm/query/query.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
@@ -55,9 +56,8 @@
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/hash.h"
 #include "tiledb/sm/misc/parse_argument.h"
-#include "tiledb/sm/query/query.h"
-#include "tiledb/sm/query/reader.h"
 #include "tiledb/sm/query/dense_reader.h"
+#include "tiledb/sm/query/reader.h"
 #include "tiledb/sm/query/sparse_global_order_reader.h"
 #include "tiledb/sm/query/sparse_unordered_with_dups_reader.h"
 #include "tiledb/sm/query/writer_base.h"
@@ -2035,7 +2035,8 @@ Status query_deserialize(
         query,
         compute_tp);
     if (!st2.ok()) {
-      LOG_FATAL(st2.message());
+      LOG_ERROR(st2.message());
+      return st2;
     }
   }
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1965,7 +1965,7 @@ void Subarray::set_add_or_coalesce_range_func() {
             std::placeholders::_3);
         break;
       default:
-        LOG_FATAL("Unexpected datatype " + datatype_str(type));
+        LOG_ERROR("Unexpected datatype " + datatype_str(type));
     }
   }
 }


### PR DESCRIPTION
Removed all uses of `LOG_FATAL` from the codebase and propagated
correct error handling up the call stack.
Removed `LOG_FATAL` API altogether as it became dead code waiting to be used in the future.

---
TYPE: FEATURE
DESC: Eliminate LOG_FATAL use from codebase
