### PR TITLE
Add new API for tiledb_ctx_alloc_with_error

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -111,6 +111,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-capi-attributes.cc
   src/unit-capi-buffer.cc
   src/unit-capi-config.cc
+  src/unit-capi-context.cc
   src/unit-capi-consolidation.cc
   src/unit-capi-dense_array.cc
   src/unit-capi-dense_array_2.cc

--- a/test/src/unit-capi-context.cc
+++ b/test/src/unit-capi-context.cc
@@ -1,0 +1,68 @@
+/**
+ * @file   unit-capi-context.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C API context object.
+ */
+
+#include "catch.hpp"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
+
+TEST_CASE("C API: Test context", "[capi][context]") {
+  tiledb_config_t* config = nullptr;
+  tiledb_error_t* error = nullptr;
+  int rc = tiledb_config_alloc(&config, &error);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+
+  rc = tiledb_config_set(config, "sm.compute_concurrency_level", "0", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  tiledb_ctx_t* ctx;
+  rc = tiledb_ctx_alloc(config, &ctx);
+  CHECK(rc == TILEDB_ERR);
+  tiledb_ctx_free(&ctx);
+  CHECK(ctx == nullptr);
+
+  rc = tiledb_ctx_alloc_with_error(config, &ctx, &error);
+  CHECK(rc == TILEDB_ERR);
+  tiledb_ctx_free(&ctx);
+  CHECK(ctx == nullptr);
+
+  const char* err_msg;
+  rc = tiledb_error_message(error, &err_msg);
+  CHECK(rc == TILEDB_OK);
+  CHECK(
+      std::string(err_msg) ==
+      "[TileDB::ThreadPool] Error: Unable to initialize a thread pool with a "
+      "concurrency level of 0.");
+
+  tiledb_error_free(&error);
+  tiledb_config_free(&config);
+}

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1207,6 +1207,61 @@ int32_t tiledb_ctx_alloc(tiledb_config_t* config, tiledb_ctx_t** ctx) try {
   return TILEDB_ERR;
 }
 
+int32_t tiledb_ctx_alloc_with_error(
+    tiledb_config_t* config, tiledb_ctx_t** ctx, tiledb_error_t** error) try {
+  if (config != nullptr && config->config_ == nullptr)
+    return TILEDB_ERR;
+
+  // Create a context object
+  *ctx = new (std::nothrow) tiledb_ctx_t;
+  if (*ctx == nullptr)
+    return TILEDB_OOM;
+
+  // Create a context object
+  (*ctx)->ctx_ = new (std::nothrow) tiledb::sm::Context();
+  if ((*ctx)->ctx_ == nullptr) {
+    delete (*ctx);
+    (*ctx) = nullptr;
+    return TILEDB_OOM;
+  }
+
+  // Initialize the context
+  auto conf =
+      (config == nullptr) ? (tiledb::sm::Config*)nullptr : config->config_;
+  auto st = (*ctx)->ctx_->init(conf);
+
+  if (!st.ok()) {
+    delete (*ctx)->ctx_;
+    delete (*ctx);
+    (*ctx) = nullptr;
+    LOG_STATUS(st);
+    create_error(error, st);
+    return TILEDB_ERR;
+  }
+
+  // Success
+  return TILEDB_OK;
+} catch (const std::bad_alloc& e) {
+  delete (*ctx)->ctx_;
+  delete (*ctx);
+  (*ctx) = nullptr;
+  auto st = Status_Error(
+      std::string("Internal TileDB uncaught std::bad_alloc exception; ") +
+      e.what());
+  LOG_STATUS(st);
+  create_error(error, st);
+  return TILEDB_OOM;
+} catch (const std::exception& e) {
+  delete (*ctx)->ctx_;
+  delete (*ctx);
+  (*ctx) = nullptr;
+  auto st = Status_Error(
+      std::string("Internal TileDB uncaught exception; ") + e.what());
+  LOG_STATUS(st);
+  create_error(error, st);
+  return TILEDB_ERR;
+}
+
 void tiledb_ctx_free(tiledb_ctx_t** ctx) {
   if (ctx != nullptr && *ctx != nullptr) {
     delete (*ctx)->ctx_;

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -295,6 +295,45 @@ TILEDB_EXPORT int32_t tiledb_query_get_status_details(
     tiledb_query_t* query,
     tiledb_query_status_details_t* status);
 
+/* ********************************* */
+/*              CONTEXT              */
+/* ********************************* */
+
+/**
+ * Creates a TileDB context, which contains the TileDB storage manager
+ * that manages everything in the TileDB library. This is a provisional API
+ * which returns an error object when the context creation fails. This API will
+ * be replaced with a more proper "v2" of context alloc in the near future. The
+ * main goal is to use to this to capture potential failures to inform the v2
+ * alloc design.
+ *
+ * **Examples:**
+ *
+ * Without config (i.e., use default configuration):
+ *
+ * @code{.c}
+ * tiledb_ctx_t* ctx;
+ * tiledb_error_t* error;
+ * tiledb_ctx_alloc_with_error(NULL, &ctx, &error);
+ * @endcode
+ *
+ * With some config:
+ *
+ * @code{.c}
+ * tiledb_ctx_t* ctx;
+ * tiledb_error_t* error;
+ * tiledb_ctx_alloc_with_error(config, &ctx, &error);
+ * @endcode
+ *
+ * @param[in] config The configuration parameters (`NULL` means default).
+ * @param[out] ctx The TileDB context to be created.
+ * @param[out] error Error object returned upon error (`NULL` if there is
+ *     no error).
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_ctx_alloc_with_error(
+    tiledb_config_t* config, tiledb_ctx_t** ctx, tiledb_error_t** error);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This API provides the ability to return an error object when allocating or init'ing the context fails. This is being introduced as an
experimental API in order to ship it to end users and test if this provides enough information to users when a context initialization fails. Its likely we want richer information but at minimal returning the error object that exists today will start to provide light on the resource contentions that can cause context alloc to fail.

---

TYPE: C_API
DESC: Introduce experimental `tiledb_ctx_alloc_with_error` to return error when context alloc fails