### PR TITLE
Add option for tile level filtering 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ if (TILEDB_TESTS)
   add_custom_target(tests)
   add_dependencies(tests tiledb_unit)
   add_dependencies(tests unit_interval unit_datum unit_dynamic_memory unit_thread_pool)
-  add_dependencies(tests unit_filter_create unit_array_schema)
+  add_dependencies(tests unit_filter unit_array_schema)
   add_dependencies(tests unit_compressors)
 endif()
 

--- a/tiledb/sm/array_schema/test/unit_dimension.cc
+++ b/tiledb/sm/array_schema/test/unit_dimension.cc
@@ -27,7 +27,7 @@
  *
  * @section DESCRIPTION
  *
- * This file defines a test `main()`
+ * This file tests the Dimension class
  */
 
 #include <catch.hpp>

--- a/tiledb/sm/filter/CMakeLists.txt
+++ b/tiledb/sm/filter/CMakeLists.txt
@@ -182,24 +182,24 @@ add_executable(compile_filter_pipeline EXCLUDE_FROM_ALL)
 target_link_libraries(compile_filter_pipeline PRIVATE filter_pipeline)
 target_sources(compile_filter_pipeline PRIVATE test/compile_filter_pipeline_main.cc)
 
- 
 
 
 if (TILEDB_TESTS)
-    add_executable(unit_filter_create EXCLUDE_FROM_ALL)
-    target_link_libraries(unit_filter_create PUBLIC all_filters)
+    add_executable(unit_filter EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_filter PUBLIC filter_pipeline)
     find_package(Catch_EP REQUIRED)
-    target_link_libraries(unit_filter_create PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_filter PUBLIC Catch2::Catch2)
 
     # Sources for tests
-    target_sources(unit_filter_create PUBLIC
+    target_sources(unit_filter PUBLIC
             test/main.cc
             test/unit_filter_create.cc
+            test/unit_filter_pipeline.cc
             )
 
     add_test(
-            NAME "unit_filter_create"
-            COMMAND $<TARGET_FILE:unit_filter_create>
+            NAME "unit_filter"
+            COMMAND $<TARGET_FILE:unit_filter>
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()

--- a/tiledb/sm/filter/bit_width_reduction_filter.h
+++ b/tiledb/sm/filter/bit_width_reduction_filter.h
@@ -1,5 +1,5 @@
 /**
- * @file   reduce_type_width_filter.h
+ * @file   bit_width_reduction_filter.h
  *
  * @section LICENSE
  *

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -39,6 +39,8 @@
 
 #include "tiledb/common/status.h"
 #include "tiledb/common/thread_pool.h"
+#include "tiledb/sm/enums/compressor.h"
+#include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/filter/filter.h"
 #include "tiledb/sm/filter/filter_buffer.h"
 #include "tiledb/sm/misc/types.h"
@@ -126,6 +128,14 @@ class FilterPipeline {
   }
 
   /**
+   * Checks if a certain filter exists in the filter pipeline
+   *
+   * @param filter The filter to search for
+   * @return True if found, false otherwise
+   */
+  bool has_filter(const Filter& filter) const;
+
+  /**
    * Returns a pointer to the filter in the pipeline at the given index.
    *
    * @param index Index of filter
@@ -175,13 +185,16 @@ class FilterPipeline {
    * @param tile Tile to filter.
    * @param offsets_tile Offets tile for tile to filter.
    * @param compute_tp The thread pool for compute-bound tasks.
+   * @param chunking True if the tile should be cut into chunks before
+   * filtering, false if not.
    * @return Status
    */
   Status run_forward(
       stats::Stats* writer_stats,
       Tile* tile,
       Tile* offsets_tile,
-      ThreadPool* compute_tp) const;
+      ThreadPool* compute_tp,
+      bool chunking = true) const;
 
   /**
    * Runs the pipeline in reverse on the given filtered tile. This is used
@@ -277,6 +290,18 @@ class FilterPipeline {
   static Status append_encryption_filter(
       FilterPipeline* pipeline, const EncryptionKey& encryption_key);
 
+  /**
+   * Checks if an attribute/dimension needs to be filtered in chunks or as a
+   * whole
+   *
+   * @param is_dim True if checking for dimension, false if attribute
+   * @param is_var True if checking for a var-sized attribute/dimension, false
+   * if not
+   * @param type Datatype of the input attribute/dimension
+   * @return True if chunking needs to be used, false if not
+   */
+  bool use_tile_chunking(bool is_dim, bool is_var, const Datatype type) const;
+
  private:
   /** A pair of FilterBuffers. */
   typedef std::pair<FilterBuffer, FilterBuffer> FilterBufferPair;
@@ -299,10 +324,15 @@ class FilterPipeline {
    * @param chunk_size Target chunk size.
    * @param tile Var tile.
    * @param offsets_tile Offsets tile.
+   * @param chunking True if the tile is filtered in chunks
    * @return Status, chunk offsets vector.
    */
-  tuple<Status, optional<std::vector<uint64_t>>> get_var_chunk_sizes(
-      uint32_t chunk_size, Tile* const tile, Tile* const offsets_tile) const;
+
+  tuple<Status, std::optional<std::vector<uint64_t>>> get_var_chunk_sizes(
+      uint32_t chunk_size,
+      Tile* const tile,
+      Tile* const offsets_tile,
+      bool chunking) const;
 
   /**
    * Run the given buffer forward through the pipeline.

--- a/tiledb/sm/filter/test/unit_filter_create.cc
+++ b/tiledb/sm/filter/test/unit_filter_create.cc
@@ -26,6 +26,9 @@
  * THE SOFTWARE.
  *
  * @section DESCRIPTION
+ *
+ * This file tests FilterCreate class
+ *
  */
 
 #include <catch.hpp>

--- a/tiledb/sm/filter/test/unit_filter_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_filter_pipeline.cc
@@ -1,0 +1,106 @@
+/**
+ * @file tiledb/sm/filter/test/unit_filter_pipeline.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file tests FilterPipeline class
+ *
+ */
+
+#include <catch.hpp>
+
+#include "tiledb/sm/enums/compressor.h"
+#include "tiledb/sm/enums/datatype.h"
+
+#include "../bit_width_reduction_filter.h"
+#include "../bitshuffle_filter.h"
+#include "../compression_filter.h"
+#include "../filter_pipeline.h"
+
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "FilterPipeline: Test if filter list has a filter", "[filter-pipeline]") {
+  FilterPipeline fp;
+  fp.add_filter(CompressionFilter(Compressor::ZSTD, 2));
+  fp.add_filter(BitWidthReductionFilter());
+  fp.add_filter(CompressionFilter(Compressor::RLE, 1));
+  fp.add_filter(CompressionFilter(Compressor::LZ4, 1));
+
+  // Check that filters are searched correctly
+  CHECK(fp.has_filter(CompressionFilter(Compressor::RLE, 0)));
+  CHECK(fp.has_filter(BitWidthReductionFilter()));
+  CHECK_FALSE(fp.has_filter(CompressionFilter(Compressor::GZIP, 0)));
+  CHECK_FALSE(fp.has_filter(BitshuffleFilter()));
+
+  // Check no error when pipeline empty
+  FilterPipeline fp2;
+  CHECK_FALSE(fp2.has_filter(CompressionFilter(Compressor::RLE, 0)));
+}
+
+TEST_CASE(
+    "FilterPipeline: Test if tile chunking should occur in filtering",
+    "[filter-pipeline]") {
+  // pipeline that contains an RLE compressor
+  FilterPipeline fp_with_rle;
+  fp_with_rle.add_filter(CompressionFilter(Compressor::ZSTD, 2));
+  fp_with_rle.add_filter(BitWidthReductionFilter());
+  fp_with_rle.add_filter(CompressionFilter(Compressor::RLE, 1));
+
+  // pipeline that doesn't contain an RLE compressor
+  FilterPipeline fp_without_rle;
+  fp_without_rle.add_filter(CompressionFilter(Compressor::ZSTD, 2));
+  fp_without_rle.add_filter(BitWidthReductionFilter());
+
+  bool is_dimension = true;
+  bool is_var_sized = true;
+
+  // Do not chunk the Tile for filtering if RLE is used for var-sized string
+  // dimensions
+  CHECK_FALSE(fp_with_rle.use_tile_chunking(
+      is_dimension, is_var_sized, Datatype::STRING_ASCII));
+
+  // Chunk in any other case
+  CHECK(fp_without_rle.use_tile_chunking(
+      is_dimension, is_var_sized, Datatype::STRING_ASCII));
+  CHECK(fp_with_rle.use_tile_chunking(
+      !is_dimension, is_var_sized, Datatype::STRING_ASCII));
+  CHECK(fp_with_rle.use_tile_chunking(
+      is_dimension, !is_var_sized, Datatype::STRING_ASCII));
+  CHECK(fp_with_rle.use_tile_chunking(
+      !is_dimension, !is_var_sized, Datatype::STRING_ASCII));
+  CHECK(fp_with_rle.use_tile_chunking(
+      is_dimension, is_var_sized, Datatype::TIME_MS));
+  CHECK(fp_with_rle.use_tile_chunking(
+      is_dimension, is_var_sized, Datatype::DATETIME_AS));
+  CHECK(fp_with_rle.use_tile_chunking(
+      is_dimension, is_var_sized, Datatype::BLOB));
+  CHECK(fp_with_rle.use_tile_chunking(
+      is_dimension, is_var_sized, Datatype::INT32));
+  CHECK(fp_with_rle.use_tile_chunking(
+      is_dimension, is_var_sized, Datatype::FLOAT64));
+}

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -759,8 +759,7 @@ Status WriterBase::filter_tile(
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(
       &filters, array_->get_encryption_key()));
 
-  // TBD: do I need to do anything for zipped coordinates / some condition on
-  // format_version? (e.g. >=5)
+  // Check if chunk or tile level filtering/unfiltering is appropriate
   bool use_chunking = filters.use_tile_chunking(
       array_schema_->is_dim(name), array_schema_->var_size(name), tile->type());
 

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -37,7 +37,9 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/enums/compressor.h"
 #include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/filter/compression_filter.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/comparators.h"
 #include "tiledb/sm/misc/hilbert.h"
@@ -757,9 +759,18 @@ Status WriterBase::filter_tile(
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(
       &filters, array_->get_encryption_key()));
 
+  // TBD: do I need to do anything for zipped coordinates / some condition on
+  // format_version? (e.g. >=5)
+  bool use_chunking = filters.use_tile_chunking(
+      array_schema_->is_dim(name), array_schema_->var_size(name), tile->type());
+
   assert(!tile->filtered());
   RETURN_NOT_OK(filters.run_forward(
-      stats_, tile, offsets_tile, storage_manager_->compute_tp()));
+      stats_,
+      tile,
+      offsets_tile,
+      storage_manager_->compute_tp(),
+      use_chunking));
   assert(tile->filtered());
 
   tile->set_pre_filtered_size(orig_size);


### PR DESCRIPTION
In order to support meaningful RLE and dictionary encoding on dimensions (and maybe attributes in the future), this PR introduces the ability enable the option to perform filtering/unfiltering on a per Tile basis rather on chunks of the Tile as it is by default the case today.

For now per Tile filtering is only enabled for RLE on var-sized string dimensions. However, the actual plugging of the RLE algorithm for strings will come in a future PR.

---
TYPE: IMPROVEMENT
DESC: Add option for tile level filtering 
