### PR TITLE
Delete allocated array schema on error of loading

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -188,8 +188,12 @@ StorageManager::load_array_schemas_and_fragment_metadata(
       fragments_to_load,
       &f_buff,
       offsets);
-  RETURN_NOT_OK_TUPLE(
-      st_fragment_meta, std::nullopt, std::nullopt, std::nullopt);
+  RETURN_NOT_OK_ELSE_TUPLE(
+      st_fragment_meta,
+      delete array_schema_latest.value(),
+      std::nullopt,
+      std::nullopt,
+      std::nullopt);
 
   return {
       Status::Ok(), array_schema_latest, array_schemas_all, fragment_metadata};
@@ -1676,7 +1680,7 @@ StorageManager::load_array_schemas(
       std::nullopt);
 
   auto&& [st, schemas] = load_all_array_schemas(array_uri, encryption_key);
-  RETURN_NOT_OK_TUPLE(st, std::nullopt, std::nullopt);
+  RETURN_NOT_OK_ELSE_TUPLE(st, delete array_schema, std::nullopt, std::nullopt);
 
   return {Status::Ok(), array_schema, schemas};
 }


### PR DESCRIPTION
If there is an error in loading all array schemas we need to make sure we delete the already allocated `latest` array schema before we return the error status. This fixes a leak on the error path of opening the array.

This code path with change with #2894 so I'm fixing it directly on `release-2.7`

---
TYPE: BUG
DESC: Free allocated latest array schema when on error of loading all array schemas
