### PR TITLE
Adds an ArrayDirectory class to manage all URIs within the array directory

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -177,6 +177,7 @@ set(TILEDB_TEST_SOURCES
   src/unit-Tile.cc
   src/unit-TileDomain.cc
   src/unit-uri.cc
+  src/unit-ArrayDirectory.cc
   src/unit-utils.cc
   src/unit-uuid.cc
   src/unit-ValidityVector.cc

--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -1223,12 +1223,12 @@ int32_t num_fragments(const std::string& array_name) {
   // Get all URIs in the array directory
   auto uris = vfs.ls(array_name);
 
-  // Exclude '__meta' folder and any file with a suffix
+  // Exclude '__meta' directory and any file with a suffix
   int ret = 0;
   for (const auto& uri : uris) {
     auto name = tiledb::sm::URI(uri).remove_trailing_slash().last_path_part();
-    if (name != tiledb::sm::constants::array_metadata_folder_name &&
-        name != tiledb::sm::constants::array_schema_folder_name &&
+    if (name != tiledb::sm::constants::array_metadata_dir_name &&
+        name != tiledb::sm::constants::array_schema_dir_name &&
         name.find_first_of('.') == std::string::npos)
       ++ret;
   }

--- a/test/src/unit-ArrayDirectory.cc
+++ b/test/src/unit-ArrayDirectory.cc
@@ -1,0 +1,93 @@
+/**
+ * @file unit-ArrayDirectory.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `ArrayDirectory` class.
+ */
+
+#include "test/src/helpers.h"
+#include "test/src/vfs_helpers.h"
+#include "tiledb/sm/array/array_directory.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
+#include <catch.hpp>
+#include <iostream>
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+struct ArrayDirectoryFx {
+  tiledb_ctx_t* ctx_;
+  tiledb_vfs_t* vfs_t_;
+  const std::vector<std::unique_ptr<SupportedFs>> fs_vec_;
+  std::string temp_dir_;
+  std::string array_name_;
+  StorageManager* storage_manager_;
+  VFS* vfs_;
+  ThreadPool* tp_;
+
+  ArrayDirectoryFx();
+  ~ArrayDirectoryFx();
+};
+
+ArrayDirectoryFx::ArrayDirectoryFx()
+    : fs_vec_(vfs_test_get_fs_vec()) {
+  // Initialize vfs test
+  REQUIRE(vfs_test_init(fs_vec_, &ctx_, &vfs_t_).ok());
+
+  // Create temporary directory
+  temp_dir_ = fs_vec_[0]->temp_dir();
+  create_dir(temp_dir_, ctx_, vfs_t_);
+
+  // Set array name
+  array_name_ = temp_dir_ + "uri_manager_array";
+
+  // Set storage manager
+  storage_manager_ = ctx_->ctx_->storage_manager();
+  vfs_ = storage_manager_->vfs();
+  tp_ = storage_manager_->compute_tp();
+}
+
+ArrayDirectoryFx::~ArrayDirectoryFx() {
+  remove_dir(temp_dir_, ctx_, vfs_t_);
+  tiledb_ctx_free(&ctx_);
+  tiledb_vfs_free(&vfs_t_);
+}
+
+TEST_CASE_METHOD(
+    ArrayDirectoryFx,
+    "ArrayDirectory: Basic tests",
+    "[ArrayDirectory][basic]") {
+  ArrayDirectory array_dir;
+}

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -1436,7 +1436,7 @@ TEST_CASE_METHOD(
 
   // Corrupt the array schema
   std::string schema_path =
-      array_name + "/" + tiledb::sm::constants::array_schema_folder_name;
+      array_name + "/" + tiledb::sm::constants::array_schema_dir_name;
   std::string to_write = "garbage";
   tiledb_vfs_fh_t* fh;
   schema_file_struct data_struct = {ctx_, vfs_, ""};
@@ -2324,7 +2324,7 @@ TEST_CASE_METHOD(
   std::string array_uri(arrays_dir + "/non_split_coords_v1_4_0");
   // Remove any failed tests
   remove_temp_dir(
-      array_uri + "/" + tiledb::sm::constants::array_schema_folder_name);
+      array_uri + "/" + tiledb::sm::constants::array_schema_dir_name);
 
   // Create an array schema evolution
   tiledb_array_schema_evolution_t* array_schema_evolution;
@@ -2393,5 +2393,5 @@ TEST_CASE_METHOD(
   tiledb_array_free(&array);
   remove_temp_dir(local_fs.file_prefix() + local_fs.temp_dir());
   remove_temp_dir(
-      array_uri + "/" + tiledb::sm::constants::array_schema_folder_name);
+      array_uri + "/" + tiledb::sm::constants::array_schema_dir_name);
 }

--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -593,9 +593,9 @@ TEST_CASE_METHOD(
 
   // Check number of metadata files
   get_num_struct data = {0};
-  auto meta_folder =
-      array_name_ + "/" + tiledb::sm::constants::array_metadata_folder_name;
-  rc = tiledb_vfs_ls(ctx_, vfs_, meta_folder.c_str(), &get_meta_num, &data);
+  auto meta_dir =
+      array_name_ + "/" + tiledb::sm::constants::array_metadata_dir_name;
+  rc = tiledb_vfs_ls(ctx_, vfs_, meta_dir.c_str(), &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 4);
 
@@ -629,7 +629,7 @@ TEST_CASE_METHOD(
 
   // Check number of metadata files
   data = {0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, meta_folder.c_str(), &get_meta_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, meta_dir.c_str(), &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -207,12 +207,12 @@ int StringDimsFx::get_dir_num(const char* path, void* data) {
   int rc = tiledb_vfs_is_dir(ctx, vfs, path, &is_dir);
   CHECK(rc == TILEDB_OK);
   auto meta_dir =
-      std::string("/") + tiledb::sm::constants::array_metadata_folder_name;
+      std::string("/") + tiledb::sm::constants::array_metadata_dir_name;
   auto schema_dir =
-      std::string("/") + tiledb::sm::constants::array_schema_folder_name;
+      std::string("/") + tiledb::sm::constants::array_schema_dir_name;
   if (!tiledb::sm::utils::parse::ends_with(path, meta_dir) &&
       !tiledb::sm::utils::parse::ends_with(path, schema_dir)) {
-    // Ignoring the meta folder and the schema folder
+    // Ignoring the meta directory and the schema directory
     data_struct->num += is_dir;
   }
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -125,6 +125,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/interval/interval.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/types/dynamic_typed_datum.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array_directory.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/array_schema.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/array_schema_evolution.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/attribute.cc

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -406,6 +406,11 @@ inline Status Status_DenseTilerError(const std::string& msg) {
 inline Status Status_QueryConditionError(const std::string& msg) {
   return Status(StatusCode::QueryConditionError, msg);
 }
+/** Return a Status_ArrayDirectoryError error class Status with a given
+ * message **/
+inline Status Status_ArrayDirectoryError(const std::string& msg) {
+  return Status(StatusCode::ArrayDirectoryError, msg);
+}
 }  // namespace common
 }  // namespace tiledb
 

--- a/tiledb/common/status_code.cc
+++ b/tiledb/common/status_code.cc
@@ -128,6 +128,8 @@ std::string_view to_string_view(const StatusCode& sc) {
       return "[TileDB::DenseTiler] Error";
     case StatusCode::QueryConditionError:
       return "[TileDB::QueryCondition] Error";
+    case StatusCode::ArrayDirectoryError:
+      return "[TileDB::ArrayDirectory] Error";
     default:
       return "[TileDB::?] Error:";
   }

--- a/tiledb/common/status_code.h
+++ b/tiledb/common/status_code.h
@@ -94,7 +94,8 @@ enum class StatusCode : char {
   ThreadPoolError,
   FragmentInfoError,
   DenseTilerError,
-  QueryConditionError
+  QueryConditionError,
+  ArrayDirectoryError
 };
 
 std::string to_string(const StatusCode& sc);

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -67,6 +67,7 @@ namespace sm {
 Array::Array(const URI& array_uri, StorageManager* storage_manager)
     : array_schema_latest_(nullptr)
     , array_uri_(array_uri)
+    , array_dir_()
     , array_uri_serialized_(array_uri)
     , encryption_key_(tdb::make_shared<EncryptionKey>(HERE()))
     , is_open_(false)
@@ -77,11 +78,13 @@ Array::Array(const URI& array_uri, StorageManager* storage_manager)
     , config_(storage_manager_->config())
     , remote_(array_uri.is_tiledb())
     , metadata_loaded_(false)
-    , non_empty_domain_computed_(false){};
+    , non_empty_domain_computed_(false) {
+}
 
 Array::Array(const Array& rhs)
     : array_schema_latest_(rhs.array_schema_latest_)
     , array_uri_(rhs.array_uri_)
+    , array_dir_(rhs.array_dir_)
     , array_uri_serialized_(rhs.array_uri_serialized_)
     , encryption_key_(rhs.encryption_key_)
     , fragment_metadata_(rhs.fragment_metadata_)
@@ -124,6 +127,10 @@ ArraySchema* Array::array_schema_latest() const {
 
 const URI& Array::array_uri() const {
   return array_uri_;
+}
+
+const ArrayDirectory& Array::array_directory() const {
+  return array_dir_;
 }
 
 const URI& Array::array_uri_serialized() const {
@@ -171,6 +178,18 @@ Status Array::open_without_fragments(
     RETURN_NOT_OK(rest_client->get_array_schema_from_rest(
         array_uri_, &array_schema_latest_));
   } else {
+    try {
+      array_dir_ = ArrayDirectory(
+          storage_manager_->vfs(),
+          storage_manager_->compute_tp(),
+          array_uri_,
+          0,
+          UINT64_MAX,
+          true);
+    } catch (const std::logic_error& le) {
+      return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+    }
+
     auto&& [st, array_schema, array_schemas] =
         storage_manager_->array_open_for_reads_without_fragments(this);
     RETURN_NOT_OK(st);
@@ -294,6 +313,17 @@ Status Array::open(
     RETURN_NOT_OK(rest_client->get_array_schema_from_rest(
         array_uri_, &array_schema_latest_));
   } else if (query_type == QueryType::READ) {
+    try {
+      array_dir_ = ArrayDirectory(
+          storage_manager_->vfs(),
+          storage_manager_->compute_tp(),
+          array_uri_,
+          timestamp_start_,
+          timestamp_end_opened_at_);
+    } catch (const std::logic_error& le) {
+      return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+    }
+
     auto&& [st, array_schema, array_schemas, fragment_metadata] =
         storage_manager_->array_open_for_reads(this);
     RETURN_NOT_OK(st);
@@ -302,6 +332,17 @@ Status Array::open(
     array_schemas_all_ = array_schemas.value();
     fragment_metadata_ = fragment_metadata.value();
   } else {
+    try {
+      array_dir_ = ArrayDirectory(
+          storage_manager_->vfs(),
+          storage_manager_->compute_tp(),
+          array_uri_,
+          timestamp_start_,
+          timestamp_end_opened_at_);
+    } catch (const std::logic_error& le) {
+      return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+    }
+
     auto&& [st, array_schema, array_schemas] =
         storage_manager_->array_open_for_writes(this);
     RETURN_NOT_OK(st);
@@ -562,6 +603,17 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
         encryption_key_->key().size());
   }
 
+  try {
+    array_dir_ = ArrayDirectory(
+        storage_manager_->vfs(),
+        storage_manager_->compute_tp(),
+        array_uri_,
+        timestamp_start_,
+        timestamp_end_opened_at_);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
+
   auto&& [st, array_schema, array_schemas, fragment_metadata] =
       storage_manager_->array_reopen(this);
   RETURN_NOT_OK(st);
@@ -773,8 +825,8 @@ Metadata* Array::metadata() {
 }
 
 Status Array::metadata(Metadata** metadata) {
-  // Load array metadata, if not loaded yet
-  if (!metadata_loaded_)
+  // Load array metadata for array opened for reads, if not loaded yet
+  if (query_type_ == QueryType::READ && !metadata_loaded_)
     RETURN_NOT_OK(load_metadata());
 
   *metadata = &metadata_;
@@ -938,12 +990,9 @@ Status Array::load_metadata() {
     RETURN_NOT_OK(rest_client->get_array_metadata_from_rest(
         array_uri_, timestamp_start_, timestamp_end_opened_at_, this));
   } else {
+    assert(array_dir_.loaded());
     RETURN_NOT_OK(storage_manager_->load_array_metadata(
-        array_uri_,
-        *encryption_key_,
-        timestamp_start_,
-        timestamp_end_opened_at_,
-        &metadata_));
+        array_dir_, *encryption_key_, &metadata_));
   }
   metadata_loaded_ = true;
   return Status::Ok();

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -40,6 +40,7 @@
 #include "tiledb/common/common.h"
 #include "tiledb/common/memory_tracker.h"
 #include "tiledb/common/status.h"
+#include "tiledb/sm/array/array_directory.h"
 #include "tiledb/sm/crypto/encryption_key.h"
 #include "tiledb/sm/fragment/fragment_info.h"
 #include "tiledb/sm/metadata/metadata.h"
@@ -77,6 +78,9 @@ class Array {
   /* ********************************* */
   /*                API                */
   /* ********************************* */
+
+  /** Returns the array directory object. */
+  const ArrayDirectory& array_directory() const;
 
   /** Sets the latest array schema.
    * @param array_schema The array schema to set.
@@ -380,6 +384,9 @@ class Array {
 
   /** The array URI. */
   URI array_uri_;
+
+  /** The array directory object for listing URIs. */
+  ArrayDirectory array_dir_;
 
   /** This is a backwards compatible URI from serialization
    *  In TileDB 2.5 we removed sending the URI but 2.4 and older were

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -1,0 +1,454 @@
+/**
+ * @file   array_directory.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class ArrayDirectory.
+ */
+
+#include "tiledb/sm/array/array_directory.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/common/stdx_string.h"
+#include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/misc/utils.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/* ********************************* */
+/*     CONSTRUCTORS & DESTRUCTORS    */
+/* ********************************* */
+
+ArrayDirectory::ArrayDirectory(
+    VFS* vfs,
+    ThreadPool* tp,
+    const URI& array_uri,
+    uint64_t timestamp_start,
+    uint64_t timestamp_end,
+    bool only_schemas)
+    : array_uri_(array_uri.add_trailing_slash())
+    , vfs_(vfs)
+    , tp_(tp)
+    , timestamp_start_(timestamp_start)
+    , timestamp_end_(timestamp_end)
+    , only_schemas_(only_schemas)
+    , loaded_(false) {
+  auto st = load();
+  if (!st.ok()) {
+    throw std::logic_error(st.message());
+  }
+}
+
+/* ********************************* */
+/*                API                */
+/* ********************************* */
+
+const URI& ArrayDirectory::array_uri() const {
+  return array_uri_;
+}
+
+const std::vector<URI>& ArrayDirectory::array_schema_uris() const {
+  return array_schema_uris_;
+}
+
+const URI& ArrayDirectory::latest_array_schema_uri() const {
+  return latest_array_schema_uri_;
+}
+
+const std::vector<URI>& ArrayDirectory::array_meta_uris_to_vacuum() const {
+  return array_meta_uris_to_vacuum_;
+}
+
+const std::vector<URI>& ArrayDirectory::array_meta_vac_uris_to_vacuum() const {
+  return array_meta_vac_uris_to_vacuum_;
+}
+
+const std::vector<TimestampedURI>& ArrayDirectory::array_meta_uris() const {
+  return array_meta_uris_;
+}
+
+Status ArrayDirectory::load() {
+  assert(!loaded_);
+
+  std::vector<ThreadPool::Task> tasks;
+
+  // Load (in parallel) the fragment URIs
+  if (!only_schemas_)
+    tasks.emplace_back(tp_->execute([&]() { return load_fragment_uris(); }));
+
+  // Load (in parallel) the array metadata URIs
+  if (!only_schemas_)
+    tasks.emplace_back(tp_->execute([&]() { return load_array_meta_uris(); }));
+
+  // Load (in parallel) the array schema URIs
+  tasks.emplace_back(tp_->execute([&]() { return load_array_schema_uris(); }));
+
+  // Wait for all tasks to complete
+  RETURN_NOT_OK(tp_->wait_all(tasks));
+
+  // The URI manager has been loaded successfully
+  loaded_ = true;
+
+  return Status::Ok();
+}
+
+const std::vector<URI>& ArrayDirectory::fragment_uris_to_vacuum() const {
+  return fragment_uris_to_vacuum_;
+}
+
+const std::vector<URI>& ArrayDirectory::fragment_vac_uris_to_vacuum() const {
+  return fragment_vac_uris_to_vacuum_;
+}
+
+const std::vector<TimestampedURI>& ArrayDirectory::fragment_uris() const {
+  return fragment_uris_;
+}
+
+const std::vector<URI>& ArrayDirectory::fragment_meta_uris() const {
+  return fragment_meta_uris_;
+}
+
+const URI& ArrayDirectory::latest_fragment_meta_uri() const {
+  return latest_fragment_meta_uri_;
+}
+
+bool ArrayDirectory::loaded() const {
+  return loaded_;
+}
+
+/* ********************************* */
+/*         PRIVATE METHODS           */
+/* ********************************* */
+
+Status ArrayDirectory::load_fragment_uris() {
+  // List the array directory URIs
+  std::vector<URI> array_dir_uris;
+  RETURN_NOT_OK(vfs_->ls(array_uri_, &array_dir_uris));
+
+  // Compute and store the fragment URIs. */
+  auto&& [st1, fragment_uris] = compute_fragment_uris(array_dir_uris);
+  RETURN_NOT_OK(st1);
+  array_dir_uris.clear();
+
+  // Compute and fragment URIs and the vacuum file URIs to vacuum. */
+  auto&& [st2, fragment_uris_to_vacuum, fragment_vac_uris_to_vacuum] =
+      compute_uris_to_vacuum(fragment_uris.value());
+  RETURN_NOT_OK(st2);
+  fragment_uris_to_vacuum_ = std::move(fragment_uris_to_vacuum.value());
+  fragment_vac_uris_to_vacuum_ = std::move(fragment_vac_uris_to_vacuum.value());
+
+  // Compute filtered fragment URIs
+  auto&& [st3, fragment_filtered_uris] =
+      compute_filtered_uris(fragment_uris.value(), fragment_uris_to_vacuum_);
+  RETURN_NOT_OK(st3);
+  fragment_uris_ = std::move(fragment_filtered_uris.value());
+  fragment_uris.value().clear();
+
+  return Status::Ok();
+}
+
+Status ArrayDirectory::load_array_meta_uris() {
+  // Load the URIs in the array metadata directory
+  std::vector<URI> array_meta_dir_uris;
+  auto array_meta_uri =
+      array_uri_.join_path(constants::array_metadata_dir_name);
+  RETURN_NOT_OK(vfs_->ls(array_meta_uri, &array_meta_dir_uris));
+
+  // Compute and array metadata URIs and the vacuum file URIs to vacuum. */
+  auto&& [st1, array_meta_uris_to_vacuum, array_meta_vac_uris_to_vacuum] =
+      compute_uris_to_vacuum(array_meta_dir_uris);
+  RETURN_NOT_OK(st1);
+  array_meta_uris_to_vacuum_ = std::move(array_meta_uris_to_vacuum.value());
+  array_meta_vac_uris_to_vacuum_ =
+      std::move(array_meta_vac_uris_to_vacuum.value());
+
+  // Compute filtered array metadata URIs
+  auto&& [st2, array_meta_filtered_uris] =
+      compute_filtered_uris(array_meta_dir_uris, array_meta_uris_to_vacuum_);
+  RETURN_NOT_OK(st2);
+  array_meta_uris_ = std::move(array_meta_filtered_uris.value());
+  array_meta_dir_uris.clear();
+
+  return Status::Ok();
+}
+
+Status ArrayDirectory::load_array_schema_uris() {
+  // Load the URIs from the array schema directory
+  std::vector<URI> array_schema_dir_uris;
+  auto schema_dir_uri = array_uri_.join_path(constants::array_schema_dir_name);
+  RETURN_NOT_OK(vfs_->ls(schema_dir_uri, &array_schema_dir_uris));
+
+  // Compute all the array schema URIs plus the latest array schema URI
+  RETURN_NOT_OK(compute_array_schema_uris(array_schema_dir_uris));
+
+  return Status::Ok();
+}
+
+tuple<Status, optional<std::vector<URI>>> ArrayDirectory::compute_fragment_uris(
+    const std::vector<URI>& array_dir_uris) {
+  std::vector<URI> fragment_uris;
+
+  // that fragments are "committed" for versions >= 5
+  std::set<URI> ok_uris;
+  for (size_t i = 0; i < array_dir_uris.size(); ++i) {
+    if (stdx::string::ends_with(
+            array_dir_uris[i].to_string(), constants::ok_file_suffix)) {
+      auto name = array_dir_uris[i].to_string();
+      name = name.substr(0, name.size() - constants::ok_file_suffix.size());
+      ok_uris.emplace(URI(name));
+    }
+  }
+
+  // Get only the committed fragment uris
+  std::vector<uint8_t> is_fragment(array_dir_uris.size(), 0);
+  auto status = parallel_for(tp_, 0, array_dir_uris.size(), [&](size_t i) {
+    if (stdx::string::starts_with(array_dir_uris[i].last_path_part(), "."))
+      return Status::Ok();
+    int32_t flag;
+    RETURN_NOT_OK(this->is_fragment(array_dir_uris[i], ok_uris, &flag));
+    is_fragment[i] = (uint8_t)flag;
+    return Status::Ok();
+  });
+  RETURN_NOT_OK_TUPLE(status, nullopt);
+
+  for (size_t i = 0; i < array_dir_uris.size(); ++i) {
+    if (is_fragment[i])
+      fragment_uris.emplace_back(array_dir_uris[i]);
+    else if (is_vacuum_file(array_dir_uris[i]))
+      fragment_uris.emplace_back(array_dir_uris[i]);
+  }
+
+  // Get the consolidated fragment metadata URIs
+  uint64_t t_latest = 0;
+  std::pair<uint64_t, uint64_t> timestamp_range;
+  for (const auto& uri : array_dir_uris) {
+    if (stdx::string::ends_with(uri.to_string(), constants::meta_file_suffix)) {
+      fragment_meta_uris_.emplace_back(uri);
+      RETURN_NOT_OK_TUPLE(
+          utils::parse::get_timestamp_range(uri, &timestamp_range), nullopt);
+      if (timestamp_range.second > t_latest) {
+        t_latest = timestamp_range.second;
+        latest_fragment_meta_uri_ = uri;
+      }
+    }
+  }
+
+  return {Status::Ok(), fragment_uris};
+}
+
+tuple<Status, optional<std::vector<URI>>, optional<std::vector<URI>>>
+ArrayDirectory::compute_uris_to_vacuum(const std::vector<URI>& uris) {
+  // Get vacuum URIs
+  std::vector<URI> vac_files;
+  std::unordered_set<std::string> non_vac_uris_set;
+  std::unordered_map<std::string, size_t> uris_map;
+  for (size_t i = 0; i < uris.size(); ++i) {
+    std::pair<uint64_t, uint64_t> timestamp_range;
+    RETURN_NOT_OK_TUPLE(
+        utils::parse::get_timestamp_range(uris[i], &timestamp_range),
+        nullopt,
+        nullopt);
+
+    if (is_vacuum_file(uris[i])) {
+      if (timestamp_range.first >= timestamp_start_ &&
+          timestamp_range.second <= timestamp_end_)
+        vac_files.emplace_back(uris[i]);
+    } else {
+      if (timestamp_range.first < timestamp_start_ ||
+          timestamp_range.second > timestamp_end_) {
+        non_vac_uris_set.emplace(uris[i].to_string());
+      } else {
+        uris_map[uris[i].to_string()] = i;
+      }
+    }
+  }
+
+  // Compute fragment URIs to vacuum as a bitmap vector
+  // Also determine which vac files to vacuum
+  std::vector<int32_t> to_vacuum_vec(uris.size(), 0);
+  std::vector<int32_t> to_vacuum_vac_files_vec(vac_files.size(), 0);
+  auto status = parallel_for(tp_, 0, vac_files.size(), [&](size_t i) {
+    uint64_t size = 0;
+    RETURN_NOT_OK(vfs_->file_size(vac_files[i], &size));
+    std::string names;
+    names.resize(size);
+    RETURN_NOT_OK(vfs_->read(vac_files[i], 0, &names[0], size));
+    std::stringstream ss(names);
+    bool vacuum_vac_file = true;
+    for (std::string uri_str; std::getline(ss, uri_str);) {
+      auto it = uris_map.find(uri_str);
+      if (it != uris_map.end())
+        to_vacuum_vec[it->second] = 1;
+
+      if (vacuum_vac_file &&
+          non_vac_uris_set.find(uri_str) != non_vac_uris_set.end()) {
+        vacuum_vac_file = false;
+      }
+    }
+
+    to_vacuum_vac_files_vec[i] = vacuum_vac_file;
+
+    return Status::Ok();
+  });
+  RETURN_NOT_OK_TUPLE(status, nullopt, nullopt);
+
+  // Compute the fragment URIs to vacuum
+  std::vector<URI> uris_to_vacuum;
+  for (size_t i = 0; i < uris.size(); ++i) {
+    if (to_vacuum_vec[i] == 1)
+      uris_to_vacuum.emplace_back(uris[i]);
+  }
+
+  // Compute the vacuum URIs to vacuum
+  std::vector<URI> vac_uris_to_vacuum;
+  for (size_t i = 0; i < vac_files.size(); ++i) {
+    if (to_vacuum_vac_files_vec[i] == 1)
+      vac_uris_to_vacuum.emplace_back(vac_files[i]);
+  }
+
+  return {Status::Ok(), uris_to_vacuum, vac_uris_to_vacuum};
+}
+
+tuple<Status, optional<std::vector<TimestampedURI>>>
+ArrayDirectory::compute_filtered_uris(
+    const std::vector<URI>& uris, const std::vector<URI>& to_ignore) {
+  std::vector<TimestampedURI> filtered_uris;
+
+  // Do nothing if there are not enough URIs
+  if (uris.empty())
+    return {Status::Ok(), filtered_uris};
+
+  // Get the URIs that must be ignored
+  std::set<URI> to_ignore_set;
+  for (const auto& uri : to_ignore)
+    to_ignore_set.emplace(uri);
+
+  // Filter based on vacuumed URIs and timestamp
+  for (auto& uri : uris) {
+    // Ignore vacuumed URIs
+    if (to_ignore_set.find(uri) != to_ignore_set.end())
+      continue;
+
+    // Also ignore any vac uris
+    if (is_vacuum_file(uri))
+      continue;
+
+    // Add only URIs whose first timestamp is greater than or equal to the
+    // timestamp_start and whose second timestamp is smaller than or equal to
+    // the timestamp_end
+    std::pair<uint64_t, uint64_t> timestamp_range;
+    RETURN_NOT_OK_TUPLE(
+        utils::parse::get_timestamp_range(uri, &timestamp_range), nullopt);
+    auto t1 = timestamp_range.first;
+    auto t2 = timestamp_range.second;
+    if (t1 >= timestamp_start_ && t2 <= timestamp_end_)
+      filtered_uris.emplace_back(uri, timestamp_range);
+  }
+
+  // Sort the names based on the timestamps
+  std::sort(filtered_uris.begin(), filtered_uris.end());
+
+  return {Status::Ok(), filtered_uris};
+}
+
+Status ArrayDirectory::compute_array_schema_uris(
+    const std::vector<URI>& array_schema_dir_uris) {
+  // Optionally add the old array schema from the root array folder
+  auto old_schema_uri = array_uri_.join_path(constants::array_schema_filename);
+  bool has_file = false;
+  RETURN_NOT_OK(vfs_->is_file(old_schema_uri, &has_file));
+  if (has_file) {
+    array_schema_uris_.push_back(old_schema_uri);
+  }
+
+  // Optionally add the new array schemas from the array schema directory
+  if (!array_schema_dir_uris.empty()) {
+    array_schema_uris_.reserve(
+        array_schema_uris_.size() + array_schema_dir_uris.size());
+    std::copy(
+        array_schema_dir_uris.begin(),
+        array_schema_dir_uris.end(),
+        std::back_inserter(array_schema_uris_));
+  }
+
+  // Error check
+  if (array_schema_uris_.empty()) {
+    return LOG_STATUS(Status_ArrayDirectoryError(
+        "Cannot compute array schemas; No array schemas found."));
+  }
+
+  // Set the latest array schema URI
+  latest_array_schema_uri_ = array_schema_uris_.back();
+  assert(!latest_array_schema_uri_.is_invalid());
+
+  return Status::Ok();
+}
+
+bool ArrayDirectory::is_vacuum_file(const URI& uri) const {
+  if (utils::parse::ends_with(uri.to_string(), constants::vacuum_file_suffix))
+    return true;
+
+  return false;
+}
+
+Status ArrayDirectory::is_fragment(
+    const URI& uri, const std::set<URI>& ok_uris, int* is_fragment) const {
+  // If the URI name has a suffix, then it is not a fragment
+  auto name = uri.remove_trailing_slash().last_path_part();
+  if (name.find_first_of('.') != std::string::npos) {
+    *is_fragment = 0;
+    return Status::Ok();
+  }
+
+  // Check set membership in ok_uris
+  if (ok_uris.find(uri) != ok_uris.end()) {
+    *is_fragment = 1;
+    return Status::Ok();
+  }
+
+  // If the format version is >= 5, then the above suffices to check if
+  // the URI is indeed a fragment
+  uint32_t version;
+  RETURN_NOT_OK(utils::parse::get_fragment_version(name, &version));
+  if (version != UINT32_MAX && version >= 5) {
+    *is_fragment = false;
+    return Status::Ok();
+  }
+
+  // Versions < 5
+  bool is_file;
+  RETURN_NOT_OK(vfs_->is_file(
+      uri.join_path(constants::fragment_metadata_filename), &is_file));
+  *is_fragment = (int)is_file;
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -1,0 +1,282 @@
+/**
+ * @file   array_directory.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ This file defines class ArrayDirectory.
+ */
+
+#ifndef TILEDB_ARRAY_DIRECTORY_H
+#define TILEDB_ARRAY_DIRECTORY_H
+
+#include "tiledb/common/status.h"
+#include "tiledb/common/thread_pool.h"
+#include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/sm/filesystem/vfs.h"
+
+#include <unordered_map>
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * Manages the various URIs inside an array directory, considering
+ * various versions of the on-disk TileDB format.
+ */
+class ArrayDirectory {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  ArrayDirectory() = default;
+
+  /**
+   * Constructor.
+   *
+   * @param vfs A pointer to a VFS object for all IO.
+   * @param tp A thread pool used for parallelism.
+   * @param array_uri The URI of the array directory.
+   * @param timestamp_start Only array fragments, metadata, etc. that
+   *     were created within timestamp range
+   *    [`timestamp_start`, `timestamp_end`] will be considered when
+   *     fetching URIs.
+   * @param timestamp_end Only array fragments, metadata, etc. that
+   *     were created within timestamp range
+   *    [`timestamp_start`, `timestamp_end`] will be considered when
+   *     fetching URIs.
+   * @param only_schema If `true`, only the array schema URIs
+   *     will be loaded.
+   */
+  ArrayDirectory(
+      VFS* vfs,
+      ThreadPool* tp,
+      const URI& array_uri,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
+      bool only_schemas = false);
+
+  /** Destructor. */
+  ~ArrayDirectory() = default;
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Returns the array URI. */
+  const URI& array_uri() const;
+
+  /** Returns the URIs of the array schema files. */
+  const std::vector<URI>& array_schema_uris() const;
+
+  /** Returns the latest array schema URI. */
+  const URI& latest_array_schema_uri() const;
+
+  /** Returns the URIs of the array metadata files to vacuum. */
+  const std::vector<URI>& array_meta_uris_to_vacuum() const;
+
+  /** Returns the URIs of the array metadata vacuum files to vacuum. */
+  const std::vector<URI>& array_meta_vac_uris_to_vacuum() const;
+
+  /** Returns the filtered array metadata URIs. */
+  const std::vector<TimestampedURI>& array_meta_uris() const;
+
+  /** Returns the fragment URIs to vacuum. */
+  const std::vector<URI>& fragment_uris_to_vacuum() const;
+
+  /** Returns the vacuum file URIs to vacuum for fragments. */
+  const std::vector<URI>& fragment_vac_uris_to_vacuum() const;
+
+  /** Returns the filtered fragment URIs. */
+  const std::vector<TimestampedURI>& fragment_uris() const;
+
+  /** Returns the URIs of the consolidated fragment metadata files. */
+  const std::vector<URI>& fragment_meta_uris() const;
+
+  /** Returns the latest consolidated fragment metadata URI. */
+  const URI& latest_fragment_meta_uri() const;
+
+  /** Returns `true` if `load` has been run. */
+  bool loaded() const;
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The array URI. */
+  URI array_uri_;
+
+  /** The storage manager. */
+  VFS* vfs_;
+
+  /** A thread pool used for parallelism. */
+  ThreadPool* tp_;
+
+  /** The URIs of all the array schema files. */
+  std::vector<URI> array_schema_uris_;
+
+  /** The latest array schema URI. */
+  URI latest_array_schema_uri_;
+
+  /** The URIs of the array metadata files to vacuum. */
+  std::vector<URI> array_meta_uris_to_vacuum_;
+
+  /** The URIs of the array metadata vac files to vacuum. */
+  std::vector<URI> array_meta_vac_uris_to_vacuum_;
+
+  /**
+   * The filtered array metadata URIs, after removing the ones that
+   * need to be vacuum and those that do not fall inside range
+   * [`timestamp_start_`, `timestamp_end_`].
+   */
+  std::vector<TimestampedURI> array_meta_uris_;
+
+  /** The fragment URIs to vacuum. */
+  std::vector<URI> fragment_uris_to_vacuum_;
+
+  /** The URIs of the fragment vac files to vacuum. */
+  std::vector<URI> fragment_vac_uris_to_vacuum_;
+
+  /**
+   * The filtered fragment URIs, after removing the ones that
+   * need to be vacuum and those that do not fall inside range
+   * [`timestamp_start_`, `timestamp_end_`].
+   */
+  std::vector<TimestampedURI> fragment_uris_;
+
+  /** The URIs of the consolidated fragment metadata files. */
+  std::vector<URI> fragment_meta_uris_;
+
+  /**
+   * The latest fragment metadata URI.
+   */
+  URI latest_fragment_meta_uri_;
+
+  /**
+   * Only array fragments, metadata, etc. that
+   * were created within timestamp range
+   *    [`timestamp_start`, `timestamp_end`] will be considered when
+   *     fetching URIs.
+   */
+  uint64_t timestamp_start_;
+
+  /**
+   * Only array fragments, metadata, etc. that
+   * were created within timestamp range
+   *    [`timestamp_start`, `timestamp_end`] will be considered when
+   *     fetching URIs.
+   */
+  uint64_t timestamp_end_;
+
+  /** If `ture`, only the array schemas will be loaded. */
+  bool only_schemas_;
+
+  /** True if `load` has been run. */
+  bool loaded_;
+
+  /* ********************************* */
+  /*          PRIVATE METHODS          */
+  /* ********************************* */
+
+  /** Loads the URIs from the various array subdirectories. */
+  Status load();
+
+  /** Loads the fragment URIs. */
+  Status load_fragment_uris();
+
+  /** Loads the array metadata URIs. */
+  Status load_array_meta_uris();
+
+  /** Loads the array schema URIs. */
+  Status load_array_schema_uris();
+
+  /**
+   * Computes the fragment URIs from the input array directory URIs.
+   */
+  tuple<Status, optional<std::vector<URI>>> compute_fragment_uris(
+      const std::vector<URI>& array_dir_uris);
+
+  /**
+   * Computes the fragment URIs and vacuum URIs to vacuum.
+   *
+   * @param uris The URIs to calculate the URIs to vacuum from.
+   * @return Status, a vector of the URIs to vacuum, a vector of
+   *     the vac file URIs to vacuum.
+   */
+  tuple<Status, optional<std::vector<URI>>, optional<std::vector<URI>>>
+  compute_uris_to_vacuum(const std::vector<URI>& uris);
+
+  /**
+   * Computes the filtered URIs based on the input, which fall
+   * in the timestamp range [`timestamp_start_`, `timestamp_end_`].
+   *
+   * @param uris The URIs to filter.
+   * @param to_ignore The URIs to ignore (because they are vacuumed).
+   * @return Status, vector of filtered timestamped URIs.
+   */
+  tuple<Status, optional<std::vector<TimestampedURI>>> compute_filtered_uris(
+      const std::vector<URI>& uris, const std::vector<URI>& to_ignore);
+
+  /**
+   * Computes and sets the final vector of array schema URIs, and the
+   * latest array schema URI, given `array_schema_dir_uris`.
+   *
+   * @return Status.
+   */
+  Status compute_array_schema_uris(
+      const std::vector<URI>& array_schema_dir_uris);
+
+  /** Returns true if the input URI is a vacuum file. */
+  bool is_vacuum_file(const URI& uri) const;
+
+  /**
+   * Checks if the input URI represents a fragment. The functions takes into
+   * account the fragment version, which is retrived directly from the URI.
+   * For versions >= 5, the function checks whether the URI is included
+   * in `ok_uris`. For versions < 5, `ok_uris` is empty so the function
+   * checks for the existence of the fragment metadata file in the fragment
+   * URI directory. Therefore, the function is more expensive for earlier
+   * fragment versions.
+   *
+   * @param uri The URI to be checked.
+   * @param ok_uris For checking URI existence of versions >= 5.
+   * @param is_fragment Set to `1` if the URI is a fragment and `0`
+   *     otherwise.
+   * @return Status
+   */
+  Status is_fragment(
+      const URI& uri, const std::set<URI>& ok_uris, int32_t* is_fragment) const;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_ARRAY_DIRECTORY_H

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -872,8 +872,8 @@ Status ArraySchema::generate_uri() {
   ss << "__" << timestamp_range_.first << "_" << timestamp_range_.second << "_"
      << uuid;
   name_ = ss.str();
-  uri_ = array_uri_.join_path(constants::array_schema_folder_name)
-             .join_path(name_);
+  uri_ =
+      array_uri_.join_path(constants::array_schema_dir_name).join_path(name_);
 
   return Status::Ok();
 }
@@ -888,8 +888,8 @@ Status ArraySchema::generate_uri(
   ss << "__" << timestamp_range_.first << "_" << timestamp_range_.second << "_"
      << uuid;
   name_ = ss.str();
-  uri_ = array_uri_.join_path(constants::array_schema_folder_name)
-             .join_path(name_);
+  uri_ =
+      array_uri_.join_path(constants::array_schema_dir_name).join_path(name_);
 
   return Status::Ok();
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2435,13 +2435,28 @@ int32_t tiledb_array_schema_load(
                 0)))
       return TILEDB_ERR;
 
-    // Load array schema
+    // For easy reference
     auto storage_manager = ctx->ctx_->storage_manager();
+    auto vfs = storage_manager->vfs();
+    auto tp = storage_manager->compute_tp();
 
+    // Load URIs from the array directory
+    tiledb::sm::ArrayDirectory array_dir;
+    try {
+      array_dir = tiledb::sm::ArrayDirectory(vfs, tp, uri, 0, UINT64_MAX, true);
+    } catch (const std::logic_error& le) {
+      auto st = Status_ArrayDirectoryError(le.what());
+      LOG_STATUS(st);
+      save_error(ctx, st);
+      delete *array_schema;
+      return TILEDB_ERR;
+    }
+
+    // Load latest array schema
     if (SAVE_ERROR_CATCH(
             ctx,
             storage_manager->load_array_schema_latest(
-                uri, key, &((*array_schema)->array_schema_)))) {
+                array_dir, key, &((*array_schema)->array_schema_)))) {
       delete *array_schema;
       return TILEDB_ERR;
     }
@@ -2514,13 +2529,28 @@ int32_t tiledb_array_schema_load_with_key(
       return TILEDB_ERR;
     }
 
-    // Load array schema
+    // For easy reference
     auto storage_manager = ctx->ctx_->storage_manager();
+    auto vfs = storage_manager->vfs();
+    auto tp = storage_manager->compute_tp();
 
+    // Load URIs from the array directory
+    tiledb::sm::ArrayDirectory array_dir;
+    try {
+      array_dir = tiledb::sm::ArrayDirectory(vfs, tp, uri, 0, UINT64_MAX, true);
+    } catch (const std::logic_error& le) {
+      auto st = Status_ArrayDirectoryError(le.what());
+      LOG_STATUS(st);
+      save_error(ctx, st);
+      delete *array_schema;
+      return TILEDB_ERR;
+    }
+
+    // Load latest array schema
     if (SAVE_ERROR_CATCH(
             ctx,
             storage_manager->load_array_schema_latest(
-                uri, key, &((*array_schema)->array_schema_)))) {
+                array_dir, key, &((*array_schema)->array_schema_)))) {
       delete *array_schema;
       *array_schema = nullptr;
       return TILEDB_ERR;
@@ -5070,10 +5100,28 @@ int32_t tiledb_array_encryption_type(
       encryption_type == nullptr)
     return TILEDB_ERR;
 
+  // For easy reference
+  auto storage_manager = ctx->ctx_->storage_manager();
+  auto vfs = storage_manager->vfs();
+  auto tp = storage_manager->compute_tp();
+  auto uri = tiledb::sm::URI(array_uri);
+
+  // Load URIs from the array directory
+  tiledb::sm::ArrayDirectory array_dir;
+  try {
+    array_dir = tiledb::sm::ArrayDirectory(vfs, tp, uri, 0, UINT64_MAX, true);
+  } catch (const std::logic_error& le) {
+    auto st = Status_ArrayDirectoryError(le.what());
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
+
+  // Get encryption type
   tiledb::sm::EncryptionType enc;
   if (SAVE_ERROR_CATCH(
           ctx,
-          ctx->ctx_->storage_manager()->array_get_encryption(array_uri, &enc)))
+          ctx->ctx_->storage_manager()->array_get_encryption(array_dir, &enc)))
     return TILEDB_ERR;
 
   *encryption_type = static_cast<tiledb_encryption_type_t>(enc);
@@ -5270,10 +5318,27 @@ int32_t tiledb_array_evolve(
               0)))
     return TILEDB_ERR;
 
+  // For easy reference
+  auto storage_manager = ctx->ctx_->storage_manager();
+  auto vfs = storage_manager->vfs();
+  auto tp = storage_manager->compute_tp();
+
+  // Load URIs from the array directory
+  tiledb::sm::ArrayDirectory array_dir;
+  try {
+    array_dir = tiledb::sm::ArrayDirectory(vfs, tp, uri, 0, UINT64_MAX, true);
+  } catch (const std::logic_error& le) {
+    auto st = Status_ArrayDirectoryError(le.what());
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
+
+  // Evolve schema
   if (SAVE_ERROR_CATCH(
           ctx,
           ctx->ctx_->storage_manager()->array_evolve_schema(
-              uri, array_schema_evolution->array_schema_evolution_, key)))
+              array_dir, array_schema_evolution->array_schema_evolution_, key)))
     return TILEDB_ERR;
 
   // Success
@@ -5295,10 +5360,27 @@ int32_t tiledb_array_upgrade_version(
     return TILEDB_ERR;
   }
 
+  // For easy reference
+  auto storage_manager = ctx->ctx_->storage_manager();
+  auto vfs = storage_manager->vfs();
+  auto tp = storage_manager->compute_tp();
+
+  // Load URIs from the array directory
+  tiledb::sm::ArrayDirectory array_dir;
+  try {
+    array_dir = tiledb::sm::ArrayDirectory(vfs, tp, uri, 0, UINT64_MAX, true);
+  } catch (const std::logic_error& le) {
+    auto st = Status_ArrayDirectoryError(le.what());
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
+
+  // Upgrade version
   if (SAVE_ERROR_CATCH(
           ctx,
           ctx->ctx_->storage_manager()->array_upgrade_version(
-              uri,
+              array_dir,
               (config == nullptr) ? &ctx->ctx_->storage_manager()->config() :
                                     config->config_)))
     return TILEDB_ERR;

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -814,6 +814,16 @@ Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
   if (!init_)
     return LOG_STATUS(Status_VFSError("Cannot list; VFS not initialized"));
 
+  // Noop if `parent` is not a directory, do not error out.
+  // For S3, GCS and Azure, `ls` on a non-directory will just
+  // return an empty `uris` vector.
+  if (!(parent.is_s3() || parent.is_gcs() || parent.is_azure())) {
+    bool flag = false;
+    RETURN_NOT_OK(is_dir(parent, &flag));
+    if (!flag)
+      return Status::Ok();
+  }
+
   std::vector<std::string> paths;
   if (parent.is_file()) {
 #ifdef _WIN32

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -33,6 +33,7 @@
 #include "tiledb/sm/fragment/fragment_info.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array/array_directory.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/misc/parallel_functions.h"
@@ -714,7 +715,7 @@ Status FragmentInfo::get_array_schema(
   uint32_t version = single_fragment_info_vec_[fid].format_version();
   if (version >= 10) {
     schema_uri =
-        array_uri_.join_path(constants::array_schema_folder_name)
+        array_uri_.join_path(constants::array_schema_dir_name)
             .join_path(single_fragment_info_vec_[fid].array_schema_name());
   } else {
     schema_uri = array_uri_.join_path(constants::array_schema_filename);
@@ -805,10 +806,10 @@ Status FragmentInfo::load(
   }
 
   if (array_uri_.is_tiledb()) {
-    auto msg =
-        std::string(
-            "FragmentInfo not supported by TileDB Cloud Arrays; Array '") +
-        array_uri_.to_string() + "' cannot be loaded";
+    auto msg = std::string(
+                   "FragmentInfo not supported in TileDB Cloud arrays; "
+                   "FragmentInfo for array '") +
+               array_uri_.to_string() + "' cannot be loaded";
     return LOG_STATUS(Status_FragmentInfoError(msg));
   }
 
@@ -822,11 +823,24 @@ Status FragmentInfo::load(
     RETURN_NOT_OK(this->set_enc_key_from_config());
   }
 
-  // Get the array schemas and fragment metadata.
+  // Create an ArrayDirectory object and load
   auto timestamp_start = compute_anterior ? 0 : timestamp_start_;
+  ArrayDirectory array_dir;
+  try {
+    array_dir = ArrayDirectory(
+        storage_manager_->vfs(),
+        storage_manager_->compute_tp(),
+        array_uri_,
+        timestamp_start,
+        timestamp_end_);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
+
+  // Get the array schemas and fragment metadata.
   auto&& [st_schemas, array_schema_latest, array_schemas_all, fragment_metadata] =
       storage_manager_->load_array_schemas_and_fragment_metadata(
-          array_uri_, nullptr, enc_key_, timestamp_start, timestamp_end_);
+          array_dir, nullptr, enc_key_);
   RETURN_NOT_OK(st_schemas);
   (void)array_schema_latest;  // Not needed here
   array_schemas_all_ = std::move(array_schemas_all.value());
@@ -885,19 +899,8 @@ Status FragmentInfo::load(
     }
   }
 
-  // TODO: don't get the fragment URIs twice, get them from
-  // get_array_schemas_and_fragment_metadata
-
-  // Clear to vacuum
-  to_vacuum_.clear();
-
   // Get the URIs to vacuum
-  std::vector<URI> vac_uris, fragment_uris;
-  URI meta_uri;
-  RETURN_NOT_OK(storage_manager_->get_fragment_uris(
-      array_uri_, &fragment_uris, &meta_uri));
-  RETURN_NOT_OK(storage_manager_->get_uris_to_vacuum(
-      fragment_uris, timestamp_start_, timestamp_end_, &to_vacuum_, &vac_uris));
+  to_vacuum_ = array_dir.fragment_uris_to_vacuum();
 
   // Get number of unconsolidated fragment metadata
   unconsolidated_metadata_num_ = 0;

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -92,7 +92,7 @@ Status Metadata::generate_uri(const URI& array_uri) {
   std::stringstream ss;
   ss << "__" << timestamp_range_.first << "_" << timestamp_range_.second << "_"
      << uuid;
-  uri_ = array_uri.join_path(constants::array_metadata_folder_name)
+  uri_ = array_uri.join_path(constants::array_metadata_dir_name)
              .join_path(ss.str());
 
   return Status::Ok();

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -71,11 +71,11 @@ const unsigned rtree_fanout = 10;
 /** The array schema file name. */
 const std::string array_schema_filename = "__array_schema.tdb";
 
-/** The array schema folder name. */
-const std::string array_schema_folder_name = "__schema";
+/** The array schema directory name. */
+const std::string array_schema_dir_name = "__schema";
 
-/** The array metadata folder name. */
-const std::string array_metadata_folder_name = "__meta";
+/** The array metadata directory name. */
+const std::string array_metadata_dir_name = "__meta";
 
 /** The fragment metadata file name. */
 const std::string fragment_metadata_filename = "__fragment_metadata.tdb";

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -62,11 +62,11 @@ extern const unsigned rtree_fanout;
 /** The array schema file name. */
 extern const std::string array_schema_filename;
 
-/** The array schema folder name. */
-extern const std::string array_schema_folder_name;
+/** The array schema directory name. */
+extern const std::string array_schema_dir_name;
 
-/** The array metadata folder name. */
-extern const std::string array_metadata_folder_name;
+/** The array metadata directory name. */
+extern const std::string array_metadata_dir_name;
 
 /** The default tile capacity. */
 extern const uint64_t capacity;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -42,6 +42,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array/array_directory.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/array_schema_evolution.h"
 #include "tiledb/sm/cache/buffer_lru_cache.h"
@@ -139,31 +140,14 @@ tuple<
     optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
     optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
 StorageManager::load_array_schemas_and_fragment_metadata(
-    const URI& array_uri,
+    const ArrayDirectory& array_dir,
     MemoryTracker* memory_tracker,
-    const EncryptionKey& enc_key,
-    uint64_t timestamp_start,
-    uint64_t timestamp_end) {
+    const EncryptionKey& enc_key) {
   auto timer_se =
-      stats_->start_timer("get_array_schemas_and_fragment_metadata");
+      stats_->start_timer("sm_load_array_schemas_and_fragment_metadata");
 
-  // Get the fragment URIs
-  std::vector<URI> fragment_uris;
-  URI meta_uri;
-  RETURN_NOT_OK_TUPLE(
-      get_fragment_uris(array_uri, &fragment_uris, &meta_uri),
-      nullopt,
-      nullopt,
-      nullopt);
-
-  // Determine which fragments to load
-  std::vector<TimestampedURI> fragments_to_load;
-  RETURN_NOT_OK_TUPLE(
-      get_sorted_uris(
-          fragment_uris, &fragments_to_load, timestamp_start, timestamp_end),
-      nullopt,
-      nullopt,
-      nullopt);
+  const auto& meta_uri = array_dir.latest_fragment_meta_uri();
+  const auto& fragments_to_load = array_dir.fragment_uris();
 
   // Get the consolidated fragment metadata
   Buffer f_buff;
@@ -176,8 +160,8 @@ StorageManager::load_array_schemas_and_fragment_metadata(
 
   // Load array schemas
   auto&& [st_schemas, array_schema_latest, array_schemas_all] =
-      load_array_schemas(array_uri, enc_key);
-  RETURN_NOT_OK_TUPLE(st_schemas, nullopt, nullopt, nullopt);
+      load_array_schemas(array_dir, enc_key);
+  RETURN_NOT_OK_TUPLE(st_schemas, std::nullopt, std::nullopt, std::nullopt);
 
   // Load the fragment metadata
   auto&& [st_fragment_meta, fragment_metadata] = load_fragment_metadata(
@@ -203,11 +187,9 @@ StorageManager::array_open_for_reads(Array* array) {
   auto timer_se = stats_->start_timer("array_open_for_reads");
   auto&& [st, array_schema_latest, array_schemas_all, fragment_metadata] =
       load_array_schemas_and_fragment_metadata(
-          array->array_uri(),
+          array->array_directory(),
           array->memory_tracker(),
-          *array->encryption_key(),
-          array->timestamp_start(),
-          array->timestamp_end_opened_at());
+          *array->encryption_key());
   RETURN_NOT_OK_TUPLE(st, nullopt, nullopt, nullopt);
 
   // Mark the array as open
@@ -223,11 +205,12 @@ tuple<
     optional<ArraySchema*>,
     optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
 StorageManager::array_open_for_reads_without_fragments(Array* array) {
-  auto timer_se = stats_->start_timer("array_open_for_reads_without_fragments");
+  auto timer_se =
+      stats_->start_timer("sm_array_open_for_reads_without_fragments");
 
   // Load array schemas
   auto&& [st_schemas, array_schema_latest, array_schemas_all] =
-      load_array_schemas(array->array_uri(), *array->encryption_key());
+      load_array_schemas(array->array_directory(), *array->encryption_key());
   RETURN_NOT_OK_TUPLE(st_schemas, nullopt, nullopt);
 
   // Mark the array as now open
@@ -251,7 +234,7 @@ StorageManager::array_open_for_writes(Array* array) {
 
   // Load array schemas
   auto&& [st_schemas, array_schema_latest, array_schemas_all] =
-      load_array_schemas(array->array_uri(), *array->encryption_key());
+      load_array_schemas(array->array_directory(), *array->encryption_key());
   RETURN_NOT_OK_TUPLE(st_schemas, nullopt, nullopt);
 
   // This library should not be able to write to newer-versioned arrays
@@ -440,20 +423,23 @@ Status StorageManager::array_vacuum_fragments(
     return logger_->status(Status_StorageManagerError(
         "Cannot vacuum fragments; Array name cannot be null"));
 
-  // Get all URIs in the array directory
-  URI array_uri(array_name);
-  std::vector<URI> uris;
-  RETURN_NOT_OK(vfs_->ls(array_uri.add_trailing_slash(), &uris));
+  // Get the fragment URIs and vacuum file URIs to be vacuum
+  ArrayDirectory array_dir;
+  try {
+    array_dir = ArrayDirectory(
+        vfs_, compute_tp_, URI(array_name), timestamp_start, timestamp_end);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
 
-  // Get URIs to be vacuumed
-  std::vector<URI> to_vacuum, vac_uris;
-  RETURN_NOT_OK(get_uris_to_vacuum(
-      uris, timestamp_start, timestamp_end, &to_vacuum, &vac_uris));
+  const auto& fragment_uris_to_vacuum = array_dir.fragment_uris_to_vacuum();
+  const auto& vac_uris_to_vacuum = array_dir.fragment_vac_uris_to_vacuum();
 
   // Delete the ok files
-  auto status =
-      parallel_for(compute_tp_, 0, to_vacuum.size(), [&, this](size_t i) {
-        auto uri = URI(to_vacuum[i].to_string() + constants::ok_file_suffix);
+  auto status = parallel_for(
+      compute_tp_, 0, fragment_uris_to_vacuum.size(), [&, this](size_t i) {
+        auto uri = URI(
+            fragment_uris_to_vacuum[i].to_string() + constants::ok_file_suffix);
         RETURN_NOT_OK(vfs_->remove_file(uri));
 
         return Status::Ok();
@@ -461,18 +447,20 @@ Status StorageManager::array_vacuum_fragments(
   RETURN_NOT_OK(status);
 
   // Delete fragment directories
-  status = parallel_for(compute_tp_, 0, to_vacuum.size(), [&, this](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_dir(to_vacuum[i]));
+  status = parallel_for(
+      compute_tp_, 0, fragment_uris_to_vacuum.size(), [&, this](size_t i) {
+        RETURN_NOT_OK(vfs_->remove_dir(fragment_uris_to_vacuum[i]));
 
-    return Status::Ok();
-  });
+        return Status::Ok();
+      });
   RETURN_NOT_OK(status);
 
   // Delete vacuum files
-  status = parallel_for(compute_tp_, 0, vac_uris.size(), [&, this](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_file(vac_uris[i]));
-    return Status::Ok();
-  });
+  status = parallel_for(
+      compute_tp_, 0, vac_uris_to_vacuum.size(), [&, this](size_t i) {
+        RETURN_NOT_OK(vfs_->remove_file(vac_uris_to_vacuum[i]));
+        return Status::Ok();
+      });
   RETURN_NOT_OK(status);
 
   return Status::Ok();
@@ -485,22 +473,22 @@ Status StorageManager::array_vacuum_fragment_meta(const char* array_name) {
 
   // Get the consolidated fragment metadata URIs to be deleted
   // (all except the last one)
-  URI array_uri(array_name);
-  std::vector<URI> uris, to_vacuum;
-  URI last;
-  RETURN_NOT_OK(vfs_->ls(array_uri.add_trailing_slash(), &uris));
-  RETURN_NOT_OK(get_consolidated_fragment_meta_uri(uris, &last));
-  to_vacuum.reserve(uris.size());
-  for (const auto& uri : uris) {
-    if (utils::parse::ends_with(uri.to_string(), constants::meta_file_suffix) &&
-        uri != last)
-      to_vacuum.emplace_back(uri);
+  ArrayDirectory array_dir;
+  try {
+    array_dir =
+        ArrayDirectory(vfs_, compute_tp_, URI(array_name), 0, UINT64_MAX);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
   }
 
+  const auto& last = array_dir.latest_fragment_meta_uri();
+  const auto& fragment_meta_uris = array_dir.fragment_meta_uris();
+
   // Vacuum after exclusively locking the array
-  auto status =
-      parallel_for(compute_tp_, 0, to_vacuum.size(), [&, this](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(to_vacuum[i]));
+  auto status = parallel_for(
+      compute_tp_, 0, fragment_meta_uris.size(), [&, this](size_t i) {
+        if (fragment_meta_uris[i] != last)
+          RETURN_NOT_OK(vfs_->remove_file(fragment_meta_uris[i]));
         return Status::Ok();
       });
   RETURN_NOT_OK(status);
@@ -514,31 +502,33 @@ Status StorageManager::array_vacuum_array_meta(
     return logger_->status(Status_StorageManagerError(
         "Cannot vacuum array metadata; Array name cannot be null"));
 
-  // Get all URIs in the array directory
-  URI array_uri(array_name);
-  auto meta_uri = array_uri.join_path(constants::array_metadata_folder_name);
-  std::vector<URI> uris;
-  RETURN_NOT_OK(vfs_->ls(meta_uri.add_trailing_slash(), &uris));
+  // Get the array metadata URIs and vacuum file URIs to be vacuum
+  ArrayDirectory array_dir;
+  try {
+    array_dir = ArrayDirectory(
+        vfs_, compute_tp_, URI(array_name), timestamp_start, timestamp_end);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
 
-  // Get URIs to be vacuumed
-  std::vector<URI> to_vacuum, vac_uris;
-  RETURN_NOT_OK(get_uris_to_vacuum(
-      uris, timestamp_start, timestamp_end, &to_vacuum, &vac_uris));
+  const auto& array_meta_uris_to_vacuum = array_dir.array_meta_uris_to_vacuum();
+  const auto& vac_uris_to_vacuum = array_dir.array_meta_vac_uris_to_vacuum();
 
   // Delete the array metadata files
-  auto status =
-      parallel_for(compute_tp_, 0, to_vacuum.size(), [&, this](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(to_vacuum[i]));
+  auto status = parallel_for(
+      compute_tp_, 0, array_meta_uris_to_vacuum.size(), [&, this](size_t i) {
+        RETURN_NOT_OK(vfs_->remove_file(array_meta_uris_to_vacuum[i]));
 
         return Status::Ok();
       });
   RETURN_NOT_OK(status);
 
   // Delete vacuum files
-  status = parallel_for(compute_tp_, 0, vac_uris.size(), [&, this](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_file(vac_uris[i]));
-    return Status::Ok();
-  });
+  status = parallel_for(
+      compute_tp_, 0, vac_uris_to_vacuum.size(), [&, this](size_t i) {
+        RETURN_NOT_OK(vfs_->remove_file(vac_uris_to_vacuum[i]));
+        return Status::Ok();
+      });
   RETURN_NOT_OK(status);
 
   return Status::Ok();
@@ -637,13 +627,13 @@ Status StorageManager::array_create(
   RETURN_NOT_OK(vfs_->create_dir(array_uri));
 
   // Create array schema directory
-  URI array_schema_folder_uri =
-      array_uri.join_path(constants::array_schema_folder_name);
-  RETURN_NOT_OK(vfs_->create_dir(array_schema_folder_uri));
+  URI array_schema_dir_uri =
+      array_uri.join_path(constants::array_schema_dir_name);
+  RETURN_NOT_OK(vfs_->create_dir(array_schema_dir_uri));
 
   // Create array metadata directory
   URI array_metadata_uri =
-      array_uri.join_path(constants::array_metadata_folder_name);
+      array_uri.join_path(constants::array_metadata_dir_name);
   RETURN_NOT_OK(vfs_->create_dir(array_metadata_uri));
   Status st;
 
@@ -696,9 +686,11 @@ Status StorageManager::array_create(
 }
 
 Status StorageManager::array_evolve_schema(
-    const URI& array_uri,
+    const ArrayDirectory& array_dir,
     ArraySchemaEvolution* schema_evolution,
     const EncryptionKey& encryption_key) {
+  const URI& array_uri = array_dir.array_uri();
+
   // Check array schema
   if (schema_evolution == nullptr) {
     return logger_->status(Status_StorageManagerError(
@@ -720,7 +712,7 @@ Status StorageManager::array_evolve_schema(
 
   ArraySchema* array_schema = (ArraySchema*)nullptr;
   RETURN_NOT_OK(
-      load_array_schema_latest(array_uri, encryption_key, &array_schema));
+      load_array_schema_latest(array_dir, encryption_key, &array_schema));
 
   // Evolve schema
   ArraySchema* array_schema_evolved = (ArraySchema*)nullptr;
@@ -744,7 +736,9 @@ Status StorageManager::array_evolve_schema(
 }
 
 Status StorageManager::array_upgrade_version(
-    const URI& array_uri, const Config* config) {
+    const ArrayDirectory& array_dir, const Config* config) {
+  const URI& array_uri = array_dir.array_uri();
+
   // Check if array exists
   bool exists = false;
   RETURN_NOT_OK(is_array(array_uri, &exists));
@@ -794,7 +788,7 @@ Status StorageManager::array_upgrade_version(
 
   ArraySchema* array_schema = (ArraySchema*)nullptr;
   RETURN_NOT_OK(
-      load_array_schema_latest(array_uri, encryption_key_cfg, &array_schema));
+      load_array_schema_latest(array_dir, encryption_key_cfg, &array_schema));
 
   if (array_schema->version() < constants::format_version) {
     Status st = array_schema->generate_uri();
@@ -807,9 +801,9 @@ Status StorageManager::array_upgrade_version(
     array_schema->set_version(constants::format_version);
 
     // Create array schema directory if necessary
-    URI array_schema_folder_uri =
-        array_uri.join_path(constants::array_schema_folder_name);
-    st = vfs_->create_dir(array_schema_folder_uri);
+    URI array_schema_dir_uri =
+        array_uri.join_path(constants::array_schema_dir_name);
+    st = vfs_->create_dir(array_schema_dir_uri);
     if (!st.ok()) {
       logger_->status(st);
       // Clean up
@@ -1101,17 +1095,16 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
 }
 
 Status StorageManager::array_get_encryption(
-    const std::string& array_uri, EncryptionType* encryption_type) {
-  URI uri(array_uri);
+    const ArrayDirectory& array_dir, EncryptionType* encryption_type) {
+  const URI& uri = array_dir.array_uri();
 
   if (uri.is_invalid())
     return logger_->status(Status_StorageManagerError(
         "Cannot get array encryption; Invalid array URI"));
 
-  URI schema_uri;
-  RETURN_NOT_OK(get_latest_array_schema_uri(uri, &schema_uri));
+  const URI& schema_uri = array_dir.latest_array_schema_uri();
 
-  // Read tile header.
+  // Read tile header
   GenericTileIO::GenericTileHeader header;
   RETURN_NOT_OK(
       GenericTileIO::read_generic_tile_header(this, schema_uri, 0, &header));
@@ -1236,132 +1229,6 @@ Status StorageManager::object_move(
   return vfs_->move_dir(old_uri, new_uri);
 }
 
-Status StorageManager::get_fragment_uris(
-    const URI& array_uri,
-    std::vector<URI>* fragment_uris,
-    URI* meta_uri) const {
-  auto timer_se = stats_->start_timer("read_get_fragment_uris");
-  // Get all uris in the array directory
-  std::vector<URI> uris;
-  RETURN_NOT_OK(vfs_->ls(array_uri.add_trailing_slash(), &uris));
-
-  // Get the fragments that have special "ok" URIs, which indicate
-  // that fragments are "committed" for versions >= 5
-  std::set<URI> ok_uris;
-  for (size_t i = 0; i < uris.size(); ++i) {
-    if (utils::parse::ends_with(
-            uris[i].to_string(), constants::ok_file_suffix)) {
-      auto name = uris[i].to_string();
-      name = name.substr(0, name.size() - constants::ok_file_suffix.size());
-      ok_uris.emplace(URI(name));
-    }
-  }
-
-  // Get only the committed fragment uris
-  std::vector<int> is_fragment(uris.size(), 0);
-  auto status = parallel_for(compute_tp_, 0, uris.size(), [&](size_t i) {
-    if (utils::parse::starts_with(uris[i].last_path_part(), "."))
-      return Status::Ok();
-    RETURN_NOT_OK(this->is_fragment(uris[i], ok_uris, &is_fragment[i]));
-    return Status::Ok();
-  });
-  RETURN_NOT_OK(status);
-
-  for (size_t i = 0; i < uris.size(); ++i) {
-    if (is_fragment[i])
-      fragment_uris->emplace_back(uris[i]);
-    else if (this->is_vacuum_file(uris[i]))
-      fragment_uris->emplace_back(uris[i]);
-  }
-
-  // Get the latest consolidated fragment metadata URI
-  RETURN_NOT_OK(get_consolidated_fragment_meta_uri(uris, meta_uri));
-
-  return Status::Ok();
-}
-
-Status StorageManager::get_uris_to_vacuum(
-    const std::vector<URI>& uris,
-    uint64_t timestamp_start,
-    uint64_t timestamp_end,
-    std::vector<URI>* to_vacuum,
-    std::vector<URI>* vac_uris,
-    bool allow_partial) const {
-  // Get vacuum URIs
-  std::vector<URI> vac_files;
-  std::unordered_set<std::string> non_vac_uris_set;
-  std::unordered_map<std::string, size_t> uris_map;
-  for (size_t i = 0; i < uris.size(); ++i) {
-    std::pair<uint64_t, uint64_t> timestamp_range;
-    RETURN_NOT_OK(utils::parse::get_timestamp_range(uris[i], &timestamp_range));
-
-    if (this->is_vacuum_file(uris[i])) {
-      if (allow_partial) {
-        if (timestamp_range.first <= timestamp_end &&
-            timestamp_range.second >= timestamp_start)
-          vac_files.emplace_back(uris[i]);
-      } else {
-        if (timestamp_range.first >= timestamp_start &&
-            timestamp_range.second <= timestamp_end)
-          vac_files.emplace_back(uris[i]);
-      }
-    } else {
-      if (timestamp_range.first < timestamp_start ||
-          timestamp_range.second > timestamp_end) {
-        non_vac_uris_set.emplace(uris[i].to_string());
-      } else {
-        uris_map[uris[i].to_string()] = i;
-      }
-    }
-  }
-
-  // Compute fragment URIs to vacuum as a bitmap vector
-  // Also determine which vac files to vacuum
-  std::vector<int32_t> to_vacuum_vec(uris.size(), 0);
-  std::vector<int32_t> to_vacuum_vac_files_vec(vac_files.size(), 0);
-  auto status =
-      parallel_for(compute_tp_, 0, vac_files.size(), [&, this](size_t i) {
-        uint64_t size = 0;
-        RETURN_NOT_OK(vfs_->file_size(vac_files[i], &size));
-        std::string names;
-        names.resize(size);
-        RETURN_NOT_OK(vfs_->read(vac_files[i], 0, &names[0], size));
-        std::stringstream ss(names);
-        bool vacuum_vac_file = true;
-        for (std::string uri_str; std::getline(ss, uri_str);) {
-          auto it = uris_map.find(uri_str);
-          if (it != uris_map.end())
-            to_vacuum_vec[it->second] = 1;
-
-          if (vacuum_vac_file &&
-              non_vac_uris_set.find(uri_str) != non_vac_uris_set.end()) {
-            vacuum_vac_file = false;
-          }
-        }
-
-        to_vacuum_vac_files_vec[i] = vacuum_vac_file;
-
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  // Compute the URIs to vacuum
-  to_vacuum->clear();
-  for (size_t i = 0; i < uris.size(); ++i) {
-    if (to_vacuum_vec[i] == 1)
-      to_vacuum->emplace_back(uris[i]);
-  }
-
-  // Compute the vac URIs to vacuum
-  vac_uris->clear();
-  for (size_t i = 0; i < vac_files.size(); ++i) {
-    if (to_vacuum_vac_files_vec[i] == 1)
-      vac_uris->emplace_back(vac_files[i]);
-  }
-
-  return Status::Ok();
-}
-
 const std::unordered_map<std::string, std::string>& StorageManager::tags()
     const {
   return tags_;
@@ -1452,7 +1319,7 @@ Status StorageManager::is_array(const URI& uri, bool* is_array) const {
   bool is_dir = false;
   // Since is_dir could return NOT Ok status, we will not use RETURN_NOT_OK here
   Status st =
-      vfs_->is_dir(uri.join_path(constants::array_schema_folder_name), &is_dir);
+      vfs_->is_dir(uri.join_path(constants::array_schema_dir_name), &is_dir);
   if (st.ok() && is_dir) {
     *is_array = true;
     return Status::Ok();
@@ -1469,107 +1336,9 @@ Status StorageManager::is_file(const URI& uri, bool* is_file) const {
   return Status::Ok();
 }
 
-Status StorageManager::is_fragment(
-    const URI& uri, const std::set<URI>& ok_uris, int* is_fragment) const {
-  // If the URI name has a suffix, then it is not a fragment
-  auto name = uri.remove_trailing_slash().last_path_part();
-  if (name.find_first_of('.') != std::string::npos) {
-    *is_fragment = 0;
-    return Status::Ok();
-  }
-
-  // Check set membership in ok_uris
-  if (ok_uris.find(uri) != ok_uris.end()) {
-    *is_fragment = 1;
-    return Status::Ok();
-  }
-
-  // If the format version is >= 5, then the above suffices to check if
-  // the URI is indeed a fragment
-  uint32_t version;
-  RETURN_NOT_OK(utils::parse::get_fragment_version(name, &version));
-  if (version != UINT32_MAX && version >= 5) {
-    *is_fragment = false;
-    return Status::Ok();
-  }
-
-  // Versions < 5
-  bool is_file;
-  RETURN_NOT_OK(vfs_->is_file(
-      uri.join_path(constants::fragment_metadata_filename), &is_file));
-  *is_fragment = (int)is_file;
-  return Status::Ok();
-}
-
 Status StorageManager::is_group(const URI& uri, bool* is_group) const {
   RETURN_NOT_OK(
       vfs_->is_file(uri.join_path(constants::group_filename), is_group));
-  return Status::Ok();
-}
-
-bool StorageManager::is_vacuum_file(const URI& uri) const {
-  // If the URI name has a suffix, then it is not a fragment
-  if (utils::parse::ends_with(uri.to_string(), constants::vacuum_file_suffix))
-    return true;
-
-  return false;
-}
-
-Status StorageManager::get_array_schema_uris(
-    const URI& array_uri, std::vector<URI>* schema_uris) const {
-  auto timer_se = stats_->start_timer("read_get_array_schema_uris");
-
-  schema_uris->clear();
-  URI old_schema_uri = array_uri.join_path(constants::array_schema_filename);
-  bool has_file = false;
-  RETURN_NOT_OK(vfs_->is_file(old_schema_uri, &has_file));
-  if (has_file) {
-    schema_uris->push_back(old_schema_uri);
-  }
-
-  URI schema_folder_uri =
-      array_uri.join_path(constants::array_schema_folder_name);
-  // Check if schema_folder_uri exists. For some file systems, such as win, ls
-  // will return error if the folder does not exist.
-  bool has_dir = false;
-  RETURN_NOT_OK(vfs_->is_dir(schema_folder_uri, &has_dir));
-  if (has_dir) {
-    std::vector<URI> array_schema_uris;
-    RETURN_NOT_OK(vfs_->ls(schema_folder_uri, &array_schema_uris));
-    if (array_schema_uris.size() > 0) {
-      schema_uris->reserve(schema_uris->size() + array_schema_uris.size());
-      std::copy(
-          array_schema_uris.begin(),
-          array_schema_uris.end(),
-          std::back_inserter(*schema_uris));
-    }
-  }
-
-  // Check if schema_uris is empty
-  if (schema_uris->empty()) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get the array schemas; No array schemas found."));
-  }
-
-  return Status::Ok();
-}
-
-Status StorageManager::get_latest_array_schema_uri(
-    const URI& array_uri, URI* uri) const {
-  auto timer_se = stats_->start_timer("read_get_latest_array_schema_uri");
-
-  std::vector<URI> schema_uris;
-  RETURN_NOT_OK(get_array_schema_uris(array_uri, &schema_uris));
-  if (schema_uris.size() == 0) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get the latest array schema; No array schemas found."));
-  }
-  *uri = schema_uris.back();
-  if (uri->is_invalid()) {
-    return logger_->status(
-        Status_StorageManagerError("Could not find array schema URI"));
-  }
-
   return Status::Ok();
 }
 
@@ -1643,17 +1412,17 @@ Status StorageManager::load_array_schema_from_uri(
 }
 
 Status StorageManager::load_array_schema_latest(
-    const URI& array_uri,
+    const ArrayDirectory& array_dir,
     const EncryptionKey& encryption_key,
     ArraySchema** array_schema) {
-  auto timer_se = stats_->start_timer("read_load_array_schema");
+  auto timer_se = stats_->start_timer("sm_load_array_schema");
 
+  const URI& array_uri = array_dir.array_uri();
   if (array_uri.is_invalid())
     return logger_->status(Status_StorageManagerError(
         "Cannot load array schema; Invalid array URI"));
 
-  URI schema_uri;
-  RETURN_NOT_OK(get_latest_array_schema_uri(array_uri, &schema_uri));
+  const URI& schema_uri = array_dir.latest_array_schema_uri();
 
   RETURN_NOT_OK(
       load_array_schema_from_uri(schema_uri, encryption_key, array_schema));
@@ -1666,14 +1435,14 @@ tuple<
     optional<ArraySchema*>,
     optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
 StorageManager::load_array_schemas(
-    const URI& array_uri, const EncryptionKey& encryption_key) {
+    const ArrayDirectory& array_dir, const EncryptionKey& encryption_key) {
   auto array_schema = (ArraySchema*)nullptr;
   RETURN_NOT_OK_TUPLE(
-      load_array_schema_latest(array_uri, encryption_key, &array_schema),
+      load_array_schema_latest(array_dir, encryption_key, &array_schema),
       nullopt,
       nullopt);
 
-  auto&& [st, schemas] = load_all_array_schemas(array_uri, encryption_key);
+  auto&& [st, schemas] = load_all_array_schemas(array_dir, encryption_key);
   RETURN_NOT_OK_TUPLE(st, nullopt, nullopt);
 
   return {Status::Ok(), array_schema, schemas};
@@ -1683,16 +1452,16 @@ tuple<
     Status,
     optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
 StorageManager::load_all_array_schemas(
-    const URI& array_uri, const EncryptionKey& encryption_key) {
-  auto timer_se = stats_->start_timer("read_load_all_array_schemas");
+    const ArrayDirectory& array_dir, const EncryptionKey& encryption_key) {
+  auto timer_se = stats_->start_timer("sm_load_all_array_schemas");
 
+  const URI& array_uri = array_dir.array_uri();
   if (array_uri.is_invalid())
     return {logger_->status(Status_StorageManagerError(
                 "Cannot load all array schemas; Invalid array URI")),
             nullopt};
 
-  std::vector<URI> schema_uris;
-  RETURN_NOT_OK_TUPLE(get_array_schema_uris(array_uri, &schema_uris), nullopt);
+  const std::vector<URI>& schema_uris = array_dir.array_schema_uris();
   if (schema_uris.empty()) {
     return {logger_->status(Status_StorageManagerError(
                 "Cannot get the array schema vector; No array schemas found.")),
@@ -1724,26 +1493,17 @@ StorageManager::load_all_array_schemas(
 }
 
 Status StorageManager::load_array_metadata(
-    const URI& array_uri,
+    const ArrayDirectory& array_dir,
     const EncryptionKey& encryption_key,
-    uint64_t timestamp_start,
-    uint64_t timestamp_end,
     Metadata* metadata) {
-  auto timer_se = stats_->start_timer("read_load_array_meta");
+  auto timer_se = stats_->start_timer("sm_load_array_metadata");
 
   // Special case
   if (metadata == nullptr)
     return Status::Ok();
 
   // Determine which array metadata to load
-  std::vector<TimestampedURI> array_metadata_to_load;
-  std::vector<URI> array_metadata_uris;
-  RETURN_NOT_OK(get_array_metadata_uris(array_uri, &array_metadata_uris));
-  RETURN_NOT_OK(get_sorted_uris(
-      array_metadata_uris,
-      &array_metadata_to_load,
-      timestamp_start,
-      timestamp_end));
+  const auto& array_metadata_to_load = array_dir.array_meta_uris();
 
   auto metadata_num = array_metadata_to_load.size();
   std::vector<tdb_shared_ptr<Buffer>> metadata_buffs;
@@ -1803,7 +1563,7 @@ Status StorageManager::object_type(const URI& uri, ObjectType* type) const {
 
   bool exists = false;
   RETURN_NOT_OK(vfs_->is_dir(
-      dir_uri.join_path(constants::array_schema_folder_name), &exists));
+      dir_uri.join_path(constants::array_schema_dir_name), &exists));
   if (exists) {
     *type = ObjectType::ARRAY;
     return Status::Ok();
@@ -2055,11 +1815,11 @@ Status StorageManager::store_array_schema(
   // Check if the array schema directory exists
   // If not create it, this is caused by a pre-v10 array
   bool schema_dir_exists = false;
-  URI array_schema_folder_uri =
-      array_schema->array_uri().join_path(constants::array_schema_folder_name);
-  RETURN_NOT_OK(is_dir(array_schema_folder_uri, &schema_dir_exists));
+  URI array_schema_dir_uri =
+      array_schema->array_uri().join_path(constants::array_schema_dir_name);
+  RETURN_NOT_OK(is_dir(array_schema_dir_uri, &schema_dir_exists));
   if (!schema_dir_exists)
-    RETURN_NOT_OK(create_dir(array_schema_folder_uri));
+    RETURN_NOT_OK(create_dir(array_schema_dir_uri));
 
   // Write to file
   Tile tile(
@@ -2161,8 +1921,7 @@ Status StorageManager::write_to_cache(
   std::string filename = uri.last_path_part();
   std::string uri_str = uri.to_string();
   if (filename == constants::fragment_metadata_filename ||
-      (uri_str.find(constants::array_schema_folder_name) !=
-       std::string::npos) ||
+      (uri_str.find(constants::array_schema_dir_name) != std::string::npos) ||
       filename == constants::array_schema_filename) {
     return Status::Ok();
   }
@@ -2198,33 +1957,6 @@ tdb_shared_ptr<Logger> StorageManager::logger() const {
 /* ****************************** */
 /*         PRIVATE METHODS        */
 /* ****************************** */
-
-Status StorageManager::get_array_metadata_uris(
-    const URI& array_uri, std::vector<URI>* array_metadata_uris) const {
-  // Get all uris in the array metadata directory
-  URI metadata_dir = array_uri.join_path(constants::array_metadata_folder_name);
-  std::vector<URI> uris;
-
-  bool is_dir;
-  RETURN_NOT_OK(vfs_->is_dir(metadata_dir, &is_dir));
-  if (!is_dir)
-    return Status::Ok();
-
-  RETURN_NOT_OK(vfs_->ls(metadata_dir.add_trailing_slash(), &uris));
-
-  // Get only the metadata uris
-  for (auto& uri : uris) {
-    auto uri_last_path = uri.last_path_part();
-    if (utils::parse::starts_with(uri_last_path, "."))
-      continue;
-
-    if (utils::parse::starts_with(uri_last_path, "__") &&
-        !utils::parse::ends_with(uri_last_path, constants::vacuum_file_suffix))
-      array_metadata_uris->push_back(uri);
-  }
-
-  return Status::Ok();
-}
 
 tuple<Status, optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
 StorageManager::load_fragment_metadata(
@@ -2341,67 +2073,6 @@ Status StorageManager::load_consolidated_fragment_meta(
     f_buff->read(&offset, sizeof(uint64_t));
     (*offsets)[name] = offset;
   }
-
-  return Status::Ok();
-}
-
-Status StorageManager::get_consolidated_fragment_meta_uri(
-    const std::vector<URI>& uris, URI* meta_uri) const {
-  uint64_t t_latest = 0;
-  std::pair<uint64_t, uint64_t> timestamp_range;
-  for (const auto& uri : uris) {
-    if (utils::parse::ends_with(uri.to_string(), constants::meta_file_suffix)) {
-      RETURN_NOT_OK(utils::parse::get_timestamp_range(uri, &timestamp_range));
-      if (timestamp_range.second > t_latest) {
-        t_latest = timestamp_range.second;
-        *meta_uri = uri;
-      }
-    }
-  }
-
-  return Status::Ok();
-}
-
-Status StorageManager::get_sorted_uris(
-    const std::vector<URI>& uris,
-    std::vector<TimestampedURI>* sorted_uris,
-    uint64_t timestamp_start,
-    uint64_t timestamp_end) const {
-  // Do nothing if there are not enough URIs
-  if (uris.empty())
-    return Status::Ok();
-
-  // Get the URIs that must be ignored
-  std::vector<URI> vac_uris, to_ignore;
-  RETURN_NOT_OK(get_uris_to_vacuum(
-      uris, timestamp_start, timestamp_end, &to_ignore, &vac_uris, false));
-  std::set<URI> to_ignore_set;
-  for (const auto& uri : to_ignore)
-    to_ignore_set.emplace(uri);
-
-  // Filter based on vacuumed URIs and timestamp
-  for (auto& uri : uris) {
-    // Ignore vacuumed URIs
-    if (to_ignore_set.find(uri) != to_ignore_set.end())
-      continue;
-
-    // Also ignore any vac uris
-    if (this->is_vacuum_file(uri))
-      continue;
-
-    // Add only URIs whose first timestamp is greater than or equal to the
-    // timestamp_start and whose second timestamp is smaller than or equal to
-    // the timestamp_end
-    std::pair<uint64_t, uint64_t> timestamp_range;
-    RETURN_NOT_OK(utils::parse::get_timestamp_range(uri, &timestamp_range));
-    auto t1 = timestamp_range.first;
-    auto t2 = timestamp_range.second;
-    if (t1 >= timestamp_start && t2 <= timestamp_end)
-      sorted_uris->emplace_back(uri, timestamp_range);
-  }
-
-  // Sort the names based on the timestamps
-  std::sort(sorted_uris->begin(), sorted_uris->end());
 
   return Status::Ok();
 }

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -77,6 +77,7 @@ class MemoryTracker;
 class Query;
 class RestClient;
 class VFS;
+class ArrayDirectory;
 
 enum class EncryptionType : uint8_t;
 enum class ObjectType : uint8_t;
@@ -147,17 +148,14 @@ class StorageManager {
 
   /**
    * Returns the array schemas and fragment metadata for the given array.
-   * The function will focus only on relevant schemas and metadata in
-   * range [timestamp_start, timestamp_end].
+   * The function will focus only on relevant schemas and metadata as
+   * dictated by the input URI manager.
    *
-   * @param array_uri The array URI.
+   * @param array_dir The ArrayDirectory object used to retrieve the
+   *     various URIs in the array directory.
    * @param memory_tracker The memory tracker of the array
    *     for which the fragment metadata is loaded.
    * @param enc_key The encryption key to use.
-   * @param timestamp_start The starting timestamp.
-   * @param timestamp_end The end timestamp.
-   *     In TileDB, timestamps are in ms elapsed since
-   *     1970-01-01 00:00:00 +0000 (UTC).
    * @return tuple of Status, latest ArraySchema, map of all array schemas and
    * vector of FragmentMetadata
    *        Status Ok on success, else error
@@ -173,11 +171,9 @@ class StorageManager {
       optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
       optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
   load_array_schemas_and_fragment_metadata(
-      const URI& array_uri,
+      const ArrayDirectory& array_dir,
       MemoryTracker* memory_tracker,
-      const EncryptionKey& enc_key,
-      uint64_t timestamp_start,
-      uint64_t timestamp_end);
+      const EncryptionKey& enc_key);
 
   /**
    * Opens an array for reads at a timestamp. All the metadata of the
@@ -365,26 +361,29 @@ class StorageManager {
   /**
    * Evolve a TileDB array schema and store its new schema.
    *
-   * @param array_uri The URI of the array to be evolved.
+   * @param array_dir The ArrayDirectory object used to retrieve the
+   *     various URIs in the array directory.
    * @param schema_evolution The schema evolution.
    * @param encryption_key The encryption key to use.
    * @return Status
    */
   Status array_evolve_schema(
-      const URI& array_uri,
+      const ArrayDirectory& array_dir,
       ArraySchemaEvolution* array_schema,
       const EncryptionKey& encryption_key);
 
   /**
    * Upgrade a TileDB array to latest format version.
    *
-   * @param array_uri The URI of the array to be upgraded.
+   * @param array_dir The ArrayDirectory object used to retrieve the
+   *     various URIs in the array directory.
    * @param config Configuration parameters for the upgrade
    *     (`nullptr` means default, which will use the config associated with
    *      this instance).
    * @return Status
    */
-  Status array_upgrade_version(const URI& array_uri, const Config* config);
+  Status array_upgrade_version(
+      const ArrayDirectory& array_dir, const Config* config);
 
   /**
    * Retrieves the non-empty domain from an array. This is the union of the
@@ -514,12 +513,13 @@ class StorageManager {
   /**
    * Retrieves the encryption type from an array.
    *
-   * @param array_uri URI of the array
+   * @param array_dir The ArrayDirectory object used to retrieve the
+   *     various URIs in the array directory.
    * @param encryption_type Set to the encryption type of the array.
    * @return Status
    */
   Status array_get_encryption(
-      const std::string& array_uri, EncryptionType* encryption_type);
+      const ArrayDirectory& array_dir, EncryptionType* encryption_type);
 
   /**
    * Pushes an async query to the queue.
@@ -543,41 +543,6 @@ class StorageManager {
 
   /** Creates an empty file with the input URI. */
   Status touch(const URI& uri);
-
-  /**
-   * Retrieves all the fragment URIs of an array, along with the latest
-   * consolidated fragment metadata URI `meta_uri`.
-   */
-  Status get_fragment_uris(
-      const URI& array_uri,
-      std::vector<URI>* fragment_uris,
-      URI* meta_uri) const;
-
-  /**
-   * It computes the URIs `to_vacuum` from the input `uris`, considering
-   * only the URIs whose first timestamp is greater than or equal to
-   * `timestamp_start` and second timestamp is smaller than or equal to
-   * `timestamp_end`. The function also retrieves the `vac_uris` (files with
-   * `.vac` suffix) that were used to compute `to_vacuum`.
-   *
-   * @param uris The input fragment URIs.
-   * @param timestamp_start The function considers only URIs whose
-   *     timestamps fall into [`timestamp_start`, `timestamp_end`].
-   * @param timestamp_end The function considers only URIs whose
-   *     timestamps fall into [`timestamp_start`, `timestamp_end`].
-   * @param to_vacuum The URIs determined that should be vacuumed.
-   * @param vac_uris The `.vac` files used to determine `to_vacuum`.
-   * @param allow_partial If `true` the function will load URIs
-   *    whose timestamps partial overlap [`timestamp_start`, `timestamp_end`].
-   * @return Status
-   */
-  Status get_uris_to_vacuum(
-      const std::vector<URI>& uris,
-      uint64_t timestamp_start,
-      uint64_t timestamp_end,
-      std::vector<URI>* to_vacuum,
-      std::vector<URI>* vac_uris,
-      bool allow_partial = true) const;
 
   /** Returns the current map of any set tags. */
   const std::unordered_map<std::string, std::string>& tags() const;
@@ -630,24 +595,6 @@ class StorageManager {
   Status is_dir(const URI& uri, bool* is_dir) const;
 
   /**
-   * Checks if the input URI represents a fragment. The functions takes into
-   * account the fragment version, which is retrived directly from the URI.
-   * For versions >= 5, the function checks whether the URI is included
-   * in `ok_uris`. For versions < 5, `ok_uris` is empty so the function
-   * checks for the existence of the fragment metadata file in the fragment
-   * URI directory. Therefore, the function is more expensive for earlier
-   * fragment versions.
-   *
-   * @param The URI to be checked.
-   * @param ok_uris For checking URI existence of versions >= 5.
-   * @param is_fragment Set to `1` if the URI is a fragment and `0`
-   *     otherwise.
-   * @return Status
-   */
-  Status is_fragment(
-      const URI& uri, const std::set<URI>& ok_uris, int* is_fragment) const;
-
-  /**
    * Checks if the input URI represents a group.
    *
    * @param The URI to be checked.
@@ -668,34 +615,6 @@ class StorageManager {
   Status is_file(const URI& uri, bool* is_file) const;
 
   /**
-   * Check if a URI is a vacuum file or not based on the file suffix
-   * @param uri
-   * @return true is vacuum file, false otherwise
-   */
-  bool is_vacuum_file(const URI& uri) const;
-
-  /**
-   * Retrieve all array schemas for an array uri under its __schema directory.
-   *
-   * @param array_uri The URI path of the array.
-   * @param uris The vector of array schema URIS sorted from earliest to the
-   * latest.
-   * @return Status
-   */
-  Status get_array_schema_uris(
-      const URI& array_uri, std::vector<URI>* schema_uris) const;
-
-  /**
-   * Get latest array schema for an array uri.
-   *
-   * @param array_uri The URI path of the array.
-   * @param uri The latest array schema URI.
-   * @return Status
-   */
-  Status get_latest_array_schema_uri(
-      const URI& array_uri, URI* schema_uri) const;
-
-  /**
    * Loads the schema of a schema uri from persistent storage into memory.
    *
    * @param array_schema_uri The URI path of the array schema.
@@ -712,13 +631,14 @@ class StorageManager {
   /**
    * Loads the latest schema of an array from persistent storage into memory.
    *
-   * @param array_uri The URI path of the array.
+   * @param array_dir The ArrayDirectory object used to retrieve the
+   *     various URIs in the array directory.
    * @param encryption_key The encryption key to use.
    * @param array_schema The array schema to be retrieved.
    * @return Status
    */
   Status load_array_schema_latest(
-      const URI& array_uri,
+      const ArrayDirectory& array_dir,
       const EncryptionKey& encryption_key,
       ArraySchema** array_schema);
 
@@ -726,7 +646,8 @@ class StorageManager {
    * It loads and returns the latest schema and all the array schemas
    * (in the presence of schema evolution).
    *
-   * @param array_uri The URI path of the array.
+   * @param array_dir The ArrayDirectory object used to retrieve the
+   *     various URIs in the array directory.
    * @param encryption_key The encryption key to use.
    * @return tuple of Status, latest array schema and all array schemas.
    *   Status Ok on success, else error
@@ -738,12 +659,14 @@ class StorageManager {
       optional<ArraySchema*>,
       std::optional<
           std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
-  load_array_schemas(const URI& array_uri, const EncryptionKey& encryption_key);
+  load_array_schemas(
+      const ArrayDirectory& array_dir, const EncryptionKey& encryption_key);
 
   /**
    * Loads all schemas of an array from persistent storage into memory.
    *
-   * @param array_uri The URI path of the array.
+   * @param array_dir The ArrayDirectory object used to retrieve the
+   *     various URIs in the array directory.
    * @param encryption_key The encryption key to use.
    * @return tuple of Status and optional unordered map. If Status is an error
    * the unordered_map will be nullopt
@@ -755,17 +678,15 @@ class StorageManager {
       std::optional<
           std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
   load_all_array_schemas(
-      const URI& array_uri, const EncryptionKey& encryption_key);
+      const ArrayDirectory& array_dir, const EncryptionKey& encryption_key);
 
   /**
-   * Loads the array metadata from persistent storage that were created
-   * at or before `timestamp_end` and at or after `timestamp_start`.
+   * Loads the array metadata from persistent storage based on
+   * the input URI manager.
    */
   Status load_array_metadata(
-      const URI& array_uri,
+      const ArrayDirectory& array_dir,
       const EncryptionKey& encryption_key,
-      uint64_t timestamp_start,
-      uint64_t timestamp_end,
       Metadata* metadata);
 
   /** Removes a TileDB object (group, array). */
@@ -1105,10 +1026,6 @@ class StorageManager {
   /** Decrement the count of in-progress queries. */
   void decrement_in_progress();
 
-  /** Retrieves all the array metadata URI's of an array. */
-  Status get_array_metadata_uris(
-      const URI& array_uri, std::vector<URI>* array_metadata_uris) const;
-
   /** Increment the count of in-progress queries. */
   void increment_in_progress();
 
@@ -1168,28 +1085,6 @@ class StorageManager {
       const EncryptionKey& enc_key,
       Buffer* f_buff,
       std::unordered_map<std::string, uint64_t>* offsets);
-
-  /**
-   * Retrieves the URI of the latest consolidated fragment metadata,
-   * among the URIs in `uris`.
-   */
-  Status get_consolidated_fragment_meta_uri(
-      const std::vector<URI>& uris, URI* meta_uri) const;
-
-  /**
-   * Applicable to fragment and array metadata URIs.
-   *
-   * Gets the sorted URIs in ascending first timestamp order,
-   * breaking ties with lexicographic
-   * sorting of UUID. Only the URIs with timestamp between `timestamp_start`
-   * and `timestamp_end` (inclusive) are considered. The sorted URIs are
-   * stored in the last input, including their timestamps.
-   */
-  Status get_sorted_uris(
-      const std::vector<URI>& uris,
-      std::vector<TimestampedURI>* sorted_uris,
-      uint64_t timestamp_start,
-      uint64_t timestamp_end) const;
 
   /** Block until there are zero in-progress queries. */
   void wait_for_zero_in_progress();


### PR DESCRIPTION
This PR adds an `ArrayDirectory` class to manage all URIs within the array directory. This introduces several performance improvements, especially around removing redundant URI listings, parallelizing URI listings, etc. It also paves the way for better format versioning, especially when we need to shuffle files around in the array directory for better performance in the future (there is an upcoming PR for that).

**Notes:**

* The PR makes `VFS::ls` a noop for POSIX and HDFS when the listed directory does not exist instead of throwing an error, matching the functionality of the object stores.
* The PR removes partial vacuuming, as that leads to incorrect behavior with time traveling. Vacuuming will be refactored soon in an upcoming PR as well, so there should be no issues here.
* The PR adds a unit test file for `ArrayDirectory`, but the unit tests are missing. This is because at the moment the class just incorporated practically existing code (moved from `StorageManager` and optimized). If there is anything wrong with the class at the moment, all the tests will break (as it affects loading fragments, schemas, metadata, etc). Moreover, this class will be enhanced in an upcoming PR that will move all URI creations from the writer and array schema classes in `ArrayDirectory`. Therefore, we will add proper unit tests in that PR.

---
TYPE: IMPROVEMENT
DESC: Adds an ArrayDirectory class to manage all URIs within the array directory.
