### PR TITLE
Range::set_start and set_end should throw instead of empty returning

### DIFF
--- a/tiledb/sm/misc/types.h
+++ b/tiledb/sm/misc/types.h
@@ -139,8 +139,9 @@ class Range {
   /** Copies 'start' into this range's start bytes for fixed-size ranges. */
   void set_start(const void* const start) {
     if (var_size_) {
-      LOG_ERROR("Unexpected var-sized range; cannot set start range.");
-      return;
+      auto msg = "Unexpected var-sized range; cannot set start range.";
+      LOG_ERROR(msg);
+      throw std::runtime_error(msg);
     }
 
     const size_t fixed_size = range_.size() / 2;
@@ -184,8 +185,9 @@ class Range {
   /** Copies 'end' into this range's end bytes for fixed-size ranges. */
   void set_end(const void* const end) {
     if (var_size_) {
-      LOG_ERROR("Unexpected var-sized range; cannot set end range.");
-      return;
+      auto msg = "Unexpected var-sized range; cannot set end range.";
+      LOG_ERROR(msg);
+      throw std::runtime_error(msg);
     }
     const size_t fixed_size = range_.size() / 2;
     std::memcpy(&range_[fixed_size], end, fixed_size);


### PR DESCRIPTION
This fixes a bug introduced with PR [#2897](https://github.com/TileDB-Inc/TileDB/pull/2897), set_start and set_end should throw instead of empty returning as pointed by @eric-hughes-tiledb.

---
TYPE: BUG
DESC: Range::set_start and set_end should throw instead of empty returning
