### PR TITLE
Listing improvements: new directory structure for array.

### DIFF
--- a/format_spec/FORMAT_SPEC.md
+++ b/format_spec/FORMAT_SPEC.md
@@ -2,7 +2,7 @@
 
 
 :information_source: **Notes:**  
-- The current TileDB format version number is **11** (`uint32_t`).
+- The current TileDB format version number is **12** (`uint32_t`).
 - All data written by TileDB and referenced in this document is **little-endian**. 
 
 ## Table of Contents

--- a/format_spec/array_file_hierarchy.md
+++ b/format_spec/array_file_hierarchy.md
@@ -3,16 +3,19 @@
 An array is a folder with the following structure:
 
 ```
-my_array                          # array folder
-    |_ __schema                   # array schema folder
-    |_ <timestamped_name>         # fragment folder
-    |_ <timestamped_name>.ok      # fragment ok file
-    |_ ...
-    |_ <timestamped_name>.vac     # fragment vacuum file
-    |_ ...                  
-    |_ <timestamped_name>.meta    # consol. fragment meta file
-    |_ ...                  
-    |_ __meta                     # array metadata folder
+my_array                                # array folder
+    |_ __schema                         # array schema folder
+    |_ __fragments                      # array fragments folder
+          |_ <timestamped_name>         # fragment folder
+          |_ ...
+    |_ commits                          # array commits folder
+          |_ <timestamped_name>.ok      # fragment ok file
+          |_ ...
+          |_ <timestamped_name>.vac     # fragment vacuum file
+    |_ fragment_meta                  
+          |_ <timestamped_name>.meta    # consol. fragment meta file
+          |_ ...                  
+    |_ __meta                           # array metadata folder
 
 ```
 
@@ -24,8 +27,8 @@ A `<timestamped_name>` above has format `__t1_t2_uuid_v`, where
 Inside the array folder, you can find the following:
 
 * [Array schema](./array_schema.md) folder `__schema`.
-* Any number of [fragment folders](./fragment.md) `<timestamped_name>`.
-* An empty file `<timestamped_name>.ok` associated with every fragment folder `<timestamped_name>`, where `<timestamped_name>` is common for the folder and the OK file. This is used to indicate that fragment `<timestamped_name>` has been *committed* (i.e., its write process finished successfully) and it is ready for use by TileDB. If the OK file does not exist, the corresponding fragment folder is ignored by TileDB during the reads.
-* Any number of [vacuum files](./vacuum_file.md) of the form `<timestamped_name>.vac`.
-* Any number of [consolidated fragment metadata files](./consolidated_fragment_metadata_file.md) of the form `<timestamped_name>.meta`.
+* Inside of a fragments folder, any number of [fragment folders](./fragment.md) `<timestamped_name>`.
+* Inside of a commit folder, an empty file `<timestamped_name>.wrt` associated with every fragment folder `<timestamped_name>`, where `<timestamped_name>` is common for the folder and the WRT file. This is used to indicate that fragment `<timestamped_name>` has been *committed* (i.e., its write process finished successfully) and it is ready for use by TileDB. If the WRT file does not exist, the corresponding fragment folder is ignored by TileDB during the reads.
+* Inside the same commit folder, any number of [vacuum files](./vacuum_file.md) of the form `<timestamped_name>.vac`.
+* Inside of a fragment metadata folder, any number of [consolidated fragment metadata files](./consolidated_fragment_metadata_file.md) of the form `<timestamped_name>.meta`.
 * [Array metadata](./array_metadata.md) folder `__meta`.

--- a/format_spec/array_file_hierarchy.md
+++ b/format_spec/array_file_hierarchy.md
@@ -8,11 +8,11 @@ my_array                                # array folder
     |_ __fragments                      # array fragments folder
           |_ <timestamped_name>         # fragment folder
           |_ ...
-    |_ commits                          # array commits folder
-          |_ <timestamped_name>.ok      # fragment ok file
+    |_ __commits                        # array commits folder
+          |_ <timestamped_name>.wrt     # fragment write file
           |_ ...
           |_ <timestamped_name>.vac     # fragment vacuum file
-    |_ fragment_meta                  
+    |_ __fragment_meta                  
           |_ <timestamped_name>.meta    # consol. fragment meta file
           |_ ...                  
     |_ __meta                           # array metadata folder

--- a/format_spec/consolidated_fragment_metadata_file.md
+++ b/format_spec/consolidated_fragment_metadata_file.md
@@ -3,10 +3,11 @@
 A consolidated fragment metadata file has name `<timestamped_name>.meta` and is located here:
 
 ```
-my_array                        # array folder
+my_array                              # array folder
    |_ ....
-   |_ <timestamped_name>.meta   # consolidated fragment metadata file
-   |_ ...
+   |_ __fragment_meta                 # array fragment metadata folder
+         |_ <timestamped_name>.meta   # consolidated fragment metadata file
+         |_ ...
 ```
 
 `<timestamped_name>` has format `__t1_t2_uuid_v`, where:

--- a/format_spec/fragment.md
+++ b/format_spec/fragment.md
@@ -5,19 +5,20 @@
 A fragment metadata folder is called `<timestamped_name>` and located here:
 
 ```
-my_array                              # array folder
+my_array                                    # array folder
    |  ...
-   |_ <timestamped_name>              # fragment folder
-   |      |_ __fragment_metadata.tdb  # fragment metadata
-   |      |_ a0.tdb                   # fixed-sized attribute 
-   |      |_ a1.tdb                   # var-sized attribute (offsets) 
-   |      |_ a1_var.tdb               # var-sized attribute (values)
-   |      |_ ...      
-   |      |_ d0.tdb                   # fixed-sized dimension 
-   |      |_ d1.tdb                   # var-sized dimension (offsets) 
-   |      |_ d1_var.tdb               # var-sized dimension (values)
-   |      |_ ...      
-   |_ ...  
+   |_ __fragments                           # array fragments folder
+         |_ <timestamped_name>              # fragment folder
+         |      |_ __fragment_metadata.tdb  # fragment metadata
+         |      |_ a0.tdb                   # fixed-sized attribute 
+         |      |_ a1.tdb                   # var-sized attribute (offsets) 
+         |      |_ a1_var.tdb               # var-sized attribute (values)
+         |      |_ ...      
+         |      |_ d0.tdb                   # fixed-sized dimension 
+         |      |_ d1.tdb                   # var-sized dimension (offsets) 
+         |      |_ d1_var.tdb               # var-sized dimension (values)
+         |      |_ ...      
+        |_ ...  
 ```
 
 `<timestamped_name>` has format `__t1_t2_uuid_v`, where:

--- a/format_spec/vacuum_file.md
+++ b/format_spec/vacuum_file.md
@@ -5,7 +5,7 @@ A vacuum file has name `__t1_t2_uuid_v.vac` and can be located either in the arr
 ```
 my_array                        # array folder
    |_ ....
-   |_ __meta                    # array commit folder
+   |_ __commits                 # array commit folder
          |___t1_t2_uuid_v.vac   # vacuum file
 ```
 

--- a/format_spec/vacuum_file.md
+++ b/format_spec/vacuum_file.md
@@ -1,12 +1,12 @@
 # Vacuum File
 
-A vacuum file has name `__t1_t2_uuid_v.vac` and can be located either in the array folder:
+A vacuum file has name `__t1_t2_uuid_v.vac` and can be located either in the array commit folder:
 
 ```
 my_array                        # array folder
    |_ ....
-   |_ __t1_t2_uuid_v.vac        # vacuum file
-   |_ ...
+   |_ __meta                    # array commit folder
+         |___t1_t2_uuid_v.vac   # vacuum file
 ```
 
 or in the array metadata folder:

--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -1221,19 +1221,9 @@ int32_t num_fragments(const std::string& array_name) {
   VFS vfs(ctx);
 
   // Get all URIs in the array directory
-  auto uris = vfs.ls(array_name);
-
-  // Exclude '__meta' directory and any file with a suffix
-  int ret = 0;
-  for (const auto& uri : uris) {
-    auto name = tiledb::sm::URI(uri).remove_trailing_slash().last_path_part();
-    if (name != tiledb::sm::constants::array_metadata_dir_name &&
-        name != tiledb::sm::constants::array_schema_dir_name &&
-        name.find_first_of('.') == std::string::npos)
-      ++ret;
-  }
-
-  return ret;
+  auto uris = vfs.ls(
+      array_name + "/" + tiledb::sm::constants::array_fragments_dir_name);
+  return static_cast<uint32_t>(uris.size());
 }
 
 std::string random_string(const uint64_t l) {
@@ -1249,6 +1239,14 @@ std::string random_string(const uint64_t l) {
   }
 
   return s;
+}
+
+std::string get_fragment_dir(std::string array_dir) {
+  return array_dir + "/" + tiledb::sm::constants::array_fragments_dir_name;
+}
+
+std::string get_commit_dir(std::string array_dir) {
+  return array_dir + "/" + tiledb::sm::constants::array_commit_dir_name;
 }
 
 template void check_subarray<int8_t>(

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -681,6 +681,16 @@ int32_t num_fragments(const std::string& array_name);
  */
 std::string random_string(const uint64_t l);
 
+/**
+ * Gets the fragments directory from the array directory.
+ */
+std::string get_fragment_dir(std::string array_dir);
+
+/**
+ * Gets the commit directory from the array directory.
+ */
+std::string get_commit_dir(std::string array_dir);
+
 }  // End of namespace test
 
 }  // End of namespace tiledb

--- a/test/src/unit-ArrayDirectory.cc
+++ b/test/src/unit-ArrayDirectory.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -32,6 +32,7 @@
  */
 
 #include "catch.hpp"
+#include "test/src/helpers.h"
 #include "tiledb/common/common.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/misc/constants.h"
@@ -42,6 +43,7 @@
 #include <thread>
 
 using namespace tiledb;
+using namespace tiledb::test;
 
 namespace {
 
@@ -694,7 +696,6 @@ TEST_CASE(
         .set_data_buffer("a", a_write)
         .set_coordinates(coords_write);
     query_w.submit();
-    fragment_uri = query_w.fragment_uri(0);
     old_array.close();
 
     // Read
@@ -713,8 +714,8 @@ TEST_CASE(
 
     // Remove created fragment and ok file
     VFS vfs(ctx);
-    vfs.remove_dir(fragment_uri);
-    vfs.remove_file(fragment_uri + ".ok");
+    vfs.remove_dir(get_fragment_dir(old_array_name));
+    vfs.remove_dir(get_commit_dir(old_array_name));
 
     REQUIRE(a_read[0] == 100);
     for (int i = 1; i < 4; i++) {
@@ -1306,7 +1307,7 @@ TEST_CASE(
   schema_folder = array_read2.uri() + "/__schema";
 
   VFS vfs(ctx);
-  vfs.remove_dir(fragment_uri);
-  vfs.remove_file(fragment_uri + ".ok");
+  vfs.remove_dir(get_fragment_dir(array_read2.uri()));
+  vfs.remove_dir(get_commit_dir(array_read2.uri()));
   vfs.remove_dir(schema_folder);
 }

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -130,7 +130,7 @@ int ArrayFx::get_fragment_timestamps(const char* path, void* data) {
   auto data_vec = (std::vector<uint64_t>*)data;
   std::pair<uint64_t, uint64_t> timestamp_range;
   if (tiledb::sm::utils::parse::ends_with(
-          path, tiledb::sm::constants::ok_file_suffix)) {
+          path, tiledb::sm::constants::write_file_suffix)) {
     auto uri = tiledb::sm::URI(path);
     if (tiledb::sm::utils::parse::get_timestamp_range(uri, &timestamp_range)
             .ok())
@@ -985,7 +985,7 @@ TEST_CASE_METHOD(
   rc = tiledb_vfs_ls(
       ctx_,
       vfs_,
-      array_name.c_str(),
+      get_commit_dir(array_name).c_str(),
       &get_fragment_timestamps,
       &fragment_timestamps);
   CHECK(rc == TILEDB_OK);

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -48,11 +48,19 @@ using namespace tiledb::test;
 struct ConsolidationFx {
   // Constants
   const char* DENSE_VECTOR_NAME = "test_consolidate_dense_vector";
+  const char* DENSE_VECTOR_FRAG_DIR =
+      "test_consolidate_dense_vector/__fragments";
+  const char* DENSE_VECTOR_FRAG_META_DIR =
+      "test_consolidate_dense_vector/__fragment_meta";
   const char* DENSE_ARRAY_NAME = "test_consolidate_dense_array";
   const char* SPARSE_ARRAY_NAME = "test_consolidate_sparse_array";
   const char* SPARSE_HETEROGENEOUS_ARRAY_NAME =
       "test_consolidate_sparse_heterogeneous_array";
   const char* SPARSE_STRING_ARRAY_NAME = "test_consolidate_sparse_string_array";
+  const char* SPARSE_STRING_ARRAY_FRAG_DIR =
+      "test_consolidate_sparse_string_array/__fragments";
+  const char* SPARSE_STRING_ARRAY_FRAG_META_DIR =
+      "test_consolidate_sparse_string_array/__fragment_meta";
 
   // TileDB context
   tiledb_ctx_t* ctx_;
@@ -144,7 +152,6 @@ struct ConsolidationFx {
   static int get_array_meta_files_callback(const char* path, void* data);
   static int get_array_meta_vac_files_callback(const char* path, void* data);
   static int get_vac_files_callback(const char* path, void* data);
-  static int get_fragment_timestamps(const char* path, void* data);
 };
 
 ConsolidationFx::ConsolidationFx() {
@@ -4079,15 +4086,7 @@ int ConsolidationFx::get_dir_num(const char* path, void* data) {
   int is_dir;
   int rc = tiledb_vfs_is_dir(ctx, vfs, path, &is_dir);
   CHECK(rc == TILEDB_OK);
-  auto meta_dir =
-      std::string("/") + tiledb::sm::constants::array_metadata_dir_name;
-  auto schema_dir =
-      std::string("/") + tiledb::sm::constants::array_schema_dir_name;
-  if (!tiledb::sm::utils::parse::ends_with(path, meta_dir) &&
-      !tiledb::sm::utils::parse::ends_with(path, schema_dir)) {
-    // Ignoring the meta directory and the schema directory
-    data_struct->num += is_dir;
-  }
+  data_struct->num += is_dir;
 
   return 1;
 }
@@ -4126,20 +4125,6 @@ int ConsolidationFx::get_vac_files_callback(const char* path, void* data) {
   if (tiledb::sm::utils::parse::ends_with(
           path, tiledb::sm::constants::vacuum_file_suffix))
     vec->emplace_back(path);
-
-  return 1;
-}
-
-int ConsolidationFx::get_fragment_timestamps(const char* path, void* data) {
-  auto data_vec = (std::vector<uint64_t>*)data;
-  std::pair<uint64_t, uint64_t> timestamp_range;
-  if (tiledb::sm::utils::parse::ends_with(
-          path, tiledb::sm::constants::ok_file_suffix)) {
-    auto uri = tiledb::sm::URI(path);
-    if (tiledb::sm::utils::parse::get_timestamp_range(uri, &timestamp_range)
-            .ok())
-      data_vec->push_back(timestamp_range.first);
-  }
 
   return 1;
 }
@@ -4297,7 +4282,7 @@ TEST_CASE_METHOD(
 
   // Check that there are 4 fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 4);
 
@@ -4350,7 +4335,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 3);
 
@@ -4403,7 +4388,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
@@ -4456,7 +4441,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 4);
 
@@ -4509,7 +4494,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 3);
 
@@ -4562,7 +4547,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
@@ -4615,7 +4600,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 
@@ -4668,7 +4653,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
@@ -4721,7 +4706,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 
@@ -4777,7 +4762,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 3);
 
@@ -4838,7 +4823,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 3);
 
@@ -4893,7 +4878,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
@@ -4955,7 +4940,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
@@ -5008,7 +4993,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 4);
 
@@ -5063,7 +5048,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
@@ -5119,7 +5104,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 
@@ -5171,7 +5156,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
@@ -5226,7 +5211,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 3);
 
@@ -5294,7 +5279,7 @@ TEST_CASE_METHOD(
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
 
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == ((should_consolidate) ? 3 : 2));
 
@@ -5307,7 +5292,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   data.num = 0;
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == ((should_consolidate) ? 1 : 2));
 
@@ -5329,13 +5314,14 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 5);
 
   // Check number of consolidated metadata files
   data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_meta_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx_, vfs_, DENSE_VECTOR_FRAG_META_DIR, &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 0);
 
@@ -5421,13 +5407,14 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 4);
 
   // Check number of consolidated metadata files
   data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_meta_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx_, vfs_, DENSE_VECTOR_FRAG_META_DIR, &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 
@@ -5441,7 +5428,7 @@ TEST_CASE_METHOD(
 
   // Check
   data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 8);
 
@@ -5460,7 +5447,8 @@ TEST_CASE_METHOD(
 
   // Check number of consolidated metadata files
   data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_meta_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx_, vfs_, DENSE_VECTOR_FRAG_META_DIR, &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
@@ -5471,7 +5459,7 @@ TEST_CASE_METHOD(
 
   // Check
   data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 8);
   read_dense_vector(1);
@@ -5499,7 +5487,8 @@ TEST_CASE_METHOD(
 
   // Check number of consolidated metadata files
   data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, DENSE_VECTOR_NAME, &get_meta_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx_, vfs_, DENSE_VECTOR_FRAG_META_DIR, &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 
@@ -5622,14 +5611,15 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, SPARSE_STRING_ARRAY_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx_, vfs_, SPARSE_STRING_ARRAY_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
   // Check number of consolidated metadata files
   data = {ctx_, vfs_, 0};
-  rc =
-      tiledb_vfs_ls(ctx_, vfs_, SPARSE_STRING_ARRAY_NAME, &get_meta_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx_, vfs_, SPARSE_STRING_ARRAY_FRAG_META_DIR, &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 
@@ -5645,8 +5635,8 @@ TEST_CASE_METHOD(
 
   // Check number of consolidated metadata files
   data = {ctx_, vfs_, 0};
-  rc =
-      tiledb_vfs_ls(ctx_, vfs_, SPARSE_STRING_ARRAY_NAME, &get_meta_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx_, vfs_, SPARSE_STRING_ARRAY_FRAG_META_DIR, &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 
@@ -5689,13 +5679,15 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct data = {ctx, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx, vfs_, SPARSE_STRING_ARRAY_NAME, &get_dir_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx, vfs_, SPARSE_STRING_ARRAY_FRAG_DIR, &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 2);
 
   // Check number of consolidated metadata files
   data = {ctx, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx, vfs_, SPARSE_STRING_ARRAY_NAME, &get_meta_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx, vfs_, SPARSE_STRING_ARRAY_FRAG_META_DIR, &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 
@@ -5716,7 +5708,8 @@ TEST_CASE_METHOD(
 
   // Check number of consolidated metadata files
   data = {ctx, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx, vfs_, SPARSE_STRING_ARRAY_NAME, &get_meta_num, &data);
+  rc = tiledb_vfs_ls(
+      ctx, vfs_, SPARSE_STRING_ARRAY_FRAG_META_DIR, &get_meta_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 1);
 

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -206,15 +206,7 @@ int StringDimsFx::get_dir_num(const char* path, void* data) {
   int is_dir;
   int rc = tiledb_vfs_is_dir(ctx, vfs, path, &is_dir);
   CHECK(rc == TILEDB_OK);
-  auto meta_dir =
-      std::string("/") + tiledb::sm::constants::array_metadata_dir_name;
-  auto schema_dir =
-      std::string("/") + tiledb::sm::constants::array_schema_dir_name;
-  if (!tiledb::sm::utils::parse::ends_with(path, meta_dir) &&
-      !tiledb::sm::utils::parse::ends_with(path, schema_dir)) {
-    // Ignoring the meta directory and the schema directory
-    data_struct->num += is_dir;
-  }
+  data_struct->num += is_dir;
 
   return 1;
 }
@@ -1897,7 +1889,8 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   get_num_struct dirs = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, array_name.c_str(), &get_dir_num, &dirs);
+  auto frag_dir = get_fragment_dir(array_name);
+  rc = tiledb_vfs_ls(ctx_, vfs_, frag_dir.c_str(), &get_dir_num, &dirs);
   CHECK(rc == TILEDB_OK);
   CHECK(dirs.num == 2);
 
@@ -1908,7 +1901,7 @@ TEST_CASE_METHOD(
 
   // Check number of fragments
   dirs = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(ctx_, vfs_, array_name.c_str(), &get_dir_num, &dirs);
+  rc = tiledb_vfs_ls(ctx_, vfs_, frag_dir.c_str(), &get_dir_num, &dirs);
   CHECK(rc == TILEDB_OK);
   CHECK(dirs.num == 1);
 

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -35,6 +35,7 @@
 #include "tiledb/sm/cpp_api/tiledb"
 
 using namespace tiledb;
+using namespace tiledb::test;
 
 void create_int32_array(const std::string& array_name) {
   Context ctx;
@@ -758,8 +759,8 @@ TEST_CASE(
   config["sm.vacuum.mode"] = "fragments";
   CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
   CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
-  auto contents = vfs.ls(array_name);
-  CHECK(contents.size() == 4);
+  auto contents = vfs.ls(get_fragment_dir(array_name));
+  CHECK(contents.size() == 1);
 
   Array array_r(ctx, array_name, TILEDB_READ);
   Query query_r(ctx, array_r, TILEDB_READ);
@@ -1137,8 +1138,8 @@ TEST_CASE(
   config["sm.vacuum.mode"] = "fragments";
   CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
   CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
-  auto contents = vfs.ls(array_name);
-  CHECK(contents.size() == 4);
+  auto contents = vfs.ls(get_fragment_dir(array_name));
+  CHECK(contents.size() == 1);
 
   Array array_r(ctx, array_name, TILEDB_READ);
   Query query_r(ctx, array_r, TILEDB_READ);
@@ -1578,8 +1579,8 @@ TEST_CASE(
   config["sm.vacuum.mode"] = "fragments";
   CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
   CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
-  auto contents = vfs.ls(array_name);
-  CHECK(contents.size() == 4);
+  auto contents = vfs.ls(get_fragment_dir(array_name));
+  CHECK(contents.size() == 1);
 
   Array array_r(ctx, array_name, TILEDB_READ);
   Query query_r(ctx, array_r, TILEDB_READ);
@@ -1863,8 +1864,8 @@ TEST_CASE(
   config["sm.vacuum.mode"] = "fragments";
   CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
   CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
-  auto contents = vfs.ls(array_name);
-  CHECK(contents.size() == 4);
+  auto contents = vfs.ls(get_fragment_dir(array_name));
+  CHECK(contents.size() == 1);
 
   // Read
   Array array_r(ctx, array_name, TILEDB_READ);

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -124,13 +124,13 @@ class ArrayDirectory {
   const URI& latest_fragment_meta_uri() const;
 
   /** Returns the URI to store fragments. */
-  URI get_fragments_uri(uint32_t write_version) const;
+  URI get_fragments_dir(uint32_t write_version) const;
 
   /** Returns the URI to store fragment metadata. */
-  URI get_fragment_metadata_uri(uint32_t write_version) const;
+  URI get_fragment_metadata_dir(uint32_t write_version) const;
 
   /** Returns the URI to store commit files. */
-  URI get_commits_uri(uint32_t write_version) const;
+  URI get_commits_dir(uint32_t write_version) const;
 
   /** Returns the URI for either an ok file or wrt file. */
   tuple<Status, optional<URI>> get_commit_uri(const URI& fragment_uri) const;
@@ -225,25 +225,25 @@ class ArrayDirectory {
   Status load();
 
   /**
-   * Loads the root directory data for v1 to v11.
+   * Loads the root directory uris for v1 to v11.
    *
    * @return Status, vector of fragment URIs, latest fragment metadata.
    */
-  tuple<Status, optional<std::vector<URI>>, optional<URI>> load_root_dir_data();
+  tuple<Status, optional<std::vector<URI>>, optional<URI>> load_root_dir_uris();
 
   /**
-   * Loads the commit directory data for v12 or higher.
+   * Loads the commit directory uris for v12 or higher.
    *
    * @return Status, vector of fragment URIs.
    */
-  tuple<Status, optional<std::vector<URI>>> load_commit_dir_data();
+  tuple<Status, optional<std::vector<URI>>> load_commit_dir_uris();
 
   /**
-   * Loads the fragment metadata directory data for v12 or higher.
+   * Loads the fragment metadata directory uris for v12 or higher.
    *
    * @return Status, latest fragment metadata.
    */
-  tuple<Status, optional<URI>> load_fragment_metadata_dir_data();
+  tuple<Status, optional<URI>> load_fragment_metadata_dir_uris();
 
   /** Loads the array metadata URIs. */
   Status load_array_meta_uris();

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -102,6 +102,10 @@ URI URI::remove_trailing_slash() const {
   return URI(uri_);
 }
 
+bool URI::empty() const {
+  return uri_.empty();
+}
+
 const char* URI::c_str() const {
   return uri_.c_str();
 }
@@ -237,19 +241,6 @@ URI URI::join_path(const std::string& path) const {
 
 std::string URI::last_path_part() const {
   return uri_.substr(uri_.find_last_of('/') + 1);
-}
-
-URI URI::parent() const {
-  if (uri_.empty())
-    return URI();
-
-  auto uri = uri_;
-  if (uri.back() == '/')
-    uri.pop_back();
-  uint64_t pos = uri.find_last_of('/');
-  if (pos == std::string::npos)
-    return URI();
-  return URI(uri_.substr(0, pos));
 }
 
 std::string URI::to_path(const std::string& uri) {

--- a/tiledb/sm/filesystem/uri.h
+++ b/tiledb/sm/filesystem/uri.h
@@ -100,6 +100,11 @@ class URI {
    */
   URI remove_trailing_slash() const;
 
+  /**
+   * Returns if the URI is empty or not.
+   */
+  bool empty() const;
+
   /** Returns a C-style pointer to the URI string. */
   const char* c_str() const;
 
@@ -231,9 +236,6 @@ class URI {
 
   /** Returns the last part of the URI (i.e., excluding the parent). */
   std::string last_path_part() const;
-
-  /** Returns the parent of the URI. */
-  URI parent() const;
 
   /**
    * Returns the URI path for the current platform, stripping the resource. For

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -77,6 +77,15 @@ const std::string array_schema_dir_name = "__schema";
 /** The array metadata directory name. */
 const std::string array_metadata_dir_name = "__meta";
 
+/** The array fragment metadata directory name. */
+const std::string array_fragment_metadata_dir_name = "__fragment_meta";
+
+/** The array fragments directory name. */
+const std::string array_fragments_dir_name = "__fragments";
+
+/** The array commit directory name. */
+const std::string array_commit_dir_name = "__commits";
+
 /** The fragment metadata file name. */
 const std::string fragment_metadata_filename = "__fragment_metadata.tdb";
 
@@ -187,6 +196,9 @@ const std::string vacuum_file_suffix = ".vac";
 
 /** Suffix for the special ok files used in TileDB. */
 const std::string ok_file_suffix = ".ok";
+
+/** Suffix for the special write files used in TileDB. */
+const std::string write_file_suffix = ".wrt";
 
 /** Suffix for the special metadata files used in TileDB. */
 const std::string meta_file_suffix = ".meta";
@@ -528,7 +540,7 @@ const int32_t library_version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
 /** The TileDB serialization format version number. */
-const uint32_t format_version = 11;
+const uint32_t format_version = 12;
 
 /** The lowest version supported for back compat writes. */
 const uint32_t back_compat_writes_min_format_version = 7;

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -78,7 +78,7 @@ const std::string array_schema_dir_name = "__schema";
 const std::string array_metadata_dir_name = "__meta";
 
 /** The array fragment metadata directory name. */
-const std::string array_fragment_metadata_dir_name = "__fragment_meta";
+const std::string array_fragment_meta_dir_name = "__fragment_meta";
 
 /** The array fragments directory name. */
 const std::string array_fragments_dir_name = "__fragments";

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -68,6 +68,15 @@ extern const std::string array_schema_dir_name;
 /** The array metadata directory name. */
 extern const std::string array_metadata_dir_name;
 
+/** The array fragment metadata directory name. */
+extern const std::string array_fragment_metadata_dir_name;
+
+/** The array fragments directory name. */
+extern const std::string array_fragments_dir_name;
+
+/** The array commit directory name. */
+extern const std::string array_commit_dir_name;
+
 /** The default tile capacity. */
 extern const uint64_t capacity;
 
@@ -172,6 +181,9 @@ extern const std::string vacuum_file_suffix;
 
 /** Suffix for the special ok files used in TileDB. */
 extern const std::string ok_file_suffix;
+
+/** Suffix for the special write files used in TileDB. */
+extern const std::string write_file_suffix;
 
 /** Suffix for the special metadata files used in TileDB. */
 extern const std::string meta_file_suffix;

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -69,7 +69,7 @@ extern const std::string array_schema_dir_name;
 extern const std::string array_metadata_dir_name;
 
 /** The array fragment metadata directory name. */
-extern const std::string array_fragment_metadata_dir_name;
+extern const std::string array_fragment_meta_dir_name;
 
 /** The array fragments directory name. */
 extern const std::string array_fragments_dir_name;

--- a/tiledb/sm/query/global_order_writer.cc
+++ b/tiledb/sm/query/global_order_writer.cc
@@ -490,9 +490,10 @@ Status GlobalOrderWriter::finalize_global_write_state() {
   RETURN_NOT_OK_ELSE(add_written_fragment_info(uri), clean_up(uri));
 
   // The following will make the fragment visible
-  auto ok_uri =
-      URI(uri.remove_trailing_slash().to_string() + constants::ok_file_suffix);
-  RETURN_NOT_OK_ELSE(storage_manager_->vfs()->touch(ok_uri), clean_up(uri));
+  auto&& [st1, commit_uri] = array_->array_directory().get_commit_uri(uri);
+  RETURN_NOT_OK_ELSE(st1, storage_manager_->vfs()->remove_dir(uri));
+  RETURN_NOT_OK_ELSE(
+      storage_manager_->vfs()->touch(commit_uri.value()), clean_up(uri));
 
   // Delete global write state
   global_write_state_.reset(nullptr);

--- a/tiledb/sm/query/ordered_writer.cc
+++ b/tiledb/sm/query/ordered_writer.cc
@@ -297,10 +297,10 @@ Status OrderedWriter::ordered_write() {
       add_written_fragment_info(uri), storage_manager_->vfs()->remove_dir(uri));
 
   // The following will make the fragment visible
-  auto ok_uri =
-      URI(uri.remove_trailing_slash().to_string() + constants::ok_file_suffix);
+  auto&& [st, commit_uri] = array_->array_directory().get_commit_uri(uri);
+  RETURN_NOT_OK_ELSE(st, storage_manager_->vfs()->remove_dir(uri));
   RETURN_NOT_OK_ELSE(
-      storage_manager_->vfs()->touch(ok_uri),
+      storage_manager_->vfs()->touch(commit_uri.value()),
       storage_manager_->vfs()->remove_dir(uri));
 
   return Status::Ok();

--- a/tiledb/sm/query/unordered_writer.cc
+++ b/tiledb/sm/query/unordered_writer.cc
@@ -682,9 +682,10 @@ Status UnorderedWriter::unordered_write() {
   RETURN_NOT_OK_ELSE(add_written_fragment_info(uri), clean_up(uri));
 
   // The following will make the fragment visible
-  auto ok_uri =
-      URI(uri.remove_trailing_slash().to_string() + constants::ok_file_suffix);
-  RETURN_NOT_OK_ELSE(storage_manager_->vfs()->touch(ok_uri), clean_up(uri));
+  auto&& [st, commit_uri] = array_->array_directory().get_commit_uri(uri);
+  RETURN_NOT_OK_ELSE(st, storage_manager_->vfs()->remove_dir(uri));
+  RETURN_NOT_OK_ELSE(
+      storage_manager_->vfs()->touch(commit_uri.value()), clean_up(uri));
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -626,9 +626,9 @@ Status WriterBase::create_fragment(
         new_fragment_name(timestamp, write_version, &new_fragment_str));
 
     auto& array_dir = array_->array_directory();
-    auto frag_uri = array_dir.get_fragments_uri(write_version);
+    auto frag_uri = array_dir.get_fragments_dir(write_version);
     RETURN_NOT_OK(storage_manager_->vfs()->create_dir(frag_uri));
-    auto commit_uri = array_dir.get_commits_uri(write_version);
+    auto commit_uri = array_dir.get_commits_dir(write_version);
     RETURN_NOT_OK(storage_manager_->vfs()->create_dir(commit_uri));
 
     uri = frag_uri.join_path(new_fragment_str);

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -621,11 +621,17 @@ Status WriterBase::create_fragment(
     uri = fragment_uri_;
   } else {
     std::string new_fragment_str;
-    RETURN_NOT_OK(new_fragment_name(
-        timestamp,
-        array_->array_schema_latest()->write_version(),
-        &new_fragment_str));
-    uri = array_schema_->array_uri().join_path(new_fragment_str);
+    auto write_version = array_->array_schema_latest()->write_version();
+    RETURN_NOT_OK(
+        new_fragment_name(timestamp, write_version, &new_fragment_str));
+
+    auto& array_dir = array_->array_directory();
+    auto frag_uri = array_dir.get_fragments_uri(write_version);
+    RETURN_NOT_OK(storage_manager_->vfs()->create_dir(frag_uri));
+    auto commit_uri = array_dir.get_commits_uri(write_version);
+    RETURN_NOT_OK(storage_manager_->vfs()->create_dir(commit_uri));
+
+    uri = frag_uri.join_path(new_fragment_str);
   }
   auto timestamp_range = std::pair<uint64_t, uint64_t>(timestamp, timestamp);
   frag_meta = tdb::make_shared<FragmentMetadata>(

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -435,7 +435,7 @@ Status Consolidator::consolidate_fragment_meta(
   RETURN_NOT_OK(st);
 
   auto& array_dir = array.array_directory();
-  auto frag_md_uri = array_dir.get_fragment_metadata_uri(write_version);
+  auto frag_md_uri = array_dir.get_fragment_metadata_dir(write_version);
   RETURN_NOT_OK(storage_manager_->vfs()->create_dir(frag_md_uri));
   uri =
       URI(frag_md_uri.to_string() + name.value() + constants::meta_file_suffix);
@@ -610,7 +610,7 @@ Status Consolidator::create_queries(
   auto&& [st, name] = compute_new_fragment_name(first, last, write_version);
   RETURN_NOT_OK(st);
   auto frag_uri =
-      array_for_reads->array_directory().get_fragments_uri(write_version);
+      array_for_reads->array_directory().get_fragments_dir(write_version);
   *new_fragment_uri = frag_uri.join_path(name.value());
 
   // Create write query

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -348,6 +348,15 @@ Status Consolidator::consolidate(
     return st;
   }
 
+  // Get the vacuum URI
+  auto&& [st_vac_uri, vac_uri] =
+      array_for_reads.array_directory().get_vaccum_uri(*new_fragment_uri);
+  if (!st_vac_uri.ok()) {
+    tdb_delete(query_r);
+    tdb_delete(query_w);
+    return st_vac_uri;
+  }
+
   // Read from one array and write to the other
   st = copy_array(query_r, query_w, &buffers, &buffer_sizes);
   if (!st.ok()) {
@@ -370,7 +379,7 @@ Status Consolidator::consolidate(
   }
 
   // Write vacuum file
-  st = write_vacuum_file(*new_fragment_uri, to_consolidate);
+  st = write_vacuum_file(vac_uri.value(), to_consolidate);
   if (!st.ok()) {
     tdb_delete(query_r);
     tdb_delete(query_w);
@@ -421,9 +430,15 @@ Status Consolidator::consolidate_fragment_meta(
   URI uri;
   auto first = meta.front()->fragment_uri();
   auto last = meta.back()->fragment_uri();
-  RETURN_NOT_OK(compute_new_fragment_uri(
-      first, last, array.array_schema_latest()->write_version(), &uri));
-  uri = URI(uri.to_string() + constants::meta_file_suffix);
+  auto write_version = array.array_schema_latest()->write_version();
+  auto&& [st, name] = compute_new_fragment_name(first, last, write_version);
+  RETURN_NOT_OK(st);
+
+  auto& array_dir = array.array_directory();
+  auto frag_md_uri = array_dir.get_fragment_metadata_uri(write_version);
+  RETURN_NOT_OK(storage_manager_->vfs()->create_dir(frag_md_uri));
+  uri =
+      URI(frag_md_uri.to_string() + name.value() + constants::meta_file_suffix);
 
   // Get the consolidated fragment metadata version
   auto meta_name = uri.remove_trailing_slash().last_path_part();
@@ -487,6 +502,7 @@ Status Consolidator::consolidate_fragment_meta(
       buff.data(),
       buff.size());
   buff.disown_data();
+
   GenericTileIO tile_io(storage_manager_, uri);
   uint64_t nbytes = 0;
   RETURN_NOT_OK_ELSE(
@@ -590,11 +606,12 @@ Status Consolidator::create_queries(
   auto first = (*query_r)->first_fragment_uri();
   auto last = (*query_r)->last_fragment_uri();
 
-  RETURN_NOT_OK(compute_new_fragment_uri(
-      first,
-      last,
-      array_for_reads->array_schema_latest()->write_version(),
-      new_fragment_uri));
+  auto write_version = array_for_reads->array_schema_latest()->write_version();
+  auto&& [st, name] = compute_new_fragment_name(first, last, write_version);
+  RETURN_NOT_OK(st);
+  auto frag_uri =
+      array_for_reads->array_directory().get_fragments_uri(write_version);
+  *new_fragment_uri = frag_uri.join_path(name.value());
 
   // Create write query
   *query_w =
@@ -724,30 +741,27 @@ Status Consolidator::compute_next_to_consolidate(
   return Status::Ok();
 }
 
-Status Consolidator::compute_new_fragment_uri(
-    const URI& first,
-    const URI& last,
-    uint32_t format_version,
-    URI* new_uri) const {
+tuple<Status, optional<std::string>> Consolidator::compute_new_fragment_name(
+    const URI& first, const URI& last, uint32_t format_version) const {
   // Get uuid
   std::string uuid;
-  RETURN_NOT_OK(uuid::generate_uuid(&uuid, false));
+  RETURN_NOT_OK_TUPLE(uuid::generate_uuid(&uuid, false), nullopt);
 
   // For creating the new fragment URI
 
   // Get timestamp ranges
   std::pair<uint64_t, uint64_t> t_first, t_last;
-  RETURN_NOT_OK(utils::parse::get_timestamp_range(first, &t_first));
-  RETURN_NOT_OK(utils::parse::get_timestamp_range(last, &t_last));
+  RETURN_NOT_OK_TUPLE(
+      utils::parse::get_timestamp_range(first, &t_first), nullopt);
+  RETURN_NOT_OK_TUPLE(
+      utils::parse::get_timestamp_range(last, &t_last), nullopt);
 
   // Create new URI
   std::stringstream ss;
-  ss << first.parent().to_string() << "/__" << t_first.first << "_"
-     << t_last.second << "_" << uuid << "_" << format_version;
+  ss << "/__" << t_first.first << "_" << t_last.second << "_" << uuid << "_"
+     << format_version;
 
-  *new_uri = URI(ss.str());
-
-  return Status::Ok();
+  return {Status::Ok(), ss.str()};
 }
 
 Status Consolidator::set_query_buffers(
@@ -885,10 +899,8 @@ Status Consolidator::set_config(const Config* config) {
 }
 
 Status Consolidator::write_vacuum_file(
-    const URI& new_uri,
+    const URI& vac_uri,
     const std::vector<TimestampedURI>& to_consolidate) const {
-  URI vac_uri = URI(new_uri.to_string() + constants::vacuum_file_suffix);
-
   std::stringstream ss;
   for (const auto& timestampedURI : to_consolidate)
     ss << timestampedURI.uri_.to_string() << "\n";

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -351,14 +351,11 @@ class Consolidator {
       NDRange* union_non_empty_domains) const;
 
   /**
-   * The new fragment URI is computed
+   * The new fragment name is computed
    * as `__<first_URI_timestamp>_<last_URI_timestamp>_<uuid>`.
    */
-  Status compute_new_fragment_uri(
-      const URI& first,
-      const URI& last,
-      uint32_t format_version,
-      URI* new_uri) const;
+  tuple<Status, optional<std::string>> compute_new_fragment_name(
+      const URI& first, const URI& last, uint32_t format_version) const;
 
   /** Checks and sets the input configuration parameters. */
   Status set_config(const Config* config);
@@ -381,7 +378,7 @@ class Consolidator {
   /** Writes the vacuum file that contains the URIs of the consolidated
    * fragments. */
   Status write_vacuum_file(
-      const URI& new_uri,
+      const URI& vac_uri,
       const std::vector<TimestampedURI>& to_consolidate) const;
 };
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -435,12 +435,13 @@ Status StorageManager::array_vacuum_fragments(
   const auto& fragment_uris_to_vacuum = array_dir.fragment_uris_to_vacuum();
   const auto& vac_uris_to_vacuum = array_dir.fragment_vac_uris_to_vacuum();
 
-  // Delete the ok files
+  // Delete the commit files
   auto status = parallel_for(
       compute_tp_, 0, fragment_uris_to_vacuum.size(), [&, this](size_t i) {
-        auto uri = URI(
-            fragment_uris_to_vacuum[i].to_string() + constants::ok_file_suffix);
-        RETURN_NOT_OK(vfs_->remove_file(uri));
+        auto&& [st, commit_uri] =
+            array_dir.get_commit_uri(fragment_uris_to_vacuum[i]);
+        RETURN_NOT_OK(st);
+        RETURN_NOT_OK(vfs_->remove_file(commit_uri.value()));
 
         return Status::Ok();
       });
@@ -631,13 +632,27 @@ Status StorageManager::array_create(
       array_uri.join_path(constants::array_schema_dir_name);
   RETURN_NOT_OK(vfs_->create_dir(array_schema_dir_uri));
 
+  // Create commit directory
+  URI array_commit_uri = array_uri.join_path(constants::array_commit_dir_name);
+  RETURN_NOT_OK(vfs_->create_dir(array_commit_uri));
+
+  // Create fragments directory
+  URI array_fragments_uri =
+      array_uri.join_path(constants::array_fragments_dir_name);
+  RETURN_NOT_OK(vfs_->create_dir(array_fragments_uri));
+
   // Create array metadata directory
   URI array_metadata_uri =
       array_uri.join_path(constants::array_metadata_dir_name);
   RETURN_NOT_OK(vfs_->create_dir(array_metadata_uri));
-  Status st;
+
+  // Create fragment metadata directory
+  URI array_fragment_metadata_uri =
+      array_uri.join_path(constants::array_fragment_metadata_dir_name);
+  RETURN_NOT_OK(vfs_->create_dir(array_fragment_metadata_uri));
 
   // Get encryption key from config
+  Status st;
   if (encryption_key.encryption_type() == EncryptionType::NO_ENCRYPTION) {
     bool found = false;
     std::string encryption_key_from_cfg =
@@ -689,7 +704,7 @@ Status StorageManager::array_evolve_schema(
     const ArrayDirectory& array_dir,
     ArraySchemaEvolution* schema_evolution,
     const EncryptionKey& encryption_key) {
-  const URI& array_uri = array_dir.array_uri();
+  const URI& array_uri = array_dir.uri();
 
   // Check array schema
   if (schema_evolution == nullptr) {
@@ -737,7 +752,7 @@ Status StorageManager::array_evolve_schema(
 
 Status StorageManager::array_upgrade_version(
     const ArrayDirectory& array_dir, const Config* config) {
-  const URI& array_uri = array_dir.array_uri();
+  const URI& array_uri = array_dir.uri();
 
   // Check if array exists
   bool exists = false;
@@ -786,42 +801,43 @@ Status StorageManager::array_upgrade_version(
         key_length));
   }
 
-  ArraySchema* array_schema = (ArraySchema*)nullptr;
-  RETURN_NOT_OK(
-      load_array_schema_latest(array_dir, encryption_key_cfg, &array_schema));
+  ArraySchema* array_schema_ptr = (ArraySchema*)nullptr;
+  RETURN_NOT_OK(load_array_schema_latest(
+      array_dir, encryption_key_cfg, &array_schema_ptr));
+  tdb_unique_ptr<ArraySchema> array_schema(array_schema_ptr);
 
   if (array_schema->version() < constants::format_version) {
-    Status st = array_schema->generate_uri();
-    if (!st.ok()) {
-      logger_->status(st);
-      // Clean up
-      tdb_delete(array_schema);
-      return st;
-    }
+    RETURN_NOT_OK_ELSE(array_schema->generate_uri(), logger_->status(st));
+
     array_schema->set_version(constants::format_version);
 
     // Create array schema directory if necessary
     URI array_schema_dir_uri =
         array_uri.join_path(constants::array_schema_dir_name);
-    st = vfs_->create_dir(array_schema_dir_uri);
-    if (!st.ok()) {
-      logger_->status(st);
-      // Clean up
-      tdb_delete(array_schema);
-      return st;
-    }
+    RETURN_NOT_OK_ELSE(
+        vfs_->create_dir(array_schema_dir_uri), logger_->status(st));
 
-    st = store_array_schema(array_schema, encryption_key_cfg);
-    if (!st.ok()) {
-      logger_->status(st);
-      // Clean up
-      tdb_delete(array_schema);
-      return st;
-    }
+    RETURN_NOT_OK_ELSE(
+        store_array_schema(array_schema.get(), encryption_key_cfg),
+        logger_->status(st));
+
+    // Create commit directory if necessary
+    URI array_commit_uri =
+        array_uri.join_path(constants::array_commit_dir_name);
+    RETURN_NOT_OK_ELSE(vfs_->create_dir(array_commit_uri), logger_->status(st));
+
+    // Create fragments directory if necessary
+    URI array_fragments_uri =
+        array_uri.join_path(constants::array_fragments_dir_name);
+    RETURN_NOT_OK_ELSE(
+        vfs_->create_dir(array_fragments_uri), logger_->status(st));
+
+    // Create fragment metadata directory if necessary
+    URI array_fragment_metadata_uri =
+        array_uri.join_path(constants::array_fragment_metadata_dir_name);
+    RETURN_NOT_OK_ELSE(
+        vfs_->create_dir(array_fragment_metadata_uri), logger_->status(st));
   }
-
-  // Clean up
-  tdb_delete(array_schema);
 
   return Status::Ok();
 }
@@ -1096,7 +1112,7 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
 
 Status StorageManager::array_get_encryption(
     const ArrayDirectory& array_dir, EncryptionType* encryption_type) {
-  const URI& uri = array_dir.array_uri();
+  const URI& uri = array_dir.uri();
 
   if (uri.is_invalid())
     return logger_->status(Status_StorageManagerError(
@@ -1417,7 +1433,7 @@ Status StorageManager::load_array_schema_latest(
     ArraySchema** array_schema) {
   auto timer_se = stats_->start_timer("sm_load_array_schema");
 
-  const URI& array_uri = array_dir.array_uri();
+  const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
     return logger_->status(Status_StorageManagerError(
         "Cannot load array schema; Invalid array URI"));
@@ -1455,7 +1471,7 @@ StorageManager::load_all_array_schemas(
     const ArrayDirectory& array_dir, const EncryptionKey& encryption_key) {
   auto timer_se = stats_->start_timer("sm_load_all_array_schemas");
 
-  const URI& array_uri = array_dir.array_uri();
+  const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
     return {logger_->status(Status_StorageManagerError(
                 "Cannot load all array schemas; Invalid array URI")),

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -648,7 +648,7 @@ Status StorageManager::array_create(
 
   // Create fragment metadata directory
   URI array_fragment_metadata_uri =
-      array_uri.join_path(constants::array_fragment_metadata_dir_name);
+      array_uri.join_path(constants::array_fragment_meta_dir_name);
   RETURN_NOT_OK(vfs_->create_dir(array_fragment_metadata_uri));
 
   // Get encryption key from config
@@ -834,7 +834,7 @@ Status StorageManager::array_upgrade_version(
 
     // Create fragment metadata directory if necessary
     URI array_fragment_metadata_uri =
-        array_uri.join_path(constants::array_fragment_metadata_dir_name);
+        array_uri.join_path(constants::array_fragment_meta_dir_name);
     RETURN_NOT_OK_ELSE(
         vfs_->create_dir(array_fragment_metadata_uri), logger_->status(st));
   }


### PR DESCRIPTION
When opening an array, certain remote file systems limit the number of
elements returned (for example: 1000 for s3). For arrays with a large
number of fragments can take a long time. In an effort to reduce the
size of the listing operations, this PR shuffles a few elements of the
array directory.

First of all, it moves all the ok files to a __commit folder and the
fragments to a __fragment folder.

Second, it moves the consolidated fragment metadata to a __fragment_meta
directory.

Finally, this PR also ensures that arrays with the old format, the new
format or a mix of both can be read.

---
TYPE: IMPROVEMENT
DESC: Listing improvements: new directory structure for array.