### PR TITLE
Enable precommit CI for clang-formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# pre-commit is a tool to perform a predefined set of tasks manually and/or
+# automatically before git commits are made.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
+repos:
+  # Autoformat: C and C++ code
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v9.0.0
+    hooks:
+    -   id: clang-format
+        types_or: [c++, c]


### PR DESCRIPTION
This pre-commit config will enable automatic clang-formatting using the pre-commit bot in GitHub PRs.
Here's an example PR on my fork for how this bot would work: https://github.com/robertbindar/TileDB/pull/3

Please note, the bot needs activation on the pre-commit CI platform [here](https://pre-commit.ci/) after this PR is merged.

Also, feel free to read the Shortcut [item](https://app.shortcut.com/tiledb-inc/story/14925/automate-formatting-with-pre-commit-github-actions-bot) tracking this change for more details on why this would be a good idea and the disadvantages coming with the current implementation of the pre-commit CI.

---
TYPE: FEATURE
DESC: Enable pre-commit bot for automatic clang-formatting of PRs
