### PR TITLE
Collect missing docs

### DIFF
--- a/doc/source/c++-api.rst
+++ b/doc/source/c++-api.rst
@@ -62,6 +62,12 @@ Query
     :project: TileDB-C++
     :members:
 
+QueryCondition
+--------------
+.. doxygenclass:: tiledb::QueryCondition
+    :project: TileDB-C++
+    :members:
+
 Subarray
 --------
 .. doxygenclass:: tiledb::Subarray

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -339,6 +339,10 @@ Attribute
     :project: TileDB-C
 .. doxygenfunction:: tiledb_attribute_get_fill_value
     :project: TileDB-C
+.. doxygenfunction:: tiledb_attribute_set_fill_value_nullable
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_attribute_get_fill_value_nullable
+    :project: TileDB-C
 
 Domain
 ------

--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -152,6 +152,8 @@ Context
     :project: TileDB-C
 .. doxygenfunction:: tiledb_ctx_free
     :project: TileDB-C
+.. doxygenfunction:: tiledb_ctx_get_stats
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_ctx_get_config
     :project: TileDB-C
 .. doxygenfunction:: tiledb_ctx_get_last_error


### PR DESCRIPTION
Some docs were not rendered, adding them to TileDB readthedocs.

---
TYPE: FEATURE
DESC: Collect missing docs
