### PR TITLE
Switching from ArraySchema* to shared_ptr<ArraySchema>

### DIFF
--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -239,7 +239,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema_latest()->domain();
+  auto dom = array_->array_->array_schema_latest().domain();
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   tdb_shared_ptr<FragmentMetadata> fragment =
@@ -247,7 +247,7 @@ TEST_CASE_METHOD(
           HERE(),
           nullptr,
           nullptr,
-          array_->array_->array_schema_latest(),
+          array_->array_->array_schema_latest_ptr(),
           URI(),
           std::make_pair<uint64_t, uint64_t>(0, 0),
           true);
@@ -313,7 +313,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema_latest()->domain();
+  auto dom = array_->array_->array_schema_latest().domain();
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   tdb_shared_ptr<FragmentMetadata> fragment =
@@ -321,7 +321,7 @@ TEST_CASE_METHOD(
           HERE(),
           nullptr,
           nullptr,
-          array_->array_->array_schema_latest(),
+          array_->array_->array_schema_latest_ptr(),
           URI(),
           std::make_pair<uint64_t, uint64_t>(0, 0),
           true);
@@ -390,7 +390,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds1, ds2};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema_latest()->domain();
+  auto dom = array_->array_->array_schema_latest().domain();
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   for (uint64_t i = 0; i < 2; i++) {
@@ -399,7 +399,7 @@ TEST_CASE_METHOD(
             HERE(),
             nullptr,
             nullptr,
-            array_->array_->array_schema_latest(),
+            array_->array_->array_schema_latest_ptr(),
             URI(),
             std::make_pair<uint64_t, uint64_t>(0, 0),
             true);
@@ -473,7 +473,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema_latest()->domain();
+  auto dom = array_->array_->array_schema_latest().domain();
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   for (uint64_t i = 0; i < 2; i++) {
@@ -482,7 +482,7 @@ TEST_CASE_METHOD(
             HERE(),
             nullptr,
             nullptr,
-            array_->array_->array_schema_latest(),
+            array_->array_->array_schema_latest_ptr(),
             URI(),
             std::make_pair<uint64_t, uint64_t>(0, 0),
             true);
@@ -691,7 +691,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema_latest()->domain();
+  auto dom = array_->array_->array_schema_latest().domain();
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   tdb_shared_ptr<FragmentMetadata> fragment =
@@ -699,7 +699,7 @@ TEST_CASE_METHOD(
           HERE(),
           nullptr,
           nullptr,
-          array_->array_->array_schema_latest(),
+          array_->array_->array_schema_latest_ptr(),
           URI(),
           std::make_pair<uint64_t, uint64_t>(0, 0),
           true);
@@ -877,7 +877,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema_latest()->domain();
+  auto dom = array_->array_->array_schema_latest().domain();
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   tdb_shared_ptr<FragmentMetadata> fragment =
@@ -885,7 +885,7 @@ TEST_CASE_METHOD(
           HERE(),
           nullptr,
           nullptr,
-          array_->array_->array_schema_latest(),
+          array_->array_->array_schema_latest_ptr(),
           URI(),
           std::make_pair<uint64_t, uint64_t>(0, 0),
           true);
@@ -1076,7 +1076,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema_latest()->domain();
+  auto dom = array_->array_->array_schema_latest().domain();
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   tdb_shared_ptr<FragmentMetadata> fragment =
@@ -1084,7 +1084,7 @@ TEST_CASE_METHOD(
           HERE(),
           nullptr,
           nullptr,
-          array_->array_->array_schema_latest(),
+          array_->array_->array_schema_latest_ptr(),
           URI(),
           std::make_pair<uint64_t, uint64_t>(0, 0),
           true);
@@ -1321,7 +1321,7 @@ TEST_CASE_METHOD(
   std::vector<NDRange> domain_slices = {ds1, ds2};
   const auto& tile_coords = subarray.tile_coords();
   std::map<const uint64_t*, ResultSpaceTile<uint64_t>> result_space_tiles;
-  auto dom = array_->array_->array_schema_latest()->domain();
+  auto dom = array_->array_->array_schema_latest().domain();
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   for (uint64_t i = 0; i < 2; i++) {
@@ -1330,7 +1330,7 @@ TEST_CASE_METHOD(
             HERE(),
             nullptr,
             nullptr,
-            array_->array_->array_schema_latest(),
+            array_->array_->array_schema_latest_ptr(),
             URI(),
             std::make_pair<uint64_t, uint64_t>(0, 0),
             true);

--- a/test/src/unit-capi-incomplete.cc
+++ b/test/src/unit-capi-incomplete.cc
@@ -546,6 +546,7 @@ void IncompleteFx::check_dense_incomplete_serialized() {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_deserialize_query(ctx_, buff, TILEDB_CAPNP, 0, query2);
   REQUIRE(rc == TILEDB_OK);
+
   // Allocate and set buffers on the "server".
   int buffer_a1_server[2];
   void* buffers_server[] = {buffer_a1_server};
@@ -580,10 +581,10 @@ void IncompleteFx::check_dense_incomplete_serialized() {
   CHECK(rc == TILEDB_OK);
 
   // Clean up
-  tiledb_array_free(&array);
-  tiledb_array_free(&array2);
   tiledb_query_free(&query);
   tiledb_query_free(&query2);
+  tiledb_array_free(&array);
+  tiledb_array_free(&array2);
   tiledb_buffer_free(&buff);
   tiledb_buffer_free(&buff2);
   tiledb_buffer_list_free(&buff_list);

--- a/test/src/unit-cppapi-metadata.cc
+++ b/test/src/unit-cppapi-metadata.cc
@@ -164,8 +164,8 @@ TEST_CASE_METHOD(
   create_default_array_1d();
 
   // Put metadata in an array opened for reads - error
-  Context ctx;
-  Array array(ctx, std::string(array_name_), TILEDB_READ);
+  tiledb::Context ctx;
+  tiledb::Array array(ctx, std::string(array_name_), TILEDB_READ);
   int v = 5;
   CHECK_THROWS(array.put_metadata("key", TILEDB_INT32, 1, &v));
   array.close();
@@ -191,8 +191,8 @@ TEST_CASE_METHOD(
   create_default_array_1d();
 
   // Open array in write mode
-  Context ctx;
-  Array array(ctx, std::string(array_name_), TILEDB_WRITE);
+  tiledb::Context ctx;
+  tiledb::Array array(ctx, std::string(array_name_), TILEDB_WRITE);
 
   // Write items
   int32_t v = 5;
@@ -275,8 +275,8 @@ TEST_CASE_METHOD(
   create_default_array_1d();
 
   // Open array in write mode
-  Context ctx;
-  Array array(ctx, std::string(array_name_), TILEDB_WRITE);
+  tiledb::Context ctx;
+  tiledb::Array array(ctx, std::string(array_name_), TILEDB_WRITE);
 
   // Write UTF-8 (≥ holds 3 bytes)
   int32_t v = 5;
@@ -315,8 +315,8 @@ TEST_CASE_METHOD(
   create_default_array_1d();
 
   // Create and open array in write mode
-  Context ctx;
-  Array array(ctx, std::string(array_name_), TILEDB_WRITE, 1);
+  tiledb::Context ctx;
+  tiledb::Array array(ctx, std::string(array_name_), TILEDB_WRITE, 1);
 
   // Write items
   int32_t v = 5;
@@ -375,8 +375,8 @@ TEST_CASE_METHOD(
   create_default_array_1d();
 
   // Create and open array in write mode
-  Context ctx;
-  Array array(ctx, array_name_, TILEDB_WRITE);
+  tiledb::Context ctx;
+  tiledb::Array array(ctx, array_name_, TILEDB_WRITE);
 
   // Write items
   int32_t v = 5;
@@ -434,9 +434,9 @@ TEST_CASE_METHOD(
   array.close();
 
   // Consolidate
-  Config consolidation_cfg;
+  tiledb::Config consolidation_cfg;
   consolidation_cfg["sm.consolidation.mode"] = "array_meta";
-  Array::consolidate(ctx, array_name_, &consolidation_cfg);
+  tiledb::Array::consolidate(ctx, array_name_, &consolidation_cfg);
 
   // Open the array in read mode
   array.open(TILEDB_READ);
@@ -458,7 +458,7 @@ TEST_CASE_METHOD(
   array.close();
 
   // Consolidate again
-  Array::consolidate(ctx, array_name_, &consolidation_cfg);
+  tiledb::Array::consolidate(ctx, array_name_, &consolidation_cfg);
 
   // Open the array in read mode
   array.open(TILEDB_READ);
@@ -486,8 +486,8 @@ TEST_CASE_METHOD(
   create_default_array_1d();
 
   // Create and open array in write mode
-  Context ctx;
-  Array array(ctx, array_name_, TILEDB_WRITE);
+  tiledb::Context ctx;
+  tiledb::Array array(ctx, array_name_, TILEDB_WRITE);
 
   // Write items
   int32_t v = 5;
@@ -533,8 +533,8 @@ TEST_CASE_METHOD(
   create_default_array_1d();
 
   // Open array in write mode
-  Context ctx;
-  Array array(ctx, array_name_, TILEDB_WRITE);
+  tiledb::Context ctx;
+  tiledb::Array array(ctx, array_name_, TILEDB_WRITE);
 
   // Write items
   int32_t v = 5;
@@ -597,8 +597,8 @@ TEST_CASE_METHOD(
       encryption_type_str((tiledb::sm::EncryptionType)enc_type_);
   cfg["sm.encryption_type"] = enc_type_str.c_str();
   cfg["sm.encryption_key"] = key_;
-  Context ctx(cfg);
-  Array array(ctx, array_name_, TILEDB_WRITE);
+  tiledb::Context ctx(cfg);
+  tiledb::Array array(ctx, array_name_, TILEDB_WRITE);
 
   // Write items
   int32_t v = 5;
@@ -656,15 +656,15 @@ TEST_CASE_METHOD(
   array.close();
 
   // Consolidate without key - error
-  Config consolidate_without_key;
-  Context ctx_without_key(consolidate_without_key);
-  CHECK_THROWS(Array::consolidate(
+  tiledb::Config consolidate_without_key;
+  tiledb::Context ctx_without_key(consolidate_without_key);
+  CHECK_THROWS(tiledb::Array::consolidate(
       ctx_without_key, array_name_, &consolidate_without_key));
 
   // Consolidate with key - ok
-  Config consolidation_cfg;
+  tiledb::Config consolidation_cfg;
   consolidation_cfg["sm.consolidation.mode"] = "array_meta";
-  Array::consolidate(ctx, array_name_, &consolidation_cfg);
+  tiledb::Array::consolidate(ctx, array_name_, &consolidation_cfg);
 
   // Open the array in read mode
   array.open(TILEDB_READ);
@@ -686,7 +686,7 @@ TEST_CASE_METHOD(
   array.close();
 
   // Consolidate again
-  Array::consolidate_metadata(ctx, array_name_, &consolidation_cfg);
+  tiledb::Array::consolidate_metadata(ctx, array_name_, &consolidation_cfg);
 
   // Open the array in read mode
   array.open(TILEDB_READ);

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -41,27 +41,27 @@ using namespace tiledb::test;
 
 TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
   const std::string array_name = "cpp_unit_array";
-  Config cfg;
+  tiledb::Config cfg;
   cfg.set("config.logging_level", "3");
-  Context ctx(cfg);
-  VFS vfs(ctx);
+  tiledb::Context ctx(cfg);
+  tiledb::VFS vfs(ctx);
 
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
   // Create
-  Domain domain(ctx);
-  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 3}}, 4))
-      .add_dimension(Dimension::create<int>(ctx, "cols", {{0, 3}}, 4));
-  ArraySchema schema(ctx, TILEDB_SPARSE);
+  tiledb::Domain domain(ctx);
+  domain.add_dimension(tiledb::Dimension::create<int>(ctx, "rows", {{0, 3}}, 4))
+      .add_dimension(tiledb::Dimension::create<int>(ctx, "cols", {{0, 3}}, 4));
+  tiledb::ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
-  schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_name, schema);
+  schema.add_attribute(tiledb::Attribute::create<int>(ctx, "a"));
+  tiledb::Array::create(array_name, schema);
 
   // Write
   std::vector<int> data_w = {1, 2, 3, 4};
   std::vector<int> coords_w = {0, 0, 1, 1, 2, 2, 3, 3};
-  Array array_w(ctx, array_name, TILEDB_WRITE);
+  tiledb::Array array_w(ctx, array_name, TILEDB_WRITE);
   tiledb::Query query_w(ctx, array_w);
   query_w.set_coordinates(coords_w)
       .set_layout(TILEDB_UNORDERED)
@@ -269,9 +269,9 @@ TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
   }
 
   SECTION("- Read ranges oob error - Subarray-query") {
-    Array array(ctx, array_name, TILEDB_READ);
-    Query query(ctx, array);
-    Config config;
+    tiledb::Array array(ctx, array_name, TILEDB_READ);
+    tiledb::Query query(ctx, array);
+    tiledb::Config config;
     config.set("sm.read_range_oob", "error");
     query.set_config(config);
     int range[] = {1, 4};
@@ -281,9 +281,9 @@ TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
   }
 
   SECTION("- Read ranges oob error - Subarray-cppapi") {
-    Array array(ctx, array_name, TILEDB_READ);
-    Subarray subarray(ctx, array);
-    Config config;
+    tiledb::Array array(ctx, array_name, TILEDB_READ);
+    tiledb::Subarray subarray(ctx, array);
+    tiledb::Config config;
     config.set("sm.read_range_oob", "error");
     subarray.set_config(config);
     int range[] = {1, 4};
@@ -293,11 +293,11 @@ TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
   }
 
   SECTION("-  set_subarray Write ranges oob error - Subarray-cppapi") {
-    Array array(ctx, array_name, TILEDB_WRITE);
-    Subarray subarray(ctx, array);
+    tiledb::Array array(ctx, array_name, TILEDB_WRITE);
+    tiledb::Subarray subarray(ctx, array);
     // default expected to err. (currently errs because sparse)
     REQUIRE_THROWS(subarray.set_subarray({1, 4, -1, 3}));
-    Config config;
+    tiledb::Config config;
     // The config option should be ignored but we set anyway.
     // (currently errs because sparse)
     config.set("sm.read_range_oob", "error");
@@ -306,9 +306,9 @@ TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
   }
 
   SECTION("- Read ranges oob warn - Subarray-query") {
-    Array array(ctx, array_name, TILEDB_READ);
-    Query query(ctx, array);
-    Config config;
+    tiledb::Array array(ctx, array_name, TILEDB_READ);
+    tiledb::Query query(ctx, array);
+    tiledb::Config config;
     config.set("sm.read_range_oob", "warn");
     query.set_config(config);
     int range[] = {1, 4};
@@ -330,11 +330,11 @@ TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
   }
 
   SECTION("- set_subarray  Write ranges oob warn - Subarray-query") {
-    Array array(ctx, array_name, TILEDB_WRITE);
-    Query query(ctx, array);
+    tiledb::Array array(ctx, array_name, TILEDB_WRITE);
+    tiledb::Query query(ctx, array);
     // throws on sparse array (set_subarray not supported)
     REQUIRE_THROWS(query.set_subarray({1, 4, -1, 3}));
-    Config config;
+    tiledb::Config config;
     config.set("sm.read_range_oob", "warn");
     query.set_config(config);
     // throws on sparse array
@@ -342,9 +342,9 @@ TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
   }
 
   SECTION("- Read ranges oob warn - Subarray-cppapi") {
-    Array array(ctx, array_name, TILEDB_READ);
-    Subarray subarray(ctx, array);
-    Config config;
+    tiledb::Array array(ctx, array_name, TILEDB_READ);
+    tiledb::Subarray subarray(ctx, array);
+    tiledb::Config config;
     config.set("sm.read_range_oob", "warn");
     subarray.set_config(config);
     int range[] = {1, 4};
@@ -352,7 +352,7 @@ TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
     subarray.add_range(0, range[0], range[1]);
     subarray.add_range(1, range2[0], range2[1]);
 
-    Query query(ctx, array);
+    tiledb::Query query(ctx, array);
     query.set_subarray(subarray);
     auto est_size = query.est_result_size("a");
     REQUIRE(est_size == 12);
@@ -374,26 +374,26 @@ TEST_CASE("C++ API: Test subarray", "[cppapi][sparse][subarray]") {
 
 TEST_CASE("C++ API: Test subarray (dense)", "[cppapi][dense][subarray]") {
   const std::string array_name = "cpp_unit_array";
-  Config cfg;
+  tiledb::Config cfg;
   cfg.set("config.logging_level", "3");
-  Context ctx(cfg);
-  VFS vfs(ctx);
+  tiledb::Context ctx(cfg);
+  tiledb::VFS vfs(ctx);
 
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
   // Create
-  Domain domain(ctx);
-  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 3}}, 4))
-      .add_dimension(Dimension::create<int>(ctx, "cols", {{0, 3}}, 4));
-  ArraySchema schema(ctx, TILEDB_DENSE);
+  tiledb::Domain domain(ctx);
+  domain.add_dimension(tiledb::Dimension::create<int>(ctx, "rows", {{0, 3}}, 4))
+      .add_dimension(tiledb::Dimension::create<int>(ctx, "cols", {{0, 3}}, 4));
+  tiledb::ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
-  schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_name, schema);
+  schema.add_attribute(tiledb::Attribute::create<int>(ctx, "a"));
+  tiledb::Array::create(array_name, schema);
 
   // Write
   std::vector<int> data_w = {1, 2, 3, 4};
-  Array array_w(ctx, array_name, TILEDB_WRITE);
+  tiledb::Array array_w(ctx, array_name, TILEDB_WRITE);
   tiledb::Query query_w(ctx, array_w);
   query_w.set_subarray({0, 1, 0, 1})
       .set_layout(TILEDB_ROW_MAJOR)
@@ -403,11 +403,11 @@ TEST_CASE("C++ API: Test subarray (dense)", "[cppapi][dense][subarray]") {
   array_w.close();
 
   SECTION("-  set_subarray Write ranges oob error - Subarray-cppapi") {
-    Array array(ctx, array_name, TILEDB_WRITE);
-    Subarray subarray(ctx, array);
+    tiledb::Array array(ctx, array_name, TILEDB_WRITE);
+    tiledb::Subarray subarray(ctx, array);
     // default expected to err.
     REQUIRE_THROWS(subarray.set_subarray({1, 4, -1, 3}));
-    Config config;
+    tiledb::Config config;
     // The config option should be ignored but we set anyway.
     config.set("sm.read_range_oob", "error");
     subarray.set_config(config);
@@ -415,11 +415,11 @@ TEST_CASE("C++ API: Test subarray (dense)", "[cppapi][dense][subarray]") {
   }
 
   SECTION("- set_subarray Write ranges oob warn - Subarray-query") {
-    Array array(ctx, array_name, TILEDB_WRITE);
-    Query query(ctx, array);
+    tiledb::Array array(ctx, array_name, TILEDB_WRITE);
+    tiledb::Query query(ctx, array);
     // default (dense) WRITE should always err/throw on oob
     REQUIRE_THROWS(query.set_subarray({1, 4, -1, 3}));
-    Config config;
+    tiledb::Config config;
     config.set("sm.read_range_oob", "warn");
     query.set_config(config);
     // (dense) WRITE should ignore sm.read_range_oob config option
@@ -428,10 +428,10 @@ TEST_CASE("C++ API: Test subarray (dense)", "[cppapi][dense][subarray]") {
   }
 
   SECTION("- set_subarray Write ranges oob warn - Subarray-cppapi") {
-    Array array(ctx, array_name, TILEDB_WRITE);
-    Subarray subarray(ctx, array);
+    tiledb::Array array(ctx, array_name, TILEDB_WRITE);
+    tiledb::Subarray subarray(ctx, array);
     REQUIRE_THROWS(subarray.set_subarray({1, 4, -1, 3}));
-    Config config;
+    tiledb::Config config;
     config.set("sm.read_range_oob", "warn");
     subarray.set_config(config);
     REQUIRE_THROWS(subarray.set_subarray({1, 4, -1, 3}));
@@ -445,23 +445,25 @@ TEST_CASE(
     "C++ API: Test subarray (incomplete) - Subarray-query",
     "[cppapi][sparse][subarray][incomplete]") {
   const std::string array_name = "cpp_unit_array";
-  Context ctx;
-  VFS vfs(ctx);
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
 
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
   // Create
-  Domain domain(ctx);
-  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+  tiledb::Domain domain(ctx);
+  domain
       .add_dimension(
-          Dimension::create<int>(ctx, "cols", {{0, 100000}}, 100001));
-  ArraySchema schema(ctx, TILEDB_SPARSE);
+          tiledb::Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+      .add_dimension(
+          tiledb::Dimension::create<int>(ctx, "cols", {{0, 100000}}, 100001));
+  tiledb::ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain)
       .set_order({{TILEDB_COL_MAJOR, TILEDB_COL_MAJOR}})
       .set_capacity(10000);
-  schema.add_attribute(Attribute::create<char>(ctx, "a"));
-  Array::create(array_name, schema);
+  schema.add_attribute(tiledb::Attribute::create<char>(ctx, "a"));
+  tiledb::Array::create(array_name, schema);
 
   // Write
   std::vector<char> data_w = {
@@ -508,7 +510,7 @@ TEST_CASE(
 
   // Submit query
   auto st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
   auto result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
@@ -517,7 +519,7 @@ TEST_CASE(
 
   // Resubmit
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
@@ -526,7 +528,7 @@ TEST_CASE(
 
   // Resubmit
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
@@ -540,7 +542,7 @@ TEST_CASE(
 
   // Resubmit
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
@@ -555,7 +557,7 @@ TEST_CASE(
 
   // Resubmit
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
@@ -569,7 +571,7 @@ TEST_CASE(
 
   // Resubmit
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
@@ -584,9 +586,9 @@ TEST_CASE(
   // Resubmit
   st = query.submit();
   if (test::use_refactored_sparse_global_order_reader()) {
-    REQUIRE(st == Query::Status::COMPLETE);
+    REQUIRE(st == tiledb::Query::Status::COMPLETE);
   } else {
-    REQUIRE(st == Query::Status::INCOMPLETE);
+    REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   }
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
@@ -602,7 +604,7 @@ TEST_CASE(
 
     // Resubmit
     st = query.submit();
-    REQUIRE(st == Query::Status::INCOMPLETE);
+    REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
     result_elts = query.result_buffer_elements();
     result_num = result_elts["rows"].second;
     REQUIRE(result_num == 1);
@@ -610,7 +612,7 @@ TEST_CASE(
 
     // Resubmit
     st = query.submit();
-    REQUIRE(st == Query::Status::COMPLETE);
+    REQUIRE(st == tiledb::Query::Status::COMPLETE);
     result_elts = query.result_buffer_elements();
     result_num = result_elts["rows"].second;
     REQUIRE(result_num == 2);
@@ -629,23 +631,25 @@ TEST_CASE(
     "C++ API: Test subarray (incomplete) - Subarray-cppapi",
     "[cppapi][sparse][subarray][incomplete]") {
   const std::string array_name = "cpp_unit_array";
-  Context ctx;
-  VFS vfs(ctx);
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
 
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
   // Create
-  Domain domain(ctx);
-  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+  tiledb::Domain domain(ctx);
+  domain
       .add_dimension(
-          Dimension::create<int>(ctx, "cols", {{0, 100000}}, 100001));
-  ArraySchema schema(ctx, TILEDB_SPARSE);
+          tiledb::Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+      .add_dimension(
+          tiledb::Dimension::create<int>(ctx, "cols", {{0, 100000}}, 100001));
+  tiledb::ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain)
       .set_order({{TILEDB_COL_MAJOR, TILEDB_COL_MAJOR}})
       .set_capacity(10000);
-  schema.add_attribute(Attribute::create<char>(ctx, "a"));
-  Array::create(array_name, schema);
+  schema.add_attribute(tiledb::Attribute::create<char>(ctx, "a"));
+  tiledb::Array::create(array_name, schema);
 
   // Write
   std::vector<char> data_w = {
@@ -727,7 +731,7 @@ TEST_CASE(
   // Submit query
   query.set_subarray(subarray);
   auto st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
   auto result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
@@ -746,7 +750,7 @@ TEST_CASE(
   // Resubmit
   query.set_subarray(subarray);
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
@@ -756,7 +760,7 @@ TEST_CASE(
   // Resubmit
   query.set_subarray(subarray);
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
@@ -771,7 +775,7 @@ TEST_CASE(
   // Resubmit
   query.set_subarray(subarray);
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
@@ -786,7 +790,7 @@ TEST_CASE(
   // Resubmit
   query.set_subarray(subarray);
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
@@ -801,7 +805,7 @@ TEST_CASE(
   // Resubmit
   query.set_subarray(subarray);
   st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   if (test::use_refactored_sparse_global_order_reader()) {
@@ -817,9 +821,9 @@ TEST_CASE(
   query.set_subarray(subarray);
   st = query.submit();
   if (test::use_refactored_sparse_global_order_reader()) {
-    REQUIRE(st == Query::Status::COMPLETE);
+    REQUIRE(st == tiledb::Query::Status::COMPLETE);
   } else {
-    REQUIRE(st == Query::Status::INCOMPLETE);
+    REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   }
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
@@ -834,7 +838,7 @@ TEST_CASE(
 
     // Resubmit
     st = query.submit();
-    REQUIRE(st == Query::Status::INCOMPLETE);
+    REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
     result_elts = query.result_buffer_elements();
     result_num = result_elts["rows"].second;
     REQUIRE(result_num == 1);
@@ -842,7 +846,7 @@ TEST_CASE(
 
     // Resubmit
     st = query.submit();
-    REQUIRE(st == Query::Status::COMPLETE);
+    REQUIRE(st == tiledb::Query::Status::COMPLETE);
     result_elts = query.result_buffer_elements();
     result_num = result_elts["rows"].second;
     REQUIRE(result_num == 2);
@@ -861,23 +865,25 @@ TEST_CASE(
     "C++ API: Test subarray (incomplete overlapping) - Subarray-query",
     "[cppapi][sparse][subarray][incomplete]") {
   const std::string array_name = "cpp_unit_array";
-  Context ctx;
-  VFS vfs(ctx);
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
 
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
   // Create
-  Domain domain(ctx);
-  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+  tiledb::Domain domain(ctx);
+  domain
       .add_dimension(
-          Dimension::create<int>(ctx, "cols", {{0, 100000}}, 100001));
-  ArraySchema schema(ctx, TILEDB_SPARSE);
+          tiledb::Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+      .add_dimension(
+          tiledb::Dimension::create<int>(ctx, "cols", {{0, 100000}}, 100001));
+  tiledb::ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain)
       .set_order({{TILEDB_COL_MAJOR, TILEDB_COL_MAJOR}})
       .set_capacity(10000);
-  schema.add_attribute(Attribute::create<char>(ctx, "a"));
-  Array::create(array_name, schema);
+  schema.add_attribute(tiledb::Attribute::create<char>(ctx, "a"));
+  tiledb::Array::create(array_name, schema);
 
   // Write
   std::vector<char> data_w = {
@@ -917,14 +923,14 @@ TEST_CASE(
 
   // Submit query
   auto st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
   auto result_num = result_elts["rows"].second;
   REQUIRE(result_num == 1);
   REQUIRE(data[0] == 'l');
 
   st = query.submit();
-  REQUIRE(st == Query::Status::COMPLETE);
+  REQUIRE(st == tiledb::Query::Status::COMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
@@ -942,23 +948,25 @@ TEST_CASE(
     "C++ API: Test subarray (incomplete overlapping) - Subarray-cppapi",
     "[cppapi][sparse][subarray][incomplete]") {
   const std::string array_name = "cpp_unit_array";
-  Context ctx;
-  VFS vfs(ctx);
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
 
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
   // Create
-  Domain domain(ctx);
-  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+  tiledb::Domain domain(ctx);
+  domain
       .add_dimension(
-          Dimension::create<int>(ctx, "cols", {{0, 100000}}, 100001));
-  ArraySchema schema(ctx, TILEDB_SPARSE);
+          tiledb::Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+      .add_dimension(
+          tiledb::Dimension::create<int>(ctx, "cols", {{0, 100000}}, 100001));
+  tiledb::ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain)
       .set_order({{TILEDB_COL_MAJOR, TILEDB_COL_MAJOR}})
       .set_capacity(10000);
-  schema.add_attribute(Attribute::create<char>(ctx, "a"));
-  Array::create(array_name, schema);
+  schema.add_attribute(tiledb::Attribute::create<char>(ctx, "a"));
+  tiledb::Array::create(array_name, schema);
 
   // Write
   std::vector<char> data_w = {
@@ -1002,7 +1010,7 @@ TEST_CASE(
   // Submit query
   query.set_subarray(subarray);
   auto st = query.submit();
-  REQUIRE(st == Query::Status::INCOMPLETE);
+  REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
   auto result_num = result_elts["rows"].second;
   REQUIRE(result_num == 1);
@@ -1010,7 +1018,7 @@ TEST_CASE(
 
   query.set_subarray(subarray);
   st = query.submit();
-  REQUIRE(st == Query::Status::COMPLETE);
+  REQUIRE(st == tiledb::Query::Status::COMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
   REQUIRE(result_num == 2);
@@ -1033,22 +1041,25 @@ TEST_CASE(
       std::make_pair(TILEDB_ROW_MAJOR, TILEDB_GLOBAL_ORDER));
 
   const std::string array_name = "cpp_unit_array";
-  Context ctx;
-  VFS vfs(ctx);
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
 
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
   // Create
-  Domain domain(ctx);
-  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
-      .add_dimension(Dimension::create<int>(ctx, "cols", {{0, 100}}, 101));
-  ArraySchema schema(ctx, TILEDB_SPARSE);
+  tiledb::Domain domain(ctx);
+  domain
+      .add_dimension(
+          tiledb::Dimension::create<int>(ctx, "rows", {{0, 100}}, 101))
+      .add_dimension(
+          tiledb::Dimension::create<int>(ctx, "cols", {{0, 100}}, 101));
+  tiledb::ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain)
       .set_order({{TILEDB_COL_MAJOR, test_pair.first}})
       .set_capacity(10000);
-  schema.add_attribute(Attribute::create<char>(ctx, "a"));
-  Array::create(array_name, schema);
+  schema.add_attribute(tiledb::Attribute::create<char>(ctx, "a"));
+  tiledb::Array::create(array_name, schema);
 
   // Open array for reading
   tiledb::Array array(ctx, array_name, TILEDB_READ);

--- a/test/src/unit-sparse-index-reader-base.cc
+++ b/test/src/unit-sparse-index-reader-base.cc
@@ -82,7 +82,8 @@ TEST_CASE(
   REQUIRE(rc == TILEDB_OK);
   tiledb_domain_free(&domain);
 
-  ResultTileWithBitmap<uint8_t> tile(0, 0, array_schema->array_schema_);
+  ResultTileWithBitmap<uint8_t> tile(
+      0, 0, *(array_schema->array_schema_.get()));
   tile.bitmap_result_num_ = 100;
 
   // Check the function with an empty bitmap.

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1263,9 +1263,9 @@ ResultTileWithBitmap<uint64_t> make_tile(uint64_t num_cells) {
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
 
-  ArraySchema schema;
-  REQUIRE(schema.set_domain(&domain).ok());
-  ResultTileWithBitmap<uint64_t> result_tile(0, 0, &schema);
+  ArraySchema array_schema;
+  REQUIRE(array_schema.set_domain(&domain).ok());
+  ResultTileWithBitmap<uint64_t> result_tile(0, 0, array_schema);
   result_tile.init_coord_tile("a", 0);
   auto tuple = result_tile.tile_tuple("a");
   REQUIRE(std::get<0>(*tuple)

--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -56,15 +56,16 @@ struct CPPFixedTileMetadataFx {
 
   void create_array(
       tiledb_layout_t layout, bool nullable, uint64_t cell_val_num) {
-    Domain domain(ctx_);
-    auto d = Dimension::create<uint32_t>(ctx_, "d", {{0, 999}}, tile_extent_);
+    tiledb::Domain domain(ctx_);
+    auto d = tiledb::Dimension::create<uint32_t>(
+        ctx_, "d", {{0, 999}}, tile_extent_);
     domain.add_dimension(d);
 
-    auto a = Attribute::create<TestType>(ctx_, "a");
+    auto a = tiledb::Attribute::create<TestType>(ctx_, "a");
     a.set_nullable(nullable);
     a.set_cell_val_num(cell_val_num);
 
-    ArraySchema schema(
+    tiledb::ArraySchema schema(
         ctx_, layout == TILEDB_ROW_MAJOR ? TILEDB_DENSE : TILEDB_SPARSE);
     schema.set_domain(domain);
     schema.add_attribute(a);
@@ -73,7 +74,7 @@ struct CPPFixedTileMetadataFx {
       schema.set_capacity(tile_extent_);
     }
 
-    Array::create(ARRAY_NAME, schema);
+    tiledb::Array::create(ARRAY_NAME, schema);
   }
 
   void write_fragment(
@@ -412,8 +413,8 @@ struct CPPFixedTileMetadataFx {
   const uint64_t tile_extent_ = 100;
   const uint64_t num_cells_ = 1000;
   const uint64_t num_tiles_ = num_cells_ / tile_extent_;
-  Context ctx_;
-  VFS vfs_;
+  tiledb::Context ctx_;
+  tiledb::VFS vfs_;
 };
 
 typedef tuple<
@@ -476,15 +477,16 @@ struct CPPVarTileMetadataFx {
   }
 
   void create_array(tiledb_layout_t layout, bool nullable) {
-    Domain domain(ctx_);
-    auto d = Dimension::create<uint32_t>(ctx_, "d", {{0, 999}}, tile_extent_);
+    tiledb::Domain domain(ctx_);
+    auto d = tiledb::Dimension::create<uint32_t>(
+        ctx_, "d", {{0, 999}}, tile_extent_);
     domain.add_dimension(d);
 
-    auto a = Attribute::create<std::string>(ctx_, "a");
+    auto a = tiledb::Attribute::create<std::string>(ctx_, "a");
     a.set_nullable(nullable);
     a.set_cell_val_num(TILEDB_VAR_NUM);
 
-    ArraySchema schema(
+    tiledb::ArraySchema schema(
         ctx_, layout == TILEDB_ROW_MAJOR ? TILEDB_DENSE : TILEDB_SPARSE);
     schema.set_domain(domain);
     schema.add_attribute(a);
@@ -493,7 +495,7 @@ struct CPPVarTileMetadataFx {
       schema.set_capacity(tile_extent_);
     }
 
-    Array::create(ARRAY_NAME, schema);
+    tiledb::Array::create(ARRAY_NAME, schema);
   }
 
   void write_fragment(
@@ -740,8 +742,8 @@ struct CPPVarTileMetadataFx {
   const uint64_t tile_extent_ = 10;
   const uint64_t num_cells_ = 1000;
   const uint64_t num_tiles_ = num_cells_ / tile_extent_;
-  Context ctx_;
-  VFS vfs_;
+  tiledb::Context ctx_;
+  tiledb::VFS vfs_;
 };
 
 TEST_CASE_METHOD(

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -370,7 +370,6 @@ Status Array::close() {
   non_empty_domain_computed_ = false;
   clear_last_max_buffer_sizes();
   fragment_metadata_.clear();
-  array_schemas_all_.clear();
 
   if (remote_) {
     // Update array metadata for write queries if metadata was written by the
@@ -398,6 +397,7 @@ Status Array::close() {
     }
   }
 
+  array_schemas_all_.clear();
   metadata_.clear();
   metadata_loaded_ = false;
   is_open_ = false;

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -85,20 +85,16 @@ class Array {
   /** Sets the latest array schema.
    * @param array_schema The array schema to set.
    */
-  void set_array_schema_latest(ArraySchema* array_schema);
-
-  /** Sets all array schemas.
-   * @param all_schemas The array schemas to set.
-   */
-  void set_array_schemas_all(
-      std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
-          all_schemas);
+  void set_array_schema_latest(const shared_ptr<ArraySchema>& array_schema);
 
   /** Returns the latest array schema. */
-  ArraySchema* array_schema_latest() const;
+  const ArraySchema& array_schema_latest() const;
+
+  /** Returns the latest array schema as a shared pointer. */
+  shared_ptr<const ArraySchema> array_schema_latest_ptr() const;
 
   /** Returns array schemas map. */
-  inline const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+  inline const std::unordered_map<std::string, shared_ptr<ArraySchema>>&
   array_schemas_all() const {
     return array_schemas_all_;
   }
@@ -184,7 +180,7 @@ class Array {
    * Returns the fragment metadata of the array. If the array is not open,
    * an empty vector is returned.
    */
-  std::vector<tdb_shared_ptr<FragmentMetadata>> fragment_metadata() const;
+  std::vector<shared_ptr<FragmentMetadata>> fragment_metadata() const;
 
   /**
    * Returns `true` if the array is empty at the time it is opened.
@@ -199,7 +195,7 @@ class Array {
   bool is_remote() const;
 
   /** Retrieves the array schema. Errors if the array is not open. */
-  Status get_array_schema(ArraySchema** array_schema) const;
+  tuple<Status, optional<shared_ptr<ArraySchema>>> get_array_schema() const;
 
   /** Retrieves the query type. Errors if the array is not open. */
   Status get_query_type(QueryType* qyery_type) const;
@@ -374,13 +370,12 @@ class Array {
   /* ********************************* */
 
   /** The latest array schema. */
-  ArraySchema* array_schema_latest_;
+  shared_ptr<ArraySchema> array_schema_latest_;
 
   /**
    * A map of all array_schemas_all
    */
-  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>
-      array_schemas_all_;
+  std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas_all_;
 
   /** The array URI. */
   URI array_uri_;
@@ -403,10 +398,10 @@ class Array {
    * bytes should be stored. Whenever a key is needed, a pointer to this
    * memory region should be passed instead of a copy of the bytes.
    */
-  tdb_shared_ptr<EncryptionKey> encryption_key_;
+  shared_ptr<EncryptionKey> encryption_key_;
 
   /** The metadata of the fragments the array was opened with. */
-  std::vector<tdb_shared_ptr<FragmentMetadata>> fragment_metadata_;
+  std::vector<shared_ptr<FragmentMetadata>> fragment_metadata_;
 
   /** `True` if the array has been opened. */
   std::atomic<bool> is_open_;

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -91,31 +91,31 @@ ArraySchema::ArraySchema(ArrayType array_type)
       constants::cell_validity_compression_level));
 }
 
-ArraySchema::ArraySchema(const ArraySchema* array_schema) {
-  allows_dups_ = array_schema->allows_dups_;
-  array_uri_ = array_schema->array_uri_;
-  uri_ = array_schema->uri_;
-  array_type_ = array_schema->array_type_;
+ArraySchema::ArraySchema(const ArraySchema& array_schema) {
+  allows_dups_ = array_schema.allows_dups_;
+  array_uri_ = array_schema.array_uri_;
+  uri_ = array_schema.uri_;
+  array_type_ = array_schema.array_type_;
   domain_ = nullptr;
-  timestamp_range_ = array_schema->timestamp_range_;
+  timestamp_range_ = array_schema.timestamp_range_;
 
-  capacity_ = array_schema->capacity_;
-  cell_order_ = array_schema->cell_order_;
-  cell_var_offsets_filters_ = array_schema->cell_var_offsets_filters_;
-  cell_validity_filters_ = array_schema->cell_validity_filters_;
-  coords_filters_ = array_schema->coords_filters_;
-  tile_order_ = array_schema->tile_order_;
-  version_ = array_schema->version_;
+  capacity_ = array_schema.capacity_;
+  cell_order_ = array_schema.cell_order_;
+  cell_var_offsets_filters_ = array_schema.cell_var_offsets_filters_;
+  cell_validity_filters_ = array_schema.cell_validity_filters_;
+  coords_filters_ = array_schema.coords_filters_;
+  tile_order_ = array_schema.tile_order_;
+  version_ = array_schema.version_;
 
-  set_domain(array_schema->domain_);
+  set_domain(array_schema.domain_);
 
   attribute_map_.clear();
-  for (auto attr : array_schema->attributes_)
+  for (auto attr : array_schema.attributes_)
     add_attribute(attr, false);
 
   // This has to be the last thing set because add_attribute sets the name
   // TODO: This behavior needs to be changed
-  name_ = array_schema->name_;
+  name_ = array_schema.name_;
 }
 
 ArraySchema::~ArraySchema() {
@@ -783,11 +783,8 @@ Status ArraySchema::get_uri(URI* uri) {
   return Status::Ok();
 }
 
-std::string ArraySchema::name() {
+const std::string& ArraySchema::name() const {
   std::lock_guard<std::mutex> lock(mtx_);
-  if (name_.empty()) {
-    generate_uri();
-  }
   return name_;
 }
 

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -78,7 +78,7 @@ class ArraySchema {
    *
    * @param array_schema The array schema to copy.
    */
-  explicit ArraySchema(const ArraySchema* array_schema);
+  explicit ArraySchema(const ArraySchema& array_schema);
 
   /** Destructor. */
   ~ArraySchema();
@@ -332,7 +332,7 @@ class ArraySchema {
   Status get_uri(URI* uri);
 
   /** Returns the schema name. If it is not set, will build it. */
-  std::string name();
+  const std::string& name() const;
 
   /** Returns the schema name. If it is not set, will returns error status. */
   Status get_name(std::string* name) const;

--- a/tiledb/sm/array_schema/array_schema_evolution.h
+++ b/tiledb/sm/array_schema/array_schema_evolution.h
@@ -79,8 +79,8 @@ class ArraySchemaEvolution {
   /*               API                 */
   /* ********************************* */
 
-  Status evolve_schema(
-      const ArraySchema* orig_schema, ArraySchema** new_schema);
+  tuple<Status, optional<shared_ptr<ArraySchema>>> evolve_schema(
+      const shared_ptr<const ArraySchema>& orig_schema);
 
   /**
    * Adds an attribute, copying the input.

--- a/tiledb/sm/c_api/tiledb_struct_def.h
+++ b/tiledb/sm/c_api/tiledb_struct_def.h
@@ -88,7 +88,7 @@ struct tiledb_attribute_t {
 };
 
 struct tiledb_array_schema_t {
-  tiledb::sm::ArraySchema* array_schema_ = nullptr;
+  shared_ptr<tiledb::sm::ArraySchema> array_schema_;
 };
 
 struct tiledb_array_schema_evolution_t {

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -273,7 +273,7 @@ Status FragmentInfo::get_non_empty_domain(
         "Cannot get non-empty domain; Dimension name argument cannot be null"));
 
   auto meta = single_fragment_info_vec_[fid].meta();
-  auto array_schema = meta->array_schema();
+  const auto& array_schema = meta->array_schema();
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
@@ -344,7 +344,7 @@ Status FragmentInfo::get_non_empty_domain_var_size(
                                  "Dimension name argument cannot be null"));
 
   auto meta = single_fragment_info_vec_[fid].meta();
-  auto array_schema = meta->array_schema();
+  const auto& array_schema = meta->array_schema();
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
@@ -411,7 +411,7 @@ Status FragmentInfo::get_non_empty_domain_var(
                                  "name argument cannot be null"));
 
   auto meta = single_fragment_info_vec_[fid].meta();
-  auto array_schema = meta->array_schema();
+  const auto& array_schema = meta->array_schema();
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
@@ -503,7 +503,7 @@ Status FragmentInfo::get_mbr(
         "Cannot get non-empty domain; Dimension name argument cannot be null"));
 
   auto meta = single_fragment_info_vec_[fid].meta();
-  auto array_schema = meta->array_schema();
+  const auto& array_schema = meta->array_schema();
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
@@ -587,7 +587,7 @@ Status FragmentInfo::get_mbr_var_size(
                                  "Dimension name argument cannot be null"));
 
   auto meta = single_fragment_info_vec_[fid].meta();
-  auto array_schema = meta->array_schema();
+  const auto& array_schema = meta->array_schema();
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
@@ -667,7 +667,7 @@ Status FragmentInfo::get_mbr_var(
                                  "name argument cannot be null"));
 
   auto meta = single_fragment_info_vec_[fid].meta();
-  auto array_schema = meta->array_schema();
+  const auto& array_schema = meta->array_schema();
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
@@ -702,15 +702,12 @@ Status FragmentInfo::get_version(uint32_t fid, uint32_t* version) const {
   return Status::Ok();
 }
 
-Status FragmentInfo::get_array_schema(
-    uint32_t fid, ArraySchema** array_schema) {
-  if (array_schema == nullptr)
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get array schema; schema argument cannot be null"));
-
+tuple<Status, optional<shared_ptr<ArraySchema>>> FragmentInfo::get_array_schema(
+    uint32_t fid) {
   if (fid >= fragment_num())
-    return LOG_STATUS(Status_FragmentInfoError(
-        "Cannot get array schema; Invalid fragment index"));
+    return {LOG_STATUS(Status_FragmentInfoError(
+                "Cannot get array schema; Invalid fragment index")),
+            nullopt};
   URI schema_uri;
   uint32_t version = single_fragment_info_vec_[fid].format_version();
   if (version >= 10) {
@@ -722,10 +719,8 @@ Status FragmentInfo::get_array_schema(
   }
 
   EncryptionKey encryption_key;
-  RETURN_NOT_OK(storage_manager_->load_array_schema_from_uri(
-      schema_uri, encryption_key, array_schema));
-
-  return Status::Ok();
+  return storage_manager_->load_array_schema_from_uri(
+      schema_uri, encryption_key);
 }
 
 Status FragmentInfo::get_array_schema_name(
@@ -873,7 +868,7 @@ Status FragmentInfo::load(
   // Create the vector that will store the SingleFragmentInfo objects
   for (uint64_t fid = 0; fid < fragment_num; fid++) {
     const auto meta = fragment_metadata_v[fid];
-    auto array_schema = meta->array_schema();
+    const auto& array_schema = meta->array_schema();
     const auto& non_empty_domain = meta->non_empty_domain();
 
     if (meta->timestamp_range().first < timestamp_start_) {
@@ -970,7 +965,7 @@ tuple<Status, optional<SingleFragmentInfo>> FragmentInfo::load(
     const URI& new_fragment_uri) const {
   SingleFragmentInfo ret;
   auto vfs = storage_manager_->vfs();
-  auto array_schema_latest =
+  const auto& array_schema_latest =
       single_fragment_info_vec_.back().meta()->array_schema();
 
   // Get timestamp range

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -221,7 +221,8 @@ class FragmentInfo {
   Status get_version(uint32_t fid, uint32_t* version) const;
 
   /** Retrieves the array schema of the fragment with the given index. */
-  Status get_array_schema(uint32_t fid, ArraySchema** array_schema);
+  tuple<Status, optional<shared_ptr<ArraySchema>>> get_array_schema(
+      uint32_t fid);
 
   /** Retrieves the array schema name of the fragment with the given index. */
   Status get_array_schema_name(uint32_t fid, const char** schema_name);
@@ -338,8 +339,7 @@ class FragmentInfo {
    * TODO: when we transition to using a shared pointer for ArraySchema
    * objects everywhere, we will not need to store this here.
    */
-  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>
-      array_schemas_all_;
+  std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas_all_;
 
   /** Information about fragments in the array. */
   std::vector<SingleFragmentInfo> single_fragment_info_vec_;

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -62,10 +62,8 @@ class FragmentMetadata {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  /**
-   * Default contructor
-   */
-  FragmentMetadata() = default;
+  /** Constructor. */
+  FragmentMetadata();
 
   /**
    * Constructor.
@@ -83,7 +81,7 @@ class FragmentMetadata {
   FragmentMetadata(
       StorageManager* storage_manager,
       MemoryTracker* memory_tracker,
-      const ArraySchema* array_schema,
+      const shared_ptr<const ArraySchema>& array_schema,
       const URI& fragment_uri,
       const std::pair<uint64_t, uint64_t>& timestamp_range,
       bool dense = true);
@@ -252,8 +250,7 @@ class FragmentMetadata {
       const EncryptionKey& encryption_key,
       Buffer* f_buff,
       uint64_t offset,
-      std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>
-          array_schemas);
+      std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas);
 
   /** Stores all the metadata to storage. */
   Status store(const EncryptionKey& encryption_key);
@@ -468,7 +465,7 @@ class FragmentMetadata {
    * @param array_schema The schema pointer.
    * @return void
    */
-  void set_array_schema(ArraySchema* array_schema);
+  void set_array_schema(const shared_ptr<const ArraySchema>& array_schema);
 
   /** Returns the tile index base value. */
   uint64_t tile_index_base() const;
@@ -724,7 +721,7 @@ class FragmentMetadata {
    *
    * @return
    */
-  const ArraySchema* array_schema() const;
+  const shared_ptr<const ArraySchema>& array_schema() const;
 
  private:
   /* ********************************* */
@@ -775,7 +772,7 @@ class FragmentMetadata {
   MemoryTracker* memory_tracker_;
 
   /** The array schema */
-  const ArraySchema* array_schema_;
+  shared_ptr<const ArraySchema> array_schema_;
 
   /** The array schema name */
   std::string array_schema_name_;
@@ -1224,7 +1221,7 @@ class FragmentMetadata {
   /** Loads the basic metadata from storage (version 2 or before). */
   Status load_v1_v2(
       const EncryptionKey& encryption_key,
-      const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+      const std::unordered_map<std::string, shared_ptr<ArraySchema>>&
           array_schemas);
 
   /**
@@ -1235,8 +1232,7 @@ class FragmentMetadata {
       const EncryptionKey& encryption_key,
       Buffer* f_buff,
       uint64_t offset,
-      std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>
-          array_schemas);
+      std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas);
 
   /**
    * Loads the footer of the metadata file, which contains
@@ -1248,8 +1244,7 @@ class FragmentMetadata {
       const EncryptionKey& encryption_key,
       Buffer* f_buff,
       uint64_t offset,
-      std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>
-          array_schemas);
+      std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas);
 
   /** Writes the sizes of each attribute file to the buffer. */
   Status write_file_sizes(Buffer* buff) const;

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -69,7 +69,7 @@ DenseTiler<T>::DenseTiler(
   assert(subarray != nullptr);
   assert(buffers != nullptr);
   for (const auto& buff : *buffers) {
-    assert(array_schema_->is_attr(buff.first));
+    assert(array_schema_.is_attr(buff.first));
     (void)buff;
   }
 
@@ -95,13 +95,13 @@ const typename DenseTiler<T>::CopyPlan DenseTiler<T>::copy_plan(
 
   // For easy reference
   CopyPlan ret;
-  auto dim_num = (int32_t)array_schema_->dim_num();
-  auto domain = array_schema_->domain();
+  auto dim_num = (int32_t)array_schema_.dim_num();
+  auto domain = array_schema_.domain();
   auto subarray = subarray_->ndrange(0);  // Guaranteed to be unary
   std::vector<std::array<T, 2>> sub(dim_num);
   for (int32_t d = 0; d < dim_num; ++d)
     sub[d] = {*(const T*)subarray[d].start(), *(const T*)subarray[d].end()};
-  auto tile_layout = array_schema_->cell_order();
+  auto tile_layout = array_schema_.cell_order();
   auto sub_layout = subarray_->layout();
 
   // Copy tile and subarray strides
@@ -195,19 +195,19 @@ Status DenseTiler<T>::get_tile(
   if (id >= tile_num_)
     return LOG_STATUS(
         Status_DenseTilerError("Cannot get tile; Invalid tile id"));
-  if (!array_schema_->is_attr(name))
+  if (!array_schema_.is_attr(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));
-  if (array_schema_->var_size(name))
+  if (array_schema_.var_size(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name +
         "' is not a fixed-sized attribute"));
 
   // For easy reference
-  auto domain = array_schema_->domain();
-  auto type = array_schema_->type(name);
+  auto domain = array_schema_.domain();
+  auto type = array_schema_.type(name);
   auto cell_num_per_tile = domain->cell_num_per_tile();
-  auto cell_size = array_schema_->cell_size(name);
+  auto cell_size = array_schema_.cell_size(name);
   auto tile_size = cell_num_per_tile * cell_size;
   auto buff = (uint8_t*)buffers_->find(name)->second.buffer_;
   assert(buff != nullptr);
@@ -229,17 +229,17 @@ Status DenseTiler<T>::get_tile_null(
   if (id >= tile_num_)
     return LOG_STATUS(
         Status_DenseTilerError("Cannot get tile; Invalid tile id"));
-  if (!array_schema_->is_attr(name))
+  if (!array_schema_.is_attr(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));
-  if (!array_schema_->is_nullable(name))
+  if (!array_schema_.is_nullable(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name +
         "' is not a nullable attribute"));
 
   // For easy reference
-  auto domain = array_schema_->domain();
-  auto type = array_schema_->type(name);
+  auto domain = array_schema_.domain();
+  auto type = array_schema_.type(name);
   auto cell_num_per_tile = domain->cell_num_per_tile();
   auto cell_size = constants::cell_validity_size;
   auto tile_size = cell_num_per_tile * cell_size;
@@ -264,17 +264,17 @@ Status DenseTiler<T>::get_tile_var(
   if (id >= tile_num_)
     return LOG_STATUS(
         Status_DenseTilerError("Cannot get tile; Invalid tile id"));
-  if (!array_schema_->is_attr(name))
+  if (!array_schema_.is_attr(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));
-  if (!array_schema_->var_size(name))
+  if (!array_schema_.var_size(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name +
         "' is not a var-sized attribute"));
 
   // For easy reference
-  auto domain = array_schema_->domain();
-  auto type = array_schema_->type(name);
+  auto domain = array_schema_.domain();
+  auto type = array_schema_.type(name);
   auto cell_num_in_tile = domain->cell_num_per_tile();
   auto tile_off_size = constants::cell_var_offset_size * cell_num_in_tile;
   auto buff_it = buffers_->find(name);
@@ -393,8 +393,8 @@ const std::vector<uint64_t>& DenseTiler<T>::first_sub_tile_coords() const {
 template <class T>
 void DenseTiler<T>::calculate_first_sub_tile_coords() {
   // For easy reference
-  auto dim_num = array_schema_->dim_num();
-  auto domain = array_schema_->domain();
+  auto dim_num = array_schema_.dim_num();
+  auto domain = array_schema_.domain();
   auto subarray = subarray_->ndrange(0);
 
   // Calculate the coordinates of the first tile in the entire
@@ -413,10 +413,10 @@ void DenseTiler<T>::calculate_first_sub_tile_coords() {
 template <class T>
 void DenseTiler<T>::calculate_subarray_tile_coord_strides() {
   // For easy reference
-  auto dim_num = (int32_t)array_schema_->dim_num();
-  auto domain = array_schema_->domain();
+  auto dim_num = (int32_t)array_schema_.dim_num();
+  auto domain = array_schema_.domain();
   auto subarray = subarray_->ndrange(0);
-  auto layout = array_schema_->tile_order();
+  auto layout = array_schema_.tile_order();
 
   // Compute offsets
   sub_tile_coord_strides_.reserve(dim_num);
@@ -444,9 +444,9 @@ void DenseTiler<T>::calculate_tile_and_subarray_strides() {
   // For easy reference
   auto sub_layout = subarray_->layout();
   assert(sub_layout == Layout::ROW_MAJOR || sub_layout == Layout::COL_MAJOR);
-  auto tile_layout = array_schema_->cell_order();
-  auto dim_num = (int32_t)array_schema_->dim_num();
-  auto domain = array_schema_->domain();
+  auto tile_layout = array_schema_.cell_order();
+  auto dim_num = (int32_t)array_schema_.dim_num();
+  auto domain = array_schema_.domain();
   auto subarray = subarray_->ndrange(0);
 
   // Compute tile strides
@@ -500,14 +500,14 @@ void DenseTiler<T>::calculate_tile_and_subarray_strides() {
 
 template <class T>
 void DenseTiler<T>::calculate_tile_num() {
-  tile_num_ = array_schema_->domain()->tile_num(subarray_->ndrange(0));
+  tile_num_ = array_schema_.domain()->tile_num(subarray_->ndrange(0));
 }
 
 template <class T>
 std::vector<uint64_t> DenseTiler<T>::tile_coords_in_sub(uint64_t id) const {
   // For easy reference
-  auto dim_num = (int32_t)array_schema_->dim_num();
-  auto layout = array_schema_->tile_order();
+  auto dim_num = (int32_t)array_schema_.dim_num();
+  auto layout = array_schema_.tile_order();
   std::vector<uint64_t> ret;
   auto tmp_idx = id;
 
@@ -530,8 +530,8 @@ std::vector<uint64_t> DenseTiler<T>::tile_coords_in_sub(uint64_t id) const {
 template <class T>
 std::vector<std::array<T, 2>> DenseTiler<T>::tile_subarray(uint64_t id) const {
   // For easy reference
-  auto dim_num = array_schema_->dim_num();
-  auto domain = array_schema_->domain();
+  auto dim_num = array_schema_.dim_num();
+  auto domain = array_schema_.domain();
 
   // Get tile coordinates in the subarray tile domain
   auto tile_coords_in_sub = this->tile_coords_in_sub(id);

--- a/tiledb/sm/query/dense_tiler.h
+++ b/tiledb/sm/query/dense_tiler.h
@@ -250,7 +250,7 @@ class DenseTiler {
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
   /** The array schema. */
-  const ArraySchema* array_schema_;
+  const ArraySchema& array_schema_;
 
   /** The input buffers, from which the tiles will be produced. */
   const std::unordered_map<std::string, QueryBuffer>* buffers_;

--- a/tiledb/sm/query/global_order_writer.cc
+++ b/tiledb/sm/query/global_order_writer.cc
@@ -138,7 +138,7 @@ Status GlobalOrderWriter::check_coord_dups() const {
   auto timer_se = stats_->start_timer("check_coord_dups");
 
   // Check if applicable
-  if (array_schema_->allows_dups() || !check_coord_dups_ || dedup_coords_)
+  if (array_schema_.allows_dups() || !check_coord_dups_ || dedup_coords_)
     return Status::Ok();
 
   if (!coords_info_.has_coords_) {
@@ -151,15 +151,15 @@ Status GlobalOrderWriter::check_coord_dups() const {
     return Status::Ok();
 
   // Prepare auxiliary vectors for better performance
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   std::vector<const unsigned char*> buffs(dim_num);
   std::vector<uint64_t> coord_sizes(dim_num);
   std::vector<const unsigned char*> buffs_var(dim_num);
   std::vector<uint64_t*> buffs_var_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_->dimension(d)->name();
+    const auto& dim_name = array_schema_.dimension(d)->name();
     buffs[d] = (const unsigned char*)buffers_.find(dim_name)->second.buffer_;
-    coord_sizes[d] = array_schema_->cell_size(dim_name);
+    coord_sizes[d] = array_schema_.cell_size(dim_name);
     buffs_var[d] =
         (const unsigned char*)buffers_.find(dim_name)->second.buffer_var_;
     buffs_var_sizes[d] = buffers_.find(dim_name)->second.buffer_var_size_;
@@ -173,7 +173,7 @@ Status GlobalOrderWriter::check_coord_dups() const {
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_->dimension(d);
+          auto dim = array_schema_.dimension(d);
           if (!dim->var_size()) {  // Fixed-sized dimensions
             if (memcmp(
                     buffs[d] + i * coord_sizes[d],
@@ -235,19 +235,19 @@ Status GlobalOrderWriter::check_global_order() const {
     return Status::Ok();
 
   // Special case for Hilbert
-  if (array_schema_->cell_order() == Layout::HILBERT)
+  if (array_schema_.cell_order() == Layout::HILBERT)
     return check_global_order_hilbert();
 
   // Prepare auxiliary vector for better performance
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   std::vector<const QueryBuffer*> buffs(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_->dimension(d)->name();
+    const auto& dim_name = array_schema_.dimension(d)->name();
     buffs[d] = &(buffers_.find(dim_name)->second);
   }
 
   // Check if all coordinates fall in the domain in parallel
-  auto domain = array_schema_->domain();
+  auto domain = array_schema_.domain();
   auto status = parallel_for(
       storage_manager_->compute_tp(),
       0,
@@ -277,10 +277,10 @@ Status GlobalOrderWriter::check_global_order() const {
 
 Status GlobalOrderWriter::check_global_order_hilbert() const {
   // Prepare auxiliary vector for better performance
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   std::vector<const QueryBuffer*> buffs(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_->dimension(d)->name();
+    const auto& dim_name = array_schema_.dimension(d)->name();
     buffs[d] = &buffers_.at(dim_name);
   }
 
@@ -317,14 +317,14 @@ void GlobalOrderWriter::clean_up(const URI& uri) {
 Status GlobalOrderWriter::filter_last_tiles(uint64_t cell_num) {
   // Adjust cell num
   for (auto& last_tiles : global_write_state_->last_tiles_) {
-    const auto var_size = array_schema_->var_size(last_tiles.first);
-    const auto nullable = array_schema_->is_nullable(last_tiles.first);
+    const auto var_size = array_schema_.var_size(last_tiles.first);
+    const auto nullable = array_schema_.is_nullable(last_tiles.first);
 
     if (var_size) {
       last_tiles.second[0].final_size(
           cell_num * constants::cell_var_offset_size);
     } else {
-      auto cell_size = array_schema_->cell_size(last_tiles.first);
+      auto cell_size = array_schema_.cell_size(last_tiles.first);
       last_tiles.second[0].final_size(cell_num * cell_size);
     }
 
@@ -368,15 +368,15 @@ Status GlobalOrderWriter::compute_coord_dups(
     return Status::Ok();
 
   // Prepare auxiliary vectors for better performance
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   std::vector<const unsigned char*> buffs(dim_num);
   std::vector<uint64_t> coord_sizes(dim_num);
   std::vector<const unsigned char*> buffs_var(dim_num);
   std::vector<uint64_t*> buffs_var_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_->dimension(d)->name();
+    const auto& dim_name = array_schema_.dimension(d)->name();
     buffs[d] = (const unsigned char*)buffers_.find(dim_name)->second.buffer_;
-    coord_sizes[d] = array_schema_->cell_size(dim_name);
+    coord_sizes[d] = array_schema_.cell_size(dim_name);
     buffs_var[d] =
         (const unsigned char*)buffers_.find(dim_name)->second.buffer_var_;
     buffs_var_sizes[d] = buffers_.find(dim_name)->second.buffer_var_size_;
@@ -391,7 +391,7 @@ Status GlobalOrderWriter::compute_coord_dups(
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_->dimension(d);
+          auto dim = array_schema_.dimension(d);
           if (!dim->var_size()) {  // Fixed-sized dimensions
             if (memcmp(
                     buffs[d] + i * coord_sizes[d],
@@ -471,7 +471,7 @@ Status GlobalOrderWriter::finalize_global_write_state() {
   // Check if the total number of cells written is equal to the subarray size
   if (!coords_info_.has_coords_) {  // This implies a dense array
     auto expected_cell_num =
-        array_schema_->domain()->cell_num(subarray_.ndrange(0));
+        array_schema_.domain()->cell_num(subarray_.ndrange(0));
     if (cell_num != expected_cell_num) {
       clean_up(uri);
       std::stringstream ss;
@@ -531,9 +531,9 @@ Status GlobalOrderWriter::global_write() {
   uint64_t tile_num = 0;
   if (!tiles.empty()) {
     auto it = tiles.begin();
-    bool var_size = array_schema_->var_size(it->first);
-    const uint64_t t = 1 + (array_schema_->var_size(it->first) ? 1 : 0) +
-                       (array_schema_->is_nullable(it->first) ? 1 : 0);
+    bool var_size = array_schema_.var_size(it->first);
+    const uint64_t t = 1 + (array_schema_.var_size(it->first) ? 1 : 0) +
+                       (array_schema_.is_nullable(it->first) ? 1 : 0);
     tile_num = it->second.size() / t;
 
     uint64_t cell_num = 0;
@@ -576,8 +576,8 @@ Status GlobalOrderWriter::global_write() {
 }
 
 Status GlobalOrderWriter::global_write_handle_last_tile() {
-  auto capacity = array_schema_->capacity();
-  auto domain = array_schema_->domain();
+  auto capacity = array_schema_.capacity();
+  auto domain = array_schema_.domain();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto cell_num_last_tiles =
@@ -623,8 +623,8 @@ Status GlobalOrderWriter::init_global_write_state() {
   for (const auto& it : buffers_) {
     // Initialize last tiles
     const auto& name = it.first;
-    const auto var_size = array_schema_->var_size(name);
-    const auto nullable = array_schema_->is_nullable(name);
+    const auto var_size = array_schema_.var_size(name);
+    const auto nullable = array_schema_.is_nullable(name);
     uint64_t num = 1 + var_size + nullable;
     auto last_tile_vector = std::pair<std::string, std::vector<WriterTile>>(
         name, std::vector<WriterTile>(num));
@@ -633,7 +633,7 @@ Status GlobalOrderWriter::init_global_write_state() {
 
     if (!var_size) {
       auto& last_tile = it_ret.first->second[0];
-      if (!array_schema_->is_nullable(name)) {
+      if (!array_schema_.is_nullable(name)) {
         RETURN_NOT_OK_ELSE(init_tile(name, &last_tile), clean_up(uri));
       } else {
         auto& last_tile_validity = it_ret.first->second[1];
@@ -644,7 +644,7 @@ Status GlobalOrderWriter::init_global_write_state() {
     } else {
       auto& last_tile = it_ret.first->second[0];
       auto& last_tile_var = it_ret.first->second[1];
-      if (!array_schema_->is_nullable(name)) {
+      if (!array_schema_.is_nullable(name)) {
         RETURN_NOT_OK_ELSE(
             init_tile(name, &last_tile, &last_tile_var), clean_up(uri));
       } else {
@@ -699,7 +699,7 @@ Status GlobalOrderWriter::prepare_full_tiles(
     const std::string& name,
     const std::set<uint64_t>& coord_dups,
     std::vector<WriterTile>* tiles) const {
-  return array_schema_->var_size(name) ?
+  return array_schema_.var_size(name) ?
              prepare_full_tiles_var(name, coord_dups, tiles) :
              prepare_full_tiles_fixed(name, coord_dups, tiles);
 }
@@ -709,15 +709,15 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
     const std::set<uint64_t>& coord_dups,
     std::vector<WriterTile>* tiles) const {
   // For easy reference
-  auto nullable = array_schema_->is_nullable(name);
+  auto nullable = array_schema_.is_nullable(name);
   auto it = buffers_.find(name);
   auto buffer = (unsigned char*)it->second.buffer_;
   auto buffer_validity = (unsigned char*)it->second.validity_vector_.buffer();
   auto buffer_size = it->second.buffer_size_;
-  auto cell_size = array_schema_->cell_size(name);
-  auto capacity = array_schema_->capacity();
+  auto cell_size = array_schema_.cell_size(name);
+  auto capacity = array_schema_.capacity();
   auto cell_num = *buffer_size / cell_size;
-  auto domain = array_schema_->domain();
+  auto domain = array_schema_.domain();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
 
@@ -880,18 +880,18 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
     std::vector<WriterTile>* tiles) const {
   // For easy reference
   auto it = buffers_.find(name);
-  auto nullable = array_schema_->is_nullable(name);
+  auto nullable = array_schema_.is_nullable(name);
   auto buffer = (uint64_t*)it->second.buffer_;
   auto buffer_var = (unsigned char*)it->second.buffer_var_;
   auto buffer_validity = (uint8_t*)it->second.validity_vector_.buffer();
   auto buffer_size = get_offset_buffer_size(*it->second.buffer_size_);
   auto buffer_var_size = it->second.buffer_var_size_;
-  auto capacity = array_schema_->capacity();
+  auto capacity = array_schema_.capacity();
   auto cell_num = buffer_size / constants::cell_var_offset_size;
-  auto domain = array_schema_->domain();
+  auto domain = array_schema_.domain();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
-  auto attr_datatype_size = datatype_size(array_schema_->type(name));
+  auto attr_datatype_size = datatype_size(array_schema_.type(name));
 
   // Do nothing if there are no cells to write
   if (cell_num == 0)

--- a/tiledb/sm/query/ordered_writer.cc
+++ b/tiledb/sm/query/ordered_writer.cc
@@ -133,9 +133,9 @@ void OrderedWriter::reset() {
 Status OrderedWriter::ordered_write() {
   // Applicable only to ordered write on dense arrays
   assert(layout_ == Layout::ROW_MAJOR || layout_ == Layout::COL_MAJOR);
-  assert(array_schema_->dense());
+  assert(array_schema_.dense());
 
-  auto type = array_schema_->domain()->dimension(0)->type();
+  auto type = array_schema_.domain()->dimension(0)->type();
   switch (type) {
     case Datatype::INT8:
       return ordered_write<int8_t>();
@@ -242,12 +242,12 @@ Status OrderedWriter::ordered_write() {
       auto buff_it = buffers_.begin();
       std::advance(buff_it, i);
       const auto& attr = buff_it->first;
-      const auto var_size = array_schema_->var_size(attr);
+      const auto var_size = array_schema_.var_size(attr);
       if (has_min_max_metadata(attr, var_size) &&
-          array_schema_->var_size(attr)) {
+          array_schema_.var_size(attr)) {
         auto& attr_tile_batches = tiles[attr];
         const uint64_t tile_num_mult =
-            1 + (var_size ? 1 : 0) + (array_schema_->is_nullable(attr) ? 1 : 0);
+            1 + (var_size ? 1 : 0) + (array_schema_.is_nullable(attr) ? 1 : 0);
         frag_meta->convert_tile_min_max_var_sizes_to_offsets(attr);
         for (auto& batch : attr_tile_batches) {
           for (uint64_t i = 0; i < batch.size(); i += tile_num_mult) {
@@ -264,9 +264,9 @@ Status OrderedWriter::ordered_write() {
     for (const auto& buff : buffers_) {
       const auto& attr = buff.first;
       auto& attr_tile_batches = tiles[attr];
-      const auto var_size = array_schema_->var_size(attr);
+      const auto var_size = array_schema_.var_size(attr);
       if (has_min_max_metadata(attr, var_size) &&
-          array_schema_->var_size(attr)) {
+          array_schema_.var_size(attr)) {
         frag_meta->convert_tile_min_max_var_sizes_to_offsets(attr);
         auto st = parallel_for(
             compute_tp, 0, attr_tile_batches.size(), [&](uint64_t b) {
@@ -274,7 +274,7 @@ Status OrderedWriter::ordered_write() {
               auto& batch = tiles[attr][b];
               const uint64_t tile_num_mult =
                   1 + (var_size ? 1 : 0) +
-                  (array_schema_->is_nullable(attr) ? 1 : 0);
+                  (array_schema_.is_nullable(attr) ? 1 : 0);
               for (uint64_t i = 0; i < batch.size(); i += tile_num_mult) {
                 auto idx = b * thread_num + i / tile_num_mult;
                 frag_meta->set_tile_min_var(attr, idx, batch[i].min());
@@ -316,12 +316,12 @@ Status OrderedWriter::prepare_filter_and_write_tiles(
   auto timer_se = stats_->start_timer("prepare_filter_and_write_tiles");
 
   // For easy reference
-  const auto type = array_schema_->type(name);
-  const auto is_dim = array_schema_->is_dim(name);
-  const bool var = array_schema_->var_size(name);
-  const auto cell_size = array_schema_->cell_size(name);
-  const auto cell_val_num = array_schema_->cell_val_num(name);
-  const bool nullable = array_schema_->is_nullable(name);
+  const auto type = array_schema_.type(name);
+  const auto is_dim = array_schema_.is_dim(name);
+  const bool var = array_schema_.var_size(name);
+  const auto cell_size = array_schema_.cell_size(name);
+  const auto cell_val_num = array_schema_.cell_val_num(name);
+  const bool nullable = array_schema_.is_nullable(name);
 
   // Initialization
   auto tile_num = dense_tiler->tile_num();

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -67,6 +67,7 @@ namespace sm {
 
 Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
     : array_(array)
+    , array_schema_(array->array_schema_latest_ptr())
     , layout_(Layout::ROW_MAJOR)
     , storage_manager_(storage_manager)
     , stats_(storage_manager_->stats()->create_child("Query"))
@@ -80,23 +81,17 @@ Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
     , offsets_buffer_name_("")
     , disable_check_global_order_(false)
     , fragment_uri_(fragment_uri) {
-  if (array != nullptr) {
-    assert(array->is_open());
-    array_schema_ = array->array_schema_latest();
+  assert(array->is_open());
+  auto st = array->get_query_type(&type_);
+  assert(st.ok());
 
-    auto st = array->get_query_type(&type_);
-    assert(st.ok());
-
-    if (type_ == QueryType::WRITE) {
-      subarray_ = Subarray(array, stats_, logger_);
-    } else {
-      subarray_ = Subarray(array, Layout::ROW_MAJOR, stats_, logger_);
-    }
-
-    fragment_metadata_ = array->fragment_metadata();
+  if (type_ == QueryType::WRITE) {
+    subarray_ = Subarray(array, stats_, logger_);
   } else {
-    type_ = QueryType::READ;
+    subarray_ = Subarray(array, Layout::ROW_MAJOR, stats_, logger_);
   }
+
+  fragment_metadata_ = array->fragment_metadata();
 
   coords_info_.coords_buffer_ = nullptr;
   coords_info_.coords_buffer_size_ = nullptr;
@@ -388,8 +383,6 @@ Status Query::get_est_result_size(const char* name, uint64_t* size) {
           Status_QueryError("Error in query estimate result size; remote "
                             "array with no rest client."));
 
-    array_schema_->set_array_uri(array_->array_uri());
-
     RETURN_NOT_OK(
         rest_client->get_query_est_result_sizes(array_->array_uri(), this));
   }
@@ -417,8 +410,6 @@ Status Query::get_est_result_size(
       return logger_->status(
           Status_QueryError("Error in query estimate result size; remote "
                             "array with no rest client."));
-
-    array_schema_->set_array_uri(array_->array_uri());
 
     RETURN_NOT_OK(
         rest_client->get_query_est_result_sizes(array_->array_uri(), this));
@@ -568,8 +559,8 @@ Array* Query::array() {
   return array_;
 }
 
-const ArraySchema* Query::array_schema() const {
-  return array_schema_;
+const ArraySchema& Query::array_schema() const {
+  return *(array_schema_.get());
 }
 
 std::vector<std::string> Query::buffer_names() const {
@@ -617,8 +608,6 @@ Status Query::finalize() {
       return logger_->status(Status_QueryError(
           "Error in query finalize; remote array with no rest client."));
 
-    array_schema_->set_array_uri(array_->array_uri());
-
     return rest_client->finalize_query_to_rest(array_->array_uri(), this);
   }
 
@@ -630,15 +619,14 @@ Status Query::finalize() {
 Status Query::get_buffer(
     const char* name, void** buffer, uint64_t** buffer_size) const {
   // Check attribute
-  auto array_schema = this->array_schema();
   if (name != constants::coords) {
-    if (array_schema->attribute(name) == nullptr &&
-        array_schema->dimension(name) == nullptr)
+    if (array_schema_->attribute(name) == nullptr &&
+        array_schema_->dimension(name) == nullptr)
       return logger_->status(Status_QueryError(
           std::string("Cannot get buffer; Invalid attribute/dimension name '") +
           name + "'"));
   }
-  if (array_schema->var_size(name))
+  if (array_schema_->var_size(name))
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is var-sized"));
 
@@ -652,17 +640,16 @@ Status Query::get_buffer(
     void** buffer_val,
     uint64_t** buffer_val_size) const {
   // Check attribute
-  auto array_schema = this->array_schema();
   if (name == constants::coords) {
     return logger_->status(
         Status_QueryError("Cannot get buffer; Coordinates are not var-sized"));
   }
-  if (array_schema->attribute(name) == nullptr &&
-      array_schema->dimension(name) == nullptr)
+  if (array_schema_->attribute(name) == nullptr &&
+      array_schema_->dimension(name) == nullptr)
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute/dimension name '") +
         name + "'"));
-  if (!array_schema->var_size(name))
+  if (!array_schema_->var_size(name))
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
 
@@ -688,17 +675,16 @@ Status Query::get_buffer(
 Status Query::get_offsets_buffer(
     const char* name, uint64_t** buffer_off, uint64_t** buffer_off_size) const {
   // Check attribute
-  auto array_schema = this->array_schema();
   if (name == constants::coords) {
     return logger_->status(
         Status_QueryError("Cannot get buffer; Coordinates are not var-sized"));
   }
-  if (array_schema->attribute(name) == nullptr &&
-      array_schema->dimension(name) == nullptr)
+  if (array_schema_->attribute(name) == nullptr &&
+      array_schema_->dimension(name) == nullptr)
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute/dimension name '") +
         name + "'"));
-  if (!array_schema->var_size(name))
+  if (!array_schema_->var_size(name))
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
 
@@ -720,10 +706,9 @@ Status Query::get_offsets_buffer(
 Status Query::get_data_buffer(
     const char* name, void** buffer, uint64_t** buffer_size) const {
   // Check attribute
-  auto array_schema = this->array_schema();
   if (name != constants::coords) {
-    if (array_schema->attribute(name) == nullptr &&
-        array_schema->dimension(name) == nullptr)
+    if (array_schema_->attribute(name) == nullptr &&
+        array_schema_->dimension(name) == nullptr)
       return logger_->status(Status_QueryError(
           std::string("Cannot get buffer; Invalid attribute/dimension name '") +
           name + "'"));
@@ -761,8 +746,7 @@ Status Query::get_validity_buffer(
     uint8_t** buffer_validity_bytemap,
     uint64_t** buffer_validity_bytemap_size) const {
   // Check attribute
-  auto array_schema = this->array_schema();
-  if (!array_schema->is_nullable(name))
+  if (!array_schema_->is_nullable(name))
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
@@ -820,15 +804,14 @@ Status Query::get_buffer(
     uint64_t** buffer_size,
     const ValidityVector** validity_vector) const {
   // Check nullable attribute
-  auto array_schema = this->array_schema();
-  if (array_schema->attribute(name) == nullptr)
+  if (array_schema_->attribute(name) == nullptr)
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute name '") + name +
         "'"));
-  if (array_schema->var_size(name))
+  if (array_schema_->var_size(name))
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is var-sized"));
-  if (!array_schema->is_nullable(name))
+  if (!array_schema_->is_nullable(name))
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
@@ -857,15 +840,14 @@ Status Query::get_buffer(
     uint64_t** buffer_val_size,
     const ValidityVector** validity_vector) const {
   // Check attribute
-  auto array_schema = this->array_schema();
-  if (array_schema->attribute(name) == nullptr)
+  if (array_schema_->attribute(name) == nullptr)
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute name '") + name +
         "'"));
-  if (!array_schema->var_size(name))
+  if (!array_schema_->var_size(name))
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is fixed-sized"));
-  if (!array_schema->is_nullable(name))
+  if (!array_schema_->is_nullable(name))
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; '") + name + "' is non-nullable"));
 
@@ -1258,11 +1240,6 @@ Status Query::set_buffer(
     return logger_->status(
         Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_QueryError("Cannot set buffer; Array schema not set"));
-
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
   const bool is_attr = array_schema_->is_attr(name);
@@ -1350,11 +1327,6 @@ Status Query::set_data_buffer(
     return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_QueryError("Cannot set buffer; Array schema not set"));
-
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
   const bool is_attr = array_schema_->is_attr(name);
@@ -1439,11 +1411,6 @@ Status Query::set_offsets_buffer(
     return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " buffer size is null"));
 
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_QueryError("Cannot set buffer; Array schema not set"));
-
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
   const bool is_attr = array_schema_->is_attr(name);
@@ -1513,11 +1480,6 @@ Status Query::set_validity_buffer(
     return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
 
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_QueryError("Cannot set buffer; Array schema not set"));
-
   // Must be an attribute
   if (!array_schema_->is_attr(name))
     return logger_->status(Status_QueryError(
@@ -1570,11 +1532,6 @@ Status Query::set_buffer(
   if (check_null_buffers && buffer_off_size == nullptr)
     return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " offset buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // For easy reference
   const bool is_dim = array_schema_->is_dim(name);
@@ -1695,11 +1652,6 @@ Status Query::set_buffer(
     return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
 
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_QueryError("Cannot set buffer; Array schema not set"));
-
   // Must be an attribute
   if (!array_schema_->is_attr(name))
     return logger_->status(Status_QueryError(
@@ -1771,11 +1723,6 @@ Status Query::set_buffer(
   if (check_null_buffers && validity_vector.buffer_size() == nullptr)
     return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
-
-  // Array schema must exist
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_QueryError("Cannot set buffer; Array schema not set"));
 
   // Must be an attribute
   if (!array_schema_->is_attr(name))
@@ -2034,7 +1981,6 @@ Status Query::submit() {
       return logger_->status(Status_QueryError(
           "Error in query submission; remote array with no rest client."));
 
-    array_schema_->set_array_uri(array_->array_uri());
     if (status_ == QueryStatus::UNINITIALIZED) {
       RETURN_NOT_OK(create_strategy());
       RETURN_NOT_OK(strategy_->init());

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -346,7 +346,7 @@ class Query {
   Array* array();
 
   /** Returns the array schema. */
-  const ArraySchema* array_schema() const;
+  const ArraySchema& array_schema() const;
 
   /** Returns the names of the buffers set by the user for the query. */
   std::vector<std::string> buffer_names() const;
@@ -869,7 +869,7 @@ class Query {
   stats::Stats* stats() const;
 
   /** Returns the scratch space used for REST requests. */
-  tdb_shared_ptr<Buffer> rest_scratch() const;
+  shared_ptr<Buffer> rest_scratch() const;
 
   /** Use the refactored dense reader or not. */
   bool use_refactored_dense_reader();
@@ -892,7 +892,7 @@ class Query {
   Array* array_;
 
   /** The array schema. */
-  ArraySchema* array_schema_;
+  shared_ptr<const ArraySchema> array_schema_;
 
   /** The config for query-level parameters only. */
   Config config_;
@@ -925,7 +925,7 @@ class Query {
   stats::Stats* stats_;
 
   /** The class logger. */
-  tdb_shared_ptr<Logger> logger_;
+  shared_ptr<Logger> logger_;
 
   /** UID of the logger instance */
   inline static std::atomic<uint64_t> logger_id_ = 0;
@@ -947,7 +947,7 @@ class Query {
   QueryCondition condition_;
 
   /** The fragment metadata that this query will focus on. */
-  std::vector<tdb_shared_ptr<FragmentMetadata>> fragment_metadata_;
+  std::vector<shared_ptr<FragmentMetadata>> fragment_metadata_;
 
   /** The current serialization state. */
   SerializationState serialization_state_;
@@ -983,7 +983,7 @@ class Query {
   URI fragment_uri_;
 
   /* Scratch space used for REST requests. */
-  tdb_shared_ptr<Buffer> rest_scratch_;
+  shared_ptr<Buffer> rest_scratch_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -92,12 +92,12 @@ Status QueryCondition::init(
   return Status::Ok();
 }
 
-Status QueryCondition::check(const ArraySchema* const array_schema) const {
+Status QueryCondition::check(const ArraySchema& array_schema) const {
   for (const auto& clause : clauses_) {
     const std::string field_name = clause.field_name_;
     const uint64_t condition_value_size = clause.condition_value_data_.size();
 
-    const Attribute* const attribute = array_schema->attribute(field_name);
+    const auto attribute = array_schema.attribute(field_name);
     if (!attribute) {
       return Status_QueryConditionError(
           "Clause field name is not an attribute " + field_name);
@@ -591,10 +591,10 @@ QueryCondition::apply_clause(
 tuple<Status, optional<std::vector<ResultCellSlab>>>
 QueryCondition::apply_clause(
     const QueryCondition::Clause& clause,
-    const ArraySchema* const array_schema,
+    const ArraySchema& array_schema,
     const uint64_t stride,
     const std::vector<ResultCellSlab>& result_cell_slabs) const {
-  auto attribute = array_schema->attribute(clause.field_name_);
+  const auto attribute = array_schema.attribute(clause.field_name_);
   if (!attribute) {
     return {
         Status_QueryConditionError("Unknown attribute " + clause.field_name_),
@@ -679,7 +679,7 @@ QueryCondition::apply_clause(
 }
 
 Status QueryCondition::apply(
-    const ArraySchema* const array_schema,
+    const ArraySchema& array_schema,
     std::vector<ResultCellSlab>& result_cell_slabs,
     const uint64_t stride) const {
   if (clauses_.empty()) {
@@ -869,15 +869,14 @@ Status QueryCondition::apply_clause_dense(
 
 Status QueryCondition::apply_clause_dense(
     const QueryCondition::Clause& clause,
-    const ArraySchema* const array_schema,
+    const ArraySchema& array_schema,
     ResultTile* result_tile,
     const uint64_t start,
     const uint64_t length,
     const uint64_t src_cell,
     const uint64_t stride,
     uint8_t* result_buffer) const {
-  const Attribute* const attribute =
-      array_schema->attribute(clause.field_name_);
+  const auto attribute = array_schema.attribute(clause.field_name_);
   if (!attribute) {
     return Status_QueryConditionError(
         "Unknown attribute " + clause.field_name_);
@@ -1086,7 +1085,7 @@ Status QueryCondition::apply_clause_dense(
 }
 
 Status QueryCondition::apply_dense(
-    const ArraySchema* const array_schema,
+    const ArraySchema& array_schema,
     ResultTile* result_tile,
     const uint64_t start,
     const uint64_t length,
@@ -1368,11 +1367,10 @@ Status QueryCondition::apply_clause_sparse(
 template <typename BitmapType>
 Status QueryCondition::apply_clause_sparse(
     const QueryCondition::Clause& clause,
-    const ArraySchema* const array_schema,
+    const ArraySchema& array_schema,
     ResultTile& result_tile,
     std::vector<BitmapType>& result_bitmap) const {
-  const Attribute* const attribute =
-      array_schema->attribute(clause.field_name_);
+  const auto attribute = array_schema.attribute(clause.field_name_);
   if (!attribute) {
     return Status_QueryConditionError(
         "Unknown attribute " + clause.field_name_);
@@ -1483,7 +1481,7 @@ Status QueryCondition::apply_clause_sparse(
 
 template <typename BitmapType>
 Status QueryCondition::apply_sparse(
-    const ArraySchema* const array_schema,
+    const ArraySchema& array_schema,
     ResultTile& result_tile,
     std::vector<BitmapType>& result_bitmap,
     uint64_t* cell_count) {
@@ -1519,8 +1517,14 @@ std::vector<QueryConditionCombinationOp> QueryCondition::combination_ops()
 
 // Explicit template instantiations.
 template Status QueryCondition::apply_sparse<uint8_t>(
-    const ArraySchema* const, ResultTile&, std::vector<uint8_t>&, uint64_t*);
+    const ArraySchema& array_schema,
+    ResultTile&,
+    std::vector<uint8_t>&,
+    uint64_t*);
 template Status QueryCondition::apply_sparse<uint64_t>(
-    const ArraySchema* const, ResultTile&, std::vector<uint64_t>&, uint64_t*);
+    const ArraySchema& array_schema,
+    ResultTile&,
+    std::vector<uint64_t>&,
+    uint64_t*);
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -189,7 +189,7 @@ class QueryCondition {
    * @param array_schema The current array schena.
    * @return Status
    */
-  Status check(const ArraySchema* array_schema) const;
+  Status check(const ArraySchema& array_schema) const;
 
   /**
    * Combines this instance with the right-hand-side instance by
@@ -226,7 +226,7 @@ class QueryCondition {
    * @return Status
    */
   Status apply(
-      const ArraySchema* array_schema,
+      const ArraySchema& array_schema,
       std::vector<ResultCellSlab>& result_cell_slabs,
       uint64_t stride) const;
 
@@ -243,7 +243,7 @@ class QueryCondition {
    * @return Status
    */
   Status apply_dense(
-      const ArraySchema* const array_schema,
+      const ArraySchema& array_schema,
       ResultTile* result_tile,
       const uint64_t start,
       const uint64_t length,
@@ -262,7 +262,7 @@ class QueryCondition {
    */
   template <typename BitmapType>
   Status apply_sparse(
-      const ArraySchema* const array_schema,
+      const ArraySchema& array_schema,
       ResultTile& result_tile,
       std::vector<BitmapType>& result_bitmap,
       uint64_t* cell_count);
@@ -390,7 +390,7 @@ class QueryCondition {
    */
   tuple<Status, optional<std::vector<ResultCellSlab>>> apply_clause(
       const QueryCondition::Clause& clause,
-      const ArraySchema* const array_schema,
+      const ArraySchema& array_schema,
       uint64_t stride,
       const std::vector<ResultCellSlab>& result_cell_slabs) const;
 
@@ -458,7 +458,7 @@ class QueryCondition {
    */
   Status apply_clause_dense(
       const QueryCondition::Clause& clause,
-      const ArraySchema* const array_schema,
+      const ArraySchema& array_schema,
       ResultTile* result_tile,
       const uint64_t start,
       const uint64_t length,
@@ -511,7 +511,7 @@ class QueryCondition {
   template <typename BitmapType>
   Status apply_clause_sparse(
       const QueryCondition::Clause& clause,
-      const ArraySchema* const array_schema,
+      const ArraySchema& array_schema,
       ResultTile& result_tile,
       std::vector<BitmapType>& result_bitmap) const;
 };

--- a/tiledb/sm/query/read_cell_slab_iter.cc
+++ b/tiledb/sm/query/read_cell_slab_iter.cc
@@ -61,7 +61,7 @@ ReadCellSlabIter<T>::ReadCellSlabIter(
     , result_coords_pos_(result_coords_pos)
     , init_result_coords_pos_(result_coords_pos) {
   domain_ = (subarray != nullptr) ?
-                subarray->array()->array_schema_latest()->domain() :
+                subarray->array()->array_schema_latest().domain() :
                 nullptr;
   layout_ = (subarray != nullptr) ? subarray->layout() : Layout::ROW_MAJOR;
   cell_slab_iter_ = CellSlabIter<T>(subarray);

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -137,13 +137,10 @@ Status Reader::init() {
   if (storage_manager_ == nullptr)
     return logger_->status(Status_ReaderError(
         "Cannot initialize reader; Storage manager not set"));
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_ReaderError("Cannot initialize reader; Array metadata not set"));
   if (buffers_.empty())
     return logger_->status(
         Status_ReaderError("Cannot initialize reader; Buffers not set"));
-  if (array_schema_->dense() && !subarray_.is_set())
+  if (array_schema_.dense() && !subarray_.is_set())
     return logger_->status(Status_ReaderError(
         "Cannot initialize reader; Dense reads must have a subarray set"));
 
@@ -189,7 +186,7 @@ Status Reader::dowork() {
 
   auto timer_se = stats_->start_timer("read");
 
-  auto dense_mode = array_schema_->dense();
+  auto dense_mode = array_schema_.dense();
 
   // Get next partition
   if (!read_state_.unsplittable_)
@@ -335,11 +332,11 @@ Status Reader::compute_range_result_coords(
     uint64_t range_idx,
     std::vector<ResultCoords>& result_coords) {
   auto coords_num = tile->cell_num();
-  auto dim_num = array_schema_->dim_num();
-  auto cell_order = array_schema_->cell_order();
+  auto dim_num = array_schema_.dim_num();
+  auto cell_order = array_schema_.cell_order();
   auto range_coords = subarray.get_range_coords(range_idx);
 
-  if (array_schema_->dense()) {
+  if (array_schema_.dense()) {
     std::vector<uint8_t> result_bitmap(coords_num, 1);
     std::vector<uint8_t> overwritten_bitmap(coords_num, 0);
 
@@ -399,8 +396,8 @@ Status Reader::compute_range_result_coords(
 
   auto range_num = subarray.range_num();
   range_result_coords.resize(range_num);
-  auto cell_order = array_schema_->cell_order();
-  auto allows_dups = array_schema_->allows_dups();
+  auto cell_order = array_schema_.cell_order();
+  auto allows_dups = array_schema_.allows_dups();
 
   // To de-dupe the ranges, we may need to sort them. If the
   // read layout is UNORDERED, we will sort by the cell layout.
@@ -555,9 +552,9 @@ Status Reader::compute_subarray_coords(
   // - there is a single fragment and one dimension
   // - there are multiple fragments and a single range and dups are not allowed
   //   (therefore, the coords in that range have already been sorted)
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   bool must_sort = true;
-  auto allows_dups = array_schema_->allows_dups();
+  auto allows_dups = array_schema_.allows_dups();
   auto single_range = (range_result_coords.size() == 1);
   if (layout_ == Layout::GLOBAL_ORDER || dim_num == 1) {
     must_sort = !belong_to_single_fragment(
@@ -613,7 +610,7 @@ Status Reader::compute_sparse_result_tiles(
           // Add tile only if it does not already exist
           if (result_tile_map->find(pair) == result_tile_map->end()) {
             result_tiles.emplace_back(
-                f, t, fragment_metadata_[f]->array_schema());
+                f, t, *(fragment_metadata_[f]->array_schema()).get());
             (*result_tile_map)[pair] = result_tiles.size() - 1;
           }
           // Always check range for multiple fragments
@@ -632,7 +629,7 @@ Status Reader::compute_sparse_result_tiles(
         // Add tile only if it does not already exist
         if (result_tile_map->find(pair) == result_tile_map->end()) {
           result_tiles.emplace_back(
-              f, t, fragment_metadata_[f]->array_schema());
+              f, t, *(fragment_metadata_[f]->array_schema()).get());
           (*result_tile_map)[pair] = result_tiles.size() - 1;
         }
         // Always check range for multiple fragments
@@ -671,10 +668,10 @@ Status Reader::copy_coordinates(
     const auto& name = it.first;
     if (read_state_.overflowed_)
       break;
-    if (!(name == constants::coords || array_schema_->is_dim(name)))
+    if (!(name == constants::coords || array_schema_.is_dim(name)))
       continue;
 
-    if (array_schema_->var_size(name))
+    if (array_schema_.var_size(name))
       var_names.emplace_back(name);
     else
       fixed_names.emplace_back(name);
@@ -734,7 +731,7 @@ Status Reader::copy_attribute_values(
       break;
     }
 
-    if (name == constants::coords || array_schema_->is_dim(name)) {
+    if (name == constants::coords || array_schema_.is_dim(name)) {
       continue;
     }
 
@@ -762,8 +759,8 @@ Status Reader::copy_fixed_cells(
     uint64_t stride,
     const std::vector<ResultCellSlab>& result_cell_slabs,
     std::vector<size_t>* fixed_cs_partitions) {
-  auto stat_type = (array_schema_->is_attr(name)) ? "copy_fixed_attr_values" :
-                                                    "copy_fixed_coords";
+  auto stat_type = (array_schema_.is_attr(name)) ? "copy_fixed_attr_values" :
+                                                   "copy_fixed_coords";
   auto timer_se = stats_->start_timer(stat_type);
 
   if (result_cell_slabs.empty()) {
@@ -773,7 +770,7 @@ Status Reader::copy_fixed_cells(
 
   auto it = buffers_.find(name);
   auto buffer_size = it->second.buffer_size_;
-  auto cell_size = array_schema_->cell_size(name);
+  auto cell_size = array_schema_.cell_size(name);
 
   // Precompute the cell range destination offsets in the buffer.
   uint64_t buffer_offset = 0;
@@ -813,7 +810,7 @@ Status Reader::copy_fixed_cells(
 
   // Update buffer offsets
   *(buffers_[name].buffer_size_) = buffer_offset;
-  if (array_schema_->is_nullable(name)) {
+  if (array_schema_.is_nullable(name)) {
     *(buffers_[name].validity_vector_.buffer_size()) =
         (buffer_offset / cell_size) * constants::cell_validity_size;
   }
@@ -865,17 +862,16 @@ Status Reader::copy_partitioned_fixed_cells(
   assert(name);
 
   // For easy reference.
-  auto nullable = array_schema_->is_nullable(*name);
+  auto nullable = array_schema_.is_nullable(*name);
   auto it = buffers_.find(*name);
   auto buffer = (unsigned char*)it->second.buffer_;
   auto buffer_validity = (unsigned char*)it->second.validity_vector_.buffer();
-  auto cell_size = array_schema_->cell_size(*name);
+  auto cell_size = array_schema_.cell_size(*name);
   ByteVecValue fill_value;
   uint8_t fill_value_validity = 0;
-  if (array_schema_->is_attr(*name)) {
-    fill_value = array_schema_->attribute(*name)->fill_value();
-    fill_value_validity =
-        array_schema_->attribute(*name)->fill_value_validity();
+  if (array_schema_.is_attr(*name)) {
+    fill_value = array_schema_.attribute(*name)->fill_value();
+    fill_value_validity = array_schema_.attribute(*name)->fill_value_validity();
   }
   uint64_t fill_value_size = (uint64_t)fill_value.size();
 
@@ -899,7 +895,7 @@ Status Reader::copy_partitioned_fixed_cells(
     // evolution. In that case we want to set the field to fill values for this
     // for this tile.
     const bool split_buffer_for_zipped_coords =
-        array_schema_->is_dim(*name) && cs.tile_->stores_zipped_coords();
+        array_schema_.is_dim(*name) && cs.tile_->stores_zipped_coords();
     if ((cs.tile_ == nullptr || cs.tile_->tile_tuple(*name) == nullptr) &&
         !split_buffer_for_zipped_coords) {  // Empty range or attributed added
                                             // in schema evolution
@@ -949,8 +945,8 @@ Status Reader::copy_var_cells(
     std::vector<ResultCellSlab>& result_cell_slabs,
     std::vector<std::pair<size_t, size_t>>* var_cs_partitions,
     size_t total_cs_length) {
-  auto stat_type = (array_schema_->is_attr(name)) ? "copy_var_attr_values" :
-                                                    "copy_var_coords";
+  auto stat_type = (array_schema_.is_attr(name)) ? "copy_var_attr_values" :
+                                                   "copy_var_coords";
   auto timer_se = stats_->start_timer(stat_type);
 
   if (result_cell_slabs.empty()) {
@@ -997,7 +993,7 @@ Status Reader::copy_var_cells(
   // Update buffer offsets
   *(buffers_[name].buffer_size_) = total_offset_size;
   *(buffers_[name].buffer_var_size_) = total_var_size;
-  if (array_schema_->is_nullable(name))
+  if (array_schema_.is_nullable(name))
     *(buffers_[name].validity_vector_.buffer_size()) = total_validity_size;
 
   return Status::Ok();
@@ -1065,12 +1061,12 @@ Status Reader::compute_var_cell_destinations(
     uint64_t* total_var_size,
     uint64_t* total_validity_size) {
   // For easy reference
-  auto nullable = array_schema_->is_nullable(name);
+  auto nullable = array_schema_.is_nullable(name);
   auto num_cs = result_cell_slabs.size();
   auto offset_size = offsets_bytesize();
   ByteVecValue fill_value;
-  if (array_schema_->is_attr(name))
-    fill_value = array_schema_->attribute(name)->fill_value();
+  if (array_schema_.is_attr(name))
+    fill_value = array_schema_.attribute(name)->fill_value();
   auto fill_value_size = (uint64_t)fill_value.size();
 
   auto it = buffers_.find(name);
@@ -1167,20 +1163,19 @@ Status Reader::copy_partitioned_var_cells(
   assert(name);
 
   auto it = buffers_.find(*name);
-  auto nullable = array_schema_->is_nullable(*name);
+  auto nullable = array_schema_.is_nullable(*name);
   auto buffer = (unsigned char*)it->second.buffer_;
   auto buffer_var = (unsigned char*)it->second.buffer_var_;
   auto buffer_validity = (unsigned char*)it->second.validity_vector_.buffer();
   auto offset_size = offsets_bytesize();
   ByteVecValue fill_value;
   uint8_t fill_value_validity = 0;
-  if (array_schema_->is_attr(*name)) {
-    fill_value = array_schema_->attribute(*name)->fill_value();
-    fill_value_validity =
-        array_schema_->attribute(*name)->fill_value_validity();
+  if (array_schema_.is_attr(*name)) {
+    fill_value = array_schema_.attribute(*name)->fill_value();
+    fill_value_validity = array_schema_.attribute(*name)->fill_value_validity();
   }
   auto fill_value_size = (uint64_t)fill_value.size();
-  auto attr_datatype_size = datatype_size(array_schema_->type(*name));
+  auto attr_datatype_size = datatype_size(array_schema_.type(*name));
 
   // Fetch the starting array offset into both `offset_offsets_per_cs`
   // and `var_offsets_per_cs`.
@@ -1282,7 +1277,7 @@ Status Reader::process_tiles(
     const ProcessTileFlags flags = name_pair.second;
     if (flags & ProcessTileFlag::READ) {
       read_names.push_back(name);
-      if (array_schema_->var_size(name))
+      if (array_schema_.var_size(name))
         var_size_read_names.emplace_back(name);
     } else if (flags & ProcessTileFlag::COPY) {
       copy_names.push_back(name);
@@ -1318,7 +1313,7 @@ Status Reader::process_tiles(
   // Handle attribute/dimensions that need to be copied but do
   // not need to be read.
   for (const auto& copy_name : copy_names) {
-    if (!array_schema_->var_size(copy_name))
+    if (!array_schema_.var_size(copy_name))
       RETURN_CANCEL_OR_ERROR(copy_fixed_cells(
           copy_name, stride, result_cell_slabs, &fixed_cs_partitions));
     else
@@ -1360,7 +1355,7 @@ Status Reader::process_tiles(
       RETURN_CANCEL_OR_ERROR(unfilter_tiles(inner_name, result_tiles, false));
 
       if (flags & ProcessTileFlag::COPY) {
-        if (!array_schema_->var_size(inner_name)) {
+        if (!array_schema_.var_size(inner_name)) {
           RETURN_CANCEL_OR_ERROR(copy_fixed_cells(
               inner_name, stride, result_cell_slabs, &fixed_cs_partitions));
         } else {
@@ -1465,7 +1460,7 @@ Status Reader::compute_result_cell_slabs_global(
     std::vector<ResultTile*>& result_tiles,
     std::vector<ResultCellSlab>& result_cell_slabs) const {
   const auto& tile_coords = subarray.tile_coords();
-  auto cell_order = array_schema_->cell_order();
+  auto cell_order = array_schema_.cell_order();
   std::vector<Subarray> tile_subarrays;
   tile_subarrays.reserve(tile_coords.size());
   uint64_t result_coords_pos = 0;
@@ -1521,14 +1516,14 @@ Status Reader::compute_result_coords(
 
   // Preload unzipped coordinate tile offsets. Note that this will
   // ignore fragments with a version < 5.
-  const auto dim_num = array_schema_->dim_num();
+  const auto dim_num = array_schema_.dim_num();
   std::vector<std::string> dim_names;
   std::vector<std::string> var_size_dim_names;
   dim_names.reserve(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& name = array_schema_->dimension(d)->name();
+    const auto& name = array_schema_.dimension(d)->name();
     dim_names.emplace_back(name);
-    if (array_schema_->var_size(name))
+    if (array_schema_.var_size(name))
       var_size_dim_names.emplace_back(name);
   }
   RETURN_CANCEL_OR_ERROR(
@@ -1588,7 +1583,7 @@ Status Reader::dedup_result_coords(
 }
 
 Status Reader::dense_read() {
-  auto type = array_schema_->domain()->dimension(0)->type();
+  auto type = array_schema_.domain()->dimension(0)->type();
   switch (type) {
     case Datatype::INT8:
       return dense_read<int8_t>();
@@ -1666,7 +1661,7 @@ Status Reader::dense_read() {
       result_tiles,
       result_cell_slabs));
 
-  auto stride = array_schema_->domain()->stride<T>(subarray.layout());
+  auto stride = array_schema_.domain()->stride<T>(subarray.layout());
   RETURN_NOT_OK(apply_query_condition(
       result_cell_slabs,
       result_tiles,
@@ -1707,7 +1702,7 @@ Status Reader::get_all_result_coords(
 
 bool Reader::has_separate_coords() const {
   for (const auto& it : buffers_) {
-    if (array_schema_->is_dim(it.first))
+    if (array_schema_.is_dim(it.first))
       return true;
   }
 
@@ -1778,8 +1773,8 @@ Status Reader::init_read_state() {
     auto buffer_size = a.second.buffer_size_;
     auto buffer_var_size = a.second.buffer_var_size_;
     auto buffer_validity_size = a.second.validity_vector_.buffer_size();
-    if (!array_schema_->var_size(attr_name)) {
-      if (!array_schema_->is_nullable(attr_name)) {
+    if (!array_schema_.var_size(attr_name)) {
+      if (!array_schema_.is_nullable(attr_name)) {
         RETURN_NOT_OK(read_state_.partitioner_.set_result_budget(
             attr_name.c_str(), *buffer_size));
       } else {
@@ -1787,7 +1782,7 @@ Status Reader::init_read_state() {
             attr_name.c_str(), *buffer_size, *buffer_validity_size));
       }
     } else {
-      if (!array_schema_->is_nullable(attr_name)) {
+      if (!array_schema_.is_nullable(attr_name)) {
         RETURN_NOT_OK(read_state_.partitioner_.set_result_budget(
             attr_name.c_str(), *buffer_size, *buffer_var_size));
       } else {
@@ -1813,7 +1808,7 @@ Status Reader::sort_result_coords(
     size_t coords_num,
     Layout layout) const {
   auto timer_se = stats_->start_timer("sort_result_coords");
-  auto domain = array_schema_->domain();
+  auto domain = array_schema_.domain();
 
   if (layout == Layout::ROW_MAJOR) {
     parallel_sort(
@@ -1822,7 +1817,7 @@ Status Reader::sort_result_coords(
     parallel_sort(
         storage_manager_->compute_tp(), iter_begin, iter_end, ColCmp(domain));
   } else if (layout == Layout::GLOBAL_ORDER) {
-    if (array_schema_->cell_order() == Layout::HILBERT) {
+    if (array_schema_.cell_order() == Layout::HILBERT) {
       std::vector<std::pair<uint64_t, uint64_t>> hilbert_values(coords_num);
       RETURN_NOT_OK(calculate_hilbert_values(iter_begin, &hilbert_values));
       parallel_sort(
@@ -1881,7 +1876,7 @@ Status Reader::sparse_read() {
 Status Reader::add_extra_offset() {
   for (const auto& it : buffers_) {
     const auto& name = it.first;
-    if (!array_schema_->var_size(name))
+    if (!array_schema_.var_size(name))
       continue;
 
     // Do not apply offset for empty results because we will
@@ -1899,8 +1894,8 @@ Status Reader::add_extra_offset() {
           it.second.buffer_var_size_,
           offsets_bytesize());
     } else if (offsets_format_mode_ == "elements") {
-      auto elements = *it.second.buffer_var_size_ /
-                      datatype_size(array_schema_->type(name));
+      auto elements =
+          *it.second.buffer_var_size_ / datatype_size(array_schema_.type(name));
       memcpy(
           buffer + *it.second.buffer_size_ - offsets_bytesize(),
           &elements,
@@ -1919,7 +1914,7 @@ bool Reader::sparse_tile_overwritten(
   const auto& mbr = fragment_metadata_[frag_idx]->mbr(tile_idx);
   assert(!mbr.empty());
   auto fragment_num = (unsigned)fragment_metadata_.size();
-  auto domain = array_schema_->domain();
+  auto domain = array_schema_.domain();
 
   for (unsigned f = frag_idx + 1; f < fragment_num; ++f) {
     if (fragment_metadata_[f]->dense() &&
@@ -1932,9 +1927,9 @@ bool Reader::sparse_tile_overwritten(
 
 void Reader::erase_coord_tiles(std::vector<ResultTile>& result_tiles) const {
   for (auto& tile : result_tiles) {
-    auto dim_num = array_schema_->dim_num();
+    auto dim_num = array_schema_.dim_num();
     for (unsigned d = 0; d < dim_num; ++d)
-      tile.erase_tile(array_schema_->dimension(d)->name());
+      tile.erase_tile(array_schema_.dimension(d)->name());
     tile.erase_tile(constants::coords);
   }
 }
@@ -1956,7 +1951,7 @@ void Reader::get_result_tile_stats(
     if (!fragment_metadata_[rt->frag_idx()]->dense())
       cell_num += rt->cell_num();
     else
-      cell_num += array_schema_->domain()->cell_num_per_tile();
+      cell_num += array_schema_.domain()->cell_num_per_tile();
   }
   stats_->add_counter("cell_num", cell_num);
 }
@@ -1965,7 +1960,7 @@ Status Reader::calculate_hilbert_values(
     std::vector<ResultCoords>::iterator iter_begin,
     std::vector<std::pair<uint64_t, uint64_t>>* hilbert_values) const {
   auto timer_se = stats_->start_timer("calculate_hilbert_values");
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   Hilbert h(dim_num);
   auto bits = h.bits();
   auto max_bucket_val = ((uint64_t)1 << bits) - 1;
@@ -1976,7 +1971,7 @@ Status Reader::calculate_hilbert_values(
       storage_manager_->compute_tp(), 0, coords_num, [&](uint64_t c) {
         std::vector<uint64_t> coords(dim_num);
         for (uint32_t d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_->dimension(d);
+          auto dim = array_schema_.dimension(d);
           coords[d] = hilbert_order::map_to_uint64(
               *dim, *(iter_begin + c), d, bits, max_bucket_val);
         }

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -129,7 +129,9 @@ void ReaderBase::compute_result_space_tiles(
       result_space_tile.append_frag_domain(frag_idx, frag_domain);
       auto tile_idx = frag_tile_domains[f].tile_pos(coords);
       ResultTile result_tile(
-          frag_idx, tile_idx, fragment_metadata[frag_idx]->array_schema());
+          frag_idx,
+          tile_idx,
+          *(fragment_metadata[frag_idx]->array_schema()).get());
       result_space_tile.set_result_tile(frag_idx, result_tile);
     }
   }
@@ -183,11 +185,11 @@ Status ReaderBase::check_validity_buffer_sizes() const {
   // a validity value for each cell.
   for (const auto& it : buffers_) {
     const std::string& name = it.first;
-    if (array_schema_->is_nullable(name)) {
+    if (array_schema_.is_nullable(name)) {
       const uint64_t buffer_size = *it.second.buffer_size_;
 
       uint64_t min_cell_num = 0;
-      if (array_schema_->var_size(name)) {
+      if (array_schema_.var_size(name)) {
         min_cell_num = buffer_size / constants::cell_var_offset_size;
 
         // If the offsets buffer contains an extra element to mark
@@ -196,7 +198,7 @@ Status ReaderBase::check_validity_buffer_sizes() const {
         if (offsets_extra_element_)
           min_cell_num = std::min<uint64_t>(0, min_cell_num - 1);
       } else {
-        min_cell_num = buffer_size / array_schema_->cell_size(name);
+        min_cell_num = buffer_size / array_schema_.cell_size(name);
       }
 
       const uint64_t buffer_validity_size =
@@ -241,7 +243,7 @@ Status ReaderBase::load_tile_offsets(
         // Filter the 'names' for format-specific names.
         std::vector<std::string> filtered_names;
         filtered_names.reserve(names.size());
-        auto schema = fragment->array_schema();
+        const auto& schema = fragment->array_schema();
         for (const auto& name : names) {
           // Applicable for zipped coordinates only to versions < 5
           if (name == constants::coords && format_version >= 5)
@@ -289,7 +291,7 @@ Status ReaderBase::load_tile_var_sizes(
         auto frag_idx = all_frag ? i : relevant_fragments->at(i);
         auto& fragment = fragment_metadata_[frag_idx];
 
-        auto schema = fragment->array_schema();
+        const auto& schema = fragment->array_schema();
         for (const auto& name : names) {
           // Not a member of array schema, this field was added in array schema
           // evolution, ignore for this fragment's tile var sizes.
@@ -314,10 +316,10 @@ Status ReaderBase::load_tile_var_sizes(
 Status ReaderBase::init_tile(
     uint32_t format_version, const std::string& name, Tile* tile) const {
   // For easy reference
-  auto cell_size = array_schema_->cell_size(name);
-  auto type = array_schema_->type(name);
+  auto cell_size = array_schema_.cell_size(name);
+  auto type = array_schema_.type(name);
   auto is_coords = (name == constants::coords);
-  auto dim_num = (is_coords) ? array_schema_->dim_num() : 0;
+  auto dim_num = (is_coords) ? array_schema_.dim_num() : 0;
 
   // Initialize
   RETURN_NOT_OK(tile->init_filtered(format_version, type, cell_size, dim_num));
@@ -331,7 +333,7 @@ Status ReaderBase::init_tile(
     Tile* tile,
     Tile* tile_var) const {
   // For easy reference
-  auto type = array_schema_->type(name);
+  auto type = array_schema_.type(name);
 
   // Initialize
   RETURN_NOT_OK(tile->init_filtered(
@@ -350,10 +352,10 @@ Status ReaderBase::init_tile_nullable(
     Tile* tile,
     Tile* tile_validity) const {
   // For easy reference
-  auto cell_size = array_schema_->cell_size(name);
-  auto type = array_schema_->type(name);
+  auto cell_size = array_schema_.cell_size(name);
+  auto type = array_schema_.type(name);
   auto is_coords = (name == constants::coords);
-  auto dim_num = (is_coords) ? array_schema_->dim_num() : 0;
+  auto dim_num = (is_coords) ? array_schema_.dim_num() : 0;
 
   // Initialize
   RETURN_NOT_OK(tile->init_filtered(format_version, type, cell_size, dim_num));
@@ -373,7 +375,7 @@ Status ReaderBase::init_tile_nullable(
     Tile* tile_var,
     Tile* tile_validity) const {
   // For easy reference
-  auto type = array_schema_->type(name);
+  auto type = array_schema_.type(name);
 
   // Initialize
   RETURN_NOT_OK(tile->init_filtered(
@@ -437,25 +439,26 @@ Status ReaderBase::read_tiles(
         continue;
 
       // Applicable to separate coordinates only to versions >= 5
-      const bool is_dim = fragment->array_schema()->is_dim(name);
+      const auto& array_schema = fragment->array_schema();
+      const bool is_dim = array_schema->is_dim(name);
       if (is_dim && format_version < 5)
         continue;
 
       // If the fragment doesn't have the attribute, this is a schema
       // evolution field and will be treated with fill-in value instead of
       // reading from disk
-      if (!fragment->array_schema()->is_field(name))
+      if (!array_schema->is_field(name))
         continue;
 
-      const bool var_size = fragment->array_schema()->var_size(name);
-      const bool nullable = fragment->array_schema()->is_nullable(name);
+      const bool var_size = array_schema->var_size(name);
+      const bool nullable = array_schema->is_nullable(name);
 
       // Initialize the tile(s)
       ResultTile::TileTuple* tile_tuple = nullptr;
       if (is_dim) {
-        const uint64_t dim_num = fragment->array_schema()->dim_num();
+        const uint64_t dim_num = array_schema->dim_num();
         for (uint64_t d = 0; d < dim_num; ++d) {
-          if (fragment->array_schema()->dimension(d)->name() == name) {
+          if (array_schema->dimension(d)->name() == name) {
             tile->init_coord_tile(name, d);
             break;
           }
@@ -697,7 +700,7 @@ ReaderBase::load_tile_chunk_data(
   // Applicable for separate coordinates only to version >= 5
   if (name != constants::coords ||
       (name == constants::coords && format_version < 5) ||
-      (array_schema_->is_dim(name) && format_version >= 5)) {
+      (array_schema_.is_dim(name) && format_version >= 5)) {
     auto tile_tuple = tile->tile_tuple(name);
 
     // Skip non-existent attributes/dimensions (e.g. coords in the
@@ -755,7 +758,7 @@ Status ReaderBase::unfilter_tile_chunk_range(
   // Applicable for separate coordinates only to version >= 5
   if (name != constants::coords ||
       (name == constants::coords && format_version < 5) ||
-      (array_schema_->is_dim(name) && format_version >= 5)) {
+      (array_schema_.is_dim(name) && format_version >= 5)) {
     auto tile_tuple = tile->tile_tuple(name);
 
     // Skip non-existent attributes/dimensions (e.g. coords in the
@@ -815,7 +818,7 @@ Status ReaderBase::zip_tile_coordinates(
     const std::string& name, Tile* tile) const {
   if (tile->stores_coords()) {
     bool using_compression =
-        array_schema_->filters(name).get_filter<CompressionFilter>() != nullptr;
+        array_schema_.filters(name).get_filter<CompressionFilter>() != nullptr;
     auto version = tile->format_version();
     if (version > 1 || using_compression) {
       RETURN_NOT_OK(tile->zip_coordinates());
@@ -838,7 +841,7 @@ Status ReaderBase::post_process_unfiltered_tile(
   // Applicable for separate coordinates only to version >= 5
   if (name != constants::coords ||
       (name == constants::coords && format_version < 5) ||
-      (array_schema_->is_dim(name) && format_version >= 5)) {
+      (array_schema_.is_dim(name) && format_version >= 5)) {
     auto tile_tuple = tile->tile_tuple(name);
 
     // Skip non-existent attributes/dimensions (e.g. coords in the
@@ -885,8 +888,8 @@ Status ReaderBase::unfilter_tiles_chunk_range(
     num_range_threads = 1 + ((num_threads - 1) / num_tiles);
   }
 
-  const auto var_size = array_schema_->var_size(name);
-  const auto nullable = array_schema_->is_nullable(name);
+  const auto var_size = array_schema_.var_size(name);
+  const auto nullable = array_schema_.is_nullable(name);
 
   // Vectors with all the necessary chunk data for unfiltering
   std::vector<ChunkData> tiles_chunk_data(num_tiles);
@@ -971,7 +974,7 @@ Status ReaderBase::unfilter_tile_chunk_range(
     const ChunkData& tile_chunk_data) const {
   assert(tile);
 
-  FilterPipeline filters = array_schema_->filters(name);
+  FilterPipeline filters = array_schema_.filters(name);
 
   // Append an encryption unfilter when necessary.
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(
@@ -1005,8 +1008,8 @@ Status ReaderBase::unfilter_tile_chunk_range(
   assert(tile);
   assert(tile_var);
 
-  FilterPipeline offset_filters = array_schema_->cell_var_offsets_filters();
-  FilterPipeline filters = array_schema_->filters(name);
+  FilterPipeline offset_filters = array_schema_.cell_var_offsets_filters();
+  FilterPipeline filters = array_schema_.filters(name);
   auto concurrency_level = storage_manager_->compute_tp()->concurrency_level();
 
   // Append an encryption unfilter when necessary.
@@ -1059,8 +1062,8 @@ Status ReaderBase::unfilter_tile_chunk_range_nullable(
   assert(tile);
   assert(tile_validity);
 
-  FilterPipeline filters = array_schema_->filters(name);
-  FilterPipeline validity_filters = array_schema_->cell_validity_filters();
+  FilterPipeline filters = array_schema_.filters(name);
+  FilterPipeline validity_filters = array_schema_.cell_validity_filters();
   auto concurrency_level = storage_manager_->compute_tp()->concurrency_level();
 
   // Append an encryption unfilter when necessary.
@@ -1113,9 +1116,9 @@ Status ReaderBase::unfilter_tile_chunk_range_nullable(
   assert(tile_var);
   assert(tile_validity);
 
-  FilterPipeline offset_filters = array_schema_->cell_var_offsets_filters();
-  FilterPipeline filters = array_schema_->filters(name);
-  FilterPipeline validity_filters = array_schema_->cell_validity_filters();
+  FilterPipeline offset_filters = array_schema_.cell_var_offsets_filters();
+  FilterPipeline filters = array_schema_.filters(name);
+  FilterPipeline validity_filters = array_schema_.cell_validity_filters();
   auto concurrency_level = storage_manager_->compute_tp()->concurrency_level();
 
   // Append an encryption unfilter when necessary.
@@ -1171,9 +1174,8 @@ Status ReaderBase::unfilter_tiles(
     const std::string& name,
     const std::vector<ResultTile*>& result_tiles,
     const bool disable_cache) const {
-  const auto stat_type = (array_schema_->is_attr(name)) ?
-                             "unfilter_attr_tiles" :
-                             "unfilter_coord_tiles";
+  const auto stat_type = (array_schema_.is_attr(name)) ? "unfilter_attr_tiles" :
+                                                         "unfilter_coord_tiles";
   const auto timer_se = stats_->start_timer(stat_type);
   // The per tile cache is only used in readers where unfiltering
   // was done in parallel on tiles. The new readers parallelize both on
@@ -1182,8 +1184,8 @@ Status ReaderBase::unfilter_tiles(
     return unfilter_tiles_chunk_range(name, result_tiles);
   }
 
-  auto var_size = array_schema_->var_size(name);
-  auto nullable = array_schema_->is_nullable(name);
+  auto var_size = array_schema_.var_size(name);
+  auto nullable = array_schema_.is_nullable(name);
   auto num_tiles = static_cast<uint64_t>(result_tiles.size());
 
   auto status = parallel_for(
@@ -1197,7 +1199,7 @@ Status ReaderBase::unfilter_tiles(
         // Applicable for separate coordinates only to version >= 5
         if (name != constants::coords ||
             (name == constants::coords && format_version < 5) ||
-            (array_schema_->is_dim(name) && format_version >= 5)) {
+            (array_schema_.is_dim(name) && format_version >= 5)) {
           auto tile_tuple = tile->tile_tuple(name);
 
           // Skip non-existent attributes/dimensions (e.g. coords in the
@@ -1285,7 +1287,7 @@ Status ReaderBase::unfilter_tiles(
 }
 
 Status ReaderBase::unfilter_tile(const std::string& name, Tile* tile) const {
-  FilterPipeline filters = array_schema_->filters(name);
+  FilterPipeline filters = array_schema_.filters(name);
 
   // Append an encryption unfilter when necessary.
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(
@@ -1303,8 +1305,8 @@ Status ReaderBase::unfilter_tile(const std::string& name, Tile* tile) const {
 
 Status ReaderBase::unfilter_tile(
     const std::string& name, Tile* tile, Tile* tile_var) const {
-  FilterPipeline offset_filters = array_schema_->cell_var_offsets_filters();
-  FilterPipeline filters = array_schema_->filters(name);
+  FilterPipeline offset_filters = array_schema_.cell_var_offsets_filters();
+  FilterPipeline filters = array_schema_.filters(name);
 
   // Append an encryption unfilter when necessary.
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(
@@ -1323,8 +1325,8 @@ Status ReaderBase::unfilter_tile(
 
 Status ReaderBase::unfilter_tile_nullable(
     const std::string& name, Tile* tile, Tile* tile_validity) const {
-  FilterPipeline filters = array_schema_->filters(name);
-  FilterPipeline validity_filters = array_schema_->cell_validity_filters();
+  FilterPipeline filters = array_schema_.filters(name);
+  FilterPipeline validity_filters = array_schema_.cell_validity_filters();
 
   // Append an encryption unfilter when necessary.
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(
@@ -1354,9 +1356,9 @@ Status ReaderBase::unfilter_tile_nullable(
     Tile* tile,
     Tile* tile_var,
     Tile* tile_validity) const {
-  FilterPipeline offset_filters = array_schema_->cell_var_offsets_filters();
-  FilterPipeline filters = array_schema_->filters(name);
-  FilterPipeline validity_filters = array_schema_->cell_validity_filters();
+  FilterPipeline offset_filters = array_schema_.cell_var_offsets_filters();
+  FilterPipeline filters = array_schema_.filters(name);
+  FilterPipeline validity_filters = array_schema_.cell_validity_filters();
 
   // Append an encryption unfilter when necessary.
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(
@@ -1393,13 +1395,13 @@ tuple<Status, optional<uint64_t>> ReaderBase::get_attribute_tile_size(
   uint64_t tile_size = 0;
   tile_size += fragment_metadata_[f]->tile_size(name, t);
 
-  if (array_schema_->var_size(name)) {
+  if (array_schema_.var_size(name)) {
     auto&& [st, temp] = fragment_metadata_[f]->tile_var_size(name, t);
     RETURN_NOT_OK_TUPLE(st, nullopt);
     tile_size += *temp;
   }
 
-  if (array_schema_->is_nullable(name)) {
+  if (array_schema_.is_nullable(name)) {
     tile_size +=
         fragment_metadata_[f]->cell_num(t) * constants::cell_validity_size;
   }
@@ -1413,9 +1415,9 @@ void ReaderBase::compute_result_space_tiles(
     const Subarray& partitioner_subarray,
     std::map<const T*, ResultSpaceTile<T>>& result_space_tiles) const {
   // For easy reference
-  auto domain = array_schema_->domain()->domain();
-  auto tile_extents = array_schema_->domain()->tile_extents();
-  auto tile_order = array_schema_->tile_order();
+  auto domain = array_schema_.domain()->domain();
+  auto tile_extents = array_schema_.domain()->tile_extents();
+  auto tile_order = array_schema_.tile_order();
 
   // Compute fragment tile domains
   std::vector<TileDomain<T>> frag_tile_domains;
@@ -1465,7 +1467,7 @@ void ReaderBase::compute_result_space_tiles(
 
 bool ReaderBase::has_coords() const {
   for (const auto& it : buffers_) {
-    if (it.first == constants::coords || array_schema_->is_dim(it.first))
+    if (it.first == constants::coords || array_schema_.is_dim(it.first))
       return true;
   }
 
@@ -1492,13 +1494,13 @@ tuple<Status, optional<bool>> ReaderBase::fill_dense_coords(
   std::vector<unsigned> dim_idx;
   std::vector<QueryBuffer*> buffers;
   auto coords_it = buffers_.find(constants::coords);
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   if (coords_it != buffers_.end()) {
     buffers.emplace_back(&(coords_it->second));
     dim_idx.emplace_back(dim_num);
   } else {
     for (unsigned d = 0; d < dim_num; ++d) {
-      const auto& dim = array_schema_->dimension(d);
+      const auto& dim = array_schema_.dimension(d);
       auto it = buffers_.find(dim->name());
       if (it != buffers_.end()) {
         buffers.emplace_back(&(it->second));
@@ -1536,7 +1538,7 @@ tuple<Status, optional<bool>> ReaderBase::fill_dense_coords_global(
     const std::vector<QueryBuffer*>& buffers,
     std::vector<uint64_t>& offsets) {
   auto tile_coords = subarray.tile_coords();
-  auto cell_order = array_schema_->cell_order();
+  auto cell_order = array_schema_.cell_order();
 
   bool overflowed = false;
   for (const auto& tc : tile_coords) {
@@ -1556,8 +1558,8 @@ tuple<Status, optional<bool>> ReaderBase::fill_dense_coords_row_col(
     const std::vector<unsigned>& dim_idx,
     const std::vector<QueryBuffer*>& buffers,
     std::vector<uint64_t>& offsets) {
-  auto cell_order = array_schema_->cell_order();
-  auto dim_num = array_schema_->dim_num();
+  auto cell_order = array_schema_.cell_order();
+  auto dim_num = array_schema_.dim_num();
 
   // Iterate over all coordinates, retrieved in cell slabs
   CellSlabIter<T> iter(&subarray);
@@ -1569,7 +1571,7 @@ tuple<Status, optional<bool>> ReaderBase::fill_dense_coords_row_col(
     // Check for overflow
     for (size_t i = 0; i < buffers.size(); ++i) {
       auto idx = (dim_idx[i] == dim_num) ? 0 : dim_idx[i];
-      auto dim = array_schema_->domain()->dimension(idx);
+      auto dim = array_schema_.domain()->dimension(idx);
       auto coord_size = dim->coord_size();
       coord_size = (dim_idx[i] == dim_num) ? coord_size * dim_num : coord_size;
       auto buff_size = *(buffers[i]->buffer_size_);
@@ -1602,7 +1604,7 @@ void ReaderBase::fill_dense_coords_row_slab(
     const std::vector<QueryBuffer*>& buffers,
     std::vector<uint64_t>& offsets) const {
   // For easy reference
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
 
   // Special zipped coordinates
   if (dim_idx.size() == 1 && dim_idx[0] == dim_num) {
@@ -1652,7 +1654,7 @@ void ReaderBase::fill_dense_coords_col_slab(
     const std::vector<QueryBuffer*>& buffers,
     std::vector<uint64_t>& offsets) const {
   // For easy reference
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
 
   // Special zipped coordinates
   if (dim_idx.size() == 1 && dim_idx[0] == dim_num) {

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -51,15 +51,14 @@ namespace sm {
 /* ****************************** */
 
 ResultTile::ResultTile(
-    unsigned frag_idx, uint64_t tile_idx, const ArraySchema* array_schema)
+    unsigned frag_idx, uint64_t tile_idx, const ArraySchema& array_schema)
     : frag_idx_(frag_idx)
     , tile_idx_(tile_idx) {
-  assert(array_schema != nullptr);
-  domain_ = array_schema->domain();
+  domain_ = array_schema.domain();
   coord_tiles_.resize(domain_->dim_num());
-  attr_tiles_.resize(array_schema->attribute_num());
-  for (uint64_t i = 0; i < array_schema->attribute_num(); i++) {
-    auto attribute = array_schema->attribute(i);
+  attr_tiles_.resize(array_schema.attribute_num());
+  for (uint64_t i = 0; i < array_schema.attribute_num(); i++) {
+    auto attribute = array_schema.attribute(i);
     attr_tiles_[i] = std::make_pair(attribute->name(), nullopt);
   }
   set_compute_results_func();

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -81,7 +81,7 @@ class ResultTile {
    * Constructor. The number of dimensions `dim_num` is used to allocate
    * the separate coordinate tiles.
    */
-  ResultTile(unsigned frag_idx, uint64_t tile_idx, const ArraySchema* schema);
+  ResultTile(unsigned frag_idx, uint64_t tile_idx, const ArraySchema& schema);
 
   DISABLE_COPY_AND_COPY_ASSIGN(ResultTile);
 

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -177,7 +177,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       const uint64_t memory_budget_qc_tiles,
       const unsigned f,
       const uint64_t t,
-      const ArraySchema* const array_schema);
+      const ArraySchema& array_schema);
 
   /**
    * Create the result tiles.

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -106,9 +106,6 @@ Status SparseIndexReaderBase::init() {
     return logger_->status(Status_ReaderError(
         "Cannot initialize sparse global order reader; Storage manager not "
         "set"));
-  if (array_schema_ == nullptr)
-    return logger_->status(Status_ReaderError(
-        "Cannot initialize sparse global order reader; Array schema not set"));
   if (buffers_.empty())
     return logger_->status(Status_ReaderError(
         "Cannot initialize sparse global order reader; Buffers not set"));
@@ -148,13 +145,13 @@ uint64_t SparseIndexReaderBase::cells_copied(
     const std::vector<std::string>& names) {
   auto& last_name = names.back();
   auto buffer_size = *buffers_[last_name].buffer_size_;
-  if (array_schema_->var_size(last_name)) {
+  if (array_schema_.var_size(last_name)) {
     if (buffer_size == 0)
       return 0;
     else
       return buffer_size / (offsets_bitsize_ / 8) - offsets_extra_element_;
   } else {
-    return buffer_size / array_schema_->cell_size(last_name);
+    return buffer_size / array_schema_.cell_size(last_name);
   }
 }
 
@@ -260,13 +257,13 @@ Status SparseIndexReaderBase::load_initial_data() {
 
   // Preload unzipped coordinate tile offsets. Note that this will
   // ignore fragments with a version < 5.
-  const auto dim_num = array_schema_->dim_num();
+  const auto dim_num = array_schema_.dim_num();
   dim_names_.reserve(dim_num);
   is_dim_var_size_.reserve(dim_num);
   std::vector<std::string> var_size_to_load;
   for (unsigned d = 0; d < dim_num; ++d) {
-    dim_names_.emplace_back(array_schema_->dimension(d)->name());
-    is_dim_var_size_.emplace_back(array_schema_->var_size(dim_names_[d]));
+    dim_names_.emplace_back(array_schema_.dimension(d)->name());
+    is_dim_var_size_.emplace_back(array_schema_.var_size(dim_names_[d]));
     if (is_dim_var_size_[d])
       var_size_to_load.emplace_back(dim_names_[d]);
   }
@@ -276,12 +273,12 @@ Status SparseIndexReaderBase::load_initial_data() {
   std::vector<std::string> attr_tile_offsets_to_load;
   for (auto& it : buffers_) {
     const auto& name = it.first;
-    if (array_schema_->is_dim(name))
+    if (array_schema_.is_dim(name))
       continue;
 
     attr_tile_offsets_to_load.emplace_back(name);
 
-    if (array_schema_->var_size(name))
+    if (array_schema_.var_size(name))
       var_size_to_load.emplace_back(name);
   }
 
@@ -355,9 +352,9 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
   auto timer_se = stats_->start_timer("compute_tile_bitmaps");
 
   // For easy reference.
-  const auto domain = array_schema_->domain();
-  const auto dim_num = array_schema_->dim_num();
-  const auto cell_order = array_schema_->cell_order();
+  const auto domain = array_schema_.domain();
+  const auto dim_num = array_schema_.dim_num();
+  const auto cell_order = array_schema_.cell_order();
 
   // No subarray set, return.
   if (!subarray_.is_set()) {
@@ -560,7 +557,7 @@ Status SparseIndexReaderBase::apply_query_condition(
 
           // Compute the result of the query condition for this tile.
           RETURN_NOT_OK(condition_.apply_sparse<BitmapType>(
-              fragment_metadata_[rt->frag_idx()]->array_schema(),
+              *(fragment_metadata_[rt->frag_idx()]->array_schema().get()),
               *rt,
               rt->bitmap_,
               &rt->bitmap_result_num_));
@@ -620,7 +617,7 @@ Status SparseIndexReaderBase::resize_output_buffers(uint64_t cells_copied) {
     const auto size = *it.second.buffer_size_;
     uint64_t num_cells = 0;
 
-    if (array_schema_->var_size(name)) {
+    if (array_schema_.var_size(name)) {
       // Get the current number of cells from the offsets buffer.
       num_cells = size / constants::cell_var_offset_size;
 
@@ -639,19 +636,19 @@ Status SparseIndexReaderBase::resize_output_buffers(uint64_t cells_copied) {
         // loaded, use it.
         if (offsets_bitsize_ == 64) {
           uint64_t offset_div =
-              elements_mode_ ? datatype_size(array_schema_->type(name)) : 1;
+              elements_mode_ ? datatype_size(array_schema_.type(name)) : 1;
           *it.second.buffer_var_size_ =
               ((uint64_t*)it.second.buffer_)[cells_copied] * offset_div;
         } else {
           uint32_t offset_div =
-              elements_mode_ ? datatype_size(array_schema_->type(name)) : 1;
+              elements_mode_ ? datatype_size(array_schema_.type(name)) : 1;
           *it.second.buffer_var_size_ =
               ((uint32_t*)it.second.buffer_)[cells_copied] * offset_div;
         }
       }
     } else {
       // Always adjust the size for fixed size attributes.
-      auto cell_size = array_schema_->cell_size(name);
+      auto cell_size = array_schema_.cell_size(name);
       *(it.second.buffer_size_) = cells_copied * cell_size;
     }
 
@@ -669,7 +666,7 @@ Status SparseIndexReaderBase::resize_output_buffers(uint64_t cells_copied) {
 Status SparseIndexReaderBase::add_extra_offset() {
   for (const auto& it : buffers_) {
     const auto& name = it.first;
-    if (!array_schema_->var_size(name))
+    if (!array_schema_.var_size(name))
       continue;
 
     auto buffer = static_cast<unsigned char*>(it.second.buffer_);
@@ -679,8 +676,8 @@ Status SparseIndexReaderBase::add_extra_offset() {
           it.second.buffer_var_size_,
           offsets_bytesize());
     } else if (offsets_format_mode_ == "elements") {
-      auto elements = *it.second.buffer_var_size_ /
-                      datatype_size(array_schema_->type(name));
+      auto elements =
+          *it.second.buffer_var_size_ / datatype_size(array_schema_.type(name));
       memcpy(
           buffer + *it.second.buffer_size_ - offsets_bytesize(),
           &elements,

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -58,7 +58,7 @@ class ResultTileWithBitmap : public ResultTile {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
   ResultTileWithBitmap(
-      unsigned frag_idx, uint64_t tile_idx, const ArraySchema* array_schema)
+      unsigned frag_idx, uint64_t tile_idx, const ArraySchema& array_schema)
       : ResultTile(frag_idx, tile_idx, array_schema)
       , bitmap_result_num_(std::numeric_limits<uint64_t>::max())
       , coords_loaded_(false) {

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -192,7 +192,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const unsigned f,
       const uint64_t t,
       const uint64_t last_t,
-      const ArraySchema* const array_schema);
+      const ArraySchema& array_schema);
 
   /**
    * Create the result tiles.

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -55,6 +55,7 @@ StrategyBase::StrategyBase(
     : stats_(stats)
     , logger_(logger)
     , array_(array)
+    , array_schema_(array->array_schema_latest())
     , config_(config)
     , buffers_(buffers)
     , layout_(layout)
@@ -63,9 +64,6 @@ StrategyBase::StrategyBase(
     , offsets_format_mode_(Config::SM_OFFSETS_FORMAT_MODE)
     , offsets_extra_element_(false)
     , offsets_bitsize_(constants::cell_var_offset_size * 8) {
-  if (array != nullptr) {
-    array_schema_ = array->array_schema_latest();
-  }
 }
 
 stats::Stats* StrategyBase::stats() const {
@@ -79,15 +77,15 @@ stats::Stats* StrategyBase::stats() const {
 void StrategyBase::get_dim_attr_stats() const {
   for (const auto& it : buffers_) {
     const auto& name = it.first;
-    auto var_size = array_schema_->var_size(name);
-    if (array_schema_->is_attr(name)) {
+    auto var_size = array_schema_.var_size(name);
+    if (array_schema_.is_attr(name)) {
       stats_->add_counter("attr_num", 1);
       if (var_size) {
         stats_->add_counter("attr_var_num", 1);
       } else {
         stats_->add_counter("attr_fixed_num", 1);
       }
-      if (array_schema_->is_nullable(name)) {
+      if (array_schema_.is_nullable(name)) {
         stats_->add_counter("attr_nullable_num", 1);
       }
     } else {

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -110,7 +110,7 @@ class StrategyBase {
   const Array* array_;
 
   /** The array schema. */
-  const ArraySchema* array_schema_;
+  const ArraySchema& array_schema_;
 
   /** The config for query-level parameters only. */
   Config& config_;

--- a/tiledb/sm/query/unordered_writer.cc
+++ b/tiledb/sm/query/unordered_writer.cc
@@ -135,7 +135,7 @@ Status UnorderedWriter::check_coord_dups(
   auto timer_se = stats_->start_timer("check_coord_dups");
 
   // Check if applicable
-  if (array_schema_->allows_dups() || !check_coord_dups_ || dedup_coords_)
+  if (array_schema_.allows_dups() || !check_coord_dups_ || dedup_coords_)
     return Status::Ok();
 
   if (!coords_info_.has_coords_) {
@@ -148,15 +148,15 @@ Status UnorderedWriter::check_coord_dups(
     return Status::Ok();
 
   // Prepare auxiliary vectors for better performance
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   std::vector<const unsigned char*> buffs(dim_num);
   std::vector<uint64_t> coord_sizes(dim_num);
   std::vector<const unsigned char*> buffs_var(dim_num);
   std::vector<uint64_t*> buffs_var_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_->dimension(d)->name();
+    const auto& dim_name = array_schema_.dimension(d)->name();
     buffs[d] = (const unsigned char*)buffers_.find(dim_name)->second.buffer_;
-    coord_sizes[d] = array_schema_->cell_size(dim_name);
+    coord_sizes[d] = array_schema_.cell_size(dim_name);
     buffs_var[d] =
         (const unsigned char*)buffers_.find(dim_name)->second.buffer_var_;
     buffs_var_sizes[d] = buffers_.find(dim_name)->second.buffer_var_size_;
@@ -170,7 +170,7 @@ Status UnorderedWriter::check_coord_dups(
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_->dimension(d);
+          auto dim = array_schema_.dimension(d);
           if (!dim->var_size()) {  // Fixed-sized dimensions
             if (memcmp(
                     buffs[d] + cell_pos[i] * coord_sizes[d],
@@ -246,15 +246,15 @@ Status UnorderedWriter::compute_coord_dups(
     return Status::Ok();
 
   // Prepare auxiliary vectors for better performance
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   std::vector<const unsigned char*> buffs(dim_num);
   std::vector<uint64_t> coord_sizes(dim_num);
   std::vector<const unsigned char*> buffs_var(dim_num);
   std::vector<uint64_t*> buffs_var_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_->dimension(d)->name();
+    const auto& dim_name = array_schema_.dimension(d)->name();
     buffs[d] = (const unsigned char*)buffers_.find(dim_name)->second.buffer_;
-    coord_sizes[d] = array_schema_->cell_size(dim_name);
+    coord_sizes[d] = array_schema_.cell_size(dim_name);
     buffs_var[d] =
         (const unsigned char*)buffers_.find(dim_name)->second.buffer_var_;
     buffs_var_sizes[d] = buffers_.find(dim_name)->second.buffer_var_size_;
@@ -269,7 +269,7 @@ Status UnorderedWriter::compute_coord_dups(
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_->dimension(d);
+          auto dim = array_schema_.dimension(d);
           if (!dim->var_size()) {  // Fixed-sized dimensions
             if (memcmp(
                     buffs[d] + cell_pos[i] * coord_sizes[d],
@@ -357,7 +357,7 @@ Status UnorderedWriter::prepare_tiles(
     const std::vector<uint64_t>& cell_pos,
     const std::set<uint64_t>& coord_dups,
     std::vector<WriterTile>* tiles) const {
-  return array_schema_->var_size(name) ?
+  return array_schema_.var_size(name) ?
              prepare_tiles_var(name, cell_pos, coord_dups, tiles) :
              prepare_tiles_fixed(name, cell_pos, coord_dups, tiles);
 }
@@ -372,16 +372,16 @@ Status UnorderedWriter::prepare_tiles_fixed(
     return Status::Ok();
 
   // For easy reference
-  auto nullable = array_schema_->is_nullable(name);
+  auto nullable = array_schema_.is_nullable(name);
   auto buffer = (unsigned char*)buffers_.find(name)->second.buffer_;
   auto buffer_validity =
       (unsigned char*)buffers_.find(name)->second.validity_vector_.buffer();
-  auto cell_size = array_schema_->cell_size(name);
+  auto cell_size = array_schema_.cell_size(name);
   auto cell_num = (uint64_t)cell_pos.size();
-  auto capacity = array_schema_->capacity();
+  auto capacity = array_schema_.capacity();
   auto dups_num = coord_dups.size();
   auto tile_num = utils::math::ceil(cell_num - dups_num, capacity);
-  auto domain = array_schema_->domain();
+  auto domain = array_schema_.domain();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
 
@@ -455,17 +455,17 @@ Status UnorderedWriter::prepare_tiles_var(
     std::vector<WriterTile>* tiles) const {
   // For easy reference
   auto it = buffers_.find(name);
-  auto nullable = array_schema_->is_nullable(name);
+  auto nullable = array_schema_.is_nullable(name);
   auto buffer = it->second.buffer_;
   auto buffer_var = (unsigned char*)it->second.buffer_var_;
   auto buffer_validity = (uint8_t*)it->second.validity_vector_.buffer();
   auto buffer_var_size = it->second.buffer_var_size_;
   auto cell_num = (uint64_t)cell_pos.size();
-  auto capacity = array_schema_->capacity();
+  auto capacity = array_schema_.capacity();
   auto dups_num = coord_dups.size();
   auto tile_num = utils::math::ceil(cell_num - dups_num, capacity);
-  auto attr_datatype_size = datatype_size(array_schema_->type(name));
-  auto domain = array_schema_->domain();
+  auto attr_datatype_size = datatype_size(array_schema_.type(name));
+  auto domain = array_schema_.domain();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
 
@@ -578,14 +578,14 @@ Status UnorderedWriter::sort_coords(std::vector<uint64_t>* cell_pos) const {
   auto timer_se = stats_->start_timer("sort_coords");
 
   // For easy reference
-  auto domain = array_schema_->domain();
-  auto cell_order = array_schema_->cell_order();
+  auto domain = array_schema_.domain();
+  auto cell_order = array_schema_.cell_order();
 
   // Prepare auxiliary vector for better performance
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   std::vector<const QueryBuffer*> buffs(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_->dimension(d)->name();
+    const auto& dim_name = array_schema_.dimension(d)->name();
     buffs[d] = &(buffers_.find(dim_name)->second);
   }
 
@@ -617,7 +617,7 @@ Status UnorderedWriter::sort_coords(std::vector<uint64_t>* cell_pos) const {
 Status UnorderedWriter::unordered_write() {
   // Applicable only to unordered write on sparse arrays
   assert(layout_ == Layout::UNORDERED);
-  assert(!array_schema_->dense());
+  assert(!array_schema_.dense());
 
   // Sort coordinates first
   std::vector<uint64_t> cell_pos;
@@ -651,8 +651,8 @@ Status UnorderedWriter::unordered_write() {
   // Set the number of tiles in the metadata
   auto it = tiles.begin();
   const uint64_t tile_num_divisor =
-      1 + (array_schema_->var_size(it->first) ? 1 : 0) +
-      (array_schema_->is_nullable(it->first) ? 1 : 0);
+      1 + (array_schema_.var_size(it->first) ? 1 : 0) +
+      (array_schema_.is_nullable(it->first) ? 1 : 0);
   auto tile_num = it->second.size() / tile_num_divisor;
   frag_meta->set_num_tiles(tile_num);
 

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -135,7 +135,7 @@ void WriterBase::set_dedup_coords(bool b) {
 Status WriterBase::check_var_attr_offsets() const {
   for (const auto& it : buffers_) {
     const auto& attr = it.first;
-    if (!array_schema_->var_size(attr)) {
+    if (!array_schema_.var_size(attr)) {
       continue;
     }
 
@@ -189,16 +189,13 @@ Status WriterBase::init() {
   if (storage_manager_ == nullptr)
     return logger_->status(
         Status_WriterError("Cannot initialize query; Storage manager not set"));
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_WriterError("Cannot initialize writer; Array schema not set"));
   if (buffers_.empty())
     return logger_->status(
         Status_WriterError("Cannot initialize writer; Buffers not set"));
-  if (array_schema_->dense() &&
+  if (array_schema_.dense() &&
       (layout_ == Layout::ROW_MAJOR || layout_ == Layout::COL_MAJOR)) {
     for (const auto& b : buffers_) {
-      if (array_schema_->is_dim(b.first)) {
+      if (array_schema_.is_dim(b.first)) {
         return logger_->status(Status_WriterError(
             "Cannot initialize writer; Sparse coordinates "
             "for dense arrays cannot be provided "
@@ -275,7 +272,7 @@ Status WriterBase::add_written_fragment_info(const URI& uri) {
 Status WriterBase::calculate_hilbert_values(
     const std::vector<const QueryBuffer*>& buffs,
     std::vector<uint64_t>* hilbert_values) const {
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   Hilbert h(dim_num);
   auto bits = h.bits();
   auto max_bucket_val = ((uint64_t)1 << bits) - 1;
@@ -289,7 +286,7 @@ Status WriterBase::calculate_hilbert_values(
       [&](uint64_t c) {
         std::vector<uint64_t> coords(dim_num);
         for (uint32_t d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_->dimension(d);
+          auto dim = array_schema_.dimension(d);
           coords[d] = hilbert_order::map_to_uint64(
               *dim, buffs[d], c, bits, max_bucket_val);
         }
@@ -305,25 +302,25 @@ Status WriterBase::calculate_hilbert_values(
 
 Status WriterBase::check_buffer_sizes() const {
   // This is applicable only to dense arrays and ordered layout
-  if (!array_schema_->dense() ||
+  if (!array_schema_.dense() ||
       (layout_ != Layout::ROW_MAJOR && layout_ != Layout::COL_MAJOR))
     return Status::Ok();
 
-  auto cell_num = array_schema_->domain()->cell_num(subarray_.ndrange(0));
+  auto cell_num = array_schema_.domain()->cell_num(subarray_.ndrange(0));
   uint64_t expected_cell_num = 0;
   for (const auto& it : buffers_) {
     const auto& attr = it.first;
-    const bool is_var = array_schema_->var_size(attr);
+    const bool is_var = array_schema_.var_size(attr);
     const uint64_t buffer_size =
         is_var ? get_offset_buffer_size(*it.second.buffer_size_) :
                  *it.second.buffer_size_;
     if (is_var) {
       expected_cell_num = buffer_size / constants::cell_var_offset_size;
     } else {
-      expected_cell_num = buffer_size / array_schema_->cell_size(attr);
+      expected_cell_num = buffer_size / array_schema_.cell_size(attr);
     }
 
-    if (array_schema_->is_nullable(attr)) {
+    if (array_schema_.is_nullable(attr)) {
       const uint64_t buffer_validity_size =
           *it.second.validity_vector_.buffer_size();
       const uint64_t expected_validity_num =
@@ -363,17 +360,17 @@ Status WriterBase::check_coord_oob() const {
     return Status::Ok();
 
   // Exit if all dimensions are strings
-  if (array_schema_->domain()->all_dims_string())
+  if (array_schema_.domain()->all_dims_string())
     return Status::Ok();
 
   // Prepare auxiliary vectors for better performance
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
   std::vector<unsigned char*> buffs(dim_num);
   std::vector<uint64_t> coord_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_->dimension(d)->name();
+    const auto& dim_name = array_schema_.dimension(d)->name();
     buffs[d] = (unsigned char*)buffers_.find(dim_name)->second.buffer_;
-    coord_sizes[d] = array_schema_->cell_size(dim_name);
+    coord_sizes[d] = array_schema_.cell_size(dim_name);
   }
 
   // Check if all coordinates fall in the domain in parallel
@@ -384,7 +381,7 @@ Status WriterBase::check_coord_oob() const {
       0,
       dim_num,
       [&](uint64_t c, unsigned d) {
-        auto dim = array_schema_->dimension(d);
+        auto dim = array_schema_.dimension(d);
         if (datatype_is_string(dim->type()))
           return Status::Ok();
         return dim->oob(buffs[d] + c * coord_sizes[d]);
@@ -397,11 +394,7 @@ Status WriterBase::check_coord_oob() const {
 }
 
 Status WriterBase::check_subarray() const {
-  if (array_schema_ == nullptr)
-    return logger_->status(
-        Status_WriterError("Cannot check subarray; Array schema not set"));
-
-  if (array_schema_->dense()) {
+  if (array_schema_.dense()) {
     if (subarray_.range_num() != 1)
       return LOG_STATUS(
           Status_WriterError("Multi-range dense writes "
@@ -431,7 +424,7 @@ std::vector<std::string> WriterBase::buffer_names() const {
   // Add to the buffer names the attributes, as well as the dimensions only if
   // coords_buffer_ has not been set
   for (const auto& it : buffers_) {
-    if (!array_schema_->is_dim(it.first) || (!coords_info_.coords_buffer_))
+    if (!array_schema_.is_dim(it.first) || (!coords_info_.coords_buffer_))
       ret.push_back(it.first);
   }
 
@@ -454,13 +447,13 @@ Status WriterBase::close_files(tdb_shared_ptr<FragmentMetadata> meta) const {
     RETURN_NOT_OK(status);
 
     file_uris.emplace_back(*uri);
-    if (array_schema_->var_size(name)) {
+    if (array_schema_.var_size(name)) {
       auto&& [status, var_uri] = meta->var_uri(name);
       RETURN_NOT_OK(status);
 
       file_uris.emplace_back(*var_uri);
     }
-    if (array_schema_->is_nullable(name)) {
+    if (array_schema_.is_nullable(name)) {
       auto&& [status, validity_uri] = meta->validity_uri(name);
       RETURN_NOT_OK(status);
 
@@ -496,10 +489,10 @@ Status WriterBase::compute_coords_metadata(
   // Compute number of tiles. Assumes all attributes and
   // and dimensions have the same number of tiles
   auto it = tiles.begin();
-  const uint64_t t = 1 + (array_schema_->var_size(it->first) ? 1 : 0) +
-                     (array_schema_->is_nullable(it->first) ? 1 : 0);
+  const uint64_t t = 1 + (array_schema_.var_size(it->first) ? 1 : 0) +
+                     (array_schema_.is_nullable(it->first) ? 1 : 0);
   auto tile_num = it->second.size() / t;
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
 
   // Compute MBRs
   auto status = parallel_for(
@@ -507,7 +500,7 @@ Status WriterBase::compute_coords_metadata(
         NDRange mbr(dim_num);
         std::vector<const void*> data(dim_num);
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_->dimension(d);
+          auto dim = array_schema_.dimension(d);
           const auto& dim_name = dim->name();
           auto tiles_it = tiles.find(dim_name);
           assert(tiles_it != tiles.end());
@@ -525,7 +518,7 @@ Status WriterBase::compute_coords_metadata(
   RETURN_NOT_OK(status);
 
   // Set last tile cell number
-  auto dim_0 = array_schema_->dimension(0);
+  auto dim_0 = array_schema_.dimension(0);
   const auto& dim_tiles = tiles.find(dim_0->name())->second;
   const auto& last_tile_pos =
       (!dim_0->var_size()) ? dim_tiles.size() - 1 : dim_tiles.size() - 2;
@@ -547,12 +540,12 @@ Status WriterBase::compute_tiles_metadata(
       std::advance(buff_it, i);
       const auto& attr = buff_it->first;
       auto& attr_tiles = tiles[attr];
-      const auto type = array_schema_->type(attr);
-      const auto is_dim = array_schema_->is_dim(attr);
-      const auto var_size = array_schema_->var_size(attr);
-      const auto nullable = array_schema_->is_nullable(attr);
-      const auto cell_size = array_schema_->cell_size(attr);
-      const auto cell_val_num = array_schema_->cell_val_num(attr);
+      const auto type = array_schema_.type(attr);
+      const auto is_dim = array_schema_.is_dim(attr);
+      const auto var_size = array_schema_.var_size(attr);
+      const auto nullable = array_schema_.is_nullable(attr);
+      const auto cell_size = array_schema_.cell_size(attr);
+      const auto cell_val_num = array_schema_.cell_val_num(attr);
       const uint64_t tile_num_mult = 1 + var_size + nullable;
       TileMetadataGenerator md_generator(
           type, is_dim, var_size, cell_size, cell_val_num);
@@ -572,12 +565,12 @@ Status WriterBase::compute_tiles_metadata(
     for (const auto& buff : buffers_) {
       const auto& attr = buff.first;
       auto& attr_tiles = tiles[attr];
-      const auto type = array_schema_->type(attr);
-      const auto is_dim = array_schema_->is_dim(attr);
-      const auto var_size = array_schema_->var_size(attr);
-      const auto nullable = array_schema_->is_nullable(attr);
-      const auto cell_size = array_schema_->cell_size(attr);
-      const auto cell_val_num = array_schema_->cell_val_num(attr);
+      const auto type = array_schema_.type(attr);
+      const auto is_dim = array_schema_.is_dim(attr);
+      const auto var_size = array_schema_.var_size(attr);
+      const auto nullable = array_schema_.is_nullable(attr);
+      const auto cell_size = array_schema_.cell_size(attr);
+      const auto cell_val_num = array_schema_.cell_val_num(attr);
       const uint64_t tile_num_mult = 1 + var_size + nullable;
       auto st = parallel_for(compute_tp, 0, tile_num, [&](uint64_t t) {
         TileMetadataGenerator md_generator(
@@ -600,11 +593,11 @@ Status WriterBase::compute_tiles_metadata(
 
 std::string WriterBase::coords_to_str(uint64_t i) const {
   std::stringstream ss;
-  auto dim_num = array_schema_->dim_num();
+  auto dim_num = array_schema_.dim_num();
 
   ss << "(";
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = array_schema_->dimension(d);
+    auto dim = array_schema_.dimension(d);
     const auto& dim_name = dim->name();
     ss << buffers_.find(dim_name)->second.dimension_datum_at(*dim, i);
     if (d < dim_num - 1)
@@ -623,7 +616,7 @@ Status WriterBase::create_fragment(
     uri = fragment_uri_;
   } else {
     std::string new_fragment_str;
-    auto write_version = array_->array_schema_latest()->write_version();
+    auto write_version = array_->array_schema_latest().write_version();
     RETURN_NOT_OK(
         new_fragment_name(timestamp, write_version, &new_fragment_str));
 
@@ -640,7 +633,7 @@ Status WriterBase::create_fragment(
       HERE(),
       storage_manager_,
       nullptr,
-      array_schema_,
+      array_->array_schema_latest_ptr(),
       uri,
       timestamp_range,
       dense);
@@ -671,8 +664,8 @@ Status WriterBase::filter_tiles(
 
 Status WriterBase::filter_tiles(
     const std::string& name, std::vector<WriterTile>* tiles) {
-  const bool var_size = array_schema_->var_size(name);
-  const bool nullable = array_schema_->is_nullable(name);
+  const bool var_size = array_schema_.var_size(name);
+  const bool nullable = array_schema_.is_nullable(name);
   const size_t tile_step = 1 + nullable + var_size;
 
   // Filter all tiles
@@ -754,11 +747,11 @@ Status WriterBase::filter_tile(
   FilterPipeline filters;
   if (offsets) {
     assert(!nullable);
-    filters = array_schema_->cell_var_offsets_filters();
+    filters = array_schema_.cell_var_offsets_filters();
   } else if (nullable) {
-    filters = array_schema_->cell_validity_filters();
+    filters = array_schema_.cell_validity_filters();
   } else {
-    filters = array_schema_->filters(name);
+    filters = array_schema_.filters(name);
   }
 
   // Append an encryption filter when necessary.
@@ -767,7 +760,7 @@ Status WriterBase::filter_tile(
 
   // Check if chunk or tile level filtering/unfiltering is appropriate
   bool use_chunking = filters.use_tile_chunking(
-      array_schema_->is_dim(name), array_schema_->var_size(name), tile->type());
+      array_schema_.is_dim(name), array_schema_.var_size(name), tile->type());
 
   assert(!tile->filtered());
   RETURN_NOT_OK(filters.run_forward(
@@ -785,33 +778,33 @@ Status WriterBase::filter_tile(
 
 bool WriterBase::has_min_max_metadata(
     const std::string& name, const bool var_size) {
-  const auto type = array_schema_->type(name);
-  const auto is_dim = array_schema_->is_dim(name);
-  const auto cell_val_num = array_schema_->cell_val_num(name);
+  const auto type = array_schema_.type(name);
+  const auto is_dim = array_schema_.is_dim(name);
+  const auto cell_val_num = array_schema_.cell_val_num(name);
   return TileMetadataGenerator::has_min_max_metadata(
       type, is_dim, var_size, cell_val_num);
 }
 
 bool WriterBase::has_sum_metadata(
     const std::string& name, const bool var_size) {
-  const auto type = array_schema_->type(name);
-  const auto cell_val_num = array_schema_->cell_val_num(name);
+  const auto type = array_schema_.type(name);
+  const auto cell_val_num = array_schema_.cell_val_num(name);
   return TileMetadataGenerator::has_sum_metadata(type, var_size, cell_val_num);
 }
 
 Status WriterBase::init_tile(const std::string& name, WriterTile* tile) const {
   // For easy reference
-  auto cell_size = array_schema_->cell_size(name);
-  auto type = array_schema_->type(name);
-  auto domain = array_schema_->domain();
-  auto capacity = array_schema_->capacity();
+  auto cell_size = array_schema_.cell_size(name);
+  auto type = array_schema_.type(name);
+  auto domain = array_schema_.domain();
+  auto capacity = array_schema_.capacity();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * cell_size;
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      array_schema_->write_version(), type, tile_size, cell_size, 0));
+      array_schema_.write_version(), type, tile_size, cell_size, 0));
 
   return Status::Ok();
 }
@@ -819,22 +812,22 @@ Status WriterBase::init_tile(const std::string& name, WriterTile* tile) const {
 Status WriterBase::init_tile(
     const std::string& name, WriterTile* tile, WriterTile* tile_var) const {
   // For easy reference
-  auto type = array_schema_->type(name);
-  auto domain = array_schema_->domain();
-  auto capacity = array_schema_->capacity();
+  auto type = array_schema_.type(name);
+  auto domain = array_schema_.domain();
+  auto capacity = array_schema_.capacity();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * constants::cell_var_offset_size;
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      array_schema_->write_version(),
+      array_schema_.write_version(),
       constants::cell_var_offset_type,
       tile_size,
       constants::cell_var_offset_size,
       0));
   RETURN_NOT_OK(tile_var->init_unfiltered(
-      array_schema_->write_version(), type, tile_size, datatype_size(type), 0));
+      array_schema_.write_version(), type, tile_size, datatype_size(type), 0));
   return Status::Ok();
 }
 
@@ -843,22 +836,22 @@ Status WriterBase::init_tile_nullable(
     WriterTile* tile,
     WriterTile* tile_validity) const {
   // For easy reference
-  auto cell_size = array_schema_->cell_size(name);
-  auto type = array_schema_->type(name);
-  auto domain = array_schema_->domain();
-  auto capacity = array_schema_->capacity();
+  auto cell_size = array_schema_.cell_size(name);
+  auto type = array_schema_.type(name);
+  auto domain = array_schema_.domain();
+  auto capacity = array_schema_.capacity();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      array_schema_->write_version(),
+      array_schema_.write_version(),
       type,
       cell_num_per_tile * cell_size,
       cell_size,
       0));
   RETURN_NOT_OK(tile_validity->init_unfiltered(
-      array_schema_->write_version(),
+      array_schema_.write_version(),
       constants::cell_validity_type,
       cell_num_per_tile * constants::cell_validity_size,
       constants::cell_validity_size,
@@ -873,24 +866,24 @@ Status WriterBase::init_tile_nullable(
     WriterTile* tile_var,
     WriterTile* tile_validity) const {
   // For easy reference
-  auto type = array_schema_->type(name);
-  auto domain = array_schema_->domain();
-  auto capacity = array_schema_->capacity();
+  auto type = array_schema_.type(name);
+  auto domain = array_schema_.domain();
+  auto capacity = array_schema_.capacity();
   auto cell_num_per_tile =
       coords_info_.has_coords_ ? capacity : domain->cell_num_per_tile();
   auto tile_size = cell_num_per_tile * constants::cell_var_offset_size;
 
   // Initialize
   RETURN_NOT_OK(tile->init_unfiltered(
-      array_schema_->write_version(),
+      array_schema_.write_version(),
       constants::cell_var_offset_type,
       tile_size,
       constants::cell_var_offset_size,
       0));
   RETURN_NOT_OK(tile_var->init_unfiltered(
-      array_schema_->write_version(), type, tile_size, datatype_size(type), 0));
+      array_schema_.write_version(), type, tile_size, datatype_size(type), 0));
   RETURN_NOT_OK(tile_validity->init_unfiltered(
-      array_schema_->write_version(),
+      array_schema_.write_version(),
       constants::cell_validity_type,
       cell_num_per_tile * constants::cell_validity_size,
       constants::cell_validity_size,
@@ -904,8 +897,8 @@ Status WriterBase::init_tiles(
     uint64_t tile_num,
     std::vector<WriterTile>* tiles) const {
   // Initialize tiles
-  const bool var_size = array_schema_->var_size(name);
-  const bool nullable = array_schema_->is_nullable(name);
+  const bool var_size = array_schema_.var_size(name);
+  const bool nullable = array_schema_.is_nullable(name);
   const size_t t =
       1 + static_cast<size_t>(var_size) + static_cast<size_t>(nullable);
   const size_t tiles_len = t * tile_num;
@@ -947,23 +940,22 @@ Status WriterBase::new_fragment_name(
 }
 
 void WriterBase::optimize_layout_for_1D() {
-  if (array_schema_->dim_num() == 1 && layout_ != Layout::GLOBAL_ORDER &&
+  if (array_schema_.dim_num() == 1 && layout_ != Layout::GLOBAL_ORDER &&
       layout_ != Layout::UNORDERED)
-    layout_ = array_schema_->cell_order();
+    layout_ = array_schema_.cell_order();
 }
 
 Status WriterBase::check_extra_element() {
   for (const auto& it : buffers_) {
     const auto& attr = it.first;
-    if (!array_schema_->var_size(attr) || array_schema_->is_dim(attr))
+    if (!array_schema_.var_size(attr) || array_schema_.is_dim(attr))
       continue;
 
     const void* buffer_off = it.second.buffer_;
     uint64_t* buffer_off_size = it.second.buffer_size_;
     const auto num_offsets = *buffer_off_size / constants::cell_var_offset_size;
     const uint64_t* buffer_val_size = it.second.buffer_var_size_;
-    const uint64_t attr_datatype_size =
-        datatype_size(array_schema_->type(attr));
+    const uint64_t attr_datatype_size = datatype_size(array_schema_.type(attr));
     const uint64_t max_offset = offsets_format_mode_ == "bytes" ?
                                     *buffer_val_size :
                                     *buffer_val_size / attr_datatype_size;
@@ -989,8 +981,8 @@ Status WriterBase::split_coords_buffer() {
     return Status::Ok();
 
   // For easy reference
-  auto dim_num = array_schema_->dim_num();
-  auto coord_size = array_schema_->domain()->dimension(0)->coord_size();
+  auto dim_num = array_schema_.dim_num();
+  auto coord_size = array_schema_.domain()->dimension(0)->coord_size();
   auto coords_size = dim_num * coord_size;
   coords_info_.coords_num_ = *coords_info_.coords_buffer_size_ / coords_size;
 
@@ -998,7 +990,7 @@ Status WriterBase::split_coords_buffer() {
 
   // New coord buffer allocations
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = array_schema_->dimension(d);
+    auto dim = array_schema_.dimension(d);
     const auto& dim_name = dim->name();
     auto coord_buffer_size = coords_info_.coords_num_ * dim->coord_size();
     auto it = coord_buffer_sizes_.emplace(dim_name, coord_buffer_size);
@@ -1015,8 +1007,8 @@ Status WriterBase::split_coords_buffer() {
   // Split coordinates
   auto coord = (unsigned char*)nullptr;
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto coord_size = array_schema_->dimension(d)->coord_size();
-    const auto& dim_name = array_schema_->dimension(d)->name();
+    auto coord_size = array_schema_.dimension(d)->coord_size();
+    const auto& dim_name = array_schema_.dimension(d)->name();
     auto buff = (unsigned char*)(buffers_[dim_name].buffer_);
     for (uint64_t c = 0; c < coords_info_.coords_num_; ++c) {
       coord = &(((unsigned char*)coords_info_
@@ -1043,12 +1035,12 @@ Status WriterBase::write_all_tiles(
       RETURN_CANCEL_OR_ERROR(write_tiles(attr, frag_meta, 0, &tiles));
 
       // Fix var size attributes metadata.
-      const auto var_size = array_schema_->var_size(attr);
+      const auto var_size = array_schema_.var_size(attr);
       if (has_min_max_metadata(attr, var_size) &&
-          array_schema_->var_size(attr)) {
+          array_schema_.var_size(attr)) {
         frag_meta->convert_tile_min_max_var_sizes_to_offsets(attr);
 
-        const auto nullable = array_schema_->is_nullable(attr);
+        const auto nullable = array_schema_.is_nullable(attr);
         const uint64_t tile_num_mult = 1 + var_size + nullable;
         for (uint64_t i = 0; i < tiles.size(); i += tile_num_mult) {
           auto tile_idx = i / tile_num_mult;
@@ -1081,8 +1073,8 @@ Status WriterBase::write_tiles(
     return Status::Ok();
 
   // For easy reference
-  const bool var_size = array_schema_->var_size(name);
-  const bool nullable = array_schema_->is_nullable(name);
+  const bool var_size = array_schema_.var_size(name);
+  const bool nullable = array_schema_.is_nullable(name);
   auto&& [status, uri] = frag_meta->uri(name);
   RETURN_NOT_OK(status);
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -114,32 +114,37 @@ Status RestClient::set_header(
   return Status::Ok();
 }
 
-Status RestClient::get_array_schema_from_rest(
-    const URI& uri, ArraySchema** array_schema) {
+tuple<Status, optional<shared_ptr<ArraySchema>>>
+RestClient::get_array_schema_from_rest(const URI& uri) {
   // Init curl and form the URL
   Curl curlc;
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK_TUPLE(uri.get_rest_components(&array_ns, &array_uri), nullopt);
   const std::string cache_key = array_ns + ":" + array_uri;
-  RETURN_NOT_OK(
-      curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
+  RETURN_NOT_OK_TUPLE(
+      curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
+      nullopt);
   const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
                           "/" + curlc.url_escape(array_uri);
 
   // Get the data
   Buffer returned_data;
-  RETURN_NOT_OK(curlc.get_data(
-      stats_, url, serialization_type_, &returned_data, cache_key));
+  RETURN_NOT_OK_TUPLE(
+      curlc.get_data(
+          stats_, url, serialization_type_, &returned_data, cache_key),
+      nullopt);
   if (returned_data.data() == nullptr || returned_data.size() == 0)
-    return LOG_STATUS(Status_RestError(
-        "Error getting array schema from REST; server returned no data."));
+    return {
+        LOG_STATUS(Status_RestError(
+            "Error getting array schema from REST; server returned no data.")),
+        nullopt};
 
   return serialization::array_schema_deserialize(
-      array_schema, serialization_type_, returned_data);
+      serialization_type_, returned_data);
 }
 
 Status RestClient::post_array_schema_to_rest(
-    const URI& uri, ArraySchema* array_schema) {
+    const URI& uri, const ArraySchema& array_schema) {
   Buffer buff;
   RETURN_NOT_OK(serialization::array_schema_serialize(
       array_schema, serialization_type_, &buff, false));
@@ -230,7 +235,7 @@ Status RestClient::get_array_non_empty_domain(
 
 Status RestClient::get_array_max_buffer_sizes(
     const URI& uri,
-    const ArraySchema* schema,
+    const ArraySchema& schema,
     const void* subarray,
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*
         buffer_sizes) {
@@ -426,7 +431,7 @@ size_t RestClient::query_post_call_back(
     void* const contents,
     const size_t content_nbytes,
     bool* const skip_retries,
-    tdb_shared_ptr<Buffer> scratch,
+    shared_ptr<Buffer> scratch,
     Query* query,
     serialization::CopyState* copy_state) {
   // All return statements in this function must pass through this wrapper.
@@ -628,11 +633,11 @@ Status RestClient::finalize_query_to_rest(const URI& uri, Query* query) {
 }
 
 Status RestClient::subarray_to_str(
-    const ArraySchema* schema,
+    const ArraySchema& schema,
     const void* subarray,
     std::string* subarray_str) {
-  const auto coords_type = schema->dimension(0)->type();
-  const auto dim_num = schema->dim_num();
+  const auto coords_type = schema.dimension(0)->type();
+  const auto dim_num = schema.dim_num();
   const auto subarray_nelts = 2 * dim_num;
 
   if (subarray == nullptr) {
@@ -836,12 +841,14 @@ Status RestClient::set_header(const std::string&, const std::string&) {
       Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
-Status RestClient::get_array_schema_from_rest(const URI&, ArraySchema**) {
-  return LOG_STATUS(
-      Status_RestError("Cannot use rest client; serialization not enabled."));
+tuple<Status, optional<shared_ptr<ArraySchema>>>
+RestClient::get_array_schema_from_rest(const URI&) {
+  return {LOG_STATUS(Status_RestError(
+              "Cannot use rest client; serialization not enabled.")),
+          nullopt};
 }
 
-Status RestClient::post_array_schema_to_rest(const URI&, ArraySchema*) {
+Status RestClient::post_array_schema_to_rest(const URI&, const ArraySchema&) {
   return LOG_STATUS(
       Status_RestError("Cannot use rest client; serialization not enabled."));
 }
@@ -858,7 +865,7 @@ Status RestClient::get_array_non_empty_domain(Array*, uint64_t, uint64_t) {
 
 Status RestClient::get_array_max_buffer_sizes(
     const URI&,
-    const ArraySchema*,
+    const ArraySchema&,
     const void*,
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*) {
   return LOG_STATUS(

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -65,13 +65,13 @@ class RestClient {
   Status set_header(const std::string& name, const std::string& value);
 
   /**
-   * Get a data encoded array schema from rest server
+   * Get a data encoded array schema from rest server.
    *
    * @param uri of array being loaded
-   * @param array_schema array schema to send to server
-   * @return Status Ok() on success Error() on failures
+   * @return Status and new ArraySchema shared pointer.
    */
-  Status get_array_schema_from_rest(const URI& uri, ArraySchema** array_schema);
+  tuple<Status, optional<shared_ptr<ArraySchema>>> get_array_schema_from_rest(
+      const URI& uri);
 
   /**
    * Post a data array schema to rest server
@@ -80,7 +80,8 @@ class RestClient {
    * @param array_schema array schema to load into
    * @return Status Ok() on success Error() on failures
    */
-  Status post_array_schema_to_rest(const URI& uri, ArraySchema* array_schema);
+  Status post_array_schema_to_rest(
+      const URI& uri, const ArraySchema& array_schema);
 
   /**
    * Deregisters an array at the given URI from the REST server.
@@ -112,7 +113,7 @@ class RestClient {
    */
   Status get_array_max_buffer_sizes(
       const URI& uri,
-      const ArraySchema* schema,
+      const ArraySchema& schema,
       const void* subarray,
       std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*
           buffer_sizes);
@@ -275,7 +276,7 @@ class RestClient {
       void* constcontents,
       const size_t content_nbytes,
       bool* constskip_retries,
-      tdb_shared_ptr<Buffer> scratch,
+      shared_ptr<Buffer> scratch,
       Query* query,
       serialization::CopyState* copy_state);
 
@@ -290,7 +291,7 @@ class RestClient {
    * @return Status
    */
   static Status subarray_to_str(
-      const ArraySchema* schema,
+      const ArraySchema& schema,
       const void* subarray,
       std::string* subarray_str);
 

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -417,12 +417,13 @@ Status RTree::deserialize_v5(ConstBuffer* cbuff, const Domain* domain) {
   for (unsigned l = 0; l < level_num; ++l) {
     RETURN_NOT_OK(cbuff->read(&mbr_num, sizeof(uint64_t)));
     levels_[l].resize(mbr_num);
+
     for (uint64_t m = 0; m < mbr_num; ++m) {
       levels_[l][m].resize(dim_num);
       for (unsigned d = 0; d < dim_num; ++d) {
-        auto dim = domain_->dimension(d);
+        auto dim = domain->dimension(d);
         if (!dim->var_size()) {  // Fixed-sized
-          auto r_size = 2 * domain->dimension(d)->coord_size();
+          auto r_size = 2 * dim->coord_size();
           levels_[l][m][d].set_range(cbuff->cur_data(), r_size);
           cbuff->advance_offset(r_size);
         } else {  // Var-sized

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -134,7 +134,7 @@ Status array_to_capnp(
   array_builder->setStartTimestamp(array->timestamp_start());
   array_builder->setEndTimestamp(array->timestamp_end());
 
-  ArraySchema* array_schema_latest = array->array_schema_latest();
+  const auto& array_schema_latest = array->array_schema_latest();
   auto array_schema_latest_builder = array_builder->initArraySchemaLatest();
   RETURN_NOT_OK(array_schema_to_capnp(
       array_schema_latest, &array_schema_latest_builder, client_side));
@@ -149,7 +149,7 @@ Status array_to_capnp(
     entry.setKey(schema.first);
     auto schema_builder = entry.initValue();
     RETURN_NOT_OK(array_schema_to_capnp(
-        schema.second.get(), &schema_builder, client_side));
+        *(schema.second.get()), &schema_builder, client_side));
   }
 
   auto nonempty_domain_builder = array_builder->initNonEmptyDomain();
@@ -188,7 +188,6 @@ Status array_from_capnp(
         all_schemas[array_schema_build.getKey()] = std::move(schema);
       }
     }
-    array->set_array_schemas_all(all_schemas);
   }
 
   if (array_reader.hasArraySchemaLatest()) {
@@ -197,7 +196,7 @@ Status array_from_capnp(
     RETURN_NOT_OK(array_schema_from_capnp(
         array_schema_latest_reader, &array_schema_latest));
     array_schema_latest->set_array_uri(array->array_uri());
-    array->set_array_schema_latest(array_schema_latest.release());
+    array->set_array_schema_latest(std::move(array_schema_latest));
   }
 
   if (array_reader.hasNonEmptyDomain()) {

--- a/tiledb/sm/serialization/array_schema.h
+++ b/tiledb/sm/serialization/array_schema.h
@@ -65,7 +65,7 @@ namespace serialization {
  * @return Status
  */
 Status array_schema_to_capnp(
-    ArraySchema* array_schema,
+    const ArraySchema& array_schema,
     capnp::ArraySchema::Builder* array_schema_builder,
     const bool client_side);
 
@@ -92,15 +92,13 @@ Status array_schema_from_capnp(
  * @return
  */
 Status array_schema_serialize(
-    ArraySchema* array_schema,
+    const ArraySchema& array_schema,
     SerializationType serialize_type,
     Buffer* serialized_buffer,
     const bool client_side);
 
-Status array_schema_deserialize(
-    ArraySchema** array_schema,
-    SerializationType serialize_type,
-    const Buffer& serialized_buffer);
+tuple<Status, optional<shared_ptr<ArraySchema>>> array_schema_deserialize(
+    SerializationType serialize_type, const Buffer& serialized_buffer);
 
 Status nonempty_domain_serialize(
     const Array* array,
@@ -131,7 +129,7 @@ Status max_buffer_sizes_serialize(
     Buffer* serialized_buffer);
 
 Status max_buffer_sizes_deserialize(
-    const ArraySchema* schema,
+    const ArraySchema& schema,
     const Buffer& serialized_buffer,
     SerializationType serialize_type,
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -405,7 +405,7 @@ Status serialize_non_empty_domain(CapnpT& builder, tiledb::sm::Array* array) {
     const auto& nonEmptyDomain = nonEmptyDomain_opt.value();
     if (!nonEmptyDomain.empty()) {
       auto nonEmptyDomainListBuilder =
-          builder.initNonEmptyDomains(array->array_schema_latest()->dim_num());
+          builder.initNonEmptyDomains(array->array_schema_latest().dim_num());
 
       for (uint64_t dimIdx = 0; dimIdx < nonEmptyDomain.size(); ++dimIdx) {
         const auto& dimNonEmptyDomain = nonEmptyDomain[dimIdx];
@@ -487,16 +487,16 @@ Status deserialize_non_empty_domain(CapnpT& reader, tiledb::sm::Array* array) {
 template <typename CapnpT>
 Status serialize_subarray(
     CapnpT& builder,
-    const tiledb::sm::ArraySchema* array_schema,
+    const tiledb::sm::ArraySchema& array_schema,
     const void* subarray) {
   // Check coords type
-  auto dim_num = array_schema->dim_num();
+  auto dim_num = array_schema.dim_num();
   uint64_t subarray_size = 0;
-  Datatype first_dimension_datatype = array_schema->dimension(0)->type();
+  Datatype first_dimension_datatype = array_schema.dimension(0)->type();
   // If all the dimensions are the same datatype, then we will store the
   // subarray in a type array for <=1.7 compatibility
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dimension = array_schema->dimension(d);
+    auto dimension = array_schema.dimension(d);
     const auto coords_type = dimension->type();
 
     if (coords_type != first_dimension_datatype) {
@@ -534,14 +534,14 @@ Status serialize_subarray(
 template <typename CapnpT>
 Status deserialize_subarray(
     const CapnpT& reader,
-    const tiledb::sm::ArraySchema* array_schema,
+    const tiledb::sm::ArraySchema& array_schema,
     void** subarray) {
   // Check coords type
-  auto dim_num = array_schema->dim_num();
+  auto dim_num = array_schema.dim_num();
   uint64_t subarray_size = 0;
-  Datatype first_dimension_datatype = array_schema->dimension(0)->type();
+  Datatype first_dimension_datatype = array_schema.dimension(0)->type();
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dimension = array_schema->dimension(d);
+    auto dimension = array_schema.dimension(d);
     const auto coords_type = dimension->type();
 
     if (coords_type != first_dimension_datatype) {

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -305,7 +305,7 @@ class Consolidator {
    * @return Status
    */
   Status create_buffers(
-      const ArraySchema* array_schema,
+      const ArraySchema& array_schema,
       std::vector<ByteVec>* buffers,
       std::vector<uint64_t>* buffer_sizes);
 
@@ -345,7 +345,7 @@ class Consolidator {
    * @return Status
    */
   Status compute_next_to_consolidate(
-      const ArraySchema* array_schema,
+      const ArraySchema& array_schema,
       const FragmentInfo& fragment_info,
       std::vector<TimestampedURI>* to_consolidate,
       NDRange* union_non_empty_domains) const;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1449,14 +1449,18 @@ tuple<
     optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
 StorageManager::load_array_schemas(
     const ArrayDirectory& array_dir, const EncryptionKey& encryption_key) {
-  auto&& [st1, array_schema] =
-      load_array_schema_latest(array_dir, encryption_key);
-  RETURN_NOT_OK_TUPLE(st1, nullopt, nullopt);
+  // Load all array schemas
+  auto&& [st, array_schemas] =
+      load_all_array_schemas(array_dir, encryption_key);
+  RETURN_NOT_OK_TUPLE(st, nullopt, nullopt);
 
-  auto&& [st2, schemas] = load_all_array_schemas(array_dir, encryption_key);
-  RETURN_NOT_OK_TUPLE(st2, nullopt, nullopt);
+  // Locate the latest array schema
+  const auto& array_schema_latest_name =
+      array_dir.latest_array_schema_uri().last_path_part();
+  auto it = array_schemas->find(array_schema_latest_name);
+  assert(it != array_schemas->end());
 
-  return {Status::Ok(), array_schema, schemas};
+  return {Status::Ok(), it->second, array_schemas};
 }
 
 tuple<

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -168,7 +168,7 @@ class StorageManager {
    */
   tuple<
       Status,
-      optional<ArraySchema*>,
+      optional<shared_ptr<ArraySchema>>,
       optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
       optional<std::vector<shared_ptr<FragmentMetadata>>>>
   load_array_schemas_and_fragment_metadata(
@@ -195,7 +195,7 @@ class StorageManager {
    */
   tuple<
       Status,
-      optional<ArraySchema*>,
+      optional<shared_ptr<ArraySchema>>,
       optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
       optional<std::vector<shared_ptr<FragmentMetadata>>>>
   array_open_for_reads(Array* array);
@@ -212,7 +212,7 @@ class StorageManager {
    */
   tuple<
       Status,
-      optional<ArraySchema*>,
+      optional<shared_ptr<ArraySchema>>,
       optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
   array_open_for_reads_without_fragments(Array* array);
 
@@ -227,7 +227,7 @@ class StorageManager {
    */
   tuple<
       Status,
-      optional<ArraySchema*>,
+      optional<shared_ptr<ArraySchema>>,
       optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
   array_open_for_writes(Array* array);
 
@@ -257,7 +257,7 @@ class StorageManager {
    */
   tuple<
       Status,
-      optional<ArraySchema*>,
+      optional<shared_ptr<ArraySchema>>,
       optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
       optional<std::vector<shared_ptr<FragmentMetadata>>>>
   array_reopen(Array* array);
@@ -356,7 +356,7 @@ class StorageManager {
    */
   Status array_create(
       const URI& array_uri,
-      ArraySchema* array_schema,
+      const shared_ptr<ArraySchema>& array_schema,
       const EncryptionKey& encryption_key);
 
   /**
@@ -619,15 +619,11 @@ class StorageManager {
    * Loads the schema of a schema uri from persistent storage into memory.
    *
    * @param array_schema_uri The URI path of the array schema.
-   * @param array_uri The URI path of the array.
    * @param encryption_key The encryption key to use.
-   * @param array_schema The array schema to be retrieved.
-   * @return Status
+   * @return Status, the loaded array schema
    */
-  Status load_array_schema_from_uri(
-      const URI& array_schema_uri,
-      const EncryptionKey& encryption_key,
-      ArraySchema** array_schema);
+  tuple<Status, optional<shared_ptr<ArraySchema>>> load_array_schema_from_uri(
+      const URI& array_schema_uri, const EncryptionKey& encryption_key);
 
   /**
    * Loads the latest schema of an array from persistent storage into memory.
@@ -635,13 +631,10 @@ class StorageManager {
    * @param array_dir The ArrayDirectory object used to retrieve the
    *     various URIs in the array directory.
    * @param encryption_key The encryption key to use.
-   * @param array_schema The array schema to be retrieved.
-   * @return Status
+   * @return Status, a new ArraySchema
    */
-  Status load_array_schema_latest(
-      const ArrayDirectory& array_dir,
-      const EncryptionKey& encryption_key,
-      ArraySchema** array_schema);
+  tuple<Status, optional<shared_ptr<ArraySchema>>> load_array_schema_latest(
+      const ArrayDirectory& array_dir, const EncryptionKey& encryption_key);
 
   /**
    * It loads and returns the latest schema and all the array schemas
@@ -657,7 +650,7 @@ class StorageManager {
    */
   tuple<
       Status,
-      optional<ArraySchema*>,
+      optional<shared_ptr<ArraySchema>>,
       optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
   load_array_schemas(
       const ArrayDirectory& array_dir, const EncryptionKey& encryption_key);
@@ -857,7 +850,8 @@ class StorageManager {
    * @return Status
    */
   Status store_array_schema(
-      ArraySchema* array_schema, const EncryptionKey& encryption_key);
+      const shared_ptr<ArraySchema>& array_schema,
+      const EncryptionKey& encryption_key);
 
   /**
    * Stores the array metadata into persistent storage.
@@ -1061,7 +1055,7 @@ class StorageManager {
   tuple<Status, optional<std::vector<shared_ptr<FragmentMetadata>>>>
   load_fragment_metadata(
       MemoryTracker* memory_tracker,
-      ArraySchema* array_schema_latest,
+      const shared_ptr<const ArraySchema>& array_schema,
       const std::unordered_map<std::string, shared_ptr<ArraySchema>>&
           array_schemas_all,
       const EncryptionKey& encryption_key,

--- a/tiledb/sm/subarray/cell_slab_iter.cc
+++ b/tiledb/sm/subarray/cell_slab_iter.cc
@@ -62,9 +62,9 @@ CellSlabIter<T>::CellSlabIter(const Subarray* subarray)
     : subarray_(subarray) {
   end_ = true;
   if (subarray != nullptr) {
-    auto array_schema = subarray->array()->array_schema_latest();
-    auto dim_num = array_schema->dim_num();
-    auto coord_size = array_schema->dimension(0)->coord_size();
+    const auto& array_schema = subarray->array()->array_schema_latest();
+    auto dim_num = array_schema.dim_num();
+    auto coord_size = array_schema.dimension(0)->coord_size();
     aux_tile_coords_.resize(dim_num);
     aux_tile_coords_2_.resize(dim_num * coord_size);
   }
@@ -245,8 +245,8 @@ template <class T>
 Status CellSlabIter<T>::init_ranges() {
   // For easy reference
   auto dim_num = subarray_->dim_num();
-  auto array_schema = subarray_->array()->array_schema_latest();
-  auto array_domain = array_schema->domain()->domain();
+  const auto& array_schema = subarray_->array()->array_schema_latest();
+  auto array_domain = array_schema.domain()->domain();
   uint64_t range_num;
   T tile_extent, dim_domain_start;
   const tiledb::sm::Range* r;
@@ -256,7 +256,7 @@ Status CellSlabIter<T>::init_ranges() {
     auto dim_dom = (const T*)array_domain[d].data();
     RETURN_NOT_OK(subarray_->get_range_num(d, &range_num));
     ranges_[d].reserve(range_num);
-    tile_extent = *(const T*)array_schema->domain()->tile_extent(d).data();
+    tile_extent = *(const T*)array_schema.domain()->tile_extent(d).data();
     dim_domain_start = dim_dom[0];
     for (uint64_t j = 0; j < range_num; ++j) {
       RETURN_NOT_OK(subarray_->get_range(d, j, &r));
@@ -281,8 +281,8 @@ Status CellSlabIter<T>::sanity_check() const {
 
   // Check type
   bool error;
-  auto array_schema = subarray_->array()->array_schema_latest();
-  auto type = array_schema->domain()->dimension(0)->type();
+  const auto& array_schema = subarray_->array()->array_schema_latest();
+  auto type = array_schema.domain()->dimension(0)->type();
   switch (type) {
     case Datatype::INT8:
       error = !std::is_same<T, int8_t>::value;

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -461,7 +461,7 @@ class Subarray {
    * @return Status
    */
   Status compute_relevant_fragment_est_result_sizes(
-      const ArraySchema* array_schema,
+      const ArraySchema& array_schema,
       bool all_dims_same_type,
       bool all_dims_fixed,
       const std::vector<tdb_shared_ptr<FragmentMetadata>>& fragment_meta,

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -160,9 +160,9 @@ Status SubarrayPartitioner::get_result_budget(
         "Cannot get result budget; Invalid budget input"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  bool is_dim = array_schema->is_dim(name);
-  bool is_attr = array_schema->is_attr(name);
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  bool is_dim = array_schema.is_dim(name);
+  bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
@@ -171,13 +171,13 @@ Status SubarrayPartitioner::get_result_budget(
         name + "'"));
 
   // Check if the attribute/dimension is fixed-sized
-  if (array_schema->var_size(name))
+  if (array_schema.var_size(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute/dimension '") +
         name + "' is var-sized"));
 
   // Check if the attribute is nullable
-  if (array_schema->is_nullable(name))
+  if (array_schema.is_nullable(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute/dimension '") +
         name + "' is nullable"));
@@ -215,9 +215,9 @@ Status SubarrayPartitioner::get_result_budget(
         "must be var-sized"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  bool is_dim = array_schema->is_dim(name);
-  bool is_attr = array_schema->is_attr(name);
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  bool is_dim = array_schema.is_dim(name);
+  bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute/dimension exists
   if (!is_dim && !is_attr)
@@ -226,13 +226,13 @@ Status SubarrayPartitioner::get_result_budget(
         name + "'"));
 
   // Check if the attribute/dimension is var-sized
-  if (!array_schema->var_size(name))
+  if (!array_schema.var_size(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute/dimension '") +
         name + "' is fixed-sized"));
 
   // Check if the attribute is nullable
-  if (array_schema->is_nullable(name))
+  if (array_schema.is_nullable(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute/dimension '") +
         name + "' is nullable"));
@@ -265,8 +265,8 @@ Status SubarrayPartitioner::get_result_budget_nullable(
         "Cannot get result budget; Invalid budget input"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  bool is_attr = array_schema->is_attr(name);
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute exists
   if (!is_attr)
@@ -275,13 +275,13 @@ Status SubarrayPartitioner::get_result_budget_nullable(
         "'"));
 
   // Check if the attribute is fixed-sized
-  if (array_schema->var_size(name))
+  if (array_schema.var_size(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute '") + name +
         "' is var-sized"));
 
   // Check if the attribute is nullable
-  if (!array_schema->is_nullable(name))
+  if (!array_schema.is_nullable(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute '") + name +
         "' is not nullable"));
@@ -318,8 +318,8 @@ Status SubarrayPartitioner::get_result_budget_nullable(
         "Cannot get result budget; Invalid budget input"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  bool is_attr = array_schema->is_attr(name);
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute exists
   if (!is_attr)
@@ -328,13 +328,13 @@ Status SubarrayPartitioner::get_result_budget_nullable(
         "'"));
 
   // Check if the attribute is var-sized
-  if (!array_schema->var_size(name))
+  if (!array_schema.var_size(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute '") + name +
         "' is fixed-sized"));
 
   // Check if the attribute is nullable
-  if (!array_schema->is_nullable(name))
+  if (!array_schema.is_nullable(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Input attribute '") + name +
         "' is not nullable"));
@@ -420,9 +420,9 @@ Status SubarrayPartitioner::set_result_budget(
         "Cannot set result budget; Attribute/Dimension name cannot be null"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  bool is_dim = array_schema->is_dim(name);
-  bool is_attr = array_schema->is_attr(name);
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  bool is_dim = array_schema.is_dim(name);
+  bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr)
@@ -431,14 +431,14 @@ Status SubarrayPartitioner::set_result_budget(
         name + "'"));
 
   // Check if the attribute/dimension is fixed-sized
-  bool var_size = (name != constants::coords && array_schema->var_size(name));
+  bool var_size = (name != constants::coords && array_schema.var_size(name));
   if (var_size)
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute/dimension '") +
         name + "' is var-sized"));
 
   // Check if the attribute/dimension is nullable
-  bool nullable = array_schema->is_nullable(name);
+  bool nullable = array_schema.is_nullable(name);
   if (nullable)
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute/dimension '") +
@@ -462,9 +462,9 @@ Status SubarrayPartitioner::set_result_budget(
         "must be var-sized"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  bool is_dim = array_schema->is_dim(name);
-  bool is_attr = array_schema->is_attr(name);
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  bool is_dim = array_schema.is_dim(name);
+  bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute/dimension exists
   if (!is_dim && !is_attr)
@@ -473,13 +473,13 @@ Status SubarrayPartitioner::set_result_budget(
         name + "'"));
 
   // Check if the attribute/dimension is var-sized
-  if (!array_schema->var_size(name))
+  if (!array_schema.var_size(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute/dimension '") +
         name + "' is fixed-sized"));
 
   // Check if the attribute/dimension is nullable
-  bool nullable = array_schema->is_nullable(name);
+  bool nullable = array_schema.is_nullable(name);
   if (nullable)
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute/dimension '") +
@@ -498,8 +498,8 @@ Status SubarrayPartitioner::set_result_budget_nullable(
         "Cannot set result budget; Attribute name cannot be null"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  bool is_attr = array_schema->is_attr(name);
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute exists
   if (!is_attr)
@@ -508,14 +508,14 @@ Status SubarrayPartitioner::set_result_budget_nullable(
         "'"));
 
   // Check if the attribute is fixed-sized
-  bool var_size = array_schema->var_size(name);
+  bool var_size = array_schema.var_size(name);
   if (var_size)
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute '") + name +
         "' is var-sized"));
 
   // Check if the attribute is nullable
-  bool nullable = array_schema->is_nullable(name);
+  bool nullable = array_schema.is_nullable(name);
   if (!nullable)
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute '") + name +
@@ -537,8 +537,8 @@ Status SubarrayPartitioner::set_result_budget_nullable(
         "Cannot set result budget; Attribute name cannot be null"));
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  bool is_attr = array_schema->is_attr(name);
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute exists
   if (!is_attr)
@@ -547,13 +547,13 @@ Status SubarrayPartitioner::set_result_budget_nullable(
         "'"));
 
   // Check if the attribute is var-sized
-  if (!array_schema->var_size(name))
+  if (!array_schema.var_size(name))
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute '") + name +
         "' is fixed-sized"));
 
   // Check if the attribute is nullable
-  bool nullable = array_schema->is_nullable(name);
+  bool nullable = array_schema.is_nullable(name);
   if (!nullable)
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Input attribute '") + name +
@@ -673,7 +673,7 @@ Status SubarrayPartitioner::calibrate_current_start_end(bool* must_split_slab) {
   }
 
   auto layout = subarray_.layout();
-  auto cell_order = subarray_.array()->array_schema_latest()->cell_order();
+  auto cell_order = subarray_.array()->array_schema_latest().cell_order();
   cell_order = (cell_order == Layout::HILBERT) ? Layout::ROW_MAJOR : cell_order;
   layout = (layout == Layout::UNORDERED) ? cell_order : layout;
   assert(layout == Layout::ROW_MAJOR || layout == Layout::COL_MAJOR);
@@ -881,13 +881,13 @@ void SubarrayPartitioner::compute_splitting_value_on_tiles(
   *unsplittable = true;
 
   // Inapplicable to Hilbert cell order
-  if (subarray_.array()->array_schema_latest()->cell_order() == Layout::HILBERT)
+  if (subarray_.array()->array_schema_latest().cell_order() == Layout::HILBERT)
     return;
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  auto dim_num = subarray_.array()->array_schema_latest()->dim_num();
-  auto layout = subarray_.array()->array_schema_latest()->tile_order();
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  auto dim_num = array_schema.dim_num();
+  auto layout = array_schema.tile_order();
   *splitting_dim = UINT32_MAX;
 
   std::vector<unsigned> dims;
@@ -902,7 +902,7 @@ void SubarrayPartitioner::compute_splitting_value_on_tiles(
   // Compute splitting dimension and value
   const Range* r;
   for (auto d : dims) {
-    auto dim = array_schema->domain()->dimension(d);
+    auto dim = array_schema.domain()->dimension(d);
     range.get_range(d, 0, &r);
     auto tiles_apart = dim->tile_num(*r) - 1;
     if (tiles_apart != 0) {
@@ -939,9 +939,9 @@ void SubarrayPartitioner::compute_splitting_value_single_range(
   }
 
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  auto dim_num = array_schema->dim_num();
-  auto cell_order = array_schema->cell_order();
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  auto dim_num = array_schema.dim_num();
+  auto cell_order = array_schema.cell_order();
   assert(!range.is_unary());
   auto layout = subarray_.layout();
   if (layout == Layout::UNORDERED && cell_order == Layout::HILBERT) {
@@ -975,7 +975,7 @@ void SubarrayPartitioner::compute_splitting_value_single_range(
   // Compute splitting dimension and value
   const Range* r;
   for (auto d : dims) {
-    auto dim = array_schema->dimension(d);
+    auto dim = array_schema.dimension(d);
     range.get_range(d, 0, &r);
     if (!r->unary()) {
       *splitting_dim = d;
@@ -999,8 +999,8 @@ void SubarrayPartitioner::compute_splitting_value_single_range_hilbert(
     bool* normal_order,
     bool* unsplittable) {
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  auto dim_num = array_schema->dim_num();
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  auto dim_num = array_schema.dim_num();
   Hilbert h(dim_num);
 
   // Compute the uint64 mapping of the range (bits properly shifted)
@@ -1019,7 +1019,7 @@ void SubarrayPartitioner::compute_splitting_value_single_range_hilbert(
       range_uint64[*splitting_dim], *splitting_dim, splitting_value);
 
   // Check for unsplittable again
-  auto dim = array_schema->dimension(*splitting_dim);
+  auto dim = array_schema.dimension(*splitting_dim);
   const Range* r;
   range.get_range(*splitting_dim, 0, &r);
   if (dim->smaller_than(*splitting_value, *r)) {
@@ -1060,11 +1060,11 @@ Status SubarrayPartitioner::compute_splitting_value_multi_range(
 
   // Multi-range partition
   auto layout = subarray_.layout();
-  auto array_schema = subarray_.array()->array_schema_latest();
-  auto dim_num = array_schema->dim_num();
-  auto cell_order = (array_schema->cell_order() == Layout::HILBERT) ?
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  auto dim_num = array_schema.dim_num();
+  auto cell_order = (array_schema.cell_order() == Layout::HILBERT) ?
                         Layout::ROW_MAJOR :
-                        array_schema->cell_order();
+                        array_schema.cell_order();
   layout = (layout == Layout::UNORDERED) ? cell_order : layout;
   *splitting_dim = UINT32_MAX;
   uint64_t range_num;
@@ -1093,7 +1093,7 @@ Status SubarrayPartitioner::compute_splitting_value_multi_range(
 
     // Check if we need to split single range
     partition.get_range(d, 0, &r);
-    auto dim = array_schema->dimension(d);
+    auto dim = array_schema.dimension(d);
     if (!r->unary()) {
       *splitting_dim = d;
       dim->splitting_value(*r, splitting_value, unsplittable);
@@ -1106,7 +1106,7 @@ Status SubarrayPartitioner::compute_splitting_value_multi_range(
 }
 
 bool SubarrayPartitioner::must_split(Subarray* partition) {
-  auto array_schema = subarray_.array()->array_schema_latest();
+  const auto& array_schema = subarray_.array()->array_schema_latest();
   bool must_split = false;
 
   uint64_t size_fixed;
@@ -1118,8 +1118,8 @@ bool SubarrayPartitioner::must_split(Subarray* partition) {
   for (const auto& b : budget_) {
     // Compute max sizes
     auto name = b.first;
-    auto var_size = array_schema->var_size(name);
-    auto nullable = array_schema->is_nullable(name);
+    auto var_size = array_schema.var_size(name);
+    auto nullable = array_schema.is_nullable(name);
 
     // Compute est sizes
     size_fixed = 0;
@@ -1365,8 +1365,8 @@ void SubarrayPartitioner::compute_range_uint64(
     std::vector<std::array<uint64_t, 2>>* range_uint64,
     bool* unsplittable) const {
   // Initializations
-  auto array_schema = subarray_.array()->array_schema_latest();
-  auto dim_num = array_schema->dim_num();
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  auto dim_num = array_schema.dim_num();
   const Range* r;
   *unsplittable = true;
   range_uint64->resize(dim_num);
@@ -1380,7 +1380,7 @@ void SubarrayPartitioner::compute_range_uint64(
   // Calculate mapped range
   bool empty_start, empty_end;
   for (uint32_t d = 0; d < dim_num; ++d) {
-    auto dim = array_schema->dimension(d);
+    auto dim = array_schema.dimension(d);
     auto var = dim->var_size();
     range.get_range(d, 0, &r);
     empty_start = var ? (r->start_size() == 0) : r->empty();
@@ -1410,8 +1410,8 @@ void SubarrayPartitioner::compute_splitting_dim_hilbert(
     const std::vector<std::array<uint64_t, 2>>& range_uint64,
     uint32_t* splitting_dim) const {
   // For easy reference
-  auto array_schema = subarray_.array()->array_schema_latest();
-  auto dim_num = array_schema->dim_num();
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  auto dim_num = array_schema.dim_num();
 
   // Prepare candidate splitting dimensions
   std::set<uint32_t> splitting_dims;
@@ -1484,8 +1484,8 @@ void SubarrayPartitioner::compute_splitting_value_hilbert(
     const std::array<uint64_t, 2>& range_uint64,
     uint32_t splitting_dim,
     ByteVecValue* splitting_value) const {
-  auto array_schema = subarray_.array()->array_schema_latest();
-  auto dim_num = array_schema->dim_num();
+  const auto& array_schema = subarray_.array()->array_schema_latest();
+  auto dim_num = array_schema.dim_num();
   uint64_t splitting_value_uint64 = range_uint64[0];  // Splitting value
   if (range_uint64[0] + 1 != range_uint64[1]) {
     uint64_t left_p2_m1, right_p2_m1;  // Left/right powers of 2 minus 1
@@ -1525,6 +1525,6 @@ void SubarrayPartitioner::compute_splitting_value_hilbert(
   auto max_bucket_val = ((uint64_t)1 << bits) - 1;
 
   *splitting_value =
-      array_schema->dimension(splitting_dim)
+      array_schema.dimension(splitting_dim)
           ->map_from_uint64(splitting_value_uint64, bits, max_bucket_val);
 }

--- a/tools/src/commands/info_command.cc
+++ b/tools/src/commands/info_command.cc
@@ -132,9 +132,9 @@ void InfoCommand::print_tile_sizes() const {
   EncryptionKey enc_key;
 
   // Compute and report mean persisted tile sizes over all attributes.
-  const auto* schema = array.array_schema_latest();
+  const auto& schema = array.array_schema_latest();
   auto fragment_metadata = array.fragment_metadata();
-  auto attributes = schema->attributes();
+  auto attributes = schema.attributes();
   uint64_t total_persisted_size = 0, total_in_memory_size = 0;
 
   // Helper function for processing each attribute.
@@ -180,7 +180,7 @@ void InfoCommand::print_tile_sizes() const {
   std::cout << "Tile stats (per attribute):" << std::endl;
 
   // Dump info about coords for sparse arrays.
-  if (!schema->dense())
+  if (!schema.dense())
     process_attr(constants::coords, false);
 
   // Dump info about the rest of the attributes
@@ -208,7 +208,7 @@ void InfoCommand::print_schema_info() const {
   THROW_NOT_OK(
       array.open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0));
 
-  array.array_schema_latest()->dump(stdout);
+  array.array_schema_latest().dump(stdout);
 
   // Close the array.
   THROW_NOT_OK(array.close());
@@ -226,8 +226,8 @@ void InfoCommand::write_svg_mbrs() const {
   THROW_NOT_OK(
       array.open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0));
 
-  const auto* schema = array.array_schema_latest();
-  auto dim_num = schema->dim_num();
+  const auto& schema = array.array_schema_latest();
+  auto dim_num = schema.dim_num();
   if (dim_num < 2) {
     THROW_NOT_OK(array.close());
     throw std::runtime_error("SVG MBRs only supported for >1D arrays.");
@@ -242,7 +242,7 @@ void InfoCommand::write_svg_mbrs() const {
   for (const auto& f : fragment_metadata) {
     const auto& mbrs = f->mbrs();
     for (const auto& mbr : mbrs) {
-      auto tup = get_mbr(mbr, schema->domain());
+      auto tup = get_mbr(mbr, schema.domain());
       min_x = std::min(min_x, std::get<0>(tup));
       min_y = std::min(min_y, std::get<1>(tup));
       max_x = std::max(max_x, std::get<0>(tup) + std::get<2>(tup));
@@ -303,15 +303,15 @@ void InfoCommand::write_text_mbrs() const {
       array.open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0));
 
   auto encryption_key = array.encryption_key();
-  const auto* schema = array.array_schema_latest();
-  auto dim_num = schema->dim_num();
+  const auto& schema = array.array_schema_latest();
+  auto dim_num = schema.dim_num();
   auto fragment_metadata = array.fragment_metadata();
   std::stringstream text;
   for (const auto& f : fragment_metadata) {
     f->load_rtree(*encryption_key);
     const auto& mbrs = f->mbrs();
     for (const auto& mbr : mbrs) {
-      auto str_mbr = mbr_to_string(mbr, schema->domain());
+      auto str_mbr = mbr_to_string(mbr, schema.domain());
       for (unsigned i = 0; i < dim_num; i++) {
         text << str_mbr[2 * i + 0] << "," << str_mbr[2 * i + 1];
         if (i < dim_num - 1)


### PR DESCRIPTION
The motivation for this PR is to avoid fetching the latest array schema twice, as well as for code cleanup purposes. 

We were fetching the latest array schema twice because of legacy code that was using raw `ArraySchema*` pointers for the latest array schema everywhere, and smart pointers for the multiple array schemas used for versioning. This PR switches from using raw array schema pointers to shared pointers wherever possible. It also fetches the latest array schema once, by grabbing it from the versioned array schemas that are loaded anyway. 

---
TYPE: IMPROVEMENT
DESC: Switch to smart pointers and const references for `ArraySchema`, and avoid fetching the latest array schema twice.
