### PR TITLE
Sparse unordered w/ dups reader: fixing memory management for tiles.

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -58,7 +58,6 @@ struct CSparseUnorderedWithDupsFx {
   std::string temp_dir_;
   std::string array_name_;
   const char* ARRAY_NAME = "test_sparse_unordered_with_dups";
-  tiledb_array_t* array_ = nullptr;
   std::string total_budget_;
   std::string ratio_tile_ranges_;
   std::string ratio_array_data_;
@@ -107,7 +106,6 @@ CSparseUnorderedWithDupsFx::CSparseUnorderedWithDupsFx() {
 }
 
 CSparseUnorderedWithDupsFx::~CSparseUnorderedWithDupsFx() {
-  tiledb_array_free(&array_);
   remove_dir(temp_dir_, ctx_, vfs_);
   tiledb_ctx_free(&ctx_);
   tiledb_vfs_free(&vfs_);
@@ -417,11 +415,13 @@ struct CSparseUnorderedWithDupsVarDataFx {
   std::string temp_dir_;
   std::string array_name_;
   const char* ARRAY_NAME = "test_sparse_unordered_with_dups_var_data";
-  tiledb_array_t* array_ = nullptr;
 
   void create_default_array_2d();
   void write_2d_fragment();
   void read_and_check_data(bool set_subarray);
+
+  tuple<tiledb_array_t*, std::vector<tdb_shared_ptr<FragmentMetadata>>>
+  open_default_array_1d_with_fragments();
 
   CSparseUnorderedWithDupsVarDataFx();
   ~CSparseUnorderedWithDupsVarDataFx();
@@ -448,7 +448,6 @@ CSparseUnorderedWithDupsVarDataFx::CSparseUnorderedWithDupsVarDataFx() {
 }
 
 CSparseUnorderedWithDupsVarDataFx::~CSparseUnorderedWithDupsVarDataFx() {
-  tiledb_array_free(&array_);
   remove_dir(temp_dir_, ctx_, vfs_);
   tiledb_ctx_free(&ctx_);
   tiledb_vfs_free(&vfs_);
@@ -597,6 +596,49 @@ void CSparseUnorderedWithDupsVarDataFx::read_and_check_data(bool set_subarray) {
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+}
+
+tuple<tiledb_array_t*, std::vector<tdb_shared_ptr<FragmentMetadata>>>
+CSparseUnorderedWithDupsVarDataFx::open_default_array_1d_with_fragments() {
+  int64_t domain[] = {1, 10};
+  int64_t tile_extent = 5;
+  // Create array
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_SPARSE,
+      {"d"},
+      {TILEDB_INT64},
+      {domain},
+      {&tile_extent},
+      {"a"},
+      {TILEDB_STRING_ASCII},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      5);
+
+  // Open array for writing.
+  tiledb_array_t* array;
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
+  tdb_shared_ptr<FragmentMetadata> fragment =
+      tdb::make_shared<FragmentMetadata>(
+          HERE(),
+          nullptr,
+          nullptr,
+          array->array_->array_schema_latest(),
+          URI(),
+          std::make_pair<uint64_t, uint64_t>(0, 0),
+          true);
+  fragments.emplace_back(std::move(fragment));
+
+  return {array, std::move(fragments)};
 }
 
 /* ********************************* */
@@ -1254,34 +1296,17 @@ TEST_CASE_METHOD(
   read_and_check_data(use_subarray);
 }
 
-/** Make a tile that will return num_cells when cell_num() is called. */
-ResultTileWithBitmap<uint64_t> make_tile(uint64_t num_cells) {
-  Domain domain;
-  Dimension dim("d", Datatype::UINT8);
-  uint8_t bounds[2] = {1, 10};
-  Range range(bounds, 2 * sizeof(uint8_t));
-  REQUIRE(dim.set_domain(range).ok());
-  REQUIRE(domain.add_dimension(&dim).ok());
-
-  ArraySchema array_schema;
-  REQUIRE(array_schema.set_domain(&domain).ok());
-  ResultTileWithBitmap<uint64_t> result_tile(0, 0, array_schema);
-  result_tile.init_coord_tile("a", 0);
-  auto tuple = result_tile.tile_tuple("a");
-  REQUIRE(std::get<0>(*tuple)
-              .init_unfiltered(0, Datatype::UINT8, num_cells, 1, 1, true)
-              .ok());
-
-  return result_tile;
-}
-
-TEST_CASE(
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsVarDataFx,
     "Sparse unordered with dups reader: test compute_var_size_offsets",
     "[sparse-unordered-with-dups][compute_var_size_offsets]") {
+  auto&& [array, fragments] = open_default_array_1d_with_fragments();
+
   // Make a vector of tiles.
-  auto tile = make_tile(5);
+  ResultTileWithBitmap<uint64_t> result_tile(
+      0, 0, array->array_->array_schema_latest());
   std::vector<ResultTileWithBitmap<uint64_t>> rt;
-  rt.push_back(std::move(tile));
+  rt.push_back(std::move(result_tile));
 
   SECTION("- No bitmap") {
   }
@@ -1301,7 +1326,7 @@ TEST_CASE(
   uint64_t offset = 0;
   for (uint64_t i = 0; i < rt.size(); i++) {
     cell_offsets[i] = offset;
-    offset += rt[i].cell_num();
+    offset += 5;
   }
   cell_offsets[rt.size()] = offset;
 
@@ -1321,6 +1346,7 @@ TEST_CASE(
       SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
           uint64_t>(
           &tiledb::test::g_helper_stats,
+          fragments,
           result_tiles,
           0,
           cell_offsets,
@@ -1331,16 +1357,24 @@ TEST_CASE(
   CHECK(cell_offsets[1] == 3);
   CHECK(result_tiles_size == 1);
   CHECK(var_buffer_size == 6);
+
+  // Clean up.
+  REQUIRE(tiledb_array_close(ctx_, array) == TILEDB_OK);
+  tiledb_array_free(&array);
 }
 
-TEST_CASE(
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsVarDataFx,
     "Sparse unordered with dups reader: test compute_var_size_offsets count "
     "bitmap",
     "[sparse-unordered-with-dups][compute_var_size_offsets][count-bitmap]") {
+  auto&& [array, fragments] = open_default_array_1d_with_fragments();
+
   // Make a vector of tiles.
-  auto tile = make_tile(5);
+  ResultTileWithBitmap<uint64_t> result_tile(
+      0, 0, array->array_->array_schema_latest());
   std::vector<ResultTileWithBitmap<uint64_t>> rt;
-  rt.push_back(std::move(tile));
+  rt.push_back(std::move(result_tile));
   rt[0].bitmap_.resize(5);
   rt[0].bitmap_ = {0, 1, 2, 0, 2};
 
@@ -1355,7 +1389,7 @@ TEST_CASE(
   uint64_t offset = 0;
   for (uint64_t i = 0; i < rt.size(); i++) {
     cell_offsets[i] = offset;
-    offset += rt[i].cell_num();
+    offset += 5;
   }
   cell_offsets[rt.size()] = offset;
 
@@ -1374,6 +1408,7 @@ TEST_CASE(
       SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
           uint64_t>(
           &tiledb::test::g_helper_stats,
+          fragments,
           result_tiles,
           0,
           cell_offsets,
@@ -1384,16 +1419,24 @@ TEST_CASE(
   CHECK(cell_offsets[1] == 3);
   CHECK(result_tiles_size == 1);
   CHECK(var_buffer_size == 6);
+
+  // Clean up.
+  REQUIRE(tiledb_array_close(ctx_, array) == TILEDB_OK);
+  tiledb_array_free(&array);
 }
 
-TEST_CASE(
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsVarDataFx,
     "Sparse unordered with dups reader: test compute_var_size_offsets "
     "continuation",
     "[sparse-unordered-with-dups][compute_var_size_offsets][continuation]") {
+  auto&& [array, fragments] = open_default_array_1d_with_fragments();
+
   // Make a vector of tiles.
-  auto tile = make_tile(5);
+  ResultTileWithBitmap<uint64_t> result_tile(
+      0, 0, array->array_->array_schema_latest());
   std::vector<ResultTileWithBitmap<uint64_t>> rt;
-  rt.push_back(std::move(tile));
+  rt.push_back(std::move(result_tile));
 
   SECTION("- No bitmap") {
   }
@@ -1413,7 +1456,7 @@ TEST_CASE(
   uint64_t offset = 0;
   for (uint64_t i = 0; i < rt.size(); i++) {
     cell_offsets[i] = offset;
-    offset += rt[i].cell_num() - 2;
+    offset += 3;
   }
   cell_offsets[rt.size()] = offset;
 
@@ -1432,6 +1475,7 @@ TEST_CASE(
       SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
           uint64_t>(
           &tiledb::test::g_helper_stats,
+          fragments,
           result_tiles,
           2,
           cell_offsets,
@@ -1442,6 +1486,10 @@ TEST_CASE(
   CHECK(cell_offsets[1] == 2);
   CHECK(result_tiles_size == 1);
   CHECK(var_buffer_size == 4);
+
+  // Clean up.
+  REQUIRE(tiledb_array_close(ctx_, array) == TILEDB_OK);
+  tiledb_array_free(&array);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -632,7 +632,7 @@ CSparseUnorderedWithDupsVarDataFx::open_default_array_1d_with_fragments() {
           HERE(),
           nullptr,
           nullptr,
-          array->array_->array_schema_latest(),
+          array->array_->array_schema_latest_ptr(),
           URI(),
           std::make_pair<uint64_t, uint64_t>(0, 0),
           true);

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -143,9 +143,11 @@ void ReaderBase::compute_result_space_tiles(
 
 void ReaderBase::clear_tiles(
     const std::string& name,
-    const std::vector<ResultTile*>& result_tiles) const {
-  for (auto& result_tile : result_tiles)
-    result_tile->erase_tile(name);
+    const std::vector<ResultTile*>& result_tiles,
+    const uint64_t min_result_tile) const {
+  for (uint64_t i = min_result_tile; i < result_tiles.size(); i++) {
+    result_tiles[i]->erase_tile(name);
+  }
 }
 
 void ReaderBase::reset_buffer_sizes() {

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -171,11 +171,13 @@ class ReaderBase : public StrategyBase {
    *
    * @param name The attribute/dimension name.
    * @param result_tiles The result tiles to delete from.
+   * @param min_result_tile The minimum index to start clearing tiles at.
    * @return void
    */
   void clear_tiles(
       const std::string& name,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<ResultTile*>& result_tiles,
+      const uint64_t min_result_tile = 0) const;
 
   /**
    * Resets the buffer sizes to the original buffer sizes. This is because

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1197,6 +1197,7 @@ template <class OffType>
 tuple<bool, uint64_t, uint64_t>
 SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
     stats::Stats* stats,
+    const std::vector<tdb_shared_ptr<FragmentMetadata>>& fragment_metadata,
     const std::vector<ResultTile*>& result_tiles,
     const uint64_t first_tile_min_pos,
     std::vector<uint64_t>& cell_offsets,
@@ -1232,7 +1233,9 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
       auto last_tile = (ResultTileWithBitmap<BitmapType>*)
           result_tiles[new_result_tiles_size];
 
-      auto last_tile_num_cells = last_tile->cell_num();
+      auto last_tile_num_cells =
+          fragment_metadata[last_tile->frag_idx()]->cell_num(
+              last_tile->tile_idx());
 
       new_result_tiles_size++;
       cell_offsets[new_result_tiles_size] =
@@ -1362,6 +1365,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
         auto&& [buffers_full, new_var_buffer_size, new_result_tiles_size] =
             compute_var_size_offsets<OffType>(
                 stats_,
+                fragment_metadata_,
                 result_tiles,
                 first_tile_min_pos,
                 cell_offsets,

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -91,6 +91,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * user buffer.
    *
    * @param stats Stats.
+   * @param fragment_metadata Fragment metadata.
    * @param result_tiles Result tiles to process, might be truncated.
    * @param first_tile_min_pos Cell progress of the first tile.
    * @param cell_offsets Cell offset per result tile.
@@ -101,6 +102,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   template <class OffType>
   static tuple<bool, uint64_t, uint64_t> compute_var_size_offsets(
       stats::Stats* stats,
+      const std::vector<tdb_shared_ptr<FragmentMetadata>>& fragment_metadata,
       const std::vector<ResultTile*>& result_tiles,
       const uint64_t first_tile_min_pos,
       std::vector<uint64_t>& cell_offsets,

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -306,7 +306,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param num_range_threads Total number of range threads.
    * @param offset_div Divisor used to convert offsets into element mode.
    * @param var_buffer_size Size of the var data buffer.
-   * @param result_tiles_size Size of result tiles to process.
    * @param result_tiles Result tiles to process.
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
@@ -319,7 +318,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const uint64_t num_range_threads,
       const OffType offset_div,
       const uint64_t var_buffer_size,
-      const uint64_t result_tiles_size,
       const std::vector<ResultTile*>& result_tiles,
       const std::vector<uint64_t>& cell_offsets,
       QueryBuffer& query_buffer,


### PR DESCRIPTION
This fixes a few issues with the reader. First, it doesn't clear query 
condition tiles during tile copy as they should be treated as coordinates 
tiles.

Second, when the result tiles vector needs to be shrunk because the var 
size data cannot fit the user's buffers, we now clear the result tiles 
from memory right away for all loaded attributes. This solves an issue 
where some tiles would be lingering in memory.

Third, it fixes computation of the offsets when a query continues to 
fill in the user's buffers after running out of memory budget for tiles.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups reader: fixing memory management for tiles.