### PR TITLE
Remove alias `tdb_shared_ptr` in `filesystem/` and `storage_manager/`.

### DIFF
--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -34,6 +34,7 @@
 #define TILEDB_AZURE_H
 
 #ifdef HAVE_AZURE
+#include "tiledb/common/common.h"
 #include "tiledb/common/status.h"
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
@@ -429,7 +430,7 @@ class Azure {
   ThreadPool* thread_pool_;
 
   /** The Azure blob storage client. */
-  tdb_shared_ptr<azure::storage_lite::blob_client> client_;
+  shared_ptr<azure::storage_lite::blob_client> client_;
 
   /** Maps a blob URI to an write cache buffer. */
   std::unordered_map<std::string, Buffer> write_cache_map_;

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -581,8 +581,7 @@ class S3 {
   mutable shared_ptr<Aws::S3::S3Client> client_;
 
   /** The AWS credetial provider. */
-  mutable shared_ptr<Aws::Auth::AWSCredentialsProvider>
-      credentials_provider_;
+  mutable shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider_;
 
   /**
    * Mutex protecting client initialization. This is mutable so that nominally

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -578,10 +578,10 @@ class S3 {
    * The lazily-initialized S3 client. This is mutable so that nominally const
    * functions can call init_client().
    */
-  mutable tdb_shared_ptr<Aws::S3::S3Client> client_;
+  mutable shared_ptr<Aws::S3::S3Client> client_;
 
   /** The AWS credetial provider. */
-  mutable tdb_shared_ptr<Aws::Auth::AWSCredentialsProvider>
+  mutable shared_ptr<Aws::Auth::AWSCredentialsProvider>
       credentials_provider_;
 
   /**

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -403,7 +403,7 @@ Status Consolidator::consolidate_fragment_meta(
   // Include only fragments with footers / separate basic metadata
   Buffer buff;
   const auto& tmp_meta = array.fragment_metadata();
-  std::vector<tdb_shared_ptr<FragmentMetadata>> meta;
+  std::vector<shared_ptr<FragmentMetadata>> meta;
   for (auto m : tmp_meta) {
     if (m->format_version() > 2)
       meta.emplace_back(m);

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -174,7 +174,7 @@ class Consolidator {
   stats::Stats* stats_;
 
   /** The class logger. */
-  tdb_shared_ptr<Logger> logger_;
+  shared_ptr<Logger> logger_;
 
   /** UID of the logger instance */
   inline static std::atomic<uint64_t> logger_id_ = 0;

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -106,10 +106,10 @@ class Context {
   mutable ThreadPool io_tp_;
 
   /** The class stats. */
-  tdb_shared_ptr<stats::Stats> stats_;
+  shared_ptr<stats::Stats> stats_;
 
   /** The class logger. */
-  tdb_shared_ptr<Logger> logger_;
+  shared_ptr<Logger> logger_;
 
   inline static std::atomic<uint64_t> logger_id_ = 0;
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1485,8 +1485,7 @@ StorageManager::load_all_array_schemas(
 
   std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas;
   for (const auto& array_schema : schema_vector) {
-    array_schemas[array_schema->name()] =
-        shared_ptr<ArraySchema>(array_schema);
+    array_schemas[array_schema->name()] = shared_ptr<ArraySchema>(array_schema);
   }
 
   return {Status::Ok(), array_schemas};

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -82,7 +82,7 @@ StorageManager::StorageManager(
     ThreadPool* const compute_tp,
     ThreadPool* const io_tp,
     stats::Stats* const parent_stats,
-    tdb_shared_ptr<Logger> logger)
+    shared_ptr<Logger> logger)
     : stats_(parent_stats->create_child("StorageManager"))
     , logger_(logger)
     , cancellation_in_progress_(false)
@@ -137,8 +137,8 @@ Status StorageManager::array_close_for_writes(Array* array) {
 tuple<
     Status,
     optional<ArraySchema*>,
-    optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
-    optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+    optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
+    optional<std::vector<shared_ptr<FragmentMetadata>>>>
 StorageManager::load_array_schemas_and_fragment_metadata(
     const ArrayDirectory& array_dir,
     MemoryTracker* memory_tracker,
@@ -181,8 +181,8 @@ StorageManager::load_array_schemas_and_fragment_metadata(
 tuple<
     Status,
     optional<ArraySchema*>,
-    optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
-    optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+    optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
+    optional<std::vector<shared_ptr<FragmentMetadata>>>>
 StorageManager::array_open_for_reads(Array* array) {
   auto timer_se = stats_->start_timer("array_open_for_reads");
   auto&& [st, array_schema_latest, array_schemas_all, fragment_metadata] =
@@ -203,7 +203,7 @@ StorageManager::array_open_for_reads(Array* array) {
 tuple<
     Status,
     optional<ArraySchema*>,
-    optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+    optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
 StorageManager::array_open_for_reads_without_fragments(Array* array) {
   auto timer_se =
       stats_->start_timer("sm_array_open_for_reads_without_fragments");
@@ -223,7 +223,7 @@ StorageManager::array_open_for_reads_without_fragments(Array* array) {
 tuple<
     Status,
     optional<ArraySchema*>,
-    optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+    optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
 StorageManager::array_open_for_writes(Array* array) {
   // Checks
   if (!vfs_->supports_uri_scheme(array->array_uri()))
@@ -258,7 +258,7 @@ StorageManager::array_open_for_writes(Array* array) {
   return {Status::Ok(), array_schema_latest, array_schemas_all};
 }
 
-tuple<Status, optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+tuple<Status, optional<std::vector<shared_ptr<FragmentMetadata>>>>
 StorageManager::array_load_fragments(
     Array* array, const std::vector<TimestampedURI>& fragments_to_load) {
   auto timer_se = stats_->start_timer("array_load_fragments");
@@ -290,8 +290,8 @@ StorageManager::array_load_fragments(
 tuple<
     Status,
     optional<ArraySchema*>,
-    optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
-    optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+    optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
+    optional<std::vector<shared_ptr<FragmentMetadata>>>>
 StorageManager::array_reopen(Array* array) {
   auto timer_se = stats_->start_timer("read_array_open");
 
@@ -1433,7 +1433,7 @@ Status StorageManager::load_array_schema_latest(
 tuple<
     Status,
     optional<ArraySchema*>,
-    optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+    optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
 StorageManager::load_array_schemas(
     const ArrayDirectory& array_dir, const EncryptionKey& encryption_key) {
   auto array_schema = (ArraySchema*)nullptr;
@@ -1450,7 +1450,7 @@ StorageManager::load_array_schemas(
 
 tuple<
     Status,
-    optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+    optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
 StorageManager::load_all_array_schemas(
     const ArrayDirectory& array_dir, const EncryptionKey& encryption_key) {
   auto timer_se = stats_->start_timer("sm_load_all_array_schemas");
@@ -1483,10 +1483,10 @@ StorageManager::load_all_array_schemas(
       });
   RETURN_NOT_OK_TUPLE(status, nullopt);
 
-  std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>> array_schemas;
+  std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas;
   for (const auto& array_schema : schema_vector) {
     array_schemas[array_schema->name()] =
-        tdb_shared_ptr<ArraySchema>(array_schema);
+        shared_ptr<ArraySchema>(array_schema);
   }
 
   return {Status::Ok(), array_schemas};
@@ -1506,7 +1506,7 @@ Status StorageManager::load_array_metadata(
   const auto& array_metadata_to_load = array_dir.array_meta_uris();
 
   auto metadata_num = array_metadata_to_load.size();
-  std::vector<tdb_shared_ptr<Buffer>> metadata_buffs;
+  std::vector<shared_ptr<Buffer>> metadata_buffs;
   metadata_buffs.resize(metadata_num);
   auto status = parallel_for(compute_tp_, 0, metadata_num, [&](size_t m) {
     const auto& uri = array_metadata_to_load[m].uri_;
@@ -1950,7 +1950,7 @@ stats::Stats* StorageManager::stats() {
   return stats_;
 }
 
-tdb_shared_ptr<Logger> StorageManager::logger() const {
+shared_ptr<Logger> StorageManager::logger() const {
   return logger_;
 }
 
@@ -1958,11 +1958,11 @@ tdb_shared_ptr<Logger> StorageManager::logger() const {
 /*         PRIVATE METHODS        */
 /* ****************************** */
 
-tuple<Status, optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+tuple<Status, optional<std::vector<shared_ptr<FragmentMetadata>>>>
 StorageManager::load_fragment_metadata(
     MemoryTracker* memory_tracker,
     ArraySchema* array_schema_latest,
-    const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+    const std::unordered_map<std::string, shared_ptr<ArraySchema>>&
         array_schemas_all,
     const EncryptionKey& encryption_key,
     const std::vector<TimestampedURI>& fragments_to_load,
@@ -1972,7 +1972,7 @@ StorageManager::load_fragment_metadata(
 
   // Load the metadata for each fragment
   auto fragment_num = fragments_to_load.size();
-  std::vector<tdb_shared_ptr<FragmentMetadata>> fragment_metadata;
+  std::vector<shared_ptr<FragmentMetadata>> fragment_metadata;
   fragment_metadata.resize(fragment_num);
   auto status = parallel_for(compute_tp_, 0, fragment_num, [&](size_t f) {
     const auto& sf = fragments_to_load[f];
@@ -1987,7 +1987,7 @@ StorageManager::load_fragment_metadata(
     // Note that the fragment metadata version is >= the array schema
     // version. Therefore, the check below is defensive and will always
     // ensure backwards compatibility.
-    tdb_shared_ptr<FragmentMetadata> metadata;
+    shared_ptr<FragmentMetadata> metadata;
     if (f_version == 1) {  // This is equivalent to format version <=2
       bool sparse;
       RETURN_NOT_OK(vfs_->is_file(coords_uri, &sparse));

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -45,6 +45,7 @@
 #include <string>
 #include <thread>
 
+#include "tiledb/common/common.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger_public.h"
 #include "tiledb/common/status.h"
@@ -118,7 +119,7 @@ class StorageManager {
       ThreadPool* compute_tp,
       ThreadPool* io_tp,
       stats::Stats* parent_stats,
-      tdb_shared_ptr<Logger> logger);
+      shared_ptr<Logger> logger);
 
   /** Destructor. */
   ~StorageManager();
@@ -168,8 +169,8 @@ class StorageManager {
   tuple<
       Status,
       optional<ArraySchema*>,
-      optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
-      optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
+      optional<std::vector<shared_ptr<FragmentMetadata>>>>
   load_array_schemas_and_fragment_metadata(
       const ArrayDirectory& array_dir,
       MemoryTracker* memory_tracker,
@@ -195,8 +196,8 @@ class StorageManager {
   tuple<
       Status,
       optional<ArraySchema*>,
-      optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
-      optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
+      optional<std::vector<shared_ptr<FragmentMetadata>>>>
   array_open_for_reads(Array* array);
 
   /**
@@ -212,7 +213,7 @@ class StorageManager {
   tuple<
       Status,
       optional<ArraySchema*>,
-      optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
   array_open_for_reads_without_fragments(Array* array);
 
   /** Opens an array for writes.
@@ -227,7 +228,7 @@ class StorageManager {
   tuple<
       Status,
       optional<ArraySchema*>,
-      optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
   array_open_for_writes(Array* array);
 
   /**
@@ -237,7 +238,7 @@ class StorageManager {
    * @param fragment_info The list of fragment info.
    * @return Status, the fragment metadata to be loaded.
    */
-  tuple<Status, optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+  tuple<Status, optional<std::vector<shared_ptr<FragmentMetadata>>>>
   array_load_fragments(
       Array* array, const std::vector<TimestampedURI>& fragment_info);
 
@@ -257,8 +258,8 @@ class StorageManager {
   tuple<
       Status,
       optional<ArraySchema*>,
-      optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>,
-      optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
+      optional<std::vector<shared_ptr<FragmentMetadata>>>>
   array_reopen(Array* array);
 
   /**
@@ -657,7 +658,7 @@ class StorageManager {
   tuple<
       Status,
       optional<ArraySchema*>,
-      optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
   load_array_schemas(
       const ArrayDirectory& array_dir, const EncryptionKey& encryption_key);
 
@@ -674,7 +675,7 @@ class StorageManager {
    */
   tuple<
       Status,
-      optional<std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>>>
+      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
   load_all_array_schemas(
       const ArrayDirectory& array_dir, const EncryptionKey& encryption_key);
 
@@ -918,7 +919,7 @@ class StorageManager {
   stats::Stats* stats();
 
   /** Returns the internal logger object. */
-  tdb_shared_ptr<Logger> logger() const;
+  shared_ptr<Logger> logger() const;
 
  private:
   /* ********************************* */
@@ -956,7 +957,7 @@ class StorageManager {
   stats::Stats* stats_;
 
   /** The class logger. */
-  tdb_shared_ptr<Logger> logger_;
+  shared_ptr<Logger> logger_;
 
   /** Set to true when tasks are being cancelled. */
   bool cancellation_in_progress_;
@@ -1057,11 +1058,11 @@ class StorageManager {
    *        Status Ok on success, else error
    *        Vector of FragmentMetadata is the fragment metadata to be retrieved.
    */
-  tuple<Status, optional<std::vector<tdb_shared_ptr<FragmentMetadata>>>>
+  tuple<Status, optional<std::vector<shared_ptr<FragmentMetadata>>>>
   load_fragment_metadata(
       MemoryTracker* memory_tracker,
       ArraySchema* array_schema_latest,
-      const std::unordered_map<std::string, tdb_shared_ptr<ArraySchema>>&
+      const std::unordered_map<std::string, shared_ptr<ArraySchema>>&
           array_schemas_all,
       const EncryptionKey& encryption_key,
       const std::vector<TimestampedURI>& fragments_to_load,


### PR DESCRIPTION
Remove alias `tdb_shared_ptr` in `filesystem/` and `storage_manager/`.

---
TYPE: NO_HISTORY
DESC: Remove alias `tdb_shared_ptr` in `filesystem/` and `storage_manager/`.
