### PR TITLE
explore incremental counter for timestamp_end_ to help avoid array/fr…

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -79,7 +79,7 @@ Array::Array(const URI& array_uri, StorageManager* storage_manager)
     , remote_(array_uri.is_tiledb())
     , metadata_loaded_(false)
     , non_empty_domain_computed_(false)
-    , timestamp_end_counter_(0) {};
+    , timestamp_end_counter_(0){};
 
 Array::Array(const Array& rhs)
     : array_schema_latest_(rhs.array_schema_latest_)

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -78,8 +78,8 @@ Array::Array(const URI& array_uri, StorageManager* storage_manager)
     , config_(storage_manager_->config())
     , remote_(array_uri.is_tiledb())
     , metadata_loaded_(false)
-    , non_empty_domain_computed_(false) {
-}
+    , non_empty_domain_computed_(false)
+    , timestamp_end_counter_(0) {};
 
 Array::Array(const Array& rhs)
     : array_schema_latest_(rhs.array_schema_latest_)
@@ -100,12 +100,22 @@ Array::Array(const Array& rhs)
     , metadata_(rhs.metadata_)
     , metadata_loaded_(rhs.metadata_loaded_)
     , non_empty_domain_computed_(rhs.non_empty_domain_computed_)
-    , non_empty_domain_(rhs.non_empty_domain_) {
+    , non_empty_domain_(rhs.non_empty_domain_)
+    , timestamp_end_counter_(rhs.timestamp_end_counter_) {
 }
 
 /* ********************************* */
 /*                API                */
 /* ********************************* */
+
+Status Array::adjust_timestamp_end_counters() {
+  timestamp_end_counter_++;
+  return Status::Ok();
+}
+
+uint64_t Array::timestamp_end_counter() {
+  return timestamp_end_counter_;
+}
 
 void Array::set_array_schema_latest(ArraySchema* array_schema) {
   array_schema_latest_ = array_schema;

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -368,6 +368,11 @@ class Array {
   /** Returns the memory tracker. */
   MemoryTracker* memory_tracker();
 
+  /** Adjust artificial timestamp_end_ resolution increase counters */
+  Status adjust_timestamp_end_counters();
+
+  uint64_t timestamp_end_counter();
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -471,6 +476,8 @@ class Array {
 
   /** Memory tracker for the array. */
   MemoryTracker memory_tracker_;
+  /** newest artificial timestamp resolution increase counter */
+  uint32_t timestamp_end_counter_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -37,8 +37,8 @@
 #include "tiledb/sm/misc/time.h"
 #include "tiledb/sm/misc/uuid.h"
 
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 
 using namespace tiledb::common;
@@ -95,10 +95,9 @@ Status Metadata::generate_uri(const URI& array_uri) {
   }
 
   std::stringstream ss;
-  ss << "__" << timestamp_range_.first << "_" << timestamp_range_.second
-     << "-" << std::hex << std::setw(8) << std::setfill('0') << timestamp_end_counter_ 
-     << "_" << std::dec
-     << uuid;
+  ss << "__" << timestamp_range_.first << "_" << timestamp_range_.second << "-"
+     << std::hex << std::setw(8) << std::setfill('0') << timestamp_end_counter_
+     << "_" << std::dec << uuid;
   uri_ = array_uri.join_path(constants::array_metadata_dir_name)
              .join_path(ss.str());
 
@@ -336,7 +335,8 @@ void Metadata::reset(uint64_t timestamp) {
   timestamp_range_ = std::make_pair(timestamp, timestamp);
 }
 
-void Metadata::set(const std::string& array_uuid, uint64_t timestamp_end_counter) {
+void Metadata::set(
+    const std::string& array_uuid, uint64_t timestamp_end_counter) {
   array_uuid_ = array_uuid;
   timestamp_end_counter_ = timestamp_end_counter;
 }

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -223,7 +223,8 @@ class Metadata {
   /**
    * Set the uuid to be used to creating a new fragment name.
    */
-  void set(const std::string& array_fragment_uuid, uint64_t timestamp_end_counter);
+  void set(
+      const std::string& array_fragment_uuid, uint64_t timestamp_end_counter);
 
   /** Returns an iterator to the beginning of the metadata. */
   iterator begin() const;

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -220,6 +220,11 @@ class Metadata {
    */
   void reset(uint64_t timestamp);
 
+  /**
+   * Set the uuid to be used to creating a new fragment name.
+   */
+  void set(const std::string& array_fragment_uuid, uint64_t timestamp_end_counter);
+
   /** Returns an iterator to the beginning of the metadata. */
   iterator begin() const;
 
@@ -258,6 +263,12 @@ class Metadata {
 
   /** The URI of the array metadata file. */
   URI uri_;
+
+  /** The uuid of the assoc'd array. */
+  std::string array_uuid_;
+
+  /** timestamp_end resolution increase counter */
+  uint64_t timestamp_end_counter_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -107,7 +107,7 @@ class StrategyBase {
   tdb_shared_ptr<Logger> logger_;
 
   /** The array. */
-  const Array* array_;
+  Array* array_;
 
   /** The array schema. */
   const ArraySchema* array_schema_;

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -32,7 +32,6 @@
 
 #include <iomanip>
 
-#include "tiledb/sm/query/writer_base.h"
 #include "tiledb/common/common.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
@@ -52,6 +51,7 @@
 #include "tiledb/sm/misc/uuid.h"
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
+#include "tiledb/sm/query/writer_base.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
@@ -943,10 +943,10 @@ Status WriterBase::new_fragment_name(
   array_->adjust_timestamp_end_counters();
   array_->metadata()->set(uuid, array_->timestamp_end_counter());
   std::stringstream ss;
-  ss << "/__" << timestamp << "_" << timestamp << "-" // "." used in utils get_timestamp_range()
+  ss << "/__" << timestamp << "_" << timestamp
+     << "-"  // "." used in utils get_timestamp_range()
      << std::hex << std::setw(8) << std::setfill('0')
-     << array_->timestamp_end_counter() << std::dec
-     << "_" << uuid << "_"
+     << array_->timestamp_end_counter() << std::dec << "_" << uuid << "_"
      << format_version;
 
   *frag_uri = ss.str();

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -30,6 +30,8 @@
  * This file implements class WriterBase.
  */
 
+#include <iomanip>
+
 #include "tiledb/sm/query/writer_base.h"
 #include "tiledb/common/common.h"
 #include "tiledb/common/heap_memory.h"
@@ -938,8 +940,13 @@ Status WriterBase::new_fragment_name(
   std::string uuid;
   frag_uri->clear();
   RETURN_NOT_OK(uuid::generate_uuid(&uuid, false));
+  array_->adjust_timestamp_end_counters();
+  array_->metadata()->set(uuid, array_->timestamp_end_counter());
   std::stringstream ss;
-  ss << "/__" << timestamp << "_" << timestamp << "_" << uuid << "_"
+  ss << "/__" << timestamp << "_" << timestamp << "-" // "." used in utils get_timestamp_range()
+     << std::hex << std::setw(8) << std::setfill('0')
+     << array_->timestamp_end_counter() << std::dec
+     << "_" << uuid << "_"
      << format_version;
 
   *frag_uri = ss.str();


### PR DESCRIPTION
add incremental counter for timestamp_end_ to help avoid array/fragment timestamp collisions possible within current timestamp precision

add counter incrementing from zero at time of open on each fragment creation to be used to uniquefy end timestamp of all fragments created during the lifetime of a particular Array object instance.



---
TYPE: BUG
DESC: timestamp_end_ "precision" increase via counter
