### PR TITLE
Don't call generate_uri in ArraySchema accessors

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -89,6 +89,9 @@ ArraySchema::ArraySchema(ArrayType array_type)
   cell_validity_filters_.add_filter(CompressionFilter(
       constants::cell_validity_compression,
       constants::cell_validity_compression_level));
+
+  // Generate URI and name for ArraySchema
+  generate_uri();
 }
 
 ArraySchema::ArraySchema(const ArraySchema& array_schema) {
@@ -113,8 +116,6 @@ ArraySchema::ArraySchema(const ArraySchema& array_schema) {
   for (auto attr : array_schema.attributes_)
     add_attribute(attr, false);
 
-  // This has to be the last thing set because add_attribute sets the name
-  // TODO: This behavior needs to be changed
   name_ = array_schema.name_;
 }
 
@@ -512,7 +513,6 @@ Status ArraySchema::add_attribute(
   attributes_.emplace_back(attr);
   attribute_map_[attr->name()] = attr.get();
 
-  RETURN_NOT_OK(generate_uri());
   return Status::Ok();
 }
 
@@ -539,7 +539,7 @@ Status ArraySchema::drop_attribute(const std::string& attr_name) {
       it = attributes_.erase(it);
     }
   }
-  RETURN_NOT_OK(generate_uri());
+
   return Status::Ok();
 }
 
@@ -758,13 +758,9 @@ uint64_t ArraySchema::timestamp_start() const {
   return timestamp_range_.first;
 }
 
-URI ArraySchema::uri() {
+const URI& ArraySchema::uri() const {
   std::lock_guard<std::mutex> lock(mtx_);
-  if (uri_.is_invalid()) {
-    generate_uri();
-  }
-  URI result = uri_;
-  return result;
+  return uri_;
 }
 
 void ArraySchema::set_uri(const URI& uri) {
@@ -774,7 +770,7 @@ void ArraySchema::set_uri(const URI& uri) {
   utils::parse::get_timestamp_range(uri_, &timestamp_range_);
 }
 
-Status ArraySchema::get_uri(URI* uri) {
+Status ArraySchema::get_uri(URI* uri) const {
   if (uri_.is_invalid()) {
     return LOG_STATUS(
         Status_ArraySchemaError("Error in ArraySchema; invalid URI"));

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -323,13 +323,13 @@ class ArraySchema {
   uint64_t timestamp_start() const;
 
   /** Returns the array schema uri. */
-  URI uri();
+  const URI& uri() const;
 
   /** Set schema URI, along with parsing out timestamp ranges and name. */
   void set_uri(const URI& uri);
 
   /** Get schema URI with return status. */
-  Status get_uri(URI* uri);
+  Status get_uri(URI* uri) const;
 
   /** Returns the schema name. If it is not set, will build it. */
   const std::string& name() const;

--- a/tiledb/sm/array_schema/array_schema_evolution.cc
+++ b/tiledb/sm/array_schema/array_schema_evolution.cc
@@ -105,6 +105,9 @@ ArraySchemaEvolution::evolve_schema(
     RETURN_NOT_OK_TUPLE(
         schema.get()->set_timestamp_range(timestamp_range_), nullopt);
     RETURN_NOT_OK_TUPLE(schema->generate_uri(timestamp_range_), nullopt);
+  } else {
+    // Generate new schema URI
+    RETURN_NOT_OK_TUPLE(schema->generate_uri(), nullopt);
   }
 
   return {Status::Ok(), schema};


### PR DESCRIPTION
This adjusts how and where we generate the array schema URI/name so we can avoid any mutation in the accessors of `ArraySchema` such as `name`.


---
TYPE: IMPROVEMENT
DESC: Avoid calling `generate_uri` in `ArraySchema` accessors
