### PR TITLE
Global order writer: initialize last_var_offsets_.

### DIFF
--- a/tiledb/sm/query/global_order_writer.cc
+++ b/tiledb/sm/query/global_order_writer.cc
@@ -658,6 +658,9 @@ Status GlobalOrderWriter::init_global_write_state() {
 
     // Initialize cells written
     global_write_state_->cells_written_[name] = 0;
+
+    // Initialize last var offsets
+    global_write_state_->last_var_offsets_[name] = 0;
   }
 
   return Status::Ok();


### PR DESCRIPTION
Initializing last_var_offsets_ in the global order writer to prevent
unordered map threading issues.

---
TYPE: IMPROVEMENT
DESC: Global order writer: initialize last_var_offsets_.
