### PR TITLE
Fragment metadata: add min/max/sun/null count.

### DIFF
--- a/format_spec/fragment.md
+++ b/format_spec/fragment.md
@@ -47,6 +47,18 @@ The fragment metadata file has the following on-disk format:
 | Variable tile sizes for attribute/dimension 1 | [Tile Offsets](#tile-offsets) | The serialized variable tile sizes for attribute/dimension 1 |
 | … | … | … |
 | Variable tile sizes for attribute/dimension N | [Tile Offsets](#tile-offsets) | The serialized variable tile sizes for attribute/dimension N |
+| Tile mins for attribute/dimension 1 | [Tile mins/maxs](#tile-mins-maxs) | The serialized mins for attribute/dimension 1 |
+| … | … | … |
+| Variable mins for attribute/dimension N | [Tile mins/maxs](#tile-mins-maxs) | The serialized mins for attribute/dimension N |
+| Tile maxs for attribute/dimension 1 | [Tile mins/maxs](#tile-mins-maxs) | The serialized maxs for attribute/dimension 1 |
+| … | … | … |
+| Variable maxs for attribute/dimension N | [Tile mins/maxs](#tile-mins-maxs) | The serialized maxs for attribute/dimension N |
+| Tile sums for attribute/dimension 1 | [Tile sums](#tile-sums) | The serialized sums for attribute/dimension 1 |
+| … | … | … |
+| Variable sums for attribute/dimension N | [Tile sums](#tile-sums) | The serialized sums for attribute/dimension N |
+| Tile null counts for attribute/dimension 1 | [Tile null count](#tile-null-count) | The serialized null counts for attribute/dimension 1 |
+| … | … | … |
+| Variable maxs for attribute/dimension N | [[Tile null count](#tile-null-count) | The serialized null counts for attribute/dimension N |
 | Metadata footer | [Footer](#footer) | Basic metadata gathered in the footer |
 
 ### R-Tree
@@ -115,6 +127,57 @@ The tile sizes is a [generic tile](./generic_tile.md) with the following interna
 | … | … | … |
 | Tile size N | `uint64_t` | Size N |
 
+### Tile Mins Maxs
+
+The tile mins maxs is a [generic tile](./generic_tile.md) with the following internal format:
+
+| **Field** | **Type** | **Description** |
+| :--- | :--- | :--- |
+| Num values | `uint64_t` | Number of values |
+| Value 1 | `type` | Value 1 or Offset 1 |
+| … | … | … |
+| Value N | `type` | Value N or Offset N |
+| Var buffer size | `uint64_t` | Var buffer size |
+| Var buffer | `uint8_t` | Var buffer |
+
+### Tile Sums
+
+The tile sums is a [generic tile](./generic_tile.md) with the following internal format:
+
+| **Field** | **Type** | **Description** |
+| :--- | :--- | :--- |
+| Num values | `uint64_t` | Number of values |
+| Value 1 | `uint64_t` | Sum 1 |
+| … | … | … |
+| Value N | `uint64_t` | Sum N |
+
+The tile null count is a [generic tile](./generic_tile.md) with the following internal format:
+
+| **Field** | **Type** | **Description** |
+| :--- | :--- | :--- |
+| Num values | `uint64_t` | Number of values |
+| Value 1 | `uint64_t` | Count 1 |
+| … | … | … |
+| Value N | `uint64_t` | Count N |
+
+The fragment min max sum null count is a [generic tile](./generic_tile.md) with the following internal format:
+
+| **Field** | **Type** | **Description** |
+| :--- | :--- | :--- |
+| Min size | `uint64_t` | Size of the min value for attribute/dimension 1 |
+| Min value | `uint8_t` | Buffer for min value for attribute/dimension 1 |
+| Max size | `uint64_t` | Size of the max value for attribute/dimension 1 |
+| Max value | `uint8_t` | Buffer for max value for attribute/dimension 1 |
+| Sum | `uint64_t` | Sum value for attribute/dimension 1 |
+| Null count | `uint64_t` | Null count value for attribute/dimension 1 |
+| … | … | … |
+| Min size | `uint64_t` | Size of the min value for attribute/dimension N |
+| Min value | `uint8_t` | Buffer for min value for attribute/dimension N |
+| Max size | `uint64_t` | Size of the max value for attribute/dimension N |
+| Max value | `uint8_t` | Buffer for max value for attribute/dimension N |
+| Sum | `uint64_t` | Sum value for attribute/dimension N |
+| Null count | `uint64_t` | Null count value for attribute/dimension N |
+
 ### Footer
 
 The footer is a simple blob \(i.e., _not a generic tile_\) with the following internal format:
@@ -155,6 +218,7 @@ The footer is a simple blob \(i.e., _not a generic tile_\) with the following in
 | Tile null counts offset for attribute/dimension 1 | `uint64_t` | The offset to the generic tile storing the tile null counts for attribute/dimension 1. |
 | … | … | … |
 | Tile null counts offset for attribute/dimension N | `uint64_t` | The offset to the generic tile storing the tile null counts for attribute/dimension N |
+| Fragment min max sum null count offset | `uint64_t` | The offset to the generic tile storing the fragment min max sum null count data. |
 | Array schema name size | `uint64_t` | The total number of characters of the array schema name. |
 | Array schema name character 1 | `char` | The first character of the array schema name. |
 | … | … | … |

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -5194,7 +5194,7 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
   rc = tiledb_config_set(
-      config, "sm.consolidation.step_size_ratio", "0.82", &error);
+      config, "sm.consolidation.step_size_ratio", "0.85", &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
 

--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -272,7 +272,7 @@ TEST_CASE(
   uint64_t size;
   rc = tiledb_fragment_info_get_fragment_size(ctx, fragment_info, 1, &size);
   CHECK(rc == TILEDB_OK);
-  CHECK(size == 2960);
+  CHECK(size == 3084);
 
   // Get dense / sparse
   int32_t dense;
@@ -504,7 +504,7 @@ TEST_CASE(
   uint64_t size;
   rc = tiledb_fragment_info_get_fragment_size(ctx, fragment_info, 1, &size);
   CHECK(rc == TILEDB_OK);
-  CHECK(size == 5173);
+  CHECK(size == 5382);
 
   // Get dense / sparse
   int32_t dense;
@@ -772,6 +772,8 @@ TEST_CASE(
   tiledb_vfs_t* vfs = nullptr;
   rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
   REQUIRE(rc == TILEDB_OK);
+
+  remove_dir(array_name, ctx, vfs);
 
   // Create array
   create_array(
@@ -1339,16 +1341,16 @@ TEST_CASE("C API: Test fragment info, dump", "[capi][fragment_info][dump]") {
       "- Unconsolidated metadata num: 3\n" + "- To vacuum num: 0\n" +
       "- Fragment #1:\n" + "  > URI: " + written_frag_uri_1 + "\n" +
       "  > Type: dense\n" + "  > Non-empty domain: [1, 6]\n" +
-      "  > Size: 2960\n" + "  > Cell num: 10\n" +
+      "  > Size: 3084\n" + "  > Cell num: 10\n" +
       "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n" + "- Fragment #2:\n" +
       "  > URI: " + written_frag_uri_2 + "\n" + "  > Type: dense\n" +
-      "  > Non-empty domain: [1, 4]\n" + "  > Size: 2909\n" +
+      "  > Non-empty domain: [1, 4]\n" + "  > Size: 3033\n" +
       "  > Cell num: 5\n" + "  > Timestamp range: [2, 2]\n" +
       "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n" + "- Fragment #3:\n" +
       "  > URI: " + written_frag_uri_3 + "\n" + "  > Type: dense\n" +
-      "  > Non-empty domain: [5, 6]\n" + "  > Size: 2957\n" +
+      "  > Non-empty domain: [5, 6]\n" + "  > Size: 3081\n" +
       "  > Cell num: 10\n" + "  > Timestamp range: [3, 3]\n" +
       "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";
@@ -1479,7 +1481,7 @@ TEST_CASE(
       "- To vacuum URIs:\n" + "  > " + written_frag_uri_1 + "\n  > " +
       written_frag_uri_2 + "\n  > " + written_frag_uri_3 + "\n" +
       "- Fragment #1:\n" + "  > URI: " + uri + "\n" + "  > Type: dense\n" +
-      "  > Non-empty domain: [1, 10]\n" + "  > Size: 2966\n" +
+      "  > Non-empty domain: [1, 10]\n" + "  > Size: 3099\n" +
       "  > Cell num: 10\n" + "  > Timestamp range: [1, 3]\n" +
       "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";
@@ -1563,7 +1565,7 @@ TEST_CASE(
       "- Unconsolidated metadata num: 1\n" + "- To vacuum num: 0\n" +
       "- Fragment #1:\n" + "  > URI: " + written_frag_uri + "\n" +
       "  > Type: sparse\n" + "  > Non-empty domain: [a, ddd]\n" +
-      "  > Size: 3204\n" + "  > Cell num: 4\n" +
+      "  > Size: 3330\n" + "  > Cell num: 4\n" +
       "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";
   FILE* gold_fout = fopen("gold_fout.txt", "w");

--- a/test/src/unit-cppapi-fragment_info.cc
+++ b/test/src/unit-cppapi-fragment_info.cc
@@ -220,7 +220,7 @@ TEST_CASE(
 
     // Get fragment size
     auto size = fragment_info.fragment_size(1);
-    CHECK(size == 2960);
+    CHECK(size == 3084);
 
     // Get dense / sparse
     auto dense = fragment_info.dense(0);
@@ -841,16 +841,16 @@ TEST_CASE(
         "- Unconsolidated metadata num: 3\n" + "- To vacuum num: 0\n" +
         "- Fragment #1:\n" + "  > URI: " + written_frag_uri_1 + "\n" +
         "  > Type: dense\n" + "  > Non-empty domain: [1, 6]\n" +
-        "  > Size: 2960\n" + "  > Cell num: 10\n" +
+        "  > Size: 3084\n" + "  > Cell num: 10\n" +
         "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n" + "- Fragment #2:\n" +
         "  > URI: " + written_frag_uri_2 + "\n" + "  > Type: dense\n" +
-        "  > Non-empty domain: [1, 4]\n" + "  > Size: 2909\n" +
+        "  > Non-empty domain: [1, 4]\n" + "  > Size: 3033\n" +
         "  > Cell num: 5\n" + "  > Timestamp range: [2, 2]\n" +
         "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n" + "- Fragment #3:\n" +
         "  > URI: " + written_frag_uri_3 + "\n" + "  > Type: dense\n" +
-        "  > Non-empty domain: [5, 6]\n" + "  > Size: 2957\n" +
+        "  > Non-empty domain: [5, 6]\n" + "  > Size: 3081\n" +
         "  > Cell num: 10\n" + "  > Timestamp range: [3, 3]\n" +
         "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n";

--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -98,24 +98,30 @@ struct CPPFixedTileMetadataFx {
     }
 
     // Ensure correct vectors are big enough for this fragment.
-    correct_mins_.resize(f + 1);
+    correct_tile_mins_.resize(f + 1);
+    correct_tile_maxs_.resize(f + 1);
+    correct_tile_sums_int_.resize(f + 1);
+    correct_tile_sums_double_.resize(f + 1);
+    correct_tile_null_counts_.resize(f + 1);
+    correct_mins_.resize(f + 1, std::numeric_limits<TestType>::max());
     correct_maxs_.resize(f + 1);
-    correct_sums_int_.resize(f + 1);
     correct_sums_double_.resize(f + 1);
+    correct_sums_int_.resize(f + 1);
     correct_null_counts_.resize(f + 1);
 
     // Compute correct values as the tile is filled with data.
-    correct_mins_[f].clear();
-    correct_maxs_[f].clear();
-    correct_sums_int_[f].clear();
-    correct_sums_double_[f].clear();
-    correct_null_counts_[f].clear();
-    correct_mins_[f].resize(num_tiles_, std::numeric_limits<TestType>::max());
-    correct_maxs_[f].resize(
+    correct_tile_mins_[f].clear();
+    correct_tile_maxs_[f].clear();
+    correct_tile_sums_int_[f].clear();
+    correct_tile_sums_double_[f].clear();
+    correct_tile_null_counts_[f].clear();
+    correct_tile_mins_[f].resize(
+        num_tiles_, std::numeric_limits<TestType>::max());
+    correct_tile_maxs_[f].resize(
         num_tiles_, std::numeric_limits<TestType>::lowest());
-    correct_sums_int_[f].resize(num_tiles_, 0);
-    correct_sums_double_[f].resize(num_tiles_, 0);
-    correct_null_counts_[f].resize(num_tiles_, 0);
+    correct_tile_sums_int_[f].resize(num_tiles_, 0);
+    correct_tile_sums_double_[f].resize(num_tiles_, 0);
+    correct_tile_null_counts_[f].resize(num_tiles_, 0);
 
     // Fill the tiles with data.
     std::vector<uint32_t> d(num_cells_);
@@ -158,25 +164,32 @@ struct CPPFixedTileMetadataFx {
 
         if constexpr (!std::is_same<TestType, char>::value) {
           if (a_val[i] == 1) {
-            correct_sums_int_[f][tile_idx] += (int64_t)val;
+            correct_tile_sums_int_[f][tile_idx] += (int64_t)val;
+            correct_sums_int_[f] += (int64_t)val;
           }
         }
       } else {
         std::uniform_real_distribution<TestType> dist(-10000, 10000);
         val = dist(random_engine);
         if (a_val[i] == 1) {
-          correct_sums_double_[f][tile_idx] += (double)val;
+          correct_tile_sums_double_[f][tile_idx] += (double)val;
+          correct_sums_double_[f] += (double)val;
         }
       }
 
       // Compute correct min/max.
       if (a_val[i] == 1) {
-        correct_mins_[f][tile_idx] = std::min(correct_mins_[f][tile_idx], val);
-        correct_maxs_[f][tile_idx] = std::max(correct_maxs_[f][tile_idx], val);
+        correct_tile_mins_[f][tile_idx] =
+            std::min(correct_tile_mins_[f][tile_idx], val);
+        correct_tile_maxs_[f][tile_idx] =
+            std::max(correct_tile_maxs_[f][tile_idx], val);
+        correct_mins_[f] = std::min(correct_mins_[f], val);
+        correct_maxs_[f] = std::max(correct_maxs_[f], val);
       }
 
       // Compute correct null count.
-      correct_null_counts_[f][tile_idx] += uint64_t(a_val[i] == 0);
+      correct_tile_null_counts_[f][tile_idx] += uint64_t(a_val[i] == 0);
+      correct_null_counts_[f] += uint64_t(a_val[i] == 0);
 
       // Set the value.
       if constexpr (std::is_same<TestType, char>::value) {
@@ -229,9 +242,13 @@ struct CPPFixedTileMetadataFx {
     rc = tiledb_array_open(ctx, array, TILEDB_READ);
     CHECK(rc == TILEDB_OK);
 
-    // Load the metadata and validate coords netadata.
+    // Load fragment metadata.
     auto frag_meta = array->array_->fragment_metadata();
     auto& enc_key = array->array_->get_encryption_key();
+    auto st = frag_meta[f]->load_fragment_min_max_sum_null_count(enc_key);
+    CHECK(st.ok());
+
+    // Load the metadata and validate coords netadata.
     bool has_coords = layout != TILEDB_ROW_MAJOR;
     if (has_coords) {
       std::vector<std::string> names_min{"d"};
@@ -255,6 +272,29 @@ struct CPPFixedTileMetadataFx {
       // Validation.
       // Min/max/sum for all null tile are invalid.
       if (!all_null) {
+        // Do fragment metadata first.
+        {
+          int64_t correct_sum =
+              (num_tiles_ * tile_extent_) * (num_tiles_ * tile_extent_ - 1) / 2;
+
+          // Validate no min.
+          auto&& [st_min, min] = frag_meta[f]->get_min("d");
+          CHECK(!st_min.ok());
+          CHECK(!min.has_value());
+
+          // Validate no max.
+          auto&& [st_max, max] = frag_meta[f]->get_max("d");
+          CHECK(!st_max.ok());
+          CHECK(!max.has_value());
+
+          // Validate sum.
+          auto&& [st_sum, sum] = frag_meta[f]->get_sum("d");
+          CHECK(st_sum.ok());
+          if (st_sum.ok()) {
+            CHECK(*(int64_t*)*sum == correct_sum);
+          }
+        }
+
         for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
           uint32_t correct_min = tile_idx * tile_extent_;
           uint32_t correct_max = tile_idx * tile_extent_ + tile_extent_ - 1;
@@ -285,9 +325,89 @@ struct CPPFixedTileMetadataFx {
       }
     }
 
+    // Do fragment metadata first for attribute.
+    {
+      // Min/max/sum for all null tile are invalid.
+      if (!all_null) {
+        if constexpr (std::is_same<TestType, char>::value) {
+          // Validate min.
+          auto&& [st_min, min] = frag_meta[f]->get_min("a");
+          CHECK(st_min.ok());
+          if (st_min.ok()) {
+            CHECK((*min).size() == cell_val_num);
+
+            // For strings, the index is stored in a signed value, switch to
+            // the index to unsigned.
+            int64_t idx = (int64_t)correct_mins_[f] -
+                          (int64_t)std::numeric_limits<char>::min();
+            CHECK(
+                0 == strncmp(
+                         (const char*)(*min).data(),
+                         string_ascii_[idx].c_str(),
+                         cell_val_num));
+          }
+
+          // Validate max.
+          auto&& [st_max, max] = frag_meta[f]->get_max("a");
+          CHECK(st_max.ok());
+          if (st_max.ok()) {
+            CHECK((*max).size() == cell_val_num);
+
+            // For strings, the index is stored in a signed value, switch to
+            // the index to unsigned.
+            int64_t idx = (int64_t)correct_maxs_[f] -
+                          (int64_t)std::numeric_limits<char>::min();
+            CHECK(
+                0 == strncmp(
+                         (const char*)(*max).data(),
+                         string_ascii_[idx].c_str(),
+                         cell_val_num));
+          }
+
+          // Validate no sum.
+          auto&& [st_sum, sum] = frag_meta[f]->get_sum("a");
+          CHECK(!st_sum.ok());
+        } else {
+          // Validate min.
+          auto&& [st_min, min] = frag_meta[f]->get_min("a");
+          CHECK(st_min.ok());
+          if (st_min.ok()) {
+            CHECK((*min).size() == sizeof(TestType));
+            CHECK(0 == memcmp((*min).data(), &correct_mins_[f], (*min).size()));
+          }
+
+          // Validate max.
+          auto&& [st_max, max] = frag_meta[f]->get_max("a");
+          CHECK(st_max.ok());
+          if (st_max.ok()) {
+            CHECK((*max).size() == sizeof(TestType));
+            CHECK(0 == memcmp((*max).data(), &correct_maxs_[f], (*max).size()));
+          }
+
+          // Validate sum.
+          auto&& [st_sum, sum] = frag_meta[f]->get_sum("a");
+          CHECK(st_sum.ok());
+          if (st_sum.ok()) {
+            if constexpr (std::is_integral_v<TestType>) {
+              CHECK(*(int64_t*)*sum == correct_sums_int_[f]);
+            } else {
+              CHECK(*(double*)*sum - correct_sums_double_[f] < 0.0001);
+            }
+          }
+        }
+      }
+
+      // Check null count.
+      auto&& [st_nc, nc] = frag_meta[f]->get_null_count("a");
+      CHECK(st_nc.ok() == nullable);
+      if (st_nc.ok()) {
+        CHECK(*nc == correct_null_counts_[f]);
+      }
+    }
+
     // Load attribute metadata.
     std::vector<std::string> names_min{"a"};
-    auto st = frag_meta[f]->load_tile_min_values(enc_key, std::move(names_min));
+    st = frag_meta[f]->load_tile_min_values(enc_key, std::move(names_min));
     CHECK(st.ok());
 
     std::vector<std::string> names_max{"a"};
@@ -317,7 +437,7 @@ struct CPPFixedTileMetadataFx {
 
             // For strings, the index is stored in a signed value, switch to
             // the index to unsigned.
-            int64_t idx = (int64_t)correct_mins_[f][tile_idx] -
+            int64_t idx = (int64_t)correct_tile_mins_[f][tile_idx] -
                           (int64_t)std::numeric_limits<char>::min();
             CHECK(
                 0 == strncmp(
@@ -335,7 +455,7 @@ struct CPPFixedTileMetadataFx {
 
             // For strings, the index is stored in a signed value, switch to
             // the index to unsigned.
-            int64_t idx = (int64_t)correct_maxs_[f][tile_idx] -
+            int64_t idx = (int64_t)correct_tile_maxs_[f][tile_idx] -
                           (int64_t)std::numeric_limits<char>::min();
             CHECK(
                 0 == strncmp(
@@ -357,7 +477,8 @@ struct CPPFixedTileMetadataFx {
           CHECK(st_min.ok());
           if (st_min.ok()) {
             CHECK(*min_size == sizeof(TestType));
-            CHECK(0 == memcmp(*min, &correct_mins_[f][tile_idx], *min_size));
+            CHECK(
+                0 == memcmp(*min, &correct_tile_mins_[f][tile_idx], *min_size));
           }
 
           // Validate max.
@@ -366,7 +487,8 @@ struct CPPFixedTileMetadataFx {
           CHECK(st_max.ok());
           if (st_max.ok()) {
             CHECK(*max_size == sizeof(TestType));
-            CHECK(0 == memcmp(*max, &correct_maxs_[f][tile_idx], *max_size));
+            CHECK(
+                0 == memcmp(*max, &correct_tile_maxs_[f][tile_idx], *max_size));
           }
 
           // Validate sum.
@@ -374,9 +496,9 @@ struct CPPFixedTileMetadataFx {
           CHECK(st_sum.ok());
           if (st_sum.ok()) {
             if constexpr (std::is_integral_v<TestType>) {
-              CHECK(*(int64_t*)*sum == correct_sums_int_[f][tile_idx]);
+              CHECK(*(int64_t*)*sum == correct_tile_sums_int_[f][tile_idx]);
             } else {
-              CHECK(*(double*)*sum == correct_sums_double_[f][tile_idx]);
+              CHECK(*(double*)*sum == correct_tile_sums_double_[f][tile_idx]);
             }
           }
         }
@@ -389,7 +511,7 @@ struct CPPFixedTileMetadataFx {
       auto&& [st_nc, nc] = frag_meta[f]->get_tile_null_count("a", tile_idx);
       CHECK(st_nc.ok() == nullable);
       if (st_nc.ok()) {
-        CHECK(*nc == correct_null_counts_[f][tile_idx]);
+        CHECK(*nc == correct_tile_null_counts_[f][tile_idx]);
       }
     }
 
@@ -402,11 +524,16 @@ struct CPPFixedTileMetadataFx {
     tiledb_ctx_free(&ctx);
   }
 
-  std::vector<std::vector<TestType>> correct_mins_;
-  std::vector<std::vector<TestType>> correct_maxs_;
-  std::vector<std::vector<int64_t>> correct_sums_int_;
-  std::vector<std::vector<double>> correct_sums_double_;
-  std::vector<std::vector<uint64_t>> correct_null_counts_;
+  std::vector<std::vector<TestType>> correct_tile_mins_;
+  std::vector<std::vector<TestType>> correct_tile_maxs_;
+  std::vector<std::vector<int64_t>> correct_tile_sums_int_;
+  std::vector<std::vector<double>> correct_tile_sums_double_;
+  std::vector<std::vector<uint64_t>> correct_tile_null_counts_;
+  std::vector<TestType> correct_mins_;
+  std::vector<TestType> correct_maxs_;
+  std::vector<int64_t> correct_sums_int_;
+  std::vector<double> correct_sums_double_;
+  std::vector<uint64_t> correct_null_counts_;
   std::vector<std::string> string_ascii_;
 
   const char* ARRAY_NAME = "tile_metadata_unit_array";
@@ -525,17 +652,21 @@ struct CPPVarTileMetadataFx {
     }
 
     // Ensure correct vectors are big enough for this fragment.
-    correct_mins_.resize(f + 1);
-    correct_maxs_.resize(f + 1);
+    correct_tile_mins_.resize(f + 1);
+    correct_tile_maxs_.resize(f + 1);
+    correct_tile_null_counts_.resize(f + 1);
+    correct_mins_.resize(f + 1, std::numeric_limits<int>::max());
+    correct_maxs_.resize(f + 1, std::numeric_limits<int>::lowest());
     correct_null_counts_.resize(f + 1);
 
     // Compute correct values as the tile is filled with data.
-    correct_mins_[f].clear();
-    correct_maxs_[f].clear();
-    correct_null_counts_[f].clear();
-    correct_mins_[f].resize(num_tiles_, std::numeric_limits<int>::max());
-    correct_maxs_[f].resize(num_tiles_, std::numeric_limits<int>::lowest());
-    correct_null_counts_[f].resize(num_tiles_, 0);
+    correct_tile_mins_[f].clear();
+    correct_tile_maxs_[f].clear();
+    correct_tile_null_counts_[f].clear();
+    correct_tile_mins_[f].resize(num_tiles_, std::numeric_limits<int>::max());
+    correct_tile_maxs_[f].resize(
+        num_tiles_, std::numeric_limits<int>::lowest());
+    correct_tile_null_counts_[f].resize(num_tiles_, 0);
 
     // Fill the tiles with data.
     uint64_t offset = 0;
@@ -551,14 +682,17 @@ struct CPPVarTileMetadataFx {
 
       // Compute correct min/max.
       if (a_val[i] == 1) {
-        correct_mins_[f][tile_idx] =
-            std::min(correct_mins_[f][tile_idx], values[i]);
-        correct_maxs_[f][tile_idx] =
-            std::max(correct_maxs_[f][tile_idx], values[i]);
+        correct_tile_mins_[f][tile_idx] =
+            std::min(correct_tile_mins_[f][tile_idx], values[i]);
+        correct_tile_maxs_[f][tile_idx] =
+            std::max(correct_tile_maxs_[f][tile_idx], values[i]);
+        correct_mins_[f] = std::min(correct_mins_[f], values[i]);
+        correct_maxs_[f] = std::max(correct_maxs_[f], values[i]);
       }
 
       // Compute correct null count.
-      correct_null_counts_[f][tile_idx] += uint64_t(a_val[i] == 0);
+      correct_tile_null_counts_[f][tile_idx] += uint64_t(a_val[i] == 0);
+      correct_null_counts_[f] += uint64_t(a_val[i] == 0);
 
       // Copy the string.
       a_offsets[i] = offset;
@@ -602,9 +736,13 @@ struct CPPVarTileMetadataFx {
     rc = tiledb_array_open(ctx, array, TILEDB_READ);
     CHECK(rc == TILEDB_OK);
 
-    // Load the metadata and validate coords netadata.
+    // Load fragment metadata.
     auto frag_meta = array->array_->fragment_metadata();
     auto& enc_key = array->array_->get_encryption_key();
+    auto st = frag_meta[f]->load_fragment_min_max_sum_null_count(enc_key);
+    CHECK(st.ok());
+
+    // Load the metadata and validate coords netadata.
     bool has_coords = layout != TILEDB_ROW_MAJOR;
     if (has_coords) {
       std::vector<std::string> names_min{"d"};
@@ -628,6 +766,29 @@ struct CPPVarTileMetadataFx {
       // Validation.
       // Min/max/sum for all null tile are invalid.
       if (!all_null) {
+        // Do fragment metadata first.
+        {
+          int64_t correct_sum =
+              (num_tiles_ * tile_extent_) * (num_tiles_ * tile_extent_ - 1) / 2;
+
+          // Validate no min.
+          auto&& [st_min, min] = frag_meta[f]->get_min("d");
+          CHECK(!st_min.ok());
+          CHECK(!min.has_value());
+
+          // Validate no max.
+          auto&& [st_max, max] = frag_meta[f]->get_max("d");
+          CHECK(!st_max.ok());
+          CHECK(!max.has_value());
+
+          // Validate sum.
+          auto&& [st_sum, sum] = frag_meta[f]->get_sum("d");
+          CHECK(st_sum.ok());
+          if (st_sum.ok()) {
+            CHECK(*(int64_t*)*sum == correct_sum);
+          }
+        }
+
         for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
           uint32_t correct_min = tile_idx * tile_extent_;
           uint32_t correct_max = tile_idx * tile_extent_ + tile_extent_ - 1;
@@ -658,9 +819,50 @@ struct CPPVarTileMetadataFx {
       }
     }
 
+    // Do fragment metadata first for attribute.
+    {
+      // Min/max/sum for all null tile are invalid.
+      if (!all_null) {
+        // Validate min.
+        auto&& [st_min, min] = frag_meta[f]->get_min("a");
+        CHECK(st_min.ok());
+        if (st_min.ok()) {
+          CHECK((*min).size() == strings_[correct_mins_[f]].size());
+          CHECK(
+              0 == strncmp(
+                       (const char*)(*min).data(),
+                       strings_[correct_mins_[f]].c_str(),
+                       strings_[correct_mins_[f]].size()));
+        }
+
+        // Validate max.
+        auto&& [st_max, max] = frag_meta[f]->get_max("a");
+        CHECK(st_max.ok());
+        if (st_max.ok()) {
+          CHECK((*max).size() == strings_[correct_maxs_[f]].size());
+          CHECK(
+              0 == strncmp(
+                       (const char*)(*max).data(),
+                       strings_[correct_maxs_[f]].c_str(),
+                       strings_[correct_maxs_[f]].size()));
+        }
+
+        // Validate no sum.
+        auto&& [st_sum, sum] = frag_meta[f]->get_sum("a");
+        CHECK(!st_sum.ok());
+      }
+
+      // Check null count.
+      auto&& [st_nc, nc] = frag_meta[f]->get_null_count("a");
+      CHECK(st_nc.ok() == nullable);
+      if (st_nc.ok()) {
+        CHECK(*nc == correct_null_counts_[f]);
+      }
+    }
+
     // Load attribute metadata.
     std::vector<std::string> names_min{"a"};
-    auto st = frag_meta[f]->load_tile_min_values(enc_key, std::move(names_min));
+    st = frag_meta[f]->load_tile_min_values(enc_key, std::move(names_min));
     CHECK(st.ok());
 
     std::vector<std::string> names_max{"a"};
@@ -685,7 +887,7 @@ struct CPPVarTileMetadataFx {
             frag_meta[f]->get_tile_min("a", tile_idx);
         CHECK(st_min.ok());
         if (st_min.ok()) {
-          int idx = correct_mins_[f][tile_idx];
+          int idx = correct_tile_mins_[f][tile_idx];
           CHECK(*min_size == strings_[idx].size());
           CHECK(
               0 == strncmp(
@@ -699,7 +901,7 @@ struct CPPVarTileMetadataFx {
             frag_meta[f]->get_tile_max("a", tile_idx);
         CHECK(st_max.ok());
         if (st_max.ok()) {
-          int idx = correct_maxs_[f][tile_idx];
+          int idx = correct_tile_maxs_[f][tile_idx];
           CHECK(*max_size == strings_[idx].size());
           CHECK(
               0 == strncmp(
@@ -720,7 +922,7 @@ struct CPPVarTileMetadataFx {
       auto&& [st_nc, nc] = frag_meta[f]->get_tile_null_count("a", tile_idx);
       CHECK(st_nc.ok() == nullable);
       if (st_nc.ok()) {
-        CHECK(*nc == correct_null_counts_[f][tile_idx]);
+        CHECK(*nc == correct_tile_null_counts_[f][tile_idx]);
       }
     }
 
@@ -733,9 +935,12 @@ struct CPPVarTileMetadataFx {
     tiledb_ctx_free(&ctx);
   }
 
-  std::vector<std::vector<int>> correct_mins_;
-  std::vector<std::vector<int>> correct_maxs_;
-  std::vector<std::vector<uint64_t>> correct_null_counts_;
+  std::vector<std::vector<int>> correct_tile_mins_;
+  std::vector<std::vector<int>> correct_tile_maxs_;
+  std::vector<std::vector<uint64_t>> correct_tile_null_counts_;
+  std::vector<int> correct_mins_;
+  std::vector<int> correct_maxs_;
+  std::vector<uint64_t> correct_null_counts_;
   std::vector<std::string> strings_;
 
   const char* ARRAY_NAME = "tile_metadata_unit_array";

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -44,6 +44,7 @@
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
@@ -53,6 +54,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <numeric>
 #include <string>
 
 using namespace tiledb::common;
@@ -333,6 +335,104 @@ void FragmentMetadata::set_tile_null_count(
   tid += tile_index_base_;
   assert(tid < tile_null_counts_[idx].size());
   tile_null_counts_[idx][tid] = null_count;
+}
+
+template <>
+void FragmentMetadata::compute_fragment_min_max_sum<char>(
+    const std::string& name);
+
+Status FragmentMetadata::compute_fragment_min_max_sum_null_count() {
+  std::vector<std::string> names;
+  names.reserve(idx_map_.size());
+  for (auto& it : idx_map_) {
+    names.emplace_back(it.first);
+  }
+
+  // Process all attributes in parallel.
+  auto status = parallel_for(
+      storage_manager_->compute_tp(), 0, idx_map_.size(), [&](uint64_t n) {
+        // For easy reference.
+        const auto& name = names[n];
+        const auto& idx = idx_map_[name];
+        const auto var_size = array_schema_->var_size(name);
+        const auto type = array_schema_->type(name);
+
+        // Compute null count.
+        fragment_null_counts_[idx] = std::accumulate(
+            tile_null_counts_[idx].begin(), tile_null_counts_[idx].end(), 0);
+
+        if (var_size) {
+          min_max_var(name);
+        } else {
+          // Switch depending on datatype.
+          switch (type) {
+            case Datatype::INT8:
+              compute_fragment_min_max_sum<int8_t>(name);
+              break;
+            case Datatype::INT16:
+              compute_fragment_min_max_sum<int16_t>(name);
+              break;
+            case Datatype::INT32:
+              compute_fragment_min_max_sum<int32_t>(name);
+              break;
+            case Datatype::INT64:
+              compute_fragment_min_max_sum<int64_t>(name);
+              break;
+            case Datatype::UINT8:
+              compute_fragment_min_max_sum<uint8_t>(name);
+              break;
+            case Datatype::UINT16:
+              compute_fragment_min_max_sum<uint16_t>(name);
+              break;
+            case Datatype::UINT32:
+              compute_fragment_min_max_sum<uint32_t>(name);
+              break;
+            case Datatype::UINT64:
+              compute_fragment_min_max_sum<uint64_t>(name);
+              break;
+            case Datatype::FLOAT32:
+              compute_fragment_min_max_sum<float>(name);
+              break;
+            case Datatype::FLOAT64:
+              compute_fragment_min_max_sum<double>(name);
+              break;
+            case Datatype::DATETIME_YEAR:
+            case Datatype::DATETIME_MONTH:
+            case Datatype::DATETIME_WEEK:
+            case Datatype::DATETIME_DAY:
+            case Datatype::DATETIME_HR:
+            case Datatype::DATETIME_MIN:
+            case Datatype::DATETIME_SEC:
+            case Datatype::DATETIME_MS:
+            case Datatype::DATETIME_US:
+            case Datatype::DATETIME_NS:
+            case Datatype::DATETIME_PS:
+            case Datatype::DATETIME_FS:
+            case Datatype::DATETIME_AS:
+            case Datatype::TIME_HR:
+            case Datatype::TIME_MIN:
+            case Datatype::TIME_SEC:
+            case Datatype::TIME_MS:
+            case Datatype::TIME_US:
+            case Datatype::TIME_NS:
+            case Datatype::TIME_PS:
+            case Datatype::TIME_FS:
+            case Datatype::TIME_AS:
+              compute_fragment_min_max_sum<int64_t>(name);
+              break;
+            case Datatype::STRING_ASCII:
+              compute_fragment_min_max_sum<char>(name);
+              break;
+            default:
+              break;
+          }
+        }
+
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  return Status::Ok();
 }
 
 void FragmentMetadata::set_array_schema(
@@ -666,6 +766,12 @@ Status FragmentMetadata::init(const NDRange& non_empty_domain) {
   tile_sums_.resize(num);
   tile_null_counts_.resize(num);
 
+  // Initialize fragment min/max/sum/null count
+  fragment_mins_.resize(num);
+  fragment_maxs_.resize(num);
+  fragment_sums_.resize(num);
+  fragment_null_counts_.resize(num);
+
   return Status::Ok();
 }
 
@@ -709,10 +815,13 @@ Status FragmentMetadata::store(const EncryptionKey& encryption_key) {
       storage_manager_->stats()->start_timer("write_store_frag_meta");
 
   assert(version_ >= 7);
-  if (version_ <= 10)
+  if (version_ <= 10) {
     return store_v7_v10(encryption_key);
-  else
-    return store_v11_or_higher(encryption_key);
+  } else if (version_ == 11) {
+    return store_v11(encryption_key);
+  } else {
+    return store_v12_or_higher(encryption_key);
+  }
 
   assert(false);
   return Status::Ok();
@@ -775,7 +884,97 @@ Status FragmentMetadata::store_v7_v10(const EncryptionKey& encryption_key) {
   return storage_manager_->close_file(fragment_metadata_uri);
 }
 
-Status FragmentMetadata::store_v11_or_higher(
+Status FragmentMetadata::store_v11(const EncryptionKey& encryption_key) {
+  auto timer_se =
+      storage_manager_->stats()->start_timer("write_store_frag_meta");
+
+  auto fragment_metadata_uri =
+      fragment_uri_.join_path(constants::fragment_metadata_filename);
+  auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
+  uint64_t offset = 0, nbytes;
+
+  // Store R-Tree
+  gt_offsets_.rtree_ = offset;
+  RETURN_NOT_OK_ELSE(store_rtree(encryption_key, &nbytes), clean_up());
+  offset += nbytes;
+
+  // Store tile offsets
+  gt_offsets_.tile_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_offsets(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store tile var offsets
+  gt_offsets_.tile_var_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_var_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_var_offsets(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store tile var sizes
+  gt_offsets_.tile_var_sizes_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_var_sizes_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_var_sizes(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store validity tile offsets
+  gt_offsets_.tile_validity_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_validity_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_validity_offsets(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store mins
+  gt_offsets_.tile_min_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_min_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(store_tile_mins(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store maxs
+  gt_offsets_.tile_max_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_max_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(store_tile_maxs(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store sums
+  gt_offsets_.tile_sum_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_sum_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(store_tile_sums(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store null counts
+  gt_offsets_.tile_null_count_offsets_.resize(num);
+  for (unsigned int i = 0; i < num; ++i) {
+    gt_offsets_.tile_null_count_offsets_[i] = offset;
+    RETURN_NOT_OK_ELSE(
+        store_tile_null_counts(i, encryption_key, &nbytes), clean_up());
+    offset += nbytes;
+  }
+
+  // Store footer
+  RETURN_NOT_OK_ELSE(store_footer(encryption_key), clean_up());
+
+  // Close file
+  return storage_manager_->close_file(fragment_metadata_uri);
+}
+
+Status FragmentMetadata::store_v12_or_higher(
     const EncryptionKey& encryption_key) {
   auto timer_se =
       storage_manager_->stats()->start_timer("write_store_frag_meta");
@@ -858,6 +1057,13 @@ Status FragmentMetadata::store_v11_or_higher(
         store_tile_null_counts(i, encryption_key, &nbytes), clean_up());
     offset += nbytes;
   }
+
+  // Store fragment min, max, sum and null count
+  gt_offsets_.tile_min_max_sum_null_count_offset_ = offset;
+  RETURN_NOT_OK_ELSE(
+      store_fragment_min_max_sum_null_count(num, encryption_key, &nbytes),
+      clean_up());
+  offset += nbytes;
 
   // Store footer
   RETURN_NOT_OK_ELSE(store_footer(encryption_key), clean_up());
@@ -1171,6 +1377,31 @@ Status FragmentMetadata::load_tile_null_count_values(
   return Status::Ok();
 }
 
+Status FragmentMetadata::load_fragment_min_max_sum_null_count(
+    const EncryptionKey& encryption_key) {
+  if (loaded_metadata_.fragment_min_max_sum_null_count_)
+    return Status::Ok();
+
+  if (version_ <= 11)
+    return Status::Ok();
+
+  std::lock_guard<std::mutex> lock(mtx_);
+
+  Buffer buff;
+  RETURN_NOT_OK(read_generic_tile_from_file(
+      encryption_key, gt_offsets_.tile_min_max_sum_null_count_offset_, &buff));
+
+  storage_manager_->stats()->add_counter(
+      "read_fragment_min_max_sum_null_count_size", buff.size());
+
+  ConstBuffer cbuff(&buff);
+  RETURN_NOT_OK(load_fragment_min_max_sum_null_count(&cbuff));
+
+  loaded_metadata_.fragment_min_max_sum_null_count_ = true;
+
+  return Status::Ok();
+}
+
 Status FragmentMetadata::file_offset(
     const std::string& name, uint64_t tile_idx, uint64_t* offset) {
   auto it = idx_map_.find(name);
@@ -1419,6 +1650,92 @@ tuple<Status, optional<uint64_t>> FragmentMetadata::get_tile_null_count(
 
   uint64_t null_count = tile_null_counts_[idx][tile_idx];
   return {Status::Ok(), null_count};
+}
+
+tuple<Status, optional<std::vector<uint8_t>>> FragmentMetadata::get_min(
+    const std::string& name) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  if (!loaded_metadata_.fragment_min_max_sum_null_count_)
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            nullopt};
+
+  const auto type = array_schema_->type(name);
+  const auto is_dim = array_schema_->is_dim(name);
+  const auto var_size = array_schema_->var_size(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+  if (!TileMetadataGenerator::has_min_max_metadata(
+          type, is_dim, var_size, cell_val_num))
+    return {Status_FragmentMetadataError(
+                "Trying to access metadata that's not present"),
+            nullopt};
+
+  return {Status::Ok(), fragment_mins_[idx]};
+}
+
+tuple<Status, optional<std::vector<uint8_t>>> FragmentMetadata::get_max(
+    const std::string& name) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  if (!loaded_metadata_.fragment_min_max_sum_null_count_)
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            nullopt};
+
+  const auto type = array_schema_->type(name);
+  const auto is_dim = array_schema_->is_dim(name);
+  const auto var_size = array_schema_->var_size(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+  if (!TileMetadataGenerator::has_min_max_metadata(
+          type, is_dim, var_size, cell_val_num))
+    return {Status_FragmentMetadataError(
+                "Trying to access metadata that's not present"),
+            nullopt};
+
+  return {Status::Ok(), fragment_maxs_[idx]};
+}
+
+tuple<Status, optional<void*>> FragmentMetadata::get_sum(
+    const std::string& name) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  if (!loaded_metadata_.fragment_min_max_sum_null_count_)
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            nullopt};
+
+  const auto type = array_schema_->type(name);
+  const auto var_size = array_schema_->var_size(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+  if (!TileMetadataGenerator::has_sum_metadata(type, var_size, cell_val_num))
+    return {Status_FragmentMetadataError(
+                "Trying to access metadata that's not present"),
+            nullopt};
+
+  return {Status::Ok(), &fragment_sums_[idx]};
+}
+
+tuple<Status, optional<uint64_t>> FragmentMetadata::get_null_count(
+    const std::string& name) {
+  auto it = idx_map_.find(name);
+  assert(it != idx_map_.end());
+  auto idx = it->second;
+  if (!loaded_metadata_.fragment_min_max_sum_null_count_)
+    return {LOG_STATUS(Status_FragmentMetadataError(
+                "Trying to access metadata that's not loaded")),
+            nullopt};
+
+  if (!array_schema_->is_nullable(name)) {
+    return {Status_FragmentMetadataError(
+                "Trying to access metadata that's not present"),
+            nullopt};
+  }
+
+  return {Status::Ok(), fragment_null_counts_[idx]};
 }
 
 uint64_t FragmentMetadata::first_timestamp() const {
@@ -2847,6 +3164,80 @@ Status FragmentMetadata::load_tile_null_count_values(
   return Status::Ok();
 }
 
+// ===== FORMAT =====
+// fragment_min_size_attr#0 (uint64_t)
+// fragment_min_attr#0 (min_size)
+// fragment_max_size_attr#0 (uint64_t)
+// fragment_max_attr#0 (max_size)
+// fragment_sum_attr#0 (uint64_t)
+// fragment_null_count_attr#0 (uint64_t)
+// ...
+// fragment_min_size_attr#<attribute_num-1> (uint64_t)
+// fragment_min_attr#<attribute_num-1> (min_size)
+// fragment_max_size_attr#<attribute_num-1> (uint64_t)
+// fragment_max_attr#<attribute_num-1> (max_size)
+// fragment_sum_attr#<attribute_num-1> (uint64_t)
+// fragment_null_count_attr#<attribute_num-1> (uint64_t)
+Status FragmentMetadata::load_fragment_min_max_sum_null_count(
+    ConstBuffer* buff) {
+  Status st;
+  auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
+
+  for (unsigned int i = 0; i < num; ++i) {
+    // Get min.
+    uint64_t min_size;
+    st = buff->read(&min_size, sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
+                                       " fragment min size failed"));
+    }
+
+    fragment_mins_[i].resize(min_size);
+    st = buff->read(fragment_mins_[i].data(), min_size);
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
+                                       " fragment min failed"));
+    }
+
+    // Get max.
+    uint64_t max_size;
+    st = buff->read(&max_size, sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
+                                       " fragment max size failed"));
+    }
+
+    fragment_maxs_[i].resize(max_size);
+    st = buff->read(fragment_maxs_[i].data(), max_size);
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
+                                       " fragment max failed"));
+    }
+
+    // Get sum.
+    st = buff->read(&fragment_sums_[i], sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
+                                       " sum failed"));
+    }
+
+    // Get null count.
+    st = buff->read(&fragment_null_counts_[i], sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
+                                       " null count failed"));
+    }
+  }
+
+  return Status::Ok();
+}
+
 Status FragmentMetadata::load_version(ConstBuffer* buff) {
   RETURN_NOT_OK(buff->read(&version_, sizeof(uint32_t)));
   return Status::Ok();
@@ -2863,14 +3254,17 @@ Status FragmentMetadata::load_sparse_tile_num(ConstBuffer* buff) {
 }
 
 Status FragmentMetadata::load_generic_tile_offsets(ConstBuffer* buff) {
-  if (version_ == 3 || version_ == 4)
+  if (version_ == 3 || version_ == 4) {
     return load_generic_tile_offsets_v3_v4(buff);
-  else if (version_ >= 5 && version_ < 7)
+  } else if (version_ >= 5 && version_ < 7) {
     return load_generic_tile_offsets_v5_v6(buff);
-  else if (version_ >= 7 && version_ < 11)
+  } else if (version_ >= 7 && version_ < 11) {
     return load_generic_tile_offsets_v7_v10(buff);
-  else
-    return load_generic_tile_offsets_v11_or_higher(buff);
+  } else if (version_ == 11) {
+    return load_generic_tile_offsets_v11(buff);
+  } else {
+    return load_generic_tile_offsets_v12_or_higher(buff);
+  }
 
   assert(false);
   return Status::Ok();
@@ -2967,7 +3361,70 @@ Status FragmentMetadata::load_generic_tile_offsets_v7_v10(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-Status FragmentMetadata::load_generic_tile_offsets_v11_or_higher(
+Status FragmentMetadata::load_generic_tile_offsets_v11(ConstBuffer* buff) {
+  // Load R-Tree offset
+  RETURN_NOT_OK(buff->read(&gt_offsets_.rtree_, sizeof(uint64_t)));
+
+  // Load offsets for tile offsets
+  auto num = array_schema_->attribute_num() + array_schema_->dim_num() + 1;
+  gt_offsets_.tile_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(buff->read(&gt_offsets_.tile_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile var offsets
+  gt_offsets_.tile_var_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_var_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile var sizes
+  gt_offsets_.tile_var_sizes_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_var_sizes_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile validity offsets
+  gt_offsets_.tile_validity_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_validity_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile min offsets
+  gt_offsets_.tile_min_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_min_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile max offsets
+  gt_offsets_.tile_max_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_max_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile sum offsets
+  gt_offsets_.tile_sum_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_sum_offsets_[i], sizeof(uint64_t)));
+  }
+
+  // Load offsets for tile null count offsets
+  gt_offsets_.tile_null_count_offsets_.resize(num);
+  for (unsigned i = 0; i < num; ++i) {
+    RETURN_NOT_OK(
+        buff->read(&gt_offsets_.tile_null_count_offsets_[i], sizeof(uint64_t)));
+  }
+
+  return Status::Ok();
+}
+
+Status FragmentMetadata::load_generic_tile_offsets_v12_or_higher(
     ConstBuffer* buff) {
   // Load R-Tree offset
   RETURN_NOT_OK(buff->read(&gt_offsets_.rtree_, sizeof(uint64_t)));
@@ -3027,6 +3484,9 @@ Status FragmentMetadata::load_generic_tile_offsets_v11_or_higher(
     RETURN_NOT_OK(
         buff->read(&gt_offsets_.tile_null_count_offsets_[i], sizeof(uint64_t)));
   }
+
+  RETURN_NOT_OK(buff->read(
+      &gt_offsets_.tile_min_max_sum_null_count_offset_, sizeof(uint64_t)));
 
   return Status::Ok();
 }
@@ -3178,6 +3638,11 @@ Status FragmentMetadata::load_footer(
   tile_max_var_buffer_.resize(num);
   tile_sums_.resize(num);
   tile_null_counts_.resize(num);
+
+  fragment_mins_.resize(num);
+  fragment_maxs_.resize(num);
+  fragment_sums_.resize(num);
+  fragment_null_counts_.resize(num);
 
   loaded_metadata_.tile_offsets_.resize(num, false);
   loaded_metadata_.tile_var_offsets_.resize(num, false);
@@ -3352,6 +3817,16 @@ Status FragmentMetadata::write_generic_tile_offsets(Buffer* buff) const {
             "Cannot serialize fragment metadata; Writing tile null counts "
             "failed"));
       }
+    }
+  }
+
+  if (version_ >= 11) {
+    st = buff->write(
+        &gt_offsets_.tile_min_max_sum_null_count_offset_, sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot serialize fragment metadata; Writing fragment min max sum "
+          "null counts failed"));
     }
   }
 
@@ -3862,6 +4337,366 @@ Status FragmentMetadata::write_tile_null_counts(unsigned idx, Buffer* buff) {
   }
 
   return Status::Ok();
+}
+
+Status FragmentMetadata::store_fragment_min_max_sum_null_count(
+    uint64_t num, const EncryptionKey& encryption_key, uint64_t* nbytes) {
+  Status st;
+  Buffer buff;
+
+  // Store all attributes.
+  for (unsigned int i = 0; i < num; ++i) {
+    // Store min.
+    uint64_t min_size = fragment_mins_[i].size();
+    st = buff.write(&min_size, sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing fragment min size failed"));
+    }
+
+    st = buff.write(fragment_mins_[i].data(), min_size);
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing fragment min failed"));
+    }
+
+    // Store max.
+    uint64_t max_size = fragment_maxs_[i].size();
+    st = buff.write(&max_size, sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing fragment max size failed"));
+    }
+
+    st = buff.write(fragment_maxs_[i].data(), max_size);
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing fragment max failed"));
+    }
+
+    // Store sum.
+    st = buff.write(&fragment_sums_[i], sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing fragment sum failed"));
+    }
+
+    // Store null count.
+    st = buff.write(&fragment_null_counts_[i], sizeof(uint64_t));
+    if (!st.ok()) {
+      return LOG_STATUS(
+          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
+                                       "Writing fragment null count failed"));
+    }
+  }
+
+  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
+
+  storage_manager_->stats()->add_counter("write_null_counts_size", *nbytes);
+
+  return Status::Ok();
+}
+
+template <class T>
+void FragmentMetadata::compute_fragment_min_max_sum(const std::string& name) {
+  // For easy reference.
+  const auto& idx = idx_map_[name];
+  const auto nullable = array_schema_->is_nullable(name);
+  const auto is_dim = array_schema_->is_dim(name);
+  const auto type = array_schema_->type(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+
+  // No metadata for dense coords
+  if (!array_schema_->dense() || !is_dim) {
+    const auto has_min_max = TileMetadataGenerator::has_min_max_metadata(
+        type, is_dim, false, cell_val_num);
+    const auto has_sum =
+        TileMetadataGenerator::has_sum_metadata(type, false, cell_val_num);
+
+    if (has_min_max) {
+      // Initialize defaults.
+      T min = metadata_generator_type_data<T>::min;
+      T max = metadata_generator_type_data<T>::max;
+
+      // Get data and tile num.
+      auto min_values =
+          static_cast<T*>(static_cast<void*>(tile_min_buffer_[idx].data()));
+      auto max_values =
+          static_cast<T*>(static_cast<void*>(tile_max_buffer_[idx].data()));
+      auto& null_count_values = tile_null_counts_[idx];
+      auto tile_num = this->tile_num();
+
+      // Process tile by tile.
+      for (uint64_t t = 0; t < tile_num; t++) {
+        const bool is_null = nullable && null_count_values[t] == cell_num(t);
+        if (!is_null) {
+          min = min < min_values[t] ? min : min_values[t];
+          max = max > max_values[t] ? max : max_values[t];
+        }
+      }
+
+      // Copy min max values.
+      fragment_mins_[idx].resize(sizeof(T));
+      fragment_maxs_[idx].resize(sizeof(T));
+      memcpy(fragment_mins_[idx].data(), &min, sizeof(T));
+      memcpy(fragment_maxs_[idx].data(), &max, sizeof(T));
+    }
+
+    if (has_sum) {
+      compute_fragment_sum<typename metadata_generator_type_data<T>::sum_type>(
+          idx, nullable);
+    }
+  }
+}
+
+template <>
+void FragmentMetadata::compute_fragment_min_max_sum<char>(
+    const std::string& name) {
+  // For easy reference.
+  const auto idx = idx_map_[name];
+  const auto nullable = array_schema_->is_nullable(name);
+  const auto is_dim = array_schema_->is_dim(name);
+  const auto type = array_schema_->type(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+
+  // Return if there's no min/max.
+  const auto has_min_max = TileMetadataGenerator::has_min_max_metadata(
+      type, is_dim, false, cell_val_num);
+  if (!has_min_max)
+    return;
+
+  // Initialize to null.
+  void* min = nullptr;
+  void* max = nullptr;
+
+  // Get data and tile num.
+  auto min_values = tile_min_buffer_[idx].data();
+  auto max_values = tile_max_buffer_[idx].data();
+  auto& null_count_values = tile_null_counts_[idx];
+  auto tile_num = this->tile_num();
+
+  // Process tile by tile.
+  for (uint64_t t = 0; t < tile_num; t++) {
+    if (!nullable || null_count_values[t] != cell_num(t)) {
+      min = (min == nullptr ||
+             strncmp((const char*)min, (const char*)min_values, cell_val_num) >
+                 0) ?
+                min_values :
+                min;
+      min_values += cell_val_num;
+      max = (max == nullptr ||
+             strncmp((const char*)max, (const char*)max_values, cell_val_num) <
+                 0) ?
+                max_values :
+                max;
+      max_values += cell_val_num;
+    }
+  }
+
+  // Copy values.
+  if (min != nullptr) {
+    fragment_mins_[idx].resize(cell_val_num);
+    memcpy(fragment_mins_[idx].data(), min, cell_val_num);
+  }
+
+  if (max != nullptr) {
+    fragment_maxs_[idx].resize(cell_val_num);
+    memcpy(fragment_maxs_[idx].data(), max, cell_val_num);
+  }
+}
+
+template <>
+void FragmentMetadata::compute_fragment_sum<int64_t>(
+    const uint64_t idx, const bool nullable) {
+  // Zero sum.
+  int64_t sum_data = 0;
+
+  // Get data and tile num.
+  auto values =
+      static_cast<int64_t*>(static_cast<void*>(tile_sums_[idx].data()));
+  auto& null_count_values = tile_null_counts_[idx];
+  auto tile_num = this->tile_num();
+
+  // Process tile by tile, swallowing overflow exception.
+  for (uint64_t t = 0; t < tile_num; t++) {
+    if (!nullable || null_count_values[t] != cell_num(t)) {
+      if (sum_data > 0 && values[t] > 0 &&
+          (sum_data > std::numeric_limits<int64_t>::max() - values[t])) {
+        sum_data = std::numeric_limits<int64_t>::max();
+        break;
+      }
+
+      if (sum_data < 0 && values[t] < 0 &&
+          (sum_data < std::numeric_limits<int64_t>::min() - values[t])) {
+        sum_data = std::numeric_limits<int64_t>::min();
+        break;
+      }
+
+      sum_data += values[t];
+    }
+  }
+
+  // Copy value.
+  memcpy(&fragment_sums_[idx], &sum_data, sizeof(int64_t));
+}
+
+template <>
+void FragmentMetadata::compute_fragment_sum<uint64_t>(
+    const uint64_t idx, const bool nullable) {
+  // Zero sum.
+  uint64_t sum_data = 0;
+
+  // Get data and tile num.
+  auto values =
+      static_cast<uint64_t*>(static_cast<void*>(tile_sums_[idx].data()));
+  auto& null_count_values = tile_null_counts_[idx];
+  auto tile_num = this->tile_num();
+
+  // Process tile by tile, swallowing overflow exception.
+  for (uint64_t t = 0; t < tile_num; t++) {
+    if (!nullable || null_count_values[t] != cell_num(t)) {
+      if (sum_data > std::numeric_limits<uint64_t>::max() - values[t]) {
+        sum_data = std::numeric_limits<uint64_t>::max();
+        break;
+      }
+
+      sum_data += values[t];
+    }
+  }
+
+  // Copy value.
+  memcpy(&fragment_sums_[idx], &sum_data, sizeof(uint64_t));
+}
+
+template <>
+void FragmentMetadata::compute_fragment_sum<double>(
+    const uint64_t idx, const bool nullable) {
+  // Zero sum.
+  double sum_data = 0;
+
+  // Get data and tile num.
+  auto values =
+      static_cast<double*>(static_cast<void*>(tile_sums_[idx].data()));
+  auto& null_count_values = tile_null_counts_[idx];
+  auto tile_num = this->tile_num();
+
+  // Process tile by tile, swallowing overflow exception.
+  for (uint64_t t = 0; t < tile_num; t++) {
+    if (!nullable || null_count_values[t] != cell_num(t)) {
+      if ((sum_data < 0.0) == (values[t] < 0.0) &&
+          std::abs(sum_data) >
+              std::numeric_limits<double>::max() - std::abs(values[t])) {
+        sum_data = sum_data < 0.0 ? std::numeric_limits<double>::lowest() :
+                                    std::numeric_limits<double>::max();
+        break;
+      }
+
+      sum_data += values[t];
+    }
+  }
+
+  // Copy value.
+  memcpy(&fragment_sums_[idx], &sum_data, sizeof(double));
+}
+
+void FragmentMetadata::min_max_var(const std::string& name) {
+  // For easy reference.
+  const auto nullable = array_schema_->is_nullable(name);
+  const auto is_dim = array_schema_->is_dim(name);
+  const auto type = array_schema_->type(name);
+  const auto cell_val_num = array_schema_->cell_val_num(name);
+  const auto idx = idx_map_[name];
+
+  // Return if there's no min/max.
+  const auto has_min_max = TileMetadataGenerator::has_min_max_metadata(
+      type, is_dim, true, cell_val_num);
+  if (!has_min_max)
+    return;
+
+  // Initialize to null.
+  void* min = nullptr;
+  void* max = nullptr;
+  uint64_t min_size = 0;
+  uint64_t max_size = 0;
+
+  // Get data and tile num.
+  auto min_offsets =
+      static_cast<uint64_t*>(static_cast<void*>(tile_min_buffer_[idx].data()));
+  auto max_offsets =
+      static_cast<uint64_t*>(static_cast<void*>(tile_max_buffer_[idx].data()));
+  auto min_values = tile_min_var_buffer_[idx].data();
+  auto max_values = tile_max_var_buffer_[idx].data();
+  auto& null_count_values = tile_null_counts_[idx];
+  auto tile_num = this->tile_num();
+
+  // Process tile by tile.
+  for (uint64_t t = 0; t < tile_num; t++) {
+    if (!nullable || null_count_values[t] != cell_num(t)) {
+      auto min_value = min_values + min_offsets[t];
+      auto min_value_size =
+          t == tile_num - 1 ?
+              tile_min_var_buffer_[idx].size() - min_offsets[t] :
+              min_offsets[t + 1] - min_offsets[t];
+      auto max_value = max_values + max_offsets[t];
+      auto max_value_size =
+          t == tile_num - 1 ?
+              tile_max_var_buffer_[idx].size() - max_offsets[t] :
+              max_offsets[t + 1] - max_offsets[t];
+      if (min == nullptr && max == nullptr) {
+        min = min_value;
+        min_size = min_value_size;
+        max = max_value;
+        max_size = max_value_size;
+      } else {
+        // Process min.
+        size_t min_cmp_size = std::min<size_t>(min_size, min_value_size);
+        int cmp =
+            strncmp(static_cast<const char*>(min), min_value, min_cmp_size);
+        if (cmp != 0) {
+          if (cmp > 0) {
+            min = min_value;
+            min_size = min_value_size;
+          }
+        } else {
+          if (min_value_size < min_size) {
+            min = min_value;
+            min_size = min_value_size;
+          }
+        }
+
+        // Process max.
+        size_t max_cmp_size = std::min<size_t>(max_size, max_value_size);
+        cmp = strncmp(static_cast<const char*>(max), max_value, max_cmp_size);
+        if (cmp != 0) {
+          if (cmp < 0) {
+            max = max_value;
+            max_size = max_value_size;
+          }
+        } else {
+          if (max_value_size > max_size) {
+            max = max_value;
+            max_size = max_value_size;
+          }
+        }
+      }
+    }
+  }
+
+  // Copy values.
+  if (min != nullptr) {
+    fragment_mins_[idx].resize(min_size);
+    memcpy(fragment_mins_[idx].data(), min, min_size);
+  }
+
+  if (max != nullptr) {
+    fragment_maxs_[idx].resize(max_size);
+    memcpy(fragment_maxs_[idx].data(), max, max_size);
+  }
 }
 
 Status FragmentMetadata::write_version(Buffer* buff) const {

--- a/tiledb/sm/query/global_order_writer.cc
+++ b/tiledb/sm/query/global_order_writer.cc
@@ -483,6 +483,10 @@ Status GlobalOrderWriter::finalize_global_write_state() {
     }
   }
 
+  // Compute fragment min/max/sum/null count
+  RETURN_NOT_OK_ELSE(
+      meta->compute_fragment_min_max_sum_null_count(), clean_up(uri));
+
   // Flush fragment metadata to storage
   RETURN_NOT_OK_ELSE(meta->store(array_->get_encryption_key()), clean_up(uri));
 

--- a/tiledb/sm/query/ordered_writer.cc
+++ b/tiledb/sm/query/ordered_writer.cc
@@ -287,6 +287,11 @@ Status OrderedWriter::ordered_write() {
     }
   }
 
+  // Compute fragment min/max/sum/null count
+  RETURN_NOT_OK_ELSE(
+      frag_meta->compute_fragment_min_max_sum_null_count(),
+      storage_manager_->vfs()->remove_dir(uri));
+
   // Write the fragment metadata
   RETURN_CANCEL_OR_ERROR_ELSE(
       frag_meta->store(array_->get_encryption_key()),

--- a/tiledb/sm/query/unordered_writer.cc
+++ b/tiledb/sm/query/unordered_writer.cc
@@ -674,6 +674,10 @@ Status UnorderedWriter::unordered_write() {
   RETURN_CANCEL_OR_ERROR_ELSE(
       write_all_tiles(frag_meta, &tiles), clean_up(uri));
 
+  // Compute fragment min/max/sum/null count
+  RETURN_NOT_OK_ELSE(
+      frag_meta->compute_fragment_min_max_sum_null_count(), clean_up(uri));
+
   // Write the fragment metadata
   RETURN_CANCEL_OR_ERROR_ELSE(
       frag_meta->store(array_->get_encryption_key()), clean_up(uri));


### PR DESCRIPTION
In #2830 min/max/sum/null count was added on a per tile basis. The work
was supposed to also include the information per fragment. This PR add
this feature.

---
TYPE: IMPROVEMENT
DESC: Fragment metadata: add min/max/sun/null count.
