### PR TITLE
Update Location of Zlib Download URL

### DIFF
--- a/cmake/Modules/FindZlib_EP.cmake
+++ b/cmake/Modules/FindZlib_EP.cmake
@@ -83,7 +83,7 @@ if (NOT ZLIB_FOUND)
 
     ExternalProject_Add(ep_zlib
       PREFIX "externals"
-      URL "http://prdownloads.sourceforge.net/libpng/zlib1211.zip?download"
+      URL "http://iweb.dl.sourceforge.net/project/libpng/zlib/1.2.11/zlib1211.zip"
       URL_HASH SHA1=bccd93ad3cee39c3d08eee68d45b3e11910299f2
       DOWNLOAD_NAME "zlib1211.zip"
       CMAKE_ARGS


### PR DESCRIPTION
The download URL for external dependency Zlib has moved. 

Fix for https://github.com/TileDB-Inc/TileDB-Py/issues/950. See comment in issue for more details.

---
TYPE: BUG 
DESC: Update Location of Zlib Download URL
