### PR TITLE
Smart pointer conversion: ArraySchema Domain

### DIFF
--- a/test/src/unit-QueryCondition.cc
+++ b/test/src/unit-QueryCondition.cc
@@ -30,6 +30,7 @@
  * Tests the `QueryCondition` class.
  */
 
+#include "tiledb/common/common.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -719,9 +720,9 @@ void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -754,9 +755,9 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -812,9 +813,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -914,9 +915,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -1481,9 +1482,9 @@ void test_apply_dense<char*>(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -1517,9 +1518,9 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -1577,9 +1578,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -1681,9 +1682,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -2250,9 +2251,9 @@ void test_apply_sparse<char*>(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -2286,9 +2287,9 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -2347,9 +2348,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -2453,9 +2454,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema
-              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
-              .ok());
+  REQUIRE(
+      array_schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain))
+          .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);

--- a/test/src/unit-QueryCondition.cc
+++ b/test/src/unit-QueryCondition.cc
@@ -719,7 +719,9 @@ void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -752,7 +754,9 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -808,7 +812,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -908,7 +914,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -1473,7 +1481,9 @@ void test_apply_dense<char*>(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -1507,7 +1517,9 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -1565,7 +1577,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -1667,7 +1681,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -2234,7 +2250,9 @@ void test_apply_sparse<char*>(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -2268,7 +2286,9 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -2327,7 +2347,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
@@ -2431,7 +2453,9 @@ TEST_CASE(
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim.set_domain(range).ok());
   REQUIRE(domain.add_dimension(&dim).ok());
-  REQUIRE(array_schema.set_domain(&domain).ok());
+  REQUIRE(array_schema
+              .set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain))
+              .ok());
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -72,7 +72,7 @@ struct ReadCellSlabIterFx {
   template <class T>
   void create_result_space_tiles(
       const std::vector<tdb_shared_ptr<FragmentMetadata>>& fragments,
-      const Domain* dom,
+      shared_ptr<const Domain> dom,
       const NDRange& dom_ndrange,
       Layout layout,
       const std::vector<NDRange>& domain_slices,
@@ -137,7 +137,7 @@ void ReadCellSlabIterFx::check_iter(
 template <class T>
 void ReadCellSlabIterFx::create_result_space_tiles(
     const std::vector<tdb_shared_ptr<FragmentMetadata>>& fragments,
-    const Domain* dom,
+    shared_ptr<const Domain> dom,
     const NDRange& dom_ndrange,
     Layout layout,
     const std::vector<NDRange>& domain_slices,

--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -32,6 +32,7 @@
 
 #include "test/src/helpers.h"
 #include "test/src/vfs_helpers.h"
+#include "tiledb/common/common.h"
 #include "tiledb/common/dynamic_memory/dynamic_memory.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
@@ -192,8 +193,7 @@ TEST_CASE_METHOD(
   CHECK(dom.add_dimension(&d2).ok());
 
   auto schema = tdb::make_shared<ArraySchema>(HERE());
-  CHECK(schema->set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom))
-            .ok());
+  CHECK(schema->set_domain(make_shared<tiledb::sm::Domain>(HERE(), &dom)).ok());
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   for (uint64_t i = 0; i < frag_tile_domains.size() + 1; i++) {

--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -192,7 +192,8 @@ TEST_CASE_METHOD(
   CHECK(dom.add_dimension(&d2).ok());
 
   auto schema = tdb::make_shared<ArraySchema>(HERE());
-  CHECK(schema->set_domain(&dom).ok());
+  CHECK(schema->set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom))
+            .ok());
 
   std::vector<tdb_shared_ptr<FragmentMetadata>> fragments;
   for (uint64_t i = 0; i < frag_tile_domains.size() + 1; i++) {

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -1551,7 +1551,7 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
   tiledb::sm::ArraySchema schema;
   tiledb::sm::Attribute attr("attr", Datatype::UINT64);
   schema.add_attribute(tdb::make_shared<tiledb::sm::Attribute>(HERE(), &attr));
-  schema.set_domain(&domain);
+  schema.set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain));
   schema.init();
 
   FilterPipeline pipeline;
@@ -1711,7 +1711,7 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
   tiledb::sm::ArraySchema schema;
   tiledb::sm::Attribute attr("attr", Datatype::UINT64);
   schema.add_attribute(tdb::make_shared<tiledb::sm::Attribute>(HERE(), &attr));
-  schema.set_domain(&domain);
+  schema.set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain));
   schema.init();
 
   FilterPipeline pipeline;

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -32,6 +32,7 @@
  */
 
 #include "test/src/helpers.h"
+#include "tiledb/common/common.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
@@ -1551,7 +1552,7 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
   tiledb::sm::ArraySchema schema;
   tiledb::sm::Attribute attr("attr", Datatype::UINT64);
   schema.add_attribute(tdb::make_shared<tiledb::sm::Attribute>(HERE(), &attr));
-  schema.set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain));
+  schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain));
   schema.init();
 
   FilterPipeline pipeline;
@@ -1711,7 +1712,7 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
   tiledb::sm::ArraySchema schema;
   tiledb::sm::Attribute attr("attr", Datatype::UINT64);
   schema.add_attribute(tdb::make_shared<tiledb::sm::Attribute>(HERE(), &attr));
-  schema.set_domain(tdb::make_shared<tiledb::sm::Domain>(HERE(), &domain));
+  schema.set_domain(make_shared<tiledb::sm::Domain>(HERE(), &domain));
   schema.init();
 
   FilterPipeline pipeline;

--- a/test/src/unit-rtree.cc
+++ b/test/src/unit-rtree.cc
@@ -115,7 +115,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   Domain dom1 =
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   std::vector<NDRange> mbrs_1d = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22});
-  RTree rtree1(&dom1, 3);
+  RTree rtree1(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   CHECK(!rtree1.set_leaf(0, mbrs_1d[0]).ok());
   rtree1.set_leaf_num(mbrs_1d.size());
   for (size_t m = 0; m < mbrs_1d.size(); ++m)
@@ -175,7 +175,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
       {&dim_extent_2, &dim_extent_2});
   std::vector<NDRange> mbrs_2d =
       create_mbrs<int64_t, 2>({1, 3, 5, 10, 20, 22, 24, 25, 11, 15, 30, 31});
-  RTree rtree2(&dom2, 5);
+  RTree rtree2(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom2), 5);
   rtree2.set_leaves(mbrs_2d);
   rtree2.build_tree();
   CHECK(rtree2.height() == 2);
@@ -213,7 +213,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
       create_mbrs<float, 1>({1.0f, 3.0f, 5.0f, 10.0f, 20.0f, 22.0f});
   Domain dom2f =
       create_domain({"d"}, {Datatype::FLOAT32}, {dim_dom_f}, {&dim_extent_f});
-  RTree rtreef(&dom2f, 5);
+  RTree rtreef(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom2f), 5);
   rtreef.set_leaves(mbrs_f);
   rtreef.build_tree();
 
@@ -255,7 +255,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 2", "[rtree][1d][2h]") {
   Domain dom1 =
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   std::vector<NDRange> mbrs = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22});
-  RTree rtree(&dom1, 3);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -301,7 +301,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 3", "[rtree][1d][3h]") {
       {1, 3, 5, 10, 20, 22, 30, 35, 36, 38, 40, 49, 50, 51, 65, 69});
   Domain dom1 =
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
-  RTree rtree(&dom1, 3);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -369,7 +369,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 2", "[rtree][2d][2h]") {
       {&dim_extent, &dim_extent});
   std::vector<NDRange> mbrs =
       create_mbrs<int32_t, 2>({1, 3, 2, 4, 5, 7, 6, 9, 10, 12, 10, 15});
-  RTree rtree(&dom2, 3);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom2), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -422,7 +422,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 3", "[rtree][2d][3h]") {
   std::vector<NDRange> mbrs = create_mbrs<int32_t, 2>(
       {1,  3,  2,  4,  5,  7,  6,  9,  10, 12, 10, 15, 11, 15, 20, 22, 16, 16,
        23, 23, 19, 20, 24, 26, 25, 28, 30, 32, 30, 35, 35, 37, 40, 42, 40, 42});
-  RTree rtree(&dom2, 3);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom2), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -499,7 +499,7 @@ TEST_CASE(
       {&uint8_extent, &int32_extent});
   std::vector<NDRange> mbrs =
       create_mbrs<uint8_t, int32_t>({0, 1, 3, 5}, {5, 6, 7, 9});
-  RTree rtree(&dom, 5);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 5);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -554,7 +554,7 @@ TEST_CASE(
       {&uint64_extent, &float_extent});
   std::vector<NDRange> mbrs =
       create_mbrs<uint64_t, float>({0, 1, 3, 5}, {.5f, .6f, .7f, .9f});
-  RTree rtree(&dom, 5);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 5);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -609,7 +609,7 @@ TEST_CASE(
       {&uint8_extent, &int32_extent});
   std::vector<NDRange> mbrs =
       create_mbrs<uint8_t, int32_t>({0, 1, 3, 5, 11, 20}, {5, 6, 7, 9, 11, 30});
-  RTree rtree(&dom, 3);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -677,7 +677,7 @@ TEST_CASE(
       {&uint8_extent, &int32_extent});
   std::vector<NDRange> mbrs = create_mbrs<uint8_t, int32_t>(
       {0, 1, 3, 5, 11, 20, 21, 26}, {5, 6, 7, 9, 11, 30, 31, 40});
-  RTree rtree(&dom, 2);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 2);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -816,7 +816,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs =
       create_str_mbrs<1>({"aa", "b", "eee", "g", "gggg", "ii"});
 
-  RTree rtree(&dom1, 3);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -903,7 +903,7 @@ TEST_CASE(
                                                   "oo",
                                                   "oop"});
 
-  RTree rtree(&dom1, 3);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -996,7 +996,7 @@ TEST_CASE(
                                                   "oo",
                                                   "qqq"});
 
-  RTree rtree(&dom, 3);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -1101,7 +1101,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs = create_str_int32_mbrs(
       {"aa", "b", "eee", "g", "gggg", "ii"}, {1, 5, 7, 8, 10, 14});
 
-  RTree rtree(&dom, 3);
+  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);

--- a/test/src/unit-rtree.cc
+++ b/test/src/unit-rtree.cc
@@ -30,6 +30,7 @@
  * Tests the `RTree` class.
  */
 
+#include "tiledb/common/common.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/layout.h"
@@ -115,7 +116,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   Domain dom1 =
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   std::vector<NDRange> mbrs_1d = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22});
-  RTree rtree1(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
+  RTree rtree1(make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   CHECK(!rtree1.set_leaf(0, mbrs_1d[0]).ok());
   rtree1.set_leaf_num(mbrs_1d.size());
   for (size_t m = 0; m < mbrs_1d.size(); ++m)
@@ -175,7 +176,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
       {&dim_extent_2, &dim_extent_2});
   std::vector<NDRange> mbrs_2d =
       create_mbrs<int64_t, 2>({1, 3, 5, 10, 20, 22, 24, 25, 11, 15, 30, 31});
-  RTree rtree2(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom2), 5);
+  RTree rtree2(make_shared<tiledb::sm::Domain>(HERE(), &dom2), 5);
   rtree2.set_leaves(mbrs_2d);
   rtree2.build_tree();
   CHECK(rtree2.height() == 2);
@@ -213,7 +214,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
       create_mbrs<float, 1>({1.0f, 3.0f, 5.0f, 10.0f, 20.0f, 22.0f});
   Domain dom2f =
       create_domain({"d"}, {Datatype::FLOAT32}, {dim_dom_f}, {&dim_extent_f});
-  RTree rtreef(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom2f), 5);
+  RTree rtreef(make_shared<tiledb::sm::Domain>(HERE(), &dom2f), 5);
   rtreef.set_leaves(mbrs_f);
   rtreef.build_tree();
 
@@ -255,7 +256,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 2", "[rtree][1d][2h]") {
   Domain dom1 =
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   std::vector<NDRange> mbrs = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22});
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -301,7 +302,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 3", "[rtree][1d][3h]") {
       {1, 3, 5, 10, 20, 22, 30, 35, 36, 38, 40, 49, 50, 51, 65, 69});
   Domain dom1 =
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -369,7 +370,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 2", "[rtree][2d][2h]") {
       {&dim_extent, &dim_extent});
   std::vector<NDRange> mbrs =
       create_mbrs<int32_t, 2>({1, 3, 2, 4, 5, 7, 6, 9, 10, 12, 10, 15});
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom2), 3);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom2), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -422,7 +423,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 3", "[rtree][2d][3h]") {
   std::vector<NDRange> mbrs = create_mbrs<int32_t, 2>(
       {1,  3,  2,  4,  5,  7,  6,  9,  10, 12, 10, 15, 11, 15, 20, 22, 16, 16,
        23, 23, 19, 20, 24, 26, 25, 28, 30, 32, 30, 35, 35, 37, 40, 42, 40, 42});
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom2), 3);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom2), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -499,7 +500,7 @@ TEST_CASE(
       {&uint8_extent, &int32_extent});
   std::vector<NDRange> mbrs =
       create_mbrs<uint8_t, int32_t>({0, 1, 3, 5}, {5, 6, 7, 9});
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 5);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom), 5);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -554,7 +555,7 @@ TEST_CASE(
       {&uint64_extent, &float_extent});
   std::vector<NDRange> mbrs =
       create_mbrs<uint64_t, float>({0, 1, 3, 5}, {.5f, .6f, .7f, .9f});
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 5);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom), 5);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -609,7 +610,7 @@ TEST_CASE(
       {&uint8_extent, &int32_extent});
   std::vector<NDRange> mbrs =
       create_mbrs<uint8_t, int32_t>({0, 1, 3, 5, 11, 20}, {5, 6, 7, 9, 11, 30});
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 3);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -677,7 +678,7 @@ TEST_CASE(
       {&uint8_extent, &int32_extent});
   std::vector<NDRange> mbrs = create_mbrs<uint8_t, int32_t>(
       {0, 1, 3, 5, 11, 20, 21, 26}, {5, 6, 7, 9, 11, 30, 31, 40});
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 2);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom), 2);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -816,7 +817,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs =
       create_str_mbrs<1>({"aa", "b", "eee", "g", "gggg", "ii"});
 
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -903,7 +904,7 @@ TEST_CASE(
                                                   "oo",
                                                   "oop"});
 
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom1), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -996,7 +997,7 @@ TEST_CASE(
                                                   "oo",
                                                   "qqq"});
 
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 3);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -1101,7 +1102,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs = create_str_int32_mbrs(
       {"aa", "b", "eee", "g", "gggg", "ii"}, {1, 5, 7, 8, 10, 14});
 
-  RTree rtree(tdb::make_shared<tiledb::sm::Domain>(HERE(), &dom), 3);
+  RTree rtree(make_shared<tiledb::sm::Domain>(HERE(), &dom), 3);
   rtree.set_leaves(mbrs);
   rtree.build_tree();
   CHECK(rtree.height() == 2);

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -596,7 +596,7 @@ Status ArraySchema::deserialize(ConstBuffer* buff) {
   }
 
   // Load domain
-  domain_ = tdb::make_shared<Domain>(HERE());
+  domain_ = make_shared<Domain>(HERE());
   RETURN_NOT_OK(domain_->deserialize(buff, version_));
 
   // Load attributes

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -596,7 +596,7 @@ Status ArraySchema::deserialize(ConstBuffer* buff) {
   }
 
   // Load domain
-  domain_ = tdb_new(Domain);
+  domain_ = tdb::make_shared<Domain>(HERE());
   RETURN_NOT_OK(domain_->deserialize(buff, version_));
 
   // Load attributes
@@ -628,8 +628,8 @@ Status ArraySchema::deserialize(ConstBuffer* buff) {
   return Status::Ok();
 }
 
-const Domain* ArraySchema::domain() const {
-  return domain_;
+shared_ptr<const Domain> ArraySchema::domain() const {
+  return std::const_pointer_cast<const Domain>(domain_);
 }
 
 Status ArraySchema::init() {
@@ -692,7 +692,7 @@ Status ArraySchema::set_cell_validity_filter_pipeline(
   return Status::Ok();
 }
 
-Status ArraySchema::set_domain(Domain* domain) {
+Status ArraySchema::set_domain(shared_ptr<Domain> domain) {
   if (domain == nullptr)
     return LOG_STATUS(
         Status_ArraySchemaError("Cannot set domain; Input domain is nullptr"));
@@ -722,8 +722,7 @@ Status ArraySchema::set_domain(Domain* domain) {
   }
 
   // Set domain
-  tdb_delete(domain_);
-  domain_ = tdb_new(Domain, domain);
+  domain_ = domain;
 
   // Create dimension map
   dim_map_.clear();
@@ -864,7 +863,6 @@ void ArraySchema::clear() {
   tile_order_ = Layout::ROW_MAJOR;
   attributes_.clear();
 
-  tdb_delete(domain_);
   domain_ = nullptr;
   timestamp_range_ = std::make_pair(0, 0);
 }

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -260,7 +260,7 @@ class ArraySchema {
   Status deserialize(ConstBuffer* buff);
 
   /** Returns the array domain. */
-  const Domain* domain() const;
+  shared_ptr<const Domain> domain() const;
 
   /**
    * Initializes the ArraySchema object. It also performs a check to see if
@@ -298,7 +298,7 @@ class ArraySchema {
    * Sets the domain. The function returns an error if the array has been
    * previously set to be a key-value store.
    */
-  Status set_domain(Domain* domain);
+  Status set_domain(shared_ptr<Domain> domain);
 
   /** Sets the tile order. */
   Status set_tile_order(Layout tile_order);
@@ -395,7 +395,7 @@ class ArraySchema {
   std::unordered_map<std::string, const Dimension*> dim_map_;
 
   /** The array domain. */
-  Domain* domain_;
+  shared_ptr<Domain> domain_;
 
   /**
    * The tile order. It can be one of the following:

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2490,7 +2490,7 @@ int32_t tiledb_array_schema_set_domain(
   if (SAVE_ERROR_CATCH(
           ctx,
           array_schema->array_schema_->set_domain(
-              tdb::make_shared<tiledb::sm::Domain>(HERE(), domain->domain_))))
+              make_shared<tiledb::sm::Domain>(HERE(), domain->domain_))))
     return TILEDB_ERR;
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2488,7 +2488,9 @@ int32_t tiledb_array_schema_set_domain(
       sanity_check(ctx, array_schema) == TILEDB_ERR)
     return TILEDB_ERR;
   if (SAVE_ERROR_CATCH(
-          ctx, array_schema->array_schema_->set_domain(domain->domain_)))
+          ctx,
+          array_schema->array_schema_->set_domain(
+              tdb::make_shared<tiledb::sm::Domain>(HERE(), domain->domain_))))
     return TILEDB_ERR;
   return TILEDB_OK;
 }
@@ -2962,7 +2964,7 @@ int32_t tiledb_array_schema_get_domain(
 
   // Create a new Domain object
   (*domain)->domain_ = new (std::nothrow)
-      tiledb::sm::Domain(array_schema->array_schema_->domain());
+      tiledb::sm::Domain(array_schema->array_schema_->domain().get());
   if ((*domain)->domain_ == nullptr) {
     delete *domain;
     *domain = nullptr;

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -94,7 +94,7 @@ Status FragmentInfo::set_config(const Config& config) {
 }
 
 void FragmentInfo::expand_anterior_ndrange(
-    const Domain* domain, const NDRange& range) {
+    shared_ptr<const Domain> domain, const NDRange& range) {
   domain->expand_ndrange(range, &anterior_ndrange_);
 }
 

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -85,7 +85,8 @@ class FragmentInfo {
   Status set_config(const Config& config);
 
   /** Expand the non empty domain before start with a new range */
-  void expand_anterior_ndrange(const Domain* domain, const NDRange& range);
+  void expand_anterior_ndrange(
+      shared_ptr<const Domain> domain, const NDRange& range);
 
   /** Dumps the fragment info in ASCII format in the selected output. */
   void dump(FILE* out) const;

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1126,7 +1126,7 @@ Status FragmentMetadata::set_num_tiles(uint64_t num_tiles) {
   return Status::Ok();
 }
 
-void FragmentMetadata::set_rtree_domain(const Domain* domain) {
+void FragmentMetadata::set_rtree_domain(shared_ptr<const Domain> domain) {
   rtree_.set_domain(domain);
 }
 

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -312,7 +312,7 @@ class FragmentMetadata {
    * @param domain The domain to be set.
    * @return Status
    */
-  void set_rtree_domain(const Domain* domain);
+  void set_rtree_domain(shared_ptr<const Domain> domain);
 
   /**
    * Sets the tile "index base" which is added to the tile index in the set_*()

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -52,7 +52,7 @@ namespace sm {
 class RowCmp {
  public:
   /** Constructor. */
-  RowCmp(const Domain* domain)
+  RowCmp(shared_ptr<const Domain> domain)
       : domain_(domain)
       , dim_num_(domain->dim_num()) {
   }
@@ -80,7 +80,7 @@ class RowCmp {
 
  private:
   /** The domain. */
-  const Domain* domain_;
+  shared_ptr<const Domain> domain_;
   /** The number of dimensions. */
   unsigned dim_num_;
 };
@@ -89,7 +89,7 @@ class RowCmp {
 class ColCmp {
  public:
   /** Constructor. */
-  ColCmp(const Domain* domain)
+  ColCmp(shared_ptr<const Domain> domain)
       : domain_(domain)
       , dim_num_(domain->dim_num()) {
   }
@@ -120,7 +120,7 @@ class ColCmp {
 
  private:
   /** The domain. */
-  const Domain* domain_;
+  shared_ptr<const Domain> domain_;
   /** The number of dimensions. */
   unsigned dim_num_;
 };
@@ -130,7 +130,7 @@ class HilbertCmp {
  public:
   /** Constructor. */
   HilbertCmp(
-      const Domain* domain,
+      shared_ptr<const Domain> domain,
       const std::vector<const QueryBuffer*>* buffs,
       const std::vector<uint64_t>* hilbert_values)
       : buffs_(buffs)
@@ -141,14 +141,15 @@ class HilbertCmp {
 
   /** Constructor. */
   HilbertCmp(
-      const Domain* domain, std::vector<ResultCoords>::iterator iter_begin)
+      shared_ptr<const Domain> domain,
+      std::vector<ResultCoords>::iterator iter_begin)
       : domain_(domain)
       , iter_begin_(iter_begin) {
     dim_num_ = domain->dim_num();
   }
 
   /** Constructor. */
-  HilbertCmp(const Domain* domain)
+  HilbertCmp(shared_ptr<const Domain> domain)
       : domain_(domain) {
     dim_num_ = domain->dim_num();
   }
@@ -245,7 +246,7 @@ class HilbertCmp {
    */
   const std::vector<const QueryBuffer*>* buffs_;
   /** The array domain. */
-  const Domain* domain_;
+  shared_ptr<const Domain> domain_;
   /** The number of dimensions. */
   unsigned dim_num_;
   /** Start iterator of result coords vector. */
@@ -265,7 +266,7 @@ class HilbertCmpReverse {
    *
    * @param domain The array domain.
    */
-  HilbertCmpReverse(const Domain* domain)
+  HilbertCmpReverse(shared_ptr<const Domain> domain)
       : cmp_(domain) {
   }
 
@@ -298,7 +299,7 @@ class GlobalCmp {
    * @param buff The buffer containing the actual values, used
    *     in positional comparisons.
    */
-  GlobalCmp(const Domain* domain)
+  GlobalCmp(shared_ptr<const Domain> domain)
       : domain_(domain) {
     dim_num_ = domain->dim_num();
     tile_order_ = domain->tile_order();
@@ -312,7 +313,9 @@ class GlobalCmp {
    * @param domain The array domain.
    * @param buffs The coordinate query buffers, one per dimension.
    */
-  GlobalCmp(const Domain* domain, const std::vector<const QueryBuffer*>* buffs)
+  GlobalCmp(
+      shared_ptr<const Domain> domain,
+      const std::vector<const QueryBuffer*>* buffs)
       : domain_(domain)
       , buffs_(buffs) {
   }
@@ -414,7 +417,7 @@ class GlobalCmp {
 
  private:
   /** The domain. */
-  const Domain* domain_;
+  shared_ptr<const Domain> domain_;
   /** The number of dimensions. */
   unsigned dim_num_;
   /** The tile order. */
@@ -441,7 +444,7 @@ class GlobalCmpReverse {
    * @param buff The buffer containing the actual values, used
    *     in positional comparisons.
    */
-  GlobalCmpReverse(const Domain* domain)
+  GlobalCmpReverse(shared_ptr<const Domain> domain)
       : cmp_(domain) {
   }
 

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -807,7 +807,7 @@ template <class DimType>
 uint64_t DenseReader::get_cell_pos_in_tile(
     const Layout& cell_order,
     const int32_t dim_num,
-    const Domain* const domain,
+    shared_ptr<const Domain> const domain,
     const ResultSpaceTile<DimType>& result_space_tile,
     const DimType* const coords) {
   uint64_t pos = 0;

--- a/tiledb/sm/query/dense_reader.h
+++ b/tiledb/sm/query/dense_reader.h
@@ -35,6 +35,7 @@
 
 #include <atomic>
 
+#include "tiledb/common/common.h"
 #include "tiledb/common/logger_public.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -176,7 +177,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
   uint64_t get_cell_pos_in_tile(
       const Layout& cell_order,
       const int32_t dim_num,
-      const Domain* const domain,
+      shared_ptr<const Domain> const domain,
       const ResultSpaceTile<DimType>& result_space_tile,
       const DimType* const coords);
 

--- a/tiledb/sm/query/read_cell_slab_iter.h
+++ b/tiledb/sm/query/read_cell_slab_iter.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_READ_CELL_SLAB_ITER_H
 #define TILEDB_READ_CELL_SLAB_ITER_H
 
+#include "tiledb/common/common.h"
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/query/result_cell_slab.h"
@@ -127,7 +128,7 @@ class ReadCellSlabIter {
   /* ********************************* */
 
   /** The array domain. */
-  const Domain* domain_;
+  shared_ptr<const Domain> domain_;
 
   /** The subarray layout. */
   Layout layout_;

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -126,7 +126,7 @@ uint64_t ResultTile::cell_num() const {
   return 0;
 }
 
-const Domain* ResultTile::domain() const {
+shared_ptr<const Domain> ResultTile::domain() const {
   return domain_;
 }
 

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -38,6 +38,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "tiledb/common/common.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/constants.h"
@@ -120,7 +121,7 @@ class ResultTile {
   const TileTuple& coord_tile(unsigned dim_idx) const;
 
   /** Returns the stored domain. */
-  const Domain* domain() const;
+  shared_ptr<const Domain> domain() const;
 
   /** Erases the tile for the input attribute/dimension. */
   void erase_tile(const std::string& name);
@@ -330,7 +331,7 @@ class ResultTile {
   /* ********************************* */
 
   /** The array domain. */
-  const Domain* domain_;
+  shared_ptr<const Domain> domain_;
 
   /** The id of the fragment this tile belongs to. */
   unsigned frag_idx_ = UINT32_MAX;

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -58,7 +58,7 @@ RTree::RTree() {
   deserialized_buffer_size_ = 0;
 }
 
-RTree::RTree(const Domain* domain, unsigned fanout)
+RTree::RTree(shared_ptr<const Domain> domain, unsigned fanout)
     : domain_(domain)
     , fanout_(fanout) {
 }
@@ -128,7 +128,7 @@ unsigned RTree::dim_num() const {
   return (domain_ == nullptr) ? 0 : domain_->dim_num();
 }
 
-const Domain* RTree::domain() const {
+shared_ptr<const Domain> RTree::domain() const {
   return domain_;
 }
 
@@ -292,7 +292,7 @@ Status RTree::serialize(Buffer* buff) const {
   return Status::Ok();
 }
 
-Status RTree::set_domain(const Domain* domain) {
+Status RTree::set_domain(shared_ptr<const Domain> domain) {
   domain_ = domain;
   return Status::Ok();
 }
@@ -332,7 +332,7 @@ Status RTree::set_leaf_num(uint64_t num) {
 }
 
 Status RTree::deserialize(
-    ConstBuffer* cbuff, const Domain* domain, uint32_t version) {
+    ConstBuffer* cbuff, shared_ptr<const Domain> domain, uint32_t version) {
   if (version < 5)
     return deserialize_v1_v4(cbuff, domain);
   return deserialize_v5(cbuff, domain);
@@ -366,7 +366,8 @@ RTree RTree::clone() const {
   return clone;
 }
 
-Status RTree::deserialize_v1_v4(ConstBuffer* cbuff, const Domain* domain) {
+Status RTree::deserialize_v1_v4(
+    ConstBuffer* cbuff, shared_ptr<const Domain> domain) {
   // For backwards compatibility, they will be ignored
   unsigned dim_num_i;
   uint8_t type_i;
@@ -400,7 +401,8 @@ Status RTree::deserialize_v1_v4(ConstBuffer* cbuff, const Domain* domain) {
   return Status::Ok();
 }
 
-Status RTree::deserialize_v5(ConstBuffer* cbuff, const Domain* domain) {
+Status RTree::deserialize_v5(
+    ConstBuffer* cbuff, shared_ptr<const Domain> domain) {
   RETURN_NOT_OK(cbuff->read(&fanout_, sizeof(fanout_)));
   unsigned level_num;
 

--- a/tiledb/sm/rtree/rtree.h
+++ b/tiledb/sm/rtree/rtree.h
@@ -35,6 +35,7 @@
 
 #include <vector>
 
+#include "tiledb/common/common.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/misc/tile_overlap.h"
@@ -65,7 +66,7 @@ class RTree {
   RTree();
 
   /** Constructor. */
-  RTree(const Domain* domain, unsigned fanout);
+  RTree(shared_ptr<const Domain> domain, unsigned fanout);
 
   /** Destructor. */
   ~RTree();
@@ -96,7 +97,7 @@ class RTree {
   unsigned dim_num() const;
 
   /** Returns the domain. */
-  const Domain* domain() const;
+  shared_ptr<const Domain> domain() const;
 
   /** Returns the fanout. */
   unsigned fanout() const;
@@ -138,7 +139,7 @@ class RTree {
   /**
    * Sets the RTree domain.
    */
-  Status set_domain(const Domain* domain);
+  Status set_domain(shared_ptr<const Domain> domain);
 
   /**
    * Sets an MBR as a leaf in the tree. The function will error out
@@ -167,7 +168,7 @@ class RTree {
    * It also sets the input domain, as that is not serialized.
    */
   Status deserialize(
-      ConstBuffer* cbuff, const Domain* domain, uint32_t version);
+      ConstBuffer* cbuff, shared_ptr<const Domain> domain, uint32_t version);
 
  private:
   /* ********************************* */
@@ -216,7 +217,7 @@ class RTree {
   /* ********************************* */
 
   /** The domain. */
-  const Domain* domain_;
+  shared_ptr<const Domain> domain_;
 
   /** The fanout of the tree. */
   unsigned fanout_;
@@ -250,7 +251,7 @@ class RTree {
    *
    * Applicable to versions 1-4
    */
-  Status deserialize_v1_v4(ConstBuffer* cbuff, const Domain* domain);
+  Status deserialize_v1_v4(ConstBuffer* cbuff, shared_ptr<const Domain> domain);
 
   /**
    * Deserializes the contents of the object from the input buffer based
@@ -259,7 +260,7 @@ class RTree {
    *
    * Applicable to versions >= 5
    */
-  Status deserialize_v5(ConstBuffer* cbuff, const Domain* domain);
+  Status deserialize_v5(ConstBuffer* cbuff, shared_ptr<const Domain> domain);
 
   /**
    * Swaps the contents (all field values) of this RTree with the

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -473,7 +473,7 @@ Status array_schema_to_capnp(
 
   // Domain
   auto domain_builder = array_schema_builder->initDomain();
-  RETURN_NOT_OK(domain_to_capnp(array_schema.domain(), &domain_builder));
+  RETURN_NOT_OK(domain_to_capnp(array_schema.domain().get(), &domain_builder));
 
   // Attributes
   const unsigned num_attrs = array_schema.attribute_num();
@@ -521,7 +521,8 @@ Status array_schema_from_capnp(
   auto domain_reader = schema_reader.getDomain();
   tdb_unique_ptr<Domain> domain;
   RETURN_NOT_OK(domain_from_capnp(domain_reader, &domain));
-  RETURN_NOT_OK((*array_schema)->set_domain(domain.get()));
+  RETURN_NOT_OK(
+      (*array_schema)->set_domain(make_shared<Domain>(HERE(), domain.get())));
 
   // Set coords filter pipelines
   if (schema_reader.hasCoordsFilterPipeline()) {

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -988,7 +988,7 @@ Status query_to_capnp(
         Status_SerializationError("Cannot serialize; array is null."));
 
   const auto& schema = query.array_schema();
-  const auto* domain = schema.domain();
+  const auto domain = schema.domain();
   if (domain == nullptr)
     return LOG_STATUS(
         Status_SerializationError("Cannot serialize; array domain is null."));
@@ -1158,7 +1158,7 @@ Status query_from_capnp(
   auto array = query->array();
 
   const auto& schema = query->array_schema();
-  const auto* domain = schema.domain();
+  const auto domain = schema.domain();
   if (domain == nullptr)
     return LOG_STATUS(
         Status_SerializationError("Cannot deserialize; array domain is null."));

--- a/tiledb/sm/storage_manager/consolidator.cc
+++ b/tiledb/sm/storage_manager/consolidator.cc
@@ -344,7 +344,7 @@ Status Consolidator::consolidate_fragments(
 }
 
 bool Consolidator::are_consolidatable(
-    const Domain* domain,
+    shared_ptr<const Domain> domain,
     const FragmentInfo& fragment_info,
     size_t start,
     size_t end,

--- a/tiledb/sm/storage_manager/consolidator.h
+++ b/tiledb/sm/storage_manager/consolidator.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_CONSOLIDATOR_H
 #define TILEDB_CONSOLIDATOR_H
 
+#include "tiledb/common/common.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger_public.h"
 #include "tiledb/common/status.h"
@@ -238,7 +239,7 @@ class Consolidator {
    *     consolidated based on the above definition.
    */
   bool are_consolidatable(
-      const Domain* domain,
+      shared_ptr<const Domain> domain,
       const FragmentInfo& fragment_info,
       size_t start,
       size_t end,

--- a/tools/src/commands/info_command.cc
+++ b/tools/src/commands/info_command.cc
@@ -333,7 +333,7 @@ void InfoCommand::write_text_mbrs() const {
 }
 
 std::tuple<double, double, double, double> InfoCommand::get_mbr(
-    const NDRange& mbr, const Domain* domain) const {
+    const NDRange& mbr, shared_ptr<const Domain> domain) const {
   assert(domain->dim_num() == 2);
   double x, y, width, height;
 
@@ -488,7 +488,7 @@ std::tuple<double, double, double, double> InfoCommand::get_mbr(
 
 // Works only for fixed-sized coordinates
 std::vector<std::string> InfoCommand::mbr_to_string(
-    const NDRange& mbr, const Domain* domain) const {
+    const NDRange& mbr, shared_ptr<const Domain> domain) const {
   std::vector<std::string> result;
   const int8_t* r8;
   const uint8_t* ru8;

--- a/tools/src/commands/info_command.h
+++ b/tools/src/commands/info_command.h
@@ -35,6 +35,7 @@
 
 #include "commands/command.h"
 
+#include "tiledb/common/common.h"
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/types.h"
@@ -86,7 +87,8 @@ class InfoCommand : public Command {
 
   /** Converts an opaque MBR to a 2D (double) rectangle. */
   std::tuple<double, double, double, double> get_mbr(
-      const sm::NDRange& mbr, const tiledb::sm::Domain* domain) const;
+      const sm::NDRange& mbr,
+      shared_ptr<const tiledb::sm::Domain> domain) const;
 
   /**
    * Converts an opaque MBR to a string vector. The vector contents are strings:
@@ -97,7 +99,8 @@ class InfoCommand : public Command {
    * @return String vector representation of MBR.
    */
   std::vector<std::string> mbr_to_string(
-      const sm::NDRange& mbr, const tiledb::sm::Domain* domain) const;
+      const sm::NDRange& mbr,
+      shared_ptr<const tiledb::sm::Domain> domain) const;
 };
 
 }  // namespace cli


### PR DESCRIPTION
Convert ArraySchema's Domain to a smart_ptr

---
TYPE: IMPROVEMENT
DESC: Smart pointer conversion: ArraySchema Domain
