### PR TITLE
Refactor tiledb::sm::serialization::dimension_from_capnp (C41)

### DIFF
--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -134,6 +134,16 @@ class Dimension {
     return datatype_size(type_);
   }
 
+  static ByteVecValue create_tile_extent(
+      const void* tile_extent_data, size_t coord_size) {
+    ByteVecValue te;
+    if (tile_extent_data != nullptr) {
+      te.resize(coord_size);
+      std::memcpy(te.data(), tile_extent_data, coord_size);
+    }
+    return te;
+  }
+
   /**
    * Populates the object members from the data in the input binary buffer.
    *

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -289,18 +289,33 @@ Status dimension_to_capnp(
 }
 
 Status dimension_from_capnp(
-    const capnp::Dimension::Reader& dimension_reader,
-    tdb_unique_ptr<Dimension>* dimension) {
+    const capnp::Dimension::Reader& dimension_reader) {
+
+/*
+   * @param name The name of the dimension.
+   * @param type The type of the dimension.
+   * @param cell_val_num The cell value number of the dimension.
+   * @param domain The range of the dimension range.
+   * @param filter_pipeline The filters of the dimension.
+   * @param tile_extent The tile extent of the dimension.
+*/
+
+  dimension_reader.getName();
+
   Datatype dim_type = Datatype::ANY;
   RETURN_NOT_OK(datatype_enum(dimension_reader.getType().cStr(), &dim_type));
-  dimension->reset(tdb_new(Dimension, dimension_reader.getName(), dim_type));
+
+  // cell val num
+  uint32_t cell_val_num = (datatype_is_string(dim_type)) ? constants::var_num : 1;
 
   if (dimension_reader.hasDomain()) {
     auto domain_reader = dimension_reader.getDomain();
     Buffer domain_buffer;
     RETURN_NOT_OK(
         utils::copy_capnp_list(domain_reader, dim_type, &domain_buffer));
-    RETURN_NOT_OK((*dimension)->set_domain_unsafe(domain_buffer.data()));
+    // domain_buffer.data() is pointer, size = datatype_size(dim_type) * 2
+  } else {
+    // default construct ??????? 
   }
 
   if (dimension_reader.hasFilterPipeline()) {

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -288,74 +288,66 @@ Status dimension_to_capnp(
   return Status::Ok();
 }
 
-Status dimension_from_capnp(
+tuple<Status, optional<shared_ptr<Dimension>>> dimension_from_capnp(
     const capnp::Dimension::Reader& dimension_reader) {
-
-/*
-   * @param name The name of the dimension.
-   * @param type The type of the dimension.
-   * @param cell_val_num The cell value number of the dimension.
-   * @param domain The range of the dimension range.
-   * @param filter_pipeline The filters of the dimension.
-   * @param tile_extent The tile extent of the dimension.
-*/
-
-  dimension_reader.getName();
-
+  // datatype
   Datatype dim_type = Datatype::ANY;
-  RETURN_NOT_OK(datatype_enum(dimension_reader.getType().cStr(), &dim_type));
+  RETURN_NOT_OK_TUPLE(
+      datatype_enum(dimension_reader.getType().cStr(), &dim_type), nullopt);
+  auto coord_size = datatype_size(dim_type);
 
   // cell val num
-  uint32_t cell_val_num = (datatype_is_string(dim_type)) ? constants::var_num : 1;
+  uint32_t cell_val_num =
+      (datatype_is_string(dim_type)) ? constants::var_num : 1;
 
+  Range domain;
   if (dimension_reader.hasDomain()) {
     auto domain_reader = dimension_reader.getDomain();
     Buffer domain_buffer;
-    RETURN_NOT_OK(
-        utils::copy_capnp_list(domain_reader, dim_type, &domain_buffer));
-    // domain_buffer.data() is pointer, size = datatype_size(dim_type) * 2
-  } else {
-    // default construct ??????? 
+    RETURN_NOT_OK_TUPLE(
+        utils::copy_capnp_list(domain_reader, dim_type, &domain_buffer),
+        nullopt);
+    domain = Range(domain_buffer.data(), coord_size * 2);
   }
 
+  tdb_unique_ptr<FilterPipeline> filters;
   if (dimension_reader.hasFilterPipeline()) {
     auto reader = dimension_reader.getFilterPipeline();
-    tdb_unique_ptr<FilterPipeline> filters;
-    RETURN_NOT_OK(filter_pipeline_from_capnp(reader, &filters));
-    RETURN_NOT_OK((*dimension)->set_filter_pipeline(filters.get()));
+    RETURN_NOT_OK_TUPLE(filter_pipeline_from_capnp(reader, &filters), nullopt);
   }
 
+  ByteVecValue tile_extent;
   if (!dimension_reader.getNullTileExtent()) {
     auto tile_extent_reader = dimension_reader.getTileExtent();
     switch (dim_type) {
       case Datatype::INT8: {
         auto val = tile_extent_reader.getInt8();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       case Datatype::UINT8: {
         auto val = tile_extent_reader.getUint8();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       case Datatype::INT16: {
         auto val = tile_extent_reader.getInt16();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       case Datatype::UINT16: {
         auto val = tile_extent_reader.getUint16();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       case Datatype::INT32: {
         auto val = tile_extent_reader.getInt32();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       case Datatype::UINT32: {
         auto val = tile_extent_reader.getUint32();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       case Datatype::DATETIME_YEAR:
@@ -382,31 +374,40 @@ Status dimension_from_capnp(
       case Datatype::TIME_AS:
       case Datatype::INT64: {
         auto val = tile_extent_reader.getInt64();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       case Datatype::UINT64: {
         auto val = tile_extent_reader.getUint64();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       case Datatype::FLOAT32: {
         auto val = tile_extent_reader.getFloat32();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       case Datatype::FLOAT64: {
         auto val = tile_extent_reader.getFloat64();
-        RETURN_NOT_OK((*dimension)->set_tile_extent(&val));
+        tile_extent = Dimension::create_tile_extent(&val, coord_size);
         break;
       }
       default:
-        return LOG_STATUS(Status_SerializationError(
-            "Error deserializing dimension; unknown datatype."));
+        return {LOG_STATUS(Status_SerializationError(
+                    "Error deserializing dimension; unknown datatype.")),
+                nullopt};
     }
   }
 
-  return Status::Ok();
+  return {Status::Ok(),
+          tiledb::common::make_shared<Dimension>(
+              HERE(),
+              dimension_reader.getName(),
+              dim_type,
+              cell_val_num,
+              domain,
+              *(filters.get()),
+              tile_extent)};
 }
 
 Status domain_to_capnp(
@@ -438,9 +439,9 @@ Status domain_from_capnp(
 
   auto dimensions = domain_reader.getDimensions();
   for (auto dimension : dimensions) {
-    tdb_unique_ptr<Dimension> dim;
-    RETURN_NOT_OK(dimension_from_capnp(dimension, &dim));
-    RETURN_NOT_OK((*domain)->add_dimension(dim.get()));
+    auto&& [st_dim, dim]{dimension_from_capnp(dimension)};
+    RETURN_NOT_OK(st_dim);
+    RETURN_NOT_OK((*domain)->add_dimension(dim.value().get()));
   }
 
   return Status::Ok();


### PR DESCRIPTION
I refactored tiledb::sm::serialization::dimension_from_capnp to be C41 compliant, so that when the attribute constructor is called it has all the fields it needs to be initialized.

---
TYPE: IMPROVEMENT
DESC: Refactored tiledb::sm::serialization::dimension_from_capnp to be C41 compliant
