### PR TITLE
[Backport release-2.6] Sparse unordered w/ dups reader: all empty string attribute fix. (#2874)

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -65,8 +65,10 @@ struct CSparseUnorderedWithDupsFx {
   std::string ratio_query_condition_;
 
   void create_default_array_1d();
+  void create_default_array_1d_string();
   void write_1d_fragment(
       int* coords, uint64_t* coords_size, int* data, uint64_t* data_size);
+  void write_1d_fragment_empty_strings(int* coords, uint64_t* coords_size);
   int32_t read(
       bool set_subarray,
       bool set_qc,
@@ -76,6 +78,13 @@ struct CSparseUnorderedWithDupsFx {
       uint64_t* data_size,
       tiledb_query_t** query = nullptr,
       tiledb_array_t** array_ret = nullptr);
+  int32_t read_strings(
+      int* coords,
+      uint64_t* coords_size,
+      char* data,
+      uint64_t* data_size,
+      uint64_t* data_offsets,
+      uint64_t* data_offsets_size);
   void reset_config();
   void update_config();
 
@@ -197,6 +206,27 @@ void CSparseUnorderedWithDupsFx::create_default_array_1d() {
       true);  // allows dups.
 }
 
+void CSparseUnorderedWithDupsFx::create_default_array_1d_string() {
+  int domain[] = {1, 20};
+  int tile_extent = 2;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_SPARSE,
+      {"d"},
+      {TILEDB_INT32},
+      {domain},
+      {&tile_extent},
+      {"a"},
+      {TILEDB_STRING_ASCII},
+      {TILEDB_VAR_NUM},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      2,
+      true);  // allows dups.
+}
+
 void CSparseUnorderedWithDupsFx::write_1d_fragment(
     int* coords, uint64_t* coords_size, int* data, uint64_t* data_size) {
   // Open array for writing.
@@ -213,6 +243,49 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment(
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Submit query.
+  rc = tiledb_query_submit(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Close array.
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up.
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+void CSparseUnorderedWithDupsFx::write_1d_fragment_empty_strings(
+    int* coords, uint64_t* coords_size) {
+  const uint64_t num_cells = *coords_size / sizeof(TILEDB_INT32);
+
+  // Open array for writing.
+  tiledb_array_t* array;
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  char data[1];
+  uint64_t data_size = 0;
+  std::vector<uint64_t> data_offsets(num_cells, 0);
+  uint64_t data_offsets_size = num_cells * sizeof(uint64_t);
+
+  // Create the query.
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, &data_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_offsets_buffer(
+      ctx_, query, "a", data_offsets.data(), &data_offsets_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
   REQUIRE(rc == TILEDB_OK);
@@ -294,6 +367,46 @@ int32_t CSparseUnorderedWithDupsFx::read(
     *array_ret = array;
   }
 
+  return ret;
+}
+
+int32_t CSparseUnorderedWithDupsFx::read_strings(
+    int* coords,
+    uint64_t* coords_size,
+    char* data,
+    uint64_t* data_size,
+    uint64_t* data_offsets,
+    uint64_t* data_offsets_size) {
+  // Open array for reading.
+  tiledb_array_t* array;
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query.
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_offsets_buffer(
+      ctx_, query, "a", data_offsets, data_offsets_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query.
+  auto ret = tiledb_query_submit(ctx_, query);
+
+  // Clean up.
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
   return ret;
 }
 
@@ -1395,4 +1508,34 @@ TEST_CASE(
   CHECK(cell_offsets[1] == 2);
   CHECK(new_result_tiles_size == 1);
   CHECK(var_buffer_size == 4);
+}
+
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsFx,
+    "Sparse unordered with dups reader: empty strings",
+    "[sparse-unordered-with-dups][empty-strings]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d_string();
+
+  // Write a fragment.
+  int coords[] = {1, 2};
+  uint64_t coords_size = sizeof(coords);
+  write_1d_fragment_empty_strings(coords, &coords_size);
+
+  // Try to read.
+  int coords_r[5];
+  char data_r[5];
+  uint64_t data_offsets_r[5];
+  uint64_t coords_r_size = sizeof(coords_r);
+  uint64_t data_r_size = sizeof(data_r);
+  uint64_t data_offsets_r_size = sizeof(data_offsets_r);
+  auto rc = read_strings(
+      coords_r,
+      &coords_r_size,
+      data_r,
+      &data_r_size,
+      data_offsets_r,
+      &data_offsets_r_size);
+  CHECK(rc == TILEDB_OK);
 }

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1235,7 +1235,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
     }
   }
 
-  if (*var_buffer_size == 0) {
+  if (*new_result_tiles_size == 1 && cell_offsets->at(1) == 0) {
     return Status::SparseUnorderedWithDupsReaderError(
         "Var size buffer cannot fit a single cell for var attribute");
   }


### PR DESCRIPTION
Backport cd53d037a7f433e0ebd1364195f0378ca7fd832e from https://github.com/TileDB-Inc/TileDB/pull/2874


---
TYPE: BUG
DESC: Sparse unordered w/ dups reader: all empty string attribute fix.