### PR TITLE
Fragment metadata: treating TILEDB_CHAR as TILEDB_STRING_ASCII.

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -421,7 +421,11 @@ Status FragmentMetadata::compute_fragment_min_max_sum_null_count() {
               compute_fragment_min_max_sum<int64_t>(name);
               break;
             case Datatype::STRING_ASCII:
+            case Datatype::CHAR:
               compute_fragment_min_max_sum<char>(name);
+              break;
+            case Datatype::BLOB:
+              compute_fragment_min_max_sum<std::byte>(name);
               break;
             default:
               break;


### PR DESCRIPTION
As a follow up to the tile metadata change to do the same thing, this
will fix the same issue for fragment metadata in 2.8.

Also adding missing support for null count for TILEDB_BLOB.

---
TYPE: IMPROVEMENT
DESC: Fragment metadata: treating TILEDB_CHAR as TILEDB_STRING_ASCII.
