### PR TITLE
VFS: adding configuration for vfs.max_batch_size.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -292,6 +292,7 @@ void check_save_to_file() {
   ss << "vfs.gcs.multi_part_size 5242880\n";
   ss << "vfs.gcs.request_timeout_ms 3000\n";
   ss << "vfs.gcs.use_multi_part_upload true\n";
+  ss << "vfs.max_batch_size " << std::to_string(UINT64_MAX) << "\n";
   ss << "vfs.min_batch_gap 512000\n";
   ss << "vfs.min_batch_size 20971520\n";
   ss << "vfs.min_parallel_size 10485760\n";
@@ -610,6 +611,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.var_offsets.mode"] = "elements";
   all_param_values["sm.max_tile_overlap_size"] = "314572800";
 
+  all_param_values["vfs.max_batch_size"] = std::to_string(UINT64_MAX);
   all_param_values["vfs.min_batch_gap"] = "512000";
   all_param_values["vfs.min_batch_size"] = "20971520";
   all_param_values["vfs.min_parallel_size"] = "10485760";
@@ -673,6 +675,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.s3.object_canned_acl"] = "NOT_SET";
 
   std::map<std::string, std::string> vfs_param_values;
+  vfs_param_values["max_batch_size"] = std::to_string(UINT64_MAX);
   vfs_param_values["min_batch_gap"] = "512000";
   vfs_param_values["min_batch_size"] = "20971520";
   vfs_param_values["min_parallel_size"] = "10485760";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -61,7 +61,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 57);
+  CHECK(names.size() == 58);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1136,6 +1136,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    (except parallel S3 writes, which are controlled by
  *    `vfs.s3.multipart_part_size`). <br>
  *    **Default**: 10MB
+ * - `vfs.max_batch_size` <br>
+ *    The maximum number of bytes in a VFS read operation<br>
+ *    **Default**: UINT64_MAX
  * - `vfs.min_batch_size` <br>
  *    The minimum number of bytes in a VFS read operation<br>
  *    **Default**: 20MB

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -118,6 +118,7 @@ const std::string Config::SM_OFFSETS_EXTRA_ELEMENT = "false";
 const std::string Config::SM_OFFSETS_FORMAT_MODE = "bytes";
 const std::string Config::SM_MAX_TILE_OVERLAP_SIZE = "314572800";  // 300MiB
 const std::string Config::VFS_MIN_PARALLEL_SIZE = "10485760";
+const std::string Config::VFS_MAX_BATCH_SIZE = std::to_string(UINT64_MAX);
 const std::string Config::VFS_MIN_BATCH_GAP = "512000";
 const std::string Config::VFS_MIN_BATCH_SIZE = "20971520";
 const std::string Config::VFS_FILE_POSIX_FILE_PERMISSIONS = "644";
@@ -282,6 +283,7 @@ Config::Config() {
   param_values_["sm.var_offsets.mode"] = SM_OFFSETS_FORMAT_MODE;
   param_values_["sm.max_tile_overlap_size"] = SM_MAX_TILE_OVERLAP_SIZE;
   param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
+  param_values_["vfs.max_batch_size"] = VFS_MAX_BATCH_SIZE;
   param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
   param_values_["vfs.read_ahead_size"] = VFS_READ_AHEAD_SIZE;
@@ -623,6 +625,8 @@ Status Config::unset(const std::string& param) {
     param_values_["sm.max_tile_overlap_size"] = SM_MAX_TILE_OVERLAP_SIZE;
   } else if (param == "vfs.min_parallel_size") {
     param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
+  } else if (param == "vfs.max_batch_size") {
+    param_values_["vfs.max_batch_size"] = VFS_MAX_BATCH_SIZE;
   } else if (param == "vfs.min_batch_gap") {
     param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   } else if (param == "vfs.min_batch_size") {
@@ -839,6 +843,8 @@ Status Config::sanity_check(
       return LOG_STATUS(
           Status_ConfigError("Invalid offsets format parameter value"));
   } else if (param == "vfs.min_parallel_size") {
+    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
+  } else if (param == "vfs.max_batch_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_batch_gap") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -306,6 +306,9 @@ class Config {
   /** The default minimum number of bytes in a parallel VFS operation. */
   static const std::string VFS_MIN_PARALLEL_SIZE;
 
+  /** The default maximum number of bytes in a batched VFS read operation. */
+  static const std::string VFS_MAX_BATCH_SIZE;
+
   /**
    * The default minimum number of bytes between two VFS read batches.
    */

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -448,6 +448,9 @@ class Config {
    *    (except parallel S3 writes, which are controlled by
    *    `vfs.s3.multipart_part_size`.) <br>
    *    **Default**: 10MB
+   * - `vfs.max_batch_size` <br>
+   *    The maximum number of bytes in a VFS read operation<br>
+   *    **Default**: UINT64_MAX
    * - `vfs.min_batch_size` <br>
    *    The minimum number of bytes in a VFS read operation<br>
    *    **Default**: 20MB

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -1479,6 +1479,10 @@ Status VFS::compute_read_batches(
     std::vector<BatchedRead>* batches) const {
   // Get config params
   bool found;
+  uint64_t max_batch_size = 0;
+  RETURN_NOT_OK(
+      config_.get<uint64_t>("vfs.max_batch_size", &max_batch_size, &found));
+  assert(found);
   uint64_t min_batch_size = 0;
   RETURN_NOT_OK(
       config_.get<uint64_t>("vfs.min_batch_size", &min_batch_size, &found));
@@ -1509,7 +1513,8 @@ Status VFS::compute_read_batches(
     uint64_t nbytes = std::get<2>(region);
     uint64_t new_batch_size = (offset + nbytes) - curr_batch.offset;
     uint64_t gap = offset - (curr_batch.offset + curr_batch.nbytes);
-    if (new_batch_size <= min_batch_size || gap <= min_batch_gap) {
+    if (new_batch_size <= max_batch_size &&
+        (new_batch_size <= min_batch_size || gap <= min_batch_gap)) {
       // Extend current batch.
       curr_batch.nbytes = new_batch_size;
       curr_batch.regions.push_back(region);


### PR DESCRIPTION
The ML team is running some performance scenarios and they are hitting
cases where growing their user buffer size has benefits up to a point,
then the performance starts to get worst. After investigation, I found
out that their scenario ends up issuing very large IO requests right
where they start to observe performance degradation. I believe I was
able to make their performance linear by limiting the batch size for an
IO request to around 100MB. This PR adds a new parameter, max_batch_size
that is defaulted to max uint64 so it will have no effect by default
but will allow the ML team to run more complete tests and confirm my
findings.

---
TYPE: IMPROVEMENT
DESC: VFS: adding configuration for vfs.max_batch_size.
