### PR TITLE
Do not store offsets when RLE is used on string dimensions

### DIFF
--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -764,7 +764,7 @@ TEST_CASE("C API: Test MBR fragment info", "[capi][fragment_info][mbr]") {
 
 TEST_CASE(
     "C API: Test fragment info, load from array with string dimension",
-    "[capi][fragment_info][load][string-dim][mbr]") {
+    "[capi][fragment_info][load][string-dims][mbr]") {
   // Create TileDB context
   tiledb_ctx_t* ctx = nullptr;
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
@@ -1509,7 +1509,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C API: Test fragment info, dump with string dimension",
-    "[capi][fragment_info][dump][string-dim]") {
+    "[capi][fragment_info][dump][string-dims]") {
   // Create TileDB context
   tiledb_ctx_t* ctx = nullptr;
   int rc = tiledb_ctx_alloc(nullptr, &ctx);

--- a/test/src/unit-compression-rle.cc
+++ b/test/src/unit-compression-rle.cc
@@ -394,7 +394,10 @@ TEST_CASE(
       "A";
   const auto exp_decomp_size = strlen(unc);
   std::vector<std::byte> decompressed(exp_decomp_size);
-  tiledb::sm::RLE::decompress<uint8_t, uint8_t>(compressed, decompressed);
+  auto num_strings = 8;
+  std::vector<uint64_t> decompressed_offsets(num_strings);
+  tiledb::sm::RLE::decompress<uint8_t, uint8_t>(
+      compressed, decompressed, decompressed_offsets);
 
   // In decompressed array there are only chars, so compare using memcpy
   CHECK(
@@ -402,6 +405,11 @@ TEST_CASE(
           unc,
           reinterpret_cast<const char*>(decompressed.data()),
           decompressed.size()) == 0);
+
+  std::vector<uint64_t> expected_offsets{0, 8, 16, 24, 32, 40, 44};
+  for (uint32_t i = 0; i < expected_offsets.size(); i++) {
+    CHECK(expected_offsets[i] == decompressed_offsets[i]);
+  }
 }
 
 typedef tuple<uint16_t, uint32_t, uint64_t> FixedTypesUnderTest;
@@ -445,13 +453,25 @@ TEMPLATE_LIST_TEST_CASE(
   const char* unc = strout.data();
   const auto exp_decomp_size = strlen(unc);
   std::vector<std::byte> decompressed(exp_decomp_size);
-  tiledb::sm::RLE::decompress<T, T>(compressed, decompressed);
+  std::vector<uint64_t> decompressed_offsets(num_strings);
+  tiledb::sm::RLE::decompress<T, T>(
+      compressed, decompressed, decompressed_offsets);
 
   CHECK(
       memcmp(
           unc,
           reinterpret_cast<const char*>(decompressed.data()),
           decompressed.size()) == 0);
+
+  std::vector<uint64_t> expected_offsets(num_strings);
+  auto len = string_rand.size();
+  int start = -1 * len;
+  std::generate(expected_offsets.begin(), expected_offsets.end(), [&] {
+    return start += len;
+  });
+  for (uint32_t i = 0; i < expected_offsets.size(); i++) {
+    CHECK(expected_offsets[i] == decompressed_offsets[i]);
+  }
 }
 
 TEST_CASE(
@@ -503,7 +523,10 @@ TEST_CASE(
       "HG5";
   const auto exp_decomp_size = strlen(unc);
   std::vector<std::byte> decompressed(exp_decomp_size);
-  tiledb::sm::RLE::decompress<uint8_t, uint8_t>(compressed, decompressed);
+  auto num_strings = 7;
+  std::vector<uint64_t> decompressed_offsets(num_strings);
+  tiledb::sm::RLE::decompress<uint8_t, uint8_t>(
+      compressed, decompressed, decompressed_offsets);
 
   // In decompressed array there are only chars, so compare using memcpy
   CHECK(
@@ -511,6 +534,11 @@ TEST_CASE(
           unc,
           reinterpret_cast<const char*>(decompressed.data()),
           decompressed.size()) == 0);
+
+  std::vector<uint64_t> expected_offsets{0, 8, 11, 13, 14, 17, 21};
+  for (uint32_t i = 0; i < expected_offsets.size(); i++) {
+    CHECK(expected_offsets[i] == decompressed_offsets[i]);
+  }
 }
 
 typedef tuple<uint8_t, uint16_t, uint32_t, uint64_t> UnsignedIntegerTypes;

--- a/test/src/unit-compression-rle.cc
+++ b/test/src/unit-compression-rle.cc
@@ -465,7 +465,7 @@ TEMPLATE_LIST_TEST_CASE(
 
   std::vector<uint64_t> expected_offsets(num_strings);
   auto len = string_rand.size();
-  int start = -1 * len;
+  auto start = -1 * len;
   std::generate(expected_offsets.begin(), expected_offsets.end(), [&] {
     return start += len;
   });

--- a/test/src/unit-cppapi-fragment_info.cc
+++ b/test/src/unit-cppapi-fragment_info.cc
@@ -401,7 +401,7 @@ TEST_CASE("C++ API: Test MBR fragment info", "[cppapi][fragment_info][mbr]") {
 
 TEST_CASE(
     "C++ API: Test fragment info, load from array with string dimension",
-    "[cppapi][fragment_info][load][string-dim][mbr]") {
+    "[cppapi][fragment_info][load][string-dims][mbr]") {
   // Create TileDB context
   Context ctx;
   Config cfg;

--- a/test/src/unit-cppapi-string-dims.cc
+++ b/test/src/unit-cppapi-string-dims.cc
@@ -123,7 +123,7 @@ void write_array_1(
 
 TEST_CASE(
     "C++ API: Test infinite string splits",
-    "[cppapi][string-dim][infinite-split]") {
+    "[cppapi][string-dims][infinite-split]") {
   const std::string array_name = "cpp_unit_array";
   Context ctx;
   VFS vfs(ctx);
@@ -199,7 +199,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API: Test default string dimensions",
-    "[cppapi][string-dim][default]") {
+    "[cppapi][string-dims][default]") {
   const std::string array_name = "cpp_unit_array";
   Context ctx;
 
@@ -429,7 +429,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API: Test default string dimensions with partitioning",
-    "[cppapi][string-dim][default][partitioning]") {
+    "[cppapi][string-dims][default][partitioning]") {
   const std::string array_name = "cpp_unit_array";
   Context ctx;
 
@@ -699,7 +699,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API: Test default string dimensions with partitioning - with SECTIONs",
-    "[cppapi][string-dim][default][partitioning]") {
+    "[cppapi][string-dims][default][partitioning]") {
   const std::string array_name = "cpp_unit_array";
   Context ctx;
 
@@ -943,7 +943,7 @@ TEST_CASE(
 TEST_CASE(
     "C++ API: Test default string dimensions with partitioning - dupsallowed, "
     "varying bufcnt",
-    "[cppapi][string-dim][default][partitioning]") {
+    "[cppapi][string-dims][default][partitioning]") {
   const std::string array_name = "cpp_unit_array";
   Context ctx;
 
@@ -1196,7 +1196,7 @@ TEST_CASE(
 TEST_CASE(
     "C++ API: Test default string dimensions with partitioning - dupsallowed - "
     "withsections",
-    "[cppapi][string-dim][default][partitioning]") {
+    "[cppapi][string-dims][default][partitioning]") {
   const std::string array_name = "cpp_unit_array";
   Context ctx;
 
@@ -1447,12 +1447,12 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API: Test filtering of string dimensions",
-    "[cppapi][string-dim][rle-strings][sparse]") {
+    "[cppapi][string-dims][rle-strings][sparse]") {
   std::string array_name = "test_rle_string_dim";
 
   // Create data buffer to use
   std::stringstream repetitions;
-  size_t repetition_num = 100;
+  size_t repetition_num = 1000000;
   for (size_t i = 0; i < repetition_num; i++)
     repetitions << "GLSD987JHY";
   std::string data =
@@ -1526,7 +1526,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API: Test adding RLE filter of string dimensions",
-    "[cppapi][string-dim][rle-strings][sparse]") {
+    "[cppapi][string-dims][rle-strings][sparse]") {
   std::string array_name = "test_rle_string_dim";
 
   Context ctx;

--- a/test/src/unit-cppapi-string-dims.cc
+++ b/test/src/unit-cppapi-string-dims.cc
@@ -1452,7 +1452,7 @@ TEST_CASE(
 
   // Create data buffer to use
   std::stringstream repetitions;
-  size_t repetition_num = 1000000;
+  size_t repetition_num = 100;
   for (size_t i = 0; i < repetition_num; i++)
     repetitions << "GLSD987JHY";
   std::string data =

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -103,6 +103,7 @@ class Add1InPlace : public tiledb::sm::Filter {
 
   Status run_reverse(
       const Tile&,
+      Tile* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
@@ -184,6 +185,7 @@ class Add1OutOfPlace : public tiledb::sm::Filter {
 
   Status run_reverse(
       const Tile&,
+      Tile* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
@@ -264,6 +266,7 @@ class AddNInPlace : public tiledb::sm::Filter {
 
   Status run_reverse(
       const Tile&,
+      Tile* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
@@ -354,6 +357,7 @@ class PseudoChecksumFilter : public tiledb::sm::Filter {
 
   Status run_reverse(
       const Tile&,
+      Tile* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
@@ -468,6 +472,7 @@ class Add1IncludingMetadataFilter : public tiledb::sm::Filter {
 
   Status run_reverse(
       const Tile&,
+      Tile* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
@@ -584,7 +589,8 @@ TEST_CASE("Filter: Test empty pipeline", "[filter][empty-pipeline]") {
   }
 
   CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
   CHECK(tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
@@ -708,7 +714,8 @@ TEST_CASE(
   }
 
   CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
   CHECK(tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
@@ -781,7 +788,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -828,7 +837,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -956,7 +967,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -1008,7 +1021,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -1084,7 +1099,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -1131,7 +1148,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -1259,7 +1278,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -1311,7 +1332,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -1387,7 +1410,8 @@ TEST_CASE(
 
   // Set up test data
   CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
   CHECK(tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
@@ -1515,7 +1539,8 @@ TEST_CASE(
   }
 
   CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
   CHECK(tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
@@ -1576,7 +1601,9 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(tile.filtered_buffer().size() < nelts * sizeof(uint64_t));
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
@@ -1599,7 +1626,9 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(tile.filtered_buffer().size() < nelts * sizeof(uint64_t));
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
@@ -1624,7 +1653,9 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(tile.filtered_buffer().size() < nelts * sizeof(uint64_t));
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
@@ -1739,7 +1770,9 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         9);  // Number of chunks
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
@@ -1765,7 +1798,9 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         9);  // Number of chunks
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
@@ -1793,7 +1828,9 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         9);  // Number of chunks
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
@@ -1877,7 +1914,9 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -1942,7 +1981,9 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -2079,7 +2120,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -2145,7 +2188,9 @@ TEST_CASE(
     }
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -2225,7 +2270,8 @@ TEST_CASE("Filter: Test pipeline modify filter", "[filter][modify]") {
   }
 
   CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
   CHECK(tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
@@ -2360,7 +2406,8 @@ TEST_CASE("Filter: Test pipeline modify filter var", "[filter][modify][var]") {
   }
 
   CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
   CHECK(tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
@@ -2453,7 +2500,8 @@ TEST_CASE("Filter: Test pipeline copy", "[filter][copy]") {
   }
 
   CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
   CHECK(tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
@@ -2550,7 +2598,9 @@ TEST_CASE("Filter: Test random pipeline", "[filter][random]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t n = 0; n < nelts; n++) {
       uint64_t elt = 0;
@@ -2595,8 +2645,9 @@ TEST_CASE(
   CHECK(tile.size() == 0);
   CHECK(tile.filtered_buffer().size() != 0);
   CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-  CHECK(
-      md5_pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+  CHECK(md5_pipeline
+            .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
   CHECK(tile.filtered_buffer().size() == 0);
   for (uint64_t n = 0; n < nelts; n++) {
     uint64_t elt = 0;
@@ -2613,7 +2664,8 @@ TEST_CASE(
   CHECK(tile.size() == 0);
   CHECK(tile.filtered_buffer().size() != 0);
   CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-  CHECK(sha_256_pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config)
+  CHECK(sha_256_pipeline
+            .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
             .ok());
   CHECK(tile.filtered_buffer().size() == 0);
   for (uint64_t n = 0; n < nelts; n++) {
@@ -2683,7 +2735,9 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(compressed_size < nelts * sizeof(uint64_t));
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -2704,8 +2758,9 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
       CHECK(tile.size() == 0);
       CHECK(tile.filtered_buffer().size() != 0);
       CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-      CHECK(
-          pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+      CHECK(pipeline
+                .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+                .ok());
       CHECK(tile.filtered_buffer().size() == 0);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
@@ -2741,7 +2796,9 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -2780,7 +2837,9 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint32_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       int32_t elt = 0;
@@ -2809,7 +2868,9 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -2953,7 +3014,9 @@ TEST_CASE(
     CHECK(compressed_size < nelts * sizeof(uint64_t));
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -2976,8 +3039,9 @@ TEST_CASE(
       CHECK(tile.size() == 0);
       CHECK(tile.filtered_buffer().size() != 0);
       CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-      CHECK(
-          pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+      CHECK(pipeline
+                .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+                .ok());
       CHECK(tile.filtered_buffer().size() == 0);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
@@ -3014,7 +3078,9 @@ TEST_CASE(
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -3078,7 +3144,9 @@ TEST_CASE(
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint32_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       int32_t elt = 0;
@@ -3108,7 +3176,9 @@ TEST_CASE(
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -3180,7 +3250,9 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
                             nelts * sizeof(uint64_t));
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -3201,8 +3273,9 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
       CHECK(tile.size() == 0);
       CHECK(tile.filtered_buffer().size() != 0);
       CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-      CHECK(
-          pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+      CHECK(pipeline
+                .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+                .ok());
       CHECK(tile.filtered_buffer().size() == 0);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
@@ -3358,7 +3431,9 @@ TEST_CASE(
         pipeline_metadata_size + total_md_size + nelts * sizeof(uint64_t));
 
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -3381,8 +3456,9 @@ TEST_CASE(
       CHECK(tile.size() == 0);
       CHECK(tile.filtered_buffer().size() != 0);
       CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-      CHECK(
-          pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+      CHECK(pipeline
+                .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+                .ok());
       CHECK(tile.filtered_buffer().size() == 0);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
@@ -3440,7 +3516,9 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -3471,8 +3549,9 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
     CHECK(tile2.size() == 0);
     CHECK(tile2.filtered_buffer().size() != 0);
     CHECK(tile2.alloc_data(nelts2 * sizeof(uint32_t)).ok());
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile2, &tp, config).ok());
+    CHECK(pipeline
+              .run_reverse(&test::g_helper_stats, &tile2, nullptr, &tp, config)
+              .ok());
     CHECK(tile2.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
@@ -3565,7 +3644,9 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -3598,8 +3679,9 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
     CHECK(tile2.size() == 0);
     CHECK(tile2.filtered_buffer().size() != 0);
     CHECK(tile2.alloc_data(nelts2 * sizeof(uint32_t)).ok());
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile2, &tp, config).ok());
+    CHECK(pipeline
+              .run_reverse(&test::g_helper_stats, &tile2, nullptr, &tp, config)
+              .ok());
     CHECK(tile2.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
@@ -3644,7 +3726,9 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -3675,8 +3759,9 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
     CHECK(tile2.size() == 0);
     CHECK(tile2.filtered_buffer().size() != 0);
     CHECK(tile2.alloc_data(nelts2 * sizeof(uint32_t)).ok());
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile2, &tp, config).ok());
+    CHECK(pipeline
+              .run_reverse(&test::g_helper_stats, &tile2, nullptr, &tp, config)
+              .ok());
     CHECK(tile2.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
@@ -3769,7 +3854,9 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -3802,8 +3889,9 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
     CHECK(tile2.size() == 0);
     CHECK(tile2.filtered_buffer().size() != 0);
     CHECK(tile2.alloc_data(nelts2 * sizeof(uint32_t)).ok());
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile2, &tp, config).ok());
+    CHECK(pipeline
+              .run_reverse(&test::g_helper_stats, &tile2, nullptr, &tp, config)
+              .ok());
     CHECK(tile2.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
@@ -3860,7 +3948,9 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
@@ -3874,8 +3964,9 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     key[0]++;
     CHECK(filter->set_key(key).ok());
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(
-        !pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(!pipeline
+               .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+               .ok());
 
     // Fix key and check success. Note: this test depends on the implementation
     // leaving the tile data unmodified when the decryption fails, which is not
@@ -3883,7 +3974,9 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     key[0]--;
     CHECK(filter->set_key(key).ok());
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, &tp, config).ok());
+    CHECK(
+        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .ok());
     CHECK(tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -279,6 +279,7 @@ Status BitWidthReductionFilter::compress_part(
 
 Status BitWidthReductionFilter::run_reverse(
     const Tile& tile,
+    Tile* const offsets_tile,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
@@ -302,29 +303,29 @@ Status BitWidthReductionFilter::run_reverse(
   switch (tile_type) {
     case Datatype::INT8:
       return run_reverse<int8_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::BLOB:
     case Datatype::UINT8:
       return run_reverse<uint8_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT16:
       return run_reverse<int16_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::UINT16:
       return run_reverse<uint16_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT32:
       return run_reverse<int>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::UINT32:
       return run_reverse<unsigned>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT64:
       return run_reverse<int64_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::UINT64:
       return run_reverse<uint64_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::DATETIME_YEAR:
     case Datatype::DATETIME_MONTH:
     case Datatype::DATETIME_WEEK:
@@ -348,7 +349,7 @@ Status BitWidthReductionFilter::run_reverse(
     case Datatype::TIME_FS:
     case Datatype::TIME_AS:
       return run_reverse<int64_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     default:
       return LOG_STATUS(
           Status_FilterError("Cannot filter; Unsupported input type"));
@@ -358,6 +359,7 @@ Status BitWidthReductionFilter::run_reverse(
 template <typename T>
 Status BitWidthReductionFilter::run_reverse(
     const Tile& tile,
+    Tile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/bit_width_reduction_filter.h
+++ b/tiledb/sm/filter/bit_width_reduction_filter.h
@@ -113,6 +113,7 @@ class BitWidthReductionFilter : public Filter {
    */
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
@@ -190,6 +191,7 @@ class BitWidthReductionFilter : public Filter {
   template <typename T>
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/bitshuffle_filter.cc
+++ b/tiledb/sm/filter/bitshuffle_filter.cc
@@ -165,6 +165,7 @@ Status BitshuffleFilter::shuffle_part(
 
 Status BitshuffleFilter::run_reverse(
     const Tile& tile,
+    Tile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/bitshuffle_filter.h
+++ b/tiledb/sm/filter/bitshuffle_filter.h
@@ -98,6 +98,7 @@ class BitshuffleFilter : public Filter {
    */
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/byteshuffle_filter.cc
+++ b/tiledb/sm/filter/byteshuffle_filter.cc
@@ -109,6 +109,7 @@ Status ByteshuffleFilter::shuffle_part(
 
 Status ByteshuffleFilter::run_reverse(
     const Tile& tile,
+    Tile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/byteshuffle_filter.h
+++ b/tiledb/sm/filter/byteshuffle_filter.h
@@ -90,6 +90,7 @@ class ByteshuffleFilter : public Filter {
    */
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/checksum_md5_filter.cc
+++ b/tiledb/sm/filter/checksum_md5_filter.cc
@@ -97,6 +97,7 @@ Status ChecksumMD5Filter::run_forward(
 
 Status ChecksumMD5Filter::run_reverse(
     const Tile&,
+    Tile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/checksum_md5_filter.h
+++ b/tiledb/sm/filter/checksum_md5_filter.h
@@ -96,6 +96,7 @@ class ChecksumMD5Filter : public Filter {
    */
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/checksum_sha256_filter.cc
+++ b/tiledb/sm/filter/checksum_sha256_filter.cc
@@ -97,6 +97,7 @@ Status ChecksumSHA256Filter::run_forward(
 
 Status ChecksumSHA256Filter::run_reverse(
     const Tile&,
+    Tile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/checksum_sha256_filter.h
+++ b/tiledb/sm/filter/checksum_sha256_filter.h
@@ -96,6 +96,7 @@ class ChecksumSHA256Filter : public Filter {
    */
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -127,6 +127,7 @@ class CompressionFilter : public Filter {
    */
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
@@ -213,6 +214,7 @@ class CompressionFilter : public Filter {
   Status decompress_var_string_coords(
       FilterBuffer& input,
       FilterBuffer& input_metadata,
+      Tile* offsets_tile,
       FilterBuffer& output) const;
 
   /** Gets an option from this filter. */

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.cc
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.cc
@@ -141,6 +141,7 @@ Status EncryptionAES256GCMFilter::encrypt_part(
 
 Status EncryptionAES256GCMFilter::run_reverse(
     const Tile&,
+    Tile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.h
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.h
@@ -109,6 +109,7 @@ class EncryptionAES256GCMFilter : public Filter {
    */
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -91,10 +91,11 @@ class Filter {
    *
    * Implemented by filter subclass.
    *
+   * @param tile Current tile on which the filter is being run
+   * @param offsets_tile Offsets tile of the current tile on which the filter is
+   * being run
    * @param input_metadata Buffer with metadata for `input`
    * @param input Buffer with data to be filtered.
-   * @param input_offsets Buffer with the offsets (if any) of the data to be
-   * filtered.
    * @param output_metadata Buffer with metadata for filtered data
    * @param output Buffer with filtered data (unused by in-place filters).
    * @return
@@ -117,6 +118,8 @@ class Filter {
    * Implemented by filter subclass.
    *
    * @param tile Current tile on which the filter is being run
+   * @param offsets_tile Offsets tile of the current tile on which the filter is
+   * being run
    * @param input_metadata Buffer with metadata for `input`
    * @param input Buffer with data to be filtered.
    * @param output_metadata Buffer with metadata for filtered data
@@ -125,6 +128,7 @@ class Filter {
    */
   virtual Status run_reverse(
       const Tile& tile,
+      Tile* const offsets_tile,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -730,8 +730,9 @@ Status FilterPipeline::append_encryption_filter(
   }
 }
 
-bool FilterPipeline::skip_offsets_filtering(Datatype type) const {
-  if (type == Datatype::STRING_ASCII) {
+bool FilterPipeline::skip_offsets_filtering(
+    Datatype type, const uint32_t version) const {
+  if (version >= 12 && type == Datatype::STRING_ASCII) {
     if (has_filter(FilterType::FILTER_RLE)) {
       return true;
     }

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -310,9 +310,12 @@ class FilterPipeline {
    * whole
    *
    * @param type Datatype of the input attribute/dimension
+   * @param type Array schema version
    * @return True if we can skip offsets filtering
    */
-  bool skip_offsets_filtering(const Datatype type) const;
+  bool skip_offsets_filtering(
+      const Datatype type,
+      const uint32_t version = constants::format_version) const;
 
   /**
    * Checks if an attribute/dimension needs to be filtered in chunks or as a

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -239,14 +239,18 @@ class FilterPipeline {
    * The length of tile_data will be the sum of all chunkI_orig_len for I in 0
    * to N.
    *
-   * @param tile Tile to filter
+   * @param reader_stats Reader stats
+   * @param tile Tile to unfilter
+   * @param offsets_tile Offsets tile to unfilter, null if it will be unfilered
+   * separately
    * @param compute_tp The thread pool for compute-bound tasks.
    * @param config The global config.
    * @return Status
    */
   Status run_reverse(
       stats::Stats* reader_stats,
-      Tile* tile,
+      Tile* const tile,
+      Tile* const offsets_tile,
       ThreadPool* compute_tp,
       const Config& config) const;
 
@@ -300,6 +304,15 @@ class FilterPipeline {
    */
   static Status append_encryption_filter(
       FilterPipeline* pipeline, const EncryptionKey& encryption_key);
+
+  /**
+   * Checks if an attribute/dimension needs to be filtered in chunks or as a
+   * whole
+   *
+   * @param type Datatype of the input attribute/dimension
+   * @return True if we can skip offsets filtering
+   */
+  bool skip_offsets_filtering(const Datatype type) const;
 
   /**
    * Checks if an attribute/dimension needs to be filtered in chunks or as a
@@ -364,6 +377,8 @@ class FilterPipeline {
    * Run the given list of chunks in reverse through the pipeline.
    *
    * @param tile Current tile on which the filter pipeline is being run
+   * @param offsets_tile Current offsets tile for var sized
+   * attributes/dimensions.
    * @param input Filtered chunk buffers to reverse.
    * @param output Chunked buffer where output of the last stage
    *    will be written.
@@ -373,6 +388,7 @@ class FilterPipeline {
    */
   Status filter_chunks_reverse(
       Tile& tile,
+      Tile* const offsets_tile,
       const std::vector<tuple<void*, uint32_t, uint32_t, uint32_t>>& input,
       ThreadPool* const compute_tp,
       const Config& config) const;
@@ -381,13 +397,15 @@ class FilterPipeline {
    * The internal work routine for `run_reverse`.
    *
    * @param tile Tile to filter
+   * @param offsets_tile Offsets tile for var sized tile to filter.
    * @param compute_tp The thread pool for compute-bound tasks.
    * @param config The global config.
    * @return Status
    */
   Status run_reverse_internal(
       stats::Stats* reader_stats,
-      Tile* tile,
+      Tile* const tile,
+      Tile* const offsets_tile,
       ThreadPool* compute_tp,
       const Config& config) const;
 };

--- a/tiledb/sm/filter/noop_filter.cc
+++ b/tiledb/sm/filter/noop_filter.cc
@@ -69,6 +69,7 @@ Status NoopFilter::run_forward(
 
 Status NoopFilter::run_reverse(
     const Tile&,
+    Tile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/noop_filter.h
+++ b/tiledb/sm/filter/noop_filter.h
@@ -70,6 +70,7 @@ class NoopFilter : public Filter {
    */
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -238,6 +238,7 @@ Status PositiveDeltaFilter::encode_part(
 
 Status PositiveDeltaFilter::run_reverse(
     const Tile& tile,
+    Tile* const offsets_tile,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
@@ -260,29 +261,29 @@ Status PositiveDeltaFilter::run_reverse(
   switch (tile_type) {
     case Datatype::INT8:
       return run_reverse<int8_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::BLOB:
     case Datatype::UINT8:
       return run_reverse<uint8_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT16:
       return run_reverse<int16_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::UINT16:
       return run_reverse<uint16_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT32:
       return run_reverse<int>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::UINT32:
       return run_reverse<unsigned>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT64:
       return run_reverse<int64_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::UINT64:
       return run_reverse<uint64_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::DATETIME_YEAR:
     case Datatype::DATETIME_MONTH:
     case Datatype::DATETIME_WEEK:
@@ -306,7 +307,7 @@ Status PositiveDeltaFilter::run_reverse(
     case Datatype::TIME_FS:
     case Datatype::TIME_AS:
       return run_reverse<int64_t>(
-          tile, input_metadata, input, output_metadata, output);
+          tile, offsets_tile, input_metadata, input, output_metadata, output);
     default:
       return LOG_STATUS(
           Status_FilterError("Cannot filter; Unsupported input type"));
@@ -316,6 +317,7 @@ Status PositiveDeltaFilter::run_reverse(
 template <typename T>
 Status PositiveDeltaFilter::run_reverse(
     const Tile& tile,
+    Tile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/positive_delta_filter.h
+++ b/tiledb/sm/filter/positive_delta_filter.h
@@ -104,6 +104,7 @@ class PositiveDeltaFilter : public Filter {
    */
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
@@ -152,6 +153,7 @@ class PositiveDeltaFilter : public Filter {
   template <typename T>
   Status run_reverse(
       const Tile& tile,
+      Tile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -1358,7 +1358,8 @@ Status ReaderBase::unfilter_tile(
   // Reverse the tile filters.
   // If offsets don't need to be unfiltered separately, it means they
   // will be created on the fly from filtered data
-  if (filters.skip_offsets_filtering(tile_var->type())) {
+  if (filters.skip_offsets_filtering(
+          tile_var->type(), array_schema_.version())) {
     RETURN_NOT_OK(filters.run_reverse(
         stats_, tile_var, tile, storage_manager_->compute_tp(), config_));
   } else {
@@ -1420,7 +1421,7 @@ Status ReaderBase::unfilter_tile_nullable(
   // Reverse the tile filters.
   // If offsets don't need to be unfiltered separately, it means they
   // will be created on the fly from filtered var-length data
-  if (filters.skip_offsets_filtering(tile->type())) {
+  if (filters.skip_offsets_filtering(tile->type(), array_schema_.version())) {
     RETURN_NOT_OK(filters.run_reverse(
         stats_,
         tile_var,

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -99,6 +99,7 @@ Status GenericTileIO::read_generic(
   RETURN_NOT_OK(header.filters.run_reverse(
       storage_manager_->stats(),
       ret.get(),
+      nullptr,
       storage_manager_->compute_tp(),
       config));
   assert(!ret->filtered());


### PR DESCRIPTION
When RLE is used for compressing string dimensions, the offset information is embedded as string size in the RLE format we have chosen: `[run_length|string_size|string]`

This PR is for skipping storing offsets for RLE encoded string dimensions as it is redundant info, and rely on `string_size` saved in RLE format to reconstruct offsets on unfiltering. This significantly improves storage size for string dimensions.

### Some more details on how this looks on disk: 
For an array of a var-sized string dimension d1, we store today for a fragment 3 files: `d1.tdb` for offsets, `d1_var.tdb` for string values and `__fragment_metadata.tdb` for metadata.

For this work, instead of completely removing the need to create and store the offsets file `d1.tdb`, which would require a lot of important changes in the code and the on-disk format, we pick a middle road: Although we keep `d1.tdb` and follow the usual format, we just write `8 bytes` (sizeof(uint64_t)) per Tile for the `Num chunks` field, which is hardcoded to 0 for every Tile (since we don't store any actual offsets).
This allows the usual Tile format to be preserved:
```
| **Field** | **Type** | **Description** |
| :--- | :--- | :--- |
| Num chunks | `uint64_t` | Number of chunks in the tile |
| Chunk 1 | [Chunk](#chunk-format) | First chunk in the tile |
| … | … | … |
```

### On-disk memory usage comparison

For the above example of var-length string dimension `d1`, with `10'000` values and Tile capacity of `1000` (aka 10 tiles), the on-disk memory for the different scenarios is:

- No compression on values (TILEDB_FILTER_NONE on values, default ZSTD on offsets)

```
% ls -la __fragments/__1647525403013_1647525403013_7b6652bbc1684adb83c1bf7e76f1c0a9_12
total 240
drwxr-xr-x  5 ypatia  staff     160 Mar 17 15:56 .
drwxr-xr-x  3 ypatia  staff      96 Mar 17 15:56 ..
-rw-r--r--  1 ypatia  staff    2252 Mar 17 15:56 __fragment_metadata.tdb
-rw-r--r--  1 ypatia  staff   12291 Mar 17 15:56 d0.tdb
-rw-r--r--  1 ypatia  staff  100020 Mar 17 15:56 d0_var.tdb

```

- Default compression (GZIP on values, ZSTD on offsets)

```

% ls -la __fragments/__1647524840329_1647524840329_d37674e953fb4867a4d8e1aafee128ae_12
total 48
drwxr-xr-x  5 ypatia  staff    160 Mar 17 15:47 .
drwxr-xr-x  3 ypatia  staff     96 Mar 17 15:47 ..
-rw-r--r--  1 ypatia  staff   2243 Mar 17 15:47 __fragment_metadata.tdb
-rw-r--r--  1 ypatia  staff  12291 Mar 17 15:47 d0.tdb
-rw-r--r--  1 ypatia  staff    652 Mar 17 15:47 d0_var.tdb
```


- RLE with offsets (by default ZSTD filtering on offsets)

```
% ls -la __fragments/__1647525108926_1647525108926_7b51e6092dbc4f8ba41a1361cf139859_12
total 48
drwxr-xr-x  5 ypatia  staff    160 Mar 17 15:51 .
drwxr-xr-x  3 ypatia  staff     96 Mar 17 15:51 ..
-rw-r--r--  1 ypatia  staff   2243 Mar 17 15:51 __fragment_metadata.tdb
-rw-r--r--  1 ypatia  staff  12291 Mar 17 15:51 d0.tdb
-rw-r--r--  1 ypatia  staff    572 Mar 17 15:51 d0_var.tdb
```

- **RLE without offsets as introduced in this PR**

```

% ls -la __fragments/__1647524649967_1647524649967_0b7be44a210545688edb0e119b3373c9_12
total 24
drwxr-xr-x  5 ypatia  staff   160 Mar 17 15:44 .
drwxr-xr-x  3 ypatia  staff    96 Mar 17 15:44 ..
-rw-r--r--  1 ypatia  staff  2234 Mar 17 15:44 __fragment_metadata.tdb
-rw-r--r--  1 ypatia  staff    80 Mar 17 15:44 d0.tdb
-rw-r--r--  1 ypatia  staff   612 Mar 17 15:44 d0_var.tdb


```
TYPE: IMPROVEMENT 
DESC: Do not store offsets when RLE is used on string dimensions
