### PR TITLE
compare to nullptr rather than NULL to avoid type mismatch warnings (…

### DIFF
--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -1189,14 +1189,14 @@ TEST_CASE_METHOD(
   const void* extent = NULL;
   rc = tiledb_dimension_get_tile_extent(ctx_, r_d1, &extent);
   REQUIRE(rc == TILEDB_OK);
-  REQUIRE(extent != NULL);
+  REQUIRE(extent != nullptr);
   CHECK(*(const int32_t*)extent == 100);
   tiledb_dimension_t* r_d2;
   rc = tiledb_domain_get_dimension_from_index(ctx_, r_domain, 1, &r_d2);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_dimension_get_tile_extent(ctx_, r_d2, &extent);
   REQUIRE(rc == TILEDB_OK);
-  REQUIRE(extent != NULL);
+  REQUIRE(extent != nullptr);
   CHECK(*(const float*)extent == d2_dom[1] - d2_dom[0]);
 
   // Clean up

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -946,7 +946,7 @@ void DenseArrayFx::check_sorted_reads(const std::string& path) {
     // Read subarray
     int* buffer = read_dense_array_2D(
         array_name, d0_lo, d0_hi, d1_lo, d1_hi, TILEDB_READ, TILEDB_ROW_MAJOR);
-    REQUIRE(buffer != NULL);
+    REQUIRE(buffer != nullptr);
 
     bool allok = true;
     // Check
@@ -1109,7 +1109,7 @@ void DenseArrayFx::check_sorted_writes(const std::string& path) {
         subarray[3],
         TILEDB_READ,
         TILEDB_ROW_MAJOR);
-    REQUIRE(read_buffer != NULL);
+    REQUIRE(read_buffer != nullptr);
 
     // Check the two buffers
     bool allok = true;
@@ -1335,7 +1335,7 @@ void DenseArrayFx::check_cancel_and_retry_writes(const std::string& path) {
       subarray[3],
       TILEDB_READ,
       TILEDB_ROW_MAJOR);
-  REQUIRE(read_buffer != NULL);
+  REQUIRE(read_buffer != nullptr);
 
   // Check the two buffers
   bool allok = true;

--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -644,7 +644,7 @@ void DenseArrayRESTFx::check_sorted_reads(const std::string& path) {
     // Read subarray
     int* buffer = read_dense_array_2D(
         array_name, d0_lo, d0_hi, d1_lo, d1_hi, TILEDB_READ, TILEDB_ROW_MAJOR);
-    REQUIRE(buffer != NULL);
+    REQUIRE(buffer != nullptr);
 
     bool allok = true;
     // Check
@@ -895,7 +895,7 @@ void DenseArrayRESTFx::check_sorted_writes(const std::string& path) {
         subarray[3],
         TILEDB_READ,
         TILEDB_ROW_MAJOR);
-    REQUIRE(read_buffer != NULL);
+    REQUIRE(read_buffer != nullptr);
 
     // Check the two buffers
     bool allok = true;

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -716,7 +716,7 @@ void SparseArrayFx::test_random_subarrays(
     // Read subarray
     int* buffer = read_sparse_array_2D(
         array_name, d0_lo, d0_hi, d1_lo, d1_hi, TILEDB_READ, TILEDB_ROW_MAJOR);
-    CHECK(buffer != NULL);
+    CHECK(buffer != nullptr);
 
     // check
     bool allok = true;


### PR DESCRIPTION
change comparisons from NULL to nullptr to avoid expression type mismatches building tiledb_unit (manifest in rtools40 build)

---
TYPE: BUG
DESC: compare nullptr, avoid catch2 comparison warning failure
