### PR TITLE
Support reading all consolidated fragment metadata files.

### DIFF
--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -1679,3 +1679,182 @@ TEST_CASE(
   tiledb_ctx_free(&ctx);
   tiledb_vfs_free(&vfs);
 }
+
+TEST_CASE(
+    "C API: Test fragment info, consolidated fragment metadata multiple",
+    "[capi][fragment_info][consolidated-metadata][multiple]") {
+  // Create TileDB context
+  tiledb_ctx_t* ctx = nullptr;
+  int rc = tiledb_ctx_alloc(nullptr, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_vfs_t* vfs = nullptr;
+  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create array
+  uint64_t domain[] = {1, 10};
+  uint64_t tile_extent = 5;
+  create_array(
+      ctx,
+      array_name,
+      TILEDB_DENSE,
+      {"d"},
+      {TILEDB_UINT64},
+      {domain},
+      {&tile_extent},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      2);
+
+  // Write a dense fragment
+  QueryBuffers buffers;
+  uint64_t subarray[] = {1, 6};
+  std::vector<int32_t> a = {1, 2, 3, 4, 5, 6};
+  uint64_t a_size = a.size() * sizeof(int32_t);
+  buffers["a"] = tiledb::test::QueryBuffer({&a[0], a_size, nullptr, 0});
+  std::string written_frag_uri;
+  write_array(
+      ctx,
+      array_name,
+      1,
+      subarray,
+      TILEDB_ROW_MAJOR,
+      buffers,
+      &written_frag_uri);
+
+  // Write another dense fragment
+  subarray[0] = 1;
+  subarray[1] = 7;
+  a = {7, 1, 2, 3, 4, 5, 6};
+  a_size = a.size() * sizeof(int32_t);
+  buffers["a"] = tiledb::test::QueryBuffer({&a[0], a_size, nullptr, 0});
+  write_array(ctx, array_name, 3, subarray, TILEDB_ROW_MAJOR, buffers);
+
+  // Create fragment info object
+  tiledb_fragment_info_t* fragment_info = nullptr;
+  rc = tiledb_fragment_info_alloc(ctx, array_name.c_str(), &fragment_info);
+  CHECK(rc == TILEDB_OK);
+
+  // Load fragment info
+  rc = tiledb_fragment_info_load(ctx, fragment_info);
+  CHECK(rc == TILEDB_OK);
+
+  // Check for consolidated metadata
+  int32_t has;
+  rc = tiledb_fragment_info_has_consolidated_metadata(
+      ctx, fragment_info, 0, &has);
+  CHECK(rc == TILEDB_OK);
+  CHECK(has == 0);
+  rc = tiledb_fragment_info_has_consolidated_metadata(
+      ctx, fragment_info, 1, &has);
+  CHECK(rc == TILEDB_OK);
+  CHECK(has == 0);
+  rc = tiledb_fragment_info_has_consolidated_metadata(
+      ctx, fragment_info, 2, &has);
+  CHECK(rc == TILEDB_ERR);
+
+  // Get number of unconsolidated fragment metadata
+  uint32_t unconsolidated = 0;
+  rc = tiledb_fragment_info_get_unconsolidated_metadata_num(
+      ctx, fragment_info, &unconsolidated);
+  CHECK(rc == TILEDB_OK);
+  CHECK(unconsolidated == 2);
+
+  // Consolidate fragment metadata
+  tiledb_config_t* config = nullptr;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.consolidation.mode", "fragment_meta", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  // Consolidate - this will consolidate only the fragment metadata
+  rc = tiledb_array_consolidate(ctx, array_name.c_str(), config);
+  CHECK(rc == TILEDB_OK);
+
+  // Load fragment info
+  rc = tiledb_fragment_info_load(ctx, fragment_info);
+  CHECK(rc == TILEDB_OK);
+
+  // Check for consolidated metadata
+  rc = tiledb_fragment_info_has_consolidated_metadata(
+      ctx, fragment_info, 0, &has);
+  CHECK(rc == TILEDB_OK);
+  CHECK(has == 1);
+  rc = tiledb_fragment_info_has_consolidated_metadata(
+      ctx, fragment_info, 1, &has);
+  CHECK(rc == TILEDB_OK);
+  CHECK(has == 1);
+
+  // Get number of unconsolidated fragment metadata
+  rc = tiledb_fragment_info_get_unconsolidated_metadata_num(
+      ctx, fragment_info, &unconsolidated);
+  CHECK(rc == TILEDB_OK);
+  CHECK(unconsolidated == 0);
+
+  // Write another dense fragment in between the existing 2
+  subarray[0] = 2;
+  subarray[1] = 9;
+  a = {6, 7, 1, 2, 3, 4, 5, 6};
+  a_size = a.size() * sizeof(int32_t);
+  buffers["a"] = tiledb::test::QueryBuffer({&a[0], a_size, nullptr, 0});
+  write_array(ctx, array_name, 2, subarray, TILEDB_ROW_MAJOR, buffers);
+
+  // Load fragment info
+  rc = tiledb_fragment_info_load(ctx, fragment_info);
+  CHECK(rc == TILEDB_OK);
+
+  // Check for consolidated metadata
+  rc = tiledb_fragment_info_has_consolidated_metadata(
+      ctx, fragment_info, 0, &has);
+  CHECK(rc == TILEDB_OK);
+  CHECK(has == 1);
+  rc = tiledb_fragment_info_has_consolidated_metadata(
+      ctx, fragment_info, 1, &has);
+  CHECK(rc == TILEDB_OK);
+  CHECK(has == 0);
+  rc = tiledb_fragment_info_has_consolidated_metadata(
+      ctx, fragment_info, 2, &has);
+  CHECK(rc == TILEDB_OK);
+  CHECK(has == 1);
+
+  // Get number of unconsolidated fragment metadata
+  rc = tiledb_fragment_info_get_unconsolidated_metadata_num(
+      ctx, fragment_info, &unconsolidated);
+  CHECK(rc == TILEDB_OK);
+  CHECK(unconsolidated == 1);
+
+  // Consolidate - this will consolidate only the fragment metadata
+  rc = tiledb_array_consolidate(ctx, array_name.c_str(), config);
+  CHECK(rc == TILEDB_OK);
+
+  // Load fragment info
+  rc = tiledb_fragment_info_load(ctx, fragment_info);
+  CHECK(rc == TILEDB_OK);
+
+  // Check again
+  rc = tiledb_fragment_info_has_consolidated_metadata(
+      ctx, fragment_info, 1, &has);
+  CHECK(rc == TILEDB_OK);
+  CHECK(has == 1);
+
+  // Get number of unconsolidated fragment metadata
+  rc = tiledb_fragment_info_get_unconsolidated_metadata_num(
+      ctx, fragment_info, &unconsolidated);
+  CHECK(rc == TILEDB_OK);
+  CHECK(unconsolidated == 0);
+
+  // Clean up
+  tiledb_fragment_info_free(&fragment_info);
+  remove_dir(array_name, ctx, vfs);
+  tiledb_ctx_free(&ctx);
+  tiledb_vfs_free(&vfs);
+  tiledb_error_free(&error);
+  tiledb_config_free(&config);
+}

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -143,9 +143,6 @@ class ArrayDirectory {
   /** Returns the URIs of the consolidated fragment metadata files. */
   const std::vector<URI>& fragment_meta_uris() const;
 
-  /** Returns the latest consolidated fragment metadata URI. */
-  const URI& latest_fragment_meta_uri() const;
-
   /** Returns the URI to store fragments. */
   URI get_fragments_dir(uint32_t write_version) const;
 
@@ -233,11 +230,6 @@ class ArrayDirectory {
   std::vector<URI> fragment_meta_uris_;
 
   /**
-   * The latest fragment metadata URI.
-   */
-  URI latest_fragment_meta_uri_;
-
-  /**
    * Only array fragments, metadata, etc. that
    * were created within timestamp range
    *    [`timestamp_start`, `timestamp_end`] will be considered when
@@ -276,10 +268,9 @@ class ArrayDirectory {
   /**
    * Loads the root directory uris for v1 to v11.
    *
-   * @return Status, vector of fragment URIs, latest fragment metadata.
+   * @return Status, vector of fragment URIs.
    */
-  tuple<Status, optional<std::vector<URI>>, optional<URI>>
-  load_root_dir_uris_v1_v11(
+  tuple<Status, optional<std::vector<URI>>> load_root_dir_uris_v1_v11(
       const std::vector<URI>& root_dir_uris,
       const std::unordered_set<std::string>& consolidated_uris_set);
 
@@ -303,9 +294,10 @@ class ArrayDirectory {
   /**
    * Loads the fragment metadata directory uris for v12 or higher.
    *
-   * @return Status, latest fragment metadata.
+   * @return Status, fragment metadata URIs.
    */
-  tuple<Status, optional<URI>> load_fragment_metadata_dir_uris_v12_or_higher();
+  tuple<Status, optional<std::vector<URI>>>
+  load_fragment_metadata_dir_uris_v12_or_higher();
 
   /**
    * Loads the commits URIs to consolidate.
@@ -343,9 +335,9 @@ class ArrayDirectory {
       const std::unordered_set<std::string>& consolidated_uris_set) const;
 
   /**
-   * Computes the latest fragment meta URI from the input array directory.
+   * Computes the fragment meta URIs from the input array directory.
    */
-  tuple<Status, optional<URI>> compute_latest_fragment_meta_uri(
+  std::vector<URI> compute_fragment_meta_uris(
       const std::vector<URI>& array_dir_uris);
 
   /**

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -1050,8 +1050,6 @@ class StorageManager {
    *     schema filename.
    * @param encryption_key The encryption key to use.
    * @param fragments_to_load The fragments whose metadata to load.
-   * @param meta_buff A buffer that may contain the consolidated fragment
-   *     metadata.
    * @param offsets A map from a fragment name to an offset in `meta_buff`
    *     where the basic fragment metadata can be found. If the offset
    *     cannot be found, then the metadata of that fragment will be loaded from
@@ -1068,8 +1066,8 @@ class StorageManager {
           array_schemas_all,
       const EncryptionKey& encryption_key,
       const std::vector<TimestampedURI>& fragments_to_load,
-      Buffer* meta_buff,
-      const std::unordered_map<std::string, uint64_t>& offsets);
+      const std::unordered_map<std::string, std::pair<Buffer*, uint64_t>>&
+          offsets);
 
   /**
    * Loads the latest consolidated fragment metadata from storage.
@@ -1077,15 +1075,12 @@ class StorageManager {
    * @param uri The URI of the consolidated fragment metadata.
    * @param enc_key The encryption key that may be needed to access the file.
    * @param f_buff The buffer to hold the consolidated fragment metadata.
-   * @param offsets A map from the fragment name to the offset in `f_buff` where
-   *     the basic fragment metadata starts.
-   * @return Status
+   * @return Status, vector from the fragment name to the offset in `f_buff`
+   *     where the basic fragment metadata starts.
    */
-  Status load_consolidated_fragment_meta(
-      const URI& uri,
-      const EncryptionKey& enc_key,
-      Buffer* f_buff,
-      std::unordered_map<std::string, uint64_t>* offsets);
+  tuple<Status, optional<std::vector<std::pair<std::string, uint64_t>>>>
+  load_consolidated_fragment_meta(
+      const URI& uri, const EncryptionKey& enc_key, Buffer* f_buff);
 
   /** Block until there are zero in-progress queries. */
   void wait_for_zero_in_progress();


### PR DESCRIPTION
This change fixes an issue with fragment metadata where the latest
timestamp cannot always be trusted. To fix this, all consolidated
fragment are loaded.

Vacuuming is still using the latest timestamp but now considers the
latest timestamp on every URI so multiple fragment metadata might be
left around. This doesn't match the behavior of the WRT consolidation,
where we only vacuum the consolidated files if a complete set of the
fragments is found inside of a consolidated file. As for now the
vacuuming API doesn't take in the key, we cannot know if a particular
file contains everything. This can be addressed in a later PR.

---
TYPE: IMPROVEMENT
DESC: Support reading all consolidated fragment metadata files.
