### PR TITLE
Adds proposed change to schema for dimension labels

### DIFF
--- a/format_spec/array_schema.md
+++ b/format_spec/array_schema.md
@@ -79,6 +79,7 @@ The dimension has internal format:
 | Domain | `uint8_t[]` | Byte array of length equal to domain size above, storing the min, max values of the dimension. |
 | Null tile extent | `uint8_t` | `1` if the dimension has a null tile extent, else `0`. |
 | Tile extent | `uint8_t[]` | Byte array of length equal to the dimension datatype size, storing the space tile extent of this dimension. |
+| Labels | [Labels](./dimension_label.md) | The labels available for the dimensions |
 
 ## Attribute
 

--- a/format_spec/dimension_label.md
+++ b/format_spec/dimension_label.md
@@ -1,0 +1,34 @@
+# Dimension Labels
+
+## Main Structure
+
+| **Field** | **Type** | **Description** |
+| :--- | :--- | :--- |
+| Number of labels | `uint32_t` | Number of dimension labels |
+| Label 1 | [Label](#label) | First label |
+| …  | … | … |
+| Label N | [Label](#label) | Nth label |
+
+## Label
+
+The label has internal format:
+
+| **Field** | **Type** | **Description** |
+| :--- | :--- | :--- |
+| Label type | `uint8_t` | Type of label \(e.g. `TILEDB_LABEL_UNIFORM`\) |
+| Label name length | `uint32_t` | Number of characters in label name |
+| Label name | `char[]` | Label name character array |
+| Label datatype | `uint8_t` | Datatype of the coordinate values |
+| Label cell val num | `uint32_t` | Number of coordinate values per cell. For variable-length labels, this is `std::numeric_limits<uint32_t>::max()` |
+| Label domain size | `uint64_t[]` | The domain size in bytes |
+| Label domain | `uint8_t[]` | Byte array of length equal to domain size above, storing the min, max values of the label. |
+| Label metadata size | `uint32_t` | Number of bytes in label metadata — may be 0. |
+| Label metadata | [Label Metadata](#label-metadata) | Label metadata, specific to each label. |
+
+## Label Metadata
+
+The label metadata are the parameters that define the label.
+
+### Uniform Label
+
+`TILEDB_LABEL_UNIFORM` does not serialize any additional options.


### PR DESCRIPTION
Proposed schema format changes for dimension labels. Dimension labels are added as part of the dimension schema. Initially only uniform (virtual) dimension labels are fully supported. 

Notes:
* The proposed specification can be expanded to allow additional dimension label types with additional parameters in the future.
* The proposed specification will not need to be modified if we decide to support multiple labels on a single dimension in the future.

---
TYPE: FORMAT
DESC: Add dimension labels to the 
