### PR TITLE
Check that array is open before getting non_empty_domain

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -347,7 +347,16 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic]") {
     query.set_layout(TILEDB_GLOBAL_ORDER);
     CHECK(query.submit() == tiledb::Query::Status::COMPLETE);
     REQUIRE_NOTHROW(query.finalize());
+
+    // Check non-empty domain while array open in write mode
+    CHECK_THROWS(array.non_empty_domain<int>(1));
+    CHECK_THROWS(array.non_empty_domain<int>("d1"));
+
     array.close();
+
+    // Check non-empty domain before open from read
+    CHECK_THROWS(array.non_empty_domain<int>(1));
+    CHECK_THROWS(array.non_empty_domain<int>("d1"));
 
     array.open(TILEDB_READ);
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -977,6 +977,11 @@ Status StorageManager::array_get_non_empty_domain(
 
 Status StorageManager::array_get_non_empty_domain_from_index(
     Array* array, unsigned idx, void* domain, bool* is_empty) {
+  // Check if array is open - must be open for reads
+  if (!array->is_open())
+    return logger_->status(Status_StorageManagerError(
+        "Cannot get non-empty domain; Array is not open"));
+
   // For easy reference
   const auto& array_schema = array->array_schema_latest();
   auto array_domain = array_schema.domain();
@@ -1007,6 +1012,11 @@ Status StorageManager::array_get_non_empty_domain_from_name(
   if (name == nullptr)
     return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension name"));
+
+  // Check if array is open - must be open for reads
+  if (!array->is_open())
+    return logger_->status(Status_StorageManagerError(
+        "Cannot get non-empty domain; Array is not open"));
 
   NDRange dom;
   RETURN_NOT_OK(array_get_non_empty_domain(array, &dom, is_empty));


### PR DESCRIPTION
Bug fix: an array needs to be checked for `is_open` before getting non_empty_domain. 

---
TYPE: BUG
DESC: Check that array is open before getting non_empty_domain
