### PR TITLE
Fixing build errors using MacOSX12.3.sdk.

### DIFF
--- a/tiledb/sm/cpp_api/deleter.h
+++ b/tiledb/sm/cpp_api/deleter.h
@@ -61,7 +61,6 @@ class Deleter {
   /* ********************************* */
 
   Deleter() = default;
-  Deleter(const Deleter&) = default;
 
   /* ********************************* */
   /*              DELETERS             */

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -1506,7 +1506,6 @@ Status VFS::compute_read_batches(
 
   // Start the first batch containing only the first region.
   BatchedRead curr_batch(sorted_regions.front());
-  uint64_t curr_batch_useful_bytes = curr_batch.nbytes;
   for (uint64_t i = 1; i < sorted_regions.size(); i++) {
     const auto& region = sorted_regions[i];
     uint64_t offset = std::get<0>(region);
@@ -1518,7 +1517,6 @@ Status VFS::compute_read_batches(
       // Extend current batch.
       curr_batch.nbytes = new_batch_size;
       curr_batch.regions.push_back(region);
-      curr_batch_useful_bytes += nbytes;
     } else {
       // Push the old batch and start a new one.
       batches->push_back(curr_batch);
@@ -1526,7 +1524,6 @@ Status VFS::compute_read_batches(
       curr_batch.nbytes = nbytes;
       curr_batch.regions.clear();
       curr_batch.regions.push_back(region);
-      curr_batch_useful_bytes = nbytes;
     }
   }
 


### PR DESCRIPTION
Fixing the following:
TileDB/tiledb/sm/filesystem/vfs.cc:1509:12: error: variable 'curr_batch_useful_bytes' set but not used [-Werror,-Wunused-but-set-variable]

test/../tiledb/sm/cpp_api/deleter.h:64:3: error: definition of implicit copy assignment operator for 'Deleter' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]

---
TYPE: IMPROVEMENT
DESC: Fixing build errors using MacOSX12.3.sdk.
