### PR TITLE
Fixing  compute_results_count_sparse_string for multiple range threads.

### DIFF
--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -852,7 +852,7 @@ void ResultTile::compute_results_count_sparse_string(
   const uint64_t zeroed_size = coords_num < 256 ? coords_num : 256;
   for (uint64_t i = min_cell; i < min_cell + coords_num; i += zeroed_size) {
     const uint64_t partition_size =
-        (i < cell_num - zeroed_size) ? zeroed_size : cell_num - i;
+        (i < max_cell - zeroed_size) ? zeroed_size : max_cell - i;
 
     // Check if all `r_bitmap` values are zero between `i` and
     // `partition_size`. To do so, first make sure the first byte is 0, then


### PR DESCRIPTION
This fixes an incorrect computation for a partition size in
compute_results_count_sparse_string when there are multiple range
threads (result tiles < num cores). The number of cells of the tile was
used when the max_cell index for this call should have been used.

---
TYPE: IMPROVEMENT
DESC: Fixing compute_results_count_sparse_string for multiple range threads.
