### PR TITLE
Replace hardcoded bytesizes in RLE for strings with dynamically inferred

### DIFF
--- a/test/src/unit-compression-rle.cc
+++ b/test/src/unit-compression-rle.cc
@@ -309,27 +309,27 @@ TEST_CASE(
   std::vector<std::string_view> simple{s8, s8, s8, s8, s8, s1, s4, s4};
   CHECK(
       tiledb::sm::RLE::calculate_compression_params(simple) ==
-      std::tuple(5, 8, 3, 13));
+      std::tuple(1, 1, 3, 13));
 
   std::vector<std::string_view> last_unique{s8, s8, s8, s8, s4, s4, s1};
   CHECK(
       tiledb::sm::RLE::calculate_compression_params(last_unique) ==
-      std::tuple(4, 8, 3, 13));
+      std::tuple(1, 1, 3, 13));
 
   std::vector<std::string_view> first_unique{s1, s15, s15, s8, s8, s1, s4, s4};
   CHECK(
       tiledb::sm::RLE::calculate_compression_params(first_unique) ==
-      std::tuple(2, 15, 5, 29));
+      std::tuple(1, 1, 5, 29));
 
   std::vector<std::string_view> all_unique{s8, s15, s1, s3, s4};
   CHECK(
       tiledb::sm::RLE::calculate_compression_params(all_unique) ==
-      std::tuple(1, 15, 5, 31));
+      std::tuple(1, 1, 5, 31));
 
   std::vector<std::string_view> single_item{s4};
   CHECK(
       tiledb::sm::RLE::calculate_compression_params(single_item) ==
-      std::tuple(1, 4, 1, 4));
+      std::tuple(1, 1, 1, 4));
 
   std::vector<std::string_view> empty_in{};
   CHECK(
@@ -346,7 +346,7 @@ TEST_CASE(
   }
   CHECK(
       tiledb::sm::RLE::calculate_compression_params(all_same) ==
-      std::tuple(300000, 5000, 1, 5000));
+      std::tuple(4, 2, 1, 5000));
 }
 
 TEST_CASE(

--- a/tiledb/sm/compressors/rle_compressor.h
+++ b/tiledb/sm/compressors/rle_compressor.h
@@ -175,6 +175,14 @@ class RLE {
   }
 
   /**
+   * Return the number of bytes required to store an integer
+   *
+   * @param param_length Number to calculate the bytesize
+   * @return Number of bytes required to store the input number
+   */
+  static uint8_t compute_bytesize(uint64_t param_length);
+
+  /**
    * Calculate RLE parameters prior to compressing a series of var-sized strings
    *
    * @param input Input in form of a memory contiguous sequence of strings
@@ -182,6 +190,40 @@ class RLE {
    */
   static tuple<uint64_t, uint64_t, uint64_t, uint64_t>
   calculate_compression_params(const span<std::string_view> input);
+
+  /**
+   * Compress variable sized strings in contiguous memory to RLE format
+   *
+   * @param input Input in form of a memory contiguous sequence of strings
+   * @param rle_len_size Bytesize to use to store run legths
+   * @param string_len_size Bytesize to use to store string sizes
+   * @param output RLE-encoded output as a series of [run
+   * length|string_size|string] items. Memory is allocated and owned by the
+   * caller
+   */
+  static Status compress(
+      const span<std::string_view> input,
+      uint64_t rle_len_size,
+      uint64_t string_len_size,
+      span<std::byte> output);
+
+  /**
+   * Decompress strings encoded in RLE format
+   *
+   * @param input Input in [run length|string_size|string] RLE format to
+   * decompress
+   * @param rle_len_size Bytesize to use to read run legths
+   * @param string_len_size Bytesize to use to read string sizes
+   * @param output Decoded output as a series of strings in contiguous memory.
+   * @param output_offsets Output offsets reconstructed from input
+   * Memory is allocated and owned by the caller
+   */
+  static Status decompress(
+      const span<const std::byte> input,
+      uint64_t rle_len_size,
+      uint64_t string_len_size,
+      span<std::byte> output,
+      span<uint64_t> output_offsets);
 
   /**
    * Compress numbers in contiguous memory to RLE format


### PR DESCRIPTION
Currently we are hardcoding the RLE length size as uint32_t and the string size as uint16_t.

However the RLE algorithm is templated and supports any integer size, so in this PR we optimize our RLE for strings to dynamically determine the smallest datatype that can fit our needs, so that we can improve storage even further.

---
TYPE: IMPROVEMENT
DESC: Dynamically infer bytesizes for run length and strings for strings RLE compression
