### PR TITLE
DimensionLabel and UniformDimensionLabel design review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ if (TILEDB_TESTS)
   add_dependencies(tests unit_array_schema unit_filter_create unit_filter_pipeline unit_metadata)
   add_dependencies(tests unit_compressors)
   add_dependencies(tests unit_range_subset)
-  add_dependencies(tests unit_dimension_label unit_uniform_mapping)
+  add_dependencies(tests unit_dimension_label)
 endif()
 
 # Build tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ if (TILEDB_TESTS)
   add_dependencies(tests unit_array_schema unit_filter_create unit_filter_pipeline unit_metadata)
   add_dependencies(tests unit_compressors)
   add_dependencies(tests unit_range_subset)
+  add_dependencies(tests unit_dimension_label unit_uniform_mapping)
 endif()
 
 # Build tools

--- a/tiledb/common/status.h
+++ b/tiledb/common/status.h
@@ -297,6 +297,10 @@ inline Status Status_VFSError(const std::string& msg) {
 inline Status Status_DimensionError(const std::string& msg) {
   return {"[TileDB::Dimension] Error", msg};
 }
+/** Return a Dimension error class Status with a given message **/
+inline Status Status_DimensionLabelError(const std::string& msg) {
+  return {"[TileDB::DimensionLabel] Error", msg};
+}
 /** Return a Domain error class Status with a given message **/
 inline Status Status_DomainError(const std::string& msg) {
   return {"[TileDB::Domain] Error", msg};

--- a/tiledb/sm/dimension_label/CMakeLists.txt
+++ b/tiledb/sm/dimension_label/CMakeLists.txt
@@ -35,11 +35,12 @@ add_library(dimension_label OBJECT dimension_label.cc )
 target_link_libraries(dimension_label PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 target_link_libraries(dimension_label PUBLIC misc_types $<TARGET_OBJECTS:misc_types>)
 target_link_libraries(dimension_label PUBLIC uniform_mapping $<TARGET_OBJECTS:uniform_mapping>)
+target_link_libraries(dimension_label PUBLIC buffer $<TARGET_OBJECTS:buffer>)
 
 add_executable(compile_dimension_label EXCLUDE_FROM_ALL)
 target_link_libraries(compile_dimension_label PRIVATE dimension_label)
 target_sources(compile_dimension_label PRIVATE test/compile_dimension_label_main.cc)
 
 if (TILEDB_TESTS)
-    add_subdirectory(test)
+  add_subdirectory(test)
 endif()

--- a/tiledb/sm/dimension_label/CMakeLists.txt
+++ b/tiledb/sm/dimension_label/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# tiledb/sm/CMakeLists.txt
+# tiledb/sm/dimension_label/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2021 TileDB, Inc.
+# Copyright (c) 2022 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,22 @@
 # THE SOFTWARE.
 #
 
-include(common-root)
+include(common NO_POLICY_SCOPE)
 
-add_subdirectory(array_schema)
-add_subdirectory(buffer)
-add_subdirectory(compressors)
-add_subdirectory(config)
-add_subdirectory(crypto)
-add_subdirectory(dimension_label)
-add_subdirectory(filesystem)
-add_subdirectory(filter)
-add_subdirectory(metadata)
-add_subdirectory(misc)
-add_subdirectory(query)
-add_subdirectory(stats)
-add_subdirectory(subarray)
-add_subdirectory(tile)
+add_library(uniform_mapping OBJECT uniform_mapping.cc)
+target_link_libraries(uniform_mapping PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+target_link_libraries(uniform_mapping PUBLIC misc_types $<TARGET_OBJECTS:misc_types>)
+target_link_libraries(uniform_mapping PUBLIC constants $<TARGET_OBJECTS:constants>)
+
+add_library(dimension_label OBJECT dimension_label.cc )
+target_link_libraries(dimension_label PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+target_link_libraries(dimension_label PUBLIC misc_types $<TARGET_OBJECTS:misc_types>)
+target_link_libraries(dimension_label PUBLIC uniform_mapping $<TARGET_OBJECTS:uniform_mapping>)
+
+add_executable(compile_dimension_label EXCLUDE_FROM_ALL)
+target_link_libraries(compile_dimension_label PRIVATE dimension_label)
+target_sources(compile_dimension_label PRIVATE test/compile_dimension_label_main.cc)
+
+if (TILEDB_TESTS)
+    add_subdirectory(test)
+endif()

--- a/tiledb/sm/dimension_label/dimension_label.cc
+++ b/tiledb/sm/dimension_label/dimension_label.cc
@@ -31,6 +31,7 @@
  */
 
 #include "dimension_label.h"
+#include "tiledb/sm/buffer/buffer.h"
 
 namespace tiledb::sm {
 
@@ -40,59 +41,67 @@ namespace tiledb::sm {
 
 DimensionLabel::DimensionLabel(
     LabelType label_type,
-    const std::string& name,
-    Datatype label_datatype,
-    uint32_t label_cell_val_num,
-    const Range& label_domain,
-    Datatype index_datatype,
-    uint32_t index_cell_val_num,
-    const Range& index_domain,
+    DimensionLabel::BaseSchema& schema,
     shared_ptr<DimensionLabelMapping> label_index_map)
-    : schema_(
-          label_type,
-          name,
-          label_datatype,
-          label_cell_val_num,
-          label_domain,
-          index_datatype,
-          index_cell_val_num,
-          index_domain)
+    : label_type_(label_type)
+    , schema_(schema)
     , label_index_map_(label_index_map) {
 }
 
 tuple<Status, shared_ptr<DimensionLabel>> DimensionLabel::create_uniform(
-    const std::string& name,
-    Datatype label_datatype,
-    uint32_t label_cell_val_num,
-    const Range& label_domain,
-    Datatype index_datatype,
-    uint32_t index_cell_val_num,
-    const Range& index_domain) {
-  if (label_cell_val_num != 1 || index_cell_val_num != 1)
+    DimensionLabel::BaseSchema&& schema) {
+  if (schema.label_cell_val_num != 1 || schema.index_cell_val_num != 1)
     return {Status_DimensionLabelError(
                 "Unable to create uniform dimension label; both label and "
                 "index must have cell value of length 1"),
             nullptr};
   try {
-    return {
-        Status::Ok(),
-        make_shared<DimensionLabel>(
-            HERE(),
-            LabelType::LABEL_UNIFORM,
-            name,
-            label_datatype,
-            label_cell_val_num,
-            label_domain,
-            index_datatype,
-            index_cell_val_num,
-            index_domain,
-            create_uniform_mapping(
-                label_datatype, label_domain, index_datatype, index_domain))};
+    return {Status::Ok(),
+            make_shared<DimensionLabel>(
+                HERE(),
+                LabelType::LABEL_UNIFORM,
+                schema,
+                create_uniform_mapping(
+                    schema.label_datatype,
+                    schema.label_domain,
+                    schema.index_datatype,
+                    schema.index_domain))};
   } catch (std::logic_error& err) {
     std::string msg{err.what()};
     return {Status_DimensionLabelError(
                 "Unable to create uniform dimension label; " + msg),
             nullptr};
+  }
+}
+
+tuple<Status, shared_ptr<DimensionLabel>> DimensionLabel::deserialize(
+    ConstBuffer* buff,
+    uint32_t version,
+    Datatype index_datatype,
+    uint32_t index_cell_val_num,
+    const Range& index_domain) {
+  // Load dimension label type
+  uint8_t label_type_data{};
+  auto status = buff->read(&label_type_data, sizeof(uint8_t));
+  if (!status.ok())
+    return {status, nullptr};
+  LabelType label_type{label_type_data};
+  // Load base dimension label data
+  auto&& [schema_status, schema] = DimensionLabel::BaseSchema::deserialize(
+      buff, version, index_datatype, index_cell_val_num, index_domain);
+  if (!status.ok())
+    return {status, nullptr};
+  // Load mapping parameters and data type.
+  switch (label_type) {
+    case LabelType::LABEL_UNIFORM:
+      return DimensionLabel::create_uniform(std::move(schema.value()));
+    default:
+      return {
+          Status_DimensionLabelError(
+              "Unabel to create dimension label; The requested dimension label "
+              "type is not supported " +
+              label_type_str(label_type)),
+          nullptr};
   }
 }
 
@@ -107,12 +116,23 @@ tuple<Status, Range> DimensionLabel::index_range(const Range& labels) const {
   }
 }
 
+Status DimensionLabel::serialize(Buffer* buff, uint32_t version) const {
+  // Write the dimension label type.
+  auto label_type_data = static_cast<uint8_t>(label_type_);
+  RETURN_NOT_OK(buff->write(&label_type_data, sizeof(uint8_t)));
+  // Write base schema.
+  RETURN_NOT_OK(schema_.serialize(buff, version));
+  // Write metadata for specific mapping - currently always zero.
+  uint32_t num_metadata{0};
+  RETURN_NOT_OK(buff->write(&num_metadata, sizeof(uint32_t)));
+  return Status::Ok();
+}
+
 /************************************************/
 /*        Dimension Label Base Schema           */
 /************************************************/
 
 DimensionLabel::BaseSchema::BaseSchema(
-    LabelType label_type,
     const std::string& name,
     Datatype label_datatype,
     uint32_t label_cell_val_num,
@@ -120,14 +140,106 @@ DimensionLabel::BaseSchema::BaseSchema(
     Datatype index_datatype,
     uint32_t index_cell_val_num,
     const Range& index_domain)
-    : label_type(label_type)
-    , name(name)
+    : name(name)
     , label_datatype(label_datatype)
     , label_cell_val_num(label_cell_val_num)
     , label_domain(label_domain)
     , index_datatype(index_datatype)
     , index_cell_val_num(index_cell_val_num)
     , index_domain(index_domain) {
+}
+
+// Format:
+// dimension label size (uint32_t)
+// dimension label name (c-string)
+// label datatype (uint8_t)
+// label number of values per cell (uint32_t)
+// label domain size (uint64_t)
+// label domain (void* - domain size)
+// label metadata size (uint32_t - specific to filter type)
+// label metadata (specific to filter type)
+tuple<Status, optional<DimensionLabel::BaseSchema>>
+DimensionLabel::BaseSchema::deserialize(
+    ConstBuffer* buff,
+    uint32_t,
+    Datatype index_datatype,
+    uint32_t index_cell_val_num,
+    const Range& index_domain) {
+  // Load dimension label name
+  uint32_t dimension_name_size;
+  auto status = buff->read(&dimension_name_size, sizeof(uint32_t));
+  if (!status.ok())
+    return {status, nullopt};
+  std::string name;
+  name.resize(dimension_name_size);
+  status = buff->read(&name[0], dimension_name_size);
+  if (!status.ok())
+    return {status, nullopt};
+  // Load label datatype
+  uint8_t datatype_data{};
+  status = buff->read(&datatype_data, sizeof(uint8_t));
+  if (!status.ok())
+    return {status, nullopt};
+  Datatype label_datatype{datatype_data};
+  // Load the number values in a cell for the label
+  uint32_t label_cell_val_num{};
+  status = buff->read(&label_cell_val_num, sizeof(uint32_t));
+  if (!status.ok())
+    return {status, nullopt};
+  // Load the label domain
+  uint64_t domain_size{};
+  status = buff->read(&domain_size, sizeof(uint64_t));
+  if (!status.ok())
+    return {status, nullopt};
+  Range label_domain;
+  if (domain_size != 0) {
+    std::vector<uint8_t> tmp(domain_size);
+    status = buff->read(&tmp[0], domain_size);
+    label_domain = Range(&tmp[0], domain_size);
+  }
+  return {Status::Ok(),
+          DimensionLabel::BaseSchema(
+              name,
+              label_datatype,
+              label_cell_val_num,
+              label_domain,
+              index_datatype,
+              index_cell_val_num,
+              index_domain)};
+}
+
+// Format:
+// dimension label size (uint32_t)
+// dimension label name (c-string)
+// label datatype (uint8_t)
+// label number of values per cell (uint32_t)
+// label domain size (uint64_t)
+// label domain (void* - domain size)
+// label metadata size (uint32_t - specific to filter type)
+// label metadata (specific to filter type)
+Status DimensionLabel::BaseSchema::serialize(Buffer* buff, uint32_t) const {
+  // Write the dimension label name size and name
+  auto name_size = (uint32_t)name.size();
+  RETURN_NOT_OK(buff->write(&name_size, sizeof(uint32_t)));
+  RETURN_NOT_OK(buff->write(name.c_str(), name_size));
+  // Write the dimension label datatype
+  auto label_datatype_data = static_cast<uint8_t>(label_datatype);
+  RETURN_NOT_OK(buff->write(&label_datatype_data, sizeof(uint8_t)));
+  // Write the dimension label number of values per cell
+  RETURN_NOT_OK(buff->write(&label_cell_val_num, sizeof(uint32_t)));
+  // Write the dimension label domain size and domain
+  if (datatype_is_string(label_datatype)) {
+    // sanity check: domain should be empty for string datatypes
+    if (!label_domain.empty())
+      throw std::logic_error("Domain should be empty for string dimensions");
+    uint64_t domain_size{0};
+    RETURN_NOT_OK(buff->write(&domain_size, sizeof(uint64_t)));
+  } else {
+    uint64_t domain_size{2 * datatype_size(label_datatype)};
+    RETURN_NOT_OK(buff->write(&domain_size, sizeof(uint64_t)));
+    RETURN_NOT_OK(buff->write(label_domain.data(), domain_size));
+  }
+  return Status::Ok();
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/dimension_label/dimension_label.cc
+++ b/tiledb/sm/dimension_label/dimension_label.cc
@@ -1,0 +1,133 @@
+/**
+ * @file   dimension_label.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the DimensionLabel class.
+ */
+
+#include "dimension_label.h"
+
+namespace tiledb::sm {
+
+/************************************************/
+/*               Dimension Label                */
+/************************************************/
+
+DimensionLabel::DimensionLabel(
+    LabelType label_type,
+    const std::string& name,
+    Datatype label_datatype,
+    uint32_t label_cell_val_num,
+    const Range& label_domain,
+    Datatype index_datatype,
+    uint32_t index_cell_val_num,
+    const Range& index_domain,
+    shared_ptr<DimensionLabelMapping> label_index_map)
+    : schema_(
+          label_type,
+          name,
+          label_datatype,
+          label_cell_val_num,
+          label_domain,
+          index_datatype,
+          index_cell_val_num,
+          index_domain)
+    , label_index_map_(label_index_map) {
+}
+
+tuple<Status, shared_ptr<DimensionLabel>> DimensionLabel::create_uniform(
+    const std::string& name,
+    Datatype label_datatype,
+    uint32_t label_cell_val_num,
+    const Range& label_domain,
+    Datatype index_datatype,
+    uint32_t index_cell_val_num,
+    const Range& index_domain) {
+  if (label_cell_val_num != 1 || index_cell_val_num != 1)
+    return {Status_DimensionLabelError(
+                "Unable to create uniform dimension label; both label and "
+                "index must have cell value of length 1"),
+            nullptr};
+  try {
+    return {
+        Status::Ok(),
+        make_shared<DimensionLabel>(
+            HERE(),
+            LabelType::LABEL_UNIFORM,
+            name,
+            label_datatype,
+            label_cell_val_num,
+            label_domain,
+            index_datatype,
+            index_cell_val_num,
+            index_domain,
+            create_uniform_mapping(
+                label_datatype, label_domain, index_datatype, index_domain))};
+  } catch (std::logic_error& err) {
+    std::string msg{err.what()};
+    return {Status_DimensionLabelError(
+                "Unable to create uniform dimension label; " + msg),
+            nullptr};
+  }
+}
+
+tuple<Status, Range> DimensionLabel::index_range(const Range& labels) const {
+  try {
+    return {Status::Ok(), label_index_map_->index_range(labels)};
+  } catch (std::logic_error& err) {
+    std::string msg{err.what()};
+    return {Status_DimensionLabelError(
+                "Unable to get index range from label range; " + msg),
+            Range()};
+  }
+}
+
+/************************************************/
+/*        Dimension Label Base Schema           */
+/************************************************/
+
+DimensionLabel::BaseSchema::BaseSchema(
+    LabelType label_type,
+    const std::string& name,
+    Datatype label_datatype,
+    uint32_t label_cell_val_num,
+    const Range& label_domain,
+    Datatype index_datatype,
+    uint32_t index_cell_val_num,
+    const Range& index_domain)
+    : label_type(label_type)
+    , name(name)
+    , label_datatype(label_datatype)
+    , label_cell_val_num(label_cell_val_num)
+    , label_domain(label_domain)
+    , index_datatype(index_datatype)
+    , index_cell_val_num(index_cell_val_num)
+    , index_domain(index_domain) {
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -1,0 +1,204 @@
+/**
+ * @file   dimension_label.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the DimensionLabel class.
+ */
+
+#ifndef TILEDB_DIMENSION_LABEL_H
+#define TILEDB_DIMENSION_LABEL_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/sm/dimension_label/dimension_label_mapping.h"
+#include "tiledb/sm/dimension_label/uniform_mapping.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/dimension_label_type.h"
+#include "tiledb/sm/misc/types.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+/**
+ * A TileDB dimension label.
+ *
+ * A dimension label is an additional set of coordinates that can be used to
+ * indirectly query an array in place of the standard dimension. The concept is
+ * analoguous to adding labels to the axis of a plot.
+ *
+ * Definitions:
+ *  * label: The new coordinates that are used to access data from the array.
+ *  * index: A coordinate from the original dimension. The index domain,
+ * index datataype, and index cell value number refer to these properties for
+ * the original dimension.
+ *
+ * There are two categories of dimension labels: virtual dimension labels and
+ * actualized dimension labels. For virtual dimension labels, the mapping from
+ * the label to the index is managed by a function that can be resolved without
+ * storing additional data on disk. For actualized dimension labels, the mapping
+ * from the label to the index is defined by a direct label-to-index map stored
+ * on-disk.
+ *
+ * Current label types:
+ *
+ * * Uniform label (virtual): A uniformly spaced grid from an numeric label type
+ * to an ``TILEDB_UINT64`` dimension.
+ *
+ */
+class DimensionLabel {
+ public:
+  /* No default constructor: not C.41 compliant. */
+  DimensionLabel() = delete;
+
+  /* Private constructor.
+   *
+   * @param label_type The dimension label type.
+   * @param name Name of the dimension label.
+   * @param label_datatype The TileDB datatype of the label.
+   * @param label_cell_val_num The number of values per cell for the label.
+   * @param label_domain The label domain. A pair of [lower, upper] bounds.
+   * @param index_datatype The TileDB datatype of the original dimension.
+   * @param index_cell_val_num The number of values per cell for the original
+   * dimension.
+   * @param index_domain The domain of the original domain. A pair of [lower,
+   * upper] bounds.
+   * @parame label_map Internal mapping from labels to indices.
+   * */
+  explicit DimensionLabel(
+      LabelType label_type,
+      const std::string& name,
+      Datatype label_datatype,
+      uint32_t label_cell_val_num,
+      const Range& label_domain,
+      Datatype index_datatype,
+      uint32_t index_cell_val_num,
+      const Range& index_domain,
+      shared_ptr<DimensionLabelMapping> label_map);
+
+  /**
+   * A factory for creating an uniform (evenly-spaced) virtual dimension label.
+   *
+   * @param name Name of the dimension label.
+   * @param label_datatype The TileDB datatype of the label.
+   * @param label_cell_val_num The number of values per cell for the label.
+   * @param label_domain The label domain. A pair of [lower, upper] bounds.
+   * @param index_datatype The TileDB datatype of the original dimension.
+   * @param index_cell_val_num The number of values per cell for the original
+   * dimension.
+   * @param index_domain The domain of the original domain. A pair of [lower,
+   * upper] bounds.
+   **/
+  static tuple<Status, shared_ptr<DimensionLabel>> create_uniform(
+      const std::string& name,
+      Datatype label_datatype,
+      uint32_t label_cell_val_num,
+      const Range& label_domain,
+      Datatype index_datatype,
+      uint32_t index_cell_val_num,
+      const Range& index_domain);
+
+  /**
+   * Returns success status and a range on the dimension coordinates that
+   * matches the label range.
+   *
+   * This function will be used to convert from a labelled Subarray to an
+   * un-labelled subarray.
+   *
+   * The index range that is returned from this function will map to the same
+   * region of the array as the input label range. The lower bound of the
+   * returned index range may round up to the nearest valid value. Similarly,
+   * the upper bound may round down to the nearest valid valid.
+   *
+   * If the input label range is out-of-bounds of the array, the status will
+   * return an error.
+   *
+   * @param label_range A range of a label coordinates. The label must be a
+   * valid non-empty range with ordered data of the label datatype.
+   * @returns {status, range} The status of the conversion and the output index
+   * range that covers the same region of the array as in the input label.
+   **/
+  tuple<Status, Range> index_range(const Range& label_range) const;
+
+  /** The core data required for all dimension labels. */
+  struct BaseSchema {
+    /** No default constructor: not C.41 compliant. */
+    BaseSchema() = delete;
+
+    /** Constructor. */
+    BaseSchema(
+        LabelType label_type,
+        const std::string& name,
+        Datatype label_datatype,
+        uint32_t label_cell_val_num,
+        const Range& label_domain,
+        Datatype index_datatype,
+        uint32_t index_cell_val_num,
+        const Range& index_domain);
+
+    /** The type of the dimension
+     *
+     * Possible types include:
+     *
+     * * LABEL_UNIFORM: A uniform (evenly space) virtual dimension label.
+     **/
+    LabelType label_type;
+
+    /** The dimension label name. */
+    std::string name;
+
+    /** The TileDB datatype of the label coordinates. */
+    Datatype label_datatype;
+
+    /** The number of values in a cell for the label coordinates. */
+    uint32_t label_cell_val_num;
+
+    /** The domain of the label. A pair of [lower, upper] bounds. */
+    Range label_domain;
+
+    /** The TileDB datatype of the original dimension. */
+    Datatype index_datatype;
+
+    /** The number of values in a cell for the original dimension. */
+    uint32_t index_cell_val_num;
+
+    /**
+     * The domain of the original dimension. A pair of [lower, upper] bounds.
+     */
+    Range index_domain;
+  };
+
+ private:
+  /** Core data needed for all dimension label types. */
+  BaseSchema schema_;
+
+  /** Label-to-index map for the dimension label.*/
+  shared_ptr<DimensionLabelMapping> label_index_map_{nullptr};
+};
+
+}  // namespace tiledb::sm
+#endif

--- a/tiledb/sm/dimension_label/dimension_label_mapping.h
+++ b/tiledb/sm/dimension_label/dimension_label_mapping.h
@@ -1,0 +1,122 @@
+/**
+ * @file dimension_label_mapping.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains classes that define the mapping from the label in a
+ * dimension label to the index, or underlying dimension.
+ */
+
+#ifndef TILEDB_DIMENSION_LABEL_MAPPING_H
+#define TILEDB_DIMENSION_LABEL_MAPPING_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/misc/types.h"
+
+namespace tiledb::sm {
+
+/**
+ * Interface for the mapping from label-to-index for TileDB dimension labels.
+ */
+class DimensionLabelMapping {
+ public:
+  virtual ~DimensionLabelMapping() = default;
+
+  /**
+   * Returns the index range that covers the same region of the domain as the
+   * input label range.
+   *
+   * This may raise a logic error for label ranges that are out-of-bounds.
+   *
+   * @param label_range A range of a label coordinates.
+   * @returns The output index range that covers the same region of the array as
+   * in the input label.
+   **/
+  virtual Range index_range(const Range& labels) const = 0;
+};
+
+template <
+    typename TLABEL,
+    typename TINDEX,
+    typename ENABLE_LABEL = TLABEL,
+    typename ENABLE_INDEX = TINDEX>
+class VirtualLabelMapping : public DimensionLabelMapping {
+ public:
+  virtual ~VirtualLabelMapping() = default;
+
+  /**
+   * Returns the index range that convers the same region of the domain as the
+   * input label range.
+   *
+   * This will raise a logic error for label ranges that are out-of-bounds.
+   *
+   * @param label_range A range of a label coordinates. The label must be a
+   * valid non-empty range with ordered data of the expected datatype.
+   * @returns The output index range that covers the same region of the array as
+   * in the input label.
+   **/
+  Range index_range(const Range& labels) const override {
+    auto label_data = static_cast<const TLABEL*>(labels.data());
+    std::array<TINDEX, 2> index_data{index_lower_bound(label_data[0]),
+                                     index_upper_bound(label_data[1])};
+    return Range(index_data.data(), 2 * sizeof(TINDEX));
+  };
+
+ protected:
+  /**
+   * Returns the index value matching the requested label.
+   *
+   * If the label is between indices, it will round up. This is used for the
+   * lower bound of a region.
+   *
+   * A logic error is thrown if the label is larger than the maximum label
+   * value.
+   *
+   * @param label Input label coordinate value.
+   * @returns The cooresponding coordinate value of the original dimension.
+   */
+  virtual TINDEX index_lower_bound(const TLABEL label) const = 0;
+
+  /**
+   * Returns the index value matching the requested label.
+   *
+   * If the label is between indices, it will round down. This is used for the
+   * upper bound of a region.
+   *
+   * A logic error is thrown if the label is smaller than the minimum label
+   * value.
+   *
+   * @param label Input label coordinate value.
+   * @returns The cooresponding coordinate value of the original dimension.
+   */
+  virtual TINDEX index_upper_bound(const TLABEL label) const = 0;
+};
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/dimension_label/test/CMakeLists.txt
+++ b/tiledb/sm/dimension_label/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# tiledb/sm/CMakeLists.txt
+# tiledb/sm/dimension_label/test/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2021 TileDB, Inc.
+# Copyright (c) 2022 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,19 +24,29 @@
 # THE SOFTWARE.
 #
 
-include(common-root)
+find_package(Catch_EP REQUIRED)
 
-add_subdirectory(array_schema)
-add_subdirectory(buffer)
-add_subdirectory(compressors)
-add_subdirectory(config)
-add_subdirectory(crypto)
-add_subdirectory(dimension_label)
-add_subdirectory(filesystem)
-add_subdirectory(filter)
-add_subdirectory(metadata)
-add_subdirectory(misc)
-add_subdirectory(query)
-add_subdirectory(stats)
-add_subdirectory(subarray)
-add_subdirectory(tile)
+add_executable(unit_dimension_label EXCLUDE_FROM_ALL)
+target_link_libraries(unit_dimension_label
+    PRIVATE dimension_label
+    PUBLIC Catch2::Catch2
+    )
+target_sources(unit_dimension_label PUBLIC main.cc unit_dimension_label.cc)
+add_test(
+    NAME "unit_dimension_label"
+    COMMAND $<TARGET_FILE:unit_dimension_label>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+
+add_executable(unit_uniform_mapping EXCLUDE_FROM_ALL)
+target_link_libraries(unit_uniform_mapping
+    PRIVATE uniform_mapping
+    PUBLIC Catch2::Catch2
+    )
+target_sources(unit_uniform_mapping PUBLIC main.cc unit_uniform_mapping.cc)
+add_test(
+    NAME "unit_uniform_mapping"
+    COMMAND $<TARGET_FILE:unit_uniform_mapping>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/tiledb/sm/dimension_label/test/CMakeLists.txt
+++ b/tiledb/sm/dimension_label/test/CMakeLists.txt
@@ -26,27 +26,20 @@
 
 find_package(Catch_EP REQUIRED)
 
-add_executable(unit_dimension_label EXCLUDE_FROM_ALL)
+add_executable(unit_dimension_label
+    EXCLUDE_FROM_ALL
+    main.cc
+    unit_dimension_label_base_schema.cc
+    unit_uniform_dimension_label.cc
+    unit_uniform_mapping.cc
+    )
 target_link_libraries(unit_dimension_label
     PRIVATE dimension_label
     PUBLIC Catch2::Catch2
     )
-target_sources(unit_dimension_label PUBLIC main.cc unit_dimension_label.cc)
+#target_sources(unit_uniform_dimension_label PUBLIC main.cc unit_uniform_dimension_label.cc)
 add_test(
     NAME "unit_dimension_label"
     COMMAND $<TARGET_FILE:unit_dimension_label>
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-
-add_executable(unit_uniform_mapping EXCLUDE_FROM_ALL)
-target_link_libraries(unit_uniform_mapping
-    PRIVATE uniform_mapping
-    PUBLIC Catch2::Catch2
-    )
-target_sources(unit_uniform_mapping PUBLIC main.cc unit_uniform_mapping.cc)
-add_test(
-    NAME "unit_uniform_mapping"
-    COMMAND $<TARGET_FILE:unit_uniform_mapping>
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/tiledb/sm/dimension_label/test/compile_dimension_label_main.cc
+++ b/tiledb/sm/dimension_label/test/compile_dimension_label_main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file compile_dimension_label_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "../dimension_label.h"
+
+int main() {
+  (void)sizeof(tiledb::sm::DimensionLabel);
+  return 0;
+}

--- a/tiledb/sm/dimension_label/test/main.cc
+++ b/tiledb/sm/dimension_label/test/main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file tiledb/sm/dimension_label/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>

--- a/tiledb/sm/dimension_label/test/unit_dimension_label.cc
+++ b/tiledb/sm/dimension_label/test/unit_dimension_label.cc
@@ -1,0 +1,287 @@
+/**
+ * @file tiledb/sm/array_schema/unit_dimension_label.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file tests the DimensionLabel class
+ */
+
+#include <array>
+#include <catch.hpp>
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/datatype.h"
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+template <typename T>
+void require_range_is_equal(const Range& result, const T start, const T end) {
+  if (result.empty()) {
+    REQUIRE(false);
+    return;
+  }
+  auto result_data = static_cast<const T*>(result.data());
+  CHECK(start == result_data[0]);
+  REQUIRE(end == result_data[1]);
+}
+
+template <typename T>
+Range create_range(const T start, const T stop) {
+  std::array<T, 2> array{start, stop};
+  return {array.data(), 2 * sizeof(T)};
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "DimensionLabel for type LABEL_UNIFORM on domain [10, 70] -> [0, 5]",
+    "[dimension_label][uniform_label]",
+    ((typename TLABEL, Datatype DLABEL), TLABEL, DLABEL),
+    (int8_t, Datatype::INT8),
+    (uint8_t, Datatype::UINT8),
+    (int16_t, Datatype::INT16),
+    (uint16_t, Datatype::UINT16),
+    (int32_t, Datatype::INT32),
+    (uint32_t, Datatype::UINT32),
+    (int64_t, Datatype::INT64),
+    (uint64_t, Datatype::UINT64),
+    (int64_t, Datatype::DATETIME_YEAR),
+    (int64_t, Datatype::DATETIME_MONTH),
+    (int64_t, Datatype::DATETIME_WEEK),
+    (int64_t, Datatype::DATETIME_DAY),
+    (int64_t, Datatype::DATETIME_HR),
+    (int64_t, Datatype::DATETIME_MIN),
+    (int64_t, Datatype::DATETIME_SEC),
+    (int64_t, Datatype::DATETIME_MS),
+    (int64_t, Datatype::DATETIME_US),
+    (int64_t, Datatype::DATETIME_NS),
+    (int64_t, Datatype::DATETIME_PS),
+    (int64_t, Datatype::DATETIME_FS),
+    (int64_t, Datatype::DATETIME_AS),
+    (int64_t, Datatype::TIME_HR),
+    (int64_t, Datatype::TIME_MIN),
+    (int64_t, Datatype::TIME_SEC),
+    (int64_t, Datatype::TIME_MS),
+    (int64_t, Datatype::TIME_US),
+    (int64_t, Datatype::TIME_NS),
+    (int64_t, Datatype::TIME_PS),
+    (int64_t, Datatype::TIME_FS),
+    (int64_t, Datatype::TIME_AS),
+    (float, Datatype::FLOAT32),
+    (double, Datatype::FLOAT64)) {
+  const uint64_t n_min{0};
+  const uint64_t n_max{5};
+  const TLABEL x_min{10};
+  const TLABEL x_max{60};
+  const auto index_domain = create_range<uint64_t>(n_min, n_max);
+  const auto label_domain = create_range<TLABEL>(x_min, x_max);
+  auto&& [status, dim_label] = DimensionLabel::create_uniform(
+      "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+  REQUIRE(status.ok());
+  REQUIRE(dim_label != nullptr);
+  SECTION("Convert full data range") {
+    auto&& [status, result] = dim_label->index_range(label_domain);
+    INFO(status.to_string());
+    REQUIRE(status.ok());
+    require_range_is_equal<uint64_t>(result, 0, 5);
+  }
+  SECTION("Convert [1, 30] -> [0, 2]") {
+    const auto label_range = create_range<TLABEL>(1, 30);
+    auto&& [status, result] = dim_label->index_range(label_range);
+    INFO(status.to_string());
+    REQUIRE(status.ok());
+    require_range_is_equal<uint64_t>(result, 0, 2);
+  }
+  SECTION("Convert [40, 40] -> [3, 3]") {
+    const auto label_range = create_range<TLABEL>(40, 40);
+    auto&& [status, result] = dim_label->index_range(label_range);
+    INFO(status.to_string());
+    REQUIRE(status.ok());
+    require_range_is_equal<uint64_t>(result, 3, 3);
+  }
+  SECTION("Convert [45, 80] -> [4, 5]") {
+    const auto label_range = create_range<TLABEL>(45, 80);
+    auto&& [status, result] = dim_label->index_range(label_range);
+    INFO(status.to_string());
+    REQUIRE(status.ok());
+    require_range_is_equal<uint64_t>(result, 4, 5);
+  }
+  SECTION("Exception [0, 5] is out of bounds") {
+    const auto label_range = create_range<TLABEL>(0, 5);
+    auto&& [status, result] = dim_label->index_range(label_range);
+    INFO(status.to_string());
+    REQUIRE(!status.ok());
+  }
+  SECTION("Exception [70, 75] is out of bounds") {
+    const auto label_range = create_range<TLABEL>(70, 75);
+    auto&& [status, result] = dim_label->index_range(label_range);
+    INFO(status.to_string());
+    REQUIRE(!status.ok());
+  }
+}
+
+TEST_CASE(
+    "DimensionLabel::create_uniform - verify status not ok for "
+    "cell value number not equal to 1",
+    "[dimension_label][uniform_label]") {
+  uint64_t index_domain_data[2] = {0, 10};
+  Range index_domain{index_domain_data, 2 * sizeof(uint64_t)};
+  float label_domain_data[2] = {-1.0, 1.0};
+  Range label_domain{label_domain_data, 2 * sizeof(float)};
+  SECTION("label_cell_val_num!=1") {
+    auto&& [status, dim_label] = DimensionLabel::create_uniform(
+        "label",
+        Datatype::FLOAT32,
+        2,
+        label_domain,
+        Datatype::UINT64,
+        1,
+        index_domain);
+    INFO(status.to_string());
+    CHECK(!status.ok());
+    REQUIRE(dim_label == nullptr);
+  }
+  SECTION("index_cell_val_num!=1") {
+    auto&& [status, dim_label] = DimensionLabel::create_uniform(
+        "label",
+        Datatype::FLOAT32,
+        1,
+        label_domain,
+        Datatype::UINT64,
+        2,
+        index_domain);
+    INFO(status.to_string());
+    CHECK(!status.ok());
+    REQUIRE(dim_label == nullptr);
+  }
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "DimensionLabel::create_uniform - verify status not ok for "
+    "invalid label domain for floating-point label",
+    "[dimension_label][uniform_label]",
+    ((typename TLABEL, Datatype DLABEL), TLABEL, DLABEL),
+    (float, Datatype::FLOAT32),
+    (double, Datatype::FLOAT64)) {
+  uint64_t index_domain_data[2] = {0, 10};
+  Range index_domain{index_domain_data, 2 * sizeof(uint64_t)};
+  SECTION("empty label domain") {
+    auto&& [status, dim_label] = DimensionLabel::create_uniform(
+        "label", DLABEL, 1, Range(), Datatype::UINT64, 1, index_domain);
+    INFO(status.to_string());
+    CHECK(!status.ok());
+    REQUIRE(dim_label == nullptr);
+  }
+  SECTION("label domain with nan") {
+    TLABEL label_domain_data[2] = {-std::numeric_limits<TLABEL>::quiet_NaN(),
+                                   std::numeric_limits<TLABEL>::quiet_NaN()};
+    Range label_domain{label_domain_data, 2 * sizeof(TLABEL)};
+    auto&& [status, dim_label] = DimensionLabel::create_uniform(
+        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    INFO(status.to_string());
+    CHECK(!status.ok());
+    REQUIRE(dim_label == nullptr);
+  }
+  SECTION("label domain with inf") {
+    TLABEL label_domain_data[2] = {-std::numeric_limits<TLABEL>::infinity(),
+                                   std::numeric_limits<TLABEL>::infinity()};
+    Range label_domain{label_domain_data, 2 * sizeof(TLABEL)};
+    auto&& [status, dim_label] = DimensionLabel::create_uniform(
+        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    CHECK(!status.ok());
+    REQUIRE(dim_label == nullptr);
+  }
+  SECTION("lower bound greater than upper bound") {
+    TLABEL label_domain_data[2] = {1.0, -1.0};
+    Range label_domain{label_domain_data, 2 * sizeof(TLABEL)};
+    auto&& [status, dim_label] = DimensionLabel::create_uniform(
+        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    INFO(status.to_string());
+    CHECK(!status.ok());
+    REQUIRE(dim_label == nullptr);
+  }
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "DimensionLabel::create_uniform - verify status not ok for "
+    "invalid label domain for integer labels",
+    "[dimension_label][uniform_label]",
+    ((typename TLABEL, Datatype DLABEL), TLABEL, DLABEL),
+    (int8_t, Datatype::INT8),
+    (uint8_t, Datatype::UINT8),
+    (int16_t, Datatype::INT16),
+    (uint16_t, Datatype::UINT16),
+    (int32_t, Datatype::INT32),
+    (uint32_t, Datatype::UINT32),
+    (int64_t, Datatype::INT64),
+    (uint64_t, Datatype::UINT64),
+    (int64_t, Datatype::DATETIME_YEAR),
+    (int64_t, Datatype::DATETIME_MONTH),
+    (int64_t, Datatype::DATETIME_WEEK),
+    (int64_t, Datatype::DATETIME_DAY),
+    (int64_t, Datatype::DATETIME_HR),
+    (int64_t, Datatype::DATETIME_MIN),
+    (int64_t, Datatype::DATETIME_SEC),
+    (int64_t, Datatype::DATETIME_MS),
+    (int64_t, Datatype::DATETIME_US),
+    (int64_t, Datatype::DATETIME_NS),
+    (int64_t, Datatype::DATETIME_PS),
+    (int64_t, Datatype::DATETIME_FS),
+    (int64_t, Datatype::DATETIME_AS),
+    (int64_t, Datatype::TIME_HR),
+    (int64_t, Datatype::TIME_MIN),
+    (int64_t, Datatype::TIME_SEC),
+    (int64_t, Datatype::TIME_MS),
+    (int64_t, Datatype::TIME_US),
+    (int64_t, Datatype::TIME_NS),
+    (int64_t, Datatype::TIME_PS),
+    (int64_t, Datatype::TIME_FS),
+    (int64_t, Datatype::TIME_AS)) {
+  const auto index_domain = create_range<uint64_t>(0, 10);
+  SECTION("empty label domain") {
+    auto&& [status, dim_label] = DimensionLabel::create_uniform(
+        "label", DLABEL, 1, Range(), Datatype::UINT64, 1, index_domain);
+    INFO(status.to_string());
+    CHECK(!status.ok());
+    REQUIRE(dim_label == nullptr);
+  }
+  SECTION("lower bound greater than upper bound") {
+    const auto label_domain = create_range<TLABEL>(10, 0);
+    auto&& [status, dim_label] = DimensionLabel::create_uniform(
+        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    INFO(status.to_string());
+    CHECK(!status.ok());
+    REQUIRE(dim_label == nullptr);
+  }
+  SECTION("bad label alignment") {
+    const auto label_domain = create_range<TLABEL>(0, 12);
+    auto&& [status, dim_label] = DimensionLabel::create_uniform(
+        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    INFO(status.to_string());
+    CHECK(!status.ok());
+    REQUIRE(dim_label == nullptr);
+  }
+}

--- a/tiledb/sm/dimension_label/test/unit_dimension_label_base_schema.cc
+++ b/tiledb/sm/dimension_label/test/unit_dimension_label_base_schema.cc
@@ -1,0 +1,124 @@
+/**
+ * @file tiledb/sm/array_schema/unit_dimension_label_base_schema.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file tests the DimensionLabel::BaseSchema class
+ */
+
+#include <array>
+#include <catch.hpp>
+#include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/datatype.h"
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+template <typename T>
+void require_range_is_equal(const Range& expected, const Range& result) {
+  if (expected.empty() || result.empty()) {
+    REQUIRE((expected.empty() && result.empty()));
+    return;
+  }
+  auto expected_data = static_cast<const T*>(expected.data());
+  auto result_data = static_cast<const T*>(result.data());
+  CHECK(expected_data[0] == result_data[0]);
+  REQUIRE(expected_data[1] == result_data[1]);
+}
+
+template <typename T>
+Range create_range(const T start, const T stop) {
+  std::array<T, 2> array{start, stop};
+  return {array.data(), 2 * sizeof(T)};
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "Round trip dimension label base schema",
+    "[dimension_label][serialize][deserialize]",
+    ((typename TLABEL, Datatype DLABEL), TLABEL, DLABEL),
+    (int8_t, Datatype::INT8),
+    (uint8_t, Datatype::UINT8),
+    (int16_t, Datatype::INT16),
+    (uint16_t, Datatype::UINT16),
+    (int32_t, Datatype::INT32),
+    (uint32_t, Datatype::UINT32),
+    (int64_t, Datatype::INT64),
+    (uint64_t, Datatype::UINT64),
+    (int64_t, Datatype::DATETIME_YEAR),
+    (int64_t, Datatype::DATETIME_MONTH),
+    (int64_t, Datatype::DATETIME_WEEK),
+    (int64_t, Datatype::DATETIME_DAY),
+    (int64_t, Datatype::DATETIME_HR),
+    (int64_t, Datatype::DATETIME_MIN),
+    (int64_t, Datatype::DATETIME_SEC),
+    (int64_t, Datatype::DATETIME_MS),
+    (int64_t, Datatype::DATETIME_US),
+    (int64_t, Datatype::DATETIME_NS),
+    (int64_t, Datatype::DATETIME_PS),
+    (int64_t, Datatype::DATETIME_FS),
+    (int64_t, Datatype::DATETIME_AS),
+    (int64_t, Datatype::TIME_HR),
+    (int64_t, Datatype::TIME_MIN),
+    (int64_t, Datatype::TIME_SEC),
+    (int64_t, Datatype::TIME_MS),
+    (int64_t, Datatype::TIME_US),
+    (int64_t, Datatype::TIME_NS),
+    (int64_t, Datatype::TIME_PS),
+    (int64_t, Datatype::TIME_FS),
+    (int64_t, Datatype::TIME_AS),
+    (float, Datatype::FLOAT32),
+    (double, Datatype::FLOAT64)) {
+  const auto index_domain = create_range<uint64_t>(0, 5);
+  const auto label_domain = create_range<TLABEL>(10, 60);
+  const uint32_t version{12};
+  DimensionLabel::BaseSchema schema{
+      "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain};
+  Buffer write_buffer;
+  auto status = schema.serialize(&write_buffer, version);
+  write_buffer.owns_data();
+  INFO(status.to_string());
+  REQUIRE(status.ok());
+  ConstBuffer read_buffer(&write_buffer);
+  auto&& [read_status, schema2] = DimensionLabel::BaseSchema::deserialize(
+      &read_buffer,
+      version,
+      schema.index_datatype,
+      schema.index_cell_val_num,
+      schema.index_domain);
+  INFO(read_status.to_string());
+  REQUIRE(read_status.ok());
+  REQUIRE(schema2.has_value());
+  CHECK(schema.name == schema2->name);
+  CHECK(schema.label_datatype == schema2->label_datatype);
+  CHECK(schema.label_cell_val_num == schema2->label_cell_val_num);
+  require_range_is_equal<TLABEL>(schema.label_domain, schema2->label_domain);
+  REQUIRE(schema.index_datatype == schema2->index_datatype);
+  REQUIRE(schema.index_cell_val_num == schema2->index_cell_val_num);
+  require_range_is_equal<uint64_t>(schema.index_domain, schema2->index_domain);
+}

--- a/tiledb/sm/dimension_label/test/unit_uniform_mapping.cc
+++ b/tiledb/sm/dimension_label/test/unit_uniform_mapping.cc
@@ -1,0 +1,223 @@
+/**
+ * @file tiledb/sm/dimension_label/unit_uniform_mapping.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file provides unit tests for the uniform mapping.
+ */
+
+#include <array>
+#include <catch.hpp>
+#include "tiledb/sm/dimension_label/uniform_mapping.h"
+#include "tiledb/sm/enums/datatype.h"
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+template <typename T>
+void require_range_is_equal(const Range& expected, const Range& result) {
+  if (expected.empty() || result.empty()) {
+    REQUIRE((expected.empty() && result.empty()));
+    return;
+  }
+  auto expected_data = static_cast<const T*>(expected.data());
+  auto result_data = static_cast<const T*>(result.data());
+  CHECK(expected_data[0] == result_data[0]);
+  REQUIRE(expected_data[1] == result_data[1]);
+}
+
+template <typename T>
+void require_range_is_equal(const Range& result, const T start, const T end) {
+  if (result.empty()) {
+    REQUIRE(false);
+    return;
+  }
+  auto result_data = static_cast<const T*>(result.data());
+  CHECK(start == result_data[0]);
+  REQUIRE(end == result_data[1]);
+}
+
+template <typename T>
+Range create_range(const T start, const T stop) {
+  std::array<T, 2> array{start, stop};
+  return {array.data(), 2 * sizeof(T)};
+}
+
+TEMPLATE_TEST_CASE(
+    "UniformMap from label [-1.5, 1.5] to index [0, 4]",
+    "[dimension_label][uniform_label]",
+    float,
+    double) {
+  const uint64_t n_min{0};
+  const uint64_t n_max{4};
+  const TestType x_min{-1.5};
+  const TestType x_max{1.5};
+  UniformMapping<TestType, uint64_t> dim_label{x_min, x_max, n_min, n_max};
+  const auto index_domain = create_range<uint64_t>(n_min, n_max);
+  const auto label_domain = create_range<TestType>(x_min, x_max);
+  SECTION("Convert full data range") {
+    auto result = dim_label.index_range(label_domain);
+    require_range_is_equal<uint64_t>(result, 0, 4);
+  }
+  SECTION("Convert [-2.0, -0.5] -> [0, 1]") {
+    const auto label_range = create_range<TestType>(-2.0, -0.5);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 0, 1);
+  }
+  SECTION("Convert [0.0, 0.0] -> [3, 3]") {
+    const auto label_range = create_range<TestType>(0.0, 0.0);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 2, 2);
+  }
+  SECTION("Convert [0.5, 2.0] -> [3, 4]") {
+    const auto label_range = create_range<TestType>(0.5, 2.0);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 3, 4);
+  }
+  SECTION("Exception [-3.5, -3.0] is out of bounds") {
+    const auto label_range = create_range<TestType>(-3.5, -3.0);
+    REQUIRE_THROWS(dim_label.index_range(label_range));
+  }
+  SECTION("Exception [3.0, 3.5] is out of bounds") {
+    const auto label_range = create_range<TestType>(3.0, 3.5);
+    REQUIRE_THROWS(dim_label.index_range(label_range));
+  }
+}
+
+TEMPLATE_TEST_CASE(
+    "UniformMap from label [-1.5, 1.5] to index [1, 5]",
+    "[dimension_label][uniform_label]",
+    float,
+    double) {
+  const uint64_t n_min{1};
+  const uint64_t n_max{5};
+  const TestType x_min{-1.5};
+  const TestType x_max{1.5};
+  UniformMapping<TestType, uint64_t> dim_label{x_min, x_max, n_min, n_max};
+  const auto index_domain = create_range<uint64_t>(n_min, n_max);
+  const auto label_domain = create_range<TestType>(x_min, x_max);
+  SECTION("Convert full data range") {
+    auto result = dim_label.index_range(label_domain);
+    require_range_is_equal<uint64_t>(result, 1, 5);
+  }
+  SECTION("Convert [-2.0, -0.5] -> [0, 1]") {
+    const auto label_range = create_range<TestType>(-2.0, -0.5);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 1, 2);
+  }
+  SECTION("Convert [0.0, 0.0] -> [3, 3]") {
+    const auto label_range = create_range<TestType>(0.0, 0.0);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 3, 3);
+  }
+  SECTION("Convert [0.5, 2.0] -> [0, 1]") {
+    const auto label_range = create_range<TestType>(0.5, 2.0);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 4, 5);
+  }
+  SECTION("Exception [-3.5, -3.0] is out of bounds") {
+    const auto label_range = create_range<TestType>(-3.5, -3.0);
+    REQUIRE_THROWS(dim_label.index_range(label_range));
+  }
+  SECTION("Exception [3.0, 3.5] is out of bounds") {
+    const auto label_range = create_range<TestType>(3.0, 3.5);
+    REQUIRE_THROWS(dim_label.index_range(label_range));
+  }
+}
+
+TEMPLATE_TEST_CASE(
+    "UniformMap on domain [-1.5, -1.5] with 1 grid point",
+    "[dimension_label][uniform_label]",
+    float,
+    double) {
+  const uint64_t n_min{1};
+  const uint64_t n_max{1};
+  const TestType x_min{-1.5};
+  const TestType x_max{-1.5};
+  UniformMapping<TestType, uint64_t> dim_label{x_min, x_max, n_min, n_max};
+  const auto index_domain = create_range<uint64_t>(n_min, n_max);
+  const auto label_domain = create_range<TestType>(x_min, x_max);
+  SECTION("Convert full data range") {
+    auto result = dim_label.index_range(label_domain);
+    require_range_is_equal<uint64_t>(result, 1, 1);
+  }
+  SECTION("Convert larger than full range") {
+    const auto label_range = create_range<TestType>(-2.0, 0.0);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 1, 1);
+  }
+}
+
+TEMPLATE_TEST_CASE(
+    "UniformMap on domain [10, 70] -> [0, 5] for all numeric label types",
+    "[dimension_label][uniform_label]",
+    uint8_t,
+    int8_t,
+    uint16_t,
+    int16_t,
+    uint32_t,
+    int32_t,
+    uint64_t,
+    int64_t,
+    float,
+    double) {
+  const uint64_t n_min{0};
+  const uint64_t n_max{5};
+  const TestType x_min{10};
+  const TestType x_max{60};
+  UniformMapping<TestType, uint64_t> dim_label{x_min, x_max, n_min, n_max};
+  const auto index_domain = create_range<uint64_t>(n_min, n_max);
+  const auto label_domain = create_range<TestType>(x_min, x_max);
+  SECTION("Convert full data range") {
+    auto result = dim_label.index_range(label_domain);
+    require_range_is_equal<uint64_t>(result, 0, 5);
+  }
+  SECTION("Convert [1, 30] -> [0, 2]") {
+    const auto label_range = create_range<TestType>(1, 30);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 0, 2);
+  }
+  SECTION("Convert [40, 40] -> [3, 3]") {
+    const auto label_range = create_range<TestType>(40, 40);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 3, 3);
+  }
+  SECTION("Convert [45, 80] -> [4, 5]") {
+    const auto label_range = create_range<TestType>(45, 80);
+    const auto result = dim_label.index_range(label_range);
+    require_range_is_equal<uint64_t>(result, 4, 5);
+  }
+  SECTION("Exception [0, 5] is out of bounds") {
+    const auto label_range = create_range<TestType>(0, 5);
+    REQUIRE_THROWS(dim_label.index_range(label_range));
+  }
+  SECTION("Exception [70, 75] is out of bounds") {
+    const auto label_range = create_range<TestType>(70, 75);
+    REQUIRE_THROWS(dim_label.index_range(label_range));
+  }
+}

--- a/tiledb/sm/dimension_label/uniform_mapping.cc
+++ b/tiledb/sm/dimension_label/uniform_mapping.cc
@@ -1,0 +1,108 @@
+/*
+ * @file uniform_mapping.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the mapping from the label to index for a dimension label
+ * that is a virtual uniform or evenly-spaced dimension.
+ */
+
+#include "tiledb/sm/dimension_label/uniform_mapping.h"
+
+namespace tiledb::sm {
+
+shared_ptr<DimensionLabelMapping> create_uniform_mapping(
+    const Datatype label_datatype,
+    const Range& label_domain,
+    const Datatype index_datatype,
+    const Range& index_domain) {
+  if (index_datatype != Datatype::UINT64)
+    throw std::invalid_argument(
+        "The uniform dimension label is only supported on UINT64 dimensions");
+  switch (label_datatype) {
+    case Datatype::INT8:
+      return UniformMapping<int8_t, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::UINT8:
+      return UniformMapping<uint8_t, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::INT16:
+      return UniformMapping<int16_t, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::UINT16:
+      return UniformMapping<uint16_t, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::INT32:
+      return UniformMapping<int32_t, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::UINT32:
+      return UniformMapping<uint32_t, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::INT64:
+      return UniformMapping<int64_t, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::UINT64:
+      return UniformMapping<uint64_t, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::FLOAT32:
+      return UniformMapping<float, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::FLOAT64:
+      return UniformMapping<double, uint64_t>::create(
+          label_domain, index_domain);
+    case Datatype::DATETIME_YEAR:
+    case Datatype::DATETIME_MONTH:
+    case Datatype::DATETIME_WEEK:
+    case Datatype::DATETIME_DAY:
+    case Datatype::DATETIME_HR:
+    case Datatype::DATETIME_MIN:
+    case Datatype::DATETIME_SEC:
+    case Datatype::DATETIME_MS:
+    case Datatype::DATETIME_US:
+    case Datatype::DATETIME_NS:
+    case Datatype::DATETIME_PS:
+    case Datatype::DATETIME_FS:
+    case Datatype::DATETIME_AS:
+    case Datatype::TIME_HR:
+    case Datatype::TIME_MIN:
+    case Datatype::TIME_SEC:
+    case Datatype::TIME_MS:
+    case Datatype::TIME_US:
+    case Datatype::TIME_NS:
+    case Datatype::TIME_PS:
+    case Datatype::TIME_FS:
+    case Datatype::TIME_AS:
+      return UniformMapping<int64_t, uint64_t>::create(
+          label_domain, index_domain);
+    default:
+      throw std::invalid_argument(
+          "The uniform dimension label does not support label datatype " +
+          datatype_str(label_datatype));
+  }
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/dimension_label/uniform_mapping.h
+++ b/tiledb/sm/dimension_label/uniform_mapping.h
@@ -1,0 +1,418 @@
+/*
+ * @file uniform_mapping.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the mapping from the label to index for a dimension label
+ * that is a virtual uniform or evenly-spaced dimension.
+ */
+
+#ifndef TILEDB_UNIFORM_MAPPING_H
+#define TILEDB_UNIFORM_MAPPING_H
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include "tiledb/common/common.h"
+#include "tiledb/sm/dimension_label/dimension_label_mapping.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/misc/types.h"
+
+namespace tiledb::sm {
+
+/**
+ * Uniform mapping for the uniform dimension label.
+ *
+ * An uniform dimension label maps an uniform grid to an integer index. This is
+ * a virtual dimesnion label; no data is stored in disk.
+ */
+template <
+    typename TLABEL,
+    typename TINDEX,
+    typename ENABLE_LABEL = TLABEL,
+    typename ENABLE_INDEX = TINDEX>
+class UniformMapping
+    : public VirtualLabelMapping<TLABEL, TINDEX, ENABLE_LABEL, ENABLE_INDEX> {
+ public:
+  /** Default constructor is not C.41 compliant. */
+  UniformMapping() = delete;
+
+  /** Constructor
+   *
+   * @param x_min Minimum value of the label dimension.
+   * @param x_max Minimum value of the label dimension.
+   * @param n_min Minimum value of the index dimension.
+   * @param n_max Maximum value of the index dimension.
+   */
+  UniformMapping(
+      const TLABEL& x_min,
+      const TLABEL& x_max,
+      const TINDEX& n_min,
+      const TINDEX& n_max);
+
+  /**
+   * Returns a pointer to a UniformMapping for specificed domains.
+   *
+   * @param label_domain Domain of the label. Pair of [lower, upper] bounds.
+   * @param index_domain Domain of the index. Pair of [lower, upper] bounds.
+   * @returns Pointer to the UniformMapping.
+   */
+  static shared_ptr<UniformMapping> create(
+      const Range& label_domain, const Range& index_domain);
+
+  /**
+   * Returns a pointer to a UniformMapping for specificed domains, skipping
+   * validity checks.
+   *
+   * @param label_domain Domain of the label. Pair of [lower, upper] bounds.
+   * @param index_domain Domain of the index. Pair of [lower, upper] bounds.
+   * @returns Pointer to the UniformMapping.
+   */
+  static shared_ptr<UniformMapping> create_unrestricted(
+      const Range& label_domain, const Range& index_domain);
+
+ protected:
+  /**
+   * Returns the index value matching the requested label.
+   *
+   * If the label is between indices, it will round up. This is used for the
+   * lower bound of a region.
+   *
+   * A logic error is thrown if the label is larger than the maximum label
+   * value.
+   *
+   * @param label Input label coordinate value.
+   * @returns The cooresponding coordinate value of the original dimension.
+   */
+  TINDEX index_lower_bound(const TLABEL label) const override;
+
+  /**
+   * Returns the index value matching the requested label.
+   *
+   * If the label is between indices, it will round down. This is used for the
+   * upper bound of a region.
+   *
+   * A logic error is thrown if the label is smaller than the minimum label
+   * value.
+   *
+   * @param label Input label coordinate value.
+   * @returns The cooresponding coordinate value of the original dimension.
+   */
+  TINDEX index_upper_bound(const TLABEL label) const override;
+};
+
+/** Uniform mapping for dimension label with floating-point labels. */
+template <typename T>
+class UniformMapping<
+    T,
+    uint64_t,
+    typename std::enable_if<std::is_floating_point<T>::value, T>::type,
+    uint64_t> : public VirtualLabelMapping<T, uint64_t, T, uint64_t> {
+ public:
+  UniformMapping() = delete;
+
+  UniformMapping(
+      const T x_min, const T x_max, const uint64_t n_min, const uint64_t n_max)
+      : n_min_(n_min)
+      , n_max_(n_max)
+      , x_min_(x_min)
+      , x_max_(x_max) {
+    // Check x_min_ and x_max_ are valid.
+    if (x_min_ > x_max_)
+      throw std::invalid_argument(
+          "Label domain cannot have minimum value " + std::to_string(x_min_) +
+          " greater than maximum value " + std::to_string(x_max_));
+    if (std::isnan(x_min_) || std::isnan(x_max_))
+      throw std::invalid_argument("Label domain cannot contain a NaN value");
+    if (std::isinf(x_min_) || std::isinf(x_max_))
+      throw std::invalid_argument(
+          "Label domain cannot contain an infinite value");
+    // Check n_min_ and n_max_ are valid.
+    if (n_min_ > n_max_)
+      throw std::invalid_argument(
+          "Index domain cannot have minimum value " + std::to_string(n_min_) +
+          " greater than maximum value " + std::to_string(n_max_));
+    // Set dx_ and check if interval is only a single point.
+    if (n_min_ == n_max_) {
+      if (x_min_ != x_max_)
+        throw std::invalid_argument(
+            "If the index domain contains only a single point, then the label "
+            "domain must only contain a single point.");
+      dx_ = 1.0;
+    } else {
+      if (x_min_ == x_max_)
+        throw std::invalid_argument(
+            "If the label contains only a single point, then the index domain "
+            "must contain only a single point.");
+      dx_ = (x_max_ - x_min_) / static_cast<T>(n_max_ - n_min_);
+    }
+  };
+
+  static shared_ptr<UniformMapping> create(
+      const Range& label_domain, const Range& index_domain) {
+    // Get index domain data and verify it is non-empty.
+    if (index_domain.empty())
+      throw std::invalid_argument("Index domain cannot be empty");
+    auto index_data = static_cast<const uint64_t*>(index_domain.data());
+    // Get the label domain data nad verify it is non-empty.
+    if (label_domain.empty())
+      throw std::invalid_argument("Label domain cannot be empty");
+    auto label_data = static_cast<const T*>(label_domain.data());
+    // Return ponter.
+    return make_shared<UniformMapping>(
+        HERE(), label_data[0], label_data[1], index_data[0], index_data[1]);
+  };
+
+  static shared_ptr<UniformMapping> create_unrestricted(
+      const Range& label_domain, const Range& index_domain) {
+    auto index_data = static_cast<const uint64_t*>(index_domain.data());
+    auto label_data = static_cast<const T*>(label_domain.data());
+    return make_shared<UniformMapping>(
+        HERE(),
+        label_data[0],
+        label_data[1],
+        index_data[0],
+        index_data[1],
+        label_data[1] - label_data[0],
+        static_cast<T>(index_data[1] - index_data[0]));
+  }
+
+ protected:
+  uint64_t index_lower_bound(const T label) const override {
+    if (label > x_max_)
+      throw std::out_of_range(
+          "Lower bound value " + std::to_string(label) +
+          " is greater than the maximum label value " + std::to_string(x_max_));
+    if (label <= x_min_)
+      return n_min_;
+    return static_cast<uint64_t>(std::ceil((label - x_min_) / dx_)) + n_min_;
+  };
+
+  uint64_t index_upper_bound(const T label) const override {
+    if (label < x_min_)
+      throw std::out_of_range(
+          "Upper bound value " + std::to_string(label) +
+          " is less than the minimum label value " + std::to_string(x_min_));
+    if (label >= x_max_)
+      return n_max_;
+    return static_cast<uint64_t>(std::floor((label - x_min_) / dx_)) + n_min_;
+  };
+
+ private:
+  /**
+   * Private constructor that skips checks.
+   *
+   * @param x_min Minimum value of the label dimension.
+   * @param x_max Minimum value of the label dimension.
+   * @param n_min Minimum value of the index dimension.
+   * @param n_max Maximum value of the index dimension.
+   * @param dx Spacing of a single interval, (x_max - x_min)/(n_max - n_min).
+   */
+  UniformMapping(
+      const T x_min,
+      const T x_max,
+      const uint64_t n_min,
+      const uint64_t n_max,
+      const T dx)
+      : n_min_(n_min)
+      , n_max_(n_max)
+      , x_min_(x_min)
+      , x_max_(x_max)
+      , dx_(dx){};
+
+  /** Minimum index value for the index domain. */
+  uint64_t n_min_{};
+
+  /** Maximum index value for the index domain. */
+  uint64_t n_max_{};
+
+  /** Minimum label value for the label domain. */
+  T x_min_{};
+
+  /** Maximum label value for the label domain. */
+  T x_max_{};
+
+  /** The width of a single interval, (x_max_ - x_min_) / (n_max_ - n_min_). */
+  T dx_{};
+};
+
+/** Uniform mapping for dimension label with integer-type labels. */
+template <typename T>
+class UniformMapping<
+    T,
+    uint64_t,
+    typename std::enable_if<std::is_integral<T>::value, T>::type,
+    uint64_t> : public VirtualLabelMapping<T, uint64_t, T, uint64_t> {
+ public:
+  UniformMapping() = delete;
+
+  UniformMapping(
+      const T x_min, const T x_max, const uint64_t n_min, const uint64_t n_max)
+      : n_min_(n_min)
+      , n_max_(n_max)
+      , x_min_(x_min)
+      , x_max_(x_max) {
+    // Check x_min_ and x_max_ are valid.
+    if (x_min_ > x_max_)
+      throw std::invalid_argument(
+          "Label domain cannot have minimum value " + std::to_string(x_min_) +
+          " greater than maximum value " + std::to_string(x_max_));
+    // Check n_min_ and n_max_ are valid.
+    if (n_min_ > n_max_)
+      throw std::invalid_argument(
+          "Index domain cannot have minimum value " + std::to_string(n_min_) +
+          " greater than maximum value " + std::to_string(n_max_));
+    // Check for over-flow error and set nintervals_
+    if (n_min_ == n_max_) {
+      if (x_min_ != x_max_)
+        throw std::invalid_argument(
+            "If the index domain contains only a single point, then the label "
+            "domain must only contain a single point.");
+      dx_ = 1;
+    } else {
+      if (x_min_ == x_max_)
+        throw std::invalid_argument(
+            "If the label contains only a single point, then the index domain "
+            "must contain only a single point.");
+      const auto ninterval = n_max_ - n_min_;
+      const uint64_t width = static_cast<uint64_t>(x_max_ - x_min_);
+      if (width % ninterval != 0)
+        throw std::invalid_argument(
+            "The uniform dimension label must align on valid points.");
+      dx_ = static_cast<T>(width / ninterval);
+    }
+  };
+
+  static shared_ptr<UniformMapping> create(
+      const Range& label_domain, const Range& index_domain) {
+    // Get index domain data and verify it is non-empty.
+    if (index_domain.empty())
+      throw std::invalid_argument("Index domain cannot be empty");
+    auto index_data = static_cast<const uint64_t*>(index_domain.data());
+    // Get the label domain data nad verify it is non-empty.
+    if (label_domain.empty())
+      throw std::invalid_argument("Label domain cannot be empty");
+    auto label_data = static_cast<const T*>(label_domain.data());
+    // Return ponter.
+    return make_shared<UniformMapping>(
+        HERE(), label_data[0], label_data[1], index_data[0], index_data[1]);
+  };
+
+  static shared_ptr<UniformMapping> create_unrestricted(
+      const Range& label_domain, const Range& index_domain) {
+    auto index_data = static_cast<const uint64_t*>(index_domain.data());
+    auto label_data = static_cast<const T*>(label_domain.data());
+    return make_shared<UniformMapping>(
+        HERE(),
+        label_data[0],
+        label_data[1],
+        index_data[0],
+        index_data[1],
+        static_cast<uint64_t>(label_data[1] - label_data[0]) /
+            (index_data[1] - index_data[0]));
+  }
+
+ protected:
+  uint64_t index_lower_bound(const T label) const override {
+    if (label > x_max_)
+      throw std::out_of_range(
+          "Lower bound value " + std::to_string(label) +
+          " is greater than the maximum label value " + std::to_string(x_max_));
+    if (label <= x_min_)
+      return n_min_;
+    return ((label - x_min_) % dx_ == 0) ?
+               (static_cast<uint64_t>((label - x_min_) / dx_) + n_min_) :
+               (static_cast<uint64_t>((label - x_min_) / dx_) + n_min_ + 1);
+  };
+
+  uint64_t index_upper_bound(const T label) const override {
+    if (label < x_min_)
+      throw std::out_of_range(
+          "Upper bound value " + std::to_string(label) +
+          " is less than the minimum label value " + std::to_string(x_min_));
+    if (label >= x_max_)
+      return n_max_;
+    return static_cast<uint64_t>((label - x_min_) / dx_) + n_min_;
+  };
+
+ private:
+  /**
+   * Private constructor that skips checks.
+   *
+   * @param x_min Minimum value of the label dimension.
+   * @param x_max Minimum value of the label dimension.
+   * @param n_min Minimum value of the index dimension.
+   * @param n_max Maximum value of the index dimension.
+   * @param dx Spacing of a single interval, (x_max - x_min)/(n_max - n_min).
+   */
+  UniformMapping(
+      const T x_min,
+      const T x_max,
+      const uint64_t n_min,
+      const uint64_t n_max,
+      const T dx)
+      : n_min_(n_min)
+      , n_max_(n_max)
+      , x_min_(x_min)
+      , x_max_(x_max)
+      , dx_(dx){};
+
+  /** Minimum index value for the index domain. */
+  uint64_t n_min_{};
+
+  /** Maximum index value for the index domain. */
+  uint64_t n_max_{};
+
+  /** Minimum label value for the label domain. */
+  T x_min_{};
+
+  /** Maximum label value for the label domain. */
+  T x_max_{};
+
+  /** The width of a single interval, (x_max_ - x_min_) / (n_min_ - n_max_). */
+  T dx_{};
+};
+
+/**
+ * Factory function for creating a dimension label mapping using the virtual
+ * uniform mapping.
+ *
+ * @param label_datatype The TileDB datatype of the label.
+ * @param label_domain The domain of the label. Pair of [lower, upper] bounds.
+ * @param index_datatype The TileDB datatype of the index.
+ * @param index_domain The domain of the index. Pair of [lower, upper] bounds.
+ * @returns A pointer to a new ``UniformMapping`` over the requested domains.
+ **/
+shared_ptr<DimensionLabelMapping> create_uniform_mapping(
+    Datatype label_datatype,
+    const Range& label_domain,
+    Datatype index_datatype,
+    const Range& index_domain);
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/enums/dimension_label_type.h
+++ b/tiledb/sm/enums/dimension_label_type.h
@@ -1,0 +1,74 @@
+/**
+ * @file tiledb/sm/enum/dimension_label_type.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This defines the TileDB LabelType enum for dimension label types.
+ */
+
+#ifndef TILEDB_LABEL_TYPE_H
+#define TILEDB_LABEL_TYPE_H
+
+#include "tiledb/common/common.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+/**
+ * A label type for a dimension label.
+ *
+ * Note: this is not yet exposed in the C API.
+ */
+enum class LabelType : uint8_t {
+  LABEL_UNIFORM = 0,
+};
+
+/** Returns the string representation of the input label type. */
+inline const std::string& label_type_str(LabelType label_type) {
+  switch (label_type) {
+    case LabelType::LABEL_UNIFORM:
+      return constants::dimension_label_uniform_str;
+    default:
+      return constants::empty_str;
+  }
+};
+
+/** Returns the label type given a string representation. */
+inline Status label_type_enum(
+    const std::string& label_type_str, LabelType* label_type) {
+  if (label_type_str == constants::dimension_label_uniform_str)
+    *label_type = LabelType::LABEL_UNIFORM;
+  else {
+    return Status_Error("Invalid LabelType " + label_type_str);
+  }
+  return Status::Ok();
+};
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -355,6 +355,9 @@ const std::string filter_option_bit_width_max_window_str =
 const std::string filter_option_positive_delta_max_window_str =
     "POSITIVE_DELTA_MAX_WINDOW";
 
+/** String describing TILEDB_LABEL_UNIFORM. */
+const std::string dimension_label_uniform_str = "LABEL_UNIFORM";
+
 /** The string representation for type int32. */
 const std::string int32_str = "INT32";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -339,6 +339,9 @@ extern const std::string filter_option_bit_width_max_window_str;
  */
 extern const std::string filter_option_positive_delta_max_window_str;
 
+/** The describing TILEDB_LABEL_UNIFORM. */
+extern const std::string dimension_label_uniform_str;
+
 /** The string representation for type int32. */
 extern const std::string int32_str;
 


### PR DESCRIPTION
This PR adds the internal `DimensionLabel` class.

General design:

The `DimensionLabel` class is intended to be included as a component the `Dimension` class. The `DimensionLabel` needs a specific mapping from the labels to the indices. Here the "labels" are the new coordinates, and the "indices" are the original coordinates for the underlying dimension.

This implementation provides a single type of mapping that creates a uniformly spaced grid on the label. It only is supported for dimensions with uint64 datatype.

In addition to creating the `DimensionLabel` class, an enum for the dimension label type is added.

---
TYPE: NO_HISTORY
