### PR TITLE
Global writes: fixing OOM on write continuation.

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -288,9 +288,10 @@ void FragmentMetadata::convert_tile_min_max_var_sizes_to_offsets(
   auto idx = it->second;
 
   // Fix the min offsets.
-  uint64_t offset = 0;
-  auto offsets = (uint64_t*)tile_min_buffer_[idx].data();
-  for (uint64_t i = 0; i < tile_min_buffer_[idx].size() / sizeof(uint64_t);
+  uint64_t offset = tile_min_var_buffer_[idx].size();
+  auto offsets = (uint64_t*)tile_min_buffer_[idx].data() + tile_index_base_;
+  for (uint64_t i = tile_index_base_;
+       i < tile_min_buffer_[idx].size() / sizeof(uint64_t);
        i++) {
     auto size = *offsets;
     *offsets = offset;
@@ -302,9 +303,10 @@ void FragmentMetadata::convert_tile_min_max_var_sizes_to_offsets(
   tile_min_var_buffer_[idx].resize(offset);
 
   // Fix the max offsets.
-  offset = 0;
-  offsets = (uint64_t*)tile_max_buffer_[idx].data();
-  for (uint64_t i = 0; i < tile_max_buffer_[idx].size() / sizeof(uint64_t);
+  offset = tile_max_var_buffer_[idx].size();
+  offsets = (uint64_t*)tile_max_buffer_[idx].data() + tile_index_base_;
+  for (uint64_t i = tile_index_base_;
+       i < tile_max_buffer_[idx].size() / sizeof(uint64_t);
        i++) {
     auto size = *offsets;
     *offsets = offset;


### PR DESCRIPTION
convert_tile_min_max_var_sizes_to_offsets is used to convert a buffer of
sizes to offsets. For global writes, the function will be called
multiple times on the same buffer so the function should resume from the
last tile that was processed. This information is already saved
in tile_index_base_ so the fix is trivial.

---
TYPE: IMPROVEMENT
DESC: Global writes: fixing OOM on write continuation.
