### PR TITLE
Assertion failure in GCS, debug build

### DIFF
--- a/test/src/unit-gcs.cc
+++ b/test/src/unit-gcs.cc
@@ -107,6 +107,20 @@ std::string GCSFx::random_bucket_name(const std::string& prefix) {
   return ss.str();
 }
 
+TEST_CASE_METHOD(GCSFx, "Test GCS init", "[gcs]") {
+  try {
+    Config config;
+    config.set("vfs.gcs.use_multi_part_upload", "true");
+    init_gcs(std::move(config));
+  } catch (...) {
+    INFO(
+        "GCS initialization failed. In order to run GCS tests, be sure to "
+        "source scripts/run-gcs.sh in this shell session before starting test "
+        "runner.");
+    REQUIRE(false);
+  }
+}
+
 TEST_CASE_METHOD(GCSFx, "Test GCS filesystem, file management", "[gcs]") {
   Config config;
   config.set("vfs.gcs.use_multi_part_upload", "true");


### PR DESCRIPTION
Implemented a check in unit-gcs.cc that ensures we run run-gcs-emu.sh from the same shell that the tests are run.

---
TYPE: BUG
DESC: Fix assertion failure in GCS, debug build
