### PR TITLE
Dense reader: fix user buffer offset computation for multi-index queries.

### DIFF
--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -5140,3 +5140,60 @@ TEST_CASE_METHOD(
 
   remove_temp_dir(temp_dir);
 }
+
+TEST_CASE_METHOD(
+    DenseArrayFx,
+    "C API: Test dense array, multi-index, out of order ranges",
+    "[capi][dense][multi-index][out-of-order-ranges]") {
+  SECTION("- No serialization") {
+    serialize_query_ = false;
+  }
+  SECTION("- Serialization") {
+    serialize_query_ = true;
+  }
+
+  SupportedFsLocal local_fs;
+  std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
+  std::string array_name = temp_dir + "dense_read_large";
+  create_temp_dir(temp_dir);
+
+  create_large_dense_array_1_attribute(array_name);
+
+  write_large_dense_array(array_name);
+
+  std::vector<TestRange> ranges;
+  ranges.emplace_back(0, 10, 16);
+  ranges.emplace_back(0, 5, 6);
+  ranges.emplace_back(1, 3, 4);
+
+  tiledb_layout_t layout = GENERATE(TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+
+  std::vector<uint64_t> a1(18);
+  read_large_dense_array(array_name, layout, ranges, a1);
+
+  // clang-format off
+  uint64_t c_a1_cm[] = {
+    503, 603, 1003, 1103, 1203, 1303, 1403, 1503, 1603, 
+    504, 604, 1004, 1104, 1204, 1304, 1404, 1504, 1604
+  };
+
+  uint64_t c_a1_rm[] = {
+    503, 504,
+    603, 604,
+    1003, 1004,
+    1103, 1104,
+    1203, 1204,
+    1303, 1304,
+    1403, 1404,
+    1503, 1504, 
+    1603, 1604
+  };
+  // clang-format on
+  if (layout == TILEDB_ROW_MAJOR) {
+    CHECK(!memcmp(c_a1_rm, a1.data(), sizeof(c_a1_rm)));
+  } else {
+    CHECK(!memcmp(c_a1_cm, a1.data(), sizeof(c_a1_cm)));
+  }
+
+  remove_temp_dir(temp_dir);
+}

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -403,6 +403,9 @@ Status DenseReader::init_read_state() {
                            "subarrays do not "
                            "support global order"));
 
+  // Make sure ranges are sorted.
+  RETURN_NOT_OK(subarray_.sort_ranges(storage_manager_->compute_tp()));
+
   // Get config values.
   bool found = false;
   uint64_t memory_budget = 0;

--- a/tiledb/sm/query/dense_reader.h
+++ b/tiledb/sm/query/dense_reader.h
@@ -56,6 +56,19 @@ class StorageManager;
 class DenseReader : public ReaderBase, public IQueryStrategy {
  public:
   /* ********************************* */
+  /*          TYPE DEFINITIONS         */
+  /* ********************************* */
+
+  /** Range information, for a dimension, used for row/col reads. */
+  struct RangeInfo {
+    /** Cell offset, per range for this dimension. */
+    std::vector<uint64_t> cell_offsets_;
+
+    /** Total cells covered by all the ranges for this dimension. */
+    uint64_t total_size_;
+  };
+
+  /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
@@ -149,7 +162,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       Subarray& subarray,
       std::vector<Subarray>& tile_subarrays,
       std::vector<uint64_t>& tile_offsets,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles);
 
   /** Fix offsets buffer after reading all offsets. */
@@ -168,7 +181,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& subarray,
       const std::vector<Subarray>& tile_subarrays,
       const std::vector<uint64_t>& tile_offsets,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
       const std::vector<uint8_t>& qc_result);
 
@@ -200,7 +213,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& tile_subarray,
       const DimType* const coords,
       const DimType* const range_coords,
-      const std::vector<uint64_t>& range_offsets);
+      const std::vector<RangeInfo>& range_info);
 
   /** Copy fixed tiles to the output buffers. */
   template <class DimType>
@@ -214,7 +227,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& subarray,
       const Subarray& tile_subarray,
       const uint64_t global_cell_offset,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       const std::vector<uint8_t>& qc_result);
 
   /** Copy a tile var offsets to the output buffers. */
@@ -230,7 +243,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& tile_subarray,
       const uint64_t global_cell_offset,
       std::vector<std::vector<void*>>& var_data,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       const std::vector<uint8_t>& qc_result);
 
   /** Copy a var tile to the output buffers. */
@@ -244,7 +257,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& tile_subarray,
       const uint64_t global_cell_offset,
       std::vector<std::vector<void*>>& var_data,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       bool last_tile,
       std::vector<uint64_t>& var_buffer_sizes);
 

--- a/tiledb/sm/query/dense_reader.h
+++ b/tiledb/sm/query/dense_reader.h
@@ -64,8 +64,8 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
     /** Cell offset, per range for this dimension. */
     std::vector<uint64_t> cell_offsets_;
 
-    /** Total cells covered by all the ranges for this dimension. */
-    uint64_t total_size_;
+    /** Multiplier to be used in offset computation. */
+    uint64_t multiplier_;
   };
 
   /* ********************************* */


### PR DESCRIPTION
The previous implementation of the dense reader would order the results
in the user buffer by N-dimension range index, for example, if there are
2 ranges set per dimensions, the data would be ordered from N-dimension
range 1 to 4. This implementation is incorrect as it doesn't really
return the data in the expected row/column major.

This change computes the correct offset for the data in the user buffers
and returns the data in true row/column major order.

---
TYPE: IMPROVEMENT
DESC: Dense reader: fix user buffer offset computation for multi-index queries.
