### PR TITLE
Split consolidator in multiple classes.

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -142,6 +142,11 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/compressors/zstd_compressor.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/config/config.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/config/config_iter.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/consolidator/array_meta_consolidator.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/consolidator/commits_consolidator.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/consolidator/consolidator.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/consolidator/fragment_consolidator.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/consolidator/fragment_meta_consolidator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/crypto.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/encryption_key.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/encryption_key_validation.cc
@@ -218,7 +223,6 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/stats.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/timer_stat.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/context.cc
-  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/consolidator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/storage_manager.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/cell_slab_iter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/range_subset.cc

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -1,0 +1,216 @@
+/**
+ * @file   array_meta_consolidator.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements the ArrayMetaConsolidator class.
+ */
+
+#include "tiledb/sm/consolidator/array_meta_consolidator.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/storage_manager.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*          CONSTRUCTOR           */
+/* ****************************** */
+
+ArrayMetaConsolidator::ArrayMetaConsolidator(
+    const Config* config, StorageManager* storage_manager)
+    : Consolidator(storage_manager) {
+  auto st = set_config(config);
+  if (!st.ok()) {
+    throw std::logic_error(st.message());
+  }
+}
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+Status ArrayMetaConsolidator::consolidate(
+    const char* array_name,
+    EncryptionType encryption_type,
+    const void* encryption_key,
+    uint32_t key_length) {
+  auto timer_se = stats_->start_timer("consolidate_array_meta");
+
+  // Open array for reading
+  auto array_uri = URI(array_name);
+  Array array_for_reads(array_uri, storage_manager_);
+  RETURN_NOT_OK(array_for_reads.open(
+      QueryType::READ,
+      config_.timestamp_start_,
+      config_.timestamp_end_,
+      encryption_type,
+      encryption_key,
+      key_length));
+
+  // Open array for writing
+  Array array_for_writes(array_uri, storage_manager_);
+  RETURN_NOT_OK_ELSE(
+      array_for_writes.open(
+          QueryType::WRITE, encryption_type, encryption_key, key_length),
+      array_for_reads.close());
+
+  // Swap the in-memory metadata between the two arrays.
+  // After that, the array for writes will store the (consolidated by
+  // the way metadata loading works) metadata of the array for reads
+  Metadata* metadata_r;
+  auto st = array_for_reads.metadata(&metadata_r);
+  if (!st.ok()) {
+    array_for_reads.close();
+    array_for_writes.close();
+    return st;
+  }
+  Metadata* metadata_w;
+  st = array_for_writes.metadata(&metadata_w);
+  if (!st.ok()) {
+    array_for_reads.close();
+    array_for_writes.close();
+    return st;
+  }
+  metadata_r->swap(metadata_w);
+
+  // Metadata uris to delete
+  const auto to_vacuum = metadata_w->loaded_metadata_uris();
+
+  // Generate new name for consolidated metadata
+  st = metadata_w->generate_uri(array_uri);
+  if (!st.ok()) {
+    array_for_reads.close();
+    array_for_writes.close();
+    return st;
+  }
+
+  // Get the new URI name
+  URI new_uri;
+  st = metadata_w->get_uri(array_uri, &new_uri);
+  if (!st.ok()) {
+    array_for_reads.close();
+    array_for_writes.close();
+    return st;
+  }
+
+  // Close arrays
+  RETURN_NOT_OK_ELSE(array_for_reads.close(), array_for_writes.close());
+  RETURN_NOT_OK(array_for_writes.close());
+
+  // Write vacuum file
+  URI vac_uri = URI(new_uri.to_string() + constants::vacuum_file_suffix);
+
+  std::stringstream ss;
+  for (const auto& uri : to_vacuum)
+    ss << uri.to_string() << "\n";
+
+  auto data = ss.str();
+  RETURN_NOT_OK(
+      storage_manager_->vfs()->write(vac_uri, data.c_str(), data.size()));
+  RETURN_NOT_OK(storage_manager_->vfs()->close_file(vac_uri));
+
+  return Status::Ok();
+}
+
+Status ArrayMetaConsolidator::vacuum(const char* array_name) {
+  if (array_name == nullptr)
+    return logger_->status(Status_StorageManagerError(
+        "Cannot vacuum array metadata; Array name cannot be null"));
+
+  // Get the array metadata URIs and vacuum file URIs to be vacuum
+  auto vfs = storage_manager_->vfs();
+  auto compute_tp = storage_manager_->compute_tp();
+  ArrayDirectory array_dir;
+  try {
+    array_dir = ArrayDirectory(
+        vfs,
+        compute_tp,
+        URI(array_name),
+        config_.vacuum_timestamp_start_,
+        config_.vacuum_timestamp_end_);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
+
+  const auto& array_meta_uris_to_vacuum = array_dir.array_meta_uris_to_vacuum();
+  const auto& vac_uris_to_vacuum = array_dir.array_meta_vac_uris_to_vacuum();
+
+  // Delete the array metadata files
+  auto status = parallel_for(
+      compute_tp, 0, array_meta_uris_to_vacuum.size(), [&](size_t i) {
+        RETURN_NOT_OK(vfs->remove_file(array_meta_uris_to_vacuum[i]));
+
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  // Delete vacuum files
+  status =
+      parallel_for(compute_tp, 0, vac_uris_to_vacuum.size(), [&](size_t i) {
+        RETURN_NOT_OK(vfs->remove_file(vac_uris_to_vacuum[i]));
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  return Status::Ok();
+}
+
+/* ****************************** */
+/*        PRIVATE METHODS         */
+/* ****************************** */
+
+Status ArrayMetaConsolidator::set_config(const Config* config) {
+  // Set the consolidation config for ease of use
+  Config merged_config = storage_manager_->config();
+  if (config) {
+    merged_config.inherit(*config);
+  }
+  bool found = false;
+  RETURN_NOT_OK(merged_config.get<uint64_t>(
+      "sm.consolidation.timestamp_start", &config_.timestamp_start_, &found));
+  assert(found);
+  RETURN_NOT_OK(merged_config.get<uint64_t>(
+      "sm.consolidation.timestamp_end", &config_.timestamp_end_, &found));
+  assert(found);
+  RETURN_NOT_OK(merged_config.get<uint64_t>(
+      "sm.vacuum.timestamp_start", &config_.vacuum_timestamp_start_, &found));
+  assert(found);
+  RETURN_NOT_OK(merged_config.get<uint64_t>(
+      "sm.vacuum.timestamp_end", &config_.vacuum_timestamp_end_, &found));
+  assert(found);
+
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/consolidator/array_meta_consolidator.h
+++ b/tiledb/sm/consolidator/array_meta_consolidator.h
@@ -1,0 +1,139 @@
+/**
+ * @file   array_meta_consolidator.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class ArrayMetaConsolidator.
+ */
+
+#ifndef TILEDB_ARRAY_META_CONSOLIDATOR_H
+#define TILEDB_ARRAY_META_CONSOLIDATOR_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/common/heap_memory.h"
+#include "tiledb/common/logger_public.h"
+#include "tiledb/common/status.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/consolidator/consolidator.h"
+#include "tiledb/sm/misc/types.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class StorageManager;
+
+/** Handles array metadata consolidation. */
+class ArrayMetaConsolidator : public Consolidator {
+  // Declare Consolidator as friend so it can use the private constructor.
+  friend class Consolidator;
+
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * Constructor.
+   *
+   * @param config Config.
+   * @param storage_manager Storage manager.
+   */
+  explicit ArrayMetaConsolidator(
+      const Config* config, StorageManager* storage_manager);
+
+  /** Destructor. */
+  ~ArrayMetaConsolidator() = default;
+
+  DISABLE_COPY_AND_COPY_ASSIGN(ArrayMetaConsolidator);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(ArrayMetaConsolidator);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Performs the consolidation operation.
+   *
+   * @param array_name URI of array to consolidate.
+   * @param encryption_type The encryption type of the array
+   * @param encryption_key If the array is encrypted, the private encryption
+   *    key. For unencrypted arrays, pass `nullptr`.
+   * @param key_length The length in bytes of the encryption key.
+   * @return Status
+   */
+  Status consolidate(
+      const char* array_name,
+      EncryptionType encryption_type,
+      const void* encryption_key,
+      uint32_t key_length);
+
+  /**
+   * Performs the vacuuming operation.
+   *
+   * @param array_name URI of array to consolidate.
+   * @return Status
+   */
+  Status vacuum(const char* array_name);
+
+ private:
+  /* ********************************* */
+  /*           TYPE DEFINITIONS        */
+  /* ********************************* */
+
+  /** Consolidation configuration parameters. */
+  struct ConsolidationConfig {
+    /** Start time for consolidation. */
+    uint64_t timestamp_start_;
+    /** End time for consolidation. */
+    uint64_t timestamp_end_;
+    /** Start time for vacuuming. */
+    uint64_t vacuum_timestamp_start_;
+    /** End time for vacuuming. */
+    uint64_t vacuum_timestamp_end_;
+  };
+
+  /* ********************************* */
+  /*          PRIVATE METHODS          */
+  /* ********************************* */
+
+  /** Checks and sets the input configuration parameters. */
+  Status set_config(const Config* config);
+
+  /* ********************************* */
+  /*        PRIVATE ATTRIBUTES         */
+  /* ********************************* */
+
+  /** Consolidation configuration parameters. */
+  ConsolidationConfig config_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_ARRAY_META_CONSOLIDATOR_H

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -1,0 +1,164 @@
+/**
+ * @file   commits_consolidator.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements the CommitsConsolidator class.
+ */
+
+#include "tiledb/sm/consolidator/commits_consolidator.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/misc/time.h"
+#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/storage_manager.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*          CONSTRUCTOR           */
+/* ****************************** */
+
+CommitsConsolidator::CommitsConsolidator(StorageManager* storage_manager)
+    : Consolidator(storage_manager) {
+}
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+Status CommitsConsolidator::consolidate(
+    const char* array_name,
+    EncryptionType encryption_type,
+    const void* encryption_key,
+    uint32_t key_length) {
+  auto timer_se = stats_->start_timer("consolidate_commits");
+
+  // Open array for writing
+  auto array_uri = URI(array_name);
+  Array array_for_writes(array_uri, storage_manager_);
+  RETURN_NOT_OK(array_for_writes.open(
+      QueryType::WRITE, encryption_type, encryption_key, key_length));
+
+  // Ensure write version is at least 12.
+  auto write_version = array_for_writes.array_schema_latest().write_version();
+  RETURN_NOT_OK(array_for_writes.close());
+  if (write_version < 12) {
+    return logger_->status(Status_ConsolidatorError(
+        "Array version should be at least 12 to consolidate commits."));
+  }
+
+  // Get the array uri to consolidate from the array directory.
+  ArrayDirectory array_dir;
+  try {
+    array_dir = ArrayDirectory(
+        storage_manager_->vfs(),
+        storage_manager_->compute_tp(),
+        URI(array_name),
+        0,
+        utils::time::timestamp_now_ms(),
+        ArrayDirectoryMode::COMMITS);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
+
+  // Get the file name.
+  auto& to_consolidate = array_dir.commit_uris_to_consolidate();
+  auto&& [st1, name] = array_dir.compute_new_fragment_name(
+      to_consolidate.front(), to_consolidate.back(), write_version);
+  RETURN_NOT_OK(st1);
+
+  // Write consolidated file, URIs are relative to the array URI.
+  std::stringstream ss;
+  auto base_uri_size = array_dir.uri().to_string().size();
+  for (const auto& uri : to_consolidate) {
+    ss << uri.to_string().substr(base_uri_size) << "\n";
+  }
+
+  auto data = ss.str();
+  URI consolidated_commits_uri =
+      array_dir.get_commits_dir(write_version)
+          .join_path(name.value() + constants::con_commits_file_suffix);
+  RETURN_NOT_OK(storage_manager_->vfs()->write(
+      consolidated_commits_uri, data.c_str(), data.size()));
+  RETURN_NOT_OK(storage_manager_->vfs()->close_file(consolidated_commits_uri));
+
+  return Status::Ok();
+}
+
+Status CommitsConsolidator::vacuum(const char* array_name) {
+  if (array_name == nullptr)
+    return logger_->status(Status_StorageManagerError(
+        "Cannot vacuum array metadata; Array name cannot be null"));
+
+  // Get the array metadata URIs and vacuum file URIs to be vacuum
+  auto vfs = storage_manager_->vfs();
+  auto compute_tp = storage_manager_->compute_tp();
+  ArrayDirectory array_dir;
+  try {
+    array_dir = ArrayDirectory(
+        vfs,
+        compute_tp,
+        URI(array_name),
+        0,
+        utils::time::timestamp_now_ms(),
+        ArrayDirectoryMode::COMMITS);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
+
+  const auto& commits_uris_to_vacuum = array_dir.commit_uris_to_vacuum();
+  const auto& consolidated_commits_uris_to_vacuum =
+      array_dir.consolidated_commits_uris_to_vacuum();
+
+  // Delete the commits files
+  auto status =
+      parallel_for(compute_tp, 0, commits_uris_to_vacuum.size(), [&](size_t i) {
+        RETURN_NOT_OK(vfs->remove_file(commits_uris_to_vacuum[i]));
+
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  // Delete vacuum files
+  status = parallel_for(
+      compute_tp, 0, consolidated_commits_uris_to_vacuum.size(), [&](size_t i) {
+        RETURN_NOT_OK(vfs->remove_file(consolidated_commits_uris_to_vacuum[i]));
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/consolidator/commits_consolidator.h
+++ b/tiledb/sm/consolidator/commits_consolidator.h
@@ -1,0 +1,103 @@
+/**
+ * @file   commits_consolidator.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class CommitsConsolidator.
+ */
+
+#ifndef TILEDB_COMMITS_CONSOLIDATOR_H
+#define TILEDB_COMMITS_CONSOLIDATOR_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/common/heap_memory.h"
+#include "tiledb/common/logger_public.h"
+#include "tiledb/common/status.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/consolidator/consolidator.h"
+#include "tiledb/sm/misc/types.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class StorageManager;
+
+/** Handles commits consolidation. */
+class CommitsConsolidator : public Consolidator {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * Constructor.
+   *
+   * @param storage_manager Storage manager.
+   */
+  explicit CommitsConsolidator(StorageManager* storage_manager);
+
+  /** Destructor. */
+  ~CommitsConsolidator() = default;
+
+  DISABLE_COPY_AND_COPY_ASSIGN(CommitsConsolidator);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(CommitsConsolidator);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Performs the consolidation operation.
+   *
+   * @param array_name URI of array to consolidate.
+   * @param encryption_type The encryption type of the array
+   * @param encryption_key If the array is encrypted, the private encryption
+   *    key. For unencrypted arrays, pass `nullptr`.
+   * @param key_length The length in bytes of the encryption key.
+   * @return Status
+   */
+  Status consolidate(
+      const char* array_name,
+      EncryptionType encryption_type,
+      const void* encryption_key,
+      uint32_t key_length);
+
+  /**
+   * Performs the vacuuming operation.
+   *
+   * @param array_name URI of array to consolidate.
+   * @return Status
+   */
+  Status vacuum(const char* array_name);
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_COMMITS_CONSOLIDATOR_H

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -1,0 +1,124 @@
+/**
+ * @file   consolidator.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements the Consolidator class.
+ */
+
+#include "tiledb/sm/consolidator/consolidator.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/sm/consolidator/array_meta_consolidator.h"
+#include "tiledb/sm/consolidator/commits_consolidator.h"
+#include "tiledb/sm/consolidator/fragment_consolidator.h"
+#include "tiledb/sm/consolidator/fragment_meta_consolidator.h"
+#include "tiledb/sm/storage_manager/storage_manager.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/* ********************************* */
+/*          FACTORY METHODS          */
+/* ********************************* */
+
+/** Factory function to create the consolidator depending on mode. */
+shared_ptr<Consolidator> Consolidator::create(
+    const ConsolidationMode mode,
+    const Config* config,
+    StorageManager* storage_manager) {
+  switch (mode) {
+    case ConsolidationMode::FRAGMENT_META:
+      return make_shared<FragmentMetaConsolidator>(HERE(), storage_manager);
+    case ConsolidationMode::FRAGMENT:
+      return make_shared<FragmentConsolidator>(HERE(), config, storage_manager);
+    case ConsolidationMode::ARRAY_META:
+      return make_shared<ArrayMetaConsolidator>(
+          HERE(), config, storage_manager);
+    case ConsolidationMode::COMMITS:
+      return make_shared<CommitsConsolidator>(HERE(), storage_manager);
+    default:
+      return nullptr;
+  }
+}
+
+ConsolidationMode Consolidator::mode_from_config(
+    const Config* config, const bool vacuum_mode) {
+  bool found = false;
+  const std::string mode = vacuum_mode ?
+                               config->get("sm.vacuum.mode", &found) :
+                               config->get("sm.consolidation.mode", &found);
+  if (!found) {
+    throw std::logic_error(
+        "Cannot consolidate; Consolidation mode cannot be null");
+  }
+
+  if (mode == "fragment_meta")
+    return ConsolidationMode::FRAGMENT_META;
+  else if (mode == "fragments")
+    return ConsolidationMode::FRAGMENT;
+  else if (mode == "array_meta")
+    return ConsolidationMode::ARRAY_META;
+  else if (mode == "commits")
+    return ConsolidationMode::COMMITS;
+
+  throw std::logic_error("Cannot consolidate; invalid configuration mode");
+}
+
+/* ****************************** */
+/*   CONSTRUCTORS & DESTRUCTORS   */
+/* ****************************** */
+
+Consolidator::Consolidator(StorageManager* storage_manager)
+    : storage_manager_(storage_manager)
+    , stats_(storage_manager_->stats()->create_child("Consolidator"))
+    , logger_(storage_manager_->logger()->clone("Consolidator", ++logger_id_)) {
+}
+
+Consolidator::~Consolidator() = default;
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+Status Consolidator::consolidate(
+    [[maybe_unused]] const char* array_name,
+    [[maybe_unused]] EncryptionType encryption_type,
+    [[maybe_unused]] const void* encryption_key,
+    [[maybe_unused]] uint32_t key_length) {
+  return logger_->status(
+      Status_ConsolidatorError("Cannot consolidate; Invalid object"));
+}
+
+Status Consolidator::vacuum([[maybe_unused]] const char* array_name) {
+  return logger_->status(
+      Status_ConsolidatorError("Cannot vacuum; Invalid object"));
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -1,0 +1,162 @@
+/**
+ * @file   consolidator.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class Consolidator.
+ */
+
+#ifndef TILEDB_CONSOLIDATOR_H
+#define TILEDB_CONSOLIDATOR_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/common/heap_memory.h"
+#include "tiledb/common/logger_public.h"
+#include "tiledb/common/status.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/misc/types.h"
+
+#include <vector>
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class ArraySchema;
+class Config;
+class Query;
+class StorageManager;
+class URI;
+
+/** Mode for the consolidator class. */
+enum class ConsolidationMode {
+  FRAGMENT,       // Fragment mode.
+  FRAGMENT_META,  // Fragment metadata mode.
+  ARRAY_META,     // Array metadata mode.
+  COMMITS         // Commits mode.
+};
+
+/** Handles array consolidation. */
+class Consolidator {
+ public:
+  /* ********************************* */
+  /*          FACTORY METHODS          */
+  /* ********************************* */
+
+  /**
+   * Factory method to make a new Consolidator instance given the config mode.
+   *
+   * @param mode Consolidation mode.
+   * @param config Configuration parameters for the consolidation
+   *     (`nullptr` means default).
+   * @param storage_manager Storage manager.
+   * @return New Consolidator instance or nullptr on error.
+   */
+  static shared_ptr<Consolidator> create(
+      const ConsolidationMode mode,
+      const Config* config,
+      StorageManager* storage_manager);
+
+  /**
+   * Returns the ConsolidationMode from the config.
+   *
+   * @param config Config.
+   * @param vacuum_mode true for vacuum mode, false otherwise.
+   * @return Consolidation mode.
+   */
+  static ConsolidationMode mode_from_config(
+      const Config* config, const bool vacuum_mode = false);
+
+  /* ********************************* */
+  /*            DESTRUCTORS            */
+  /* ********************************* */
+
+  /** Destructor. */
+  virtual ~Consolidator();
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Performs the consolidation operation.
+   *
+   * @param array_name URI of array to consolidate.
+   * @param encryption_type The encryption type of the array
+   * @param encryption_key If the array is encrypted, the private encryption
+   *    key. For unencrypted arrays, pass `nullptr`.
+   * @param key_length The length in bytes of the encryption key.
+   * @return Status
+   */
+  virtual Status consolidate(
+      const char* array_name,
+      EncryptionType encryption_type,
+      const void* encryption_key,
+      uint32_t key_length);
+
+  /**
+   * Performs the vacuuming operation.
+   *
+   * @param array_name URI of array to vacuum.
+   * @return Status
+   */
+  virtual Status vacuum(const char* array_name);
+
+ protected:
+  /* ********************************* */
+  /*      PROTECTED CONSTRUCTORS       */
+  /* ********************************* */
+
+  /**
+   * Constructor.
+   *
+   * @param storage_manager Storage manager.
+   */
+  explicit Consolidator(StorageManager* storage_manager);
+
+  /* ********************************* */
+  /*       PROTECTED ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The storage manager. */
+  StorageManager* storage_manager_;
+
+  /** The class stats. */
+  stats::Stats* stats_;
+
+  /** The class logger. */
+  shared_ptr<Logger> logger_;
+
+  /** UID of the logger instance */
+  inline static std::atomic<uint64_t> logger_id_ = 0;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_FRAGMENT_H

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -1,11 +1,11 @@
 /**
- * @file   consolidator.cc
+ * @file   fragment_consolidator.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,22 +30,15 @@
  * This file implements the Consolidator class.
  */
 
-#include "tiledb/sm/storage_manager/consolidator.h"
+#include "tiledb/sm/consolidator/fragment_consolidator.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/enums/query_type.h"
-#include "tiledb/sm/filesystem/vfs.h"
-#include "tiledb/sm/fragment/single_fragment_info.h"
-#include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/time.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
-#include "tiledb/sm/tile/generic_tile_io.h"
-#include "tiledb/sm/tile/tile.h"
 
 #include <iostream>
 #include <sstream>
@@ -56,196 +49,23 @@ namespace tiledb {
 namespace sm {
 
 /* ****************************** */
-/*   CONSTRUCTORS & DESTRUCTORS   */
+/*          CONSTRUCTOR           */
 /* ****************************** */
 
-Consolidator::Consolidator(StorageManager* storage_manager)
-    : storage_manager_(storage_manager)
-    , stats_(storage_manager_->stats()->create_child("Consolidator"))
-    , logger_(storage_manager_->logger()->clone("Consolidator", ++logger_id_)) {
+FragmentConsolidator::FragmentConsolidator(
+    const Config* config, StorageManager* storage_manager)
+    : Consolidator(storage_manager) {
+  auto st = set_config(config);
+  if (!st.ok()) {
+    throw std::logic_error(st.message());
+  }
 }
-
-Consolidator::~Consolidator() = default;
 
 /* ****************************** */
 /*               API              */
 /* ****************************** */
 
-Status Consolidator::consolidate(
-    const char* array_name,
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length,
-    const Config* config) {
-  // Set config parameters
-  RETURN_NOT_OK(set_config(config));
-
-  // Consolidate based on mode
-  URI array_uri = URI(array_name);
-  if (config_.mode_ == "fragment_meta")
-    return consolidate_fragment_meta(
-        array_uri, encryption_type, encryption_key, key_length);
-  else if (config_.mode_ == "fragments")
-    return consolidate_fragments(
-        array_name, encryption_type, encryption_key, key_length);
-  else if (config_.mode_ == "array_meta")
-    return consolidate_array_meta(
-        array_name, encryption_type, encryption_key, key_length);
-  else if (config_.mode_ == "commits")
-    return consolidate_commits(
-        array_name, encryption_type, encryption_key, key_length);
-
-  return logger_->status(Status_ConsolidatorError(
-      "Cannot consolidate; Invalid consolidation mode"));
-}
-
-Status Consolidator::consolidate_array_meta(
-    const char* array_name,
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length) {
-  auto timer_se = stats_->start_timer("consolidate_array_meta");
-
-  // Open array for reading
-  auto array_uri = URI(array_name);
-  Array array_for_reads(array_uri, storage_manager_);
-  RETURN_NOT_OK(array_for_reads.open(
-      QueryType::READ,
-      config_.timestamp_start_,
-      config_.timestamp_end_,
-      encryption_type,
-      encryption_key,
-      key_length));
-
-  // Open array for writing
-  Array array_for_writes(array_uri, storage_manager_);
-  RETURN_NOT_OK_ELSE(
-      array_for_writes.open(
-          QueryType::WRITE, encryption_type, encryption_key, key_length),
-      array_for_reads.close());
-
-  // Swap the in-memory metadata between the two arrays.
-  // After that, the array for writes will store the (consolidated by
-  // the way metadata loading works) metadata of the array for reads
-  Metadata* metadata_r;
-  auto st = array_for_reads.metadata(&metadata_r);
-  if (!st.ok()) {
-    array_for_reads.close();
-    array_for_writes.close();
-    return st;
-  }
-  Metadata* metadata_w;
-  st = array_for_writes.metadata(&metadata_w);
-  if (!st.ok()) {
-    array_for_reads.close();
-    array_for_writes.close();
-    return st;
-  }
-  metadata_r->swap(metadata_w);
-
-  // Metadata uris to delete
-  const auto to_vacuum = metadata_w->loaded_metadata_uris();
-
-  // Generate new name for consolidated metadata
-  st = metadata_w->generate_uri(array_uri);
-  if (!st.ok()) {
-    array_for_reads.close();
-    array_for_writes.close();
-    return st;
-  }
-
-  // Get the new URI name
-  URI new_uri;
-  st = metadata_w->get_uri(array_uri, &new_uri);
-  if (!st.ok()) {
-    array_for_reads.close();
-    array_for_writes.close();
-    return st;
-  }
-
-  // Close arrays
-  RETURN_NOT_OK_ELSE(array_for_reads.close(), array_for_writes.close());
-  RETURN_NOT_OK(array_for_writes.close());
-
-  // Write vacuum file
-  URI vac_uri = URI(new_uri.to_string() + constants::vacuum_file_suffix);
-
-  std::stringstream ss;
-  for (const auto& uri : to_vacuum)
-    ss << uri.to_string() << "\n";
-
-  auto data = ss.str();
-  RETURN_NOT_OK(
-      storage_manager_->vfs()->write(vac_uri, data.c_str(), data.size()));
-  RETURN_NOT_OK(storage_manager_->vfs()->close_file(vac_uri));
-
-  return Status::Ok();
-}
-
-Status Consolidator::consolidate_commits(
-    const char* array_name,
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length) {
-  auto timer_se = stats_->start_timer("consolidate_commits");
-
-  // Open array for writing
-  auto array_uri = URI(array_name);
-  Array array_for_writes(array_uri, storage_manager_);
-  RETURN_NOT_OK(array_for_writes.open(
-      QueryType::WRITE, encryption_type, encryption_key, key_length));
-
-  // Ensure write version is at least 12.
-  auto write_version = array_for_writes.array_schema_latest().write_version();
-  RETURN_NOT_OK(array_for_writes.close());
-  if (write_version < 12) {
-    return logger_->status(Status_ConsolidatorError(
-        "Array version should be at least 12 to consolidate commits."));
-  }
-
-  // Get the array uri to consolidate from the array directory.
-  ArrayDirectory array_dir;
-  try {
-    array_dir = ArrayDirectory(
-        storage_manager_->vfs(),
-        storage_manager_->compute_tp(),
-        URI(array_name),
-        0,
-        utils::time::timestamp_now_ms(),
-        ArrayDirectoryMode::COMMITS);
-  } catch (const std::logic_error& le) {
-    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
-  }
-
-  // Get the file name.
-  auto& to_consolidate = array_dir.commit_uris_to_consolidate();
-  auto&& [st1, name] = array_dir.compute_new_fragment_name(
-      to_consolidate.front(), to_consolidate.back(), write_version);
-  RETURN_NOT_OK(st1);
-
-  // Write consolidated file, URIs are relative to the array URI.
-  std::stringstream ss;
-  auto base_uri_size = array_dir.uri().to_string().size();
-  for (const auto& uri : to_consolidate) {
-    ss << uri.to_string().substr(base_uri_size) << "\n";
-  }
-
-  auto data = ss.str();
-  URI consolidated_commits_uri =
-      array_dir.get_commits_dir(write_version)
-          .join_path(name.value() + constants::con_commits_file_suffix);
-  RETURN_NOT_OK(storage_manager_->vfs()->write(
-      consolidated_commits_uri, data.c_str(), data.size()));
-  RETURN_NOT_OK(storage_manager_->vfs()->close_file(consolidated_commits_uri));
-
-  return Status::Ok();
-}
-
-/* ****************************** */
-/*        PRIVATE METHODS         */
-/* ****************************** */
-
-Status Consolidator::consolidate_fragments(
+Status FragmentConsolidator::consolidate(
     const char* array_name,
     EncryptionType encryption_type,
     const void* encryption_key,
@@ -343,7 +163,89 @@ Status Consolidator::consolidate_fragments(
   return Status::Ok();
 }
 
-bool Consolidator::are_consolidatable(
+Status FragmentConsolidator::vacuum(const char* array_name) {
+  if (array_name == nullptr)
+    return logger_->status(Status_StorageManagerError(
+        "Cannot vacuum fragments; Array name cannot be null"));
+
+  // Get the fragment URIs and vacuum file URIs to be vacuum
+  auto vfs = storage_manager_->vfs();
+  auto compute_tp = storage_manager_->compute_tp();
+  ArrayDirectory array_dir;
+  try {
+    array_dir = ArrayDirectory(
+        vfs,
+        compute_tp,
+        URI(array_name),
+        config_.vacuum_timestamp_start_,
+        config_.vacuum_timestamp_end_,
+        ArrayDirectoryMode::VACUUM_FRAGMENTS);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
+
+  const auto& fragment_uris_to_vacuum = array_dir.fragment_uris_to_vacuum();
+  const auto& commit_uris_to_vacuum = array_dir.commit_uris_to_vacuum();
+  const auto& commit_uris_to_ignore = array_dir.commit_uris_to_ignore();
+  const auto& vac_uris_to_vacuum = array_dir.fragment_vac_uris_to_vacuum();
+
+  if (commit_uris_to_ignore.size() > 0) {
+    // Write an ignore file to ensure consolidated WRT files still work
+    auto&& [st1, name] = array_dir.compute_new_fragment_name(
+        commit_uris_to_ignore.front(),
+        commit_uris_to_ignore.back(),
+        constants::format_version);
+    RETURN_NOT_OK(st1);
+
+    // Write URIs, relative to the array URI.
+    std::stringstream ss;
+    auto base_uri_size = array_dir.uri().to_string().size();
+    for (const auto& uri : commit_uris_to_ignore) {
+      ss << uri.to_string().substr(base_uri_size) << "\n";
+    }
+
+    auto data = ss.str();
+    URI ignore_file_uri =
+        array_dir.get_commits_dir(constants::format_version)
+            .join_path(name.value() + constants::ignore_file_suffix);
+    RETURN_NOT_OK(vfs->write(ignore_file_uri, data.c_str(), data.size()));
+    RETURN_NOT_OK(vfs->close_file(ignore_file_uri));
+  }
+
+  // Delete the commit files
+  auto status =
+      parallel_for(compute_tp, 0, commit_uris_to_vacuum.size(), [&](size_t i) {
+        RETURN_NOT_OK(vfs->remove_file(commit_uris_to_vacuum[i]));
+
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  // Delete fragment directories
+  status = parallel_for(
+      compute_tp, 0, fragment_uris_to_vacuum.size(), [&](size_t i) {
+        RETURN_NOT_OK(vfs->remove_dir(fragment_uris_to_vacuum[i]));
+
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  // Delete vacuum files
+  status =
+      parallel_for(compute_tp, 0, vac_uris_to_vacuum.size(), [&](size_t i) {
+        RETURN_NOT_OK(vfs->remove_file(vac_uris_to_vacuum[i]));
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  return Status::Ok();
+}
+
+/* ****************************** */
+/*        PRIVATE METHODS         */
+/* ****************************** */
+
+bool FragmentConsolidator::are_consolidatable(
     shared_ptr<const Domain> domain,
     const FragmentInfo& fragment_info,
     size_t start,
@@ -372,7 +274,7 @@ bool Consolidator::are_consolidatable(
   return (double(union_cell_num) / sum_cell_num) <= config_.amplification_;
 }
 
-Status Consolidator::consolidate(
+Status FragmentConsolidator::consolidate(
     Array& array_for_reads,
     Array& array_for_writes,
     const std::vector<TimestampedURI>& to_consolidate,
@@ -459,126 +361,7 @@ Status Consolidator::consolidate(
   return st;
 }
 
-Status Consolidator::consolidate_fragment_meta(
-    const URI& array_uri,
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length) {
-  auto timer_se = stats_->start_timer("consolidate_frag_meta");
-
-  // Open array for reading
-  Array array(array_uri, storage_manager_);
-  RETURN_NOT_OK(
-      array.open(QueryType::READ, encryption_type, encryption_key, key_length));
-
-  // Include only fragments with footers / separate basic metadata
-  Buffer buff;
-  const auto& tmp_meta = array.fragment_metadata();
-  std::vector<shared_ptr<FragmentMetadata>> meta;
-  for (auto m : tmp_meta) {
-    if (m->format_version() > 2)
-      meta.emplace_back(m);
-  }
-  auto fragment_num = (unsigned)meta.size();
-
-  // Do not consolidate if the number of fragments is not >1
-  if (fragment_num < 2)
-    return array.close();
-
-  // Write number of fragments
-  RETURN_NOT_OK(buff.write(&fragment_num, sizeof(uint32_t)));
-
-  // Compute new URI
-  URI uri;
-  auto& array_dir = array.array_directory();
-  auto first = meta.front()->fragment_uri();
-  auto last = meta.back()->fragment_uri();
-  auto write_version = array.array_schema_latest().write_version();
-  auto&& [st, name] =
-      array_dir.compute_new_fragment_name(first, last, write_version);
-  RETURN_NOT_OK(st);
-
-  auto frag_md_uri = array_dir.get_fragment_metadata_dir(write_version);
-  RETURN_NOT_OK(storage_manager_->vfs()->create_dir(frag_md_uri));
-  uri =
-      URI(frag_md_uri.to_string() + name.value() + constants::meta_file_suffix);
-
-  // Get the consolidated fragment metadata version
-  auto meta_name = uri.remove_trailing_slash().last_path_part();
-  auto pos = meta_name.find_last_of('.');
-  meta_name = (pos == std::string::npos) ? meta_name : meta_name.substr(0, pos);
-  uint32_t meta_version = 0;
-  RETURN_NOT_OK(utils::parse::get_fragment_version(meta_name, &meta_version));
-
-  // Calculate offset of first fragment footer
-  uint64_t offset = sizeof(uint32_t);  // Fragment num
-  for (auto m : meta) {
-    offset += sizeof(uint64_t);  // Name size
-    if (meta_version >= 9) {
-      offset += m->fragment_uri().last_path_part().size();  // Name
-    } else {
-      offset += m->fragment_uri().to_string().size();  // Name
-    }
-    offset += sizeof(uint64_t);  // Offset
-  }
-
-  // Serialize all fragment names and footer offsets into a single buffer
-  for (auto m : meta) {
-    // Write name size and name
-    std::string name;
-    if (meta_version >= 9) {
-      name = m->fragment_uri().last_path_part();
-    } else {
-      name = m->fragment_uri().to_string();
-    }
-    auto name_size = (uint64_t)name.size();
-    RETURN_NOT_OK(buff.write(&name_size, sizeof(uint64_t)));
-    RETURN_NOT_OK(buff.write(name.c_str(), name_size));
-    RETURN_NOT_OK(buff.write(&offset, sizeof(uint64_t)));
-
-    offset += m->footer_size();
-  }
-
-  // Serialize all fragment metadata footers in parallel
-  std::vector<Buffer> buffs(meta.size());
-  auto status = parallel_for(
-      storage_manager_->compute_tp(), 0, buffs.size(), [&](size_t i) {
-        RETURN_NOT_OK(meta[i]->write_footer(&buffs[i]));
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  // Combine serialized fragment metadata footers into a single buffer
-  for (const auto& b : buffs)
-    RETURN_NOT_OK(buff.write(b.data(), b.size()));
-
-  // Close array
-  RETURN_NOT_OK(array.close());
-
-  // Write to file
-  EncryptionKey enc_key;
-  RETURN_NOT_OK(enc_key.set_key(encryption_type, encryption_key, key_length));
-  Tile tile(
-      constants::generic_tile_datatype,
-      constants::generic_tile_cell_size,
-      0,
-      buff.data(),
-      buff.size());
-  buff.disown_data();
-
-  GenericTileIO tile_io(storage_manager_, uri);
-  uint64_t nbytes = 0;
-  RETURN_NOT_OK_ELSE(
-      tile_io.write_generic(&tile, enc_key, &nbytes), buff.clear());
-  (void)nbytes;
-  RETURN_NOT_OK_ELSE(storage_manager_->close_file(uri), buff.clear());
-
-  buff.clear();
-
-  return Status::Ok();
-}
-
-Status Consolidator::copy_array(
+Status FragmentConsolidator::copy_array(
     Query* query_r,
     Query* query_w,
     std::vector<ByteVec>* buffers,
@@ -606,7 +389,7 @@ Status Consolidator::copy_array(
   return Status::Ok();
 }
 
-Status Consolidator::create_buffers(
+Status FragmentConsolidator::create_buffers(
     const ArraySchema& array_schema,
     std::vector<ByteVec>* buffers,
     std::vector<uint64_t>* buffer_sizes) {
@@ -643,7 +426,7 @@ Status Consolidator::create_buffers(
   return Status::Ok();
 }
 
-Status Consolidator::create_queries(
+Status FragmentConsolidator::create_queries(
     Array* array_for_reads,
     Array* array_for_writes,
     const NDRange& subarray,
@@ -689,7 +472,7 @@ Status Consolidator::create_queries(
   return Status::Ok();
 }
 
-Status Consolidator::compute_next_to_consolidate(
+Status FragmentConsolidator::compute_next_to_consolidate(
     const ArraySchema& array_schema,
     const FragmentInfo& fragment_info,
     std::vector<TimestampedURI>* to_consolidate,
@@ -806,7 +589,7 @@ Status Consolidator::compute_next_to_consolidate(
   return Status::Ok();
 }
 
-Status Consolidator::set_query_buffers(
+Status FragmentConsolidator::set_query_buffers(
     Query* query,
     std::vector<ByteVec>* buffers,
     std::vector<uint64_t>* buffer_sizes) const {
@@ -877,11 +660,12 @@ Status Consolidator::set_query_buffers(
   return Status::Ok();
 }
 
-Status Consolidator::set_config(const Config* config) {
+Status FragmentConsolidator::set_config(const Config* config) {
   // Set the consolidation config for ease of use
   Config merged_config = storage_manager_->config();
-  if (config)
+  if (config) {
     merged_config.inherit(*config);
+  }
   bool found = false;
   config_.amplification_ = 0.0f;
   RETURN_NOT_OK(merged_config.get<float>(
@@ -907,11 +691,6 @@ Status Consolidator::set_config(const Config* config) {
   RETURN_NOT_OK(merged_config.get<uint32_t>(
       "sm.consolidation.step_max_frags", &config_.max_frags_, &found));
   assert(found);
-  const std::string mode = merged_config.get("sm.consolidation.mode", &found);
-  if (!found)
-    return logger_->status(Status_ConsolidatorError(
-        "Cannot consolidate; Consolidation mode cannot be null"));
-  config_.mode_ = mode;
   RETURN_NOT_OK(merged_config.get<uint64_t>(
       "sm.consolidation.timestamp_start", &config_.timestamp_start_, &found));
   assert(found);
@@ -922,6 +701,12 @@ Status Consolidator::set_config(const Config* config) {
       merged_config.get("sm.query.sparse_global_order.reader", &found);
   assert(found);
   config_.use_refactored_reader_ = reader.compare("refactored") == 0;
+  RETURN_NOT_OK(merged_config.get<uint64_t>(
+      "sm.vacuum.timestamp_start", &config_.vacuum_timestamp_start_, &found));
+  assert(found);
+  RETURN_NOT_OK(merged_config.get<uint64_t>(
+      "sm.vacuum.timestamp_end", &config_.vacuum_timestamp_end_, &found));
+  assert(found);
 
   // Sanity checks
   if (config_.min_frags_ > config_.max_frags_)
@@ -940,7 +725,7 @@ Status Consolidator::set_config(const Config* config) {
   return Status::Ok();
 }
 
-Status Consolidator::write_vacuum_file(
+Status FragmentConsolidator::write_vacuum_file(
     const URI& vac_uri,
     const std::vector<TimestampedURI>& to_consolidate) const {
   std::stringstream ss;

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -1,0 +1,224 @@
+/**
+ * @file   fragment_meta_consolidator.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements the FragmentMetaConsolidator class.
+ */
+
+#include "tiledb/sm/consolidator/fragment_meta_consolidator.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/storage_manager.h"
+#include "tiledb/sm/tile/generic_tile_io.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*          CONSTRUCTOR           */
+/* ****************************** */
+
+FragmentMetaConsolidator::FragmentMetaConsolidator(
+    StorageManager* storage_manager)
+    : Consolidator(storage_manager) {
+}
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+Status FragmentMetaConsolidator::consolidate(
+    const char* array_name,
+    EncryptionType encryption_type,
+    const void* encryption_key,
+    uint32_t key_length) {
+  auto timer_se = stats_->start_timer("consolidate_frag_meta");
+
+  // Open array for reading
+
+  Array array(URI(array_name), storage_manager_);
+  RETURN_NOT_OK(
+      array.open(QueryType::READ, encryption_type, encryption_key, key_length));
+
+  // Include only fragments with footers / separate basic metadata
+  Buffer buff;
+  const auto& tmp_meta = array.fragment_metadata();
+  std::vector<shared_ptr<FragmentMetadata>> meta;
+  for (auto m : tmp_meta) {
+    if (m->format_version() > 2)
+      meta.emplace_back(m);
+  }
+  auto fragment_num = (unsigned)meta.size();
+
+  // Do not consolidate if the number of fragments is not >1
+  if (fragment_num < 2)
+    return array.close();
+
+  // Write number of fragments
+  RETURN_NOT_OK(buff.write(&fragment_num, sizeof(uint32_t)));
+
+  // Compute new URI
+  URI uri;
+  auto& array_dir = array.array_directory();
+  auto first = meta.front()->fragment_uri();
+  auto last = meta.back()->fragment_uri();
+  auto write_version = array.array_schema_latest().write_version();
+  auto&& [st, name] =
+      array_dir.compute_new_fragment_name(first, last, write_version);
+  RETURN_NOT_OK(st);
+
+  auto frag_md_uri = array_dir.get_fragment_metadata_dir(write_version);
+  RETURN_NOT_OK(storage_manager_->vfs()->create_dir(frag_md_uri));
+  uri =
+      URI(frag_md_uri.to_string() + name.value() + constants::meta_file_suffix);
+
+  // Get the consolidated fragment metadata version
+  auto meta_name = uri.remove_trailing_slash().last_path_part();
+  auto pos = meta_name.find_last_of('.');
+  meta_name = (pos == std::string::npos) ? meta_name : meta_name.substr(0, pos);
+  uint32_t meta_version = 0;
+  RETURN_NOT_OK(utils::parse::get_fragment_version(meta_name, &meta_version));
+
+  // Calculate offset of first fragment footer
+  uint64_t offset = sizeof(uint32_t);  // Fragment num
+  for (auto m : meta) {
+    offset += sizeof(uint64_t);  // Name size
+    if (meta_version >= 9) {
+      offset += m->fragment_uri().last_path_part().size();  // Name
+    } else {
+      offset += m->fragment_uri().to_string().size();  // Name
+    }
+    offset += sizeof(uint64_t);  // Offset
+  }
+
+  // Serialize all fragment names and footer offsets into a single buffer
+  for (auto m : meta) {
+    // Write name size and name
+    std::string name;
+    if (meta_version >= 9) {
+      name = m->fragment_uri().last_path_part();
+    } else {
+      name = m->fragment_uri().to_string();
+    }
+    auto name_size = (uint64_t)name.size();
+    RETURN_NOT_OK(buff.write(&name_size, sizeof(uint64_t)));
+    RETURN_NOT_OK(buff.write(name.c_str(), name_size));
+    RETURN_NOT_OK(buff.write(&offset, sizeof(uint64_t)));
+
+    offset += m->footer_size();
+  }
+
+  // Serialize all fragment metadata footers in parallel
+  std::vector<Buffer> buffs(meta.size());
+  auto status = parallel_for(
+      storage_manager_->compute_tp(), 0, buffs.size(), [&](size_t i) {
+        RETURN_NOT_OK(meta[i]->write_footer(&buffs[i]));
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  // Combine serialized fragment metadata footers into a single buffer
+  for (const auto& b : buffs)
+    RETURN_NOT_OK(buff.write(b.data(), b.size()));
+
+  // Close array
+  RETURN_NOT_OK(array.close());
+
+  // Write to file
+  EncryptionKey enc_key;
+  RETURN_NOT_OK(enc_key.set_key(encryption_type, encryption_key, key_length));
+  Tile tile(
+      constants::generic_tile_datatype,
+      constants::generic_tile_cell_size,
+      0,
+      buff.data(),
+      buff.size());
+  buff.disown_data();
+
+  GenericTileIO tile_io(storage_manager_, uri);
+  uint64_t nbytes = 0;
+  RETURN_NOT_OK_ELSE(
+      tile_io.write_generic(&tile, enc_key, &nbytes), buff.clear());
+  (void)nbytes;
+  RETURN_NOT_OK_ELSE(storage_manager_->close_file(uri), buff.clear());
+
+  buff.clear();
+
+  return Status::Ok();
+}
+
+Status FragmentMetaConsolidator::vacuum(const char* array_name) {
+  if (array_name == nullptr)
+    return logger_->status(Status_StorageManagerError(
+        "Cannot vacuum fragment metadata; Array name cannot be null"));
+
+  // Get the consolidated fragment metadata URIs to be deleted
+  // (all except the last one)
+  auto vfs = storage_manager_->vfs();
+  auto compute_tp = storage_manager_->compute_tp();
+  ArrayDirectory array_dir;
+  try {
+    array_dir = ArrayDirectory(vfs, compute_tp, URI(array_name), 0, UINT64_MAX);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
+
+  const auto& fragment_meta_uris = array_dir.fragment_meta_uris();
+
+  // Get the latest timestamp
+  uint64_t t_latest = 0;
+  for (const auto& uri : fragment_meta_uris) {
+    std::pair<uint64_t, uint64_t> timestamp_range;
+    RETURN_NOT_OK(utils::parse::get_timestamp_range(uri, &timestamp_range));
+    if (timestamp_range.second > t_latest) {
+      t_latest = timestamp_range.second;
+    }
+  }
+
+  // Vacuum
+  auto status =
+      parallel_for(compute_tp, 0, fragment_meta_uris.size(), [&](size_t i) {
+        auto& uri = fragment_meta_uris[i];
+        std::pair<uint64_t, uint64_t> timestamp_range;
+        RETURN_NOT_OK(utils::parse::get_timestamp_range(uri, &timestamp_range));
+        if (timestamp_range.second != t_latest)
+          RETURN_NOT_OK(vfs->remove_file(uri));
+        return Status::Ok();
+      });
+  RETURN_NOT_OK(status);
+
+  return Status::Ok();
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.h
@@ -1,0 +1,103 @@
+/**
+ * @file   fragment_meta_consolidator.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class FragmentMetaConsolidator.
+ */
+
+#ifndef TILEDB_FRAGMENT_META_CONSOLIDATOR_H
+#define TILEDB_FRAGMENT_META_CONSOLIDATOR_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/common/heap_memory.h"
+#include "tiledb/common/logger_public.h"
+#include "tiledb/common/status.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/consolidator/consolidator.h"
+#include "tiledb/sm/misc/types.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class StorageManager;
+
+/** Handles fragment metadata consolidation. */
+class FragmentMetaConsolidator : public Consolidator {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * Constructor.
+   *
+   * @param storage_manager Storage manager.
+   */
+  explicit FragmentMetaConsolidator(StorageManager* storage_manager);
+
+  /** Destructor. */
+  ~FragmentMetaConsolidator() = default;
+
+  DISABLE_COPY_AND_COPY_ASSIGN(FragmentMetaConsolidator);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(FragmentMetaConsolidator);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Performs the consolidation operation.
+   *
+   * @param array_name URI of array to consolidate.
+   * @param encryption_type The encryption type of the array
+   * @param encryption_key If the array is encrypted, the private encryption
+   *    key. For unencrypted arrays, pass `nullptr`.
+   * @param key_length The length in bytes of the encryption key.
+   * @return Status
+   */
+  Status consolidate(
+      const char* array_name,
+      EncryptionType encryption_type,
+      const void* encryption_key,
+      uint32_t key_length);
+
+  /**
+   * Performs the vacuuming operation.
+   *
+   * @param array_name URI of array to consolidate.
+   * @return Status
+   */
+  Status vacuum(const char* array_name);
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_FRAGMENT_META_CONSOLIDATOR_H

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -46,6 +46,7 @@
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/array_schema_evolution.h"
 #include "tiledb/sm/cache/buffer_lru_cache.h"
+#include "tiledb/sm/consolidator/consolidator.h"
 #include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/enums/object_type.h"
@@ -61,7 +62,6 @@
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/stats/global_stats.h"
-#include "tiledb/sm/storage_manager/consolidator.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile.h"
@@ -384,9 +384,10 @@ Status StorageManager::array_consolidate(
   }
 
   // Consolidate
-  Consolidator consolidator(this);
-  return consolidator.consolidate(
-      array_name, encryption_type, encryption_key, key_length, config);
+  auto mode = Consolidator::mode_from_config(config);
+  auto consolidator = Consolidator::create(mode, config, this);
+  return consolidator->consolidate(
+      array_name, encryption_type, encryption_key, key_length);
 }
 
 Status StorageManager::array_vacuum(
@@ -397,241 +398,9 @@ Status StorageManager::array_vacuum(
     config = &config_;
   }
 
-  // Get mode
-  const char* mode;
-  RETURN_NOT_OK(config->get("sm.vacuum.mode", &mode));
-
-  bool found = false;
-  uint64_t timestamp_start;
-  RETURN_NOT_OK(config->get<uint64_t>(
-      "sm.vacuum.timestamp_start", &timestamp_start, &found));
-  assert(found);
-
-  uint64_t timestamp_end;
-  RETURN_NOT_OK(
-      config->get<uint64_t>("sm.vacuum.timestamp_end", &timestamp_end, &found));
-  assert(found);
-
-  if (mode == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum array; Vacuum mode cannot be null"));
-  else if (std::string(mode) == "fragments")
-    RETURN_NOT_OK(
-        array_vacuum_fragments(array_name, timestamp_start, timestamp_end));
-  else if (std::string(mode) == "fragment_meta")
-    RETURN_NOT_OK(array_vacuum_fragment_meta(array_name));
-  else if (std::string(mode) == "array_meta")
-    RETURN_NOT_OK(
-        array_vacuum_array_meta(array_name, timestamp_start, timestamp_end));
-  else if (std::string(mode) == "commits")
-    RETURN_NOT_OK(array_vacuum_commits(array_name));
-  else
-    return logger_->status(
-        Status_StorageManagerError("Cannot vacuum array; Invalid vacuum mode"));
-
-  return Status::Ok();
-}
-
-Status StorageManager::array_vacuum_fragments(
-    const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end) {
-  if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum fragments; Array name cannot be null"));
-
-  // Get the fragment URIs and vacuum file URIs to be vacuum
-  ArrayDirectory array_dir;
-  try {
-    array_dir = ArrayDirectory(
-        vfs_,
-        compute_tp_,
-        URI(array_name),
-        timestamp_start,
-        timestamp_end,
-        ArrayDirectoryMode::VACUUM_FRAGMENTS);
-  } catch (const std::logic_error& le) {
-    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
-  }
-
-  const auto& fragment_uris_to_vacuum = array_dir.fragment_uris_to_vacuum();
-  const auto& commit_uris_to_vacuum = array_dir.commit_uris_to_vacuum();
-  const auto& commit_uris_to_ignore = array_dir.commit_uris_to_ignore();
-  const auto& vac_uris_to_vacuum = array_dir.fragment_vac_uris_to_vacuum();
-
-  if (commit_uris_to_ignore.size() > 0) {
-    // Write an ignore file to ensure consolidated WRT files still work
-    auto&& [st1, name] = array_dir.compute_new_fragment_name(
-        commit_uris_to_ignore.front(),
-        commit_uris_to_ignore.back(),
-        constants::format_version);
-    RETURN_NOT_OK(st1);
-
-    // Write URIs, relative to the array URI.
-    std::stringstream ss;
-    auto base_uri_size = array_dir.uri().to_string().size();
-    for (const auto& uri : commit_uris_to_ignore) {
-      ss << uri.to_string().substr(base_uri_size) << "\n";
-    }
-
-    auto data = ss.str();
-    URI ignore_file_uri =
-        array_dir.get_commits_dir(constants::format_version)
-            .join_path(name.value() + constants::ignore_file_suffix);
-    RETURN_NOT_OK(vfs_->write(ignore_file_uri, data.c_str(), data.size()));
-    RETURN_NOT_OK(vfs_->close_file(ignore_file_uri));
-  }
-
-  // Delete the commit files
-  auto status = parallel_for(
-      compute_tp_, 0, commit_uris_to_vacuum.size(), [&, this](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(commit_uris_to_vacuum[i]));
-
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  // Delete fragment directories
-  status = parallel_for(
-      compute_tp_, 0, fragment_uris_to_vacuum.size(), [&, this](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_dir(fragment_uris_to_vacuum[i]));
-
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  // Delete vacuum files
-  status = parallel_for(
-      compute_tp_, 0, vac_uris_to_vacuum.size(), [&, this](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(vac_uris_to_vacuum[i]));
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  return Status::Ok();
-}
-
-Status StorageManager::array_vacuum_fragment_meta(const char* array_name) {
-  if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum fragment metadata; Array name cannot be null"));
-
-  // Get the consolidated fragment metadata URIs to be deleted
-  // (all except the last one)
-  ArrayDirectory array_dir;
-  try {
-    array_dir =
-        ArrayDirectory(vfs_, compute_tp_, URI(array_name), 0, UINT64_MAX);
-  } catch (const std::logic_error& le) {
-    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
-  }
-
-  const auto& fragment_meta_uris = array_dir.fragment_meta_uris();
-
-  // Get the latest timestamp
-  uint64_t t_latest = 0;
-  for (const auto& uri : fragment_meta_uris) {
-    std::pair<uint64_t, uint64_t> timestamp_range;
-    RETURN_NOT_OK(utils::parse::get_timestamp_range(uri, &timestamp_range));
-    if (timestamp_range.second > t_latest) {
-      t_latest = timestamp_range.second;
-    }
-  }
-
-  // Vacuum
-  auto status = parallel_for(
-      compute_tp_, 0, fragment_meta_uris.size(), [&, this](size_t i) {
-        auto& uri = fragment_meta_uris[i];
-        std::pair<uint64_t, uint64_t> timestamp_range;
-        RETURN_NOT_OK(utils::parse::get_timestamp_range(uri, &timestamp_range));
-        if (timestamp_range.second != t_latest)
-          RETURN_NOT_OK(vfs_->remove_file(uri));
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  return Status::Ok();
-}
-
-Status StorageManager::array_vacuum_array_meta(
-    const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end) {
-  if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum array metadata; Array name cannot be null"));
-
-  // Get the array metadata URIs and vacuum file URIs to be vacuum
-  ArrayDirectory array_dir;
-  try {
-    array_dir = ArrayDirectory(
-        vfs_, compute_tp_, URI(array_name), timestamp_start, timestamp_end);
-  } catch (const std::logic_error& le) {
-    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
-  }
-
-  const auto& array_meta_uris_to_vacuum = array_dir.array_meta_uris_to_vacuum();
-  const auto& vac_uris_to_vacuum = array_dir.array_meta_vac_uris_to_vacuum();
-
-  // Delete the array metadata files
-  auto status = parallel_for(
-      compute_tp_, 0, array_meta_uris_to_vacuum.size(), [&, this](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(array_meta_uris_to_vacuum[i]));
-
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  // Delete vacuum files
-  status = parallel_for(
-      compute_tp_, 0, vac_uris_to_vacuum.size(), [&, this](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(vac_uris_to_vacuum[i]));
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  return Status::Ok();
-}
-
-Status StorageManager::array_vacuum_commits(const char* array_name) {
-  if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum array metadata; Array name cannot be null"));
-
-  // Get the array metadata URIs and vacuum file URIs to be vacuum
-  ArrayDirectory array_dir;
-  try {
-    array_dir = ArrayDirectory(
-        vfs_,
-        compute_tp_,
-        URI(array_name),
-        0,
-        utils::time::timestamp_now_ms(),
-        ArrayDirectoryMode::COMMITS);
-  } catch (const std::logic_error& le) {
-    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
-  }
-
-  const auto& commits_uris_to_vacuum = array_dir.commit_uris_to_vacuum();
-  const auto& consolidated_commits_uris_to_vacuum =
-      array_dir.consolidated_commits_uris_to_vacuum();
-
-  // Delete the commits files
-  auto status = parallel_for(
-      compute_tp_, 0, commits_uris_to_vacuum.size(), [&, this](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(commits_uris_to_vacuum[i]));
-
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  // Delete vacuum files
-  status = parallel_for(
-      compute_tp_,
-      0,
-      consolidated_commits_uris_to_vacuum.size(),
-      [&, this](size_t i) {
-        RETURN_NOT_OK(
-            vfs_->remove_file(consolidated_commits_uris_to_vacuum[i]));
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
+  auto mode = Consolidator::mode_from_config(config, true);
+  auto consolidator = Consolidator::create(mode, config, this);
+  return consolidator->vacuum(array_name);
 
   return Status::Ok();
 }
@@ -697,8 +466,9 @@ Status StorageManager::array_metadata_consolidate(
   }
 
   // Consolidate
-  Consolidator consolidator(this);
-  return consolidator.consolidate_array_meta(
+  auto consolidator =
+      Consolidator::create(ConsolidationMode::ARRAY_META, config, this);
+  return consolidator->consolidate(
       array_name, encryption_type, encryption_key, key_length);
 }
 

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -294,46 +294,6 @@ class StorageManager {
   Status array_vacuum(const char* array_name, const Config* config);
 
   /**
-   * Cleans up fragments that took part in consolidation. Note that this
-   * will coarsen the granularity of time traveling (see docs for more
-   * information).
-   *
-   * @param array_name The name of the array to be vacuumed.
-   * @param timestamp_start The timestamp to start vacuuming at.
-   * @param timestamp_end The timestamp to end vacuuming at.
-   * @return Status
-   */
-  Status array_vacuum_fragments(
-      const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end);
-
-  /**
-   * Cleans up consolidated fragment metadata (all except the last one).
-   *
-   * @param array_name The name of the array to be consolidated.
-   * @return Status
-   */
-  Status array_vacuum_fragment_meta(const char* array_name);
-
-  /**
-   * Cleans up consolidated array metadata.
-   *
-   * @param array_name The name of the array to be consolidated.
-   * @param timestamp_start The timestamp to start vacuuming at.
-   * @param timestamp_end The timestamp to end vacuuming at.
-   * @return Status
-   */
-  Status array_vacuum_array_meta(
-      const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end);
-
-  /**
-   * Cleans up consolidated commit files.
-   *
-   * @param array_name The name of the array to be consolidated.
-   * @return Status
-   */
-  Status array_vacuum_commits(const char* array_name);
-
-  /**
    * Consolidates the metadata of an array into a single file.
    *
    * @param array_name The name of the array whose metadata will be


### PR DESCRIPTION
This breaks the consolidator code into seperate classes for the
consolidation of array metadata, fragments, fragment metadata and
commits. It also moves the new classes to a separate directory. For
vacuuming, the code has been removed from the storage manager and into
the seperate consolidator classes.

---
TYPE: IMPROVEMENT
DESC: Split consolidator in multiple classes.
