### PR TITLE
Remove duplicated artifact upload to hopefully fix SC-15404

### DIFF
--- a/scripts/azure-linux_mac-release.yml
+++ b/scripts/azure-linux_mac-release.yml
@@ -111,14 +111,15 @@ steps:
     includeRootFolder: false
     archiveType: 'tar' # Options: zip, 7z, tar, wim
     tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
-    archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir-$(ARTIFACT_EXTRAS).tar.gz
+    archiveFile: $(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(ARTIFACT_ARCH)-build-dir.tar.gz
     replaceExistingArchive: true
     verbose: true # Optional
 
 - task: PublishBuildArtifacts@1
   inputs:
-    pathToPublish: '$(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-build-dir-$(ARTIFACT_EXTRAS).tar.gz'
+    pathToPublish: '$(Build.ArtifactStagingDirectory)/tiledb-$(ARTIFACT_OS)-$(ARTIFACT_ARCH)-build-dir.tar.gz'
     artifactName: 'build-dirs'
+  condition: succeeded()
 
 - script: |
     echo $sourceVersion


### PR DESCRIPTION
Fix duplicated artifact name causing overlapped upload failure. The linux artifact has the same name for the standard and "noavx2" jobs, so if the jobs run simultaneously and try to upload at the same time, we get "blob upload failed" errors.

  - https://github.com/microsoft/azure-pipelines-tasks/issues/12102#issuecomment-676736884
 
---
TYPE: NO_HISTORY
