### PR TITLE
only call deflateEnd on specific errors returned from init failure

### DIFF
--- a/tiledb/sm/compressors/gzip_compressor.cc
+++ b/tiledb/sm/compressors/gzip_compressor.cc
@@ -65,7 +65,9 @@ Status GZip::compress(
       deflateInit(&strm, level < level_limit_ ? GZip::default_level() : level);
 
   if (ret != Z_OK) {
-    (void)deflateEnd(&strm);
+    if ((ret != Z_MEM_ERROR && ret != Z_STREAM_ERROR)) {
+      (void)deflateEnd(&strm);
+    }
     return LOG_STATUS(Status_GZipError("Cannot compress with GZIP"));
   }
 


### PR DESCRIPTION
call deflateEnd on errors from init only on errors that should not lead to possible SEGVs

---
TYPE: BUG
DESC: avoid incorrect use of deflateEnd on init errors
