### PR TITLE
[ci] Pin werkzeug to fix GCS emulator startup

### DIFF
--- a/scripts/install-gcs-emu.sh
+++ b/scripts/install-gcs-emu.sh
@@ -44,6 +44,7 @@ install_gcs(){
     sed 's/git+git:/git+https:/' /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt > /tmp/tdbpatchedrequirements.txt
     echo 'itsdangerous==2.0.1' >> /tmp/tdbpatchedrequirements.txt
     echo 'jinja2<3.1 # pinned due to incompatibility with gcs emulator 1.23' >> /tmp/tdbpatchedrequirements.txt
+    echo 'werkzeug<2.1 # pinned due to incompatibility with gcs emulator 1.23' >> /tmp/tdbpatchedrequirements.txt
     cp -f /tmp/tdbpatchedrequirements.txt /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt
     pip3 install -r /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt
 }


### PR DESCRIPTION
Fix another emulator incompatibility with new PyPI version of dependency.

---
TYPE: NO_HISTORY