### PR TITLE
Incorrect validity result count in REST query

### DIFF
--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -805,13 +805,8 @@ Status RestClient::update_attribute_buffer_sizes(
       *query_buffer.buffer_size_ = state.data_size;
 
     bool nullable = query->array_schema().is_nullable(name);
-    uint8_t* validity_buffer = nullptr;
-    uint64_t* validity_buffer_size = nullptr;
-    RETURN_NOT_OK(query->get_validity_buffer(
-        name.c_str(), &validity_buffer, &validity_buffer_size));
-
-    if (nullable && validity_buffer_size) {
-      *validity_buffer_size = state.validity_size;
+    if (nullable && query_buffer.validity_vector_.buffer_size()) {
+      *query_buffer.validity_vector_.buffer_size() = state.validity_size;
     }
   }
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -803,6 +803,16 @@ Status RestClient::update_attribute_buffer_sizes(
       *query_buffer.buffer_size_ = state.offset_size;
     } else if (query_buffer.buffer_size_ != nullptr)
       *query_buffer.buffer_size_ = state.data_size;
+
+    bool nullable = query->array_schema().is_nullable(name);
+    uint8_t* validity_buffer = nullptr;
+    uint64_t* validity_buffer_size = nullptr;
+    RETURN_NOT_OK(query->get_validity_buffer(
+        name.c_str(), &validity_buffer, &validity_buffer_size));
+
+    if (nullable && validity_buffer_size) {
+      *validity_buffer_size = state.validity_size;
+    }
   }
 
   return Status::Ok();

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1424,6 +1424,9 @@ Status query_from_capnp(
                   curr_offset_size + fixedlen_size_to_copy;
             if (existing_buffer_size_ptr != nullptr)
               *existing_buffer_size_ptr = curr_data_size + varlen_size;
+            if (nullable && existing_validity_buffer_size_ptr != nullptr)
+              *existing_validity_buffer_size_ptr =
+                  curr_validity_size + validitylen_size;
           } else {
             // Accumulate total bytes copied (caller's responsibility to
             // eventually update the query).
@@ -1435,11 +1438,6 @@ Status query_from_capnp(
             // Set whether the extra offset was included or not
             attr_copy_state->last_query_added_extra_offset =
                 query_reader.getVarOffsetsAddExtraElement();
-          }
-
-          if (nullable && existing_validity_buffer_size_ptr) {
-            *existing_validity_buffer_size_ptr =
-                curr_validity_size + validitylen_size;
           }
         } else {
           // Fixed size attribute; buffers already set.

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1424,9 +1424,6 @@ Status query_from_capnp(
                   curr_offset_size + fixedlen_size_to_copy;
             if (existing_buffer_size_ptr != nullptr)
               *existing_buffer_size_ptr = curr_data_size + varlen_size;
-            if (nullable && existing_validity_buffer_size_ptr != nullptr)
-              *existing_validity_buffer_size_ptr =
-                  curr_validity_size + validitylen_size;
           } else {
             // Accumulate total bytes copied (caller's responsibility to
             // eventually update the query).
@@ -1438,6 +1435,11 @@ Status query_from_capnp(
             // Set whether the extra offset was included or not
             attr_copy_state->last_query_added_extra_offset =
                 query_reader.getVarOffsetsAddExtraElement();
+          }
+
+          if (nullable && existing_validity_buffer_size_ptr) {
+            *existing_validity_buffer_size_ptr =
+                curr_validity_size + validitylen_size;
           }
         } else {
           // Fixed size attribute; buffers already set.


### PR DESCRIPTION
The bug can be reproduced by querying a variable size nullable attribute on a tiledb array (e.g. `gene_name` in `tiledb://TileDB-Inc/ensembl-grch38-v104`)

Results I get running @ihnorton's code on the array above, `gene_name` attribute, ranges `A-Z`, `a-z`:
```
query status: INCOMPLETE
name: gene_name first: 897110 second: 4719726 third: 897110
```

The query deserialization code ends up not writing to the `existing_validity_buffer_size_ptr` pointer, thus the validity buffer size returned by `result_buffer_elements_nullable` ended up always being equal to the size of the initial vector passed by the user.

It's very difficult to follow the logic in `query_from_capnp` and find a fix for this bug that can be logically explained. By intuition, it seems to me like there would be no reason not to write into  `existing_validity_buffer_size_ptr` independent on whether `attr_copy_state` is nullptr or not.

To help the reviewer:
- The execution for @ihnorton 's test case in https://app.shortcut.com/tiledb-inc/story/16221/incorrect-validity-result-count-after-rest-query enters the `else` branch in `serialization/query.cc:1424`
- debugger dump of some vars:
    - `attr_copy_state` != nullptr
    - `nullable` == true
    - `type` == `QueryType::Read`
    - `context` == `SerializationContext::CLIENT`
    -  `var_size` == true
  
---
TYPE: BUG
DESC: Incorrect validity result count in REST query
