### PR TITLE
Sparse readers: using zipped coords buffers for fragment version < 5.

### DIFF
--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -1002,7 +1002,9 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
 
         // Get source buffers.
         const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
-        const auto tile_tuple = rt->tile_tuple(name);
+        const auto tile_tuple = stores_zipped_coords ?
+                                    rt->tile_tuple(constants::coords) :
+                                    rt->tile_tuple(name);
         const auto t = &std::get<0>(*tile_tuple);
         const auto src_buff = t->data_as<uint8_t>();
         const auto t_val = &std::get<2>(*tile_tuple);

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -807,7 +807,9 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
     uint8_t* val_buffer) {
   // Get source buffers.
   const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
-  const auto tile_tuple = rt->tile_tuple(name);
+  const auto tile_tuple = stores_zipped_coords ?
+                              rt->tile_tuple(constants::coords) :
+                              rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
   const auto src_buff = t->data_as<uint8_t>();
 
@@ -860,7 +862,9 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
     uint8_t* val_buffer) {
   // Get source buffers.
   const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
-  const auto tile_tuple = rt->tile_tuple(name);
+  const auto tile_tuple = stores_zipped_coords ?
+                              rt->tile_tuple(constants::coords) :
+                              rt->tile_tuple(name);
   const auto t = &std::get<0>(*tile_tuple);
   const auto src_buff = t->data_as<uint8_t>();
   const auto t_val = &std::get<2>(*tile_tuple);


### PR DESCRIPTION
When a fragment's version is smaller than 5, use the zipped coords
buffer to copy coordinates.

---
TYPE: IMPROVEMENT
DESC: Sparse readers: using zipped coords buffers for fragment version < 5.
