### PR TITLE
[Backport release-2.8] Backport 3002 to release 2.8

### DIFF
--- a/scripts/install-gcs-emu.sh
+++ b/scripts/install-gcs-emu.sh
@@ -44,6 +44,7 @@ install_gcs(){
     sed 's/git+git:/git+https:/' /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt > /tmp/tdbpatchedrequirements.txt
     echo 'itsdangerous==2.0.1' >> /tmp/tdbpatchedrequirements.txt
     echo 'jinja2<3.1 # pinned due to incompatibility with gcs emulator 1.23' >> /tmp/tdbpatchedrequirements.txt
+    echo 'werkzeug<2.1 # pinned due to incompatibility with gcs emulator 1.23' >> /tmp/tdbpatchedrequirements.txt
     cp -f /tmp/tdbpatchedrequirements.txt /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt
     pip3 install -r /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt
 }

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -58,6 +58,18 @@
 
 using namespace tiledb::test;
 
+struct TestRange {
+  TestRange(uint64_t i, uint64_t min, uint64_t max)
+      : i_(i)
+      , min_(min)
+      , max_(max) {
+  }
+
+  uint64_t i_;
+  uint64_t min_;
+  uint64_t max_;
+};
+
 struct DenseArrayFx {
   // Constant parameters
   const char* ATTR_NAME = "a";
@@ -102,10 +114,12 @@ struct DenseArrayFx {
   void create_dense_array(const std::string& array_name);
   void create_dense_array_1_attribute(const std::string& array_name);
   void create_dense_array_same_tile(const std::string& array_name);
+  void create_large_dense_array_1_attribute(const std::string& array_name);
   void write_dense_vector_mixed(const std::string& array_name);
   void write_dense_array(const std::string& array_name);
   void write_dense_array_missing_attributes(const std::string& array_name);
   void write_partial_dense_array(const std::string& array_name);
+  void write_large_dense_array(const std::string& array_name);
   void read_dense_vector_mixed(const std::string& array_name);
   void read_dense_array_with_coords_full_global(
       const std::string& array_name, bool split_coords);
@@ -119,6 +133,11 @@ struct DenseArrayFx {
       const std::string& array_name, bool split_coords);
   void read_dense_array_with_coords_subarray_col(
       const std::string& array_name, bool split_coords);
+  void read_large_dense_array(
+      const std::string& array_name,
+      const tiledb_layout_t layout,
+      std::vector<TestRange>& ranges,
+      std::vector<uint64_t>& a1);
   void set_small_memory_budget();
   static std::string random_name(const std::string& prefix);
 
@@ -1555,6 +1574,63 @@ void DenseArrayFx::create_dense_array_same_tile(const std::string& array_name) {
   tiledb_array_schema_free(&array_schema);
 }
 
+void DenseArrayFx::create_large_dense_array_1_attribute(
+    const std::string& array_name) {
+  // Create dimensions
+  uint64_t dim_domain[] = {1, 20, 1, 15};
+  uint64_t tile_extents[] = {4, 3};
+  tiledb_dimension_t* d1;
+  int rc = tiledb_dimension_alloc(
+      ctx_, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0], &d1);
+  CHECK(rc == TILEDB_OK);
+  tiledb_dimension_t* d2;
+  rc = tiledb_dimension_alloc(
+      ctx_, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1], &d2);
+  CHECK(rc == TILEDB_OK);
+
+  // Create domain
+  tiledb_domain_t* domain;
+  rc = tiledb_domain_alloc(ctx_, &domain);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, d1);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, d2);
+  CHECK(rc == TILEDB_OK);
+
+  // Create attributes
+  tiledb_attribute_t* a1;
+  rc = tiledb_attribute_alloc(ctx_, "a1", TILEDB_UINT64, &a1);
+  CHECK(rc == TILEDB_OK);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  rc = tiledb_array_schema_alloc(ctx_, TILEDB_DENSE, &array_schema);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_tile_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_domain(ctx_, array_schema, domain);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_schema_add_attribute(ctx_, array_schema, a1);
+  CHECK(rc == TILEDB_OK);
+
+  // Check array schema
+  rc = tiledb_array_schema_check(ctx_, array_schema);
+  CHECK(rc == TILEDB_OK);
+
+  // Create array
+  rc = tiledb_array_create(ctx_, array_name.c_str(), array_schema);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_attribute_free(&a1);
+  tiledb_dimension_free(&d1);
+  tiledb_dimension_free(&d2);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
+}
+
 void DenseArrayFx::check_return_coords(
     const std::string& path, bool split_coords) {
   std::string array_name = path + "return_coords";
@@ -1767,6 +1843,68 @@ void DenseArrayFx::write_partial_dense_array(const std::string& array_name) {
   CHECK(rc == TILEDB_OK);
   uint64_t subarray[] = {3, 4, 3, 4};
   rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query
+  rc = submit_query_wrapper(array_name, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Finalize query
+  rc = tiledb_query_finalize(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+void DenseArrayFx::write_large_dense_array(const std::string& array_name) {
+  // Prepare cell buffers
+  // clang-format off
+  uint64_t buffer_a1[] = {
+     101,  102,  103,  104,  105,  106,  107,  108,  109,  110,  111,  112,  113,  114,  115,
+     201,  202,  203,  204,  205,  206,  207,  208,  209,  210,  211,  212,  213,  214,  215,
+     301,  302,  303,  304,  305,  306,  307,  308,  309,  310,  311,  312,  313,  314,  315,
+     401,  402,  403,  404,  405,  406,  407,  408,  409,  410,  411,  412,  413,  414,  415,
+     501,  502,  503,  504,  505,  506,  507,  508,  509,  510,  511,  512,  513,  514,  515,
+     601,  602,  603,  604,  605,  606,  607,  608,  609,  610,  611,  612,  613,  614,  615,
+     701,  702,  703,  704,  705,  706,  707,  708,  709,  710,  711,  712,  713,  714,  715,
+     801,  802,  803,  804,  805,  806,  807,  808,  809,  810,  811,  812,  813,  814,  815,
+     901,  902,  903,  904,  905,  906,  907,  908,  909,  910,  911,  912,  913,  914,  915,
+    1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015,
+    1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113, 1114, 1115,
+    1201, 1202, 1203, 1204, 1205, 1206, 1207, 1208, 1209, 1210, 1211, 1212, 1213, 1214, 1215,
+    1301, 1302, 1303, 1304, 1305, 1306, 1307, 1308, 1309, 1310, 1311, 1312, 1313, 1314, 1315,
+    1401, 1402, 1403, 1404, 1405, 1406, 1407, 1408, 1409, 1410, 1411, 1412, 1413, 1414, 1415,
+    1501, 1502, 1503, 1504, 1505, 1506, 1507, 1508, 1509, 1510, 1511, 1512, 1513, 1514, 1515,
+    1601, 1602, 1603, 1604, 1605, 1606, 1607, 1608, 1609, 1610, 1611, 1612, 1613, 1614, 1615,
+    1701, 1702, 1703, 1704, 1705, 1706, 1707, 1708, 1709, 1710, 1711, 1712, 1713, 1714, 1715,
+    1801, 1802, 1803, 1804, 1805, 1806, 1807, 1808, 1809, 1810, 1811, 1812, 1813, 1814, 1815,
+    1901, 1902, 1903, 1904, 1905, 1906, 1907, 1908, 1909, 1910, 1911, 1912, 1913, 1914, 1915,
+    2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015,
+  };
+
+  uint64_t buffer_size = sizeof(buffer_a1);
+  // clang-format on
+
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a1", buffer_a1, &buffer_size);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -2728,6 +2866,57 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_col(
   free(buffer_coords_dim2);
   free(buffer_d1);
   free(buffer_d2);
+}
+
+void DenseArrayFx::read_large_dense_array(
+    const std::string& array_name,
+    const tiledb_layout_t layout,
+    std::vector<TestRange>& ranges,
+    std::vector<uint64_t>& a1) {
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx_, query, layout);
+  CHECK(rc == TILEDB_OK);
+
+  for (auto& range : ranges) {
+    rc = tiledb_query_add_range(
+        ctx_, query, range.i_, &range.min_, &range.max_, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+  }
+
+  uint64_t buffer_a1_size = a1.size() * sizeof(uint64_t);
+  rc = tiledb_query_set_data_buffer(
+      ctx_, query, "a1", a1.data(), &buffer_a1_size);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query
+  rc = submit_query_wrapper(array_name, query);
+  CHECK(rc == TILEDB_OK);
+
+  tiledb_query_status_t status;
+  rc = tiledb_query_get_status(ctx_, query, &status);
+  CHECK(status == TILEDB_COMPLETED);
+
+  // Finalize query
+  rc = tiledb_query_finalize(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
 }
 
 void DenseArrayFx::check_non_empty_domain(const std::string& path) {
@@ -4760,6 +4949,251 @@ TEST_CASE_METHOD(
 
   CHECK(!memcmp(c_a1, read_a1, sizeof(c_a1)));
   CHECK(!memcmp(c_a1, read_a2, sizeof(c_a1)));
+
+  remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    DenseArrayFx,
+    "C API: Test dense array, simple multi-index",
+    "[capi][dense][multi-index][simple]") {
+  SECTION("- No serialization") {
+    serialize_query_ = false;
+  }
+  SECTION("- Serialization") {
+    serialize_query_ = true;
+  }
+
+  SupportedFsLocal local_fs;
+  std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
+  std::string array_name = temp_dir + "dense_read_large";
+  create_temp_dir(temp_dir);
+
+  create_large_dense_array_1_attribute(array_name);
+
+  write_large_dense_array(array_name);
+
+  std::vector<TestRange> ranges;
+  ranges.emplace_back(0, 2, 4);
+  ranges.emplace_back(0, 17, 19);
+  ranges.emplace_back(1, 2, 2);
+  ranges.emplace_back(1, 14, 14);
+
+  tiledb_layout_t layout = GENERATE(TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+
+  std::vector<uint64_t> a1(12);
+  read_large_dense_array(array_name, layout, ranges, a1);
+
+  // clang-format off
+  uint64_t c_a1_cm[] = {
+    202, 302, 402,
+    1702, 1802, 1902,
+    214, 314, 414,
+    1714, 1814, 1914
+  };
+
+  uint64_t c_a1_rm[] = {
+    202, 214,
+    302, 314,
+    402, 414,
+    1702, 1714,
+    1802, 1814,
+    1902, 1914
+  };
+  // clang-format on
+  if (layout == TILEDB_ROW_MAJOR) {
+    CHECK(!memcmp(c_a1_rm, a1.data(), sizeof(c_a1_rm)));
+  } else {
+    CHECK(!memcmp(c_a1_cm, a1.data(), sizeof(c_a1_cm)));
+  }
+
+  remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    DenseArrayFx,
+    "C API: Test dense array, complex multi-index",
+    "[capi][dense][multi-index][complex]") {
+  SECTION("- No serialization") {
+    serialize_query_ = false;
+  }
+  SECTION("- Serialization") {
+    serialize_query_ = true;
+  }
+
+  SupportedFsLocal local_fs;
+  std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
+  std::string array_name = temp_dir + "dense_read_large";
+  create_temp_dir(temp_dir);
+
+  create_large_dense_array_1_attribute(array_name);
+
+  write_large_dense_array(array_name);
+
+  std::vector<TestRange> ranges;
+  ranges.emplace_back(0, 2, 4);
+  ranges.emplace_back(0, 7, 9);
+  ranges.emplace_back(0, 12, 14);
+  ranges.emplace_back(0, 17, 19);
+  ranges.emplace_back(1, 2, 2);
+  ranges.emplace_back(1, 5, 5);
+  ranges.emplace_back(1, 8, 8);
+  ranges.emplace_back(1, 11, 11);
+  ranges.emplace_back(1, 14, 14);
+
+  tiledb_layout_t layout = GENERATE(TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+
+  std::vector<uint64_t> a1(60);
+  read_large_dense_array(array_name, layout, ranges, a1);
+
+  // clang-format off
+  uint64_t c_a1_cm[] = {
+    202, 302, 402, 702, 802, 902,
+    1202, 1302, 1402, 1702, 1802, 1902,
+    205, 305, 405, 705, 805, 905,
+    1205, 1305, 1405, 1705, 1805, 1905,
+    208, 308, 408, 708, 808, 908,
+    1208, 1308, 1408, 1708, 1808, 1908,
+    211, 311, 411, 711, 811, 911,
+    1211, 1311, 1411, 1711, 1811, 1911,
+    214, 314, 414, 714, 814, 914,
+    1214, 1314, 1414, 1714, 1814, 1914
+  };
+
+  uint64_t c_a1_rm[] = {
+    202, 205, 208, 211, 214,
+    302, 305, 308, 311, 314,
+    402, 405, 408, 411, 414,
+    702, 705, 708, 711, 714,
+    802, 805, 808, 811, 814,
+    902, 905, 908, 911, 914,
+    1202, 1205, 1208, 1211, 1214,
+    1302, 1305, 1308, 1311, 1314,
+    1402, 1405, 1408, 1411, 1414,
+    1702, 1705, 1708, 1711, 1714,
+    1802, 1805, 1808, 1811, 1814,
+    1902, 1905, 1908, 1911, 1914
+  };
+  // clang-format on
+  if (layout == TILEDB_ROW_MAJOR) {
+    CHECK(!memcmp(c_a1_rm, a1.data(), sizeof(c_a1_rm)));
+  } else {
+    CHECK(!memcmp(c_a1_cm, a1.data(), sizeof(c_a1_cm)));
+  }
+
+  remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    DenseArrayFx,
+    "C API: Test dense array, multi-index, cross tile boundary",
+    "[capi][dense][multi-index][cross-tile-boundary]") {
+  SECTION("- No serialization") {
+    serialize_query_ = false;
+  }
+  SECTION("- Serialization") {
+    serialize_query_ = true;
+  }
+
+  SupportedFsLocal local_fs;
+  std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
+  std::string array_name = temp_dir + "dense_read_large";
+  create_temp_dir(temp_dir);
+
+  create_large_dense_array_1_attribute(array_name);
+
+  write_large_dense_array(array_name);
+
+  std::vector<TestRange> ranges;
+  ranges.emplace_back(0, 5, 6);
+  ranges.emplace_back(0, 10, 16);
+  ranges.emplace_back(1, 3, 4);
+
+  tiledb_layout_t layout = GENERATE(TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+
+  std::vector<uint64_t> a1(18);
+  read_large_dense_array(array_name, layout, ranges, a1);
+
+  // clang-format off
+  uint64_t c_a1_cm[] = {
+    503, 603, 1003, 1103, 1203, 1303, 1403, 1503, 1603,
+    504, 604, 1004, 1104, 1204, 1304, 1404, 1504, 1604
+  };
+
+  uint64_t c_a1_rm[] = {
+    503, 504,
+    603, 604,
+    1003, 1004,
+    1103, 1104,
+    1203, 1204,
+    1303, 1304,
+    1403, 1404,
+    1503, 1504,
+    1603, 1604
+  };
+  // clang-format on
+  if (layout == TILEDB_ROW_MAJOR) {
+    CHECK(!memcmp(c_a1_rm, a1.data(), sizeof(c_a1_rm)));
+  } else {
+    CHECK(!memcmp(c_a1_cm, a1.data(), sizeof(c_a1_cm)));
+  }
+
+  remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    DenseArrayFx,
+    "C API: Test dense array, multi-index, out of order ranges",
+    "[capi][dense][multi-index][out-of-order-ranges]") {
+  SECTION("- No serialization") {
+    serialize_query_ = false;
+  }
+  SECTION("- Serialization") {
+    serialize_query_ = true;
+  }
+
+  SupportedFsLocal local_fs;
+  std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
+  std::string array_name = temp_dir + "dense_read_large";
+  create_temp_dir(temp_dir);
+
+  create_large_dense_array_1_attribute(array_name);
+
+  write_large_dense_array(array_name);
+
+  std::vector<TestRange> ranges;
+  ranges.emplace_back(0, 10, 16);
+  ranges.emplace_back(0, 5, 6);
+  ranges.emplace_back(1, 3, 4);
+
+  tiledb_layout_t layout = GENERATE(TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR);
+
+  std::vector<uint64_t> a1(18);
+  read_large_dense_array(array_name, layout, ranges, a1);
+
+  // clang-format off
+  uint64_t c_a1_cm[] = {
+    503, 603, 1003, 1103, 1203, 1303, 1403, 1503, 1603,
+    504, 604, 1004, 1104, 1204, 1304, 1404, 1504, 1604
+  };
+
+  uint64_t c_a1_rm[] = {
+    503, 504,
+    603, 604,
+    1003, 1004,
+    1103, 1104,
+    1203, 1204,
+    1303, 1304,
+    1403, 1404,
+    1503, 1504,
+    1603, 1604
+  };
+  // clang-format on
+  if (layout == TILEDB_ROW_MAJOR) {
+    CHECK(!memcmp(c_a1_rm, a1.data(), sizeof(c_a1_rm)));
+  } else {
+    CHECK(!memcmp(c_a1_cm, a1.data(), sizeof(c_a1_cm)));
+  }
 
   remove_temp_dir(temp_dir);
 }

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -241,6 +241,7 @@ Status DenseReader::dense_read() {
   assert(std::is_integral<DimType>::value);
 
   // For easy reference.
+  const auto dim_num = array_schema_.dim_num();
   auto& subarray = read_state_.partitioner_.current();
   RETURN_NOT_OK(subarray.compute_tile_coords<DimType>());
 
@@ -274,9 +275,9 @@ Status DenseReader::dense_read() {
       });
   RETURN_NOT_OK(status);
 
-  // Compute tile offsets for global order and range offsets for row/col major.
+  // Compute tile offsets for global order or range info for row/col major.
   std::vector<uint64_t> tile_offsets;
-  std::vector<uint64_t> range_offsets;
+  std::vector<RangeInfo> range_info(dim_num);
 
   if (layout_ == Layout::GLOBAL_ORDER) {
     tile_offsets.reserve(tile_coords.size());
@@ -287,12 +288,38 @@ Status DenseReader::dense_read() {
       tile_offset += tile_subarray.cell_num();
     }
   } else {
-    range_offsets.reserve(subarray.range_num());
+    for (uint32_t d = 0; d < dim_num; d++) {
+      auto& ranges = subarray.ranges_for_dim(d);
 
-    uint64_t range_offset = 0;
-    for (uint64_t r = 0; r < subarray.range_num(); r++) {
-      range_offsets.emplace_back(range_offset);
-      range_offset += subarray.cell_num(r);
+      // Compute the 1D offset for every range in this dimension.
+      range_info[d].cell_offsets_.reserve(ranges.size());
+      uint64_t offset = 0;
+      for (uint64_t r = 0; r < ranges.size(); r++) {
+        range_info[d].cell_offsets_.emplace_back(offset);
+
+        // Increment the offset with the number of cells in this 1D range.
+        auto range = static_cast<const DimType*>(ranges[r].data());
+        offset += range[1] - range[0] + 1;
+      }
+
+      // Sets the initial multiplier, will be adjusted in the next step.
+      range_info[d].multiplier_ = offset;
+    }
+  }
+
+  // Compute the correct multipliers.
+  uint64_t mult = 1;
+  if (subarray.layout() == Layout::COL_MAJOR) {
+    for (int32_t d = 0; d < static_cast<int32_t>(dim_num); d++) {
+      auto saved = mult;
+      mult *= range_info[d].multiplier_;
+      range_info[d].multiplier_ = saved;
+    }
+  } else {
+    for (int32_t d = static_cast<int32_t>(dim_num) - 1; d >= 0; d--) {
+      auto saved = mult;
+      mult *= range_info[d].multiplier_;
+      range_info[d].multiplier_ = saved;
     }
   }
 
@@ -337,11 +364,7 @@ Status DenseReader::dense_read() {
 
   // Compute the result of the query condition.
   auto&& [st, qc_result] = apply_query_condition<DimType, OffType>(
-      subarray,
-      tile_subarrays,
-      tile_offsets,
-      range_offsets,
-      result_space_tiles);
+      subarray, tile_subarrays, tile_offsets, range_info, result_space_tiles);
   RETURN_CANCEL_OR_ERROR(st);
 
   // Copy attribute data to users buffers.
@@ -351,7 +374,7 @@ Status DenseReader::dense_read() {
       subarray,
       tile_subarrays,
       tile_offsets,
-      range_offsets,
+      range_info,
       result_space_tiles,
       *qc_result);
   RETURN_CANCEL_OR_ERROR(status);
@@ -379,6 +402,9 @@ Status DenseReader::init_read_state() {
                            "state; Multi-range "
                            "subarrays do not "
                            "support global order"));
+
+  // Make sure ranges are sorted.
+  RETURN_NOT_OK(subarray_.sort_ranges(storage_manager_->compute_tp()));
 
   // Get config values.
   bool found = false;
@@ -474,7 +500,7 @@ DenseReader::apply_query_condition(
     Subarray& subarray,
     std::vector<Subarray>& tile_subarrays,
     std::vector<uint64_t>& tile_offsets,
-    const std::vector<uint64_t>& range_offsets,
+    const std::vector<RangeInfo>& range_info,
     std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles) {
   std::vector<uint8_t> qc_result;
   if (!condition_.clauses().empty()) {
@@ -520,7 +546,7 @@ DenseReader::apply_query_condition(
                   tile_subarrays[t],
                   cell_slab.coords_.data(),
                   iter.range_coords(),
-                  range_offsets);
+                  range_info);
               dest_ptr = qc_result.data() + cell_offset;
             }
 
@@ -614,7 +640,7 @@ Status DenseReader::read_attributes(
     const Subarray& subarray,
     const std::vector<Subarray>& tile_subarrays,
     const std::vector<uint64_t>& tile_offsets,
-    const std::vector<uint64_t>& range_offsets,
+    const std::vector<RangeInfo>& range_info,
     std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
     const std::vector<uint8_t>& qc_result) {
   // For easy reference
@@ -679,7 +705,7 @@ Status DenseReader::read_attributes(
               tile_subarrays[t],
               global_order ? tile_offsets[t] : 0,
               var_data,
-              range_offsets,
+              range_info,
               qc_result);
         });
     RETURN_NOT_OK(status);
@@ -726,7 +752,7 @@ Status DenseReader::read_attributes(
               tile_subarrays[t],
               global_order ? tile_offsets[t] : 0,
               var_data,
-              range_offsets,
+              range_info,
               t == tile_coords.size() - 1,
               var_buffer_sizes);
 
@@ -781,7 +807,7 @@ Status DenseReader::read_attributes(
               subarray,
               tile_subarrays[t],
               global_order ? tile_offsets[t] : 0,
-              range_offsets,
+              range_info,
               qc_result));
 
           return Status::Ok();
@@ -841,7 +867,7 @@ tuple<bool, uint64_t, uint64_t> DenseReader::cell_slab_overlaps_range(
 
   // Check if there is any overlap.
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dom = (const DimType*)ndrange[d].data();
+    auto dom = static_cast<const DimType*>(ndrange[d].data());
     if (d == slab_dim) {
       if (slab_end < dom[0] || slab_start > dom[1]) {
         return {false, 0, 0};
@@ -852,7 +878,7 @@ tuple<bool, uint64_t, uint64_t> DenseReader::cell_slab_overlaps_range(
   }
 
   // Compute the normalized start and end coordinates for the slab.
-  auto dom = (const DimType*)ndrange[slab_dim].data();
+  auto dom = static_cast<const DimType*>(ndrange[slab_dim].data());
   auto start = std::max(slab_start, dom[0]) - slab_start;
   auto end = std::min(slab_end, dom[1]) - slab_start;
   return {true, start, end};
@@ -865,39 +891,33 @@ uint64_t DenseReader::get_dest_cell_offset_row_col(
     const Subarray& tile_subarray,
     const DimType* const coords,
     const DimType* const range_coords,
-    const std::vector<uint64_t>& range_offsets) {
+    const std::vector<RangeInfo>& range_info) {
   uint64_t ret = 0;
-  uint64_t mult = 1;
-
-  uint64_t r = 0;
   std::vector<uint64_t> converted_range_coords(dim_num);
   if (subarray.range_num() > 1) {
     tile_subarray.get_original_range_coords(
         range_coords, &converted_range_coords);
-    r = subarray.range_idx(converted_range_coords);
   }
 
   if (subarray.layout() == Layout::COL_MAJOR) {
     for (int32_t d = 0; d < dim_num; d++) {
-      auto subarray_dom =
-          (DimType*)subarray
-              .ranges_for_dim((uint32_t)d)[converted_range_coords[d]]
-              .data();
-      ret += mult * (coords[d] - subarray_dom[0]);
-      mult *= subarray_dom[1] - subarray_dom[0] + 1;
+      auto r = converted_range_coords[d];
+      auto min = *static_cast<const DimType*>(
+          subarray.ranges_for_dim((uint32_t)d)[r].start());
+      ret += range_info[d].multiplier_ *
+             (coords[d] - min + range_info[d].cell_offsets_[r]);
     }
   } else {
     for (int32_t d = dim_num - 1; d >= 0; d--) {
-      auto subarray_dom =
-          (DimType*)subarray
-              .ranges_for_dim((uint32_t)d)[converted_range_coords[d]]
-              .data();
-      ret += mult * (coords[d] - subarray_dom[0]);
-      mult *= subarray_dom[1] - subarray_dom[0] + 1;
+      auto r = converted_range_coords[d];
+      auto min = *static_cast<const DimType*>(
+          subarray.ranges_for_dim((uint32_t)d)[r].start());
+      ret += range_info[d].multiplier_ *
+             (coords[d] - min + range_info[d].cell_offsets_[r]);
     }
   }
 
-  return ret + range_offsets[r];
+  return ret;
 }
 
 template <class DimType>
@@ -911,7 +931,7 @@ Status DenseReader::copy_fixed_tiles(
     const Subarray& subarray,
     const Subarray& tile_subarray,
     const uint64_t global_cell_offset,
-    const std::vector<uint64_t>& range_offsets,
+    const std::vector<RangeInfo>& range_info,
     const std::vector<uint8_t>& qc_result) {
   // For easy reference
   const auto dim_num = array_schema_.dim_num();
@@ -941,7 +961,7 @@ Status DenseReader::copy_fixed_tiles(
           tile_subarray,
           cell_slab.coords_.data(),
           iter.range_coords(),
-          range_offsets);
+          range_info);
     }
 
     // Get the source cell offset.
@@ -1113,7 +1133,7 @@ Status DenseReader::copy_offset_tiles(
     const Subarray& tile_subarray,
     const uint64_t global_cell_offset,
     std::vector<std::vector<void*>>& var_data,
-    const std::vector<uint64_t>& range_offsets,
+    const std::vector<RangeInfo>& range_info,
     const std::vector<uint8_t>& qc_result) {
   // For easy reference
   const auto domain = array_schema_.domain();
@@ -1144,7 +1164,7 @@ Status DenseReader::copy_offset_tiles(
           tile_subarray,
           cell_slab.coords_.data(),
           iter.range_coords(),
-          range_offsets);
+          range_info);
     }
 
     // Get the source cell offset.
@@ -1300,7 +1320,7 @@ Status DenseReader::copy_var_tiles(
     const Subarray& tile_subarray,
     const uint64_t global_cell_offset,
     std::vector<std::vector<void*>>& var_data,
-    const std::vector<uint64_t>& range_offsets,
+    const std::vector<RangeInfo>& range_info,
     bool last_tile,
     std::vector<uint64_t>& var_buffer_sizes) {
   // For easy reference
@@ -1324,7 +1344,7 @@ Status DenseReader::copy_var_tiles(
           tile_subarray,
           cell_slab.coords_.data(),
           iter.range_coords(),
-          range_offsets);
+          range_info);
     }
 
     for (uint64_t n = 0; n < names.size(); n++) {

--- a/tiledb/sm/query/dense_reader.h
+++ b/tiledb/sm/query/dense_reader.h
@@ -55,6 +55,19 @@ class StorageManager;
 class DenseReader : public ReaderBase, public IQueryStrategy {
  public:
   /* ********************************* */
+  /*          TYPE DEFINITIONS         */
+  /* ********************************* */
+
+  /** Range information, for a dimension, used for row/col reads. */
+  struct RangeInfo {
+    /** Cell offset, per range for this dimension. */
+    std::vector<uint64_t> cell_offsets_;
+
+    /** Multiplier to be used in offset computation. */
+    uint64_t multiplier_;
+  };
+
+  /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
@@ -148,7 +161,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       Subarray& subarray,
       std::vector<Subarray>& tile_subarrays,
       std::vector<uint64_t>& tile_offsets,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles);
 
   /** Fix offsets buffer after reading all offsets. */
@@ -167,7 +180,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& subarray,
       const std::vector<Subarray>& tile_subarrays,
       const std::vector<uint64_t>& tile_offsets,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
       const std::vector<uint8_t>& qc_result);
 
@@ -199,7 +212,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& tile_subarray,
       const DimType* const coords,
       const DimType* const range_coords,
-      const std::vector<uint64_t>& range_offsets);
+      const std::vector<RangeInfo>& range_info);
 
   /** Copy fixed tiles to the output buffers. */
   template <class DimType>
@@ -213,7 +226,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& subarray,
       const Subarray& tile_subarray,
       const uint64_t global_cell_offset,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       const std::vector<uint8_t>& qc_result);
 
   /** Copy a tile var offsets to the output buffers. */
@@ -229,7 +242,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& tile_subarray,
       const uint64_t global_cell_offset,
       std::vector<std::vector<void*>>& var_data,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       const std::vector<uint8_t>& qc_result);
 
   /** Copy a var tile to the output buffers. */
@@ -243,7 +256,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const Subarray& tile_subarray,
       const uint64_t global_cell_offset,
       std::vector<std::vector<void*>>& var_data,
-      const std::vector<uint64_t>& range_offsets,
+      const std::vector<RangeInfo>& range_info,
       bool last_tile,
       std::vector<uint64_t>& var_buffer_sizes);
 


### PR DESCRIPTION
---
TYPE: IMPROVEMENT
DESC: Dense reader: fix user buffer offset computation for multi-index queries.

(cherry picked from commit https://github.com/TileDB-Inc/TileDB/commit/740c589c6d9df044b0197cd9fba08c061363231e)
