### PR TITLE
tiledb_group_dump_str should takes a uint_8

### DIFF
--- a/scripts/install-gcs-emu.sh
+++ b/scripts/install-gcs-emu.sh
@@ -44,6 +44,7 @@ install_gcs(){
     sed 's/git+git:/git+https:/' /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt > /tmp/tdbpatchedrequirements.txt
     echo 'itsdangerous==2.0.1' >> /tmp/tdbpatchedrequirements.txt
     echo 'jinja2<3.1 # pinned due to incompatibility with gcs emulator 1.23' >> /tmp/tdbpatchedrequirements.txt
+    echo 'werkzeug<2.1 # pinned due to incompatibility with gcs emulator 1.23' >> /tmp/tdbpatchedrequirements.txt
     cp -f /tmp/tdbpatchedrequirements.txt /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt
     pip3 install -r /tmp/google-cloud-cpp-1.23.0/google/cloud/storage/emulator/requirements.txt
 }

--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -591,7 +591,7 @@ TEST_CASE_METHOD(
   // Group is the latest element
   group1_expected.resize(group1_expected.size() - 1);
 
-  rc = tiledb_group_remove_member(ctx_, group2, array3_uri.c_str());
+  rc = tiledb_group_remove_member(ctx_, group2, array3_relative_uri.c_str());
   REQUIRE(rc == TILEDB_OK);
   // There should be nothing left in group2
   group2_expected.clear();

--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -480,7 +480,7 @@ TEST_CASE_METHOD(
   // Group is the latest element
   group1_expected.resize(group1_expected.size() - 1);
 
-  group2.remove_member(array3_uri.to_string());
+  group2.remove_member(array3_relative_uri);
   // There should be nothing left in group2
   group2_expected.clear();
 

--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -383,6 +383,11 @@ TEST_CASE_METHOD(
   REQUIRE_THAT(
       group2_received, Catch::Matchers::UnorderedEquals(group2_expected));
 
+  // Check that out of bounds indexing throws
+  REQUIRE_THROWS(group1.member(10));
+  // Checks for off by one indexing
+  REQUIRE_THROWS(group1.member(group1_expected.size()));
+
   // Close group
   group1.close();
   group2.close();

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -757,7 +757,10 @@ TILEDB_EXPORT int32_t tiledb_group_get_query_type(
  * @return  `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int32_t tiledb_group_dump_str(
-    tiledb_ctx_t* ctx, tiledb_group_t* group, char** dump_ascii, int recursive);
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    char** dump_ascii,
+    uint8_t recursive);
 
 #ifdef __cplusplus
 }

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -489,7 +489,7 @@ int32_t tiledb_group_dump_str(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     char** dump_ascii,
-    const int recursive) {
+    const uint8_t recursive) {
   if (sanity_check(ctx) == TILEDB_ERR)
     return TILEDB_ERR;
 

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -634,7 +634,7 @@ Group::member_by_index(uint64_t index) {
     ;
   }
 
-  if (index > members_vec_.size()) {
+  if (index >= members_vec_.size()) {
     return {
         Status_GroupError(
             "index " + std::to_string(index) + " is larger than member count " +

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -527,7 +527,21 @@ Status Group::mark_member_for_removal(const std::string& uri) {
         ", member already set for adding.");
   }
 
-  members_to_remove_.emplace(uri);
+  if (members_.find(uri) != members_.end()) {
+    members_to_remove_.emplace(uri);
+    return Status::Ok();
+  } else {
+    // try URI to see if we need to convert the local file to file://
+    URI uri_uri(uri);
+    if (members_.find(uri_uri.to_string()) != members_.end()) {
+      members_to_remove_.emplace(uri_uri.to_string());
+      return Status::Ok();
+    } else {
+      return Status_GroupError(
+          "Cannot remove group member " + uri +
+          ", member does not exist in group.");
+    }
+  }
   return Status::Ok();
 }
 


### PR DESCRIPTION
This was merged as taking an `int` but it should be a `uint_8` to align with other bool parameters

Not adding a history as this is a fix on the rc for the main group release.

---
TYPE: NO_HISTORY
DESC: NO_HISTORY