### PR TITLE
Sparse unordered w/ dups reader: coord tiles management fix.

### DIFF
--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1378,10 +1378,11 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
 
         // Clear tiles from memory and adjust result_tiles.
         for (const auto& idx : *index_to_copy) {
-          const auto& name = names[idx];
-          if (condition_.field_names().count(name) == 0 &&
-              (!subarray_.is_set() || !is_dim)) {
-            clear_tiles(name, result_tiles, new_result_tiles_size);
+          const auto& name_to_clear = names[idx];
+          const auto is_dim_to_clear = array_schema_.is_dim(name_to_clear);
+          if (condition_.field_names().count(name_to_clear) == 0 &&
+              (!subarray_.is_set() || !is_dim_to_clear)) {
+            clear_tiles(name_to_clear, result_tiles, new_result_tiles_size);
           }
         }
         result_tiles.resize(new_result_tiles_size);


### PR DESCRIPTION
When clearing tiles during a var size overflow, we should only clear
attribute tiles as coord tiles are counted in another memory budget and
cleaned up later. There was a small logic bug where is_dim was used to
determine if we were dealing with a dimension or not, but this variable
was for the attribute currently being copied, and not the attribute
considered for cleanup.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups reader: coord tiles management fix.
