### PR TITLE
Only check non-tiledb/object store URIs for directory existing in ObjectType

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1722,7 +1722,7 @@ Status StorageManager::object_type(const URI& uri, ObjectType* type) const {
     auto uri_str = uri.to_string();
     dir_uri =
         URI(utils::parse::ends_with(uri_str, "/") ? uri_str : (uri_str + "/"));
-  } else {
+  } else if (!uri.is_tiledb()) {
     // For non public cloud backends, listing a non-directory is an error.
     bool is_dir = false;
     RETURN_NOT_OK(vfs_->is_dir(uri, &is_dir));


### PR DESCRIPTION
Only check non-tiledb/object store URIs for directory existing in `StorageManager::ObjectType`

---
TYPE: BUG
DESC: Only check non-tiledb/object store URIs for directory existing in `StorageManager::ObjectType`
