### PR TITLE
Add missing config settings in doxygen comment for groups

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1131,6 +1131,13 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    **Default**: 0.1
  *    The maximum byte size to read-ahead from the backend. <br>
  *    **Default**: 102400
+ * - `sm.group.timestamp_start` <br>
+ *    The start timestamp used for opening the group. <br>
+ *    **Default**: 0
+ * - `sm.group.timestamp_end` <br>
+ *    The end timestamp used for opening the group. <br>
+ *    Also used for the write timestamp if set. <br>
+ *    **Default**: UINT64_MAX
  * -  `vfs.read_ahead_cache_size` <br>
  *    The the total maximum size of the read-ahead cache, which is an LRU. <br>
  *    **Default**: 10485760

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -439,6 +439,13 @@ class Config {
    *    **Default**: 0.1
    *    The maximum byte size to read-ahead from the backend. <br>
    *    **Default**: 102400
+   * - `sm.group.timestamp_start` <br>
+   *    The start timestamp used for opening the group. <br>
+   *    **Default**: 0
+   * - `sm.group.timestamp_end` <br>
+   *    The end timestamp used for opening the group. <br>
+   *    Also used for the write timestamp if set. <br>
+   *    **Default**: UINT64_MAX
    * -  `vfs.read_ahead_cache_size` <br>
    *    The the total maximum size of the read-ahead cache, which is an LRU.
    *    <br>


### PR DESCRIPTION
Add missing config settings in doxygen comment for groups

---
TYPE: NO_HISTORY
DESC: NO_HISTORY
