### PR TITLE
update doc for tiledb_array_schema_evolution_set_timestamp_range

### DIFF
--- a/tiledb/sm/array_schema/array_schema_evolution.cc
+++ b/tiledb/sm/array_schema/array_schema_evolution.cc
@@ -179,6 +179,12 @@ std::vector<std::string> ArraySchemaEvolution::attribute_names_to_drop() const {
 
 Status ArraySchemaEvolution::set_timestamp_range(
     const std::pair<uint64_t, uint64_t>& timestamp_range) {
+  if (timestamp_range.first != timestamp_range.second) {
+    throw std::runtime_error(std::string(
+        "Cannot set timestamp range; first element " +
+        std::to_string(timestamp_range.first) + " and second element " +
+        std::to_string(timestamp_range.second) + " are not equal!"));
+  }
   timestamp_range_ = timestamp_range;
   return Status::Ok();
 }

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -130,10 +130,9 @@ TILEDB_EXPORT int32_t tiledb_array_schema_evolution_drop_attribute(
 
 /**
  * Sets timestamp range in an array schema evolution
- * The evolved schema could have the same timestamp as previous schema.
- * This function can be used to set a different timestamp for the evolved
- * schema. The lo and hi values must be the same, otherwise it will throw a
- * runtime error.
+ * This function sets the output timestamp of the committed array schema after
+ * evolution. The lo and hi values are currently required to be the same or else
+ * an error is thrown.
  *
  * **Example:**
  *

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -130,9 +130,10 @@ TILEDB_EXPORT int32_t tiledb_array_schema_evolution_drop_attribute(
 
 /**
  * Sets timestamp range in an array schema evolution
- * The consecutive evolved schemas could have the same timestamps.
- * This function can be used to set different timestamps for consecutive
- * schemas.
+ * The evolved schema could have the same timestamp as previous schema.
+ * This function can be used to set a different timestamp for the evolved
+ * schema. The lo and hi values must be the same, otherwise it will throw a
+ * runtime error.
  *
  * **Example:**
  *
@@ -145,7 +146,8 @@ TILEDB_EXPORT int32_t tiledb_array_schema_evolution_drop_attribute(
  * @param ctx The TileDB context.
  * @param array_schema_evolution The schema evolution.
  * @param lo The lower bound of timestamp range.
- * @param hi The upper bound of timestamp range.
+ * @param hi The upper bound of timestamp range, it must euqal to the lower
+ * bound.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int32_t tiledb_array_schema_evolution_set_timestamp_range(

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -130,6 +130,9 @@ TILEDB_EXPORT int32_t tiledb_array_schema_evolution_drop_attribute(
 
 /**
  * Sets timestamp range in an array schema evolution
+ * The consecutive evolved schemas could have the same timestamps.
+ * This function can be used to set different timestamps for consecutive
+ * schemas.
  *
  * **Example:**
  *
@@ -141,7 +144,8 @@ TILEDB_EXPORT int32_t tiledb_array_schema_evolution_drop_attribute(
  *
  * @param ctx The TileDB context.
  * @param array_schema_evolution The schema evolution.
- * @param attribute_name The name of the attribute to be dropped.
+ * @param lo The lower bound of timestamp range.
+ * @param hi The upper bound of timestamp range.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int32_t tiledb_array_schema_evolution_set_timestamp_range(
@@ -154,6 +158,24 @@ TILEDB_EXPORT int32_t tiledb_array_schema_evolution_set_timestamp_range(
 /*          ARRAY SCHEMA             */
 /* ********************************* */
 
+/**
+ * Gets timestamp range in an array schema evolution
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint64_t timestamp_lo = 0;
+ * uint64_t timestamp_hi = 0;
+ * tiledb_array_schema_evolution_timestamp_range(ctx,
+ * array_schema_evolution, &timestamp_lo, &timestamp_hi);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array_schema_evolution The schema evolution.
+ * @param lo The lower bound of timestamp range.
+ * @param hi The upper bound of timestamp range.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
 TILEDB_EXPORT int32_t tiledb_array_schema_timestamp_range(
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,


### PR DESCRIPTION
This PR updated doc for  c-api functions tiledb_array_schema_evolution_set_timestamp_range and  tiledb_array_schema_evolution_timestamp_range. 

---
TYPE: IMPROVEMENT 
DESC: Add more detailed doc for schema evolution timestamp range functions.
