### PR TITLE
Consolidate query condition value and size into UntypedDatumView

### DIFF
--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -621,11 +621,10 @@ QueryCondition::apply_clause(
           result_cell_slabs);
       break;
     default:
-      return {
-          Status_QueryConditionError(
-              "Cannot perform query comparison; Unknown query "
-              "condition operator"),
-          nullopt};
+      return {Status_QueryConditionError(
+                  "Cannot perform query comparison; Unknown query "
+                  "condition operator"),
+              nullopt};
   }
 
   return {Status::Ok(), std::move(ret)};
@@ -782,12 +781,11 @@ QueryCondition::apply_clause(
     case Datatype::STRING_UCS2:
     case Datatype::STRING_UCS4:
     default:
-      return {
-          Status_QueryConditionError(
-              "Cannot perform query comparison; Unsupported query "
-              "conditional type on " +
-              clause.field_name_),
-          nullopt};
+      return {Status_QueryConditionError(
+                  "Cannot perform query comparison; Unsupported query "
+                  "conditional type on " +
+                  clause.field_name_),
+              nullopt};
   }
 
   return {Status::Ok(), nullopt};

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -489,8 +489,8 @@ std::vector<ResultCellSlab> QueryCondition::apply_clause(
         const auto& tile_offsets = std::get<0>(*tile_tuple);
         const uint64_t* buffer_offsets =
             static_cast<uint64_t*>(tile_offsets.data());
-        const size_t buffer_offsets_el =
-            static_cast<size_t>(tile_offsets.size() / constants::cell_var_offset_size);
+        const size_t buffer_offsets_el = static_cast<size_t>(
+            tile_offsets.size() / constants::cell_var_offset_size);
 
         // Iterate through each cell in this slab.
         while (c < length) {
@@ -839,8 +839,8 @@ void QueryCondition::apply_clause_dense(
     const auto& tile_offsets = std::get<0>(*tile_tuple);
     const uint64_t* buffer_offsets =
         static_cast<uint64_t*>(tile_offsets.data()) + src_cell;
-    const size_t buffer_offsets_el =
-        static_cast<size_t>(tile_offsets.size() / constants::cell_var_offset_size);
+    const size_t buffer_offsets_el = static_cast<size_t>(
+        tile_offsets.size() / constants::cell_var_offset_size);
 
     // Iterate through each cell in this slab.
     for (size_t c = 0; c < length; ++c) {
@@ -848,7 +848,8 @@ void QueryCondition::apply_clause_dense(
       // is string data requiring a strcmp which cannot be vectorized, this is
       // ok.
       if (result_buffer[start + c] != 0) {
-        const size_t buffer_offset = static_cast<size_t>(buffer_offsets[start + c * stride]);
+        const size_t buffer_offset =
+            static_cast<size_t>(buffer_offsets[start + c * stride]);
         const size_t next_cell_offset =
             (start + c * stride + 1 < buffer_offsets_el) ?
                 buffer_offsets[start + c * stride + 1] :
@@ -1413,7 +1414,7 @@ void QueryCondition::apply_clause_sparse(
         const size_t buffer_offset = static_cast<size_t>(buffer_offsets[c]);
         const size_t next_cell_offset =
             (c + 1 < buffer_offsets_el) ? buffer_offsets[c + 1] : buffer_size;
-        
+
         // In-memory data can be indexed with size_t
         const size_t cell_size = next_cell_offset - buffer_offset;
 

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -61,7 +61,7 @@ class QueryCondition {
     Clause(
         std::string&& field_name,
         const void* const condition_value,
-        const uint64_t condition_value_size,
+        const size_t condition_value_size,
         const QueryConditionOp op)
         : field_name_(std::move(field_name))
         , condition_value_data_(condition_value_size)
@@ -184,7 +184,7 @@ class QueryCondition {
   Status init(
       std::string&& field_name,
       const void* condition_value,
-      uint64_t condition_value_size,
+      size_t condition_value_size,
       QueryConditionOp op);
 
   /**
@@ -359,7 +359,7 @@ class QueryCondition {
   template <typename T, QueryConditionOp Op>
   std::vector<ResultCellSlab> apply_clause(
       const Clause& clause,
-      uint64_t stride,
+      size_t stride,
       const bool var_size,
       const bool nullable,
       const UntypedDatumView& fill_value,
@@ -379,7 +379,7 @@ class QueryCondition {
   template <typename T>
   tuple<Status, optional<std::vector<ResultCellSlab>>> apply_clause(
       const Clause& clause,
-      uint64_t stride,
+      size_t stride,
       const bool var_size,
       const bool nullable,
       const UntypedDatumView& fill_value,
@@ -398,7 +398,7 @@ class QueryCondition {
   tuple<Status, optional<std::vector<ResultCellSlab>>> apply_clause(
       const QueryCondition::Clause& clause,
       const ArraySchema& array_schema,
-      uint64_t stride,
+      size_t stride,
       const std::vector<ResultCellSlab>& result_cell_slabs) const;
 
   /**
@@ -418,10 +418,10 @@ class QueryCondition {
   void apply_clause_dense(
       const QueryCondition::Clause& clause,
       ResultTile* result_tile,
-      const uint64_t start,
-      const uint64_t length,
-      const uint64_t src_cell,
-      const uint64_t stride,
+      const size_t start,
+      const size_t length,
+      const size_t src_cell,
+      const size_t stride,
       const bool var_size,
       uint8_t* result_buffer) const;
 
@@ -442,10 +442,10 @@ class QueryCondition {
   Status apply_clause_dense(
       const Clause& clause,
       ResultTile* result_tile,
-      const uint64_t start,
-      const uint64_t length,
-      const uint64_t src_cell,
-      const uint64_t stride,
+      const size_t start,
+      const size_t length,
+      const size_t src_cell,
+      const size_t stride,
       const bool var_size,
       uint8_t* result_buffer) const;
 
@@ -467,10 +467,10 @@ class QueryCondition {
       const QueryCondition::Clause& clause,
       const ArraySchema& array_schema,
       ResultTile* result_tile,
-      const uint64_t start,
-      const uint64_t length,
-      const uint64_t src_cell,
-      const uint64_t stride,
+      const size_t start,
+      const size_t length,
+      const size_t src_cell,
+      const size_t stride,
       uint8_t* result_buffer) const;
 
   /**


### PR DESCRIPTION
(From 15762).  Replace the use of pairs of `void*` and `uint64_t` (pointer and size) to demarcate data with a single `UntypedDatumView` object.  Replaced the `void* condition_value_` in `Clause` with `UntypedDatumView condition_value_view_`.  This will point to `condition_value_data_.data()` when not a nullptr and also reflect `condition_value_data_.size()`.  The view is used instead of `condition_value_data_` because we need to be able to represent `nullptr` in the clauses (for nullable attribute types).  All comparison functions in query_condition.cpp that previously used pointer-size for arguments now take a const reference to an `UntypedDatumView`.  `std::span` may work equally well - `UntypedDatumView` was used for simplicity.

---
TYPE:  IMPROVEMENT 
DESC: Replace the use of pairs of `void*` and `uint64_t` (pointer and size) to demarcate data with `UntypedDatumView`.
