### PR TITLE
Add new Dictionary encoding filter definition

### DIFF
--- a/format_spec/FORMAT_SPEC.md
+++ b/format_spec/FORMAT_SPEC.md
@@ -2,7 +2,7 @@
 
 **Notes:**  
 
-* The current TileDB format version number is **12** (`uint32_t`).
+* The current TileDB format version number is **13** (`uint32_t`).
 * All data written by TileDB and referenced in this document is **little-endian**. 
 
 ## Table of Contents

--- a/format_spec/filter_pipeline.md
+++ b/format_spec/filter_pipeline.md
@@ -34,7 +34,7 @@ The filter options are configuration parameters for the filters that do not chan
 
 ### Main Compressor Options
 
-For the compression filters \(any of the filter types `TILEDB_FILTER_{GZIP,ZSTD,LZ4,RLE,BZIP2,DOUBLE_DELTA}`\) the filter options have internal format:
+For the compression filters \(any of the filter types `TILEDB_FILTER_{GZIP,ZSTD,LZ4,RLE,BZIP2,DOUBLE_DELTA,DICTIONARY}`\) the filter options have internal format:
 
 | **Field** | **Type** | **Description** |
 | :--- | :--- | :--- |

--- a/test/src/unit-capi-enum_values.cc
+++ b/test/src/unit-capi-enum_values.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -107,6 +107,9 @@ TEST_CASE("C API: Test enum values", "[capi][enums]") {
   REQUIRE(TILEDB_FILTER_BYTESHUFFLE == 9);
   REQUIRE(TILEDB_FILTER_POSITIVE_DELTA == 10);
   REQUIRE((uint8_t)FilterType::INTERNAL_FILTER_AES_256_GCM == 11);
+  REQUIRE(TILEDB_FILTER_CHECKSUM_MD5 == 12);
+  REQUIRE(TILEDB_FILTER_CHECKSUM_SHA256 == 13);
+  REQUIRE(TILEDB_FILTER_DICTIONARY == 14);
 
   /** Filter option */
   REQUIRE(TILEDB_COMPRESSION_LEVEL == 0);
@@ -414,6 +417,17 @@ TEST_CASE("C API: Test enum string conversion", "[capi][enums]") {
       (tiledb_filter_type_from_str("POSITIVE_DELTA", &filter_type) ==
            TILEDB_OK &&
        filter_type == TILEDB_FILTER_POSITIVE_DELTA));
+  REQUIRE(
+      (tiledb_filter_type_from_str("CHECKSUM_MD5", &filter_type) == TILEDB_OK &&
+       filter_type == TILEDB_FILTER_CHECKSUM_MD5));
+  REQUIRE(
+      (tiledb_filter_type_from_str("CHECKSUM_SHA256", &filter_type) ==
+           TILEDB_OK &&
+       filter_type == TILEDB_FILTER_CHECKSUM_SHA256));
+  REQUIRE(
+      (tiledb_filter_type_from_str("DICTIONARY_ENCODING", &filter_type) ==
+           TILEDB_OK &&
+       filter_type == TILEDB_FILTER_DICTIONARY));
 
   tiledb_filter_option_t filter_option;
   REQUIRE(

--- a/tiledb/sm/c_api/tiledb_enum.h
+++ b/tiledb/sm/c_api/tiledb_enum.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -194,6 +194,8 @@
     TILEDB_FILTER_TYPE_ENUM(FILTER_CHECKSUM_MD5) = 12,
     /** SHA256 checksum filter. */
     TILEDB_FILTER_TYPE_ENUM(FILTER_CHECKSUM_SHA256) = 13,
+    /** Dictionary encoding filter. */
+    TILEDB_FILTER_TYPE_ENUM(FILTER_DICTIONARY) = 14,
 #endif
 
 #ifdef TILEDB_FILTER_OPTION_ENUM

--- a/tiledb/sm/cpp_api/filter.h
+++ b/tiledb/sm/cpp_api/filter.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -275,6 +275,8 @@ class Filter {
         return "CHECKSUM_MD5";
       case TILEDB_FILTER_CHECKSUM_SHA256:
         return "CHECKSUM_SHA256";
+      case TILEDB_FILTER_DICTIONARY:
+        return "DICTIONARY_ENCODING";
     }
     return "";
   }

--- a/tiledb/sm/enums/compressor.h
+++ b/tiledb/sm/enums/compressor.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -59,7 +59,9 @@ enum class Compressor : uint8_t {
   /** Bzip2 compressor */
   BZIP2 = 5,
   /** Double-delta compressor */
-  DOUBLE_DELTA = 6
+  DOUBLE_DELTA = 6,
+  /** Dictionary compressor */
+  DICTIONARY_ENCODING = 7,
 };
 
 /** Returns the string representation of the input compressor. */
@@ -79,6 +81,8 @@ inline const std::string& compressor_str(Compressor type) {
       return constants::bzip2_str;
     case Compressor::DOUBLE_DELTA:
       return constants::double_delta_str;
+    case Compressor::DICTIONARY_ENCODING:
+      return constants::filter_dictionary_str;
     default:
       return constants::empty_str;
   }
@@ -101,6 +105,8 @@ inline Status compressor_enum(
     *compressor = Compressor::BZIP2;
   else if (compressor_type_str == constants::double_delta_str)
     *compressor = Compressor::DOUBLE_DELTA;
+  else if (compressor_type_str == constants::filter_dictionary_str)
+    *compressor = Compressor::DICTIONARY_ENCODING;
   else {
     return Status_Error("Invalid Compressor " + compressor_type_str);
   }

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -85,6 +85,8 @@ inline const std::string& filter_type_str(FilterType filter_type) {
       return constants::filter_checksum_md5_str;
     case FilterType::FILTER_CHECKSUM_SHA256:
       return constants::filter_checksum_sha256_str;
+    case FilterType::FILTER_DICTIONARY:
+      return constants::filter_dictionary_str;
     default:
       return constants::empty_str;
   }
@@ -119,6 +121,8 @@ inline Status filter_type_enum(
     *filter_type = FilterType::FILTER_CHECKSUM_MD5;
   else if (filter_type_str == constants::filter_checksum_sha256_str)
     *filter_type = FilterType::FILTER_CHECKSUM_SHA256;
+  else if (filter_type_str == constants::filter_dictionary_str)
+    *filter_type = FilterType::FILTER_DICTIONARY;
   else {
     return Status_Error("Invalid FilterType " + filter_type_str);
   }

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -108,6 +108,9 @@ void CompressionFilter::dump(FILE* out) const {
     case Compressor::DOUBLE_DELTA:
       compressor_str = "DOUBLE_DELTA";
       break;
+    case Compressor::DICTIONARY_ENCODING:
+      compressor_str = "DICTIONARY_ENCODING";
+      break;
     default:
       compressor_str = "NO_COMPRESSION";
   }
@@ -144,6 +147,8 @@ FilterType CompressionFilter::compressor_to_filter(Compressor compressor) {
       return FilterType::FILTER_BZIP2;
     case Compressor::DOUBLE_DELTA:
       return FilterType::FILTER_DOUBLE_DELTA;
+    case Compressor::DICTIONARY_ENCODING:
+      return FilterType::FILTER_DICTIONARY;
     default:
       assert(false);
       return FilterType::FILTER_NONE;
@@ -166,6 +171,8 @@ Compressor CompressionFilter::filter_to_compressor(FilterType type) {
       return Compressor::BZIP2;
     case FilterType::FILTER_DOUBLE_DELTA:
       return Compressor::DOUBLE_DELTA;
+    case FilterType::FILTER_DICTIONARY:
+      return Compressor::DICTIONARY_ENCODING;
     default:
       assert(false);
       return Compressor::NO_COMPRESSION;
@@ -359,6 +366,9 @@ Status CompressionFilter::compress_part(
     case Compressor::DOUBLE_DELTA:
       RETURN_NOT_OK(DoubleDelta::compress(type, &input_buffer, output));
       break;
+    case Compressor::DICTIONARY_ENCODING:
+      // TODO: add method when available
+      break;
     default:
       assert(0);
   }
@@ -426,6 +436,9 @@ Status CompressionFilter::decompress_part(
       break;
     case Compressor::DOUBLE_DELTA:
       st = DoubleDelta::decompress(type, &input_buffer, &output_buffer);
+      break;
+    case Compressor::DICTIONARY_ENCODING:
+      // TODO: add method when available
       break;
   }
 
@@ -580,6 +593,8 @@ uint64_t CompressionFilter::overhead(const Tile& tile, uint64_t nbytes) const {
       return BZip::overhead(nbytes);
     case Compressor::DOUBLE_DELTA:
       return DoubleDelta::overhead(nbytes);
+    case Compressor::DICTIONARY_ENCODING:
+    // TODO: add method when available
     default:
       // No compression
       return 0;

--- a/tiledb/sm/filter/filter_create.cc
+++ b/tiledb/sm/filter/filter_create.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -57,6 +57,7 @@ tiledb::sm::Filter* tiledb::sm::FilterCreate::make(FilterType type) {
     case tiledb::sm::FilterType::FILTER_RLE:
     case tiledb::sm::FilterType::FILTER_BZIP2:
     case tiledb::sm::FilterType::FILTER_DOUBLE_DELTA:
+    case tiledb::sm::FilterType::FILTER_DICTIONARY:
       return tdb_new(tiledb::sm::CompressionFilter, type, -1);
     case tiledb::sm::FilterType::FILTER_BIT_WIDTH_REDUCTION:
       return tdb_new(tiledb::sm::BitWidthReductionFilter);
@@ -111,7 +112,8 @@ tiledb::sm::FilterCreate::deserialize(
     case FilterType::FILTER_LZ4:
     case FilterType::FILTER_RLE:
     case FilterType::FILTER_BZIP2:
-    case FilterType::FILTER_DOUBLE_DELTA: {
+    case FilterType::FILTER_DOUBLE_DELTA:
+    case FilterType::FILTER_DICTIONARY: {
       uint8_t compressor_char;
       int compression_level;
       st = (buff->read(&compressor_char, sizeof(uint8_t)));

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -343,6 +343,9 @@ const std::string filter_checksum_md5_str = "CHECKSUM_MD5";
 /** String describing FILTER_CHECKSUM_SHA256. */
 const std::string filter_checksum_sha256_str = "CHECKSUM_SHA256";
 
+/** String describing FILTER_DICTIONARY. */
+const std::string filter_dictionary_str = "DICTIONARY_ENCODING";
+
 /** The string representation for FilterOption type compression_level. */
 const std::string filter_option_compression_level_str = "COMPRESSION_LEVEL";
 
@@ -546,7 +549,7 @@ const int32_t library_version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
 /** The TileDB serialization format version number. */
-const uint32_t format_version = 12;
+const uint32_t format_version = 13;
 
 /** The lowest version supported for back compat writes. */
 const uint32_t back_compat_writes_min_format_version = 7;

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -328,6 +328,9 @@ extern const std::string filter_checksum_md5_str;
 
 /** String describing FILTER_CHECKSUM_SHA256. */
 extern const std::string filter_checksum_sha256_str;
+
+/** String describing FILTER_DICTIONARY. */
+extern const std::string filter_dictionary_str;
 
 /** The string representation for FilterOption type compression_level. */
 extern const std::string filter_option_compression_level_str;

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -104,7 +104,8 @@ Status filter_pipeline_to_capnp(
       case FilterType::FILTER_LZ4:
       case FilterType::FILTER_RLE:
       case FilterType::FILTER_BZIP2:
-      case FilterType::FILTER_DOUBLE_DELTA: {
+      case FilterType::FILTER_DOUBLE_DELTA:
+      case FilterType::FILTER_DICTIONARY: {
         int32_t level;
         RETURN_NOT_OK(
             filter->get_option(FilterOption::COMPRESSION_LEVEL, &level));
@@ -145,7 +146,8 @@ static tuple<Status, optional<shared_ptr<Filter>>> filter_constructor(
     case FilterType::FILTER_LZ4:
     case FilterType::FILTER_RLE:
     case FilterType::FILTER_BZIP2:
-    case FilterType::FILTER_DOUBLE_DELTA: {
+    case FilterType::FILTER_DOUBLE_DELTA:
+    case FilterType::FILTER_DICTIONARY: {
       auto data = reader.getData();
       int32_t level = data.getInt32();
       return {


### PR DESCRIPTION
As a first step towards the integration of Dictionary encoding algorithm as a filter in TileDB, this PR is adding Dictionary encoding as an available filter in enums and updates on disk-format version and documentation.

---
TYPE: IMPROVEMENT
DESC: Introduce dictionary-encoding as an enum option for filters

TYPE: FORMAT
DESC: Update on-disk format because of the new available compressor for Dictionary-encoding of strings
