### PR TITLE
Add serialize/deserialize to dimension labels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ if (TILEDB_TESTS)
   add_dependencies(tests unit_array_schema unit_filter_create unit_filter_pipeline unit_metadata)
   add_dependencies(tests unit_compressors)
   add_dependencies(tests unit_range_subset)
-  add_dependencies(tests unit_dimension_label unit_uniform_mapping)
+  add_dependencies(tests unit_dimension_label)
 endif()
 
 # Build tools

--- a/tiledb/sm/dimension_label/CMakeLists.txt
+++ b/tiledb/sm/dimension_label/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(dimension_label OBJECT dimension_label.cc )
 target_link_libraries(dimension_label PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 target_link_libraries(dimension_label PUBLIC misc_types $<TARGET_OBJECTS:misc_types>)
 target_link_libraries(dimension_label PUBLIC uniform_mapping $<TARGET_OBJECTS:uniform_mapping>)
+target_link_libraries(dimension_label PUBLIC buffer $<TARGET_OBJECTS:buffer>)
 
 add_executable(compile_dimension_label EXCLUDE_FROM_ALL)
 target_link_libraries(compile_dimension_label PRIVATE dimension_label)

--- a/tiledb/sm/dimension_label/CMakeLists.txt
+++ b/tiledb/sm/dimension_label/CMakeLists.txt
@@ -42,5 +42,5 @@ target_link_libraries(compile_dimension_label PRIVATE dimension_label)
 target_sources(compile_dimension_label PRIVATE test/compile_dimension_label_main.cc)
 
 if (TILEDB_TESTS)
-    add_subdirectory(test)
+  add_subdirectory(test)
 endif()

--- a/tiledb/sm/dimension_label/dimension_label.cc
+++ b/tiledb/sm/dimension_label/dimension_label.cc
@@ -31,6 +31,7 @@
  */
 
 #include "dimension_label.h"
+#include "tiledb/sm/buffer/buffer.h"
 
 namespace tiledb::sm {
 
@@ -73,6 +74,37 @@ tuple<Status, shared_ptr<DimensionLabel>> DimensionLabel::create_uniform(
   }
 }
 
+tuple<Status, shared_ptr<DimensionLabel>> DimensionLabel::deserialize(
+    ConstBuffer* buff,
+    uint32_t version,
+    Datatype index_datatype,
+    uint32_t index_cell_val_num,
+    const Range& index_domain) {
+  // Load dimension label type
+  uint8_t label_type_data{};
+  auto status = buff->read(&label_type_data, sizeof(uint8_t));
+  if (!status.ok())
+    return {status, nullptr};
+  LabelType label_type{label_type_data};
+  // Load base dimension label data
+  auto&& [schema_status, schema] = DimensionLabel::BaseSchema::deserialize(
+      buff, version, index_datatype, index_cell_val_num, index_domain);
+  if (!status.ok())
+    return {status, nullptr};
+  // Load mapping parameters and data type.
+  switch (label_type) {
+    case LabelType::LABEL_UNIFORM:
+      return DimensionLabel::create_uniform(std::move(schema.value()));
+    default:
+      return {
+          Status_DimensionLabelError(
+              "Unabel to create dimension label; The requested dimension label "
+              "type is not supported " +
+              label_type_str(label_type)),
+          nullptr};
+  }
+}
+
 tuple<Status, Range> DimensionLabel::index_range(const Range& labels) const {
   try {
     return {Status::Ok(), label_index_map_->index_range(labels)};
@@ -82,6 +114,18 @@ tuple<Status, Range> DimensionLabel::index_range(const Range& labels) const {
                 "Unable to get index range from label range; " + msg),
             Range()};
   }
+}
+
+Status DimensionLabel::serialize(Buffer* buff, uint32_t version) const {
+  // Write the dimension label type.
+  auto label_type_data = static_cast<uint8_t>(label_type_);
+  RETURN_NOT_OK(buff->write(&label_type_data, sizeof(uint8_t)));
+  // Write base schema.
+  RETURN_NOT_OK(schema_.serialize(buff, version));
+  // Write metadata for specific mapping - currently always zero.
+  uint32_t num_metadata{0};
+  RETURN_NOT_OK(buff->write(&num_metadata, sizeof(uint32_t)));
+  return Status::Ok();
 }
 
 /************************************************/
@@ -103,6 +147,99 @@ DimensionLabel::BaseSchema::BaseSchema(
     , index_datatype(index_datatype)
     , index_cell_val_num(index_cell_val_num)
     , index_domain(index_domain) {
+}
+
+// Format:
+// dimension label size (uint32_t)
+// dimension label name (c-string)
+// label datatype (uint8_t)
+// label number of values per cell (uint32_t)
+// label domain size (uint64_t)
+// label domain (void* - domain size)
+// label metadata size (uint32_t - specific to filter type)
+// label metadata (specific to filter type)
+tuple<Status, optional<DimensionLabel::BaseSchema>>
+DimensionLabel::BaseSchema::deserialize(
+    ConstBuffer* buff,
+    uint32_t,
+    Datatype index_datatype,
+    uint32_t index_cell_val_num,
+    const Range& index_domain) {
+  // Load dimension label name
+  uint32_t dimension_name_size;
+  auto status = buff->read(&dimension_name_size, sizeof(uint32_t));
+  if (!status.ok())
+    return {status, nullopt};
+  std::string name;
+  name.resize(dimension_name_size);
+  status = buff->read(&name[0], dimension_name_size);
+  if (!status.ok())
+    return {status, nullopt};
+  // Load label datatype
+  uint8_t datatype_data{};
+  status = buff->read(&datatype_data, sizeof(uint8_t));
+  if (!status.ok())
+    return {status, nullopt};
+  Datatype label_datatype{datatype_data};
+  // Load the number values in a cell for the label
+  uint32_t label_cell_val_num{};
+  status = buff->read(&label_cell_val_num, sizeof(uint32_t));
+  if (!status.ok())
+    return {status, nullopt};
+  // Load the label domain
+  uint64_t domain_size{};
+  status = buff->read(&domain_size, sizeof(uint64_t));
+  if (!status.ok())
+    return {status, nullopt};
+  Range label_domain;
+  if (domain_size != 0) {
+    std::vector<uint8_t> tmp(domain_size);
+    status = buff->read(&tmp[0], domain_size);
+    label_domain = Range(&tmp[0], domain_size);
+  }
+  return {Status::Ok(),
+          DimensionLabel::BaseSchema(
+              name,
+              label_datatype,
+              label_cell_val_num,
+              label_domain,
+              index_datatype,
+              index_cell_val_num,
+              index_domain)};
+}
+
+// Format:
+// dimension label size (uint32_t)
+// dimension label name (c-string)
+// label datatype (uint8_t)
+// label number of values per cell (uint32_t)
+// label domain size (uint64_t)
+// label domain (void* - domain size)
+// label metadata size (uint32_t - specific to filter type)
+// label metadata (specific to filter type)
+Status DimensionLabel::BaseSchema::serialize(Buffer* buff, uint32_t) const {
+  // Write the dimension label name size and name
+  auto name_size = (uint32_t)name.size();
+  RETURN_NOT_OK(buff->write(&name_size, sizeof(uint32_t)));
+  RETURN_NOT_OK(buff->write(name.c_str(), name_size));
+  // Write the dimension label datatype
+  auto label_datatype_data = static_cast<uint8_t>(label_datatype);
+  RETURN_NOT_OK(buff->write(&label_datatype_data, sizeof(uint8_t)));
+  // Write the dimension label number of values per cell
+  RETURN_NOT_OK(buff->write(&label_cell_val_num, sizeof(uint32_t)));
+  // Write the dimension label domain size and domain
+  if (datatype_is_string(label_datatype)) {
+    // sanity check: domain should be empty for string datatypes
+    if (!label_domain.empty())
+      throw std::logic_error("Domain should be empty for string dimensions");
+    uint64_t domain_size{0};
+    RETURN_NOT_OK(buff->write(&domain_size, sizeof(uint64_t)));
+  } else {
+    uint64_t domain_size{2 * datatype_size(label_datatype)};
+    RETURN_NOT_OK(buff->write(&domain_size, sizeof(uint64_t)));
+    RETURN_NOT_OK(buff->write(label_domain.data(), domain_size));
+  }
+  return Status::Ok();
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -44,6 +44,9 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
+class Buffer;
+class ConstBuffer;
+
 /**
  * A TileDB dimension label.
  *
@@ -109,6 +112,30 @@ class DimensionLabel {
      * The domain of the original dimension. A pair of [lower, upper] bounds.
      */
     Range index_domain;
+
+    /**
+     * Populates the object members from the data in the input binary buffer.
+     *
+     * @param buff THe buffer to deserialize from.
+     * @param version The format spec version.
+     * @returns {status, dimension_label} The status of the deserialization and
+     * a pointer to the deserialized dimension label.
+     */
+    static tuple<Status, optional<DimensionLabel::BaseSchema>> deserialize(
+        ConstBuffer* buff,
+        uint32_t version,
+        Datatype index_datatype,
+        uint32_t index_cell_val_num,
+        const Range& index_domain);
+
+    /**
+     * Serializes the object members into a binary buffer.
+     *
+     * @param buff The buffer to serialize the data into.
+     * @param version The format spec version.
+     * @returns The status of the serialization.
+     */
+    Status serialize(Buffer* buff, uint32_t version) const;
   };
 
   /* No default constructor: not C.41 compliant. */
@@ -132,6 +159,20 @@ class DimensionLabel {
    **/
   static tuple<Status, shared_ptr<DimensionLabel>> create_uniform(
       DimensionLabel::BaseSchema&& schema);
+  /**
+   * Populates the object members from the data in the input binary buffer.
+   *
+   * @param buff THe buffer to deserialize from.
+   * @param version The format spec version.
+   * @returns {status, dimension_label} The status of the deserialization and
+   * a pointer to the deserialized dimension label.
+   */
+  static tuple<Status, shared_ptr<DimensionLabel>> deserialize(
+      ConstBuffer* buff,
+      uint32_t version,
+      Datatype index_datatype,
+      uint32_t index_cell_val_num,
+      const Range& index_domain);
 
   /**
    * Returns success status and a range on the dimension coordinates that
@@ -154,6 +195,15 @@ class DimensionLabel {
    * range that covers the same region of the array as in the input label.
    **/
   tuple<Status, Range> index_range(const Range& label_range) const;
+
+  /**
+   * Serializes the object members into a binary buffer.
+   *
+   * @param buff The buffer to serialize the data into.
+   * @param version The format spec version.
+   * @returns The status of the serialization.
+   */
+  Status serialize(Buffer* buff, uint32_t version) const;
 
  private:
   /**

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -174,6 +174,24 @@ class DimensionLabel {
       uint32_t index_cell_val_num,
       const Range& index_domain);
 
+  /** Returns the number of values per cell for the index. */
+  inline uint32_t index_cell_val_num() const {
+    return schema_.index_cell_val_num;
+  }
+
+  /** Returns the datatype of the original dimension. */
+  inline Datatype index_datatype() const {
+    return schema_.index_datatype;
+  }
+
+  /**
+   * Returnd the domain of the original dimension. A pair of [lower, upper]
+   * bounds.
+   **/
+  inline const Range& index_domain() const {
+    return schema_.index_domain;
+  }
+
   /**
    * Returns success status and a range on the dimension coordinates that
    * matches the label range.
@@ -196,6 +214,31 @@ class DimensionLabel {
    **/
   tuple<Status, Range> index_range(const Range& label_range) const;
 
+  /** Returns the number of values per cell for the label. */
+  inline uint32_t label_cell_val_num() const {
+    return schema_.label_cell_val_num;
+  }
+
+  /** Returns the datatype of the label. */
+  inline Datatype label_datatype() const {
+    return schema_.label_datatype;
+  }
+
+  /** Returns the domain of the label. A pair of [lower, upper] bounds. */
+  inline const Range& label_domain() const {
+    return schema_.label_domain;
+  }
+
+  /** Returns the type of the dimension label. */
+  inline LabelType label_type() const {
+    return label_type_;
+  }
+
+  /** Returns the name of the dimension label. */
+  inline const std::string& name() const {
+    return schema_.name;
+  }
+
   /**
    * Serializes the object members into a binary buffer.
    *
@@ -207,7 +250,7 @@ class DimensionLabel {
 
  private:
   /**
-   * The type of the dimension.
+   * The type of the dimension label.
    *
    * Possible types include:
    *

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -72,78 +72,6 @@ namespace tiledb::sm {
  */
 class DimensionLabel {
  public:
-  /* No default constructor: not C.41 compliant. */
-  DimensionLabel() = delete;
-
-  /* Private constructor.
-   *
-   * @param label_type The dimension label type.
-   * @param name Name of the dimension label.
-   * @param label_datatype The TileDB datatype of the label.
-   * @param label_cell_val_num The number of values per cell for the label.
-   * @param label_domain The label domain. A pair of [lower, upper] bounds.
-   * @param index_datatype The TileDB datatype of the original dimension.
-   * @param index_cell_val_num The number of values per cell for the original
-   * dimension.
-   * @param index_domain The domain of the original domain. A pair of [lower,
-   * upper] bounds.
-   * @parame label_map Internal mapping from labels to indices.
-   * */
-  explicit DimensionLabel(
-      LabelType label_type,
-      const std::string& name,
-      Datatype label_datatype,
-      uint32_t label_cell_val_num,
-      const Range& label_domain,
-      Datatype index_datatype,
-      uint32_t index_cell_val_num,
-      const Range& index_domain,
-      shared_ptr<DimensionLabelMapping> label_map);
-
-  /**
-   * A factory for creating an uniform (evenly-spaced) virtual dimension label.
-   *
-   * @param name Name of the dimension label.
-   * @param label_datatype The TileDB datatype of the label.
-   * @param label_cell_val_num The number of values per cell for the label.
-   * @param label_domain The label domain. A pair of [lower, upper] bounds.
-   * @param index_datatype The TileDB datatype of the original dimension.
-   * @param index_cell_val_num The number of values per cell for the original
-   * dimension.
-   * @param index_domain The domain of the original domain. A pair of [lower,
-   * upper] bounds.
-   **/
-  static tuple<Status, shared_ptr<DimensionLabel>> create_uniform(
-      const std::string& name,
-      Datatype label_datatype,
-      uint32_t label_cell_val_num,
-      const Range& label_domain,
-      Datatype index_datatype,
-      uint32_t index_cell_val_num,
-      const Range& index_domain);
-
-  /**
-   * Returns success status and a range on the dimension coordinates that
-   * matches the label range.
-   *
-   * This function will be used to convert from a labelled Subarray to an
-   * un-labelled subarray.
-   *
-   * The index range that is returned from this function will map to the same
-   * region of the array as the input label range. The lower bound of the
-   * returned index range may round up to the nearest valid value. Similarly,
-   * the upper bound may round down to the nearest valid valid.
-   *
-   * If the input label range is out-of-bounds of the array, the status will
-   * return an error.
-   *
-   * @param label_range A range of a label coordinates. The label must be a
-   * valid non-empty range with ordered data of the label datatype.
-   * @returns {status, range} The status of the conversion and the output index
-   * range that covers the same region of the array as in the input label.
-   **/
-  tuple<Status, Range> index_range(const Range& label_range) const;
-
   /** The core data required for all dimension labels. */
   struct BaseSchema {
     /** No default constructor: not C.41 compliant. */
@@ -151,7 +79,6 @@ class DimensionLabel {
 
     /** Constructor. */
     BaseSchema(
-        LabelType label_type,
         const std::string& name,
         Datatype label_datatype,
         uint32_t label_cell_val_num,
@@ -159,14 +86,6 @@ class DimensionLabel {
         Datatype index_datatype,
         uint32_t index_cell_val_num,
         const Range& index_domain);
-
-    /** The type of the dimension
-     *
-     * Possible types include:
-     *
-     * * LABEL_UNIFORM: A uniform (evenly space) virtual dimension label.
-     **/
-    LabelType label_type;
 
     /** The dimension label name. */
     std::string name;
@@ -192,7 +111,60 @@ class DimensionLabel {
     Range index_domain;
   };
 
+  /* No default constructor: not C.41 compliant. */
+  DimensionLabel() = delete;
+
+  /* Constructor.
+   *
+   * @param label_type The dimension label type.
+   * @param schema Fundamental data required for all dimension labels.
+   * @param label_map Internal mapping from labels to indices.
+   **/
+  explicit DimensionLabel(
+      LabelType label_type,
+      DimensionLabel::BaseSchema& schema,
+      shared_ptr<DimensionLabelMapping> label_map);
+
+  /**
+   * A factory for creating an uniform (evenly-spaced) virtual dimension label.
+   *
+   * @param schema Fundamental data required for all dimension labels.
+   **/
+  static tuple<Status, shared_ptr<DimensionLabel>> create_uniform(
+      DimensionLabel::BaseSchema&& schema);
+
+  /**
+   * Returns success status and a range on the dimension coordinates that
+   * matches the label range.
+   *
+   * This function will be used to convert from a labelled Subarray to an
+   * un-labelled subarray.
+   *
+   * The index range that is returned from this function will map to the same
+   * region of the array as the input label range. The lower bound of the
+   * returned index range may round up to the nearest valid value. Similarly,
+   * the upper bound may round down to the nearest valid valid.
+   *
+   * If the input label range is out-of-bounds of the array, the status will
+   * return an error.
+   *
+   * @param label_range A range of a label coordinates. The label must be a
+   * valid non-empty range with ordered data of the label datatype.
+   * @returns {status, range} The status of the conversion and the output index
+   * range that covers the same region of the array as in the input label.
+   **/
+  tuple<Status, Range> index_range(const Range& label_range) const;
+
  private:
+  /**
+   * The type of the dimension.
+   *
+   * Possible types include:
+   *
+   *  * LABEL_UNIFORM: A uniform (evenly space) virtual dimension label.
+   **/
+  LabelType label_type_;
+
   /** Core data needed for all dimension label types. */
   BaseSchema schema_;
 

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -118,6 +118,12 @@ class DimensionLabel {
      *
      * @param buff THe buffer to deserialize from.
      * @param version The format spec version.
+     * @param index_datatype Datatype of the dimension the dimension label is
+     * attached to.
+     * @param index_cell_val_num Number of values per cell of the dimension the
+     * dimension label is attached to.
+     * @param index_domain The domain of the dimension the dimension label is
+     * attached to.
      * @returns {status, dimension_label} The status of the deserialization and
      * a pointer to the deserialized dimension label.
      */
@@ -164,6 +170,12 @@ class DimensionLabel {
    *
    * @param buff THe buffer to deserialize from.
    * @param version The format spec version.
+   * @param index_datatype Datatype of the dimension the dimension label is
+   * attached to.
+   * @param index_cell_val_num Number of values per cell of the dimension the
+   * dimension label is attached to.
+   * @param index_domain The domain of the dimension the dimension label is
+   * attached to.
    * @returns {status, dimension_label} The status of the deserialization and
    * a pointer to the deserialized dimension label.
    */

--- a/tiledb/sm/dimension_label/test/CMakeLists.txt
+++ b/tiledb/sm/dimension_label/test/CMakeLists.txt
@@ -26,27 +26,20 @@
 
 find_package(Catch_EP REQUIRED)
 
-add_executable(unit_dimension_label EXCLUDE_FROM_ALL)
+add_executable(unit_dimension_label
+    EXCLUDE_FROM_ALL
+    main.cc
+    unit_dimension_label_base_schema.cc
+    unit_uniform_dimension_label.cc
+    unit_uniform_mapping.cc
+    )
 target_link_libraries(unit_dimension_label
     PRIVATE dimension_label
     PUBLIC Catch2::Catch2
     )
-target_sources(unit_dimension_label PUBLIC main.cc unit_dimension_label.cc)
+#target_sources(unit_uniform_dimension_label PUBLIC main.cc unit_uniform_dimension_label.cc)
 add_test(
     NAME "unit_dimension_label"
     COMMAND $<TARGET_FILE:unit_dimension_label>
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-
-add_executable(unit_uniform_mapping EXCLUDE_FROM_ALL)
-target_link_libraries(unit_uniform_mapping
-    PRIVATE uniform_mapping
-    PUBLIC Catch2::Catch2
-    )
-target_sources(unit_uniform_mapping PUBLIC main.cc unit_uniform_mapping.cc)
-add_test(
-    NAME "unit_uniform_mapping"
-    COMMAND $<TARGET_FILE:unit_uniform_mapping>
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/tiledb/sm/dimension_label/test/unit_dimension_label.cc
+++ b/tiledb/sm/dimension_label/test/unit_dimension_label.cc
@@ -98,8 +98,9 @@ TEMPLATE_TEST_CASE_SIG(
   const TLABEL x_max{60};
   const auto index_domain = create_range<uint64_t>(n_min, n_max);
   const auto label_domain = create_range<TLABEL>(x_min, x_max);
-  auto&& [status, dim_label] = DimensionLabel::create_uniform(
-      "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+  auto&& [status, dim_label] =
+      DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+          "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain));
   REQUIRE(status.ok());
   REQUIRE(dim_label != nullptr);
   SECTION("Convert full data range") {
@@ -152,27 +153,29 @@ TEST_CASE(
   float label_domain_data[2] = {-1.0, 1.0};
   Range label_domain{label_domain_data, 2 * sizeof(float)};
   SECTION("label_cell_val_num!=1") {
-    auto&& [status, dim_label] = DimensionLabel::create_uniform(
-        "label",
-        Datatype::FLOAT32,
-        2,
-        label_domain,
-        Datatype::UINT64,
-        1,
-        index_domain);
+    auto&& [status, dim_label] =
+        DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+            "label",
+            Datatype::FLOAT32,
+            2,
+            label_domain,
+            Datatype::UINT64,
+            1,
+            index_domain));
     INFO(status.to_string());
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);
   }
   SECTION("index_cell_val_num!=1") {
-    auto&& [status, dim_label] = DimensionLabel::create_uniform(
-        "label",
-        Datatype::FLOAT32,
-        1,
-        label_domain,
-        Datatype::UINT64,
-        2,
-        index_domain);
+    auto&& [status, dim_label] =
+        DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+            "label",
+            Datatype::FLOAT32,
+            1,
+            label_domain,
+            Datatype::UINT64,
+            2,
+            index_domain));
     INFO(status.to_string());
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);
@@ -189,8 +192,9 @@ TEMPLATE_TEST_CASE_SIG(
   uint64_t index_domain_data[2] = {0, 10};
   Range index_domain{index_domain_data, 2 * sizeof(uint64_t)};
   SECTION("empty label domain") {
-    auto&& [status, dim_label] = DimensionLabel::create_uniform(
-        "label", DLABEL, 1, Range(), Datatype::UINT64, 1, index_domain);
+    auto&& [status, dim_label] =
+        DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+            "label", DLABEL, 1, Range(), Datatype::UINT64, 1, index_domain));
     INFO(status.to_string());
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);
@@ -199,8 +203,15 @@ TEMPLATE_TEST_CASE_SIG(
     TLABEL label_domain_data[2] = {-std::numeric_limits<TLABEL>::quiet_NaN(),
                                    std::numeric_limits<TLABEL>::quiet_NaN()};
     Range label_domain{label_domain_data, 2 * sizeof(TLABEL)};
-    auto&& [status, dim_label] = DimensionLabel::create_uniform(
-        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    auto&& [status, dim_label] =
+        DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+            "label",
+            DLABEL,
+            1,
+            label_domain,
+            Datatype::UINT64,
+            1,
+            index_domain));
     INFO(status.to_string());
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);
@@ -209,16 +220,30 @@ TEMPLATE_TEST_CASE_SIG(
     TLABEL label_domain_data[2] = {-std::numeric_limits<TLABEL>::infinity(),
                                    std::numeric_limits<TLABEL>::infinity()};
     Range label_domain{label_domain_data, 2 * sizeof(TLABEL)};
-    auto&& [status, dim_label] = DimensionLabel::create_uniform(
-        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    auto&& [status, dim_label] =
+        DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+            "label",
+            DLABEL,
+            1,
+            label_domain,
+            Datatype::UINT64,
+            1,
+            index_domain));
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);
   }
   SECTION("lower bound greater than upper bound") {
     TLABEL label_domain_data[2] = {1.0, -1.0};
     Range label_domain{label_domain_data, 2 * sizeof(TLABEL)};
-    auto&& [status, dim_label] = DimensionLabel::create_uniform(
-        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    auto&& [status, dim_label] =
+        DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+            "label",
+            DLABEL,
+            1,
+            label_domain,
+            Datatype::UINT64,
+            1,
+            index_domain));
     INFO(status.to_string());
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);
@@ -262,24 +287,39 @@ TEMPLATE_TEST_CASE_SIG(
     (int64_t, Datatype::TIME_AS)) {
   const auto index_domain = create_range<uint64_t>(0, 10);
   SECTION("empty label domain") {
-    auto&& [status, dim_label] = DimensionLabel::create_uniform(
-        "label", DLABEL, 1, Range(), Datatype::UINT64, 1, index_domain);
+    auto&& [status, dim_label] =
+        DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+            "label", DLABEL, 1, Range(), Datatype::UINT64, 1, index_domain));
     INFO(status.to_string());
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);
   }
   SECTION("lower bound greater than upper bound") {
     const auto label_domain = create_range<TLABEL>(10, 0);
-    auto&& [status, dim_label] = DimensionLabel::create_uniform(
-        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    auto&& [status, dim_label] =
+        DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+            "label",
+            DLABEL,
+            1,
+            label_domain,
+            Datatype::UINT64,
+            1,
+            index_domain));
     INFO(status.to_string());
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);
   }
   SECTION("bad label alignment") {
     const auto label_domain = create_range<TLABEL>(0, 12);
-    auto&& [status, dim_label] = DimensionLabel::create_uniform(
-        "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain);
+    auto&& [status, dim_label] =
+        DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+            "label",
+            DLABEL,
+            1,
+            label_domain,
+            Datatype::UINT64,
+            1,
+            index_domain));
     INFO(status.to_string());
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);

--- a/tiledb/sm/dimension_label/test/unit_dimension_label_base_schema.cc
+++ b/tiledb/sm/dimension_label/test/unit_dimension_label_base_schema.cc
@@ -1,0 +1,124 @@
+/**
+ * @file tiledb/sm/array_schema/unit_dimension_label_base_schema.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file tests the DimensionLabel::BaseSchema class
+ */
+
+#include <array>
+#include <catch.hpp>
+#include "tiledb/sm/buffer/buffer.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/datatype.h"
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+template <typename T>
+void require_range_is_equal(const Range& expected, const Range& result) {
+  if (expected.empty() || result.empty()) {
+    REQUIRE((expected.empty() && result.empty()));
+    return;
+  }
+  auto expected_data = static_cast<const T*>(expected.data());
+  auto result_data = static_cast<const T*>(result.data());
+  CHECK(expected_data[0] == result_data[0]);
+  REQUIRE(expected_data[1] == result_data[1]);
+}
+
+template <typename T>
+Range create_range(const T start, const T stop) {
+  std::array<T, 2> array{start, stop};
+  return {array.data(), 2 * sizeof(T)};
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "Round trip dimension label base schema",
+    "[dimension_label][serialize][deserialize]",
+    ((typename TLABEL, Datatype DLABEL), TLABEL, DLABEL),
+    (int8_t, Datatype::INT8),
+    (uint8_t, Datatype::UINT8),
+    (int16_t, Datatype::INT16),
+    (uint16_t, Datatype::UINT16),
+    (int32_t, Datatype::INT32),
+    (uint32_t, Datatype::UINT32),
+    (int64_t, Datatype::INT64),
+    (uint64_t, Datatype::UINT64),
+    (int64_t, Datatype::DATETIME_YEAR),
+    (int64_t, Datatype::DATETIME_MONTH),
+    (int64_t, Datatype::DATETIME_WEEK),
+    (int64_t, Datatype::DATETIME_DAY),
+    (int64_t, Datatype::DATETIME_HR),
+    (int64_t, Datatype::DATETIME_MIN),
+    (int64_t, Datatype::DATETIME_SEC),
+    (int64_t, Datatype::DATETIME_MS),
+    (int64_t, Datatype::DATETIME_US),
+    (int64_t, Datatype::DATETIME_NS),
+    (int64_t, Datatype::DATETIME_PS),
+    (int64_t, Datatype::DATETIME_FS),
+    (int64_t, Datatype::DATETIME_AS),
+    (int64_t, Datatype::TIME_HR),
+    (int64_t, Datatype::TIME_MIN),
+    (int64_t, Datatype::TIME_SEC),
+    (int64_t, Datatype::TIME_MS),
+    (int64_t, Datatype::TIME_US),
+    (int64_t, Datatype::TIME_NS),
+    (int64_t, Datatype::TIME_PS),
+    (int64_t, Datatype::TIME_FS),
+    (int64_t, Datatype::TIME_AS),
+    (float, Datatype::FLOAT32),
+    (double, Datatype::FLOAT64)) {
+  const auto index_domain = create_range<uint64_t>(0, 5);
+  const auto label_domain = create_range<TLABEL>(10, 60);
+  const uint32_t version{12};
+  DimensionLabel::BaseSchema schema{
+      "label", DLABEL, 1, label_domain, Datatype::UINT64, 1, index_domain};
+  Buffer write_buffer;
+  auto status = schema.serialize(&write_buffer, version);
+  write_buffer.owns_data();
+  INFO(status.to_string());
+  REQUIRE(status.ok());
+  ConstBuffer read_buffer(&write_buffer);
+  auto&& [read_status, schema2] = DimensionLabel::BaseSchema::deserialize(
+      &read_buffer,
+      version,
+      schema.index_datatype,
+      schema.index_cell_val_num,
+      schema.index_domain);
+  INFO(read_status.to_string());
+  REQUIRE(read_status.ok());
+  REQUIRE(schema2.has_value());
+  CHECK(schema.name == schema2->name);
+  CHECK(schema.label_datatype == schema2->label_datatype);
+  CHECK(schema.label_cell_val_num == schema2->label_cell_val_num);
+  require_range_is_equal<TLABEL>(schema.label_domain, schema2->label_domain);
+  REQUIRE(schema.index_datatype == schema2->index_datatype);
+  REQUIRE(schema.index_cell_val_num == schema2->index_cell_val_num);
+  require_range_is_equal<uint64_t>(schema.index_domain, schema2->index_domain);
+}

--- a/tiledb/sm/dimension_label/test/unit_uniform_dimension_label.cc
+++ b/tiledb/sm/dimension_label/test/unit_uniform_dimension_label.cc
@@ -1,11 +1,11 @@
 /**
- * @file tiledb/sm/array_schema/unit_dimension_label.cc
+ * @file tiledb/sm/array_schema/unit_uniform_dimension_label.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,11 +27,12 @@
  *
  * @section DESCRIPTION
  *
- * This file tests the DimensionLabel class
+ * This file tests the uniform (evenly-spaced) virtual dimension label.
  */
 
 #include <array>
 #include <catch.hpp>
+#include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/dimension_label/dimension_label.h"
 #include "tiledb/sm/enums/datatype.h"
 
@@ -48,6 +49,18 @@ void require_range_is_equal(const Range& result, const T start, const T end) {
   auto result_data = static_cast<const T*>(result.data());
   CHECK(start == result_data[0]);
   REQUIRE(end == result_data[1]);
+}
+
+template <typename T>
+void require_range_is_equal(const Range& expected, const Range& result) {
+  if (expected.empty() || result.empty()) {
+    REQUIRE((expected.empty() && result.empty()));
+    return;
+  }
+  auto expected_data = static_cast<const T*>(expected.data());
+  auto result_data = static_cast<const T*>(result.data());
+  CHECK(expected_data[0] == result_data[0]);
+  REQUIRE(expected_data[1] == result_data[1]);
 }
 
 template <typename T>
@@ -324,4 +337,82 @@ TEMPLATE_TEST_CASE_SIG(
     CHECK(!status.ok());
     REQUIRE(dim_label == nullptr);
   }
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "Round-trip uniform dimension label serialization",
+    "[dimension_label][uniform_label][serialize][deserialize]",
+    ((typename TLABEL, Datatype DLABEL), TLABEL, DLABEL),
+    (int8_t, Datatype::INT8),
+    (uint8_t, Datatype::UINT8),
+    (int16_t, Datatype::INT16),
+    (uint16_t, Datatype::UINT16),
+    (int32_t, Datatype::INT32),
+    (uint32_t, Datatype::UINT32),
+    (int64_t, Datatype::INT64),
+    (uint64_t, Datatype::UINT64),
+    (int64_t, Datatype::DATETIME_YEAR),
+    (int64_t, Datatype::DATETIME_MONTH),
+    (int64_t, Datatype::DATETIME_WEEK),
+    (int64_t, Datatype::DATETIME_DAY),
+    (int64_t, Datatype::DATETIME_HR),
+    (int64_t, Datatype::DATETIME_MIN),
+    (int64_t, Datatype::DATETIME_SEC),
+    (int64_t, Datatype::DATETIME_MS),
+    (int64_t, Datatype::DATETIME_US),
+    (int64_t, Datatype::DATETIME_NS),
+    (int64_t, Datatype::DATETIME_PS),
+    (int64_t, Datatype::DATETIME_FS),
+    (int64_t, Datatype::DATETIME_AS),
+    (int64_t, Datatype::TIME_HR),
+    (int64_t, Datatype::TIME_MIN),
+    (int64_t, Datatype::TIME_SEC),
+    (int64_t, Datatype::TIME_MS),
+    (int64_t, Datatype::TIME_US),
+    (int64_t, Datatype::TIME_NS),
+    (int64_t, Datatype::TIME_PS),
+    (int64_t, Datatype::TIME_FS),
+    (int64_t, Datatype::TIME_AS),
+    (float, Datatype::FLOAT32),
+    (double, Datatype::FLOAT64)) {
+  const uint32_t version{12};
+  const std::string name{"label"};
+  const uint32_t label_cell_val_num{1};
+  const auto label_domain = create_range<TLABEL>(0, 50);
+  const Datatype index_datatype{Datatype::UINT64};
+  const uint32_t index_cell_val_num{1};
+  const auto index_domain = create_range<uint64_t>(0, 5);
+  auto&& [status, dim_label] =
+      DimensionLabel::create_uniform(DimensionLabel::BaseSchema(
+          name,
+          DLABEL,
+          label_cell_val_num,
+          label_domain,
+          index_datatype,
+          index_cell_val_num,
+          index_domain));
+  REQUIRE(status.ok());
+  REQUIRE(dim_label != nullptr);
+  // Serialize the dimension label.
+  Buffer write_buffer;
+  status = dim_label->serialize(&write_buffer, version);
+  write_buffer.owns_data();
+  INFO(status.to_string());
+  REQUIRE(status.ok());
+  // Deserialize the dimension label.
+  ConstBuffer read_buffer(&write_buffer);
+  auto&& [read_status, dim_label2] = DimensionLabel::deserialize(
+      &read_buffer, version, index_datatype, index_cell_val_num, index_domain);
+  INFO(read_status.to_string());
+  REQUIRE(read_status.ok());
+  REQUIRE(dim_label2 != nullptr);
+  // Check values.
+  CHECK(dim_label2->label_type() == LabelType::LABEL_UNIFORM);
+  CHECK(dim_label2->name() == name);
+  CHECK(dim_label2->label_datatype() == DLABEL);
+  CHECK(dim_label2->label_cell_val_num() == label_cell_val_num);
+  require_range_is_equal<TLABEL>(dim_label2->label_domain(), label_domain);
+  REQUIRE(dim_label2->index_datatype() == index_datatype);
+  REQUIRE(dim_label2->index_cell_val_num() == index_cell_val_num);
+  require_range_is_equal<uint64_t>(dim_label2->index_domain(), index_domain);
 }


### PR DESCRIPTION
This PR adds serialization and deserialization routines to dimension labels. 

Supplementary changes:
* Simplify input to factory method using base schema.
* Consolidates unit tests for dimension label into a single executable.

---
TYPE: NO_HISTORY
DESC:  Adds serialization and deserialization routines to dimension label 
