### PR TITLE
Run doc-render job on doc-only PRs, and not on non-doc PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,6 +4,10 @@ on:
     types:
       - closed
       - labeled
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 jobs:
   backport:

--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -1,6 +1,11 @@
 name: Build-Dockerfile
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 jobs:
   build-dockerfile:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,7 +1,15 @@
 name: build-docs
 on:
   push:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 jobs:
   build:

--- a/.github/workflows/build-macOS11-GCS.yml
+++ b/.github/workflows/build-macOS11-GCS.yml
@@ -5,9 +5,17 @@ on:
       - dev
       - release-*
       - refs/tags/*
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build-macOS11-S3.yml
+++ b/.github/workflows/build-macOS11-S3.yml
@@ -5,9 +5,17 @@ on:
       - dev
       - release-*
       - refs/tags/*
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build-ubuntu16.04-HDFS.yml
+++ b/.github/workflows/build-ubuntu16.04-HDFS.yml
@@ -5,9 +5,17 @@ on:
       - dev
       - release-*
       - refs/tags/*
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_HDFS: ON

--- a/.github/workflows/build-ubuntu20.04-AZURE.yml
+++ b/.github/workflows/build-ubuntu20.04-AZURE.yml
@@ -5,9 +5,18 @@ on:
       - dev
       - release-*
       - refs/tags/*
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
+
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_AZURE: ON

--- a/.github/workflows/build-ubuntu20.04-GCS.yml
+++ b/.github/workflows/build-ubuntu20.04-GCS.yml
@@ -5,9 +5,18 @@ on:
       - dev
       - release-*
       - refs/tags/*
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
+
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_GCS: ON

--- a/.github/workflows/build-ubuntu20.04-S3.yml
+++ b/.github/workflows/build-ubuntu20.04-S3.yml
@@ -5,9 +5,18 @@ on:
       - dev
       - release-*
       - refs/tags/*
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
+
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_STATIC: OFF

--- a/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
+++ b/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
@@ -5,9 +5,18 @@ on:
       - dev
       - release-*
       - refs/tags/*
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
+
 env:
   TILEDB_SERIALIZATION: ON # NOTE: currently defined directly inline
   CXX: g++

--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -1,7 +1,16 @@
 name: build-ubuntu-20.04-backwards-compatibility
 on:
   push:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
+
 env:
   CXX: g++
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,7 +2,15 @@ name: windows build
 
 on:
   push:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,7 +1,15 @@
 name: check-formatting
 on:
   push:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 jobs:
   build:

--- a/.github/workflows/check-heap-memory-api-violations.yml
+++ b/.github/workflows/check-heap-memory-api-violations.yml
@@ -1,7 +1,15 @@
 name: check-heap-memory-api-violations
 on:
   push:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 jobs:
   build:

--- a/.github/workflows/check-pr-body.yml
+++ b/.github/workflows/check-pr-body.yml
@@ -3,6 +3,10 @@ name: Check PR body
 on:
   pull_request:
     types: [opened, edited]
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 jobs:
   check_pr_body:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -2,7 +2,15 @@ name: msys2
 
 on:
   push:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 jobs:
   build:

--- a/.github/workflows/quarto-render.yml
+++ b/.github/workflows/quarto-render.yml
@@ -3,7 +3,15 @@
 name: Render and deploy Quarto files
 on: 
   push:
+    paths:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
+    paths:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 jobs:
   quarto-render-and-deploy:

--- a/.github/workflows/rtools40.yml
+++ b/.github/workflows/rtools40.yml
@@ -2,7 +2,15 @@ name: rtools40
 
 on:
   push:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 jobs:
   build:

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -1,7 +1,15 @@
 name: unit-test-standalone
 on:
   push:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
   pull_request:
+    paths-ignore:
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF


### PR DESCRIPTION
We found on https://github.com/TileDB-Inc/TileDB/pull/3043 that lots of CI was getting triggered for a doc-only PR.

Also, fix `main` -> `dev` in `.github/workflows/quarto-render.yml`.

---
TYPE: IMPROVEMENT
DESC: Run doc-render job on doc-only PRs, and not on non-doc PRs
