### PR TITLE
Sparse Global Order Reader Fix: Break At Correct Number of Cell

### DIFF
--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -217,7 +217,7 @@ void read_and_check_empty_coords_array(
   query.set_data_buffer("attr", attr_val);
   query.set_offsets_buffer("attr", attr_off);
 
-  // Query outside uniwrtten coordinates of the array
+  // Query outside unwritten coordinates of the array
   int64_t d1_start = 1, d1_end = 2;
   int64_t d2_start = 3, d2_end = 4;
   query.add_range("d1", d1_start, d1_end);

--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -205,6 +205,37 @@ void partial_read_and_check_sparse_array(
   array.close();
 }
 
+void read_and_check_empty_coords_array(
+    Context ctx, const std::string& array_name, tiledb_layout_t layout) {
+  Array array(ctx, array_name, TILEDB_READ);
+  Query query(ctx, array, TILEDB_READ);
+
+  std::vector<int32_t> attr_val(4);
+  std::vector<uint64_t> attr_off(4);
+
+  query.set_layout(layout);
+  query.set_data_buffer("attr", attr_val);
+  query.set_offsets_buffer("attr", attr_off);
+
+  // Query outside uniwrtten coordinates of the array
+  int64_t d1_start = 1, d1_end = 2;
+  int64_t d2_start = 3, d2_end = 4;
+  query.add_range("d1", d1_start, d1_end);
+  query.add_range("d2", d2_start, d2_end);
+
+  CHECK_NOTHROW(query.submit());
+
+  // Check the element offsets are properly returned
+  uint64_t offset_elem_num = 0, data_vals_num = 0, validity_elem_num = 0;
+  std::tie(offset_elem_num, data_vals_num, validity_elem_num) =
+      query.result_buffer_elements_nullable()["attr"];
+
+  CHECK(offset_elem_num == 0);
+  CHECK(data_vals_num == 0);
+
+  array.close();
+}
+
 void create_dense_array(const std::string& array_name) {
   Context ctx;
   VFS vfs(ctx);
@@ -678,6 +709,47 @@ TEST_CASE(
         }
       }
 
+      SECTION("Query unwritten coordinates") {
+        CHECK((std::string)config["sm.var_offsets.mode"] == "bytes");
+        Context ctx(config);
+
+        // Write data with extra element indicating total number of bytes
+        data_offsets.push_back(sizeof(data[0]) * data.size());
+
+        SECTION("Unordered write") {
+          write_sparse_array(
+              ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
+          SECTION("Row major read") {
+            read_and_check_empty_coords_array(
+                ctx, array_name, TILEDB_ROW_MAJOR);
+          }
+          SECTION("Global order read") {
+            read_and_check_empty_coords_array(
+                ctx, array_name, TILEDB_GLOBAL_ORDER);
+          }
+          SECTION("Unordered read") {
+            read_and_check_empty_coords_array(
+                ctx, array_name, TILEDB_UNORDERED);
+          }
+        }
+        SECTION("Global order write") {
+          write_sparse_array(
+              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
+          SECTION("Row major read") {
+            read_and_check_empty_coords_array(
+                ctx, array_name, TILEDB_ROW_MAJOR);
+          }
+          SECTION("Global order read") {
+            read_and_check_empty_coords_array(
+                ctx, array_name, TILEDB_GLOBAL_ORDER);
+          }
+          SECTION("Unordered read") {
+            read_and_check_empty_coords_array(
+                ctx, array_name, TILEDB_UNORDERED);
+          }
+        }
+      }
+
       SECTION("User offsets buffer too small") {
         Context ctx(config);
 
@@ -1100,7 +1172,8 @@ TEST_CASE(
         config["sm.var_offsets.mode"] = "elements";
         Context ctx(config);
 
-        // Write data with extra element indicating the total number of elements
+        // Write data with extra element indicating the total number of
+        // elements
         element_offsets.push_back(data.size());
 
         SECTION("Ordered write") {

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -1151,7 +1151,8 @@ uint64_t SparseGlobalOrderReader::compute_var_size_offsets(
 
   // Switch offsets buffer from cell size to offsets.
   auto offsets_buff = (OffType*)query_buffer.buffer_;
-  for (uint64_t c = 0; c < cell_offsets[result_cell_slabs.size()]; c++) {
+  for (uint64_t c = cell_offsets[0]; c < cell_offsets[result_cell_slabs.size()];
+       c++) {
     auto tmp = offsets_buff[c];
     offsets_buff[c] = new_var_buffer_size;
     new_var_buffer_size += tmp;
@@ -1162,47 +1163,46 @@ uint64_t SparseGlobalOrderReader::compute_var_size_offsets(
     // Buffers are full.
     buffers_full_ = true;
 
-    // First find the last full result tile that we can fit.
+    // Make sure that the start of the last RCS can fit the buffers. If not,
+    // pop the last slab until it does.
     auto total_cells = cell_offsets[result_cell_slabs.size() - 1];
     new_var_buffer_size = ((OffType*)query_buffer.buffer_)[total_cells];
     while (query_buffer.original_buffer_var_size_ < new_var_buffer_size) {
-      // Revert progress for this slab, and pop it.
+      // Revert progress for this slab in read state, and pop it.
       auto& last_rcs = result_cell_slabs.back();
       read_state_.frag_tile_idx_[last_rcs.tile_->frag_idx()] =
           std::pair<uint64_t, uint64_t>(
               last_rcs.tile_->tile_idx(), last_rcs.start_);
       result_cell_slabs.pop_back();
 
+      // Update the new var buffer size.
       auto total_cells = cell_offsets[result_cell_slabs.size() - 1];
       new_var_buffer_size = ((OffType*)query_buffer.buffer_)[total_cells];
     }
 
-    // Add in a partial slab if the buffer is not full.
-    if (query_buffer.original_buffer_var_size_ != new_var_buffer_size) {
-      auto& last_rcs = result_cell_slabs.back();
+    // Add as many cells from the last slab as possible, it could be 0.
+    auto& last_rcs = result_cell_slabs.back();
 
-      // Find the totals cells we can fit.
-      auto total_cells = cell_offsets[result_cell_slabs.size() - 1];
-      auto max = cell_offsets[result_cell_slabs.size()] - 1;
-      for (; total_cells < max; total_cells++) {
-        if (((OffType*)query_buffer.buffer_)[total_cells] >
-            query_buffer.original_buffer_var_size_)
-          break;
-      }
-
-      // Adjust cell offsets and rcs length.
-      cell_offsets[result_cell_slabs.size()] = total_cells;
-      last_rcs.length_ =
-          total_cells - cell_offsets[result_cell_slabs.size() - 1];
-
-      // Update the buffer size.
-      new_var_buffer_size = ((OffType*)query_buffer.buffer_)[total_cells];
-
-      // Update the cell progress.
-      read_state_.frag_tile_idx_[last_rcs.tile_->frag_idx()] =
-          std::pair<uint64_t, uint64_t>(
-              last_rcs.tile_->tile_idx(), last_rcs.start_ + last_rcs.length_);
+    // Find the totals cells we can fit.
+    total_cells = cell_offsets[result_cell_slabs.size() - 1];
+    auto max = cell_offsets[result_cell_slabs.size()] - 1;
+    for (; total_cells < max; total_cells++) {
+      if (((OffType*)query_buffer.buffer_)[total_cells + 1] >
+          query_buffer.original_buffer_var_size_)
+        break;
     }
+
+    // Adjust cell offsets and rcs length.
+    cell_offsets[result_cell_slabs.size()] = total_cells;
+    last_rcs.length_ = total_cells - cell_offsets[result_cell_slabs.size() - 1];
+
+    // Update the buffer size.
+    new_var_buffer_size = ((OffType*)query_buffer.buffer_)[total_cells];
+
+    // Update the cell progress.
+    read_state_.frag_tile_idx_[last_rcs.tile_->frag_idx()] =
+        std::pair<uint64_t, uint64_t>(
+            last_rcs.tile_->tile_idx(), last_rcs.start_ + last_rcs.length_);
   }
 
   return new_var_buffer_size;

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -1424,7 +1424,7 @@ Status SparseGlobalOrderReader::end_iteration() {
     num_rt += result_tiles_[f].size();
   }
 
-  logger_->debug("Done with iteration, num result tiles {1}", num_rt);
+  logger_->debug("Done with iteration, num result tiles {0}", num_rt);
 
   array_memory_tracker_->set_budget(std::numeric_limits<uint64_t>::max());
   return Status::Ok();


### PR DESCRIPTION
* Changes by @KiterLuc
* Previously, the loop broke when the number of cells becomes +1 cells
  larger than what the buffer could hold. Now, the conditional statement
  compares against `total_cells + 1` to break at the correct number of
  cells
* Bug fix for `cell_offsets[0]` when switching offsets buffer from cell
  size to offsets
* Update inline comments to be clearer

---
TYPE: BUG
DESC: Sparse Global Order Reader Fix: Decrement Total Cells
