### PR TITLE
[Backport release-2.8] update validity buffer size via query_buffer.validity_vector_

### DIFF
--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -805,6 +805,11 @@ Status RestClient::update_attribute_buffer_sizes(
       *query_buffer.buffer_size_ = state.offset_size;
     } else if (query_buffer.buffer_size_ != nullptr)
       *query_buffer.buffer_size_ = state.data_size;
+
+    bool nullable = query->array_schema().is_nullable(name);
+    if (nullable && query_buffer.validity_vector_.buffer_size()) {
+      *query_buffer.validity_vector_.buffer_size() = state.validity_size;
+    }
   }
 
   return Status::Ok();


### PR DESCRIPTION
Backport 503c076d2d7115c4359f3a11b9f026d3559fc2b6 from #3015

---
TYPE: BUG
DESC: Incorrect validity result count in REST query
