### PR TITLE
Sparse Index Reader Fix: Check For Empty Buffer

### DIFF
--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -1387,6 +1387,11 @@ Status DenseReader::add_extra_offset() {
     if (!array_schema_.var_size(name))
       continue;
 
+    // Do not apply offset for empty results because we will
+    // write backwards and corrupt memory we don't own.
+    if (*it.second.buffer_size_ == 0)
+      continue;
+
     auto buffer = static_cast<unsigned char*>(it.second.buffer_);
     if (offsets_format_mode_ == "bytes") {
       memcpy(

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -669,7 +669,9 @@ Status SparseIndexReaderBase::add_extra_offset() {
     if (!array_schema_.var_size(name))
       continue;
 
-    if (*it.second.buffer_size_ <= 0)
+    // Do not apply offset for empty results because we will
+    // write backwards and corrupt memory we don't own.
+    if (*it.second.buffer_size_ == 0)
       continue;
 
     auto buffer = static_cast<unsigned char*>(it.second.buffer_);

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -669,6 +669,9 @@ Status SparseIndexReaderBase::add_extra_offset() {
     if (!array_schema_.var_size(name))
       continue;
 
+    if (*it.second.buffer_size_ <= 0)
+      continue;
+
     auto buffer = static_cast<unsigned char*>(it.second.buffer_);
     if (offsets_format_mode_ == "bytes") {
       memcpy(


### PR DESCRIPTION
* Check if the buffer is empty in `SparseIndexReaderBase::add_extra_offset`
  first. Otherwise the dest in `memcpy` will point to a location
  `offsets_bytesize()` prior to the start of the buffer.

---
TYPE: BUG
DESC: Sparse Index Reader Fix: Check For Empty Buffer
