### PR TITLE
Refactor repeated encryption get stanza

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -803,7 +803,7 @@ TEST_CASE_METHOD(
     rc = tiledb_config_set(cfg, "sm.encryption_type", "NO_ENCRYPTION", &err);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(err == nullptr);
-    rc = tiledb_config_set(cfg, "sm.encryption_key", "0", &err);
+    rc = tiledb_config_set(cfg, "sm.encryption_key", "", &err);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(err == nullptr);
     rc = tiledb_array_set_config(ctx_, array, cfg);

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -246,8 +246,12 @@ Status Array::open(
   }
 
   // Get encryption key from config
+  Status st;
+  EncryptionType t;
+  std::string key;
+  uint32_t len;
   if (encryption_key == nullptr) {
-    auto&& [st, t, key, len] = EncryptionKey::get_encryption_from_cfg(config_);
+    std::tie(st, t, key, len) = EncryptionKey::get_encryption_from_cfg(config_);
     RETURN_NOT_OK(st);
     if (!key.empty()) {
       encryption_key = key.c_str();

--- a/tiledb/sm/crypto/encryption_key.h
+++ b/tiledb/sm/crypto/encryption_key.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_ENCRYPTION_KEY_H
 #define TILEDB_ENCRYPTION_KEY_H
 
+#include "tiledb/common/common.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/buffer/buffer.h"
 
@@ -42,6 +43,8 @@ using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {
+
+class Config;
 
 enum class EncryptionType : uint8_t;
 
@@ -71,6 +74,13 @@ class EncryptionKey {
    */
   static bool is_valid_key_length(
       EncryptionType encryption_type, uint32_t key_length);
+
+  /**
+   * Returns the encryption type, key and key length from the passed
+   * Config object
+   */
+  static tuple<Status, EncryptionType, std::string, uint32_t>
+  get_encryption_from_cfg(const Config& cfg);
 
   /** Returns a ConstBuffer holding a pointer to the key bytes. */
   ConstBuffer key() const;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -351,8 +351,12 @@ Status StorageManager::array_consolidate(
   }
 
   // Get encryption key from config
+  Status st;
+  EncryptionType t;
+  std::string key;
+  uint32_t len;
   if (encryption_key == nullptr) {
-    auto&& [st, t, key, len] = EncryptionKey::get_encryption_from_cfg(*config);
+    std::tie(st, t, key, len) = EncryptionKey::get_encryption_from_cfg(*config);
     RETURN_NOT_OK(st);
     if (!key.empty()) {
       encryption_key = key.c_str();
@@ -411,8 +415,12 @@ Status StorageManager::array_metadata_consolidate(
   }
 
   // Get encryption key from config
+  Status st;
+  EncryptionType t;
+  std::string key;
+  uint32_t len;
   if (encryption_key == nullptr) {
-    auto&& [st, t, key, len] = EncryptionKey::get_encryption_from_cfg(*config);
+    std::tie(st, t, key, len) = EncryptionKey::get_encryption_from_cfg(*config);
     RETURN_NOT_OK(st);
     if (!key.empty()) {
       encryption_key = key.c_str();
@@ -480,10 +488,12 @@ Status StorageManager::array_create(
 
   // Get encryption key from config
   Status st;
+  EncryptionType t;
+  std::string key;
+  uint32_t len;
   if (encryption_key.encryption_type() == EncryptionType::NO_ENCRYPTION) {
-    auto&& [status, t, key, len] =
-        EncryptionKey::get_encryption_from_cfg(config_);
-    RETURN_NOT_OK(status);
+    std::tie(st, t, key, len) = EncryptionKey::get_encryption_from_cfg(config_);
+    RETURN_NOT_OK(st);
 
     EncryptionKey encryption_key_cfg;
     if (key.empty()) {
@@ -1170,10 +1180,13 @@ StorageManager::load_array_schema_from_uri(
   Tile* tile = nullptr;
 
   // Get encryption key from config
+  Status st;
+  EncryptionType t;
+  std::string key;
+  uint32_t len;
   if (encryption_key.encryption_type() == EncryptionType::NO_ENCRYPTION) {
-    auto&& [status, t, key, len] =
-        EncryptionKey::get_encryption_from_cfg(config_);
-    RETURN_NOT_OK_TUPLE(status, nullopt);
+    std::tie(st, t, key, len) = EncryptionKey::get_encryption_from_cfg(config_);
+    RETURN_NOT_OK_TUPLE(st, nullopt);
 
     EncryptionKey encryption_key_cfg;
     if (key.empty()) {
@@ -1193,7 +1206,7 @@ StorageManager::load_array_schema_from_uri(
   Buffer buff;
   buff.realloc(tile->size());
   buff.set_size(tile->size());
-  auto st = tile->read(buff.data(), 0, buff.size());
+  st = tile->read(buff.data(), 0, buff.size());
   tdb_delete(tile);
   RETURN_NOT_OK_TUPLE(st, nullopt);
 


### PR DESCRIPTION
Refactor 6 almost identical code sequences that are used in `storage_manager.cc` and `array.cc`, also in the new Group API, into an external function.

Notes to the reviewers:
It might be that the decisions I took below might alter some corner cases I failed to see, backward compatibility, etc. So please read the notes below.
- The refactored code is missing `assert`s  that were present in the original code. This version returns Status codes when things go sideways whilst reading the encryption configuration.
- I altered a test case that was failing for me.
The test case sets `"sm.encryption_key"` to `"0"`, but a comment two lines above says `Check ok with null key`. The test case was failing for me because "0" has a length of 1, which is an invalid length for an encryption key, so the new function returned an error Status.
With the original code, the test was not failing because "0" was being detected as an invalid-length key, but no error was being returned, the code was running the rest of the function with `encryption_key=nullptr` and `key_length=0`.
I'm not sure what's the expected behavior here, I altered the test case because it seemed like a mistake to me.

---
TYPE: IMPROVEMENT
DESC: Refactor repeated encryption get stanza
