### PR TITLE
Update page-titling convention to use frontmatter-style titles

### DIFF
--- a/format_spec/FORMAT_SPEC.md
+++ b/format_spec/FORMAT_SPEC.md
@@ -1,4 +1,6 @@
-# Format Specification
+---
+title: Format Specification
+---
 
 **Notes:**  
 

--- a/format_spec/array_file_hierarchy.md
+++ b/format_spec/array_file_hierarchy.md
@@ -1,4 +1,6 @@
-# Array File Hierarchy
+---
+title: Array File Hierarchy
+---
 
 An array is a folder with the following structure:
 

--- a/format_spec/array_metadata.md
+++ b/format_spec/array_metadata.md
@@ -1,4 +1,6 @@
-# Array Metadata
+---
+title: Array Metadata
+---
 
 ## Main Structure
 

--- a/format_spec/array_schema.md
+++ b/format_spec/array_schema.md
@@ -1,4 +1,6 @@
-# Array Schema
+---
+title: Array Schema
+---
 
 ## Current Array Schema Version
 

--- a/format_spec/consolidated_commits_file.md
+++ b/format_spec/consolidated_commits_file.md
@@ -1,4 +1,6 @@
-# Consolidated Commits File
+---
+title: Consolidated Commits File
+---
 
 A consolidated commits file has name `<timestamped_name>.con` and is located here:
 

--- a/format_spec/consolidated_fragment_metadata_file.md
+++ b/format_spec/consolidated_fragment_metadata_file.md
@@ -1,4 +1,6 @@
-# Consolidated Fragment Metadata File
+---
+title: Consolidated Fragment Metadata File
+---
 
 A consolidated fragment metadata file has name `<timestamped_name>.meta` and is located here:
 

--- a/format_spec/filter_pipeline.md
+++ b/format_spec/filter_pipeline.md
@@ -1,4 +1,6 @@
-# Filter Pipeline
+---
+title: Filter Pipeline
+---
 
 ## Main Structure
 

--- a/format_spec/fragment.md
+++ b/format_spec/fragment.md
@@ -1,4 +1,6 @@
-# Fragment
+---
+title: Fragment
+---
 
 ## Main Structure
 

--- a/format_spec/generic_tile.md
+++ b/format_spec/generic_tile.md
@@ -1,4 +1,6 @@
-# Generic Tile
+---
+title: Generic Tile
+---
 
 The generic tile is a [tile](./tile.md) prepended with some extra header data, so that it can be used stand-alone without requiring extra information from the array schema. A generic tile has the following on-disk format:
 

--- a/format_spec/group_file_hierarchy.md
+++ b/format_spec/group_file_hierarchy.md
@@ -1,4 +1,6 @@
-# Group File Hierarchy
+---
+title: Group File Hierarchy
+---
 
 A TileDB group is a folder with a single file in it:
 

--- a/format_spec/ignore_file.md
+++ b/format_spec/ignore_file.md
@@ -1,4 +1,6 @@
-# Ignore File
+---
+title: Ignore File
+---
 
 A ignore file has name `__t1_t2_uuid_v.ign` and is located in the array commit folder:
 

--- a/format_spec/tile.md
+++ b/format_spec/tile.md
@@ -1,4 +1,6 @@
-# Tile
+---
+title: Tile
+---
 
 ## Main Structure
 

--- a/format_spec/vacuum_file.md
+++ b/format_spec/vacuum_file.md
@@ -1,4 +1,6 @@
-# Vacuum File
+---
+title: Vacuum File
+---
 
 A vacuum file has name `__t1_t2_uuid_v.vac` and can be located either in the array commit folder:
 

--- a/index.md
+++ b/index.md
@@ -1,3 +1,5 @@
-# Public code docs
+---
+title: Public code docs
+---
 
 This is public documentation of the code within this repository.


### PR DESCRIPTION
Following https://github.com/quarto-dev/quarto-cli/discussions/507. TL;DR page titles are rendered correctly on mobile now.

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: Make HTML docs render titles correctly on mobile
