### PR TITLE
change to avoid possible file sharing violations

### DIFF
--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -306,9 +306,10 @@ tuple<Status, optional<std::vector<directory_entry>>> Win::ls_with_sizes(
       if (is_dir(file_path)) {
         entries.emplace_back(file_path, 0);
       } else {
-        uint64_t size;
-        RETURN_NOT_OK_TUPLE(file_size(file_path, &size), nullopt);
-        entries.emplace_back(file_path, size);
+        ULARGE_INTEGER size;
+        size.LowPart = find_data.nFileSizeLow;
+        size.HighPart = find_data.nFileSizeHigh;
+        entries.emplace_back(file_path, size.QuadPart);
       }
     }
 


### PR DESCRIPTION
change method of obtaining file size in ls_with_sizes() to avoid the file sharing conflicts possible when Createfile()/GetFileSizeEx() was used

---
TYPE: BUG
DESC: use different API approach to avoid possible file sharing violation
