### PR TITLE
Adjust group cap'n proto spec and various minor improvements

### DIFF
--- a/examples/c_api/groups.c
+++ b/examples/c_api/groups.c
@@ -120,16 +120,14 @@ void create_arrays_groups() {
   tiledb_group_alloc(ctx, "my_group", &my_group);
   tiledb_group_open(ctx, my_group, TILEDB_WRITE);
 
-  tiledb_group_add_member(ctx, my_group, "my_group/dense_arrays/array_A", 1);
-  tiledb_group_add_member(ctx, my_group, "my_group/dense_arrays/array_B", 1);
-  tiledb_group_add_member(ctx, my_group, "my_group/sparse_arrays", 1);
+  tiledb_group_add_member(ctx, my_group, "dense_arrays/array_A", 1);
+  tiledb_group_add_member(ctx, my_group, "dense_arrays/array_B", 1);
+  tiledb_group_add_member(ctx, my_group, "sparse_arrays", 1);
 
   tiledb_group_alloc(ctx, "my_group/sparse_arrays", &sparse_arrays_group);
   tiledb_group_open(ctx, sparse_arrays_group, TILEDB_WRITE);
-  tiledb_group_add_member(
-      ctx, sparse_arrays_group, "my_group/sparse_arrays/array_C", 1);
-  tiledb_group_add_member(
-      ctx, sparse_arrays_group, "my_group/sparse_arrays/array_C", 1);
+  tiledb_group_add_member(ctx, sparse_arrays_group, "array_C", 1);
+  tiledb_group_add_member(ctx, sparse_arrays_group, "array_D", 1);
 
   tiledb_group_close(ctx, my_group);
   tiledb_group_close(ctx, sparse_arrays_group);
@@ -153,7 +151,6 @@ void print_group() {
   tiledb_group_dump_str(ctx, my_group, &str, 1);
 
   printf("%s\n", str);
-
   free(str);
 
   tiledb_group_close(ctx, my_group);

--- a/examples/c_api/groups.c
+++ b/examples/c_api/groups.c
@@ -147,7 +147,7 @@ void print_group() {
   tiledb_group_t* my_group;
 
   tiledb_group_alloc(ctx, "my_group", &my_group);
-  tiledb_group_open(ctx, my_group, TILEDB_WRITE);
+  tiledb_group_open(ctx, my_group, TILEDB_READ);
 
   char* str;
   tiledb_group_dump_str(ctx, my_group, &str, 1);
@@ -155,6 +155,7 @@ void print_group() {
   printf("%s\n", str);
 
   free(str);
+
   tiledb_group_close(ctx, my_group);
   tiledb_group_free(&my_group);
 }

--- a/examples/cpp_api/groups.cc
+++ b/examples/cpp_api/groups.cc
@@ -78,13 +78,13 @@ void create_arrays_groups() {
   create_array("my_group/sparse_arrays/array_D", TILEDB_SPARSE);
 
   tiledb::Group group(ctx, "my_group", TILEDB_WRITE);
-  group.add_member("my_group/dense_arrays/array_A", true);
-  group.add_member("my_group/dense_arrays/array_B", true);
-  group.add_member("my_group/sparse_arrays", true);
+  group.add_member("dense_arrays/array_A", true);
+  group.add_member("dense_arrays/array_B", true);
+  group.add_member("sparse_arrays", true);
 
   tiledb::Group group_sparse(ctx, "my_group/sparse_arrays", TILEDB_WRITE);
-  group_sparse.add_member("my_group/sparse_arrays/array_C", true);
-  group_sparse.add_member("my_group/sparse_arrays/array_D", true);
+  group_sparse.add_member("array_C", true);
+  group_sparse.add_member("array_D", true);
 }
 
 void print_group() {

--- a/test/src/serialization_wrappers.cc
+++ b/test/src/serialization_wrappers.cc
@@ -82,3 +82,21 @@ int tiledb_array_create_serialization_wrapper(
 
   return rc;
 }
+
+int tiledb_group_serialize(
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group_serialized,
+    tiledb_group_t* group_deserialized,
+    tiledb_serialization_type_t serialize_type) {
+  // Serialize and Deserialize
+  tiledb_buffer_t* buffer;
+  int rc =
+      tiledb_serialize_group(ctx, group_serialized, serialize_type, 1, &buffer);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_deserialize_group(
+      ctx, buffer, serialize_type, 0, group_deserialized);
+  REQUIRE(rc == TILEDB_OK);
+
+  return rc;
+}

--- a/test/src/serialization_wrappers.h
+++ b/test/src/serialization_wrappers.h
@@ -52,4 +52,19 @@ int tiledb_array_create_serialization_wrapper(
     tiledb_array_schema_t* array_schema,
     bool serialize_array_schema);
 
+/**
+ * Wrap a group in serialize/deserialize call
+ *
+ * @param ctx tiledb context
+ * @param group_serialized group to serialize
+ * @param group_deserialized group to deserialize into
+ * @param serialize_type serialization format
+ * @return status
+ */
+int tiledb_group_serialize(
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group_serialized,
+    tiledb_group_t* group_deserialized,
+    tiledb_serialization_type_t serialize_type);
+
 #endif  // TILEDB_TEST_SERIALIZATION_WRAPPERS_H

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -225,6 +225,7 @@ void check_save_to_file() {
 #else
   ss << "config.logging_level 0\n";
 #endif
+  ss << "rest.curl.verbose false\n";
   ss << "rest.http_compressor any\n";
   ss << "rest.retry_count 25\n";
   ss << "rest.retry_delay_factor 1.25\n";
@@ -557,6 +558,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["rest.retry_delay_factor"] = "1.25";
   all_param_values["rest.retry_initial_delay_ms"] = "500";
   all_param_values["rest.retry_http_codes"] = "503";
+  all_param_values["rest.curl.verbose"] = "false";
   all_param_values["sm.encryption_key"] = "";
   all_param_values["sm.encryption_type"] = "NO_ENCRYPTION";
   all_param_values["sm.dedup_coords"] = "false";

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1405,6 +1405,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config);
  *    The delay factor to exponentially wait until further retries of a failed
  *    REST request <br>
  *    **Default**: 1.25
+ * - `rest.curl.verbose` <br>
+ * Set curl to run in verbose mode for REST requests <br>
+ * curl will print to stdout with this option
+ *    **Default**: false
  *
  * **Example:**
  *

--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -468,7 +468,7 @@ TILEDB_EXPORT int32_t tiledb_deserialize_config(
  * @param serialization_type Type of serialization to use
  * @param client_side If set to 1, deserialize from "client-side" perspective.
  *    Else, "server-side."
- * @param buffer_list Will be set to a newly allocated buffer list containing
+ * @param tiledb_buffer_t Will be set to a newly allocated buffer containing
  *    the serialized group.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
@@ -477,7 +477,7 @@ TILEDB_EXPORT int32_t tiledb_serialize_group(
     const tiledb_group_t* group,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_list_t** buffer_list);
+    tiledb_buffer_t** buffer_list);
 
 /**
  * Deserializes into an existing group from the given buffer.

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -64,6 +64,7 @@ const std::string Config::REST_RETRY_HTTP_CODES = "503";
 const std::string Config::REST_RETRY_COUNT = "25";
 const std::string Config::REST_RETRY_INITIAL_DELAY_MS = "500";
 const std::string Config::REST_RETRY_DELAY_FACTOR = "1.25";
+const std::string Config::REST_CURL_VERBOSE = "false";
 const std::string Config::SM_ENCRYPTION_KEY = "";
 const std::string Config::SM_ENCRYPTION_TYPE = "NO_ENCRYPTION";
 const std::string Config::SM_DEDUP_COORDS = "false";
@@ -219,6 +220,7 @@ Config::Config() {
   param_values_["rest.retry_count"] = REST_RETRY_COUNT;
   param_values_["rest.retry_initial_delay_ms"] = REST_RETRY_INITIAL_DELAY_MS;
   param_values_["rest.retry_delay_factor"] = REST_RETRY_DELAY_FACTOR;
+  param_values_["rest.curl.verbose"] = REST_CURL_VERBOSE;
   param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
   param_values_["config.logging_level"] = CONFIG_LOGGING_LEVEL;
   param_values_["config.logging_format"] = CONFIG_LOGGING_DEFAULT_FORMAT;
@@ -512,6 +514,8 @@ Status Config::unset(const std::string& param) {
     param_values_["rest.retry_initial_delay_ms"] = REST_RETRY_INITIAL_DELAY_MS;
   } else if (param == "rest.retry_delay_factor") {
     param_values_["rest.retry_delay_factor"] = REST_RETRY_DELAY_FACTOR;
+  } else if (param == "rest.curl.verbose") {
+    param_values_["rest.curl.verbose"] = REST_CURL_VERBOSE;
   } else if (param == "config.env_var_prefix") {
     param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
   } else if (param == "config.logging_level") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -77,6 +77,9 @@ class Config {
   /** The default exponential delay factor for retrying a http request. */
   static const std::string REST_RETRY_DELAY_FACTOR;
 
+  /** The default for Curl's verbose mode used by REST. */
+  static const std::string REST_CURL_VERBOSE;
+
   /** The prefix to use for checking for parameter environmental variables. */
   static const std::string CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -715,6 +715,10 @@ class Config {
    *    The delay factor to exponentially wait until further retries of a
    *    failed REST request <br>
    *    **Default**: 1.25
+   * - `rest.curl.verbose` <br>
+   * Set curl to run in verbose mode for REST requests <br>
+   * curl will print to stdout with this option
+   *    **Default**: false
    */
   Config& set(const std::string& param, const std::string& value) {
     tiledb_error_t* err;

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -136,6 +136,11 @@ Status Group::open(QueryType query_type) {
     }
   }
 
+  // Make sure to reset any values
+  changes_applied_ = false;
+  members_to_remove_.clear();
+  members_to_add_.clear();
+
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
@@ -226,6 +231,10 @@ Status Group::close() {
           return Status_GroupError(
               "Error closing group; remote group with no REST client.");
         RETURN_NOT_OK(rest_client->patch_group_to_rest(group_uri_, this));
+
+        changes_applied_ = true;
+        members_to_remove_.clear();
+        members_to_add_.clear();
       }
     }
 

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -418,6 +418,10 @@ Metadata* Group::metadata() {
   return &metadata_;
 }
 
+const Metadata* Group::metadata() const {
+  return &metadata_;
+}
+
 Status Group::metadata(Metadata** metadata) {
   // Load group metadata, if not loaded yet
   if (!metadata_loaded_)
@@ -426,6 +430,10 @@ Status Group::metadata(Metadata** metadata) {
   *metadata = &metadata_;
 
   return Status::Ok();
+}
+
+void Group::set_metadata_loaded(const bool metadata_loaded) {
+  metadata_loaded_ = metadata_loaded;
 }
 
 const EncryptionKey* Group::encryption_key() const {

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -140,6 +140,7 @@ Status Group::open(QueryType query_type) {
   changes_applied_ = false;
   members_to_remove_.clear();
   members_to_add_.clear();
+  members_.clear();
 
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
@@ -255,6 +256,7 @@ Status Group::close() {
   metadata_.clear();
   metadata_loaded_ = false;
   is_open_ = false;
+  clear();
 
   return Status::Ok();
 }

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -466,6 +466,16 @@ Status Group::set_config(Config config) {
   return Status::Ok();
 }
 
+Status Group::clear() {
+  members_.clear();
+  members_vec_.clear();
+  members_to_remove_.clear();
+  members_to_add_.clear();
+  changes_applied_ = false;
+
+  return Status::Ok();
+}
+
 Status Group::add_member(const tdb_shared_ptr<GroupMember>& group_member) {
   std::lock_guard<std::mutex> lck(mtx_);
   const std::string& uri = group_member->uri().to_string();

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -505,6 +505,11 @@ Status Group::mark_member_for_addition(
   ObjectType type = ObjectType::INVALID;
   RETURN_NOT_OK(
       storage_manager_->object_type(absolute_group_member_uri, &type));
+  if (type == ObjectType::INVALID) {
+    return Status_GroupError(
+        "Cannot add group member " + absolute_group_member_uri.to_string() +
+        ", type is INVALID. The member likely does not exist.");
+  }
 
   auto group_member =
       tdb::make_shared<GroupMemberV1>(HERE(), group_member_uri, type, relative);

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -156,11 +156,21 @@ class Group {
    * @note This is potentially an unsafe operation
    * it could have contention with locks from lazy loading of metadata.
    * This should only be used by the serialization class
-   * (tiledb/sm/serialization/group_schema_latest.cc). In that class we need to
+   * (tiledb/sm/serialization/group.cc). In that class we need to
    * fetch the underlying Metadata object to set the values we are loading from
    * REST. A lock should already by taken before load_metadata is called.
    */
   Metadata* metadata();
+  const Metadata* metadata() const;
+
+  /**
+   * Set metadata loaded
+   * * This should only be used by the serialization class
+   * (tiledb/sm/serialization/group.cc).
+   * @param bool metadata was loaded
+   * @return void
+   */
+  void set_metadata_loaded(const bool metadata_loaded);
 
   /** Returns a constant pointer to the encryption key. */
   const EncryptionKey* encryption_key() const;

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -299,6 +299,14 @@ class Group {
   bool changes_applied() const;
 
   /**
+   * Set changes applied, only used in serialization
+   * @param changes_applied should changes be considered to be applied? If so
+   * then this will enable writes from a deserialized group
+   *
+   */
+  void set_changes_applied(bool changes_applied);
+
+  /**
    * Get count of members
    *
    * @return tuple of Status and optional member count

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -76,6 +76,13 @@ class Group {
   Status close();
 
   /**
+   * Clear a group
+   *
+   * @return
+   */
+  Status clear();
+
+  /**
    * Deletes metadata from an group opened in WRITE mode.
    *
    * @param key The key of the metadata item to be deleted.

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -117,7 +117,6 @@ Status GroupDirectory::load() {
   std::vector<ThreadPool::Task> tasks;
   std::vector<URI> root_dir_uris;
   std::vector<URI> commits_dir_uris;
-  URI latest_fragment_meta_uri_v12_or_higher;
 
   // Lists all directories in parallel. Skipping for schema only.
   // Some processing is also done here for things that don't depend on others.
@@ -318,8 +317,9 @@ GroupDirectory::compute_filtered_uris(
   std::vector<TimestampedURI> filtered_uris;
 
   // Do nothing if there are not enough URIs
-  if (uris.empty())
+  if (uris.empty()) {
     return {Status::Ok(), filtered_uris};
+  }
 
   // Get the URIs that must be ignored
   std::unordered_set<std::string> to_ignore_set;

--- a/tiledb/sm/group/group_member_v1.cc
+++ b/tiledb/sm/group/group_member_v1.cc
@@ -43,15 +43,17 @@ GroupMemberV1::GroupMemberV1(
 
 // ===== FORMAT =====
 // format_version (uint32_t)
+// type (uint8_t)
+// relative (uint8_t)
 // uri_size (uint32_t)
 // uri (string)
-// type (uint8_t)
 Status GroupMemberV1::serialize(Buffer* buff) {
   RETURN_NOT_OK(buff->write(
       &GroupMemberV1::format_version_, sizeof(GroupMemberV1::format_version_)));
 
   // Write type
-  RETURN_NOT_OK(buff->write(&type_, sizeof(type_)));
+  uint8_t type = static_cast<uint8_t>(type_);
+  RETURN_NOT_OK(buff->write(&type, sizeof(type)));
 
   // Write relative
   RETURN_NOT_OK(buff->write(&relative_, sizeof(relative_)));
@@ -66,8 +68,10 @@ Status GroupMemberV1::serialize(Buffer* buff) {
 
 std::tuple<Status, std::optional<tdb_shared_ptr<GroupMember>>>
 GroupMemberV1::deserialize(ConstBuffer* buff) {
-  ObjectType type = ObjectType::INVALID;
-  RETURN_NOT_OK_TUPLE(buff->read(&type, sizeof(type)), std::nullopt);
+  uint8_t type_placeholder;
+  RETURN_NOT_OK_TUPLE(
+      buff->read(&type_placeholder, sizeof(type_placeholder)), std::nullopt);
+  ObjectType type = static_cast<ObjectType>(type_placeholder);
 
   bool relative;
   RETURN_NOT_OK_TUPLE(buff->read(&relative, sizeof(relative)), std::nullopt);

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -249,12 +249,14 @@ size_t write_header_callback(
   return size * count;
 }
 
-Curl::Curl()
+Curl::Curl(const std::shared_ptr<Logger>& logger)
     : config_(nullptr)
     , curl_(nullptr, curl_easy_cleanup)
     , retry_count_(0)
     , retry_delay_factor_(0)
-    , retry_initial_delay_ms_(0) {
+    , retry_initial_delay_ms_(0)
+
+    , logger_(logger->clone("curl ", ++logger_id_)) {
 }
 
 Status Curl::init(

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -255,7 +255,6 @@ Curl::Curl(const std::shared_ptr<Logger>& logger)
     , retry_count_(0)
     , retry_delay_factor_(0)
     , retry_initial_delay_ms_(0)
-
     , logger_(logger->clone("curl ", ++logger_id_)) {
 }
 
@@ -720,6 +719,7 @@ Status Curl::post_data_common(
   } else {
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, data->total_size());
   }
+  logger_->debug("posting {} bytes to", data->total_size());
 
   // Set auth and content-type for request
   *headers = nullptr;
@@ -881,6 +881,7 @@ Status Curl::patch_data_common(
         Status_RestError("Error posting data; curl instance is null."));
 
   const uint64_t post_size_limit = uint64_t(2) * 1024 * 1024 * 1024;
+  logger_->debug("patching {} bytes to", data->total_size());
   if (data->total_size() > post_size_limit) {
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, data->total_size());
   } else {
@@ -942,6 +943,7 @@ Status Curl::put_data_common(
         Status_RestError("Error posting data; curl instance is null."));
 
   const uint64_t post_size_limit = uint64_t(2) * 1024 * 1024 * 1024;
+  logger_->debug("puting {} bytes to", data->total_size());
   if (data->total_size() > post_size_limit) {
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, data->total_size());
   } else {

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -892,7 +892,7 @@ Status Curl::patch_data_common(
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
-        Status_RestError("Error posting data; curl instance is null."));
+        Status_RestError("Error patching data; curl instance is null."));
 
   const uint64_t post_size_limit = uint64_t(2) * 1024 * 1024 * 1024;
   logger_->debug("patching {} bytes to", data->total_size());
@@ -909,7 +909,10 @@ Status Curl::patch_data_common(
       set_content_type(serialization_type, headers),
       curl_slist_free_all(*headers));
 
-  /* HTTP PUT please */
+  /* Set POST so curl sends the body */
+  curl_easy_setopt(curl, CURLOPT_POST, 1);
+
+  /* HTTP PATCH please */
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PATCH");
   curl_easy_setopt(
       curl, CURLOPT_READFUNCTION, buffer_list_read_memory_callback);
@@ -954,10 +957,10 @@ Status Curl::put_data_common(
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
-        Status_RestError("Error posting data; curl instance is null."));
+        Status_RestError("Error putting data; curl instance is null."));
 
   const uint64_t post_size_limit = uint64_t(2) * 1024 * 1024 * 1024;
-  logger_->debug("puting {} bytes to", data->total_size());
+  logger_->debug("putting {} bytes to", data->total_size());
   if (data->total_size() > post_size_limit) {
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, data->total_size());
   } else {
@@ -970,6 +973,9 @@ Status Curl::put_data_common(
   RETURN_NOT_OK_ELSE(
       set_content_type(serialization_type, headers),
       curl_slist_free_all(*headers));
+
+  /* Set POST so curl sends the body */
+  curl_easy_setopt(curl, CURLOPT_POST, 1);
 
   /* HTTP PUT please */
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -781,6 +781,7 @@ Status Curl::options(
     stats::Stats* const stats,
     const std::string& url,
     SerializationType serialization_type,
+    Buffer* returned_data,
     const std::string& res_ns_uri) {
   CURL* curl = curl_.get();
   if (curl == nullptr)
@@ -797,14 +798,20 @@ Status Curl::options(
   /* pass our list of custom made headers */
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 
+  /* HTTP OPTIONS please */
+  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
+
+  /* HEAD */
+  curl_easy_setopt(curl, CURLOPT_NOBODY, 1);
+
   CURLcode ret;
   headerData.uri = &res_ns_uri;
-  auto st = make_curl_request_options_common(stats, url.c_str(), &ret);
+  auto st = make_curl_request(stats, url.c_str(), &ret, returned_data);
   curl_slist_free_all(headers);
   RETURN_NOT_OK(st);
 
   // Check for errors
-  RETURN_NOT_OK(check_curl_errors(ret, "OPTIONS"));
+  RETURN_NOT_OK(check_curl_errors(ret, "OPTIONS", returned_data));
 
   return Status::Ok();
 }
@@ -972,110 +979,5 @@ Status Curl::put_data_common(
 
   return Status::Ok();
 }
-
-Status Curl::make_curl_request_options_common(
-    stats::Stats* const stats,
-    const char* const url,
-    CURLcode* const curl_code) const {
-  CURL* curl = curl_.get();
-  if (curl == nullptr)
-    return LOG_STATUS(
-        Status_RestError("Cannot make curl request; curl instance is null."));
-
-  *curl_code = CURLE_OK;
-  uint64_t retry_delay = retry_initial_delay_ms_;
-  // <= because the 0ths retry is actually the initial request
-  for (uint8_t i = 0; i <= retry_count_; i++) {
-    /* set url to fetch */
-    curl_easy_setopt(curl, CURLOPT_URL, url);
-
-    /* HTTP OPTIONS please */
-    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "OPTIONS");
-
-    /* HEAD */
-    curl_easy_setopt(curl, CURLOPT_NOBODY, 1);
-
-    /* set default user agent */
-    // curl_easy_setopt(curl, CURLOPT_USERAGENT, "libcurl-agent/1.0");
-
-    /* Fail on error */
-    // curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
-
-    /* set timeout */
-    // curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
-
-    /* set compression */
-    const char* compressor = nullptr;
-    RETURN_NOT_OK(config_->get("rest.http_compressor", &compressor));
-
-    if (compressor != nullptr) {
-      // curl expects lowecase strings so let's convert
-      std::string comp(compressor);
-      std::locale loc;
-      for (std::string::size_type j = 0; j < comp.length(); ++j)
-        comp[j] = std::tolower(comp[j], loc);
-
-      if (comp != "none") {
-        if (comp == "any") {
-          comp = "";
-        }
-        curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, comp.c_str());
-      }
-    }
-
-    /* enable location redirects */
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
-
-    /* set maximum allowed redirects */
-    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 1);
-
-    /* enable forwarding auth to redirects */
-    curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 1L);
-
-    /* fetch the url */
-    CURLcode tmp_curl_code = curl_easy_perform(curl);
-
-    bool retry;
-    RETURN_NOT_OK(should_retry(&retry));
-    /* If Curl call was successful (not http status, but no socket error, etc)
-     * break */
-    if (tmp_curl_code == CURLE_OK && !retry) {
-      break;
-    }
-
-    /* Only store the first non-OK curl code, because it will likely be more
-     * useful than the curl codes from the retries. */
-    if (*curl_code == CURLE_OK) {
-      *curl_code = tmp_curl_code;
-    }
-
-    // Only sleep if this isn't the last failed request allowed
-    if (i < retry_count_ - 1) {
-      long http_code = 0;
-      if (curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code) !=
-          CURLE_OK)
-        return LOG_STATUS(Status_RestError(
-            "Error checking curl error; could not get HTTP code."));
-
-      global_logger().debug(
-          "Request to {} failed with http response code {}, will sleep {}ms, "
-          "retry count {}",
-          url,
-          http_code,
-          retry_delay,
-          i);
-      // Increment counter for number of retries
-      stats->add_counter("rest_http_retries", 1);
-      stats->add_counter("rest_http_retry_time", retry_delay);
-      // Sleep for retry delay
-      std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay));
-      // Increment retry delay, cast to uint64_t and we can ignore any rounding
-      retry_delay = static_cast<uint64_t>(retry_delay * retry_delay_factor_);
-    }
-  }
-
-  return Status::Ok();
-}
-
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -255,7 +255,8 @@ Curl::Curl(const std::shared_ptr<Logger>& logger)
     , retry_count_(0)
     , retry_delay_factor_(0)
     , retry_initial_delay_ms_(0)
-    , logger_(logger->clone("curl ", ++logger_id_)) {
+    , logger_(logger->clone("curl ", ++logger_id_))
+    , verbose_(false) {
 }
 
 Status Curl::init(
@@ -337,6 +338,9 @@ Status Curl::init(
 
   RETURN_NOT_OK(config_->get_vector<uint32_t>(
       "rest.retry_http_codes", &retry_http_codes_, &found));
+  assert(found);
+
+  RETURN_NOT_OK(config_->get<bool>("rest.curl.verbose", &verbose_, &found));
   assert(found);
 
   return Status::Ok();
@@ -474,6 +478,9 @@ Status Curl::make_curl_request_common(
     /* pass fetch buffer pointer */
     curl_easy_setopt(
         curl, CURLOPT_WRITEDATA, static_cast<void*>(&write_cb_state));
+
+    /* Set curl verbose mode */
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, verbose_);
 
     /* set default user agent */
     // curl_easy_setopt(curl, CURLOPT_USERAGENT, "libcurl-agent/1.0");

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -38,6 +38,7 @@
 #if !defined(NOMINMAX)
 #define NOMINMAX  // curl may include windows headers
 #endif
+
 #include <curl/curl.h>
 #include <cstdlib>
 #include <functional>
@@ -45,6 +46,9 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+
+#include "tiledb/common/dynamic_memory/dynamic_memory.h"
+#include "tiledb/common/logger_public.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/buffer_list.h"
 #include "tiledb/sm/config/config.h"
@@ -97,7 +101,7 @@ size_t write_header_callback(
 class Curl {
  public:
   /** Constructor. */
-  Curl();
+  explicit Curl(const std::shared_ptr<Logger>& logger);
 
   /** Destructor. */
   ~Curl() = default;
@@ -355,6 +359,12 @@ class Curl {
 
   /** List of http status codes to retry. */
   std::vector<uint32_t> retry_http_codes_;
+
+  /** The class logger. */
+  std::shared_ptr<Logger> logger_;
+
+  /** UID of the logger instance */
+  inline static std::atomic<uint64_t> logger_id_ = 0;
 
   /**
    * Populates the curl slist with authorization (token or username+password),

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -199,6 +199,7 @@ class Curl {
    * @param stats The stats instance to record into
    * @param url URL to post to
    * @param serialization_type Serialization type to use
+   * @param returned_data Buffer to store response data
    * @param res_ns_uri Array Namespace and URI
    * @return Status
    */
@@ -206,6 +207,7 @@ class Curl {
       stats::Stats* const stats,
       const std::string& url,
       SerializationType serialization_type,
+      Buffer* returned_data,
       const std::string& res_ns_uri);
 
   /**

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -368,6 +368,9 @@ class Curl {
   /** UID of the logger instance */
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
+  /** Verbose logging in curl. */
+  bool verbose_;
+
   /**
    * Populates the curl slist with authorization (token or username+password),
    * and any extra headers.

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -1044,7 +1044,7 @@ Status RestClient::post_group_from_rest(const URI& uri, Group* group) {
 
   // Ensure data has a null delimiter for cap'n proto if using JSON
   RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
-  return serialization::group_deserialize(
+  return serialization::group_details_deserialize(
       group, serialization_type_, returned_data);
 }
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -1043,7 +1043,7 @@ Status RestClient::post_group_from_rest(const URI& uri, Group* group) {
       group, serialization_type_, returned_data);
 }
 
-Status RestClient::post_group_to_rest(const URI& uri, Group* group) {
+Status RestClient::patch_group_to_rest(const URI& uri, Group* group) {
   if (group == nullptr)
     return LOG_STATUS(
         Status_RestError("Error posting group to REST; group is null."));
@@ -1051,6 +1051,7 @@ Status RestClient::post_group_to_rest(const URI& uri, Group* group) {
   Buffer buff;
   RETURN_NOT_OK(
       serialization::group_update_serialize(group, serialization_type_, &buff));
+
   // Wrap in a list
   BufferList serialized;
   RETURN_NOT_OK(serialized.add_buffer(std::move(buff)));
@@ -1195,7 +1196,7 @@ Status RestClient::post_group_from_rest(const URI&, Group*) {
       Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 
-Status RestClient::post_group_to_rest(const URI&, Group*) {
+Status RestClient::patch_group_to_rest(const URI&, Group*) {
   return LOG_STATUS(
       Status_RestError("Cannot use rest client; serialization not enabled."));
 }

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -992,8 +992,8 @@ Status RestClient::post_group_from_rest(const URI& uri, Group* group) {
         Status_RestError("Error posting group to REST; group is null."));
 
   Buffer buff;
-  RETURN_NOT_OK(serialization::config_serialize(
-      group->config(), serialization_type_, &buff, true));
+  RETURN_NOT_OK(
+      serialization::group_serialize(group, serialization_type_, &buff));
   // Wrap in a list
   BufferList serialized;
   RETURN_NOT_OK(serialized.add_buffer(std::move(buff)));

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -220,7 +220,7 @@ RestClient::get_array_schema_from_rest(const URI& uri) {
 
   // Ensure data has a null delimiter for cap'n proto if using JSON
   RETURN_NOT_OK_TUPLE(
-      ensure_json_null_delimited_string(returned_data), nullopt);
+      ensure_json_null_delimited_string(&returned_data), nullopt);
   return serialization::array_schema_deserialize(
       serialization_type_, returned_data);
 }
@@ -311,7 +311,7 @@ Status RestClient::get_array_non_empty_domain(
                          "from REST; server returned no data."));
 
   // Ensure data has a null delimiter for cap'n proto if using JSON
-  RETURN_NOT_OK(ensure_json_null_delimited_string(returned_data));
+  RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
 
   // Deserialize data returned
   return serialization::nonempty_domain_deserialize(
@@ -352,7 +352,7 @@ Status RestClient::get_array_max_buffer_sizes(
                          "from REST; server returned no data."));
 
   // Ensure data has a null delimiter for cap'n proto if using JSON
-  RETURN_NOT_OK(ensure_json_null_delimited_string(returned_data));
+  RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
 
   // Deserialize data returned
   return serialization::max_buffer_sizes_deserialize(
@@ -390,7 +390,7 @@ Status RestClient::get_array_metadata_from_rest(
         "Error getting array metadata from REST; server returned no data."));
 
   // Ensure data has a null delimiter for cap'n proto if using JSON
-  RETURN_NOT_OK(ensure_json_null_delimited_string(returned_data));
+  RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
   return serialization::metadata_deserialize(
       array->metadata(), serialization_type_, returned_data);
 }
@@ -878,7 +878,7 @@ Status RestClient::get_query_est_result_sizes(const URI& uri, Query* query) {
         "Error getting array metadata from REST; server returned no data."));
 
   // Ensure data has a null delimiter for cap'n proto if using JSON
-  RETURN_NOT_OK(ensure_json_null_delimited_string(returned_data));
+  RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
   return serialization::query_est_result_size_deserialize(
       query, serialization_type_, true, returned_data);
 }
@@ -944,7 +944,7 @@ Status RestClient::post_group_metadata_from_rest(const URI& uri, Group* group) {
         "Error getting group metadata from REST; server returned no data."));
 
   // Ensure data has a null delimiter for cap'n proto if using JSON
-  RETURN_NOT_OK(ensure_json_null_delimited_string(returned_data));
+  RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
   return serialization::metadata_deserialize(
       group->metadata(), serialization_type_, returned_data);
 }
@@ -1041,7 +1041,7 @@ Status RestClient::post_group_from_rest(const URI& uri, Group* group) {
         "Error getting group from REST; server returned no data."));
 
   // Ensure data has a null delimiter for cap'n proto if using JSON
-  RETURN_NOT_OK(ensure_json_null_delimited_string(returned_data));
+  RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
   return serialization::group_deserialize(
       group, serialization_type_, returned_data);
 }
@@ -1075,10 +1075,10 @@ Status RestClient::patch_group_to_rest(const URI& uri, Group* group) {
       stats_, url, serialization_type_, &serialized, &returned_data, cache_key);
 }
 
-Status RestClient::ensure_json_null_delimited_string(Buffer& buffer) {
+Status RestClient::ensure_json_null_delimited_string(Buffer* buffer) {
   if (serialization_type_ == SerializationType::JSON &&
-      buffer.value<char>(buffer.size() - 1) != '\0') {
-    RETURN_NOT_OK(buffer.write("\0", 1));
+      buffer->value<char>(buffer->size() - 1) != '\0') {
+    RETURN_NOT_OK(buffer->write("\0", sizeof(char)));
   }
   return Status::Ok();
 }

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -172,7 +172,9 @@ tuple<Status, std::optional<bool>> RestClient::check_group_exists_from_rest(
                           "/" + curlc.url_escape(group_uri);
 
   // Make the request, the returned data is ignored for now.
-  auto curl_st = curlc.options(stats_, url, serialization_type_, cache_key);
+  Buffer returned_data;
+  auto curl_st = curlc.options(
+      stats_, url, serialization_type_, &returned_data, cache_key);
 
   auto&& [status_st, http_status_code] = curlc.last_http_status_code();
   RETURN_NOT_OK_TUPLE(status_st, std::nullopt);

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -1051,7 +1051,7 @@ Status RestClient::post_group_from_rest(const URI& uri, Group* group) {
 Status RestClient::patch_group_to_rest(const URI& uri, Group* group) {
   if (group == nullptr)
     return LOG_STATUS(
-        Status_RestError("Error posting group to REST; group is null."));
+        Status_RestError("Error patching group to REST; group is null."));
 
   Buffer buff;
   RETURN_NOT_OK(

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -36,6 +36,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "tiledb/common/logger_public.h"
 #include "tiledb/common/status.h"
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/group/group.h"
@@ -60,7 +61,10 @@ class RestClient {
 
   /** Initialize the REST client with the given config. */
   Status init(
-      stats::Stats* parent_stats, const Config* config, ThreadPool* compute_tp);
+      stats::Stats* parent_stats,
+      const Config* config,
+      ThreadPool* compute_tp,
+      const std::shared_ptr<Logger>& logger);
 
   /** Sets a header that will be attached to all requests. */
   Status set_header(const std::string& name, const std::string& value);
@@ -291,6 +295,12 @@ class RestClient {
 
   /** Mutex for thread-safety. */
   mutable std::mutex redirect_mtx_;
+
+  /** The class logger. */
+  shared_ptr<Logger> logger_;
+
+  /** UID of the logger instance */
+  inline static std::atomic<uint64_t> logger_id_ = 0;
 
   /* ********************************* */
   /*         PRIVATE METHODS           */

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -382,6 +382,15 @@ class RestClient {
    * @return Returns the redirection URI if exists and empty string otherwise
    */
   std::string redirect_uri(const std::string& cache_key);
+
+  /**
+   * Cap'n proto requires JSON messages to be null terminated c-style strings.
+   * This function checks if using JSON that returned buffers are null delimited
+   *
+   * @param buffer of server message
+   * @return Status
+   */
+  Status ensure_json_null_delimited_string(Buffer& buffer);
 };
 
 }  // namespace sm

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -241,7 +241,7 @@ class RestClient {
    * @param group Group to serialize
    * @return Status
    */
-  Status post_group_to_rest(const URI& uri, Group* group);
+  Status patch_group_to_rest(const URI& uri, Group* group);
 
   /**
    * Post group create to the REST server.

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -400,7 +400,7 @@ class RestClient {
    * @param buffer of server message
    * @return Status
    */
-  Status ensure_json_null_delimited_string(Buffer& buffer);
+  Status ensure_json_null_delimited_string(Buffer* buffer);
 };
 
 }  // namespace sm

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -55,7 +55,8 @@ namespace serialization {
 #ifdef TILEDB_SERIALIZATION
 
 Status metadata_to_capnp(
-    Metadata* metadata, capnp::ArrayMetadata::Builder* array_metadata_builder) {
+    const Metadata* metadata,
+    capnp::ArrayMetadata::Builder* array_metadata_builder) {
   if (metadata == nullptr)
     return LOG_STATUS(Status_SerializationError(
         "Error serializing array metadata; array metadata instance is null"));

--- a/tiledb/sm/serialization/array.h
+++ b/tiledb/sm/serialization/array.h
@@ -91,7 +91,8 @@ Status metadata_from_capnp(
  * @return Status
  */
 Status metadata_to_capnp(
-    Metadata* metadata, capnp::ArrayMetadata::Builder* array_metadata_builder);
+    const Metadata* metadata,
+    capnp::ArrayMetadata::Builder* array_metadata_builder);
 #endif
 
 Status array_serialize(

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -154,6 +154,8 @@ Status group_details_from_capnp(
     group->set_metadata_loaded(true);
   }
 
+  group->set_changes_applied(true);
+
   return Status::Ok();
 }
 

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -278,7 +278,15 @@ Status group_create_details_to_capnp(
         Status_SerializationError("Error serializing group; group is null."));
   }
 
-  group_create_details_builder->setUri(group->group_uri().to_string());
+  const auto& group_uri = group->group_uri();
+  if (group_uri.is_tiledb()) {
+    std::string group_ns, group_uri_component;
+    RETURN_NOT_OK(group->group_uri().get_rest_components(
+        &group_ns, &group_uri_component));
+    group_create_details_builder->setUri(group_uri_component);
+  } else {
+    group_create_details_builder->setUri(group_uri.to_string());
+  }
 
   return Status::Ok();
 }

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -497,18 +497,19 @@ Status group_update_deserialize(
       }
       default: {
         return LOG_STATUS(Status_SerializationError(
-            "Error deserializing group; Unknown serialization type "
+            "Error deserializing group update; Unknown serialization type "
             "passed"));
       }
     }
 
   } catch (kj::Exception& e) {
     return LOG_STATUS(Status_SerializationError(
-        "Error deserializing group; kj::Exception: " +
+        "Error deserializing group update; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
     return LOG_STATUS(Status_SerializationError(
-        "Error deserializing group; exception " + std::string(e.what())));
+        "Error deserializing group update; exception " +
+        std::string(e.what())));
   }
 
   return Status::Ok();

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -316,6 +316,7 @@ Status group_serialize(
     switch (serialize_type) {
       case SerializationType::JSON: {
         ::capnp::JsonCodec json;
+        json.handleByAnnotation<capnp::Group>();
         kj::String capnp_json = json.encode(groupBuilder);
         const auto json_len = capnp_json.size();
         const char nul = '\0';
@@ -360,6 +361,7 @@ Status group_deserialize(
     switch (serialize_type) {
       case SerializationType::JSON: {
         ::capnp::JsonCodec json;
+        json.handleByAnnotation<capnp::Group>();
         ::capnp::MallocMessageBuilder message_builder;
         capnp::Group::Builder group_builder =
             message_builder.initRoot<capnp::Group>();
@@ -415,6 +417,7 @@ Status group_update_serialize(
     switch (serialize_type) {
       case SerializationType::JSON: {
         ::capnp::JsonCodec json;
+        json.handleByAnnotation<capnp::GroupUpdate>();
         kj::String capnp_json = json.encode(groupUpdateBuilder);
         const auto json_len = capnp_json.size();
         const char nul = '\0';
@@ -459,6 +462,7 @@ Status group_update_deserialize(
     switch (serialize_type) {
       case SerializationType::JSON: {
         ::capnp::JsonCodec json;
+        json.handleByAnnotation<capnp::GroupUpdate>();
         ::capnp::MallocMessageBuilder message_builder;
         capnp::GroupUpdate::Builder group_update_builder =
             message_builder.initRoot<capnp::GroupUpdate>();
@@ -515,6 +519,7 @@ Status group_create_serialize(
     switch (serialize_type) {
       case SerializationType::JSON: {
         ::capnp::JsonCodec json;
+        json.handleByAnnotation<capnp::GroupCreate>();
         kj::String capnp_json = json.encode(group_create_builder);
         const auto json_len = capnp_json.size();
         const char nul = '\0';
@@ -541,7 +546,7 @@ Status group_create_serialize(
 
   } catch (kj::Exception& e) {
     return LOG_STATUS(Status_SerializationError(
-        "Error serializing group ccreate; kj::Exception: " +
+        "Error serializing group create; kj::Exception: " +
         std::string(e.getDescription().cStr())));
   } catch (std::exception& e) {
     return LOG_STATUS(Status_SerializationError(

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -153,8 +153,11 @@ Status group_to_capnp(
   auto config_builder = group_builder->initConfig();
   RETURN_NOT_OK(config_to_capnp(group->config(), &config_builder));
 
-  auto group_details_builder = group_builder->initGroup();
-  RETURN_NOT_OK(group_details_to_capnp(group, &group_details_builder));
+  const auto& group_members = group->members();
+  if (!group_members.empty()) {
+    auto group_details_builder = group_builder->initGroup();
+    RETURN_NOT_OK(group_details_to_capnp(group, &group_details_builder));
+  }
 
   return Status::Ok();
 }

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -196,8 +196,8 @@ Status group_update_details_to_capnp(
     capnp::GroupUpdate::GroupUpdateDetails::Builder*
         group_update_details_builder) {
   if (group == nullptr) {
-    return LOG_STATUS(
-        Status_SerializationError("Error serializing group; group is null."));
+    return LOG_STATUS(Status_SerializationError(
+        "Error serializing group details; group is null."));
   }
 
   const auto& group_members_to_add = group->members_to_add();

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -169,11 +169,8 @@ Status group_to_capnp(
   auto config_builder = group_builder->initConfig();
   RETURN_NOT_OK(config_to_capnp(group->config(), &config_builder));
 
-  const auto& group_members = group->members();
-  if (!group_members.empty()) {
-    auto group_details_builder = group_builder->initGroup();
-    RETURN_NOT_OK(group_details_to_capnp(group, &group_details_builder));
-  }
+  auto group_details_builder = group_builder->initGroup();
+  RETURN_NOT_OK(group_details_to_capnp(group, &group_details_builder));
 
   return Status::Ok();
 }

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -187,6 +187,7 @@ Status group_from_capnp(
   }
 
   if (group_reader.hasGroup()) {
+    group->clear();
     RETURN_NOT_OK(group_details_from_capnp(group_reader.getGroup(), group));
   }
 

--- a/tiledb/sm/serialization/group.h
+++ b/tiledb/sm/serialization/group.h
@@ -132,7 +132,7 @@ Status group_update_deserialize(
 /**
  * Serialize a group's creation state via Cap'n Prto
  *
- * @param Group group object to serialize
+ * @param group group object to serialize
  * @param serialize_type format to serialize into Cap'n Proto or JSON
  * @param serialized_buffer buffer to store serialized bytes in
  * serialize the array URI
@@ -142,6 +142,21 @@ Status group_create_serialize(
     const Group* group,
     SerializationType serialize_type,
     Buffer* serialized_buffer);
+
+/**
+ * Serialize a group metadata for remote POSTING
+ *
+ * @param group group object to serialize
+ * @param serialize_type format to serialize into Cap'n Proto or JSON
+ * @param serialized_buffer buffer to store serialized bytes in
+ * serialize the array URI
+ * @return Status
+ */
+Status group_metadata_serialize(
+    const Group* group,
+    SerializationType serialize_type,
+    Buffer* serialized_buffer);
+
 }  // namespace serialization
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/serialization/group.h
+++ b/tiledb/sm/serialization/group.h
@@ -76,6 +76,33 @@ Status group_deserialize(
     const Buffer& serialized_buffer);
 
 /**
+ * Serialize a group details via Cap'n Prto
+ *
+ * @param Group group object to serialize
+ * @param serialize_type format to serialize into Cap'n Proto or JSON
+ * @param serialized_buffer buffer to store serialized bytes in
+ * serialize the array URI
+ * @return Status
+ */
+Status group_details_serialize(
+    const Group* group,
+    SerializationType serialize_type,
+    Buffer* serialized_buffer);
+
+/**
+ * Deserialize a group details via Cap'n proto
+ *
+ * @param group to deserialize into
+ * @param serialize_type format the data is serialized in Cap'n Proto of JSON
+ * @param serialized_buffer buffer to read serialized bytes from
+ * @return Status
+ */
+Status group_details_deserialize(
+    Group* group,
+    SerializationType serialize_type,
+    const Buffer& serialized_buffer);
+
+/**
  * Serialize a group's update state via Cap'n Prto
  *
  * @param Group group object to serialize

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
@@ -5062,6 +5062,70 @@ const ::capnp::_::RawSchema s_bda7916926591c22 = {
   0, 3, i_bda7916926591c22, nullptr, nullptr, { &s_bda7916926591c22, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<49> b_838188de0fd57580 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    128, 117, 213,  15, 222, 136, 129, 131,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,   2,   1,   0,   0,
+     33,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     29,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  71, 114, 111, 117, 112,  77,
+    101, 116,  97, 100,  97, 116,  97,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0,  74,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     44,   0,   0,   0,   3,   0,   1,   0,
+     56,   0,   0,   0,   2,   0,   1,   0,
+     99, 111, 110, 102, 105, 103,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+     54, 173,  17, 129,  75,  91, 201, 182,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    109, 101, 116,  97, 100,  97, 116,  97,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    187,  49, 206, 223, 175, 220,  55, 151,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_838188de0fd57580 = b_838188de0fd57580.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_838188de0fd57580[] = {
+  &s_9737dcafdfce31bb,
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_838188de0fd57580[] = {0, 1};
+static const uint16_t i_838188de0fd57580[] = {0, 1};
+const ::capnp::_::RawSchema s_838188de0fd57580 = {
+  0x838188de0fd57580, b_838188de0fd57580.words, 49, d_838188de0fd57580, m_838188de0fd57580,
+  2, 2, i_838188de0fd57580, nullptr, nullptr, { &s_838188de0fd57580, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<64> b_c41bcc7e8cc58f18 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
      24, 143, 197, 140, 126, 204,  27, 196,
@@ -5974,6 +6038,14 @@ constexpr uint16_t EstimatedResultSize::MemorySize::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind EstimatedResultSize::MemorySize::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* EstimatedResultSize::MemorySize::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// GroupMetadata
+constexpr uint16_t GroupMetadata::_capnpPrivate::dataWordSize;
+constexpr uint16_t GroupMetadata::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind GroupMetadata::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* GroupMetadata::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 // GroupMember

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
@@ -5137,45 +5137,42 @@ const ::capnp::_::RawSchema s_c41bcc7e8cc58f18 = {
   0, 3, i_c41bcc7e8cc58f18, nullptr, nullptr, { &s_c41bcc7e8cc58f18, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<67> b_dcdd20e1b79e915a = {
+static const ::capnp::_::AlignedData<60> b_dcdd20e1b79e915a = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
      90, 145, 158, 183, 225,  32, 221, 220,
      18,   0,   0,   0,   1,   0,   0,   0,
     127, 216, 135, 181,  36, 146, 125, 181,
-      3,   0,   7,   0,   0,   0,   0,   0,
+      2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 194,   0,   0,   0,
-     29,   0,   0,   0,   7,   0,   0,   0,
+     29,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     25,   0,   0,   0, 175,   0,   0,   0,
+     41,   0,   0,   0, 119,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     116, 105, 108, 101, 100,  98,  45, 114,
     101, 115, 116,  46,  99,  97, 112, 110,
     112,  58,  71, 114, 111, 117, 112,   0,
-      0,   0,   0,   0,   1,   0,   1,   0,
-     12,   0,   0,   0,   3,   0,   4,   0,
+      4,   0,   0,   0,   1,   0,   1,   0,
+    193, 117, 180,  21, 199,  16, 234, 162,
+      1,   0,   0,   0, 106,   0,   0,   0,
+     71, 114, 111, 117, 112,  68, 101, 116,
+     97, 105, 108, 115,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     69,   0,   0,   0,  58,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     64,   0,   0,   0,   3,   0,   1,   0,
-     76,   0,   0,   0,   2,   0,   1,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
       1,   0,   0,   0,   1,   0,   0,   0,
       0,   0,   1,   0,   1,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     73,   0,   0,   0,  66,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     68,   0,   0,   0,   3,   0,   1,   0,
-     96,   0,   0,   0,   2,   0,   1,   0,
-      2,   0,   0,   0,   2,   0,   0,   0,
-      0,   0,   1,   0,   2,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     93,   0,   0,   0,  74,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     92,   0,   0,   0,   3,   0,   1,   0,
-    104,   0,   0,   0,   2,   0,   1,   0,
+     45,   0,   0,   0,  50,   0,   0,   0,
+     45,   0,   0,   0,  31,   0,   0,   0,
+     76,   0,   0,   0,   3,   0,   1,   0,
+     88,   0,   0,   0,   2,   0,   1,   0,
      99, 111, 110, 102, 105, 103,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
      54, 173,  17, 129,  75,  91, 201, 182,
@@ -5184,6 +5181,71 @@ static const ::capnp::_::AlignedData<67> b_dcdd20e1b79e915a = {
      16,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    103, 114, 111, 117, 112,   0,   0,   0,
+      4,   0,   0,   0,   1,   0,   2,   0,
+     61, 124,  46,  28, 214,  31,  91, 250,
+      4,   0,   0,   0,   2,   0,   1,   0,
+     16,   0,   0,   0,   0,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0,  50,   0,   0,   0,
+    103, 114, 111, 117, 112,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    193, 117, 180,  21, 199,  16, 234, 162,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_dcdd20e1b79e915a = b_dcdd20e1b79e915a.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_dcdd20e1b79e915a[] = {
+  &s_a2ea10c715b475c1,
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_dcdd20e1b79e915a[] = {0, 1};
+static const uint16_t i_dcdd20e1b79e915a[] = {0, 1};
+const ::capnp::_::RawSchema s_dcdd20e1b79e915a = {
+  0xdcdd20e1b79e915a, b_dcdd20e1b79e915a.words, 60, d_dcdd20e1b79e915a, m_dcdd20e1b79e915a,
+  2, 2, i_dcdd20e1b79e915a, nullptr, nullptr, { &s_dcdd20e1b79e915a, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<54> b_a2ea10c715b475c1 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    193, 117, 180,  21, 199,  16, 234, 162,
+     24,   0,   0,   0,   1,   0,   0,   0,
+     90, 145, 158, 183, 225,  32, 221, 220,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  42,   1,   0,   0,
+     37,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     33,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  71, 114, 111, 117, 112,  46,
+     71, 114, 111, 117, 112,  68, 101, 116,
+     97, 105, 108, 115,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  66,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     64,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     61,   0,   0,   0,  74,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     60,   0,   0,   0,   3,   0,   1,   0,
+     72,   0,   0,   0,   2,   0,   1,   0,
     109, 101, 109,  98, 101, 114, 115,   0,
      14,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -5206,60 +5268,57 @@ static const ::capnp::_::AlignedData<67> b_dcdd20e1b79e915a = {
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
-::capnp::word const* const bp_dcdd20e1b79e915a = b_dcdd20e1b79e915a.words;
+::capnp::word const* const bp_a2ea10c715b475c1 = b_a2ea10c715b475c1.words;
 #if !CAPNP_LITE
-static const ::capnp::_::RawSchema* const d_dcdd20e1b79e915a[] = {
+static const ::capnp::_::RawSchema* const d_a2ea10c715b475c1[] = {
   &s_9737dcafdfce31bb,
-  &s_b6c95b4b8111ad36,
   &s_c41bcc7e8cc58f18,
 };
-static const uint16_t m_dcdd20e1b79e915a[] = {0, 1, 2};
-static const uint16_t i_dcdd20e1b79e915a[] = {0, 1, 2};
-const ::capnp::_::RawSchema s_dcdd20e1b79e915a = {
-  0xdcdd20e1b79e915a, b_dcdd20e1b79e915a.words, 67, d_dcdd20e1b79e915a, m_dcdd20e1b79e915a,
-  3, 3, i_dcdd20e1b79e915a, nullptr, nullptr, { &s_dcdd20e1b79e915a, nullptr, nullptr, 0, 0, nullptr }
+static const uint16_t m_a2ea10c715b475c1[] = {0, 1};
+static const uint16_t i_a2ea10c715b475c1[] = {0, 1};
+const ::capnp::_::RawSchema s_a2ea10c715b475c1 = {
+  0xa2ea10c715b475c1, b_a2ea10c715b475c1.words, 54, d_a2ea10c715b475c1, m_a2ea10c715b475c1,
+  2, 2, i_a2ea10c715b475c1, nullptr, nullptr, { &s_a2ea10c715b475c1, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<94> b_c4e54a63294eddb7 = {
+static const ::capnp::_::AlignedData<64> b_c4e54a63294eddb7 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     183, 221,  78,  41,  99,  74, 229, 196,
      18,   0,   0,   0,   1,   0,   0,   0,
     127, 216, 135, 181,  36, 146, 125, 181,
-      3,   0,   7,   0,   0,   0,   0,   0,
+      2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 242,   0,   0,   0,
-     33,   0,   0,   0,   7,   0,   0,   0,
+     33,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     29,   0,   0,   0, 175,   0,   0,   0,
+     49,   0,   0,   0, 119,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     116, 105, 108, 101, 100,  98,  45, 114,
     101, 115, 116,  46,  99,  97, 112, 110,
     112,  58,  71, 114, 111, 117, 112,  85,
     112, 100,  97, 116, 101,   0,   0,   0,
-      0,   0,   0,   0,   1,   0,   1,   0,
-     12,   0,   0,   0,   3,   0,   4,   0,
+      4,   0,   0,   0,   1,   0,   1,   0,
+     64, 222, 155, 117,  70,  30, 176, 131,
+      1,   0,   0,   0, 154,   0,   0,   0,
+     71, 114, 111, 117, 112,  85, 112, 100,
+     97, 116, 101,  68, 101, 116,  97, 105,
+    108, 115,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     69,   0,   0,   0,  58,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     64,   0,   0,   0,   3,   0,   1,   0,
-     76,   0,   0,   0,   2,   0,   1,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
       1,   0,   0,   0,   1,   0,   0,   0,
       0,   0,   1,   0,   1,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     73,   0,   0,   0, 130,   0,   0,   0,
-     77,   0,   0,   0,  31,   0,   0,   0,
-    116,   0,   0,   0,   3,   0,   1,   0,
-    144,   0,   0,   0,   2,   0,   1,   0,
-      2,   0,   0,   0,   2,   0,   0,   0,
-      0,   0,   1,   0,   2,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-    141,   0,   0,   0, 106,   0,   0,   0,
-    145,   0,   0,   0,  31,   0,   0,   0,
-    180,   0,   0,   0,   3,   0,   1,   0,
-    208,   0,   0,   0,   2,   0,   1,   0,
+     45,   0,   0,   0,  98,   0,   0,   0,
+     49,   0,   0,   0,  31,   0,   0,   0,
+     84,   0,   0,   0,   3,   0,   1,   0,
+     96,   0,   0,   0,   2,   0,   1,   0,
      99, 111, 110, 102, 105, 103,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
      54, 173,  17, 129,  75,  91, 201, 182,
@@ -5268,6 +5327,75 @@ static const ::capnp::_::AlignedData<94> b_c4e54a63294eddb7 = {
      16,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    103, 114, 111, 117, 112,  85, 112, 100,
+     97, 116, 101,   0,   0,   0,   0,   0,
+      4,   0,   0,   0,   1,   0,   2,   0,
+     61, 124,  46,  28, 214,  31,  91, 250,
+      4,   0,   0,   0,   2,   0,   1,   0,
+     20,   0,   0,   0,   0,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0, 114,   0,   0,   0,
+    103, 114, 111, 117, 112,  95,  99, 104,
+     97, 110, 103, 101, 115,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+     64, 222, 155, 117,  70,  30, 176, 131,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_c4e54a63294eddb7 = b_c4e54a63294eddb7.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_c4e54a63294eddb7[] = {
+  &s_83b01e46759bde40,
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_c4e54a63294eddb7[] = {0, 1};
+static const uint16_t i_c4e54a63294eddb7[] = {0, 1};
+const ::capnp::_::RawSchema s_c4e54a63294eddb7 = {
+  0xc4e54a63294eddb7, b_c4e54a63294eddb7.words, 64, d_c4e54a63294eddb7, m_c4e54a63294eddb7,
+  2, 2, i_c4e54a63294eddb7, nullptr, nullptr, { &s_c4e54a63294eddb7, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<82> b_83b01e46759bde40 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+     64, 222, 155, 117,  70,  30, 176, 131,
+     30,   0,   0,   0,   1,   0,   0,   0,
+    183, 221,  78,  41,  99,  74, 229, 196,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0, 138,   1,   0,   0,
+     45,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  71, 114, 111, 117, 112,  85,
+    112, 100,  97, 116, 101,  46,  71, 114,
+    111, 117, 112,  85, 112, 100,  97, 116,
+    101,  68, 101, 116,  97, 105, 108, 115,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0, 130,   0,   0,   0,
+     45,   0,   0,   0,  31,   0,   0,   0,
+     84,   0,   0,   0,   3,   0,   1,   0,
+    112,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    109,   0,   0,   0, 106,   0,   0,   0,
+    113,   0,   0,   0,  31,   0,   0,   0,
+    148,   0,   0,   0,   3,   0,   1,   0,
+    176,   0,   0,   0,   2,   0,   1,   0,
     109, 101, 109,  98, 101, 114, 115,  84,
     111,  82, 101, 109, 111, 118, 101,   0,
       4,   0,   0,   0,   1,   0,   2,   0,
@@ -5316,20 +5444,19 @@ static const ::capnp::_::AlignedData<94> b_c4e54a63294eddb7 = {
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
-::capnp::word const* const bp_c4e54a63294eddb7 = b_c4e54a63294eddb7.words;
+::capnp::word const* const bp_83b01e46759bde40 = b_83b01e46759bde40.words;
 #if !CAPNP_LITE
-static const ::capnp::_::RawSchema* const d_c4e54a63294eddb7[] = {
-  &s_b6c95b4b8111ad36,
+static const ::capnp::_::RawSchema* const d_83b01e46759bde40[] = {
   &s_c41bcc7e8cc58f18,
 };
-static const uint16_t m_c4e54a63294eddb7[] = {0, 2, 1};
-static const uint16_t i_c4e54a63294eddb7[] = {0, 1, 2};
-const ::capnp::_::RawSchema s_c4e54a63294eddb7 = {
-  0xc4e54a63294eddb7, b_c4e54a63294eddb7.words, 94, d_c4e54a63294eddb7, m_c4e54a63294eddb7,
-  2, 3, i_c4e54a63294eddb7, nullptr, nullptr, { &s_c4e54a63294eddb7, nullptr, nullptr, 0, 0, nullptr }
+static const uint16_t m_83b01e46759bde40[] = {1, 0};
+static const uint16_t i_83b01e46759bde40[] = {0, 1};
+const ::capnp::_::RawSchema s_83b01e46759bde40 = {
+  0x83b01e46759bde40, b_83b01e46759bde40.words, 82, d_83b01e46759bde40, m_83b01e46759bde40,
+  1, 2, i_83b01e46759bde40, nullptr, nullptr, { &s_83b01e46759bde40, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
+static const ::capnp::_::AlignedData<64> b_fb7f36ad4d8ffe84 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     132, 254, 143,  77, 173,  54, 127, 251,
      18,   0,   0,   0,   1,   0,   0,   0,
@@ -5337,16 +5464,21 @@ static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
       2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 242,   0,   0,   0,
-     33,   0,   0,   0,   7,   0,   0,   0,
+     33,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     29,   0,   0,   0, 119,   0,   0,   0,
+     49,   0,   0,   0, 119,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     116, 105, 108, 101, 100,  98,  45, 114,
     101, 115, 116,  46,  99,  97, 112, 110,
     112,  58,  71, 114, 111, 117, 112,  67,
     114, 101,  97, 116, 101,   0,   0,   0,
-      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   1,   0,   1,   0,
+    169, 134,  94, 215, 154,  69, 253, 213,
+      1,   0,   0,   0, 154,   0,   0,   0,
+     71, 114, 111, 117, 112,  67, 114, 101,
+     97, 116, 101,  68, 101, 116,  97, 105,
+    108, 115,   0,   0,   0,   0,   0,   0,
       8,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
@@ -5358,10 +5490,10 @@ static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
       1,   0,   0,   0,   1,   0,   0,   0,
       0,   0,   1,   0,   1,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     45,   0,   0,   0,  34,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     40,   0,   0,   0,   3,   0,   1,   0,
-     52,   0,   0,   0,   2,   0,   1,   0,
+     45,   0,   0,   0, 106,   0,   0,   0,
+     49,   0,   0,   0,  31,   0,   0,   0,
+     84,   0,   0,   0,   3,   0,   1,   0,
+     96,   0,   0,   0,   2,   0,   1,   0,
      99, 111, 110, 102, 105, 103,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
      54, 173,  17, 129,  75,  91, 201, 182,
@@ -5370,6 +5502,68 @@ static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
      16,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    103, 114, 111, 117, 112,  68, 101, 116,
+     97, 105, 108, 115,   0,   0,   0,   0,
+      4,   0,   0,   0,   1,   0,   2,   0,
+     61, 124,  46,  28, 214,  31,  91, 250,
+      4,   0,   0,   0,   2,   0,   1,   0,
+     20,   0,   0,   0,   0,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0, 114,   0,   0,   0,
+    103, 114, 111, 117, 112,  95, 100, 101,
+    116,  97, 105, 108, 115,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    169, 134,  94, 215, 154,  69, 253, 213,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_fb7f36ad4d8ffe84 = b_fb7f36ad4d8ffe84.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_fb7f36ad4d8ffe84[] = {
+  &s_b6c95b4b8111ad36,
+  &s_d5fd459ad75e86a9,
+};
+static const uint16_t m_fb7f36ad4d8ffe84[] = {0, 1};
+static const uint16_t i_fb7f36ad4d8ffe84[] = {0, 1};
+const ::capnp::_::RawSchema s_fb7f36ad4d8ffe84 = {
+  0xfb7f36ad4d8ffe84, b_fb7f36ad4d8ffe84.words, 64, d_fb7f36ad4d8ffe84, m_fb7f36ad4d8ffe84,
+  2, 2, i_fb7f36ad4d8ffe84, nullptr, nullptr, { &s_fb7f36ad4d8ffe84, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<36> b_d5fd459ad75e86a9 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    169, 134,  94, 215, 154,  69, 253, 213,
+     30,   0,   0,   0,   1,   0,   0,   0,
+    132, 254, 143,  77, 173,  54, 127, 251,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0, 138,   1,   0,   0,
+     45,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  63,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  71, 114, 111, 117, 112,  67,
+    114, 101,  97, 116, 101,  46,  71, 114,
+    111, 117, 112,  67, 114, 101,  97, 116,
+    101,  68, 101, 116,  97, 105, 108, 115,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     13,   0,   0,   0,  34,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   1,   0,
+     20,   0,   0,   0,   2,   0,   1,   0,
     117, 114, 105,   0,   0,   0,   0,   0,
      12,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -5379,16 +5573,13 @@ static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
-::capnp::word const* const bp_fb7f36ad4d8ffe84 = b_fb7f36ad4d8ffe84.words;
+::capnp::word const* const bp_d5fd459ad75e86a9 = b_d5fd459ad75e86a9.words;
 #if !CAPNP_LITE
-static const ::capnp::_::RawSchema* const d_fb7f36ad4d8ffe84[] = {
-  &s_b6c95b4b8111ad36,
-};
-static const uint16_t m_fb7f36ad4d8ffe84[] = {0, 1};
-static const uint16_t i_fb7f36ad4d8ffe84[] = {0, 1};
-const ::capnp::_::RawSchema s_fb7f36ad4d8ffe84 = {
-  0xfb7f36ad4d8ffe84, b_fb7f36ad4d8ffe84.words, 48, d_fb7f36ad4d8ffe84, m_fb7f36ad4d8ffe84,
-  1, 2, i_fb7f36ad4d8ffe84, nullptr, nullptr, { &s_fb7f36ad4d8ffe84, nullptr, nullptr, 0, 0, nullptr }
+static const uint16_t m_d5fd459ad75e86a9[] = {0};
+static const uint16_t i_d5fd459ad75e86a9[] = {0};
+const ::capnp::_::RawSchema s_d5fd459ad75e86a9 = {
+  0xd5fd459ad75e86a9, b_d5fd459ad75e86a9.words, 36, nullptr, m_d5fd459ad75e86a9,
+  0, 1, i_d5fd459ad75e86a9, nullptr, nullptr, { &s_d5fd459ad75e86a9, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
 }  // namespace schemas
@@ -5801,6 +5992,14 @@ constexpr ::capnp::Kind Group::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* Group::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
+// Group::GroupDetails
+constexpr uint16_t Group::GroupDetails::_capnpPrivate::dataWordSize;
+constexpr uint16_t Group::GroupDetails::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind Group::GroupDetails::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* Group::GroupDetails::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
 // GroupUpdate
 constexpr uint16_t GroupUpdate::_capnpPrivate::dataWordSize;
 constexpr uint16_t GroupUpdate::_capnpPrivate::pointerCount;
@@ -5809,12 +6008,28 @@ constexpr ::capnp::Kind GroupUpdate::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* GroupUpdate::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
+// GroupUpdate::GroupUpdateDetails
+constexpr uint16_t GroupUpdate::GroupUpdateDetails::_capnpPrivate::dataWordSize;
+constexpr uint16_t GroupUpdate::GroupUpdateDetails::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind GroupUpdate::GroupUpdateDetails::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* GroupUpdate::GroupUpdateDetails::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
 // GroupCreate
 constexpr uint16_t GroupCreate::_capnpPrivate::dataWordSize;
 constexpr uint16_t GroupCreate::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind GroupCreate::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* GroupCreate::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// GroupCreate::GroupCreateDetails
+constexpr uint16_t GroupCreate::GroupCreateDetails::_capnpPrivate::dataWordSize;
+constexpr uint16_t GroupCreate::GroupCreateDetails::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind GroupCreate::GroupCreateDetails::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* GroupCreate::GroupCreateDetails::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
@@ -64,6 +64,7 @@ CAPNP_DECLARE_SCHEMA(926fe1c3b12ed651);
 CAPNP_DECLARE_SCHEMA(8cd4e323f1feea3b);
 CAPNP_DECLARE_SCHEMA(92c8467685565269);
 CAPNP_DECLARE_SCHEMA(bda7916926591c22);
+CAPNP_DECLARE_SCHEMA(838188de0fd57580);
 CAPNP_DECLARE_SCHEMA(c41bcc7e8cc58f18);
 CAPNP_DECLARE_SCHEMA(dcdd20e1b79e915a);
 CAPNP_DECLARE_SCHEMA(a2ea10c715b475c1);
@@ -971,6 +972,23 @@ struct EstimatedResultSize::MemorySize {
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(bda7916926591c22, 3, 0)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct GroupMetadata {
+  GroupMetadata() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(838188de0fd57580, 0, 2)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -8023,6 +8041,127 @@ class EstimatedResultSize::MemorySize::Pipeline {
   inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
       : _typeless(kj::mv(typeless)) {
   }
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class GroupMetadata::Reader {
+ public:
+  typedef GroupMetadata Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig() const;
+  inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
+
+  inline bool hasMetadata() const;
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader getMetadata()
+      const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class GroupMetadata::Builder {
+ public:
+  typedef GroupMetadata Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig();
+  inline ::tiledb::sm::serialization::capnp::Config::Builder getConfig();
+  inline void setConfig(
+      ::tiledb::sm::serialization::capnp::Config::Reader value);
+  inline ::tiledb::sm::serialization::capnp::Config::Builder initConfig();
+  inline void adoptConfig(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+  disownConfig();
+
+  inline bool hasMetadata();
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
+  getMetadata();
+  inline void setMetadata(
+      ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader value);
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
+  initMetadata();
+  inline void adoptMetadata(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>&&
+          value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>
+  disownMetadata();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class GroupMetadata::Pipeline {
+ public:
+  typedef GroupMetadata Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline
+  getMetadata();
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -17059,6 +17198,113 @@ inline void EstimatedResultSize::MemorySize::Builder::setSizeValidity(
     ::uint64_t value) {
   _builder.setDataField<::uint64_t>(
       ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
+}
+
+inline bool GroupMetadata::Reader::hasConfig() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool GroupMetadata::Builder::hasConfig() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Config::Reader
+GroupMetadata::Reader::getConfig() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+GroupMetadata::Builder::getConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Config::Pipeline
+GroupMetadata::Pipeline::getConfig() {
+  return ::tiledb::sm::serialization::capnp::Config::Pipeline(
+      _typeless.getPointerField(0));
+}
+#endif  // !CAPNP_LITE
+inline void GroupMetadata::Builder::setConfig(
+    ::tiledb::sm::serialization::capnp::Config::Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::set(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      value);
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+GroupMetadata::Builder::initConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void GroupMetadata::Builder::adoptConfig(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::adopt(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+GroupMetadata::Builder::disownConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool GroupMetadata::Reader::hasMetadata() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool GroupMetadata::Builder::hasMetadata() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader
+GroupMetadata::Reader::getMetadata() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::get(
+          _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
+GroupMetadata::Builder::getMetadata() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::get(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline
+GroupMetadata::Pipeline::getMetadata() {
+  return ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline(
+      _typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void GroupMetadata::Builder::setMetadata(
+    ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader value) {
+  ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::set(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
+GroupMetadata::Builder::initMetadata() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::init(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void GroupMetadata::Builder::adoptMetadata(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>&&
+        value) {
+  ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>
+GroupMetadata::Builder::disownMetadata() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool GroupMember::Reader::hasUri() const {

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
@@ -66,8 +66,11 @@ CAPNP_DECLARE_SCHEMA(92c8467685565269);
 CAPNP_DECLARE_SCHEMA(bda7916926591c22);
 CAPNP_DECLARE_SCHEMA(c41bcc7e8cc58f18);
 CAPNP_DECLARE_SCHEMA(dcdd20e1b79e915a);
+CAPNP_DECLARE_SCHEMA(a2ea10c715b475c1);
 CAPNP_DECLARE_SCHEMA(c4e54a63294eddb7);
+CAPNP_DECLARE_SCHEMA(83b01e46759bde40);
 CAPNP_DECLARE_SCHEMA(fb7f36ad4d8ffe84);
+CAPNP_DECLARE_SCHEMA(d5fd459ad75e86a9);
 
 }  // namespace schemas
 }  // namespace capnp
@@ -999,9 +1002,27 @@ struct Group {
   class Reader;
   class Builder;
   class Pipeline;
+  struct GroupDetails;
 
   struct _capnpPrivate {
-    CAPNP_DECLARE_STRUCT_HEADER(dcdd20e1b79e915a, 0, 3)
+    CAPNP_DECLARE_STRUCT_HEADER(dcdd20e1b79e915a, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct Group::GroupDetails {
+  GroupDetails() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(a2ea10c715b475c1, 0, 2)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -1016,9 +1037,27 @@ struct GroupUpdate {
   class Reader;
   class Builder;
   class Pipeline;
+  struct GroupUpdateDetails;
 
   struct _capnpPrivate {
-    CAPNP_DECLARE_STRUCT_HEADER(c4e54a63294eddb7, 0, 3)
+    CAPNP_DECLARE_STRUCT_HEADER(c4e54a63294eddb7, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct GroupUpdate::GroupUpdateDetails {
+  GroupUpdateDetails() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(83b01e46759bde40, 0, 2)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -1033,9 +1072,27 @@ struct GroupCreate {
   class Reader;
   class Builder;
   class Pipeline;
+  struct GroupCreateDetails;
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(fb7f36ad4d8ffe84, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct GroupCreate::GroupCreateDetails {
+  GroupCreateDetails() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(d5fd459ad75e86a9, 0, 1)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -8109,15 +8166,9 @@ class Group::Reader {
   inline bool hasConfig() const;
   inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
 
-  inline bool hasMembers() const;
-  inline ::capnp::List<
-      ::tiledb::sm::serialization::capnp::GroupMember,
-      ::capnp::Kind::STRUCT>::Reader
-  getMembers() const;
-
-  inline bool hasMetadata() const;
-  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader getMetadata()
-      const;
+  inline bool hasGroup() const;
+  inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Reader
+  getGroup() const;
 
  private:
   ::capnp::_::StructReader _reader;
@@ -8168,6 +8219,121 @@ class Group::Builder {
   inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
   disownConfig();
 
+  inline bool hasGroup();
+  inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Builder
+  getGroup();
+  inline void setGroup(
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails::Reader value);
+  inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Builder
+  initGroup();
+  inline void adoptGroup(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Group::GroupDetails>&&
+          value);
+  inline ::capnp::Orphan<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>
+  disownGroup();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class Group::Pipeline {
+ public:
+  typedef Group Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+  inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Pipeline
+  getGroup();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class Group::GroupDetails::Reader {
+ public:
+  typedef GroupDetails Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasMembers() const;
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::GroupMember,
+      ::capnp::Kind::STRUCT>::Reader
+  getMembers() const;
+
+  inline bool hasMetadata() const;
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader getMetadata()
+      const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class Group::GroupDetails::Builder {
+ public:
+  typedef GroupDetails Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
   inline bool hasMembers();
   inline ::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
@@ -8211,9 +8377,9 @@ class Group::Builder {
 };
 
 #if !CAPNP_LITE
-class Group::Pipeline {
+class Group::GroupDetails::Pipeline {
  public:
-  typedef Group Pipelines;
+  typedef GroupDetails Pipelines;
 
   inline Pipeline(decltype(nullptr))
       : _typeless(nullptr) {
@@ -8222,7 +8388,6 @@ class Group::Pipeline {
       : _typeless(kj::mv(typeless)) {
   }
 
-  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
   inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline
   getMetadata();
 
@@ -8256,15 +8421,10 @@ class GroupUpdate::Reader {
   inline bool hasConfig() const;
   inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
 
-  inline bool hasMembersToRemove() const;
-  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
-  getMembersToRemove() const;
-
-  inline bool hasMembersToAdd() const;
-  inline ::capnp::List<
-      ::tiledb::sm::serialization::capnp::GroupMember,
-      ::capnp::Kind::STRUCT>::Reader
-  getMembersToAdd() const;
+  inline bool hasGroupUpdate() const;
+  inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Reader
+      getGroupUpdate() const;
 
  private:
   ::capnp::_::StructReader _reader;
@@ -8315,6 +8475,125 @@ class GroupUpdate::Builder {
   inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
   disownConfig();
 
+  inline bool hasGroupUpdate();
+  inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Builder
+      getGroupUpdate();
+  inline void setGroupUpdate(::tiledb::sm::serialization::capnp::GroupUpdate::
+                                 GroupUpdateDetails::Reader value);
+  inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Builder
+      initGroupUpdate();
+  inline void adoptGroupUpdate(
+      ::capnp::Orphan<
+          ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>&&
+          value);
+  inline ::capnp::Orphan<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>
+  disownGroupUpdate();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class GroupUpdate::Pipeline {
+ public:
+  typedef GroupUpdate Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+  inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Pipeline
+      getGroupUpdate();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class GroupUpdate::GroupUpdateDetails::Reader {
+ public:
+  typedef GroupUpdateDetails Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasMembersToRemove() const;
+  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
+  getMembersToRemove() const;
+
+  inline bool hasMembersToAdd() const;
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::GroupMember,
+      ::capnp::Kind::STRUCT>::Reader
+  getMembersToAdd() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class GroupUpdate::GroupUpdateDetails::Builder {
+ public:
+  typedef GroupUpdateDetails Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
   inline bool hasMembersToRemove();
   inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
   getMembersToRemove();
@@ -8361,9 +8640,9 @@ class GroupUpdate::Builder {
 };
 
 #if !CAPNP_LITE
-class GroupUpdate::Pipeline {
+class GroupUpdate::GroupUpdateDetails::Pipeline {
  public:
-  typedef GroupUpdate Pipelines;
+  typedef GroupUpdateDetails Pipelines;
 
   inline Pipeline(decltype(nullptr))
       : _typeless(nullptr) {
@@ -8371,8 +8650,6 @@ class GroupUpdate::Pipeline {
   inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
       : _typeless(kj::mv(typeless)) {
   }
-
-  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -8404,8 +8681,10 @@ class GroupCreate::Reader {
   inline bool hasConfig() const;
   inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
 
-  inline bool hasUri() const;
-  inline ::capnp::Text::Reader getUri() const;
+  inline bool hasGroupDetails() const;
+  inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Reader
+      getGroupDetails() const;
 
  private:
   ::capnp::_::StructReader _reader;
@@ -8456,12 +8735,22 @@ class GroupCreate::Builder {
   inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
   disownConfig();
 
-  inline bool hasUri();
-  inline ::capnp::Text::Builder getUri();
-  inline void setUri(::capnp::Text::Reader value);
-  inline ::capnp::Text::Builder initUri(unsigned int size);
-  inline void adoptUri(::capnp::Orphan<::capnp::Text>&& value);
-  inline ::capnp::Orphan<::capnp::Text> disownUri();
+  inline bool hasGroupDetails();
+  inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Builder
+      getGroupDetails();
+  inline void setGroupDetails(::tiledb::sm::serialization::capnp::GroupCreate::
+                                  GroupCreateDetails::Reader value);
+  inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Builder
+      initGroupDetails();
+  inline void adoptGroupDetails(
+      ::capnp::Orphan<
+          ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>&&
+          value);
+  inline ::capnp::Orphan<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>
+  disownGroupDetails();
 
  private:
   ::capnp::_::StructBuilder _builder;
@@ -8485,6 +8774,106 @@ class GroupCreate::Pipeline {
   }
 
   inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+  inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Pipeline
+      getGroupDetails();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class GroupCreate::GroupCreateDetails::Reader {
+ public:
+  typedef GroupCreateDetails Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasUri() const;
+  inline ::capnp::Text::Reader getUri() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class GroupCreate::GroupCreateDetails::Builder {
+ public:
+  typedef GroupCreateDetails Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasUri();
+  inline ::capnp::Text::Builder getUri();
+  inline void setUri(::capnp::Text::Reader value);
+  inline ::capnp::Text::Builder initUri(unsigned int size);
+  inline void adoptUri(::capnp::Orphan<::capnp::Text>&& value);
+  inline ::capnp::Orphan<::capnp::Text> disownUri();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class GroupCreate::GroupCreateDetails::Pipeline {
+ public:
+  typedef GroupCreateDetails Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -16810,58 +17199,115 @@ Group::Builder::disownConfig() {
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
-inline bool Group::Reader::hasMembers() const {
+inline bool Group::Reader::hasGroup() const {
   return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool Group::Builder::hasMembers() {
+inline bool Group::Builder::hasGroup() {
   return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Reader
+Group::Reader::getGroup() const {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      get(_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Builder
+Group::Builder::getGroup() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      get(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Pipeline
+Group::Pipeline::getGroup() {
+  return ::tiledb::sm::serialization::capnp::Group::GroupDetails::Pipeline(
+      _typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void Group::Builder::setGroup(
+    ::tiledb::sm::serialization::capnp::Group::GroupDetails::Reader value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Builder
+Group::Builder::initGroup() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      init(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void Group::Builder::adoptGroup(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Group::GroupDetails>&&
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Group::GroupDetails>
+Group::Builder::disownGroup() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+
+inline bool Group::GroupDetails::Reader::hasMembers() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool Group::GroupDetails::Builder::hasMembers() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
               .isNull();
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Reader
-Group::Reader::getMembers() const {
+Group::GroupDetails::Reader::getMembers() const {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::get(_reader
                                        .getPointerField(
-                                           ::capnp::bounded<1>() *
+                                           ::capnp::bounded<0>() *
                                            ::capnp::POINTERS));
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Builder
-Group::Builder::getMembers() {
+Group::GroupDetails::Builder::getMembers() {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::get(_builder
                                        .getPointerField(
-                                           ::capnp::bounded<1>() *
+                                           ::capnp::bounded<0>() *
                                            ::capnp::POINTERS));
 }
-inline void Group::Builder::setMembers(
+inline void Group::GroupDetails::Builder::setMembers(
     ::capnp::List<
         ::tiledb::sm::serialization::capnp::GroupMember,
         ::capnp::Kind::STRUCT>::Reader value) {
   ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
-      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      set(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           value);
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Builder
-Group::Builder::initMembers(unsigned int size) {
+Group::GroupDetails::Builder::initMembers(unsigned int size) {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
       init(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           size);
 }
-inline void Group::Builder::adoptMembers(
+inline void Group::GroupDetails::Builder::adoptMembers(
     ::capnp::Orphan<::capnp::List<
         ::tiledb::sm::serialization::capnp::GroupMember,
         ::capnp::Kind::STRUCT>>&& value) {
@@ -16869,74 +17315,74 @@ inline void Group::Builder::adoptMembers(
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
       adopt(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           kj::mv(value));
 }
 inline ::capnp::Orphan<::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>>
-Group::Builder::disownMembers() {
+Group::GroupDetails::Builder::disownMembers() {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::disown(_builder
                                           .getPointerField(
-                                              ::capnp::bounded<1>() *
+                                              ::capnp::bounded<0>() *
                                               ::capnp::POINTERS));
 }
 
-inline bool Group::Reader::hasMetadata() const {
-  return !_reader.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS)
+inline bool Group::GroupDetails::Reader::hasMetadata() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool Group::Builder::hasMetadata() {
-  return !_builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS)
+inline bool Group::GroupDetails::Builder::hasMetadata() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
 inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader
-Group::Reader::getMetadata() const {
+Group::GroupDetails::Reader::getMetadata() const {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::get(
-          _reader.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS));
+          _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
-Group::Builder::getMetadata() {
+Group::GroupDetails::Builder::getMetadata() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::get(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS));
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline
-Group::Pipeline::getMetadata() {
+Group::GroupDetails::Pipeline::getMetadata() {
   return ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline(
-      _typeless.getPointerField(2));
+      _typeless.getPointerField(1));
 }
 #endif  // !CAPNP_LITE
-inline void Group::Builder::setMetadata(
+inline void Group::GroupDetails::Builder::setMetadata(
     ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader value) {
   ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::set(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           value);
 }
 inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
-Group::Builder::initMetadata() {
+Group::GroupDetails::Builder::initMetadata() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::init(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS));
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline void Group::Builder::adoptMetadata(
+inline void Group::GroupDetails::Builder::adoptMetadata(
     ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>&&
         value) {
   ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::adopt(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           kj::mv(value));
 }
 inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>
-Group::Builder::disownMetadata() {
+Group::GroupDetails::Builder::disownMetadata() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::disown(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS));
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool GroupUpdate::Reader::hasConfig() const {
@@ -16991,114 +17437,180 @@ GroupUpdate::Builder::disownConfig() {
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
-inline bool GroupUpdate::Reader::hasMembersToRemove() const {
+inline bool GroupUpdate::Reader::hasGroupUpdate() const {
   return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool GroupUpdate::Builder::hasMembersToRemove() {
+inline bool GroupUpdate::Builder::hasGroupUpdate() {
   return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
-GroupUpdate::Reader::getMembersToRemove() const {
-  return ::capnp::_::
-      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
-          _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+    Reader
+    GroupUpdate::Reader::getGroupUpdate() const {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      get(_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
-GroupUpdate::Builder::getMembersToRemove() {
-  return ::capnp::_::
-      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+    Builder
+    GroupUpdate::Builder::getGroupUpdate() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      get(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+    Pipeline
+    GroupUpdate::Pipeline::getGroupUpdate() {
+  return ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Pipeline(_typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void GroupUpdate::Builder::setGroupUpdate(
+    ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::Reader
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+    Builder
+    GroupUpdate::Builder::initGroupUpdate() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      init(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void GroupUpdate::Builder::adoptGroupUpdate(
+    ::capnp::Orphan<
+        ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>&&
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<
+    ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>
+GroupUpdate::Builder::disownGroupUpdate() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      disown(
           _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline void GroupUpdate::Builder::setMembersToRemove(
+
+inline bool GroupUpdate::GroupUpdateDetails::Reader::hasMembersToRemove()
+    const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool GroupUpdate::GroupUpdateDetails::Builder::hasMembersToRemove() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
+GroupUpdate::GroupUpdateDetails::Reader::getMembersToRemove() const {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+GroupUpdate::GroupUpdateDetails::Builder::getMembersToRemove() {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void GroupUpdate::GroupUpdateDetails::Builder::setMembersToRemove(
     ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader value) {
   ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::set(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           value);
 }
-inline void GroupUpdate::Builder::setMembersToRemove(
+inline void GroupUpdate::GroupUpdateDetails::Builder::setMembersToRemove(
     ::kj::ArrayPtr<const ::capnp::Text::Reader> value) {
   ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::set(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           value);
 }
 inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
-GroupUpdate::Builder::initMembersToRemove(unsigned int size) {
+GroupUpdate::GroupUpdateDetails::Builder::initMembersToRemove(
+    unsigned int size) {
   return ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::init(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           size);
 }
-inline void GroupUpdate::Builder::adoptMembersToRemove(
+inline void GroupUpdate::GroupUpdateDetails::Builder::adoptMembersToRemove(
     ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>&&
         value) {
   ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::adopt(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           kj::mv(value));
 }
 inline ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>
-GroupUpdate::Builder::disownMembersToRemove() {
+GroupUpdate::GroupUpdateDetails::Builder::disownMembersToRemove() {
   return ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::disown(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
-inline bool GroupUpdate::Reader::hasMembersToAdd() const {
-  return !_reader.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS)
+inline bool GroupUpdate::GroupUpdateDetails::Reader::hasMembersToAdd() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool GroupUpdate::Builder::hasMembersToAdd() {
-  return !_builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS)
+inline bool GroupUpdate::GroupUpdateDetails::Builder::hasMembersToAdd() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Reader
-GroupUpdate::Reader::getMembersToAdd() const {
+GroupUpdate::GroupUpdateDetails::Reader::getMembersToAdd() const {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::get(_reader
                                        .getPointerField(
-                                           ::capnp::bounded<2>() *
+                                           ::capnp::bounded<1>() *
                                            ::capnp::POINTERS));
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Builder
-GroupUpdate::Builder::getMembersToAdd() {
+GroupUpdate::GroupUpdateDetails::Builder::getMembersToAdd() {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::get(_builder
                                        .getPointerField(
-                                           ::capnp::bounded<2>() *
+                                           ::capnp::bounded<1>() *
                                            ::capnp::POINTERS));
 }
-inline void GroupUpdate::Builder::setMembersToAdd(
+inline void GroupUpdate::GroupUpdateDetails::Builder::setMembersToAdd(
     ::capnp::List<
         ::tiledb::sm::serialization::capnp::GroupMember,
         ::capnp::Kind::STRUCT>::Reader value) {
   ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
-      set(_builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           value);
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Builder
-GroupUpdate::Builder::initMembersToAdd(unsigned int size) {
+GroupUpdate::GroupUpdateDetails::Builder::initMembersToAdd(unsigned int size) {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
       init(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           size);
 }
-inline void GroupUpdate::Builder::adoptMembersToAdd(
+inline void GroupUpdate::GroupUpdateDetails::Builder::adoptMembersToAdd(
     ::capnp::Orphan<::capnp::List<
         ::tiledb::sm::serialization::capnp::GroupMember,
         ::capnp::Kind::STRUCT>>&& value) {
@@ -17106,18 +17618,18 @@ inline void GroupUpdate::Builder::adoptMembersToAdd(
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
       adopt(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           kj::mv(value));
 }
 inline ::capnp::Orphan<::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>>
-GroupUpdate::Builder::disownMembersToAdd() {
+GroupUpdate::GroupUpdateDetails::Builder::disownMembersToAdd() {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::disown(_builder
                                           .getPointerField(
-                                              ::capnp::bounded<2>() *
+                                              ::capnp::bounded<1>() *
                                               ::capnp::POINTERS));
 }
 
@@ -17173,41 +17685,110 @@ GroupCreate::Builder::disownConfig() {
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
-inline bool GroupCreate::Reader::hasUri() const {
+inline bool GroupCreate::Reader::hasGroupDetails() const {
   return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool GroupCreate::Builder::hasUri() {
+inline bool GroupCreate::Builder::hasGroupDetails() {
   return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline ::capnp::Text::Reader GroupCreate::Reader::getUri() const {
-  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
-      _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+    Reader
+    GroupCreate::Reader::getGroupDetails() const {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      get(_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline ::capnp::Text::Builder GroupCreate::Builder::getUri() {
-  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+    Builder
+    GroupCreate::Builder::getGroupDetails() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      get(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline void GroupCreate::Builder::setUri(::capnp::Text::Reader value) {
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+    Pipeline
+    GroupCreate::Pipeline::getGroupDetails() {
+  return ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Pipeline(_typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void GroupCreate::Builder::setGroupDetails(
+    ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::Reader
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+    Builder
+    GroupCreate::Builder::initGroupDetails() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      init(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void GroupCreate::Builder::adoptGroupDetails(
+    ::capnp::Orphan<
+        ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>&&
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<
+    ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>
+GroupCreate::Builder::disownGroupDetails() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+
+inline bool GroupCreate::GroupCreateDetails::Reader::hasUri() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool GroupCreate::GroupCreateDetails::Builder::hasUri() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::Text::Reader GroupCreate::GroupCreateDetails::Reader::getUri()
+    const {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::capnp::Text::Builder
+GroupCreate::GroupCreateDetails::Builder::getUri() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void GroupCreate::GroupCreateDetails::Builder::setUri(
+    ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers<::capnp::Text>::set(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
       value);
 }
-inline ::capnp::Text::Builder GroupCreate::Builder::initUri(unsigned int size) {
+inline ::capnp::Text::Builder GroupCreate::GroupCreateDetails::Builder::initUri(
+    unsigned int size) {
   return ::capnp::_::PointerHelpers<::capnp::Text>::init(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
       size);
 }
-inline void GroupCreate::Builder::adoptUri(
+inline void GroupCreate::GroupCreateDetails::Builder::adoptUri(
     ::capnp::Orphan<::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers<::capnp::Text>::adopt(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
       kj::mv(value));
 }
-inline ::capnp::Orphan<::capnp::Text> GroupCreate::Builder::disownUri() {
+inline ::capnp::Orphan<::capnp::Text>
+GroupCreate::GroupCreateDetails::Builder::disownUri() {
   return ::capnp::_::PointerHelpers<::capnp::Text>::disown(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace capnp

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -635,31 +635,50 @@ struct GroupMember {
 }
 
 struct Group {
+  # Group
+
+  struct GroupDetails {
+    members @0 :List(GroupMember);
+    # list of Members in group
+
+    metadata  @1 :ArrayMetadata;
+    # metadata attached to group
+  }
+
   config @0 :Config;
   # Config
 
-  members @1 :List(GroupMember);
-  # list of Members in group
-
-  metadata  @2 :ArrayMetadata;
-  # metadata attached to group
+  group @1 :GroupDetails  $Json.name("group");
 }
 
 struct GroupUpdate {
+  struct GroupUpdateDetails {
+    membersToRemove @0 :List(Text) $Json.name("members_to_remove");
+    # members to remove
+
+    membersToAdd @1 :List(GroupMember) $Json.name("members_to_add");
+    # members to add
+  }
+
   config @0 :Config;
   # Config
 
-  membersToRemove @1 :List(Text) $Json.name("members_to_remove");
-  # members to remove
-
-  membersToAdd @2 :List(GroupMember) $Json.name("members_to_add");
-  # members to add
+  groupUpdate @1 :GroupUpdateDetails  $Json.name("group_changes");
+  # group update detials
 }
 
 struct GroupCreate {
+  # Create group details
+
+  struct GroupCreateDetails {
+  # details of a group
+
+    uri @0 :Text;
+    # URI where group should be created
+  }
+
   config @0 :Config;
   # Config
 
-  uri @1 :Text;
-  # URI where group should be created
+  groupDetails @1 :GroupCreateDetails $Json.name("group_details");
 }

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -623,6 +623,14 @@ struct EstimatedResultSize {
   memorySizes @1 :Map(Text, MemorySize);
 }
 
+struct GroupMetadata {
+  config @0 :Config;
+  # Config
+
+  metadata  @1 :ArrayMetadata;
+  # metadata attached to group
+}
+
 struct GroupMember {
   uri @0 :Text;
   # URI of group Member

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -663,7 +663,7 @@ struct GroupUpdate {
   config @0 :Config;
   # Config
 
-  groupUpdate @1 :GroupUpdateDetails  $Json.name("group_changes");
+  groupUpdate @1 :GroupUpdateDetails $Json.name("group_changes");
   # group update detials
 }
 

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
@@ -5062,6 +5062,70 @@ const ::capnp::_::RawSchema s_bda7916926591c22 = {
   0, 3, i_bda7916926591c22, nullptr, nullptr, { &s_bda7916926591c22, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<49> b_838188de0fd57580 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    128, 117, 213,  15, 222, 136, 129, 131,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,   2,   1,   0,   0,
+     33,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     29,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  71, 114, 111, 117, 112,  77,
+    101, 116,  97, 100,  97, 116,  97,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0,  74,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     44,   0,   0,   0,   3,   0,   1,   0,
+     56,   0,   0,   0,   2,   0,   1,   0,
+     99, 111, 110, 102, 105, 103,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+     54, 173,  17, 129,  75,  91, 201, 182,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    109, 101, 116,  97, 100,  97, 116,  97,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    187,  49, 206, 223, 175, 220,  55, 151,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_838188de0fd57580 = b_838188de0fd57580.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_838188de0fd57580[] = {
+  &s_9737dcafdfce31bb,
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_838188de0fd57580[] = {0, 1};
+static const uint16_t i_838188de0fd57580[] = {0, 1};
+const ::capnp::_::RawSchema s_838188de0fd57580 = {
+  0x838188de0fd57580, b_838188de0fd57580.words, 49, d_838188de0fd57580, m_838188de0fd57580,
+  2, 2, i_838188de0fd57580, nullptr, nullptr, { &s_838188de0fd57580, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<64> b_c41bcc7e8cc58f18 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
      24, 143, 197, 140, 126, 204,  27, 196,
@@ -5974,6 +6038,14 @@ constexpr uint16_t EstimatedResultSize::MemorySize::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind EstimatedResultSize::MemorySize::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* EstimatedResultSize::MemorySize::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// GroupMetadata
+constexpr uint16_t GroupMetadata::_capnpPrivate::dataWordSize;
+constexpr uint16_t GroupMetadata::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind GroupMetadata::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* GroupMetadata::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 // GroupMember

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
@@ -5137,45 +5137,42 @@ const ::capnp::_::RawSchema s_c41bcc7e8cc58f18 = {
   0, 3, i_c41bcc7e8cc58f18, nullptr, nullptr, { &s_c41bcc7e8cc58f18, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<67> b_dcdd20e1b79e915a = {
+static const ::capnp::_::AlignedData<60> b_dcdd20e1b79e915a = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
      90, 145, 158, 183, 225,  32, 221, 220,
      18,   0,   0,   0,   1,   0,   0,   0,
     127, 216, 135, 181,  36, 146, 125, 181,
-      3,   0,   7,   0,   0,   0,   0,   0,
+      2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 194,   0,   0,   0,
-     29,   0,   0,   0,   7,   0,   0,   0,
+     29,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     25,   0,   0,   0, 175,   0,   0,   0,
+     41,   0,   0,   0, 119,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     116, 105, 108, 101, 100,  98,  45, 114,
     101, 115, 116,  46,  99,  97, 112, 110,
     112,  58,  71, 114, 111, 117, 112,   0,
-      0,   0,   0,   0,   1,   0,   1,   0,
-     12,   0,   0,   0,   3,   0,   4,   0,
+      4,   0,   0,   0,   1,   0,   1,   0,
+    193, 117, 180,  21, 199,  16, 234, 162,
+      1,   0,   0,   0, 106,   0,   0,   0,
+     71, 114, 111, 117, 112,  68, 101, 116,
+     97, 105, 108, 115,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     69,   0,   0,   0,  58,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     64,   0,   0,   0,   3,   0,   1,   0,
-     76,   0,   0,   0,   2,   0,   1,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
       1,   0,   0,   0,   1,   0,   0,   0,
       0,   0,   1,   0,   1,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     73,   0,   0,   0,  66,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     68,   0,   0,   0,   3,   0,   1,   0,
-     96,   0,   0,   0,   2,   0,   1,   0,
-      2,   0,   0,   0,   2,   0,   0,   0,
-      0,   0,   1,   0,   2,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     93,   0,   0,   0,  74,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     92,   0,   0,   0,   3,   0,   1,   0,
-    104,   0,   0,   0,   2,   0,   1,   0,
+     45,   0,   0,   0,  50,   0,   0,   0,
+     45,   0,   0,   0,  31,   0,   0,   0,
+     76,   0,   0,   0,   3,   0,   1,   0,
+     88,   0,   0,   0,   2,   0,   1,   0,
      99, 111, 110, 102, 105, 103,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
      54, 173,  17, 129,  75,  91, 201, 182,
@@ -5184,6 +5181,71 @@ static const ::capnp::_::AlignedData<67> b_dcdd20e1b79e915a = {
      16,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    103, 114, 111, 117, 112,   0,   0,   0,
+      4,   0,   0,   0,   1,   0,   2,   0,
+     61, 124,  46,  28, 214,  31,  91, 250,
+      4,   0,   0,   0,   2,   0,   1,   0,
+     16,   0,   0,   0,   0,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0,  50,   0,   0,   0,
+    103, 114, 111, 117, 112,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    193, 117, 180,  21, 199,  16, 234, 162,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_dcdd20e1b79e915a = b_dcdd20e1b79e915a.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_dcdd20e1b79e915a[] = {
+  &s_a2ea10c715b475c1,
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_dcdd20e1b79e915a[] = {0, 1};
+static const uint16_t i_dcdd20e1b79e915a[] = {0, 1};
+const ::capnp::_::RawSchema s_dcdd20e1b79e915a = {
+  0xdcdd20e1b79e915a, b_dcdd20e1b79e915a.words, 60, d_dcdd20e1b79e915a, m_dcdd20e1b79e915a,
+  2, 2, i_dcdd20e1b79e915a, nullptr, nullptr, { &s_dcdd20e1b79e915a, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<54> b_a2ea10c715b475c1 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    193, 117, 180,  21, 199,  16, 234, 162,
+     24,   0,   0,   0,   1,   0,   0,   0,
+     90, 145, 158, 183, 225,  32, 221, 220,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  42,   1,   0,   0,
+     37,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     33,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  71, 114, 111, 117, 112,  46,
+     71, 114, 111, 117, 112,  68, 101, 116,
+     97, 105, 108, 115,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  66,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     64,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     61,   0,   0,   0,  74,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     60,   0,   0,   0,   3,   0,   1,   0,
+     72,   0,   0,   0,   2,   0,   1,   0,
     109, 101, 109,  98, 101, 114, 115,   0,
      14,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -5206,60 +5268,57 @@ static const ::capnp::_::AlignedData<67> b_dcdd20e1b79e915a = {
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
-::capnp::word const* const bp_dcdd20e1b79e915a = b_dcdd20e1b79e915a.words;
+::capnp::word const* const bp_a2ea10c715b475c1 = b_a2ea10c715b475c1.words;
 #if !CAPNP_LITE
-static const ::capnp::_::RawSchema* const d_dcdd20e1b79e915a[] = {
+static const ::capnp::_::RawSchema* const d_a2ea10c715b475c1[] = {
   &s_9737dcafdfce31bb,
-  &s_b6c95b4b8111ad36,
   &s_c41bcc7e8cc58f18,
 };
-static const uint16_t m_dcdd20e1b79e915a[] = {0, 1, 2};
-static const uint16_t i_dcdd20e1b79e915a[] = {0, 1, 2};
-const ::capnp::_::RawSchema s_dcdd20e1b79e915a = {
-  0xdcdd20e1b79e915a, b_dcdd20e1b79e915a.words, 67, d_dcdd20e1b79e915a, m_dcdd20e1b79e915a,
-  3, 3, i_dcdd20e1b79e915a, nullptr, nullptr, { &s_dcdd20e1b79e915a, nullptr, nullptr, 0, 0, nullptr }
+static const uint16_t m_a2ea10c715b475c1[] = {0, 1};
+static const uint16_t i_a2ea10c715b475c1[] = {0, 1};
+const ::capnp::_::RawSchema s_a2ea10c715b475c1 = {
+  0xa2ea10c715b475c1, b_a2ea10c715b475c1.words, 54, d_a2ea10c715b475c1, m_a2ea10c715b475c1,
+  2, 2, i_a2ea10c715b475c1, nullptr, nullptr, { &s_a2ea10c715b475c1, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<94> b_c4e54a63294eddb7 = {
+static const ::capnp::_::AlignedData<64> b_c4e54a63294eddb7 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     183, 221,  78,  41,  99,  74, 229, 196,
      18,   0,   0,   0,   1,   0,   0,   0,
     127, 216, 135, 181,  36, 146, 125, 181,
-      3,   0,   7,   0,   0,   0,   0,   0,
+      2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 242,   0,   0,   0,
-     33,   0,   0,   0,   7,   0,   0,   0,
+     33,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     29,   0,   0,   0, 175,   0,   0,   0,
+     49,   0,   0,   0, 119,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     116, 105, 108, 101, 100,  98,  45, 114,
     101, 115, 116,  46,  99,  97, 112, 110,
     112,  58,  71, 114, 111, 117, 112,  85,
     112, 100,  97, 116, 101,   0,   0,   0,
-      0,   0,   0,   0,   1,   0,   1,   0,
-     12,   0,   0,   0,   3,   0,   4,   0,
+      4,   0,   0,   0,   1,   0,   1,   0,
+     64, 222, 155, 117,  70,  30, 176, 131,
+      1,   0,   0,   0, 154,   0,   0,   0,
+     71, 114, 111, 117, 112,  85, 112, 100,
+     97, 116, 101,  68, 101, 116,  97, 105,
+    108, 115,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     69,   0,   0,   0,  58,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     64,   0,   0,   0,   3,   0,   1,   0,
-     76,   0,   0,   0,   2,   0,   1,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
       1,   0,   0,   0,   1,   0,   0,   0,
       0,   0,   1,   0,   1,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     73,   0,   0,   0, 130,   0,   0,   0,
-     77,   0,   0,   0,  31,   0,   0,   0,
-    116,   0,   0,   0,   3,   0,   1,   0,
-    144,   0,   0,   0,   2,   0,   1,   0,
-      2,   0,   0,   0,   2,   0,   0,   0,
-      0,   0,   1,   0,   2,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-    141,   0,   0,   0, 106,   0,   0,   0,
-    145,   0,   0,   0,  31,   0,   0,   0,
-    180,   0,   0,   0,   3,   0,   1,   0,
-    208,   0,   0,   0,   2,   0,   1,   0,
+     45,   0,   0,   0,  98,   0,   0,   0,
+     49,   0,   0,   0,  31,   0,   0,   0,
+     84,   0,   0,   0,   3,   0,   1,   0,
+     96,   0,   0,   0,   2,   0,   1,   0,
      99, 111, 110, 102, 105, 103,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
      54, 173,  17, 129,  75,  91, 201, 182,
@@ -5268,6 +5327,75 @@ static const ::capnp::_::AlignedData<94> b_c4e54a63294eddb7 = {
      16,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    103, 114, 111, 117, 112,  85, 112, 100,
+     97, 116, 101,   0,   0,   0,   0,   0,
+      4,   0,   0,   0,   1,   0,   2,   0,
+     61, 124,  46,  28, 214,  31,  91, 250,
+      4,   0,   0,   0,   2,   0,   1,   0,
+     20,   0,   0,   0,   0,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0, 114,   0,   0,   0,
+    103, 114, 111, 117, 112,  95,  99, 104,
+     97, 110, 103, 101, 115,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+     64, 222, 155, 117,  70,  30, 176, 131,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_c4e54a63294eddb7 = b_c4e54a63294eddb7.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_c4e54a63294eddb7[] = {
+  &s_83b01e46759bde40,
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_c4e54a63294eddb7[] = {0, 1};
+static const uint16_t i_c4e54a63294eddb7[] = {0, 1};
+const ::capnp::_::RawSchema s_c4e54a63294eddb7 = {
+  0xc4e54a63294eddb7, b_c4e54a63294eddb7.words, 64, d_c4e54a63294eddb7, m_c4e54a63294eddb7,
+  2, 2, i_c4e54a63294eddb7, nullptr, nullptr, { &s_c4e54a63294eddb7, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<82> b_83b01e46759bde40 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+     64, 222, 155, 117,  70,  30, 176, 131,
+     30,   0,   0,   0,   1,   0,   0,   0,
+    183, 221,  78,  41,  99,  74, 229, 196,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0, 138,   1,   0,   0,
+     45,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  71, 114, 111, 117, 112,  85,
+    112, 100,  97, 116, 101,  46,  71, 114,
+    111, 117, 112,  85, 112, 100,  97, 116,
+    101,  68, 101, 116,  97, 105, 108, 115,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0, 130,   0,   0,   0,
+     45,   0,   0,   0,  31,   0,   0,   0,
+     84,   0,   0,   0,   3,   0,   1,   0,
+    112,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    109,   0,   0,   0, 106,   0,   0,   0,
+    113,   0,   0,   0,  31,   0,   0,   0,
+    148,   0,   0,   0,   3,   0,   1,   0,
+    176,   0,   0,   0,   2,   0,   1,   0,
     109, 101, 109,  98, 101, 114, 115,  84,
     111,  82, 101, 109, 111, 118, 101,   0,
       4,   0,   0,   0,   1,   0,   2,   0,
@@ -5316,20 +5444,19 @@ static const ::capnp::_::AlignedData<94> b_c4e54a63294eddb7 = {
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
-::capnp::word const* const bp_c4e54a63294eddb7 = b_c4e54a63294eddb7.words;
+::capnp::word const* const bp_83b01e46759bde40 = b_83b01e46759bde40.words;
 #if !CAPNP_LITE
-static const ::capnp::_::RawSchema* const d_c4e54a63294eddb7[] = {
-  &s_b6c95b4b8111ad36,
+static const ::capnp::_::RawSchema* const d_83b01e46759bde40[] = {
   &s_c41bcc7e8cc58f18,
 };
-static const uint16_t m_c4e54a63294eddb7[] = {0, 2, 1};
-static const uint16_t i_c4e54a63294eddb7[] = {0, 1, 2};
-const ::capnp::_::RawSchema s_c4e54a63294eddb7 = {
-  0xc4e54a63294eddb7, b_c4e54a63294eddb7.words, 94, d_c4e54a63294eddb7, m_c4e54a63294eddb7,
-  2, 3, i_c4e54a63294eddb7, nullptr, nullptr, { &s_c4e54a63294eddb7, nullptr, nullptr, 0, 0, nullptr }
+static const uint16_t m_83b01e46759bde40[] = {1, 0};
+static const uint16_t i_83b01e46759bde40[] = {0, 1};
+const ::capnp::_::RawSchema s_83b01e46759bde40 = {
+  0x83b01e46759bde40, b_83b01e46759bde40.words, 82, d_83b01e46759bde40, m_83b01e46759bde40,
+  1, 2, i_83b01e46759bde40, nullptr, nullptr, { &s_83b01e46759bde40, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
+static const ::capnp::_::AlignedData<64> b_fb7f36ad4d8ffe84 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     132, 254, 143,  77, 173,  54, 127, 251,
      18,   0,   0,   0,   1,   0,   0,   0,
@@ -5337,16 +5464,21 @@ static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
       2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 242,   0,   0,   0,
-     33,   0,   0,   0,   7,   0,   0,   0,
+     33,   0,   0,   0,  23,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     29,   0,   0,   0, 119,   0,   0,   0,
+     49,   0,   0,   0, 119,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     116, 105, 108, 101, 100,  98,  45, 114,
     101, 115, 116,  46,  99,  97, 112, 110,
     112,  58,  71, 114, 111, 117, 112,  67,
     114, 101,  97, 116, 101,   0,   0,   0,
-      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   1,   0,   1,   0,
+    169, 134,  94, 215, 154,  69, 253, 213,
+      1,   0,   0,   0, 154,   0,   0,   0,
+     71, 114, 111, 117, 112,  67, 114, 101,
+     97, 116, 101,  68, 101, 116,  97, 105,
+    108, 115,   0,   0,   0,   0,   0,   0,
       8,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
@@ -5358,10 +5490,10 @@ static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
       1,   0,   0,   0,   1,   0,   0,   0,
       0,   0,   1,   0,   1,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     45,   0,   0,   0,  34,   0,   0,   0,
-      0,   0,   0,   0,   0,   0,   0,   0,
-     40,   0,   0,   0,   3,   0,   1,   0,
-     52,   0,   0,   0,   2,   0,   1,   0,
+     45,   0,   0,   0, 106,   0,   0,   0,
+     49,   0,   0,   0,  31,   0,   0,   0,
+     84,   0,   0,   0,   3,   0,   1,   0,
+     96,   0,   0,   0,   2,   0,   1,   0,
      99, 111, 110, 102, 105, 103,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
      54, 173,  17, 129,  75,  91, 201, 182,
@@ -5370,6 +5502,68 @@ static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
      16,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+    103, 114, 111, 117, 112,  68, 101, 116,
+     97, 105, 108, 115,   0,   0,   0,   0,
+      4,   0,   0,   0,   1,   0,   2,   0,
+     61, 124,  46,  28, 214,  31,  91, 250,
+      4,   0,   0,   0,   2,   0,   1,   0,
+     20,   0,   0,   0,   0,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0, 114,   0,   0,   0,
+    103, 114, 111, 117, 112,  95, 100, 101,
+    116,  97, 105, 108, 115,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    169, 134,  94, 215, 154,  69, 253, 213,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_fb7f36ad4d8ffe84 = b_fb7f36ad4d8ffe84.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_fb7f36ad4d8ffe84[] = {
+  &s_b6c95b4b8111ad36,
+  &s_d5fd459ad75e86a9,
+};
+static const uint16_t m_fb7f36ad4d8ffe84[] = {0, 1};
+static const uint16_t i_fb7f36ad4d8ffe84[] = {0, 1};
+const ::capnp::_::RawSchema s_fb7f36ad4d8ffe84 = {
+  0xfb7f36ad4d8ffe84, b_fb7f36ad4d8ffe84.words, 64, d_fb7f36ad4d8ffe84, m_fb7f36ad4d8ffe84,
+  2, 2, i_fb7f36ad4d8ffe84, nullptr, nullptr, { &s_fb7f36ad4d8ffe84, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<36> b_d5fd459ad75e86a9 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    169, 134,  94, 215, 154,  69, 253, 213,
+     30,   0,   0,   0,   1,   0,   0,   0,
+    132, 254, 143,  77, 173,  54, 127, 251,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0, 138,   1,   0,   0,
+     45,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  63,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  71, 114, 111, 117, 112,  67,
+    114, 101,  97, 116, 101,  46,  71, 114,
+    111, 117, 112,  67, 114, 101,  97, 116,
+    101,  68, 101, 116,  97, 105, 108, 115,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     13,   0,   0,   0,  34,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   1,   0,
+     20,   0,   0,   0,   2,   0,   1,   0,
     117, 114, 105,   0,   0,   0,   0,   0,
      12,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
@@ -5379,16 +5573,13 @@ static const ::capnp::_::AlignedData<48> b_fb7f36ad4d8ffe84 = {
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
-::capnp::word const* const bp_fb7f36ad4d8ffe84 = b_fb7f36ad4d8ffe84.words;
+::capnp::word const* const bp_d5fd459ad75e86a9 = b_d5fd459ad75e86a9.words;
 #if !CAPNP_LITE
-static const ::capnp::_::RawSchema* const d_fb7f36ad4d8ffe84[] = {
-  &s_b6c95b4b8111ad36,
-};
-static const uint16_t m_fb7f36ad4d8ffe84[] = {0, 1};
-static const uint16_t i_fb7f36ad4d8ffe84[] = {0, 1};
-const ::capnp::_::RawSchema s_fb7f36ad4d8ffe84 = {
-  0xfb7f36ad4d8ffe84, b_fb7f36ad4d8ffe84.words, 48, d_fb7f36ad4d8ffe84, m_fb7f36ad4d8ffe84,
-  1, 2, i_fb7f36ad4d8ffe84, nullptr, nullptr, { &s_fb7f36ad4d8ffe84, nullptr, nullptr, 0, 0, nullptr }
+static const uint16_t m_d5fd459ad75e86a9[] = {0};
+static const uint16_t i_d5fd459ad75e86a9[] = {0};
+const ::capnp::_::RawSchema s_d5fd459ad75e86a9 = {
+  0xd5fd459ad75e86a9, b_d5fd459ad75e86a9.words, 36, nullptr, m_d5fd459ad75e86a9,
+  0, 1, i_d5fd459ad75e86a9, nullptr, nullptr, { &s_d5fd459ad75e86a9, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
 }  // namespace schemas
@@ -5801,6 +5992,14 @@ constexpr ::capnp::Kind Group::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* Group::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
+// Group::GroupDetails
+constexpr uint16_t Group::GroupDetails::_capnpPrivate::dataWordSize;
+constexpr uint16_t Group::GroupDetails::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind Group::GroupDetails::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* Group::GroupDetails::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
 // GroupUpdate
 constexpr uint16_t GroupUpdate::_capnpPrivate::dataWordSize;
 constexpr uint16_t GroupUpdate::_capnpPrivate::pointerCount;
@@ -5809,12 +6008,28 @@ constexpr ::capnp::Kind GroupUpdate::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* GroupUpdate::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
+// GroupUpdate::GroupUpdateDetails
+constexpr uint16_t GroupUpdate::GroupUpdateDetails::_capnpPrivate::dataWordSize;
+constexpr uint16_t GroupUpdate::GroupUpdateDetails::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind GroupUpdate::GroupUpdateDetails::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* GroupUpdate::GroupUpdateDetails::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
 // GroupCreate
 constexpr uint16_t GroupCreate::_capnpPrivate::dataWordSize;
 constexpr uint16_t GroupCreate::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind GroupCreate::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* GroupCreate::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// GroupCreate::GroupCreateDetails
+constexpr uint16_t GroupCreate::GroupCreateDetails::_capnpPrivate::dataWordSize;
+constexpr uint16_t GroupCreate::GroupCreateDetails::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind GroupCreate::GroupCreateDetails::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* GroupCreate::GroupCreateDetails::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
@@ -64,6 +64,7 @@ CAPNP_DECLARE_SCHEMA(926fe1c3b12ed651);
 CAPNP_DECLARE_SCHEMA(8cd4e323f1feea3b);
 CAPNP_DECLARE_SCHEMA(92c8467685565269);
 CAPNP_DECLARE_SCHEMA(bda7916926591c22);
+CAPNP_DECLARE_SCHEMA(838188de0fd57580);
 CAPNP_DECLARE_SCHEMA(c41bcc7e8cc58f18);
 CAPNP_DECLARE_SCHEMA(dcdd20e1b79e915a);
 CAPNP_DECLARE_SCHEMA(a2ea10c715b475c1);
@@ -971,6 +972,23 @@ struct EstimatedResultSize::MemorySize {
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(bda7916926591c22, 3, 0)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct GroupMetadata {
+  GroupMetadata() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(838188de0fd57580, 0, 2)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -8023,6 +8041,127 @@ class EstimatedResultSize::MemorySize::Pipeline {
   inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
       : _typeless(kj::mv(typeless)) {
   }
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class GroupMetadata::Reader {
+ public:
+  typedef GroupMetadata Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig() const;
+  inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
+
+  inline bool hasMetadata() const;
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader getMetadata()
+      const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class GroupMetadata::Builder {
+ public:
+  typedef GroupMetadata Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig();
+  inline ::tiledb::sm::serialization::capnp::Config::Builder getConfig();
+  inline void setConfig(
+      ::tiledb::sm::serialization::capnp::Config::Reader value);
+  inline ::tiledb::sm::serialization::capnp::Config::Builder initConfig();
+  inline void adoptConfig(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+  disownConfig();
+
+  inline bool hasMetadata();
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
+  getMetadata();
+  inline void setMetadata(
+      ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader value);
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
+  initMetadata();
+  inline void adoptMetadata(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>&&
+          value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>
+  disownMetadata();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class GroupMetadata::Pipeline {
+ public:
+  typedef GroupMetadata Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline
+  getMetadata();
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -17059,6 +17198,113 @@ inline void EstimatedResultSize::MemorySize::Builder::setSizeValidity(
     ::uint64_t value) {
   _builder.setDataField<::uint64_t>(
       ::capnp::bounded<2>() * ::capnp::ELEMENTS, value);
+}
+
+inline bool GroupMetadata::Reader::hasConfig() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool GroupMetadata::Builder::hasConfig() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Config::Reader
+GroupMetadata::Reader::getConfig() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+GroupMetadata::Builder::getConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Config::Pipeline
+GroupMetadata::Pipeline::getConfig() {
+  return ::tiledb::sm::serialization::capnp::Config::Pipeline(
+      _typeless.getPointerField(0));
+}
+#endif  // !CAPNP_LITE
+inline void GroupMetadata::Builder::setConfig(
+    ::tiledb::sm::serialization::capnp::Config::Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::set(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      value);
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+GroupMetadata::Builder::initConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void GroupMetadata::Builder::adoptConfig(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::adopt(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+GroupMetadata::Builder::disownConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool GroupMetadata::Reader::hasMetadata() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool GroupMetadata::Builder::hasMetadata() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader
+GroupMetadata::Reader::getMetadata() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::get(
+          _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
+GroupMetadata::Builder::getMetadata() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::get(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline
+GroupMetadata::Pipeline::getMetadata() {
+  return ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline(
+      _typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void GroupMetadata::Builder::setMetadata(
+    ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader value) {
+  ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::set(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
+GroupMetadata::Builder::initMetadata() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::init(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void GroupMetadata::Builder::adoptMetadata(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>&&
+        value) {
+  ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>
+GroupMetadata::Builder::disownMetadata() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool GroupMember::Reader::hasUri() const {

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
@@ -66,8 +66,11 @@ CAPNP_DECLARE_SCHEMA(92c8467685565269);
 CAPNP_DECLARE_SCHEMA(bda7916926591c22);
 CAPNP_DECLARE_SCHEMA(c41bcc7e8cc58f18);
 CAPNP_DECLARE_SCHEMA(dcdd20e1b79e915a);
+CAPNP_DECLARE_SCHEMA(a2ea10c715b475c1);
 CAPNP_DECLARE_SCHEMA(c4e54a63294eddb7);
+CAPNP_DECLARE_SCHEMA(83b01e46759bde40);
 CAPNP_DECLARE_SCHEMA(fb7f36ad4d8ffe84);
+CAPNP_DECLARE_SCHEMA(d5fd459ad75e86a9);
 
 }  // namespace schemas
 }  // namespace capnp
@@ -999,9 +1002,27 @@ struct Group {
   class Reader;
   class Builder;
   class Pipeline;
+  struct GroupDetails;
 
   struct _capnpPrivate {
-    CAPNP_DECLARE_STRUCT_HEADER(dcdd20e1b79e915a, 0, 3)
+    CAPNP_DECLARE_STRUCT_HEADER(dcdd20e1b79e915a, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct Group::GroupDetails {
+  GroupDetails() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(a2ea10c715b475c1, 0, 2)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -1016,9 +1037,27 @@ struct GroupUpdate {
   class Reader;
   class Builder;
   class Pipeline;
+  struct GroupUpdateDetails;
 
   struct _capnpPrivate {
-    CAPNP_DECLARE_STRUCT_HEADER(c4e54a63294eddb7, 0, 3)
+    CAPNP_DECLARE_STRUCT_HEADER(c4e54a63294eddb7, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct GroupUpdate::GroupUpdateDetails {
+  GroupUpdateDetails() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(83b01e46759bde40, 0, 2)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -1033,9 +1072,27 @@ struct GroupCreate {
   class Reader;
   class Builder;
   class Pipeline;
+  struct GroupCreateDetails;
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(fb7f36ad4d8ffe84, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct GroupCreate::GroupCreateDetails {
+  GroupCreateDetails() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(d5fd459ad75e86a9, 0, 1)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -8109,15 +8166,9 @@ class Group::Reader {
   inline bool hasConfig() const;
   inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
 
-  inline bool hasMembers() const;
-  inline ::capnp::List<
-      ::tiledb::sm::serialization::capnp::GroupMember,
-      ::capnp::Kind::STRUCT>::Reader
-  getMembers() const;
-
-  inline bool hasMetadata() const;
-  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader getMetadata()
-      const;
+  inline bool hasGroup() const;
+  inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Reader
+  getGroup() const;
 
  private:
   ::capnp::_::StructReader _reader;
@@ -8168,6 +8219,121 @@ class Group::Builder {
   inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
   disownConfig();
 
+  inline bool hasGroup();
+  inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Builder
+  getGroup();
+  inline void setGroup(
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails::Reader value);
+  inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Builder
+  initGroup();
+  inline void adoptGroup(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Group::GroupDetails>&&
+          value);
+  inline ::capnp::Orphan<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>
+  disownGroup();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class Group::Pipeline {
+ public:
+  typedef Group Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+  inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Pipeline
+  getGroup();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class Group::GroupDetails::Reader {
+ public:
+  typedef GroupDetails Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasMembers() const;
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::GroupMember,
+      ::capnp::Kind::STRUCT>::Reader
+  getMembers() const;
+
+  inline bool hasMetadata() const;
+  inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader getMetadata()
+      const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class Group::GroupDetails::Builder {
+ public:
+  typedef GroupDetails Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
   inline bool hasMembers();
   inline ::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
@@ -8211,9 +8377,9 @@ class Group::Builder {
 };
 
 #if !CAPNP_LITE
-class Group::Pipeline {
+class Group::GroupDetails::Pipeline {
  public:
-  typedef Group Pipelines;
+  typedef GroupDetails Pipelines;
 
   inline Pipeline(decltype(nullptr))
       : _typeless(nullptr) {
@@ -8222,7 +8388,6 @@ class Group::Pipeline {
       : _typeless(kj::mv(typeless)) {
   }
 
-  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
   inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline
   getMetadata();
 
@@ -8256,15 +8421,10 @@ class GroupUpdate::Reader {
   inline bool hasConfig() const;
   inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
 
-  inline bool hasMembersToRemove() const;
-  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
-  getMembersToRemove() const;
-
-  inline bool hasMembersToAdd() const;
-  inline ::capnp::List<
-      ::tiledb::sm::serialization::capnp::GroupMember,
-      ::capnp::Kind::STRUCT>::Reader
-  getMembersToAdd() const;
+  inline bool hasGroupUpdate() const;
+  inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Reader
+      getGroupUpdate() const;
 
  private:
   ::capnp::_::StructReader _reader;
@@ -8315,6 +8475,125 @@ class GroupUpdate::Builder {
   inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
   disownConfig();
 
+  inline bool hasGroupUpdate();
+  inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Builder
+      getGroupUpdate();
+  inline void setGroupUpdate(::tiledb::sm::serialization::capnp::GroupUpdate::
+                                 GroupUpdateDetails::Reader value);
+  inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Builder
+      initGroupUpdate();
+  inline void adoptGroupUpdate(
+      ::capnp::Orphan<
+          ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>&&
+          value);
+  inline ::capnp::Orphan<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>
+  disownGroupUpdate();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class GroupUpdate::Pipeline {
+ public:
+  typedef GroupUpdate Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+  inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Pipeline
+      getGroupUpdate();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class GroupUpdate::GroupUpdateDetails::Reader {
+ public:
+  typedef GroupUpdateDetails Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasMembersToRemove() const;
+  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
+  getMembersToRemove() const;
+
+  inline bool hasMembersToAdd() const;
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::GroupMember,
+      ::capnp::Kind::STRUCT>::Reader
+  getMembersToAdd() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class GroupUpdate::GroupUpdateDetails::Builder {
+ public:
+  typedef GroupUpdateDetails Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
   inline bool hasMembersToRemove();
   inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
   getMembersToRemove();
@@ -8361,9 +8640,9 @@ class GroupUpdate::Builder {
 };
 
 #if !CAPNP_LITE
-class GroupUpdate::Pipeline {
+class GroupUpdate::GroupUpdateDetails::Pipeline {
  public:
-  typedef GroupUpdate Pipelines;
+  typedef GroupUpdateDetails Pipelines;
 
   inline Pipeline(decltype(nullptr))
       : _typeless(nullptr) {
@@ -8371,8 +8650,6 @@ class GroupUpdate::Pipeline {
   inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
       : _typeless(kj::mv(typeless)) {
   }
-
-  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -8404,8 +8681,10 @@ class GroupCreate::Reader {
   inline bool hasConfig() const;
   inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
 
-  inline bool hasUri() const;
-  inline ::capnp::Text::Reader getUri() const;
+  inline bool hasGroupDetails() const;
+  inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Reader
+      getGroupDetails() const;
 
  private:
   ::capnp::_::StructReader _reader;
@@ -8456,12 +8735,22 @@ class GroupCreate::Builder {
   inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
   disownConfig();
 
-  inline bool hasUri();
-  inline ::capnp::Text::Builder getUri();
-  inline void setUri(::capnp::Text::Reader value);
-  inline ::capnp::Text::Builder initUri(unsigned int size);
-  inline void adoptUri(::capnp::Orphan<::capnp::Text>&& value);
-  inline ::capnp::Orphan<::capnp::Text> disownUri();
+  inline bool hasGroupDetails();
+  inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Builder
+      getGroupDetails();
+  inline void setGroupDetails(::tiledb::sm::serialization::capnp::GroupCreate::
+                                  GroupCreateDetails::Reader value);
+  inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Builder
+      initGroupDetails();
+  inline void adoptGroupDetails(
+      ::capnp::Orphan<
+          ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>&&
+          value);
+  inline ::capnp::Orphan<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>
+  disownGroupDetails();
 
  private:
   ::capnp::_::StructBuilder _builder;
@@ -8485,6 +8774,106 @@ class GroupCreate::Pipeline {
   }
 
   inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+  inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Pipeline
+      getGroupDetails();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class GroupCreate::GroupCreateDetails::Reader {
+ public:
+  typedef GroupCreateDetails Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasUri() const;
+  inline ::capnp::Text::Reader getUri() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class GroupCreate::GroupCreateDetails::Builder {
+ public:
+  typedef GroupCreateDetails Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasUri();
+  inline ::capnp::Text::Builder getUri();
+  inline void setUri(::capnp::Text::Reader value);
+  inline ::capnp::Text::Builder initUri(unsigned int size);
+  inline void adoptUri(::capnp::Orphan<::capnp::Text>&& value);
+  inline ::capnp::Orphan<::capnp::Text> disownUri();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class GroupCreate::GroupCreateDetails::Pipeline {
+ public:
+  typedef GroupCreateDetails Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -16810,58 +17199,115 @@ Group::Builder::disownConfig() {
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
-inline bool Group::Reader::hasMembers() const {
+inline bool Group::Reader::hasGroup() const {
   return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool Group::Builder::hasMembers() {
+inline bool Group::Builder::hasGroup() {
   return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Reader
+Group::Reader::getGroup() const {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      get(_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Builder
+Group::Builder::getGroup() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      get(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Pipeline
+Group::Pipeline::getGroup() {
+  return ::tiledb::sm::serialization::capnp::Group::GroupDetails::Pipeline(
+      _typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void Group::Builder::setGroup(
+    ::tiledb::sm::serialization::capnp::Group::GroupDetails::Reader value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::Group::GroupDetails::Builder
+Group::Builder::initGroup() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      init(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void Group::Builder::adoptGroup(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Group::GroupDetails>&&
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Group::GroupDetails>
+Group::Builder::disownGroup() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::Group::GroupDetails>::
+      disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+
+inline bool Group::GroupDetails::Reader::hasMembers() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool Group::GroupDetails::Builder::hasMembers() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
               .isNull();
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Reader
-Group::Reader::getMembers() const {
+Group::GroupDetails::Reader::getMembers() const {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::get(_reader
                                        .getPointerField(
-                                           ::capnp::bounded<1>() *
+                                           ::capnp::bounded<0>() *
                                            ::capnp::POINTERS));
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Builder
-Group::Builder::getMembers() {
+Group::GroupDetails::Builder::getMembers() {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::get(_builder
                                        .getPointerField(
-                                           ::capnp::bounded<1>() *
+                                           ::capnp::bounded<0>() *
                                            ::capnp::POINTERS));
 }
-inline void Group::Builder::setMembers(
+inline void Group::GroupDetails::Builder::setMembers(
     ::capnp::List<
         ::tiledb::sm::serialization::capnp::GroupMember,
         ::capnp::Kind::STRUCT>::Reader value) {
   ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
-      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      set(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           value);
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Builder
-Group::Builder::initMembers(unsigned int size) {
+Group::GroupDetails::Builder::initMembers(unsigned int size) {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
       init(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           size);
 }
-inline void Group::Builder::adoptMembers(
+inline void Group::GroupDetails::Builder::adoptMembers(
     ::capnp::Orphan<::capnp::List<
         ::tiledb::sm::serialization::capnp::GroupMember,
         ::capnp::Kind::STRUCT>>&& value) {
@@ -16869,74 +17315,74 @@ inline void Group::Builder::adoptMembers(
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
       adopt(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           kj::mv(value));
 }
 inline ::capnp::Orphan<::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>>
-Group::Builder::disownMembers() {
+Group::GroupDetails::Builder::disownMembers() {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::disown(_builder
                                           .getPointerField(
-                                              ::capnp::bounded<1>() *
+                                              ::capnp::bounded<0>() *
                                               ::capnp::POINTERS));
 }
 
-inline bool Group::Reader::hasMetadata() const {
-  return !_reader.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS)
+inline bool Group::GroupDetails::Reader::hasMetadata() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool Group::Builder::hasMetadata() {
-  return !_builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS)
+inline bool Group::GroupDetails::Builder::hasMetadata() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
 inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader
-Group::Reader::getMetadata() const {
+Group::GroupDetails::Reader::getMetadata() const {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::get(
-          _reader.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS));
+          _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
-Group::Builder::getMetadata() {
+Group::GroupDetails::Builder::getMetadata() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::get(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS));
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 #if !CAPNP_LITE
 inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline
-Group::Pipeline::getMetadata() {
+Group::GroupDetails::Pipeline::getMetadata() {
   return ::tiledb::sm::serialization::capnp::ArrayMetadata::Pipeline(
-      _typeless.getPointerField(2));
+      _typeless.getPointerField(1));
 }
 #endif  // !CAPNP_LITE
-inline void Group::Builder::setMetadata(
+inline void Group::GroupDetails::Builder::setMetadata(
     ::tiledb::sm::serialization::capnp::ArrayMetadata::Reader value) {
   ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::set(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           value);
 }
 inline ::tiledb::sm::serialization::capnp::ArrayMetadata::Builder
-Group::Builder::initMetadata() {
+Group::GroupDetails::Builder::initMetadata() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::init(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS));
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline void Group::Builder::adoptMetadata(
+inline void Group::GroupDetails::Builder::adoptMetadata(
     ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>&&
         value) {
   ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::adopt(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           kj::mv(value));
 }
 inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArrayMetadata>
-Group::Builder::disownMetadata() {
+Group::GroupDetails::Builder::disownMetadata() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::ArrayMetadata>::disown(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS));
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool GroupUpdate::Reader::hasConfig() const {
@@ -16991,114 +17437,180 @@ GroupUpdate::Builder::disownConfig() {
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
-inline bool GroupUpdate::Reader::hasMembersToRemove() const {
+inline bool GroupUpdate::Reader::hasGroupUpdate() const {
   return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool GroupUpdate::Builder::hasMembersToRemove() {
+inline bool GroupUpdate::Builder::hasGroupUpdate() {
   return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
-GroupUpdate::Reader::getMembersToRemove() const {
-  return ::capnp::_::
-      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
-          _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+    Reader
+    GroupUpdate::Reader::getGroupUpdate() const {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      get(_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
-GroupUpdate::Builder::getMembersToRemove() {
-  return ::capnp::_::
-      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+    Builder
+    GroupUpdate::Builder::getGroupUpdate() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      get(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+    Pipeline
+    GroupUpdate::Pipeline::getGroupUpdate() {
+  return ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+      Pipeline(_typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void GroupUpdate::Builder::setGroupUpdate(
+    ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::Reader
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails::
+    Builder
+    GroupUpdate::Builder::initGroupUpdate() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      init(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void GroupUpdate::Builder::adoptGroupUpdate(
+    ::capnp::Orphan<
+        ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>&&
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<
+    ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>
+GroupUpdate::Builder::disownGroupUpdate() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupUpdate::GroupUpdateDetails>::
+      disown(
           _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline void GroupUpdate::Builder::setMembersToRemove(
+
+inline bool GroupUpdate::GroupUpdateDetails::Reader::hasMembersToRemove()
+    const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool GroupUpdate::GroupUpdateDetails::Builder::hasMembersToRemove() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
+GroupUpdate::GroupUpdateDetails::Reader::getMembersToRemove() const {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+GroupUpdate::GroupUpdateDetails::Builder::getMembersToRemove() {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void GroupUpdate::GroupUpdateDetails::Builder::setMembersToRemove(
     ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader value) {
   ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::set(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           value);
 }
-inline void GroupUpdate::Builder::setMembersToRemove(
+inline void GroupUpdate::GroupUpdateDetails::Builder::setMembersToRemove(
     ::kj::ArrayPtr<const ::capnp::Text::Reader> value) {
   ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::set(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           value);
 }
 inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
-GroupUpdate::Builder::initMembersToRemove(unsigned int size) {
+GroupUpdate::GroupUpdateDetails::Builder::initMembersToRemove(
+    unsigned int size) {
   return ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::init(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           size);
 }
-inline void GroupUpdate::Builder::adoptMembersToRemove(
+inline void GroupUpdate::GroupUpdateDetails::Builder::adoptMembersToRemove(
     ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>&&
         value) {
   ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::adopt(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
           kj::mv(value));
 }
 inline ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>
-GroupUpdate::Builder::disownMembersToRemove() {
+GroupUpdate::GroupUpdateDetails::Builder::disownMembersToRemove() {
   return ::capnp::_::
       PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::disown(
-          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
-inline bool GroupUpdate::Reader::hasMembersToAdd() const {
-  return !_reader.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS)
+inline bool GroupUpdate::GroupUpdateDetails::Reader::hasMembersToAdd() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool GroupUpdate::Builder::hasMembersToAdd() {
-  return !_builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS)
+inline bool GroupUpdate::GroupUpdateDetails::Builder::hasMembersToAdd() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Reader
-GroupUpdate::Reader::getMembersToAdd() const {
+GroupUpdate::GroupUpdateDetails::Reader::getMembersToAdd() const {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::get(_reader
                                        .getPointerField(
-                                           ::capnp::bounded<2>() *
+                                           ::capnp::bounded<1>() *
                                            ::capnp::POINTERS));
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Builder
-GroupUpdate::Builder::getMembersToAdd() {
+GroupUpdate::GroupUpdateDetails::Builder::getMembersToAdd() {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::get(_builder
                                        .getPointerField(
-                                           ::capnp::bounded<2>() *
+                                           ::capnp::bounded<1>() *
                                            ::capnp::POINTERS));
 }
-inline void GroupUpdate::Builder::setMembersToAdd(
+inline void GroupUpdate::GroupUpdateDetails::Builder::setMembersToAdd(
     ::capnp::List<
         ::tiledb::sm::serialization::capnp::GroupMember,
         ::capnp::Kind::STRUCT>::Reader value) {
   ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
-      set(_builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           value);
 }
 inline ::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>::Builder
-GroupUpdate::Builder::initMembersToAdd(unsigned int size) {
+GroupUpdate::GroupUpdateDetails::Builder::initMembersToAdd(unsigned int size) {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
       init(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           size);
 }
-inline void GroupUpdate::Builder::adoptMembersToAdd(
+inline void GroupUpdate::GroupUpdateDetails::Builder::adoptMembersToAdd(
     ::capnp::Orphan<::capnp::List<
         ::tiledb::sm::serialization::capnp::GroupMember,
         ::capnp::Kind::STRUCT>>&& value) {
@@ -17106,18 +17618,18 @@ inline void GroupUpdate::Builder::adoptMembersToAdd(
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::
       adopt(
-          _builder.getPointerField(::capnp::bounded<2>() * ::capnp::POINTERS),
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
           kj::mv(value));
 }
 inline ::capnp::Orphan<::capnp::List<
     ::tiledb::sm::serialization::capnp::GroupMember,
     ::capnp::Kind::STRUCT>>
-GroupUpdate::Builder::disownMembersToAdd() {
+GroupUpdate::GroupUpdateDetails::Builder::disownMembersToAdd() {
   return ::capnp::_::PointerHelpers<::capnp::List<
       ::tiledb::sm::serialization::capnp::GroupMember,
       ::capnp::Kind::STRUCT>>::disown(_builder
                                           .getPointerField(
-                                              ::capnp::bounded<2>() *
+                                              ::capnp::bounded<1>() *
                                               ::capnp::POINTERS));
 }
 
@@ -17173,41 +17685,110 @@ GroupCreate::Builder::disownConfig() {
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
-inline bool GroupCreate::Reader::hasUri() const {
+inline bool GroupCreate::Reader::hasGroupDetails() const {
   return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline bool GroupCreate::Builder::hasUri() {
+inline bool GroupCreate::Builder::hasGroupDetails() {
   return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
               .isNull();
 }
-inline ::capnp::Text::Reader GroupCreate::Reader::getUri() const {
-  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
-      _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+    Reader
+    GroupCreate::Reader::getGroupDetails() const {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      get(_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline ::capnp::Text::Builder GroupCreate::Builder::getUri() {
-  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+    Builder
+    GroupCreate::Builder::getGroupDetails() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      get(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
-inline void GroupCreate::Builder::setUri(::capnp::Text::Reader value) {
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+    Pipeline
+    GroupCreate::Pipeline::getGroupDetails() {
+  return ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+      Pipeline(_typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void GroupCreate::Builder::setGroupDetails(
+    ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::Reader
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails::
+    Builder
+    GroupCreate::Builder::initGroupDetails() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      init(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void GroupCreate::Builder::adoptGroupDetails(
+    ::capnp::Orphan<
+        ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>&&
+        value) {
+  ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<
+    ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>
+GroupCreate::Builder::disownGroupDetails() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::GroupCreate::GroupCreateDetails>::
+      disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+
+inline bool GroupCreate::GroupCreateDetails::Reader::hasUri() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool GroupCreate::GroupCreateDetails::Builder::hasUri() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::Text::Reader GroupCreate::GroupCreateDetails::Reader::getUri()
+    const {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::capnp::Text::Builder
+GroupCreate::GroupCreateDetails::Builder::getUri() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void GroupCreate::GroupCreateDetails::Builder::setUri(
+    ::capnp::Text::Reader value) {
   ::capnp::_::PointerHelpers<::capnp::Text>::set(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
       value);
 }
-inline ::capnp::Text::Builder GroupCreate::Builder::initUri(unsigned int size) {
+inline ::capnp::Text::Builder GroupCreate::GroupCreateDetails::Builder::initUri(
+    unsigned int size) {
   return ::capnp::_::PointerHelpers<::capnp::Text>::init(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
       size);
 }
-inline void GroupCreate::Builder::adoptUri(
+inline void GroupCreate::GroupCreateDetails::Builder::adoptUri(
     ::capnp::Orphan<::capnp::Text>&& value) {
   ::capnp::_::PointerHelpers<::capnp::Text>::adopt(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
       kj::mv(value));
 }
-inline ::capnp::Orphan<::capnp::Text> GroupCreate::Builder::disownUri() {
+inline ::capnp::Orphan<::capnp::Text>
+GroupCreate::GroupCreateDetails::Builder::disownUri() {
   return ::capnp::_::PointerHelpers<::capnp::Text>::disown(
-      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace capnp

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1713,10 +1713,10 @@ Status StorageManager::load_array_metadata(
   stats_->add_counter("read_array_meta_size", meta_size);
 
   // Deserialize metadata buffers
-  metadata->deserialize(metadata_buffs);
+  RETURN_NOT_OK(metadata->deserialize(metadata_buffs));
 
   // Sets the loaded metadata URIs
-  metadata->set_loaded_metadata_uris(array_metadata_to_load);
+  RETURN_NOT_OK(metadata->set_loaded_metadata_uris(array_metadata_to_load));
 
   return Status::Ok();
 }

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -2115,7 +2115,7 @@ Status StorageManager::init_rest_client() {
   RETURN_NOT_OK(config_.get("rest.server_address", &server_address));
   if (server_address != nullptr) {
     rest_client_.reset(tdb_new(RestClient));
-    RETURN_NOT_OK(rest_client_->init(stats_, &config_, compute_tp_));
+    RETURN_NOT_OK(rest_client_->init(stats_, &config_, compute_tp_, logger_));
   }
 
   return Status::Ok();

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -308,10 +308,14 @@ class StorageManager {
   /** Opens an group for writes.
    *
    * @param group The group to open.
-   * @return tuple of Status
+   * @return tuple of Status, latest GroupSchema and map of all group schemas
    *        Status Ok on success, else error
    */
-  std::tuple<Status> group_open_for_writes(Group* group);
+  std::tuple<
+      Status,
+      std::optional<
+          const std::unordered_map<std::string, tdb_shared_ptr<GroupMember>>>>
+  group_open_for_writes(Group* group);
 
   /**
    * Load fragments for an already open array.


### PR DESCRIPTION
We've made minor modifications to the cap'n proto spec for groups, adjusting to standardize the handling of configs for the various requests. We also introduced some additional debug support, such as a config `rest.curl.verbose` for running curl in verbose mode, a logger to the `RestClient` and `Curl` classes, and some minor adjustments to the dump printing. The example files modified slightly to provide a better example.

Overall many files were touch but if you ignore the cap'n proto generated classes this change is quite small in functionality. An additional unit test for round-tripping the updated serialization spec is also included.


---
TYPE: IMPROVEMENT
DESC: Adjustments to the group serialization support for better standardization of config handling.
