### PR TITLE
Global writer: fixing write continuation for fixed sized attributes.

### DIFF
--- a/tiledb/sm/query/global_order_writer.cc
+++ b/tiledb/sm/query/global_order_writer.cc
@@ -779,18 +779,20 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
             init_tile_nullable(name, &((*tiles)[i]), &((*tiles)[i + 1])));
 
     // Handle last tile (it must be either full or empty)
+    uint64_t tile_idx = 0;
     if (last_tile_cell_idx == cell_num_per_tile) {
       (*tiles)[0].swap(last_tile);
       if (nullable) {
         (*tiles)[1].swap(last_tile_validity);
       }
+      tile_idx += t;
     } else {
       assert(last_tile_cell_idx == 0);
     }
 
     // Write all remaining cells one by one
     if (coord_dups.empty()) {
-      for (uint64_t tile_idx = 0, i = 0; i < cell_num_to_write;) {
+      for (uint64_t i = 0; i < cell_num_to_write;) {
         RETURN_NOT_OK((*tiles)[tile_idx].write(
             buffer + cell_idx * cell_size, 0, cell_size * cell_num_per_tile));
 


### PR DESCRIPTION
When continuing global writes with a partially written tile, the partial
tile is completed and swapped with the first tile in the result vector,
then the remainder of the cells is written but should start at the next
tile, which was not the case in the current implementation. This fixes
the issue.

Note that this doesn't include unit tests to unblock the 2.8 release.

---
TYPE: IMPROVEMENT
DESC: Global writer: fixing write continuation for fixed sized attributes.
