### PR TITLE
tiledb_serialize_array_metadata should load metadata

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -818,7 +818,7 @@ Status Array::has_metadata_key(
   return Status::Ok();
 }
 
-Metadata* Array::metadata() {
+Metadata* Array::unsafe_metadata() {
   return &metadata_;
 }
 

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -351,7 +351,7 @@ class Array {
    * fetch the underlying Metadata object to set the values we are loading from
    * REST. A lock should already by taken before load_metadata is called.
    */
-  Metadata* metadata();
+  Metadata* unsafe_metadata();
 
   /** Returns the non-empty domain of the opened array.
    *  If the non_empty_domain has not been computed or loaded

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -6311,11 +6311,17 @@ int32_t tiledb_serialize_array_metadata(
       sanity_check(ctx, *buffer) == TILEDB_ERR)
     return TILEDB_ERR;
 
+  // Get metadata to serialize, this will load it if it does not exist
+  tiledb::sm::Metadata* metadata;
+  if (SAVE_ERROR_CATCH(ctx, array->array_->metadata(&metadata))) {
+    return TILEDB_ERR;
+  }
+
   // Serialize
   if (SAVE_ERROR_CATCH(
           ctx,
           tiledb::sm::serialization::metadata_serialize(
-              array->array_->metadata(),
+              metadata,
               (tiledb::sm::SerializationType)serialize_type,
               (*buffer)->buffer_))) {
     detail::tiledb_buffer_free(buffer);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -6346,7 +6346,7 @@ int32_t tiledb_deserialize_array_metadata(
   if (SAVE_ERROR_CATCH(
           ctx,
           tiledb::sm::serialization::metadata_deserialize(
-              array->array_->metadata(),
+              array->array_->unsafe_metadata(),
               (tiledb::sm::SerializationType)serialize_type,
               *(buffer->buffer_)))) {
     return TILEDB_ERR;

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -530,7 +530,7 @@ int32_t tiledb_serialize_group_metadata(
   if (SAVE_ERROR_CATCH(
           ctx,
           tiledb::sm::serialization::metadata_serialize(
-              group->group_->metadata(),
+              group->group_->unsafe_metadata(),
               (tiledb::sm::SerializationType)serialize_type,
               (*buffer)->buffer_))) {
     tiledb_buffer_free(buffer);
@@ -555,7 +555,7 @@ int32_t tiledb_deserialize_group_metadata(
   if (SAVE_ERROR_CATCH(
           ctx,
           tiledb::sm::serialization::metadata_deserialize(
-              group->group_->metadata(),
+              group->group_->unsafe_metadata(),
               (tiledb::sm::SerializationType)serialize_type,
               *(buffer->buffer_)))) {
     return TILEDB_ERR;

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -429,7 +429,7 @@ Status Group::has_metadata_key(
   return Status::Ok();
 }
 
-Metadata* Group::metadata() {
+Metadata* Group::unsafe_metadata() {
   return &metadata_;
 }
 

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -167,7 +167,7 @@ class Group {
    * fetch the underlying Metadata object to set the values we are loading from
    * REST. A lock should already by taken before load_metadata is called.
    */
-  Metadata* metadata();
+  Metadata* unsafe_metadata();
   const Metadata* metadata() const;
 
   /**

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -395,7 +395,7 @@ Status RestClient::get_array_metadata_from_rest(
   // Ensure data has a null delimiter for cap'n proto if using JSON
   RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
   return serialization::metadata_deserialize(
-      array->metadata(), serialization_type_, returned_data);
+      array->unsafe_metadata(), serialization_type_, returned_data);
 }
 
 Status RestClient::post_array_metadata_to_rest(
@@ -409,7 +409,7 @@ Status RestClient::post_array_metadata_to_rest(
 
   Buffer buff;
   RETURN_NOT_OK(serialization::metadata_serialize(
-      array->metadata(), serialization_type_, &buff));
+      array->unsafe_metadata(), serialization_type_, &buff));
   // Wrap in a list
   BufferList serialized;
   RETURN_NOT_OK(serialized.add_buffer(std::move(buff)));
@@ -961,7 +961,7 @@ Status RestClient::post_group_metadata_from_rest(const URI& uri, Group* group) {
   // Ensure data has a null delimiter for cap'n proto if using JSON
   RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
   return serialization::metadata_deserialize(
-      group->metadata(), serialization_type_, returned_data);
+      group->unsafe_metadata(), serialization_type_, returned_data);
 }
 
 Status RestClient::put_group_metadata_to_rest(const URI& uri, Group* group) {

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -148,7 +148,8 @@ Status array_to_capnp(
       utils::serialize_non_empty_domain(nonempty_domain_builder, array));
 
   auto array_metadata_builder = array_builder->initArrayMetadata();
-  RETURN_NOT_OK(metadata_to_capnp(array->metadata(), &array_metadata_builder));
+  RETURN_NOT_OK(
+      metadata_to_capnp(array->unsafe_metadata(), &array_metadata_builder));
 
   return Status::Ok();
 }
@@ -201,7 +202,7 @@ Status array_from_capnp(
     const auto& array_metadata_reader = array_reader.getArrayMetadata();
     // Deserialize
     RETURN_NOT_OK(
-        metadata_from_capnp(array_metadata_reader, array->metadata()));
+        metadata_from_capnp(array_metadata_reader, array->unsafe_metadata()));
   }
 
   return Status::Ok();

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -165,7 +165,7 @@ Status group_details_from_capnp(
 
   if (group_details_reader.hasMetadata()) {
     RETURN_NOT_OK(metadata_from_capnp(
-        group_details_reader.getMetadata(), group->metadata()));
+        group_details_reader.getMetadata(), group->unsafe_metadata()));
     group->set_metadata_loaded(true);
   }
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -129,7 +129,7 @@ Status StorageManager::array_close_for_writes(Array* array) {
 
   // Flush the array metadata
   RETURN_NOT_OK(store_metadata(
-      array->array_uri(), *array->encryption_key(), array->metadata()));
+      array->array_uri(), *array->encryption_key(), array->unsafe_metadata()));
 
   // Remove entry from open arrays
   std::lock_guard<std::mutex> lock{open_arrays_mtx_};
@@ -153,7 +153,7 @@ Status StorageManager::group_close_for_writes(Group* group) {
 
   // Flush the group metadata
   RETURN_NOT_OK(store_metadata(
-      group->group_uri(), *group->encryption_key(), group->metadata()));
+      group->group_uri(), *group->encryption_key(), group->unsafe_metadata()));
 
   // Store any changes required
   if (group->changes_applied()) {


### PR DESCRIPTION
The previous behavior of this function was to load the array metadata if it had not yet been loaded. This is required because array metadata is lazily loaded on first access. The behavior was changed, unintentionally, in PR #2966.

---
TYPE: BUG
DESC: `tiledb_serialize_array_metadata` should load metadata if its not loaded before serializing
