### PR TITLE
tiledb_serialize_group_metadata should load metadata

### DIFF
--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -526,11 +526,17 @@ int32_t tiledb_serialize_group_metadata(
       sanity_check(ctx, *buffer) == TILEDB_ERR)
     return TILEDB_ERR;
 
+  // Get metadata to serialize, this will load it if it does not exist
+  tiledb::sm::Metadata* metadata;
+  if (SAVE_ERROR_CATCH(ctx, group->group_->metadata(&metadata))) {
+    return TILEDB_ERR;
+  }
+
   // Serialize
   if (SAVE_ERROR_CATCH(
           ctx,
           tiledb::sm::serialization::metadata_serialize(
-              group->group_->unsafe_metadata(),
+              metadata,
               (tiledb::sm::SerializationType)serialize_type,
               (*buffer)->buffer_))) {
     tiledb_buffer_free(buffer);


### PR DESCRIPTION
The setup for `tiledb_serialize_group_metadata` was based on the incorrect (broken in the changes) `tiledb_serialize_array_metadata`. This fixes group serialization in the same way we fixed arrays in #3065.


---
TYPE: BUG
DESC: `tiledb_serialize_group_metadata` should load group metadata if its not loaded.
