### PR TITLE
[Backport release-2.8] tiledb_serialize_group_metadata should load metadata

### DIFF
--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -523,11 +523,17 @@ int32_t tiledb_serialize_group_metadata(
       sanity_check(ctx, *buffer) == TILEDB_ERR)
     return TILEDB_ERR;
 
+  // Get metadata to serialize, this will load it if it does not exist
+  tiledb::sm::Metadata* metadata;
+  if (SAVE_ERROR_CATCH(ctx, group->group_->metadata(&metadata))) {
+    return TILEDB_ERR;
+  }
+
   // Serialize
   if (SAVE_ERROR_CATCH(
           ctx,
           tiledb::sm::serialization::metadata_serialize(
-              group->group_->metadata(),
+              metadata,
               (tiledb::sm::SerializationType)serialize_type,
               (*buffer)->buffer_))) {
     tiledb_buffer_free(buffer);


### PR DESCRIPTION
Backport 9a51c7260a19823f54a4ca7113d706ab30c30f5c from https://github.com/TileDB-Inc/TileDB/pull/3070

---
TYPE: BUG
DESC: `tiledb_serialize_group_metadata` should load group metadata if its not loaded.

