### PR TITLE
Support Dictionary-encoding filter for string dimensions and attributes

### DIFF
--- a/test/src/unit-compression-rle.cc
+++ b/test/src/unit-compression-rle.cc
@@ -297,7 +297,7 @@ TEST_CASE(
 
 TEST_CASE(
     "Compression-RLE: Test bytesize computation",
-    "[compression][rle][rle-strings][ypatia]") {
+    "[compression][rle][rle-strings]") {
   REQUIRE_THROWS_AS(RLE::compute_bytesize(0), std::logic_error);
   CHECK(RLE::compute_bytesize(1) == 1);
   CHECK(RLE::compute_bytesize(0xff) == 1);

--- a/test/src/unit-cppapi-filter.cc
+++ b/test/src/unit-cppapi-filter.cc
@@ -284,8 +284,8 @@ void read_and_check_sparse_array_string_attr(
 }
 
 TEST_CASE(
-    "C++ API: Filter strings with RLE, sparse array",
-    "[cppapi][filter][rle-strings][sparse][ypatia]") {
+    "C++ API: Filter strings with RLE or Dictionary encoding, sparse array",
+    "[cppapi][filter][rle-strings][dict-strings][sparse]") {
   using namespace tiledb;
   Context ctx;
   VFS vfs(ctx);
@@ -294,11 +294,11 @@ TEST_CASE(
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
-  // auto f = GENERATE(TILEDB_FILTER_RLE, TILEDB_FILTER_DICTIONARY);
+  auto f = GENERATE(TILEDB_FILTER_RLE, TILEDB_FILTER_DICTIONARY);
 
   // Create schema with filter lists
   FilterList a1_filters(ctx);
-  a1_filters.add_filter({ctx, TILEDB_FILTER_RLE});
+  a1_filters.add_filter({ctx, f});
 
   auto a1 = Attribute::create<std::string>(ctx, "a1");
   a1.set_cell_val_num(TILEDB_VAR_NUM);
@@ -414,8 +414,8 @@ void read_and_check_dense_array_string_attr(
 }
 
 TEST_CASE(
-    "C++ API: Filter strings with RLE, dense array",
-    "[cppapi][filter][rle-strings][dense]") {
+    "C++ API: Filter strings with RLE or Dictionary encoding, dense array",
+    "[cppapi][filter][rle-strings][dict-strings][dense]") {
   using namespace tiledb;
   Context ctx;
   VFS vfs(ctx);
@@ -428,9 +428,10 @@ TEST_CASE(
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 
+  auto f = GENERATE(TILEDB_FILTER_RLE, TILEDB_FILTER_DICTIONARY);
   // Create schema with filter lists
   FilterList a1_filters(ctx);
-  a1_filters.add_filter({ctx, TILEDB_FILTER_RLE});
+  a1_filters.add_filter({ctx, f});
 
   auto a1 = Attribute::create<std::string>(ctx, "a1");
   a1.set_cell_val_num(TILEDB_VAR_NUM);

--- a/test/src/unit-cppapi-filter.cc
+++ b/test/src/unit-cppapi-filter.cc
@@ -285,7 +285,7 @@ void read_and_check_sparse_array_string_attr(
 
 TEST_CASE(
     "C++ API: Filter strings with RLE, sparse array",
-    "[cppapi][filter][rle-strings][sparse]") {
+    "[cppapi][filter][rle-strings][sparse][ypatia]") {
   using namespace tiledb;
   Context ctx;
   VFS vfs(ctx);
@@ -293,6 +293,8 @@ TEST_CASE(
 
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
+
+  // auto f = GENERATE(TILEDB_FILTER_RLE, TILEDB_FILTER_DICTIONARY);
 
   // Create schema with filter lists
   FilterList a1_filters(ctx);

--- a/test/src/unit-cppapi-string-dims.cc
+++ b/test/src/unit-cppapi-string-dims.cc
@@ -1494,7 +1494,7 @@ void read_and_check_sparse_array_string_dim(
 
 TEST_CASE(
     "C++ API: Test filtering of string dimensions on sparse arrays",
-    "[cppapi][string-dims][rle-strings][sparse]") {
+    "[cppapi][string-dims][rle-strings][dict-strings][sparse]") {
   std::string array_name = "test_rle_string_dim";
 
   // Create data buffer to use
@@ -1522,8 +1522,9 @@ TEST_CASE(
   auto dim =
       Dimension::create(ctx, "dim1", TILEDB_STRING_ASCII, nullptr, nullptr);
 
+  auto f = GENERATE(TILEDB_FILTER_RLE, TILEDB_FILTER_DICTIONARY);
   // Create compressor as a filter
-  Filter filter(ctx, TILEDB_FILTER_RLE);
+  Filter filter(ctx, f);
   // Create filter list
   FilterList filter_list(ctx);
   // Add compressor to filter list
@@ -1576,7 +1577,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API: Test adding RLE filter of string dimensions",
-    "[cppapi][string-dims][rle-strings][sparse]") {
+    "[cppapi][string-dims][rle-strings][dict-strings][sparse]") {
   std::string array_name = "test_rle_string_dim";
 
   Context ctx;
@@ -1588,7 +1589,8 @@ TEST_CASE(
       tiledb::Dimension::create<int32_t>(ctx, "id", {{1, 100}}, 10);
 
   // Create filters
-  Filter rle_filter(ctx, TILEDB_FILTER_RLE);
+  auto f = GENERATE(TILEDB_FILTER_RLE, TILEDB_FILTER_DICTIONARY);
+  Filter rle_filter(ctx, f);
   Filter another_filter(ctx, TILEDB_FILTER_CHECKSUM_MD5);
 
   // Create filter list with RLE only

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -139,6 +139,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cache/buffer_lru_cache.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/compressors/bzip_compressor.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/compressors/dd_compressor.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/compressors/dict_compressor.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/compressors/gzip_compressor.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/compressors/lz4_compressor.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/compressors/rle_compressor.cc

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -251,7 +251,7 @@ Status ArraySchema::check() const {
   }
 
   RETURN_NOT_OK(check_double_delta_compressor(coords_filters()));
-  RETURN_NOT_OK(check_rle_compressor(coords_filters()));
+  RETURN_NOT_OK(check_string_compressor(coords_filters()));
 
   if (!check_attribute_dimension_names())
     return LOG_STATUS(
@@ -671,7 +671,7 @@ void ArraySchema::set_capacity(uint64_t capacity) {
 
 Status ArraySchema::set_coords_filter_pipeline(const FilterPipeline* pipeline) {
   assert(pipeline);
-  RETURN_NOT_OK(check_rle_compressor(*pipeline));
+  RETURN_NOT_OK(check_string_compressor(*pipeline));
   RETURN_NOT_OK(check_double_delta_compressor(*pipeline));
 
   coords_filters_ = *pipeline;
@@ -863,14 +863,17 @@ Status ArraySchema::check_double_delta_compressor(
   return Status::Ok();
 }
 
-Status ArraySchema::check_rle_compressor(const FilterPipeline& filters) const {
-  // There is no error if only 1 filter is used for RLE
-  if (filters.size() <= 1 || !filters.has_filter(FilterType::FILTER_RLE)) {
+Status ArraySchema::check_string_compressor(
+    const FilterPipeline& filters) const {
+  // There is no error if only 1 filter is used for RLE or Dictionary-encoding
+  if (filters.size() <= 1 ||
+      !(filters.has_filter(FilterType::FILTER_RLE) ||
+        filters.has_filter(FilterType::FILTER_DICTIONARY))) {
     return Status::Ok();
   }
 
   // Error if there are also other filters set for a string dimension together
-  // with RLE
+  // with RLE or Dictionary-encoding
   auto dim_num = domain_->dim_num();
   for (unsigned d = 0; d < dim_num; ++d) {
     auto dim = domain_->dimension(d);
@@ -879,9 +882,15 @@ Status ArraySchema::check_rle_compressor(const FilterPipeline& filters) const {
     // list already set for that dimension (then coords_filters_ will be used)
     if (dim->type() == Datatype::STRING_ASCII && dim->var_size() &&
         dim_filters.empty()) {
-      return LOG_STATUS(Status_ArraySchemaError(
-          "RLE filter cannot be combined with other filters when applied to "
-          "variable length string dimensions"));
+      if (filters.has_filter(FilterType::FILTER_RLE)) {
+        return LOG_STATUS(Status_ArraySchemaError(
+            "RLE filter cannot be combined with other filters when applied to "
+            "variable length string dimensions"));
+      } else {
+        return LOG_STATUS(Status_ArraySchemaError(
+            "Dictionary-encoding filter cannot be combined with other filters "
+            "when applied to variable length string dimensions"));
+      }
     }
   }
 

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -444,10 +444,10 @@ class ArraySchema {
       const FilterPipeline& coords_filters) const;
 
   /**
-   * Returns error if RLE is used for string dimensions but it is not the only
-   * filter in the filter list.
+   * Returns error if RLE or Dictionary encoding is used for string
+   * dimensions but it is not the only filter in the filter list.
    */
-  Status check_rle_compressor(const FilterPipeline& coords_filters) const;
+  Status check_string_compressor(const FilterPipeline& coords_filters) const;
 
   /** Clears all members. Use with caution! */
   void clear();

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -294,6 +294,10 @@ Status Attribute::set_filter_pipeline(const FilterPipeline* pipeline) {
       return LOG_STATUS(Status_AttributeError(
           "RLE filter cannot be combined with other filters when applied to "
           "variable length string attributes"));
+    } else if (pipeline->has_filter(FilterType::FILTER_DICTIONARY)) {
+      return LOG_STATUS(Status_AttributeError(
+          "Dictionary-encoding filter cannot be combined with other filters "
+          "when applied to variable length string attributes"));
     }
   }
 

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1437,6 +1437,10 @@ Status Dimension::set_filter_pipeline(const FilterPipeline* pipeline) {
       return LOG_STATUS(Status_DimensionError(
           "RLE filter cannot be combined with other filters when applied to "
           "variable length string dimensions"));
+    } else if (pipeline->has_filter(FilterType::FILTER_DICTIONARY)) {
+      return LOG_STATUS(Status_AttributeError(
+          "Dictionary-encoding filter cannot be combined with other filters "
+          "when applied to variable length string dimensions"));
     }
   }
 

--- a/tiledb/sm/compressors/CMakeLists.txt
+++ b/tiledb/sm/compressors/CMakeLists.txt
@@ -29,7 +29,7 @@ include(common NO_POLICY_SCOPE)
 #
 # `compressors` object library
 #
-add_library(compressors OBJECT bzip_compressor.cc dd_compressor.cc gzip_compressor.cc lz4_compressor.cc rle_compressor.cc zstd_compressor.cc)
+add_library(compressors OBJECT bzip_compressor.cc dd_compressor.cc dict_compressor.cc gzip_compressor.cc lz4_compressor.cc rle_compressor.cc zstd_compressor.cc)
 target_link_libraries(compressors PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 target_link_libraries(compressors PUBLIC buffer $<TARGET_OBJECTS:buffer>)
 find_package(Bzip2_EP REQUIRED)

--- a/tiledb/sm/compressors/dict_compressor.cc
+++ b/tiledb/sm/compressors/dict_compressor.cc
@@ -1,0 +1,89 @@
+/**
+ * @file   dict_compressor.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements the dictionary compression class for strings.
+ */
+
+#include "dict_compressor.h"
+
+#include "tiledb/common/common.h"
+#include "tiledb/common/logger.h"
+
+#include <vector>
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+std::vector<std::string_view> DictEncoding::compress(
+    const span<std::string_view> input,
+    uint64_t word_id_size,
+    span<std::byte> output) {
+  if (input.empty() || output.empty() || word_id_size == 0) {
+    throw std::logic_error(
+        "Failed compressing strings with dictionary; empty input arguments");
+  }
+
+  if (word_id_size <= 1) {
+    return compress<uint8_t>(input, output);
+  } else if (word_id_size <= 2) {
+    return compress<uint16_t>(input, output);
+  } else if (word_id_size <= 4) {
+    return compress<uint32_t>(input, output);
+  } else {
+    return compress<uint64_t>(input, output);
+  }
+}
+
+void DictEncoding::decompress(
+    const span<const std::byte> input,
+    const std::vector<std::string_view>& dict,
+    uint64_t word_id_size,
+    span<std::byte> output,
+    span<uint64_t> output_offsets) {
+  if (input.empty() || output.empty() || word_id_size == 0) {
+    throw std::logic_error(
+        "Failed decompressing dictionary-encoded strings; empty input "
+        "arguments");
+  }
+
+  if (word_id_size <= 1) {
+    decompress<uint8_t>(input, dict, output, output_offsets);
+  } else if (word_id_size <= 2) {
+    decompress<uint16_t>(input, dict, output, output_offsets);
+  } else if (word_id_size <= 4) {
+    decompress<uint32_t>(input, dict, output, output_offsets);
+  } else {
+    decompress<uint64_t>(input, dict, output, output_offsets);
+  }
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/compressors/dict_compressor.h
+++ b/tiledb/sm/compressors/dict_compressor.h
@@ -49,13 +49,37 @@ namespace sm {
 /** Handles dictionary compression/decompression of variable sized strings. */
 class DictEncoding {
  public:
-  // TODO: add docstring
+  /**
+   * Compress variable sized strings into dictionary encoded format
+   *
+   * @param input Input in form of a memory contiguous sequence of
+   * strings
+   * @param word_id_size Bytesize to use to store word ids
+   * @param output Dictionary-encoded output in ids. Memory is allocated and
+   * owned by the caller
+   * @return A dictionary in the form of a vector of string_views, where indices
+   * are the word_ids of each word. Those string_views point to strings in
+   * input, so input memory should not be freed before dictionary data is
+   * consumed
+   */
   static std::vector<std::string_view> compress(
       const span<std::string_view> input,
       const uint8_t word_id_size,
       span<std::byte> output);
 
-  // TODO: add docstring
+  /**
+   * Decompress strings that are encoded in dictionary format
+   *
+   * @param input Input dictionary-encoded format of ids of type T
+   * @param dict The dictionary to be used for decoding a word id into a string.
+   * Expected type is a vector of strings, where indices are the ids of
+   * each word
+   * @param word_id_size Bytesize to use to read word ids
+   * @param output Dictionary-encoded output as a series of ids of size T.
+   * Memory is allocated and owned by the caller
+   * @param output_offsets Output offsets reconstructed from decoding the
+   * Dictionary compressed input. Memory is allocated and owned by the caller
+   */
   static void decompress(
       const span<const std::byte> input,
       const span<const std::string> dict,
@@ -63,13 +87,30 @@ class DictEncoding {
       span<std::byte> output,
       span<uint64_t> output_offsets);
 
-  // TODO: add docstring
+  /**
+   * Serialize string-id dictionary to store it in memory
+   *
+   * @param dict The dictionary to be used for decoding a word id into a string.
+   * Expected type is a vector of strings, where indices are the ids of
+   * each word
+   * @param strlen_bytesize Bytesize to use to serialize the lenghts of strings
+   * @param dict_size Estimated size of the serialized dict
+   * @return The serialized dictionary in format
+   * [size_str1|str1|...|size_strN|strN]
+   */
   static std::vector<std::byte> serialize_dictionary(
       const span<std::string_view> dict,
       const size_t strlen_bytesize,
       const size_t dict_size);
 
-  // TODO: add docstring
+  /**
+   * Deserialize string-id dictionary to restore it from memory
+   *
+   * @param serialized_dict The dictionary to restore in serialized format
+   * @param strlen_bytesize Bytesize to use to serialize the lenghts of strings
+   * @return The dictionary in the original format of vector of strings, where
+   * indices are the ids of each word
+   */
   static std::vector<std::string> deserialize_dictionary(
       const span<std::byte> serialized_dict, size_t strlen_bytesize);
 
@@ -107,7 +148,6 @@ class DictEncoding {
     const auto word_id_size = sizeof(T);
     // hash table to store string - unique id associations
     std::unordered_map<std::string_view, T> word_ids;
-    // auto out_offset = &output[0];
     auto out_index = 0;
 
     for (uint64_t i = 0; i < input.size(); i++) {
@@ -173,9 +213,9 @@ class DictEncoding {
 
     std::vector<std::byte> serialized_dict(dict_size);
     size_t out_index = 0;
-    for (const auto dict_entry : dict) {
+    for (const auto& dict_entry : dict) {
       utils::endianness::encode_be<T>(
-          dict_entry.size(), &serialized_dict[out_index]);
+          static_cast<T>(dict_entry.size()), &serialized_dict[out_index]);
       out_index += sizeof(T);
       memcpy(&serialized_dict[out_index], dict_entry.data(), dict_entry.size());
       out_index += dict_entry.size();
@@ -196,7 +236,6 @@ class DictEncoding {
     }
 
     std::vector<std::string> dict;
-    // fixme preallocate?
     dict.reserve(serialized_dict.size());
     T str_len = 0;
 

--- a/tiledb/sm/compressors/rle_compressor.cc
+++ b/tiledb/sm/compressors/rle_compressor.cc
@@ -197,7 +197,6 @@ tuple<uint64_t, uint64_t, uint64_t, uint64_t> RLE::calculate_compression_params(
           output_strings_size};
 }
 
-// TODO: throw instead of returning status
 Status RLE::compress(
     const span<std::string_view> input,
     uint64_t rle_len_size,

--- a/tiledb/sm/compressors/rle_compressor.cc
+++ b/tiledb/sm/compressors/rle_compressor.cc
@@ -256,8 +256,8 @@ Status RLE::compress(
 
 Status RLE::decompress(
     const span<const std::byte> input,
-    uint64_t rle_len_size,
-    uint64_t string_len_size,
+    const uint8_t rle_len_size,
+    const uint8_t string_len_size,
     span<std::byte> output,
     span<uint64_t> output_offsets) {
   if (input.empty() || output.empty() || rle_len_size == 0 ||

--- a/tiledb/sm/compressors/rle_compressor.cc
+++ b/tiledb/sm/compressors/rle_compressor.cc
@@ -30,7 +30,7 @@
  * This file implements the rle compressor class.
  */
 
-#include "tiledb/sm/compressors/rle_compressor.h"
+#include "rle_compressor.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"
 
@@ -197,6 +197,7 @@ tuple<uint64_t, uint64_t, uint64_t, uint64_t> RLE::calculate_compression_params(
           output_strings_size};
 }
 
+// TODO: throw instead of returning status
 Status RLE::compress(
     const span<std::string_view> input,
     uint64_t rle_len_size,

--- a/tiledb/sm/compressors/rle_compressor.h
+++ b/tiledb/sm/compressors/rle_compressor.h
@@ -98,9 +98,9 @@ class RLE {
     if (input.empty() || output.empty())
       return;
 
-    const size_t run_size = sizeof(T);
-    const size_t str_len_size = sizeof(P);
-    const size_t max_run_length = std::numeric_limits<T>::max();
+    const uint64_t run_size = sizeof(T);
+    const uint64_t str_len_size = sizeof(P);
+    const uint64_t max_run_length = std::numeric_limits<T>::max();
 
     T run_length = 1;
     auto out_offset = &output[0];
@@ -158,10 +158,10 @@ class RLE {
 
     T run_length = 0;
     P string_length = 0;
-    size_t out_offset = 0;
+    uint64_t out_offset = 0;
     size_t offset_index = 0;
     // Iterate input to read [run length|string size|string] items
-    size_t in_index = 0;
+    uint64_t in_index = 0;
     while (in_index < input.size()) {
       run_length = utils::endianness::decode_be<T>(&input[in_index]);
       in_index += run_size;

--- a/tiledb/sm/compressors/rle_compressor.h
+++ b/tiledb/sm/compressors/rle_compressor.h
@@ -222,8 +222,8 @@ class RLE {
    */
   static Status decompress(
       const span<const std::byte> input,
-      uint64_t rle_len_size,
-      uint64_t string_len_size,
+      const uint8_t rle_len_size,
+      const uint8_t string_len_size,
       span<std::byte> output,
       span<uint64_t> output_offsets);
 

--- a/tiledb/sm/compressors/rle_compressor.h
+++ b/tiledb/sm/compressors/rle_compressor.h
@@ -98,9 +98,9 @@ class RLE {
     if (input.empty() || output.empty())
       return;
 
-    const uint64_t run_size = sizeof(T);
-    const uint64_t str_len_size = sizeof(P);
-    const uint64_t max_run_length = std::numeric_limits<T>::max();
+    const size_t run_size = sizeof(T);
+    const size_t str_len_size = sizeof(P);
+    const size_t max_run_length = std::numeric_limits<T>::max();
 
     T run_length = 1;
     auto out_offset = &output[0];
@@ -142,6 +142,8 @@ class RLE {
    * decompress
    * @param output Decoded output as a series of strings in contiguous memory.
    * Memory is allocated and owned by the caller
+   * @param output_offsets Output offsets reconstructed from decoding the RLE
+   * compressed input. Memory is allocated and owned by the caller
    */
   template <class T, class P>
   static void decompress(
@@ -156,10 +158,10 @@ class RLE {
 
     T run_length = 0;
     P string_length = 0;
-    uint64_t out_offset = 0;
+    size_t out_offset = 0;
     size_t offset_index = 0;
     // Iterate input to read [run length|string size|string] items
-    uint64_t in_index = 0;
+    size_t in_index = 0;
     while (in_index < input.size()) {
       run_length = utils::endianness::decode_be<T>(&input[in_index]);
       in_index += run_size;

--- a/tiledb/sm/compressors/test/unit_dict_compressor.cc
+++ b/tiledb/sm/compressors/test/unit_dict_compressor.cc
@@ -121,8 +121,8 @@ TEMPLATE_LIST_TEST_CASE(
     FixedTypesUnderTest) {
   typedef TestType T;
   // pick values of at least 2 bytes
-  uint64_t num_strings = 5;  // std::numeric_limits<uint8_t>::max() + 1;
-  uint64_t string_len = 2;   // std::numeric_limits<uint8_t>::max() + 1;
+  uint64_t num_strings = std::numeric_limits<uint8_t>::max() + 1;
+  uint64_t string_len = std::numeric_limits<uint8_t>::max() + 1;
   // a single string repeated
   std::srand(10);
   std::string string_rand = random_string(string_len);

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -238,9 +238,18 @@ class CompressionFilter : public Filter {
   /** Initializes the decompression resource pool */
   void init_decompression_resource_pool(uint64_t size) override;
 
-  /** Creates a vector of views of the input strings */
-  static std::vector<std::string_view> create_input_view(
+  /** Creates a vector of views of the input strings and returns the max string
+   * size */
+  static tuple<std::vector<std::string_view>, uint64_t> create_input_view(
       const FilterBuffer& input, Tile* const offsets_tile);
+
+  /**
+   * Return the number of bytes required to store an integer
+   *
+   * @param param_length Number to calculate the bytesize
+   * @return Number of bytes required to store the input number
+   */
+  static uint8_t compute_bytesize(uint64_t param_length);
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -731,21 +731,25 @@ Status FilterPipeline::append_encryption_filter(
 }
 
 bool FilterPipeline::skip_offsets_filtering(
-    Datatype type, const uint32_t version) const {
-  if (version >= 12 && type == Datatype::STRING_ASCII) {
-    if (has_filter(FilterType::FILTER_RLE) ||
-        has_filter(FilterType::FILTER_DICTIONARY)) {
-      return true;
-    }
+    const Datatype type, const uint32_t version) const {
+  if (version >= 12 && type == Datatype::STRING_ASCII &&
+      has_filter(FilterType::FILTER_RLE)) {
+    return true;
+  } else if (
+      version >= 13 && type == Datatype::STRING_ASCII &&
+      has_filter(FilterType::FILTER_DICTIONARY)) {
+    return true;
   }
 
   return false;
 }
 
-bool FilterPipeline::use_tile_chunking(bool is_var, Datatype type) const {
+bool FilterPipeline::use_tile_chunking(
+    const bool is_var, const uint32_t version, const Datatype type) const {
   if (is_var && type == Datatype::STRING_ASCII) {
-    if (has_filter(FilterType::FILTER_RLE) ||
-        has_filter(FilterType::FILTER_DICTIONARY)) {
+    if (version >= 12 && has_filter(FilterType::FILTER_RLE)) {
+      return false;
+    } else if (version >= 13 && has_filter(FilterType::FILTER_DICTIONARY)) {
       return false;
     }
   }

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -733,7 +733,8 @@ Status FilterPipeline::append_encryption_filter(
 bool FilterPipeline::skip_offsets_filtering(
     Datatype type, const uint32_t version) const {
   if (version >= 12 && type == Datatype::STRING_ASCII) {
-    if (has_filter(FilterType::FILTER_RLE)) {
+    if (has_filter(FilterType::FILTER_RLE) ||
+        has_filter(FilterType::FILTER_DICTIONARY)) {
       return true;
     }
   }
@@ -743,7 +744,8 @@ bool FilterPipeline::skip_offsets_filtering(
 
 bool FilterPipeline::use_tile_chunking(bool is_var, Datatype type) const {
   if (is_var && type == Datatype::STRING_ASCII) {
-    if (has_filter(FilterType::FILTER_RLE)) {
+    if (has_filter(FilterType::FILTER_RLE) ||
+        has_filter(FilterType::FILTER_DICTIONARY)) {
       return false;
     }
   }

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -310,7 +310,7 @@ class FilterPipeline {
    * whole
    *
    * @param type Datatype of the input attribute/dimension
-   * @param type Array schema version
+   * @param version Array schema version
    * @return True if we can skip offsets filtering
    */
   bool skip_offsets_filtering(
@@ -323,10 +323,12 @@ class FilterPipeline {
    *
    * @param is_var True if checking for a var-sized attribute/dimension, false
    * if not
+   * @param version Array schema version
    * @param type Datatype of the input attribute/dimension
    * @return True if chunking needs to be used, false if not
    */
-  bool use_tile_chunking(bool is_var, const Datatype type) const;
+  bool use_tile_chunking(
+      const bool is_var, const uint32_t version, const Datatype type) const;
 
  private:
   /** A pair of FilterBuffers. */

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -1217,7 +1217,8 @@ Status ReaderBase::unfilter_tiles(
   auto chunking = true;
   if (var_size) {
     auto filters = array_schema_.filters(name);
-    chunking = filters.use_tile_chunking(var_size, array_schema_.type(name));
+    chunking = filters.use_tile_chunking(
+        var_size, array_schema_.version(), array_schema_.type(name));
   }
 
   // The per tile cache is only used in readers where unfiltering

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -771,8 +771,8 @@ Status WriterBase::filter_tile(
       &filters, array_->get_encryption_key()));
 
   // Check if chunk or tile level filtering/unfiltering is appropriate
-  bool use_chunking =
-      filters.use_tile_chunking(array_schema_.var_size(name), tile->type());
+  bool use_chunking = filters.use_tile_chunking(
+      array_schema_.var_size(name), array_schema_.version(), tile->type());
 
   assert(!tile->filtered());
   RETURN_NOT_OK(filters.run_forward(


### PR DESCRIPTION
We have integrated in our codebase an algorithm for dictionary-encoding of strings in https://github.com/TileDB-Inc/TileDB/pull/2880, and we have defined a new Dictionary-encoding compressor in https://github.com/TileDB-Inc/TileDB/pull/3042. 
This PR is about bringing those two together, aka integrating this new filter definition with the actual algorithm so that TILEDB_FILTER_DICTIONARY can be use as a new filter for compressing var-sized string dimensions and attributes.

---
TYPE: FEATURE
DESC: Support Dictionary-encoding filter for string dimensions and attributes
