### PR TITLE
C++ API function to check if Config contains a parameter

### DIFF
--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -52,6 +52,12 @@ TEST_CASE("C++ API: Config", "[cppapi][config]") {
 
   auto readInvalidKey = [&config]() { std::string result2 = config["bar"]; };
   REQUIRE_THROWS_AS(readInvalidKey(), tiledb::TileDBError);
+
+  bool contains = config.contains("foo");
+  CHECK(contains == true);
+
+  contains = config.contains("bar");
+  CHECK(contains == false);
 }
 
 TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -750,10 +750,10 @@ class Config {
    * @param param Name of configuration parameter
    * @return true if the parameter exists, false otherwise
    */
-  bool contains(const std::string& param) const {
+  bool contains(const std::string_view& param) const {
     const char* val;
     tiledb_error_t* err;
-    tiledb_config_get(config_.get(), param.c_str(), &val, &err);
+    tiledb_config_get(config_.get(), param.data(), &val, &err);
 
     return val != nullptr;
   }

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -754,7 +754,6 @@ class Config {
     const char* val;
     tiledb_error_t* err;
     tiledb_config_get(config_.get(), param.c_str(), &val, &err);
-    impl::check_config_error(err);
 
     return val != nullptr;
   }

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -746,6 +746,20 @@ class Config {
   }
 
   /**
+   * Check if a configuration parameter exists.
+   * @param param Name of configuration parameter
+   * @return true if the parameter exists, false otherwise
+   */
+  bool contains(const std::string& param) const {
+    const char* val;
+    tiledb_error_t* err;
+    tiledb_config_get(config_.get(), param.c_str(), &val, &err);
+    impl::check_config_error(err);
+
+    return val != nullptr;
+  }
+
+  /**
    * Operator that enables setting parameters with `[]`.
    *
    * **Example:**


### PR DESCRIPTION
Add a C++ API function to check if Config contains a parameter. This avoids using `get` with a `try/catch` block to handle parameters that are not defined.

---
TYPE: CPP_API
DESC: Add function to check if Config contains a parameter
