### PR TITLE
Fix typo "not opened in read mode" when expecting write mode

### DIFF
--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -581,7 +581,7 @@ Status Group::mark_member_for_removal(const std::string& uri) {
   // Check mode
   if (query_type_ != QueryType::WRITE) {
     return Status_GroupError(
-        "Cannot get member; Group was not opened in read mode");
+        "Cannot get member; Group was not opened in write mode");
   }
   if (members_to_add_.find(uri) != members_to_add_.end()) {
     return Status_GroupError(


### PR DESCRIPTION
Adding a member using 2.8.0, group opened in read mode, get message

```
> tiledb_group_add_member(grp=grp, uri=obs_uri, relative=FALSE, name="obs")
Error in libtiledb_group_add_member(grp@ptr, uri, relative, name) :
  [TileDB::?] Error:: Cannot get member; Group was not opened in read mode
```

One callsite was already fixed between `2.8.0` and `HEAD`; this fixes the other (remove member)

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: Fix typo "not opened in read mode" when expecting write mode
