### PR TITLE
Add golang annotation to capnp spec file

### DIFF
--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -3,6 +3,9 @@
 using Json = import "/capnp/compat/json.capnp";
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("tiledb::sm::serialization::capnp");
+using Go = import "/go.capnp";
+$Go.package("capnp_models");
+$Go.import("capnp_models");
 
 struct DomainArray {
   int8 @0 :List(Int8);
@@ -675,7 +678,7 @@ struct GroupUpdate {
   # Config
 
   groupUpdate @1 :GroupUpdateDetails $Json.name("group_changes");
-  # group update detials
+  # group update details
 }
 
 struct GroupCreate {


### PR DESCRIPTION
This allows golang users to generate golang structures based on the spec file if needed.



---
TYPE: IMPROVEMENT
DESC: Add golang annotation to capnp spec file
