### PR TITLE
Reset group metadata only based on end timestamp

### DIFF
--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -205,7 +205,7 @@ Status Group::open(QueryType query_type) {
       }
     }
 
-    metadata_.reset(timestamp_start_, timestamp_end_);
+    metadata_.reset(timestamp_end_);
   }
 
   query_type_ = query_type;


### PR DESCRIPTION
This is the behavior that Arrays use, and the single timestamp reset will update 0 to be current time. The two timestamp reset takes the values verbatim which was causing a deviation in behavior compared to Arrays.


---
TYPE: BUG
DESC: Reset group metadata only based on end timestamp to ensure its always reset to now
