### PR TITLE
 Update group post from rest to use group_metadata_serialize over config_serialize

### DIFF
--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -929,8 +929,8 @@ Status RestClient::post_group_metadata_from_rest(const URI& uri, Group* group) {
         "Error posting group metadata from REST; group is null."));
 
   Buffer buff;
-  RETURN_NOT_OK(serialization::config_serialize(
-      group->config(), serialization_type_, &buff, true));
+  RETURN_NOT_OK(serialization::group_metadata_serialize(
+      group, serialization_type_, &buff));
   // Wrap in a list
   BufferList serialized;
   RETURN_NOT_OK(serialized.add_buffer(std::move(buff)));

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -94,10 +94,12 @@ Status metadata_from_capnp(
 
     auto value_ptr = entry_reader.getValue();
     const void* value = (void*)value_ptr.begin();
-    if (value_ptr.size() != datatype_size(type) * value_num)
+    if (value_ptr.size() != datatype_size(type) * value_num) {
       return LOG_STATUS(Status_SerializationError(
           "Error deserializing array metadata; value size sanity check "
-          "failed."));
+          "failed for " +
+          key + "."));
+    }
 
     if (entry_reader.getDel()) {
       RETURN_NOT_OK(metadata->del(key.c_str()));


### PR DESCRIPTION
This brings the route inline with the over functions of not using the low level config object directly but wrapping into higher level capnp classes.

---
TYPE: IMPROVEMENT
DESC:  Update group metadata REST request to standardize cap'n proto class usage
