### PR TITLE
Use legacy sparse global order reader for 2.9

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -269,7 +269,7 @@ void check_save_to_file() {
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.query.dense.reader refactored\n";
-  ss << "sm.query.sparse_global_order.reader refactored\n";
+  ss << "sm.query.sparse_global_order.reader legacy\n";
   ss << "sm.query.sparse_unordered_with_dups.reader refactored\n";
   ss << "sm.read_range_oob warn\n";
   ss << "sm.skip_checksum_validation false\n";
@@ -570,7 +570,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.memory_budget"] = "5368709120";
   all_param_values["sm.memory_budget_var"] = "10737418240";
   all_param_values["sm.query.dense.reader"] = "refactored";
-  all_param_values["sm.query.sparse_global_order.reader"] = "refactored";
+  all_param_values["sm.query.sparse_global_order.reader"] = "legacy";
   all_param_values["sm.query.sparse_unordered_with_dups.reader"] = "refactored";
   all_param_values["sm.mem.malloc_trim"] = "true";
   all_param_values["sm.mem.total_budget"] = "10737418240";

--- a/test/src/unit-rtree.cc
+++ b/test/src/unit-rtree.cc
@@ -829,7 +829,9 @@ std::vector<NDRange> create_str_int32_mbrs(
 }
 
 std::pair<std::string, std::string> range_to_str(const Range& r) {
-  return std::pair<std::string, std::string>(r.start_str(), r.end_str());
+  auto start = std::string((const char*)r.start(), r.start_size());
+  auto end = std::string((const char*)r.end(), r.end_size());
+  return std::pair<std::string, std::string>(start, end);
 }
 
 TEST_CASE(

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -848,7 +848,7 @@ void Dimension::relevant_ranges(
     const NDRange& ranges,
     const Range& mbr,
     std::vector<uint64_t>& relevant_ranges) {
-  const auto mbr_data = (const T*)mbr.start_fixed();
+  const auto mbr_data = (const T*)mbr.start();
   const auto mbr_start = mbr_data[0];
   const auto mbr_end = mbr_data[1];
 
@@ -858,7 +858,7 @@ void Dimension::relevant_ranges(
       ranges.end(),
       mbr_start,
       [&](const Range& a, const T value) {
-        return ((const T*)a.start_fixed())[1] < value;
+        return ((const T*)a.start())[1] < value;
       });
 
   if (it == ranges.end())
@@ -870,7 +870,7 @@ void Dimension::relevant_ranges(
   // conditional exit in the for loop below
   auto it2 = std::lower_bound(
       it, ranges.end(), mbr_end, [&](const Range& a, const T value) {
-        return ((const T*)a.start_fixed())[0] < value;
+        return ((const T*)a.start())[0] < value;
       });
 
   // If the upper bound isn't the end add +1 to the index
@@ -881,7 +881,7 @@ void Dimension::relevant_ranges(
 
   // Loop over only potential relevant ranges
   for (uint64_t r = start_range; r < end_range; ++r) {
-    const auto d1 = (const T*)ranges[r].start_fixed();
+    const auto d1 = (const T*)ranges[r].start();
 
     if ((d1[0] <= mbr_end && d1[1] >= mbr_start))
       relevant_ranges.emplace_back(r);
@@ -922,13 +922,13 @@ std::vector<bool> Dimension::covered_vec(
     const NDRange& ranges,
     const Range& mbr,
     const std::vector<uint64_t>& relevant_ranges) {
-  auto d1 = (const T*)mbr.start_fixed();
+  auto d1 = (const T*)mbr.start();
 
   std::vector<bool> covered;
   covered.resize(relevant_ranges.size());
   for (uint64_t i = 0; i < relevant_ranges.size(); i++) {
     auto r = relevant_ranges[i];
-    auto d2 = (const T*)ranges[r].start_fixed();
+    auto d2 = (const T*)ranges[r].start();
 
     covered[i] = d1[0] >= d2[0] && d1[1] <= d2[1];
   }
@@ -1208,8 +1208,8 @@ uint64_t Dimension::map_to_uint64_2(
   assert(coord != nullptr);
   assert(!dim->domain().empty());
 
-  double dom_start_T = *(const T*)dim->domain().start_fixed();
-  double dom_end_T = *(const T*)dim->domain().end_fixed();
+  double dom_start_T = *(const T*)dim->domain().start();
+  double dom_end_T = *(const T*)dim->domain().end();
   auto dom_range_T = dom_end_T - dom_start_T;
   auto norm_coord_T = *(const T*)coord - dom_start_T;
   return (norm_coord_T / dom_range_T) * max_bucket_val;
@@ -1258,10 +1258,10 @@ ByteVecValue Dimension::map_from_uint64(
 
   // Add domain start
   auto value_T = static_cast<T>(value);
-  value_T += *(const T*)dim->domain().start_fixed();
+  value_T += *(const T*)dim->domain().start();
 
-  auto dom_start_T = *(const T*)dim->domain().start_fixed();
-  auto dom_end_T = *(const T*)dim->domain().end_fixed();
+  auto dom_start_T = *(const T*)dim->domain().start();
+  auto dom_end_T = *(const T*)dim->domain().end();
   double dom_range_T = dom_end_T - dom_start_T;
 
   // Essentially take the largest value in the bucket
@@ -1322,7 +1322,7 @@ bool Dimension::smaller_than(
   assert(value);
 
   auto value_T = *(const T*)(value.data());
-  auto range_start_T = *(const T*)range.start_fixed();
+  auto range_start_T = *(const T*)range.start();
   return value_T < range_start_T;
 }
 

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -77,7 +77,7 @@ const std::string Config::SM_SKIP_EST_SIZE_PARTITIONING = "false";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
 const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
 const std::string Config::SM_QUERY_DENSE_READER = "refactored";
-const std::string Config::SM_QUERY_SPARSE_GLOBAL_ORDER_READER = "refactored";
+const std::string Config::SM_QUERY_SPARSE_GLOBAL_ORDER_READER = "legacy";
 const std::string Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER =
     "refactored";
 const std::string Config::SM_MEM_MALLOC_TRIM = "true";

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -412,10 +412,10 @@ Status FragmentInfo::get_non_empty_domain_var(
         "Cannot get non-empty domain var; Dimension is fixed-sized"));
 
   assert(!non_empty_domain[did].empty());
-  auto start_str = non_empty_domain[did].start_str();
-  std::memcpy(start, start_str.data(), start_str.size());
-  auto end_str = non_empty_domain[did].end_str();
-  std::memcpy(end, end_str.data(), end_str.size());
+  std::memcpy(
+      start, non_empty_domain[did].start(), non_empty_domain[did].start_size());
+  std::memcpy(
+      end, non_empty_domain[did].end(), non_empty_domain[did].end_size());
 
   return Status::Ok();
 }
@@ -664,10 +664,14 @@ Status FragmentInfo::get_mbr_var(
         "Cannot get MBR var; Dimension is fixed-sized"));
 
   assert(!minimum_bounding_rectangle[did].empty());
-  auto start_str = minimum_bounding_rectangle[did].start_str();
-  std::memcpy(start, start_str.data(), start_str.size());
-  auto end_str = minimum_bounding_rectangle[did].end_str();
-  std::memcpy(end, end_str.data(), end_str.size());
+  std::memcpy(
+      start,
+      minimum_bounding_rectangle[did].start(),
+      minimum_bounding_rectangle[did].start_size());
+  std::memcpy(
+      end,
+      minimum_bounding_rectangle[did].end(),
+      minimum_bounding_rectangle[did].end_size());
 
   return Status::Ok();
 }

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -239,9 +239,7 @@ void FragmentMetadata::set_tile_min_var(
                   tile_min_var_buffer_[idx].size() - offset[0];
 
   // Copy var data
-  if (size) {  // avoid (potentially) illegal index ref's when size is zero
-    memcpy(&tile_min_var_buffer_[idx][offset[0]], min, size);
-  }
+  memcpy(&tile_min_var_buffer_[idx][offset[0]], min, size);
 }
 
 void FragmentMetadata::set_tile_max(
@@ -283,9 +281,7 @@ void FragmentMetadata::set_tile_max_var(
                   tile_max_var_buffer_[idx].size() - offset[0];
 
   // Copy var data
-  if (size) {  // avoid (potentially) illegal index ref's when size is zero
-    memcpy(&tile_max_var_buffer_[idx][offset[0]], max, size);
-  }
+  memcpy(&tile_max_var_buffer_[idx][offset[0]], max, size);
 }
 
 void FragmentMetadata::convert_tile_min_max_var_sizes_to_offsets(
@@ -3015,13 +3011,11 @@ Status FragmentMetadata::load_tile_min_values(unsigned idx, ConstBuffer* buff) {
           "Cannot load fragment metadata; Reading tile min buffer failed"));
     }
 
-    if (var_buffer_size) {
-      tile_min_var_buffer_[idx].resize(var_buffer_size);
-      st = buff->read(&tile_min_var_buffer_[idx][0], var_buffer_size);
-      if (!st.ok()) {
-        return LOG_STATUS(Status_FragmentMetadataError(
-            "Cannot load fragment metadata; Reading tile min buffer failed"));
-      }
+    tile_min_var_buffer_[idx].resize(var_buffer_size);
+    st = buff->read(&tile_min_var_buffer_[idx][0], var_buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load fragment metadata; Reading tile min buffer failed"));
     }
   }
 
@@ -3077,14 +3071,11 @@ Status FragmentMetadata::load_tile_max_values(unsigned idx, ConstBuffer* buff) {
           "Cannot load fragment metadata; Reading tile max buffer failed"));
     }
 
-    if (var_buffer_size) {
-      tile_max_var_buffer_[idx].resize(var_buffer_size);
-      st = buff->read(&tile_max_var_buffer_[idx][0], var_buffer_size);
-      if (!st.ok()) {
-        return LOG_STATUS(
-            Status_FragmentMetadataError("Cannot load fragment metadata; "
-                                         "Reading tile max var buffer failed"));
-      }
+    tile_max_var_buffer_[idx].resize(var_buffer_size);
+    st = buff->read(&tile_max_var_buffer_[idx][0], var_buffer_size);
+    if (!st.ok()) {
+      return LOG_STATUS(Status_FragmentMetadataError(
+          "Cannot load fragment metadata; Reading tile max var buffer failed"));
     }
   }
 

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -900,7 +900,7 @@ uint64_t DenseReader::get_dest_cell_offset_row_col(
     for (int32_t d = 0; d < dim_num; d++) {
       auto r = converted_range_coords[d];
       auto min = *static_cast<const DimType*>(
-          subarray.ranges_for_dim((uint32_t)d)[r].start_fixed());
+          subarray.ranges_for_dim((uint32_t)d)[r].start());
       ret += range_info[d].multiplier_ *
              (coords[d] - min + range_info[d].cell_offsets_[r]);
     }
@@ -908,7 +908,7 @@ uint64_t DenseReader::get_dest_cell_offset_row_col(
     for (int32_t d = dim_num - 1; d >= 0; d--) {
       auto r = converted_range_coords[d];
       auto min = *static_cast<const DimType*>(
-          subarray.ranges_for_dim((uint32_t)d)[r].start_fixed());
+          subarray.ranges_for_dim((uint32_t)d)[r].start());
       ret += range_info[d].multiplier_ *
              (coords[d] - min + range_info[d].cell_offsets_[r]);
     }

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -101,8 +101,7 @@ const typename DenseTiler<T>::CopyPlan DenseTiler<T>::copy_plan(
   auto subarray = subarray_->ndrange(0);  // Guaranteed to be unary
   std::vector<std::array<T, 2>> sub(dim_num);
   for (int32_t d = 0; d < dim_num; ++d)
-    sub[d] = {*(const T*)subarray[d].start_fixed(),
-              *(const T*)subarray[d].end_fixed()};
+    sub[d] = {*(const T*)subarray[d].start(), *(const T*)subarray[d].end()};
   auto tile_layout = array_schema_.cell_order();
   auto sub_layout = subarray_->layout();
 
@@ -404,8 +403,8 @@ void DenseTiler<T>::calculate_first_sub_tile_coords() {
   // left cell)
   first_sub_tile_coords_.resize(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    T dom_start = *(const T*)domain.dimension(d)->domain().start_fixed();
-    T sub_start = *(const T*)subarray[d].start_fixed();
+    T dom_start = *(const T*)domain.dimension(d)->domain().start();
+    T sub_start = *(const T*)subarray[d].start();
     T tile_extent = *(const T*)domain.tile_extent(d).data();
     first_sub_tile_coords_[d] =
         Dimension::tile_idx(sub_start, dom_start, tile_extent);
@@ -481,8 +480,8 @@ void DenseTiler<T>::calculate_tile_and_subarray_strides() {
     sub_strides_el_[dim_num - 1] = 1;
     if (dim_num > 1) {
       for (auto d = dim_num - 2; d >= 0; --d) {
-        auto sub_range_start = *(const T*)subarray[d + 1].start_fixed();
-        auto sub_range_end = *(const T*)subarray[d + 1].end_fixed();
+        auto sub_range_start = *(const T*)subarray[d + 1].start();
+        auto sub_range_end = *(const T*)subarray[d + 1].end();
         auto sub_extent = sub_range_end - sub_range_start + 1;
         sub_strides_el_[d] = sub_strides_el_[d + 1] * sub_extent;
       }
@@ -491,8 +490,8 @@ void DenseTiler<T>::calculate_tile_and_subarray_strides() {
     sub_strides_el_[0] = 1;
     if (dim_num > 1) {
       for (auto d = 1; d < dim_num; ++d) {
-        auto sub_range_start = *(const T*)subarray[d - 1].start_fixed();
-        auto sub_range_end = *(const T*)subarray[d - 1].end_fixed();
+        auto sub_range_start = *(const T*)subarray[d - 1].start();
+        auto sub_range_end = *(const T*)subarray[d - 1].end();
         auto sub_extent = sub_range_end - sub_range_start + 1;
         sub_strides_el_[d] = sub_strides_el_[d - 1] * sub_extent;
       }
@@ -546,7 +545,7 @@ std::vector<std::array<T, 2>> DenseTiler<T>::tile_subarray(uint64_t id) const {
   // Calculate tile subarray based on the tile coordinates in the domain
   std::vector<std::array<T, 2>> ret(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dom_start = *(const T*)domain.dimension(d)->domain().start_fixed();
+    auto dom_start = *(const T*)domain.dimension(d)->domain().start();
     auto tile_extent = *(const T*)domain.tile_extent(d).data();
     ret[d][0] = Dimension::tile_coord_low(
         tile_coords_in_dom[d], dom_start, tile_extent);

--- a/tiledb/sm/query/global_order_writer.cc
+++ b/tiledb/sm/query/global_order_writer.cc
@@ -720,11 +720,7 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
 
   // First fill the last tile
   auto& last_tile = global_write_state_->last_tiles_[name][0];
-  decltype(&global_write_state_->last_tiles_[name][1]) last_tile_validity =
-      nullptr;
-  if (nullable) {
-    last_tile_validity = &global_write_state_->last_tiles_[name][1];
-  }
+  auto& last_tile_validity = global_write_state_->last_tiles_[name][1];
   uint64_t cell_idx = 0;
   uint64_t last_tile_cell_idx =
       global_write_state_->cells_written_[name] % cell_num_per_tile;
@@ -736,7 +732,7 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
             last_tile_cell_idx * cell_size,
             cell_size));
         if (nullable) {
-          RETURN_NOT_OK(last_tile_validity->write(
+          RETURN_NOT_OK(last_tile_validity.write(
               buffer_validity + cell_idx * constants::cell_validity_size,
               last_tile_cell_idx * constants::cell_validity_size,
               constants::cell_validity_size));
@@ -752,7 +748,7 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
               last_tile_cell_idx * cell_size,
               cell_size));
           if (nullable) {
-            RETURN_NOT_OK(last_tile_validity->write(
+            RETURN_NOT_OK(last_tile_validity.write(
                 buffer_validity + cell_idx * constants::cell_validity_size,
                 last_tile_cell_idx * constants::cell_validity_size,
                 constants::cell_validity_size));
@@ -787,7 +783,7 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
     if (last_tile_cell_idx == cell_num_per_tile) {
       (*tiles)[0].swap(last_tile);
       if (nullable) {
-        (*tiles)[1].swap(*last_tile_validity);
+        (*tiles)[1].swap(last_tile_validity);
       }
       tile_idx += t;
     } else {
@@ -844,7 +840,7 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
           last_tile_cell_idx * cell_size,
           cell_size));
       if (nullable) {
-        RETURN_NOT_OK(last_tile_validity->write(
+        RETURN_NOT_OK(last_tile_validity.write(
             buffer_validity + cell_idx * constants::cell_validity_size,
             last_tile_cell_idx * constants::cell_validity_size,
             constants::cell_validity_size));
@@ -858,7 +854,7 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
             last_tile_cell_idx * cell_size,
             cell_size));
         if (nullable) {
-          RETURN_NOT_OK(last_tile_validity->write(
+          RETURN_NOT_OK(last_tile_validity.write(
               buffer_validity + cell_idx * constants::cell_validity_size,
               last_tile_cell_idx * constants::cell_validity_size,
               constants::cell_validity_size));
@@ -900,10 +896,7 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
   auto& last_tile_vector = global_write_state_->last_tiles_[name];
   auto& last_tile = last_tile_vector[0];
   auto& last_tile_var = last_tile_vector[1];
-  decltype(&last_tile_vector[2]) last_tile_validity = nullptr;
-  if (nullable) {
-    last_tile_validity = &last_tile_vector[2];
-  }
+  auto& last_tile_validity = last_tile_vector[2];
   auto& last_var_offset = global_write_state_->last_var_offsets_[name];
   uint64_t cell_idx = 0;
   uint64_t last_tile_cell_idx =
@@ -931,7 +924,7 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
 
         // Write validity value(s).
         if (nullable)
-          RETURN_NOT_OK(last_tile_validity->write(
+          RETURN_NOT_OK(last_tile_validity.write(
               buffer_validity + cell_idx,
               last_tile_cell_idx * constants::cell_validity_size,
               constants::cell_validity_size));
@@ -963,7 +956,7 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
 
           // Write validity value(s).
           if (nullable)
-            RETURN_NOT_OK(last_tile_validity->write(
+            RETURN_NOT_OK(last_tile_validity.write(
                 buffer_validity + cell_idx,
                 last_tile_cell_idx * constants::cell_validity_size,
                 constants::cell_validity_size));
@@ -1002,7 +995,7 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
       (*tiles)[0].swap(last_tile);
       (*tiles)[1].swap(last_tile_var);
       if (nullable) {
-        (*tiles)[2].swap(*last_tile_validity);
+        (*tiles)[2].swap(last_tile_validity);
       }
       tile_idx += t;
     } else {
@@ -1118,7 +1111,7 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
 
       // Write validity value(s).
       if (nullable)
-        RETURN_NOT_OK(last_tile_validity->write(
+        RETURN_NOT_OK(last_tile_validity.write(
             buffer_validity + cell_idx,
             last_tile_cell_idx * constants::cell_validity_size,
             constants::cell_validity_size));
@@ -1146,7 +1139,7 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
 
         // Write validity value(s).
         if (nullable)
-          RETURN_NOT_OK(last_tile_validity->write(
+          RETURN_NOT_OK(last_tile_validity.write(
               buffer_validity + cell_idx,
               last_tile_cell_idx * constants::cell_validity_size,
               constants::cell_validity_size));

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -928,7 +928,7 @@ void ResultTile::compute_results_count_sparse(
               range_indexes.end(),
               c,
               [&](const uint64_t& index, const T& value) {
-                return ((const T*)ranges[index].start_fixed())[1] < value;
+                return ((const T*)ranges[index].start())[1] < value;
               });
 
           // If we didn't find a range we can set count to 0 and skip to next.
@@ -944,7 +944,7 @@ void ResultTile::compute_results_count_sparse(
               range_indexes.end(),
               c,
               [&](const uint64_t& index, const T& value) {
-                return ((const T*)ranges[index].start_fixed())[0] < value;
+                return ((const T*)ranges[index].start())[0] < value;
               });
 
           // If the upper bound isn't the end add +1 to the index.
@@ -958,8 +958,7 @@ void ResultTile::compute_results_count_sparse(
           // dim.
           uint64_t count = 0;
           for (uint64_t j = start_range_idx; j < end_range_idx; ++j) {
-            const auto& range =
-                (const T*)ranges[range_indexes[j]].start_fixed();
+            const auto& range = (const T*)ranges[range_indexes[j]].start();
             count += c >= range[0] && c <= range[1];
           }
 
@@ -982,7 +981,7 @@ void ResultTile::compute_results_count_sparse(
         T c = coords[pos * dim_num + dim_idx];
         uint64_t count = 0;
         for (uint64_t i = 0; i < range_indexes.size(); i++) {
-          const auto& range = (const T*)ranges[range_indexes[i]].start_fixed();
+          const auto& range = (const T*)ranges[range_indexes[i]].start();
           count += c >= range[0] && c <= range[1];
         }
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1045,10 +1045,8 @@ Status StorageManager::array_get_non_empty_domain_var_from_index(
   if (*is_empty)
     return Status::Ok();
 
-  auto start_str = dom[idx].start_str();
-  std::memcpy(start, start_str.data(), start_str.size());
-  auto end_str = dom[idx].end_str();
-  std::memcpy(end, end_str.data(), end_str.size());
+  std::memcpy(start, dom[idx].start(), dom[idx].start_size());
+  std::memcpy(end, dom[idx].end(), dom[idx].end_size());
 
   return Status::Ok();
 }
@@ -1077,10 +1075,8 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
       }
 
       if (!*is_empty) {
-        auto start_str = dom[d].start_str();
-        std::memcpy(start, start_str.data(), start_str.size());
-        auto end_str = dom[d].end_str();
-        std::memcpy(end, end_str.data(), end_str.size());
+        std::memcpy(start, dom[d].start(), dom[d].start_size());
+        std::memcpy(end, dom[d].end(), dom[d].end_size());
       }
 
       return Status::Ok();

--- a/tiledb/sm/subarray/range_subset.h
+++ b/tiledb/sm/subarray/range_subset.h
@@ -75,14 +75,14 @@ struct AddStrategy<
     // last range on `ranges`, they are contiguous and will be coalesced.
     Range& last_range = ranges.back();
     const bool contiguous_after =
-        *static_cast<const T*>(last_range.end_fixed()) !=
+        *static_cast<const T*>(last_range.end()) !=
             std::numeric_limits<T>::max() &&
-        *static_cast<const T*>(last_range.end_fixed()) + 1 ==
-            *static_cast<const T*>(new_range.start_fixed());
+        *static_cast<const T*>(last_range.end()) + 1 ==
+            *static_cast<const T*>(new_range.start());
 
     // Coalesce `range` with `last_range` if they are contiguous.
     if (contiguous_after) {
-      last_range.set_end_fixed(new_range.end_fixed());
+      last_range.set_end(new_range.end());
     } else {
       ranges.emplace_back(new_range);
     }
@@ -115,8 +115,8 @@ struct SortStrategy<
         ranges.begin(),
         ranges.end(),
         [&](const Range& a, const Range& b) {
-          const T* a_data = static_cast<const T*>(a.start_fixed());
-          const T* b_data = static_cast<const T*>(b.start_fixed());
+          const T* a_data = static_cast<const T*>(a.start());
+          const T* b_data = static_cast<const T*>(b.start());
           return a_data[0] < b_data[0] ||
                  (a_data[0] == b_data[0] && a_data[1] < b_data[1]);
         });

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -695,15 +695,8 @@ Status Subarray::get_range(
     return logger_->status(
         Status_SubarrayError("Cannot get range; Invalid range index"));
 
-  auto& range = range_subset_[dim_idx][range_idx];
-  auto is_var = range.var_size();
-  if (is_var) {
-    *start = range_subset_[dim_idx][range_idx].start_str().data();
-    *end = range_subset_[dim_idx][range_idx].end_str().data();
-  } else {
-    *start = range_subset_[dim_idx][range_idx].start_fixed();
-    *end = range_subset_[dim_idx][range_idx].end_fixed();
-  }
+  *start = range_subset_[dim_idx][range_idx].start();
+  *end = range_subset_[dim_idx][range_idx].end();
 
   return Status::Ok();
 }

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -1389,27 +1389,15 @@ void SubarrayPartitioner::compute_range_uint64(
         var ? dim->map_to_uint64(
                   max_string.data(), max_string.size(), bits, max_bucket_val) :
               (UINT64_MAX >> (64 - bits));
-    if (r->var_size()) {
-      auto start_str = r->start_str();
-      (*range_uint64)[d][0] =
-          empty_start ? 0 :  // min default
-              dim->map_to_uint64(
-                  start_str.data(), start_str.size(), bits, max_bucket_val);
-      auto end_str = r->end_str();
-      (*range_uint64)[d][1] =
-          empty_end ? max_default :
-                      dim->map_to_uint64(
-                          end_str.data(), end_str.size(), bits, max_bucket_val);
-    } else {
-      // Note: coord_size is ignored for fixed size in map_to_uint64.
-      (*range_uint64)[d][0] =
-          empty_start ? 0 :  // min default
-              dim->map_to_uint64(r->start_fixed(), 0, bits, max_bucket_val);
-      (*range_uint64)[d][1] =
-          empty_end ?
-              max_default :
-              dim->map_to_uint64(r->end_fixed(), 0, bits, max_bucket_val);
-    }
+
+    (*range_uint64)[d][0] =
+        empty_start ? 0 :  // min default
+            dim->map_to_uint64(
+                r->start(), r->start_size(), bits, max_bucket_val);
+    (*range_uint64)[d][1] =
+        empty_end ?
+            max_default :
+            dim->map_to_uint64(r->end(), r->end_size(), bits, max_bucket_val);
 
     assert((*range_uint64)[d][0] <= (*range_uint64)[d][1]);
 

--- a/tiledb/sm/subarray/test/unit_range_subset.cc
+++ b/tiledb/sm/subarray/test/unit_range_subset.cc
@@ -48,8 +48,8 @@ TEST_CASE("CreateDefaultRangeSetAndSuperset") {
   CHECK(range_subset.num_ranges() == 1);
   Range default_range = range_subset[0];
   CHECK(!default_range.empty());
-  const uint64_t* start = (uint64_t*)default_range.start_fixed();
-  const uint64_t* end = (uint64_t*)default_range.end_fixed();
+  const uint64_t* start = (uint64_t*)default_range.start();
+  const uint64_t* end = (uint64_t*)default_range.end();
   CHECK(*start == 0);
   CHECK(*end == 10);
 }
@@ -69,8 +69,8 @@ TEST_CASE("RangeSetAndSuperset::RangeSetAndSuperset") {
     range_subset.add_range_unrestricted(r2);
     CHECK(range_subset.num_ranges() == 1);
     auto combined_range = range_subset[0];
-    const uint64_t* start = (uint64_t*)combined_range.start_fixed();
-    const uint64_t* end = (uint64_t*)combined_range.end_fixed();
+    const uint64_t* start = (uint64_t*)combined_range.start();
+    const uint64_t* end = (uint64_t*)combined_range.end();
     CHECK(*start == 1);
     CHECK(*end == 5);
   }
@@ -118,14 +118,14 @@ TEST_CASE(
     CHECK(range_subset.num_ranges() == 2);
     // Check the first range.
     auto result_range = range_subset[0];
-    const uint64_t* start = (uint64_t*)result_range.start_fixed();
-    const uint64_t* end = (uint64_t*)result_range.end_fixed();
+    const uint64_t* start = (uint64_t*)result_range.start();
+    const uint64_t* end = (uint64_t*)result_range.end();
     CHECK(*start == 1);
     CHECK(*end == 2);
     // Check the second range.
     result_range = range_subset[1];
-    start = (uint64_t*)result_range.start_fixed();
-    end = (uint64_t*)result_range.end_fixed();
+    start = (uint64_t*)result_range.start();
+    end = (uint64_t*)result_range.end();
     CHECK(*start == 4);
     CHECK(*end == 5);
   }

--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -91,7 +91,6 @@ class Range {
   void set_range(const void* r, uint64_t r_size) {
     range_.resize(r_size);
     std::memcpy(range_.data(), r, r_size);
-    var_size_ = false;
   }
 
   /** Sets a var-sized range serialized in `r`. */
@@ -131,14 +130,12 @@ class Range {
   }
 
   /** Returns a pointer to the start of the range. */
-  const void* start_fixed() const {
-    assert(!var_size_);
-    assert(range_.size() != 0);
+  const void* start() const {
     return range_.data();
   }
 
   /** Copies 'start' into this range's start bytes for fixed-size ranges. */
-  void set_start_fixed(const void* const start) {
+  void set_start(const void* const start) {
     if (var_size_) {
       auto msg = "Unexpected var-sized range; cannot set start range.";
       LOG_ERROR(msg);
@@ -151,23 +148,12 @@ class Range {
 
   /** Returns the start as a string view. */
   std::string_view start_str() const {
-    if (range_start_size_ == 0) {
-      return {nullptr, 0};
-    }
-    return std::string_view(
-        reinterpret_cast<const char*>(range_.data()), range_start_size_);
+    return std::string_view((const char*)start(), start_size());
   }
 
   /** Returns the end as a string view. */
   std::string_view end_str() const {
-    assert(var_size_);
-    auto size = range_.size() - range_start_size_;
-    if (size == 0) {
-      return {nullptr, 0};
-    }
-
-    return std::string_view(
-        reinterpret_cast<const char*>(range_.data()) + range_start_size_, size);
+    return std::string_view((const char*)end(), end_size());
   }
 
   /**
@@ -175,8 +161,6 @@ class Range {
    * Non-zero only for var-sized ranges.
    */
   uint64_t start_size() const {
-    if (!var_size_)
-      return 0;
     return range_start_size_;
   }
 
@@ -191,15 +175,13 @@ class Range {
   }
 
   /** Returns a pointer to the end of the range. */
-  const void* end_fixed() const {
-    assert(!var_size_);
-    assert(range_.size() != 0);
-    auto end_pos = range_.size() / 2;
-    return &range_[end_pos];
+  const void* end() const {
+    auto end_pos = var_size_ ? range_start_size_ : range_.size() / 2;
+    return range_.empty() ? nullptr : &range_[end_pos];
   }
 
   /** Copies 'end' into this range's end bytes for fixed-size ranges. */
-  void set_end_fixed(const void* const end) {
+  void set_end(const void* const end) {
     if (var_size_) {
       auto msg = "Unexpected var-sized range; cannot set end range.";
       LOG_ERROR(msg);


### PR DESCRIPTION
As planned, this reverts commit 4b19377386e025cc6f7cfcd70c104262e437eeac for the `release-2.9` branch.

---
TYPE: FEATURE
DESC: Use legacy sparse global order reader for 2.9