### PR TITLE
[debugging] Use legacy sparse global order reader for 2.9

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -269,7 +269,7 @@ void check_save_to_file() {
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
   ss << "sm.query.dense.reader refactored\n";
-  ss << "sm.query.sparse_global_order.reader refactored\n";
+  ss << "sm.query.sparse_global_order.reader legacy\n";
   ss << "sm.query.sparse_unordered_with_dups.reader refactored\n";
   ss << "sm.read_range_oob warn\n";
   ss << "sm.skip_checksum_validation false\n";
@@ -570,7 +570,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.memory_budget"] = "5368709120";
   all_param_values["sm.memory_budget_var"] = "10737418240";
   all_param_values["sm.query.dense.reader"] = "refactored";
-  all_param_values["sm.query.sparse_global_order.reader"] = "refactored";
+  all_param_values["sm.query.sparse_global_order.reader"] = "legacy";
   all_param_values["sm.query.sparse_unordered_with_dups.reader"] = "refactored";
   all_param_values["sm.mem.malloc_trim"] = "true";
   all_param_values["sm.mem.total_budget"] = "10737418240";

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -77,7 +77,7 @@ const std::string Config::SM_SKIP_EST_SIZE_PARTITIONING = "false";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
 const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
 const std::string Config::SM_QUERY_DENSE_READER = "refactored";
-const std::string Config::SM_QUERY_SPARSE_GLOBAL_ORDER_READER = "refactored";
+const std::string Config::SM_QUERY_SPARSE_GLOBAL_ORDER_READER = "legacy";
 const std::string Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER =
     "refactored";
 const std::string Config::SM_MEM_MALLOC_TRIM = "true";

--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -160,7 +160,10 @@ class Range {
 
   /** Returns the end as a string view. */
   std::string_view end_str() const {
-    assert(var_size_);
+    assert(var_size_  // must be variable
+        // or have no data if 'fixed' (primarily default construction)
+        || !range_.size() 
+    );
     auto size = range_.size() - range_start_size_;
     if (size == 0) {
       return {nullptr, 0};

--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -160,10 +160,9 @@ class Range {
 
   /** Returns the end as a string view. */
   std::string_view end_str() const {
-    assert(var_size_  // must be variable
-        // or have no data if 'fixed' (primarily default construction)
-        || !range_.size() 
-    );
+    // must be variable
+    // or have no data if 'fixed' (primarily default construction)
+    assert(var_size_ || !range_.size());
     auto size = range_.size() - range_start_size_;
     if (size == 0) {
       return {nullptr, 0};


### PR DESCRIPTION
As planned, this reverts commit 4b19377386e025cc6f7cfcd70c104262e437eeac for the `release-2.9` branch.

---
TYPE: FEATURE
DESC: Use legacy sparse global order reader for 2.9

<long description>

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
