### PR TITLE
Sparse unordered w/ dups reader: fix incomplete reason for cloud reads.

### DIFF
--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -93,8 +93,7 @@ bool SparseUnorderedWithDupsReader<BitmapType>::incomplete() const {
 template <class BitmapType>
 QueryStatusDetailsReason
 SparseUnorderedWithDupsReader<BitmapType>::status_incomplete_reason() const {
-  // Returning early for deserialized incomplete queries.
-  if (result_tiles_.empty())
+  if (array_->is_remote())
     return QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE;
 
   if (!incomplete())


### PR DESCRIPTION
Status incomplete reason was using the fact that for deserialized
queries, result tiles were not created to know it was a cloud read. The
reader changed and this behavior is no longer true. This fixes the
issue by using is_remote() on the array, which is the proper way.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups reader: fix incomplete reason for cloud reads.
