### PR TITLE
Add doc config and tiledb_version.h to CI ignore

### DIFF
--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -6,6 +6,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 jobs:
   build-dockerfile:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -5,11 +5,15 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     paths-ignore:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 jobs:
   build:

--- a/.github/workflows/build-macOS11-GCS.yml
+++ b/.github/workflows/build-macOS11-GCS.yml
@@ -9,6 +9,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
@@ -16,6 +18,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build-macOS11-S3.yml
+++ b/.github/workflows/build-macOS11-S3.yml
@@ -9,6 +9,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
@@ -16,6 +18,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build-ubuntu16.04-HDFS.yml
+++ b/.github/workflows/build-ubuntu16.04-HDFS.yml
@@ -9,6 +9,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
@@ -16,6 +18,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_HDFS: ON

--- a/.github/workflows/build-ubuntu20.04-AZURE.yml
+++ b/.github/workflows/build-ubuntu20.04-AZURE.yml
@@ -9,6 +9,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
@@ -16,6 +18,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF

--- a/.github/workflows/build-ubuntu20.04-GCS.yml
+++ b/.github/workflows/build-ubuntu20.04-GCS.yml
@@ -9,6 +9,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
@@ -16,6 +18,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF

--- a/.github/workflows/build-ubuntu20.04-S3.yml
+++ b/.github/workflows/build-ubuntu20.04-S3.yml
@@ -9,6 +9,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
@@ -16,6 +18,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF

--- a/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
+++ b/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
@@ -9,6 +9,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string
@@ -16,6 +18,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 env:
   TILEDB_SERIALIZATION: ON # NOTE: currently defined directly inline

--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -5,11 +5,15 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     paths-ignore:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 env:
   CXX: g++

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,11 +6,15 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     paths-ignore:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -5,11 +5,17 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      # We specifically check formatting for the tiledb_version.h
+      # - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     paths-ignore:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      # We specifically check formatting for the tiledb_version.h
+      # - 'tiledb/sm/c_api/tiledb_version.h'
 
 jobs:
   build:

--- a/.github/workflows/check-heap-memory-api-violations.yml
+++ b/.github/workflows/check-heap-memory-api-violations.yml
@@ -5,11 +5,15 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     paths-ignore:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 jobs:
   build:

--- a/.github/workflows/check-pr-body.yml
+++ b/.github/workflows/check-pr-body.yml
@@ -7,6 +7,8 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 jobs:
   check_pr_body:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -6,11 +6,15 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     paths-ignore:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 jobs:
   build:

--- a/.github/workflows/quarto-render.yml
+++ b/.github/workflows/quarto-render.yml
@@ -7,11 +7,15 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     paths:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 jobs:
   quarto-render-and-deploy:

--- a/.github/workflows/rtools40.yml
+++ b/.github/workflows/rtools40.yml
@@ -6,11 +6,15 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     paths-ignore:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 jobs:
   build:

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -5,11 +5,15 @@ on:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     paths-ignore:
       - '_quarto.yml'
       - 'quarto-materials/*'
       - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF


### PR DESCRIPTION
This prevents github actions from running for PRs that only attempt to update the history and version. This improves the release process by reducing the time it takes for a release by 1-2 hours for the whole CI job and reduces general CI contention.


---
TYPE: NO_HISTORY
DESC: NO_HISTORY
