### PR TITLE
Bugfix for #3088

### DIFF
--- a/cmake/Modules/FindMagic_EP.cmake
+++ b/cmake/Modules/FindMagic_EP.cmake
@@ -28,6 +28,7 @@
 #   - libmagic_INCLUDE_DIR, directory containing headers
 #   - libmagic_LIBRARIES, the Magic library path
 #   - libmagic_FOUND, whether Magic has been found
+#   - libmagic_DICTIONARY, whether magic.mgc has been found
 #   - The libmagic imported target
 
 # Include some common helper functions.
@@ -63,6 +64,12 @@ if (TILEDB_LIBMAGIC_EP_BUILT)
     PATHS ${LIBMAGIC_PATHS}
     PATH_SUFFIXES lib a
     #${TILEDB_DEPS_NO_DEFAULT_PATH}
+    ${NO_DEFAULT_PATH}
+  )
+
+  find_file(libmagic_DICTIONARY magic.mgc
+    PATHS ${LIBMAGIC_PATHS}
+    PATH_SUFFIXES bin share
     ${NO_DEFAULT_PATH}
   )
 
@@ -111,6 +118,11 @@ if(NOT TILEDB_LIBMAGIC_EP_BUILT)
 
     set(TILEDB_LIBMAGIC_DIR "${TILEDB_EP_INSTALL_PREFIX}")
 
+    find_file(libmagic_DICTIONARY magic.mgc
+      PATHS ${TILEDB_LIBMAGIC_DIR}
+      PATH_SUFFIXES bin share
+      ${NO_DEFAULT_PATH}
+    )
   else()
     message(FATAL_ERROR "Unable to find Magic")
   endif()

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -337,24 +337,10 @@ add_dependencies(TILEDB_CORE_OBJECTS compressors)
 set(MGC_GZIPPED_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/magic_mgc_gzipped.bin")
 set(MGC_GZIPPED_BIN_PATH2 "${CMAKE_CURRENT_BINARY_DIR}/sm/misc/magic_mgc_gzipped.bin")
 
-
-if(WIN32)
-  if(MSVC)
-    set(tdb_gzip_embedded_data_EXECUTABLE "${TILEDB_EP_BASE}/../tiledb/tiledb/sm/compressors/${CMAKE_BUILD_TYPE}/tdb_gzip_embedded_data.exe")
-  else()
-    set(tdb_gzip_embedded_data_EXECUTABLE "${TILEDB_EP_BASE}/../tiledb/tiledb/sm/compressors/tdb_gzip_embedded_data.exe")
-  endif()
-else()
-  set(tdb_gzip_embedded_data_EXECUTABLE "${TILEDB_EP_BASE}/../tiledb/tiledb/sm/compressors/tdb_gzip_embedded_data")
-endif()
-
-set(MAGIC_MGC_DICT "${TILEDB_EP_BASE}/install/bin/magic.mgc")
-message(STATUS "MAGIC_MGC_DICT is ${MAGIC_MGC_DICT}")
-
 add_custom_command(
   OUTPUT "${MGC_GZIPPED_BIN_PATH}" #${CMAKE_CURRENT_BINARY_DIR}/mgc_gzipped.bin
-  DEPENDS "${MAGIC_MGC_DICT}"
-  COMMAND "${tdb_gzip_embedded_data_EXECUTABLE}" < "${MAGIC_MGC_DICT}" "${MGC_GZIPPED_BIN_PATH}"
+  DEPENDS "${libmagic_DICTIONARY}"
+  COMMAND "$<TARGET_FILE:tdb_gzip_embedded_data>" < "${libmagic_DICTIONARY}" "${MGC_GZIPPED_BIN_PATH}"
   # also put it where unit_mgc_dict build can find it
   COMMAND ${CMAKE_COMMAND} -E copy "${MGC_GZIPPED_BIN_PATH}" "${MGC_GZIPPED_BIN_PATH2}"
 )

--- a/tiledb/sm/misc/CMakeLists.txt
+++ b/tiledb/sm/misc/CMakeLists.txt
@@ -121,10 +121,8 @@ target_link_libraries(compile_uuid PRIVATE uuid)
 target_sources(compile_uuid PRIVATE test/compile_uuid_main.cc)
 
 # simple unit test of magic.mgc embedded data vs external data
-find_file(MAGIC_MGC_PATH magic.mgc REQUIRED
-  PATHS ${TILEDB_EP_BASE}/install/bin
-)
-if(MAGIC_MGC_PATH-NOTFOUND)
+find_package(Magic_EP REQUIRED)
+if(NOT EXISTS ${libmagic_DICTIONARY})
   message(FATAL_ERROR "Failed to find libmagic 'magic.mgc' file.")
 endif()
 add_executable(unit_mgc_dict EXCLUDE_FROM_ALL)
@@ -138,8 +136,7 @@ target_link_libraries(unit_mgc_dict PRIVATE
   libmagic
   )
 
-target_compile_options(unit_mgc_dict PRIVATE -DTILEDB_PATH_TO_MAGIC_MGC=\"${MAGIC_MGC_PATH}\")
-find_package(Magic_EP REQUIRED)
+target_compile_options(unit_mgc_dict PRIVATE -DTILEDB_PATH_TO_MAGIC_MGC=\"${libmagic_DICTIONARY}\")
 target_include_directories(unit_mgc_dict
   PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
If you do not use a superbuild but build the library yourself and then link to it, some parts of the CMake script do not work because absolute paths are stored there.

---
TYPE: NO_HISTORY
DESC: see #3117