### PR TITLE
adjust assert for problematic var_size_ Range usage after earlier changes

### DIFF
--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -162,7 +162,7 @@ class Range {
 
   /** Returns the end as a string view. */
   std::string_view end_str() const {
-    // must be variable
+    // Must be variable
     // or have no data if 'fixed' (primarily default construction)
     assert(var_size_ || !range_.size());
     auto size = range_.size() - range_start_size_;

--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -162,7 +162,9 @@ class Range {
 
   /** Returns the end as a string view. */
   std::string_view end_str() const {
-    assert(var_size_);
+    // must be variable
+    // or have no data if 'fixed' (primarily default construction)
+    assert(var_size_ || !range_.size());
     auto size = range_.size() - range_start_size_;
     if (size == 0) {
       return {nullptr, 0};


### PR DESCRIPTION
change assert to be compatible with Range object without data and !var_size_, avoiding failure in legacy global sparse order reader

---
TYPE: BUG
DESC: adjust assert for var Range usage in legacy global order reader
