### PR TITLE
Fix manylinux release build linkage error after 3088

### DIFF
--- a/cmake/Modules/FindMagic_EP.cmake
+++ b/cmake/Modules/FindMagic_EP.cmake
@@ -67,12 +67,6 @@ if (TILEDB_LIBMAGIC_EP_BUILT)
     ${NO_DEFAULT_PATH}
   )
 
-  find_file(libmagic_DICTIONARY magic.mgc
-    PATHS ${LIBMAGIC_PATHS}
-    PATH_SUFFIXES bin share
-    ${NO_DEFAULT_PATH}
-  )
-
   include(FindPackageHandleStandardArgs)
   FIND_PACKAGE_HANDLE_STANDARD_ARGS(libmagic
     REQUIRED_VARS libmagic_LIBRARIES libmagic_INCLUDE_DIR
@@ -116,17 +110,16 @@ if(NOT TILEDB_LIBMAGIC_EP_BUILT)
       -DTILEDB_LIBMAGIC_EP_BUILT=TRUE
     )
 
-    set(TILEDB_LIBMAGIC_DIR "${TILEDB_EP_INSTALL_PREFIX}")
-
-    find_file(libmagic_DICTIONARY magic.mgc
-      PATHS ${TILEDB_LIBMAGIC_DIR}
-      PATH_SUFFIXES bin share
-      ${NO_DEFAULT_PATH}
-    )
   else()
     message(FATAL_ERROR "Unable to find Magic")
   endif()
 endif()
+
+find_file(libmagic_DICTIONARY magic.mgc
+  PATHS ${LIBMAGIC_PATHS}
+  PATH_SUFFIXES bin share
+  ${NO_DEFAULT_PATH}
+)
 
 if (libmagic_FOUND AND NOT TARGET libmagic)
   message(STATUS "Found Magic, adding imported target: ${libmagic_LIBRARIES}")

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -331,9 +331,6 @@ add_library(TILEDB_CORE_OBJECTS OBJECT
 )
 
 
-add_dependencies(TILEDB_CORE_OBJECTS tdb_gzip_embedded_data)
-add_dependencies(TILEDB_CORE_OBJECTS compressors)
-
 set(MGC_GZIPPED_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/magic_mgc_gzipped.bin")
 set(MGC_GZIPPED_BIN_PATH2 "${CMAKE_CURRENT_BINARY_DIR}/sm/misc/magic_mgc_gzipped.bin")
 

--- a/tiledb/sm/compressors/CMakeLists.txt
+++ b/tiledb/sm/compressors/CMakeLists.txt
@@ -44,22 +44,35 @@ target_link_libraries(compressors PUBLIC Bzip2::Bzip2 LZ4::LZ4 Zlib::Zlib Zstd::
 add_executable(compile_compressors EXCLUDE_FROM_ALL)
 target_link_libraries(compile_compressors PRIVATE compressors)
 target_sources(compile_compressors PRIVATE
-        test/compile_compressors_main.cc $<TARGET_OBJECTS:compressors>
+        test/compile_compressors_main.cc
 )
 
 #
 # tiledb crude gzip archiver initially for embedding magic.mgc
 #
 add_executable(tdb_gzip_embedded_data)
-target_link_libraries(tdb_gzip_embedded_data PRIVATE compressors)
 target_sources(tdb_gzip_embedded_data PRIVATE
         util/tdb_gzip_embedded_data.cc 
-        $<TARGET_OBJECTS:compressors>
 )
+
 target_link_libraries(
     tdb_gzip_embedded_data PUBLIC 
-    filter # OBJECTS library
+    filter
+    compressors
     )
+
+target_include_directories(tdb_gzip_embedded_data PRIVATE
+        $<TARGET_PROPERTY:TILEDB_CORE_OBJECTS,INCLUDE_DIRECTORIES>
+)
+# Link to Threads::Threads if library or flag needed to enable threading.
+find_package(Threads REQUIRED)
+if (TRUE) #(CMAKE_THREAD_LIBS_INIT)
+  target_link_libraries(tdb_gzip_embedded_data PRIVATE Threads::Threads)
+endif()
+# On Linux, must explicitly link -ldl for static linking to libzstd.
+if (NOT WIN32)
+  target_link_libraries(tdb_gzip_embedded_data PRIVATE dl)
+endif()
 
 if (TILEDB_TESTS)
     add_executable(unit_compressors EXCLUDE_FROM_ALL)


### PR DESCRIPTION
- Fix linkage errors in manylinux release build related to pthread and
  dl linkage.
- Remove no-op libmagic find_file

<long description>

---
TYPE: NO_HISTORY
DESC: Fix manylinux release build linkage error after 3088
