### PR TITLE
cmake: Fix undefined MSVC_MP_FLAG variable in mingw

### DIFF
--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -55,7 +55,8 @@ if (TILEDB_TESTS)
   )
 endif()
 
-if (WIN32)
+# MSVC_MP_FLAG is defined in MSVC only
+if (MSVC)
   list(APPEND INHERITED_CMAKE_ARGS
     -DMSVC_MP_FLAG=${MSVC_MP_FLAG}
   )

--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -55,8 +55,8 @@ if (TILEDB_TESTS)
   )
 endif()
 
-# MSVC_MP_FLAG is defined in MSVC only
-if (MSVC)
+# MSVC_MP_FLAG is defined by bootstrap.ps1
+if (DEFINED MSVC_MP_FLAG)
   list(APPEND INHERITED_CMAKE_ARGS
     -DMSVC_MP_FLAG=${MSVC_MP_FLAG}
   )


### PR DESCRIPTION
MSVC_MP_FLAG is defined for MSVC only. So, check MSVC instead of WIN32 platform.
This fixes CMake Warning:
Manually-specified variables were not used by the project:
MSVC_MP_FLAG

---

TYPE: NO_HISTORY