### PR TITLE
Rearrange context member initialization

### DIFF
--- a/test/src/unit-capi-context.cc
+++ b/test/src/unit-capi-context.cc
@@ -44,23 +44,20 @@ TEST_CASE("C API: Test context", "[capi][context]") {
   REQUIRE(rc == TILEDB_OK);
   CHECK(error == nullptr);
 
+  // Check alloc and alloc_with_error on non-error case
+  // It is allowed to create a thread pool with concurrency level = 0
   rc = tiledb_config_set(config, "sm.compute_concurrency_level", "0", &error);
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
   tiledb_ctx_t* ctx{nullptr};
   rc = tiledb_ctx_alloc(config, &ctx);
-
-  // It is allowed to create a thread pool with concurrency level = 0
   CHECK(rc == TILEDB_OK);
   tiledb_ctx_free(&ctx);
   CHECK(ctx == nullptr);
 
   rc = tiledb_ctx_alloc_with_error(config, &ctx, &error);
-
-  // It is allowed to create a thread pool with concurrency level = 0
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
-
   tiledb_ctx_free(&ctx);
   CHECK(ctx == nullptr);
 
@@ -91,6 +88,25 @@ TEST_CASE("C API: Test context", "[capi][context]") {
       "pool of "
       "concurrency level " +
           too_large + "; Requested size too large");
+
+  // Check another non-failure
+  // Set this to non-error value
+  rc = tiledb_config_set(
+      config,
+      "sm.compute_concurrency_level",
+      std::to_string(4).c_str(),
+      &error);
+
+  // Set deprecated config
+  rc = tiledb_config_set(
+      config, "sm.num_reader_threads", std::to_string(7).c_str(), &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+
+  rc = tiledb_ctx_alloc(config, &ctx);
+  CHECK(rc == TILEDB_OK);
+  tiledb_ctx_free(&ctx);
+  CHECK(ctx == nullptr);
 
   tiledb_error_free(&error);
   tiledb_config_free(&config);

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -412,7 +412,7 @@ TEST_CASE("ThreadPool: Test Exceptions", "[threadpool]") {
   std::atomic<int> result(0);
   ThreadPool pool{7};
 
-  Status unripe_banana_status = Status_TaskError("Caught Unripe banana");
+  Status unripe_banana_status = Status_TaskError("Caught msg: Unripe banana");
   Status unbaked_potato_status = Status_TileError("Unbaked potato");
 
   SECTION("One task error exception") {

--- a/tiledb/common/thread_pool/thread_pool.h
+++ b/tiledb/common/thread_pool/thread_pool.h
@@ -128,8 +128,9 @@ class ThreadPool {
   }
 
   /**
-   * Wait on all the given tasks to complete. This is safe to call recursively
-   * and may execute pending tasks on the calling thread while waiting.
+   * Wait on all the given tasks to complete. This function is safe to call
+   * recursively and may execute pending tasks on the calling thread while
+   * waiting.
    *
    * @param tasks Task list to wait on.
    * @return Status::Ok if all tasks returned Status::Ok, otherwise the first
@@ -138,9 +139,14 @@ class ThreadPool {
   Status wait_all(std::vector<Task>& tasks);
 
   /**
-   * Wait on all the given tasks to complete, return a vector of their return
-   * Status. This is safe to call recursively and may execute pending tasks
-   * on the calling thread while waiting.
+   * Wait on all the given tasks to complete, returning a vector of their return
+   * Status.  Exceptions caught while waiting are returned as Status_TaskError.
+   * Status are saved at the same index in the return vector as the
+   * corresponding task in the input vector.  The status vector may contain more
+   * than one error Status.
+   *
+   * This function is safe to call recursively and may execute pending tasks
+   * with the calling thread while waiting.
    *
    * @param tasks Task list to wait on
    * @return Vector of each task's Status.

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -48,11 +48,11 @@ namespace sm {
 // preceding members to be initialized for its initialization.
 Context::Context(const Config& config)
     : last_error_(Status::Ok())
+    , logger_(make_shared<Logger>(
+          HERE(), "Context: " + std::to_string(++logger_id_)))
     , compute_tp_(get_compute_thread_count(config))
     , io_tp_(get_io_thread_count(config))
     , stats_(make_shared<stats::Stats>(HERE(), "Context"))
-    , logger_(make_shared<Logger>(
-          HERE(), "Context: " + std::to_string(++logger_id_)))
     , storage_manager_{} {
   if (!init(config).ok()) {
     logger_->status(

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -93,6 +93,9 @@ class Context {
   /** A mutex for thread-safety. */
   std::mutex mtx_;
 
+  /** The class logger. */
+  shared_ptr<Logger> logger_;
+
   /** The thread pool for compute-bound tasks. */
   mutable ThreadPool compute_tp_;
 
@@ -101,9 +104,6 @@ class Context {
 
   /** The class stats. */
   shared_ptr<stats::Stats> stats_;
-
-  /** The class logger. */
-  shared_ptr<Logger> logger_;
 
   /** The storage manager. */
   tdb_unique_ptr<StorageManager> storage_manager_;


### PR DESCRIPTION
- Rearranged context member initialization so logger is initialized prior to getting thread counts (which may log).  
- Removed logging from `ThreadPool` constructor.
- Updated test in unit-capi-context.cc to initialize context with `sm.num_reader_threads` config set and to verify no errors on construction in that case.
- Updated a few comments.

---

closes https://github.com/TileDB-Inc/TileDB-Py/issues/1062

---
TYPE: BUG
DESC: Rearrange context member initialization so logger is initialized prior to getting thread counts (which may log)
