### PR TITLE
Dimension::dimension_ptr, part 1

### DIFF
--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -72,6 +72,12 @@ Domain::Domain(
     , dimensions_(dimensions)
     , dim_num_((unsigned int)dimensions.size())
     , tile_order_(tile_order) {
+  // Initialize the dimensions mirror
+  dimension_ptrs_.reserve(dimensions_.size());
+  for (const auto& dim : dimensions_) {
+    dimension_ptrs_.emplace_back(dim.get());
+  }
+
   // Compute number of cells per tile
   compute_cell_num_per_tile();
 
@@ -87,9 +93,15 @@ Domain::Domain(const Domain* domain) {
   cell_order_cmp_func_2_ = domain->cell_order_cmp_func_2_;
   tile_order_cmp_func_ = domain->tile_order_cmp_func_;
 
-  dimensions_.reserve(domain->dimensions_.size());
-  for (const auto& dim : domain->dimensions_)
-    dimensions_.emplace_back(tdb_new(Dimension, dim.get()));
+  const auto n_dimensions{domain->dimensions_.size()};
+  dimensions_.reserve(n_dimensions);
+  for (const auto& dim : domain->dimensions_) {
+    dimensions_.emplace_back(dim);
+  }
+  dimension_ptrs_.reserve(n_dimensions);
+  for (const auto dim_ptr : domain->dimension_ptrs_) {
+    dimension_ptrs_.emplace_back(dim_ptr);
+  }
 
   tile_order_ = domain->tile_order_;
 }
@@ -97,23 +109,25 @@ Domain::Domain(const Domain* domain) {
 Domain::Domain(Domain&& rhs)
     : cell_num_per_tile_(rhs.cell_num_per_tile_)
     , cell_order_(rhs.cell_order_)
-    , dimensions_(std::move(rhs.dimensions_))
+    , dimensions_(move(rhs.dimensions_))
+    , dimension_ptrs_(move(rhs.dimension_ptrs_))
     , dim_num_(rhs.dim_num_)
     , tile_order_(rhs.tile_order_)
-    , cell_order_cmp_func_(std::move(rhs.cell_order_cmp_func_))
-    , cell_order_cmp_func_2_(std::move(rhs.cell_order_cmp_func_2_))
-    , tile_order_cmp_func_(std::move(rhs.tile_order_cmp_func_)) {
+    , cell_order_cmp_func_(move(rhs.cell_order_cmp_func_))
+    , cell_order_cmp_func_2_(move(rhs.cell_order_cmp_func_2_))
+    , tile_order_cmp_func_(move(rhs.tile_order_cmp_func_)) {
 }
 
 Domain& Domain::operator=(Domain&& rhs) {
   cell_num_per_tile_ = rhs.cell_num_per_tile_;
   cell_order_ = rhs.cell_order_;
   dim_num_ = rhs.dim_num_;
-  cell_order_cmp_func_ = std::move(rhs.cell_order_cmp_func_);
-  tile_order_cmp_func_ = std::move(rhs.tile_order_cmp_func_);
-  dimensions_ = std::move(rhs.dimensions_);
+  cell_order_cmp_func_ = move(rhs.cell_order_cmp_func_);
+  tile_order_cmp_func_ = move(rhs.tile_order_cmp_func_);
+  dimensions_ = move(rhs.dimensions_);
+  dimension_ptrs_ = move(rhs.dimension_ptrs_);
   tile_order_ = rhs.tile_order_;
-  cell_order_cmp_func_2_ = std::move(rhs.cell_order_cmp_func_2_);
+  cell_order_cmp_func_2_ = move(rhs.cell_order_cmp_func_2_);
 
   return *this;
 }
@@ -132,13 +146,14 @@ Layout Domain::tile_order() const {
 
 Status Domain::add_dimension(shared_ptr<Dimension> dim) {
   dimensions_.emplace_back(dim);
+  dimension_ptrs_.emplace_back(dim.get());
   ++dim_num_;
 
   return Status::Ok();
 }
 
 bool Domain::all_dims_fixed() const {
-  for (const auto& dim : dimensions_) {
+  for (const auto dim : dimension_ptrs_) {
     if (dim->var_size())
       return false;
   }
@@ -147,7 +162,7 @@ bool Domain::all_dims_fixed() const {
 }
 
 bool Domain::all_dims_int() const {
-  for (const auto& dim : dimensions_) {
+  for (const auto dim : dimension_ptrs_) {
     if (!datatype_is_integer(dim->type()))
       return false;
   }
@@ -156,7 +171,7 @@ bool Domain::all_dims_int() const {
 }
 
 bool Domain::all_dims_string() const {
-  for (const auto& dim : dimensions_) {
+  for (const auto dim : dimension_ptrs_) {
     if (!datatype_is_string(dim->type()))
       return false;
   }
@@ -165,7 +180,7 @@ bool Domain::all_dims_string() const {
 }
 
 bool Domain::all_dims_real() const {
-  for (const auto& dim : dimensions_) {
+  for (const auto dim : dimension_ptrs_) {
     if (!datatype_is_real(dim->type()))
       return false;
   }
@@ -174,12 +189,12 @@ bool Domain::all_dims_real() const {
 }
 
 bool Domain::all_dims_same_type() const {
-  if (dim_num_ == 0)
+  if (dim_num_ <= 1)
     return true;
 
-  auto type = dimensions_[0]->type();
+  auto type = dimension_ptrs_[0]->type();
   for (unsigned d = 1; d < dim_num_; ++d) {
-    if (dimensions_[d]->type() != type)
+    if (dimension_ptrs_[d]->type() != type)
       return false;
   }
 
@@ -237,7 +252,7 @@ int Domain::cell_order_cmp_impl(
 int Domain::cell_order_cmp(
     unsigned dim_idx, UntypedDatumView a, UntypedDatumView b) const {
   // Handle variable-sized dimensions
-  if (dimensions_[dim_idx]->var_size()) {
+  if (dimension_ptrs_[dim_idx]->var_size()) {
     std::string_view s_a{static_cast<const char*>(a.content()), a.size()};
     std::string_view s_b{static_cast<const char*>(b.content()), b.size()};
 
@@ -302,7 +317,7 @@ int Domain::cell_order_cmp(
 
 void Domain::crop_ndrange(NDRange* ndrange) const {
   for (unsigned d = 0; d < dim_num_; ++d)
-    dimensions_[d]->crop_range(&(*ndrange)[d]);
+    dimension_ptrs_[d]->crop_range(&(*ndrange)[d]);
 }
 
 tuple<Status, optional<shared_ptr<Domain>>> Domain::deserialize(
@@ -341,20 +356,21 @@ tuple<Status, optional<shared_ptr<Domain>>> Domain::deserialize(
 
 const Range& Domain::domain(unsigned i) const {
   assert(i < dim_num_);
-  return dimensions_[i]->domain();
+  return dimension_ptrs_[i]->domain();
 }
 
 NDRange Domain::domain() const {
   NDRange ret(dim_num_);
   for (unsigned d = 0; d < dim_num_; ++d)
-    ret[d] = dimensions_[d]->domain();
+    ret[d] = dimension_ptrs_[d]->domain();
 
   return ret;
 }
 
 shared_ptr<const Dimension> Domain::dimension(unsigned int i) const {
-  if (i > dim_num_)
+  if (i > dim_num_) {
     return nullptr;
+  }
   return dimensions_[i];
 }
 
@@ -372,7 +388,7 @@ void Domain::dump(FILE* out) const {
   if (out == nullptr)
     out = stdout;
 
-  for (const auto& dim : dimensions_) {
+  for (const auto dim : dimension_ptrs_) {
     fprintf(out, "\n");
     dim->dump(out);
   }
@@ -389,7 +405,7 @@ void Domain::expand_ndrange(const NDRange& r1, NDRange* r2) const {
 
   // Expand r2 along all dimensions
   for (unsigned d = 0; d < dim_num_; ++d) {
-    const auto& dim = dimensions_[d];
+    const auto dim = dimension_ptrs_[d];
     if (!dim->var_size())
       dim->expand_range(r1[d], &(*r2)[d]);
     else
@@ -399,10 +415,11 @@ void Domain::expand_ndrange(const NDRange& r1, NDRange* r2) const {
 
 void Domain::expand_to_tiles(NDRange* ndrange) const {
   for (unsigned d = 0; d < dim_num_; ++d) {
-    const auto& dim = dimensions_[d];
+    const auto dim = dimension_ptrs_[d];
     // Applicable only to fixed-sized dimensions
-    if (!dim->var_size())
-      dimensions_[d]->expand_to_tile(&(*ndrange)[d]);
+    if (!dim->var_size()) {
+      dim->expand_to_tile(&(*ndrange)[d]);
+    }
   }
 }
 
@@ -518,7 +535,7 @@ void Domain::get_tile_subarray(
 Status Domain::has_dimension(const std::string& name, bool* has_dim) const {
   *has_dim = false;
 
-  for (const auto& dim : dimensions_) {
+  for (const auto dim : dimension_ptrs_) {
     if (name == dim->name()) {
       *has_dim = true;
       break;
@@ -531,7 +548,7 @@ Status Domain::has_dimension(const std::string& name, bool* has_dim) const {
 Status Domain::get_dimension_index(
     const std::string& name, unsigned* dim_idx) const {
   for (unsigned d = 0; d < dim_num_; ++d) {
-    if (dimensions_[d]->name() == name) {
+    if (dimension_ptrs_[d]->name() == name) {
       *dim_idx = d;
       return Status::Ok();
     }
@@ -614,7 +631,7 @@ uint64_t Domain::stride(Layout subarray_layout) const {
 
 const ByteVecValue& Domain::tile_extent(unsigned i) const {
   assert(i < dim_num_);
-  return dimensions_[i]->tile_extent();
+  return dimension_ptrs_[i]->tile_extent();
 }
 
 std::vector<ByteVecValue> Domain::tile_extents() const {
@@ -628,7 +645,7 @@ std::vector<ByteVecValue> Domain::tile_extents() const {
 uint64_t Domain::tile_num(const NDRange& ndrange) const {
   uint64_t ret = 1;
   for (unsigned d = 0; d < dim_num_; ++d)
-    ret *= dimensions_[d]->tile_num(ndrange[d]);
+    ret *= dimension_ptrs_[d]->tile_num(ndrange[d]);
 
   return ret;
 }
@@ -637,7 +654,7 @@ uint64_t Domain::cell_num(const NDRange& ndrange) const {
   assert(!ndrange.empty());
   uint64_t cell_num = 1, range;
   for (unsigned d = 0; d < dim_num_; ++d) {
-    range = dimensions_[d]->domain_range(ndrange[d]);
+    range = dimension_ptrs_[d]->domain_range(ndrange[d]);
     if (range == std::numeric_limits<uint64_t>::max())  // Overflow
       return range;
 
@@ -654,7 +671,7 @@ bool Domain::covered(const NDRange& r1, const NDRange& r2) const {
   assert(r2.size() == dim_num_);
 
   for (unsigned d = 0; d < dim_num_; ++d) {
-    if (!dimensions_[d]->covered(r1[d], r2[d]))
+    if (!dimension_ptrs_[d]->covered(r1[d], r2[d]))
       return false;
   }
 
@@ -666,7 +683,7 @@ bool Domain::overlap(const NDRange& r1, const NDRange& r2) const {
   assert(r2.size() == dim_num_);
 
   for (unsigned d = 0; d < dim_num_; ++d) {
-    if (!dimensions_[d]->overlap(r1[d], r2[d]))
+    if (!dimension_ptrs_[d]->overlap(r1[d], r2[d]))
       return false;
   }
 
@@ -685,10 +702,10 @@ double Domain::overlap_ratio(
     if (r1_default[d])
       continue;
 
-    if (!dimensions_[d]->overlap(r1[d], r2[d]))
+    if (!dimension_ptrs_[d]->overlap(r1[d], r2[d]))
       return 0.0;
 
-    ratio *= dimensions_[d]->overlap_ratio(r1[d], r2[d]);
+    ratio *= dimension_ptrs_[d]->overlap_ratio(r1[d], r2[d]);
 
     // If ratio goes to 0, then the subarray overlap is much smaller than the
     // volume of the MBR. Since we have already guaranteed that there is an
@@ -779,7 +796,7 @@ void Domain::compute_cell_num_per_tile() {
     return;
 
   // Invoke the proper templated function
-  auto type = dimensions_[0]->type();
+  auto type{dimension_ptrs_[0]->type()};
   switch (type) {
     case Datatype::INT32:
       compute_cell_num_per_tile<int>();
@@ -857,7 +874,7 @@ void Domain::set_tile_cell_order_cmp_funcs() {
   cell_order_cmp_func_.resize(dim_num_);
   cell_order_cmp_func_2_.resize(dim_num_);
   for (unsigned d = 0; d < dim_num_; ++d) {
-    auto type = dimensions_[d]->type();
+    auto type{dimension_ptrs_[d]->type()};
     switch (type) {
       case Datatype::INT32:
         tile_order_cmp_func_[d] = tile_order_cmp_impl<int32_t>;

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -285,11 +285,9 @@ int Domain::cell_order_cmp(
     const type::DomainDataRef& left, const type::DomainDataRef& right) const {
   if (cell_order_ == Layout::ROW_MAJOR) {
     for (unsigned d = 0; d < dim_num_; ++d) {
-      auto dim = dimension(d);
+      auto dim = dimension_ptr(d);
       auto res = cell_order_cmp_func_[d](
-          dim.get(),
-          left.dimension_datum_view(d),
-          right.dimension_datum_view(d));
+          dim, left.dimension_datum_view(d), right.dimension_datum_view(d));
 
       if (res == 1 || res == -1)
         return res;
@@ -297,11 +295,9 @@ int Domain::cell_order_cmp(
     }
   } else {  // COL_MAJOR
     for (unsigned d = dim_num_ - 1;; --d) {
-      auto dim = dimension(d);
+      auto dim = dimension_ptr(d);
       auto res = cell_order_cmp_func_[d](
-          dim.get(),
-          left.dimension_datum_view(d),
-          right.dimension_datum_view(d));
+          dim, left.dimension_datum_view(d), right.dimension_datum_view(d));
 
       if (res == 1 || res == -1)
         return res;
@@ -741,14 +737,14 @@ int Domain::tile_order_cmp(
     const type::DomainDataRef& left, const type::DomainDataRef& right) const {
   if (tile_order_ == Layout::ROW_MAJOR) {
     for (unsigned d = 0; d < dim_num_; ++d) {
-      auto dim = dimension(d);
+      auto dim = dimension_ptr(d);
 
       // Inapplicable to var-sized dimensions or absent tile extents
       if (dim->var_size() || !dim->tile_extent())
         continue;
 
       auto res = tile_order_cmp_func_[d](
-          dim.get(),
+          dim,
           left.dimension_datum_view(d).content(),
           right.dimension_datum_view(d).content());
 
@@ -758,12 +754,12 @@ int Domain::tile_order_cmp(
     }
   } else {  // COL_MAJOR
     for (unsigned d = dim_num_ - 1;; --d) {
-      auto dim = dimension(d);
+      auto dim = dimension_ptr(d);
 
       // Inapplicable to var-sized dimensions or absent tile extents
       if (!dim->var_size() && dim->tile_extent()) {
         auto res = tile_order_cmp_func_[d](
-            dim.get(),
+            dim,
             left.dimension_datum_view(d).content(),
             right.dimension_datum_view(d).content());
 

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -215,6 +215,13 @@ class Domain {
   /** Returns the i-th dimensions (nullptr upon error). */
   shared_ptr<const Dimension> dimension(unsigned int i) const;
 
+  inline const Dimension* dimension_ptr(unsigned int i) const {
+    if (i > dim_num_) {
+      throw std::invalid_argument("invalid dimension index");
+    }
+    return dimension_ptrs_[i];
+  }
+
   /** Returns the dimension given a name (nullptr upon error). */
   shared_ptr<const Dimension> dimension(const std::string& name) const;
 
@@ -468,8 +475,17 @@ class Domain {
   /** The cell order of the array the domain belongs to. */
   Layout cell_order_;
 
-  /** The domain dimensions. */
+  /**
+   * Allocation for the dimensions of this domain.
+   *
+   * This array holds the memory resource for the dimensions.
+   */
   std::vector<shared_ptr<Dimension>> dimensions_;
+
+  /**
+   * Non-allocating mirror of the dimensions vector.
+   */
+  std::vector<const Dimension*> dimension_ptrs_;
 
   /** The number of dimensions. */
   unsigned dim_num_;

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -64,7 +64,7 @@ class CellCmpBase {
 
   [[nodiscard]] int cell_order_cmp_RC(
       unsigned int d, const ResultCoords& a, const ResultCoords& b) const {
-    const auto& dim{*(domain_.dimension(d))};
+    const auto& dim{*(domain_.dimension_ptr(d))};
     auto v1{a.dimension_datum(dim, d)};
     auto v2{b.dimension_datum(dim, d)};
     return domain_.cell_order_cmp(d, v1, v2);
@@ -287,7 +287,7 @@ class GlobalCmp : protected CellCmpBase {
     if (tile_order_ == Layout::ROW_MAJOR) {
       for (unsigned d = 0; d < dim_num_; ++d) {
         // Not applicable to var-sized dimensions
-        if (domain_.dimension(d)->var_size())
+        if (domain_.dimension_ptr(d)->var_size())
           continue;
 
         auto res = domain_.tile_order_cmp(d, a.coord(d), b.coord(d));
@@ -302,7 +302,7 @@ class GlobalCmp : protected CellCmpBase {
       assert(tile_order_ == Layout::COL_MAJOR);
       for (unsigned d = dim_num_ - 1;; --d) {
         // Not applicable to var-sized dimensions
-        if (domain_.dimension(d)->var_size())
+        if (domain_.dimension_ptr(d)->var_size())
           continue;
 
         auto res = domain_.tile_order_cmp(d, a.coord(d), b.coord(d));

--- a/tiledb/sm/query/domain_buffer.h
+++ b/tiledb/sm/query/domain_buffer.h
@@ -100,7 +100,7 @@ class DomainBufferDataRef : public detail::DomainBuffersTypes,
   }
 
   UntypedDatumView dimension_datum_view(unsigned int i) const override {
-    return {qb_[i]->dimension_datum_at(*domain_.dimension(i), k_).datum()};
+    return {qb_[i]->dimension_datum_at(*domain_.dimension_ptr(i), k_).datum()};
   }
 
   DomainBufferDataRef(const Domain& domain) = delete;
@@ -198,7 +198,7 @@ class DomainBuffersView : public detail::DomainBuffersTypes {
         size_t k) {
       // Construct datum in place with placement-new
       new (item) UntypedDatumView{
-          qb[i]->dimension_datum_at(*domain.dimension(i), k).datum()};
+          qb[i]->dimension_datum_at(*domain.dimension_ptr(i), k).datum()};
     }
   };
 


### PR DESCRIPTION
Add member function `Dimension::dimension_ptr`, returning a plain pointer instead of `shared_ptr`. Add member variable `Dimension::dimension_ptrs_` that mirrors the `dimensions_` vector, allowing `dimension_ptr` to be as efficient as possible. 

There's a small change in behavior with invalid arguments. The old version (still in use) returned `nullptr`, which was (almost?) never checked, so invalid arguments would segfault. The new version throws. It will still fail, just not fail by crashing.

Part 1 uses `dimension_ptr` in comparison functions and within `class Dimension` only, to address an immediate need. Future work will change the return value to a reference and rename the functions. These changes are too extensive to commingle with a short fix to unblock release.

---
TYPE: NO_HISTORY
DESC: `Dimension::dimension_ptr`
