### PR TITLE
dimension_ptr functions, part 2

### DIFF
--- a/test/src/unit-domain.cc
+++ b/test/src/unit-domain.cc
@@ -119,13 +119,13 @@ TEST_CASE("Domain: Test deserialization", "[domain][deserialize") {
   REQUIRE(st_dom.ok());
   CHECK(dom.value()->dim_num() == dim_num);
 
-  auto dim1 = dom.value()->dimension("d1");
+  auto dim1{dom.value()->dimension_ptr("d1")};
   CHECK(dim1->name() == dimension_name1);
   CHECK(dim1->type() == type1);
   CHECK(dim1->cell_val_num() == cell_val_num1);
   CHECK(dim1->filters().size() == num_filters1);
 
-  auto dim2 = dom.value()->dimension("d2");
+  auto dim2{dom.value()->dimension_ptr("d2")};
   CHECK(dim2->name() == dimension_name2);
   CHECK(dim2->type() == type2);
   CHECK(dim2->cell_val_num() == cell_val_num2);

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -860,14 +860,16 @@ void Array::clear_last_max_buffer_sizes() {
 
 Status Array::compute_max_buffer_sizes(const void* subarray) {
   // Applicable only to domains where all dimensions have the same type
-  if (!array_schema_latest_->domain().all_dims_same_type())
+  if (!array_schema_latest_->domain().all_dims_same_type()) {
     return LOG_STATUS(
         Status_ArrayError("Cannot compute max buffer sizes; Inapplicable when "
                           "dimension domains have different types"));
+  }
 
   // Allocate space for max buffer sizes subarray
   auto dim_num = array_schema_latest_->dim_num();
-  auto coord_size = array_schema_latest_->domain().dimension(0)->coord_size();
+  auto coord_size{
+      array_schema_latest_->domain().dimension_ptr(0)->coord_size()};
   auto subarray_size = 2 * dim_num * coord_size;
   last_max_buffer_sizes_subarray_.resize(subarray_size);
 
@@ -887,7 +889,7 @@ Status Array::compute_max_buffer_sizes(const void* subarray) {
         std::pair<uint64_t, uint64_t>(0, 0);
     for (unsigned d = 0; d < dim_num; ++d)
       last_max_buffer_sizes_
-          [array_schema_latest_->domain().dimension(d)->name()] =
+          [array_schema_latest_->domain().dimension_ptr(d)->name()] =
               std::pair<uint64_t, uint64_t>(0, 0);
 
     RETURN_NOT_OK(compute_max_buffer_sizes(subarray, &last_max_buffer_sizes_));
@@ -929,7 +931,7 @@ Status Array::compute_max_buffer_sizes(
   auto sub_ptr = (const unsigned char*)subarray;
   uint64_t offset = 0;
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto r_size = 2 * array_schema_latest_->dimension(d)->coord_size();
+    auto r_size{2 * array_schema_latest_->dimension_ptr(d)->coord_size()};
     sub[d] = Range(&sub_ptr[offset], r_size);
     offset += r_size;
   }

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -132,7 +132,7 @@ ArraySchema::ArraySchema(
   // Create dimension map
   dim_map_.clear();
   for (unsigned d = 0; d < domain_->dim_num(); ++d) {
-    auto dim = domain_->dimension(d);
+    auto dim{domain_->dimension_ptr(d)};
     dim_map_[dim->name()] = dim;
   }
 
@@ -237,7 +237,7 @@ uint64_t ArraySchema::cell_size(const std::string& name) const {
   if (name == constants::coords) {
     auto dim_num = domain_->dim_num();
     assert(dim_num > 0);
-    auto coord_size = domain_->dimension(0)->coord_size();
+    auto coord_size{domain_->dimension_ptr(0)->coord_size()};
     return dim_num * coord_size;
   }
 
@@ -302,7 +302,7 @@ Status ArraySchema::check() const {
   }
 
   if (array_type_ == ArrayType::DENSE) {
-    auto type = domain_->dimension(0)->type();
+    auto type{domain_->dimension_ptr(0)->type()};
     if (datatype_is_real(type)) {
       return LOG_STATUS(
           Status_ArraySchemaError("Array schema check failed; Dense arrays "
@@ -363,12 +363,11 @@ bool ArraySchema::dense() const {
   return array_type_ == ArrayType::DENSE;
 }
 
-shared_ptr<const Dimension> ArraySchema::dimension(unsigned int i) const {
-  return domain_->dimension(i);
+const Dimension* ArraySchema::dimension_ptr(unsigned int i) const {
+  return domain_->dimension_ptr(i);
 }
 
-shared_ptr<const Dimension> ArraySchema::dimension(
-    const std::string& name) const {
+const Dimension* ArraySchema::dimension_ptr(const std::string& name) const {
   auto it = dim_map_.find(name);
   return it == dim_map_.end() ? nullptr : it->second;
 }
@@ -378,7 +377,7 @@ std::vector<std::string> ArraySchema::dim_names() const {
   std::vector<std::string> ret;
   ret.reserve(dim_num);
   for (uint32_t d = 0; d < dim_num; ++d)
-    ret.emplace_back(domain_->dimension(d)->name());
+    ret.emplace_back(domain_->dimension_ptr(d)->name());
 
   return ret;
 }
@@ -388,7 +387,7 @@ std::vector<Datatype> ArraySchema::dim_types() const {
   std::vector<Datatype> ret;
   ret.reserve(dim_num);
   for (uint32_t d = 0; d < dim_num; ++d)
-    ret.emplace_back(domain_->dimension(d)->type());
+    ret.emplace_back(domain_->dimension_ptr(d)->type());
 
   return ret;
 }
@@ -449,7 +448,7 @@ bool ArraySchema::is_attr(const std::string& name) const {
 }
 
 bool ArraySchema::is_dim(const std::string& name) const {
-  return this->dimension(name) != nullptr;
+  return this->dimension_ptr(name) != nullptr;
 }
 
 bool ArraySchema::is_field(const std::string& name) const {
@@ -529,7 +528,7 @@ Layout ArraySchema::tile_order() const {
 Datatype ArraySchema::type(const std::string& name) const {
   // Special zipped coordinates attribute
   if (name == constants::coords)
-    return domain_->dimension(0)->type();
+    return domain_->dimension_ptr(0)->type();
 
   // Attribute
   auto attr_it = attribute_map_.find(name);
@@ -748,7 +747,7 @@ ArraySchema ArraySchema::deserialize(ConstBuffer* buff, const URI& uri) {
   }
 
   if (array_type == ArrayType::DENSE) {
-    auto type = domain.value()->dimension(0)->type();
+    auto type{domain.value()->dimension_ptr(0)->type()};
     if (datatype_is_real(type)) {
       throw StatusException(
           Status_ArraySchemaError("Array schema check failed; Dense arrays "
@@ -855,7 +854,7 @@ Status ArraySchema::set_domain(shared_ptr<Domain> domain) {
           Status_ArraySchemaError("Cannot set domain; In dense arrays, all "
                                   "dimensions must have the same datatype"));
 
-    auto type = domain->dimension(0)->type();
+    auto type{domain->dimension_ptr(0)->type()};
     if (!datatype_is_integer(type) && !datatype_is_datetime(type) &&
         !datatype_is_time(type)) {
       return LOG_STATUS(Status_ArraySchemaError(
@@ -876,7 +875,7 @@ Status ArraySchema::set_domain(shared_ptr<Domain> domain) {
   dim_map_.clear();
   auto dim_num = domain_->dim_num();
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = dimension(d);
+    auto dim{dimension_ptr(d)};
     dim_map_[dim->name()] = dim;
   }
 
@@ -939,7 +938,7 @@ bool ArraySchema::check_attribute_dimension_names() const {
   for (auto attr : attributes_)
     names.insert(attr->name());
   for (unsigned int i = 0; i < dim_num; ++i)
-    names.insert(domain_->dimension(i)->name());
+    names.insert(domain_->dimension_ptr(i)->name());
   return (names.size() == attributes_.size() + dim_num);
 }
 
@@ -963,7 +962,7 @@ Status ArraySchema::check_double_delta_compressor(
   // A dimension inherits the filters when it has no filters.
   auto dim_num = domain_->dim_num();
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = domain_->dimension(d);
+    auto dim{domain_->dimension_ptr(d)};
     const auto& dim_filters = dim->filters();
     auto dim_type = dim->type();
     if (datatype_is_real(dim_type) && dim_filters.empty())
@@ -988,7 +987,7 @@ Status ArraySchema::check_string_compressor(
   // with RLE or Dictionary-encoding
   auto dim_num = domain_->dim_num();
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = domain_->dimension(d);
+    auto dim{domain_->dimension_ptr(d)};
     const auto& dim_filters = dim->filters();
     // if it's a var-length string dimension and there is no specific filter
     // list already set for that dimension (then coords_filters_ will be used)

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -194,13 +194,13 @@ class ArraySchema {
   bool dense() const;
 
   /** Returns the i-th dimension. */
-  shared_ptr<const Dimension> dimension(unsigned int i) const;
+  const Dimension* dimension_ptr(unsigned int i) const;
 
   /**
    * Returns a constant pointer to the selected dimension (nullptr if it
    * does not exist).
    */
-  shared_ptr<const Dimension> dimension(const std::string& name) const;
+  const Dimension* dimension_ptr(const std::string& name) const;
 
   /** Returns the dimension names. */
   std::vector<std::string> dim_names() const;
@@ -408,7 +408,7 @@ class ArraySchema {
   shared_ptr<Domain> domain_;
 
   /** It maps each dimension name to the corresponding dimension object. */
-  std::unordered_map<std::string, shared_ptr<const Dimension>> dim_map_;
+  std::unordered_map<std::string, const Dimension*> dim_map_;
 
   /**
    * The cell order. It can be one of the following:

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -72,10 +72,17 @@ Domain::Domain(
     , dimensions_(dimensions)
     , dim_num_((unsigned int)dimensions.size())
     , tile_order_(tile_order) {
-  // Initialize the dimensions mirror
+  /*
+   * Verify that the input vector has no non-null elements in order to meet the
+   * class invariant. Initialize the dimensions mirror.
+   */
   dimension_ptrs_.reserve(dimensions_.size());
   for (const auto& dim : dimensions_) {
-    dimension_ptrs_.emplace_back(dim.get());
+    auto p{dim.get()};
+    if (p == nullptr) {
+      throw std::invalid_argument("May not have null dimensions in a domain");
+    }
+    dimension_ptrs_.emplace_back(p);
   }
 
   // Compute number of cells per tile
@@ -147,6 +154,7 @@ Layout Domain::tile_order() const {
 Status Domain::add_dimension(shared_ptr<Dimension> dim) {
   auto p{dim.get()};
   if (p == nullptr) {
+    // Class invariant prohibits null dimensions in a domain.
     throw std::invalid_argument("May not add null dimensions to a domain");
   }
   dimensions_.emplace_back(dim);

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -212,6 +212,16 @@ class Domain {
   /** Returns the domain as a N-dimensional range object. */
   NDRange domain() const;
 
+  /**
+   * Return a pointer to the dimension given by the argument index
+   *
+   * This function does not return `nullptr`. It throws if the argument is
+   * invalid. It relies on the class invariant that absent dimensions (as
+   * manifested by a null pointer) are not allowed.
+   *
+   * @param i index of the dimension within the domain
+   * @return non-null pointer to the dimension
+   */
   inline const Dimension* dimension_ptr(unsigned int i) const {
     if (i > dim_num_) {
       throw std::invalid_argument("invalid dimension index");
@@ -475,12 +485,23 @@ class Domain {
   /**
    * Allocation for the dimensions of this domain.
    *
-   * This array holds the memory resource for the dimensions.
+   * This array keeps the memory resource for the dimensions. This is its only
+   * responsibility, and as such only appears in initialization code. Pointers
+   * to the stored `Dimension` objects are mirrored in `dimension_ptrs_`.
+   *
+   * @invariant All pointers in the vector are non-null.
    */
   std::vector<shared_ptr<Dimension>> dimensions_;
 
   /**
    * Non-allocating mirror of the dimensions vector.
+   *
+   * This vector holds pointers to the dimensions for ordinary, efficient use.
+   * The `shared_ptr` of `dimensions_` is only used for resource management, so
+   * this variable mirrors just the pointers, avoiding all overhead of using
+   * `shared_ptr` ordinarily.
+   *
+   * @invariant All pointers in the vector are non-null.
    */
   std::vector<const Dimension*> dimension_ptrs_;
 

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -212,9 +212,6 @@ class Domain {
   /** Returns the domain as a N-dimensional range object. */
   NDRange domain() const;
 
-  /** Returns the i-th dimensions (nullptr upon error). */
-  shared_ptr<const Dimension> dimension(unsigned int i) const;
-
   inline const Dimension* dimension_ptr(unsigned int i) const {
     if (i > dim_num_) {
       throw std::invalid_argument("invalid dimension index");
@@ -223,7 +220,7 @@ class Domain {
   }
 
   /** Returns the dimension given a name (nullptr upon error). */
-  shared_ptr<const Dimension> dimension(const std::string& name) const;
+  const Dimension* dimension_ptr(const std::string& name) const;
 
   /** Dumps the domain in ASCII format in the selected output. */
   void dump(FILE* out) const;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1500,7 +1500,8 @@ int32_t tiledb_domain_get_type(
     return TILEDB_ERR;
   }
 
-  *type = static_cast<tiledb_datatype_t>(domain->domain_->dimension(0)->type());
+  *type =
+      static_cast<tiledb_datatype_t>(domain->domain_->dimension_ptr(0)->type());
   return TILEDB_OK;
 }
 
@@ -1736,7 +1737,7 @@ int32_t tiledb_domain_get_dimension_from_index(
     return TILEDB_OOM;
   }
   (*dim)->dim_ = new (std::nothrow)
-      tiledb::sm::Dimension(domain->domain_->dimension(index).get());
+      tiledb::sm::Dimension(domain->domain_->dimension_ptr(index));
   if ((*dim)->dim_ == nullptr) {
     delete *dim;
     *dim = nullptr;
@@ -1763,7 +1764,7 @@ int32_t tiledb_domain_get_dimension_from_name(
     return TILEDB_OK;
   }
   std::string name_string(name);
-  auto found_dim = domain->domain_->dimension(name_string).get();
+  auto found_dim = domain->domain_->dimension_ptr(name_string);
 
   if (found_dim == nullptr) {
     auto st = Status_DomainError(

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -507,7 +507,7 @@ Status FragmentConsolidator::create_buffers(
   }
   if (sparse) {
     for (unsigned i = 0; i < dim_num; ++i)
-      buffer_num += (domain.dimension(i)->var_size()) ? 2 : 1;
+      buffer_num += (domain.dimension_ptr(i)->var_size()) ? 2 : 1;
   }
 
   // Create buffers
@@ -737,7 +737,7 @@ Status FragmentConsolidator::set_query_buffers(
   }
   if (!dense) {
     for (unsigned d = 0; d < dim_num; ++d) {
-      auto dim = array_schema.dimension(d);
+      auto dim{array_schema.dimension_ptr(d)};
       auto dim_name = dim->name();
       if (!dim->var_size()) {
         RETURN_NOT_OK(query->set_data_buffer(

--- a/tiledb/sm/cpp_api/arrow_io_impl.h
+++ b/tiledb/sm/cpp_api/arrow_io_impl.h
@@ -319,7 +319,7 @@ TypeInfo tiledb_dt_info(const ArraySchema& schema, const std::string& name) {
     return retval;
   } else if (schema.domain().has_dimension(name)) {
     auto dom = schema.domain();
-    auto dim = *dom.dimension(name);
+    auto dim = dom.dimension(name);
 
     auto retval = TypeInfo();
     retval.type = dim.type();

--- a/tiledb/sm/cpp_api/arrow_io_impl.h
+++ b/tiledb/sm/cpp_api/arrow_io_impl.h
@@ -319,7 +319,7 @@ TypeInfo tiledb_dt_info(const ArraySchema& schema, const std::string& name) {
     return retval;
   } else if (schema.domain().has_dimension(name)) {
     auto dom = schema.domain();
-    auto dim = *dom.dimension_ptr(name);
+    auto dim = *dom.dimension(name);
 
     auto retval = TypeInfo();
     retval.type = dim.type();

--- a/tiledb/sm/cpp_api/arrow_io_impl.h
+++ b/tiledb/sm/cpp_api/arrow_io_impl.h
@@ -319,7 +319,7 @@ TypeInfo tiledb_dt_info(const ArraySchema& schema, const std::string& name) {
     return retval;
   } else if (schema.domain().has_dimension(name)) {
     auto dom = schema.domain();
-    auto dim = dom.dimension(name);
+    auto dim = *dom.dimension_ptr(name);
 
     auto retval = TypeInfo();
     retval.type = dim.type();

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -297,7 +297,7 @@ Status FragmentInfo::get_non_empty_domain(
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
-    if (dim_name == array_schema->dimension(did)->name()) {
+    if (dim_name == array_schema->dimension_ptr(did)->name()) {
       break;
     }
   }
@@ -368,7 +368,7 @@ Status FragmentInfo::get_non_empty_domain_var_size(
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
-    if (dim_name == array_schema->dimension(did)->name()) {
+    if (dim_name == array_schema->dimension_ptr(did)->name()) {
       break;
     }
   }
@@ -435,7 +435,7 @@ Status FragmentInfo::get_non_empty_domain_var(
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
-    if (dim_name == array_schema->dimension(did)->name()) {
+    if (dim_name == array_schema->dimension_ptr(did)->name()) {
       break;
     }
   }
@@ -527,7 +527,7 @@ Status FragmentInfo::get_mbr(
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
-    if (dim_name == array_schema->dimension(did)->name()) {
+    if (dim_name == array_schema->dimension_ptr(did)->name()) {
       break;
     }
   }
@@ -611,7 +611,7 @@ Status FragmentInfo::get_mbr_var_size(
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
-    if (dim_name == array_schema->dimension(did)->name()) {
+    if (dim_name == array_schema->dimension_ptr(did)->name()) {
       break;
     }
   }
@@ -687,7 +687,7 @@ Status FragmentInfo::get_mbr_var(
   auto dim_num = array_schema->dim_num();
   uint32_t did;
   for (did = 0; did < dim_num; ++did) {
-    if (dim_name == array_schema->dimension(did)->name()) {
+    if (dim_name == array_schema->dimension_ptr(did)->name()) {
       break;
     }
   }

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -480,7 +480,7 @@ uint64_t FragmentMetadata::cell_num(uint64_t tile_pos) const {
 std::vector<Datatype> FragmentMetadata::dim_types() const {
   std::vector<Datatype> ret;
   for (uint32_t d = 0; d < array_schema_->dim_num(); d++) {
-    ret.emplace_back(array_schema_->dimension(d)->type());
+    ret.emplace_back(array_schema_->dimension_ptr(d)->type());
   }
 
   return ret;
@@ -501,7 +501,7 @@ Status FragmentMetadata::add_max_buffer_sizes(
   NDRange sub_nd(dim_num);
   uint64_t offset = 0;
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto r_size = 2 * array_schema_->dimension(d)->coord_size();
+    auto r_size{2 * array_schema_->dimension_ptr(d)->coord_size()};
     sub_nd[d].set_range(&sub_ptr[offset], r_size);
     offset += r_size;
   }
@@ -516,7 +516,7 @@ Status FragmentMetadata::add_max_buffer_sizes_dense(
         buffer_sizes) {
   // Note: applicable only to the dense case where all dimensions
   // have the same type
-  auto type = array_schema_->dimension(0)->type();
+  auto type{array_schema_->dimension_ptr(0)->type()};
   switch (type) {
     case Datatype::INT32:
       return add_max_buffer_sizes_dense<int32_t>(
@@ -1212,7 +1212,7 @@ tuple<Status, optional<std::string>> FragmentMetadata::encode_name(
   }
 
   for (unsigned i = 0; i < array_schema_->dim_num(); ++i) {
-    const std::string dim_name = array_schema_->dimension(i)->name();
+    const auto& dim_name{array_schema_->dimension_ptr(i)->name()};
     if (dim_name == name) {
       const unsigned dim_idx = idx - array_schema_->attribute_num() - 1;
       return {Status::Ok(), "d" + std::to_string(dim_idx)};
@@ -1881,7 +1881,7 @@ uint64_t FragmentMetadata::footer_size_v3_v4() const {
   auto attribute_num = array_schema_->attribute_num();
   auto dim_num = array_schema_->dim_num();
   // v3 and v4 support only arrays where all dimensions have the same type
-  auto domain_size = 2 * dim_num * array_schema_->dimension(0)->coord_size();
+  auto domain_size{2 * dim_num * array_schema_->dimension_ptr(0)->coord_size()};
 
   // Get footer size
   uint64_t size = 0;
@@ -1914,12 +1914,13 @@ uint64_t FragmentMetadata::footer_size_v5_v6() const {
     // function is not called then.
     assert(array_schema_->domain().all_dims_fixed());
     for (unsigned d = 0; d < dim_num; ++d)
-      domain_size += 2 * array_schema_->domain().dimension(d)->coord_size();
+      domain_size += 2 * array_schema_->domain().dimension_ptr(d)->coord_size();
   } else {
     for (unsigned d = 0; d < dim_num; ++d) {
       domain_size += non_empty_domain_[d].size();
-      if (array_schema_->dimension(d)->var_size())
-        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized
+      if (array_schema_->dimension_ptr(d)->var_size()) {
+        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized}
+      }
     }
   }
 
@@ -1954,12 +1955,13 @@ uint64_t FragmentMetadata::footer_size_v7_v10() const {
     // function is not called then.
     assert(array_schema_->domain().all_dims_fixed());
     for (unsigned d = 0; d < dim_num; ++d)
-      domain_size += 2 * array_schema_->domain().dimension(d)->coord_size();
+      domain_size += 2 * array_schema_->domain().dimension_ptr(d)->coord_size();
   } else {
     for (unsigned d = 0; d < dim_num; ++d) {
       domain_size += non_empty_domain_[d].size();
-      if (array_schema_->dimension(d)->var_size())
-        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized
+      if (array_schema_->dimension_ptr(d)->var_size()) {
+        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized}
+      }
     }
   }
 
@@ -1996,12 +1998,13 @@ uint64_t FragmentMetadata::footer_size_v11_or_higher() const {
     // function is not called then.
     assert(array_schema_->domain().all_dims_fixed());
     for (unsigned d = 0; d < dim_num; ++d)
-      domain_size += 2 * array_schema_->domain().dimension(d)->coord_size();
+      domain_size += 2 * array_schema_->domain().dimension_ptr(d)->coord_size();
   } else {
     for (unsigned d = 0; d < dim_num; ++d) {
       domain_size += non_empty_domain_[d].size();
-      if (array_schema_->dimension(d)->var_size())
-        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized
+      if (array_schema_->dimension_ptr(d)->var_size()) {
+        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized}
+      }
     }
   }
 
@@ -2037,7 +2040,7 @@ std::vector<uint64_t> FragmentMetadata::compute_overlapping_tile_ids(
   auto dim_num = array_schema_->dim_num();
 
   // Temporary domain vector
-  auto coord_size = array_schema_->domain().dimension(0)->coord_size();
+  auto coord_size{array_schema_->domain().dimension_ptr(0)->coord_size()};
   auto temp_size = 2 * dim_num * coord_size;
   std::vector<uint8_t> temp(temp_size);
   uint8_t offset = 0;
@@ -2085,7 +2088,7 @@ FragmentMetadata::compute_overlapping_tile_ids_cov(const T* subarray) const {
   auto dim_num = array_schema_->dim_num();
 
   // Temporary domain vector
-  auto coord_size = array_schema_->domain().dimension(0)->coord_size();
+  auto coord_size{array_schema_->domain().dimension_ptr(0)->coord_size()};
   auto temp_size = 2 * dim_num * coord_size;
   std::vector<uint8_t> temp(temp_size);
   uint8_t offset = 0;
@@ -2386,7 +2389,7 @@ Status FragmentMetadata::load_bounding_coords(ConstBuffer* buff) {
 
   // Get bounding coordinates
   // Note: This version supports only dimensions domains with the same type
-  auto coord_size = array_schema_->domain().dimension(0)->coord_size();
+  auto coord_size{array_schema_->domain().dimension_ptr(0)->coord_size()};
   auto dim_num = array_schema_->domain().dim_num();
   uint64_t bounding_coords_size = 2 * dim_num * coord_size;
   bounding_coords_.resize(bounding_coords_num);
@@ -2527,7 +2530,7 @@ Status FragmentMetadata::load_mbrs(ConstBuffer* buff) {
   for (uint64_t m = 0; m < mbr_num; ++m) {
     NDRange mbr(dim_num);
     for (unsigned d = 0; d < dim_num; ++d) {
-      auto r_size = 2 * domain.dimension(d)->coord_size();
+      auto r_size{2 * domain.dimension_ptr(d)->coord_size()};
       mbr[d].set_range(buff->cur_data(), r_size);
       buff->advance_offset(r_size);
     }
@@ -2568,7 +2571,7 @@ Status FragmentMetadata::load_non_empty_domain_v1_v2(ConstBuffer* buff) {
     non_empty_domain_.resize(dim_num);
     uint64_t offset = 0;
     for (unsigned d = 0; d < dim_num; ++d) {
-      auto coord_size = array_schema_->dimension(d)->coord_size();
+      auto coord_size{array_schema_->dimension_ptr(d)->coord_size()};
       Range r(&temp[offset], 2 * coord_size);
       non_empty_domain_[d] = std::move(r);
       offset += 2 * coord_size;
@@ -2596,14 +2599,14 @@ Status FragmentMetadata::load_non_empty_domain_v3_v4(ConstBuffer* buff) {
   if (!null_non_empty_domain) {
     auto dim_num = array_schema_->dim_num();
     // Note: These versions supports only dimensions domains with the same type
-    auto coord_size = array_schema_->domain().dimension(0)->coord_size();
-    auto domain_size = 2 * dim_num * coord_size;
+    auto coord_size_0{array_schema_->domain().dimension_ptr(0)->coord_size()};
+    auto domain_size = 2 * dim_num * coord_size_0;
     std::vector<uint8_t> temp(domain_size);
     RETURN_NOT_OK(buff->read(&temp[0], domain_size));
     non_empty_domain_.resize(dim_num);
     uint64_t offset = 0;
     for (unsigned d = 0; d < dim_num; ++d) {
-      auto coord_size = array_schema_->dimension(d)->coord_size();
+      auto coord_size{array_schema_->dimension_ptr(d)->coord_size()};
       Range r(&temp[offset], 2 * coord_size);
       non_empty_domain_[d] = std::move(r);
       offset += 2 * coord_size;
@@ -2633,7 +2636,7 @@ Status FragmentMetadata::load_non_empty_domain_v5_or_higher(ConstBuffer* buff) {
     auto dim_num = array_schema_->dim_num();
     non_empty_domain_.resize(dim_num);
     for (unsigned d = 0; d < dim_num; ++d) {
-      auto dim = domain.dimension(d);
+      auto dim{domain.dimension_ptr(d)};
       if (!dim->var_size()) {  // Fixed-sized
         auto r_size = 2 * dim->coord_size();
         non_empty_domain_[d].set_range(buff->cur_data(), r_size);
@@ -3904,14 +3907,13 @@ Status FragmentMetadata::write_non_empty_domain(Buffer* buff) const {
   RETURN_NOT_OK(buff->write(&null_non_empty_domain, sizeof(char)));
 
   // Write domain size
-  uint64_t domain_size = 0;
   auto& domain = array_schema_->domain();
   auto dim_num = domain.dim_num();
   if (non_empty_domain_.empty()) {
     // Applicable only to homogeneous domains with fixed-sized types
     assert(domain.all_dims_fixed());
     assert(domain.all_dims_same_type());
-    domain_size = 2 * dim_num * domain.dimension(0)->coord_size();
+    auto domain_size{2 * dim_num * domain.dimension_ptr(0)->coord_size()};
 
     // Write domain (dummy values)
     std::vector<uint8_t> d(domain_size, 0);
@@ -3919,7 +3921,7 @@ Status FragmentMetadata::write_non_empty_domain(Buffer* buff) const {
   } else {
     // Write non-empty domain
     for (unsigned d = 0; d < dim_num; ++d) {
-      auto dim = domain.dimension(d);
+      auto dim{domain.dimension_ptr(d)};
       const auto& r = non_empty_domain_[d];
       if (!dim->var_size()) {  // Fixed-sized
         RETURN_NOT_OK(buff->write(r.data(), r.size()));
@@ -4762,7 +4764,7 @@ void FragmentMetadata::build_idx_map() {
   }
   idx_map_[constants::coords] = array_schema_->attribute_num();
   for (unsigned i = 0; i < array_schema_->dim_num(); ++i) {
-    auto dim_name = array_schema_->dimension(i)->name();
+    const auto& dim_name{array_schema_->dimension_ptr(i)->name()};
     idx_map_[dim_name] = array_schema_->attribute_num() + 1 + i;
   }
 }

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -2003,7 +2003,7 @@ uint64_t FragmentMetadata::footer_size_v11_or_higher() const {
     for (unsigned d = 0; d < dim_num; ++d) {
       domain_size += non_empty_domain_[d].size();
       if (array_schema_->dimension_ptr(d)->var_size()) {
-        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized}
+        domain_size += 2 * sizeof(uint64_t);  // Two more sizes get serialized
       }
     }
   }

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -186,7 +186,7 @@ void DenseReader::reset() {
 
 template <class OffType>
 Status DenseReader::dense_read() {
-  auto type = array_schema_.domain().dimension(0)->type();
+  auto type{array_schema_.domain().dimension_ptr(0)->type()};
   switch (type) {
     case Datatype::INT8:
       return dense_read<int8_t, OffType>();

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -404,9 +404,9 @@ void DenseTiler<T>::calculate_first_sub_tile_coords() {
   // left cell)
   first_sub_tile_coords_.resize(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    T dom_start = *(const T*)domain.dimension(d)->domain().start_fixed();
-    T sub_start = *(const T*)subarray[d].start_fixed();
-    T tile_extent = *(const T*)domain.tile_extent(d).data();
+    T dom_start{*(const T*)domain.dimension_ptr(d)->domain().start_fixed()};
+    T sub_start{*(const T*)subarray[d].start_fixed()};
+    T tile_extent{*(const T*)domain.tile_extent(d).data()};
     first_sub_tile_coords_[d] =
         Dimension::tile_idx(sub_start, dom_start, tile_extent);
   }
@@ -425,7 +425,7 @@ void DenseTiler<T>::calculate_subarray_tile_coord_strides() {
   if (layout == Layout::ROW_MAJOR) {
     sub_tile_coord_strides_.push_back(1);
     for (auto d = dim_num - 2; d >= 0; --d) {
-      auto tile_num = domain.dimension(d + 1)->tile_num(subarray[d + 1]);
+      auto tile_num{domain.dimension_ptr(d + 1)->tile_num(subarray[d + 1])};
       sub_tile_coord_strides_.push_back(
           sub_tile_coord_strides_.back() * tile_num);
     }
@@ -434,7 +434,7 @@ void DenseTiler<T>::calculate_subarray_tile_coord_strides() {
   } else {  // COL_MAJOR
     sub_tile_coord_strides_.push_back(1);
     for (int32_t d = 1; d < dim_num; ++d) {
-      auto tile_num = domain.dimension(d - 1)->tile_num(subarray[d - 1]);
+      auto tile_num{domain.dimension_ptr(d - 1)->tile_num(subarray[d - 1])};
       sub_tile_coord_strides_.push_back(
           sub_tile_coord_strides_.back() * tile_num);
     }
@@ -546,7 +546,7 @@ std::vector<std::array<T, 2>> DenseTiler<T>::tile_subarray(uint64_t id) const {
   // Calculate tile subarray based on the tile coordinates in the domain
   std::vector<std::array<T, 2>> ret(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dom_start = *(const T*)domain.dimension(d)->domain().start_fixed();
+    auto dom_start{*(const T*)domain.dimension_ptr(d)->domain().start_fixed()};
     auto tile_extent = *(const T*)domain.tile_extent(d).data();
     ret[d][0] = Dimension::tile_coord_low(
         tile_coords_in_dom[d], dom_start, tile_extent);

--- a/tiledb/sm/query/domain_buffer.h
+++ b/tiledb/sm/query/domain_buffer.h
@@ -130,7 +130,7 @@ class SingleCoord {
       , single_offset_(1) {
     sizes_[schema.dim_num()] = sizeof(uint64_t);
     for (unsigned d = 0; d < coords_.size(); ++d) {
-      bool var_size = schema.dimension(d)->var_size();
+      bool var_size = schema.dimension_ptr(d)->var_size();
       auto dv = coord.dimension_datum_view(d);
       sizes_[d] = dv.size();
       coords_[d].resize(sizes_[d]);

--- a/tiledb/sm/query/domain_buffer.h
+++ b/tiledb/sm/query/domain_buffer.h
@@ -213,7 +213,7 @@ class DomainBuffersView : public detail::DomainBuffersTypes {
       : qb_(schema.dim_num()) {
     auto n_dimensions{schema.dim_num()};
     for (decltype(n_dimensions) i = 0; i < n_dimensions; ++i) {
-      const auto& name = schema.dimension(i)->name();
+      const auto& name{schema.dimension_ptr(i)->name()};
       qb_[i] = &buffers.at(name);
     }
   }

--- a/tiledb/sm/query/global_order_writer.cc
+++ b/tiledb/sm/query/global_order_writer.cc
@@ -157,7 +157,7 @@ Status GlobalOrderWriter::check_coord_dups() const {
   std::vector<const unsigned char*> buffs_var(dim_num);
   std::vector<uint64_t*> buffs_var_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_.dimension(d)->name();
+    const auto& dim_name{array_schema_.dimension_ptr(d)->name()};
     buffs[d] = (const unsigned char*)buffers_.find(dim_name)->second.buffer_;
     coord_sizes[d] = array_schema_.cell_size(dim_name);
     buffs_var[d] =
@@ -173,7 +173,7 @@ Status GlobalOrderWriter::check_coord_dups() const {
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_.dimension(d);
+          auto dim{array_schema_.dimension_ptr(d)};
           if (!dim->var_size()) {  // Fixed-sized dimensions
             if (memcmp(
                     buffs[d] + i * coord_sizes[d],
@@ -402,7 +402,7 @@ Status GlobalOrderWriter::compute_coord_dups(
   std::vector<const unsigned char*> buffs_var(dim_num);
   std::vector<uint64_t*> buffs_var_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_.dimension(d)->name();
+    const auto& dim_name{array_schema_.dimension_ptr(d)->name()};
     buffs[d] = (const unsigned char*)buffers_.find(dim_name)->second.buffer_;
     coord_sizes[d] = array_schema_.cell_size(dim_name);
     buffs_var[d] =
@@ -419,7 +419,7 @@ Status GlobalOrderWriter::compute_coord_dups(
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_.dimension(d);
+          auto dim{array_schema_.dimension_ptr(d)};
           if (!dim->var_size()) {  // Fixed-sized dimensions
             if (memcmp(
                     buffs[d] + i * coord_sizes[d],

--- a/tiledb/sm/query/ordered_writer.cc
+++ b/tiledb/sm/query/ordered_writer.cc
@@ -135,7 +135,7 @@ Status OrderedWriter::ordered_write() {
   assert(layout_ == Layout::ROW_MAJOR || layout_ == Layout::COL_MAJOR);
   assert(array_schema_.dense());
 
-  auto type = array_schema_.domain().dimension(0)->type();
+  auto type{array_schema_.domain().dimension_ptr(0)->type()};
   switch (type) {
     case Datatype::INT8:
       return ordered_write<int8_t>();

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -140,13 +140,13 @@ Status Query::add_range(
     return logger_->status(Status_QueryError(
         "Cannot add range; Setting range stride is currently unsupported"));
 
-  if (array_schema_->domain().dimension(dim_idx)->var_size())
+  if (array_schema_->domain().dimension_ptr(dim_idx)->var_size())
     return logger_->status(
         Status_QueryError("Cannot add range; Range must be fixed-sized"));
 
   // Prepare a temp range
   std::vector<uint8_t> range;
-  auto coord_size = array_schema_->dimension(dim_idx)->coord_size();
+  auto coord_size{array_schema_->dimension_ptr(dim_idx)->coord_size()};
   range.resize(2 * coord_size);
   std::memcpy(&range[0], start, coord_size);
   std::memcpy(&range[coord_size], end, coord_size);
@@ -196,7 +196,7 @@ Status Query::add_range_var(
     return logger_->status(
         Status_QueryError("Cannot add range; Invalid range"));
 
-  if (!array_schema_->domain().dimension(dim_idx)->var_size())
+  if (!array_schema_->domain().dimension_ptr(dim_idx)->var_size())
     return logger_->status(
         Status_QueryError("Cannot add range; Range must be variable-sized"));
 
@@ -622,7 +622,7 @@ Status Query::get_buffer(
   // Check attribute
   if (name != constants::coords) {
     if (array_schema_->attribute(name) == nullptr &&
-        array_schema_->dimension(name) == nullptr)
+        array_schema_->dimension_ptr(name) == nullptr)
       return logger_->status(Status_QueryError(
           std::string("Cannot get buffer; Invalid attribute/dimension name '") +
           name + "'"));
@@ -646,7 +646,7 @@ Status Query::get_buffer(
         Status_QueryError("Cannot get buffer; Coordinates are not var-sized"));
   }
   if (array_schema_->attribute(name) == nullptr &&
-      array_schema_->dimension(name) == nullptr)
+      array_schema_->dimension_ptr(name) == nullptr)
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute/dimension name '") +
         name + "'"));
@@ -681,7 +681,7 @@ Status Query::get_offsets_buffer(
         Status_QueryError("Cannot get buffer; Coordinates are not var-sized"));
   }
   if (array_schema_->attribute(name) == nullptr &&
-      array_schema_->dimension(name) == nullptr)
+      array_schema_->dimension_ptr(name) == nullptr)
     return logger_->status(Status_QueryError(
         std::string("Cannot get buffer; Invalid attribute/dimension name '") +
         name + "'"));
@@ -709,7 +709,7 @@ Status Query::get_data_buffer(
   // Check attribute
   if (name != constants::coords) {
     if (array_schema_->attribute(name) == nullptr &&
-        array_schema_->dimension(name) == nullptr)
+        array_schema_->dimension_ptr(name) == nullptr)
       return logger_->status(Status_QueryError(
           std::string("Cannot get buffer; Invalid attribute/dimension name '") +
           name + "'"));
@@ -1842,7 +1842,7 @@ Status Query::set_subarray(const void* subarray) {
     }
 
     for (unsigned d = 0; d < dim_num; ++d) {
-      auto r_size = 2 * array_schema_->dimension(d)->coord_size();
+      auto r_size{2 * array_schema_->dimension_ptr(d)->coord_size()};
       Range range(&s_ptr[offset], r_size);
       RETURN_NOT_OK(sub.add_range(d, std::move(range), err_on_range_oob));
       offset += r_size;

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -1522,7 +1522,7 @@ Status Reader::compute_result_coords(
   std::vector<std::string> var_size_dim_names;
   dim_names.reserve(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& name = array_schema_.dimension(d)->name();
+    const auto& name{array_schema_.dimension_ptr(d)->name()};
     dim_names.emplace_back(name);
     if (array_schema_.var_size(name))
       var_size_dim_names.emplace_back(name);
@@ -1584,7 +1584,7 @@ Status Reader::dedup_result_coords(
 }
 
 Status Reader::dense_read() {
-  auto type = array_schema_.domain().dimension(0)->type();
+  auto type{array_schema_.domain().dimension_ptr(0)->type()};
   switch (type) {
     case Datatype::INT8:
       return dense_read<int8_t>();
@@ -1930,7 +1930,7 @@ void Reader::erase_coord_tiles(std::vector<ResultTile>& result_tiles) const {
   for (auto& tile : result_tiles) {
     auto dim_num = array_schema_.dim_num();
     for (unsigned d = 0; d < dim_num; ++d)
-      tile.erase_tile(array_schema_.dimension(d)->name());
+      tile.erase_tile(array_schema_.dimension_ptr(d)->name());
     tile.erase_tile(constants::coords);
   }
 }
@@ -1972,7 +1972,7 @@ Status Reader::calculate_hilbert_values(
       storage_manager_->compute_tp(), 0, coords_num, [&](uint64_t c) {
         std::vector<uint64_t> coords(dim_num);
         for (uint32_t d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_.dimension(d);
+          auto dim{array_schema_.dimension_ptr(d)};
           coords[d] = hilbert_order::map_to_uint64(
               *dim, *(iter_begin + c), d, bits, max_bucket_val);
         }

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -461,7 +461,7 @@ Status ReaderBase::read_tiles(
       if (is_dim) {
         const uint64_t dim_num = array_schema->dim_num();
         for (uint64_t d = 0; d < dim_num; ++d) {
-          if (array_schema->dimension(d)->name() == name) {
+          if (array_schema->dimension_ptr(d)->name() == name) {
             tile->init_coord_tile(name, d);
             break;
           }
@@ -1566,7 +1566,7 @@ tuple<Status, optional<bool>> ReaderBase::fill_dense_coords(
     dim_idx.emplace_back(dim_num);
   } else {
     for (unsigned d = 0; d < dim_num; ++d) {
-      const auto& dim = array_schema_.dimension(d);
+      const auto dim{array_schema_.dimension_ptr(d)};
       auto it = buffers_.find(dim->name());
       if (it != buffers_.end()) {
         buffers.emplace_back(&(it->second));
@@ -1637,8 +1637,7 @@ tuple<Status, optional<bool>> ReaderBase::fill_dense_coords_row_col(
     // Check for overflow
     for (size_t i = 0; i < buffers.size(); ++i) {
       auto idx = (dim_idx[i] == dim_num) ? 0 : dim_idx[i];
-      auto dim = array_schema_.domain().dimension(idx);
-      auto coord_size = dim->coord_size();
+      auto coord_size{array_schema_.domain().dimension_ptr(idx)->coord_size()};
       coord_size = (dim_idx[i] == dim_num) ? coord_size * dim_num : coord_size;
       auto buff_size = *(buffers[i]->buffer_size_);
       auto offset = offsets[i];

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -254,7 +254,7 @@ bool ResultTile::same_coords(
     const ResultTile& rt, uint64_t pos_a, uint64_t pos_b) const {
   auto dim_num = coord_tiles_.size();
   for (unsigned d = 0; d < dim_num; ++d) {
-    if (!domain_->dimension(d)->var_size()) {  // Fixed-sized
+    if (!domain_->dimension_ptr(d)->var_size()) {  // Fixed-sized
       if (std::memcmp(coord(pos_a, d), rt.coord(pos_b, d), coord_size(d)) != 0)
         return false;
     } else {  // Var-sized
@@ -322,7 +322,7 @@ Status ResultTile::read(
     assert(name != constants::coords);
     int dim_offset = 0;
     for (uint32_t i = 0; i < domain_->dim_num(); ++i) {
-      if (domain_->dimension(i)->name() == name) {
+      if (domain_->dimension_ptr(i)->name() == name) {
         dim_offset = i;
         break;
       }
@@ -1078,7 +1078,7 @@ void ResultTile::set_compute_results_func() {
   compute_results_count_sparse_uint8_t_func_.resize(dim_num);
   compute_results_count_sparse_uint64_t_func_.resize(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = domain_->dimension(d);
+    auto dim{domain_->dimension_ptr(d)};
     switch (dim->type()) {
       case Datatype::INT32:
         compute_results_dense_func_[d] = compute_results_dense<int32_t>;

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -556,7 +556,7 @@ Status SparseGlobalOrderReader::compute_hilbert_values(
           if (tile->bitmap_.size() == 0 || tile->bitmap_[rc.pos_]) {
             // Compute Hilbert number for all dimensions first.
             for (uint32_t d = 0; d < dim_num; ++d) {
-              auto dim = array_schema_.dimension(d);
+              auto dim{array_schema_.dimension_ptr(d)};
               coords[d] = hilbert_order::map_to_uint64(
                   *dim, rc, d, bits, max_bucket_val);
             }

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -263,7 +263,7 @@ Status SparseIndexReaderBase::load_initial_data() {
   is_dim_var_size_.reserve(dim_num);
   std::vector<std::string> var_size_to_load;
   for (unsigned d = 0; d < dim_num; ++d) {
-    dim_names_.emplace_back(array_schema_.dimension(d)->name());
+    dim_names_.emplace_back(array_schema_.dimension_ptr(d)->name());
     is_dim_var_size_.emplace_back(array_schema_.var_size(dim_names_[d]));
     if (is_dim_var_size_[d])
       var_size_to_load.emplace_back(dim_names_[d]);
@@ -433,7 +433,7 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
           // Compute the list of range index to process.
           std::vector<uint64_t> relevant_ranges;
           relevant_ranges.reserve(ranges_for_dim.size());
-          domain.dimension(dim_idx)->relevant_ranges(
+          domain.dimension_ptr(dim_idx)->relevant_ranges(
               ranges_for_dim, mbr[dim_idx], relevant_ranges);
 
           // For non overlapping ranges, if we have full overlap on any range
@@ -441,7 +441,7 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
           const bool is_uint8_t = std::is_same<BitmapType, uint8_t>::value;
           if (is_uint8_t) {
             std::vector<bool> covered_bitmap =
-                domain.dimension(dim_idx)->covered_vec(
+                domain.dimension_ptr(dim_idx)->covered_vec(
                     ranges_for_dim, mbr[dim_idx], relevant_ranges);
 
             // See if any range is covered.

--- a/tiledb/sm/query/unordered_writer.cc
+++ b/tiledb/sm/query/unordered_writer.cc
@@ -154,7 +154,7 @@ Status UnorderedWriter::check_coord_dups(
   std::vector<const unsigned char*> buffs_var(dim_num);
   std::vector<uint64_t*> buffs_var_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_.dimension(d)->name();
+    const auto& dim_name{array_schema_.dimension_ptr(d)->name()};
     buffs[d] = (const unsigned char*)buffers_.find(dim_name)->second.buffer_;
     coord_sizes[d] = array_schema_.cell_size(dim_name);
     buffs_var[d] =
@@ -170,7 +170,7 @@ Status UnorderedWriter::check_coord_dups(
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_.dimension(d);
+          auto dim{array_schema_.dimension_ptr(d)};
           if (!dim->var_size()) {  // Fixed-sized dimensions
             if (memcmp(
                     buffs[d] + cell_pos[i] * coord_sizes[d],
@@ -252,7 +252,7 @@ Status UnorderedWriter::compute_coord_dups(
   std::vector<const unsigned char*> buffs_var(dim_num);
   std::vector<uint64_t*> buffs_var_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_.dimension(d)->name();
+    const auto& dim_name{array_schema_.dimension_ptr(d)->name()};
     buffs[d] = (const unsigned char*)buffers_.find(dim_name)->second.buffer_;
     coord_sizes[d] = array_schema_.cell_size(dim_name);
     buffs_var[d] =
@@ -269,7 +269,7 @@ Status UnorderedWriter::compute_coord_dups(
         // Check for duplicate in adjacent cells
         bool found_dup = true;
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_.dimension(d);
+          auto dim{array_schema_.dimension_ptr(d)};
           if (!dim->var_size()) {  // Fixed-sized dimensions
             if (memcmp(
                     buffs[d] + cell_pos[i] * coord_sizes[d],

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -285,7 +285,7 @@ Status WriterBase::calculate_hilbert_values(
       [&](uint64_t c) {
         std::vector<uint64_t> coords(dim_num);
         for (uint32_t d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_.dimension(d);
+          auto dim{array_schema_.dimension_ptr(d)};
           coords[d] = hilbert_order::map_to_uint64(
               *dim, domain_buffers[d], c, bits, max_bucket_val);
         }
@@ -367,7 +367,7 @@ Status WriterBase::check_coord_oob() const {
   std::vector<unsigned char*> buffs(dim_num);
   std::vector<uint64_t> coord_sizes(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
-    const auto& dim_name = array_schema_.dimension(d)->name();
+    const auto& dim_name{array_schema_.dimension_ptr(d)->name()};
     buffs[d] = (unsigned char*)buffers_.find(dim_name)->second.buffer_;
     coord_sizes[d] = array_schema_.cell_size(dim_name);
   }
@@ -380,7 +380,7 @@ Status WriterBase::check_coord_oob() const {
       0,
       dim_num,
       [&](uint64_t c, unsigned d) {
-        auto dim = array_schema_.dimension(d);
+        auto dim{array_schema_.dimension_ptr(d)};
         if (datatype_is_string(dim->type()))
           return Status::Ok();
         return dim->oob(buffs[d] + c * coord_sizes[d]);
@@ -499,7 +499,7 @@ Status WriterBase::compute_coords_metadata(
         NDRange mbr(dim_num);
         std::vector<const void*> data(dim_num);
         for (unsigned d = 0; d < dim_num; ++d) {
-          auto dim = array_schema_.dimension(d);
+          auto dim{array_schema_.dimension_ptr(d)};
           const auto& dim_name = dim->name();
           auto tiles_it = tiles.find(dim_name);
           assert(tiles_it != tiles.end());
@@ -517,7 +517,7 @@ Status WriterBase::compute_coords_metadata(
   RETURN_NOT_OK(status);
 
   // Set last tile cell number
-  auto dim_0 = array_schema_.dimension(0);
+  auto dim_0{array_schema_.dimension_ptr(0)};
   const auto& dim_tiles = tiles.find(dim_0->name())->second;
   const auto& last_tile_pos =
       (!dim_0->var_size()) ? dim_tiles.size() - 1 : dim_tiles.size() - 2;
@@ -596,7 +596,7 @@ std::string WriterBase::coords_to_str(uint64_t i) const {
 
   ss << "(";
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = array_schema_.dimension(d);
+    auto dim{array_schema_.dimension_ptr(d)};
     const auto& dim_name = dim->name();
     ss << buffers_.find(dim_name)->second.dimension_datum_at(*dim, i);
     if (d < dim_num - 1)
@@ -994,15 +994,15 @@ Status WriterBase::split_coords_buffer() {
 
   // For easy reference
   auto dim_num = array_schema_.dim_num();
-  auto coord_size = array_schema_.domain().dimension(0)->coord_size();
-  auto coords_size = dim_num * coord_size;
+  auto coords_size{dim_num *
+                   array_schema_.domain().dimension_ptr(0)->coord_size()};
   coords_info_.coords_num_ = *coords_info_.coords_buffer_size_ / coords_size;
 
   clear_coord_buffers();
 
   // New coord buffer allocations
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = array_schema_.dimension(d);
+    auto dim{array_schema_.dimension_ptr(d)};
     const auto& dim_name = dim->name();
     auto coord_buffer_size = coords_info_.coords_num_ * dim->coord_size();
     auto it = coord_buffer_sizes_.emplace(dim_name, coord_buffer_size);
@@ -1019,8 +1019,8 @@ Status WriterBase::split_coords_buffer() {
   // Split coordinates
   auto coord = (unsigned char*)nullptr;
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto coord_size = array_schema_.dimension(d)->coord_size();
-    const auto& dim_name = array_schema_.dimension(d)->name();
+    auto coord_size{array_schema_.dimension_ptr(d)->coord_size()};
+    const auto& dim_name{array_schema_.dimension_ptr(d)->name()};
     auto buff = (unsigned char*)(buffers_[dim_name].buffer_);
     for (uint64_t c = 0; c < coords_info_.coords_num_; ++c) {
       coord = &(((unsigned char*)coords_info_

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -729,7 +729,7 @@ Status RestClient::subarray_to_str(
     const ArraySchema& schema,
     const void* subarray,
     std::string* subarray_str) {
-  const auto coords_type = schema.dimension(0)->type();
+  const auto coords_type{schema.dimension_ptr(0)->type()};
   const auto dim_num = schema.dim_num();
   const auto subarray_nelts = 2 * dim_num;
 

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -204,9 +204,9 @@ void RTree::compute_tile_bitmap(
     const auto& mbr = levels_[entry.level_][entry.mbr_idx_];
 
     // If there is overlap
-    if (domain_->dimension(d)->overlap(range, mbr[d])) {
+    if (domain_->dimension_ptr(d)->overlap(range, mbr[d])) {
       // If there is full overlap
-      if (domain_->dimension(d)->covered(mbr[d], range)) {
+      if (domain_->dimension_ptr(d)->covered(mbr[d], range)) {
         auto subtree_leaf_num = this->subtree_leaf_num(entry.level_);
         assert(subtree_leaf_num > 0);
         uint64_t start = entry.mbr_idx_ * subtree_leaf_num;
@@ -269,8 +269,7 @@ Status RTree::serialize(Buffer* buff) const {
     for (uint64_t m = 0; m < mbr_num; ++m) {
       for (unsigned d = 0; d < dim_num; ++d) {
         const auto& r = levels_[l][m][d];
-        auto dim = domain_->dimension(d);
-        if (!dim->var_size()) {  // Fixed-sized
+        if (!domain_->dimension_ptr(d)->var_size()) {  // Fixed-sized
           // Just write the plain range
           RETURN_NOT_OK(buff->write(r.data(), r.size()));
         } else {  // Var-sized
@@ -378,7 +377,7 @@ Status RTree::deserialize_v1_v4(ConstBuffer* cbuff, const Domain* domain) {
     for (uint64_t m = 0; m < mbr_num; ++m) {
       levels_[l][m].resize(dim_num);
       for (unsigned d = 0; d < dim_num; ++d) {
-        auto r_size = 2 * domain->dimension(d)->coord_size();
+        auto r_size{2 * domain->dimension_ptr(d)->coord_size()};
         levels_[l][m][d].set_range(cbuff->cur_data(), r_size);
         cbuff->advance_offset(r_size);
       }
@@ -412,7 +411,7 @@ Status RTree::deserialize_v5(ConstBuffer* cbuff, const Domain* domain) {
     for (uint64_t m = 0; m < mbr_num; ++m) {
       levels_[l][m].resize(dim_num);
       for (unsigned d = 0; d < dim_num; ++d) {
-        auto dim = domain->dimension(d);
+        auto dim{domain->dimension_ptr(d)};
         if (!dim->var_size()) {  // Fixed-sized
           auto r_size = 2 * dim->coord_size();
           levels_[l][m][d].set_range(cbuff->cur_data(), r_size);

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -418,7 +418,7 @@ Status domain_to_capnp(
     return LOG_STATUS(
         Status_SerializationError("Error serializing domain; domain is null."));
 
-  domainBuilder->setType(datatype_str(domain->dimension(0)->type()));
+  domainBuilder->setType(datatype_str(domain->dimension_ptr(0)->type()));
   domainBuilder->setTileOrder(layout_str(domain->tile_order()));
   domainBuilder->setCellOrder(layout_str(domain->cell_order()));
 
@@ -426,7 +426,7 @@ Status domain_to_capnp(
   auto dimensions_builder = domainBuilder->initDimensions(ndims);
   for (unsigned i = 0; i < ndims; i++) {
     auto dim_builder = dimensions_builder[i];
-    RETURN_NOT_OK(dimension_to_capnp(domain->dimension(i).get(), &dim_builder));
+    RETURN_NOT_OK(dimension_to_capnp(domain->dimension_ptr(i), &dim_builder));
   }
 
   return Status::Ok();
@@ -954,7 +954,9 @@ Status nonempty_domain_deserialize(
           RETURN_NOT_OK(utils::deserialize_subarray(
               reader.getNonEmptyDomain(), schema, &subarray));
           std::memcpy(
-              nonempty_domain, subarray, 2 * schema.dimension(0)->coord_size());
+              nonempty_domain,
+              subarray,
+              2 * schema.dimension_ptr(0)->coord_size());
           tdb_free(subarray);
         }
 
@@ -975,7 +977,9 @@ Status nonempty_domain_deserialize(
           RETURN_NOT_OK(utils::deserialize_subarray(
               reader.getNonEmptyDomain(), schema, &subarray));
           std::memcpy(
-              nonempty_domain, subarray, 2 * schema.dimension(0)->coord_size());
+              nonempty_domain,
+              subarray,
+              2 * schema.dimension_ptr(0)->coord_size());
           tdb_free(subarray);
         }
 

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -491,11 +491,11 @@ Status serialize_subarray(
   // Check coords type
   auto dim_num = array_schema.dim_num();
   uint64_t subarray_size = 0;
-  Datatype first_dimension_datatype = array_schema.dimension(0)->type();
+  Datatype first_dimension_datatype{array_schema.dimension_ptr(0)->type()};
   // If all the dimensions are the same datatype, then we will store the
   // subarray in a type array for <=1.7 compatibility
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dimension = array_schema.dimension(d);
+    auto dimension{array_schema.dimension_ptr(d)};
     const auto coords_type = dimension->type();
 
     if (coords_type != first_dimension_datatype) {
@@ -538,9 +538,9 @@ Status deserialize_subarray(
   // Check coords type
   auto dim_num = array_schema.dim_num();
   uint64_t subarray_size = 0;
-  Datatype first_dimension_datatype = array_schema.dimension(0)->type();
+  Datatype first_dimension_datatype{array_schema.dimension_ptr(0)->type()};
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dimension = array_schema.dimension(d);
+    auto dimension{array_schema.dimension_ptr(d)};
     const auto coords_type = dimension->type();
 
     if (coords_type != first_dimension_datatype) {

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -140,7 +140,7 @@ Status subarray_to_capnp(
   const uint32_t dim_num = subarray->dim_num();
   auto ranges_builder = builder->initRanges(dim_num);
   for (uint32_t i = 0; i < dim_num; i++) {
-    const auto datatype = schema.dimension(i)->type();
+    const auto datatype{schema.dimension_ptr(i)->type()};
     auto range_builder = ranges_builder[i];
     const auto& ranges = subarray->ranges_for_dim(i);
     range_builder.setType(datatype_str(datatype));

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -898,9 +898,9 @@ Status StorageManager::array_get_non_empty_domain_from_index(
   if (idx >= array_schema.dim_num())
     return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension index"));
-  if (array_domain.dimension(idx)->var_size()) {
+  if (array_domain.dimension_ptr(idx)->var_size()) {
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
-    errmsg += array_domain.dimension(idx)->name();
+    errmsg += array_domain.dimension_ptr(idx)->name();
     errmsg += "' is variable-sized";
     return logger_->status(Status_StorageManagerError(errmsg));
   }
@@ -933,10 +933,10 @@ Status StorageManager::array_get_non_empty_domain_from_name(
   auto& array_domain{array_schema.domain()};
   auto dim_num = array_schema.dim_num();
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim_name = array_schema.dimension(d)->name();
+    const auto& dim_name{array_schema.dimension_ptr(d)->name()};
     if (name == dim_name) {
       // Sanity check
-      if (array_domain.dimension(d)->var_size()) {
+      if (array_domain.dimension_ptr(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is variable-sized";
         return logger_->status(Status_StorageManagerError(errmsg));
@@ -967,9 +967,9 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_index(
   if (idx >= array_schema.dim_num())
     return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension index"));
-  if (!array_domain.dimension(idx)->var_size()) {
+  if (!array_domain.dimension_ptr(idx)->var_size()) {
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
-    errmsg += array_domain.dimension(idx)->name();
+    errmsg += array_domain.dimension_ptr(idx)->name();
     errmsg += "' is fixed-sized";
     return logger_->status(Status_StorageManagerError(errmsg));
   }
@@ -1006,10 +1006,10 @@ Status StorageManager::array_get_non_empty_domain_var_size_from_name(
   auto& array_domain{array_schema.domain()};
   auto dim_num = array_schema.dim_num();
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim_name = array_schema.dimension(d)->name();
+    const auto& dim_name{array_schema.dimension_ptr(d)->name()};
     if (name == dim_name) {
       // Sanity check
-      if (!array_domain.dimension(d)->var_size()) {
+      if (!array_domain.dimension_ptr(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is fixed-sized";
         return logger_->status(Status_StorageManagerError(errmsg));
@@ -1042,9 +1042,9 @@ Status StorageManager::array_get_non_empty_domain_var_from_index(
   if (idx >= array_schema.dim_num())
     return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Invalid dimension index"));
-  if (!array_domain.dimension(idx)->var_size()) {
+  if (!array_domain.dimension_ptr(idx)->var_size()) {
     std::string errmsg = "Cannot get non-empty domain; Dimension '";
-    errmsg += array_domain.dimension(idx)->name();
+    errmsg += array_domain.dimension_ptr(idx)->name();
     errmsg += "' is fixed-sized";
     return logger_->status(Status_StorageManagerError(errmsg));
   }
@@ -1077,10 +1077,10 @@ Status StorageManager::array_get_non_empty_domain_var_from_name(
   auto& array_domain{array_schema.domain()};
   auto dim_num = array_schema.dim_num();
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim_name = array_schema.dimension(d)->name();
+    const auto& dim_name{array_schema.dimension_ptr(d)->name()};
     if (name == dim_name) {
       // Sanity check
-      if (!array_domain.dimension(d)->var_size()) {
+      if (!array_domain.dimension_ptr(d)->var_size()) {
         std::string errmsg = "Cannot get non-empty domain; Dimension '";
         errmsg += dim_name + "' is fixed-sized";
         return logger_->status(Status_StorageManagerError(errmsg));

--- a/tiledb/sm/subarray/cell_slab_iter.cc
+++ b/tiledb/sm/subarray/cell_slab_iter.cc
@@ -66,7 +66,7 @@ CellSlabIter<T>::CellSlabIter(const Subarray* subarray)
   if (subarray != nullptr) {
     const auto& array_schema = subarray->array()->array_schema_latest();
     auto dim_num = array_schema.dim_num();
-    auto coord_size = array_schema.dimension(0)->coord_size();
+    auto coord_size{array_schema.dimension_ptr(0)->coord_size()};
     aux_tile_coords_.resize(dim_num);
     aux_tile_coords_2_.resize(dim_num * coord_size);
   }
@@ -284,7 +284,7 @@ Status CellSlabIter<T>::sanity_check() const {
   // Check type
   bool error;
   const auto& array_schema = subarray_->array()->array_schema_latest();
-  auto type = array_schema.domain().dimension(0)->type();
+  auto type = array_schema.domain().dimension_ptr(0)->type();
   switch (type) {
     case Datatype::INT8:
       error = !std::is_same<T, int8_t>::value;

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -173,7 +173,7 @@ Status Subarray::add_range(
   }
 
   // Restrict the range to the dimension domain and add.
-  auto dim = array_->array_schema_latest().dimension(dim_idx);
+  auto dim{array_->array_schema_latest().dimension_ptr(dim_idx)};
   if (!read_range_oob_error)
     RETURN_NOT_OK(dim->adjust_range_oob(&range));
   RETURN_NOT_OK(dim->check_range(range));
@@ -213,7 +213,7 @@ Status Subarray::set_subarray(const void* subarray) {
     uint64_t offset = 0;
     for (unsigned d = 0; d < dim_num; ++d) {
       auto r_size =
-          2 * array_->array_schema_latest().dimension(d)->coord_size();
+          2 * array_->array_schema_latest().dimension_ptr(d)->coord_size();
       Range range(&s_ptr[offset], r_size);
       RETURN_NOT_OK(this->add_range(d, std::move(range), err_on_range_oob_));
       offset += r_size;
@@ -252,7 +252,7 @@ Status Subarray::add_range(
 
   if (this->array_->array_schema_latest()
           .domain()
-          .dimension(dim_idx)
+          .dimension_ptr(dim_idx)
           ->var_size())
     return LOG_STATUS(
         Status_SubarrayError("Cannot add range; Range must be fixed-sized"));
@@ -260,7 +260,7 @@ Status Subarray::add_range(
   // Prepare a temp range
   std::vector<uint8_t> range;
   auto coord_size =
-      this->array_->array_schema_latest().dimension(dim_idx)->coord_size();
+      this->array_->array_schema_latest().dimension_ptr(dim_idx)->coord_size();
   range.resize(2 * coord_size);
   std::memcpy(&range[0], start, coord_size);
   std::memcpy(&range[coord_size], end, coord_size);
@@ -296,7 +296,7 @@ Status Subarray::add_point_ranges(
 
   if (this->array_->array_schema_latest()
           .domain()
-          .dimension(dim_idx)
+          .dimension_ptr(dim_idx)
           ->var_size())
     return LOG_STATUS(
         Status_SubarrayError("Cannot add range; Range must be fixed-sized"));
@@ -304,7 +304,7 @@ Status Subarray::add_point_ranges(
   // Prepare a temp range
   std::vector<uint8_t> range;
   auto coord_size =
-      this->array_->array_schema_latest().dimension(dim_idx)->coord_size();
+      this->array_->array_schema_latest().dimension_ptr(dim_idx)->coord_size();
   range.resize(2 * coord_size);
 
   for (size_t i = 0; i < count; i++) {
@@ -349,7 +349,10 @@ Status Subarray::add_range_var(
       (end == nullptr && end_size != 0))
     return LOG_STATUS(Status_SubarrayError("Cannot add range; Invalid range"));
 
-  if (!array_->array_schema_latest().domain().dimension(dim_idx)->var_size())
+  if (!array_->array_schema_latest()
+           .domain()
+           .dimension_ptr(dim_idx)
+           ->var_size())
     return LOG_STATUS(
         Status_SubarrayError("Cannot add range; Range must be variable-sized"));
 
@@ -485,7 +488,7 @@ uint64_t Subarray::cell_num() const {
   unsigned dim_num = array_schema.dim_num();
   uint64_t ret = 1;
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = array_schema.dimension(d);
+    auto dim{array_schema.dimension_ptr(d)};
     uint64_t num = 0;
     auto& range_subset = range_subset_[d];
     for (uint64_t index = 0; index < range_subset.num_ranges(); ++index)
@@ -509,7 +512,8 @@ uint64_t Subarray::cell_num(uint64_t range_idx) const {
   // Unary case or GLOBAL_ORDER
   if (range_num() == 1) {
     for (unsigned d = 0; d < dim_num; ++d) {
-      range_cell_num = domain.dimension(d)->domain_range(range_subset_[d][0]);
+      range_cell_num =
+          domain.dimension_ptr(d)->domain_range(range_subset_[d][0]);
       if (range_cell_num == std::numeric_limits<uint64_t>::max())  // Overflow
         return range_cell_num;
 
@@ -525,7 +529,7 @@ uint64_t Subarray::cell_num(uint64_t range_idx) const {
   if (layout == Layout::ROW_MAJOR) {
     assert(!range_offsets_.empty());
     for (unsigned d = 0; d < dim_num; ++d) {
-      range_cell_num = domain.dimension(d)->domain_range(
+      range_cell_num = domain.dimension_ptr(d)->domain_range(
           range_subset_[d][tmp_idx / range_offsets_[d]]);
       tmp_idx %= range_offsets_[d];
       if (range_cell_num == std::numeric_limits<uint64_t>::max())  // Overflow
@@ -538,7 +542,7 @@ uint64_t Subarray::cell_num(uint64_t range_idx) const {
   } else if (layout == Layout::COL_MAJOR) {
     assert(!range_offsets_.empty());
     for (unsigned d = dim_num - 1;; --d) {
-      range_cell_num = domain.dimension(d)->domain_range(
+      range_cell_num = domain.dimension_ptr(d)->domain_range(
           range_subset_[d][tmp_idx / range_offsets_[d]]);
       tmp_idx %= range_offsets_[d];
       if (range_cell_num == std::numeric_limits<uint64_t>::max())  // Overflow
@@ -565,7 +569,7 @@ uint64_t Subarray::cell_num(const std::vector<uint64_t>& range_coords) const {
 
   uint64_t ret = 1;
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = array_schema.dimension(d);
+    auto dim{array_schema.dimension_ptr(d)};
     ret = utils::math::safe_mul(
         ret, dim->domain_range(range_subset_[d][range_coords[d]]));
     if (ret == std::numeric_limits<uint64_t>::max())  // Overflow
@@ -597,7 +601,7 @@ bool Subarray::coincides_with_tiles() const {
 
   auto dim_num = array_->array_schema_latest().dim_num();
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto dim = array_->array_schema_latest().dimension(d);
+    auto dim{array_->array_schema_latest().dimension_ptr(d)};
     if (!dim->coincides_with_tiles(range_subset_[d][0]))
       return false;
   }
@@ -620,7 +624,7 @@ Subarray Subarray::crop_to_tile(const T* tile_coords, Layout layout) const {
 
   // Compute cropped subarray
   for (unsigned d = 0; d < dim_num(); ++d) {
-    auto r_size = 2 * array_schema.dimension(d)->coord_size();
+    auto r_size{2 * array_schema.dimension_ptr(d)->coord_size()};
     uint64_t i = 0;
     for (size_t r = 0; r < range_subset_[d].num_ranges(); ++r) {
       const auto& range = range_subset_[d][r];
@@ -719,7 +723,7 @@ Status Subarray::get_range_var_size(
     return logger_->status(Status_SubarrayError(
         "Cannot get var range size; Invalid dimension index"));
 
-  auto dim = schema.domain().dimension(dim_idx);
+  auto dim{schema.domain().dimension_ptr(dim_idx)};
   if (!dim->var_size())
     return logger_->status(Status_SubarrayError(
         "Cannot get var range size; Dimension " + dim->name() +
@@ -831,7 +835,7 @@ bool Subarray::is_unary(uint64_t range_idx) const {
 
 void Subarray::set_is_default(uint32_t dim_index, bool is_default) {
   if (is_default) {
-    auto dim = array_->array_schema_latest().dimension(dim_index);
+    auto dim{array_->array_schema_latest().dimension_ptr(dim_index)};
     range_subset_.at(dim_index) = RangeSetAndSuperset(
         dim->type(), dim->domain(), is_default, coalesce_ranges_);
   }
@@ -1529,7 +1533,7 @@ const std::vector<Range>& Subarray::ranges_for_dim(uint32_t dim_idx) const {
 
 Status Subarray::set_ranges_for_dim(
     uint32_t dim_idx, const std::vector<Range>& ranges) {
-  auto dim = array_->array_schema_latest().dimension(dim_idx);
+  auto dim{array_->array_schema_latest().dimension_ptr(dim_idx)};
   range_subset_[dim_idx] =
       RangeSetAndSuperset(dim->type(), dim->domain(), false, coalesce_ranges_);
   is_default_[dim_idx] = false;
@@ -1557,7 +1561,7 @@ Status Subarray::split(
   for (unsigned d = 0; d < dim_num; ++d) {
     const auto& r = range_subset_[d][0];
     if (d == splitting_dim) {
-      auto dim = array_->array_schema_latest().dimension(d);
+      auto dim{array_->array_schema_latest().dimension_ptr(d)};
       dim->split_range(r, splitting_value, &sr1, &sr2);
       RETURN_NOT_OK(r1->add_range_unsafe(d, sr1));
       RETURN_NOT_OK(r2->add_range_unsafe(d, sr2));
@@ -1611,7 +1615,7 @@ Status Subarray::split(
         }
       } else {  // Need to split a single range
         const auto& r = range_subset_[d][0];
-        auto dim = array_schema.dimension(d);
+        auto dim{array_schema.dimension_ptr(d)};
         dim->split_range(r, splitting_value, &sr1, &sr2);
         RETURN_NOT_OK(r1->add_range_unsafe(d, sr1));
         RETURN_NOT_OK(r2->add_range_unsafe(d, sr2));
@@ -1640,7 +1644,7 @@ const T* Subarray::tile_coords_ptr(
     const std::vector<T>& tile_coords,
     std::vector<uint8_t>* aux_tile_coords) const {
   auto dim_num = array_->array_schema_latest().dim_num();
-  auto coord_size = array_->array_schema_latest().dimension(0)->coord_size();
+  auto coord_size{array_->array_schema_latest().dimension_ptr(0)->coord_size()};
   std::memcpy(&((*aux_tile_coords)[0]), &tile_coords[0], dim_num * coord_size);
   auto it = tile_coords_map_.find(*aux_tile_coords);
   if (it == tile_coords_map_.end())
@@ -1861,7 +1865,7 @@ void Subarray::add_default_ranges() {
 
   range_subset_.clear();
   for (unsigned dim_index = 0; dim_index < dim_num; ++dim_index) {
-    auto dim = domain.dimension(dim_index);
+    auto dim{domain.dimension_ptr(dim_index)};
     range_subset_.push_back(RangeSetAndSuperset(
         dim->type(), dim->domain(), true, coalesce_ranges_));
   }
@@ -1937,7 +1941,7 @@ Status Subarray::compute_est_result_size(
     if (i < attribute_num)
       names[i] = attributes[i]->name();
     else if (i < attribute_num + dim_num)
-      names[i] = array_schema.domain().dimension(i - attribute_num)->name();
+      names[i] = array_schema.domain().dimension_ptr(i - attribute_num)->name();
     else
       names[i] = constants::coords;
   }
@@ -2126,7 +2130,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
     uint64_t cell_num = 1;
     auto dim_num = array_schema.dim_num();
     for (unsigned d = 0; d < dim_num; ++d) {
-      auto dim = array_schema.dimension(d);
+      auto dim{array_schema.dimension_ptr(d)};
       cell_num = utils::math::safe_mul(
           cell_num, dim->domain_range(range_subset_[d][range_coords[d]]));
     }
@@ -2194,7 +2198,7 @@ Status Subarray::compute_tile_coords_col() {
 
   tile_coords_.resize(tile_coords_num);
   std::vector<uint8_t> coords;
-  auto coords_size = dim_num * array_schema.dimension(0)->coord_size();
+  auto coords_size{dim_num * array_schema.dimension_ptr(0)->coord_size()};
   coords.resize(coords_size);
   size_t coord_size = sizeof(T);
   size_t tile_coords_pos = 0;
@@ -2254,7 +2258,7 @@ Status Subarray::compute_tile_coords_row() {
 
   tile_coords_.resize(tile_coords_num);
   std::vector<uint8_t> coords;
-  auto coords_size = dim_num * array_schema.dimension(0)->coord_size();
+  auto coords_size{dim_num * array_schema.dimension_ptr(0)->coord_size()};
   coords.resize(coords_size);
   size_t coord_size = sizeof(T);
   size_t tile_coords_pos = 0;
@@ -2511,7 +2515,7 @@ Subarray Subarray::clone() const {
 TileOverlap Subarray::compute_tile_overlap(
     uint64_t range_idx, unsigned fid) const {
   assert(array_->array_schema_latest().dense());
-  auto type = array_->array_schema_latest().dimension(0)->type();
+  auto type{array_->array_schema_latest().dimension_ptr(0)->type()};
   switch (type) {
     case Datatype::INT8:
       return compute_tile_overlap<int8_t>(range_idx, fid);
@@ -2813,7 +2817,7 @@ Status Subarray::compute_relevant_fragments_for_dim(
     const std::vector<uint64_t>& end_coords,
     std::vector<uint8_t>* const frag_bytemap) const {
   const auto meta = array_->fragment_metadata();
-  auto dim = array_->array_schema_latest().dimension(dim_idx);
+  auto dim{array_->array_schema_latest().dimension_ptr(dim_idx)};
 
   return parallel_for(compute_tp, 0, fragment_num, [&](const uint64_t f) {
     // We're done when we have already determined fragment `f` to
@@ -2967,7 +2971,7 @@ template <typename T>
 tuple<Status, optional<bool>> Subarray::non_overlapping_ranges_for_dim(
     const uint64_t dim_idx) {
   const auto& ranges = range_subset_[dim_idx].ranges();
-  auto dim = array_->array_schema_latest().dimension(dim_idx);
+  auto dim{array_->array_schema_latest().dimension_ptr(dim_idx)};
 
   if (ranges.size() > 1) {
     for (uint64_t r = 0; r < ranges.size() - 1; r++) {
@@ -2981,8 +2985,8 @@ tuple<Status, optional<bool>> Subarray::non_overlapping_ranges_for_dim(
 
 tuple<Status, optional<bool>> Subarray::non_overlapping_ranges_for_dim(
     const uint64_t dim_idx) {
-  const Datatype& datatype =
-      array_->array_schema_latest().dimension(dim_idx)->type();
+  const Datatype& datatype{
+      array_->array_schema_latest().dimension_ptr(dim_idx)->type()};
   switch (datatype) {
     case Datatype::INT8:
       return non_overlapping_ranges_for_dim<int8_t>(dim_idx);

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -902,7 +902,7 @@ void SubarrayPartitioner::compute_splitting_value_on_tiles(
   // Compute splitting dimension and value
   const Range* r;
   for (auto d : dims) {
-    auto dim = array_schema.domain().dimension(d);
+    auto dim{array_schema.domain().dimension_ptr(d)};
     range.get_range(d, 0, &r);
     auto tiles_apart = dim->tile_num(*r) - 1;
     if (tiles_apart != 0) {
@@ -975,7 +975,7 @@ void SubarrayPartitioner::compute_splitting_value_single_range(
   // Compute splitting dimension and value
   const Range* r;
   for (auto d : dims) {
-    auto dim = array_schema.dimension(d);
+    auto dim{array_schema.dimension_ptr(d)};
     range.get_range(d, 0, &r);
     if (!r->unary()) {
       *splitting_dim = d;
@@ -1019,7 +1019,7 @@ void SubarrayPartitioner::compute_splitting_value_single_range_hilbert(
       range_uint64[*splitting_dim], *splitting_dim, splitting_value);
 
   // Check for unsplittable again
-  auto dim = array_schema.dimension(*splitting_dim);
+  auto dim{array_schema.dimension_ptr(*splitting_dim)};
   const Range* r;
   range.get_range(*splitting_dim, 0, &r);
   if (dim->smaller_than(*splitting_value, *r)) {
@@ -1093,7 +1093,7 @@ Status SubarrayPartitioner::compute_splitting_value_multi_range(
 
     // Check if we need to split single range
     partition.get_range(d, 0, &r);
-    auto dim = array_schema.dimension(d);
+    auto dim{array_schema.dimension_ptr(d)};
     if (!r->unary()) {
       *splitting_dim = d;
       dim->splitting_value(*r, splitting_value, unsplittable);
@@ -1380,7 +1380,7 @@ void SubarrayPartitioner::compute_range_uint64(
   // Calculate mapped range
   bool empty_start, empty_end;
   for (uint32_t d = 0; d < dim_num; ++d) {
-    auto dim = array_schema.dimension(d);
+    auto dim{array_schema.dimension_ptr(d)};
     auto var = dim->var_size();
     range.get_range(d, 0, &r);
     empty_start = var ? (r->start_size() == 0) : r->empty();
@@ -1537,6 +1537,6 @@ void SubarrayPartitioner::compute_splitting_value_hilbert(
   auto max_bucket_val = ((uint64_t)1 << bits) - 1;
 
   *splitting_value =
-      array_schema.dimension(splitting_dim)
+      array_schema.dimension_ptr(splitting_dim)
           ->map_from_uint64(splitting_value_uint64, bits, max_bucket_val);
 }

--- a/tools/src/commands/info_command.cc
+++ b/tools/src/commands/info_command.cc
@@ -335,7 +335,7 @@ std::tuple<double, double, double, double> InfoCommand::get_mbr(
   double x, y, width, height;
 
   // First dimension
-  auto d1_type = domain.dimension(0)->type();
+  auto d1_type = domain.dimension_ptr(0)->type();
   switch (d1_type) {
     case Datatype::INT8:
       y = static_cast<const int8_t*>(mbr[0].data())[0];
@@ -408,7 +408,7 @@ std::tuple<double, double, double, double> InfoCommand::get_mbr(
   }
 
   // Second dimension
-  auto d2_type = domain.dimension(1)->type();
+  auto d2_type = domain.dimension_ptr(1)->type();
   switch (d2_type) {
     case Datatype::INT8:
       x = static_cast<const int8_t*>(mbr[1].data())[0];
@@ -499,7 +499,7 @@ std::vector<std::string> InfoCommand::mbr_to_string(
   const double* rf64;
   auto dim_num = domain.dim_num();
   for (unsigned d = 0; d < dim_num; d++) {
-    auto type = domain.dimension(d)->type();
+    auto type = domain.dimension_ptr(d)->type();
     switch (type) {
       case sm::Datatype::STRING_ASCII:
         result.push_back(std::string(mbr[d].start_str()));


### PR DESCRIPTION
Change all `dimension` functions that return `shared_ptr` to `dimension_ptr` functions that return plain pointers, both in `class Domain` and in `class ArraySchema`.

---
TYPE: NO_HISTORY
DESC: more dimension_ptr
