### PR TITLE
Consolidation with timestamps: enabling in fragment consolidator.

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -242,7 +242,7 @@ uint64_t ArraySchema::cell_size(const std::string& name) const {
   }
 
   if (name == constants::timestamps) {
-    return sizeof(uint64_t);
+    return constants::timestamp_size;
   }
 
   // Attribute
@@ -535,7 +535,7 @@ Datatype ArraySchema::type(const std::string& name) const {
     return domain_->dimension_ptr(0)->type();
 
   if (name == constants::timestamps)
-    return Datatype::UINT64;
+    return constants::timestamp_type;
 
   // Attribute
   auto attr_it = attribute_map_.find(name);

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -241,6 +241,10 @@ uint64_t ArraySchema::cell_size(const std::string& name) const {
     return dim_num * coord_size;
   }
 
+  if (name == constants::timestamps) {
+    return sizeof(uint64_t);
+  }
+
   // Attribute
   auto attr_it = attribute_map_.find(name);
   if (attr_it != attribute_map_.end()) {
@@ -263,7 +267,7 @@ uint64_t ArraySchema::cell_size(const std::string& name) const {
 
 unsigned int ArraySchema::cell_val_num(const std::string& name) const {
   // Special zipped coordinates
-  if (name == constants::coords)
+  if (name == constants::coords || name == constants::timestamps)
     return 1;
 
   // Attribute
@@ -340,7 +344,7 @@ Status ArraySchema::check_attributes(
 }
 
 const FilterPipeline& ArraySchema::filters(const std::string& name) const {
-  if (name == constants::coords)
+  if (name == constants::coords || name == constants::timestamps)
     return coords_filters();
 
   // Attribute
@@ -530,6 +534,9 @@ Datatype ArraySchema::type(const std::string& name) const {
   if (name == constants::coords)
     return domain_->dimension_ptr(0)->type();
 
+  if (name == constants::timestamps)
+    return Datatype::UINT64;
+
   // Attribute
   auto attr_it = attribute_map_.find(name);
   if (attr_it != attribute_map_.end())
@@ -543,7 +550,7 @@ Datatype ArraySchema::type(const std::string& name) const {
 
 bool ArraySchema::var_size(const std::string& name) const {
   // Special case for zipped coordinates
-  if (name == constants::coords)
+  if (name == constants::coords || name == constants::timestamps)
     return false;
 
   // Attribute

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -509,6 +509,9 @@ Status FragmentConsolidator::create_buffers(
     for (unsigned i = 0; i < dim_num; ++i)
       buffer_num += (domain.dimension_ptr(i)->var_size()) ? 2 : 1;
   }
+  if (config_.with_timestamps_ && sparse) {
+    buffer_num++;
+  }
 
   // Create buffers
   buffers->resize(buffer_num);
@@ -533,6 +536,8 @@ Status FragmentConsolidator::create_queries(
     URI* new_fragment_uri) {
   auto timer_se = stats_->start_timer("consolidate_create_queries");
 
+  const auto dense = array_for_reads->array_schema_latest().dense();
+
   // Note: it is safe to use `set_subarray_safe` for `subarray` below
   // because the subarray is calculated by the TileDB algorithm (it
   // is not a user input prone to errors).
@@ -542,9 +547,14 @@ Status FragmentConsolidator::create_queries(
   RETURN_NOT_OK((*query_r)->set_layout(Layout::GLOBAL_ORDER));
 
   // Refactored reader optimizes for no subarray.
-  if (!config_.use_refactored_reader_ ||
-      array_for_reads->array_schema_latest().dense())
+  if (!config_.use_refactored_reader_ || dense) {
     RETURN_NOT_OK((*query_r)->set_subarray_unsafe(subarray));
+  }
+
+  // Enable consolidation with timestamps on the reader, if applicable.
+  if (config_.with_timestamps_ && !dense) {
+    (*query_r)->set_consolidation_with_timestamps();
+  }
 
   // Get last fragment URI, which will be the URI of the consolidated fragment
   auto first = (*query_r)->first_fragment_uri();
@@ -755,6 +765,14 @@ Status FragmentConsolidator::set_query_buffers(
     }
   }
 
+  if (config_.with_timestamps_ && !dense) {
+    RETURN_NOT_OK(query->set_data_buffer(
+        constants::timestamps,
+        (void*)&(*buffers)[bid][0],
+        &(*buffer_sizes)[bid]));
+    ++bid;
+  }
+
   return Status::Ok();
 }
 
@@ -795,11 +813,9 @@ Status FragmentConsolidator::set_config(const Config* config) {
   RETURN_NOT_OK(merged_config.get<uint64_t>(
       "sm.consolidation.timestamp_end", &config_.timestamp_end_, &found));
   assert(found);
-  config_.include_timestamps_ = false;
+  config_.with_timestamps_ = false;
   RETURN_NOT_OK(merged_config.get<bool>(
-      "sm.consolidation.with_timestamps",
-      &config_.include_timestamps_,
-      &found));
+      "sm.consolidation.with_timestamps", &config_.with_timestamps_, &found));
   assert(found);
   std::string reader =
       merged_config.get("sm.query.sparse_global_order.reader", &found);
@@ -825,6 +841,10 @@ Status FragmentConsolidator::set_config(const Config* config) {
     return logger_->status(
         Status_ConsolidatorError("Invalid configuration; Amplification config "
                                  "parameter must be non-negative"));
+  if (config_.with_timestamps_ && !config_.use_refactored_reader_)
+    return logger_->status(
+        Status_ConsolidatorError("Invalid configuration; Consolidation with "
+                                 "timestamps requires refactored reader"));
 
   return Status::Ok();
 }

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -137,7 +137,7 @@ class FragmentConsolidator : public Consolidator {
     /**
      * Include timestamps in the consolidated fragment or not.
      */
-    bool include_timestamps_;
+    bool with_timestamps_;
     /**
      * The factor by which the size of the dense fragment resulting
      * from consolidating a set of fragments (containing at least one

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -83,6 +83,7 @@ class FragmentMetadata {
    *     In TileDB, timestamps are in ms elapsed since
    *     1970-01-01 00:00:00 +0000 (UTC).
    * @param dense Indicates whether the fragment is dense or sparse.
+   * @param has_timestamps Does the fragment contains timestamps.
    */
   FragmentMetadata(
       StorageManager* storage_manager,
@@ -90,7 +91,8 @@ class FragmentMetadata {
       const shared_ptr<const ArraySchema>& array_schema,
       const URI& fragment_uri,
       const std::pair<uint64_t, uint64_t>& timestamp_range,
-      bool dense = true);
+      bool dense = true,
+      bool has_timestamps = false);
 
   /** Destructor. */
   ~FragmentMetadata();
@@ -837,7 +839,7 @@ class FragmentMetadata {
   /**
    * Maps an attribute or dimension to an index used in the various vector
    * class members. Attributes are first, then TILEDB_COORDS, then the
-   * dimensions.
+   * dimensions, then timestamp.
    */
   std::unordered_map<std::string, unsigned> idx_map_;
 

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -125,6 +125,12 @@ const std::string coords = "__coords";
 /** Special name reserved for the timestamp attribute. */
 const std::string timestamps = "__timestamps";
 
+/** The size of a timestamp cell. */
+const uint64_t timestamp_size = sizeof(uint64_t);
+
+/** The type of a variable offset cell. */
+extern const Datatype timestamp_type = Datatype::UINT64;
+
 /** The default compressor for the coordinates. */
 Compressor coords_compression = Compressor::ZSTD;
 

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -122,6 +122,9 @@ int cell_validity_compression_level = -1;
 /** Special name reserved for the coordinates attribute. */
 const std::string coords = "__coords";
 
+/** Special name reserved for the timestamp attribute. */
+const std::string timestamps = "__timestamps";
+
 /** The default compressor for the coordinates. */
 Compressor coords_compression = Compressor::ZSTD;
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -119,6 +119,9 @@ extern int coords_compression_level;
 /** Special name reserved for the coordinates attribute. */
 extern const std::string coords;
 
+/** Special name reserved for the timestamp attribute. */
+extern const std::string timestamps;
+
 /** The special value for an empty int32. */
 extern const int empty_int32;
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -122,6 +122,12 @@ extern const std::string coords;
 /** Special name reserved for the timestamp attribute. */
 extern const std::string timestamps;
 
+/** The size of a timestamp cell. */
+extern const uint64_t timestamp_size;
+
+/** The type of a variable offset cell. */
+extern const Datatype timestamp_type;
+
 /** The special value for an empty int32. */
 extern const int empty_int32;
 

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1146,22 +1146,31 @@ void Query::clear_strategy() {
 }
 
 Status Query::disable_check_global_order() {
-  if (status_ != QueryStatus::UNINITIALIZED)
+  if (status_ != QueryStatus::UNINITIALIZED) {
     return logger_->status(Status_QueryError(
         "Cannot disable checking global order after initialization"));
+  }
 
-  if (type_ == QueryType::READ)
+  if (type_ == QueryType::READ) {
     return logger_->status(Status_QueryError(
         "Cannot disable checking global order; Applicable only to writes"));
+  }
 
   disable_check_global_order_ = true;
   return Status::Ok();
 }
 
 Status Query::set_consolidation_with_timestamps() {
-  if (status_ != QueryStatus::UNINITIALIZED)
+  if (status_ != QueryStatus::UNINITIALIZED) {
     return logger_->status(Status_QueryError(
-        "Cannot disable checking global order after initialization"));
+        "Cannot enable consolidation with timestamps after initialization"));
+  }
+
+  if (type_ != QueryType::READ) {
+    return logger_->status(Status_QueryError(
+        "Cannot enable consolidation with timestamps; Applicable only to "
+        "reads"));
+  }
 
   consolidation_with_timestamps_ = true;
   return Status::Ok();

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -81,6 +81,7 @@ Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
     , data_buffer_name_("")
     , offsets_buffer_name_("")
     , disable_check_global_order_(false)
+    , consolidation_with_timestamps_(false)
     , fragment_uri_(fragment_uri) {
   assert(array->is_open());
   auto st = array->get_query_type(&type_);
@@ -1088,7 +1089,8 @@ Status Query::create_strategy() {
           buffers_,
           subarray_,
           layout_,
-          condition_));
+          condition_,
+          consolidation_with_timestamps_));
     } else if (use_refactored_dense_reader() && array_schema_->dense()) {
       bool all_dense = true;
       for (auto& frag_md : fragment_metadata_)
@@ -1156,6 +1158,15 @@ Status Query::disable_check_global_order() {
   return Status::Ok();
 }
 
+Status Query::set_consolidation_with_timestamps() {
+  if (status_ != QueryStatus::UNINITIALIZED)
+    return logger_->status(Status_QueryError(
+        "Cannot disable checking global order after initialization"));
+
+  consolidation_with_timestamps_ = true;
+  return Status::Ok();
+}
+
 Status Query::check_buffer_names() {
   if (type_ == QueryType::WRITE) {
     // If the array is sparse, the coordinates must be provided
@@ -1172,6 +1183,8 @@ Status Query::check_buffer_names() {
 
     // All attributes/dimensions must be provided
     auto expected_num = array_schema_->attribute_num();
+    expected_num += static_cast<decltype(expected_num)>(
+        buffers_.count(constants::timestamps));
     expected_num += (coord_buffer_is_set_ || coord_data_buffer_is_set_ ||
                      coord_offsets_buffer_is_set_) ?
                         array_schema_->dim_num() :
@@ -1333,7 +1346,8 @@ Status Query::set_data_buffer(
   const bool is_attr = array_schema_->is_attr(name);
 
   // Check that attribute/dimension exists
-  if (name != constants::coords && !is_dim && !is_attr)
+  if (name != constants::coords && name != constants::timestamps && !is_dim &&
+      !is_attr)
     return logger_->status(Status_QueryError(
         std::string("Cannot set buffer; Invalid attribute/dimension '") + name +
         "'"));

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -562,6 +562,11 @@ class Query {
   Status disable_check_global_order();
 
   /**
+   * Enables consolidation with timestamps.
+   */
+  Status set_consolidation_with_timestamps();
+
+  /**
    * Sets the config for the Query
    *
    * This function overrides the config for Query-level parameters only.
@@ -979,6 +984,11 @@ class Query {
    * in the global order. This supercedes the config.
    */
   bool disable_check_global_order_;
+
+  /**
+   * If `true`, it will enable consolidation with timestamps on the reader.
+   */
+  bool consolidation_with_timestamps_;
 
   /** The name of the new fragment to be created for writes. */
   URI fragment_uri_;

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -69,7 +69,8 @@ SparseGlobalOrderReader::SparseGlobalOrderReader(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
-    QueryCondition& condition)
+    QueryCondition& condition,
+    bool consolidation_with_timestamps)
     : SparseIndexReaderBase(
           stats,
           logger->clone("SparseGlobalOrderReader", ++logger_id_),
@@ -82,7 +83,8 @@ SparseGlobalOrderReader::SparseGlobalOrderReader(
           condition)
     , result_tiles_(array->fragment_metadata().size())
     , memory_used_for_coords_(array->fragment_metadata().size())
-    , memory_used_for_qc_tiles_(array->fragment_metadata().size()) {
+    , memory_used_for_qc_tiles_(array->fragment_metadata().size())
+    , consolidation_with_timestamps_(consolidation_with_timestamps) {
 }
 
 /* ****************************** */
@@ -140,6 +142,11 @@ Status SparseGlobalOrderReader::initialize_memory_budget() {
 
 Status SparseGlobalOrderReader::dowork() {
   auto timer_se = stats_->start_timer("dowork");
+
+  if (consolidation_with_timestamps_) {
+    return logger_->status(Status_SparseGlobalOrderReaderError(
+        "Consolidation with timestamps not yet implemented"));
+  }
 
   // For easy reference.
   auto fragment_num = fragment_metadata_.size();

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -73,7 +73,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition);
+      QueryCondition& condition,
+      bool consolidation_with_timestamps);
 
   /** Destructor. */
   ~SparseGlobalOrderReader() = default;
@@ -154,6 +155,9 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
 
   /** Memory budget per fragment for qc tiles. */
   double per_fragment_qc_memory_;
+
+  /** Enables consolidation with timestamps or not. */
+  bool consolidation_with_timestamps_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -586,6 +586,12 @@ SparseIndexReaderBase::read_and_unfilter_attributes(
   uint64_t memory_used = 0;
   while (*buffer_idx < names.size()) {
     auto& name = names[*buffer_idx];
+
+    if (name == constants::timestamps) {
+      (*buffer_idx)++;
+      continue;
+    }
+
     auto attr_mem_usage = mem_usage_per_attr[*buffer_idx];
     if (memory_used + attr_mem_usage < memory_budget) {
       memory_used += attr_mem_usage;

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -628,6 +628,7 @@ Status WriterBase::create_fragment(
     uri = frag_uri.join_path(new_fragment_str);
   }
   auto timestamp_range = std::pair<uint64_t, uint64_t>(timestamp, timestamp);
+  const bool has_timestamps = buffers_.count(constants::timestamps) != 0;
   frag_meta = make_shared<FragmentMetadata>(
       HERE(),
       storage_manager_,
@@ -635,7 +636,8 @@ Status WriterBase::create_fragment(
       array_->array_schema_latest_ptr(),
       uri,
       timestamp_range,
-      dense);
+      dense,
+      has_timestamps);
 
   RETURN_NOT_OK((frag_meta)->init(subarray_.ndrange(0)));
   return storage_manager_->create_dir(uri);


### PR DESCRIPTION
This adds the required code to enable consolidation with timestamps from
the fragment consolidator including:
- The ability to set a __timestamps buffer on the query.
- A query API to tell the reader that it's performing a read for the
consolidation with timestamps.
- The writer sets the has_timestamps_ member on the fragment metadata.
- Array schema changes to support __timestamps.
- Fragment metadata changes to write t.tdb.

---
TYPE: IMPROVEMENT
DESC: Consolidation with timestamps: enabling in fragment consolidator.
