### PR TITLE
Filter pipeline: fixing empty pipeline, multi chunk, refactored queries.

### DIFF
--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -499,7 +499,7 @@ Status FilterPipeline::run_reverse_chunk_range(
       void* output_chunk_buffer =
           static_cast<char*>(tile->data()) + chunk_data.chunk_offsets_[i];
       RETURN_NOT_OK(input_data.copy_to(output_chunk_buffer));
-      return Status::Ok();
+      continue;
     }
 
     // Apply the filters sequentially in reverse.


### PR DESCRIPTION
When running queries that have dimensions or attributes with and empty
filter pipeline, only the first chunks of a tile will be copied. This
also only happens for the refactored readers. Note that if there are
more cores than tiles, more chunks will be copied but likely not all.

---
TYPE: IMPROVEMENT
DESC: Filter pipeline: fixing empty pipeline, multi chunk, refactored queries.