### PR TITLE
Sparse global order reader: prevent dims from being unfiltered twice.

### DIFF
--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -1075,9 +1075,9 @@ SparseGlobalOrderReader::respect_copy_memory_budget(
             unordered_set<std::pair<uint64_t, uint64_t>, utils::hash::pair_hash>
                 accounted_tiles;
 
-        // For dimensions, when we have a subarray, tiles are already all
+        // For dimensions or query condition fields, tiles are already all
         // loaded in memory.
-        if ((subarray_.is_set() && array_schema_.is_dim(name)) ||
+        if (array_schema_.is_dim(name) ||
             condition_.field_names().count(name) != 0)
           return Status::Ok();
 


### PR DESCRIPTION
For the sparse global order reader, coordinates are always loaded, so
when computing the size for a dimension, it doesn't matter if a subarray
is pressent or not, it should always be 0.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: prevent dims from being unfiltered twice.
