### PR TITLE
Consolidation w/ timestamps: writing timestamps tiles.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -120,6 +120,7 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-capi-config.cc
   src/unit-capi-context.cc
   src/unit-capi-consolidation.cc
+  src/unit-capi-consolidation-with-timestamps.cc
   src/unit-capi-dense_array.cc
   src/unit-capi-dense_array_2.cc
   src/unit-capi-dense_neg.cc

--- a/test/src/unit-capi-consolidation-with-timestamps.cc
+++ b/test/src/unit-capi-consolidation-with-timestamps.cc
@@ -1,0 +1,398 @@
+/**
+ * @file   unit-capi-consolidation-with-timestamps.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C API consolidation with timestamps.
+ */
+
+#include "catch.hpp"
+#include "test/src/helpers.h"
+#include "tiledb/common/stdx_string.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/enums/encryption_type.h"
+#include "tiledb/sm/misc/tdb_time.h"
+#include "tiledb/storage_format/uri/parse_uri.h"
+
+#include <climits>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+
+using namespace tiledb::test;
+
+/** Tests for C API consolidation with timestamps. */
+struct ConsolidationWithTimestampsFx {
+  // Constants
+  const char* SPARSE_ARRAY_NAME = "test_consolidate_sparse_array";
+  const char* SPARSE_ARRAY_FRAG_DIR =
+      "test_consolidate_sparse_array/__fragments";
+
+  // TileDB context
+  tiledb_ctx_t* ctx_;
+  tiledb_vfs_t* vfs_;
+
+  // Encryption parameters
+  tiledb_encryption_type_t encryption_type_ = TILEDB_NO_ENCRYPTION;
+  const char* encryption_key_ = nullptr;
+
+  // Constructors/destructors
+  ConsolidationWithTimestampsFx();
+  ~ConsolidationWithTimestampsFx();
+
+  // Functions
+  void create_sparse_array();
+  void write_sparse(
+      std::vector<int> a1,
+      std::vector<uint64_t> dim1,
+      std::vector<uint64_t> dim2,
+      uint64_t timestamp);
+  void consolidate_sparse();
+  void check_timestamps_file(std::vector<uint64_t> expected);
+
+  void remove_sparse_array();
+  void remove_array(const std::string& array_name);
+  bool is_array(const std::string& array_name);
+
+  static int find_consolidated_frag_uri(const char* path, void* data);
+};
+
+ConsolidationWithTimestampsFx::ConsolidationWithTimestampsFx() {
+  ctx_ = nullptr;
+  REQUIRE(tiledb_ctx_alloc(nullptr, &ctx_) == TILEDB_OK);
+  vfs_ = nullptr;
+  REQUIRE(tiledb_vfs_alloc(ctx_, nullptr, &vfs_) == TILEDB_OK);
+}
+
+ConsolidationWithTimestampsFx::~ConsolidationWithTimestampsFx() {
+  tiledb_ctx_free(&ctx_);
+  tiledb_vfs_free(&vfs_);
+}
+
+void ConsolidationWithTimestampsFx::create_sparse_array() {
+  // Create dimensions
+  uint64_t dim_domain[] = {1, 4, 1, 4};
+  uint64_t tile_extents[] = {2, 2};
+  tiledb_dimension_t* d1;
+  int rc = tiledb_dimension_alloc(
+      ctx_, "d1", TILEDB_UINT64, &dim_domain[0], &tile_extents[0], &d1);
+  CHECK(rc == TILEDB_OK);
+  tiledb_dimension_t* d2;
+  rc = tiledb_dimension_alloc(
+      ctx_, "d2", TILEDB_UINT64, &dim_domain[2], &tile_extents[1], &d2);
+  CHECK(rc == TILEDB_OK);
+
+  // Create domain
+  tiledb_domain_t* domain;
+  rc = tiledb_domain_alloc(ctx_, &domain);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, d1);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, d2);
+  CHECK(rc == TILEDB_OK);
+
+  // Create attributes
+  tiledb_attribute_t* a1;
+  rc = tiledb_attribute_alloc(ctx_, "a1", TILEDB_INT32, &a1);
+  CHECK(rc == TILEDB_OK);
+  rc = set_attribute_compression_filter(ctx_, a1, TILEDB_FILTER_LZ4, -1);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_attribute_set_cell_val_num(ctx_, a1, 1);
+  CHECK(rc == TILEDB_OK);
+
+  // Create array schmea
+  tiledb_array_schema_t* array_schema;
+  rc = tiledb_array_schema_alloc(ctx_, TILEDB_SPARSE, &array_schema);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_tile_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_capacity(ctx_, array_schema, 20);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_domain(ctx_, array_schema, domain);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_schema_add_attribute(ctx_, array_schema, a1);
+  CHECK(rc == TILEDB_OK);
+
+  // Set up filters
+  tiledb_filter_t* filter;
+  rc = tiledb_filter_alloc(ctx_, TILEDB_FILTER_NONE, &filter);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_filter_list_t* filter_list;
+  rc = tiledb_filter_list_alloc(ctx_, &filter_list);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_filter_list_add_filter(ctx_, filter_list, filter);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_filter_free(&filter);
+
+  rc = tiledb_array_schema_set_coords_filter_list(
+      ctx_, array_schema, filter_list);
+  CHECK(rc == TILEDB_OK);
+
+  // Check array schema
+  rc = tiledb_array_schema_check(ctx_, array_schema);
+  CHECK(rc == TILEDB_OK);
+
+  // Create array
+  if (encryption_type_ != TILEDB_NO_ENCRYPTION) {
+    tiledb_ctx_free(&ctx_);
+    tiledb_vfs_free(&vfs_);
+    tiledb_config_t* cfg;
+    tiledb_error_t* err = nullptr;
+    rc = tiledb_config_alloc(&cfg, &err);
+    REQUIRE(rc == TILEDB_OK);
+    REQUIRE(err == nullptr);
+    std::string encryption_type_string =
+        encryption_type_str((tiledb::sm::EncryptionType)encryption_type_);
+    rc = tiledb_config_set(
+        cfg, "sm.encryption_type", encryption_type_string.c_str(), &err);
+    REQUIRE(err == nullptr);
+    rc = tiledb_config_set(cfg, "sm.encryption_key", encryption_key_, &err);
+    REQUIRE(rc == TILEDB_OK);
+    REQUIRE(err == nullptr);
+    REQUIRE(tiledb_ctx_alloc(cfg, &ctx_) == TILEDB_OK);
+    REQUIRE(tiledb_vfs_alloc(ctx_, cfg, &vfs_) == TILEDB_OK);
+    tiledb_config_free(&cfg);
+  }
+  rc = tiledb_array_create(ctx_, SPARSE_ARRAY_NAME, array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_attribute_free(&a1);
+  tiledb_dimension_free(&d1);
+  tiledb_dimension_free(&d2);
+  tiledb_domain_free(&domain);
+  tiledb_filter_list_free(&filter_list);
+  tiledb_array_schema_free(&array_schema);
+}
+
+void ConsolidationWithTimestampsFx::write_sparse(
+    std::vector<int> a1,
+    std::vector<uint64_t> dim1,
+    std::vector<uint64_t> dim2,
+    uint64_t timestamp) {
+  // Prepare cell buffers
+  void* buffers[] = {a1.data(), dim1.data(), dim2.data()};
+  uint64_t buffer_sizes[] = {a1.size() * sizeof(int),
+                             dim1.size() * sizeof(uint64_t)};
+
+  // Open array
+  tiledb_array_t* array;
+  int rc = tiledb_array_alloc(ctx_, SPARSE_ARRAY_NAME, &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_set_open_timestamp_end(ctx_, array, timestamp);
+  CHECK(rc == TILEDB_OK);
+  if (encryption_type_ != TILEDB_NO_ENCRYPTION) {
+    tiledb_config_t* cfg;
+    tiledb_error_t* err = nullptr;
+    rc = tiledb_config_alloc(&cfg, &err);
+    REQUIRE(rc == TILEDB_OK);
+    REQUIRE(err == nullptr);
+    std::string encryption_type_string =
+        encryption_type_str((tiledb::sm::EncryptionType)encryption_type_);
+    rc = tiledb_config_set(
+        cfg, "sm.encryption_type", encryption_type_string.c_str(), &err);
+    REQUIRE(rc == TILEDB_OK);
+    REQUIRE(err == nullptr);
+    rc = tiledb_config_set(cfg, "sm.encryption_key", encryption_key_, &err);
+    REQUIRE(rc == TILEDB_OK);
+    REQUIRE(err == nullptr);
+    rc = tiledb_array_set_config(ctx_, array, cfg);
+    REQUIRE(rc == TILEDB_OK);
+    tiledb_config_free(&cfg);
+  }
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create query
+  tiledb_query_t* query;
+  const char* attributes[] = {"a1", "d1", "d2"};
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(
+      ctx_, query, attributes[0], buffers[0], &buffer_sizes[0]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(
+      ctx_, query, attributes[1], buffers[1], &buffer_sizes[1]);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(
+      ctx_, query, attributes[2], buffers[2], &buffer_sizes[1]);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query
+  rc = tiledb_query_submit(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Finalize query
+  rc = tiledb_query_finalize(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+void ConsolidationWithTimestampsFx::consolidate_sparse() {
+  int rc;
+  tiledb_config_t* cfg;
+  tiledb_error_t* err = nullptr;
+  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
+  REQUIRE(err == nullptr);
+
+  rc = tiledb_config_set(cfg, "sm.consolidation.with_timestamps", "true", &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+
+  if (encryption_type_ != TILEDB_NO_ENCRYPTION) {
+    std::string encryption_type_string =
+        encryption_type_str((tiledb::sm::EncryptionType)encryption_type_);
+    rc = tiledb_config_set(
+        cfg, "sm.encryption_type", encryption_type_string.c_str(), &err);
+    REQUIRE(err == nullptr);
+    rc = tiledb_config_set(cfg, "sm.encryption_key", encryption_key_, &err);
+    REQUIRE(rc == TILEDB_OK);
+    REQUIRE(err == nullptr);
+  }
+  rc = tiledb_array_consolidate(ctx_, SPARSE_ARRAY_NAME, cfg);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_config_free(&cfg);
+}
+
+void ConsolidationWithTimestampsFx::check_timestamps_file(
+    std::vector<uint64_t> expected) {
+  std::string consolidated_fragment_uri;
+  auto rc = tiledb_vfs_ls(
+      ctx_,
+      vfs_,
+      SPARSE_ARRAY_FRAG_DIR,
+      &find_consolidated_frag_uri,
+      &consolidated_fragment_uri);
+  REQUIRE(rc == TILEDB_OK);
+
+  auto timestamps_file = consolidated_fragment_uri + "/t.tdb";
+
+  tiledb_vfs_fh_t* fh;
+  rc = tiledb_vfs_open(
+      ctx_, vfs_, timestamps_file.c_str(), TILEDB_VFS_READ, &fh);
+  REQUIRE(rc == TILEDB_OK);
+
+  uint64_t off = 0;
+  uint64_t num_tiles;
+  rc = tiledb_vfs_read(ctx_, fh, off, &num_tiles, sizeof(uint64_t));
+  REQUIRE(rc == TILEDB_OK);
+  off += sizeof(uint64_t);
+  REQUIRE(num_tiles == 1);
+
+  uint32_t filtered_size;
+  rc = tiledb_vfs_read(ctx_, fh, off, &filtered_size, sizeof(uint32_t));
+  REQUIRE(rc == TILEDB_OK);
+  off += sizeof(uint32_t);
+  REQUIRE(filtered_size == expected.size() * sizeof(uint64_t));
+
+  uint32_t unfiltered_size;
+  rc = tiledb_vfs_read(ctx_, fh, off, &unfiltered_size, sizeof(uint32_t));
+  REQUIRE(rc == TILEDB_OK);
+  off += sizeof(uint32_t);
+  REQUIRE(unfiltered_size == expected.size() * sizeof(uint64_t));
+
+  uint32_t md_size;
+  rc = tiledb_vfs_read(ctx_, fh, off, &md_size, sizeof(uint32_t));
+  REQUIRE(rc == TILEDB_OK);
+  off += sizeof(uint32_t);
+  REQUIRE(md_size == 0);
+
+  std::vector<uint64_t> written(unfiltered_size / sizeof(uint64_t));
+  rc = tiledb_vfs_read(ctx_, fh, off, written.data(), unfiltered_size);
+  REQUIRE(rc == TILEDB_OK);
+
+  for (uint64_t i = 0; i < expected.size(); i++) {
+    REQUIRE(expected[i] == written[i]);
+  }
+  tiledb_vfs_fh_free(&fh);
+}
+
+void ConsolidationWithTimestampsFx::remove_array(
+    const std::string& array_name) {
+  if (!is_array(array_name))
+    return;
+
+  CHECK(tiledb_object_remove(ctx_, array_name.c_str()) == TILEDB_OK);
+}
+
+void ConsolidationWithTimestampsFx::remove_sparse_array() {
+  remove_array(SPARSE_ARRAY_NAME);
+}
+
+bool ConsolidationWithTimestampsFx::is_array(const std::string& array_name) {
+  tiledb_object_t type = TILEDB_INVALID;
+  REQUIRE(tiledb_object_type(ctx_, array_name.c_str(), &type) == TILEDB_OK);
+  return type == TILEDB_ARRAY;
+}
+
+int ConsolidationWithTimestampsFx::find_consolidated_frag_uri(
+    const char* path, void* data) {
+  std::string fragment = path;
+  if (fragment.find("__1_2_") != std::string::npos) {
+    auto uri = (std::string*)data;
+    *uri = path;
+  }
+
+  return 1;
+}
+
+TEST_CASE_METHOD(
+    ConsolidationWithTimestampsFx,
+    "C API: Test consolidation with timestamps",
+    "[capi][consolidation-with-timestamps]") {
+  remove_sparse_array();
+  create_sparse_array();
+
+  // Write first fragment.
+  write_sparse(
+      {0, 1, 2, 3, 4, 5, 6, 7},
+      {1, 1, 1, 2, 3, 4, 3, 3},
+      {1, 2, 4, 3, 1, 2, 3, 4},
+      1);
+
+  // Write second fragment.
+  write_sparse({8, 9, 10, 11}, {2, 2, 3, 3}, {2, 3, 2, 3}, 2);
+
+  // Consolidate.
+  consolidate_sparse();
+
+  // Check t.tdb file.
+  check_timestamps_file({1, 1, 2, 1, 1, 2, 1, 2, 1, 1, 2, 1});
+
+  remove_sparse_array();
+}

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -573,7 +573,7 @@ Status FragmentConsolidator::create_queries(
   *query_w =
       tdb_new(Query, storage_manager_, array_for_writes, *new_fragment_uri);
   RETURN_NOT_OK((*query_w)->set_layout(Layout::GLOBAL_ORDER));
-  RETURN_NOT_OK((*query_w)->disable_check_global_order());
+  RETURN_NOT_OK((*query_w)->disable_checks_consolidation());
   if (array_for_reads->array_schema_latest().dense())
     RETURN_NOT_OK((*query_w)->set_subarray_unsafe(subarray));
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -707,6 +707,10 @@ bool FragmentMetadata::has_consolidated_footer() const {
   return has_consolidated_footer_;
 }
 
+bool FragmentMetadata::has_timestamps() const {
+  return has_timestamps_;
+}
+
 Status FragmentMetadata::get_tile_overlap(
     const NDRange& range,
     std::vector<bool>& is_default,

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -224,6 +224,9 @@ class FragmentMetadata {
   /** Returns true if the metadata footer is consolidated. */
   bool has_consolidated_footer() const;
 
+  /** Returns true if the fragment has timestamps. */
+  bool has_timestamps() const;
+
   /**
    * Retrieves the overlap of all MBRs with the input ND range.
    */

--- a/tiledb/sm/query/global_order_writer.cc
+++ b/tiledb/sm/query/global_order_writer.cc
@@ -75,7 +75,7 @@ GlobalOrderWriter::GlobalOrderWriter(
     Subarray& subarray,
     Layout layout,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
-    bool disable_check_global_order,
+    bool disable_checks_consolidation,
     Query::CoordsInfo& coords_info,
     URI fragment_uri)
     : WriterBase(
@@ -88,7 +88,7 @@ GlobalOrderWriter::GlobalOrderWriter(
           subarray,
           layout,
           written_fragment_info,
-          disable_check_global_order,
+          disable_checks_consolidation,
           coords_info,
           fragment_uri) {
 }

--- a/tiledb/sm/query/global_order_writer.h
+++ b/tiledb/sm/query/global_order_writer.h
@@ -107,7 +107,7 @@ class GlobalOrderWriter : public WriterBase {
       Subarray& subarray,
       Layout layout,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
-      bool disable_check_global_order,
+      bool disable_checks_consolidation,
       Query::CoordsInfo& coords_info_,
       URI fragment_uri = URI(""));
 

--- a/tiledb/sm/query/ordered_writer.cc
+++ b/tiledb/sm/query/ordered_writer.cc
@@ -75,7 +75,6 @@ OrderedWriter::OrderedWriter(
     Subarray& subarray,
     Layout layout,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
-    bool disable_check_global_order,
     Query::CoordsInfo& coords_info,
     URI fragment_uri)
     : WriterBase(
@@ -88,7 +87,7 @@ OrderedWriter::OrderedWriter(
           subarray,
           layout,
           written_fragment_info,
-          disable_check_global_order,
+          false,
           coords_info,
           fragment_uri) {
 }

--- a/tiledb/sm/query/ordered_writer.h
+++ b/tiledb/sm/query/ordered_writer.h
@@ -62,7 +62,6 @@ class OrderedWriter : public WriterBase {
       Subarray& subarray,
       Layout layout,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
-      bool disable_check_global_order,
       Query::CoordsInfo& coords_info_,
       URI fragment_uri = URI(""));
 

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -80,7 +80,7 @@ Query::Query(StorageManager* storage_manager, Array* array, URI fragment_uri)
     , coord_offsets_buffer_is_set_(false)
     , data_buffer_name_("")
     , offsets_buffer_name_("")
-    , disable_check_global_order_(false)
+    , disable_checks_consolidation_(false)
     , consolidation_with_timestamps_(false)
     , fragment_uri_(fragment_uri) {
   assert(array->is_open());
@@ -1000,7 +1000,6 @@ Status Query::create_strategy() {
           subarray_,
           layout_,
           written_fragment_info_,
-          disable_check_global_order_,
           coords_info_,
           fragment_uri_));
     } else if (layout_ == Layout::UNORDERED) {
@@ -1015,7 +1014,6 @@ Status Query::create_strategy() {
           subarray_,
           layout_,
           written_fragment_info_,
-          disable_check_global_order_,
           coords_info_,
           fragment_uri_));
     } else if (layout_ == Layout::GLOBAL_ORDER) {
@@ -1030,7 +1028,7 @@ Status Query::create_strategy() {
           subarray_,
           layout_,
           written_fragment_info_,
-          disable_check_global_order_,
+          disable_checks_consolidation_,
           coords_info_,
           fragment_uri_));
     } else {
@@ -1145,7 +1143,7 @@ void Query::clear_strategy() {
   strategy_ = nullptr;
 }
 
-Status Query::disable_check_global_order() {
+Status Query::disable_checks_consolidation() {
   if (status_ != QueryStatus::UNINITIALIZED) {
     return logger_->status(Status_QueryError(
         "Cannot disable checking global order after initialization"));
@@ -1153,10 +1151,10 @@ Status Query::disable_check_global_order() {
 
   if (type_ == QueryType::READ) {
     return logger_->status(Status_QueryError(
-        "Cannot disable checking global order; Applicable only to writes"));
+        "Cannot disable checks for consolidation; Applicable only to writes"));
   }
 
-  disable_check_global_order_ = true;
+  disable_checks_consolidation_ = true;
   return Status::Ok();
 }
 

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1146,7 +1146,7 @@ void Query::clear_strategy() {
 Status Query::disable_checks_consolidation() {
   if (status_ != QueryStatus::UNINITIALIZED) {
     return logger_->status(Status_QueryError(
-        "Cannot disable checking global order after initialization"));
+        "Cannot disable checks for consolidation after initialization"));
   }
 
   if (type_ == QueryType::READ) {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -556,10 +556,10 @@ class Query {
   void clear_strategy();
 
   /**
-   * Disables checking the global order. Applicable only to writes.
-   * This option will supercede the config.
+   * Disables checking the global order and coordinate duplicates. Applicable
+   * only to writes. This option will supercede the config.
    */
-  Status disable_check_global_order();
+  Status disable_checks_consolidation();
 
   /**
    * Enables consolidation with timestamps.
@@ -981,9 +981,9 @@ class Query {
 
   /**
    * If `true`, it will not check if the written coordinates are
-   * in the global order. This supercedes the config.
+   * in the global order or have duplicates. This supercedes the config.
    */
-  bool disable_check_global_order_;
+  bool disable_checks_consolidation_;
 
   /**
    * If `true`, it will enable consolidation with timestamps on the reader.

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -223,6 +223,12 @@ Status ReaderBase::check_validity_buffer_sizes() const {
   return Status::Ok();
 }
 
+bool ReaderBase::timestamps_not_present(
+    const std::string& name,
+    const std::shared_ptr<tiledb::sm::FragmentMetadata>& frag_md) const {
+  return name == constants::timestamps && !frag_md->has_timestamps();
+}
+
 Status ReaderBase::load_tile_offsets(
     Subarray& subarray, const std::vector<std::string>& names) {
   auto timer_se = stats_->start_timer("load_tile_offsets");
@@ -457,7 +463,7 @@ Status ReaderBase::read_tiles(
       }
 
       // If the fragment doesn't include timestamps
-      if (name == constants::timestamps && !fragment->has_timestamps()) {
+      if (timestamps_not_present(name, fragment)) {
         continue;
       }
 
@@ -722,7 +728,7 @@ ReaderBase::load_tile_chunk_data(
     }
 
     // If the fragment doesn't include timestamps
-    if (name == constants::timestamps && !fragment->has_timestamps()) {
+    if (timestamps_not_present(name, fragment)) {
       return {Status::Ok(), nullopt, nullopt, nullopt};
     }
 
@@ -780,7 +786,7 @@ Status ReaderBase::unfilter_tile_chunk_range(
     }
 
     // If the fragment doesn't include timestamps
-    if (name == constants::timestamps && !fragment->has_timestamps()) {
+    if (timestamps_not_present(name, fragment)) {
       return Status::Ok();
     }
 
@@ -869,7 +875,7 @@ Status ReaderBase::post_process_unfiltered_tile(
     }
 
     // If the fragment doesn't include timestamps
-    if (name == constants::timestamps && !fragment->has_timestamps()) {
+    if (timestamps_not_present(name, fragment)) {
       return Status::Ok();
     }
 
@@ -1276,7 +1282,7 @@ Status ReaderBase::unfilter_tiles(
           }
 
           // If the fragment doesn't include timestamps
-          if (name == constants::timestamps && !fragment->has_timestamps()) {
+          if (timestamps_not_present(name, fragment)) {
             return Status::Ok();
           }
 

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -438,20 +438,28 @@ Status ReaderBase::read_tiles(
       const uint32_t format_version = fragment->format_version();
 
       // Applicable for zipped coordinates only to versions < 5
-      if (name == constants::coords && format_version >= 5)
+      if (name == constants::coords && format_version >= 5) {
         continue;
+      }
 
       // Applicable to separate coordinates only to versions >= 5
       const auto& array_schema = fragment->array_schema();
       const bool is_dim = array_schema->is_dim(name);
-      if (is_dim && format_version < 5)
+      if (is_dim && format_version < 5) {
         continue;
+      }
 
       // If the fragment doesn't have the attribute, this is a schema
       // evolution field and will be treated with fill-in value instead of
       // reading from disk
-      if (!array_schema->is_field(name))
+      if (!array_schema->is_field(name)) {
         continue;
+      }
+
+      // If the fragment doesn't include timestamps
+      if (name == constants::timestamps && !fragment->has_timestamps()) {
+        continue;
+      }
 
       const bool var_size = array_schema->var_size(name);
       const bool nullable = array_schema->is_nullable(name);
@@ -694,8 +702,8 @@ ReaderBase::load_tile_chunk_data(
   assert(tile_chunk_var_data);
   assert(tile_chunk_validity_data);
 
-  const auto format_version =
-      fragment_metadata_[tile->frag_idx()]->format_version();
+  auto& fragment = fragment_metadata_[tile->frag_idx()];
+  const auto format_version = fragment->format_version();
   uint64_t unfiltered_tile_size = 0, unfiltered_tile_var_size = 0,
            unfiltered_tile_validity_size = 0;
 
@@ -709,8 +717,14 @@ ReaderBase::load_tile_chunk_data(
     // Skip non-existent attributes/dimensions (e.g. coords in the
     // dense case).
     if (tile_tuple == nullptr ||
-        std::get<0>(*tile_tuple).filtered_buffer().size() == 0)
+        std::get<0>(*tile_tuple).filtered_buffer().size() == 0) {
       return {Status::Ok(), nullopt, nullopt, nullopt};
+    }
+
+    // If the fragment doesn't include timestamps
+    if (name == constants::timestamps && !fragment->has_timestamps()) {
+      return {Status::Ok(), nullopt, nullopt, nullopt};
+    }
 
     const auto t = &std::get<0>(*tile_tuple);
     const auto t_var = &std::get<1>(*tile_tuple);
@@ -761,8 +775,14 @@ Status ReaderBase::unfilter_tile_chunk_range(
     // Skip non-existent attributes/dimensions (e.g. coords in the
     // dense case).
     if (tile_tuple == nullptr ||
-        std::get<0>(*tile_tuple).filtered_buffer().size() == 0)
+        std::get<0>(*tile_tuple).filtered_buffer().size() == 0) {
       return Status::Ok();
+    }
+
+    // If the fragment doesn't include timestamps
+    if (name == constants::timestamps && !fragment->has_timestamps()) {
+      return Status::Ok();
+    }
 
     auto t = &std::get<0>(*tile_tuple);
     auto t_var = &std::get<1>(*tile_tuple);
@@ -844,8 +864,14 @@ Status ReaderBase::post_process_unfiltered_tile(
     // Skip non-existent attributes/dimensions (e.g. coords in the
     // dense case).
     if (tile_tuple == nullptr ||
-        std::get<0>(*tile_tuple).filtered_buffer().size() == 0)
+        std::get<0>(*tile_tuple).filtered_buffer().size() == 0) {
       return Status::Ok();
+    }
+
+    // If the fragment doesn't include timestamps
+    if (name == constants::timestamps && !fragment->has_timestamps()) {
+      return Status::Ok();
+    }
 
     auto t = &std::get<0>(*tile_tuple);
     auto t_var = &std::get<1>(*tile_tuple);
@@ -1245,8 +1271,14 @@ Status ReaderBase::unfilter_tiles(
           // Skip non-existent attributes/dimensions (e.g. coords in the
           // dense case).
           if (tile_tuple == nullptr ||
-              std::get<0>(*tile_tuple).filtered_buffer().size() == 0)
+              std::get<0>(*tile_tuple).filtered_buffer().size() == 0) {
             return Status::Ok();
+          }
+
+          // If the fragment doesn't include timestamps
+          if (name == constants::timestamps && !fragment->has_timestamps()) {
+            return Status::Ok();
+          }
 
           auto& t = std::get<0>(*tile_tuple);
           auto& t_var = std::get<1>(*tile_tuple);

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -197,6 +197,14 @@ class ReaderBase : public StrategyBase {
   Status check_validity_buffer_sizes() const;
 
   /**
+   * Skip read/unfilter operations for timestamps attribute and fragments
+   * without timestamps.
+   */
+  bool timestamps_not_present(
+      const std::string& name,
+      const std::shared_ptr<tiledb::sm::FragmentMetadata>& frag_md) const;
+
+  /**
    * Loads tile offsets for each attribute/dimension name into
    * their associated element in `fragment_metadata_`.
    *

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -842,7 +842,8 @@ Status SparseGlobalOrderReader::copy_offsets_tiles(
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
         auto& rcs = result_cell_slabs[i];
-        auto rt = (ResultTileWithBitmap<uint8_t>*)result_cell_slabs[i].tile_;
+        auto rt = static_cast<ResultTileWithBitmap<uint8_t>*>(
+            result_cell_slabs[i].tile_);
 
         // Get source buffers.
         const auto tile_tuple = rt->tile_tuple(name);
@@ -1001,7 +1002,8 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
         auto& rcs = result_cell_slabs[i];
-        auto rt = (ResultTileWithBitmap<uint8_t>*)result_cell_slabs[i].tile_;
+        auto rt = static_cast<ResultTileWithBitmap<uint8_t>*>(
+            result_cell_slabs[i].tile_);
 
         // Get source buffers.
         const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
@@ -1074,8 +1076,9 @@ Status SparseGlobalOrderReader::copy_timestamps_tiles(
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
         auto& rcs = result_cell_slabs[i];
-        auto rt = (ResultTileWithBitmap<uint8_t>*)result_cell_slabs[i].tile_;
-        const uint64_t cell_size = sizeof(uint64_t);
+        auto rt = static_cast<ResultTileWithBitmap<uint8_t>*>(
+            result_cell_slabs[i].tile_);
+        const uint64_t cell_size = constants::timestamp_size;
 
         // Get source buffers.
         const auto tile_tuple = rt->tile_tuple(constants::timestamps);
@@ -1156,6 +1159,9 @@ SparseGlobalOrderReader::respect_copy_memory_budget(
               (ResultTileWithBitmap<uint8_t>*)result_cell_slabs[idx].tile_;
           auto id =
               std::pair<uint64_t, uint64_t>(rt->frag_idx(), rt->tile_idx());
+
+          // Timestamp attribute might not have tiles if this isn't a
+          // consolidated fragment with timestamps.
           const bool has_tile =
               !is_timestamps ||
               fragment_metadata_[rt->frag_idx()]->has_timestamps();

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -336,6 +336,22 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       QueryBuffer& query_buffer);
 
   /**
+   * Copy timestamps tiles.
+   *
+   * @param num_range_threads Total number of range threads.
+   * @param result_cell_slabs Result cell slabs to process.
+   * @param cell_offsets Cell offset per result tile.
+   * @param query_buffer Query buffer to operate on.
+   *
+   * @return Status.
+   */
+  Status copy_timestamps_tiles(
+      const uint64_t num_range_threads,
+      const std::vector<ResultCellSlab>& result_cell_slabs,
+      const std::vector<uint64_t>& cell_offsets,
+      QueryBuffer& query_buffer);
+
+  /**
    * Make sure we respect memory budget for copy operation by making sure that,
    * for all attributes to be copied, the size of tiles in memory can fit into
    * the budget.

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -587,11 +587,6 @@ SparseIndexReaderBase::read_and_unfilter_attributes(
   while (*buffer_idx < names.size()) {
     auto& name = names[*buffer_idx];
 
-    if (name == constants::timestamps) {
-      (*buffer_idx)++;
-      continue;
-    }
-
     auto attr_mem_usage = mem_usage_per_attr[*buffer_idx];
     if (memory_used + attr_mem_usage < memory_budget) {
       memory_used += attr_mem_usage;

--- a/tiledb/sm/query/unordered_writer.cc
+++ b/tiledb/sm/query/unordered_writer.cc
@@ -75,7 +75,6 @@ UnorderedWriter::UnorderedWriter(
     Subarray& subarray,
     Layout layout,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
-    bool disable_check_global_order,
     Query::CoordsInfo& coords_info,
     URI fragment_uri)
     : WriterBase(
@@ -88,7 +87,7 @@ UnorderedWriter::UnorderedWriter(
           subarray,
           layout,
           written_fragment_info,
-          disable_check_global_order,
+          false,
           coords_info,
           fragment_uri) {
 }

--- a/tiledb/sm/query/unordered_writer.h
+++ b/tiledb/sm/query/unordered_writer.h
@@ -62,7 +62,6 @@ class UnorderedWriter : public WriterBase {
       Subarray& subarray,
       Layout layout,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
-      bool disable_check_global_order,
       Query::CoordsInfo& coords_info_,
       URI fragment_uri = URI(""));
 

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -76,7 +76,7 @@ WriterBase::WriterBase(
     Subarray& subarray,
     Layout layout,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
-    bool disable_check_global_order,
+    bool disable_checks_consolidation,
     Query::CoordsInfo& coords_info,
     URI fragment_uri)
     : StrategyBase(
@@ -88,7 +88,7 @@ WriterBase::WriterBase(
           buffers,
           subarray,
           layout)
-    , disable_check_global_order_(disable_check_global_order)
+    , disable_checks_consolidation_(disable_checks_consolidation)
     , coords_info_(coords_info)
     , check_coord_dups_(false)
     , check_coord_oob_(false)
@@ -212,10 +212,11 @@ Status WriterBase::init() {
   RETURN_NOT_OK(config_.get("sm.dedup_coords", &dedup_coords));
   assert(check_coord_dups != nullptr && dedup_coords != nullptr);
   check_coord_dups_ =
-      disable_check_global_order_ ? false : !strcmp(check_coord_dups, "true");
+      disable_checks_consolidation_ ? false : !strcmp(check_coord_dups, "true");
   check_coord_oob_ = !strcmp(check_coord_oob, "true");
-  check_global_order_ =
-      disable_check_global_order_ ? false : !strcmp(check_global_order, "true");
+  check_global_order_ = disable_checks_consolidation_ ?
+                            false :
+                            !strcmp(check_global_order, "true");
   dedup_coords_ = !strcmp(dedup_coords, "true");
   bool found = false;
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);

--- a/tiledb/sm/query/writer_base.cc
+++ b/tiledb/sm/query/writer_base.cc
@@ -211,7 +211,8 @@ Status WriterBase::init() {
   RETURN_NOT_OK(config_.get("sm.check_global_order", &check_global_order));
   RETURN_NOT_OK(config_.get("sm.dedup_coords", &dedup_coords));
   assert(check_coord_dups != nullptr && dedup_coords != nullptr);
-  check_coord_dups_ = !strcmp(check_coord_dups, "true");
+  check_coord_dups_ =
+      disable_check_global_order_ ? false : !strcmp(check_coord_dups, "true");
   check_coord_oob_ = !strcmp(check_coord_oob, "true");
   check_global_order_ =
       disable_check_global_order_ ? false : !strcmp(check_global_order, "true");

--- a/tiledb/sm/query/writer_base.h
+++ b/tiledb/sm/query/writer_base.h
@@ -75,7 +75,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
       Subarray& subarray,
       Layout layout,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
-      bool disable_check_global_order,
+      bool disable_checks_consolidation,
       Query::CoordsInfo& coords_info_,
       URI fragment_uri = URI(""));
 
@@ -140,9 +140,9 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
 
   /**
    * If `true`, it will not check if the written coordinates are
-   * in the global order. This supercedes the config.
+   * in the global order or have duplicates. This supercedes the config.
    */
-  bool disable_check_global_order_;
+  bool disable_checks_consolidation_;
 
   /** Keeps track of the coords data. */
   Query::CoordsInfo& coords_info_;


### PR DESCRIPTION
This modifies the sparse global order reader to fill in the __timestamps
buffer with the timestamp data. It also modifies read_tiles and
unfilter_tiles to skip tiles with no timestamp data, and allows the tile
copy for the reader to copy timestamps values depending on wether or not
the tile contains timestamps information (using the fragment timestamp
if it doesn't). Finally, this modifies the merge operation to include
all duplicated coordinates into the cells slabs for consolidation reads,
but it does not, for regular reads select the appropriate cell (the one
with the greater timestamp) in consolidated fragments with timestamps.
This will be added in a later PR.
    
---
TYPE: IMPROVEMENT
DESC: Consolidation w/ timestamps: writing timestamps tiles.