### PR TITLE
Changes test_assert path used to locate try_assert

### DIFF
--- a/test/ci/CMakeLists.txt
+++ b/test/ci/CMakeLists.txt
@@ -17,6 +17,20 @@ if (TILEDB_ASSERTIONS)
   )
 endif()
 
+if (MSVC)
+  target_compile_definitions(
+    test_assert
+    PRIVATE
+    -DTILEDB_PATH_TO_TRY_ASSERT="${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}"
+  )
+else()
+  target_compile_definitions(
+    test_assert
+    PRIVATE
+    -DTILEDB_PATH_TO_TRY_ASSERT="${CMAKE_CURRENT_BINARY_DIR}"
+  )
+endif()
+
 add_executable(
   try_assert
   try_assert.cc

--- a/test/ci/test_assert.cc
+++ b/test/ci/test_assert.cc
@@ -44,7 +44,7 @@ constexpr int assert_exit_code = 6;
 #endif
 
 TEST_CASE("CI: Test assertions configuration", "[ci][assertions]") {
-  int retval = system("./try_assert");
+  int retval = system(TILEDB_PATH_TO_TRY_ASSERT "/try_assert");
 
 #ifdef TILEDB_ASSERTIONS
   REQUIRE(retval == assert_exit_code);


### PR DESCRIPTION
Changes so test_assert can be run from outside build directory and still find try_assert within that build directory

---
TYPE: BUG
DESC: Change test_assert path used to locate try_assert
