### PR TITLE
example writing_sparse_global_<c,cpp>, change illegal write to be legal

### DIFF
--- a/examples/c_api/writing_sparse_global.c
+++ b/examples/c_api/writing_sparse_global.c
@@ -114,7 +114,7 @@ void write_array() {
   tiledb_query_submit(ctx, query);
 
   // Prepare data for second write
-  int coords_rows_2[] = {2};
+  int coords_rows_2[] = {3};
   int coords_cols_2[] = {3};
   uint64_t coords_size_2 = sizeof(coords_rows_2);
   int data_2[] = {3};

--- a/examples/cpp_api/writing_sparse_global.cc
+++ b/examples/cpp_api/writing_sparse_global.cc
@@ -82,7 +82,7 @@ void write_array() {
   query.submit();
 
   // Submit second query
-  std::vector<int> coords_rows_2 = {2};
+  std::vector<int> coords_rows_2 = {3};
   std::vector<int> coords_cols_2 = {3};
   std::vector<int> data_2 = {3};
   query.set_data_buffer("a", data_2)


### PR DESCRIPTION
change coordinate of second write to be legal, avoiding recently implemented error check/report

---
TYPE: BUG
DESC: example writing_sparse_global_<c,cpp>, change illegal write to be legal
