### PR TITLE
Unordered writer: fixing segfault for empty writes.

### DIFF
--- a/tiledb/sm/query/global_order_writer.cc
+++ b/tiledb/sm/query/global_order_writer.cc
@@ -496,6 +496,12 @@ Status GlobalOrderWriter::finalize_global_write_state() {
     }
   }
 
+  // No cells written, clean up empty fragment.
+  if (cell_num == 0) {
+    clean_up(uri);
+    return Status::Ok();
+  }
+
   // Check if the total number of cells written is equal to the subarray size
   if (!coords_info_.has_coords_) {  // This implies a dense array
     auto expected_cell_num =

--- a/tiledb/sm/query/unordered_writer.cc
+++ b/tiledb/sm/query/unordered_writer.cc
@@ -557,7 +557,9 @@ Status UnorderedWriter::prepare_tiles_var(
     }
   }
 
-  (*tiles)[tile_idx + 1].final_size(offset);
+  if (cell_num > 0) {
+    (*tiles)[tile_idx + 1].final_size(offset);
+  }
 
   uint64_t last_tile_cell_num = (cell_num - dups_num) % capacity;
   if (last_tile_cell_num != 0) {
@@ -635,8 +637,10 @@ Status UnorderedWriter::unordered_write() {
   coord_dups.clear();
 
   // No tiles
-  if (tiles.empty() || tiles.begin()->second.empty())
+  if (tiles.empty() || tiles.begin()->second.empty()) {
+    clean_up(uri);
     return Status::Ok();
+  }
 
   // Set the number of tiles in the metadata
   auto it = tiles.begin();


### PR DESCRIPTION
Fix for https://github.com/TileDB-Inc/TileDB-Py/issues/1086.

---
TYPE: IMPROVEMENT
DESC: Unordered writer: fixing segfault for empty writes.
