### PR TITLE
change to avoid msvc warning causing build error

### DIFF
--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -41,7 +41,14 @@
 
 size_t random_ms(size_t max = 3) {
   thread_local static std::mt19937 generator(
+#if defined(_MSC_VER)
+      // MSVC expects unsigned int, std::hash<...id>() not compatible with msvc
+      // mt19937
+      static_cast<unsigned int>(
+          std::hash<std::thread::id>()(std::this_thread::get_id())));
+#else
       std::hash<std::thread::id>()(std::this_thread::get_id()));
+#endif
   std::uniform_int_distribution<size_t> distribution(0, max);
   return distribution(generator);
 }

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -32,17 +32,17 @@
 
 #include "unit_thread_pool.h"
 
+#include <stdint.h>
 #include <atomic>
 #include <catch.hpp>
-#include <iostream>
-#include <stdint.h>
 #include <iostream>
 
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/misc/cancelable_tasks.h"
 
 size_t random_ms(size_t max = 3) {
-  thread_local static uint64_t generator_seed = std::hash<std::thread::id>()(std::this_thread::get_id());
+  thread_local static uint64_t generator_seed =
+      std::hash<std::thread::id>()(std::this_thread::get_id());
   thread_local static std::mt19937_64 generator(generator_seed);
   thread_local static bool reported_seed = false;
   if (!reported_seed) {

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -44,11 +44,6 @@ size_t random_ms(size_t max = 3) {
   thread_local static uint64_t generator_seed =
       std::hash<std::thread::id>()(std::this_thread::get_id());
   thread_local static std::mt19937_64 generator(generator_seed);
-  thread_local static bool reported_seed = false;
-  if (!reported_seed) {
-    std::cout << "random_ms(), generator_seed " << generator_seed << std::endl;
-    reported_seed = true;
-  }
   std::uniform_int_distribution<size_t> distribution(0, max);
   return distribution(generator);
 }


### PR DESCRIPTION
change to use underlying std::mt19937_64 available on all platforms in use and not suffering from the narrowing conversion warning problem

---
TYPE: BUG
DESC: change to avoid warning causing build error with msvc
