### PR TITLE
Add Datatype::TILEDB_BOOL

### DIFF
--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -299,6 +299,7 @@ TEST_CASE(
                 &buffers);
             break;
           }
+          case TILEDB_BOOL:
           case TILEDB_UINT8: {
             set_buffer_wrapper<uint8_t>(
                 query,
@@ -586,6 +587,7 @@ TEST_CASE(
             REQUIRE(static_cast<int8_t*>(std::get<1>(buffer))[0] == 1);
             break;
           }
+          case TILEDB_BOOL:
           case TILEDB_UINT8: {
             REQUIRE(static_cast<uint8_t*>(std::get<1>(buffer))[0] == 1);
             break;
@@ -790,6 +792,7 @@ TEST_CASE(
                 &buffers);
             break;
           }
+          case TILEDB_BOOL:
           case TILEDB_UINT8: {
             set_buffer_wrapper<uint8_t>(
                 query,
@@ -1113,6 +1116,7 @@ TEST_CASE(
             REQUIRE(static_cast<int8_t*>(std::get<1>(buffer))[0] == 1);
             break;
           }
+          case TILEDB_BOOL:
           case TILEDB_UINT8: {
             REQUIRE(static_cast<uint8_t*>(std::get<1>(buffer))[0] == 1);
             break;

--- a/test/src/unit-capi-attributes.cc
+++ b/test/src/unit-capi-attributes.cc
@@ -290,8 +290,8 @@ TEST_CASE_METHOD(
     create_dense_vector(array_name, attr_name, TILEDB_BLOB);
 
     // Prepare cell buffers
-    uint8_t buffer_a1[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    uint64_t buffer_a1_size = sizeof(buffer_a1);
+    uint8_t buffer_write[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    uint64_t buffer_write_size = sizeof(buffer_write);
 
     // Open array
     int64_t subarray[] = {1, 10};
@@ -310,7 +310,7 @@ TEST_CASE_METHOD(
     rc = tiledb_query_set_subarray(ctx_, query, subarray);
     CHECK(rc == TILEDB_OK);
     rc = tiledb_query_set_data_buffer(
-        ctx_, query, attr_name.c_str(), buffer_a1, &buffer_a1_size);
+        ctx_, query, attr_name.c_str(), buffer_write, &buffer_write_size);
     CHECK(rc == TILEDB_OK);
 
     rc = tiledb_query_submit(ctx_, query);
@@ -353,9 +353,111 @@ TEST_CASE_METHOD(
     tiledb_query_free(&query);
 
     // Check correctness
-    uint8_t buffer_read_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    CHECK(!std::memcmp(buffer_read, buffer_read_c, sizeof(buffer_read_c)));
-    CHECK(buffer_read_size == sizeof(buffer_read_c));
+    CHECK(!std::memcmp(buffer_read, buffer_write, buffer_write_size));
+    CHECK(buffer_read_size == buffer_write_size);
+
+    remove_temp_dir(temp_dir);
+  }
+}
+
+/**
+ * Note: TILEDB_BOOL is currently equivalent to TILEDB_UINT8.
+ *
+ * Future improvements on the bool Datatype could impact this test.
+ */
+TEST_CASE_METHOD(
+    Attributesfx,
+    "C API: Test attributes with tiledb_bool datatype",
+    "[capi][attributes][tiledb_bool]") {
+  for (const auto& fs : fs_vec_) {
+    std::string temp_dir = fs->temp_dir();
+    std::string array_name = temp_dir;
+    std::string attr_name = "attr";
+
+    // Create new TileDB context with file lock config disabled, rest the
+    // same.
+    tiledb_ctx_free(&ctx_);
+    tiledb_vfs_free(&vfs_);
+
+    tiledb_config_t* config = nullptr;
+    tiledb_error_t* error = nullptr;
+    REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+    REQUIRE(error == nullptr);
+
+    REQUIRE(vfs_test_init(fs_vec_, &ctx_, &vfs_, config).ok());
+
+    tiledb_config_free(&config);
+
+    create_temp_dir(temp_dir);
+
+    create_dense_vector(array_name, attr_name, TILEDB_BOOL);
+
+    // Prepare cell buffers
+    uint8_t buffer_write[] = {0, 1, 1, 0, 0, 0, 1, 0, 1, 1};
+    uint64_t buffer_write_size = sizeof(buffer_write);
+
+    // Open array
+    int64_t subarray[] = {1, 10};
+    tiledb_array_t* array;
+    int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+    CHECK(rc == TILEDB_OK);
+
+    // Submit query
+    tiledb_query_t* query;
+    rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_subarray(ctx_, query, subarray);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_data_buffer(
+        ctx_, query, attr_name.c_str(), buffer_write, &buffer_write_size);
+    CHECK(rc == TILEDB_OK);
+
+    rc = tiledb_query_submit(ctx_, query);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_finalize(ctx_, query);
+    CHECK(rc == TILEDB_OK);
+
+    // Close array and clean up
+    rc = tiledb_array_close(ctx_, array);
+    CHECK(rc == TILEDB_OK);
+    tiledb_array_free(&array);
+    tiledb_query_free(&query);
+
+    int buffer_read[10];
+    uint64_t buffer_read_size = sizeof(buffer_read);
+
+    // Open array
+    rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+    CHECK(rc == TILEDB_OK);
+
+    // Submit query
+    rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_subarray(ctx_, query, subarray);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_data_buffer(
+        ctx_, query, attr_name.c_str(), buffer_read, &buffer_read_size);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_submit(ctx_, query);
+    CHECK(rc == TILEDB_OK);
+
+    // Close array and clean up
+    rc = tiledb_array_close(ctx_, array);
+    CHECK(rc == TILEDB_OK);
+    tiledb_array_free(&array);
+    tiledb_query_free(&query);
+
+    // Check correctness
+    CHECK(!std::memcmp(buffer_read, buffer_write, buffer_write_size));
+    CHECK(buffer_read_size == buffer_write_size);
 
     remove_temp_dir(temp_dir);
   }

--- a/test/src/unit-capi-enum_values.cc
+++ b/test/src/unit-capi-enum_values.cc
@@ -83,6 +83,7 @@ TEST_CASE("C API: Test enum values", "[capi][enums]") {
   REQUIRE(TILEDB_STRING_UCS4 == 16);
   REQUIRE(TILEDB_ANY == 17);
   REQUIRE(TILEDB_BLOB == 40);
+  REQUIRE(TILEDB_BOOL == 41);
 
   /** Array type */
   REQUIRE(TILEDB_DENSE == 0);
@@ -224,6 +225,12 @@ TEST_CASE("C API: Test enum string conversion", "[capi][enums]") {
   REQUIRE(
       (tiledb_datatype_from_str("BLOB", &datatype) == TILEDB_OK &&
        datatype == TILEDB_BLOB));
+  REQUIRE(
+      (tiledb_datatype_to_str(TILEDB_BOOL, &c_str) == TILEDB_OK &&
+       std::string(c_str) == "BOOL"));
+  REQUIRE(
+      (tiledb_datatype_from_str("BOOL", &datatype) == TILEDB_OK &&
+       datatype == TILEDB_BOOL));
   REQUIRE(
       (tiledb_datatype_to_str(TILEDB_INT8, &c_str) == TILEDB_OK &&
        std::string(c_str) == "INT8"));

--- a/test/src/unit-cppapi-query.cc
+++ b/test/src/unit-cppapi-query.cc
@@ -291,3 +291,56 @@ TEST_CASE(
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 }
+
+/**
+ * #TODO: Change data_w to be type std::vector<bool>.
+ *
+ * Note: This is not a trivial change; It will require bitset optimization in
+ * the implementation of Query::set_data_buffer.
+ */
+TEST_CASE(
+    "C++ API: Test boolean query buffer", "[cppapi][query][bool_buffer]") {
+  const std::string array_name = "bool_buffer_array";
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  // Create the array
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<uint8_t>(ctx, "rows", {{0, 3}}, 4))
+      .add_dimension(Dimension::create<uint8_t>(ctx, "cols", {{0, 3}}, 4));
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  schema.add_attribute(Attribute::create<uint8_t>(ctx, "a"));
+  Array::create(array_name, schema);
+
+  // Write some initial data and close the array.
+  std::vector<uint8_t> data_w = {0, 1, 0, 1};
+  std::vector<uint8_t> coords_w = {0, 0, 1, 1, 2, 2, 3, 3};
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w);
+  query_w.set_coordinates(coords_w)
+      .set_layout(TILEDB_UNORDERED)
+      .set_data_buffer("a", data_w);
+  query_w.submit();
+  query_w.finalize();
+  array_w.close();
+
+  // Read the array.
+  Array array_r(ctx, array_name, TILEDB_READ);
+  Query query_r(ctx, array_r);
+  std::vector<uint8_t> data_r(4);
+  query_r.set_layout(TILEDB_ROW_MAJOR).set_data_buffer("a", data_r);
+  query_r.submit();
+  REQUIRE(data_r[0] == data_w[0]);
+  REQUIRE(data_r[1] == data_w[1]);
+  REQUIRE(data_r[2] == data_w[2]);
+  REQUIRE(data_r[3] == data_w[3]);
+  query_r.finalize();
+  array_r.close();
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+}

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1852,6 +1852,7 @@ std::string Dimension::domain_str() const {
 
     case Datatype::BLOB:
     case Datatype::CHAR:
+    case Datatype::BOOL:
     case Datatype::STRING_ASCII:
     case Datatype::STRING_UTF8:
     case Datatype::STRING_UTF16:
@@ -1950,6 +1951,7 @@ std::string Dimension::tile_extent_str() const {
 
     case Datatype::BLOB:
     case Datatype::CHAR:
+    case Datatype::BOOL:
     case Datatype::STRING_ASCII:
     case Datatype::STRING_UTF8:
     case Datatype::STRING_UTF16:

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -960,6 +960,7 @@ void Domain::set_tile_cell_order_cmp_funcs() {
         break;
       case Datatype::BLOB:
       case Datatype::CHAR:
+      case Datatype::BOOL:
       case Datatype::STRING_UTF8:
       case Datatype::STRING_UTF16:
       case Datatype::STRING_UTF32:

--- a/tiledb/sm/c_api/tiledb_enum.h
+++ b/tiledb/sm/c_api/tiledb_enum.h
@@ -144,6 +144,8 @@
     TILEDB_DATATYPE_ENUM(TIME_AS) = 39,
     /** std::byte */
     TILEDB_DATATYPE_ENUM(BLOB) = 40,
+    /** Boolean */
+    TILEDB_DATATYPE_ENUM(BOOL) = 41,
 #endif
 
 #ifdef TILEDB_ARRAY_TYPE_ENUM

--- a/tiledb/sm/compressors/dd_compressor.cc
+++ b/tiledb/sm/compressors/dd_compressor.cc
@@ -59,6 +59,7 @@ Status DoubleDelta::compress(
       return DoubleDelta::compress<std::byte>(input_buffer, output_buffer);
     case Datatype::INT8:
       return DoubleDelta::compress<int8_t>(input_buffer, output_buffer);
+    case Datatype::BOOL:
     case Datatype::UINT8:
       return DoubleDelta::compress<uint8_t>(input_buffer, output_buffer);
     case Datatype::INT16:
@@ -111,10 +112,6 @@ Status DoubleDelta::compress(
       return LOG_STATUS(Status_CompressionError(
           "Cannot compress tile with DoubleDelta; Float "
           "datatypes are not supported"));
-    case Datatype::BOOL:
-      return LOG_STATUS(Status_CompressionError(
-          "Cannot compress tile with DoubleDelta; Boolean "
-          "datatypes are not supported"));
   }
 
   assert(false);
@@ -131,6 +128,7 @@ Status DoubleDelta::decompress(
       return DoubleDelta::decompress<std::byte>(input_buffer, output_buffer);
     case Datatype::INT8:
       return DoubleDelta::decompress<int8_t>(input_buffer, output_buffer);
+    case Datatype::BOOL:
     case Datatype::UINT8:
       return DoubleDelta::decompress<uint8_t>(input_buffer, output_buffer);
     case Datatype::INT16:
@@ -182,10 +180,6 @@ Status DoubleDelta::decompress(
     case Datatype::FLOAT64:
       return LOG_STATUS(Status_CompressionError(
           "Cannot decompress tile with DoubleDelta; Float "
-          "datatypes are not supported"));
-    case Datatype::BOOL:
-      return LOG_STATUS(Status_CompressionError(
-          "Cannot decompress tile with DoubleDelta; Boolean "
           "datatypes are not supported"));
   }
 

--- a/tiledb/sm/compressors/dd_compressor.cc
+++ b/tiledb/sm/compressors/dd_compressor.cc
@@ -111,6 +111,10 @@ Status DoubleDelta::compress(
       return LOG_STATUS(Status_CompressionError(
           "Cannot compress tile with DoubleDelta; Float "
           "datatypes are not supported"));
+    case Datatype::BOOL:
+      return LOG_STATUS(Status_CompressionError(
+          "Cannot compress tile with DoubleDelta; Boolean "
+          "datatypes are not supported"));
   }
 
   assert(false);
@@ -178,6 +182,10 @@ Status DoubleDelta::decompress(
     case Datatype::FLOAT64:
       return LOG_STATUS(Status_CompressionError(
           "Cannot decompress tile with DoubleDelta; Float "
+          "datatypes are not supported"));
+    case Datatype::BOOL:
+      return LOG_STATUS(Status_CompressionError(
+          "Cannot decompress tile with DoubleDelta; Boolean "
           "datatypes are not supported"));
   }
 

--- a/tiledb/sm/cpp_api/dimension.h
+++ b/tiledb/sm/cpp_api/dimension.h
@@ -249,6 +249,7 @@ class Dimension {
         return "";
       case TILEDB_BLOB:
       case TILEDB_CHAR:
+      case TILEDB_BOOL:
       case TILEDB_STRING_UTF8:
       case TILEDB_STRING_UTF16:
       case TILEDB_STRING_UTF32:
@@ -367,6 +368,7 @@ class Dimension {
         return "";
       case TILEDB_BLOB:
       case TILEDB_CHAR:
+      case TILEDB_BOOL:
       case TILEDB_STRING_UTF8:
       case TILEDB_STRING_UTF16:
       case TILEDB_STRING_UTF32:

--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -181,6 +181,13 @@ struct tiledb_to_type<TILEDB_BLOB> {
 };
 
 template <>
+struct tiledb_to_type<TILEDB_BOOL> {
+  using type = uint8_t;
+  static const tiledb_datatype_t tiledb_type = TILEDB_BOOL;
+  static constexpr const char* name = "BOOL";
+};
+
+template <>
 struct tiledb_to_type<TILEDB_INT8> {
   using type = int8_t;
   static const tiledb_datatype_t tiledb_type = TILEDB_INT8;

--- a/tiledb/sm/enums/datatype.h
+++ b/tiledb/sm/enums/datatype.h
@@ -66,6 +66,8 @@ inline uint64_t datatype_size(Datatype type) noexcept {
       return sizeof(char);
     case Datatype::BLOB:
       return sizeof(std::byte);
+    case Datatype::BOOL:
+      return sizeof(uint8_t);
     case Datatype::INT8:
       return sizeof(int8_t);
     case Datatype::UINT8:
@@ -136,6 +138,8 @@ inline const std::string& datatype_str(Datatype type) {
       return constants::char_str;
     case Datatype::BLOB:
       return constants::blob_str;
+    case Datatype::BOOL:
+      return constants::bool_str;
     case Datatype::INT8:
       return constants::int8_str;
     case Datatype::UINT8:
@@ -226,6 +230,8 @@ inline Status datatype_enum(
     *datatype = Datatype::CHAR;
   else if (datatype_str == constants::blob_str)
     *datatype = Datatype::BLOB;
+  else if (datatype_str == constants::bool_str)
+    *datatype = Datatype::BOOL;
   else if (datatype_str == constants::int8_str)
     *datatype = Datatype::INT8;
   else if (datatype_str == constants::uint8_str)
@@ -313,11 +319,11 @@ inline bool datatype_is_string(Datatype type) {
 /** Returns true if the input datatype is an integer type. */
 inline bool datatype_is_integer(Datatype type) {
   return (
-      type == Datatype::BLOB || type == Datatype::INT8 ||
-      type == Datatype::UINT8 || type == Datatype::INT16 ||
-      type == Datatype::UINT16 || type == Datatype::INT32 ||
-      type == Datatype::UINT32 || type == Datatype::INT64 ||
-      type == Datatype::UINT64);
+      type == Datatype::BLOB || type == Datatype::BOOL ||
+      type == Datatype::INT8 || type == Datatype::UINT8 ||
+      type == Datatype::INT16 || type == Datatype::UINT16 ||
+      type == Datatype::INT32 || type == Datatype::UINT32 ||
+      type == Datatype::INT64 || type == Datatype::UINT64);
 }
 
 /** Returns true if the input datatype is a real type. */
@@ -345,6 +351,11 @@ inline bool datatype_is_time(Datatype type) {
       type == Datatype::TIME_US || type == Datatype::TIME_NS ||
       type == Datatype::TIME_PS || type == Datatype::TIME_FS ||
       type == Datatype::TIME_AS);
+}
+
+/** Returns true if the input datatype is a boolean type. */
+inline bool datatype_is_boolean(Datatype type) {
+  return (type == Datatype::BOOL);
 }
 
 }  // namespace sm

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -122,6 +122,7 @@ Status BitWidthReductionFilter::run_forward(
       return run_forward<int8_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::BLOB:
+    case Datatype::BOOL:
     case Datatype::UINT8:
       return run_forward<uint8_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
@@ -305,6 +306,7 @@ Status BitWidthReductionFilter::run_reverse(
       return run_reverse<int8_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::BLOB:
+    case Datatype::BOOL:
     case Datatype::UINT8:
       return run_reverse<uint8_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -84,6 +84,7 @@ Status PositiveDeltaFilter::run_forward(
       return run_forward<int8_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::BLOB:
+    case Datatype::BOOL:
     case Datatype::UINT8:
       return run_forward<uint8_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
@@ -263,6 +264,7 @@ Status PositiveDeltaFilter::run_reverse(
       return run_reverse<int8_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::BLOB:
+    case Datatype::BOOL:
     case Datatype::UINT8:
       return run_reverse<uint8_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -387,6 +387,7 @@ Status FragmentMetadata::compute_fragment_min_max_sum_null_count() {
             case Datatype::INT64:
               compute_fragment_min_max_sum<int64_t>(name);
               break;
+            case Datatype::BOOL:
             case Datatype::UINT8:
               compute_fragment_min_max_sum<uint8_t>(name);
               break;

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -149,6 +149,9 @@ const char empty_char = std::numeric_limits<char>::min();
 /** The special value for an empty blob. */
 constexpr std::byte empty_blob{0};
 
+/** The special value for an empty bool. */
+const uint8_t empty_bool = 0;
+
 /** The special value for an empty int8. */
 const int8_t empty_int8 = std::numeric_limits<int8_t>::min();
 
@@ -381,6 +384,9 @@ const std::string char_str = "CHAR";
 
 /** The string representation for type blob. */
 const std::string blob_str = "BLOB";
+
+/** The string representation for type bool. */
+const std::string bool_str = "BOOL";
 
 /** The string representation for type int8. */
 const std::string int8_str = "INT8";
@@ -640,6 +646,8 @@ const void* fill_value(Datatype type) {
   switch (type) {
     case Datatype::BLOB:
       return &constants::empty_blob;
+    case Datatype::BOOL:
+      return &constants::empty_bool;
     case Datatype::INT8:
       return &constants::empty_int8;
     case Datatype::UINT8:

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -134,6 +134,9 @@ extern const double empty_float64;
 /** The special value for an empty char. */
 extern const char empty_char;
 
+/** The special value for an empty bool. */
+extern const uint8_t empty_bool;
+
 /** The special value for an empty int8. */
 extern const int8_t empty_int8;
 
@@ -365,6 +368,9 @@ extern const std::string char_str;
 
 /** The string representation for type blob. */
 extern const std::string blob_str;
+
+/** The string representation for type bool. */
+extern const std::string bool_str;
 
 /** The string representation for type int8. */
 extern const std::string int8_str;

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -608,6 +608,7 @@ QueryCondition::apply_clause(
     case Datatype::INT8:
       return apply_clause<int8_t>(
           clause, stride, var_size, nullable, fill_value, result_cell_slabs);
+    case Datatype::BOOL:
     case Datatype::UINT8:
       return apply_clause<uint8_t>(
           clause, stride, var_size, nullable, fill_value, result_cell_slabs);
@@ -924,6 +925,7 @@ Status QueryCondition::apply_clause_dense(
           stride,
           var_size,
           result_buffer);
+    case Datatype::BOOL:
     case Datatype::UINT8:
       return apply_clause_dense<uint8_t>(
           clause,
@@ -1410,6 +1412,7 @@ Status QueryCondition::apply_clause_sparse(
     case Datatype::INT8:
       return apply_clause_sparse<int8_t, BitmapType>(
           clause, result_tile, var_size, result_bitmap);
+    case Datatype::BOOL:
     case Datatype::UINT8:
       return apply_clause_sparse<uint8_t, BitmapType>(
           clause, result_tile, var_size, result_bitmap);

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -133,6 +133,7 @@ Status set_capnp_array_ptr(
     case tiledb::sm::Datatype::STRING_ASCII:
     case tiledb::sm::Datatype::STRING_UTF8:
     case tiledb::sm::Datatype::BLOB:
+    case tiledb::sm::Datatype::BOOL:
     case tiledb::sm::Datatype::UINT8:
       builder.setUint8(kj::arrayPtr(static_cast<const uint8_t*>(ptr), size));
       break;
@@ -213,6 +214,7 @@ Status set_capnp_scalar(
       builder.setInt8(*static_cast<const int8_t*>(value));
       break;
     case tiledb::sm::Datatype::BLOB:
+    case tiledb::sm::Datatype::BOOL:
     case tiledb::sm::Datatype::UINT8:
       builder.setUint8(*static_cast<const uint8_t*>(value));
       break;
@@ -321,6 +323,7 @@ Status copy_capnp_list(
         RETURN_NOT_OK(copy_capnp_list<int8_t>(reader.getInt8(), buffer));
       break;
     case tiledb::sm::Datatype::BLOB:
+    case tiledb::sm::Datatype::BOOL:
     case tiledb::sm::Datatype::UINT8:
       if (reader.hasUint8())
         RETURN_NOT_OK(copy_capnp_list<uint8_t>(reader.getUint8(), buffer));

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -3012,6 +3012,7 @@ tuple<Status, optional<bool>> Subarray::non_overlapping_ranges_for_dim(
       return non_overlapping_ranges_for_dim<char>(dim_idx);
     case Datatype::CHAR:
     case Datatype::BLOB:
+    case Datatype::BOOL:
     case Datatype::STRING_UTF8:
     case Datatype::STRING_UTF16:
     case Datatype::STRING_UTF32:

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -458,6 +458,7 @@ void TileMetadataGenerator::process_tile(
       case Datatype::INT64:
         process_tile<int64_t>(tile, tile_validity);
         break;
+      case Datatype::BOOL:
       case Datatype::UINT8:
         process_tile<uint8_t>(tile, tile_validity);
         break;


### PR DESCRIPTION
Add new Datatype, TILEDB_BOOL. The boolean is stored as a uint8_t and is mostly treated as such. Modifications will need to be made to `Query::set_data_buffer` to allow for true boolean query buffers. Further, there is currently no restraint on the allowed values of TILEDB_BOOL. Future changes will allow only for values {0, 1}. 

---
TYPE: FEATURE
DESC: Add TILEDB_BOOL Datatype
