### PR TITLE
avoid vs2019 unit_range warning as error

### DIFF
--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -41,7 +41,14 @@
 
 size_t random_ms(size_t max = 3) {
   thread_local static std::mt19937 generator(
+#if defined(_MSC_VER)
+      // MSVC expects unsigned int, std::hash<...id>() not compatible with msvc
+      // mt19937
+      static_cast<unsigned int>(
+          std::hash<std::thread::id>()(std::this_thread::get_id())));
+#else
       std::hash<std::thread::id>()(std::this_thread::get_id()));
+#endif
   std::uniform_int_distribution<size_t> distribution(0, max);
   return distribution(generator);
 }

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -32,17 +32,17 @@
 
 #include "unit_thread_pool.h"
 
+#include <stdint.h>
 #include <atomic>
 #include <catch.hpp>
-#include <iostream>
-#include <stdint.h>
 #include <iostream>
 
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/misc/cancelable_tasks.h"
 
 size_t random_ms(size_t max = 3) {
-  thread_local static uint64_t generator_seed = std::hash<std::thread::id>()(std::this_thread::get_id());
+  thread_local static uint64_t generator_seed =
+      std::hash<std::thread::id>()(std::this_thread::get_id());
   thread_local static std::mt19937_64 generator(generator_seed);
   thread_local static bool reported_seed = false;
   if (!reported_seed) {

--- a/tiledb/type/range/test/unit_check_range_is_subset.cc
+++ b/tiledb/type/range/test/unit_check_range_is_subset.cc
@@ -131,32 +131,32 @@ TEMPLATE_TEST_CASE(
 
 TEMPLATE_TEST_CASE(
     "Test check_is_subset for floating-point types", "[range]", float, double) {
-  TestType superset_data[2]{-10.5, 3.33};
+  TestType superset_data[2]{-10.5f, 3.33f};
   Range superset{&superset_data[0], 2 * sizeof(TestType)};
   SECTION("Test full domain is a valid subset") {
     auto status = check_range_is_subset<TestType>(superset, superset);
     REQUIRE(status.ok());
   }
   SECTION("Test simple proper subset is a valid subset") {
-    TestType data[2]{-2.5, 2.5};
+    TestType data[2]{-2.5f, 2.5f};
     Range range{&data[0], 2 * sizeof(TestType)};
     auto status = check_range_is_subset<TestType>(superset, range);
     REQUIRE(status.ok());
   }
   SECTION("Test a non-valid subset with lower bound less than superset") {
-    TestType data[2]{-20.5, 0.0};
+    TestType data[2]{-20.5f, 0.0f};
     Range range{&data[0], 2 * sizeof(TestType)};
     auto status = check_range_is_subset<TestType>(superset, range);
     REQUIRE(!status.ok());
   }
   SECTION("Test a non-valid subset with upper bound more than superset") {
-    TestType data[2]{0.0, 20.5};
+    TestType data[2]{0.0f, 20.5f};
     Range range{&data[0], 2 * sizeof(TestType)};
     auto status = check_range_is_subset<TestType>(superset, range);
     REQUIRE(!status.ok());
   }
   SECTION("Test a non-valid subset that is a proper superset") {
-    TestType data[2]{-20.0, 20.0};
+    TestType data[2]{-20.0f, 20.0f};
     Range range{&data[0], 2 * sizeof(TestType)};
     auto status = check_range_is_subset<TestType>(superset, range);
     REQUIRE(!status.ok());


### PR DESCRIPTION
add 'f' suffix to literal real value initializations (all falling within range of float) to avoid vs2019 warning-as-error failures

---
TYPE: BUG
DESC: avoid unit_range warning as error
