### PR TITLE
Sparse global order reader: Check correct incomplete reason in case of too small user buffer

### DIFF
--- a/test/src/unit-capi-incomplete.cc
+++ b/test/src/unit-capi-incomplete.cc
@@ -1131,6 +1131,11 @@ void IncompleteFx::check_sparse_unsplittable_overflow() {
   CHECK(status == TILEDB_INCOMPLETE);
   CHECK(buffer_sizes[0] == 0);
 
+  tiledb_query_status_details_t details;
+  rc = tiledb_query_get_status_details(ctx_, query, &details);
+  CHECK(rc == TILEDB_OK);
+  CHECK(details.incomplete_reason == TILEDB_REASON_USER_BUFFER_SIZE);
+
   // Finalize query
   rc = tiledb_query_finalize(ctx_, query);
   REQUIRE(rc == TILEDB_OK);

--- a/tiledb/sm/enums/query_status_details.h
+++ b/tiledb/sm/enums/query_status_details.h
@@ -1,5 +1,5 @@
 /**
- * @file query_status.h
+ * @file query_status_details.h
  *
  * @section LICENSE
  *
@@ -27,8 +27,8 @@
  *
  * @section DESCRIPTION
  *
- * This defines the tiledb QueryStatus enum that maps to tiledb_query_status_t
- * C-api enum.
+ * This defines the tiledb QueryStatusDetailsReason enum that maps to
+ * tiledb_query_status_details_t C-api enum.
  */
 
 #ifndef TILEDB_QUERY_STATUS_DETAILS_H

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -1303,10 +1303,6 @@ Status SparseGlobalOrderReader::process_slabs(
         // Adjust the offsets buffer and make sure all data fits.
         var_buffer_size = compute_var_size_offsets<OffType>(
             stats_, result_cell_slabs, cell_offsets, query_buffer);
-        if (result_cell_slabs.empty()) {
-          return Status_SparseGlobalOrderReaderError(
-              "Var size buffer cannot fit a single cell for var attribute");
-        }
 
         // Now copy the var size data.
         RETURN_NOT_OK(copy_var_data_tiles(

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -1303,6 +1303,10 @@ Status SparseGlobalOrderReader::process_slabs(
         // Adjust the offsets buffer and make sure all data fits.
         var_buffer_size = compute_var_size_offsets<OffType>(
             stats_, result_cell_slabs, cell_offsets, query_buffer);
+        if (result_cell_slabs.empty()) {
+          return Status_SparseGlobalOrderReaderError(
+              "Var size buffer cannot fit a single cell for var attribute");
+        }
 
         // Now copy the var size data.
         RETURN_NOT_OK(copy_var_data_tiles(

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -444,7 +444,7 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_parallelization_parameters(
   // Prevent processing past the end of the cells in case there are more
   // threads than cells.
   auto cell_num = max_pos_tile - min_pos_tile;
-  if (range_thread_idx > cell_num - 1) {
+  if (cell_num == 0 || range_thread_idx > cell_num - 1) {
     return {true, 0, 0, 0};
   }
 
@@ -1368,10 +1368,6 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
                 first_tile_min_pos,
                 cell_offsets,
                 query_buffer);
-        if (new_result_tiles_size == 1 && cell_offsets[1] == 0) {
-          return Status_SparseUnorderedWithDupsReaderError(
-              "Var size buffer cannot fit a single cell for var attribute");
-        }
         buffers_full_ |= buffers_full;
 
         // Clear tiles from memory and adjust result_tiles.


### PR DESCRIPTION
In the current code, if the user provides a buffer that is too small to fit a single cell of the data he is trying to read, the reader is silently returning. We should instead return an error to the user explaining why the query is incomplete and no data was returned.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: Check the right incomplete reason is returned in case of too small user buffer