### PR TITLE
avoid vs2019 unit_range warning as error

### DIFF
--- a/tiledb/type/range/test/unit_check_range_is_subset.cc
+++ b/tiledb/type/range/test/unit_check_range_is_subset.cc
@@ -131,7 +131,7 @@ TEMPLATE_TEST_CASE(
 
 TEMPLATE_TEST_CASE(
     "Test check_is_subset for floating-point types", "[range]", float, double) {
-  TestType superset_data[2]{-10.5, 3.33};
+  TestType superset_data[2]{-10.5, 3.33f};
   Range superset{&superset_data[0], 2 * sizeof(TestType)};
   SECTION("Test full domain is a valid subset") {
     auto status = check_range_is_subset<TestType>(superset, superset);

--- a/tiledb/type/range/test/unit_crop_range.cc
+++ b/tiledb/type/range/test/unit_crop_range.cc
@@ -128,7 +128,7 @@ TEMPLATE_TEST_CASE(
 
 TEMPLATE_TEST_CASE(
     "Test intersect_range for floating-point types", "[range]", float, double) {
-  TestType bounds[2]{-10.5, 3.33};
+  TestType bounds[2]{-10.5, 3.33f};
   SECTION("Test crop on bounds is a no-op") {
     test_crop_range<TestType>(bounds, bounds, bounds);
   }
@@ -143,7 +143,7 @@ TEMPLATE_TEST_CASE(
   }
   SECTION("Test crop upper bound") {
     TestType range[2]{0.0, 20.5};
-    TestType result[2]{0.0, 3.33};
+    TestType result[2]{0.0, 3.33f};
     test_crop_range<TestType>(bounds, range, result);
   }
   SECTION("Test crop both bounds") {


### PR DESCRIPTION
add 'f' suffix to literal real value initializations (all falling within range of float) to avoid vs2019 warning-as-error failures

---
TYPE: BUG
DESC: avoid unit_range warning as error build failures
