### PR TITLE
Sparse global order reader: refactor merge algorithm.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,10 +174,11 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-ReadCellSlabIter.cc
   src/unit-Reader.cc
   src/unit-resource-pool.cc
+  src/unit-result-coords.cc
+  src/unit-result-tile.cc
   src/unit-rtree.cc
   src/unit-s3-no-multipart.cc
   src/unit-s3.cc
-  src/unit-sparse-index-reader-base.cc
   src/unit-sparse-global-order-reader.cc
   src/unit-sparse-unordered-with-dups-reader.cc
   src/unit-status.cc

--- a/test/src/unit-result-coords.cc
+++ b/test/src/unit-result-coords.cc
@@ -1,0 +1,201 @@
+/**
+ * @file unit-result-coords.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for the ResultCoords classes.
+ */
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+
+#include "test/src/helpers.h"
+#include "tiledb/sm/query/result_coords.h"
+#include "tiledb/sm/query/sparse_index_reader_base.h"
+
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
+#include <catch.hpp>
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+struct CResultCoordsFx {
+  tiledb_ctx_t* ctx_ = nullptr;
+  tiledb_vfs_t* vfs_ = nullptr;
+  std::string temp_dir_;
+  std::string array_name_;
+  const char* ARRAY_NAME = "test_result_coords";
+  tiledb_array_t* array_;
+
+  CResultCoordsFx();
+  ~CResultCoordsFx();
+
+  GlobalOrderResultTile make_tile_with_num_cells(uint64_t num_cells);
+};
+
+CResultCoordsFx::CResultCoordsFx() {
+  tiledb_config_t* config;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  tiledb_config_free(&config);
+
+  // Create temporary directory based on the supported filesystem.
+#ifdef _WIN32
+  temp_dir_ = tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
+#else
+  temp_dir_ = "file://" + tiledb::sm::Posix::current_dir() + "/tiledb_test/";
+#endif
+  create_dir(temp_dir_, ctx_, vfs_);
+  array_name_ = temp_dir_ + ARRAY_NAME;
+
+  int64_t domain[] = {1, 10};
+  int64_t tile_extent = 5;
+  // Create array
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_SPARSE,
+      {"d"},
+      {TILEDB_INT64},
+      {domain},
+      {&tile_extent},
+      {"a"},
+      {TILEDB_STRING_ASCII},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      5);
+
+  // Open array for reading.
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array_);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array_, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+}
+
+CResultCoordsFx::~CResultCoordsFx() {
+  // Clean up.
+  REQUIRE(tiledb_array_close(ctx_, array_) == TILEDB_OK);
+  tiledb_array_free(&array_);
+
+  remove_dir(temp_dir_, ctx_, vfs_);
+  tiledb_ctx_free(&ctx_);
+  tiledb_vfs_free(&vfs_);
+}
+
+GlobalOrderResultTile CResultCoordsFx::make_tile_with_num_cells(
+    uint64_t num_cells) {
+  GlobalOrderResultTile result_tile(
+      0, 0, array_->array_->array_schema_latest());
+  auto tile_tuple = result_tile.tile_tuple(constants::coords);
+  Tile* const tile = &std::get<0>(*tile_tuple);
+  auto cell_size = sizeof(int64_t);
+  REQUIRE(tile->init_unfiltered(
+                  constants::format_version,
+                  Datatype::INT64,
+                  num_cells * cell_size,
+                  cell_size,
+                  0)
+              .ok());
+
+  return result_tile;
+}
+
+/* ********************************* */
+/*                TESTS              */
+/* ********************************* */
+
+// Simple comparator class that will only look at pos_.
+class Cmp {
+ public:
+  Cmp() {
+  }
+
+  bool operator()(
+      const GlobalOrderResultCoords& a,
+      const GlobalOrderResultCoords& b) const {
+    if (a.pos_ == b.pos_) {
+      return true;
+    }
+
+    return false;
+  }
+};
+
+TEST_CASE_METHOD(
+    CResultCoordsFx,
+    "GlobalOrderResultCoords: test max_slab_length",
+    "[globalorderresultcoords][max_slab_length]") {
+  auto tile = make_tile_with_num_cells(5);
+
+  // Test max_slab_length with no bitmap.
+  GlobalOrderResultCoords rc1(&tile, 1);
+  REQUIRE(rc1.max_slab_length() == 4);
+
+  // Test max_slab_length with bitmap.
+  tile.bitmap_ = {0, 1, 1, 1, 1};
+  tile.bitmap_result_num_ = 4;
+  REQUIRE(rc1.max_slab_length() == 4);
+
+  // Test max_slab_length with bitmap.
+  tile.bitmap_ = {0, 1, 1, 1, 0};
+  tile.bitmap_result_num_ = 3;
+  REQUIRE(rc1.max_slab_length() == 3);
+}
+
+TEST_CASE_METHOD(
+    CResultCoordsFx,
+    "GlobalOrderResultCoords: test max_slab_length with comparator",
+    "[globalorderresultcoords][max_slab_length_with_comp]") {
+  auto tile = make_tile_with_num_cells(5);
+  Cmp cmp;
+
+  // Test max_slab_length with no bitmap and comparator.
+  GlobalOrderResultCoords rc1(&tile, 1);
+  REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 2);
+
+  // Test max_slab_length with bitmap and comparator.
+  tile.bitmap_ = {0, 1, 1, 1, 1};
+  tile.bitmap_result_num_ = 4;
+  REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 10), cmp) == 4);
+  REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 2);
+
+  // Test max_slab_length with bitmap.
+  tile.bitmap_ = {0, 1, 1, 1, 0};
+  tile.bitmap_result_num_ = 3;
+  REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 10), cmp) == 3);
+  REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 2);
+}

--- a/test/src/unit-result-coords.cc
+++ b/test/src/unit-result-coords.cc
@@ -165,15 +165,21 @@ TEST_CASE_METHOD(
   GlobalOrderResultCoords rc1(&tile, 1);
   REQUIRE(rc1.max_slab_length() == 4);
 
-  // Test max_slab_length with bitmap.
+  // Test max_slab_length with bitmap 1.
   tile.bitmap_ = {0, 1, 1, 1, 1};
   tile.bitmap_result_num_ = 4;
   REQUIRE(rc1.max_slab_length() == 4);
 
-  // Test max_slab_length with bitmap.
+  // Test max_slab_length with bitmap 2.
   tile.bitmap_ = {0, 1, 1, 1, 0};
   tile.bitmap_result_num_ = 3;
   REQUIRE(rc1.max_slab_length() == 3);
+
+  // Test max_slab_length with bitmap 3.
+  tile.bitmap_ = {0, 1, 1, 1, 0};
+  tile.bitmap_result_num_ = 3;
+  rc1.pos_ = 0;
+  REQUIRE(rc1.max_slab_length() == 0);
 }
 
 TEST_CASE_METHOD(
@@ -187,15 +193,52 @@ TEST_CASE_METHOD(
   GlobalOrderResultCoords rc1(&tile, 1);
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 2);
 
-  // Test max_slab_length with bitmap and comparator.
+  // Test max_slab_length with bitmap and comparator 1.
   tile.bitmap_ = {0, 1, 1, 1, 1};
   tile.bitmap_result_num_ = 4;
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 10), cmp) == 4);
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 2);
 
-  // Test max_slab_length with bitmap.
+  // Test max_slab_length with bitmap and comparator 2.
   tile.bitmap_ = {0, 1, 1, 1, 0};
   tile.bitmap_result_num_ = 3;
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 10), cmp) == 3);
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 2);
+
+  // Test max_slab_length with bitmap and comparator 3.
+  tile.bitmap_ = {0, 1, 1, 1, 0};
+  tile.bitmap_result_num_ = 3;
+  rc1.pos_ = 0;
+  REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 0);
+}
+
+TEST_CASE_METHOD(
+    CResultCoordsFx,
+    "GlobalOrderResultCoords: advance_to_next_cell",
+    "[globalorderresultcoords][advance_to_next_cell]") {
+  auto tile = make_tile_with_num_cells(5);
+  Cmp cmp;
+
+  GlobalOrderResultCoords rc1(&tile, 0);
+  tile.bitmap_ = {0, 1, 1, 0, 1};
+  tile.bitmap_result_num_ = 3;
+  REQUIRE(rc1.advance_to_next_cell() == true);
+  REQUIRE(rc1.pos_ == 1);
+  REQUIRE(rc1.advance_to_next_cell() == true);
+  REQUIRE(rc1.pos_ == 2);
+  REQUIRE(rc1.advance_to_next_cell() == true);
+  REQUIRE(rc1.pos_ == 4);
+  REQUIRE(rc1.advance_to_next_cell() == false);
+
+  // Recreate to test that we don't move pos_ on the first call.
+  GlobalOrderResultCoords rc2(&tile, 0);
+  tile.bitmap_ = {1, 1, 1, 0, 0};
+  tile.bitmap_result_num_ = 3;
+  REQUIRE(rc2.advance_to_next_cell() == true);
+  REQUIRE(rc2.pos_ == 0);
+  REQUIRE(rc2.advance_to_next_cell() == true);
+  REQUIRE(rc2.pos_ == 1);
+  REQUIRE(rc2.advance_to_next_cell() == true);
+  REQUIRE(rc2.pos_ == 2);
+  REQUIRE(rc2.advance_to_next_cell() == false);
 }

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -1,5 +1,5 @@
 /**
- * @file unit-sparse-index-reader-base.cc
+ * @file unit-result-tile.cc
  *
  * @section LICENSE
  *
@@ -27,7 +27,7 @@
  *
  * @section DESCRIPTION
  *
- * Tests for the sparse index reader base class.
+ * Tests for the ResultTile classes.
  */
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
@@ -99,9 +99,6 @@ TEST_CASE(
   tile.bitmap_[6] = 0;
   CHECK(tile.result_num_between_pos(2, 10) == 7);
   CHECK(tile.pos_with_given_result_sum(2, 8) == 10);
-
-  rc = tiledb_array_schema_check(ctx, array_schema);
-  REQUIRE(rc == TILEDB_OK);
 
   tiledb_ctx_free(&ctx);
 }

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -793,7 +793,7 @@ TEST_CASE_METHOD(
       read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
 
-  // Should read two tile (6 values).
+  // Should read (6 values).
   CHECK(24 == data_r_size);
   CHECK(24 == coords_r_size);
 

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -63,7 +63,7 @@ struct CSparseGlobalOrderFx {
   std::string ratio_coords_;
   std::string ratio_query_condition_;
 
-  void create_default_array_1d();
+  void create_default_array_1d(bool allow_dups = false);
   void write_1d_fragment(
       int* coords, uint64_t* coords_size, int* data, uint64_t* data_size);
   int32_t read(
@@ -175,7 +175,7 @@ void CSparseGlobalOrderFx::update_config() {
   tiledb_config_free(&config);
 }
 
-void CSparseGlobalOrderFx::create_default_array_1d() {
+void CSparseGlobalOrderFx::create_default_array_1d(bool allow_dups) {
   int domain[] = {1, 20};
   int tile_extent = 2;
   create_array(
@@ -193,7 +193,7 @@ void CSparseGlobalOrderFx::create_default_array_1d() {
       TILEDB_ROW_MAJOR,
       TILEDB_ROW_MAJOR,
       2,
-      false);
+      allow_dups);
 }
 
 void CSparseGlobalOrderFx::write_1d_fragment(
@@ -756,6 +756,49 @@ TEST_CASE_METHOD(
 
   int coords_c[] = {1, 2, 3, 4, 5, 6};
   int data_c[] = {1, 2, 3, 4, 5, 6};
+  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
+  CHECK(!std::memcmp(data_c, data_r, data_r_size));
+}
+
+TEST_CASE_METHOD(
+    CSparseGlobalOrderFx,
+    "Sparse global order reader: merge with subarray and dups",
+    "[sparse-global-order][merge][subarray][dups]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d(true);
+
+  bool use_subarray = false;
+
+  int coords_1[] = {8, 9, 10, 11, 12, 13};
+  int data_1[] = {8, 9, 10, 11, 12, 13};
+
+  int coords_2[] = {8, 9, 10, 11, 12, 13};
+  int data_2[] = {8, 9, 10, 11, 12, 13};
+
+  uint64_t coords_size = sizeof(coords_1);
+  uint64_t data_size = sizeof(data_1);
+
+  // Create the aray.
+  write_1d_fragment(coords_1, &coords_size, data_1, &data_size);
+  write_1d_fragment(coords_2, &coords_size, data_2, &data_size);
+
+  // Read.
+  int coords_r[6];
+  int data_r[6];
+  uint64_t coords_r_size = sizeof(coords_r);
+  uint64_t data_r_size = sizeof(data_r);
+
+  auto rc =
+      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
+  CHECK(rc == TILEDB_OK);
+
+  // Should read two tile (6 values).
+  CHECK(24 == data_r_size);
+  CHECK(24 == coords_r_size);
+
+  int coords_c[] = {8, 8, 9, 9, 10, 10};
+  int data_c[] = {8, 8, 9, 9, 10, 10};
   CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
   CHECK(!std::memcmp(data_c, data_r, data_r_size));
 }

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -620,7 +620,7 @@ CSparseUnorderedWithDupsVarDataFx::open_default_array_1d_with_fragments() {
       TILEDB_ROW_MAJOR,
       5);
 
-  // Open array for writing.
+  // Open array for reading.
   tiledb_array_t* array;
   auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
   REQUIRE(rc == TILEDB_OK);

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -153,8 +153,8 @@ class HilbertCmp : protected CellCmpBase {
   bool operator()(
       const GlobalOrderResultCoords& a,
       const GlobalOrderResultCoords& b) const {
-    auto hilbert_a = a.tile_->hilbert_values_[a.pos_];
-    auto hilbert_b = b.tile_->hilbert_values_[b.pos_];
+    auto hilbert_a = a.tile_->hilbert_value(a.pos_);
+    auto hilbert_b = b.tile_->hilbert_value(b.pos_);
     if (hilbert_a < hilbert_b)
       return true;
     else if (hilbert_a > hilbert_b)

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -42,7 +42,7 @@
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/query/domain_buffer.h"
 #include "tiledb/sm/query/result_coords.h"
-#include "tiledb/sm/query/sparse_index_reader_base.h"
+#include "tiledb/sm/query/sparse_global_order_reader.h"
 
 using namespace tiledb::common;
 
@@ -62,8 +62,9 @@ class CellCmpBase {
       , dim_num_(domain.dim_num()) {
   }
 
+  template <class RCType>
   [[nodiscard]] int cell_order_cmp_RC(
-      unsigned int d, const ResultCoords& a, const ResultCoords& b) const {
+      unsigned int d, const RCType& a, const RCType& b) const {
     const auto& dim{*(domain_.dimension_ptr(d))};
     auto v1{a.dimension_datum(dim, d)};
     auto v2{b.dimension_datum(dim, d)};
@@ -149,11 +150,11 @@ class HilbertCmp : protected CellCmpBase {
    * @param b The second coordinate.
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
-  bool operator()(const ResultCoords& a, const ResultCoords& b) const {
-    auto hilbert_a =
-        ((ResultTileWithBitmap<uint8_t>*)a.tile_)->hilbert_values_[a.pos_];
-    auto hilbert_b =
-        ((ResultTileWithBitmap<uint8_t>*)b.tile_)->hilbert_values_[b.pos_];
+  bool operator()(
+      const GlobalOrderResultCoords& a,
+      const GlobalOrderResultCoords& b) const {
+    auto hilbert_a = a.tile_->hilbert_values_[a.pos_];
+    auto hilbert_b = b.tile_->hilbert_values_[b.pos_];
     if (hilbert_a < hilbert_b)
       return true;
     else if (hilbert_a > hilbert_b)
@@ -196,7 +197,8 @@ class HilbertCmpReverse {
    * @param b The second coordinate.
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
-  bool operator()(const ResultCoords& a, const ResultCoords& b) const {
+  template <class RCType>
+  bool operator()(const RCType& a, const RCType& b) const {
     return !cmp_.operator()(a, b);
   }
 
@@ -283,7 +285,8 @@ class GlobalCmp : protected CellCmpBase {
    * @param b The second coordinate.
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
-  bool operator()(const ResultCoords& a, const ResultCoords& b) const {
+  template <class RCType>
+  bool operator()(const RCType& a, const RCType& b) const {
     if (tile_order_ == Layout::ROW_MAJOR) {
       for (unsigned d = 0; d < dim_num_; ++d) {
         // Not applicable to var-sized dimensions
@@ -373,7 +376,8 @@ class GlobalCmpReverse {
    * @param b The second coordinate.
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
-  bool operator()(const ResultCoords& a, const ResultCoords& b) const {
+  template <class RCType>
+  bool operator()(const RCType& a, const RCType& b) const {
     return !cmp_.operator()(a, b);
   }
 

--- a/tiledb/sm/query/hilbert_order.cc
+++ b/tiledb/sm/query/hilbert_order.cc
@@ -45,14 +45,20 @@ uint64_t map_to_uint64(
       d.datum().content(), d.datum().size(), bits, max_bucket_val);
 }
 
+template <class RCType>
 uint64_t map_to_uint64(
     const Dimension& dim,
-    const ResultCoords& coord,
+    const RCType& coord,
     uint32_t dim_idx,
     int bits,
     uint64_t max_bucket_val) {
   auto d{coord.dimension_datum(dim, dim_idx)};
   return dim.map_to_uint64(d.content(), d.size(), bits, max_bucket_val);
 }
+
+template uint64_t map_to_uint64<GlobalOrderResultCoords>(
+    const Dimension&, const GlobalOrderResultCoords&, uint32_t, int, uint64_t);
+template uint64_t map_to_uint64<ResultCoords>(
+    const Dimension&, const ResultCoords&, uint32_t, int, uint64_t);
 
 }  // namespace tiledb::sm::hilbert_order

--- a/tiledb/sm/query/hilbert_order.h
+++ b/tiledb/sm/query/hilbert_order.h
@@ -43,9 +43,10 @@ uint64_t map_to_uint64(
     int bits,
     uint64_t max_bucket_val);
 
+template <class RCType>
 uint64_t map_to_uint64(
     const Dimension& dim,
-    const ResultCoords& coord,
+    const RCType& coord,
     uint32_t dim_idx,
     int bits,
     uint64_t max_bucket_val);

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -45,11 +45,14 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+class GlobalOrderResultTile;
+
 /**
  * Stores information about cell coordinates of a sparse fragment
  * that are in the result of a subarray query.
  */
-struct ResultCoords {
+template <class ResultTileType>
+struct ResultCoordsBase {
   /**
    * The result tile the coords belong to.
    *
@@ -57,43 +60,20 @@ struct ResultCoords {
    * sparse_read/dense_read, so the lifetime of this struct must not exceed
    * the scope of those functions.
    */
-  ResultTile* tile_;
+  ResultTileType* tile_;
   /** The position of the coordinates in the tile. */
   uint64_t pos_;
-  /** Whether this instance is "valid". */
-  bool valid_;
 
   /** Constructor. */
-  ResultCoords()
+  ResultCoordsBase()
       : tile_(nullptr)
-      , pos_(0)
-      , valid_(false) {
+      , pos_(0) {
   }
 
   /** Constructor. */
-  ResultCoords(ResultTile* tile, uint64_t pos)
+  ResultCoordsBase(ResultTileType* tile, uint64_t pos)
       : tile_(tile)
-      , pos_(pos)
-      , valid_(true) {
-  }
-
-  /** Moves to the next cell */
-  inline bool next() {
-    if (pos_ == tile_->cell_num() - 1)
-      return false;
-
-    pos_++;
-    return true;
-  }
-
-  /** Invalidate this instance. */
-  inline void invalidate() {
-    valid_ = false;
-  }
-
-  /** Return true if this instance is valid. */
-  inline bool valid() const {
-    return valid_;
+      , pos_(pos) {
   }
 
   /**
@@ -130,9 +110,129 @@ struct ResultCoords {
    * calling ResultCoords object and the input are the same across all
    * dimensions.
    */
-  bool same_coords(const ResultCoords& rc) const {
+  bool same_coords(const ResultCoordsBase& rc) const {
     return tile_->same_coords(*(rc.tile_), pos_, rc.pos_);
   }
+};
+
+struct ResultCoords : public ResultCoordsBase<ResultTile> {
+  /** Constructor. */
+  ResultCoords()
+      : ResultCoordsBase()
+      , valid_(false) {
+  }
+
+  /** Constructor. */
+  ResultCoords(ResultTile* tile, uint64_t pos)
+      : ResultCoordsBase(tile, pos)
+      , valid_(true) {
+  }
+
+  /** Invalidate this instance. */
+  inline void invalidate() {
+    valid_ = false;
+  }
+
+  /** Return true if this instance is valid. */
+  inline bool valid() const {
+    return valid_;
+  }
+
+  /** Whether this instance is "valid". */
+  bool valid_;
+};
+
+struct GlobalOrderResultCoords
+    : public ResultCoordsBase<GlobalOrderResultTile> {
+  /** Constructor. */
+  GlobalOrderResultCoords(GlobalOrderResultTile* tile, uint64_t pos)
+      : ResultCoordsBase(tile, pos)
+      , init_(false) {
+  }
+
+  /** Returns the next available cell in the tile. */
+  bool next_cell() {
+    pos_ += init_;
+    init_ = true;
+    if (pos_ != tile_->cell_num()) {
+      if (tile_->bitmap_.size() > 0) {
+        while (pos_ < tile_->cell_num()) {
+          if (tile_->bitmap_[pos_]) {
+            return true;
+          }
+          pos_++;
+        }
+      } else {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Get the maximum slab length that can be created (when there's no other
+   * fragments left).
+   */
+  uint64_t max_slab_length() {
+    uint64_t ret = 1;
+    auto has_bmp = tile_->bitmap_.size() > 0;
+    uint64_t next_pos = pos_ + 1;
+    if (has_bmp) {
+      // With bitmap, find the longest contiguous set of bits in the bitmap
+      // from the current position.
+      while (next_pos < tile_->cell_num() - 1 && tile_->bitmap_[next_pos]) {
+        next_pos++;
+        ret++;
+      }
+    } else {
+      // No bitmap, add all cells from current position.
+      ret = tile_->cell_num() - pos_;
+    }
+
+    return ret;
+  }
+
+  /**
+   * Get the maximum slab length that can be created using the next result
+   * coords in the queue.
+   */
+  template <class CompType>
+  uint64_t max_slab_length(
+      const GlobalOrderResultCoords& next, const CompType& cmp) {
+    uint64_t ret = 1;
+
+    // Store the original position and move to the next cell.
+    uint64_t orig_pos = pos_;
+    pos_++;
+
+    auto has_bmp = tile_->bitmap_.size() > 0;
+    if (has_bmp) {
+      // With bitmap, find the longest contiguous set of bits in the bitmap
+      // from the current position, with coordinares smaller than the next one
+      // in the queue.
+      while (pos_ < tile_->cell_num() - 1 && tile_->bitmap_[pos_] &&
+             !cmp(*this, next)) {
+        pos_++;
+        ret++;
+      }
+    } else {
+      // No bitmap, add all cells from current position, with coordinares
+      // smaller than the next one in the queue.
+      while (pos_ < tile_->cell_num() - 1 && !cmp(*this, next)) {
+        pos_++;
+        ret++;
+      }
+    }
+
+    // Restore the original position.
+    pos_ = orig_pos;
+    return ret;
+  }
+
+ private:
+  /** Initially set to false on first call to next_cell. */
+  bool init_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -178,6 +178,11 @@ struct GlobalOrderResultCoords
     uint64_t ret = 1;
     uint64_t next_pos = pos_ + 1;
     if (tile_->has_bmp()) {
+      // Current cell is not in the bitmap.
+      if (!tile_->bitmap_[pos_]) {
+        return 0;
+      }
+
       // With bitmap, find the longest contiguous set of bits in the bitmap
       // from the current position.
       while (next_pos < tile_->cell_num() && tile_->bitmap_[next_pos]) {
@@ -201,14 +206,19 @@ struct GlobalOrderResultCoords
       const GlobalOrderResultCoords& next, const CompType& cmp) {
     uint64_t ret = 1;
 
-    // Store the original position and move to the next cell.
+    // Store the original position.
     uint64_t orig_pos = pos_;
-    pos_++;
 
     if (tile_->has_bmp()) {
+      // Current cell is not in the bitmap.
+      if (!tile_->bitmap_[pos_]) {
+        return 0;
+      }
+
       // With bitmap, find the longest contiguous set of bits in the bitmap
       // from the current position, with coordinares smaller than the next one
       // in the queue.
+      pos_++;
       while (pos_ < tile_->cell_num() && tile_->bitmap_[pos_] &&
              !cmp(*this, next)) {
         pos_++;
@@ -217,6 +227,7 @@ struct GlobalOrderResultCoords
     } else {
       // No bitmap, add all cells from current position, with coordinares
       // smaller than the next one in the queue.
+      pos_++;
       while (pos_ < tile_->cell_num() - 1 && !cmp(*this, next)) {
         pos_++;
         ret++;

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -150,12 +150,12 @@ struct GlobalOrderResultCoords
       , init_(false) {
   }
 
-  /** Returns the next available cell in the tile. */
-  bool next_cell() {
+  /** Advance to the next available cell in the tile. */
+  bool advance_to_next_cell() {
     pos_ += init_;
     init_ = true;
     if (pos_ != tile_->cell_num()) {
-      if (tile_->bitmap_.size() > 0) {
+      if (tile_->has_bmp()) {
         while (pos_ < tile_->cell_num()) {
           if (tile_->bitmap_[pos_]) {
             return true;
@@ -176,12 +176,11 @@ struct GlobalOrderResultCoords
    */
   uint64_t max_slab_length() {
     uint64_t ret = 1;
-    auto has_bmp = tile_->bitmap_.size() > 0;
     uint64_t next_pos = pos_ + 1;
-    if (has_bmp) {
+    if (tile_->has_bmp()) {
       // With bitmap, find the longest contiguous set of bits in the bitmap
       // from the current position.
-      while (next_pos < tile_->cell_num() - 1 && tile_->bitmap_[next_pos]) {
+      while (next_pos < tile_->cell_num() && tile_->bitmap_[next_pos]) {
         next_pos++;
         ret++;
       }
@@ -206,12 +205,11 @@ struct GlobalOrderResultCoords
     uint64_t orig_pos = pos_;
     pos_++;
 
-    auto has_bmp = tile_->bitmap_.size() > 0;
-    if (has_bmp) {
+    if (tile_->has_bmp()) {
       // With bitmap, find the longest contiguous set of bits in the bitmap
       // from the current position, with coordinares smaller than the next one
       // in the queue.
-      while (pos_ < tile_->cell_num() - 1 && tile_->bitmap_[pos_] &&
+      while (pos_ < tile_->cell_num() && tile_->bitmap_[pos_] &&
              !cmp(*this, next)) {
         pos_++;
         ret++;

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -494,8 +494,8 @@ class ResultTileWithBitmap : public ResultTile {
   /* ********************************* */
 
   /**
-   * Returns the number of cells that are before a certain cell index in the
-   * bitmap.
+   * Returns the number of cells that are that are between two cell positions
+   * in the bitmap.
    *
    * @param start_pos Starting cell position in the bitmap.
    * @param end_pos End position in the bitmap.
@@ -514,7 +514,7 @@ class ResultTileWithBitmap : public ResultTile {
   }
 
   /**
-   * Returns cell index from a number of cells inside of the bitmap.
+   * Returns the position (index) inside of the bitmap given a number of cells.
    *
    * @param start_pos Starting cell position in the bitmap.
    * @param result_num Number of results to advance.
@@ -538,6 +538,11 @@ class ResultTileWithBitmap : public ResultTile {
     }
 
     return bitmap_.size() - 1;
+  }
+
+  /** Does this tile have a bitmap. */
+  inline bool has_bmp() {
+    return bitmap_.size() > 0;
   }
 
   /** Swaps the contents (all field values) of this tile with the given tile. */
@@ -600,8 +605,34 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<uint8_t> {
     std::swap(hilbert_values_, tile.hilbert_values_);
   }
 
+  /** Returns if the tile was used by the merge or not. */
+  inline bool used() {
+    return used_;
+  }
+
+  /** Set the tile as used by the merge. */
+  inline void set_used() {
+    used_ = true;
+  }
+
+  /** Allocate space for the hilbert values vector. */
+  inline void allocate_hilbert_vector() {
+    hilbert_values_.resize(cell_num());
+  }
+
+  /** Get the hilbert value at an index. */
+  inline uint64_t hilbert_value(uint64_t i) {
+    return hilbert_values_[i];
+  }
+
+  /** Set a hilbert value. */
+  inline void set_hilbert_value(uint64_t i, uint64_t v) {
+    hilbert_values_[i] = v;
+  }
+
+ private:
   /* ********************************* */
-  /*         PUBLIC ATTRIBUTES         */
+  /*        PRIVATE ATTRIBUTES         */
   /* ********************************* */
 
   /** Hilbert values for this tile. */

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -456,6 +456,161 @@ class ResultTile {
       const std::string_view& range_end);
 };
 
+/** Result tile with bitmap. */
+template <class BitmapType>
+class ResultTileWithBitmap : public ResultTile {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+  ResultTileWithBitmap() = default;
+
+  ResultTileWithBitmap(
+      unsigned frag_idx, uint64_t tile_idx, const ArraySchema& array_schema)
+      : ResultTile(frag_idx, tile_idx, array_schema)
+      , bitmap_result_num_(std::numeric_limits<uint64_t>::max())
+      , coords_loaded_(false) {
+  }
+
+  /** Move constructor. */
+  ResultTileWithBitmap(ResultTileWithBitmap<BitmapType>&& other) noexcept {
+    // Swap with the argument
+    swap(other);
+  }
+
+  /** Move-assign operator. */
+  ResultTileWithBitmap<BitmapType>& operator=(
+      ResultTileWithBitmap<BitmapType>&& other) {
+    // Swap with the argument
+    swap(other);
+
+    return *this;
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(ResultTileWithBitmap);
+
+  /* ********************************* */
+  /*          PUBLIC METHODS           */
+  /* ********************************* */
+
+  /**
+   * Returns the number of cells that are before a certain cell index in the
+   * bitmap.
+   *
+   * @param start_pos Starting cell position in the bitmap.
+   * @param end_pos End position in the bitmap.
+   *
+   * @return Result number between the positions.
+   */
+  uint64_t result_num_between_pos(uint64_t start_pos, uint64_t end_pos) const {
+    if (bitmap_.size() == 0)
+      return end_pos - start_pos;
+
+    uint64_t result_num = 0;
+    for (uint64_t c = start_pos; c < end_pos; c++)
+      result_num += bitmap_[c];
+
+    return result_num;
+  }
+
+  /**
+   * Returns cell index from a number of cells inside of the bitmap.
+   *
+   * @param start_pos Starting cell position in the bitmap.
+   * @param result_num Number of results to advance.
+   *
+   * @return Cell position found, or maximum position.
+   */
+  uint64_t pos_with_given_result_sum(
+      uint64_t start_pos, uint64_t result_num) const {
+    assert(
+        bitmap_result_num_ != std::numeric_limits<uint64_t>::max() &&
+        result_num != 0);
+    if (bitmap_.size() == 0)
+      return start_pos + result_num - 1;
+
+    uint64_t sum = 0;
+    for (uint64_t c = start_pos; c < bitmap_.size(); c++) {
+      sum += bitmap_[c];
+      if (sum == result_num) {
+        return c;
+      }
+    }
+
+    return bitmap_.size() - 1;
+  }
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(ResultTileWithBitmap<BitmapType>& tile) {
+    ResultTile::swap(tile);
+    std::swap(bitmap_, tile.bitmap_);
+    std::swap(bitmap_result_num_, tile.bitmap_result_num_);
+    std::swap(coords_loaded_, tile.coords_loaded_);
+  }
+
+  /* ********************************* */
+  /*         PUBLIC ATTRIBUTES         */
+  /* ********************************* */
+
+  /** Bitmap for this tile. */
+  std::vector<BitmapType> bitmap_;
+
+  /** Number of cells in this bitmap. */
+  uint64_t bitmap_result_num_;
+
+  /** Were the coordinates loaded for this tile. */
+  bool coords_loaded_;
+};
+
+/** Global order result tile. */
+class GlobalOrderResultTile : public ResultTileWithBitmap<uint8_t> {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+  GlobalOrderResultTile(
+      unsigned frag_idx, uint64_t tile_idx, const ArraySchema& array_schema)
+      : ResultTileWithBitmap<uint8_t>(frag_idx, tile_idx, array_schema)
+      , used_(false) {
+  }
+
+  /** Move constructor. */
+  GlobalOrderResultTile(GlobalOrderResultTile&& other) noexcept {
+    // Swap with the argument
+    swap(other);
+  }
+
+  /** Move-assign operator. */
+  GlobalOrderResultTile& operator=(GlobalOrderResultTile&& other) {
+    // Swap with the argument
+    swap(other);
+
+    return *this;
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(GlobalOrderResultTile);
+
+  /* ********************************* */
+  /*          PUBLIC METHODS           */
+  /* ********************************* */
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(GlobalOrderResultTile& tile) {
+    ResultTileWithBitmap<uint8_t>::swap(tile);
+    std::swap(hilbert_values_, tile.hilbert_values_);
+  }
+
+  /* ********************************* */
+  /*         PUBLIC ATTRIBUTES         */
+  /* ********************************* */
+
+  /** Hilbert values for this tile. */
+  std::vector<uint64_t> hilbert_values_;
+
+  /** Was the tile used in the merge. */
+  bool used_;
+};
+
 }  // namespace sm
 }  // namespace tiledb
 

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -368,7 +368,7 @@ tuple<Status, optional<bool>> SparseGlobalOrderReader::create_result_tiles() {
           auto tile_num = fragment_metadata_[f]->tile_num();
 
           // Figure out the start index.
-          auto start = read_state_.frag_tile_idx_[f].first;
+          auto start = read_state_.frag_idx_[f].tile_idx_;
           if (!result_tiles_[f].empty()) {
             start = std::max(start, result_tiles_[f].back().tile_idx() + 1);
           }
@@ -461,65 +461,54 @@ SparseGlobalOrderReader::compute_result_cell_slab() {
   }
 }
 
-template <class T>
-tuple<Status, optional<bool>> SparseGlobalOrderReader::add_next_tile_to_queue(
-    unsigned int frag_idx,
-    uint64_t cell_idx,
-    std::vector<std::list<ResultTileWithBitmap<uint8_t>>::iterator>&
-        result_tiles_it,
-    std::vector<uint8_t>& result_tile_used,
-    std::priority_queue<ResultCoords, std::vector<ResultCoords>, T>& tile_queue,
-    std::mutex& tile_queue_mutex) {
-  bool found = false;
+template <class CompType>
+tuple<Status, optional<bool>> SparseGlobalOrderReader::add_next_cell_to_queue(
+    GlobalOrderResultCoords& rc,
+    std::vector<TileListIt>& result_tiles_it,
+    TileMinHeap<CompType>& tile_queue) {
+  // Try the next cell in the same tile.
+  auto frag_idx = rc.tile_->frag_idx();
+  bool found = rc.next_cell();
+
+  // If found, update the fragment index, add the cell to the queue and return.
+  if (found) {
+    std::unique_lock<std::mutex> ul(tile_queue_mutex_);
+    read_state_.frag_idx_[frag_idx] = FragIdx(rc.tile_->tile_idx(), rc.pos_);
+    tile_queue.emplace(std::move(rc));
+    return {Status::Ok(), false};
+  }
+
+  // Save the potential tile to delete and increment the tile iterator.
+  auto to_delete = result_tiles_it[frag_idx];
+  result_tiles_it[frag_idx]++;
 
   // Remove the tile from result tiles if it wasn't used at all.
-  if (!result_tile_used[frag_idx]) {
-    auto to_delete = result_tiles_it[frag_idx];
-    to_delete--;
+  if (!rc.tile_->used_) {
     remove_result_tile(frag_idx, to_delete);
   }
 
-  // Try to find a tile.
-  while (!found && result_tiles_it[frag_idx] != result_tiles_[frag_idx].end()) {
-    bool has_bmp = result_tiles_it[frag_idx]->bitmap_.size() > 0;
-    found = !has_bmp;
-    auto tile = &*result_tiles_it[frag_idx];
+  // Try to find a new tile.
+  if (result_tiles_it[frag_idx] != result_tiles_[frag_idx].end()) {
+    // Find a cell in the current result tile.
+    GlobalOrderResultCoords rc(&*result_tiles_it[frag_idx], 0);
+    found = rc.next_cell();
 
-    // Find a cell that's in the subarray.
-    if (has_bmp) {
-      while (cell_idx < tile->cell_num()) {
-        if (tile->bitmap_.size() == 0 || tile->bitmap_[cell_idx]) {
-          found = true;
-          break;
-        }
+    // All tiles should at least have one cell available.
+    assert(found == true);
 
-        cell_idx++;
-      }
+    // Insert the cell in the queue.
+    {
+      std::unique_lock<std::mutex> ul(tile_queue_mutex_);
+      tile_queue.emplace(std::move(rc));
     }
-
-    // There was more tiles in this fragment, insert it in the queue.
-    if (found) {
-      std::unique_lock<std::mutex> ul(tile_queue_mutex);
-      tile_queue.emplace(tile, cell_idx);
-      result_tiles_it[frag_idx]++;
-    } else {
-      // Remove the tile.
-      auto to_delete = result_tiles_it[frag_idx];
-      result_tiles_it[frag_idx]++;
-      remove_result_tile(frag_idx, to_delete);
-    }
-
-    result_tile_used[frag_idx] = false;
-
-    // Once we move to the next tile, the saved cell index doesn't matter.
-    cell_idx = 0;
+    read_state_.frag_idx_[frag_idx] = FragIdx(rc.tile_->tile_idx(), rc.pos_);
   }
 
   if (!found) {
     // Increment the tile index, which should clear all tiles in end_iteration.
     if (!result_tiles_[frag_idx].empty()) {
-      read_state_.frag_tile_idx_[frag_idx].first++;
-      read_state_.frag_tile_idx_[frag_idx].second = 0;
+      read_state_.frag_idx_[frag_idx].tile_idx_++;
+      read_state_.frag_idx_[frag_idx].cell_idx_ = 0;
     }
 
     // This fragment has more tiles potentially.
@@ -529,6 +518,7 @@ tuple<Status, optional<bool>> SparseGlobalOrderReader::add_next_tile_to_queue(
     }
   }
 
+  // We don't need more tiles as a tile was found.
   return {Status::Ok(), false};
 }
 
@@ -547,9 +537,9 @@ Status SparseGlobalOrderReader::compute_hilbert_values(
   // Parallelize on tiles.
   auto status = parallel_for(
       storage_manager_->compute_tp(), 0, result_tiles.size(), [&](uint64_t t) {
-        auto tile = (ResultTileWithBitmap<uint8_t>*)result_tiles[t];
+        auto tile = (GlobalOrderResultTile*)result_tiles[t];
         auto cell_num = tile->cell_num();
-        auto rc = ResultCoords(tile, 0);
+        auto rc = GlobalOrderResultCoords(tile, 0);
         std::vector<uint64_t> coords(dim_num);
 
         tile->hilbert_values_.resize(cell_num);
@@ -575,9 +565,10 @@ Status SparseGlobalOrderReader::compute_hilbert_values(
   return Status::Ok();
 }
 
-template <class T>
+template <class CompType>
 tuple<Status, optional<std::vector<ResultCellSlab>>>
-SparseGlobalOrderReader::merge_result_cell_slabs(uint64_t num_cells, T cmp) {
+SparseGlobalOrderReader::merge_result_cell_slabs(
+    uint64_t num_cells, CompType cmp) {
   auto timer_se = stats_->start_timer("merge_result_cell_slabs");
   std::vector<ResultCellSlab> result_cell_slabs;
 
@@ -586,42 +577,29 @@ SparseGlobalOrderReader::merge_result_cell_slabs(uint64_t num_cells, T cmp) {
   // For easy reference.
   auto allows_dups = array_schema_.allows_dups();
 
-  // A tile min heap, contains one ResultCoords per fragment.
-  std::vector<ResultCoords> container;
+  // A tile min heap, contains one GlobalOrderResultCoords per fragment.
+  std::vector<GlobalOrderResultCoords> container;
   container.reserve(result_tiles_.size());
-  std::priority_queue<ResultCoords, std::vector<ResultCoords>, T> tile_queue(
-      cmp, std::move(container));
-
-  std::mutex tile_queue_mutex;
+  TileMinHeap<CompType> tile_queue(cmp, std::move(container));
 
   // If any fragments needs to load more tiles.
   bool need_more_tiles = false;
 
   // Tile iterators, per fragments.
-  std::vector<std::list<ResultTileWithBitmap<uint8_t>>::iterator>
-      result_tiles_it(result_tiles_.size());
+  std::vector<TileListIt> result_tiles_it(result_tiles_.size());
 
-  // Boolean per fragment that keeps track of when a tile is used.
-  std::vector<uint8_t> result_tile_used(result_tiles_.size(), true);
-
-  // For all fragments, get the first tile.
+  // For all fragments, get the first tile in the sorting queue.
   auto status = parallel_for(
       storage_manager_->compute_tp(), 0, result_tiles_.size(), [&](uint64_t f) {
         if (result_tiles_[f].size() > 0) {
           // Initialize the iterator for this fragment.
           result_tiles_it[f] = result_tiles_[f].begin();
 
-          // Get the cell index we were processing.
-          auto cell_idx = read_state_.frag_tile_idx_[f].second;
-
           // Add the tile to the queue.
-          auto&& [st, more_tiles] = add_next_tile_to_queue(
-              f,
-              cell_idx,
-              result_tiles_it,
-              result_tile_used,
-              tile_queue,
-              tile_queue_mutex);
+          GlobalOrderResultCoords rc(
+              &*(result_tiles_it[f]), read_state_.frag_idx_[f].cell_idx_);
+          auto&& [st, more_tiles] =
+              add_next_cell_to_queue(rc, result_tiles_it, tile_queue);
           RETURN_NOT_OK(st);
           need_more_tiles = *more_tiles;
         }
@@ -639,151 +617,68 @@ SparseGlobalOrderReader::merge_result_cell_slabs(uint64_t num_cells, T cmp) {
     while (!tile_queue.empty() && to_process.same_coords(tile_queue.top()) &&
            num_cells > 0) {
       // Potentially the next cell.
-      auto next_tile = tile_queue.top();
+      auto to_process_dup = tile_queue.top();
       tile_queue.pop();
 
       // Take the cell with the highest fagment index.
-      if (to_process.tile_->frag_idx() < next_tile.tile_->frag_idx()) {
-        std::swap(to_process, next_tile);
+      if (to_process.tile_->frag_idx() < to_process_dup.tile_->frag_idx()) {
+        std::swap(to_process, to_process_dup);
       }
 
       // If we allow duplicates, or for consolidation with timestamps, create
       // one slab for all the dups.
+      auto tile = to_process_dup.tile_;
       if (allows_dups || consolidation_with_timestamps_) {
-        result_tile_used[next_tile.tile_->frag_idx()] = true;
-        result_cell_slabs.emplace_back(next_tile.tile_, next_tile.pos_, 1);
+        tile->used_ = true;
+        result_cell_slabs.emplace_back(
+            to_process_dup.tile_, to_process_dup.pos_, 1);
         num_cells--;
-        read_state_.frag_tile_idx_[next_tile.tile_->frag_idx()] =
-            std::pair<uint64_t, uint64_t>(
-                next_tile.tile_->tile_idx(), next_tile.pos_);
       }
 
       // Put the next cell in the queue.
-      if (!next_tile.next()) {
-        // Done with this tile, fetch another.
-        auto&& [st, more_tiles] = add_next_tile_to_queue(
-            next_tile.tile_->frag_idx(),
-            0,
-            result_tiles_it,
-            result_tile_used,
-            tile_queue,
-            tile_queue_mutex);
-        RETURN_NOT_OK_TUPLE(st, nullopt);
-        need_more_tiles = *more_tiles;
-      } else {
-        tile_queue.emplace(std::move(next_tile));
-      }
+      auto&& [st, more_tiles] =
+          add_next_cell_to_queue(to_process_dup, result_tiles_it, tile_queue);
+      RETURN_NOT_OK_TUPLE(st, nullopt);
+      need_more_tiles = *more_tiles;
     }
 
     if (num_cells == 0) {
       break;
     }
 
-    // Get the tile and flag it as used.
-    auto tile = (ResultTileWithBitmap<uint8_t>*)to_process.tile_;
-    auto has_bmp = tile->bitmap_.size() > 0;
-    result_tile_used[tile->frag_idx()] = true;
-
-    // Find how many cells to process using the top of the queue.
-    // Temp result coord used to find the last position.
-    ResultCoords temp_rc = to_process;
-
-    // Check the top of the queue against last possible cell in the current
-    // tile.
-    if (!has_bmp) {
-      temp_rc.pos_ =
-          std::min(tile->cell_num() - 1, to_process.pos_ + num_cells - 1);
-    } else {
-      temp_rc.pos_ =
-          tile->pos_with_given_result_sum(to_process.pos_, num_cells);
-    }
-
-    // If there is more than one fragment and we can't add the whole tile,
-    // find the last possible cell in this tile smaller than the top of the
-    // queue. Otherwise we are adding everything.
-    if (!tile_queue.empty()) {
-      auto& next_tile = tile_queue.top();
-      if (cmp(temp_rc, next_tile)) {
-        // Run a bisection seach on to find the last cell.
-        uint64_t left = to_process.pos_;
-        uint64_t right = temp_rc.pos_;
-        while (left != right - 1) {
-          // Check against mid.
-          temp_rc.pos_ = left + (right - left) / 2;
-
-          if (!cmp(temp_rc, next_tile))
-            left = temp_rc.pos_;
-          else
-            right = temp_rc.pos_;
-        }
-
-        // Left is the last position smaller than the top of the queue.
-        temp_rc.pos_ = left;
-      }
-    }
-
-    // Generate the result cell slabs.
+    // Get data from the result coord.
+    auto tile = to_process.tile_;
     auto start = to_process.pos_;
     const auto tile_idx = tile->tile_idx();
-    auto& frag_idx = read_state_.frag_tile_idx_[tile->frag_idx()];
+    const auto frag_idx = tile->frag_idx();
 
-    // If no bitmap is set, add all cells.
-    if (!has_bmp) {
-      auto length = std::min(temp_rc.pos_ - to_process.pos_ + 1, num_cells);
-      result_cell_slabs.emplace_back(tile, start, length);
-      frag_idx = std::pair<uint64_t, uint64_t>(tile_idx, start + length);
-      num_cells -= length;
+    // Flag the tile as used.
+    to_process.tile_->used_ = true;
+
+    // Compute the length of the cell slab.
+    uint64_t length = std::numeric_limits<uint64_t>::max();
+    if (tile_queue.empty()) {
+      length = to_process.max_slab_length();
     } else {
-      // Process all cells, when there is a "hole" in the cell contiguity,
-      // push a new cell slab.
-      uint64_t length = 0;
-      for (auto c = to_process.pos_; c <= temp_rc.pos_; c++) {
-        if (!tile->bitmap_[c]) {
-          if (length != 0) {
-            result_cell_slabs.emplace_back(tile, start, length);
-            frag_idx = std::pair<uint64_t, uint64_t>(tile_idx, start + length);
-            num_cells -= length;
-            length = 0;
-          }
-
-          start = c + 1;
-        } else {
-          length++;
-
-          if (length == num_cells)
-            break;
-        }
-      }
-
-      // Add the last cell slab.
-      if (length != 0) {
-        result_cell_slabs.emplace_back(tile, start, length);
-        frag_idx = std::pair<uint64_t, uint64_t>(tile_idx, start + length - 1);
-        num_cells -= length;
-      }
+      length = to_process.max_slab_length(tile_queue.top(), cmp);
     }
 
-    // Update the position in the tile.
-    to_process.pos_ = temp_rc.pos_;
+    // Make sure we don't merge more cells than the buffers.
+    length = std::min(length, num_cells);
+
+    // Generate the result cell slabs.
+    result_cell_slabs.emplace_back(tile, start, length);
+    read_state_.frag_idx_[frag_idx] = FragIdx(tile_idx, start + length);
+    num_cells -= length;
+
+    // Update the position in the result coord.
+    to_process.pos_ += length - 1;
 
     // Put the next cell in the queue.
-    if (!to_process.next()) {
-      // Done with this tile, fetch another.
-      auto&& [st, more_tiles] = add_next_tile_to_queue(
-          tile->frag_idx(),
-          0,
-          result_tiles_it,
-          result_tile_used,
-          tile_queue,
-          tile_queue_mutex);
-      RETURN_NOT_OK_TUPLE(st, nullopt);
-      need_more_tiles = *more_tiles;
-    } else {
-      // Put the next cell on the queue to be resorted.
-      read_state_.frag_tile_idx_[tile->frag_idx()] =
-          std::pair<uint64_t, uint64_t>(tile->tile_idx(), to_process.pos_);
-      tile_queue.emplace(std::move(to_process));
-    }
+    auto&& [st, more_tiles] =
+        add_next_cell_to_queue(to_process, result_tiles_it, tile_queue);
+    RETURN_NOT_OK_TUPLE(st, nullopt);
+    need_more_tiles = *more_tiles;
   }
 
   buffers_full_ = num_cells == 0;
@@ -842,8 +737,8 @@ Status SparseGlobalOrderReader::copy_offsets_tiles(
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
         auto& rcs = result_cell_slabs[i];
-        auto rt = static_cast<ResultTileWithBitmap<uint8_t>*>(
-            result_cell_slabs[i].tile_);
+        auto rt =
+            static_cast<GlobalOrderResultTile*>(result_cell_slabs[i].tile_);
 
         // Get source buffers.
         const auto tile_tuple = rt->tile_tuple(name);
@@ -1002,8 +897,8 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
         auto& rcs = result_cell_slabs[i];
-        auto rt = static_cast<ResultTileWithBitmap<uint8_t>*>(
-            result_cell_slabs[i].tile_);
+        auto rt =
+            static_cast<GlobalOrderResultTile*>(result_cell_slabs[i].tile_);
 
         // Get source buffers.
         const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
@@ -1076,8 +971,8 @@ Status SparseGlobalOrderReader::copy_timestamps_tiles(
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
         auto& rcs = result_cell_slabs[i];
-        auto rt = static_cast<ResultTileWithBitmap<uint8_t>*>(
-            result_cell_slabs[i].tile_);
+        auto rt =
+            static_cast<GlobalOrderResultTile*>(result_cell_slabs[i].tile_);
         const uint64_t cell_size = constants::timestamp_size;
 
         // Get source buffers.
@@ -1156,7 +1051,7 @@ SparseGlobalOrderReader::respect_copy_memory_budget(
         uint64_t idx = 0;
         for (; idx < max_cs_idx; idx++) {
           auto rt =
-              (ResultTileWithBitmap<uint8_t>*)result_cell_slabs[idx].tile_;
+              static_cast<GlobalOrderResultTile*>(result_cell_slabs[idx].tile_);
           auto id =
               std::pair<uint64_t, uint64_t>(rt->frag_idx(), rt->tile_idx());
 
@@ -1247,9 +1142,8 @@ uint64_t SparseGlobalOrderReader::compute_var_size_offsets(
     while (query_buffer.original_buffer_var_size_ < new_var_buffer_size) {
       // Revert progress for this slab in read state, and pop it.
       auto& last_rcs = result_cell_slabs.back();
-      read_state_.frag_tile_idx_[last_rcs.tile_->frag_idx()] =
-          std::pair<uint64_t, uint64_t>(
-              last_rcs.tile_->tile_idx(), last_rcs.start_);
+      read_state_.frag_idx_[last_rcs.tile_->frag_idx()] =
+          FragIdx(last_rcs.tile_->tile_idx(), last_rcs.start_);
       result_cell_slabs.pop_back();
 
       // Update the new var buffer size.
@@ -1282,9 +1176,8 @@ uint64_t SparseGlobalOrderReader::compute_var_size_offsets(
     new_var_buffer_size = ((OffType*)query_buffer.buffer_)[total_cells];
 
     // Update the cell progress.
-    read_state_.frag_tile_idx_[last_rcs.tile_->frag_idx()] =
-        std::pair<uint64_t, uint64_t>(
-            last_rcs.tile_->tile_idx(), last_rcs.start_ + last_rcs.length_);
+    read_state_.frag_idx_[last_rcs.tile_->frag_idx()] =
+        FragIdx(last_rcs.tile_->tile_idx(), last_rcs.start_ + last_rcs.length_);
   }
 
   return new_var_buffer_size;
@@ -1449,8 +1342,7 @@ Status SparseGlobalOrderReader::process_slabs(
 }
 
 Status SparseGlobalOrderReader::remove_result_tile(
-    const unsigned frag_idx,
-    std::list<ResultTileWithBitmap<uint8_t>>::iterator rt) {
+    const unsigned frag_idx, TileListIt rt) {
   // Remove coord tile size from memory budget.
   auto tile_idx = rt->tile_idx();
   auto&& [st, tiles_sizes] = get_coord_tiles_size<uint8_t>(
@@ -1491,7 +1383,7 @@ Status SparseGlobalOrderReader::end_iteration() {
       storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
         while (!result_tiles_[f].empty() &&
                result_tiles_[f].front().tile_idx() !=
-                   read_state_.frag_tile_idx_[f].first) {
+                   read_state_.frag_idx_[f].tile_idx_) {
           RETURN_NOT_OK(remove_result_tile(f, result_tiles_[f].begin()));
         }
 

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -551,7 +551,7 @@ Status SparseIndexReaderBase::apply_query_condition(
           }
 
           // Full overlap in bitmap calculation, make a bitmap.
-          if (rt->bitmap_.size() == 0) {
+          if (!rt->has_bmp()) {
             rt->bitmap_.resize(cell_num, 1);
             rt->bitmap_result_num_ = cell_num;
           }

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -217,7 +217,7 @@ Status SparseIndexReaderBase::load_initial_data() {
   auto fragment_num = fragment_metadata_.size();
 
   // Make sure there is enough space for tiles data.
-  read_state_.frag_tile_idx_.resize(fragment_num);
+  read_state_.frag_idx_.resize(fragment_num);
   all_tiles_loaded_.resize(fragment_num);
 
   // Calculate ranges of tiles in the subarray, if set.
@@ -233,7 +233,7 @@ Status SparseIndexReaderBase::load_initial_data() {
     // later.
     RETURN_NOT_OK(subarray_.precompute_all_ranges_tile_overlap(
         storage_manager_->compute_tp(),
-        read_state_.frag_tile_idx_,
+        read_state_.frag_idx_,
         &result_tile_ranges_));
 
     for (auto frag_result_tile_ranges : result_tile_ranges_) {

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -50,122 +50,54 @@ class MemoryTracker;
 class StorageManager;
 class Subarray;
 
-/** Result tile with bitmap. */
-template <class BitmapType>
-class ResultTileWithBitmap : public ResultTile {
+class FragIdx {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
-  ResultTileWithBitmap(
-      unsigned frag_idx, uint64_t tile_idx, const ArraySchema& array_schema)
-      : ResultTile(frag_idx, tile_idx, array_schema)
-      , bitmap_result_num_(std::numeric_limits<uint64_t>::max())
-      , coords_loaded_(false) {
+  FragIdx() = default;
+
+  FragIdx(uint64_t tile_idx, uint64_t cell_idx)
+      : tile_idx_(tile_idx)
+      , cell_idx_(cell_idx) {
   }
 
   /** Move constructor. */
-  ResultTileWithBitmap(ResultTileWithBitmap<BitmapType>&& other) noexcept {
+  FragIdx(FragIdx&& other) noexcept {
     // Swap with the argument
     swap(other);
   }
 
   /** Move-assign operator. */
-  ResultTileWithBitmap<BitmapType>& operator=(
-      ResultTileWithBitmap<BitmapType>&& other) {
+  FragIdx& operator=(FragIdx&& other) {
     // Swap with the argument
     swap(other);
 
     return *this;
   }
 
-  DISABLE_COPY_AND_COPY_ASSIGN(ResultTileWithBitmap);
+  DISABLE_COPY_AND_COPY_ASSIGN(FragIdx);
 
   /* ********************************* */
   /*          PUBLIC METHODS           */
   /* ********************************* */
 
-  /**
-   * Returns the number of cells that are before a certain cell index in the
-   * bitmap.
-   *
-   * @param start_pos Starting cell position in the bitmap.
-   * @param end_pos End position in the bitmap.
-   *
-   * @return Result number between the positions.
-   */
-  uint64_t result_num_between_pos(uint64_t start_pos, uint64_t end_pos) const {
-    if (bitmap_.size() == 0)
-      return end_pos - start_pos;
-
-    uint64_t result_num = 0;
-    for (uint64_t c = start_pos; c < end_pos; c++)
-      result_num += bitmap_[c];
-
-    return result_num;
-  }
-
-  /**
-   * Returns cell index from a number of cells inside of the bitmap.
-   *
-   * @param start_pos Starting cell position in the bitmap.
-   * @param result_num Number of results to advance.
-   *
-   * @return Cell position found, or maximum position.
-   */
-  uint64_t pos_with_given_result_sum(
-      uint64_t start_pos, uint64_t result_num) const {
-    assert(
-        bitmap_result_num_ != std::numeric_limits<uint64_t>::max() &&
-        result_num != 0);
-    if (bitmap_.size() == 0)
-      return start_pos + result_num - 1;
-
-    uint64_t sum = 0;
-    for (uint64_t c = start_pos; c < bitmap_.size(); c++) {
-      sum += bitmap_[c];
-      if (sum == result_num) {
-        return c;
-      }
-    }
-
-    return bitmap_.size() - 1;
-  }
-
   /** Swaps the contents (all field values) of this tile with the given tile. */
-  void swap(ResultTileWithBitmap<BitmapType>& tile) {
-    ResultTile::swap(tile);
-    std::swap(bitmap_, tile.bitmap_);
-    std::swap(bitmap_result_num_, tile.bitmap_result_num_);
-    std::swap(coords_loaded_, tile.coords_loaded_);
-    std::swap(hilbert_values_, tile.hilbert_values_);
+  void swap(FragIdx& frag_tile_idx) {
+    std::swap(tile_idx_, frag_tile_idx.tile_idx_);
+    std::swap(cell_idx_, frag_tile_idx.cell_idx_);
   }
 
   /* ********************************* */
   /*         PUBLIC ATTRIBUTES         */
   /* ********************************* */
 
-  /** Bitmap for this tile. */
-  std::vector<BitmapType> bitmap_;
+  /** Tile index. */
+  uint64_t tile_idx_;
 
-  /** Number of cells in this bitmap. */
-  uint64_t bitmap_result_num_;
-
-  /** Was the query condition processed for this tile. */
-  bool coords_loaded_;
-
-  /** Hilbert values for this tile. */
-  std::vector<uint64_t> hilbert_values_;
+  /** Cell index. */
+  uint64_t cell_idx_;
 };
-
-/**
- * Result tile list per fragments. For sparse global order reader, this will
- * be the list of tiles loaded per fragments. For the unordered with duplicates
- * reader, all tiles will be in fragment 0.
- */
-template <typename BitmapType>
-using ResultTileListPerFragment =
-    std::vector<std::list<ResultTileWithBitmap<BitmapType>>>;
 
 /** Processes read queries. */
 class SparseIndexReaderBase : public ReaderBase {
@@ -177,7 +109,7 @@ class SparseIndexReaderBase : public ReaderBase {
   /** The state for a read sparse global order query. */
   struct ReadState {
     /** The tile index inside of each fragments. */
-    std::vector<std::pair<uint64_t, uint64_t>> frag_tile_idx_;
+    std::vector<FragIdx> frag_idx_;
 
     /** Is the reader done with the query. */
     bool done_adding_result_tiles_;

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -77,8 +77,7 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
           buffers,
           subarray,
           layout,
-          condition)
-    , result_tiles_(1) {
+          condition) {
 }
 
 /* ****************************** */
@@ -87,7 +86,7 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
 
 template <class BitmapType>
 bool SparseUnorderedWithDupsReader<BitmapType>::incomplete() const {
-  return !read_state_.done_adding_result_tiles_ || !result_tiles_[0].empty();
+  return !read_state_.done_adding_result_tiles_ || !result_tiles_.empty();
 }
 
 template <class BitmapType>
@@ -99,7 +98,7 @@ SparseUnorderedWithDupsReader<BitmapType>::status_incomplete_reason() const {
   if (!incomplete())
     return QueryStatusDetailsReason::REASON_NONE;
 
-  return result_tiles_[0].empty() ?
+  return result_tiles_.empty() ?
              QueryStatusDetailsReason::REASON_MEMORY_BUDGET :
              QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE;
 }
@@ -189,7 +188,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
     RETURN_NOT_OK(create_result_tiles());
 
     // No more tiles to process, done.
-    if (result_tiles_[0].empty()) {
+    if (result_tiles_.empty()) {
       assert(read_state_.done_adding_result_tiles_);
       break;
     }
@@ -197,14 +196,12 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
     // Generate the list of created/loaded result tiles.
     std::vector<ResultTile*> result_tiles_created;
     std::vector<ResultTile*> result_tiles_loaded;
-    for (auto& rt_list : result_tiles_) {
-      for (auto& result_tile : rt_list) {
-        if (!result_tile.coords_loaded_) {
-          result_tile.coords_loaded_ = true;
-          result_tiles_created.emplace_back(&result_tile);
-        } else {
-          result_tiles_loaded.emplace_back(&result_tile);
-        }
+    for (auto& result_tile : result_tiles_) {
+      if (!result_tile.coords_loaded_) {
+        result_tile.coords_loaded_ = true;
+        result_tiles_created.emplace_back(&result_tile);
+      } else {
+        result_tiles_loaded.emplace_back(&result_tile);
       }
     }
 
@@ -230,8 +227,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
       result_tiles_created.resize(current);
 
       // Clear result tiles that are not necessary anymore, part 2.
-      auto it = result_tiles_[0].begin();
-      while (it != result_tiles_[0].end()) {
+      auto it = result_tiles_.begin();
+      while (it != result_tiles_.end()) {
         auto f = it->frag_idx();
         if (it->bitmap_result_num_ == 0) {
           RETURN_NOT_OK(remove_result_tile(f, it++));
@@ -247,7 +244,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
     }
 
     // No more tiles to process, continue.
-    if (result_tiles_[0].empty()) {
+    if (result_tiles_.empty()) {
       continue;
     }
 
@@ -304,7 +301,7 @@ SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
   memory_used_qc_tiles_total_ += tiles_size_qc;
 
   // Add the result tile.
-  result_tiles_[0].emplace_back(f, t, array_schema);
+  result_tiles_.emplace_back(f, t, array_schema);
 
   // Are all tiles loaded for this fragment.
   if (t == last_t)
@@ -356,7 +353,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
                   "Budget exceeded adding result tiles, fragment {0}, tile {1}",
                   f,
                   t);
-              if (result_tiles_[0].empty())
+              if (result_tiles_.empty())
                 return logger_->status(
                     Status_SparseUnorderedWithDupsReaderError(
                         "Cannot load a single tile, increase memory budget"));
@@ -384,10 +381,9 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
         auto tile_num = fragment_metadata_[f]->tile_num();
 
         // Figure out the start index.
-        auto start = read_state_.frag_tile_idx_[f].first;
-        if (!result_tiles_[0].empty() &&
-            result_tiles_[0].back().frag_idx() == f) {
-          start = std::max(start, result_tiles_[0].back().tile_idx() + 1);
+        auto start = read_state_.frag_idx_[f].tile_idx_;
+        if (!result_tiles_.empty() && result_tiles_.back().frag_idx() == f) {
+          start = std::max(start, result_tiles_.back().tile_idx() + 1);
         }
 
         // Add all tiles for this fragment.
@@ -407,7 +403,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
                 "Budget exceeded adding result tiles, fragment {0}, tile {1}",
                 f,
                 t);
-            if (result_tiles_[0].empty())
+            if (result_tiles_.empty())
               return logger_->status(Status_SparseUnorderedWithDupsReaderError(
                   "Cannot load a single tile, increase memory budget"));
             budget_exceeded = true;
@@ -426,8 +422,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
   }
 
   logger_->debug(
-      "Done adding result tiles, num result tiles {0}",
-      result_tiles_[0].size());
+      "Done adding result tiles, num result tiles {0}", result_tiles_.size());
 
   if (done_adding_result_tiles) {
     logger_->debug("All result tiles loaded");
@@ -645,7 +640,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
         // We might have a partially processed result tile from last run.
         auto min_pos_tile = 0;
         if (i == 0) {
-          min_pos_tile = read_state_.frag_tile_idx_[rt->frag_idx()].second;
+          min_pos_tile = read_state_.frag_idx_[rt->frag_idx()].cell_idx_;
         }
 
         auto max_pos_tile =
@@ -979,7 +974,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
         // We might have a partially processed result tile from last run.
         auto min_pos_tile = 0;
         if (i == 0) {
-          min_pos_tile = read_state_.frag_tile_idx_[rt->frag_idx()].second;
+          min_pos_tile = read_state_.frag_idx_[rt->frag_idx()].cell_idx_;
         }
 
         auto max_pos_tile =
@@ -1083,14 +1078,14 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_fixed_results_to_copy(
     // First tile might have been partially copied. Adjust cell_num to account
     // for it.
     if (i == 0) {
-      if (read_state_.frag_tile_idx_[rt->frag_idx()].first == rt->tile_idx()) {
+      if (read_state_.frag_idx_[rt->frag_idx()].tile_idx_ == rt->tile_idx()) {
         if (rt->bitmap_result_num_ != std::numeric_limits<uint64_t>::max()) {
           if (rt->bitmap_result_num_ != 0) {
-            auto pos = read_state_.frag_tile_idx_[rt->frag_idx()].second;
+            auto pos = read_state_.frag_idx_[rt->frag_idx()].cell_idx_;
             cell_num -= rt->result_num_between_pos(0, pos);
           }
         } else {
-          cell_num -= read_state_.frag_tile_idx_[rt->frag_idx()].second;
+          cell_num -= read_state_.frag_idx_[rt->frag_idx()].cell_idx_;
         }
       }
     }
@@ -1362,7 +1357,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
 
       if (var_sized) {
         auto first_tile_min_pos =
-            read_state_.frag_tile_idx_[result_tiles[0]->frag_idx()].second;
+            read_state_.frag_idx_[result_tiles[0]->frag_idx()].cell_idx_;
 
         // Adjust the offsets buffer and make sure all data fits.
         auto&& [buffers_full, new_var_buffer_size, new_result_tiles_size] =
@@ -1430,22 +1425,21 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
   // Compute the number of cells copied for the last tile before updating tile
   // index.
   auto last_tile = (ResultTileWithBitmap<BitmapType>*)result_tiles.back();
-  auto& frag_tile_idx = read_state_.frag_tile_idx_[last_tile->frag_idx()];
+  auto& frag_tile_idx = read_state_.frag_idx_[last_tile->frag_idx()];
   auto last_tile_cells_copied =
       cell_offsets[result_tiles.size()] - cell_offsets[result_tiles.size() - 1];
-  if (frag_tile_idx.first == last_tile->tile_idx()) {
+  if (frag_tile_idx.tile_idx_ == last_tile->tile_idx()) {
     if (last_tile->bitmap_result_num_ != std::numeric_limits<uint64_t>::max()) {
       last_tile_cells_copied +=
-          last_tile->result_num_between_pos(0, frag_tile_idx.second);
+          last_tile->result_num_between_pos(0, frag_tile_idx.cell_idx_);
     } else {
-      last_tile_cells_copied += frag_tile_idx.second;
+      last_tile_cells_copied += frag_tile_idx.cell_idx_;
     }
   }
 
   // Adjust tile index.
   for (auto rt : result_tiles) {
-    read_state_.frag_tile_idx_[rt->frag_idx()] =
-        std::make_pair(rt->tile_idx() + 1, 0);
+    read_state_.frag_idx_[rt->frag_idx()] = FragIdx(rt->tile_idx() + 1, 0);
   }
 
   // If the last tile is not fully copied, save the cell index.
@@ -1454,13 +1448,13 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
           last_tile->tile_idx());
   if (last_tile->bitmap_result_num_ != std::numeric_limits<uint64_t>::max()) {
     if (last_tile->bitmap_result_num_ != last_tile_cells_copied) {
-      frag_tile_idx.first = last_tile->tile_idx();
-      frag_tile_idx.second =
+      frag_tile_idx.tile_idx_ = last_tile->tile_idx();
+      frag_tile_idx.cell_idx_ =
           last_tile->pos_with_given_result_sum(0, last_tile_cells_copied) + 1;
     }
   } else if (last_tile_num_cells != last_tile_cells_copied) {
-    frag_tile_idx.first = last_tile->tile_idx();
-    frag_tile_idx.second = last_tile_cells_copied;
+    frag_tile_idx.tile_idx_ = last_tile->tile_idx();
+    frag_tile_idx.cell_idx_ = last_tile_cells_copied;
   }
 
   logger_->debug("Done copying tiles");
@@ -1486,7 +1480,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
   }
 
   // Delete the tile.
-  result_tiles_[0].erase(rt);
+  result_tiles_.erase(rt);
 
   return Status::Ok();
 }
@@ -1494,13 +1488,13 @@ Status SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
 template <class BitmapType>
 Status SparseUnorderedWithDupsReader<BitmapType>::end_iteration() {
   // Clear result tiles that are not necessary anymore.
-  while (!result_tiles_[0].empty() &&
-         result_tiles_[0].front().tile_idx() <
-             read_state_.frag_tile_idx_[result_tiles_[0].front().frag_idx()]
-                 .first) {
-    const auto f = result_tiles_[0].front().frag_idx();
+  while (
+      !result_tiles_.empty() &&
+      result_tiles_.front().tile_idx() <
+          read_state_.frag_idx_[result_tiles_.front().frag_idx()].tile_idx_) {
+    const auto f = result_tiles_.front().frag_idx();
 
-    RETURN_NOT_OK(remove_result_tile(f, result_tiles_[0].begin()));
+    RETURN_NOT_OK(remove_result_tile(f, result_tiles_.begin()));
   }
 
   // Validate memory usage.
@@ -1511,7 +1505,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::end_iteration() {
   }
 
   logger_->debug(
-      "Done with iteration, num result tiles {0}", result_tiles_[0].size());
+      "Done with iteration, num result tiles {0}", result_tiles_.size());
 
   const auto uint64_t_max = std::numeric_limits<uint64_t>::max();
   array_memory_tracker_->set_budget(uint64_t_max);

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -550,7 +550,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
   // 0 sized bitmap means full tile, full tile copy done below.
-  if (rt->bitmap_.size() != 0) {
+  if (rt->has_bmp()) {
     // Process all cells. Last cell might be taken out for vectorization.
     uint64_t end = (src_max_pos == cell_num) ? src_max_pos - 1 : src_max_pos;
     for (uint64_t c = src_min_pos; c < end; c++) {
@@ -863,8 +863,8 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
   const auto src_buff = t->data_as<uint8_t>();
   const auto t_val = &std::get<2>(*tile_tuple);
 
-  // 0 sized bitmap means full tile, full tile copy done below.
-  if (rt->bitmap_.size() != 0) {
+  // Partial tile copy, full tile copy done below.
+  if (rt->has_bmp()) {
     // Copy values.
     if (!stores_zipped_coords) {
       // Go through bitmap, when there is a hole in cell contiguity, do a
@@ -1240,7 +1240,7 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
           new_result_tiles_size > 0 ? cell_offsets[new_result_tiles_size - 1] :
                                       0;
 
-      const bool has_bmp = last_tile->bitmap_.size() != 0;
+      const bool has_bmp = last_tile->has_bmp();
       const auto min_pos = new_result_tiles_size == 1 ? first_tile_min_pos : 0;
       for (uint64_t c = min_pos; c < last_tile_num_cells - 1; c++) {
         auto cell_count = has_bmp ? last_tile->bitmap_[c] : 1;

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -168,7 +168,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
   /** Result tiles currently loaded. */
-  ResultTileListPerFragment<BitmapType> result_tiles_;
+  std::list<ResultTileWithBitmap<BitmapType>> result_tiles_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -498,10 +498,10 @@ Status index_read_state_to_capnp(
       read_state->done_adding_result_tiles_);
 
   auto frag_tile_idx_builder =
-      read_state_builder.initFragTileIdx(read_state->frag_tile_idx_.size());
-  for (size_t i = 0; i < read_state->frag_tile_idx_.size(); ++i) {
-    frag_tile_idx_builder[i].setTileIdx(read_state->frag_tile_idx_[i].first);
-    frag_tile_idx_builder[i].setCellIdx(read_state->frag_tile_idx_[i].second);
+      read_state_builder.initFragTileIdx(read_state->frag_idx_.size());
+  for (size_t i = 0; i < read_state->frag_idx_.size(); ++i) {
+    frag_tile_idx_builder[i].setTileIdx(read_state->frag_idx_[i].tile_idx_);
+    frag_tile_idx_builder[i].setCellIdx(read_state->frag_idx_[i].cell_idx_);
   }
 
   return Status::Ok();
@@ -567,12 +567,12 @@ Status index_read_state_from_capnp(
       read_state_reader.getDoneAddingResultTiles();
 
   assert(read_state_reader.hasFragTileIdx());
-  read_state->frag_tile_idx_.clear();
+  read_state->frag_idx_.clear();
   for (const auto rcs : read_state_reader.getFragTileIdx()) {
     auto tile_idx = rcs.getTileIdx();
     auto cell_idx = rcs.getCellIdx();
 
-    read_state->frag_tile_idx_.emplace_back(tile_idx, cell_idx);
+    read_state->frag_idx_.emplace_back(tile_idx, cell_idx);
   }
 
   return Status::Ok();

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -52,6 +52,7 @@
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/query.h"
+#include "tiledb/sm/query/sparse_index_reader_base.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/rtree/rtree.h"
 #include "tiledb/sm/stats/global_stats.h"
@@ -2383,7 +2384,7 @@ Status Subarray::precompute_tile_overlap(
 
 Status Subarray::precompute_all_ranges_tile_overlap(
     ThreadPool* const compute_tp,
-    std::vector<std::pair<uint64_t, uint64_t>>& frag_tile_idx,
+    std::vector<FragIdx>& frag_tile_idx,
     std::vector<std::vector<std::pair<uint64_t, uint64_t>>>*
         result_tile_ranges) {
   auto timer_se = stats_->start_timer("read_compute_simple_tile_overlap");
@@ -2465,7 +2466,7 @@ Status Subarray::precompute_all_ranges_tile_overlap(
         // contiguity, push a new result tile range.
         uint64_t end = tile_bitmaps[0].size() - 1;
         uint64_t length = 0;
-        int64_t min = static_cast<int64_t>(frag_tile_idx[f].first);
+        int64_t min = static_cast<int64_t>(frag_tile_idx[f].tile_idx_);
         for (int64_t t = tile_bitmaps[0].size() - 1; t >= min; t--) {
           bool comb = true;
           for (unsigned d = 0; d < dim_num; d++) {

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -68,6 +68,7 @@ namespace sm {
 class Array;
 class ArraySchema;
 class EncryptionKey;
+class FragIdx;
 class FragmentMetadata;
 class StorageManager;
 
@@ -439,7 +440,7 @@ class Subarray {
    */
   Status precompute_all_ranges_tile_overlap(
       ThreadPool* const compute_tp,
-      std::vector<std::pair<uint64_t, uint64_t>>& frag_tile_idx,
+      std::vector<FragIdx>& frag_tile_idx,
       std::vector<std::vector<std::pair<uint64_t, uint64_t>>>*
           result_tile_ranges);
 


### PR DESCRIPTION
While running tests with real world array, I noticed that the
optimization trying to find the the length of a cell slab once a cell
to be merged was found didn't work. Trying to use a binary search across
the whole tile resulted in more comparisons than a linear search since
the cell slab lengths are never that long. Also, next_cell in
ResultCoords didn't use the bitmap, which caused some issues, so
ResultCoords was split into two classes, ResultCoords and
GlobalOrderResultCoords (which has access to the bitmap). This also
allowed to push some of the logic of the merge down into that class to
simplify graetly the merge function.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: refactor merge algorithm.