### PR TITLE
Add TEST as PR type

### DIFF
--- a/scripts/parse_pr.py
+++ b/scripts/parse_pr.py
@@ -17,6 +17,7 @@ type_mapping = {
     "API": "## API additions",
     "C_API": "### C API",
     "CPP_API": "### C++ API",
+    "TEST": "## Test only changes",
 }
 
 


### PR DESCRIPTION
Sometimes we open PRs that include only tests in order to increase coverage or verify a certain behavior. This is for adding a type for this kind of PRs in the list of predefined choices in the PR description.

---
TYPE: NO_HISTORY
DESC: Add TEST as PR type