### PR TITLE
Sparse unordered w/ dups reader: fixing overflow on int value.

### DIFF
--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -1358,7 +1358,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
             query_buffer));
       }
 
-      auto var_buffer_size = 0;
+      uint64_t var_buffer_size = 0;
 
       if (var_sized) {
         auto first_tile_min_pos =


### PR DESCRIPTION
A variable was declared with auto var_buffer_size = 0; which caused it
to be an int. When the var size user buffer becomes more than 4GB, this
will yield incorrect computations.

---
TYPE: BUG
DESC: Sparse unordered w/ dups reader: fixing overflow on int value.
