### PR TITLE
Size types

### DIFF
--- a/tiledb/common/common-std.h
+++ b/tiledb/common/common-std.h
@@ -36,6 +36,17 @@
 #ifndef TILEDB_COMMON_COMMON_STD_H
 #define TILEDB_COMMON_COMMON_STD_H
 
+#include <cstdint>
+
+/**
+ * Size type for anything in external storage.
+ *
+ * Note that on some platforms `storage_size_t` may be larger than `size_t`. It
+ * should not be assumed that anything in external storage will fit in memory
+ * (even virtual memory).
+ */
+using storage_size_t = uint64_t;
+
 /*
  * Value manipulation
  */

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -131,7 +131,7 @@ ArraySchema::ArraySchema(
 
   // Create dimension map
   dim_map_.clear();
-  for (unsigned d = 0; d < domain_->dim_num(); ++d) {
+  for (dimension_size_type d = 0; d < domain_->dim_num(); ++d) {
     auto dim{domain_->dimension_ptr(d)};
     dim_map_[dim->name()] = dim;
   }
@@ -204,7 +204,7 @@ const URI& ArraySchema::array_uri() const {
   return array_uri_;
 }
 
-const Attribute* ArraySchema::attribute(unsigned int id) const {
+const Attribute* ArraySchema::attribute(attribute_size_type id) const {
   if (id < attributes_.size())
     return attributes_[id].get();
   return nullptr;
@@ -215,8 +215,8 @@ const Attribute* ArraySchema::attribute(const std::string& name) const {
   return it == attribute_map_.end() ? nullptr : it->second;
 }
 
-unsigned int ArraySchema::attribute_num() const {
-  return (unsigned)attributes_.size();
+ArraySchema::attribute_size_type ArraySchema::attribute_num() const {
+  return static_cast<attribute_size_type>(attributes_.size());
 }
 
 const std::vector<shared_ptr<const Attribute>>& ArraySchema::attributes()
@@ -367,7 +367,7 @@ bool ArraySchema::dense() const {
   return array_type_ == ArrayType::DENSE;
 }
 
-const Dimension* ArraySchema::dimension_ptr(unsigned int i) const {
+const Dimension* ArraySchema::dimension_ptr(dimension_size_type i) const {
   return domain_->dimension_ptr(i);
 }
 
@@ -396,7 +396,7 @@ std::vector<Datatype> ArraySchema::dim_types() const {
   return ret;
 }
 
-unsigned int ArraySchema::dim_num() const {
+ArraySchema::dimension_size_type ArraySchema::dim_num() const {
   return domain_->dim_num();
 }
 
@@ -881,7 +881,7 @@ Status ArraySchema::set_domain(shared_ptr<Domain> domain) {
   // Create dimension map
   dim_map_.clear();
   auto dim_num = domain_->dim_num();
-  for (unsigned d = 0; d < dim_num; ++d) {
+  for (dimension_size_type d = 0; d < dim_num; ++d) {
     auto dim{dimension_ptr(d)};
     dim_map_[dim->name()] = dim;
   }
@@ -944,7 +944,7 @@ bool ArraySchema::check_attribute_dimension_names() const {
   auto dim_num = this->dim_num();
   for (auto attr : attributes_)
     names.insert(attr->name());
-  for (unsigned int i = 0; i < dim_num; ++i)
+  for (dimension_size_type i = 0; i < dim_num; ++i)
     names.insert(domain_->dimension_ptr(i)->name());
   return (names.size() == attributes_.size() + dim_num);
 }
@@ -968,7 +968,7 @@ Status ArraySchema::check_double_delta_compressor(
   // Error if any real dimension inherits the coord filters with DOUBLE DELTA.
   // A dimension inherits the filters when it has no filters.
   auto dim_num = domain_->dim_num();
-  for (unsigned d = 0; d < dim_num; ++d) {
+  for (dimension_size_type d = 0; d < dim_num; ++d) {
     auto dim{domain_->dimension_ptr(d)};
     const auto& dim_filters = dim->filters();
     auto dim_type = dim->type();
@@ -993,7 +993,7 @@ Status ArraySchema::check_string_compressor(
   // Error if there are also other filters set for a string dimension together
   // with RLE or Dictionary-encoding
   auto dim_num = domain_->dim_num();
-  for (unsigned d = 0; d < dim_num; ++d) {
+  for (dimension_size_type d = 0; d < dim_num; ++d) {
     auto dim{domain_->dimension_ptr(d)};
     const auto& dim_filters = dim->filters();
     // if it's a var-length string dimension and there is no specific filter

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -63,6 +63,21 @@ enum class Layout : uint8_t;
 /** Specifies the array schema. */
 class ArraySchema {
  public:
+  /**
+   * Size type for the number of dimensions of an array and for dimension
+   * indices.
+   *
+   * Note: This should be the same as `Domain::dimension_size_type`. We're
+   * not including `domain.h`, otherwise we'd use that definition here.
+   */
+  using dimension_size_type = unsigned int;
+
+  /**
+   * Size type for the number of attributes of an array and for attribute
+   * indices.
+   */
+  using attribute_size_type = unsigned int;
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -133,7 +148,7 @@ class ArraySchema {
    * Returns a constant pointer to the selected attribute (nullptr if it
    * does not exist).
    */
-  const Attribute* attribute(unsigned int id) const;
+  const Attribute* attribute(attribute_size_type id) const;
 
   /**
    * Returns a constant pointer to the selected attribute (nullptr if it
@@ -142,7 +157,7 @@ class ArraySchema {
   const Attribute* attribute(const std::string& name) const;
 
   /** Returns the number of attributes. */
-  unsigned int attribute_num() const;
+  attribute_size_type attribute_num() const;
 
   /** Returns the attributes. */
   const std::vector<shared_ptr<const Attribute>>& attributes() const;
@@ -194,7 +209,7 @@ class ArraySchema {
   bool dense() const;
 
   /** Returns the i-th dimension. */
-  const Dimension* dimension_ptr(unsigned int i) const;
+  const Dimension* dimension_ptr(dimension_size_type i) const;
 
   /**
    * Returns a constant pointer to the selected dimension (nullptr if it
@@ -209,7 +224,7 @@ class ArraySchema {
   std::vector<Datatype> dim_types() const;
 
   /** Returns the number of dimensions. */
-  unsigned int dim_num() const;
+  dimension_size_type dim_num() const;
 
   /** Dumps the array schema in ASCII format in the selected output. */
   void dump(FILE* out) const;

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -70,7 +70,7 @@ Domain::Domain(
     Layout tile_order)
     : cell_order_(cell_order)
     , dimensions_(dimensions)
-    , dim_num_((unsigned int)dimensions.size())
+    , dim_num_(static_cast<dimension_size_type>(dimensions.size()))
     , tile_order_(tile_order) {
   /*
    * Verify that the input vector has no non-null elements in order to meet the
@@ -377,7 +377,7 @@ NDRange Domain::domain() const {
 }
 
 const Dimension* Domain::dimension_ptr(const std::string& name) const {
-  for (unsigned int i = 0; i < dim_num_; i++) {
+  for (dimension_size_type i = 0; i < dim_num_; i++) {
     const auto dim = dimension_ptrs_[i];
     if (dim->name() == name) {
       return dim;
@@ -976,7 +976,7 @@ void Domain::set_tile_cell_order_cmp_funcs() {
 
 template <class T>
 void Domain::get_next_tile_coords_col(const T* domain, T* tile_coords) const {
-  unsigned int i = 0;
+  dimension_size_type i = 0;
   ++tile_coords[i];
 
   while (i < dim_num_ - 1 && tile_coords[i] > domain[2 * i + 1]) {
@@ -988,7 +988,7 @@ void Domain::get_next_tile_coords_col(const T* domain, T* tile_coords) const {
 template <class T>
 void Domain::get_next_tile_coords_col(
     const T* domain, T* tile_coords, bool* in) const {
-  unsigned int i = 0;
+  dimension_size_type i = 0;
   ++tile_coords[i];
 
   while (i < dim_num_ - 1 && tile_coords[i] > domain[2 * i + 1]) {
@@ -1001,7 +1001,7 @@ void Domain::get_next_tile_coords_col(
 
 template <class T>
 void Domain::get_next_tile_coords_row(const T* domain, T* tile_coords) const {
-  unsigned int i = dim_num_ - 1;
+  dimension_size_type i = dim_num_ - 1;
   ++tile_coords[i];
 
   while (i > 0 && tile_coords[i] > domain[2 * i + 1]) {
@@ -1013,7 +1013,7 @@ void Domain::get_next_tile_coords_row(const T* domain, T* tile_coords) const {
 template <class T>
 void Domain::get_next_tile_coords_row(
     const T* domain, T* tile_coords, bool* in) const {
-  unsigned int i = dim_num_ - 1;
+  dimension_size_type i = dim_num_ - 1;
   ++tile_coords[i];
 
   while (i > 0 && tile_coords[i] > domain[2 * i + 1]) {
@@ -1068,7 +1068,7 @@ uint64_t Domain::get_tile_pos_row(const T* domain, const T* tile_coords) const {
 
   // Calculate position
   uint64_t pos = 0;
-  for (unsigned int i = 0; i < dim_num_; ++i)
+  for (dimension_size_type i = 0; i < dim_num_; ++i)
     pos += tile_coords[i] * tile_offsets[i];
 
   // Return

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -62,6 +62,12 @@ enum class Layout : uint8_t;
 /** Defines an array domain, which consists of dimensions. */
 class Domain {
  public:
+  /**
+   * Size type for the number of dimensions of an array and for dimension
+   * indices.
+   */
+  using dimension_size_type = unsigned int;
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -202,7 +208,7 @@ class Domain {
   Layout tile_order() const;
 
   /** Returns the number of dimensions. */
-  inline unsigned int dim_num() const {
+  inline dimension_size_type dim_num() const {
     return dim_num_;
   }
 
@@ -222,7 +228,7 @@ class Domain {
    * @param i index of the dimension within the domain
    * @return non-null pointer to the dimension
    */
-  inline const Dimension* dimension_ptr(unsigned int i) const {
+  inline const Dimension* dimension_ptr(dimension_size_type i) const {
     if (i > dim_num_) {
       throw std::invalid_argument("invalid dimension index");
     }


### PR DESCRIPTION
Add `storage_size_t` for general use. Its name is modeled after `size_t`.

Add `dimension_size_type` and `attribute_size_type` to `class ArraySchema`. Add `dimension_size_type` to `class Domain`. These names are modeled after `size_type` for standard library containers.

---
TYPE: NO_HISTORY
DESC: size types
