### PR TITLE
Activate rtools builds to support R 4.1.*

### DIFF
--- a/.github/workflows/rtools40.yml
+++ b/.github/workflows/rtools40.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       matrix:
         include: [
-          #{ msystem: MINGW64, toolchain: x86_64 },
-          #{ msystem: MINGW32, toolchain: i686 },
+          { msystem: MINGW64, toolchain: x86_64 },
+          { msystem: MINGW32, toolchain: i686 },
           { msystem: ucrt64, toolchain: "ucrt-x86_64" }
         ]
       fail-fast: false


### PR DESCRIPTION
CRAN will support non-ucrt builds as long as R 4.1.* is 'old-release' i.e. until (likely standard schedule) next April.  We should therefore continue to build the artifacts.

---
TYPE: NO_HISTORY 
DESC: Enable rtools4 to support R 4.1.*