### PR TITLE
Update Zlib Download URL

### DIFF
--- a/cmake/Modules/FindZlib_EP.cmake
+++ b/cmake/Modules/FindZlib_EP.cmake
@@ -84,7 +84,7 @@ if (NOT ZLIB_FOUND)
     ExternalProject_Add(ep_zlib
       PREFIX "externals"
       URL "https://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib1211.zip"
-      URL_HASH SHA1=b8d230cc5effe6dffa2807e0e342245b0683f2df
+      URL_HASH SHA1=bccd93ad3cee39c3d08eee68d45b3e11910299f2
       DOWNLOAD_NAME "zlib1211.zip"
       CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}

--- a/cmake/Modules/FindZlib_EP.cmake
+++ b/cmake/Modules/FindZlib_EP.cmake
@@ -83,8 +83,8 @@ if (NOT ZLIB_FOUND)
 
     ExternalProject_Add(ep_zlib
       PREFIX "externals"
-      URL "http://iweb.dl.sourceforge.net/project/libpng/zlib/1.2.11/zlib1211.zip"
-      URL_HASH SHA1=bccd93ad3cee39c3d08eee68d45b3e11910299f2
+      URL "https://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib1211.zip"
+      URL_HASH SHA1=b8d230cc5effe6dffa2807e0e342245b0683f2df
       DOWNLOAD_NAME "zlib1211.zip"
       CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}


### PR DESCRIPTION
The previous download URL for zlib is no longer valid
```
(tiledb-3.10) vivian@mangonada:~/TileDB/cmake/Modules$ curl --head http://iweb.dl.sourceforge.net/project/libpng/zlib/1.2.11/zlib1211.zip
curl: (7) Failed to connect to iweb.dl.sourceforge.net port 80 after 1129 ms: No route to host
```

Needs to be updated to
```
(tiledb-3.10) vivian@mangonada:~/TileDB/cmake/Modules$ curl --head https://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib1211.zip
HTTP/2 302
server: nginx
date: Fri, 20 May 2022 13:44:53 GMT
content-type: text/html; charset=UTF-8
location: https://versaweb.dl.sourceforge.net/project/libpng/zlib/1.2.11/zlib1211.zip
content-disposition: attachment; filename="zlib1211.zip"
set-cookie: sf_mirror_attempt=libpng:versaweb:zlib/1.2.11/zlib1211.zip; Max-Age=120; Path=/; expires=Fri, 20-May-2022 13:46:53 GMT
```
---
TYPE: BUG
DESC: Update Zlib Download URL