### PR TITLE
Validate Dimension Datatype upon Dimension construction

### DIFF
--- a/.github/workflows/mingw-w64-tiledb/PKGBUILD
+++ b/.github/workflows/mingw-w64-tiledb/PKGBUILD
@@ -43,7 +43,7 @@ build() {
     ..
   make
   make -C tiledb
-  
+
 # in a local environ, can build to demo/check for previously seen (windows event) handle leakge
 # apparently due to issues with mingw std library implementation.
 # note that with S3 enabled above, and minio not running, the aws sdk may fatally error on exit.

--- a/format_spec/consolidated_commits_file.md
+++ b/format_spec/consolidated_commits_file.md
@@ -18,7 +18,7 @@ my_array                              # array folder
 * `uuid` is a unique identifier
 * `v` is the format version
 
-There may be multiple such files in the array commits folder. Each consolidated commits file combines a list of fragments commits or delete commits. 
+There may be multiple such files in the array commits folder. Each consolidated commits file combines a list of fragments commits or delete commits.
 | **Field** | **Type** | **Description** |
 | :--- | :--- | :--- |
 | Commit 1 | `uint8_t[]` | Commit 1 |

--- a/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
@@ -418,7 +418,7 @@ TEST_CASE_METHOD(
   auto timestamps_ptr =
       GENERATE_REF(as<std::vector<uint64_t>*>{}, nullptr, &timestamps);
 
-  uint64_t tstamp = 7;  
+  uint64_t tstamp = 7;
   SECTION("Read after all writes") {
     // Read after both writes - should see everything.
     tstamp = 7;

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -2168,3 +2168,55 @@ TEST_CASE_METHOD(
   remove_temp_dir(local_fs.file_prefix() + local_fs.temp_dir());
 #endif
 }
+
+TEST_CASE_METHOD(
+    ArrayFx, "Test dimension datatypes", "[array][dimension][datatypes]") {
+  SupportedFsLocal local_fs;
+  std::string array_name =
+      local_fs.file_prefix() + local_fs.temp_dir() + "array_dim_types";
+  create_temp_dir(local_fs.file_prefix() + local_fs.temp_dir());
+
+  uint64_t dim_domain[] = {1, 10, 1, 10};
+  uint64_t tile_extent = 2;
+  tiledb_dimension_t* dim;
+
+  SECTION("- valid and supported Datatypes") {
+    std::vector<tiledb_datatype_t> valid_supported_types = {TILEDB_UINT64,
+                                                            TILEDB_INT64};
+
+    for (auto dim_type : valid_supported_types) {
+      int rc = tiledb_dimension_alloc(
+          ctx_, "dim", dim_type, dim_domain, &tile_extent, &dim);
+      REQUIRE(rc == TILEDB_OK);
+    }
+  }
+
+  SECTION("- valid and unsupported Datatypes") {
+    std::vector<tiledb_datatype_t> valid_unsupported_types = {TILEDB_CHAR,
+                                                              TILEDB_BOOL};
+
+    for (auto dim_type : valid_unsupported_types) {
+      int rc = tiledb_dimension_alloc(
+          ctx_, "dim", dim_type, dim_domain, &tile_extent, &dim);
+      REQUIRE(rc == TILEDB_ERR);
+    }
+  }
+
+  SECTION("- invalid Datatypes") {
+    std::vector<std::underlying_type_t<tiledb_datatype_t>> invalid_datatypes = {
+        42, 100};
+
+    for (auto dim_type : invalid_datatypes) {
+      int rc = tiledb_dimension_alloc(
+          ctx_,
+          "dim",
+          tiledb_datatype_t(dim_type),
+          dim_domain,
+          &tile_extent,
+          &dim);
+      REQUIRE(rc == TILEDB_ERR);
+    }
+  }
+
+  tiledb_dimension_free(&dim);
+}

--- a/tiledb/api/C_API_STRUCTURE.md
+++ b/tiledb/api/C_API_STRUCTURE.md
@@ -5,10 +5,10 @@
 The C API consists of layers starting with the API functions themselves and ending with classes that call into the non-API parts of the core library. There are five layers, each with its own responsibilities.
 
 ### Public API functions
-  
+
 Public API functions themselves are declared with `extern "C"` linkage. They are implemented as wrappers around an API implementation function. There is a one-to-one relationship between public API functions and API implementation functions.
 
-Public API functions are responsible for uniform error processing through handling exceptions. The wrapper provides uniformity of behavior for (1) return values, (2) logging format, (3) error return. Non-uniform error handling may be done outside this layer, although that's not usually necessary. 
+Public API functions are responsible for uniform error processing through handling exceptions. The wrapper provides uniformity of behavior for (1) return values, (2) logging format, (3) error return. Non-uniform error handling may be done outside this layer, although that's not usually necessary.
 
 ### API implementation functions
 

--- a/tiledb/api/c_api/DIRECTORY.md
+++ b/tiledb/api/c_api/DIRECTORY.md
@@ -2,7 +2,7 @@
 
 The C API code is in sections, roughly one for each type exposed through the API.
 Each section has its own directory, containing two headers, at least one API source file, and unit tests.
- 
+
 * **External header**. This header is included in the top-level `tiledb.h` header. These headers will be included in both C and C++ programs and must compile appropriately.
   * Declares C API functions.
   * Only included in `tiledb.h`. Should not appear elsewhere, including in other external headers.
@@ -11,7 +11,7 @@ Each section has its own directory, containing two headers, at least one API sou
   * Uses name convention `<section>_api_external.h`
 * **Internal header**. This header is not user-visible and is for inclusion in API source files.
   * Only included in API sources and API white-box unit tests. Since these headers are not user-visible, they do not appear in integration tests; such test should only use external headers.
-  * Included source files in other sections as the arguments of C API function dictate. 
+  * Included source files in other sections as the arguments of C API function dictate.
   * Uses name convention `<section>_api_internal.h`
 * **API source**
   * Defines C API functions with an exception wrapper around a matching implementation function.

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -59,6 +59,7 @@ namespace sm {
 Dimension::Dimension(const std::string& name, Datatype type)
     : name_(name)
     , type_(type) {
+  ensure_datatype_is_supported(type_);
   cell_val_num_ = (datatype_is_string(type)) ? constants::var_num : 1;
   set_ceil_to_tile_func();
   set_coincides_with_tiles_func();
@@ -95,6 +96,7 @@ Dimension::Dimension(
     , name_(name)
     , tile_extent_(tile_extent)
     , type_(type) {
+  ensure_datatype_is_supported(type_);
   set_ceil_to_tile_func();
   set_coincides_with_tiles_func();
   set_compute_mbr_func();
@@ -126,6 +128,9 @@ Dimension::Dimension(const Dimension* dim) {
   name_ = dim->name();
   tile_extent_ = dim->tile_extent();
   type_ = dim->type_;
+
+  // Validate type
+  ensure_datatype_is_supported(type_);
 
   // Set fuctions
   ceil_to_tile_func_ = dim->ceil_to_tile_func_;
@@ -1840,6 +1845,33 @@ std::string Dimension::domain_str() const {
 
   assert(false);
   return "";
+}
+
+void Dimension::ensure_datatype_is_supported(Datatype type) const {
+  try {
+    ensure_datatype_is_valid(type);
+  } catch (...) {
+    std::throw_with_nested(
+        std::logic_error("[Dimension::ensure_datatype_is_supported] "));
+    return;
+  }
+
+  switch (type) {
+    case Datatype::CHAR:
+    case Datatype::BLOB:
+    case Datatype::BOOL:
+    case Datatype::STRING_UTF8:
+    case Datatype::STRING_UTF16:
+    case Datatype::STRING_UTF32:
+    case Datatype::STRING_UCS2:
+    case Datatype::STRING_UCS4:
+    case Datatype::ANY:
+      throw std::logic_error(
+          "Datatype::" + datatype_str(type) +
+          " is not a valid Dimension Datatype");
+    default:
+      return;
+  }
 }
 
 std::string Dimension::tile_extent_str() const {

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -66,7 +66,14 @@ class FilterPipeline;
 enum class Compressor : uint8_t;
 enum class Datatype : uint8_t;
 
-/** Manipulates a TileDB dimension. */
+/** Manipulates a TileDB dimension.
+ *
+ * Note: as laid out in the Storage Format,
+ * the following Datatypes are not valid for Dimension:
+ * TILEDB_CHAR, TILEDB_BLOB, TILEDB_BOOL, TILEDB_STRING_UTF8,
+ * TILEDB_STRING_UTF16, TILEDB_STRING_UTF32, TILEDB_STRING_UCS2,
+ * TILEDB_STRING_UCS4, TILEDB_ANY
+ */
 class Dimension {
  public:
   /* ********************************* */
@@ -999,6 +1006,9 @@ class Dimension {
 
   /** Returns the domain in string format. */
   std::string domain_str() const;
+
+  /** Throws error if the input type is not a supported Dimension Datatype. */
+  void ensure_datatype_is_supported(Datatype type) const;
 
   /** Returns the tile extent in string format. */
   std::string tile_extent_str() const;

--- a/tiledb/sm/array_schema/test/unit_dimension.cc
+++ b/tiledb/sm/array_schema/test/unit_dimension.cc
@@ -188,6 +188,75 @@ TEST_CASE("Dimension: Test deserialize,string", "[dimension][deserialize]") {
   CHECK(dim.value()->var_size() == true);
 }
 
+TEST_CASE("Dimension: Test datatypes", "[dimension][datatypes]") {
+  std::string dim_name = "dim";
+
+  SECTION("- valid and supported Datatypes") {
+    std::vector<Datatype> valid_supported_datatypes = {
+        Datatype::INT32,          Datatype::INT64,
+        Datatype::FLOAT32,        Datatype::FLOAT64,
+        Datatype::INT8,           Datatype::UINT8,
+        Datatype::INT16,          Datatype::UINT16,
+        Datatype::UINT32,         Datatype::UINT64,
+        Datatype::STRING_ASCII,   Datatype::DATETIME_YEAR,
+        Datatype::DATETIME_MONTH, Datatype::DATETIME_WEEK,
+        Datatype::DATETIME_DAY,   Datatype::DATETIME_HR,
+        Datatype::DATETIME_MIN,   Datatype::DATETIME_SEC,
+        Datatype::DATETIME_MS,    Datatype::DATETIME_US,
+        Datatype::DATETIME_NS,    Datatype::DATETIME_PS,
+        Datatype::DATETIME_FS,    Datatype::DATETIME_AS,
+        Datatype::TIME_HR,        Datatype::TIME_MIN,
+        Datatype::TIME_SEC,       Datatype::TIME_MS,
+        Datatype::TIME_US,        Datatype::TIME_NS,
+        Datatype::TIME_PS,        Datatype::TIME_FS,
+        Datatype::TIME_AS};
+
+    for (Datatype type : valid_supported_datatypes) {
+      try {
+        Dimension dim{dim_name, type};
+      } catch (...) {
+        throw std::logic_error("Uncaught exception in Dimension constructor");
+      }
+    }
+  }
+
+  SECTION("- valid and unsupported Datatypes") {
+    std::vector<Datatype> valid_unsupported_datatypes = {Datatype::CHAR,
+                                                         Datatype::BLOB,
+                                                         Datatype::BOOL,
+                                                         Datatype::STRING_UTF8,
+                                                         Datatype::STRING_UTF16,
+                                                         Datatype::STRING_UTF32,
+                                                         Datatype::STRING_UCS2,
+                                                         Datatype::STRING_UCS4,
+                                                         Datatype::ANY};
+
+    for (Datatype type : valid_unsupported_datatypes) {
+      try {
+        Dimension dim{dim_name, type};
+      } catch (std::exception& e) {
+        CHECK(
+            e.what() == "Datatype::" + datatype_str(type) +
+                            " is not a valid Dimension Datatype");
+      }
+    }
+  }
+
+  SECTION("- invalid Datatypes") {
+    std::vector<std::underlying_type_t<Datatype>> invalid_datatypes = {42, 100};
+
+    for (auto type : invalid_datatypes) {
+      try {
+        Dimension dim{dim_name, Datatype(type)};
+      } catch (std::exception& e) {
+        CHECK(
+            std::string(e.what()) ==
+            "[Dimension::ensure_datatype_is_supported] ");
+      }
+    }
+  }
+}
+
 typedef tuple<
     int8_t,
     int16_t,

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1370,6 +1370,7 @@ int32_t tiledb_dimension_alloc(
   // Create a new Dimension object
   (*dim)->dim_ = new (std::nothrow)
       tiledb::sm::Dimension(name, static_cast<tiledb::sm::Datatype>(type));
+
   if ((*dim)->dim_ == nullptr) {
     delete *dim;
     *dim = nullptr;

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -2604,6 +2604,12 @@ TILEDB_EXPORT int32_t tiledb_domain_dump(
  *     ctx, "dim_0", TILEDB_INT64, dim_domain, &tile_extent, &dim);
  * @endcode
  *
+ * Note: as laid out in the Storage Format,
+ * the following Datatypes are not valid for Dimension:
+ * TILEDB_CHAR, TILEDB_BLOB, TILEDB_BOOL, TILEDB_STRING_UTF8,
+ * TILEDB_STRING_UTF16, TILEDB_STRING_UTF32, TILEDB_STRING_UCS2,
+ * TILEDB_STRING_UCS4, TILEDB_ANY
+ *
  * @param ctx The TileDB context.
  * @param name The dimension name.
  * @param type The dimension type.

--- a/tiledb/sm/cpp_api/dimension.h
+++ b/tiledb/sm/cpp_api/dimension.h
@@ -60,6 +60,12 @@ namespace tiledb {
  * // Create a dimension with inclusive domain [0,1000] and tile extent 100.
  * domain.add_dimension(Dimension::create<int32_t>(ctx, "d", {{0, 1000}}, 100));
  * @endcode
+ *
+ * Note: as laid out in the Storage Format,
+ * the following Datatypes are not valid for Dimension:
+ * TILEDB_CHAR, TILEDB_BLOB, TILEDB_BOOL, TILEDB_STRING_UTF8,
+ * TILEDB_STRING_UTF16, TILEDB_STRING_UTF32, TILEDB_STRING_UCS2,
+ * TILEDB_STRING_UCS4, TILEDB_ANY
  **/
 class Dimension {
  public:

--- a/tiledb/storage_format/DIRECTORY.md
+++ b/tiledb/storage_format/DIRECTORY.md
@@ -13,3 +13,17 @@ Here's a partial list of concerns that are out of scope:
 
 * **Storage access.** Nothing in this directory has direct access to an object store or a file system. A user of these classes must provide the results of a storage operation to this code for parsing and interpretation.
 * **State maintenance.** This code has the notion of an "array in a directory", but it does not provide any notion of "the current state" of an array in storage. The concept here is that of an array a data type, not as a variable of that data type. 
+
+## Useful Information
+The following is the list of Datatypes that are **not** supported by the Dimension class. 
+Please note that this information is repeated in the C API, C++ API, and the Dimension class. 
+
+* TILEDB_CHAR
+* TILEDB_BLOB
+* TILEDB_BOOL
+* TILEDB_STRING_UTF8
+* TILEDB_STRING_UTF16
+* TILEDB_STRING_UTF32
+* TILEDB_STRING_UCS2
+* TILEDB_STRING_UCS4
+* TILEDB_ANY

--- a/tiledb/storage_format/DIRECTORY.md
+++ b/tiledb/storage_format/DIRECTORY.md
@@ -12,11 +12,11 @@ Each of these entities may be regarded as having syntax and semantics: what a va
 Here's a partial list of concerns that are out of scope:
 
 * **Storage access.** Nothing in this directory has direct access to an object store or a file system. A user of these classes must provide the results of a storage operation to this code for parsing and interpretation.
-* **State maintenance.** This code has the notion of an "array in a directory", but it does not provide any notion of "the current state" of an array in storage. The concept here is that of an array a data type, not as a variable of that data type. 
+* **State maintenance.** This code has the notion of an "array in a directory", but it does not provide any notion of "the current state" of an array in storage. The concept here is that of an array a data type, not as a variable of that data type.
 
 ## Useful Information
-The following is the list of Datatypes that are **not** supported by the Dimension class. 
-Please note that this information is repeated in the C API, C++ API, and the Dimension class. 
+The following is the list of Datatypes that are **not** supported by the Dimension class.
+Please note that this information is repeated in the C API, C++ API, and the Dimension class.
 
 * TILEDB_CHAR
 * TILEDB_BLOB


### PR DESCRIPTION
Now that Dimension is C.41 compliant, the constructor must take on the responsibility of validation. A new API has been added that validates the incoming Datatype for Dimensions, disallowing certain types. 

---

SC-17968

---
TYPE: IMPROVEMENT
DESC: Validate Dimension datatype
