### PR TITLE
lums/dag api iteration one [skip ci]

### DIFF
--- a/experimental/tiledb/common/CMakeLists.txt
+++ b/experimental/tiledb/common/CMakeLists.txt
@@ -1,10 +1,9 @@
 #
-# experimental/tiledb/CMakeLists.txt
-#
+# experimental/tiledb/common/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2021 TileDB, Inc.
+# Copyright (c) 2021-2022 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +23,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-include(common NO_POLICY_SCOPE)
 
-add_subdirectory(common)
+include(common-root)
+include(common)
+
+add_subdirectory(dag)

--- a/experimental/tiledb/common/dag/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
-# experimental/tiledb/CMakeLists.txt
+# experimental/tiledb/common/dag/CMakeLists.txt
 #
 #
 # The MIT License
 #
-# Copyright (c) 2021 TileDB, Inc.
+# Copyright (c) 2022 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-include(common NO_POLICY_SCOPE)
 
-add_subdirectory(common)
+# add_subdirectory(data_block)
+# add_subdirectory(edge)
+add_subdirectory(execution)
+# add_subdirectory(graph)
+# add_subdirectory(node)
+add_subdirectory(ports)
+add_subdirectory(utils)

--- a/experimental/tiledb/common/dag/data_block/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/data_block/CMakeLists.txt
@@ -1,0 +1,69 @@
+#
+# experimental/tiledb/common/data_block/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common NO_POLICY_SCOPE)
+
+list(APPEND SOURCES
+    data_block.cc
+)
+gather_sources(${SOURCES})
+
+#
+# Object library for other units to depend upon
+#
+add_library(data_block OBJECT ${SOURCES})
+target_link_libraries(data_block PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_data_block EXCLUDE_FROM_ALL)
+target_link_libraries(compile_data_block PRIVATE data_block)
+target_sources(compile_data_block PRIVATE test/compile_data_block_main.cc)
+
+if (TILEDB_TESTS)
+    add_executable(unit_data_block EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_data_block PUBLIC data_block)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_data_block PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_data_block PUBLIC $<TARGET_OBJECTS:thread_pool>)
+
+    # Sources for code elsewhere required for tests
+    target_sources(unit_data_block PUBLIC ${DEPENDENT_SOURCES})
+
+    # Sources for tests
+    target_sources(unit_data_block PUBLIC
+            test/main.cc
+            test/unit_data_block.cc
+            )
+
+    add_test(
+            NAME "unit_data_block"
+            COMMAND $<TARGET_FILE:unit_data_block> --durations=yes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/experimental/tiledb/common/dag/data_block/data_block.h
+++ b/experimental/tiledb/common/dag/data_block/data_block.h
@@ -1,0 +1,144 @@
+/**
+ * @file   data_block.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the DataBlock class for dag.
+ */
+
+#ifndef TILEDB_DAG_DATA_BLOCK_H
+#define TILEDB_DAG_DATA_BLOCK_H
+
+namespace tiledb::common {
+
+/**
+ * A fixed size block, an untyped carrier for data to be interpreted by its
+ * users.
+ *
+ * Intended to be allocated from a pool with a bitmap allocation strategy.
+ *
+ * Implemented internally as a span.
+ *
+ * Implements standard library interface for random access container.
+ */
+class DataBlock {
+  constexpr static const size_t N_ = 4'194'304;  // 4M
+
+  using storage_t = std::vector<std::byte>;  // For prototyping
+  using data_t = tcb::span<std::byte>;
+  storage_t storage_;
+  data_t data_;
+
+ public:
+  DataBlock()
+      : storage_(N_)
+      , data_(storage_.data(), storage_.data()) {
+  }
+
+  using DataBlockIterator = data_t::iterator;
+  using DataBlockConstIterator = data_t::iterator;
+
+  using value_type = data_t::value_type;
+  // using  allocator_type = ??
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = data_t::pointer;
+  using const_pointer = data_t::const_pointer;
+  using iterator = DataBlockIterator;
+  using const_iterator = DataBlockConstIterator;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  reference operator[](size_type idx) {
+    return data_[idx];
+  }
+  const_reference operator[](size_type idx) const {
+    return data_[idx];
+  }
+
+  pointer data() {
+    return data_.data();
+  }
+  const_pointer data() const {
+    return data_.data();
+  }
+
+  iterator begin() {
+    return data_.begin();
+  }
+  const_iterator begin() const {
+    return data_.begin();
+  }
+  const_iterator cbegin() const {
+    return data_.begin();
+  }
+  reverse_iterator rbegin() {
+    return data_.rbegin();
+  }
+  const_reverse_iterator rbegin() const {
+    return data_.rbegin();
+  }
+  const_reverse_iterator crbegin() const {
+    return data_.rbegin();
+  }
+
+  iterator end() {
+    return data_.end();
+  }
+  const_iterator end() const {
+    return data_.end();
+  }
+  const_iterator cend() const {
+    return data_.end();
+  }
+  reverse_iterator rend() {
+    return data_.rend();
+  }
+  const_reverse_iterator rend() const {
+    return data_.rend();
+  }
+  const_reverse_iterator crend() const {
+    return data_.rend();
+  }
+
+  bool empty() const {
+    return data_.empty();
+  }
+
+  size_t size() const {
+    return data_.size();
+  }
+  size_t capacity() const {
+    return storage_.size();
+  }
+};
+
+}  // namespace tiledb::common
+
+#endif  // TILEDB_DAG_DATA_BLOCK_H

--- a/experimental/tiledb/common/dag/data_block/data_block.h
+++ b/experimental/tiledb/common/dag/data_block/data_block.h
@@ -56,7 +56,7 @@ class DataBlock {
  public:
   DataBlock()
       : storage_(N_)
-      , data_(storage_.data(), storage_.data()) {
+      , data_(storage_.data(), storage_.size()) {
   }
 
   using DataBlockIterator = data_t::iterator;

--- a/experimental/tiledb/common/dag/data_block/test/unit_data_block.cc
+++ b/experimental/tiledb/common/dag/data_block/test/unit_data_block.cc
@@ -1,0 +1,59 @@
+#if 0
+void db_test_0(DataBlock& db) {
+  auto a = db.begin();
+  auto b = db.cbegin();
+  auto c = db.end();
+  auto d = db.cend();
+
+  REQUIRE(a == b);
+  REQUIRE(++a == ++b);
+  REQUIRE(a++ == b++);
+  REQUIRE(a == b);
+  REQUIRE(++a != b);
+  REQUIRE(a == ++b);
+  REQUIRE(c == d);
+  auto e = c + 5;
+  auto f = d + 5;
+  REQUIRE(c == e - 5);
+  REQUIRE(d == f - 5);
+  REQUIRE(e == f);
+  REQUIRE(e - 5 == f - 5);
+  auto g = a + 1;
+  REQUIRE(g > a);
+  REQUIRE(g >= a);
+  REQUIRE(a < g);
+  REQUIRE(a <= g);
+}
+
+void db_test_1(const DataBlock& db) {
+  auto a = db.begin();
+  auto b = db.cbegin();
+  auto c = db.end();
+  auto d = db.cend();
+
+  REQUIRE(a == b);
+  REQUIRE(++a == ++b);
+  REQUIRE(a++ == b++);
+  REQUIRE(a == b);
+  REQUIRE(++a != b);
+  REQUIRE(a == ++b);
+  REQUIRE(c == d);
+  auto e = c + 5;
+  auto f = d + 5;
+  REQUIRE(c == e - 5);
+  REQUIRE(d == f - 5);
+  REQUIRE(e == f);
+  REQUIRE(e - 5 == f - 5);
+  auto g = a + 1;
+  REQUIRE(g > a);
+  REQUIRE(g >= a);
+  REQUIRE(a < g);
+  REQUIRE(a <= g);
+}
+
+TEST_CASE("Ports: Test create DataBlock", "[ports]") {
+  auto db = DataBlock();
+  db_test_0(db);
+  db_test_1(db);
+}
+#endif

--- a/experimental/tiledb/common/dag/edge/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/edge/CMakeLists.txt
@@ -1,0 +1,69 @@
+#
+# experimental/tiledb/common/edge/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common NO_POLICY_SCOPE)
+
+list(APPEND SOURCES
+    edge.cc
+)
+gather_sources(${SOURCES})
+
+#
+# Object library for other units to depend upon
+#
+add_library(edge OBJECT ${SOURCES})
+target_link_libraries(edge PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_edge EXCLUDE_FROM_ALL)
+target_link_libraries(compile_edge PRIVATE edge)
+target_sources(compile_edge PRIVATE test/compile_edge_main.cc)
+
+if (TILEDB_TESTS)
+    add_executable(unit_edge EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_edge PUBLIC edge)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_edge PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_edge PUBLIC $<TARGET_OBJECTS:thread_pool>)
+
+    # Sources for code elsewhere required for tests
+    target_sources(unit_edge PUBLIC ${DEPENDENT_SOURCES})
+
+    # Sources for tests
+    target_sources(unit_edge PUBLIC
+            test/main.cc
+            test/unit_edge.cc
+            )
+
+    add_test(
+            NAME "unit_edge"
+            COMMAND $<TARGET_FILE:unit_edge> --durations=yes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/experimental/tiledb/common/dag/edge/edge.h
+++ b/experimental/tiledb/common/dag/edge/edge.h
@@ -1,0 +1,58 @@
+/**
+ * @file   edge.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the edge class for dag.
+ */
+
+#ifndef TILEDB_DAG_EDGE_H
+#define TILEDB_DAG_EDGE_H
+
+namespace tiledb::common {
+
+/**
+ * An edge in a task graph.
+ *
+ * Contains a queue of blocks of size 3, that is, at any time it has between 0
+ * and 3 blocks in it.  Three blocks in the queue allows one to be written to on
+ * one side of the edge, read from on the other side of the edge, with one ready
+ * to be read.
+ *
+ * Edges implement a demand-pull pattern for synchronization.
+ */
+template <class Block>
+class Edge : public Source<Block>, public Sink<Block> {
+  EdgeQueue<Block*> queue_;
+
+ public:
+  Edge(Source<Block>& from, Sink<Block>& to);
+};
+
+}  // namespace tiledb::common
+
+#endif  // TILEDB_DAG_EDGE_H

--- a/experimental/tiledb/common/dag/execution/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/execution/CMakeLists.txt
@@ -1,0 +1,92 @@
+#
+# experimental/tiledb/common/execution/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common NO_POLICY_SCOPE)
+
+list(APPEND SOURCES
+  threadpool.cc
+)
+gather_sources(${SOURCES})
+
+#
+# Object library for other units to depend upon
+#
+add_library(execution OBJECT ${SOURCES})
+target_link_libraries(execution PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_execution EXCLUDE_FROM_ALL)
+target_link_libraries(compile_execution PRIVATE execution)
+target_sources(compile_execution PRIVATE test/compile_execution_main.cc)
+
+if (TILEDB_TESTS)
+    add_executable(unit_execution EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_execution PUBLIC execution)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_execution PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_execution PUBLIC $<TARGET_OBJECTS:thread_pool>)
+
+    # Sources for code elsewhere required for tests
+    target_sources(unit_execution PUBLIC ${DEPENDENT_SOURCES})
+
+    # Sources for tests
+    target_sources(unit_execution PUBLIC
+            test/main.cc
+            test/unit_execution.cc
+            )
+
+    add_test(
+            NAME "unit_execution"
+            COMMAND $<TARGET_FILE:unit_execution> --durations=yes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	    )
+
+    add_executable(unit_threadpool EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_threadpool PUBLIC execution)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_threadpool PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_threadpool PUBLIC $<TARGET_OBJECTS:thread_pool>)
+
+    # Sources for code elsewhere required for tests
+    target_sources(unit_threadpool PUBLIC ${DEPENDENT_SOURCES})
+
+    # Sources for tests
+    target_sources(unit_threadpool PUBLIC
+            test/main.cc
+            test/unit_threadpool.cc
+            )
+
+    add_test(
+            NAME "unit_threadpool"
+            COMMAND $<TARGET_FILE:unit_threadpool> --durations=yes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+
+	    )
+
+endif()

--- a/experimental/tiledb/common/dag/execution/scheduler.h
+++ b/experimental/tiledb/common/dag/execution/scheduler.h
@@ -1,0 +1,59 @@
+/**
+ * @file   scheduler.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares scheduler(s) for dag.
+ */
+
+#ifndef TILEDB_DAG_SCHEDULER_H
+#define TILEDB_DAG_SCHEDULER_HH
+
+namespace tiledb::common {
+
+/**
+ * Scheduler for the graph.
+ *
+ * The scheduler owns a thread pool. It is also an active object; at least one
+ * thread in its pool is dedicated to its own operation.
+ */
+template <class Block>
+class Scheduler {
+  ThreadPool tp_;
+
+ public:
+  void notify_alive(Source<Block>*);
+  void notify_quiescent(Source<Block>*);
+  void notify_alive(Sink<Block>*);
+  void notify_quiescent(Sink<Block>*);
+  // Possibly needed
+  // wakeup(Source *);
+  // wakeup(Sink *);
+};
+
+}  // namespace tiledb::common
+#endif  // TILEDB_DAG_SCHEDULER_HH

--- a/experimental/tiledb/common/dag/execution/test/main.cc
+++ b/experimental/tiledb/common/dag/execution/test/main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file experimental/tiledb/common/dag/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>

--- a/experimental/tiledb/common/dag/execution/test/unit_threadpool.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_threadpool.cc
@@ -1,0 +1,62 @@
+/**
+ * @file unit_threadpool.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the threadpool class.
+ */
+
+#include "catch.hpp"
+#include "experimental/tiledb/common/dag/execution/threadpool.h"
+
+// using namespace tiledb::common;
+
+TEST_CASE("Threadpool: Test construct", "[threadpool]") {
+  auto a = ThreadPool<false, false, false>(4);
+  CHECK(a.num_threads() == 4);
+
+  auto b = ThreadPool<false, false, true>(4);
+  CHECK(a.num_threads() == 4);
+
+  auto c = ThreadPool<false, true, false>(4);
+  CHECK(c.num_threads() == 4);
+
+  auto d = ThreadPool<false, true, true>(4);
+  CHECK(d.num_threads() == 4);
+
+  auto e = ThreadPool<true, false, false>(4);
+  CHECK(e.num_threads() == 4);
+
+  auto f = ThreadPool<true, false, true>(4);
+  CHECK(f.num_threads() == 4);
+
+  auto g = ThreadPool<true, true, false>(4);
+  CHECK(g.num_threads() == 4);
+
+  auto h = ThreadPool<true, true, true>(4);
+  CHECK(g.num_threads() == 4);
+}

--- a/experimental/tiledb/common/dag/execution/threadpool.cc
+++ b/experimental/tiledb/common/dag/execution/threadpool.cc
@@ -1,0 +1,1 @@
+#include "threadpool.h"

--- a/experimental/tiledb/common/dag/execution/threadpool.h
+++ b/experimental/tiledb/common/dag/execution/threadpool.h
@@ -1,0 +1,240 @@
+/**
+ * @file   threadpool.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares a threadpool with various parameterized capabilities.
+ */
+
+#ifndef TILEDB_THREADPOOL_H
+#define TILEDB_THREADPOOL_H
+
+#include "../utils/bounded_buffer.h"
+
+#include <functional>
+#include <future>
+#include <iostream>
+#include <type_traits>
+#include <vector>
+
+namespace tiledb::common {
+
+template <bool MultipleQueues>
+struct QueueBase;
+template <>
+struct QueueBase<true> {
+  QueueBase(size_t num_threads)
+      : task_queues_(num_threads) {
+  }
+
+  std::atomic<size_t> index_;
+  const size_t rounds_{3};
+  std::vector<ProducerConsumerQueue<std::shared_ptr<std::function<void()>>>>
+      task_queues_;
+};
+
+template <>
+struct QueueBase<false> {
+  QueueBase(size_t) {
+  }
+  ProducerConsumerQueue<std::shared_ptr<std::function<void()>>> task_queue_;
+};
+
+template <
+    bool WorkStealing = false,
+    bool MultipleQueues = false,
+    bool RecursivePush = true>
+class ThreadPool : public QueueBase<MultipleQueues> {
+ public:
+  using QBase = QueueBase<MultipleQueues>;
+
+  explicit ThreadPool(size_t concurrency = std::thread::hardware_concurrency())
+      : QueueBase<MultipleQueues>(concurrency)
+      , num_threads_(concurrency) {
+    threads_.reserve(num_threads_);
+
+    for (size_t i = 0; i < num_threads_; ++i) {
+      std::thread tmp = std::thread(&ThreadPool::worker, this, i);
+      threads_.emplace_back(std::move(tmp));
+    }
+  }
+
+  ~ThreadPool() {
+    if constexpr (MultipleQueues) {
+      for (auto& t : QBase::task_queues_) {
+        t.shutdown();
+      }
+
+    } else {
+      QBase::task_queue_.shutdown();
+    }
+
+    for (auto&& t : threads_) {
+      t.join();
+    }
+    threads_.clear();
+  }
+
+ public:
+  template <class Fn, class... Args>
+  auto async(Fn&& f, Args&&... args) {
+    using R = std::invoke_result_t<std::decay_t<Fn>, std::decay_t<Args>...>;
+
+    std::shared_ptr<std::promise<R>> task_promise(new std::promise<R>);
+    std::future<R> future = task_promise->get_future();
+
+    auto task = std::make_shared<std::function<void()>>(
+        [f = std::forward<Fn>(f),
+         args = std::make_tuple(std::forward<Args>(args)...),
+         task_promise]() mutable {
+          try {
+            if constexpr (std::is_void_v<R>) {
+              std::apply(std::move(f), std::move(args));
+              task_promise->set_value();
+            } else {
+              task_promise->set_value(
+                  std::apply(std::move(f), std::move(args)));
+            }
+          } catch (...) {
+            task_promise->set_exception(std::current_exception());
+          }
+        });
+
+    if constexpr (RecursivePush) {
+      if constexpr (MultipleQueues) {
+        size_t i = QBase::index_++;
+        QBase::task_queues_[i % num_threads_].push(task);
+      } else {
+        QBase::task_queue_.push(task);
+      }
+    } else {
+      bool found = false;
+      for (auto& j : threads_) {
+        if (j.get_id() == std::this_thread::get_id()) {
+          found = true;
+          break;
+        }
+      }
+
+      if (found) {
+        (*task)();
+      } else {
+        if constexpr (MultipleQueues) {
+          size_t i = QBase::index_++;
+          QBase::task_queues_[i % num_threads_].push(task);
+        } else {
+          QBase::task_queue_.push(task);
+        }
+      }
+    }
+
+    return future;
+  }
+
+  template <class R, bool U = WorkStealing, std::enable_if_t<U, bool> = true>
+  auto wait(std::future<R>&& task) {
+    while (true) {
+      if (task.wait_for(std::chrono::milliseconds(0)) ==
+          std::future_status::ready) {
+        if constexpr (std::is_void_v<R>) {
+          task.wait();
+          return;
+        } else {
+          auto ret = task.get();
+          return ret;
+        }
+      } else {
+        std::optional<std::shared_ptr<std::function<void()>>> val;
+
+        if constexpr (MultipleQueues) {
+          size_t i = QBase::index_++;
+          for (size_t j = 0; j < num_threads_ * QBase::rounds_; ++j) {
+            val = QBase::task_queues_[(i + j) % num_threads_].try_pop();
+
+            if (val) {
+              break;
+            }
+          }
+        } else {
+          val = QBase::task_queue_.try_pop();
+        }
+
+        if (val) {
+          (*(*val))();
+        } else {
+          std::this_thread::yield();
+        }
+      }
+    }
+  }
+
+  template <class R, bool U = WorkStealing, std::enable_if_t<!U, bool> = true>
+  auto wait(std::future<R>& task) {
+    return wait(std::move(task));
+  }
+
+  size_t num_threads() {
+    return num_threads_;
+  }
+
+ private:
+  void worker(size_t i) {
+    while (true) {
+      std::optional<std::shared_ptr<std::function<void()>>> val;
+
+      if constexpr (MultipleQueues) {
+        for (size_t j = 0; j < num_threads_ * QBase::rounds_; ++j) {
+          val = QBase::task_queues_[(i + j) % num_threads_].try_pop();
+          if (val) {
+            break;
+          }
+        }
+      } else {
+        val = QBase::task_queue_.try_pop();
+      }
+
+      if (!val) {
+        if constexpr (MultipleQueues) {
+          val = QBase::task_queues_[i].pop();
+        } else {
+          val = QBase::task_queue_.pop();
+        }
+      }
+      if (val) {
+        (*(*val))();
+      } else {
+        break;
+      }
+    }
+  }
+
+  const size_t num_threads_;
+  std::vector<std::thread> threads_;
+};
+
+}  // namespace tiledb::common
+#endif  // TILEDB_THREADPOOL_H

--- a/experimental/tiledb/common/dag/graph/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/graph/CMakeLists.txt
@@ -1,0 +1,69 @@
+#
+# experimental/tiledb/common/graph/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common NO_POLICY_SCOPE)
+
+list(APPEND SOURCES
+    graph.cc
+)
+gather_sources(${SOURCES})
+
+#
+# Object library for other units to depend upon
+#
+add_library(graph OBJECT ${SOURCES})
+target_link_libraries(graph PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_graph EXCLUDE_FROM_ALL)
+target_link_libraries(compile_graph PRIVATE graph)
+target_sources(compile_graph PRIVATE test/compile_graph_main.cc)
+
+if (TILEDB_TESTS)
+    add_executable(unit_graph EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_graph PUBLIC graph)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_graph PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_graph PUBLIC $<TARGET_OBJECTS:thread_pool>)
+
+    # Sources for code elsewhere required for tests
+    target_sources(unit_graph PUBLIC ${DEPENDENT_SOURCES})
+
+    # Sources for tests
+    target_sources(unit_graph PUBLIC
+            test/main.cc
+            test/unit_graph.cc
+            )
+
+    add_test(
+            NAME "unit_graph"
+            COMMAND $<TARGET_FILE:unit_graph> --durations=yes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/experimental/tiledb/common/dag/graph/dag.cc
+++ b/experimental/tiledb/common/dag/graph/dag.cc
@@ -1,0 +1,36 @@
+/**
+ * @file   dag.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the Dag class.
+ */
+
+#include <cassert>
+
+#include "experimental/tiledb/common/dag/dag.h"
+#include "tiledb/common/logger.h"

--- a/experimental/tiledb/common/dag/graph/dag.h
+++ b/experimental/tiledb/common/dag/graph/dag.h
@@ -1,0 +1,48 @@
+/**
+ * @file   dag.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the Dag class as well as its associated classes.
+ */
+
+#ifndef TILEDB_DAG_H
+#define TILEDB_DAG_H
+
+#include <cstddef>
+#include <mutex>
+#include <optional>
+
+#include "experimental/tiledb/common/node/edge.h"
+#include "experimental/tiledb/common/node/node.h"
+#include "experimental/tiledb/common/ports/ports.h"
+#include "tiledb/common/common-std.h"
+#include "tiledb/common/thread_pool.h"
+
+namespace tiledb::common {}  // namespace tiledb::common
+
+#endif  // TILEDB_DAG_H

--- a/experimental/tiledb/common/dag/node/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/node/CMakeLists.txt
@@ -1,0 +1,69 @@
+#
+# experimental/tiledb/common/node/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common NO_POLICY_SCOPE)
+
+list(APPEND SOURCES
+    node.cc
+)
+gather_sources(${SOURCES})
+
+#
+# Object library for other units to depend upon
+#
+add_library(node OBJECT ${SOURCES})
+target_link_libraries(node PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_node EXCLUDE_FROM_ALL)
+target_link_libraries(compile_node PRIVATE node)
+target_sources(compile_node PRIVATE test/compile_node_main.cc)
+
+if (TILEDB_TESTS)
+    add_executable(unit_node EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_node PUBLIC node)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_node PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_node PUBLIC $<TARGET_OBJECTS:thread_pool>)
+
+    # Sources for code elsewhere required for tests
+    target_sources(unit_node PUBLIC ${DEPENDENT_SOURCES})
+
+    # Sources for tests
+    target_sources(unit_node PUBLIC
+            test/main.cc
+            test/unit_node.cc
+            )
+
+    add_test(
+            NAME "unit_node"
+            COMMAND $<TARGET_FILE:unit_node> --durations=yes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/experimental/tiledb/common/dag/node/node.h
+++ b/experimental/tiledb/common/dag/node/node.h
@@ -1,0 +1,45 @@
+/**
+ * @file   node.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the nodes classes for dag.
+ */
+
+#ifndef TILEDB_DAG_NODE_H
+#define TILEDB_DAG_NODE_H
+
+namespace tiledb::common {
+
+/*
+ * To be defined. First test is to hook up a raw source and a raw sink with an
+ * edge.
+ */
+class Node;
+
+}  // namespace tiledb::common
+#endif  // TILEDB_DAG_NODE_H

--- a/experimental/tiledb/common/dag/ports/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/ports/CMakeLists.txt
@@ -1,0 +1,113 @@
+#
+# experimental/tiledb/common/ports/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common NO_POLICY_SCOPE)
+
+list(APPEND PORT_SOURCES
+    ports.cc
+)
+gather_sources(${PORT_SOURCES})
+
+#
+# Object library for other units to depend upon
+#
+add_library(ports OBJECT ${PORT_SOURCES})
+target_link_libraries(ports PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_ports EXCLUDE_FROM_ALL)
+target_link_libraries(compile_ports PRIVATE ports)
+target_sources(compile_ports PRIVATE test/compile_ports_main.cc)
+
+if (TILEDB_TESTS)
+    add_executable(unit_ports EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_ports PUBLIC ports)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_ports PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_ports PUBLIC $<TARGET_OBJECTS:thread_pool>)
+
+    # Sources for code elsewhere required for tests
+    target_sources(unit_ports PUBLIC ${DEPENDENT_SOURCES})
+
+    # Sources for tests
+    target_sources(unit_ports PUBLIC
+            test/main.cc
+            test/unit_ports.cc
+            )
+
+    add_test(
+            NAME "unit_ports"
+            COMMAND $<TARGET_FILE:unit_ports> --durations=yes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+endif()
+
+
+list(APPEND FSM_SOURCES
+    fsm.cc
+)
+gather_sources(${FSM_SOURCES})
+
+
+#
+# Object library for other units to depend upon
+#
+add_library(fsm OBJECT ${FSM_SOURCES})
+target_link_libraries(fsm PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_fsm EXCLUDE_FROM_ALL)
+target_link_libraries(compile_fsm PRIVATE fsm)
+target_sources(compile_fsm PRIVATE test/compile_fsm_main.cc)
+
+if (TILEDB_TESTS)
+    add_executable(unit_fsm EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_fsm PUBLIC fsm)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_fsm PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_fsm PUBLIC $<TARGET_OBJECTS:thread_pool>)
+
+    # Sources for code elsewhere required for tests
+    target_sources(unit_fsm PUBLIC ${DEPENDENT_SOURCES})
+
+    # Sources for tests
+    target_sources(unit_fsm PUBLIC
+            test/main.cc
+            test/unit_fsm.cc
+            )
+
+    add_test(
+            NAME "unit_fsm"
+            COMMAND $<TARGET_FILE:unit_fsm> --durations=yes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/experimental/tiledb/common/dag/ports/fsm.cc
+++ b/experimental/tiledb/common/dag/ports/fsm.cc
@@ -1,0 +1,36 @@
+/**
+ * @file   fsm.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the fsm classes for dag.
+ */
+
+#include <cassert>
+
+#include "experimental/tiledb/common/dag/ports/fsm.h"
+#include "tiledb/common/logger.h"

--- a/experimental/tiledb/common/dag/ports/fsm.h
+++ b/experimental/tiledb/common/dag/ports/fsm.h
@@ -1,0 +1,301 @@
+/**
+ * @file   fsm.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the finite state machine for communicating ports.
+ *
+ */
+
+#ifndef TILEDB_DAG_FSM_H
+#define TILEDB_DAG_FSM_H
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace tiledb::common {
+
+// clang-format off
+/**
+ * This is the state transition table for a simple state machine for two
+ * communicating ports.  Each port has two states, empty or full.  There are
+ * three events: source_fill, sink_drain, and swap.  For simplicty there are
+ * currently no defined events for startup, stop, forced shutdown, or abort
+ * (though we have an event enum that anticipates shutdown).
+ *
+ *    +-----------------+---------------------------------------------------+
+ *    |      States     |                    Events                         |
+ *    +--------+--------+-------------+------------+-------------+----------+
+ *    | Source |  Sink  | source_fill | swap       | sink_drain  | shutdown |
+ *    |--------+--------+-------------+------------+-------------+----------+
+ *    | empty  | empty  | full/empty  |            |             |          |
+ *    |--------+--------+-------------+------------+-------------+----------+
+ *    | empty  | full   | full/full   |            | empty/empty |          |
+ *    |--------+--------+-------------+------------+-------------+----------+
+ *    | full   | empty  |             | empty/full |             |          |
+ *    |--------+--------+-------------+------------+-------------+----------+
+ *    | full   | full   |             |            | full/empty  |          |
+ *    +--------+--------+-------------+------------+-------------+----------+
+ *
+ *
+ *
+ * The basic behavior of a user of a source port is
+ *   init: { state == empty_full }
+ *   start: { state == empty_full /\ state == empty_empty }
+ *   while (not done)
+ *     loop_begin: { state == empty_empty /\ state == empty_full }
+ *     pre_produce: { state == empty_empty /\ state == empty_full }
+ *     invoke producer function
+ *     during producer function, sink could have drained
+ *     source_fill: { state == full_empty /\ state == full_full }
+ *     sink.notify()
+ *     wait
+ *     post wait, the following could have happened
+ *       sink could have swapped -> state = empty_full
+ *       sink could have drained -> state = full_empty
+ *     post_wait: { state == full_empty /\ state == empty_full }
+ *     if (state == full_empty)
+ *       pre_swap: { state ==  full_empty }
+ *       swap elements
+ *       post_swap: { state ==  empty_full }
+ *       sink.notify()
+ *     else
+ *       else_swap: { state == empty_empty \/ state == empty_full
+ *   post_loop: { state == empty_empty \/ state == empty_full }
+ *
+ *
+ * The basic behavior of a user of a sink port is
+ *   We perform some initializetion to get into a proper starting state
+ *   init: { state == empty_full /\ state == full_full }
+ *   drain: { state == empty_empty /\ state == full_empty }
+ *   start: { state == empty_empty /\ state == full_empty }
+ *   source.notify()
+ *   while (not done)
+ *     loop_begin: { state == empty_empty /\ state == full_empty }
+ *     wait
+ *     post wait, the following could have happened
+ *       source could have swapped -> state = empty_full
+ *       source could have filled  -> full_empty
+ *     post_wait: { state == full_empty /\ state == empty_full }
+ *     if (state == full_empty)
+ *       pre_swap: { state == full_empty }
+ *       swap
+ *       post_swap: { state ==  empty_full }
+ *       source.notify()
+ *     else
+ *       else_swap: { state == full_empty /\ state == empty_full }
+ *     pre_consume: { state == empty_full /\ state == full_full }
+ *     invoke consumer function
+ *     during consumer function, source could have filled
+ *     drain: { state == empty_empty /\ state == full_empty }
+ *     source.notify()
+ *  post_loop: { state = empty_empty }
+ *
+ *
+ */
+// clang-format on
+
+/**
+ * An enum representing the different states of the bound ports
+ */
+enum class PortState {
+  empty_empty,
+  empty_full,
+  full_empty,
+  full_full,
+  error,
+  done
+};
+
+namespace {
+constexpr unsigned short to_index(PortState x) {
+  return static_cast<unsigned short>(x);
+}
+
+/**
+ * Number of states in the Port state machine
+ */
+constexpr unsigned short n_states = to_index(PortState::done) + 1;
+}  // namespace
+
+/**
+ * Strings for each enum member, for debugging.
+ */
+static std::vector<std::string> port_state_strings{
+    "empty_empty",
+    "empty_full",
+    "full_empty",
+    "full_full",
+    "error",
+    "done",
+};
+
+/**
+ * Function to convert a state to a string.
+ *
+ * @param event The event to stringify.
+ * @return The string corresponding to the event.
+ */
+static auto str(PortState st) {
+  return port_state_strings[static_cast<int>(st)];
+}
+
+enum class PortEvent : unsigned short {
+  source_fill,
+  swap,
+  sink_drain,
+  shutdown
+};
+
+inline constexpr unsigned short to_index(PortEvent x) {
+  return static_cast<unsigned short>(x);
+}
+
+/**
+ * Number of events in the PortEvent state machine
+ */
+constexpr unsigned int n_events = to_index(PortEvent::shutdown) + 1;
+
+/**
+ * Strings for each enum member, for debugging.
+ */
+static std::vector<std::string> event_strings{
+    "source_fill",
+    "swap",
+    "sink_drain",
+    "shutdown",
+};
+
+/**
+ * Function to convert event to a string.
+ *
+ * @param event The event to stringify.
+ * @return The string corresponding to the event.
+ */
+static auto str(PortEvent ev) {
+  return event_strings[static_cast<int>(ev)];
+}
+
+/**
+ * State transition table.
+ *
+ * Originally included start events and separate sink_drained and source_filled
+ * events. The start events are not necessary for a connected source and sink
+ * if the initial state of the fsm is empty_full. The source_fill and
+ * source_filled are really the same event, as are sink_drained and
+ * sink_drain. Without start events, there are also no start states.
+ *
+ * The original fsm also included a "ready" state for source and sink, but this
+ * was absorbed into "full" for source and "empty" for sink since the transition
+ * from ready to those states wwas "always", i.e., it did not require an actual
+ * event for that state transition to happen.  Moreover, the state of the source
+ * and sink is really just the state of the item it contains.
+ *
+ */
+namespace {
+
+// clang-format off
+  constexpr PortState transition_table[n_states][n_events] {
+  /* source_sink */    /* source_fill */      /* swap */             /* sink_drain */        /* shutdown */
+
+  /* empty_empty */  { PortState::full_empty, PortState::error,      PortState::error,       PortState::error },
+  /* empty_full  */  { PortState::full_full,  PortState::error,      PortState::empty_empty, PortState::error },
+  /* full_empty  */  { PortState::error,      PortState::empty_full, PortState::error,       PortState::error },
+  /* full_full   */  { PortState::error,      PortState::error,      PortState::full_empty,  PortState::error },
+
+  /* error       */  { PortState::error,      PortState::error,      PortState::error,       PortState::error },
+  /* done        */  { PortState::error,      PortState::error,      PortState::error,       PortState::error },
+  };
+// clang-format on
+
+  }  // namespace
+
+/**
+ * Class representing states of a bound source and sink node.
+ * The class is agnostic as to how the events are actually
+ * implemented by the users of the the state machine.
+ *
+ * Todo: Derived class to represent bound nodes.
+ */
+class PortStateMachine {
+ private:
+  PortState state_;
+
+ public:
+  /**
+   * Default constructor
+   */
+  PortStateMachine()
+      : state_(PortState::empty_full){};
+
+  /**
+   * Return the current state
+   */
+  [[nodiscard]] inline PortState state() const {
+    return state_;
+  }
+
+ public:
+  /**
+   * Function to handle state transitions based on external events.
+   *
+   * Todo: Protect state transitions with mutex?
+   *
+   * Todo: Make event() private and create do_fill(), do_drain(),
+   * and do_swap() public members.
+   *
+   * Todo: Investigate coroutine-like approach for corresponding with external
+   * events so that the procession of steps is driven by the state machine
+   * rather than the user of the state machine.
+   *
+   * Some code that prints state information is currently included for debugging
+   * purposes.
+   *
+   * @param event The event to be processed
+   * @param event msg A debugging string to preface printout information for the
+   * state transition
+   */
+  void event(PortEvent event, const std::string msg = "") {
+    auto new_state{transition_table[to_index(state_)][to_index(event)]};
+
+    if (msg != "") {
+      std::cout << msg + " " + str(event) + ": " + str(state_) + " -> " +
+                       str(new_state)
+                << std::endl;
+    }
+
+    /*
+     * Assign new state
+     */
+    state_ = new_state;
+  }
+};
+}  // namespace tiledb::common
+
+#endif  // TILEDB_DAG_FSM_H

--- a/experimental/tiledb/common/dag/ports/fsm.h
+++ b/experimental/tiledb/common/dag/ports/fsm.h
@@ -438,9 +438,9 @@ namespace {
 constexpr const PortState transition_table[n_states][n_events] {
   /* source_sink */    /* source_fill */      /* swap */             /* sink_drain */        /* shutdown */
 
-  /* empty_empty */  { PortState::full_empty, PortState::error,      PortState::empty_empty, PortState::error },
+  /* empty_empty */  { PortState::full_empty, PortState::error,      PortState::error,       PortState::error },
   /* empty_full  */  { PortState::full_full,  PortState::error,      PortState::empty_empty, PortState::error },
-  /* full_empty  */  { PortState::error,      PortState::empty_full, PortState::full_empty,  PortState::error },
+  /* full_empty  */  { PortState::error,      PortState::empty_full, PortState::error,       PortState::error },
   /* full_full   */  { PortState::error,      PortState::error,      PortState::full_empty,  PortState::error },
 
   /* error       */  { PortState::error,      PortState::error,      PortState::error,       PortState::error },
@@ -494,7 +494,7 @@ class PortFiniteStateMachine {
    * Default constructor
    */
   PortFiniteStateMachine()
-      : state_(PortState::empty_empty){};
+      : state_(PortState::empty_full){};
 
   /**
    * Return the current state

--- a/experimental/tiledb/common/dag/ports/fsm.h
+++ b/experimental/tiledb/common/dag/ports/fsm.h
@@ -45,7 +45,7 @@ namespace tiledb::common {
 /**
  * This is the state transition table for a simple state machine for two
  * communicating ports.  Each port has two states, empty or full.  There are
- * three events: source_fill, sink_drain, and swap.  For simplicty there are
+ * three events: source_fill, swap, and sink_drain.  For simplicty there are
  * currently no defined events for startup, stop, forced shutdown, or abort
  * (though we have an event enum that anticipates shutdown).
  *
@@ -64,65 +64,238 @@ namespace tiledb::common {
  *    +--------+--------+-------------+------------+-------------+----------+
  *
  *
+ * The entry and exit functions for a state transition from old to new are
+ * called in the following way:
+ *
+ * begin_transition: given old_state and event
+ *
+ *    execute exit(old_state, event)
+ *    new_state = transition(old_state, event)
+ *    execute entry(new_state, event)
+ *
+ * (It is perhaps somewhat non-intuitive that the state transition executes 
+ * exit and then executes entry.)
+ *
+ * Desired usage of a source port / fsm from a source node:
+ *
+ * while (true) {
+ *   produce an item
+ *   cause event filled
+ * }
+ *
+ *
+ * Desired usage of a sink port / fsm from a source node:
+ *
+ * while (true) {
+ *   cause event drained
+ *   consume an item
+ * }
+ *
+ *
+ * We can look at the states of the FSM as the ports proceed through a data exchange.
  *
  * The basic behavior of a user of a source port is
- *   init: { state == empty_full }
- *   start: { state == empty_full /\ state == empty_empty }
+ *   init: { state == empty_empty }
+ *   start: { state == empty_empty }
  *   while (not done)
- *     loop_begin: { state == empty_empty /\ state == empty_full }
- *     pre_produce: { state == empty_empty /\ state == empty_full }
+ *     loop_begin: { state == empty_empty ∨ state == empty_full }
+ *     pre_produce: { state == empty_empty ∨ state == empty_full }
  *     invoke producer function
  *     during producer function, sink could have drained
- *     source_fill: { state == full_empty /\ state == full_full }
+ *     source_fill: { state == full_empty ∨ state == full_full }
  *     sink.notify()
  *     wait
  *     post wait, the following could have happened
  *       sink could have swapped -> state = empty_full
  *       sink could have drained -> state = full_empty
- *     post_wait: { state == full_empty /\ state == empty_full }
+ *       sink could have swapped and drained -> state = empty_empty
+ *     post_wait: { state == full_empty ∨ state == empty_full ∨ state == empty_empty }
  *     if (state == full_empty)
  *       pre_swap: { state ==  full_empty }
  *       swap elements
  *       post_swap: { state ==  empty_full }
  *       sink.notify()
  *     else
- *       else_swap: { state == empty_empty \/ state == empty_full
- *   post_loop: { state == empty_empty \/ state == empty_full }
+ *       else_swap: { state == empty_empty ∨ state == empty_full }
+ *   post_loop: { state == empty_empty ∨ state == empty_full }
  *
  *
  * The basic behavior of a user of a sink port is
  *   We perform some initializetion to get into a proper starting state
- *   init: { state == empty_full /\ state == full_full }
- *   drain: { state == empty_empty /\ state == full_empty }
- *   start: { state == empty_empty /\ state == full_empty }
- *   source.notify()
+ *   init: { state == empty_empty }
+ *   start: { state == empty_empty ∨ state == full_empty }
  *   while (not done)
- *     loop_begin: { state == empty_empty /\ state == full_empty }
+ *     loop_begin: { state == empty_empty ∨ state == full_empty }
+ *     source.notify()
  *     wait
  *     post wait, the following could have happened
  *       source could have swapped -> state = empty_full
  *       source could have filled  -> full_empty
- *     post_wait: { state == full_empty /\ state == empty_full }
+ *       source could have swapped and filled -> state = full_full
+ *     post_wait: { state == full_empty ∨ state == empty_full ∨ state == full_full }
  *     if (state == full_empty)
  *       pre_swap: { state == full_empty }
  *       swap
  *       post_swap: { state ==  empty_full }
  *       source.notify()
  *     else
- *       else_swap: { state == full_empty /\ state == empty_full }
- *     pre_consume: { state == empty_full /\ state == full_full }
+ *       else_swap: { state == full_empty ∨ state == empty_full }
+ *     pre_consume: { state == empty_full ∨ state == full_full }
  *     invoke consumer function
  *     during consumer function, source could have filled
- *     drain: { state == empty_empty /\ state == full_empty }
- *     source.notify()
+ *     drain: { state == empty_empty ∨ state == full_empty }
  *  post_loop: { state = empty_empty }
  *
+ *
+ * We can also look at the behavior of the states from the point of view of the FSM.
+ *
+ * source:
+ *   while (true) {
+ *
+ *     ( event called by node )
+ *
+ *    source_entry:
+ *     { state == empty_full ∨ state == empty_empty } ∧ { source_item == true }
+ *
+ *     do filled transition : event(drained)
+ *
+ *     { state == full_empty ∨ state == full_full } ∧ { source_item == true }
+ *
+ *     notify sink : entry(full_empty/full_full)
+ *
+ *     wait
+ *     { state != full_full } ∧ { source_item == true ∨ source_item == false }
+ *     if state is full_empty
+ *       { state == full_empty } ∧ { source_item == true }
+ *       do_swap
+ *       { state == full_empty } ∧ { source_item == false }
+ *       do swap transition
+ *       { state == empty_full } ∧ { source_item == false }
+ *       notify sink
+ *       { state == empty_full ∨ state = empty_empty } ∧ { source_item == false }
+ *
+ *     else { state == empty_full ∨ state == empty_empty } ∧ { source_item == false }
+ *
+ *     return
+ *       { state == empty_full ∨ state = empty_empty } ∧ { source_item == false }
+ *   }
+ *
+ * sink:
+ *   while (true)
+ *
+ *     ( event called by node )
+ *
+ *    sink_entry:
+ *     { state == empty_full ∨ state == full_full } ∧ { sink_item == false }
+ *
+ *     do drained transition : event(drained)
+ *
+ *     { state == full_empty ∨ state == empty_empty } ∧ { sink_item == false }
+ *
+ *     notify source  : entry(full_empty/empty_empty, drained)
+ *     wait
+ *
+ *     { state != empty_empty } ∧ { sink_item == false ∨ sink_item == true }
+ *     if state is full_empty
+ *       { state == full_empty } ∧ { sink_item == false }
+ *
+ *       do_swap 
+ *
+ *       { state == full_empty } ∧ { sink_item == false }
+ *
+ *       do swap transition : state <- empty_full
+ *
+ *       { state == empty_full } ∧ { sink_item == true }
+ *
+ *       notify source : entry(empty_full, swap)
+ *
+ *       { state == empty_full ∨ state == full_full} ∧ { sink_item == true } 
+ *     else { state == empty_full ∨ state == full_full } ∧ { sink_item == true }
+ *
+ *     return { state == empty_full ∨ state == full_full } ∧ { sink_item == true }
+ * 
+ *
+ * Note that the loop structures for the source and sink are essentially the same.  The difference
+ * is in the states at each point.
+ *
+ * We can write a generic source / sink program -- the differences between the two are
+ * separated by a /, with source on the left and sink on the right.
+ *
+ *   function run:
+ *   while (true) {
+ *
+ *     source entry:
+ *       { state == empty_full ∨ state == empty_empty } / { state == empty_full ∨ state == full_full }
+ *
+ *       call back do_fill     / call back do_drain
+ *       do filled transition  / do drained transition
+ *
+ *       { state == full_empty ∨ state == full_full } / { state == full_empty ∨ state == empty_empty }
+ *
+ *     sink entry:
+ *       call back notify_wait  
+ *
+ *       { state != full_full } / { state != empty_empty }
+ *
+ *       if state is full_empty
+ *         do_swap
+ *         do swap transition 
+ *         call back notify_other
+ *
+ *         { state == empty_full } / { state == empty_full }
+ *
+ *       else { state == empty_full ∨ state == empty_empty } / { state == empty_full ∨ state == full_full }
+ *   }
+ *
+ *
+ * To factor out what functionality to incorporate into the entry and exit points of the
+ * finite-state machine, recall there are only two external events -- source_fill and sink_drain.
+ *
+ * Base on the pseudocode above, and the predicate annotations therein, we can see we need
+ * two entry functions -- one for when the source enters the full state, and one for when the
+ * sink enters the empty state. (In fact, since we can express the contents of that function
+ * in the same way for both cases, we really only need one function for both cases.  We show
+ * the cases separately for clarity.)
+ *
+ * In the case of the source, on entry, we need to do the following:
+ * 
+ *   notify the sink
+ *   wait for the sink to become empty
+ *   on wakeup, if the current state is full_empty, perform a swap and set the state to empty_full
+ *
+ *
+ * In the case of the sink, on entry, we need to do the following:
+ *
+ * Notify the source
+ *   wait for the source to become full  
+ *   on wakeup, if the current state is full_empty, perform a swap and set the state to empty_full
+ *
+ * When we are using locks and condition variables, a single cv can be shared between source and
+ * sink because (presumably), they will never sleep at the same time.  In that case, only a single
+ * function is needed for source entry and sink entry.
+ *
+ * The table for entry functions contains actions to be performend on state transitions (as
+ * described above: 
+ *
+ *    +-----------------+---------------------------------------------------+
+ *    |      States     |                    Events                         |
+ *    +--------+--------+-------------+------------+-------------+----------+
+ *    | Source |  Sink  | source_fill | swap       | sink_drain  | shutdown |
+ *    |--------+--------+-------------+------------+-------------+----------+
+ *    | empty  | empty  |             |            | snk_swap    |          |
+ *    |--------+--------+-------------+------------+-------------+----------+
+ *    | empty  | full   |             |            |             |          |
+ *    |--------+--------+-------------+------------+-------------+----------+
+ *    | full   | empty  | src_swap    |            | snk_swap    |          |
+ *    |--------+--------+-------------+------------+-------------+----------+
+ *    | full   | full   | src_swap    |            |             |          |
+ *    +--------+--------+-------------+------------+-------------+----------+
  *
  */
 // clang-format on
 
 /**
- * An enum representing the different states of the bound ports
+ * An enum representing the different states of the bound ports.
  */
 enum class PortState {
   empty_empty,
@@ -162,7 +335,7 @@ static std::vector<std::string> port_state_strings{
  * @param event The event to stringify.
  * @return The string corresponding to the event.
  */
-static auto str(PortState st) {
+static inline auto str(PortState st) {
   return port_state_strings[static_cast<int>(st)];
 }
 
@@ -198,8 +371,49 @@ static std::vector<std::string> event_strings{
  * @param event The event to stringify.
  * @return The string corresponding to the event.
  */
-static auto str(PortEvent ev) {
+static inline auto str(PortEvent ev) {
   return event_strings[static_cast<int>(ev)];
+}
+
+/**
+ * Port Actions
+ */
+enum class PortAction : unsigned short {
+  none,
+  ac_return,
+  src_swap,
+  snk_swap,
+  error,
+};
+
+inline constexpr unsigned short to_index(PortAction x) {
+  return static_cast<unsigned short>(x);
+}
+
+/**
+ * Number of actions in the Port state machine
+ */
+constexpr unsigned int n_actions = to_index(PortAction::error) + 1;
+
+/**
+ * Strings for each enum member, for debugging.
+ */
+static std::vector<std::string> action_strings{
+    "none",
+    "ac_return",
+    "src_swap",
+    "snk_swap",
+    "error",
+};
+
+/**
+ * Function to convert an action to a string.
+ *
+ * @param ac The action to stringify.
+ * @return The string corresponding to the action.
+ */
+static auto inline str(PortAction ac) {
+  return action_strings[static_cast<int>(ac)];
 }
 
 /**
@@ -221,44 +435,95 @@ static auto str(PortEvent ev) {
 namespace {
 
 // clang-format off
-  constexpr PortState transition_table[n_states][n_events] {
+constexpr const PortState transition_table[n_states][n_events] {
   /* source_sink */    /* source_fill */      /* swap */             /* sink_drain */        /* shutdown */
 
-  /* empty_empty */  { PortState::full_empty, PortState::error,      PortState::error,       PortState::error },
+  /* empty_empty */  { PortState::full_empty, PortState::error,      PortState::empty_empty, PortState::error },
   /* empty_full  */  { PortState::full_full,  PortState::error,      PortState::empty_empty, PortState::error },
-  /* full_empty  */  { PortState::error,      PortState::empty_full, PortState::error,       PortState::error },
+  /* full_empty  */  { PortState::error,      PortState::empty_full, PortState::full_empty,  PortState::error },
   /* full_full   */  { PortState::error,      PortState::error,      PortState::full_empty,  PortState::error },
 
   /* error       */  { PortState::error,      PortState::error,      PortState::error,       PortState::error },
   /* done        */  { PortState::error,      PortState::error,      PortState::error,       PortState::error },
   };
+
+
+constexpr const PortAction entry_table[n_states][n_events] {
+  /* source_sink */    /* source_fill */      /* swap */             /* sink_drain */        /* shutdown */
+
+  /* empty_empty */  { PortAction::none,       PortAction::ac_return,  PortAction::snk_swap,     PortAction::none },
+  /* empty_full  */  { PortAction::none,       PortAction::ac_return,  PortAction::none,         PortAction::none },
+  /* full_empty  */  { PortAction::src_swap,   PortAction::ac_return,  PortAction::snk_swap,     PortAction::none },
+  /* full_full   */  { PortAction::src_swap,   PortAction::ac_return,  PortAction::none,         PortAction::none },
+
+  /* error       */  { PortAction::none,       PortAction::none,        PortAction::none,        PortAction::none },
+  /* done        */  { PortAction::none,       PortAction::none,        PortAction::none,        PortAction::none },
+  };
+
+
+constexpr const PortAction exit_table[n_states][n_events] {
+  /* source_sink */    /* source_fill */      /* swap */             /* sink_drain */        /* shutdown */
+
+  /* empty_empty */  { PortAction::none,       PortAction::none,       PortAction::none,         PortAction::none },
+  /* empty_full  */  { PortAction::none,       PortAction::none,       PortAction::none,         PortAction::none },
+  /* full_empty  */  { PortAction::none,       PortAction::none,       PortAction::none,         PortAction::none },
+  /* full_full   */  { PortAction::none,       PortAction::none,       PortAction::none,         PortAction::none },
+
+  /* error       */  { PortAction::none,       PortAction::none,       PortAction::none,         PortAction::none },
+  /* done        */  { PortAction::none,       PortAction::none,       PortAction::none,         PortAction::none },
+  };
+
 // clang-format on
 
-  }  // namespace
+}  // namespace
 
 /**
  * Class representing states of a bound source and sink node.
  * The class is agnostic as to how the events are actually
  * implemented by the users of the the state machine.
  *
- * Todo: Derived class to represent bound nodes.
  */
-class PortStateMachine {
+template <class ActionPolicy>
+class PortFiniteStateMachine {
  private:
   PortState state_;
+  PortState next_state_;
 
  public:
   /**
    * Default constructor
    */
-  PortStateMachine()
-      : state_(PortState::empty_full){};
+  PortFiniteStateMachine()
+      : state_(PortState::empty_empty){};
 
   /**
    * Return the current state
    */
   [[nodiscard]] inline PortState state() const {
     return state_;
+  }
+
+  /**
+   * Return the next state
+   */
+  [[nodiscard]] inline PortState next_state() const {
+    return next_state_;
+  }
+
+  /**
+   * Set state
+   */
+  inline PortState set_state(PortState next_state_) {
+    state_ = next_state_;
+    return state_;
+  }
+
+  /**
+   * Set next state
+   */
+  inline PortState set_next_state(PortState next_state) {
+    next_state_ = next_state;
+    return next_state_;
   }
 
  public:
@@ -274,28 +539,199 @@ class PortStateMachine {
    * events so that the procession of steps is driven by the state machine
    * rather than the user of the state machine.
    *
-   * Some code that prints state information is currently included for debugging
-   * purposes.
+   * Some code that prints state information is currently included for
+   * debugging purposes.
    *
    * @param event The event to be processed
-   * @param event msg A debugging string to preface printout information for the
-   * state transition
+   * @param event msg A debugging string to preface printout information for
+   * the state transition
    */
+  std::mutex mutex_;
+  bool debug_{false};
+
+  using lock_type = std::unique_lock<std::mutex>;
+
   void event(PortEvent event, const std::string msg = "") {
-    auto new_state{transition_table[to_index(state_)][to_index(event)]};
+    std::unique_lock lock(mutex_);
+
+    next_state_ = transition_table[to_index(state_)][to_index(event)];
+    auto exit_action{exit_table[to_index(state_)][to_index(event)]};
+    auto entry_action{entry_table[to_index(next_state_)][to_index(event)]};
 
     if (msg != "") {
-      std::cout << msg + " " + str(event) + ": " + str(state_) + " -> " +
-                       str(new_state)
-                << std::endl;
+      std::cout << "On event start: " + msg + " " + str(event) + ": " +
+                       str(state_) + " (" + str(exit_action) + ") -> (" +
+                       str(entry_action)
+                << ") " + str(next_state_) << std::endl;
+    }
+
+    /**
+     * Perform any exit actions.
+     */
+    switch (exit_action) {
+      case PortAction::none:
+        break;
+
+      case PortAction::ac_return:
+        if (debug_)
+          std::cout << "      exit about to ac_return" << std::endl;
+        static_cast<ActionPolicy&>(*this).on_ac_return(lock);
+        return;
+        break;
+
+      case PortAction::src_swap:
+        if (debug_)
+          std::cout << "      exit about to src_swap" << std::endl;
+        static_cast<ActionPolicy&>(*this).on_source_swap(lock);
+        break;
+
+      case PortAction::snk_swap:
+        if (debug_)
+          std::cout << "      exit about to snk_swap" << std::endl;
+        static_cast<ActionPolicy&>(*this).on_sink_swap(lock);
+        break;
+
+      default:
+        throw std::logic_error("Unexpected entry action");
+    }
+
+    if (msg != "") {
+      if (debug_)
+        std::cout << "Post exit: " + msg + " " + str(event) + ": " +
+                         str(state_) + " (" + str(exit_action) + ") -> (" +
+                         str(entry_action)
+                  << ") " + str(next_state_) << std::endl;
     }
 
     /*
      * Assign new state
      */
-    state_ = new_state;
+    state_ = next_state_;
+
+    entry_action = entry_table[to_index(next_state_)][to_index(event)];
+
+    if (msg != "") {
+      std::cout << "Pre entry event: " + msg + " " + str(event) + ": " +
+                       str(state_) + " (" + str(exit_action) + ") -> (" +
+                       str(entry_action)
+                << ") " + str(next_state_) << std::endl;
+    }
+
+    /**
+     * Perform any entry actions.
+     */
+    switch (entry_action) {
+      case PortAction::none:
+        break;
+
+      case PortAction::ac_return:
+
+        if (debug_)
+          std::cout << "      entry about to ac_return" << std::endl;
+
+        static_cast<ActionPolicy&>(*this).on_ac_return(lock);
+        return;
+        break;
+
+      case PortAction::src_swap:
+
+        if (debug_)
+          std::cout << "      entry about to src_swap" << std::endl;
+
+        static_cast<ActionPolicy&>(*this).on_source_swap(lock);
+        break;
+
+      case PortAction::snk_swap:
+
+        if (debug_)
+          std::cout << "      entry about to sink_swap" << std::endl;
+
+        static_cast<ActionPolicy&>(*this).on_sink_swap(lock);
+        break;
+
+      default:
+        throw std::logic_error("Unexpected entry action");
+    }
+
+    if (msg != "") {
+      std::cout << "Post entry event: " + msg + " " + str(event) + ": " +
+                       str(state_) + " (" + str(exit_action) + ") -> (" +
+                       str(entry_action)
+                << ") " + str(next_state_) << std::endl;
+    }
   }
 };
+
+/**
+ * Null action policy
+ */
+template <class T = size_t>
+class NullStateMachine : public PortFiniteStateMachine<NullStateMachine<T>> {
+  using FSM = PortFiniteStateMachine<NullStateMachine<T>>;
+  using lock_type = typename FSM::lock_type;
+
+ public:
+  inline void on_ac_return() {
+  }
+  inline void on_source_swap() {
+  }
+  inline void on_sink_swap() {
+  }
+};
+
+/**
+ * Debug action policy
+ */
+template <class T = size_t>
+class DebugStateMachine : public PortFiniteStateMachine<DebugStateMachine<T>> {
+  using FSM = PortFiniteStateMachine<DebugStateMachine<T>>;
+
+  using lock_type = typename FSM::lock_type;
+
+ public:
+  inline void on_ac_return(lock_type&) {
+    if (FSM::debug_)
+      std::cout << "    "
+                << "Action return" << std::endl;
+  }
+  inline void on_source_swap(lock_type&) {
+    if (FSM::debug_)
+
+      std::cout << "    "
+                << "Action swap source" << std::endl;
+  }
+  inline void on_sink_swap(lock_type&) {
+    if (FSM::debug_)
+
+      std::cout << "    "
+                << "Action swap sink" << std::endl;
+  }
+};
+
+/**
+ * Debug action policy with some non-copyable elements (to verify compilation)
+ */
+class DebugStateMachineWithLock
+    : public PortFiniteStateMachine<DebugStateMachineWithLock> {
+  std::mutex(mutex_);
+  std::condition_variable sink_cv_;
+  std::condition_variable source_cv_;
+
+ public:
+  inline void on_ac_return(lock_type&) {
+    std::cout << "    "
+              << "Action return" << std::endl;
+  }
+  inline void on_source_swap(lock_type&) {
+    std::cout << "    "
+              << "Action swap source" << std::endl;
+  }
+  inline void on_sink_swap(lock_type&) {
+    std::cout << "    "
+              << "Action swap sink" << std::endl;
+  }
+};
+
 }  // namespace tiledb::common
 
 #endif  // TILEDB_DAG_FSM_H

--- a/experimental/tiledb/common/dag/ports/ports.cc
+++ b/experimental/tiledb/common/dag/ports/ports.cc
@@ -1,0 +1,36 @@
+/**
+ * @file   ports.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the ports classes for dag.
+ */
+
+#include <cassert>
+
+#include "experimental/tiledb/common/dag/ports/ports.h"
+#include "tiledb/common/logger.h"

--- a/experimental/tiledb/common/dag/ports/ports.h
+++ b/experimental/tiledb/common/dag/ports/ports.h
@@ -1,0 +1,329 @@
+/**
+ * @file   ports.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the Source and Sink ports for dag.
+ *
+ *
+ * States for objects containing Source or Sink member variables.
+ *
+ * The design goal of these states is to limit the total number of std::thread
+ * objects that simultaneously exist. Instead of a worker thread blocking
+ * because correspondent source is empty or because a correspondent sink is
+ * full, the worker can simply return. Tasks may become dormant without any
+ * thread that runs them needing to block.
+ *
+ * States:
+ *   Quiescent: initial and final state. No correspondent sources or sinks
+ *   Dormant: Some correspondent exists, but no thread is currently active
+ *   Active: Some correspondent exists, and some thread is currently active
+ *
+ * An element is alive if it is either dormant or active, that is, some
+ * correspondent exists, regardless of thread state.
+ *
+ * Invariant: an element is registered with the scheduler as alive if and only
+ * if the element is alive. Invariant: each element is registered with the
+ * scheduler as either alive or quiescent.
+ *
+ * Todo: Refactor to use a Port base class.
+ */
+
+#ifndef TILEDB_DAG_PORTS_H
+#define TILEDB_DAG_PORTS_H
+
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+
+#include "fsm.h"
+
+namespace tiledb::common {
+
+/* Forward declarations */
+template <class Block>
+class Source;
+
+template <class Block>
+class Sink;
+
+/**
+ * A data flow source, used by both edges and nodes.
+ *
+ * Source objects have three states: empty, full, and ready.
+ */
+template <class Block>
+class Source {
+  friend class Sink<Block>;
+
+  template <class Bl>
+  friend void unbind(Source<Bl>& src);
+
+  /**
+   * @inv If an item is present, `try_send` will succeed.
+   */
+  std::optional<Block> item_{};
+
+  /**
+   * The correspondent Sink, if any
+   */
+  Sink<Block>* correspondent_{nullptr};
+
+ public:
+  /**
+   *
+   */
+  void submit(Block& item) {
+    std::optional<Block> tmp{};
+    std::swap(item_, tmp);
+    (corresponent_->fsm).event(src_data_fill);
+    (corresponent_->fsm).event(source_filled);
+    src_cv.notify_one();
+  }
+
+  void try_swap() {
+    if (ready) {
+      std::swap(item_, correspondent_->item_);
+      (corresponent_->fsm).event(source_swap);
+      signal();
+    }
+  }
+
+  /**
+   * Assign a correspondent for this Source.
+   */
+  void bind(Sink<Block>& predecessor) {
+    if (correspondent_ == nullptr) {
+      correspondent_ = &predecessor;
+    } else {
+      throw std::runtime_error(
+          "Attempting to bind to already bound correspondent");
+    }
+  }
+
+  /**
+   * Check if Sink is bound to a source
+   */
+  bool is_bound() const {
+    return correspondent_ != nullptr;
+  }
+
+  /**
+   * Remove the current correspondent, if any.
+   */
+  void unbind() {
+    correspondent_ = nullptr;
+  }
+};
+
+/**
+ * A data flow sink, used by both edges and nodes.
+ *
+ * Sink objects have two states: empy, full, and ready.
+ */
+template <class Block>
+class Sink {
+  friend class Source<Block>;
+
+  template <class Bl>
+  friend void bind(Source<Bl>& src, Sink<Bl>& snk);
+
+  template <class Bl>
+  friend void unbind(Source<Bl>& src, Sink<Bl>& snk);
+
+  template <class Bl>
+  friend void unbind(Sink<Bl>& snk);
+
+  /**
+   * @inv If an item is present, `try_receive` will succeed.
+   */
+  std::optional<Block> item_;
+
+  /**
+   * The correspondent Source, if any
+   */
+  Source<Block>* correspondent_{nullptr};
+
+  /**
+   * Mutex shared by a correspondent pair. It's defined in only the Sink
+   * arbitrarily.  Protects transfer of data item from Source to the Sink.
+   */
+  std::mutex mutex_;
+
+ public:
+  /**
+   * Notification function to be called by a correspondent Source to signal that
+   * it is ready to send data. If `try_put()` is called immediately, it should
+   * ordinarily succeed.
+   *
+   * At the point of construction it should be as if
+   * ready_to_send(false) was called in the constructor body.
+   *
+   * @pre This Sink object is registered as alive with the Scheduler.
+   */
+  void ready_to_send();
+
+  /**
+   * Retrieve `item_` from the Sink.
+   *
+   * @return The retrieved `item_`.  The return value will be empty if
+   * the `item_` is empty.
+   */
+  std::optional<Block> retrieve() {
+    std::scoped_lock lock(mutex_);
+    std::optional<Block> tmp{};
+    swap(tmp, item_);
+    return tmp;
+  }
+
+  /**
+   * Receive a block from a correspondent Source. Called by the Source.
+   *
+   * If `item_` is empty when `try_put` is called, it will be swapped with
+   * the item being sent and true will be returned.  Otherwise, false will
+   * be returned.
+   *
+   * @return true if items were successfully swapped
+   * @post If return value is true, item_ will be full
+   */
+  bool try_put() {
+    std::scoped_lock lock(mutex_);
+    if (!item_.has_value() && (correspondent_->item_).has_value()) {
+      std::swap(item_, correspondent_->item_);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Assign a correspondent for this Sink.
+   */
+  void bind(Source<Block>& successor) {
+    if (correspondent_ == nullptr) {
+      correspondent_ = &successor;
+    } else {
+      throw std::runtime_error(
+          "Attempting to bind to already bound correspondent");
+    }
+  }
+
+  /**
+   * Check if Sink is bound to a source
+   */
+  bool is_bound() const {
+    return correspondent_ != nullptr;
+  }
+
+  /**
+   * Remove the current correspondent, if any.
+   */
+  void unbind() {
+    if (correspondent_ == nullptr) {
+      throw std::runtime_error("Attempting to unbind unbound correspondent");
+    } else {
+      correspondent_ = nullptr;
+    }
+  }
+};
+
+/**
+ * Assign sink as correspondent to source and vice versa.
+ *
+ * @pre Both src and snk are unbound
+ */
+template <class Block>
+inline void bind(Source<Block>& src, Sink<Block>& snk) {
+  std::scoped_lock(snk.mutex_);
+  src.bind(snk);
+  snk.bind(src);
+  assert(src == snk.correspondent_ && snk == src.correspondent_);
+}
+
+/**
+ * Assign sink as correspondent to source and vice versa.
+ *
+ * @pre Both src and snk are unbound
+ */
+template <class Block>
+inline void bind(Sink<Block>& snk, Source<Block>& src) {
+  bind(src, snk);
+}
+
+/**
+ * Remove the correspondent relationship between a source and sink
+ *
+ * @param src A Souce port
+ * @param snk A Sink port
+ *
+ * @pre `src` and `snk` are in a correspondent relationship.
+ */
+template <class Block>
+inline void unbind(Source<Block>& src, Sink<Block>& snk) {
+  std::scoped_lock(snk.mutex_);
+  assert(src == snk.correspondent_ && snk == src.correspondent_);
+
+  src.unbind();
+  snk.unbind();
+};
+
+/**
+ * Remove the correspondent relationship between a source and sink
+ *
+ * @param snk A Sink port
+ * @param snk A Source port
+ *
+ * @pre `src` and `snk` are in a correspondent relationship.
+ */
+template <class Block>
+inline void unbind(Sink<Block>& snk, Source<Block>& src) {
+  unbind(src, snk);
+};
+
+/**
+ * Remove the correspondent relationship between a Source  and
+ * its correspondent Sink
+ *
+ * @param src A Source port.
+ */
+template <class Block>
+inline void unbind(Source<Block>& src) {
+  unbind(src, *(src.correspondent_));
+};
+
+/**
+ * Remove the correspondent relationship between a Sink and
+ * its correspondent Source
+ *
+ * @param src A Sink port.
+ */
+template <class Block>
+inline void unbind(Sink<Block>& snk) {
+  unbind(*(snk.correspondent_), snk);
+};
+
+}  // namespace tiledb::common
+#endif  // TILEDB_DAG_PORTS_H

--- a/experimental/tiledb/common/dag/ports/ports.h
+++ b/experimental/tiledb/common/dag/ports/ports.h
@@ -56,6 +56,8 @@
 #ifndef TILEDB_DAG_PORTS_H
 #define TILEDB_DAG_PORTS_H
 
+#if 0
+
 #include <condition_variable>
 #include <mutex>
 #include <optional>
@@ -63,6 +65,9 @@
 #include "fsm.h"
 
 namespace tiledb::common {
+
+
+
 
 /* Forward declarations */
 template <class Block>
@@ -326,4 +331,6 @@ inline void unbind(Sink<Block>& snk) {
 };
 
 }  // namespace tiledb::common
+
+#endif
 #endif  // TILEDB_DAG_PORTS_H

--- a/experimental/tiledb/common/dag/ports/test/compile_fsm_main.cc
+++ b/experimental/tiledb/common/dag/ports/test/compile_fsm_main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file compile_fsm_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "../ports.h"
+
+int main() {
+  (void)sizeof(tiledb::common::PortStateMachine);
+  return 0;
+}

--- a/experimental/tiledb/common/dag/ports/test/compile_ports_main.cc
+++ b/experimental/tiledb/common/dag/ports/test/compile_ports_main.cc
@@ -1,0 +1,35 @@
+/**
+ * @file compile_ports_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "../ports.h"
+
+int main() {
+  (void)sizeof(tiledb::common::Sink);
+  (void)sizeof(tiledb::common::Source);
+  return 0;
+}

--- a/experimental/tiledb/common/dag/ports/test/main.cc
+++ b/experimental/tiledb/common/dag/ports/test/main.cc
@@ -1,0 +1,35 @@
+/**
+ * @file experimental/tiledb/common/dag/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "unit_fsm.h"
+#include "unit_ports.h"

--- a/experimental/tiledb/common/dag/ports/test/pseudo_nodes.h
+++ b/experimental/tiledb/common/dag/ports/test/pseudo_nodes.h
@@ -1,0 +1,163 @@
+/**
+ * @file pseudo_nodes.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines some elementary node types for testing
+ */
+
+#ifndef TILEDB_DAG_PSEUDO_NODES_H
+#define TILEDB_DAG_PSEUDO_NODES_H
+
+#include <atomic>
+#include "../ports.h"
+
+namespace tiledb::common {
+
+template <class Block = size_t>
+class generator {
+  std::atomic<Block> N_{0};
+  std::atomic<Block> i_{0};
+
+ public:
+  generator(Block N)
+      : N_{N} {
+  }
+  generator(const generator& rhs)
+      : N_(rhs.N_.load())
+      , i_(rhs.i_.load()) {
+  }
+
+  Block operator()() {
+    return i_++;
+  }
+};
+
+/**
+ * Prototype source node.  Constructed with a function that creates items.
+ */
+template <class Block = size_t>
+class producer_node : public Source<Block> {
+  using Base = Source<Block>;
+  std::atomic<size_t> i_{0};
+  size_t N_{0};
+  std::function<Block()> f_;
+
+ public:
+  /**
+   * Constructor
+   * @param f A function that accepts items.
+   * @tparam The type of the function (or function object) that generates items.
+   */
+  template <class Function>
+  explicit producer_node(Function&& f)
+      : f_{std::forward<Function>(f)} {
+  }
+
+  /**
+   * Generate an output.
+   */
+  void run() {
+    while (true) {
+      auto item = f_();
+      submit(item);
+      wait();
+      try_swap();
+    }
+  }
+};
+
+/**
+ * Consumer function object class.  Takes items and puts them on an Output
+ * Iterator.
+ */
+template <class OutputIterator, class Block = size_t>
+class consumer {
+  OutputIterator iter_;
+
+ public:
+  consumer(OutputIterator iter)
+      : iter_(iter) {
+  }
+  void operator()(Block& item) {
+    *iter_++ = item;
+  }
+};
+
+/**
+ * A proto consumer node.  Constructed with a function that accepts items.
+ */
+template <class Block = size_t>
+class consumer_node : public Sink<Block> {
+  using Base = Sink<Block>;
+  std::function<void(Block&)> f_;
+
+ public:
+  /**
+   * Constructor
+   * @param f A function that accepts items.
+   * @tparam The type of the function (or function object) that accepts items.
+   */
+  template <class Function>
+  explicit consumer_node(Function&& f)
+      : f_{std::forward<Function>(f)} {
+  }
+
+  /**
+   *  Receive an item from a Source
+   */
+  void run() {
+    f_(Base::item_);
+  }
+};
+
+/**
+ * Purely notional proto `function_node`.  Constructed with function that
+ * accepts an item and returns an item.
+ */
+template <class Block>
+class function_node : public Source<Block>, public Sink<Block> {
+  std::function<Block(Block)> f_;
+  using SourceBase = Source<Block>;
+  using SinkBase = Sink<Block>;
+
+ public:
+  template <class Function>
+  function_node(Function&& f)
+      : f_{std::forward<Function>(f)} {
+  }
+
+  /**
+   * Receive an item from a source and put it on a sink.
+   */
+  Block run() {
+    SinkBase::item_ = f_(SourceBase::item_);
+  }
+};
+
+}  // namespace tiledb::common
+#endif  // TILEDB_DAG_PSEUDO_NODES_H

--- a/experimental/tiledb/common/dag/ports/test/unit_fsm.cc
+++ b/experimental/tiledb/common/dag/ports/test/unit_fsm.cc
@@ -1,0 +1,471 @@
+/**
+ * @file unit_fsm.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the ports finite state machine.
+ */
+
+#include "unit_fsm.h"
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include "experimental/tiledb/common/dag/ports/fsm.h"
+
+using namespace tiledb::common;
+
+TEST_CASE("Port FSM: Construct", "[fsm]") {
+  [[maybe_unused]] auto a = PortStateMachine{};
+
+  CHECK(a.state() == PortState::empty_full);
+}
+
+TEST_CASE("Port FSM: Start up", "[fsm]") {
+  [[maybe_unused]] auto a = PortStateMachine{};
+
+  CHECK(a.state() == PortState::empty_full);
+
+  SECTION("start source") {
+    a.event(PortEvent::source_fill);
+    CHECK(a.state() == PortState::full_full);
+  }
+
+  SECTION("start sink") {
+    a.event(PortEvent::sink_drain);
+    CHECK(a.state() == PortState::empty_empty);
+  }
+}
+
+TEST_CASE("Port FSM: Basic manual sequence", "[fsm]") {
+  [[maybe_unused]] auto a = PortStateMachine{};
+
+  CHECK(a.state() == PortState::empty_full);
+
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_full");
+  a.event(PortEvent::sink_drain);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(str(a.state()) == "empty_full");
+
+  a.event(PortEvent::sink_drain);
+  CHECK(str(a.state()) == "empty_empty");
+
+  CHECK(str(a.state()) == "empty_empty");
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(a.state() == PortState::empty_full);
+
+  a.event(PortEvent::sink_drain);
+  CHECK(a.state() == PortState::empty_empty);
+
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(str(a.state()) == "empty_full");
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_full");
+  a.event(PortEvent::sink_drain);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(str(a.state()) == "empty_full");
+
+  a.event(PortEvent::sink_drain);
+  CHECK(a.state() == PortState::empty_empty);
+
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(str(a.state()) == "empty_full");
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_full");
+  a.event(PortEvent::sink_drain);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(str(a.state()) == "empty_full");
+
+  a.event(PortEvent::sink_drain);
+  CHECK(a.state() == PortState::empty_empty);
+
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(str(a.state()) == "empty_full");
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_full");
+  a.event(PortEvent::sink_drain);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(str(a.state()) == "empty_full");
+
+  a.event(PortEvent::sink_drain);
+  CHECK(a.state() == PortState::empty_empty);
+
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(str(a.state()) == "empty_full");
+  a.event(PortEvent::source_fill);
+  CHECK(str(a.state()) == "full_full");
+  a.event(PortEvent::sink_drain);
+  CHECK(str(a.state()) == "full_empty");
+  a.event(PortEvent::swap);
+  CHECK(str(a.state()) == "empty_full");
+
+  a.event(PortEvent::sink_drain);
+  CHECK(a.state() == PortState::empty_empty);
+}
+
+std::string is_src_empty(PortState st) {
+  if (str(st) == "empty_full" || str(st) == "empty_empty") {
+    return {};
+  }
+  return str(st);
+}
+
+std::string is_src_full(PortState st) {
+  if (str(st) == "full_full" || str(st) == "full_empty") {
+    return {};
+  }
+  return str(st);
+}
+
+std::string is_src_post_swap(PortState st) {
+  if (str(st) == "full_empty" || str(st) == "empty_full" ||
+      str(st) == "empty_empty") {
+    return {};
+  }
+  return str(st);
+}
+
+std::string is_snk_empty(PortState st) {
+  if (str(st) == "full_empty" || str(st) == "empty_empty") {
+    return {};
+  }
+  return str(st);
+}
+
+std::string is_snk_full(PortState st) {
+  if (str(st) == "full_full" || str(st) == "empty_full") {
+    return {};
+  }
+  return str(st);
+}
+
+std::string is_snk_post_swap(PortState st) {
+  if (str(st) == "full_empty" || str(st) == "empty_full" ||
+      str(st) == "full_full") {
+    return {};
+  }
+  return str(st);
+}
+
+size_t random_us(size_t max = 7500) {
+  thread_local static uint64_t generator_seed =
+      std::hash<std::thread::id>()(std::this_thread::get_id());
+  thread_local static std::mt19937_64 generator(generator_seed);
+  std::uniform_int_distribution<size_t> distribution(0, max);
+  return distribution(generator);
+}
+
+TEST_CASE("Port FSM: Asynchronous source and sink", "[fsm]") {
+  constexpr bool debug = false;
+
+  [[maybe_unused]] auto a = PortStateMachine{};
+
+  CHECK(str(a.state()) == "empty_full");
+
+  std::mutex mutex_;
+  std::condition_variable source_cv, sink_cv;
+
+  size_t rounds = 37;
+  if (debug)
+    rounds = 3;
+
+  int source_item{0};
+  int sink_item{0};
+
+  int source_swaps{};
+  int sink_swaps{};
+
+  /**
+   * The basic behavior of a user of a source port is described in fsm.h.
+   *
+   * This test function loops for a given number of rounds, executing the
+   * workflow shown in fsm.h. CHECKs are made for each of the predicates
+   * therein.
+   */
+  auto source_node = [&]() {
+    size_t n = rounds;
+
+    // Take a really big lock to keep events atomic with checks.
+    std::unique_lock lock(mutex_);
+
+    // start: { state == empty_full /\ state == empty_empty }
+    CHECK(is_src_empty(a.state()) == "");
+
+    // Event loop for source
+    while (n--) {
+      // Begin production of new item
+      // loop_begin: { state == empty_empty /\ state == empty_full }
+      CHECK(is_src_empty(a.state()) == "");
+      {
+        if (debug)
+          std::cout << "source filling " << str(a.state()) << std::endl;
+
+        // pre_produce: { state == empty_empty /\ state == empty_full }
+        CHECK(is_src_empty(a.state()) == "");
+        lock.unlock();
+        std::this_thread::sleep_for(std::chrono::microseconds(random_us(7500)));
+        lock.lock();
+      }
+
+      CHECK(source_item == 0);
+      source_item = 1;
+
+      a.event(PortEvent::source_fill, debug ? "source" : "");
+
+      // source_fill: { state == full_empty /\ state == full_full }
+      CHECK(is_src_full(a.state()) == "");
+      sink_cv.notify_one();
+      source_cv.wait(lock);
+
+      // post_wait: { state == full_empty \/ state == empty_full \/
+      //             state == empty_empty }
+      CHECK(is_src_post_swap(a.state()) == "");
+
+      if (a.state() == PortState::full_empty) {
+        // pre_swap: { state == full_empty }
+        CHECK(str(a.state()) == "full_empty");
+        if (debug)
+          std::cout << "source swapping " << str(a.state()) << std::endl;
+
+        a.event(PortEvent::swap, debug ? "source" : "");
+        source_swaps++;
+
+        // post_swap: { state == empty_full }
+        CHECK(is_src_empty(a.state()) == "");
+        CHECK(is_snk_full(a.state()) == "");
+
+        // { source_item == 1 /\ sink_item == 0 }
+        CHECK(source_item == 1);
+        CHECK(sink_item == 0);
+        std::swap(source_item, sink_item);
+
+        // { source_item == 0 /\ sink_item == 1 }
+        CHECK(source_item == 0);
+        CHECK(sink_item == 1);
+
+        sink_cv.notify_one();
+      } else {
+        // else_swap: { state == empty_empty \/ state == empty_full }
+        CHECK(is_src_empty(a.state()) == "");
+
+        if (debug)
+
+          std::cout << "source try_swap: "
+                    << port_state_strings[static_cast<int>(a.state())]
+                    << std::endl;
+
+        // { source_item == 0 }
+        CHECK(source_item == 0);
+      }
+    }
+
+    // post_loop: { state == empty_empty }
+    CHECK(is_src_empty(a.state()) == "");
+
+    // { source_item == 0 }
+    CHECK(source_item == 0);
+  };
+
+  /**
+   * The basic behavior of a user of a sink port is described in fsm.h.
+   *
+   * This test function loops for a given number of rounds, executing the
+   * workflow shown in fsm.h. CHECKs are made for each of the predicates
+   * therein.
+   */
+  auto sink_node = [&]() {
+    size_t n = rounds;
+
+    // Take a really big lock to keep events atomic with checks.
+    std::unique_lock lock(mutex_);
+
+    /**
+     * Initialization for sink_node, to emulate it having been filled (necessary
+     * to avoid deadlocking).
+     */
+    // init: { state == empty_full /\ state == full_full }
+    CHECK(is_snk_full(a.state()) == "");
+
+    a.event(PortEvent::sink_drain, debug ? "sink" : "");
+    CHECK(is_snk_empty(a.state()) == "");
+    source_cv.notify_one();
+
+    // Event loop for sink
+    while (n--) {
+      // loop_begin: { state == empty_empty /\ state == full_empty }
+      CHECK(is_snk_empty(a.state()) == "");
+
+      sink_cv.wait(lock);
+
+      // post_wait: { state == full_empty \/ state == empty_full \/
+      //              state == full_full }
+      CHECK(is_snk_post_swap(a.state()) == "");
+
+      if (debug)
+        std::cout << "sink coming out of wait  " << str(a.state()) << std::endl;
+
+      if (a.state() == PortState::full_empty) {
+        // pre_swap: { state == full_empty }
+        CHECK(str(a.state()) == "full_empty");
+        a.event(PortEvent::swap, debug ? "sink" : "");
+
+        // post_swap: { state == full_empty }
+        CHECK(is_src_empty(a.state()) == "");
+        CHECK(is_snk_full(a.state()) == "");
+
+        // { source_item == 1 /\ sink_item == 0 }
+        CHECK(source_item == 1);
+        CHECK(sink_item == 0);
+        std::swap(source_item, sink_item);
+        sink_swaps++;
+
+        // { source_item == 0 /\ sink_item == 1 }
+        CHECK(source_item == 0);
+        CHECK(sink_item == 1);
+
+        source_cv.notify_one();
+      } else {
+        // else_swap: { state == empty_full \/ state == full_full }
+        CHECK(is_snk_full(a.state()) == "");
+
+        if (debug)
+          std::cout << "sink try swap " << str(a.state()) << std::endl;
+
+        // { sink_item == 1 }
+        CHECK(sink_item == 1);
+      }
+
+      // pre_consume: { state == empty_full /\ state == full_full }
+      CHECK(is_snk_full(a.state()) == "");
+      {
+        if (debug)
+          std::cout << "sink retrieving " << str(a.state()) << std::endl;
+
+        lock.unlock();
+        std::this_thread::sleep_for(std::chrono::microseconds(random_us(7500)));
+        lock.lock();
+      }
+      a.event(PortEvent::sink_drain, debug ? "sink" : "");
+
+      // drain: { state == empty_empty /\ state == full_empty }
+      CHECK(is_snk_empty(a.state()) == "");
+
+      CHECK(sink_item == 1);
+      sink_item = 0;
+      source_cv.notify_one();
+    }
+    // post_loop: { state == empty_empty }
+    CHECK(str(a.state()) == "empty_empty");
+
+    // { source_item == 0 /\ sink_item == 0 }
+    CHECK(source_item == 0);
+    CHECK(sink_item == 0);
+  };
+
+  /**
+   * Test asynchronous execution of source and sink functions.  We use different
+   * combinations of orderings for launching the asynchronous tasks, as well as
+   * for waiting on their completion.  For now we use std::async.
+   */
+  SECTION("launch source before sink, get source before sink") {
+    auto fut_a = std::async(std::launch::async, source_node);
+    auto fut_b = std::async(std::launch::async, sink_node);
+
+    fut_a.get();
+    fut_b.get();
+  }
+
+  SECTION("launch sink before source, get source before sink") {
+    auto fut_b = std::async(std::launch::async, sink_node);
+    auto fut_a = std::async(std::launch::async, source_node);
+
+    fut_a.get();
+    fut_b.get();
+  }
+
+  SECTION("launch source before sink, get sink before source") {
+    auto fut_a = std::async(std::launch::async, source_node);
+    auto fut_b = std::async(std::launch::async, sink_node);
+
+    fut_b.get();
+    fut_a.get();
+  }
+
+  SECTION("launch sink before source, get sink before source") {
+    auto fut_b = std::async(std::launch::async, sink_node);
+    auto fut_a = std::async(std::launch::async, source_node);
+
+    fut_b.get();
+    fut_a.get();
+  }
+
+  /** Final check after each section
+   *
+   * The final state should be empty for both source and sink and both items
+   * should be empty.
+   *
+   */
+  // { state == empty_empty }
+  CHECK(str(a.state()) == "empty_empty");
+  CHECK(is_src_empty(a.state()) == "");
+  CHECK(is_snk_empty(a.state()) == "");
+
+  // { source_item == 0 /\ sink_item == 0 }
+  CHECK(source_item == 0);
+  CHECK(sink_item == 0);
+
+  /**
+   * Check that there were an expected number of swaps between the source and
+   * the sink.  In debug mode, print out the number of each.  Over multiple
+   * runs, we expect the number of each to change.
+   */
+  if (debug) {
+    std::cout << source_swaps << " source_swaps and " << sink_swaps
+              << " sink_swaps" << std::endl;
+    CHECK((source_swaps + sink_swaps) == 3);
+  } else {
+    CHECK((source_swaps + sink_swaps) == 37);
+  }
+}

--- a/experimental/tiledb/common/dag/ports/test/unit_fsm.h
+++ b/experimental/tiledb/common/dag/ports/test/unit_fsm.h
@@ -1,0 +1,34 @@
+/**
+ * @file experimental/tiledb/common/thread_pool/test/unit_fsm.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_UNIT_FSM_H
+#define TILEDB_UNIT_FSM_H
+#include <catch.hpp>
+#endif  // TILEDB_UNIT_FSM_H

--- a/experimental/tiledb/common/dag/ports/test/unit_ports.cc
+++ b/experimental/tiledb/common/dag/ports/test/unit_ports.cc
@@ -1,0 +1,218 @@
+/**
+ * @file unit_ports.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the ports classes, `Source` and `Sink`.  We use some pseudo-nodes
+ * for the testing.
+ */
+
+#include "unit_ports.h"
+#include "experimental/tiledb/common/dag/ports/ports.h"
+#include "pseudo_nodes.h"
+
+using namespace tiledb::common;
+
+TEST_CASE("Ports: Test bind", "[ports]") {
+  Source<int> left;
+  Sink<int> right;
+  bind(left, right);
+}
+
+TEST_CASE(
+    "Ports: Test connect proto consumer_node and proto producer_node",
+    "[ports]") {
+  auto pn = Source<size_t>{};
+  auto cn = Sink<size_t>{};
+
+  CHECK(pn.is_bound() == false);
+  CHECK(cn.is_bound() == false);
+
+  bind(pn, cn);
+
+  SECTION("check bound") {
+    CHECK(pn.is_bound() == true);
+    CHECK(cn.is_bound() == true);
+  }
+
+  SECTION("unbind both") {
+    unbind(pn, cn);
+
+    CHECK(pn.is_bound() == false);
+    CHECK(cn.is_bound() == false);
+  }
+
+  SECTION("bind other way") {
+    unbind(pn, cn);
+
+    bind(cn, pn);
+    CHECK(pn.is_bound() == true);
+    CHECK(cn.is_bound() == true);
+  }
+
+  SECTION("unbind and rebind both") {
+    unbind(pn, cn);
+
+    CHECK(pn.is_bound() == false);
+    CHECK(cn.is_bound() == false);
+
+    bind(pn, cn);
+
+    CHECK(pn.is_bound() == true);
+    CHECK(cn.is_bound() == true);
+  }
+
+  SECTION("unbind only pn (member)") {
+    pn.unbind();
+    CHECK(pn.is_bound() == false);
+    CHECK(cn.is_bound() == true);
+    cn.unbind();
+    CHECK(pn.is_bound() == false);
+    CHECK(cn.is_bound() == false);
+  }
+
+  SECTION("unbind only cn (member)") {
+    cn.unbind();
+    CHECK(pn.is_bound() == true);
+    CHECK(cn.is_bound() == false);
+    pn.unbind();
+    CHECK(pn.is_bound() == false);
+    CHECK(cn.is_bound() == false);
+  }
+
+  SECTION("unbind only pn (member)") {
+    pn.unbind();
+    CHECK(pn.is_bound() == false);
+    CHECK(cn.is_bound() == true);
+    cn.unbind();
+    CHECK(pn.is_bound() == false);
+    CHECK(cn.is_bound() == false);
+  }
+
+  SECTION("unbind from cn") {
+    unbind(cn);
+    CHECK(pn.is_bound() == false);
+    CHECK(cn.is_bound() == false);
+  }
+
+  SECTION("unbind from pn") {
+    unbind(pn);
+    CHECK(pn.is_bound() == false);
+    CHECK(cn.is_bound() == false);
+  }
+}
+
+TEST_CASE("Ports: Test exceptions", "[ports]") {
+  auto pn = Source<size_t>{};
+  auto cn = Sink<size_t>{};
+
+  bind(pn, cn);
+
+  SECTION("Invalid bind") {
+    CHECK_THROWS(bind(pn, cn));
+  }
+  SECTION("Invalid bind, one side") {
+    pn.unbind();
+    CHECK_THROWS(bind(pn, cn));
+  }
+  SECTION("Invalid bind, one side") {
+    cn.unbind();
+    CHECK_THROWS(bind(pn, cn));
+  }
+}
+
+TEST_CASE("Ports: Manual set source port values", "[ports]") {
+  Source<size_t> src;
+  Sink<size_t> snk;
+
+  SECTION("set source in bound pair") {
+    bind(src, snk);
+    CHECK(src.try_set(5) == true);
+  }
+  SECTION("set source in unbound src") {
+    CHECK(src.try_set(5) == false);
+  }
+  SECTION("set source that has value") {
+    bind(src, snk);
+    CHECK(src.try_set(5) == true);
+    CHECK(src.try_set(5) == false);
+  }
+}
+
+TEST_CASE("Ports: Manual retrieve sink values", "[ports]") {
+  Source<size_t> src;
+  Sink<size_t> snk;
+
+  SECTION("set source in bound pair") {
+    bind(src, snk);
+    CHECK(snk.retrieve().has_value() == false);
+  }
+}
+
+TEST_CASE("Ports: Manual send and receive", "[ports]") {
+  Source<size_t> src;
+  Sink<size_t> snk;
+
+  bind(src, snk);
+  CHECK(src.try_set(5) == true);
+  CHECK(snk.retrieve().has_value() == false);
+
+  SECTION("transfer value to snk") {
+    CHECK(src.try_get() == true);
+  }
+  SECTION("transfer value to snk, check snk has value") {
+    CHECK(src.try_get() == true);
+    CHECK(snk.retrieve().has_value() == true);
+  }
+  SECTION("transfer value to snk, check snk value") {
+    CHECK(src.try_get() == true);
+    CHECK(snk.retrieve() == 5);
+  }
+  SECTION("transfer value from src") {
+    CHECK(snk.try_put() == true);
+  }
+  SECTION("transfer value to snk, check snk has value") {
+    CHECK(snk.try_put() == true);
+    CHECK(snk.retrieve().has_value() == true);
+  }
+  SECTION("transfer value to snk, check snk value") {
+    CHECK(snk.try_put() == true);
+    CHECK(snk.retrieve() == 5);
+  }
+}
+
+TEST_CASE("Ports: Test construct proto producer_node", "[ports]") {
+  auto gen = generator<size_t>(10UL);
+  auto pn = producer_node<size_t>(std::move(gen));
+}
+
+TEST_CASE("Ports: Test construct proto consumer_node", "[ports]") {
+  std::vector<size_t> v;
+  auto con = consumer<std::back_insert_iterator<std::vector<size_t>>>(
+      std::back_insert_iterator<std::vector<size_t>>(v));
+  auto cn = consumer_node<size_t>(std::move(con));
+}

--- a/experimental/tiledb/common/dag/ports/test/unit_ports.h
+++ b/experimental/tiledb/common/dag/ports/test/unit_ports.h
@@ -1,0 +1,34 @@
+/**
+ * @file experimental/tiledb/common/thread_pool/test/unit_dag.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_UNIT_PORTS_H
+#define TILEDB_UNIT_PORTS_H
+#include <catch.hpp>
+#endif  // TILEDB_UNIT_PORTS_H

--- a/experimental/tiledb/common/dag/utils/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/utils/CMakeLists.txt
@@ -1,0 +1,69 @@
+#
+# experimental/tiledb/common/utils/CMakeLists.txt
+#
+#
+# The MIT License
+#
+# Copyright (c) 2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common NO_POLICY_SCOPE)
+
+list(APPEND SOURCES
+  range_join.cc
+)
+gather_sources(${SOURCES})
+
+#
+# Object library for other units to depend upon
+#
+add_library(utils OBJECT ${SOURCES})
+target_link_libraries(utils PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_utils EXCLUDE_FROM_ALL)
+target_link_libraries(compile_utils PRIVATE utils)
+target_sources(compile_utils PRIVATE test/compile_utils_main.cc)
+
+if (TILEDB_TESTS)
+    add_executable(unit_range_join EXCLUDE_FROM_ALL)
+    target_link_libraries(unit_range_join PUBLIC utils)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_range_join PUBLIC Catch2::Catch2)
+    target_link_libraries(unit_range_join PUBLIC $<TARGET_OBJECTS:thread_pool>)
+
+    # Sources for code elsewhere required for tests
+    target_sources(unit_range_join PUBLIC ${DEPENDENT_SOURCES})
+
+    # Sources for tests
+    target_sources(unit_range_join PUBLIC
+            test/main.cc
+            test/unit_range_join.cc
+            )
+
+    add_test(
+            NAME "unit_range_join"
+            COMMAND $<TARGET_FILE:unit_range_join> --durations=yes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/experimental/tiledb/common/dag/utils/arrow_proxy.hpp
+++ b/experimental/tiledb/common/dag/utils/arrow_proxy.hpp
@@ -1,0 +1,6 @@
+
+template <class Reference>
+struct arrow_proxy {
+  Reference  r;
+  Reference* operator->() { return &r; }
+};

--- a/experimental/tiledb/common/dag/utils/bounded_buffer.h
+++ b/experimental/tiledb/common/dag/utils/bounded_buffer.h
@@ -1,0 +1,286 @@
+/**
+ * @file   producer_consumer_queue.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares a classic/basic generic producer-consumer queue.
+ */
+
+#ifndef TILEDB_BOUNDED_BUFFER_H
+#define TILEDB_BOUNDED_BUFFER_H
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <type_traits>
+
+#include <deque>
+#include <queue>
+
+namespace tiledb::common {
+
+template <class Item, class Container, bool Bounded>
+class BoundedBufferQ {
+ public:
+  BoundedBufferQ(size_t max_size = std::numeric_limits<size_t>::max())
+      : max_size_(max_size) {
+  }
+  BoundedBufferQ(const BoundedBufferQ&) = delete;
+  BoundedBufferQ& operator=(const BoundedBufferQ&) = delete;
+
+  BoundedBufferQ(BoundedBufferQ&& rhs)
+      : max_size_(rhs.max_size_)
+      , queue_(std::move(rhs.queue_))
+      , draining_{rhs.draining_.load()}
+      , shutdown_{rhs.shutdown_.load()} {
+  }
+
+  /**
+   * Push an item onto the producer-consumer queue.
+   *
+   * @param item Item to be pushed onto the queue.
+   * @return bool indicating whether the item was successfully pushed or not.
+   */
+  bool push(const Item& item) {
+    std::unique_lock lock{mutex_};
+
+    if constexpr (Bounded) {
+      if (queue_.size() >= max_size_) {
+        full_cv_.wait(lock, [this]() {
+          return queue_.size() < max_size_ || draining_ || shutdown_;
+        });
+      }
+    }
+    if (draining_ || shutdown_) {
+      return false;
+    }
+
+    if constexpr (std::is_same<Container, std::queue<Item>>::value) {
+      queue_.push(item);
+    } else if constexpr (std::is_same<Container, std::deque<Item>>::value) {
+      queue_.push_front(item);
+    } else {
+      // Compile-time error if neither std::queue nor std::deque
+      queue_.no_push(item);
+    }
+
+    empty_cv_.notify_one();
+    return true;
+  }
+
+  /**
+   * Push an item onto the producer-consumer queue.
+   *
+   * @param item Item to be pushed onto the queue.
+   * @return bool indicating whether the item was successfully pushed or not.
+   */
+  bool push(Item&& item) {
+    std::unique_lock lock{mutex_};
+    if constexpr (Bounded) {
+      if (queue_.size() >= max_size_) {
+        full_cv_.wait(lock, [this]() {
+          return queue_.size() < max_size_ || draining_ || shutdown_;
+        });
+      }
+    }
+
+    if (draining_ || shutdown_) {
+      return false;
+    }
+
+    if constexpr (std::is_same<Container, std::queue<Item>>::value) {
+      queue_.push(std::move(item));
+    } else if constexpr (std::is_same<Container, std::deque<Item>>::value) {
+      queue_.push_front(std::move(item));
+    } else {
+      // Compile-time error if neither std::queue nor std::deque
+      queue_.no_push(item);
+    }
+
+    empty_cv_.notify_one();
+    return true;
+  }
+
+  /**
+   * Try to pop an item from the queue.  If no item is available
+   * the function returns nothing.  It does not sleep.
+   *
+   * @returns Item from the queue, if available, otherwise nothing.
+   */
+  std::optional<Item> try_pop() {
+    std::scoped_lock lock{mutex_};
+
+    if (queue_.empty() || draining_ || shutdown_) {
+      return {};
+    }
+    Item item = queue_.front();
+
+    if constexpr (std::is_same<Container, std::queue<Item>>::value) {
+      queue_.pop(item);
+    } else if constexpr (std::is_same<Container, std::deque<Item>>::value) {
+      queue_.pop_front();
+    } else {
+      // Compile-time error if neither std::queue nor std::deque
+      queue_.no_pop(item);
+    }
+
+    full_cv_.notify_one();
+    return item;
+  }
+
+  /**
+   * Pop an item from the queue.  If the queue is empty, the calling
+   * thread will wait on a condition variable until an item becomes
+   * available.  If the queue is empty and the queue is closed
+   * (shutting down), nothing is returned.  If the queue is not
+   * empty and the queue is closed, an item will be returned.
+   *
+   * @returns Item from the queue, if available, otherwise nothing.
+   */
+  std::optional<Item> pop() {
+    std::unique_lock lock{mutex_};
+
+    empty_cv_.wait(
+        lock, [this]() { return !queue_.empty() || draining_ || shutdown_; });
+
+    if ((draining_ && queue_.empty()) || shutdown_) {
+      return {};
+    }
+    Item item = queue_.front();
+
+    if constexpr (std::is_same<Container, std::queue<Item>>::value) {
+      queue_.pop();
+    } else if constexpr (std::is_same<Container, std::deque<Item>>::value) {
+      queue_.pop_front();
+    } else {
+      // Compile-time error if neither std::queue nor std::deque
+      queue_.no_pop(item);
+    }
+
+    full_cv_.notify_one();
+    return item;
+  }
+
+  /**
+   * Pop an item from the back of the queue (if using a deque).
+   * If the queue is empty, the calling
+   * thread will wait on a condition variable until an item becomes
+   * available.  If the queue is empty and the queue is closed
+   * (shutting down), nothing is returned.  If the queue is not
+   * empty and the queue is closed, an item will be returned.
+   *
+   * @returns Item from the queue, if available, otherwise nothing.
+   */
+  template <class Q = Item>
+  typename std::enable_if<
+      std::is_same_v<Container, std::deque<Q>>,
+      std::optional<Q>>::type
+  pop_back() {
+    std::unique_lock lock{mutex_};
+
+    empty_cv_.wait(
+        lock, [this]() { return !queue_.empty() || draining_ || shutdown_; });
+
+    if ((draining_ && queue_.empty()) || shutdown_) {
+      return {};
+    }
+    Item item = queue_.back();
+    queue_.pop_back();
+
+    full_cv_.notify_one();
+    return item;
+  }
+
+  /**
+   * Try to pop an item from the back of the queue (if using a deque).
+   * If the queue is empty or if it is closed (shutting down), return
+   * nothing.
+   *
+   * @returns Item from the queue, if available, otherwise nothing.
+   */
+  template <class Q = Item>
+  typename std::enable_if<
+      std::is_same_v<Container, std::deque<Q>>,
+      std::optional<Q>>::type
+  try_pop_back() {
+    std::unique_lock lock{mutex_};
+
+    if (queue_.empty() || draining_ || shutdown_) {
+      return {};
+    }
+    Item item = queue_.back();
+    queue_.pop_back();
+
+    full_cv_.notify_one();
+    return item;
+  }
+
+  /**
+   * Soft shutdown of the queue.  The queue is closed and all threads waiting on
+   * items are notified.  Any threads waiting on pop() will then return nothing.
+   */
+  void drain() {
+    std::scoped_lock lock{mutex_};
+    draining_ = true;
+    empty_cv_.notify_all();
+    full_cv_.notify_all();
+  }
+
+  /**
+   * Hard shutdown of the queue.  The queue is closed and all threads waiting on
+   * items are notified.  Any threads waiting on pop() will then return nothing.
+   */
+  void shutdown() {
+    std::scoped_lock lock{mutex_};
+    shutdown_ = true;
+    empty_cv_.notify_all();
+    full_cv_.notify_all();
+  }
+
+  /**
+   * TODO: Conditionally include max_size and full_cv.
+   */
+ private:
+  size_t max_size_;
+  Container queue_;
+  std::condition_variable empty_cv_;
+  std::condition_variable full_cv_;
+  mutable std::mutex mutex_;
+  std::atomic<bool> draining_{false};
+  std::atomic<bool> shutdown_{false};
+};
+
+template <class Item, class Container = std::deque<Item>>
+using ProducerConsumerQueue = BoundedBufferQ<Item, Container, false>;
+
+template <class Item, class Container = std::deque<Item>>
+using BoundedBuffer = BoundedBufferQ<Item, Container, true>;
+
+}  // namespace tiledb::common
+
+#endif  // TILEDB_BOUNDED_BUFFER_H

--- a/experimental/tiledb/common/dag/utils/print_types.h
+++ b/experimental/tiledb/common/dag/utils/print_types.h
@@ -1,0 +1,25 @@
+/**
+ * @file print_types.hpp
+ *
+ * @copyright SPDX-FileCopyrightText: 2022 Battelle Memorial Institute
+ * @copyright SPDX-FileCopyrightText: 2022 University of Washington
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * @authors
+ *   Luke D'Alessandro
+ *
+ */
+
+#ifndef PRINT_TYPES_HPP
+#define PRINT_TYPES_HPP
+
+template <class... Ts>
+struct print_types_t;
+
+template <class... Ts>
+constexpr auto print_types(Ts...) {
+  return print_types_t<Ts...>{};
+}
+
+#endif // PRINT_TYPES_HPP

--- a/experimental/tiledb/common/dag/utils/range_join.cc
+++ b/experimental/tiledb/common/dag/utils/range_join.cc
@@ -1,0 +1,1 @@
+#include "range_join.h"

--- a/experimental/tiledb/common/dag/utils/range_join.h
+++ b/experimental/tiledb/common/dag/utils/range_join.h
@@ -1,0 +1,274 @@
+/**
+ * @file   range_join.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares an adaptor for joining a range of containers into
+ * a view of a single container.  Modeled after std::ranges::join (and
+ * derived from NWGraph hierarchical graph container).
+ *
+ * Todo: Add variadic constructor / initializer list constructor so
+ * that a range_join view can be constructed from a collection of
+ * containers, rather than having to explicitly form a container
+ * of containers (which could be expensive to construct).
+ *
+ * Todo: Create a random_access_range view if the constituent inner
+ * ranges are random_access.
+ */
+
+#ifndef TILEDB_RANGE_JOIN_H
+#define TILEDB_RANGE_JOIN_H
+
+#include <iterator>
+#include <tuple>
+#include <utility>
+#include "arrow_proxy.hpp"
+
+namespace tiledb::common {
+
+/*
+ * Some useful type aliases
+ */
+template <class T>
+using const_iterator_t = typename T::const_iterator;
+
+template <class T>
+using iterator_t = typename T::iterator;
+
+template <typename G>
+using inner_range_t = typename G::value_type;
+
+template <typename G>
+using inner_iterator_t = iterator_t<inner_range_t<G>>;
+
+template <typename G>
+using inner_const_iterator_t = const_iterator_t<inner_range_t<G>>;
+
+template <typename G>
+using inner_value_t = typename inner_range_t<G>::value_type;
+
+template <typename G>
+using inner_reference_t = typename inner_range_t<G>::reference;
+
+/**
+ * A joined range view class.  Creates a single view of
+ * a range of ranges.  Currently, creates an input_range
+ * view.
+ */
+template <class RangeOfRanges>
+class join {
+  using range_of_ranges_iterator = std::conditional_t<
+      std::is_const_v<RangeOfRanges>,
+      const_iterator_t<const RangeOfRanges>,
+      iterator_t<RangeOfRanges>>;
+
+  using inner_range_iterator = std::conditional_t<
+      std::is_const_v<RangeOfRanges>,
+      inner_iterator_t<RangeOfRanges>,
+      inner_iterator_t<RangeOfRanges>>;
+
+  range_of_ranges_iterator outer_begin_;
+  range_of_ranges_iterator outer_end_;
+
+ public:
+  /**
+   * Construct view from a range of ranges.  The
+   * resulting view will appear as a single range, equal
+   * to the concatenation of the inner ranges.
+   */
+  explicit join(RangeOfRanges& g)
+      : outer_begin_(g.begin())
+      , outer_end_(g.end()) {
+  }
+
+  // Default copy constructor and assignment operators are fine.
+  join(const join&) = default;
+  join(join&&) = default;
+  join& operator=(const join&) = default;
+  join& operator=(join&&) = default;
+
+  template <bool is_const>
+  class join_iterator {
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = inner_value_t<RangeOfRanges>;
+    using difference_type = std::ptrdiff_t;
+    using reference = inner_reference_t<RangeOfRanges>;
+    using pointer = arrow_proxy<reference>;
+
+   private:
+    range_of_ranges_iterator first_;     //!<
+    range_of_ranges_iterator last_;      //!<
+    inner_range_iterator u_begin_ = {};  //!<
+    inner_range_iterator u_end_ = {};    //!<
+
+    join_iterator(const join_iterator& b, unsigned long step)
+        : join_iterator(b) {
+      first_ += step;
+    }
+
+    void check() {
+      while (u_begin_ == u_end_ &&
+             first_ !=
+                 last_) {  // make sure we start at a valid dereference point
+        if (++first_ != last_) {
+          u_begin_ = (*first_).begin();
+          u_end_ = (*first_).end();
+        } else
+          break;
+      }
+    }
+
+   public:
+    friend join_iterator<!is_const>;
+
+    join_iterator(range_of_ranges_iterator begin, range_of_ranges_iterator end)
+        : first_(begin)
+        , last_(end) {
+      if (first_ != last_) {
+        u_begin_ = (*first_).begin();
+        u_end_ = (*first_).end();
+        check();
+      }
+    }
+
+    join_iterator() = default;
+    join_iterator(const join_iterator&) = default;
+    join_iterator(join_iterator&&) = default;
+
+    template <typename = std::enable_if<is_const>>
+    join_iterator(const join_iterator<false>& rhs)
+        : first_(rhs.first_)
+        , last_(rhs.last_)
+        , u_begin_(rhs.u_begin_)
+        , u_end_(rhs.u_end_) {
+    }
+
+    join_iterator& operator=(const join_iterator&) = default;
+    join_iterator& operator=(join_iterator&&) = default;
+
+    template <typename = std::enable_if<is_const>>
+    join_iterator& operator=(
+        const join_iterator<false>& rhs)  // requires(is_const)
+    {
+      first_ = rhs.first_;
+      last_ = rhs.last_;
+      u_begin_ = rhs.u_begin_;
+      u_end_ = rhs.u_end_;
+      return *this;
+    }
+
+    friend bool operator==(const join_iterator& a, const join_iterator& b) {
+      return a.first_ == b.first_;
+    }
+    friend bool operator!=(const join_iterator& a, const join_iterator& b) {
+      return a.first_ != b.first_;
+    }
+    friend auto operator<(const join_iterator& a, const join_iterator& b) {
+      return a.first_ < b.first_;
+    }
+    friend auto operator<=(const join_iterator& a, const join_iterator& b) {
+      return a.first_ <= b.first_;
+    }
+    friend auto operator>(const join_iterator& a, const join_iterator& b) {
+      return a.first_ > b.first_;
+    }
+    friend auto operator>=(const join_iterator& a, const join_iterator& b) {
+      return a.first_ >= b.first_;
+    }
+
+    join_iterator& operator++() {
+      ++u_begin_;
+
+      check();
+      return *this;
+    }
+
+    join_iterator operator++(int) const {
+      join_iterator it = *this;
+      ++(*this);
+      return it;
+    }
+
+    reference operator*() const {
+      return reference(*u_begin_);
+    }
+
+    pointer operator->() const {
+      return {**this};
+    }
+
+    difference_type operator-(const join_iterator& b) const {
+      return first_ - b.first_;
+    }
+    join_iterator operator+(difference_type step) const {
+      return join_iterator(*this, step);
+    }
+  };
+
+  using iterator = join_iterator<false>;
+  using const_iterator = join_iterator<true>;
+
+  using value_type = typename iterator::value_type;
+  using reference = typename iterator::reference;
+
+  iterator begin() {
+    return {outer_begin_, outer_end_};
+  }
+  const_iterator begin() const {
+    return {outer_begin_, outer_end_};
+  }
+  const_iterator cbegin() const {
+    return {outer_begin_, outer_end_};
+  }
+
+  iterator end() {
+    return {outer_end_, outer_end_};
+  }
+  const_iterator end() const {
+    return {outer_end_, outer_end_};
+  }
+  const_iterator cend() const {
+    return {outer_end_, outer_end_};
+  }
+
+  std::size_t size() const {
+    return std::distance(outer_begin_, outer_end_);
+  }
+  bool empty() const {
+    return begin() == end();
+  }
+};
+
+template <class RangeOfRanges>
+static inline join<RangeOfRanges> make_join(RangeOfRanges& g) {
+  return {g};
+}
+
+}  // namespace tiledb::common
+
+#endif  // TILEDB_RANGE_JOIN_H

--- a/experimental/tiledb/common/dag/utils/test/main.cc
+++ b/experimental/tiledb/common/dag/utils/test/main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file experimental/tiledb/common/dag/utils/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>

--- a/experimental/tiledb/common/dag/utils/test/unit_range_join.cc
+++ b/experimental/tiledb/common/dag/utils/test/unit_range_join.cc
@@ -1,0 +1,177 @@
+/**
+ * @file unit_join.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the join class.
+ */
+
+#include <iostream>
+#include <list>
+#include <vector>
+#include "external/include/span/span.hpp"
+
+#include "catch.hpp"
+#include "experimental/tiledb/common/dag/utils/range_join.h"
+
+using namespace tiledb::common;
+
+TEST_CASE("Join: Test construct", "[join]") {
+}
+
+TEST_CASE("Join: Test list of list", "[join]") {
+  std::list<int> a{1, 2, 3, 4};
+  std::list<int> b{5, 6, 7, 8};
+  std::list<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+  std::list<std::list<int>> d{a, b};
+  auto e = join(d);
+
+  SECTION("check c vs e") {
+    CHECK(std::equal(c.begin(), c.end(), e.begin()));
+  }
+  SECTION("check e vs c") {
+    CHECK(std::equal(e.begin(), e.end(), c.begin()));
+  }
+}
+
+TEST_CASE("Join: Test list of vector", "[join]") {
+  std::vector<int> a{1, 2, 3, 4};
+  std::vector<int> b{5, 6, 7, 8};
+  std::list<std::vector<int>> d{a, b};
+  auto e = join(d);
+
+  SECTION("check c vs e, list") {
+    std::list<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(c.begin(), c.end(), e.begin()));
+  }
+  SECTION("check e vs c, list") {
+    std::list<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(e.begin(), e.end(), c.begin()));
+  }
+  SECTION("check c vs e, vector") {
+    std::vector<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(c.begin(), c.end(), e.begin()));
+  }
+  SECTION("check e vs c, vector") {
+    std::vector<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(e.begin(), e.end(), c.begin()));
+  }
+}
+
+TEST_CASE("Join: Test vector of lists", "[join]") {
+  std::list<int> a{1, 2, 3, 4};
+  std::list<int> b{5, 6, 7, 8};
+  std::vector<std::list<int>> d{a, b};
+  auto e = join(d);
+
+  SECTION("check c vs e, list") {
+    std::list<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(c.begin(), c.end(), e.begin()));
+  }
+  SECTION("check e vs c, list") {
+    std::list<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(e.begin(), e.end(), c.begin()));
+  }
+  SECTION("check c vs e, vector") {
+    std::vector<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(c.begin(), c.end(), e.begin()));
+  }
+  SECTION("check e vs c, vector") {
+    std::vector<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(e.begin(), e.end(), c.begin()));
+  }
+}
+
+TEST_CASE("Join: Test list of spans", "[join]") {
+  std::vector<int> a{1, 2, 3, 4};
+  std::vector<int> b{5, 6, 7, 8};
+  std::list<tcb::span<int>> d{tcb::span<int>{a}, tcb::span<int>{b}};
+  auto e = join(d);
+
+  SECTION("check c vs e, list") {
+    std::list<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(c.begin(), c.end(), e.begin()));
+  }
+  SECTION("check e vs c, list") {
+    std::list<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(e.begin(), e.end(), c.begin()));
+  }
+  SECTION("check c vs e, vector") {
+    std::vector<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(c.begin(), c.end(), e.begin()));
+  }
+  SECTION("check e vs c, vector") {
+    std::vector<int> c{1, 2, 3, 4, 5, 6, 7, 8};
+    CHECK(std::equal(e.begin(), e.end(), c.begin()));
+  }
+}
+
+TEST_CASE("Join: Truncated list of spans", "[join]") {
+  std::vector<int> a{1, 2, 3, 4};
+  std::vector<int> b{5, 6, 7, 8};
+  std::list<tcb::span<int>> d{tcb::span<int>{a.data(), a.size() - 1},
+                              tcb::span<int>{b.data(), b.size() - 2}};
+  auto e = join(d);
+
+  SECTION("check c vs e, list") {
+    std::list<int> c{1, 2, 3, 5, 6};
+    CHECK(std::equal(c.begin(), c.end(), e.begin()));
+  }
+  SECTION("check e vs c, list") {
+    std::list<int> c{1, 2, 3, 5, 6};
+    CHECK(std::equal(e.begin(), e.end(), c.begin()));
+  }
+  SECTION("check c vs e, vector") {
+    std::vector<int> c{1, 2, 3, 5, 6};
+    CHECK(std::equal(c.begin(), c.end(), e.begin()));
+  }
+  SECTION("check e vs c, vector") {
+    std::vector<int> c{1, 2, 3, 5, 6};
+    CHECK(std::equal(e.begin(), e.end(), c.begin()));
+  }
+}
+
+TEST_CASE("Join: join of join", "[join]") {
+  std::vector<int> a{1, 2, 3, 4};
+  std::vector<int> b{5, 6, 7, 8};
+  std::vector<int> c{9, 10, 11, 12};
+  std::vector<int> d{13, 14, 15, 16};
+  std::list<std::vector<int>> e{std::vector<int>{a}, std::vector<int>{b}};
+  std::list<std::vector<int>> f{std::vector<int>{c}, std::vector<int>{d}};
+  auto g = join(e);
+  auto h = join(f);
+  std::list<join<std::list<std::vector<int>>>> i{g, h};
+  auto j = join{i};
+  std::list<int> k{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
+  SECTION("check j vs k") {
+    CHECK(std::equal(j.begin(), j.end(), k.begin()));
+  }
+  SECTION("check k vs j") {
+    CHECK(std::equal(k.begin(), k.end(), j.begin()));
+  }
+}


### PR DESCRIPTION
Initial scaffolding for task graph API, for comment only.  Primary classes of interest are `Source` and `Sink`, which will essentially be "data ports" for task graph nodes.  Source is a provider of data; `Sink` is a consumer of data.  Also provided are APIs for an `Edge` class and an `EdgeQueue` class; an `Edge` contains an `EdgeQueue` and connects a `Source` to a `Sink`.  As currently envisioned, a task graph will pass `DataBlock`s, which are fixed-size containers of bytes.

The code has been developed in the experimental directory and includes necessary cmake files to build its unit tests. 

The primary focus of this iteration has been on the `Source` and `Sink` port.  The nodes can be bound together so they communicate with each other:  a `Source` port sends data to a `Sink` port. The data contained in a `Sink` is held in an internal data member `item_`.  Similarly, `Sink` has a data member `item_` to receive data.  Functionality of the data transfer is accomplished via a simple finite-state machine defined in fsm.h.

A unit test `unit_fsm` contains some basic tests of the transitions in the finite-state machine, as well as an emulation of an asynchronous producer task sending data to an asynchronous consumer task.

---
TYPE: NO_HISTORY 
DESC: Comment only.  Initial scaffolding for task graph API.
