### PR TITLE
Dense reader: improving parallelization.

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -244,6 +244,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray_partitioner.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray_tile_overlap.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/tile_cell_slab_iter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/generic_tile_io.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile_metadata_generator.cc

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -615,7 +615,7 @@ DenseReader::apply_query_condition(
               // clause.
               auto&& [overlaps, start, end] = cell_slab_overlaps_range(
                   dim_num,
-                  frag_domains[i].second,
+                  frag_domains[i].domain(),
                   iter.cell_slab_coords(),
                   iter.cell_slab_length());
               if (overlaps) {
@@ -627,10 +627,10 @@ DenseReader::apply_query_condition(
                 }
 
                 RETURN_NOT_OK(condition_.apply_dense(
-                    *(fragment_metadata_[frag_domains[i].first]
+                    *(fragment_metadata_[frag_domains[i].fid()]
                           ->array_schema()
                           .get()),
-                    it->second.result_tile(frag_domains[i].first),
+                    it->second.result_tile(frag_domains[i].fid()),
                     start,
                     end - start + 1,
                     iter.pos_in_tile(),
@@ -921,7 +921,7 @@ Status DenseReader::copy_fixed_tiles(
   std::vector<ResultTile::TileTuple*> tile_tuples(frag_domains.size());
   for (uint32_t fd = 0; fd < frag_domains.size(); ++fd) {
     tile_tuples[fd] =
-        result_space_tile.result_tile(frag_domains[fd].first)->tile_tuple(name);
+        result_space_tile.result_tile(frag_domains[fd].fid())->tile_tuple(name);
     assert(tile_tuples[fd] != nullptr);
   }
 
@@ -953,7 +953,7 @@ Status DenseReader::copy_fixed_tiles(
       // If the cell slab overlaps this fragment domain range, copy data.
       auto&& [overlaps, start, end] = cell_slab_overlaps_range(
           dim_num,
-          frag_domains[fd].second,
+          frag_domains[fd].domain(),
           iter.cell_slab_coords(),
           iter.cell_slab_length());
       if (overlaps) {
@@ -1109,7 +1109,7 @@ Status DenseReader::copy_offset_tiles(
   std::vector<ResultTile::TileTuple*> tile_tuples(frag_domains.size());
   for (uint32_t fd = 0; fd < frag_domains.size(); ++fd) {
     tile_tuples[fd] =
-        result_space_tile.result_tile(frag_domains[fd].first)->tile_tuple(name);
+        result_space_tile.result_tile(frag_domains[fd].fid())->tile_tuple(name);
     assert(tile_tuples[fd] != nullptr);
   }
 
@@ -1144,7 +1144,7 @@ Status DenseReader::copy_offset_tiles(
       // If the cell slab overlaps this fragment domain range, copy data.
       auto&& [overlaps, start, end] = cell_slab_overlaps_range(
           dim_num,
-          frag_domains[fd].second,
+          frag_domains[fd].domain(),
           iter.cell_slab_coords(),
           iter.cell_slab_length());
       if (overlaps) {

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -43,7 +43,6 @@
 #include "tiledb/sm/query/result_tile.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
-#include "tiledb/sm/subarray/cell_slab_iter.h"
 #include "tiledb/sm/subarray/subarray.h"
 
 using namespace tiledb;
@@ -251,6 +250,14 @@ Status DenseReader::dense_read() {
   const auto dim_num = array_schema_.dim_num();
   auto& subarray = read_state_.partitioner_.current();
   RETURN_NOT_OK(subarray.compute_tile_coords<DimType>());
+  const auto& domain{array_schema_.domain()};
+
+  // Cache tile extents.
+  std::vector<DimType> tile_extents(dim_num);
+  for (uint32_t d = 0; d < dim_num; d++) {
+    tile_extents[d] =
+        *reinterpret_cast<const DimType*>(domain.tile_extent(d).data());
+  }
 
   // Compute result space tiles. The result space tiles hold all the
   // relevant result tiles of the dense fragments.
@@ -284,7 +291,7 @@ Status DenseReader::dense_read() {
 
   // Compute tile offsets for global order or range info for row/col major.
   std::vector<uint64_t> tile_offsets;
-  std::vector<RangeInfo> range_info(dim_num);
+  std::vector<RangeInfo<DimType>> range_info(dim_num);
 
   if (layout_ == Layout::GLOBAL_ORDER) {
     tile_offsets.reserve(tile_coords.size());
@@ -300,8 +307,11 @@ Status DenseReader::dense_read() {
 
       // Compute the 1D offset for every range in this dimension.
       range_info[d].cell_offsets_.reserve(ranges.size());
+      range_info[d].mins_.reserve(ranges.size());
       uint64_t offset = 0;
       for (uint64_t r = 0; r < ranges.size(); r++) {
+        range_info[d].mins_.emplace_back(
+            *static_cast<const DimType*>(ranges[r].start_fixed()));
         range_info[d].cell_offsets_.emplace_back(offset);
 
         // Increment the offset with the number of cells in this 1D range.
@@ -328,6 +338,14 @@ Status DenseReader::dense_read() {
       mult *= range_info[d].multiplier_;
       range_info[d].multiplier_ = saved;
     }
+  }
+
+  // Compute parallelization parameters.
+  uint64_t num_range_threads = 1;
+  const auto num_threads = storage_manager_->compute_tp()->concurrency_level();
+  if (tile_coords.size() < num_threads) {
+    // Ceil the division between thread_num and tile_num.
+    num_range_threads = 1 + ((num_threads - 1) / tile_coords.size());
   }
 
   // Compute attribute names to load and copy.
@@ -362,29 +380,42 @@ Status DenseReader::dense_read() {
   RETURN_CANCEL_OR_ERROR(
       load_tile_offsets(read_state_.partitioner_.subarray(), names));
 
-  // Read and unfilter tiles.
-  RETURN_CANCEL_OR_ERROR(read_attribute_tiles(names, result_tiles));
-
-  for (const auto& name : names) {
-    RETURN_CANCEL_OR_ERROR(unfilter_tiles(name, result_tiles));
-  }
-
-  // Compute the result of the query condition.
   auto&& [st, qc_result] = apply_query_condition<DimType, OffType>(
-      subarray, tile_subarrays, tile_offsets, range_info, result_space_tiles);
-  RETURN_CANCEL_OR_ERROR(st);
-
-  // Copy attribute data to users buffers.
-  status = copy_attributes<DimType, OffType>(
-      fixed_names,
-      var_names,
       subarray,
+      tile_extents,
+      result_tiles,
       tile_subarrays,
       tile_offsets,
       range_info,
       result_space_tiles,
-      *qc_result);
-  RETURN_CANCEL_OR_ERROR(status);
+      num_range_threads);
+  RETURN_CANCEL_OR_ERROR(st);
+
+  // Process attributes.
+  std::vector<std::string> to_read(1);
+  for (auto& name : names) {
+    if (condition_.field_names().count(name) == 0) {
+      // Read and unfilter tiles.
+      to_read[0] = name;
+      RETURN_CANCEL_OR_ERROR(read_attribute_tiles(to_read, result_tiles));
+      RETURN_CANCEL_OR_ERROR(unfilter_tiles(name, result_tiles));
+    }
+
+    // Copy attribute data to users buffers.
+    status = copy_attribute<DimType, OffType>(
+        name,
+        tile_extents,
+        subarray,
+        tile_subarrays,
+        tile_offsets,
+        range_info,
+        result_space_tiles,
+        *qc_result,
+        num_range_threads);
+    RETURN_CANCEL_OR_ERROR(status);
+
+    clear_tiles(name, result_tiles);
+  }
 
   if (read_state_.overflowed_)
     Status::Ok();
@@ -502,10 +533,13 @@ template <class DimType, class OffType>
 tuple<Status, optional<std::vector<uint8_t>>>
 DenseReader::apply_query_condition(
     Subarray& subarray,
+    const std::vector<DimType>& tile_extents,
+    std::vector<ResultTile*>& result_tiles,
     std::vector<Subarray>& tile_subarrays,
     std::vector<uint64_t>& tile_offsets,
-    const std::vector<RangeInfo>& range_info,
-    std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles) {
+    const std::vector<RangeInfo<DimType>>& range_info,
+    std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
+    const uint64_t num_range_threads) {
   auto timer_se = stats_->start_timer("apply_query_condition");
   std::vector<uint8_t> qc_result;
   if (!condition_.empty()) {
@@ -514,9 +548,21 @@ DenseReader::apply_query_condition(
     const auto cell_num = subarray.cell_num();
     const auto dim_num = array_schema_.dim_num();
     auto stride = array_schema_.domain().stride<DimType>(layout_);
-    const auto& domain{array_schema_.domain()};
     const auto cell_order = array_schema_.cell_order();
     const auto global_order = layout_ == Layout::GLOBAL_ORDER;
+
+    // Compute the result of the query condition.
+    std::vector<std::string> qc_names;
+    qc_names.reserve(condition_.field_names().size());
+    for (auto& name : condition_.field_names()) {
+      qc_names.emplace_back(name);
+    }
+
+    // Read and unfilter query condition attributes.
+    RETURN_CANCEL_OR_ERROR_TUPLE(read_attribute_tiles(qc_names, result_tiles));
+    for (auto& name : qc_names) {
+      RETURN_CANCEL_OR_ERROR_TUPLE(unfilter_tiles(name, result_tiles));
+    }
 
     if (stride == UINT64_MAX) {
       stride = 1;
@@ -526,42 +572,41 @@ DenseReader::apply_query_condition(
     qc_result.resize(cell_num, 1);
 
     // Process all tiles in parallel.
-    auto status = parallel_for(
-        storage_manager_->compute_tp(), 0, tile_coords.size(), [&](uint64_t t) {
+    auto status = parallel_for_2d(
+        storage_manager_->compute_tp(),
+        0,
+        tile_coords.size(),
+        0,
+        num_range_threads,
+        [&](uint64_t t, uint64_t range_thread_idx) {
           // Find out result space tile and tile subarray.
           const DimType* tc = (DimType*)&tile_coords[t][0];
           auto it = result_space_tiles.find(tc);
           assert(it != result_space_tiles.end());
 
+          // Iterate over all coordinates, retrieved in cell slab.
           const auto& frag_domains = it->second.frag_domains();
-          uint64_t cell_offset = global_order ? tile_offsets[t] : 0;
+          TileCellSlabIter<DimType> iter(
+              range_thread_idx,
+              num_range_threads,
+              subarray,
+              tile_subarrays[t],
+              tile_extents,
+              it->second.start_coords(),
+              range_info,
+              cell_order);
+
+          // Compute cell offset and destination pointer.
+          uint64_t cell_offset =
+              global_order ? tile_offsets[t] + iter.global_offset() : 0;
           auto dest_ptr = qc_result.data() + cell_offset;
 
-          // Iterate over all coordinates, retrieved in cell slab.
-          CellSlabIter<DimType> iter(&tile_subarrays[t]);
-          RETURN_NOT_OK(iter.begin());
           while (!iter.end()) {
-            auto cell_slab = iter.cell_slab();
-
             // Compute destination pointer for row/col major orders.
             if (!global_order) {
-              cell_offset = get_dest_cell_offset_row_col(
-                  dim_num,
-                  subarray,
-                  tile_subarrays[t],
-                  cell_slab.coords_.data(),
-                  iter.range_coords(),
-                  range_info);
+              cell_offset = iter.dest_offset_row_col();
               dest_ptr = qc_result.data() + cell_offset;
             }
-
-            // Get the source cell offset.
-            uint64_t src_cell = get_cell_pos_in_tile(
-                cell_order,
-                dim_num,
-                domain,
-                it->second,
-                cell_slab.coords_.data());
 
             for (int32_t i = static_cast<int32_t>(frag_domains.size()) - 1;
                  i >= 0;
@@ -571,8 +616,8 @@ DenseReader::apply_query_condition(
               auto&& [overlaps, start, end] = cell_slab_overlaps_range(
                   dim_num,
                   frag_domains[i].second,
-                  cell_slab.coords_.data(),
-                  cell_slab.length_);
+                  iter.cell_slab_coords(),
+                  iter.cell_slab_length());
               if (overlaps) {
                 // Re-initialize the bitmap to 1 in case of overlapping domains.
                 if (i != static_cast<int32_t>(frag_domains.size()) - 1) {
@@ -588,7 +633,7 @@ DenseReader::apply_query_condition(
                     it->second.result_tile(frag_domains[i].first),
                     start,
                     end - start + 1,
-                    src_cell,
+                    iter.pos_in_tile(),
                     stride,
                     dest_ptr));
               }
@@ -596,7 +641,7 @@ DenseReader::apply_query_condition(
 
             // Adjust the destination pointers for global order.
             if (global_order) {
-              dest_ptr += cell_slab.length_;
+              dest_ptr += iter.cell_slab_length();
             }
 
             ++iter;
@@ -648,67 +693,45 @@ uint64_t DenseReader::fix_offsets_buffer(
 }
 
 template <class DimType, class OffType>
-Status DenseReader::copy_attributes(
-    const std::vector<std::string>& fixed_names,
-    const std::vector<std::string>& var_names,
+Status DenseReader::copy_attribute(
+    const std::string& name,
+    const std::vector<DimType>& tile_extents,
     const Subarray& subarray,
     const std::vector<Subarray>& tile_subarrays,
     const std::vector<uint64_t>& tile_offsets,
-    const std::vector<RangeInfo>& range_info,
+    const std::vector<RangeInfo<DimType>>& range_info,
     std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
-    const std::vector<uint8_t>& qc_result) {
-  auto timer_se = stats_->start_timer("copy_attributes");
+    const std::vector<uint8_t>& qc_result,
+    const uint64_t num_range_threads) {
+  auto timer_se = stats_->start_timer("copy_attribute");
 
   // For easy reference
   const auto& tile_coords = subarray.tile_coords();
   const auto cell_num = subarray.cell_num();
   const auto global_order = layout_ == Layout::GLOBAL_ORDER;
 
-  if (!var_names.empty()) {
+  if (array_schema_.var_size(name)) {
     // Make sure the user offset buffers are big enough.
-    for (auto& name : var_names) {
-      const auto required_size =
-          (cell_num + offsets_extra_element_) * sizeof(OffType);
-      if (required_size > *buffers_[name].buffer_size_) {
-        read_state_.overflowed_ = true;
-        return Status::Ok();
-      }
+    const auto required_size =
+        (cell_num + offsets_extra_element_) * sizeof(OffType);
+    if (required_size > *buffers_[name].buffer_size_) {
+      read_state_.overflowed_ = true;
+      return Status::Ok();
     }
 
     // Vector to hold pointers to the var data.
-    std::vector<std::vector<void*>> var_data(var_names.size());
-    for (auto& var_data_buff : var_data) {
-      var_data_buff.resize(cell_num);
-    }
+    std::vector<void*> var_data(cell_num);
 
-    // Make some vectors to prevent map lookups.
-    std::vector<uint8_t*> dst_off_bufs;
-    std::vector<uint8_t*> dst_var_bufs;
-    std::vector<uint8_t*> dst_val_bufs;
-    std::vector<const Attribute*> attributes;
-    std::vector<uint64_t> data_type_sizes;
-    dst_off_bufs.reserve(var_names.size());
-    dst_var_bufs.reserve(var_names.size());
-    dst_val_bufs.reserve(var_names.size());
-    attributes.reserve(var_names.size());
-    data_type_sizes.reserve(var_names.size());
-
-    for (auto& name : var_names) {
-      dst_off_bufs.push_back((uint8_t*)buffers_[name].buffer_);
-      dst_var_bufs.push_back((uint8_t*)buffers_[name].buffer_var_);
-      dst_val_bufs.push_back(buffers_[name].validity_vector_.buffer());
-      attributes.push_back(array_schema_.attribute(name));
-      data_type_sizes.push_back(datatype_size(array_schema_.type(name)));
-    }
-
-    // Process offsets in parallel.
+    // Process offsets.
     {
       auto timer_se = stats_->start_timer("copy_offset_tiles");
-      auto status = parallel_for(
+      auto status = parallel_for_2d(
           storage_manager_->compute_tp(),
           0,
           tile_coords.size(),
-          [&](uint64_t t) {
+          0,
+          num_range_threads,
+          [&](uint64_t t, uint64_t range_thread_idx) {
             // Find out result space tile and tile subarray.
             const DimType* tc = (DimType*)&tile_coords[t][0];
             auto it = result_space_tiles.find(tc);
@@ -716,117 +739,96 @@ Status DenseReader::copy_attributes(
 
             // Copy the tile offsets.
             return copy_offset_tiles<DimType, OffType>(
-                var_names,
-                dst_off_bufs,
-                dst_val_bufs,
-                attributes,
-                data_type_sizes,
+                name,
+                tile_extents,
                 it->second,
                 subarray,
                 tile_subarrays[t],
                 global_order ? tile_offsets[t] : 0,
                 var_data,
                 range_info,
-                qc_result);
+                qc_result,
+                range_thread_idx,
+                num_range_threads);
           });
       RETURN_NOT_OK(status);
     }
 
-    // We have the cell lengths in the users buffer, convert to offsets.
-    std::vector<uint64_t> var_buffer_sizes(var_names.size());
+    uint64_t var_buffer_size;
     {
+      // We have the cell lengths in the users buffer, convert to offsets.
       auto timer_se = stats_->start_timer("fix_offset_tiles");
-      auto status = parallel_for(
-          storage_manager_->compute_tp(), 0, var_names.size(), [&](uint64_t n) {
-            const auto& name = var_names[n];
-            const bool nullable = array_schema_.is_nullable(name);
-            var_buffer_sizes[n] = fix_offsets_buffer<OffType>(
-                name, nullable, cell_num, var_data[n]);
+      const bool nullable = array_schema_.is_nullable(name);
+      var_buffer_size =
+          fix_offsets_buffer<OffType>(name, nullable, cell_num, var_data);
 
-            // Make sure the user var buffer is big enough.
-            uint64_t required_var_size = var_buffer_sizes[n];
-            if (elements_mode_)
-              required_var_size *= datatype_size(array_schema_.type(name));
+      // Make sure the user var buffer is big enough.
+      uint64_t required_var_size = var_buffer_size;
+      if (elements_mode_) {
+        required_var_size *= datatype_size(array_schema_.type(name));
+      }
 
-            // Exit early in case of overflow.
-            if (read_state_.overflowed_ ||
-                required_var_size > *buffers_[name].buffer_var_size_) {
-              read_state_.overflowed_ = true;
-              return Status::Ok();
-            }
+      // Exit early in case of overflow.
+      if (read_state_.overflowed_ ||
+          required_var_size > *buffers_[name].buffer_var_size_) {
+        read_state_.overflowed_ = true;
+        return Status::Ok();
+      }
 
-            *buffers_[name].buffer_var_size_ = required_var_size;
-            return Status::Ok();
-          });
-      RETURN_NOT_OK(status);
-    }
-
-    if (read_state_.overflowed_) {
-      return Status::Ok();
+      *buffers_[name].buffer_var_size_ = required_var_size;
     }
 
     {
       auto timer_se = stats_->start_timer("copy_var_tiles");
       // Process var data in parallel.
-      auto status = parallel_for(
+      auto status = parallel_for_2d(
           storage_manager_->compute_tp(),
           0,
           tile_coords.size(),
-          [&](uint64_t t) {
+          0,
+          num_range_threads,
+          [&](uint64_t t, uint64_t range_thread_idx) {
+            // Find out result space tile and tile subarray.
+            const DimType* tc = (DimType*)&tile_coords[t][0];
+            auto it = result_space_tiles.find(tc);
+            assert(it != result_space_tiles.end());
+
             return copy_var_tiles<DimType, OffType>(
-                var_names,
-                dst_var_bufs,
-                dst_off_bufs,
-                data_type_sizes,
+                name,
+                tile_extents,
+                it->second,
                 subarray,
                 tile_subarrays[t],
                 global_order ? tile_offsets[t] : 0,
                 var_data,
                 range_info,
                 t == tile_coords.size() - 1,
-                var_buffer_sizes);
+                var_buffer_size,
+                range_thread_idx,
+                num_range_threads);
 
             return Status::Ok();
           });
       RETURN_NOT_OK(status);
     }
-  }
-
-  if (!fixed_names.empty()) {
-    // Make sure the user fixed buffers are big enough.
-    for (auto& name : fixed_names) {
-      const auto required_size = cell_num * array_schema_.cell_size(name);
-      if (required_size > *buffers_[name].buffer_size_) {
-        read_state_.overflowed_ = true;
-        return Status::Ok();
-      }
-    }
-
-    // Make some vectors to prevent map lookups.
-    std::vector<uint8_t*> dst_bufs;
-    std::vector<uint8_t*> dst_val_bufs;
-    std::vector<const Attribute*> attributes;
-    std::vector<uint64_t> cell_sizes;
-    dst_bufs.reserve(fixed_names.size());
-    dst_val_bufs.reserve(fixed_names.size());
-    attributes.reserve(fixed_names.size());
-    cell_sizes.reserve(fixed_names.size());
-
-    for (auto& name : fixed_names) {
-      dst_bufs.push_back((uint8_t*)buffers_[name].buffer_);
-      dst_val_bufs.push_back(buffers_[name].validity_vector_.buffer());
-      attributes.push_back(array_schema_.attribute(name));
-      cell_sizes.push_back(array_schema_.cell_size(name));
+  } else {
+    // Make sure the user fixed buffer is big enough.
+    const auto required_size = cell_num * array_schema_.cell_size(name);
+    if (required_size > *buffers_[name].buffer_size_) {
+      read_state_.overflowed_ = true;
+      return Status::Ok();
     }
 
     {
       auto timer_se = stats_->start_timer("copy_fixed_tiles");
       // Process values in parallel.
-      auto status = parallel_for(
+      auto status = parallel_for_2d(
           storage_manager_->compute_tp(),
           0,
           tile_coords.size(),
-          [&](uint64_t t) {
+          0,
+          num_range_threads,
+          [&](uint64_t t, uint64_t range_thread_idx) {
             // Find out result space tile and tile subarray.
             const DimType* tc = (DimType*)&tile_coords[t][0];
             auto it = result_space_tiles.find(tc);
@@ -834,17 +836,16 @@ Status DenseReader::copy_attributes(
 
             // Copy the tile fixed values.
             RETURN_NOT_OK(copy_fixed_tiles(
-                fixed_names,
-                dst_bufs,
-                dst_val_bufs,
-                attributes,
-                cell_sizes,
+                name,
+                tile_extents,
                 it->second,
                 subarray,
                 tile_subarrays[t],
                 global_order ? tile_offsets[t] : 0,
                 range_info,
-                qc_result));
+                qc_result,
+                range_thread_idx,
+                num_range_threads));
 
             return Status::Ok();
           });
@@ -852,14 +853,10 @@ Status DenseReader::copy_attributes(
     }
 
     // Set the output size for the fixed buffer.
-    for (auto& name : fixed_names) {
-      const auto required_size = cell_num * array_schema_.cell_size(name);
+    *buffers_[name].buffer_size_ = required_size;
 
-      // Set the output size for the fixed buffer.
-      *buffers_[name].buffer_size_ = required_size;
-
-      if (array_schema_.is_nullable(name))
-        *buffers_[name].validity_vector_.buffer_size() = cell_num;
+    if (array_schema_.is_nullable(name)) {
+      *buffers_[name].validity_vector_.buffer_size() = cell_num;
     }
   }
 
@@ -867,36 +864,10 @@ Status DenseReader::copy_attributes(
 }
 
 template <class DimType>
-uint64_t DenseReader::get_cell_pos_in_tile(
-    const Layout& cell_order,
-    const int32_t dim_num,
-    const Domain& domain,
-    const ResultSpaceTile<DimType>& result_space_tile,
-    const DimType* const coords) {
-  uint64_t pos = 0;
-  uint64_t mult = 1;
-
-  const auto& start = result_space_tile.start_coords();
-  if (cell_order == Layout::COL_MAJOR) {
-    for (int32_t d = 0; d < dim_num; d++) {
-      pos += mult * (coords[d] - start[d]);
-      mult *= *(const DimType*)domain.tile_extent(d).data();
-    }
-  } else {
-    for (auto d = dim_num - 1; d >= 0; d--) {
-      pos += mult * (coords[d] - start[d]);
-      mult *= *(const DimType*)domain.tile_extent(d).data();
-    }
-  }
-
-  return pos;
-}
-
-template <class DimType>
 tuple<bool, uint64_t, uint64_t> DenseReader::cell_slab_overlaps_range(
     const unsigned dim_num,
     const NDRange& ndrange,
-    const DimType* coords,
+    const std::vector<DimType>& coords,
     const uint64_t length) {
   const unsigned slab_dim = (layout_ == Layout::COL_MAJOR) ? 0 : dim_num - 1;
   const DimType slab_start = coords[slab_dim];
@@ -922,92 +893,60 @@ tuple<bool, uint64_t, uint64_t> DenseReader::cell_slab_overlaps_range(
 }
 
 template <class DimType>
-uint64_t DenseReader::get_dest_cell_offset_row_col(
-    const int32_t dim_num,
-    const Subarray& subarray,
-    const Subarray& tile_subarray,
-    const DimType* const coords,
-    const DimType* const range_coords,
-    const std::vector<RangeInfo>& range_info) {
-  uint64_t ret = 0;
-  std::vector<uint64_t> converted_range_coords(dim_num);
-  if (subarray.range_num() > 1) {
-    tile_subarray.get_original_range_coords(
-        range_coords, &converted_range_coords);
-  }
-
-  if (subarray.layout() == Layout::COL_MAJOR) {
-    for (int32_t d = 0; d < dim_num; d++) {
-      auto r = converted_range_coords[d];
-      auto min = *static_cast<const DimType*>(
-          subarray.ranges_for_dim((uint32_t)d)[r].start_fixed());
-      ret += range_info[d].multiplier_ *
-             (coords[d] - min + range_info[d].cell_offsets_[r]);
-    }
-  } else {
-    for (int32_t d = dim_num - 1; d >= 0; d--) {
-      auto r = converted_range_coords[d];
-      auto min = *static_cast<const DimType*>(
-          subarray.ranges_for_dim((uint32_t)d)[r].start_fixed());
-      ret += range_info[d].multiplier_ *
-             (coords[d] - min + range_info[d].cell_offsets_[r]);
-    }
-  }
-
-  return ret;
-}
-
-template <class DimType>
 Status DenseReader::copy_fixed_tiles(
-    const std::vector<std::string>& names,
-    const std::vector<uint8_t*>& dst_bufs,
-    const std::vector<uint8_t*>& dst_val_bufs,
-    const std::vector<const Attribute*>& attributes,
-    const std::vector<uint64_t>& cell_sizes,
+    const std::string& name,
+    const std::vector<DimType>& tile_extents,
     ResultSpaceTile<DimType>& result_space_tile,
     const Subarray& subarray,
     const Subarray& tile_subarray,
     const uint64_t global_cell_offset,
-    const std::vector<RangeInfo>& range_info,
-    const std::vector<uint8_t>& qc_result) {
+    const std::vector<RangeInfo<DimType>>& range_info,
+    const std::vector<uint8_t>& qc_result,
+    const uint64_t range_thread_idx,
+    const uint64_t num_range_threads) {
   // For easy reference
   const auto dim_num = array_schema_.dim_num();
-  const auto& domain{array_schema_.domain()};
   const auto cell_order = array_schema_.cell_order();
   auto stride = array_schema_.domain().stride<DimType>(layout_);
   const auto& frag_domains = result_space_tile.frag_domains();
+  auto dst_buf = static_cast<uint8_t*>(buffers_[name].buffer_);
+  auto dst_val_buf = buffers_[name].validity_vector_.buffer();
+  const auto attribute = array_schema_.attribute(name);
+  const auto cell_size = array_schema_.cell_size(name);
+  const auto nullable = attribute->nullable();
+  const auto& fill_value = attribute->fill_value();
+  const auto& fill_value_nullable = attribute->fill_value_validity();
+
+  // Cache tile tuples.
+  std::vector<ResultTile::TileTuple*> tile_tuples(frag_domains.size());
+  for (uint32_t fd = 0; fd < frag_domains.size(); ++fd) {
+    tile_tuples[fd] =
+        result_space_tile.result_tile(frag_domains[fd].first)->tile_tuple(name);
+    assert(tile_tuples[fd] != nullptr);
+  }
 
   if (stride == UINT64_MAX) {
     stride = 1;
   }
 
-  // Initialise for global order, will be adjusted later for row/col major.
-  uint64_t cell_offset = global_cell_offset;
-
   // Iterate over all coordinates, retrieved in cell slab.
-  CellSlabIter<DimType> iter(&tile_subarray);
-  RETURN_CANCEL_OR_ERROR(iter.begin());
-  while (!iter.end()) {
-    auto cell_slab = iter.cell_slab();
+  TileCellSlabIter<DimType> iter(
+      range_thread_idx,
+      num_range_threads,
+      subarray,
+      tile_subarray,
+      tile_extents,
+      result_space_tile.start_coords(),
+      range_info,
+      cell_order);
 
+  // Initialise for global order, will be adjusted later for row/col major.
+  uint64_t cell_offset = global_cell_offset + iter.global_offset();
+  while (!iter.end()) {
     // Compute cell offset for row/col major orders.
     if (layout_ != Layout::GLOBAL_ORDER) {
-      cell_offset = get_dest_cell_offset_row_col(
-          dim_num,
-          subarray,
-          tile_subarray,
-          cell_slab.coords_.data(),
-          iter.range_coords(),
-          range_info);
+      cell_offset = iter.dest_offset_row_col();
     }
-
-    // Get the source cell offset.
-    uint64_t src_cell = get_cell_pos_in_tile(
-        cell_order,
-        dim_num,
-        domain,
-        result_space_tile,
-        cell_slab.coords_.data());
 
     // Iterate through all fragment domains and copy data.
     for (int32_t fd = (int32_t)frag_domains.size() - 1; fd >= 0; --fd) {
@@ -1015,58 +954,49 @@ Status DenseReader::copy_fixed_tiles(
       auto&& [overlaps, start, end] = cell_slab_overlaps_range(
           dim_num,
           frag_domains[fd].second,
-          cell_slab.coords_.data(),
-          cell_slab.length_);
+          iter.cell_slab_coords(),
+          iter.cell_slab_length());
       if (overlaps) {
-        for (uint64_t n = 0; n < names.size(); n++) {
-          // Calculate the destination pointers.
-          const auto cell_size = cell_sizes[n];
-          auto dest_ptr = dst_bufs[n] + cell_offset * cell_size;
-          auto dest_validity_ptr = dst_val_bufs[n] + cell_offset;
+        // Calculate the destination pointers.
+        auto dest_ptr = dst_buf + cell_offset * cell_size;
+        auto dest_validity_ptr = dst_val_buf + cell_offset;
 
-          // Get the tile buffers.
-          const auto tile_tuple =
-              result_space_tile.result_tile(frag_domains[fd].first)
-                  ->tile_tuple(names[n]);
-          assert(tile_tuple != nullptr);
-          const Tile* const tile = &std::get<0>(*tile_tuple);
-          const Tile* const tile_nullable = &std::get<2>(*tile_tuple);
+        // Get the tile buffers.
+        const Tile* const tile = &std::get<0>(*tile_tuples[fd]);
+        const Tile* const tile_nullable = &std::get<2>(*tile_tuples[fd]);
 
-          auto src_offset = src_cell + start * stride;
+        auto src_offset = iter.pos_in_tile() + start * stride;
 
-          // If the subarray and tile are in the same order, copy the whole
-          // slab.
-          if (stride == 1) {
+        // If the subarray and tile are in the same order, copy the whole
+        // slab.
+        if (stride == 1) {
+          std::memcpy(
+              dest_ptr + cell_size * start,
+              tile->data_as<char>() + cell_size * src_offset,
+              cell_size * (end - start + 1));
+
+          if (nullable) {
             std::memcpy(
-                dest_ptr + cell_size * start,
-                tile->data_as<char>() + cell_size * src_offset,
-                cell_size * (end - start + 1));
+                dest_validity_ptr + start,
+                tile_nullable->data_as<char>() + src_offset,
+                (end - start + 1));
+          }
+        } else {
+          // Go cell by cell.
+          auto src = tile->data_as<char>() + cell_size * src_offset;
+          auto src_validity =
+              nullable ? tile_nullable->data_as<char>() + src_offset : nullptr;
+          auto dest = dest_ptr + cell_size * start;
+          auto dest_validity = dest_validity_ptr + start;
+          for (uint64_t i = 0; i < end - start + 1; ++i) {
+            std::memcpy(dest, src, cell_size);
+            src += cell_size * stride;
+            dest += cell_size;
 
-            if (attributes[n]->nullable()) {
-              std::memcpy(
-                  dest_validity_ptr + start,
-                  tile_nullable->data_as<char>() + src_offset,
-                  (end - start + 1));
-            }
-          } else {
-            // Go cell by cell.
-            const auto nullable = attributes[n]->nullable();
-            auto src = tile->data_as<char>() + cell_size * src_offset;
-            auto src_validity =
-                nullable ? tile_nullable->data_as<char>() + src_offset :
-                           nullptr;
-            auto dest = dest_ptr + cell_size * start;
-            auto dest_validity = dest_validity_ptr + start;
-            for (uint64_t i = 0; i < end - start + 1; ++i) {
-              std::memcpy(dest, src, cell_size);
-              src += cell_size * stride;
-              dest += cell_size;
-
-              if (nullable) {
-                memcpy(dest_validity, src_validity, 1);
-                src_validity += stride;
-                dest_validity++;
-              }
+            if (nullable) {
+              memcpy(dest_validity, src_validity, 1);
+              src_validity += stride;
+              dest_validity++;
             }
           }
         }
@@ -1076,72 +1006,64 @@ Status DenseReader::copy_fixed_tiles(
 
       // Fill the non written cells for the first fragment domain with the fill
       // value.
-      for (uint64_t n = 0; n < names.size(); n++) {
-        // Calculate the destination pointers.
-        const auto cell_size = cell_sizes[n];
-        auto dest_ptr = dst_bufs[n] + cell_offset * cell_size;
-        auto dest_validity_ptr = dst_val_bufs[n] + cell_offset;
-        const auto& fill_value = attributes[n]->fill_value();
-        const auto& fill_value_nullable = attributes[n]->fill_value_validity();
 
-        // Do the filling.
-        if (fd == (int32_t)frag_domains.size() - 1) {
-          auto buff = dest_ptr;
-          for (uint64_t i = 0; i < start; ++i) {
-            std::memcpy(buff, fill_value.data(), fill_value.size());
-            buff += fill_value.size();
-          }
+      // Calculate the destination pointers.
+      auto dest_ptr = dst_buf + cell_offset * cell_size;
+      auto dest_validity_ptr = dst_val_buf + cell_offset;
 
-          buff = dest_ptr + end * fill_value.size();
-          for (uint64_t i = 0; i < cell_slab.length_ - end; ++i) {
-            std::memcpy(buff, fill_value.data(), fill_value.size());
-            buff += fill_value.size();
-          }
+      // Do the filling.
+      if (fd == (int32_t)frag_domains.size() - 1) {
+        auto buff = dest_ptr;
+        for (uint64_t i = 0; i < start; ++i) {
+          std::memcpy(buff, fill_value.data(), fill_value.size());
+          buff += fill_value.size();
+        }
 
-          if (attributes[n]->nullable()) {
-            std::memset(dest_validity_ptr, fill_value_nullable, start);
-            std::memset(
-                dest_validity_ptr + end,
-                fill_value_nullable,
-                cell_slab.length_ - end);
-          }
+        buff = dest_ptr + end * fill_value.size();
+        for (uint64_t i = 0; i < iter.cell_slab_length() - end; ++i) {
+          std::memcpy(buff, fill_value.data(), fill_value.size());
+          buff += fill_value.size();
+        }
+
+        if (nullable) {
+          std::memset(dest_validity_ptr, fill_value_nullable, start);
+          std::memset(
+              dest_validity_ptr + end,
+              fill_value_nullable,
+              iter.cell_slab_length() - end);
         }
       }
     }
 
     // Check if we need to fill the whole slab or apply query condition.
-    for (uint64_t n = 0; n < names.size(); n++) {
-      // Calculate the destination pointers.
-      const auto cell_size = cell_sizes[n];
-      auto dest_ptr = dst_bufs[n] + cell_offset * cell_size;
-      auto dest_validity_ptr = dst_val_bufs[n] + cell_offset;
-      const auto& fill_value = attributes[n]->fill_value();
-      const auto& fill_value_nullable = attributes[n]->fill_value_validity();
 
-      // Need to fill the whole slab.
-      if (frag_domains.size() == 0) {
-        auto buff = dest_ptr;
-        for (uint64_t i = 0; i < cell_slab.length_; ++i) {
-          std::memcpy(buff, fill_value.data(), fill_value.size());
-          buff += fill_value.size();
-        }
+    // Calculate the destination pointers.
+    auto dest_ptr = dst_buf + cell_offset * cell_size;
+    auto dest_validity_ptr = dst_val_buf + cell_offset;
 
-        if (attributes[n]->nullable()) {
-          std::memset(
-              dest_validity_ptr, fill_value_nullable, cell_slab.length_);
-        }
+    // Need to fill the whole slab.
+    if (frag_domains.size() == 0) {
+      auto buff = dest_ptr;
+      for (uint64_t i = 0; i < iter.cell_slab_length(); ++i) {
+        std::memcpy(buff, fill_value.data(), fill_value.size());
+        buff += fill_value.size();
       }
 
-      // Apply query condition results to this slab.
-      if (!condition_.empty()) {
-        for (uint64_t c = 0; c < cell_slab.length_; c++) {
-          if (!(qc_result[c + cell_offset] & 0x1)) {
-            memcpy(
-                dest_ptr + c * cell_size, fill_value.data(), fill_value.size());
+      if (nullable) {
+        std::memset(
+            dest_validity_ptr, fill_value_nullable, iter.cell_slab_length());
+      }
+    }
 
-            if (attributes[n]->nullable()) {
-              std::memset(dest_validity_ptr + c, fill_value_nullable, 1);
-            }
+    // Apply query condition results to this slab.
+    if (!condition_.empty()) {
+      for (uint64_t c = 0; c < iter.cell_slab_length(); c++) {
+        if (!(qc_result[c + cell_offset] & 0x1)) {
+          memcpy(
+              dest_ptr + c * cell_size, fill_value.data(), fill_value.size());
+
+          if (nullable) {
+            std::memset(dest_validity_ptr + c, fill_value_nullable, 1);
           }
         }
       }
@@ -1149,7 +1071,7 @@ Status DenseReader::copy_fixed_tiles(
 
     // Adjust the cell offset for global order.
     if (layout_ == Layout::GLOBAL_ORDER) {
-      cell_offset += cell_slab.length_;
+      cell_offset += iter.cell_slab_length();
     }
 
     ++iter;
@@ -1160,57 +1082,62 @@ Status DenseReader::copy_fixed_tiles(
 
 template <class DimType, class OffType>
 Status DenseReader::copy_offset_tiles(
-    const std::vector<std::string>& names,
-    const std::vector<uint8_t*>& dst_bufs,
-    const std::vector<uint8_t*>& dst_val_bufs,
-    const std::vector<const Attribute*>& attributes,
-    const std::vector<uint64_t>& data_type_sizes,
+    const std::string& name,
+    const std::vector<DimType>& tile_extents,
     ResultSpaceTile<DimType>& result_space_tile,
     const Subarray& subarray,
     const Subarray& tile_subarray,
     const uint64_t global_cell_offset,
-    std::vector<std::vector<void*>>& var_data,
-    const std::vector<RangeInfo>& range_info,
-    const std::vector<uint8_t>& qc_result) {
+    std::vector<void*>& var_data,
+    const std::vector<RangeInfo<DimType>>& range_info,
+    const std::vector<uint8_t>& qc_result,
+    const uint64_t range_thread_idx,
+    const uint64_t num_range_threads) {
   // For easy reference
-  const auto& domain{array_schema_.domain()};
   const auto dim_num = array_schema_.dim_num();
   const auto cell_order = array_schema_.cell_order();
   const auto cell_num_per_tile = array_schema_.domain().cell_num_per_tile();
   auto stride = array_schema_.domain().stride<DimType>(layout_);
   const auto& frag_domains = result_space_tile.frag_domains();
+  auto dst_buf = static_cast<uint8_t*>(buffers_[name].buffer_);
+  auto dst_val_buf = buffers_[name].validity_vector_.buffer();
+  const auto attribute = array_schema_.attribute(name);
+  const auto data_type_size = datatype_size(array_schema_.type(name));
+  const auto nullable = attribute->nullable();
+
+  // Cache tile tuples.
+  std::vector<ResultTile::TileTuple*> tile_tuples(frag_domains.size());
+  for (uint32_t fd = 0; fd < frag_domains.size(); ++fd) {
+    tile_tuples[fd] =
+        result_space_tile.result_tile(frag_domains[fd].first)->tile_tuple(name);
+    assert(tile_tuples[fd] != nullptr);
+  }
 
   if (stride == UINT64_MAX) {
     stride = 1;
   }
 
-  // Initialise for global order, will be adjusted later for row/col major.
-  uint64_t cell_offset = global_cell_offset;
-
   // Iterate over all coordinates, retrieved in cell slabs
-  CellSlabIter<DimType> iter(&tile_subarray);
-  RETURN_CANCEL_OR_ERROR(iter.begin());
-  while (!iter.end()) {
-    auto cell_slab = iter.cell_slab();
+  TileCellSlabIter<DimType> iter(
+      range_thread_idx,
+      num_range_threads,
+      subarray,
+      tile_subarray,
+      tile_extents,
+      result_space_tile.start_coords(),
+      range_info,
+      cell_order);
 
+  // Initialise for global order, will be adjusted later for row/col major.
+  uint64_t cell_offset = global_cell_offset + iter.global_offset();
+  while (!iter.end()) {
     // Compute cell offset for row/col major orders.
     if (layout_ != Layout::GLOBAL_ORDER) {
-      cell_offset = get_dest_cell_offset_row_col(
-          dim_num,
-          subarray,
-          tile_subarray,
-          cell_slab.coords_.data(),
-          iter.range_coords(),
-          range_info);
+      cell_offset = iter.dest_offset_row_col();
     }
 
     // Get the source cell offset.
-    uint64_t src_cell = get_cell_pos_in_tile(
-        cell_order,
-        dim_num,
-        domain,
-        result_space_tile,
-        cell_slab.coords_.data());
+    uint64_t src_cell = iter.pos_in_tile();
 
     // Iterate through all fragment domains and copy data.
     for (int32_t fd = (int32_t)frag_domains.size() - 1; fd >= 0; --fd) {
@@ -1218,61 +1145,58 @@ Status DenseReader::copy_offset_tiles(
       auto&& [overlaps, start, end] = cell_slab_overlaps_range(
           dim_num,
           frag_domains[fd].second,
-          cell_slab.coords_.data(),
-          cell_slab.length_);
+          iter.cell_slab_coords(),
+          iter.cell_slab_length());
       if (overlaps) {
-        for (uint64_t n = 0; n < names.size(); n++) {
-          // Calculate the destination pointers.
-          auto dest_ptr = dst_bufs[n] + cell_offset * sizeof(OffType);
-          auto var_data_buff = var_data[n].data() + cell_offset;
-          auto dest_validity_ptr = dst_val_bufs[n] + cell_offset;
+        // Calculate the destination pointers.
+        auto dest_ptr = dst_buf + cell_offset * sizeof(OffType);
+        auto var_data_buff = var_data.data() + cell_offset;
+        auto dest_validity_ptr = dst_val_buf + cell_offset;
 
-          // Get the tile buffers.
-          const auto tile_tuple =
-              result_space_tile.result_tile(frag_domains[fd].first)
-                  ->tile_tuple(names[n]);
-          assert(tile_tuple != nullptr);
-          const Tile* const t_var = &std::get<1>(*tile_tuple);
+        // Get the tile buffers.
+        const Tile* const t_var = &std::get<1>(*tile_tuples[fd]);
 
-          // Setup variables for the copy.
-          auto src_buff = (uint64_t*)std::get<0>(*tile_tuple).data() +
-                          start * stride + src_cell;
-          auto src_buff_validity =
-              attributes[n]->nullable() ?
-                  (uint8_t*)std::get<2>(*tile_tuple).data() + start + src_cell :
-                  nullptr;
-          auto div = elements_mode_ ? data_type_sizes[n] : 1;
-          auto dest = (OffType*)dest_ptr + start;
+        // Setup variables for the copy.
+        auto src_buff =
+            static_cast<uint64_t*>(std::get<0>(*tile_tuples[fd]).data()) +
+            start * stride + src_cell;
+        auto src_buff_validity =
+            nullable ?
+                static_cast<uint8_t*>(std::get<2>(*tile_tuples[fd]).data()) +
+                    start + src_cell :
+                nullptr;
+        auto div = elements_mode_ ? data_type_size : 1;
+        auto dest = (OffType*)dest_ptr + start;
 
-          // Copy the data cell by cell, last copy was taken out to take
-          // advantage of vectorization.
-          uint64_t i = 0;
+        // Copy the data cell by cell, last copy was taken out to take
+        // advantage of vectorization.
+        uint64_t i = 0;
+        for (; i < end - start; ++i) {
+          auto i_src = i * stride;
+          dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
+          var_data_buff[i + start] = t_var->data_as<char>() + src_buff[i_src];
+        }
+
+        if (nullable) {
+          i = 0;
           for (; i < end - start; ++i) {
-            auto i_src = i * stride;
-            dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
-            var_data_buff[i + start] = t_var->data_as<char>() + src_buff[i_src];
-          }
-
-          if (attributes[n]->nullable()) {
-            i = 0;
-            for (; i < end - start; ++i) {
-              dest_validity_ptr[start + i] = src_buff_validity[i * stride];
-            }
-          }
-
-          // Copy the last value.
-          if (start + src_cell + (end - start) * stride >=
-              cell_num_per_tile - 1) {
-            dest[i] = (t_var->size() - src_buff[i * stride]) / div;
-          } else {
-            auto i_src = i * stride;
-            dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
-          }
-          var_data_buff[i + start] =
-              t_var->data_as<char>() + src_buff[i * stride];
-
-          if (attributes[n]->nullable())
             dest_validity_ptr[start + i] = src_buff_validity[i * stride];
+          }
+        }
+
+        // Copy the last value.
+        if (start + src_cell + (end - start) * stride >=
+            cell_num_per_tile - 1) {
+          dest[i] = (t_var->size() - src_buff[i * stride]) / div;
+        } else {
+          auto i_src = i * stride;
+          dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
+        }
+        var_data_buff[i + start] =
+            t_var->data_as<char>() + src_buff[i * stride];
+
+        if (nullable) {
+          dest_validity_ptr[start + i] = src_buff_validity[i * stride];
         }
 
         end = end + 1;
@@ -1280,65 +1204,63 @@ Status DenseReader::copy_offset_tiles(
 
       // Fill the non written cells for the first fragment domain with max
       // value.
-      for (uint64_t n = 0; n < names.size(); n++) {
-        // Calculate the destination pointers.
-        auto dest_ptr = dst_bufs[n] + cell_offset * sizeof(OffType);
-        auto dest_validity_ptr = dst_val_bufs[n] + cell_offset;
-        const auto& fill_value_nullable = attributes[n]->fill_value_validity();
 
-        // Do the filling.
-        if (fd == (int32_t)frag_domains.size() - 1) {
-          memset(dest_ptr, 0xFF, start * sizeof(OffType));
-          memset(
-              dest_ptr + end * sizeof(OffType),
-              0xFF,
-              (cell_slab.length_ - end) * sizeof(OffType));
+      // Calculate the destination pointers.
+      auto dest_ptr = dst_buf + cell_offset * sizeof(OffType);
+      auto dest_validity_ptr = dst_val_buf + cell_offset;
+      const auto& fill_value_nullable = attribute->fill_value_validity();
 
-          if (attributes[n]->nullable()) {
-            std::memset(dest_validity_ptr, fill_value_nullable, start);
-            std::memset(
-                dest_validity_ptr + end,
-                fill_value_nullable,
-                cell_slab.length_ - end);
-          }
+      // Do the filling.
+      if (fd == (int32_t)frag_domains.size() - 1) {
+        memset(dest_ptr, 0xFF, start * sizeof(OffType));
+        memset(
+            dest_ptr + end * sizeof(OffType),
+            0xFF,
+            (iter.cell_slab_length() - end) * sizeof(OffType));
+
+        if (nullable) {
+          std::memset(dest_validity_ptr, fill_value_nullable, start);
+          std::memset(
+              dest_validity_ptr + end,
+              fill_value_nullable,
+              iter.cell_slab_length() - end);
         }
       }
     }
 
     // Check if we need to fill the whole slab or apply query condition.
-    for (uint64_t n = 0; n < names.size(); n++) {
-      // Calculate the destination pointers.
-      auto dest_ptr = dst_bufs[n] + cell_offset * sizeof(OffType);
-      auto dest_validity_ptr = dst_val_bufs[n] + cell_offset;
-      const auto& fill_value_nullable = attributes[n]->fill_value_validity();
 
-      // Need to fill the whole slab.
-      if (frag_domains.size() == 0) {
-        memset(dest_ptr, 0xFF, cell_slab.length_ * sizeof(OffType));
+    // Calculate the destination pointers.
+    auto dest_ptr = dst_buf + cell_offset * sizeof(OffType);
+    auto dest_validity_ptr = dst_val_buf + cell_offset;
+    const auto& fill_value_nullable = attribute->fill_value_validity();
 
-        if (attributes[n]->nullable()) {
-          std::memset(
-              dest_validity_ptr, fill_value_nullable, cell_slab.length_);
-        }
+    // Need to fill the whole slab.
+    if (frag_domains.size() == 0) {
+      memset(dest_ptr, 0xFF, iter.cell_slab_length() * sizeof(OffType));
+
+      if (nullable) {
+        std::memset(
+            dest_validity_ptr, fill_value_nullable, iter.cell_slab_length());
       }
+    }
 
-      if (!condition_.empty()) {
-        // Apply query condition results to this slab.
-        for (uint64_t c = 0; c < cell_slab.length_; c++) {
-          if (!(qc_result[c + cell_offset] & 0x1)) {
-            memset(dest_ptr + c * sizeof(OffType), 0xFF, sizeof(OffType));
-          }
+    if (!condition_.empty()) {
+      // Apply query condition results to this slab.
+      for (uint64_t c = 0; c < iter.cell_slab_length(); c++) {
+        if (!(qc_result[c + cell_offset] & 0x1)) {
+          memset(dest_ptr + c * sizeof(OffType), 0xFF, sizeof(OffType));
+        }
 
-          if (attributes[n]->nullable()) {
-            std::memset(dest_validity_ptr + c, fill_value_nullable, 1);
-          }
+        if (nullable) {
+          std::memset(dest_validity_ptr + c, fill_value_nullable, 1);
         }
       }
     }
 
     // Adjust the cell offset for global order.
     if (layout_ == Layout::GLOBAL_ORDER) {
-      cell_offset += cell_slab.length_;
+      cell_offset += iter.cell_slab_length();
     }
 
     ++iter;
@@ -1349,69 +1271,73 @@ Status DenseReader::copy_offset_tiles(
 
 template <class DimType, class OffType>
 Status DenseReader::copy_var_tiles(
-    const std::vector<std::string>& names,
-    const std::vector<uint8_t*>& dst_bufs,
-    const std::vector<uint8_t*>& offsets_bufs,
-    const std::vector<uint64_t>& data_type_sizes,
+    const std::string& name,
+    const std::vector<DimType>& tile_extents,
+    ResultSpaceTile<DimType>& result_space_tile,
     const Subarray& subarray,
     const Subarray& tile_subarray,
     const uint64_t global_cell_offset,
-    std::vector<std::vector<void*>>& var_data,
-    const std::vector<RangeInfo>& range_info,
+    std::vector<void*>& var_data,
+    const std::vector<RangeInfo<DimType>>& range_info,
     bool last_tile,
-    std::vector<uint64_t>& var_buffer_sizes) {
+    uint64_t var_buffer_size,
+    const uint64_t range_thread_idx,
+    const uint64_t num_range_threads) {
   // For easy reference
-  auto dim_num = array_schema_.dim_num();
-
-  // Initialise for global order, will be adjusted later for row/col major.
-  uint64_t cell_offset = global_cell_offset;
+  const auto cell_order = array_schema_.cell_order();
+  auto dst_buf = static_cast<uint8_t*>(buffers_[name].buffer_var_);
+  auto offsets_buf = static_cast<OffType*>(buffers_[name].buffer_);
+  const auto data_type_size = datatype_size(array_schema_.type(name));
 
   // Iterate over all coordinates, retrieved in cell slabs
-  CellSlabIter<DimType> iter(&tile_subarray);
-  RETURN_CANCEL_OR_ERROR(iter.begin());
-  while (!iter.end()) {
-    auto cell_slab = iter.cell_slab();
-    ++iter;
+  TileCellSlabIter<DimType> iter(
+      range_thread_idx,
+      num_range_threads,
+      subarray,
+      tile_subarray,
+      tile_extents,
+      result_space_tile.start_coords(),
+      range_info,
+      cell_order);
 
+  // Initialise for global order, will be adjusted later for row/col major.
+  uint64_t cell_offset = global_cell_offset + iter.global_offset();
+  while (!iter.end()) {
     // Compute cell offset for row/col major orders.
     if (layout_ != Layout::GLOBAL_ORDER) {
-      cell_offset = get_dest_cell_offset_row_col(
-          dim_num,
-          subarray,
-          tile_subarray,
-          cell_slab.coords_.data(),
-          iter.range_coords(),
-          range_info);
+      cell_offset = iter.dest_offset_row_col();
     }
 
-    for (uint64_t n = 0; n < names.size(); n++) {
-      // Setup variables for the copy.
-      auto mult = elements_mode_ ? data_type_sizes[n] : 1;
-      uint64_t size = 0;
-      uint64_t offset = 0;
-      uint64_t i = 0;
+    auto cell_slab_length = iter.cell_slab_length();
+    ++iter;
 
-      // Copy the data cell by cell, last copy was taken out to take advantage
-      // of vectorization.
-      for (; i < cell_slab.length_ - 1; i++) {
-        offset = ((OffType*)offsets_bufs[n])[cell_offset + i] * mult;
-        size = ((OffType*)offsets_bufs[n])[cell_offset + i + 1] * mult - offset;
-        std::memcpy(dst_bufs[n] + offset, var_data[n][cell_offset + i], size);
-      }
+    // Setup variables for the copy.
+    auto mult = elements_mode_ ? data_type_size : 1;
+    uint64_t size = 0;
+    uint64_t offset = 0;
+    uint64_t i = 0;
 
-      // Do the last copy.
-      offset = ((OffType*)offsets_bufs[n])[cell_offset + i] * mult;
-      if (last_tile && iter.end() && i == cell_slab.length_ - 1) {
-        size = var_buffer_sizes[n] * mult - offset;
-      } else {
-        size = ((OffType*)offsets_bufs[n])[cell_offset + i + 1] * mult - offset;
-      }
-      std::memcpy(dst_bufs[n] + offset, var_data[n][cell_offset + i], size);
+    // Copy the data cell by cell, last copy was taken out to take advantage
+    // of vectorization.
+    for (; i < cell_slab_length - 1; i++) {
+      offset = offsets_buf[cell_offset + i] * mult;
+      size = offsets_buf[cell_offset + i + 1] * mult - offset;
+      std::memcpy(dst_buf + offset, var_data[cell_offset + i], size);
     }
+
+    // Do the last copy.
+    offset = offsets_buf[cell_offset + i] * mult;
+    if (last_tile && iter.last_slab() && i == cell_slab_length - 1) {
+      size = var_buffer_size * mult - offset;
+    } else {
+      size = offsets_buf[cell_offset + i + 1] * mult - offset;
+    }
+    std::memcpy(dst_buf + offset, var_data[cell_offset + i], size);
 
     // Adjust cell offset for global order.
-    if (layout_ == Layout::GLOBAL_ORDER)
-      cell_offset += cell_slab.length_;
+    if (layout_ == Layout::GLOBAL_ORDER) {
+      cell_offset += cell_slab_length;
+    }
   }
 
   return Status::Ok();
@@ -1421,13 +1347,15 @@ Status DenseReader::add_extra_offset() {
   // Add extra offset element for all var size offset buffers.
   for (const auto& it : buffers_) {
     const auto& name = it.first;
-    if (!array_schema_.var_size(name))
+    if (!array_schema_.var_size(name)) {
       continue;
+    }
 
     // Do not apply offset for empty results because we will
     // write backwards and corrupt memory we don't own.
-    if (*it.second.buffer_size_ == 0)
+    if (*it.second.buffer_size_ == 0) {
       continue;
+    }
 
     auto buffer = static_cast<unsigned char*>(it.second.buffer_);
     if (offsets_format_mode_ == "bytes") {

--- a/tiledb/sm/query/dense_reader.h
+++ b/tiledb/sm/query/dense_reader.h
@@ -39,6 +39,7 @@
 #include "tiledb/common/logger_public.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/array_schema/dynamic_array.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/query/iquery_strategy.h"
 #include "tiledb/sm/query/query_buffer.h"
@@ -150,7 +151,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       Subarray& subarray,
       const std::vector<DimType>& tile_extents,
       std::vector<ResultTile*>& result_tiles,
-      std::vector<Subarray>& tile_subarrays,
+      DynamicArray<Subarray>& tile_subarrays,
       std::vector<uint64_t>& tile_offsets,
       const std::vector<RangeInfo<DimType>>& range_info,
       std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
@@ -170,7 +171,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::string& name,
       const std::vector<DimType>& tile_extents,
       const Subarray& subarray,
-      const std::vector<Subarray>& tile_subarrays,
+      const DynamicArray<Subarray>& tile_subarrays,
       const std::vector<uint64_t>& tile_offsets,
       const std::vector<RangeInfo<DimType>>& range_info,
       std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,

--- a/tiledb/sm/query/read_cell_slab_iter.cc
+++ b/tiledb/sm/query/read_cell_slab_iter.cc
@@ -299,7 +299,7 @@ void ReadCellSlabIter<T>::compute_result_cell_slabs_dense(
   for (const auto& fd : frag_domains) {
     for (auto pit = to_process.begin(); pit != to_process.end();) {
       compute_cell_slab_overlap(
-          *pit, fd.second, &slab_overlap, &overlap_length, &overlap_type);
+          *pit, fd.domain(), &slab_overlap, &overlap_length, &overlap_type);
 
       // No overlap
       if (overlap_type == 0) {
@@ -310,7 +310,7 @@ void ReadCellSlabIter<T>::compute_result_cell_slabs_dense(
       // Compute new result cell slab
       compute_cell_slab_start(
           &slab_overlap[0], result_space_tile->start_coords(), &start);
-      auto tile = result_space_tile->result_tile(fd.first);
+      auto tile = result_space_tile->result_tile(fd.fid());
       result_cell_slabs.emplace_back(tile, start, overlap_length);
 
       // If it is partial overlap, we need to create up to two new cell slabs

--- a/tiledb/sm/query/result_space_tile.h
+++ b/tiledb/sm/query/result_space_tile.h
@@ -47,6 +47,32 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+/** Fragment domain structure (fragment id, fragment domain). */
+struct FragmentDomain {
+ public:
+  /** Delete default constructor. */
+  FragmentDomain() = delete;
+
+  /** Constructor. */
+  FragmentDomain(
+      unsigned fragment_id, const std::reference_wrapper<const NDRange>& domain)
+      : fragment_id_(fragment_id)
+      , domain_(domain) {
+  }
+
+  inline unsigned fid() const {
+    return fragment_id_;
+  }
+
+  inline const NDRange& domain() const {
+    return domain_;
+  }
+
+ private:
+  unsigned fragment_id_;
+  NDRange domain_;
+};
+
 /**
  * Stores information about a space tile covered by a subarray query.
  *
@@ -74,7 +100,7 @@ class ResultSpaceTile {
   ResultSpaceTile& operator=(ResultSpaceTile&&) = default;
 
   /** Returns the fragment domains. */
-  const std::vector<std::pair<unsigned, NDRange>>& frag_domains() const {
+  const std::vector<FragmentDomain>& frag_domains() const {
     return frag_domains_;
   }
 
@@ -117,8 +143,8 @@ class ResultSpaceTile {
     if (frag_domains_.size() != rst.frag_domains_.size())
       return false;
     for (size_t i = 0; i < frag_domains_.size(); ++i) {
-      if (!(frag_domains_[i].first == rst.frag_domains_[i].first &&
-            frag_domains_[i].second == rst.frag_domains_[i].second))
+      if (!(frag_domains_[i].fid() == rst.frag_domains_[i].fid() &&
+            frag_domains_[i].domain() == rst.frag_domains_[i].domain()))
         return false;
     }
 
@@ -131,12 +157,11 @@ class ResultSpaceTile {
   std::vector<T> start_coords_;
 
   /**
-   * A vector of pairs `(fragment id, fragment domain)`, sorted on
-   * fragment id in descending order. Note that only fragments
-   * with domains that intersect this space tile will be included
-   * in this vector.
+   * A vector of fragment domains, sorted on fragment id in descending order.
+   * Note that only fragments with domains that intersect this space tile will
+   * be included in this vector.
    */
-  std::vector<std::pair<unsigned, NDRange>> frag_domains_;
+  std::vector<FragmentDomain> frag_domains_;
 
   /**
    * The (dense) result tiles for this space tile, as a map

--- a/tiledb/sm/subarray/cell_slab_iter.cc
+++ b/tiledb/sm/subarray/cell_slab_iter.cc
@@ -99,11 +99,6 @@ CellSlab<T> CellSlabIter<T>::cell_slab() const {
 }
 
 template <class T>
-T* CellSlabIter<T>::range_coords() {
-  return range_coords_.data();
-}
-
-template <class T>
 bool CellSlabIter<T>::end() const {
   return end_;
 }

--- a/tiledb/sm/subarray/cell_slab_iter.h
+++ b/tiledb/sm/subarray/cell_slab_iter.h
@@ -160,9 +160,6 @@ class CellSlabIter {
   /** Returns the current cell slab. */
   CellSlab<T> cell_slab() const;
 
-  /** Returns the current range coords. */
-  T* range_coords();
-
   /** Checks if the iterator has reached the end. */
   bool end() const;
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1462,15 +1462,6 @@ uint64_t Subarray::range_idx(const std::vector<uint64_t>& range_coords) const {
   return ret;
 }
 
-template <class T>
-void Subarray::get_original_range_coords(
-    const T* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const {
-  auto dim_num = this->dim_num();
-  for (unsigned i = 0; i < dim_num; ++i)
-    original_range_coords->at(i) = original_range_idx_[i][range_coords[i]];
-}
-
 uint64_t Subarray::range_num() const {
   if (range_subset_.empty())
     return 0;
@@ -1530,10 +1521,6 @@ NDRange Subarray::ndrange(const std::vector<uint64_t>& range_coords) const {
   for (unsigned d = 0; d < dim_num; ++d)
     ret.emplace_back(range_subset_[d][range_coords[d]]);
   return ret;
-}
-
-const std::vector<Range>& Subarray::ranges_for_dim(uint32_t dim_idx) const {
-  return range_subset_[dim_idx].ranges();
 }
 
 Status Subarray::set_ranges_for_dim(
@@ -3122,37 +3109,6 @@ template Subarray Subarray::crop_to_tile<float>(
     const float* tile_coords, Layout layout) const;
 template Subarray Subarray::crop_to_tile<double>(
     const double* tile_coords, Layout layout) const;
-
-template void Subarray::get_original_range_coords<int8_t>(
-    const int8_t* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
-template void Subarray::get_original_range_coords<uint8_t>(
-    const uint8_t* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
-template void Subarray::get_original_range_coords<int16_t>(
-    const int16_t* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
-template void Subarray::get_original_range_coords<uint16_t>(
-    const uint16_t* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
-template void Subarray::get_original_range_coords<int32_t>(
-    const int32_t* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
-template void Subarray::get_original_range_coords<uint32_t>(
-    const uint32_t* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
-template void Subarray::get_original_range_coords<int64_t>(
-    const int64_t* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
-template void Subarray::get_original_range_coords<uint64_t>(
-    const uint64_t* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
-template void Subarray::get_original_range_coords<float>(
-    const float* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
-template void Subarray::get_original_range_coords<double>(
-    const double* const range_coords,
-    std::vector<uint64_t>* original_range_coords) const;
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -618,38 +618,17 @@ template <class T>
 Subarray Subarray::crop_to_tile(const T* tile_coords, Layout layout) const {
   // TBD: is it ok that Subarray log id will increase as if it's a new subarray?
   Subarray ret(array_, layout, stats_->parent(), logger_, false);
-
-  T new_range[2];
-  bool overlaps;
-
-  // Get tile subarray based on the input coordinates
-  const auto& array_schema = array_->array_schema_latest();
-  std::vector<T> tile_subarray(2 * dim_num());
-  array_schema.domain().get_tile_subarray(tile_coords, &tile_subarray[0]);
-
-  // Compute cropped subarray
-  for (unsigned d = 0; d < dim_num(); ++d) {
-    auto r_size{2 * array_schema.dimension_ptr(d)->coord_size()};
-    uint64_t i = 0;
-    for (size_t r = 0; r < range_subset_[d].num_ranges(); ++r) {
-      const auto& range = range_subset_[d][r];
-      utils::geometry::overlap(
-          (const T*)range.data(),
-          &tile_subarray[2 * d],
-          1,
-          new_range,
-          &overlaps);
-
-      if (overlaps) {
-        ret.add_range_unsafe(d, Range(new_range, r_size));
-        ret.original_range_idx_.resize(dim_num());
-        ret.original_range_idx_[d].resize(i + 1);
-        ret.original_range_idx_[d][i++] = r;
-      }
-    }
-  }
+  crop_to_tile_impl(tile_coords, ret);
 
   return ret;
+}
+
+template <class T>
+void Subarray::crop_to_tile(
+    Subarray* ret, const T* tile_coords, Layout layout) const {
+  new (ret) Subarray(array_, layout, stats_->parent(), logger_, false);
+  Subarray(array_, layout, stats_->parent(), logger_, false);
+  crop_to_tile_impl(tile_coords, *ret);
 }
 
 uint32_t Subarray::dim_num() const {
@@ -3046,6 +3025,39 @@ tuple<Status, optional<bool>> Subarray::non_overlapping_ranges_for_dim(
   ;
 }
 
+template <class T>
+void Subarray::crop_to_tile_impl(const T* tile_coords, Subarray& ret) const {
+  T new_range[2];
+  bool overlaps;
+
+  // Get tile subarray based on the input coordinates
+  const auto& array_schema = array_->array_schema_latest();
+  std::vector<T> tile_subarray(2 * dim_num());
+  array_schema.domain().get_tile_subarray(tile_coords, &tile_subarray[0]);
+
+  // Compute cropped subarray
+  for (unsigned d = 0; d < dim_num(); ++d) {
+    auto r_size{2 * array_schema.dimension_ptr(d)->coord_size()};
+    uint64_t i = 0;
+    for (size_t r = 0; r < range_subset_[d].num_ranges(); ++r) {
+      const auto& range = range_subset_[d][r];
+      utils::geometry::overlap(
+          (const T*)range.data(),
+          &tile_subarray[2 * d],
+          1,
+          new_range,
+          &overlaps);
+
+      if (overlaps) {
+        ret.add_range_unsafe(d, Range(new_range, r_size));
+        ret.original_range_idx_.resize(dim_num());
+        ret.original_range_idx_[d].resize(i + 1);
+        ret.original_range_idx_[d][i++] = r;
+      }
+    }
+  }
+}
+
 // Explicit instantiations
 template Status Subarray::compute_tile_coords<int8_t>();
 template Status Subarray::compute_tile_coords<uint8_t>();
@@ -3109,6 +3121,27 @@ template Subarray Subarray::crop_to_tile<float>(
     const float* tile_coords, Layout layout) const;
 template Subarray Subarray::crop_to_tile<double>(
     const double* tile_coords, Layout layout) const;
+
+template void Subarray::crop_to_tile<int8_t>(
+    Subarray* ret, const int8_t* tile_coords, Layout layout) const;
+template void Subarray::crop_to_tile<uint8_t>(
+    Subarray* ret, const uint8_t* tile_coords, Layout layout) const;
+template void Subarray::crop_to_tile<int16_t>(
+    Subarray* ret, const int16_t* tile_coords, Layout layout) const;
+template void Subarray::crop_to_tile<uint16_t>(
+    Subarray* ret, const uint16_t* tile_coords, Layout layout) const;
+template void Subarray::crop_to_tile<int32_t>(
+    Subarray* ret, const int32_t* tile_coords, Layout layout) const;
+template void Subarray::crop_to_tile<uint32_t>(
+    Subarray* ret, const uint32_t* tile_coords, Layout layout) const;
+template void Subarray::crop_to_tile<int64_t>(
+    Subarray* ret, const int64_t* tile_coords, Layout layout) const;
+template void Subarray::crop_to_tile<uint64_t>(
+    Subarray* ret, const uint64_t* tile_coords, Layout layout) const;
+template void Subarray::crop_to_tile<float>(
+    Subarray* ret, const float* tile_coords, Layout layout) const;
+template void Subarray::crop_to_tile<double>(
+    Subarray* ret, const double* tile_coords, Layout layout) const;
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -754,12 +754,10 @@ class Subarray {
   /** Returns the flattened 1D id of the range with the input coordinates. */
   uint64_t range_idx(const std::vector<uint64_t>& range_coords) const;
 
-  /** Returns the flattened 1D id of the range with the input coordinates for
-   * the original subarray. */
-  template <class T>
-  void get_original_range_coords(
-      const T* const range_coords,
-      std::vector<uint64_t>* original_range_coords) const;
+  /** Returns the orignal range indexes. */
+  inline const std::vector<std::vector<uint64_t>>& original_range_idx() const {
+    return original_range_idx_;
+  }
 
   /** The total number of multi-dimensional ranges in the subarray. */
   uint64_t range_num() const;
@@ -780,7 +778,9 @@ class Subarray {
    * Returns the `Range` vector for the given dimension index.
    * @note Intended for serialization only
    */
-  const std::vector<Range>& ranges_for_dim(uint32_t dim_idx) const;
+  inline const std::vector<Range>& ranges_for_dim(uint32_t dim_idx) const {
+    return range_subset_[dim_idx].ranges();
+  }
 
   /**
    * Directly sets the `Range` vector for the given dimension index, making

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -488,6 +488,14 @@ class Subarray {
   template <class T>
   Subarray crop_to_tile(const T* tile_coords, Layout layout) const;
 
+  /**
+   * Returns a cropped version of the subarray, constrained in the
+   * tile with the input coordinates. The new subarray will have
+   * the input `layout`.
+   */
+  template <class T>
+  void crop_to_tile(Subarray* ret, const T* tile_coords, Layout layout) const;
+
   /** Returns the number of dimensions of the subarray. */
   uint32_t dim_num() const;
 
@@ -1295,6 +1303,14 @@ class Subarray {
    */
   tuple<Status, optional<bool>> non_overlapping_ranges_for_dim(
       const uint64_t dim_idx);
+
+  /**
+   * Returns a cropped version of the subarray, constrained in the
+   * tile with the input coordinates. The new subarray will have
+   * the input `layout`.
+   */
+  template <class T>
+  void crop_to_tile_impl(const T* tile_coords, Subarray& ret) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/subarray/tile_cell_slab_iter.cc
+++ b/tiledb/sm/subarray/tile_cell_slab_iter.cc
@@ -1,0 +1,375 @@
+/**
+ * @file   tile_cell_slab_iter.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class TileCellSlabIter.
+ */
+
+#include "tiledb/sm/subarray/tile_cell_slab_iter.h"
+#include "tiledb/common/logger.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/array_schema/domain.h"
+#include "tiledb/sm/enums/layout.h"
+#include "tiledb/sm/misc/types.h"
+#include "tiledb/type/range/range.h"
+
+#include <cassert>
+#include <iostream>
+
+using namespace tiledb::common;
+using namespace tiledb::type;
+
+namespace tiledb {
+namespace sm {
+
+/* ****************************** */
+/*   CONSTRUCTORS & DESTRUCTORS   */
+/* ****************************** */
+
+template <class T>
+TileCellSlabIter<T>::TileCellSlabIter(
+    const uint64_t range_thread_idx,
+    const uint64_t num_range_threads,
+    const Subarray& root_subarray,
+    const Subarray& subarray,
+    const std::vector<T>& tile_extents,
+    const std::vector<T>& start_coords,
+    const std::vector<RangeInfo<T>>& range_info,
+    const Layout cell_order)
+    : num_ranges_(root_subarray.range_num())
+    , original_range_idx_(subarray.original_range_idx())
+    , range_info_(range_info)
+    , layout_(subarray.layout())
+    , dim_num_(subarray.dim_num())
+    , global_offset_(0)
+    , pos_in_tile_(0)
+    , dest_offset_row_col_(0)
+    , num_(std::numeric_limits<uint64_t>::max())
+    , end_(false)
+    , last_(true)
+    , global_order_(root_subarray.layout() == Layout::GLOBAL_ORDER)
+    , mult_extents_(subarray.dim_num())
+    , start_coords_(start_coords) {
+  if (!init_ranges(subarray).ok()) {
+    throw std::logic_error(
+        "Could not initialize TileCellSlabIter in constructor");
+  }
+
+  init_coords();
+  init_cell_slab_lengths();
+
+  if (num_range_threads != 1) {
+    // Compute cells per dimensions.
+    std::vector<uint64_t> cell_idx(dim_num_);
+    for (int d = 0; d < dim_num_; ++d) {
+      for (auto& range : ranges_[d]) {
+        cell_idx[d] += range.end_ - range.start_ + 1;
+      }
+    }
+
+    // Compute total number of slabs not including the last dimension as we
+    // do not split on the last dimension.
+    uint64_t num_slabs = 1;
+    if (layout_ == Layout::ROW_MAJOR) {
+      for (int d = 0; d < dim_num_ - 1; ++d) {
+        num_slabs *= cell_idx[d];
+      }
+    } else {  // COL_MAJOR
+      for (int d = dim_num_ - 1; d > 0; --d) {
+        num_slabs *= cell_idx[d];
+      }
+    }
+
+    // Prevent processing past the end in case there are more threads than
+    // slabs.
+    if (num_slabs != 0 && range_thread_idx < num_slabs) {
+      // Compute the cells to process.
+      auto part_num = std::min(num_slabs, num_range_threads);
+      uint64_t min = (range_thread_idx * num_slabs + part_num - 1) / part_num;
+      uint64_t max = std::min(
+          ((range_thread_idx + 1) * num_slabs + part_num - 1) / part_num,
+          num_slabs);
+
+      last_ = max == num_slabs;
+      num_ = max - min;
+
+      // Compute range coords and global offset.
+      if (layout_ == Layout::ROW_MAJOR) {
+        global_offset_ = min * cell_idx[dim_num_ - 1];
+        cell_idx[dim_num_ - 1] = 0;
+        for (int d = dim_num_ - 2; d >= 0; --d) {
+          uint64_t temp = min % cell_idx[d];
+          min /= cell_idx[d];
+          cell_idx[d] = temp;
+        }
+      } else {  // COL_MAJOR
+        global_offset_ = min * cell_idx[0];
+        cell_idx[0] = 0;
+        for (int d = 1; d < dim_num_; ++d) {
+          uint64_t temp = min % cell_idx[d];
+          min /= cell_idx[d];
+          cell_idx[d] = temp;
+        }
+      }
+
+      for (unsigned d = 0; d < cell_idx.size(); ++d) {
+        range_coords_[d] = 0;
+        for (auto& range : ranges_[d]) {
+          auto length = static_cast<uint64_t>(range.end_ - range.start_ + 1);
+          if (cell_idx[d] < length) {
+            cell_slab_coords_[d] = range.start_ + static_cast<T>(cell_idx[d]);
+            break;
+          } else {
+            range_coords_[d]++;
+            cell_idx[d] -= length;
+          }
+        }
+      }
+
+      if (layout_ == Layout::ROW_MAJOR) {
+        num_ *= ranges_[dim_num_ - 1].size();
+      } else {  // COL_MAJOR
+        num_ *= ranges_[0].size();
+      }
+    } else {
+      num_ = 0;
+    }
+  }
+
+  uint64_t mult = 1;
+  if (cell_order == Layout::COL_MAJOR) {
+    for (int32_t d = 0; d < dim_num_; d++) {
+      mult_extents_[d] = mult;
+      mult *= tile_extents[d];
+    }
+  } else {
+    for (auto d = dim_num_ - 1; d >= 0; d--) {
+      mult_extents_[d] = mult;
+      mult *= tile_extents[d];
+    }
+  }
+
+  update_cell_slab();
+}
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+template <class T>
+void TileCellSlabIter<T>::operator++() {
+  num_--;
+  // If at the end, do nothing
+  if (num_ == 0 || end_) {
+    return;
+  }
+
+  // Advance the iterator
+  if (layout_ == Layout::ROW_MAJOR) {
+    advance_row();
+  } else {
+    advance_col();
+  }
+
+  if (!end_) {
+    update_cell_slab();
+  }
+}
+
+/* ****************************** */
+/*          PRIVATE METHODS       */
+/* ****************************** */
+
+template <class T>
+void TileCellSlabIter<T>::advance_col() {
+  for (int i = 0; i < dim_num_; ++i) {
+    cell_slab_coords_[i] += (i == 0) ? cell_slab_lengths_[range_coords_[i]] : 1;
+    if (cell_slab_coords_[i] > ranges_[i][range_coords_[i]].end_) {
+      ++range_coords_[i];
+      if (range_coords_[i] < (T)ranges_[i].size())
+        cell_slab_coords_[i] = ranges_[i][range_coords_[i]].start_;
+    }
+
+    if (range_coords_[i] < (T)ranges_[i].size()) {
+      break;
+    } else {
+      // The iterator has reached the end
+      if (i == dim_num_ - 1) {
+        end_ = true;
+        return;
+      }
+
+      range_coords_[i] = 0;
+      cell_slab_coords_[i] = ranges_[i][0].start_;
+    }
+  }
+}
+
+template <class T>
+void TileCellSlabIter<T>::advance_row() {
+  for (int i = dim_num_ - 1; i >= 0; --i) {
+    cell_slab_coords_[i] +=
+        (i == dim_num_ - 1) ? cell_slab_lengths_[range_coords_[i]] : 1;
+    if (cell_slab_coords_[i] > ranges_[i][range_coords_[i]].end_) {
+      ++range_coords_[i];
+      if (range_coords_[i] < (T)ranges_[i].size())
+        cell_slab_coords_[i] = ranges_[i][range_coords_[i]].start_;
+    }
+
+    if (range_coords_[i] < (T)ranges_[i].size()) {
+      break;
+    } else {
+      // The iterator has reached the end
+      if (i == 0) {
+        end_ = true;
+        return;
+      }
+
+      range_coords_[i] = 0;
+      cell_slab_coords_[i] = ranges_[i][0].start_;
+    }
+  }
+}
+
+template <class T>
+void TileCellSlabIter<T>::init_cell_slab_lengths() {
+  if (layout_ == Layout::ROW_MAJOR) {
+    auto range_num = ranges_[dim_num_ - 1].size();
+    cell_slab_lengths_.resize(range_num);
+    for (size_t i = 0; i < range_num; ++i) {
+      cell_slab_lengths_[i] =
+          ranges_[dim_num_ - 1][i].end_ - ranges_[dim_num_ - 1][i].start_ + 1;
+    }
+  } else {
+    assert(layout_ == Layout::COL_MAJOR);
+    auto range_num = ranges_[0].size();
+    cell_slab_lengths_.resize(range_num);
+    for (size_t i = 0; i < range_num; ++i) {
+      cell_slab_lengths_[i] = ranges_[0][i].end_ - ranges_[0][i].start_ + 1;
+    }
+  }
+}
+
+template <class T>
+void TileCellSlabIter<T>::init_coords() {
+  range_coords_.resize(dim_num_);
+  cell_slab_coords_.resize(dim_num_);
+  for (int i = 0; i < dim_num_; ++i) {
+    range_coords_[i] = 0;
+    cell_slab_coords_[i] = ranges_[i][0].start_;
+  }
+}
+
+template <class T>
+Status TileCellSlabIter<T>::init_ranges(const Subarray& subarray) {
+  // For easy reference
+  const auto& array_schema = subarray.array()->array_schema_latest();
+  auto array_domain = array_schema.domain().domain();
+  uint64_t range_num;
+  const tiledb::type::Range* r;
+  ranges_.resize(dim_num_);
+  for (int d = 0; d < dim_num_; ++d) {
+    RETURN_NOT_OK(subarray.get_range_num(d, &range_num));
+    ranges_[d].reserve(range_num);
+    for (uint64_t j = 0; j < range_num; ++j) {
+      RETURN_NOT_OK(subarray.get_range(d, j, &r));
+      auto range = (const T*)(*r).data();
+      ranges_[d].emplace_back(range[0], range[1]);
+    }
+  }
+
+  return Status::Ok();
+}
+
+template <class T>
+void TileCellSlabIter<T>::update_cell_slab() {
+  // Compute the cell slab length.
+  cell_slab_length_ = (layout_ == Layout::ROW_MAJOR) ?
+                          cell_slab_lengths_[range_coords_[dim_num_ - 1]] :
+                          cell_slab_lengths_[range_coords_[0]];
+
+  // Compute position in tile.
+  pos_in_tile_ = 0;
+  for (int32_t d = 0; d < dim_num_; d++) {
+    pos_in_tile_ +=
+        mult_extents_[d] * (cell_slab_coords_[d] - start_coords_[d]);
+  }
+
+  // Compute destination offset for row/col orders.
+  if (!global_order_) {
+    dest_offset_row_col_ = 0;
+    if (num_ranges_ == 1) {
+      if (layout_ == Layout::COL_MAJOR) {
+        for (int32_t d = 0; d < dim_num_; d++) {
+          const auto& ri = range_info_[d];
+          dest_offset_row_col_ +=
+              ri.multiplier_ * (cell_slab_coords_[d] - ri.mins_[0]);
+        }
+      } else {
+        for (int32_t d = dim_num_ - 1; d >= 0; d--) {
+          const auto& ri = range_info_[d];
+          dest_offset_row_col_ +=
+              ri.multiplier_ * (cell_slab_coords_[d] - ri.mins_[0]);
+        }
+      }
+    } else {
+      if (layout_ == Layout::COL_MAJOR) {
+        for (int32_t d = 0; d < dim_num_; d++) {
+          const auto& ri = range_info_[d];
+          auto r = original_range_idx_[d][range_coords_[d]];
+          dest_offset_row_col_ +=
+              ri.multiplier_ *
+              (cell_slab_coords_[d] - ri.mins_[r] + ri.cell_offsets_[r]);
+        }
+      } else {
+        for (int32_t d = dim_num_ - 1; d >= 0; d--) {
+          const auto& ri = range_info_[d];
+          auto r = original_range_idx_[d][range_coords_[d]];
+          dest_offset_row_col_ +=
+              ri.multiplier_ *
+              (cell_slab_coords_[d] - ri.mins_[r] + ri.cell_offsets_[r]);
+        }
+      }
+    }
+  }
+}
+
+// Explicit template instantiations
+template class TileCellSlabIter<int8_t>;
+template class TileCellSlabIter<uint8_t>;
+template class TileCellSlabIter<int16_t>;
+template class TileCellSlabIter<uint16_t>;
+template class TileCellSlabIter<int32_t>;
+template class TileCellSlabIter<uint32_t>;
+template class TileCellSlabIter<int64_t>;
+template class TileCellSlabIter<uint64_t>;
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/subarray/tile_cell_slab_iter.h
+++ b/tiledb/sm/subarray/tile_cell_slab_iter.h
@@ -108,6 +108,9 @@ class TileCellSlabIter {
   /** Destructor. */
   ~TileCellSlabIter() = default;
 
+  DISABLE_COPY_AND_COPY_ASSIGN(TileCellSlabIter);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(TileCellSlabIter);
+
   /* ********************************* */
   /*                 API               */
   /* ********************************* */

--- a/tiledb/sm/subarray/tile_cell_slab_iter.h
+++ b/tiledb/sm/subarray/tile_cell_slab_iter.h
@@ -1,0 +1,261 @@
+/**
+ * @file   tile_cell_slab_iter.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class TileCellSlabIter.
+ */
+
+#ifndef TILEDB_TILE_CELL_SLAB_ITER_H
+#define TILEDB_TILE_CELL_SLAB_ITER_H
+
+#include "tiledb/sm/enums/layout.h"
+#include "tiledb/sm/subarray/subarray.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * Stores range information, for a dimension, used for row/col reads. This is
+ * used to cache information used to compute where data will be copied in the
+ * output subarray.
+ */
+template <class DimType>
+struct RangeInfo {
+  /** Cell offset, per range for this dimension. */
+  std::vector<uint64_t> cell_offsets_;
+
+  /** Min, per range for this dimension. */
+  std::vector<DimType> mins_;
+
+  /**
+   * Multiplier that contains the product of the total range length for
+   * previous dimensions.
+   */
+  uint64_t multiplier_;
+};
+
+template <class T>
+class TileCellSlabIter {
+ public:
+  /* ********************************* */
+  /*          TYPE DEFINITIONS         */
+  /* ********************************* */
+
+  /**
+   * Stores information about a range along a single dimension. The
+   * whole range resides in a single tile.
+   */
+  struct Range {
+    /** The start of the range in global coordinates. */
+    T start_;
+    /** The end of the range in global coordinates. */
+    T end_;
+
+    /** Constructor. */
+    Range(T start, T end)
+        : start_(start)
+        , end_(end) {
+    }
+
+    /** Equality operator. */
+    bool operator==(const Range& r) const {
+      return (r.start_ == start_ && r.end_ == end_);
+    }
+  };
+
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  explicit TileCellSlabIter(
+      const uint64_t range_thread_idx,
+      const uint64_t num_range_threads,
+      const Subarray& root_subarray,
+      const Subarray& subarray,
+      const std::vector<T>& tile_extents,
+      const std::vector<T>& start_coords,
+      const std::vector<RangeInfo<T>>& range_info,
+      const Layout cell_order);
+
+  /** Destructor. */
+  ~TileCellSlabIter() = default;
+
+  /* ********************************* */
+  /*                 API               */
+  /* ********************************* */
+
+  /** Returns the current cell slab coords. */
+  inline const std::vector<T>& cell_slab_coords() const {
+    return cell_slab_coords_;
+  }
+
+  /** Returns the input cell position in the tile for the current cell slab. */
+  inline uint64_t pos_in_tile() const {
+    return pos_in_tile_;
+  }
+
+  /**
+   * Returns the destination cell position for the current cell slab for
+   * row/col major reads.
+   */
+  inline uint64_t dest_offset_row_col() const {
+    return dest_offset_row_col_;
+  }
+
+  /** Returns the global offset. */
+  inline uint64_t global_offset() const {
+    return global_offset_;
+  };
+
+  /** Returns the current cell slab length. */
+  inline uint64_t cell_slab_length() const {
+    return cell_slab_length_;
+  }
+
+  /** Checks if the iterator has reached the end. */
+  inline bool end() const {
+    return end_ || num_ == 0;
+  }
+
+  /** Checks if the iterator has reached the last slab. */
+  inline bool last_slab() const {
+    return last_ && end();
+  }
+
+  /** Advances the iterator to the next cell slab. */
+  void operator++();
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** Number of ranges. */
+  uint64_t num_ranges_;
+
+  /** Original range indexes. */
+  const std::vector<std::vector<uint64_t>>& original_range_idx_;
+
+  /** Range info. */
+  const std::vector<RangeInfo<T>>& range_info_;
+
+  /** The current cell slab length. */
+  uint64_t cell_slab_length_;
+
+  /** The layout of the tile. */
+  Layout layout_;
+
+  /** Number of dimensions. */
+  int dim_num_;
+
+  /** Global offset. */
+  uint64_t global_offset_;
+
+  /** Current cell position in tile. */
+  uint64_t pos_in_tile_;
+
+  /** Current destination cell offset for row/col orders. */
+  uint64_t dest_offset_row_col_;
+
+  /** Number of slabs left. */
+  uint64_t num_;
+
+  /**
+   * The coordinates of the current range that the next
+   * cell slab will be retrieved from.
+   */
+  std::vector<T> range_coords_;
+
+  /** The starting (global) coordinates of the current cell slab. */
+  std::vector<T> cell_slab_coords_;
+
+  /** The length of a cell slab, one per range along the minor dimension. */
+  std::vector<uint64_t> cell_slab_lengths_;
+
+  /** `True` if the iterator has reached its end. */
+  bool end_;
+
+  /** `True` if the iterator is the last of the range threads. */
+  bool last_;
+
+  /** `True` if the request is in global order. */
+  bool global_order_;
+
+  /**
+   * A list of ranges per dimension. This is derived from the `subarray_`
+   * ranges, after appropriately splitting them so that no range crosses
+   * more that one tile.
+   */
+  std::vector<std::vector<Range>> ranges_;
+
+  /** Saved multiplication of tile extents in cell order. */
+  std::vector<uint64_t> mult_extents_;
+
+  /** start coordinates of the tile. */
+  const std::vector<T>& start_coords_;
+
+  /* ********************************* */
+  /*           PRIVATE METHODS         */
+  /* ********************************* */
+
+  /** Advances to the next cell slab when the layout is col-major. */
+  void advance_col();
+
+  /** Advances to the next cell slab when the layout is row-major. */
+  void advance_row();
+
+  /**
+   * Initializes the cell slab length for each range along the minor
+   * dimension.
+   */
+  void init_cell_slab_lengths();
+
+  /** Initializes the range coords and the cell slab coords. */
+  void init_coords();
+
+  /**
+   * Initializes the ranges per dimension, splitting appropriately the
+   * subarray ranges on tile boundaries. Eventually the produced `ranges_`
+   * should not never cross more than one tile.
+   */
+  Status init_ranges(const Subarray& subarray);
+
+  /**
+   * Updates the current cell slab, based on the current state of
+   * the iterator.
+   */
+  void update_cell_slab();
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_TILE_CELL_SLAB_ITER_H

--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -128,12 +128,12 @@ class Range {
   }
 
   /** Returns the pointer to the range flattened bytes. */
-  const void* data() const {
+  inline const void* data() const {
     return range_.empty() ? nullptr : range_.data();
   }
 
   /** Returns a pointer to the start of the range. */
-  const void* start_fixed() const {
+  inline const void* start_fixed() const {
     assert(!var_size_);
     assert(range_.size() != 0);
     return range_.data();


### PR DESCRIPTION
Before, the dense reader would only parallelize on tiles. This change
implements parallelization within a tile too if there are more cores
than tiles.

Also, it used to load all attributes in memory and then copy to the
users buffers. This was done because CellSlabIter is heavy and we could
run less iterations on it. Unfortunately, when the in memory size of
tiles get very large (greater than 4GB) it causes the copy operation to
run slower because the user's buffers are very far from the actual data.
We now load one attribute at a time and to mitigate the CellSlabIter
issue, a new faster iterator (TileCellSlabIter) was implemented that
iterates on the slabs within a tile only.

---

SC-10669

---
TYPE: IMPROVEMENT
DESC: Dense reader: improving parallelization.