### PR TITLE
Use sparse global ordered reader for unordered queries with no dups.

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -1199,6 +1199,24 @@ std::string get_commit_dir(std::string array_dir) {
   return array_dir + "/" + tiledb::sm::constants::array_commits_dir_name;
 }
 
+template <class T>
+void check_counts(T* vals, uint64_t num, std::vector<uint64_t> expected) {
+  auto expected_size = static_cast<T>(expected.size());
+  std::vector<uint64_t> counts(expected.size());
+  for (uint64_t i = 0; i < num; i++) {
+    CHECK(vals[i] >= 0);
+    CHECK(vals[i] < expected_size);
+
+    if (vals[i] >= 0 && vals[i] < expected_size) {
+      counts[vals[i]]++;
+    }
+  }
+
+  for (uint64_t i = 0; i < expected.size(); i++) {
+    CHECK(counts[i] == expected[i]);
+  }
+}
+
 template void check_subarray<int8_t>(
     tiledb::sm::Subarray& subarray, const SubarrayRanges<int8_t>& ranges);
 template void check_subarray<uint8_t>(
@@ -1566,6 +1584,11 @@ template void read_array<double>(
     const SubarrayRanges<double>& ranges,
     tiledb_layout_t layout,
     const QueryBuffers& buffers);
+
+template void check_counts<int32_t>(
+    int32_t* vals, uint64_t num, std::vector<uint64_t> expected);
+template void check_counts<uint64_t>(
+    uint64_t* vals, uint64_t num, std::vector<uint64_t> expected);
 
 }  // End of namespace test
 

--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -1200,10 +1200,10 @@ std::string get_commit_dir(std::string array_dir) {
 }
 
 template <class T>
-void check_counts(T* vals, uint64_t num, std::vector<uint64_t> expected) {
+void check_counts(span<T> vals, std::vector<uint64_t> expected) {
   auto expected_size = static_cast<T>(expected.size());
   std::vector<uint64_t> counts(expected.size());
-  for (uint64_t i = 0; i < num; i++) {
+  for (uint64_t i = 0; i < vals.size(); i++) {
     CHECK(vals[i] >= 0);
     CHECK(vals[i] < expected_size);
 
@@ -1586,9 +1586,9 @@ template void read_array<double>(
     const QueryBuffers& buffers);
 
 template void check_counts<int32_t>(
-    int32_t* vals, uint64_t num, std::vector<uint64_t> expected);
+    span<int32_t> vals, std::vector<uint64_t> expected);
 template void check_counts<uint64_t>(
-    uint64_t* vals, uint64_t num, std::vector<uint64_t> expected);
+    span<uint64_t> vals, std::vector<uint64_t> expected);
 
 }  // End of namespace test
 

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -696,7 +696,7 @@ std::string get_commit_dir(std::string array_dir);
  * Check count of values against a vector of expected counts for an array.
  */
 template <class T>
-void check_counts(T* vals, uint64_t num, std::vector<uint64_t> expected);
+void check_counts(span<T> vals, std::vector<uint64_t> expected);
 
 }  // End of namespace test
 

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -692,6 +692,12 @@ std::string get_fragment_dir(std::string array_dir);
  */
 std::string get_commit_dir(std::string array_dir);
 
+/**
+ * Check count of values against a vector of expected counts for an array.
+ */
+template <class T>
+void check_counts(T* vals, uint64_t num, std::vector<uint64_t> expected);
+
 }  // End of namespace test
 
 }  // End of namespace tiledb

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -3278,29 +3278,11 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(status == TILEDB_COMPLETED);
 
-  CHECK(a1[0] == 1);
-  CHECK(a1[1] == 2);
-  CHECK(a1[2] == 5);
-  CHECK(a1[3] == 6);
-  CHECK(a1[4] == 7);
-  CHECK(a1[5] == 1);
-  CHECK(a1[6] == 2);
+  check_counts(a1, 7, {0, 2, 2, 0, 0, 1, 1, 1});
   CHECK(a1_size == 7 * sizeof(int));
+  check_counts(coords_dim1, 7, {0, 4, 0, 2, 1});
+  check_counts(coords_dim2, 7, {0, 0, 3, 1, 3});
   CHECK(coords_size == 7 * sizeof(uint64_t));
-  CHECK(coords_dim1[0] == 1);
-  CHECK(coords_dim2[0] == 2);
-  CHECK(coords_dim1[1] == 1);
-  CHECK(coords_dim2[1] == 4);
-  CHECK(coords_dim1[2] == 4);
-  CHECK(coords_dim2[2] == 2);
-  CHECK(coords_dim1[3] == 3);
-  CHECK(coords_dim2[3] == 3);
-  CHECK(coords_dim1[4] == 3);
-  CHECK(coords_dim2[4] == 4);
-  CHECK(coords_dim1[5] == 1);
-  CHECK(coords_dim2[5] == 2);
-  CHECK(coords_dim1[6] == 1);
-  CHECK(coords_dim2[6] == 4);
 
   // Close array
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
@@ -3376,14 +3358,22 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(status == TILEDB_INCOMPLETE);
 
-  CHECK(a1_size == 2 * sizeof(int));
-  CHECK(a1[0] == 1);
-  CHECK(a1[1] == 2);
-  CHECK(coords_size == 2 * sizeof(uint64_t));
-  CHECK(coords_dim1[0] == 1);
-  CHECK(coords_dim2[0] == 2);
-  CHECK(coords_dim1[1] == 1);
-  CHECK(coords_dim2[1] == 4);
+  if (use_refactored_sparse_global_order_reader()) {
+    CHECK(a1_size == 3 * sizeof(int));
+    check_counts(a1, 3, {0, 1, 1, 0, 0, 1});
+    CHECK(coords_size == 3 * sizeof(uint64_t));
+    check_counts(coords_dim1, 3, {0, 2, 0, 0, 1});
+    check_counts(coords_dim2, 3, {0, 0, 2, 0, 1});
+  } else {
+    CHECK(a1_size == 2 * sizeof(int));
+    CHECK(a1[0] == 1);
+    CHECK(a1[1] == 2);
+    CHECK(coords_size == 2 * sizeof(uint64_t));
+    CHECK(coords_dim1[0] == 1);
+    CHECK(coords_dim2[0] == 2);
+    CHECK(coords_dim1[1] == 1);
+    CHECK(coords_dim2[1] == 4);
+  }
 
   rc = tiledb_query_submit(ctx, query);
   CHECK(rc == TILEDB_OK);
@@ -3391,17 +3381,25 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(status == TILEDB_COMPLETED);
 
-  CHECK(a1_size == 3 * sizeof(int));
-  CHECK(a1[0] == 5);
-  CHECK(a1[1] == 6);
-  CHECK(a1[2] == 7);
-  CHECK(coords_size == 3 * sizeof(uint64_t));
-  CHECK(coords_dim1[0] == 4);
-  CHECK(coords_dim2[0] == 2);
-  CHECK(coords_dim1[1] == 3);
-  CHECK(coords_dim2[1] == 3);
-  CHECK(coords_dim1[2] == 3);
-  CHECK(coords_dim2[2] == 4);
+  if (use_refactored_sparse_global_order_reader()) {
+    CHECK(a1_size == 2 * sizeof(int));
+    check_counts(a1, 2, {0, 0, 0, 0, 0, 0, 1, 1});
+    CHECK(coords_size == 2 * sizeof(uint64_t));
+    check_counts(coords_dim1, 2, {0, 0, 0, 2});
+    check_counts(coords_dim2, 2, {0, 0, 0, 1, 1});
+  } else {
+    CHECK(a1_size == 3 * sizeof(int));
+    CHECK(a1[0] == 5);
+    CHECK(a1[1] == 6);
+    CHECK(a1[2] == 7);
+    CHECK(coords_size == 3 * sizeof(uint64_t));
+    CHECK(coords_dim1[0] == 4);
+    CHECK(coords_dim2[0] == 2);
+    CHECK(coords_dim1[1] == 3);
+    CHECK(coords_dim2[1] == 3);
+    CHECK(coords_dim1[2] == 3);
+    CHECK(coords_dim2[2] == 4);
+  }
 
   // Close array
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
@@ -3478,22 +3476,10 @@ TEST_CASE_METHOD(
   REQUIRE(status == TILEDB_COMPLETED);
 
   CHECK(a1_size == 5 * sizeof(int));
-  CHECK(a1[0] == 1);
-  CHECK(a1[1] == 2);
-  CHECK(a1[2] == 5);
-  CHECK(a1[3] == 6);
-  CHECK(a1[4] == 7);
+  check_counts(a1, 5, {0, 1, 1, 0, 0, 1, 1, 1});
   CHECK(coords_size == 5 * sizeof(uint64_t));
-  CHECK(coords_dim1[0] == 1);
-  CHECK(coords_dim2[0] == 2);
-  CHECK(coords_dim1[1] == 1);
-  CHECK(coords_dim2[1] == 4);
-  CHECK(coords_dim1[2] == 4);
-  CHECK(coords_dim2[2] == 2);
-  CHECK(coords_dim1[3] == 3);
-  CHECK(coords_dim2[3] == 3);
-  CHECK(coords_dim1[4] == 3);
-  CHECK(coords_dim2[4] == 4);
+  check_counts(coords_dim1, 5, {0, 2, 0, 2, 1});
+  check_counts(coords_dim2, 5, {0, 0, 2, 1, 2});
 
   // Close array
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -3278,10 +3278,10 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(status == TILEDB_COMPLETED);
 
-  check_counts(a1, 7, {0, 2, 2, 0, 0, 1, 1, 1});
+  check_counts(span(a1, 7), {0, 2, 2, 0, 0, 1, 1, 1});
   CHECK(a1_size == 7 * sizeof(int));
-  check_counts(coords_dim1, 7, {0, 4, 0, 2, 1});
-  check_counts(coords_dim2, 7, {0, 0, 3, 1, 3});
+  check_counts(span(coords_dim1, 7), {0, 4, 0, 2, 1});
+  check_counts(span(coords_dim2, 7), {0, 0, 3, 1, 3});
   CHECK(coords_size == 7 * sizeof(uint64_t));
 
   // Close array
@@ -3360,10 +3360,10 @@ TEST_CASE_METHOD(
 
   if (use_refactored_sparse_global_order_reader()) {
     CHECK(a1_size == 3 * sizeof(int));
-    check_counts(a1, 3, {0, 1, 1, 0, 0, 1});
+    check_counts(span(a1, 3), {0, 1, 1, 0, 0, 1});
     CHECK(coords_size == 3 * sizeof(uint64_t));
-    check_counts(coords_dim1, 3, {0, 2, 0, 0, 1});
-    check_counts(coords_dim2, 3, {0, 0, 2, 0, 1});
+    check_counts(span(coords_dim1, 3), {0, 2, 0, 0, 1});
+    check_counts(span(coords_dim2, 3), {0, 0, 2, 0, 1});
   } else {
     CHECK(a1_size == 2 * sizeof(int));
     CHECK(a1[0] == 1);
@@ -3383,10 +3383,10 @@ TEST_CASE_METHOD(
 
   if (use_refactored_sparse_global_order_reader()) {
     CHECK(a1_size == 2 * sizeof(int));
-    check_counts(a1, 2, {0, 0, 0, 0, 0, 0, 1, 1});
+    check_counts(span(a1, 2), {0, 0, 0, 0, 0, 0, 1, 1});
     CHECK(coords_size == 2 * sizeof(uint64_t));
-    check_counts(coords_dim1, 2, {0, 0, 0, 2});
-    check_counts(coords_dim2, 2, {0, 0, 0, 1, 1});
+    check_counts(span(coords_dim1, 2), {0, 0, 0, 2});
+    check_counts(span(coords_dim2, 2), {0, 0, 0, 1, 1});
   } else {
     CHECK(a1_size == 3 * sizeof(int));
     CHECK(a1[0] == 5);
@@ -3476,10 +3476,10 @@ TEST_CASE_METHOD(
   REQUIRE(status == TILEDB_COMPLETED);
 
   CHECK(a1_size == 5 * sizeof(int));
-  check_counts(a1, 5, {0, 1, 1, 0, 0, 1, 1, 1});
+  check_counts(span(a1, 5), {0, 1, 1, 0, 0, 1, 1, 1});
   CHECK(coords_size == 5 * sizeof(uint64_t));
-  check_counts(coords_dim1, 5, {0, 2, 0, 2, 1});
-  check_counts(coords_dim2, 5, {0, 0, 2, 1, 2});
+  check_counts(span(coords_dim1, 5), {0, 2, 0, 2, 1});
+  check_counts(span(coords_dim2, 5), {0, 0, 2, 1, 2});
 
   // Close array
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -377,16 +377,14 @@ TEST_CASE(
     CHECK_NOTHROW(query_r.submit());
     CHECK(query_r.query_status() == tiledb::Query::Status::COMPLETE);
     // check number of results
-    CHECK(query_r.result_buffer_elements()["a"].second == 6);
+    uint64_t num = query_r.result_buffer_elements()["a"].second;
+    CHECK(num == 6);
     array_r.close();
 
     // Check results
-    std::vector<int32_t> c_buff_a = {2, 3, 1, 2, 4, 1, 0};
-    std::vector<int32_t> c_buff_d1 = {1, 1, 4, 1, 5, 4, 0};
-    std::vector<int32_t> c_buff_d2 = {3, 1, 2, 3, 4, 2, 0};
-    CHECK(r_buff_a == c_buff_a);
-    CHECK(r_buff_d1 == c_buff_d1);
-    CHECK(r_buff_d2 == c_buff_d2);
+    check_counts(r_buff_a.data(), num, {0, 2, 2, 1, 1});
+    check_counts(r_buff_d1.data(), num, {0, 3, 0, 0, 2, 1});
+    check_counts(r_buff_d2.data(), num, {0, 1, 2, 2, 1});
   }
 
   // Remove array

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -382,9 +382,9 @@ TEST_CASE(
     array_r.close();
 
     // Check results
-    check_counts(r_buff_a.data(), num, {0, 2, 2, 1, 1});
-    check_counts(r_buff_d1.data(), num, {0, 3, 0, 0, 2, 1});
-    check_counts(r_buff_d2.data(), num, {0, 1, 2, 2, 1});
+    check_counts(span(r_buff_a.data(), num), {0, 2, 2, 1, 1});
+    check_counts(span(r_buff_d1.data(), num), {0, 3, 0, 0, 2, 1});
+    check_counts(span(r_buff_d2.data(), num), {0, 1, 2, 2, 1});
   }
 
   // Remove array

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -926,16 +926,29 @@ TEST_CASE(
   REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
   auto result_num = result_elts["rows"].second;
-  REQUIRE(result_num == 1);
-  REQUIRE(data[0] == 'l');
+
+  if (use_refactored_sparse_global_order_reader()) {
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'l');
+    REQUIRE(data[1] == 'l');
+  } else {
+    REQUIRE(result_num == 1);
+    REQUIRE(data[0] == 'l');
+  }
 
   st = query.submit();
   REQUIRE(st == tiledb::Query::Status::COMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
-  REQUIRE(result_num == 2);
-  REQUIRE(data[0] == 'l');
-  REQUIRE(data[1] == 'm');
+
+  if (use_refactored_sparse_global_order_reader()) {
+    REQUIRE(result_num == 1);
+    REQUIRE(data[0] == 'm');
+  } else {
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'l');
+    REQUIRE(data[1] == 'm');
+  }
 
   // Close array.
   array.close();
@@ -1013,17 +1026,30 @@ TEST_CASE(
   REQUIRE(st == tiledb::Query::Status::INCOMPLETE);
   auto result_elts = query.result_buffer_elements();
   auto result_num = result_elts["rows"].second;
-  REQUIRE(result_num == 1);
-  REQUIRE(data[0] == 'l');
+
+  if (use_refactored_sparse_global_order_reader()) {
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'l');
+    REQUIRE(data[1] == 'l');
+  } else {
+    REQUIRE(result_num == 1);
+    REQUIRE(data[0] == 'l');
+  }
 
   query.set_subarray(subarray);
   st = query.submit();
   REQUIRE(st == tiledb::Query::Status::COMPLETE);
   result_elts = query.result_buffer_elements();
   result_num = result_elts["rows"].second;
-  REQUIRE(result_num == 2);
-  REQUIRE(data[0] == 'l');
-  REQUIRE(data[1] == 'm');
+
+  if (use_refactored_sparse_global_order_reader()) {
+    REQUIRE(result_num == 1);
+    REQUIRE(data[0] == 'm');
+  } else {
+    REQUIRE(result_num == 2);
+    REQUIRE(data[0] == 'l');
+    REQUIRE(data[1] == 'm');
+  }
 
   // Close array.
   array.close();

--- a/test/src/unit-result-coords.cc
+++ b/test/src/unit-result-coords.cc
@@ -58,7 +58,7 @@ struct CResultCoordsFx {
   CResultCoordsFx();
   ~CResultCoordsFx();
 
-  GlobalOrderResultTile make_tile_with_num_cells(uint64_t num_cells);
+  GlobalOrderResultTile<uint8_t> make_tile_with_num_cells(uint64_t num_cells);
 };
 
 CResultCoordsFx::CResultCoordsFx() {
@@ -116,9 +116,9 @@ CResultCoordsFx::~CResultCoordsFx() {
   tiledb_vfs_free(&vfs_);
 }
 
-GlobalOrderResultTile CResultCoordsFx::make_tile_with_num_cells(
+GlobalOrderResultTile<uint8_t> CResultCoordsFx::make_tile_with_num_cells(
     uint64_t num_cells) {
-  GlobalOrderResultTile result_tile(
+  GlobalOrderResultTile<uint8_t> result_tile(
       0, 0, array_->array_->array_schema_latest());
   auto tile_tuple = result_tile.tile_tuple(constants::coords);
   Tile* const tile = &std::get<0>(*tile_tuple);
@@ -145,8 +145,8 @@ class Cmp {
   }
 
   bool operator()(
-      const GlobalOrderResultCoords& a,
-      const GlobalOrderResultCoords& b) const {
+      const GlobalOrderResultCoords<uint8_t>& a,
+      const GlobalOrderResultCoords<uint8_t>& b) const {
     if (a.pos_ == b.pos_) {
       return true;
     }

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -451,7 +451,8 @@ TEST_CASE_METHOD(
 
   // Check the internal loop count against expected value.
   auto stats =
-      ((sm::SparseGlobalOrderReader*)query->query_->strategy())->stats();
+      ((sm::SparseGlobalOrderReader<uint8_t>*)query->query_->strategy())
+          ->stats();
   REQUIRE(stats != nullptr);
   auto counters = stats->counters();
   REQUIRE(counters != nullptr);
@@ -646,7 +647,8 @@ TEST_CASE_METHOD(
 
   // Check the internal loop count against expected value.
   auto stats =
-      ((sm::SparseGlobalOrderReader*)query->query_->strategy())->stats();
+      ((sm::SparseGlobalOrderReader<uint8_t>*)query->query_->strategy())
+          ->stats();
   REQUIRE(stats != nullptr);
   auto counters = stats->counters();
   REQUIRE(counters != nullptr);

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -150,9 +150,10 @@ class HilbertCmp : protected CellCmpBase {
    * @param b The second coordinate.
    * @return `true` if `a` precedes `b` and `false` otherwise.
    */
+  template <class BitmapType>
   bool operator()(
-      const GlobalOrderResultCoords& a,
-      const GlobalOrderResultCoords& b) const {
+      const GlobalOrderResultCoords<BitmapType>& a,
+      const GlobalOrderResultCoords<BitmapType>& b) const {
     auto hilbert_a = a.tile_->hilbert_value(a.pos_);
     auto hilbert_b = b.tile_->hilbert_value(b.pos_);
     if (hilbert_a < hilbert_b)

--- a/tiledb/sm/query/hilbert_order.cc
+++ b/tiledb/sm/query/hilbert_order.cc
@@ -56,8 +56,18 @@ uint64_t map_to_uint64(
   return dim.map_to_uint64(d.content(), d.size(), bits, max_bucket_val);
 }
 
-template uint64_t map_to_uint64<GlobalOrderResultCoords>(
-    const Dimension&, const GlobalOrderResultCoords&, uint32_t, int, uint64_t);
+template uint64_t map_to_uint64<GlobalOrderResultCoords<uint8_t>>(
+    const Dimension&,
+    const GlobalOrderResultCoords<uint8_t>&,
+    uint32_t,
+    int,
+    uint64_t);
+template uint64_t map_to_uint64<GlobalOrderResultCoords<uint64_t>>(
+    const Dimension&,
+    const GlobalOrderResultCoords<uint64_t>&,
+    uint32_t,
+    int,
+    uint64_t);
 template uint64_t map_to_uint64<ResultCoords>(
     const Dimension&, const ResultCoords&, uint32_t, int, uint64_t);
 

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -191,9 +191,10 @@ struct GlobalOrderResultCoords
 
       // For overlapping ranges, if there's more than one cell in the bitmap,
       // return 1.
-      if (std::is_same<BitmapType, uint64_t>::value &&
-          base::tile_->bitmap_[base::pos_] != 1) {
-        return 1;
+      if constexpr (std::is_same<BitmapType, uint64_t>::value) {
+        if (base::tile_->bitmap_[base::pos_] != 1) {
+          return 1;
+        }
       }
 
       // With bitmap, find the longest contiguous set of bits in the bitmap
@@ -231,9 +232,10 @@ struct GlobalOrderResultCoords
 
       // For overlapping ranges, if there's more than one cell in the bitmap,
       // return 1.
-      if (std::is_same<BitmapType, uint64_t>::value &&
-          base::tile_->bitmap_[base::pos_] != 1) {
-        return 1;
+      if constexpr (std::is_same<BitmapType, uint64_t>::value) {
+        if (base::tile_->bitmap_[base::pos_] != 1) {
+          return 1;
+        }
       }
 
       // With bitmap, find the longest contiguous set of bits in the bitmap

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -198,7 +198,7 @@ struct GlobalOrderResultCoords
 
       // With bitmap, find the longest contiguous set of bits in the bitmap
       // from the current position.
-      while (next_pos < cell_num && base::tile_->bitmap_[next_pos]) {
+      while (next_pos < cell_num && base::tile_->bitmap_[next_pos] == 1) {
         next_pos++;
         ret++;
       }
@@ -240,7 +240,8 @@ struct GlobalOrderResultCoords
       // from the current position, with coordinares smaller than the next one
       // in the queue.
       base::pos_++;
-      while (base::pos_ < cell_num && base::tile_->bitmap_[base::pos_] && !cmp(*this, next)) {
+      while (base::pos_ < cell_num && base::tile_->bitmap_[base::pos_] &&
+             !cmp(*this, next)) {
         base::pos_++;
         ret++;
       }

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -191,7 +191,8 @@ struct GlobalOrderResultCoords
 
       // For overlapping ranges, if there's more than one cell in the bitmap,
       // return 1.
-      if constexpr (std::is_same<BitmapType, uint64_t>::value) {
+      const bool overlapping_ranges = std::is_same<BitmapType, uint64_t>::value;
+      if constexpr (overlapping_ranges) {
         if (base::tile_->bitmap_[base::pos_] != 1) {
           return 1;
         }
@@ -232,7 +233,8 @@ struct GlobalOrderResultCoords
 
       // For overlapping ranges, if there's more than one cell in the bitmap,
       // return 1.
-      if constexpr (std::is_same<BitmapType, uint64_t>::value) {
+      const bool overlapping_ranges = std::is_same<BitmapType, uint64_t>::value;
+      if constexpr (overlapping_ranges) {
         if (base::tile_->bitmap_[base::pos_] != 1) {
           return 1;
         }

--- a/tiledb/sm/query/result_coords.h
+++ b/tiledb/sm/query/result_coords.h
@@ -45,6 +45,7 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+template <class BitmapType>
 class GlobalOrderResultTile;
 
 /**
@@ -142,26 +143,29 @@ struct ResultCoords : public ResultCoordsBase<ResultTile> {
   bool valid_;
 };
 
+template <class BitmapType>
 struct GlobalOrderResultCoords
-    : public ResultCoordsBase<GlobalOrderResultTile> {
+    : public ResultCoordsBase<GlobalOrderResultTile<BitmapType>> {
+  using base = ResultCoordsBase<GlobalOrderResultTile<BitmapType>>;
+
   /** Constructor. */
-  GlobalOrderResultCoords(GlobalOrderResultTile* tile, uint64_t pos)
-      : ResultCoordsBase(tile, pos)
+  GlobalOrderResultCoords(GlobalOrderResultTile<BitmapType>* tile, uint64_t pos)
+      : ResultCoordsBase<GlobalOrderResultTile<BitmapType>>(tile, pos)
       , init_(false) {
   }
 
   /** Advance to the next available cell in the tile. */
   bool advance_to_next_cell() {
-    pos_ += init_;
+    base::pos_ += init_;
     init_ = true;
-    uint64_t cell_num = tile_->cell_num();
-    if (pos_ != cell_num) {
-      if (tile_->has_bmp()) {
-        while (pos_ < cell_num) {
-          if (tile_->bitmap_[pos_]) {
+    uint64_t cell_num = base::tile_->cell_num();
+    if (base::pos_ != cell_num) {
+      if (base::tile_->has_bmp()) {
+        while (base::pos_ < cell_num) {
+          if (base::tile_->bitmap_[base::pos_]) {
             return true;
           }
-          pos_++;
+          base::pos_++;
         }
       } else {
         return true;
@@ -177,23 +181,30 @@ struct GlobalOrderResultCoords
    */
   uint64_t max_slab_length() {
     uint64_t ret = 1;
-    uint64_t cell_num = tile_->cell_num();
-    uint64_t next_pos = pos_ + 1;
-    if (tile_->has_bmp()) {
+    uint64_t cell_num = base::tile_->cell_num();
+    uint64_t next_pos = base::pos_ + 1;
+    if (base::tile_->has_bmp()) {
       // Current cell is not in the bitmap.
-      if (!tile_->bitmap_[pos_]) {
+      if (!base::tile_->bitmap_[base::pos_]) {
         return 0;
+      }
+
+      // For overlapping ranges, if there's more than one cell in the bitmap,
+      // return 1.
+      if (std::is_same<BitmapType, uint64_t>::value &&
+          base::tile_->bitmap_[base::pos_] != 1) {
+        return 1;
       }
 
       // With bitmap, find the longest contiguous set of bits in the bitmap
       // from the current position.
-      while (next_pos < cell_num && tile_->bitmap_[next_pos]) {
+      while (next_pos < cell_num && base::tile_->bitmap_[next_pos]) {
         next_pos++;
         ret++;
       }
     } else {
       // No bitmap, add all cells from current position.
-      ret = cell_num - pos_;
+      ret = cell_num - base::pos_;
     }
 
     return ret;
@@ -207,37 +218,44 @@ struct GlobalOrderResultCoords
   uint64_t max_slab_length(
       const GlobalOrderResultCoords& next, const CompType& cmp) {
     uint64_t ret = 1;
-    uint64_t cell_num = tile_->cell_num();
+    uint64_t cell_num = base::tile_->cell_num();
 
     // Store the original position.
-    uint64_t orig_pos = pos_;
+    uint64_t orig_pos = base::pos_;
 
-    if (tile_->has_bmp()) {
+    if (base::tile_->has_bmp()) {
       // Current cell is not in the bitmap.
-      if (!tile_->bitmap_[pos_]) {
+      if (!base::tile_->bitmap_[base::pos_]) {
         return 0;
+      }
+
+      // For overlapping ranges, if there's more than one cell in the bitmap,
+      // return 1.
+      if (std::is_same<BitmapType, uint64_t>::value &&
+          base::tile_->bitmap_[base::pos_] != 1) {
+        return 1;
       }
 
       // With bitmap, find the longest contiguous set of bits in the bitmap
       // from the current position, with coordinares smaller than the next one
       // in the queue.
-      pos_++;
-      while (pos_ < cell_num && tile_->bitmap_[pos_] && !cmp(*this, next)) {
-        pos_++;
+      base::pos_++;
+      while (base::pos_ < cell_num && base::tile_->bitmap_[base::pos_] && !cmp(*this, next)) {
+        base::pos_++;
         ret++;
       }
     } else {
       // No bitmap, add all cells from current position, with coordinares
       // smaller than the next one in the queue.
-      pos_++;
-      while (pos_ < cell_num - 1 && !cmp(*this, next)) {
-        pos_++;
+      base::pos_++;
+      while (base::pos_ < cell_num - 1 && !cmp(*this, next)) {
+        base::pos_++;
         ret++;
       }
     }
 
     // Restore the original position.
-    pos_ = orig_pos;
+    base::pos_ = orig_pos;
     return ret;
   }
 

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -586,14 +586,15 @@ class ResultTileWithBitmap : public ResultTile {
 };
 
 /** Global order result tile. */
-class GlobalOrderResultTile : public ResultTileWithBitmap<uint8_t> {
+template <class BitmapType>
+class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
   GlobalOrderResultTile(
       unsigned frag_idx, uint64_t tile_idx, const ArraySchema& array_schema)
-      : ResultTileWithBitmap<uint8_t>(frag_idx, tile_idx, array_schema)
+      : ResultTileWithBitmap<BitmapType>(frag_idx, tile_idx, array_schema)
       , used_(false) {
   }
 
@@ -635,7 +636,7 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<uint8_t> {
 
   /** Allocate space for the hilbert values vector. */
   inline void allocate_hilbert_vector() {
-    hilbert_values_.resize(cell_num());
+    hilbert_values_.resize(ResultTile::cell_num());
   }
 
   /** Get the hilbert value at an index. */
@@ -651,7 +652,7 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<uint8_t> {
   /** Return first cell index in bitmap. */
   uint64_t first_cell_in_bitmap() {
     uint64_t ret = 0;
-    while (!bitmap_[ret]) {
+    while (!ResultTileWithBitmap<BitmapType>::bitmap_[ret]) {
       ret++;
     }
 
@@ -660,8 +661,8 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<uint8_t> {
 
   /** Return first cell index in bitmap. */
   uint64_t last_cell_in_bitmap() {
-    uint64_t ret = bitmap_.size() - 1;
-    while (!bitmap_[ret]) {
+    uint64_t ret = ResultTileWithBitmap<BitmapType>::bitmap_.size() - 1;
+    while (!ResultTileWithBitmap<BitmapType>::bitmap_[ret]) {
       ret--;
     }
 

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -62,7 +62,8 @@ namespace sm {
 /*          CONSTRUCTORS          */
 /* ****************************** */
 
-SparseGlobalOrderReader::SparseGlobalOrderReader(
+template <class BitmapType>
+SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
     stats::Stats* stats,
     shared_ptr<Logger> logger,
     StorageManager* storage_manager,
@@ -94,18 +95,21 @@ SparseGlobalOrderReader::SparseGlobalOrderReader(
 /*               API              */
 /* ****************************** */
 
-bool SparseGlobalOrderReader::incomplete() const {
+template <class BitmapType>
+bool SparseGlobalOrderReader<BitmapType>::incomplete() const {
   return !read_state_.done_adding_result_tiles_ ||
          memory_used_for_coords_total_ != 0;
 }
 
-QueryStatusDetailsReason SparseGlobalOrderReader::status_incomplete_reason()
-    const {
+template <class BitmapType>
+QueryStatusDetailsReason
+SparseGlobalOrderReader<BitmapType>::status_incomplete_reason() const {
   return incomplete() ? QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE :
                         QueryStatusDetailsReason::REASON_NONE;
 }
 
-Status SparseGlobalOrderReader::init() {
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::init() {
   RETURN_NOT_OK(SparseIndexReaderBase::init());
 
   // Initialize memory budget variables.
@@ -114,7 +118,8 @@ Status SparseGlobalOrderReader::init() {
   return Status::Ok();
 }
 
-Status SparseGlobalOrderReader::initialize_memory_budget() {
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::initialize_memory_budget() {
   bool found = false;
   RETURN_NOT_OK(
       config_.get<uint64_t>("sm.mem.total_budget", &memory_budget_, &found));
@@ -143,7 +148,8 @@ Status SparseGlobalOrderReader::initialize_memory_budget() {
   return Status::Ok();
 }
 
-Status SparseGlobalOrderReader::dowork() {
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::dowork() {
   auto timer_se = stats_->start_timer("dowork");
 
   // For easy reference.
@@ -200,10 +206,10 @@ Status SparseGlobalOrderReader::dowork() {
       RETURN_NOT_OK(read_and_unfilter_coords(true, tmp_result_tiles));
 
       // Compute the tile bitmaps.
-      RETURN_NOT_OK(compute_tile_bitmaps<uint8_t>(tmp_result_tiles));
+      RETURN_NOT_OK(compute_tile_bitmaps<BitmapType>(tmp_result_tiles));
 
       // Apply query condition.
-      RETURN_NOT_OK(apply_query_condition<uint8_t>(tmp_result_tiles));
+      RETURN_NOT_OK(apply_query_condition<BitmapType>(tmp_result_tiles));
 
       // Run deduplication for tiles with timestamps, if required.
       RETURN_NOT_OK(dedup_tiles_with_timestamps(tmp_result_tiles));
@@ -268,10 +274,13 @@ Status SparseGlobalOrderReader::dowork() {
   return Status::Ok();
 }
 
-void SparseGlobalOrderReader::reset() {
+template <class BitmapType>
+void SparseGlobalOrderReader<BitmapType>::reset() {
 }
 
-tuple<Status, optional<bool>> SparseGlobalOrderReader::add_result_tile(
+template <class BitmapType>
+tuple<Status, optional<bool>>
+SparseGlobalOrderReader<BitmapType>::add_result_tile(
     const unsigned dim_num,
     const uint64_t memory_budget_coords_tiles,
     const uint64_t memory_budget_qc_tiles,
@@ -283,7 +292,8 @@ tuple<Status, optional<bool>> SparseGlobalOrderReader::add_result_tile(
   }
 
   // Calculate memory consumption for this tile.
-  auto&& [st, tiles_sizes] = get_coord_tiles_size<uint8_t>(true, dim_num, f, t);
+  auto&& [st, tiles_sizes] =
+      get_coord_tiles_size<BitmapType>(true, dim_num, f, t);
   RETURN_NOT_OK_TUPLE(st, nullopt);
   auto tiles_size = tiles_sizes->first;
   auto tiles_size_qc = tiles_sizes->second;
@@ -316,7 +326,9 @@ tuple<Status, optional<bool>> SparseGlobalOrderReader::add_result_tile(
   return {Status::Ok(), false};
 }
 
-tuple<Status, optional<bool>> SparseGlobalOrderReader::create_result_tiles() {
+template <class BitmapType>
+tuple<Status, optional<bool>>
+SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
   auto timer_se = stats_->start_timer("create_result_tiles");
 
   // For easy reference.
@@ -439,7 +451,8 @@ tuple<Status, optional<bool>> SparseGlobalOrderReader::create_result_tiles() {
   return {Status::Ok(), tiles_found};
 }
 
-Status SparseGlobalOrderReader::dedup_tiles_with_timestamps(
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::dedup_tiles_with_timestamps(
     std::vector<ResultTile*>& result_tiles) {
   // For consolidation with timestamps or arrays with duplicates, no need to
   // do deduplication.
@@ -455,7 +468,8 @@ Status SparseGlobalOrderReader::dedup_tiles_with_timestamps(
         const auto f = result_tiles[t]->frag_idx();
         if (fragment_metadata_[f]->has_timestamps()) {
           // For easy reference.
-          auto rt = static_cast<GlobalOrderResultTile*>(result_tiles[t]);
+          auto rt =
+              static_cast<GlobalOrderResultTile<BitmapType>*>(result_tiles[t]);
           auto cell_num =
               fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
@@ -516,7 +530,8 @@ Status SparseGlobalOrderReader::dedup_tiles_with_timestamps(
   return Status::Ok();
 }
 
-Status SparseGlobalOrderReader::dedup_fragments_with_timestamps() {
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps() {
   // For consolidation with timestamps or arrays with duplicates, no need to
   // do deduplication.
   if (consolidation_with_timestamps_ || array_schema_.allows_dups()) {
@@ -599,8 +614,9 @@ Status SparseGlobalOrderReader::dedup_fragments_with_timestamps() {
   return Status::Ok();
 }
 
+template <class BitmapType>
 tuple<Status, optional<std::vector<ResultCellSlab>>>
-SparseGlobalOrderReader::compute_result_cell_slab() {
+SparseGlobalOrderReader<BitmapType>::compute_result_cell_slab() {
   auto timer_se = stats_->start_timer("compute_result_cell_slab");
 
   // First try to limit the maximum number of cells we copy using the size
@@ -639,10 +655,12 @@ SparseGlobalOrderReader::compute_result_cell_slab() {
   }
 }
 
+template <class BitmapType>
 template <class CompType>
-tuple<Status, optional<bool>> SparseGlobalOrderReader::add_next_cell_to_queue(
+tuple<Status, optional<bool>>
+SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
     bool dups,
-    GlobalOrderResultCoords& rc,
+    GlobalOrderResultCoords<BitmapType>& rc,
     std::vector<TileListIt>& result_tiles_it,
     TileMinHeap<CompType>& tile_queue) {
   auto frag_idx = rc.tile_->frag_idx();
@@ -719,7 +737,8 @@ tuple<Status, optional<bool>> SparseGlobalOrderReader::add_next_cell_to_queue(
   return {Status::Ok(), false};
 }
 
-Status SparseGlobalOrderReader::compute_hilbert_values(
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::compute_hilbert_values(
     std::vector<ResultTile*>& result_tiles) {
   auto timer_se = stats_->start_timer("compute_hilbert_values");
 
@@ -734,7 +753,8 @@ Status SparseGlobalOrderReader::compute_hilbert_values(
   // Parallelize on tiles.
   auto status = parallel_for(
       storage_manager_->compute_tp(), 0, result_tiles.size(), [&](uint64_t t) {
-        auto tile = static_cast<GlobalOrderResultTile*>(result_tiles[t]);
+        auto tile =
+            static_cast<GlobalOrderResultTile<BitmapType>*>(result_tiles[t]);
         auto cell_num =
             fragment_metadata_[tile->frag_idx()]->cell_num(tile->tile_idx());
         auto rc = GlobalOrderResultCoords(tile, 0);
@@ -763,8 +783,9 @@ Status SparseGlobalOrderReader::compute_hilbert_values(
   return Status::Ok();
 }
 
-uint64_t SparseGlobalOrderReader::get_timestamp(
-    const GlobalOrderResultCoords& rc) const {
+template <class BitmapType>
+uint64_t SparseGlobalOrderReader<BitmapType>::get_timestamp(
+    const GlobalOrderResultCoords<BitmapType>& rc) const {
   const auto f = rc.tile_->frag_idx();
   if (fragment_metadata_[f]->has_timestamps()) {
     return rc.tile_->timestamp(rc.pos_);
@@ -773,9 +794,10 @@ uint64_t SparseGlobalOrderReader::get_timestamp(
   }
 }
 
+template <class BitmapType>
 template <class CompType>
 tuple<Status, optional<std::vector<ResultCellSlab>>>
-SparseGlobalOrderReader::merge_result_cell_slabs(
+SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
     uint64_t num_cells, CompType cmp) {
   auto timer_se = stats_->start_timer("merge_result_cell_slabs");
   std::vector<ResultCellSlab> result_cell_slabs;
@@ -786,7 +808,7 @@ SparseGlobalOrderReader::merge_result_cell_slabs(
   auto dups = array_schema_.allows_dups() || consolidation_with_timestamps_;
 
   // A tile min heap, contains one GlobalOrderResultCoords per fragment.
-  std::vector<GlobalOrderResultCoords> container;
+  std::vector<GlobalOrderResultCoords<BitmapType>> container;
   container.reserve(result_tiles_.size());
   TileMinHeap<CompType> tile_queue(cmp, std::move(container));
 
@@ -822,6 +844,8 @@ SparseGlobalOrderReader::merge_result_cell_slabs(
       });
   RETURN_NOT_OK_ELSE_TUPLE(status, logger_->status(status), nullopt);
 
+  const bool non_overlapping_ranges = std::is_same<BitmapType, uint8_t>::value;
+
   // Process all elements.
   while (!tile_queue.empty() && !need_more_tiles && num_cells > 0) {
     auto to_process = tile_queue.top();
@@ -838,9 +862,24 @@ SparseGlobalOrderReader::merge_result_cell_slabs(
       auto tile = to_process_dup.tile_;
       if (dups) {
         tile->set_used();
-        result_cell_slabs.emplace_back(
-            to_process_dup.tile_, to_process_dup.pos_, 1);
-        num_cells--;
+        if (non_overlapping_ranges) {
+          result_cell_slabs.emplace_back(
+              to_process_dup.tile_, to_process_dup.pos_, 1);
+          num_cells--;
+        } else {
+          // For overlapping ranges, create as many slabs as there are counts.
+          auto num = to_process_dup.tile_->bitmap_[to_process_dup.pos_];
+          if (num_cells < num) {
+            num_cells = 0;
+            break;
+          }
+
+          for (uint64_t i = 0; i < num; i++) {
+            result_cell_slabs.emplace_back(
+                to_process_dup.tile_, to_process_dup.pos_, 1);
+            num_cells--;
+          }
+        }
 
         if (num_cells == 0) {
           break;
@@ -894,9 +933,24 @@ SparseGlobalOrderReader::merge_result_cell_slabs(
     }
 
     // Generate the result cell slabs.
-    result_cell_slabs.emplace_back(tile, start, length);
-    read_state_.frag_idx_[frag_idx] = FragIdx(tile_idx, start + length);
-    num_cells -= length;
+    if (non_overlapping_ranges) {
+      result_cell_slabs.emplace_back(tile, start, length);
+      read_state_.frag_idx_[frag_idx] = FragIdx(tile_idx, start + length);
+      num_cells -= length;
+    } else {
+      auto num = to_process.tile_->bitmap_[to_process.pos_];
+      if (num > num_cells) {
+        num_cells = 0;
+        break;
+      }
+
+      for (uint64_t i = 0; i < num; i++) {
+        result_cell_slabs.emplace_back(tile, start, length);
+        num_cells -= length;
+      }
+
+      read_state_.frag_idx_[frag_idx] = FragIdx(tile_idx, start + length);
+    }
 
     // Put the next cell in the queue.
     auto&& [st, more_tiles] =
@@ -915,8 +969,9 @@ SparseGlobalOrderReader::merge_result_cell_slabs(
   return {Status::Ok(), std::move(result_cell_slabs)};
 };
 
+template <class BitmapType>
 tuple<uint64_t, uint64_t, uint64_t, bool>
-SparseGlobalOrderReader::compute_parallelization_parameters(
+SparseGlobalOrderReader<BitmapType>::compute_parallelization_parameters(
     const uint64_t range_thread_idx,
     const uint64_t num_range_threads,
     const uint64_t start,
@@ -939,8 +994,9 @@ SparseGlobalOrderReader::compute_parallelization_parameters(
   return {min_pos, max_pos, cell_offset + min_pos - start, false};
 }
 
+template <class BitmapType>
 template <class OffType>
-Status SparseGlobalOrderReader::copy_offsets_tiles(
+Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
     const std::string& name,
     const uint64_t num_range_threads,
     const bool nullable,
@@ -961,15 +1017,15 @@ Status SparseGlobalOrderReader::copy_offsets_tiles(
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
         auto& rcs = result_cell_slabs[i];
-        auto rt =
-            static_cast<GlobalOrderResultTile*>(result_cell_slabs[i].tile_);
+        auto rt = static_cast<GlobalOrderResultTile<BitmapType>*>(
+            result_cell_slabs[i].tile_);
 
         // Get source buffers.
         const auto tile_tuple = rt->tile_tuple(name);
         const auto t = &std::get<0>(*tile_tuple);
         const auto t_var = &std::get<1>(*tile_tuple);
-        const auto src_buff = t->data_as<uint64_t>();
-        const auto src_var_buff = t_var->data_as<char>();
+        const auto src_buff = t->template data_as<uint64_t>();
+        const auto src_var_buff = t_var->template data_as<char>();
         const auto t_val = &std::get<2>(*tile_tuple);
         const auto cell_num =
             fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
@@ -1010,7 +1066,7 @@ Status SparseGlobalOrderReader::copy_offsets_tiles(
 
         // Copy nullable values.
         if (nullable) {
-          const auto src_val_buff = t_val->data_as<uint8_t>();
+          const auto src_val_buff = t_val->template data_as<uint8_t>();
           for (uint64_t c = min_pos; c < max_pos; c++) {
             *val_buffer = src_val_buff[c];
             val_buffer++;
@@ -1024,8 +1080,9 @@ Status SparseGlobalOrderReader::copy_offsets_tiles(
   return Status::Ok();
 }
 
+template <class BitmapType>
 template <class OffType>
-Status SparseGlobalOrderReader::copy_var_data_tiles(
+Status SparseGlobalOrderReader<BitmapType>::copy_var_data_tiles(
     const uint64_t num_range_threads,
     const OffType offset_div,
     const uint64_t var_buffer_size,
@@ -1099,7 +1156,8 @@ Status SparseGlobalOrderReader::copy_var_data_tiles(
   return Status::Ok();
 }
 
-Status SparseGlobalOrderReader::copy_fixed_data_tiles(
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
     const std::string& name,
     const uint64_t num_range_threads,
     const bool is_dim,
@@ -1121,8 +1179,8 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
         auto& rcs = result_cell_slabs[i];
-        auto rt =
-            static_cast<GlobalOrderResultTile*>(result_cell_slabs[i].tile_);
+        auto rt = static_cast<GlobalOrderResultTile<BitmapType>*>(
+            result_cell_slabs[i].tile_);
 
         // Get source buffers.
         const auto stores_zipped_coords = is_dim && rt->stores_zipped_coords();
@@ -1130,7 +1188,7 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
                                     rt->tile_tuple(constants::coords) :
                                     rt->tile_tuple(name);
         const auto t = &std::get<0>(*tile_tuple);
-        const auto src_buff = t->data_as<uint8_t>();
+        const auto src_buff = t->template data_as<uint8_t>();
         const auto t_val = &std::get<2>(*tile_tuple);
 
         // Compute parallelization parameters.
@@ -1167,7 +1225,7 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
         }
 
         if (nullable) {
-          const auto src_val_buff = t_val->data_as<uint8_t>();
+          const auto src_val_buff = t_val->template data_as<uint8_t>();
           memcpy(val_buffer, src_val_buff + min_pos, max_pos - min_pos);
         }
 
@@ -1178,7 +1236,8 @@ Status SparseGlobalOrderReader::copy_fixed_data_tiles(
   return Status::Ok();
 }
 
-Status SparseGlobalOrderReader::copy_timestamps_tiles(
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
     const uint64_t num_range_threads,
     const std::vector<ResultCellSlab>& result_cell_slabs,
     const std::vector<uint64_t>& cell_offsets,
@@ -1195,8 +1254,8 @@ Status SparseGlobalOrderReader::copy_timestamps_tiles(
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
         auto& rcs = result_cell_slabs[i];
-        auto rt =
-            static_cast<GlobalOrderResultTile*>(result_cell_slabs[i].tile_);
+        auto rt = static_cast<GlobalOrderResultTile<BitmapType>*>(
+            result_cell_slabs[i].tile_);
         const uint64_t cell_size = constants::timestamp_size;
 
         // Get source buffers.
@@ -1221,7 +1280,7 @@ Status SparseGlobalOrderReader::copy_timestamps_tiles(
 
         if (fragment_metadata_[rt->frag_idx()]->has_timestamps()) {
           // Copy tile.
-          const auto src_buff = t->data_as<uint8_t>();
+          const auto src_buff = t->template data_as<uint8_t>();
           memcpy(
               buffer,
               src_buff + min_pos * cell_size,
@@ -1242,8 +1301,9 @@ Status SparseGlobalOrderReader::copy_timestamps_tiles(
   return Status::Ok();
 }
 
+template <class BitmapType>
 tuple<Status, optional<std::vector<uint64_t>>>
-SparseGlobalOrderReader::respect_copy_memory_budget(
+SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
     const std::vector<std::string>& names,
     const uint64_t memory_budget,
     std::vector<ResultCellSlab>& result_cell_slabs) {
@@ -1273,8 +1333,8 @@ SparseGlobalOrderReader::respect_copy_memory_budget(
         // Get the size for all tiles.
         uint64_t idx = 0;
         for (; idx < max_cs_idx; idx++) {
-          auto rt =
-              static_cast<GlobalOrderResultTile*>(result_cell_slabs[idx].tile_);
+          auto rt = static_cast<GlobalOrderResultTile<BitmapType>*>(
+              result_cell_slabs[idx].tile_);
           auto id =
               std::pair<uint64_t, uint64_t>(rt->frag_idx(), rt->tile_idx());
 
@@ -1334,8 +1394,9 @@ SparseGlobalOrderReader::respect_copy_memory_budget(
   return {Status::Ok(), std::move(total_mem_usage_per_attr)};
 }
 
+template <class BitmapType>
 template <class OffType>
-uint64_t SparseGlobalOrderReader::compute_var_size_offsets(
+uint64_t SparseGlobalOrderReader<BitmapType>::compute_var_size_offsets(
     stats::Stats* stats,
     std::vector<ResultCellSlab>& result_cell_slabs,
     std::vector<uint64_t>& cell_offsets,
@@ -1406,8 +1467,9 @@ uint64_t SparseGlobalOrderReader::compute_var_size_offsets(
   return new_var_buffer_size;
 }
 
+template <class BitmapType>
 template <class OffType>
-Status SparseGlobalOrderReader::process_slabs(
+Status SparseGlobalOrderReader<BitmapType>::process_slabs(
     std::vector<std::string>& names,
     std::vector<ResultCellSlab>& result_cell_slabs) {
   auto timer_se = stats_->start_timer("process_slabs");
@@ -1564,11 +1626,12 @@ Status SparseGlobalOrderReader::process_slabs(
   return Status::Ok();
 }
 
-Status SparseGlobalOrderReader::remove_result_tile(
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::remove_result_tile(
     const unsigned frag_idx, TileListIt rt) {
   // Remove coord tile size from memory budget.
   auto tile_idx = rt->tile_idx();
-  auto&& [st, tiles_sizes] = get_coord_tiles_size<uint8_t>(
+  auto&& [st, tiles_sizes] = get_coord_tiles_size<BitmapType>(
       true, array_schema_.dim_num(), frag_idx, tile_idx);
   RETURN_NOT_OK(st);
   auto tiles_size = tiles_sizes->first;
@@ -1597,7 +1660,8 @@ Status SparseGlobalOrderReader::remove_result_tile(
   return Status::Ok();
 }
 
-Status SparseGlobalOrderReader::end_iteration() {
+template <class BitmapType>
+Status SparseGlobalOrderReader<BitmapType>::end_iteration() {
   // For easy reference.
   auto fragment_num = fragment_metadata_.size();
 
@@ -1630,6 +1694,30 @@ Status SparseGlobalOrderReader::end_iteration() {
   array_memory_tracker_->set_budget(std::numeric_limits<uint64_t>::max());
   return Status::Ok();
 }
+
+// Explicit template instantiations
+template SparseGlobalOrderReader<uint8_t>::SparseGlobalOrderReader(
+    stats::Stats*,
+    shared_ptr<Logger>,
+    StorageManager*,
+    Array*,
+    Config&,
+    std::unordered_map<std::string, QueryBuffer>&,
+    Subarray&,
+    Layout,
+    QueryCondition&,
+    bool);
+template SparseGlobalOrderReader<uint64_t>::SparseGlobalOrderReader(
+    stats::Stats*,
+    shared_ptr<Logger>,
+    StorageManager*,
+    Array*,
+    Config&,
+    std::unordered_map<std::string, QueryBuffer>&,
+    Subarray&,
+    Layout,
+    QueryCondition&,
+    bool);
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -251,7 +251,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * fragment with timestamps.
    */
   inline bool last_in_memory_cell_of_consolidated_fragment(
-      const unsigned int frag_idx, const GlobalOrderResultCoords<BitmapType>& rc) const {
+      const unsigned int frag_idx,
+      const GlobalOrderResultCoords<BitmapType>& rc) const {
     return !all_tiles_loaded_[frag_idx] &&
            fragment_metadata_[frag_idx]->has_timestamps() &&
            rc.tile_->tile_idx() == last_cells_[frag_idx].tile_idx_ &&

--- a/tiledb/sm/query/sparse_global_order_reader.h
+++ b/tiledb/sm/query/sparse_global_order_reader.h
@@ -56,6 +56,8 @@ class Array;
 class StorageManager;
 
 /** Processes sparse global order read queries. */
+
+template <class BitmapType>
 class SparseGlobalOrderReader : public SparseIndexReaderBase,
                                 public IQueryStrategy {
  public:
@@ -142,7 +144,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
   /** The result tiles currently loaded. */
-  std::vector<std::list<GlobalOrderResultTile>> result_tiles_;
+  std::vector<std::list<GlobalOrderResultTile<BitmapType>>> result_tiles_;
 
   /** Memory used for coordinates tiles per fragment. */
   std::vector<uint64_t> memory_used_for_coords_;
@@ -172,12 +174,13 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /** Tile min heap. */
   template <typename CompType>
   using TileMinHeap = std::priority_queue<
-      GlobalOrderResultCoords,
-      std::vector<GlobalOrderResultCoords>,
+      GlobalOrderResultCoords<BitmapType>,
+      std::vector<GlobalOrderResultCoords<BitmapType>>,
       CompType>;
 
   /** Tile list iterator. */
-  using TileListIt = std::list<GlobalOrderResultTile>::iterator;
+  using TileListIt =
+      typename std::list<GlobalOrderResultTile<BitmapType>>::iterator;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */
@@ -248,7 +251,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * fragment with timestamps.
    */
   inline bool last_in_memory_cell_of_consolidated_fragment(
-      const unsigned int frag_idx, const GlobalOrderResultCoords& rc) const {
+      const unsigned int frag_idx, const GlobalOrderResultCoords<BitmapType>& rc) const {
     return !all_tiles_loaded_[frag_idx] &&
            fragment_metadata_[frag_idx]->has_timestamps() &&
            rc.tile_->tile_idx() == last_cells_[frag_idx].tile_idx_ &&
@@ -269,7 +272,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   template <class CompType>
   tuple<Status, optional<bool>> add_next_cell_to_queue(
       bool dups,
-      GlobalOrderResultCoords& rc,
+      GlobalOrderResultCoords<BitmapType>& rc,
       std::vector<TileListIt>& result_tiles_it,
       TileMinHeap<CompType>& tile_queue);
 
@@ -289,7 +292,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    *
    * @return timestamp.
    */
-  uint64_t get_timestamp(const GlobalOrderResultCoords& rc) const;
+  uint64_t get_timestamp(const GlobalOrderResultCoords<BitmapType>& rc) const;
 
   /**
    * Compute the result cell slabs once tiles are loaded.

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1089,16 +1089,29 @@ Status query_to_capnp(
       }
     } else if (
         query.use_refactored_sparse_global_order_reader() && !schema.dense() &&
-        (layout == Layout::GLOBAL_ORDER ||
-         (layout == Layout::UNORDERED && query.subarray()->range_num() <= 1))) {
+        (layout == Layout::GLOBAL_ORDER || layout == Layout::UNORDERED)) {
       auto builder = query_builder->initReaderIndex();
-      auto reader = (SparseGlobalOrderReader*)query.strategy();
 
-      query_builder->setVarOffsetsMode(reader->offsets_mode());
-      query_builder->setVarOffsetsAddExtraElement(
-          reader->offsets_extra_element());
-      query_builder->setVarOffsetsBitsize(reader->offsets_bitsize());
-      RETURN_NOT_OK(index_reader_to_capnp(query, *reader, &builder));
+      auto&& [st, non_overlapping_ranges]{query.non_overlapping_ranges()};
+      RETURN_NOT_OK(st);
+
+      if (*non_overlapping_ranges) {
+        auto reader = (SparseGlobalOrderReader<uint8_t>*)query.strategy();
+
+        query_builder->setVarOffsetsMode(reader->offsets_mode());
+        query_builder->setVarOffsetsAddExtraElement(
+            reader->offsets_extra_element());
+        query_builder->setVarOffsetsBitsize(reader->offsets_bitsize());
+        RETURN_NOT_OK(index_reader_to_capnp(query, *reader, &builder));
+      } else {
+        auto reader = (SparseGlobalOrderReader<uint64_t>*)query.strategy();
+
+        query_builder->setVarOffsetsMode(reader->offsets_mode());
+        query_builder->setVarOffsetsAddExtraElement(
+            reader->offsets_extra_element());
+        query_builder->setVarOffsetsBitsize(reader->offsets_bitsize());
+        RETURN_NOT_OK(index_reader_to_capnp(query, *reader, &builder));
+      }
     } else if (
         query.use_refactored_dense_reader() && all_dense && schema.dense()) {
       auto builder = query_builder->initDenseReader();
@@ -1624,26 +1637,52 @@ Status query_from_capnp(
       query->clear_strategy();
       RETURN_NOT_OK(query->set_layout_unsafe(layout));
 
+      auto&& [st, non_overlapping_ranges]{query->non_overlapping_ranges()};
+      RETURN_NOT_OK(st);
+
       auto reader_reader = query_reader.getReaderIndex();
-      auto reader = (SparseGlobalOrderReader*)query->strategy();
 
-      if (query_reader.hasVarOffsetsMode()) {
+      if (*non_overlapping_ranges) {
+        auto reader = (SparseGlobalOrderReader<uint8_t>*)query->strategy();
+
+        if (query_reader.hasVarOffsetsMode()) {
+          RETURN_NOT_OK(
+              reader->set_offsets_mode(query_reader.getVarOffsetsMode()));
+        }
+
+        RETURN_NOT_OK(reader->set_offsets_extra_element(
+            query_reader.getVarOffsetsAddExtraElement()));
+
+        if (query_reader.getVarOffsetsBitsize() > 0) {
+          RETURN_NOT_OK(
+              reader->set_offsets_bitsize(query_reader.getVarOffsetsBitsize()));
+        }
+
+        RETURN_NOT_OK(reader->initialize_memory_budget());
+
         RETURN_NOT_OK(
-            reader->set_offsets_mode(query_reader.getVarOffsetsMode()));
-      }
+            index_reader_from_capnp(schema, reader_reader, query, reader));
+      } else {
+        auto reader = (SparseGlobalOrderReader<uint64_t>*)query->strategy();
 
-      RETURN_NOT_OK(reader->set_offsets_extra_element(
-          query_reader.getVarOffsetsAddExtraElement()));
+        if (query_reader.hasVarOffsetsMode()) {
+          RETURN_NOT_OK(
+              reader->set_offsets_mode(query_reader.getVarOffsetsMode()));
+        }
 
-      if (query_reader.getVarOffsetsBitsize() > 0) {
+        RETURN_NOT_OK(reader->set_offsets_extra_element(
+            query_reader.getVarOffsetsAddExtraElement()));
+
+        if (query_reader.getVarOffsetsBitsize() > 0) {
+          RETURN_NOT_OK(
+              reader->set_offsets_bitsize(query_reader.getVarOffsetsBitsize()));
+        }
+
+        RETURN_NOT_OK(reader->initialize_memory_budget());
+
         RETURN_NOT_OK(
-            reader->set_offsets_bitsize(query_reader.getVarOffsetsBitsize()));
+            index_reader_from_capnp(schema, reader_reader, query, reader));
       }
-
-      RETURN_NOT_OK(reader->initialize_memory_budget());
-
-      RETURN_NOT_OK(
-          index_reader_from_capnp(schema, reader_reader, query, reader));
     } else if (
         query_reader.hasReaderIndex() && !schema.dense() &&
         layout == Layout::UNORDERED && schema.allows_dups()) {


### PR DESCRIPTION
This change modifies the sparse global order reader to process unordered
queries made on arrays with duplicates. As we don't care about the
order of the data, we can ignore the constraint that we only support
one range for global order.

This also fixes an issue in bitmap computation for multiplicities,
where the relevant ranges were not computed properly for count bitmaps.

---
TYPE: IMPROVEMENT
DESC: Use sparse global ordered reader for unordered queries with no dups.
