### PR TITLE
Sparse index readers: fixing queries with overlapping ranges.

### DIFF
--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -782,35 +782,34 @@ void Dimension::relevant_ranges<char>(
       });
 
   // If we have no ranges just exit early
-  if (it == ranges.end())
+  if (it == ranges.end()) {
     return;
+  }
 
   // Set start index
-  const uint64_t start_range_idx = std::distance(ranges.begin(), it);
+  const uint64_t start_range = std::distance(ranges.begin(), it);
 
-  // Binary search to find the last range containing the start mbr.
+  // Find upper bound to end comparisons. Finding this early allows avoiding the
+  // conditional exit in the for loop below
   auto it2 = std::lower_bound(
       it,
       ranges.end(),
       mbr_end,
       [&](const Range& a, const std::string_view& value) {
-        return a.start_str() < value;
+        return a.start_str() <= value;
       });
 
-  // If the upper bound isn't the end add +1 to the index
-  uint64_t offset = 0;
-  if (it2 != ranges.end())
-    offset = 1;
-  const uint64_t end_range_idx =
-      std::distance(it, it2) + start_range_idx + offset;
+  // Set end index
+  const uint64_t end_range = std::distance(it, it2) + start_range;
 
   // Loop over only potential relevant ranges
-  for (uint64_t r = start_range_idx; r < end_range_idx; ++r) {
+  for (uint64_t r = start_range; r < end_range; ++r) {
     const auto& r1_start = ranges[r].start_str();
     const auto& r1_end = ranges[r].end_str();
 
-    if (r1_start <= mbr_end && mbr_start <= r1_end)
+    if (r1_start <= mbr_end && mbr_start <= r1_end) {
       relevant_ranges.emplace_back(r);
+    }
   }
 }
 
@@ -832,30 +831,30 @@ void Dimension::relevant_ranges(
         return ((const T*)a.start_fixed())[1] < value;
       });
 
-  if (it == ranges.end())
+  if (it == ranges.end()) {
     return;
+  }
 
+  // Set start index
   const uint64_t start_range = std::distance(ranges.begin(), it);
 
   // Find upper bound to end comparisons. Finding this early allows avoiding the
   // conditional exit in the for loop below
   auto it2 = std::lower_bound(
       it, ranges.end(), mbr_end, [&](const Range& a, const T value) {
-        return ((const T*)a.start_fixed())[0] < value;
+        return ((const T*)a.start_fixed())[0] <= value;
       });
 
-  // If the upper bound isn't the end add +1 to the index
-  uint64_t offset = 0;
-  if (it2 != ranges.end())
-    offset = 1;
-  const uint64_t end_range = std::distance(it, it2) + start_range + offset;
+  // Set end index
+  const uint64_t end_range = std::distance(it, it2) + start_range;
 
   // Loop over only potential relevant ranges
   for (uint64_t r = start_range; r < end_range; ++r) {
     const auto d1 = (const T*)ranges[r].start_fixed();
 
-    if ((d1[0] <= mbr_end && d1[1] >= mbr_start))
+    if ((d1[0] <= mbr_end && d1[1] >= mbr_start)) {
       relevant_ranges.emplace_back(r);
+    }
   }
 }
 

--- a/tiledb/sm/array_schema/test/unit_dimension.cc
+++ b/tiledb/sm/array_schema/test/unit_dimension.cc
@@ -38,6 +38,63 @@ using namespace tiledb;
 using namespace tiledb::common;
 using namespace tiledb::sm;
 
+using Datatype = tiledb::sm::Datatype;
+
+template <class T>
+struct type_to_datatype {
+  static Datatype datatype;
+};
+
+template <>
+struct type_to_datatype<int8_t> {
+  static constexpr Datatype datatype = Datatype::INT8;
+};
+
+template <>
+struct type_to_datatype<int16_t> {
+  static constexpr Datatype datatype = Datatype::INT16;
+};
+
+template <>
+struct type_to_datatype<int32_t> {
+  static constexpr Datatype datatype = Datatype::INT32;
+};
+
+template <>
+struct type_to_datatype<int64_t> {
+  static constexpr Datatype datatype = Datatype::INT64;
+};
+
+template <>
+struct type_to_datatype<uint8_t> {
+  static constexpr Datatype datatype = Datatype::UINT8;
+};
+
+template <>
+struct type_to_datatype<uint16_t> {
+  static constexpr Datatype datatype = Datatype::UINT16;
+};
+
+template <>
+struct type_to_datatype<uint32_t> {
+  static constexpr Datatype datatype = Datatype::UINT32;
+};
+
+template <>
+struct type_to_datatype<uint64_t> {
+  static constexpr Datatype datatype = Datatype::UINT64;
+};
+
+template <>
+struct type_to_datatype<float> {
+  static constexpr Datatype datatype = Datatype::FLOAT32;
+};
+
+template <>
+struct type_to_datatype<double> {
+  static constexpr Datatype datatype = Datatype::FLOAT64;
+};
+
 template <class T, int n>
 inline T& dim_buffer_offset(void* p) {
   return *static_cast<T*>(static_cast<void*>(static_cast<char*>(p) + n));
@@ -211,5 +268,89 @@ TEMPLATE_LIST_TEST_CASE(
         CHECK(Dimension::tile_idx(val, domain_low, tile_extent) == idx);
       }
     }
+  }
+}
+
+void check_relevant_ranges(
+    std::vector<uint64_t>& relevant_ranges, std::vector<uint64_t>& expected) {
+  CHECK(relevant_ranges.size() == expected.size());
+  for (uint64_t r = 0; r < expected.size(); r++) {
+    CHECK(relevant_ranges[r] == expected[r]);
+  }
+}
+
+typedef tuple<
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t>
+    FixedTypes;
+TEMPLATE_LIST_TEST_CASE(
+    "test relevant_ranges", "[dimension][relevant_ranges][fixed]", FixedTypes) {
+  typedef TestType T;
+  auto tiledb_type = type_to_datatype<T>().datatype;
+  Dimension dim{"", tiledb_type};
+
+  std::vector<T> range_data = {
+      1, 1, 1, 1, 2, 2, 3, 4, 5, 6, 5, 7, 8, 9, 50, 56};
+  NDRange ranges;
+  for (uint64_t r = 0; r < range_data.size() / 2; r++) {
+    ranges.emplace_back(&range_data[r * 2], 2 * sizeof(T));
+  }
+
+  // Test data.
+  std::vector<std::vector<T>> mbr_data = {{1, 1}, {2, 6}, {7, 8}};
+  std::vector<std::vector<uint64_t>> expected = {{0, 1}, {2, 3, 4, 5}, {5, 6}};
+
+  // Compute and check relevant ranges.
+  for (uint64_t i = 0; i < mbr_data.size(); i++) {
+    Range mbr(mbr_data[i].data(), 2 * sizeof(T));
+
+    std::vector<uint64_t> relevant_ranges;
+    dim.relevant_ranges(ranges, mbr, relevant_ranges);
+    check_relevant_ranges(relevant_ranges, expected[i]);
+  }
+}
+
+TEST_CASE("test relevant_ranges", "[dimension][relevant_ranges][string]") {
+  Dimension dim{"", Datatype::STRING_ASCII};
+
+  std::vector<char> range_data = {'a',
+                                  'a',
+                                  'a',
+                                  'a',
+                                  'b',
+                                  'b',
+                                  'c',
+                                  'd',
+                                  'e',
+                                  'f',
+                                  'e',
+                                  'g',
+                                  'h',
+                                  'i',
+                                  'y',
+                                  'z'};
+  NDRange ranges;
+  for (uint64_t r = 0; r < range_data.size() / 2; r++) {
+    ranges.emplace_back(&range_data[r * 2], 2, 1);
+  }
+
+  // Test data.
+  std::vector<std::vector<char>> mbr_data = {
+      {'a', 'a'}, {'b', 'f'}, {'g', 'h'}};
+  std::vector<std::vector<uint64_t>> expected = {{0, 1}, {2, 3, 4, 5}, {5, 6}};
+
+  // Compute and check relevant ranges.
+  for (uint64_t i = 0; i < mbr_data.size(); i++) {
+    Range mbr(mbr_data[i].data(), 2, 1);
+
+    std::vector<uint64_t> relevant_ranges;
+    dim.relevant_ranges(ranges, mbr, relevant_ranges);
+    check_relevant_ranges(relevant_ranges, expected[i]);
   }
 }

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -966,15 +966,10 @@ void ResultTile::compute_results_count_sparse(
               range_indexes.end(),
               c,
               [&](const uint64_t& index, const T& value) {
-                return ((const T*)ranges[index].start_fixed())[0] < value;
+                return ((const T*)ranges[index].start_fixed())[0] <= value;
               });
 
-          // If the upper bound isn't the end add +1 to the index.
-          uint64_t offset = 0;
-          if (it2 != range_indexes.end())
-            offset = 1;
-          uint64_t end_range_idx =
-              std::distance(it, it2) + start_range_idx + offset;
+          uint64_t end_range_idx = std::distance(it, it2) + start_range_idx;
 
           // Iterate through all relevant ranges and compute the count for this
           // dim.

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1851,7 +1851,10 @@ tuple<Status, optional<bool>> Subarray::non_overlapping_ranges(
       array_->array_schema_latest().dim_num(),
       [&](uint64_t dim_idx) {
         auto&& [status, nor]{non_overlapping_ranges_for_dim(dim_idx)};
-        non_overlapping_ranges = *nor;
+
+        if (!*nor) {
+          non_overlapping_ranges = false;
+        }
 
         return status;
       });


### PR DESCRIPTION
Queries with overlapping ranges has an issue where sometimes, ranges
would not be returned by Dimension::relevant_ranges. This addresses the
issue.

---
TYPE: BUG
DESC: Sparse index readers: fixing queries with overlapping ranges.
