### PR TITLE
changes to aid building against tiledb static (after libmagic additions)

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -576,6 +576,8 @@ target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
     Zlib::Zlib
     Zstd::Zstd
     libmagic
+    pcre2-8
+    pcre2-posix
 )
 
 if (NOT WIN32)
@@ -849,6 +851,8 @@ if (TILEDB_STATIC)
   append_dep_lib(GCSSDK::crc32c)
   append_dep_lib(spdlog::spdlog)
   append_dep_lib(libmagic)
+  append_dep_lib(pcre2-8)
+  append_dep_lib(pcre2-posix)
 endif()
 
 ############################################################


### PR DESCRIPTION
add pcre2* libs assoc'd with file-windows libmagic build needed for linking with static tiledb
---
TYPE: BUG
DESC: changes to aid building against tiledb static (after libmagic additions)
