### PR TITLE
Fix bad_optional_access exceptions when running consolidation with timestamps tests

### DIFF
--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -726,12 +726,12 @@ ReaderBase::load_tile_chunk_data(
     // dense case).
     if (tile_tuple == nullptr ||
         std::get<0>(*tile_tuple).filtered_buffer().size() == 0) {
-      return {Status::Ok(), nullopt, nullopt, nullopt};
+      return {Status::Ok(), 0, 0, 0};
     }
 
     // If the fragment doesn't include timestamps
     if (timestamps_not_present(name, fragment)) {
-      return {Status::Ok(), nullopt, nullopt, nullopt};
+      return {Status::Ok(), 0, 0, 0};
     }
 
     const auto t = &std::get<0>(*tile_tuple);


### PR DESCRIPTION
When running consolidation-with-timestamps unit test we get a series of access violations that are caught at the top level and don't fail the tests :

```
[2022-05-25 13:04:03.638] [Process: 47770] [error] [Global] [TileDB::Task] Error: Caught std::exception: bad_optional_access 
[2022-05-25 13:04:03.639] [Process: 47770] [error] [Global] [TileDB::Task] Error: Caught std::exception: bad_optional_access
```
We fix this by returning default values for some non-error cases instead of `nullopt`.

---
TYPE: BUG
DESC: Fix bad_optional_access exceptions when running consolidation with timestamps tests
