### PR TITLE
Remove timestamp-based vacuuming

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -277,8 +277,6 @@ void check_save_to_file() {
   ss << "sm.skip_est_size_partitioning false\n";
   ss << "sm.tile_cache_size 10000000\n";
   ss << "sm.vacuum.mode fragments\n";
-  ss << "sm.vacuum.timestamp_end " << std::to_string(UINT64_MAX) << "\n";
-  ss << "sm.vacuum.timestamp_start 0\n";
   ss << "sm.var_offsets.bitsize 64\n";
   ss << "sm.var_offsets.extra_element false\n";
   ss << "sm.var_offsets.mode bytes\n";
@@ -612,8 +610,6 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.consolidation.mode"] = "fragments";
   all_param_values["sm.read_range_oob"] = "warn";
   all_param_values["sm.vacuum.mode"] = "fragments";
-  all_param_values["sm.vacuum.timestamp_start"] = "0";
-  all_param_values["sm.vacuum.timestamp_end"] = std::to_string(UINT64_MAX);
   all_param_values["sm.var_offsets.bitsize"] = "32";
   all_param_values["sm.var_offsets.extra_element"] = "true";
   all_param_values["sm.var_offsets.mode"] = "elements";

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -138,10 +138,7 @@ struct ConsolidationFx {
       uint64_t end = UINT64_MAX);
   void consolidate_sparse_heterogeneous();
   void consolidate_sparse_string();
-  void vacuum_dense(
-      const std::string& mode = "fragments",
-      uint64_t start = 0,
-      uint64_t end = UINT64_MAX);
+  void vacuum_dense(const std::string& mode = "fragments");
   void vacuum_sparse(
       const std::string& mode = "fragments",
       uint64_t start = 0,
@@ -4351,8 +4348,7 @@ void ConsolidationFx::consolidate_sparse_string() {
   REQUIRE(rc == TILEDB_OK);
 }
 
-void ConsolidationFx::vacuum_dense(
-    const std::string& mode, uint64_t start, uint64_t end) {
+void ConsolidationFx::vacuum_dense(const std::string& mode) {
   int rc;
   tiledb_config_t* cfg;
   tiledb_error_t* err = nullptr;
@@ -4361,15 +4357,6 @@ void ConsolidationFx::vacuum_dense(
   rc = tiledb_config_set(cfg, "sm.vacuum.mode", mode.c_str(), &err);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.vacuum.timestamp_start", std::to_string(start).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.vacuum.timestamp_end", std::to_string(end).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-
   rc = tiledb_array_vacuum(ctx_, DENSE_ARRAY_NAME, cfg);
   REQUIRE(rc == TILEDB_OK);
 
@@ -6437,10 +6424,7 @@ TEST_CASE_METHOD(
     consolidate_dense("fragments", start2, end2);
     CHECK(get_num_fragments_to_vacuum_dense() == 4);
 
-    vacuum_dense("fragments", start1, end1);
-    CHECK(get_num_fragments_to_vacuum_dense() == 2);
-
-    vacuum_dense("fragments", start2, end2);
+    vacuum_dense("fragments");
     CHECK(get_num_fragments_to_vacuum_dense() == 0);
   }
 
@@ -6468,14 +6452,7 @@ TEST_CASE_METHOD(
     get_array_meta_files_dense(array_meta_files);
     CHECK(array_meta_files.size() == 7);
 
-    vacuum_dense("array_meta", start1, end1);
-
-    get_array_meta_vac_files_dense(array_meta_vac_files);
-    CHECK(array_meta_vac_files.size() == 1);
-    get_array_meta_files_dense(array_meta_files);
-    CHECK(array_meta_files.size() == 5);
-
-    vacuum_dense("array_meta", start2, end2);
+    vacuum_dense("array_meta");
 
     get_array_meta_vac_files_dense(array_meta_vac_files);
     CHECK(array_meta_vac_files.size() == 0);

--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -96,7 +96,7 @@ struct GroupFx {
       tiledb::sm::URI group_uri, std::vector<std::string>& files) const;
   void get_meta_vac_files(
       tiledb::sm::URI group_uri, std::vector<std::string>& files) const;
-  void vacuum(const char* group_uri, uint64_t start, uint64_t end) const;
+  void vacuum(const char* group_uri) const;
 };
 
 GroupFx::GroupFx()
@@ -219,25 +219,14 @@ void GroupFx::consolidate(
   tiledb_config_free(&cfg);
 }
 
-void GroupFx::vacuum(
-    const char* group_uri, uint64_t start, uint64_t end) const {
+void GroupFx::vacuum(const char* group_uri) const {
   int rc;
   tiledb_config_t* cfg;
   tiledb_error_t* err = nullptr;
   REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
   REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.vacuum.timestamp_start", std::to_string(start).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-  rc = tiledb_config_set(
-      cfg, "sm.vacuum.timestamp_end", std::to_string(end).c_str(), &err);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(err == nullptr);
-
   rc = tiledb_group_vacuum_metadata(ctx_, group_uri, cfg);
   REQUIRE(rc == TILEDB_OK);
-
   tiledb_config_free(&cfg);
 }
 
@@ -725,14 +714,7 @@ TEST_CASE_METHOD(
   get_meta_files(group_uri, group_meta_files);
   CHECK(group_meta_files.size() == 7);
 
-  vacuum(group_uri.c_str(), start1, end1);
-
-  get_meta_vac_files(group_uri, group_meta_vac_files);
-  CHECK(group_meta_vac_files.size() == 1);
-  get_meta_files(group_uri, group_meta_files);
-  CHECK(group_meta_files.size() == 5);
-
-  vacuum(group_uri.c_str(), start2, end2);
+  vacuum(group_uri.c_str());
 
   get_meta_vac_files(group_uri, group_meta_vac_files);
   CHECK(group_meta_vac_files.size() == 0);
@@ -746,7 +728,7 @@ TEST_CASE_METHOD(
   get_meta_files(group_uri, group_meta_files);
   CHECK(group_meta_files.size() == 4);
 
-  vacuum(group_uri.c_str(), start, end);
+  vacuum(group_uri.c_str());
 
   get_meta_vac_files(group_uri, group_meta_vac_files);
   CHECK(group_meta_vac_files.size() == 0);

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1025,18 +1025,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    `fragment_meta` (remove only consolidated fragment metadata), or
  *    `array_meta` (remove consolidated array metadata files). <br>
  *    **Default**: fragments
- * - `sm.vacuum.timestamp_start` <br>
- *    **Experimental** <br>
- *    When set, an array will be vacuumed between this value and
- *    `sm.vacuum.timestamp_end` (inclusive). <br>
- *    Only for `fragments` and `array_meta` vacuum mode. <br>
- *    **Default**: 0
- * - `sm.vacuum.timestamp_end` <br>
- *    **Experimental** <br>
- *    When set, an array will be vacuumed between `sm.vacuum.timestamp_start`
- *    and this value (inclusive). <br>
- *    Only for `fragments` and `array_meta` vacuum mode. <br>
- *    **Default**: UINT64_MAX
  * - `sm.consolidation_mode` <br>
  *    The consolidation mode, one of `fragments` (consolidate all fragments),
  *    `fragment_meta` (consolidate only fragment metadata footers to a single

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -283,8 +283,6 @@ Config::Config() {
   param_values_["sm.consolidation.with_timestamps"] =
       SM_CONSOLIDATION_WITH_TIMESTAMPS;
   param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
-  param_values_["sm.vacuum.timestamp_start"] = SM_VACUUM_TIMESTAMP_START;
-  param_values_["sm.vacuum.timestamp_end"] = SM_VACUUM_TIMESTAMP_END;
   param_values_["sm.var_offsets.bitsize"] = SM_OFFSETS_BITSIZE;
   param_values_["sm.var_offsets.extra_element"] = SM_OFFSETS_EXTRA_ELEMENT;
   param_values_["sm.var_offsets.mode"] = SM_OFFSETS_FORMAT_MODE;
@@ -625,10 +623,6 @@ Status Config::unset(const std::string& param) {
         SM_CONSOLIDATION_WITH_TIMESTAMPS;
   } else if (param == "sm.vacuum.mode") {
     param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
-  } else if (param == "sm.vacuum.timestamp_start") {
-    param_values_["sm.vacuum.timestamp_start"] = SM_VACUUM_TIMESTAMP_START;
-  } else if (param == "sm.vacuum.timestamp_end") {
-    param_values_["sm.vacuum.timestamp_end"] = SM_VACUUM_TIMESTAMP_END;
   } else if (param == "sm.var_offsets.bitsize") {
     param_values_["sm.var_offsets.bitsize"] = SM_OFFSETS_BITSIZE;
   } else if (param == "sm.var_offsets.extra_element") {

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -157,8 +157,8 @@ Status ArrayMetaConsolidator::vacuum(const char* array_name) {
         vfs,
         compute_tp,
         URI(array_name),
-        config_.vacuum_timestamp_start_,
-        config_.vacuum_timestamp_end_,
+        0,
+        std::numeric_limits<uint64_t>::max(),
         false);
   } catch (const std::logic_error& le) {
     return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
@@ -203,12 +203,6 @@ Status ArrayMetaConsolidator::set_config(const Config* config) {
   assert(found);
   RETURN_NOT_OK(merged_config.get<uint64_t>(
       "sm.consolidation.timestamp_end", &config_.timestamp_end_, &found));
-  assert(found);
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
-      "sm.vacuum.timestamp_start", &config_.vacuum_timestamp_start_, &found));
-  assert(found);
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
-      "sm.vacuum.timestamp_end", &config_.vacuum_timestamp_end_, &found));
   assert(found);
 
   return Status::Ok();

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -149,10 +149,6 @@ class Consolidator {
     uint64_t timestamp_start_;
     /** End time for consolidation. */
     uint64_t timestamp_end_;
-    /** Start time for vacuuming. */
-    uint64_t vacuum_timestamp_start_;
-    /** End time for vacuuming. */
-    uint64_t vacuum_timestamp_end_;
   };
 
   /* ********************************* */

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -287,8 +287,8 @@ Status FragmentConsolidator::vacuum(const char* array_name) {
         vfs,
         compute_tp,
         URI(array_name),
-        config_.vacuum_timestamp_start_,
-        config_.vacuum_timestamp_end_,
+        0,
+        std::numeric_limits<uint64_t>::max(),
         config_.with_timestamps_,
         ArrayDirectoryMode::VACUUM_FRAGMENTS);
   } catch (const std::logic_error& le) {
@@ -834,12 +834,6 @@ Status FragmentConsolidator::set_config(const Config* config) {
       merged_config.get("sm.query.sparse_global_order.reader", &found);
   assert(found);
   config_.use_refactored_reader_ = reader.compare("refactored") == 0;
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
-      "sm.vacuum.timestamp_start", &config_.vacuum_timestamp_start_, &found));
-  assert(found);
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
-      "sm.vacuum.timestamp_end", &config_.vacuum_timestamp_end_, &found));
-  assert(found);
 
   // Sanity checks
   if (config_.min_frags_ > config_.max_frags_)

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -155,8 +155,8 @@ Status GroupMetaConsolidator::vacuum(const char* group_name) {
         vfs,
         compute_tp,
         URI(group_name),
-        config_.vacuum_timestamp_start_,
-        config_.vacuum_timestamp_end_);
+        0,
+        std::numeric_limits<uint64_t>::max());
   } catch (const std::logic_error& le) {
     return LOG_STATUS(Status_GroupDirectoryError(le.what()));
   }
@@ -200,12 +200,6 @@ Status GroupMetaConsolidator::set_config(const Config* config) {
   assert(found);
   RETURN_NOT_OK(merged_config.get<uint64_t>(
       "sm.consolidation.timestamp_end", &config_.timestamp_end_, &found));
-  assert(found);
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
-      "sm.vacuum.timestamp_start", &config_.vacuum_timestamp_start_, &found));
-  assert(found);
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
-      "sm.vacuum.timestamp_end", &config_.vacuum_timestamp_end_, &found));
   assert(found);
 
   return Status::Ok();

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -311,18 +311,6 @@ class Config {
    *    `fragment_meta` (remove only consolidated fragment metadata), or
    *    `array_meta` (remove consolidated array metadata files). <br>
    *    **Default**: fragments
-   * - `sm.vacuum.timestamp_start` <br>
-   *    **Experimental** <br>
-   *    When set, an array will be vacuumed between this value and
-   *    `sm.vacuum.timestamp_end` (inclusive). <br>
-   *    Only for `fragments` and `array_meta` vacuum mode. <br>
-   *    **Default**: 0
-   * - `sm.vacuum.timestamp_end` <br>
-   *    **Experimental** <br>
-   *    When set, an array will be vacuumed between `sm.vacuum.timestamp_start`
-   *    and this value (inclusive). <br>
-   *    Only for `fragments` and `array_meta` vacuum mode. <br>
-   *    **Default**: UINT64_MAX
    * - `sm.consolidation_mode` <br>
    *    The consolidation mode, one of `fragments` (consolidate all fragments),
    *    `fragment_meta` (consolidate only fragment metadata footers to a single


### PR DESCRIPTION
As a followup of PR 3175, @KiterLuc proposed we remove all timestamp-based vacuuming.

---
TYPE: IMPROVEMENT
DESC: Remove timestamp-based vacuuming
