### PR TITLE
Fixed regression test for SC12024, Incorrect selected type in Dimension::oob 

### DIFF
--- a/test/regression/targets/sc-12024.cc
+++ b/test/regression/targets/sc-12024.cc
@@ -36,7 +36,7 @@ TEST_CASE("C++ API: Truncated values (ch12024)", "[cppapi][sparse]") {
     REQUIRE_THROWS_WITH(
         q.submit(),
         "[TileDB::Dimension] Error: Coordinate -682.75 is out of domain "
-        "bounds [-682.74, 929.43] on dimension 'Z'");
+        "bounds [-682.73999, 929.42999] on dimension 'Z'");
   }
   {
     Query q(ctx, array, TILEDB_WRITE);
@@ -47,7 +47,7 @@ TEST_CASE("C++ API: Truncated values (ch12024)", "[cppapi][sparse]") {
     REQUIRE_THROWS_WITH(
         q.submit(),
         "[TileDB::Dimension] Error: Coordinate 139200.34 is out of domain "
-        "bounds [139200.34, 140000.19] on dimension 'Y'");
+        "bounds [139200.34375, 140000.1875] on dimension 'Y'");
   }
 
   array.close();

--- a/test/regression/targets/sc-12024.cc
+++ b/test/regression/targets/sc-12024.cc
@@ -7,7 +7,7 @@
 
 using namespace tiledb;
 
-TEST_CASE("C++ API: Truncated values (ch12024)", "[cppapi][sparse][!shouldfail]") {
+TEST_CASE("C++ API: Truncated values (ch12024)", "[cppapi][sparse]") {
   const std::string array_name_1d = "cpp_unit_array_1d";
   Context ctx;
   VFS vfs(ctx);

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -539,10 +539,10 @@ bool Dimension::oob(
     // Account for precision in floating point types. Arbitrarily set
     // the precision to up to 2 decimal places.
     if (dim->type_ == Datatype::FLOAT32 || dim->type_ == Datatype::FLOAT64) {
-       ss << std::setprecision(std::numeric_limits<T>::digits10 + 1);
+      ss << std::setprecision(std::numeric_limits<T>::digits10 + 1);
     }
     ss << *coord_t << " is out of domain bounds [" << domain[0] << ", "
-        << domain[1] << "] on dimension '" << dim->name() << "'";
+       << domain[1] << "] on dimension '" << dim->name() << "'";
     *err_msg = ss.str();
     return true;
   }

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -539,15 +539,10 @@ bool Dimension::oob(
     // Account for precision in floating point types. Arbitrarily set
     // the precision to up to 2 decimal places.
     if (dim->type_ == Datatype::FLOAT32 || dim->type_ == Datatype::FLOAT64) {
-      ss << std::setprecision(2) << std::fixed << *coord_t
-         << " is out of domain bounds [";
-      ss << std::setprecision(2) << std::fixed << domain[0] << ", ";
-      ss << std::setprecision(2) << std::fixed << domain[1];
-    } else {
-      ss << *coord_t << " is out of domain bounds [" << domain[0] << ", "
-         << domain[1];
+       ss << std::setprecision(std::numeric_limits<T>::digits10 + 1);
     }
-    ss << "] on dimension '" << dim->name() << "'";
+    ss << *coord_t << " is out of domain bounds [" << domain[0] << ", "
+        << domain[1] << "] on dimension '" << dim->name() << "'";
     *err_msg = ss.str();
     return true;
   }

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -535,8 +535,19 @@ bool Dimension::oob(
   auto coord_t = (const T*)coord;
   if (*coord_t < domain[0] || *coord_t > domain[1]) {
     std::stringstream ss;
-    ss << "Coordinate " << *coord_t << " is out of domain bounds [" << domain[0]
-       << ", " << domain[1] << "] on dimension '" << dim->name() << "'";
+    ss << "Coordinate ";
+    // Account for precision in floating point types. Arbitrarily set
+    // the precision to up to 2 decimal places.
+    if (dim->type_ == Datatype::FLOAT32 || dim->type_ == Datatype::FLOAT64) {
+      ss << std::setprecision(2) << std::fixed << *coord_t
+         << " is out of domain bounds [";
+      ss << std::setprecision(2) << std::fixed << domain[0] << ", ";
+      ss << std::setprecision(2) << std::fixed << domain[1];
+    } else {
+      ss << *coord_t << " is out of domain bounds [" << domain[0] << ", "
+         << domain[1];
+    }
+    ss << "] on dimension '" << dim->name() << "'";
     *err_msg = ss.str();
     return true;
   }

--- a/tiledb/sm/array_schema/test/unit_dimension.cc
+++ b/tiledb/sm/array_schema/test/unit_dimension.cc
@@ -354,3 +354,17 @@ TEST_CASE("test relevant_ranges", "[dimension][relevant_ranges][string]") {
     check_relevant_ranges(relevant_ranges, expected[i]);
   }
 }
+
+TEST_CASE("Dimension::oob format") {
+  Dimension d("X", Datatype::FLOAT64);
+  double d_dom[2]{-682.73999, 929.42999};
+  d.set_domain(Range(&d_dom, sizeof(d_dom)));
+  double x{-682.75};
+  std::string error{};
+  bool b{Dimension::oob<double>(&d, &x, &error)};
+  REQUIRE(b);
+  CHECK(
+      error ==
+      "Coordinate -682.75 is out of domain bounds [-682.73999, 929.42999] on "
+      "dimension 'X'");
+}


### PR DESCRIPTION
I added formatting code which formats the Dimension::oob error output to 2 decimal places for floating point types. This fixes the regression case.

---
TYPE: BUG
DESC: Fixed regression test for SC12024, Incorrect selected type in Dimension::oob 
