### PR TITLE
Consolidation with timestamps: filter sparse reader results based on read time.

### DIFF
--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -677,37 +677,39 @@ TEST_CASE_METHOD(
   tiledb_layout_t layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
 
   std::string stats;
-  std::vector<int> a1(10);
+  std::vector<int> a(10);
   std::vector<uint64_t> dim1(10);
   std::vector<uint64_t> dim2(10);
-  // Read after both writes - should see everything
-  read_sparse(a1, dim1, dim2, stats, layout, 4);
+  SECTION("Read after all writes") {
+    // Read after both writes - should see everything
+    read_sparse(a, dim1, dim2, stats, layout, 4);
 
-  std::vector<int> c_a1_opt1 = {0, 1, 8, 2, 3, 9, 10, 11};
-  std::vector<int> c_a1_opt2 = {0, 1, 8, 2, 9, 3, 10, 11};
-  std::vector<uint64_t> c_dim1 = {1, 1, 2, 1, 2, 2, 3, 3};
-  std::vector<uint64_t> c_dim2 = {1, 2, 2, 4, 3, 3, 2, 3};
-  CHECK(
-      (!memcmp(c_a1_opt1.data(), a1.data(), c_a1_opt1.size() * sizeof(int)) ||
-       !memcmp(c_a1_opt2.data(), a1.data(), c_a1_opt2.size() * sizeof(int))));
-  CHECK(!memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
-  CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+    std::vector<int> c_a_opt1 = {0, 1, 8, 2, 3, 9, 10, 11};
+    std::vector<int> c_a_opt2 = {0, 1, 8, 2, 9, 3, 10, 11};
+    std::vector<uint64_t> c_dim1 = {1, 1, 2, 1, 2, 2, 3, 3};
+    std::vector<uint64_t> c_dim2 = {1, 2, 2, 4, 3, 3, 2, 3};
+    CHECK(
+        (!memcmp(c_a_opt1.data(), a.data(), c_a_opt1.size() * sizeof(int)) ||
+         !memcmp(c_a_opt2.data(), a.data(), c_a_opt2.size() * sizeof(int))));
+    CHECK(
+        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+    CHECK(
+        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  }
 
-  std::vector<int> a(10);
-  std::vector<uint64_t> dima1(10);
-  std::vector<uint64_t> dima2(10);
+  SECTION("Read between the 2 writes") {
+    // Should see only first write
+    read_sparse(a, dim1, dim2, stats, layout, 2);
 
-  // Read between writes - should see only first write
-  read_sparse(a, dima1, dima2, stats, layout, 2);
-
-  std::vector<int> pc_a = {0, 1, 2, 3};
-  std::vector<uint64_t> pc_dima1 = {1, 1, 1, 2};
-  std::vector<uint64_t> pc_dima2 = {1, 2, 4, 3};
-  CHECK(!memcmp(pc_a.data(), a.data(), pc_a.size() * sizeof(int)));
-  CHECK(!memcmp(
-      pc_dima1.data(), dima1.data(), pc_dima1.size() * sizeof(uint64_t)));
-  CHECK(!memcmp(
-      pc_dima2.data(), dima2.data(), pc_dima2.size() * sizeof(uint64_t)));
+    std::vector<int> c_a = {0, 1, 2, 3};
+    std::vector<uint64_t> c_dim1 = {1, 1, 1, 2};
+    std::vector<uint64_t> c_dim2 = {1, 2, 4, 3};
+    CHECK(!memcmp(c_a.data(), a.data(), c_a.size() * sizeof(int)));
+    CHECK(
+        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+    CHECK(
+        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  }
 
   remove_sparse_array();
 }
@@ -730,31 +732,32 @@ TEST_CASE_METHOD(
   consolidate_sparse();
 
   std::string stats;
-  std::vector<int> a1(10);
+  std::vector<int> a(10);
   std::vector<uint64_t> dim1(10);
   std::vector<uint64_t> dim2(10);
-  read_sparse(a1, dim1, dim2, stats, TILEDB_GLOBAL_ORDER, 4);
+  SECTION("Read after all writes") {
+    read_sparse(a, dim1, dim2, stats, TILEDB_GLOBAL_ORDER, 4);
 
-  std::vector<int> c_a1 = {0, 1, 8, 2, 9, 10, 11};
-  std::vector<uint64_t> c_dim1 = {1, 1, 2, 1, 2, 3, 3};
-  std::vector<uint64_t> c_dim2 = {1, 2, 2, 4, 3, 2, 3};
-  CHECK(!memcmp(c_a1.data(), a1.data(), sizeof(c_a1)));
-  CHECK(!memcmp(c_dim1.data(), dim1.data(), sizeof(c_dim1)));
-  CHECK(!memcmp(c_dim2.data(), dim2.data(), sizeof(c_dim2)));
+    std::vector<int> c_a = {0, 1, 8, 2, 9, 10, 11};
+    std::vector<uint64_t> c_dim1 = {1, 1, 2, 1, 2, 3, 3};
+    std::vector<uint64_t> c_dim2 = {1, 2, 2, 4, 3, 2, 3};
+    CHECK(!memcmp(c_a.data(), a.data(), sizeof(c_a)));
+    CHECK(!memcmp(c_dim1.data(), dim1.data(), sizeof(c_dim1)));
+    CHECK(!memcmp(c_dim2.data(), dim2.data(), sizeof(c_dim2)));
+  }
 
-  std::vector<int> a(10, 0);
-  std::vector<uint64_t> dima1(10);
-  std::vector<uint64_t> dima2(10);
-  read_sparse(a, dima1, dima2, stats, TILEDB_GLOBAL_ORDER, 2);
+  SECTION("Read between the 2 writes") {
+    read_sparse(a, dim1, dim2, stats, TILEDB_GLOBAL_ORDER, 2);
 
-  std::vector<int> pc_a = {0, 1, 2, 3};
-  std::vector<uint64_t> pc_dima1 = {1, 1, 1, 2};
-  std::vector<uint64_t> pc_dima2 = {1, 2, 4, 3};
-  CHECK(!memcmp(pc_a.data(), a.data(), pc_a.size() * sizeof(int)));
-  CHECK(!memcmp(
-      pc_dima1.data(), dima1.data(), pc_dima1.size() * sizeof(uint64_t)));
-  CHECK(!memcmp(
-      pc_dima2.data(), dima2.data(), pc_dima2.size() * sizeof(uint64_t)));
+    std::vector<int> c_a = {0, 1, 2, 3};
+    std::vector<uint64_t> c_dim1 = {1, 1, 1, 2};
+    std::vector<uint64_t> c_dim2 = {1, 2, 4, 3};
+    CHECK(!memcmp(c_a.data(), a.data(), c_a.size() * sizeof(int)));
+    CHECK(
+        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+    CHECK(
+        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  }
 
   remove_sparse_array();
 }
@@ -788,43 +791,183 @@ TEST_CASE_METHOD(
 
   std::string stats;
   // TBD: why 15 in user buffer not enough?
-  std::vector<int> a1(16);
+  std::vector<int> a(16);
   std::vector<uint64_t> dim1(16);
   std::vector<uint64_t> dim2(16);
 
-  // Read after both writes - should see everything
-  read_sparse(a1, dim1, dim2, stats, layout, 7);
-
-  std::vector<int> c_a1_opt1 = {
-      0, 1, 8, 4, 9, 2, 3, 5, 10, 6, 11, 12, 7, 13, 14, 15};
-  std::vector<int> c_a1_opt2 = {
-      0, 1, 8, 4, 9, 2, 3, 5, 10, 6, 11, 12, 13, 7, 14, 15};
-  std::vector<uint64_t> c_dim1 = {
-      1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 3, 4};
-  std::vector<uint64_t> c_dim2 = {
-      1, 2, 1, 2, 3, 4, 3, 4, 1, 2, 1, 2, 3, 3, 4, 4};
-  CHECK(
-      (!memcmp(c_a1_opt1.data(), a1.data(), c_a1_opt1.size() * sizeof(int)) ||
-       !memcmp(c_a1_opt2.data(), a1.data(), c_a1_opt2.size() * sizeof(int))));
-  CHECK(!memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
-  CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  SECTION("Read after all writes") {
+    // Read after both writes - should see everything
+    read_sparse(a, dim1, dim2, stats, layout, 7);
+    std::vector<int> c_a_opt1 = {
+        0, 1, 8, 4, 9, 2, 3, 5, 10, 6, 11, 12, 7, 13, 14, 15};
+    std::vector<int> c_a_opt2 = {
+        0, 1, 8, 4, 9, 2, 3, 5, 10, 6, 11, 12, 13, 7, 14, 15};
+    std::vector<uint64_t> c_dim1 = {
+        1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 3, 4};
+    std::vector<uint64_t> c_dim2 = {
+        1, 2, 1, 2, 3, 4, 3, 4, 1, 2, 1, 2, 3, 3, 4, 4};
+    CHECK(
+        (!memcmp(c_a_opt1.data(), a.data(), c_a_opt1.size() * sizeof(int)) ||
+         !memcmp(c_a_opt2.data(), a.data(), c_a_opt2.size() * sizeof(int))));
+    CHECK(
+        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+    CHECK(
+        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  }
 
   // Read with full coverage on first 2 consolidated, partial coverage on second
   // 2 consolidated
+  SECTION("Read between the 2 writes") {
+    read_sparse(a, dim1, dim2, stats, layout, 5);
+
+    std::vector<int> c_a = {0, 1, 8, 4, 9, 2, 3, 5, 10, 6, 11, 7};
+    std::vector<uint64_t> c_dim1 = {1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 3};
+    std::vector<uint64_t> c_dim2 = {1, 2, 1, 2, 3, 4, 3, 4, 1, 2, 1, 3};
+    CHECK(!memcmp(c_a.data(), a.data(), c_a.size() * sizeof(int)));
+    CHECK(
+        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+    CHECK(
+        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  }
+  remove_sparse_array();
+}
+
+TEST_CASE_METHOD(
+    ConsolidationWithTimestampsFx,
+    "CPP API: Test consolidation with timestamps, reopen",
+    "[cppapi][consolidation-with-timestamps][partial-read][dups][testtt]") {
+  remove_sparse_array();
+  // enable duplicates
+  create_sparse_array(true);
+
+  // Write first fragment.
+  write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
+  // Write second fragment.
+  write_sparse({4, 5, 6, 7}, {2, 2, 3, 3}, {2, 3, 2, 3}, 3);
+  // Write third  fragment.
+  write_sparse({8, 9, 10, 11}, {1, 2, 3, 4}, {3, 4, 1, 1}, 5);
+
+  // Consolidate.
+  consolidate_sparse();
+
+  tiledb_layout_t layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
+
+  std::string stats;
   std::vector<int> a(16);
-  std::vector<uint64_t> dima1(16);
-  std::vector<uint64_t> dima2(16);
+  std::vector<uint64_t> dim1(16);
+  std::vector<uint64_t> dim2(16);
 
-  read_sparse(a, dima1, dima2, stats, layout, 5);
+  SECTION("Read in the middle") {
+    // Read between 2 and 4
+    Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_READ);
+    array.set_open_timestamp_start(2);
+    array.set_open_timestamp_end(4);
+    array.reopen();
 
-  std::vector<int> pc_a = {0, 1, 8, 4, 9, 2, 3, 5, 10, 6, 11, 7};
-  std::vector<uint64_t> pc_dima1 = {1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 3};
-  std::vector<uint64_t> pc_dima2 = {1, 2, 1, 2, 3, 4, 3, 4, 1, 2, 1, 3};
-  CHECK(!memcmp(pc_a.data(), a.data(), pc_a.size() * sizeof(int)));
-  CHECK(!memcmp(
-      pc_dima1.data(), dima1.data(), pc_dima1.size() * sizeof(uint64_t)));
-  CHECK(!memcmp(
-      pc_dima2.data(), dima2.data(), pc_dima2.size() * sizeof(uint64_t)));
+    // Create query
+    Query query(ctx_, array, TILEDB_READ);
+    query.set_layout(layout);
+    query.set_data_buffer("a1", a);
+    query.set_data_buffer("d1", dim1);
+    query.set_data_buffer("d2", dim2);
+
+    // Submit/finalize the query
+    query.submit();
+    CHECK(query.query_status() == Query::Status::COMPLETE);
+
+    // Get the query stats.
+    stats = query.stats();
+
+    // Close array
+    array.close();
+
+    // Expect to read only what was written at time 3
+    std::vector<int> c_a = {4, 5, 6, 7};
+    std::vector<uint64_t> c_dim1 = {2, 2, 3, 3};
+    std::vector<uint64_t> c_dim2 = {2, 3, 2, 3};
+    CHECK(!memcmp(c_a.data(), a.data(), c_a.size() * sizeof(int)));
+    CHECK(
+        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+    CHECK(
+        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  }
+
+  SECTION("Read the last 2 writes only") {
+    // Read between 2 and 6, that should include the last 2 writes
+    Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_READ);
+    array.set_open_timestamp_start(2);
+    array.set_open_timestamp_end(6);
+    array.reopen();
+
+    // Create query
+    Query query(ctx_, array, TILEDB_READ);
+    query.set_layout(layout);
+    query.set_data_buffer("a1", a);
+    query.set_data_buffer("d1", dim1);
+    query.set_data_buffer("d2", dim2);
+
+    // Submit/finalize the query
+    query.submit();
+    CHECK(query.query_status() == Query::Status::COMPLETE);
+
+    // Get the query stats.
+    stats = query.stats();
+
+    // Close array
+    array.close();
+
+    write_sparse({4, 5, 6, 7}, {2, 2, 3, 3}, {2, 3, 2, 3}, 3);
+    // Write third  fragment.
+    write_sparse({8, 9, 10, 11}, {1, 2, 3, 4}, {3, 4, 1, 1}, 5);
+
+    // Expect to read what the last 2 writes wrote
+    std::vector<int> c_a = {4, 8, 5, 9, 10, 6, 11, 7};
+    std::vector<uint64_t> c_dim1 = {2, 1, 2, 2, 3, 3, 4, 3};
+    std::vector<uint64_t> c_dim2 = {2, 3, 3, 4, 1, 2, 1, 3};
+    CHECK(!memcmp(c_a.data(), a.data(), c_a.size() * sizeof(int)));
+    CHECK(
+        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+    CHECK(
+        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  }
+
+  SECTION("Read the first 2 writes only") {
+    // Read between 1 and 3, that should include the first 2 writes
+    Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_READ);
+    array.set_open_timestamp_start(0);
+    array.set_open_timestamp_end(4);
+    array.reopen();
+
+    // Create query
+    Query query(ctx_, array, TILEDB_READ);
+    query.set_layout(layout);
+    query.set_data_buffer("a1", a);
+    query.set_data_buffer("d1", dim1);
+    query.set_data_buffer("d2", dim2);
+
+    // Submit/finalize the query
+    query.submit();
+    CHECK(query.query_status() == Query::Status::COMPLETE);
+
+    // Get the query stats.
+    stats = query.stats();
+
+    // Close array
+    array.close();
+
+    // Expect to read what the first 2 writes wrote
+    std::vector<int> c_a_opt1 = {0, 1, 4, 2, 5, 3, 6, 7};
+    std::vector<int> c_a_opt2 = {0, 1, 4, 2, 3, 5, 6, 7};
+    std::vector<uint64_t> c_dim1 = {1, 1, 2, 1, 2, 2, 3, 3};
+    std::vector<uint64_t> c_dim2 = {1, 2, 2, 4, 3, 3, 2, 3};
+    CHECK(
+        (!memcmp(c_a_opt1.data(), a.data(), c_a_opt1.size() * sizeof(int)) ||
+         !memcmp(c_a_opt2.data(), a.data(), c_a_opt2.size() * sizeof(int))));
+    CHECK(
+        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+    CHECK(
+        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  }
 
   remove_sparse_array();
 }

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -791,16 +791,17 @@ class FragmentMetadata {
    * Checks if the fragment overlaps partially (not fully) with a given
    * array open - end time.
    *
-   * @param array_start_timestamps Array open time
+   * @param array_start_timestamp Array open time
    * @param array_end_timestamp Array end time
    *
    * @return True if there is partial overlap, false if there is full or no
    * overlap
    */
   inline bool partial_time_overlap(
-      uint64_t array_start_timestamp, uint64_t array_end_timestamp) const {
-    auto fragment_timestamp_start = timestamp_range_.first;
-    auto fragment_timestamp_end = timestamp_range_.second;
+      const uint64_t array_start_timestamp,
+      const uint64_t array_end_timestamp) const {
+    const auto fragment_timestamp_start = timestamp_range_.first;
+    const auto fragment_timestamp_end = timestamp_range_.second;
 
     return (array_start_timestamp > fragment_timestamp_start &&
             array_start_timestamp <= fragment_timestamp_end) ||

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -788,6 +788,27 @@ class FragmentMetadata {
       const EncryptionKey& encryption_key);
 
   /**
+   * Checks if the fragment overlaps partially (not fully) with a given
+   * array open - end time.
+   *
+   * @param array_start_timestamps Array open time
+   * @param array_end_timestamp Array end time
+   *
+   * @return True if there is partial overlap, false if there is full or no
+   * overlap
+   */
+  inline bool partial_time_overlap(
+      uint64_t array_start_timestamp, uint64_t array_end_timestamp) const {
+    auto fragment_timestamp_start = timestamp_range_.first;
+    auto fragment_timestamp_end = timestamp_range_.second;
+
+    return (array_start_timestamp > fragment_timestamp_start &&
+            array_start_timestamp <= fragment_timestamp_end) ||
+           (array_end_timestamp < fragment_timestamp_end &&
+            array_end_timestamp >= fragment_timestamp_start);
+  }
+
+  /**
    * Returns ArraySchema
    *
    * @return

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1372,17 +1372,21 @@ Status QueryCondition::apply_clause_sparse(
     const ArraySchema& array_schema,
     ResultTile& result_tile,
     std::vector<BitmapType>& result_bitmap) const {
-  const auto attribute = array_schema.attribute(clause.field_name_);
-  if (!attribute) {
-    return Status_QueryConditionError(
-        "Unknown attribute " + clause.field_name_);
+  bool var_size = false, nullable = false;
+  Datatype type = Datatype::UINT64;
+  if (clause.field_name_ != constants::timestamps) {
+    const auto attribute = array_schema.attribute(clause.field_name_);
+    if (!attribute) {
+      return Status_QueryConditionError(
+          "Unknown attribute " + clause.field_name_);
+    }
+
+    var_size = attribute->var_size();
+    nullable = attribute->nullable();
+    type = attribute->type();
   }
 
-  const bool var_size = attribute->var_size();
-  const bool nullable = attribute->nullable();
-
   // Process the validity buffer now.
-
   if (nullable) {
     const auto tile_tuple = result_tile.tile_tuple(clause.field_name_);
     const auto& tile_validity = std::get<2>(*tile_tuple);
@@ -1409,7 +1413,7 @@ Status QueryCondition::apply_clause_sparse(
     }
   }
 
-  switch (attribute->type()) {
+  switch (type) {
     case Datatype::INT8:
       return apply_clause_sparse<int8_t, BitmapType>(
           clause, result_tile, var_size, result_bitmap);

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1373,6 +1373,7 @@ Status QueryCondition::apply_clause_sparse(
     ResultTile& result_tile,
     std::vector<BitmapType>& result_bitmap) const {
   bool var_size = false, nullable = false;
+  // initialize to timestamps type
   Datatype type = Datatype::UINT64;
   if (clause.field_name_ != constants::timestamps) {
     const auto attribute = array_schema.attribute(clause.field_name_);

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -167,6 +167,12 @@ class ReaderBase : public StrategyBase {
   /** Disable the tile cache or not. */
   bool disable_cache_;
 
+  /**
+   * The condition to apply on results when there is partial time overlap
+   * with at least one fragment
+   * */
+  QueryCondition partial_overlap_condition_;
+
   /* ********************************* */
   /*         PROTECTED METHODS         */
   /* ********************************* */
@@ -235,10 +241,16 @@ class ReaderBase : public StrategyBase {
    * Checks if at least one fragment overlaps partially with the
    * time at which the read is taking place.
    *
-   * @param subarray The subarray of this read operation.
    * @return True if at least one fragment partially overlaps.
    */
-  bool partial_consolidated_fragment_overlap(Subarray& subarray) const;
+  bool partial_consolidated_fragment_overlap() const;
+
+  /**
+   * Add a condition for partial time overlap based on array open and
+   * end times, to be used to filter out results on fragments that have
+   * been consolidated with timestamps
+   */
+  Status add_partial_overlap_condition();
 
   /**
    * Loads tile var sizes for each attribute/dimension name into

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -232,6 +232,15 @@ class ReaderBase : public StrategyBase {
       Subarray& subarray, const std::vector<std::string>& names);
 
   /**
+   * Checks if at least one fragment overlaps partially with the
+   * time at which the read is taking place.
+   *
+   * @param subarray The subarray of this read operation.
+   * @return True if at least one fragment partially overlaps.
+   */
+  bool partial_consolidated_fragment_overlap(Subarray& subarray) const;
+
+  /**
    * Loads tile var sizes for each attribute/dimension name into
    * their associated element in `fragment_metadata_`.
    *

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -164,7 +164,7 @@ Status SparseGlobalOrderReader::dowork() {
   }
 
   // Load initial data, if not loaded already.
-  RETURN_NOT_OK(load_initial_data(true));
+  RETURN_NOT_OK(load_initial_data());
 
   // Attributes names to process.
   std::vector<std::string> names;
@@ -197,7 +197,7 @@ Status SparseGlobalOrderReader::dowork() {
       }
 
       // Read and unfilter coords.
-      RETURN_NOT_OK(read_and_unfilter_coords(true, true, tmp_result_tiles));
+      RETURN_NOT_OK(read_and_unfilter_coords(true, tmp_result_tiles));
 
       // Compute the tile bitmaps.
       RETURN_NOT_OK(compute_tile_bitmaps<uint8_t>(tmp_result_tiles));

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -212,6 +212,15 @@ Status SparseIndexReaderBase::load_initial_data() {
   auto timer_se = stats_->start_timer("load_initial_data");
   read_state_.done_adding_result_tiles_ = false;
 
+  // Make a list of dim/attr that will be loaded for query condition.
+  if (!initial_data_loaded_) {
+    if (!condition_.empty()) {
+      for (auto& name : condition_.field_names()) {
+        qc_loaded_names_.emplace_back(name);
+      }
+    }
+  }
+
   // For easy reference.
   auto fragment_num = fragment_metadata_.size();
 
@@ -298,15 +307,6 @@ Status SparseIndexReaderBase::load_initial_data() {
     }
 
     RETURN_CANCEL_OR_ERROR(add_partial_overlap_condition());
-  }
-
-  // Make a list of dim/attr that will be loaded for query condition.
-  if (!initial_data_loaded_) {
-    if (!condition_.empty()) {
-      for (auto& name : condition_.field_names()) {
-        qc_loaded_names_.emplace_back(name);
-      }
-    }
   }
 
   // Load tile offsets and var sizes for attributes.

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -306,6 +306,10 @@ class SparseIndexReaderBase : public ReaderBase {
   /** If the user requested timestamps attribute in the query */
   bool user_requested_timestamps_;
 
+  /** The condition to apply on timestamps when there is partial time overlap
+   * with at least one fragment */
+  QueryCondition partial_overlap_condition_;
+
   /* ********************************* */
   /*         PROTECTED METHODS         */
   /* ********************************* */
@@ -432,13 +436,20 @@ class SparseIndexReaderBase : public ReaderBase {
   void remove_result_tile_range(uint64_t f);
 
   /**
-   * Checks if timestamps should be loaded for a fragment
+   * Checks if timestamps should be loaded for a fragment.
    *
    * @param f Fragment index.
-   * @return True if timestamps should be included, false if they are not
+   * @return True if timestamps should be included, false if they are not.
    * needed.
    */
   bool include_timestamps(const unsigned f);
+
+  /**
+   * Checks if consolidation with timestamps is enabled in config.
+   *
+   * @return True if consolidation with timestamps is enabled, false if not.
+   */
+  bool consolidation_with_timestamps_config_enabled() const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -306,9 +306,11 @@ class SparseIndexReaderBase : public ReaderBase {
   /** If the user requested timestamps attribute in the query */
   bool user_requested_timestamps_;
 
-  /** The condition to apply on timestamps when there is partial time overlap
-   * with at least one fragment */
-  QueryCondition partial_overlap_condition_;
+  /**
+   * If the special timestamps attribute should be loaded to memory for
+   * this query
+   */
+  bool use_timestamps_;
 
   /* ********************************* */
   /*         PROTECTED METHODS         */
@@ -340,25 +342,20 @@ class SparseIndexReaderBase : public ReaderBase {
   /**
    * Load tile offsets and result tile ranges.
    *
-   * @param include_timestamps Include timestamps or not.
-   *
    * @return Status.
    */
-  Status load_initial_data(bool include_timestamps);
+  Status load_initial_data();
 
   /**
    * Read and unfilter coord tiles.
    *
    * @param include_coords Include coordinates or not.
-   * @param include_timestamps Include timestamps or not.
    * @param result_tiles The result tiles to process.
    *
    * @return Status.
    */
   Status read_and_unfilter_coords(
-      bool include_coords,
-      bool include_timestamps,
-      const std::vector<ResultTile*>& result_tiles);
+      bool include_coords, const std::vector<ResultTile*>& result_tiles);
 
   /**
    * Allocate a tile bitmap if required for this tile.
@@ -443,13 +440,6 @@ class SparseIndexReaderBase : public ReaderBase {
    * needed.
    */
   bool include_timestamps(const unsigned f);
-
-  /**
-   * Checks if consolidation with timestamps is enabled in config.
-   *
-   * @return True if consolidation with timestamps is enabled, false if not.
-   */
-  bool consolidation_with_timestamps_config_enabled() const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -169,7 +169,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
   }
 
   // Load initial data, if not loaded already.
-  RETURN_NOT_OK(load_initial_data(false));
+  RETURN_NOT_OK(load_initial_data());
 
   // Attributes names to process.
   std::vector<std::string> names;
@@ -207,8 +207,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
 
     if (!result_tiles_created.empty()) {
       // Read and unfilter coords.
-      RETURN_NOT_OK(read_and_unfilter_coords(
-          subarray_.is_set(), false, result_tiles_created));
+      RETURN_NOT_OK(
+          read_and_unfilter_coords(subarray_.is_set(), result_tiles_created));
 
       // Compute the tile bitmaps.
       RETURN_NOT_OK(compute_tile_bitmaps<BitmapType>(result_tiles_created));

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -1187,6 +1187,9 @@ class StorageManager {
 
   /** Sets default tag values on this StorageManager. */
   Status set_default_tags();
+
+  inline bool partial_time_overlap(
+      uint64_t array_start_timestamp, uint64_t array_end_timestamp) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -1187,9 +1187,6 @@ class StorageManager {
 
   /** Sets default tag values on this StorageManager. */
   Status set_default_tags();
-
-  inline bool partial_time_overlap(
-      uint64_t array_start_timestamp, uint64_t array_end_timestamp) const;
 };
 
 }  // namespace sm


### PR DESCRIPTION
Now that consolidated fragments include a timestamps attribute that tracks the time each cell was written, we can use this information when reading in order to time-travel.
This PR adapts the sparse readers to take into account the timestamp of the read operation in order to build under the hood a query condition that will fetch only the part of the consolidated fragment that was written before the read time. 

---
TYPE: IMPROVEMENT
DESC: Consolidation with timestamps: filter sparse reader results based on read time.
