### PR TITLE
Make filestore api get configurable buffer sizes

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -225,6 +225,7 @@ void check_save_to_file() {
 #else
   ss << "config.logging_level 0\n";
 #endif
+  ss << "filestore.buffer_size 1024\n";
   ss << "rest.curl.verbose false\n";
   ss << "rest.http_compressor any\n";
   ss << "rest.retry_count 25\n";
@@ -550,6 +551,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["config.env_var_prefix"] = "TILEDB_";
   all_param_values["config.logging_level"] = "2";
   all_param_values["config.logging_format"] = "JSON";
+  all_param_values["filestore.buffer_size"] = "1024";
   all_param_values["rest.server_address"] = "https://api.tiledb.com";
   all_param_values["rest.server_serialization_format"] = "CAPNP";
   all_param_values["rest.http_compressor"] = "any";

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -225,7 +225,7 @@ void check_save_to_file() {
 #else
   ss << "config.logging_level 0\n";
 #endif
-  ss << "filestore.buffer_size 1024\n";
+  ss << "filestore.buffer_size 104857600\n";
   ss << "rest.curl.verbose false\n";
   ss << "rest.http_compressor any\n";
   ss << "rest.retry_count 25\n";
@@ -551,7 +551,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["config.env_var_prefix"] = "TILEDB_";
   all_param_values["config.logging_level"] = "2";
   all_param_values["config.logging_format"] = "JSON";
-  all_param_values["filestore.buffer_size"] = "1024";
+  all_param_values["filestore.buffer_size"] = "104857600";
   all_param_values["rest.server_address"] = "https://api.tiledb.com";
   all_param_values["rest.server_serialization_format"] = "CAPNP";
   all_param_values["rest.http_compressor"] = "any";

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1428,7 +1428,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    Specifies the size in bytes of the internal buffers used in the filestore
  *    API. The size should be bigger than the minimum tile size filestore
  *    currently supports, that is currently 1024bytes. <br>
- *    **Default**: 1024
+ *    **Default**: 100MB
  *
  * **Example:**
  *

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1424,6 +1424,11 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * Set curl to run in verbose mode for REST requests <br>
  * curl will print to stdout with this option
  *    **Default**: false
+ * - `filestore.buffer_size` <br>
+ *    Specifies the size in bytes of the internal buffers used in the filestore
+ *    API. The size should be bigger than the minimum tile size filestore
+ *    currently supports, that is currently 1024bytes. <br>
+ *    **Default**: 1024
  *
  * **Example:**
  *

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -183,6 +183,7 @@ const std::string Config::VFS_S3_OBJECT_CANNED_ACL = "NOT_SET";
 const std::string Config::VFS_HDFS_KERB_TICKET_CACHE_PATH = "";
 const std::string Config::VFS_HDFS_NAME_NODE_URI = "";
 const std::string Config::VFS_HDFS_USERNAME = "";
+const std::string Config::FILESTORE_BUFFER_SIZE = "1024";
 /* ****************************** */
 /*        PRIVATE CONSTANTS       */
 /* ****************************** */
@@ -356,6 +357,7 @@ Config::Config() {
   param_values_["vfs.hdfs.username"] = VFS_HDFS_USERNAME;
   param_values_["vfs.hdfs.kerb_ticket_cache_path"] =
       VFS_HDFS_KERB_TICKET_CACHE_PATH;
+  param_values_["filestore.buffer_size"] = FILESTORE_BUFFER_SIZE;
 }
 
 Config::~Config() = default;
@@ -761,6 +763,8 @@ Status Config::unset(const std::string& param) {
   } else if (param == "vfs.hdfs.kerb_ticket_cache_path") {
     param_values_["vfs.hdfs.kerb_ticket_cache_path"] =
         VFS_HDFS_KERB_TICKET_CACHE_PATH;
+  } else if (param == "filestore.buffer_size") {
+    param_values_["filestore.buffer_size"] = FILESTORE_BUFFER_SIZE;
   } else {
     param_values_.erase(param);
   }

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -183,7 +183,7 @@ const std::string Config::VFS_S3_OBJECT_CANNED_ACL = "NOT_SET";
 const std::string Config::VFS_HDFS_KERB_TICKET_CACHE_PATH = "";
 const std::string Config::VFS_HDFS_NAME_NODE_URI = "";
 const std::string Config::VFS_HDFS_USERNAME = "";
-const std::string Config::FILESTORE_BUFFER_SIZE = "1024";
+const std::string Config::FILESTORE_BUFFER_SIZE = "104857600";
 /* ****************************** */
 /*        PRIVATE CONSTANTS       */
 /* ****************************** */

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -496,6 +496,12 @@ class Config {
   /** S3 default object canned ACL */
   static const std::string VFS_S3_OBJECT_CANNED_ACL;
 
+  /**
+   * Specifies the size in bytes of the internal buffers used in the filestore
+   * API. The size should be bigger than the minimum tile size filestore
+   * currently supports, that is currently 1024bytes. */
+  static const std::string FILESTORE_BUFFER_SIZE;
+
   /* ****************************** */
   /*        OTHER CONSTANTS         */
   /* ****************************** */

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -712,6 +712,11 @@ class Config {
    * Set curl to run in verbose mode for REST requests <br>
    * curl will print to stdout with this option
    *    **Default**: false
+   * - `filestore.buffer_size` <br>
+   *    Specifies the size in bytes of the internal buffers used in the
+   * filestore API. The size should be bigger than the minimum tile size
+   * filestore currently supports, that is currently 1024bytes. <br>
+   *    **Default**: 1024
    */
   Config& set(const std::string& param, const std::string& value) {
     tiledb_error_t* err;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -716,7 +716,7 @@ class Config {
    *    Specifies the size in bytes of the internal buffers used in the
    * filestore API. The size should be bigger than the minimum tile size
    * filestore currently supports, that is currently 1024bytes. <br>
-   *    **Default**: 1024
+   *    **Default**: 100MB
    */
   Config& set(const std::string& param, const std::string& value) {
     tiledb_error_t* err;


### PR DESCRIPTION
Part of ch18107 we discovered that users should have the ability to pass via config the size of the internal buffers used to import/export files/arrays, thus get get a speedup from making less requests to an underlying remote storage.

---
TYPE: IMPROVEMENT
DESC: Make filestore api get configurable buffer sizes
