### PR TITLE
Posix: cache cwd.

### DIFF
--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -99,6 +99,7 @@ regex_unique_ptr = re.compile(r"unique_ptr<")
 unique_ptr_exceptions = {
     "*": ["tdb_unique_ptr", "tiledb_unique_ptr"],
     "zstd_compressor.h": ["std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx_;", "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx_;"],
+    "posix.cc": ["static std::unique_ptr<char, decltype(&free)> cwd_(getcwd(nullptr, 0), free);"],
     "curl.h": ["std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>"],
     "tile.h": ["std::unique_ptr<char, void (*)(void*)> data_;"],
 }

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -202,12 +202,8 @@ Status Posix::touch(const std::string& filename) const {
 }
 
 std::string Posix::current_dir() {
-  std::string dir;
-  char* path = getcwd(nullptr, 0);
-  if (path != nullptr) {
-    dir = path;
-    free(path);
-  }
+  static std::unique_ptr<char, decltype(&free)> cwd_(getcwd(nullptr, 0), free);
+  std::string dir = cwd_.get();
   return dir;
 }
 


### PR DESCRIPTION
This caches the command working directory on posix for posix to prevent
allocating memory twice each time a URI is created.

---
TYPE: IMPROVEMENT
DESC: Posix: cache cwd.
