### PR TITLE
Consolidation w timestamps: cell slab length computations fix.

### DIFF
--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -883,13 +883,20 @@ SparseGlobalOrderReader::merge_result_cell_slabs(
     // Make sure we don't merge more cells than the buffers.
     length = std::min(length, num_cells);
 
+    // Update the position in the result coord.
+    to_process.pos_ += length - 1;
+
+    // Make sure we don't process the last loaded cell of a consolidated
+    // with timestamps fragment if there are more tiles for that fragment.
+    if (last_in_memory_cell_of_consolidated_fragment(frag_idx, to_process)) {
+      length--;
+      to_process.pos_--;
+    }
+
     // Generate the result cell slabs.
     result_cell_slabs.emplace_back(tile, start, length);
     read_state_.frag_idx_[frag_idx] = FragIdx(tile_idx, start + length);
     num_cells -= length;
-
-    // Update the position in the result coord.
-    to_process.pos_ += length - 1;
 
     // Put the next cell in the queue.
     auto&& [st, more_tiles] =


### PR DESCRIPTION
When a fragment with timestamps gets merged, the maximum length of the
cell slab doesn't check if the last cell of the slab is the last cell
of a consolidated fragment with timestamps when there are more tiles
available to merge. In rare cases, this could cause to merge a cell with
the same coordinate twice.

---
TYPE: IMPROVEMENT
DESC: Consolidation w timestamps: cell slab length computations fix.
