### PR TITLE
Consolidation with timestamps: original reader reads fragments.

### DIFF
--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -4717,7 +4717,7 @@ TEST_CASE_METHOD(
 
   SupportedFsLocal local_fs;
   std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
-  std::string array_name = temp_dir + "default-dim";
+  std::string array_name = temp_dir + "unary-range";
   create_temp_dir(temp_dir);
 
   // Create and write dense array
@@ -4972,7 +4972,7 @@ TEST_CASE_METHOD(
 
   SupportedFsLocal local_fs;
   std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
-  std::string array_name = temp_dir + "dense_read_large";
+  std::string array_name = temp_dir + "dense_read_multi_index_simple";
   create_temp_dir(temp_dir);
 
   create_large_dense_array_1_attribute(array_name);
@@ -5029,7 +5029,7 @@ TEST_CASE_METHOD(
 
   SupportedFsLocal local_fs;
   std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
-  std::string array_name = temp_dir + "dense_read_large";
+  std::string array_name = temp_dir + "dense_read_multi_index_complex";
   create_temp_dir(temp_dir);
 
   create_large_dense_array_1_attribute(array_name);
@@ -5103,7 +5103,7 @@ TEST_CASE_METHOD(
 
   SupportedFsLocal local_fs;
   std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
-  std::string array_name = temp_dir + "dense_read_large";
+  std::string array_name = temp_dir + "dense_read_multi_index_cross_tile";
   create_temp_dir(temp_dir);
 
   create_large_dense_array_1_attribute(array_name);
@@ -5160,7 +5160,7 @@ TEST_CASE_METHOD(
 
   SupportedFsLocal local_fs;
   std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
-  std::string array_name = temp_dir + "dense_read_large";
+  std::string array_name = temp_dir + "dense_read_multi_out_of_order";
   create_temp_dir(temp_dir);
 
   create_large_dense_array_1_attribute(array_name);
@@ -5217,7 +5217,7 @@ TEST_CASE_METHOD(
 
   SupportedFsLocal local_fs;
   std::string temp_dir = local_fs.file_prefix() + local_fs.temp_dir();
-  std::string array_name = temp_dir + "dense_read_large";
+  std::string array_name = temp_dir + "dense_read_multi_index_coalesce";
   create_temp_dir(temp_dir);
 
   create_large_dense_array_1_attribute(array_name);

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1501,7 +1501,10 @@ Status QueryCondition::apply_sparse(
         apply_clause_sparse(clause, array_schema, result_tile, result_bitmap));
   }
 
-  *cell_count = std::accumulate(result_bitmap.begin(), result_bitmap.end(), 0);
+  if (cell_count != nullptr) {
+    *cell_count =
+        std::accumulate(result_bitmap.begin(), result_bitmap.end(), 0);
+  }
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -377,6 +377,15 @@ Status Reader::compute_range_result_coords(
       }
     }
 
+    // Apply partial overlap condition, if required.
+    const auto frag_meta = fragment_metadata_[tile->frag_idx()];
+    const bool partial_overlap = frag_meta->partial_time_overlap(
+        array_->timestamp_start(), array_->timestamp_end_opened_at());
+    if (frag_meta->has_timestamps() && partial_overlap) {
+      RETURN_NOT_OK(partial_overlap_condition_.apply_sparse<uint8_t>(
+          *(frag_meta->array_schema().get()), *tile, result_bitmap, nullptr));
+    }
+
     // Gather results
     for (uint64_t pos = 0; pos < coords_num; ++pos) {
       if (result_bitmap[pos])
@@ -614,8 +623,9 @@ Status Reader::compute_sparse_result_tiles(
                 f, t, *(fragment_metadata_[f]->array_schema()).get());
             (*result_tile_map)[pair] = result_tiles.size() - 1;
           }
-          // Always check range for multiple fragments
-          if (f > first_fragment[r])
+          // Always check range for multiple fragments or fragments with
+          // timestamps.
+          if (f > first_fragment[r] || fragment_metadata_[f]->has_timestamps())
             (*single_fragment)[r] = false;
           else
             first_fragment[r] = f;
@@ -633,8 +643,9 @@ Status Reader::compute_sparse_result_tiles(
               f, t, *(fragment_metadata_[f]->array_schema()).get());
           (*result_tile_map)[pair] = result_tiles.size() - 1;
         }
-        // Always check range for multiple fragments
-        if (f > first_fragment[r])
+        // Always check range for multiple fragments or fragments with
+        // timestamps.
+        if (f > first_fragment[r] || fragment_metadata_[f]->has_timestamps())
           (*single_fragment)[r] = false;
         else
           first_fragment[r] = f;
@@ -1544,6 +1555,17 @@ Status Reader::compute_result_coords(
     RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, tmp_result_tiles));
   }
 
+  // Rand and unfilter timestamps, if required.
+  if (use_timestamps_) {
+    std::vector<std::string> timestamps = {constants::timestamps};
+    RETURN_CANCEL_OR_ERROR(
+        load_tile_offsets(read_state_.partitioner_.subarray(), timestamps));
+
+    RETURN_CANCEL_OR_ERROR(read_attribute_tiles(timestamps, tmp_result_tiles));
+    RETURN_CANCEL_OR_ERROR(
+        unfilter_tiles(constants::timestamps, tmp_result_tiles));
+  }
+
   // Compute the read coordinates for all fragments for each subarray range.
   std::vector<std::vector<ResultCoords>> range_result_coords;
   RETURN_CANCEL_OR_ERROR(compute_range_result_coords(
@@ -1569,7 +1591,7 @@ Status Reader::dedup_result_coords(
   while (it != coords_end) {
     auto next_it = skip_invalid_elements(std::next(it), coords_end);
     if (next_it != coords_end && it->same_coords(*next_it)) {
-      if (it->tile_->frag_idx() < next_it->tile_->frag_idx()) {
+      if (get_timestamp(*it) < get_timestamp(*next_it)) {
         it->invalidate();
         it = skip_invalid_elements(++it, coords_end);
       } else {
@@ -1692,10 +1714,29 @@ Status Reader::dense_read() {
 }
 
 Status Reader::get_all_result_coords(
-    ResultTile* tile, std::vector<ResultCoords>& result_coords) const {
+    ResultTile* tile, std::vector<ResultCoords>& result_coords) {
   auto coords_num = tile->cell_num();
-  for (uint64_t i = 0; i < coords_num; ++i)
-    result_coords.emplace_back(tile, i);
+
+  // Apply partial overlap condition, if required.
+  const auto frag_meta = fragment_metadata_[tile->frag_idx()];
+  const bool partial_overlap = frag_meta->partial_time_overlap(
+      array_->timestamp_start(), array_->timestamp_end_opened_at());
+  if (fragment_metadata_[tile->frag_idx()]->has_timestamps() &&
+      partial_overlap) {
+    std::vector<uint8_t> result_bitmap(coords_num, 1);
+    RETURN_NOT_OK(partial_overlap_condition_.apply_sparse<uint8_t>(
+        *(frag_meta->array_schema().get()), *tile, result_bitmap, nullptr));
+
+    for (uint64_t i = 0; i < coords_num; ++i) {
+      if (result_bitmap[i]) {
+        result_coords.emplace_back(tile, i);
+      }
+    }
+  } else {
+    for (uint64_t i = 0; i < coords_num; ++i) {
+      result_coords.emplace_back(tile, i);
+    }
+  }
 
   return Status::Ok();
 }
@@ -1846,6 +1887,18 @@ Status Reader::sparse_read() {
   // sparse fragments
   std::vector<ResultCoords> result_coords;
   std::vector<ResultTile> sparse_result_tiles;
+
+  // Set timestamps variables
+  user_requested_timestamps_ = buffers_.count(constants::timestamps) != 0;
+  const bool partial_consol_fragment_overlap =
+      partial_consolidated_fragment_overlap();
+  use_timestamps_ = partial_consol_fragment_overlap ||
+                    !array_schema_.allows_dups() || user_requested_timestamps_;
+
+  // Add partial overlap condition for timestamps, if required.
+  if (partial_consol_fragment_overlap) {
+    RETURN_NOT_OK(add_partial_overlap_condition());
+  }
 
   RETURN_NOT_OK(compute_result_coords(sparse_result_tiles, result_coords));
   std::vector<ResultTile*> result_tiles;

--- a/tiledb/sm/query/reader.cc
+++ b/tiledb/sm/query/reader.cc
@@ -179,6 +179,15 @@ Status Reader::complete_read_loop() {
   return Status::Ok();
 }
 
+uint64_t Reader::get_timestamp(const ResultCoords& rc) const {
+  const auto f = rc.tile_->frag_idx();
+  if (fragment_metadata_[f]->has_timestamps()) {
+    return rc.tile_->timestamp(rc.pos_);
+  } else {
+    return fragment_timestamp(rc.tile_);
+  }
+}
+
 Status Reader::dowork() {
   // Check that the query condition is valid.
   RETURN_NOT_OK(condition_.check(array_schema_));
@@ -1555,7 +1564,7 @@ Status Reader::compute_result_coords(
     RETURN_CANCEL_OR_ERROR(unfilter_tiles(dim_name, tmp_result_tiles));
   }
 
-  // Rand and unfilter timestamps, if required.
+  // Read and unfilter timestamps, if required.
   if (use_timestamps_) {
     std::vector<std::string> timestamps = {constants::timestamps};
     RETURN_CANCEL_OR_ERROR(

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -703,14 +703,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
    *
    * @return timestamp.
    */
-  uint64_t get_timestamp(const ResultCoords& rc) const {
-    const auto f = rc.tile_->frag_idx();
-    if (fragment_metadata_[f]->has_timestamps()) {
-      return rc.tile_->timestamp(rc.pos_);
-    } else {
-      return fragment_timestamp(rc.tile_);
-    }
-  }
+  uint64_t get_timestamp(const ResultCoords& rc) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/reader.h
+++ b/tiledb/sm/query/reader.h
@@ -604,7 +604,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
    * @return Status
    */
   Status get_all_result_coords(
-      ResultTile* tile, std::vector<ResultCoords>& result_coords) const;
+      ResultTile* tile, std::vector<ResultCoords>& result_coords);
 
   /**
    * Returns `true` if a coordinate buffer for a separate dimension
@@ -695,6 +695,22 @@ class Reader : public ReaderBase, public IQueryStrategy {
 
   /** Perform necessary checks before exiting a read loop */
   Status complete_read_loop();
+
+  /**
+   * Get the timestamp value for a result coords.
+   *
+   * @param rc Result coords.
+   *
+   * @return timestamp.
+   */
+  uint64_t get_timestamp(const ResultCoords& rc) const {
+    const auto f = rc.tile_->frag_idx();
+    if (fragment_metadata_[f]->has_timestamps()) {
+      return rc.tile_->timestamp(rc.pos_);
+    } else {
+      return fragment_timestamp(rc.tile_);
+    }
+  }
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/reader_base.h
+++ b/tiledb/sm/query/reader_base.h
@@ -173,6 +173,15 @@ class ReaderBase : public StrategyBase {
    * */
   QueryCondition partial_overlap_condition_;
 
+  /** If the user requested timestamps attribute in the query */
+  bool user_requested_timestamps_;
+
+  /**
+   * If the special timestamps attribute should be loaded to memory for
+   * this query
+   */
+  bool use_timestamps_;
+
   /* ********************************* */
   /*         PROTECTED METHODS         */
   /* ********************************* */
@@ -211,10 +220,18 @@ class ReaderBase : public StrategyBase {
    * without timestamps.
    */
   inline bool timestamps_not_present(
-      const std::string& name,
-      const std::shared_ptr<tiledb::sm::FragmentMetadata>& frag_md) const {
-    return name == constants::timestamps && !frag_md->has_timestamps();
+      const std::string& name, const unsigned f) const {
+    return name == constants::timestamps && !include_timestamps(f);
   }
+
+  /**
+   * Checks if timestamps should be loaded for a fragment.
+   *
+   * @param f Fragment index.
+   * @return True if timestamps should be included, false if they are not.
+   * needed.
+   */
+  bool include_timestamps(const unsigned f) const;
 
   /**
    * Returns the fragment timestamp for a result tile.

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -84,9 +84,7 @@ SparseIndexReaderBase::SparseIndexReaderBase(
     , memory_budget_ratio_query_condition_(0.25)
     , memory_budget_ratio_tile_ranges_(0.1)
     , memory_budget_ratio_array_data_(0.1)
-    , buffers_full_(false)
-    , user_requested_timestamps_(false)
-    , use_timestamps_(false) {
+    , buffers_full_(false) {
   read_state_.done_adding_result_tiles_ = false;
   disable_cache_ = true;
 }
@@ -295,18 +293,19 @@ Status SparseIndexReaderBase::load_initial_data() {
     }
   }
 
-  use_timestamps_ = partial_consolidated_fragment_overlap() ||
+  const bool partial_consol_fragment_overlap =
+      partial_consolidated_fragment_overlap();
+  use_timestamps_ = partial_consol_fragment_overlap ||
                     !array_schema_.allows_dups() || user_requested_timestamps_;
 
-  // Add timestamps and filter by timestamps condition if required. If the user
-  // has requested timestamps the special attribute will already be in the list,
-  // so don't include it again
-  if (use_timestamps_) {
-    if (!user_requested_timestamps_) {
-      attr_tile_offsets_to_load.emplace_back(constants::timestamps);
-    }
-
+  // Add partial overlap condition, if required.
+  if (partial_consol_fragment_overlap) {
     RETURN_CANCEL_OR_ERROR(add_partial_overlap_condition());
+  }
+
+  // Load tile offsets for timestamps, ir required.
+  if (use_timestamps_) {
+    attr_tile_offsets_to_load.emplace_back(constants::timestamps);
   }
 
   // Load tile offsets and var sizes for attributes.
@@ -755,14 +754,6 @@ void SparseIndexReaderBase::remove_result_tile_range(uint64_t f) {
     std::unique_lock<std::mutex> lck(mem_budget_mtx_);
     memory_used_result_tile_ranges_ -= sizeof(std::pair<uint64_t, uint64_t>);
   }
-}
-
-bool SparseIndexReaderBase::include_timestamps(const unsigned f) {
-  return fragment_metadata_[f]->has_timestamps() &&
-         (user_requested_timestamps_ ||
-          fragment_metadata_[f]->partial_time_overlap(
-              array_->timestamp_start(), array_->timestamp_end_opened_at()) ||
-          !array_schema_.allows_dups());
 }
 
 // Explicit template instantiations

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -303,8 +303,10 @@ Status SparseIndexReaderBase::load_initial_data() {
     RETURN_CANCEL_OR_ERROR(add_partial_overlap_condition());
   }
 
-  // Load tile offsets for timestamps, ir required.
-  if (use_timestamps_) {
+  // Add timestamps and filter by timestamps condition if required. If the user
+  // has requested timestamps the special attribute will already be in the list,
+  // so don't include it again
+  if (use_timestamps_ && !user_requested_timestamps_) {
     attr_tile_offsets_to_load.emplace_back(constants::timestamps);
   }
 

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -303,15 +303,6 @@ class SparseIndexReaderBase : public ReaderBase {
   /** List of tiles to ignore. */
   std::unordered_set<IgnoredTile, ignored_tile_hash> ignored_tiles_;
 
-  /** If the user requested timestamps attribute in the query */
-  bool user_requested_timestamps_;
-
-  /**
-   * If the special timestamps attribute should be loaded to memory for
-   * this query
-   */
-  bool use_timestamps_;
-
   /* ********************************* */
   /*         PROTECTED METHODS         */
   /* ********************************* */
@@ -431,15 +422,6 @@ class SparseIndexReaderBase : public ReaderBase {
    * @param f Fragment index.
    */
   void remove_result_tile_range(uint64_t f);
-
-  /**
-   * Checks if timestamps should be loaded for a fragment.
-   *
-   * @param f Fragment index.
-   * @return True if timestamps should be included, false if they are not.
-   * needed.
-   */
-  bool include_timestamps(const unsigned f);
 };
 
 }  // namespace sm


### PR DESCRIPTION
This enables the original reader to read fragments with timestamps. The
first step was read and unfilter the required timestamp tiles, which
heavily leveraged work in previous PRs. Second step was to use the time
filtering again already mostly implemented in previous PRs to filter
cells that don't match the array start/end open times. Then the
deduplication algorithm already present in the reader was modified to
run for arrays with no duplicates for single fragment ranges if that
fragment has timestamps. Deduplication now also uses
timestamps instead of fragment indexes to select the correct cell.

---
TYPE: IMPROVEMENT
DESC: Consolidation with timestamps: original reader reads fragments.
