### PR TITLE
Apply TILEDB_NO_API_DEPRECATION_WARNINGS to C++ API

### DIFF
--- a/tiledb/sm/cpp_api/tiledb
+++ b/tiledb/sm/cpp_api/tiledb
@@ -35,6 +35,17 @@
 #ifndef TILEDB_CPP_H
 #define TILEDB_CPP_H
 
+#ifdef TILEDB_NO_API_DEPRECATION_WARNINGS
+// Define these before including tiledb_export.h to avoid their normal
+// definitions.
+#ifndef TILEDB_DEPRECATED
+#define TILEDB_DEPRECATED
+#endif
+#ifndef TILEDB_DEPRECATED_EXPORT
+#define TILEDB_DEPRECATED_EXPORT
+#endif
+#endif
+
 #include "array.h"
 #include "array_schema.h"
 #include "attribute.h"


### PR DESCRIPTION
The C API header tiledb.h may not come first in C++ API header includes,
so we need to apply these overrides here too.

---
TYPE: CPP_API
DESC: Apply TILEDB_NO_API_DEPRECATION_WARNINGS to C++ API
