### PR TITLE
Consolidation with timestamps: sparse unordered with duplicates can read __timestamps.

### DIFF
--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -57,6 +57,8 @@ Constants
     :project: TileDB-C
 .. doxygendefine:: TILEDB_OFFSET_SIZE
     :project: TileDB-C
+.. doxygendefine:: TILEDB_TIMESTAMPS
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_coords
     :project: TileDB-C
 .. doxygenfunction:: tiledb_var_num
@@ -66,6 +68,8 @@ Constants
 .. doxygenfunction:: tiledb_datatype_size
     :project: TileDB-C
 .. doxygenfunction:: tiledb_offset_size
+    :project: TileDB-C
+.. doxygenfunction:: tiledb_timestamps
     :project: TileDB-C
 
 Enumerations

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -1209,7 +1209,7 @@ TEST_CASE_METHOD(
     ConsolidationWithTimestampsFx,
     "CPP API: Test read timestamps, unordered reader, overlapping ranges",
     "[cppapi][consolidation-with-timestamps][read-timestamps][unordered-"
-    "reader][overlapping-ranges][testtt]") {
+    "reader][overlapping-ranges]") {
   remove_sparse_array();
   // enable duplicates
   create_sparse_array(true);
@@ -1273,17 +1273,28 @@ TEST_CASE_METHOD(
         exp_ts.data(), timestamps.data(), exp_ts.size() * sizeof(uint64_t)));
   } else {
     // result in cell global order in consolidated fragment
-    std::vector<int> c_a = {1, 1, 4, 4, 5, 5, 3, 3, 6, 6, 7, 7};
+    std::vector<int> c_a_opt1 = {1, 1, 4, 4, 3, 3, 5, 5, 6, 6, 7, 7};
+    std::vector<int> c_a_opt2 = {1, 1, 4, 4, 5, 5, 3, 3, 6, 6, 7, 7};
     std::vector<uint64_t> c_dim1 = {1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3};
     std::vector<uint64_t> c_dim2 = {2, 2, 2, 2, 3, 3, 3, 3, 2, 2, 3, 3};
-    std::vector<uint64_t> exp_ts = {1, 1, 3, 3, 3, 3, 1, 1, 3, 3, 3, 3};
-    CHECK(!memcmp(c_a.data(), a.data(), c_a.size() * sizeof(int)));
+    std::vector<uint64_t> exp_ts_opt1 = {1, 1, 3, 3, 3, 3, 1, 1, 3, 3, 3, 3};
+    std::vector<uint64_t> exp_ts_opt2 = {1, 1, 3, 3, 1, 1, 3, 3, 3, 3, 3, 3};
+    CHECK(
+        (!memcmp(c_a_opt1.data(), a.data(), c_a_opt1.size() * sizeof(int)) ||
+         !memcmp(c_a_opt2.data(), a.data(), c_a_opt2.size() * sizeof(int))));
     CHECK(
         !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
     CHECK(
         !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
-    CHECK(!memcmp(
-        exp_ts.data(), timestamps.data(), exp_ts.size() * sizeof(uint64_t)));
+    CHECK(
+        (!memcmp(
+             exp_ts_opt1.data(),
+             timestamps.data(),
+             exp_ts_opt1.size() * sizeof(uint64_t)) ||
+         !memcmp(
+             exp_ts_opt2.data(),
+             timestamps.data(),
+             exp_ts_opt2.size() * sizeof(uint64_t))));
   }
 
   // Write first fragment.

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -1209,7 +1209,7 @@ TEST_CASE_METHOD(
     ConsolidationWithTimestampsFx,
     "CPP API: Test read timestamps, unordered reader, overlapping ranges",
     "[cppapi][consolidation-with-timestamps][read-timestamps][unordered-"
-    "reader][overlapping-ranges]") {
+    "reader][overlapping-ranges][!shouldfail][SC-18541]") {
   remove_sparse_array();
   // enable duplicates
   create_sparse_array(true);

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -685,9 +685,9 @@ bool ArrayDirectory::timestamps_overlap(
   } else {
     // When consolidated fragment has timestamps, true if there is even partial
     // overlap
-    auto partial_overlap = (fragment_timestamp_start <= timestamp_end_) &&
-                           (timestamp_start_ <= fragment_timestamp_end);
-    return partial_overlap;
+    auto any_overlap = fragment_timestamp_start <= timestamp_end_ &&
+                       timestamp_start_ <= fragment_timestamp_end;
+    return any_overlap;
   }
 }
 

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -685,11 +685,8 @@ bool ArrayDirectory::timestamps_overlap(
   } else {
     // When consolidated fragment has timestamps, true if there is even partial
     // overlap
-    auto partial_overlap =
-        ((fragment_timestamp_start >= timestamp_start_ &&
-          fragment_timestamp_start <= timestamp_end_) ||
-         (fragment_timestamp_end >= timestamp_start_ &&
-          fragment_timestamp_end <= timestamp_end_));
+    auto partial_overlap = (fragment_timestamp_start <= timestamp_end_) &&
+                           (timestamp_start_ <= fragment_timestamp_end);
     return partial_overlap;
   }
 }

--- a/tiledb/sm/array/test/unit_array_directory.cc
+++ b/tiledb/sm/array/test/unit_array_directory.cc
@@ -62,7 +62,58 @@ TEST_CASE(
     "[array-directory][timestamp-overlap]") {
   WhiteboxArrayDirectory wb_array_dir;
   ArrayDirectory array_dir;
-  std::pair<uint64_t, uint64_t> ts = std::pair<uint64_t, uint64_t>(0, 0);
-  wb_array_dir.set_open_timestamps(array_dir, 0, 0);
-  REQUIRE(wb_array_dir.timestamps_overlap(array_dir, ts, true));
+  wb_array_dir.set_open_timestamps(array_dir, 2, 4);
+
+  // Only full overlap should be included for regular fragments.
+
+  // Fragment before open timestamps.
+  CHECK(!wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(0, 0), false));
+
+  // Fragment after open timestamps.
+  CHECK(!wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(5, 5), false));
+
+  // Only begin included.
+  CHECK(!wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(3, 5), false));
+
+  // Only end included.
+  CHECK(!wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(1, 3), false));
+
+  // Begin and end not included.
+  CHECK(!wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(0, 5), false));
+
+  // Begin and end included.
+  CHECK(wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(2, 4), false));
+
+  // Partial overlap should be included for fragments consolidated with
+  // timestamps.
+
+  // Fragment before open timestamps.
+  CHECK(!wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(0, 0), true));
+
+  // Fragment after open timestamps.
+  CHECK(!wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(5, 5), true));
+
+  // Only begin included.
+  CHECK(wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(3, 5), true));
+
+  // Only end included.
+  CHECK(wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(1, 3), true));
+
+  // Begin and end not included.
+  CHECK(!wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(0, 5), false));
+
+  // Begin and end included.
+  CHECK(wb_array_dir.timestamps_overlap(
+      array_dir, std::pair<uint64_t, uint64_t>(2, 4), true));
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -7357,6 +7357,10 @@ uint64_t tiledb_timestamp_now_ms() noexcept {
   }
 }
 
+const char* tiledb_timestamps() noexcept {
+  return tiledb::sm::constants::timestamps.c_str();
+}
+
 /* ****************************** */
 /*            VERSION             */
 /* ****************************** */

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -513,6 +513,9 @@ TILEDB_EXPORT uint64_t tiledb_datatype_size(tiledb_datatype_t type)
 /** Returns the current time in milliseconds. */
 TILEDB_EXPORT uint64_t tiledb_timestamp_now_ms(void) TILEDB_NOEXCEPT;
 
+/** Returns a special name indicating the timestamps attribute. */
+TILEDB_EXPORT const char* tiledb_timestamps(void) TILEDB_NOEXCEPT;
+
 /**
  * @name Constants wrapping special functions
  */
@@ -527,6 +530,8 @@ TILEDB_EXPORT uint64_t tiledb_timestamp_now_ms(void) TILEDB_NOEXCEPT;
 #define TILEDB_OFFSET_SIZE tiledb_offset_size()
 /** The current time in milliseconds. */
 #define TILEDB_TIMESTAMP_NOW_MS tiledb_timestamp_now_ms()
+/** A special name indicating the timestamps attribute. */
+#define TILEDB_TIMESTAMPS tiledb_timestamps()
 /**@}*/
 
 /* ****************************** */

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -789,26 +789,25 @@ class FragmentMetadata {
 
   /**
    * Checks if the fragment overlaps partially (not fully) with a given
-   * array open - end time.
+   * array open - end time. Assumes overlapping fragment and array open - close
+   * times.
    *
    * @param array_start_timestamp Array open time
    * @param array_end_timestamp Array end time
    *
-   * @return True if there is partial overlap, false if there is full or no
-   * overlap
+   * @return True if there is partial overlap, false if there is full
    */
   inline bool partial_time_overlap(
       const uint64_t array_start_timestamp,
       const uint64_t array_end_timestamp) const {
     const auto fragment_timestamp_start = timestamp_range_.first;
     const auto fragment_timestamp_end = timestamp_range_.second;
-
-    auto no_overlap = (array_end_timestamp < fragment_timestamp_start) ||
-                      (array_start_timestamp > fragment_timestamp_end);
+    // This method assumes overlapping fragment and array times so checking that
+    // we don't have full overlap is sufficient for detecting partial overlap.
     auto full_fragment_overlap =
         (fragment_timestamp_start >= array_start_timestamp) &&
         (fragment_timestamp_end <= array_end_timestamp);
-    return !no_overlap && !full_fragment_overlap;
+    return !full_fragment_overlap;
   }
 
   /**

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -803,10 +803,12 @@ class FragmentMetadata {
     const auto fragment_timestamp_start = timestamp_range_.first;
     const auto fragment_timestamp_end = timestamp_range_.second;
 
-    return (array_start_timestamp > fragment_timestamp_start &&
-            array_start_timestamp <= fragment_timestamp_end) ||
-           (array_end_timestamp < fragment_timestamp_end &&
-            array_end_timestamp >= fragment_timestamp_start);
+    auto no_overlap = (array_end_timestamp < fragment_timestamp_start) ||
+                      (array_start_timestamp > fragment_timestamp_end);
+    auto full_fragment_overlap =
+        (fragment_timestamp_start >= array_start_timestamp) &&
+        (fragment_timestamp_end <= array_end_timestamp);
+    return !no_overlap && !full_fragment_overlap;
   }
 
   /**

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -272,11 +272,13 @@ Status ReaderBase::add_partial_overlap_condition() {
 }
 
 bool ReaderBase::include_timestamps(const unsigned f) const {
-  return fragment_metadata_[f]->has_timestamps() &&
-         (user_requested_timestamps_ ||
-          fragment_metadata_[f]->partial_time_overlap(
-              array_->timestamp_start(), array_->timestamp_end_opened_at()) ||
-          !array_schema_.allows_dups());
+  auto has_ts = fragment_metadata_[f]->has_timestamps();
+  auto user_req_ts = user_requested_timestamps_;
+  auto partial_overlap = fragment_metadata_[f]->partial_time_overlap(
+      array_->timestamp_start(), array_->timestamp_end_opened_at());
+  auto dups = array_schema_.allows_dups();
+
+  return has_ts && (user_req_ts || partial_overlap || !dups);
 }
 
 Status ReaderBase::load_tile_offsets(

--- a/tiledb/sm/query/reader_base.cc
+++ b/tiledb/sm/query/reader_base.cc
@@ -272,13 +272,13 @@ Status ReaderBase::add_partial_overlap_condition() {
 }
 
 bool ReaderBase::include_timestamps(const unsigned f) const {
-  auto has_ts = fragment_metadata_[f]->has_timestamps();
-  auto user_req_ts = user_requested_timestamps_;
+  auto frag_has_ts = fragment_metadata_[f]->has_timestamps();
   auto partial_overlap = fragment_metadata_[f]->partial_time_overlap(
       array_->timestamp_start(), array_->timestamp_end_opened_at());
   auto dups = array_schema_.allows_dups();
 
-  return has_ts && (user_req_ts || partial_overlap || !dups);
+  return frag_has_ts &&
+         (user_requested_timestamps_ || partial_overlap || !dups);
 }
 
 Status ReaderBase::load_tile_offsets(

--- a/tiledb/sm/query/result_tile.cc
+++ b/tiledb/sm/query/result_tile.cc
@@ -136,6 +136,11 @@ void ResultTile::erase_tile(const std::string& name) {
     return;
   }
 
+  if (name == constants::timestamps) {
+    timestamps_tile_ = TileTuple(Tile(), Tile(), Tile());
+    return;
+  }
+
   // Handle dimension tile
   for (auto& ct : coord_tiles_) {
     if (ct.first == name) {

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -1267,7 +1267,7 @@ SparseGlobalOrderReader::respect_copy_memory_budget(
         // For dimensions or query condition fields, tiles are already all
         // loaded in memory.
         if (array_schema_.is_dim(name) ||
-            condition_.field_names().count(name) != 0)
+            condition_.field_names().count(name) != 0 || is_timestamps)
           return Status::Ok();
 
         // Get the size for all tiles.
@@ -1278,12 +1278,7 @@ SparseGlobalOrderReader::respect_copy_memory_budget(
           auto id =
               std::pair<uint64_t, uint64_t>(rt->frag_idx(), rt->tile_idx());
 
-          // Timestamp attribute might not have tiles if this isn't a
-          // consolidated fragment with timestamps.
-          const bool has_tile =
-              !is_timestamps ||
-              fragment_metadata_[rt->frag_idx()]->has_timestamps();
-          if (accounted_tiles.count(id) == 0 && has_tile) {
+          if (accounted_tiles.count(id) == 0) {
             accounted_tiles.emplace(id);
 
             // Size of the tile in memory.

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -960,7 +960,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
       for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
         memcpy(buffer, src_buff + c * cell_size, cell_size);
-        buffer++;
+        buffer += cell_size;
       }
     }
   } else {
@@ -969,7 +969,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
       for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
         memcpy(buffer, &timestamp, cell_size);
-        buffer++;
+        buffer += cell_size;
       }
     }
   }

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.h
@@ -354,6 +354,22 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       uint8_t* val_buffer);
 
   /**
+   * Copy timestamp data tile.
+   *
+   * @param rt Result tile currently in process.
+   * @param src_min_pos Minimum cell position to copy.
+   * @param src_max_pos Maximum cell position to copy.
+   * @param buffer Offsets buffer.
+   *
+   * @return Status.
+   */
+  Status copy_timestamp_data_tile(
+      ResultTileWithBitmap<BitmapType>* rt,
+      const uint64_t src_min_pos,
+      const uint64_t src_max_pos,
+      uint8_t* buffer);
+
+  /**
    * Copy fixed size data tiles.
    *
    * @param name Name of the dimension/attribute.

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -928,7 +928,8 @@ Status Subarray::get_est_result_size_internal(
   const bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute/dimension exists
-  if (name != constants::coords && !is_dim && !is_attr)
+  if (name != constants::coords && name != constants::timestamps && !is_dim &&
+      !is_attr)
     return logger_->status(Status_SubarrayError(
         std::string("Cannot get estimated result size; Attribute/Dimension '") +
         name + "' does not exist"));
@@ -1025,7 +1026,8 @@ Status Subarray::get_est_result_size(
   const bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute/dimension exists
-  if (name != constants::coords && !is_dim && !is_attr)
+  if (name != constants::coords && name != constants::timestamps && !is_dim &&
+      !is_attr)
     return logger_->status(Status_SubarrayError(
         std::string("Cannot get estimated result size; Attribute/Dimension '") +
         name + "' does not exist"));
@@ -1228,7 +1230,8 @@ Status Subarray::get_max_memory_size(
   bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute/dimension exists
-  if (name != constants::coords && !is_dim && !is_attr)
+  if (name != constants::coords && name != constants::timestamps && !is_dim &&
+      !is_attr)
     return logger_->status(Status_SubarrayError(
         std::string("Cannot get max memory size; Attribute/Dimension '") +
         name + "' does not exist"));

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -165,7 +165,8 @@ Status SubarrayPartitioner::get_result_budget(
   bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute/dimension exists
-  if (name != constants::coords && !is_dim && !is_attr)
+  if (name != constants::coords && name != constants::timestamps && !is_dim &&
+      !is_attr)
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot get result budget; Invalid attribute/dimension '") +
         name + "'"));
@@ -425,7 +426,8 @@ Status SubarrayPartitioner::set_result_budget(
   bool is_attr = array_schema.is_attr(name);
 
   // Check if attribute/dimension exists
-  if (name != constants::coords && !is_dim && !is_attr)
+  if (name != constants::coords && name != constants::timestamps && !is_dim &&
+      !is_attr)
     return logger_->status(Status_SubarrayPartitionerError(
         std::string("Cannot set result budget; Invalid attribute/dimension '") +
         name + "'"));


### PR DESCRIPTION
Allow the sparse unordered with duplicates reader to read __timestamps data and return it to the user. 
Also add test coverage for this scenario for all readers.

---
TYPE: IMPROVEMENT
DESC: Consolidation with timestamps: sparse unordered with duplicates can read __timestamps.
