### PR TITLE
Dense reader: fixing query conditions with overlapping domains.

### DIFF
--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -1013,7 +1013,6 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   Attribute attr = Attribute::create<int>(ctx, "a");
-
   int fill_value = -1;
   attr.set_fill_value(&fill_value, sizeof(int));
   schema.add_attribute(attr);

--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -1047,7 +1047,7 @@ TEST_CASE(
   // Query the data with query condition a > 4.
   QueryCondition qc(ctx);
   int val1 = 4;
-  qc.init("a", &val1, sizeof(float), TILEDB_GT);
+  qc.init("a", &val1, sizeof(int), TILEDB_GT);
 
   std::vector<int> vals_read(10);
   Query query_r(ctx, array_r, TILEDB_READ);
@@ -1058,7 +1058,7 @@ TEST_CASE(
   REQUIRE(query_r.submit() == Query::Status::COMPLETE);
 
   std::vector<int> c_vals_read = {-1, -1, 7, 7, 7, 7, -1, -1, -1, -1};
-  CHECK(0 == memcmp(vals_read.data(), c_vals_read.data(), 10));
+  CHECK(0 == memcmp(vals_read.data(), c_vals_read.data(), 10 * sizeof(int)));
 
   array_r.close();
 

--- a/tiledb/sm/query/dense_reader.cc
+++ b/tiledb/sm/query/dense_reader.cc
@@ -563,7 +563,9 @@ DenseReader::apply_query_condition(
                 it->second,
                 cell_slab.coords_.data());
 
-            for (int32_t i = (int32_t)frag_domains.size() - 1; i >= 0; --i) {
+            for (int32_t i = static_cast<int32_t>(frag_domains.size()) - 1;
+                 i >= 0;
+                 --i) {
               // If the cell slab overlaps this fragment domain range, apply
               // clause.
               auto&& [overlaps, start, end] = cell_slab_overlaps_range(
@@ -572,6 +574,13 @@ DenseReader::apply_query_condition(
                   cell_slab.coords_.data(),
                   cell_slab.length_);
               if (overlaps) {
+                // Re-initialize the bitmap to 1 in case of overlapping domains.
+                if (i != static_cast<int32_t>(frag_domains.size()) - 1) {
+                  for (uint64_t c = start; c <= end; c++) {
+                    dest_ptr[c] = 1;
+                  }
+                }
+
                 RETURN_NOT_OK(condition_.apply_dense(
                     *(fragment_metadata_[frag_domains[i].first]
                           ->array_schema()


### PR DESCRIPTION
When applying query condition on dense fragments, we need to reset the
result bitmap to 1 for fragment domains that aren't the first one. This
is to prevent the case where a cell didn't match the query condition in
a previous fragment but with the new value, it now does.

---
TYPE: IMPROVEMENT
DESC: Dense reader: fixing query conditions with overlapping domains.
