### PR TITLE
Fix File API failure when importing into TileDB Cloud array

### DIFF
--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -286,12 +286,12 @@ TILEDB_EXPORT int32_t tiledb_filestore_uri_import(
   };
 
   uint64_t start_range = 0;
-  uint64_t end_range = tile_extent - 1;
+  uint64_t end_range = *buffer_size - 1;
   while (input.read(reinterpret_cast<char*>(buffer.data()), *buffer_size)) {
     if (is_tiledb_uri) {
       tiledb_cloud_fix(start_range, end_range, buffer.size());
-      start_range += tile_extent;
-      end_range += tile_extent;
+      start_range += *buffer_size;
+      end_range += *buffer_size;
     } else {
       query.set_data_buffer(
           tiledb::sm::constants::filestore_attribute_name,


### PR DESCRIPTION
The bug was introduced with PR 3216, the API was trying to write in row-major order `tile_extent` bytes instead of `filestore.buffer_size` bytes. Most probably a rebase leftover given the dependency on PR 3223.

---
TYPE: BUG
DESC: Fix File API failure when importing into TileDB Cloud array
