### PR TITLE
Support TILEDB_BOOL in tiledb::sm::utils::parse::to_str

### DIFF
--- a/tiledb/sm/misc/parse_argument.cc
+++ b/tiledb/sm/misc/parse_argument.cc
@@ -318,6 +318,10 @@ std::string to_str(const void* value, Datatype type) {
     case Datatype::TIME_AS:
       ss << *(const int64_t*)value;
       break;
+    case Datatype::BLOB:
+      // For printing to string use unsigned int value
+      ss << *(const uint8_t*)value;
+      break;
     default:
       assert(false);
   }

--- a/tiledb/sm/misc/parse_argument.cc
+++ b/tiledb/sm/misc/parse_argument.cc
@@ -322,6 +322,8 @@ std::string to_str(const void* value, Datatype type) {
       // For printing to string use unsigned int value
       ss << *(const uint8_t*)value;
       break;
+    case Datatype::BOOL:
+      ss << *(const bool*)value;
     default:
       assert(false);
   }


### PR DESCRIPTION
This support printing bool in `tiledb::sm::utils::parse::to_str`. This is used only for `tiledb::sm::Attribute::dump()` for `tiledb::sm::Attribute::fill_value_str`. This PR is based on #3250 to avoid conflicts with the support for `TILEDB_BLOB`.


---
TYPE: BUG
DESC: Fix printing of TILEDB_BOOL attributes in `Attribute::Dump`
