### PR TITLE
Optimize compute_results_count_sparse_string.

### DIFF
--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -43,6 +43,7 @@
 #endif
 
 #include <catch.hpp>
+#include <numeric>
 
 using namespace tiledb::sm;
 using namespace tiledb::test;

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -31,6 +31,7 @@
  */
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/misc/types.h"
 
 #include "test/src/helpers.h"
 #include "tiledb/sm/query/sparse_index_reader_base.h"
@@ -49,6 +50,71 @@ using namespace tiledb::test;
 /* ********************************* */
 /*                TESTS              */
 /* ********************************* */
+
+struct CResultTileFx {
+  tiledb_ctx_t* ctx_ = nullptr;
+  tiledb_vfs_t* vfs_ = nullptr;
+  std::string temp_dir_;
+  std::string array_name_;
+  const char* ARRAY_NAME = "test_result_coords";
+  tiledb_array_t* array_;
+
+  CResultTileFx();
+  ~CResultTileFx();
+};
+
+CResultTileFx::CResultTileFx() {
+  tiledb_config_t* config;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  tiledb_config_free(&config);
+
+  // Create temporary directory based on the supported filesystem.
+#ifdef _WIN32
+  temp_dir_ = tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
+#else
+  temp_dir_ = "file://" + tiledb::sm::Posix::current_dir() + "/tiledb_test/";
+#endif
+  create_dir(temp_dir_, ctx_, vfs_);
+  array_name_ = temp_dir_ + ARRAY_NAME;
+
+  // Create array
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_SPARSE,
+      {"d1", "d2"},
+      {TILEDB_STRING_ASCII, TILEDB_STRING_ASCII},
+      {nullptr, nullptr},
+      {nullptr, nullptr},
+      {"a"},
+      {TILEDB_STRING_ASCII},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      100000);
+
+  // Open array for reading.
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array_);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array_, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+}
+
+CResultTileFx::~CResultTileFx() {
+  // Clean up.
+  REQUIRE(tiledb_array_close(ctx_, array_) == TILEDB_OK);
+  tiledb_array_free(&array_);
+
+  remove_dir(temp_dir_, ctx_, vfs_);
+  tiledb_ctx_free(&ctx_);
+  tiledb_vfs_free(&vfs_);
+}
 
 TEST_CASE(
     "ResultTileWithBitmap: result_num_between_pos and "
@@ -101,4 +167,214 @@ TEST_CASE(
   CHECK(tile.pos_with_given_result_sum(2, 8) == 10);
 
   tiledb_ctx_free(&ctx);
+}
+
+TEST_CASE_METHOD(
+    CResultTileFx,
+    "Test compute_results_count_sparse_string non overlapping",
+    "[resulttile][compute_results_count_sparse_string][non-overlapping]") {
+  bool first_dim = GENERATE(true, false);
+  std::string dim_name = first_dim ? "d1" : "d2";
+  uint64_t dim_idx = first_dim ? 0 : 1;
+  uint64_t num_cells = 8;
+
+  ResultTile rt(0, 0, array_->array_->array_schema_latest());
+
+  // Make sure cell_num() will return the correct value.
+  if (!first_dim) {
+    rt.init_coord_tile("d1", 0);
+    auto tile_tuple = rt.tile_tuple("d1");
+    Tile* const t = &std::get<0>(*tile_tuple);
+    t->init_unfiltered(
+        constants::format_version,
+        constants::cell_var_offset_type,
+        num_cells * constants::cell_var_offset_size,
+        constants::cell_var_offset_size,
+        0);
+  }
+
+  rt.init_coord_tile(dim_name, dim_idx);
+  auto tile_tuple = rt.tile_tuple(dim_name);
+  Tile* const t = &std::get<0>(*tile_tuple);
+  Tile* const t_var = &std::get<1>(*tile_tuple);
+
+  // Initialize offsets, use 1 character strings.
+  t->init_unfiltered(
+      constants::format_version,
+      constants::cell_var_offset_type,
+      num_cells * constants::cell_var_offset_size,
+      constants::cell_var_offset_size,
+      dim_idx);
+  uint64_t* offsets = (uint64_t*)t->data();
+  for (uint64_t i = 0; i < num_cells; i++) {
+    offsets[i] = i;
+  }
+
+  // Initialize data, use incrementing single string values starting with 'a'.
+  t_var->init_unfiltered(
+      constants::format_version, Datatype::STRING_ASCII, num_cells, 1, 0);
+  char* var = (char*)t_var->data();
+  for (uint64_t i = 0; i < num_cells; i++) {
+    var[i] = 'a' + i;
+  }
+
+  // Initialize ranges.
+  NDRange ranges;
+  char temp[2];
+  std::vector<uint8_t> exp_result_count;
+  SECTION("- First and last cell included") {
+    ranges.resize(2);
+    temp[0] = temp[1] = 'a';
+    ranges[0] = Range(temp, 2, 1);
+
+    temp[0] = temp[1] = 'h';
+    ranges[1] = Range(temp, 2, 1);
+
+    exp_result_count = {1, 0, 0, 0, 0, 0, 0, 1};
+  }
+
+  SECTION("- Middle cells included") {
+    ranges.resize(1);
+    temp[0] = 'b';
+    temp[1] = 'g';
+    ranges[0] = Range(temp, 2, 1);
+
+    exp_result_count = {0, 1, 1, 1, 1, 1, 1, 0};
+  }
+
+  std::vector<uint64_t> range_indexes(ranges.size());
+  std::iota(range_indexes.begin(), range_indexes.end(), 0);
+
+  std::vector<uint8_t> result_count(num_cells, 1);
+  ResultTile::compute_results_count_sparse_string(
+      &rt,
+      dim_idx,
+      ranges,
+      range_indexes,
+      result_count,
+      Layout::ROW_MAJOR,
+      0,
+      num_cells);
+
+  CHECK(memcmp(result_count.data(), exp_result_count.data(), num_cells) == 0);
+}
+
+TEST_CASE_METHOD(
+    CResultTileFx,
+    "Test compute_results_count_sparse_string overlapping",
+    "[resulttile][compute_results_count_sparse_string][overlapping]") {
+  bool first_dim = GENERATE(true, false);
+  std::string dim_name = first_dim ? "d1" : "d2";
+  uint64_t dim_idx = first_dim ? 0 : 1;
+  uint64_t num_cells = 8;
+
+  ResultTile rt(0, 0, array_->array_->array_schema_latest());
+
+  // Make sure cell_num() will return the correct value.
+  if (!first_dim) {
+    rt.init_coord_tile("d1", 0);
+    auto tile_tuple = rt.tile_tuple("d1");
+    Tile* const t = &std::get<0>(*tile_tuple);
+    t->init_unfiltered(
+        constants::format_version,
+        constants::cell_var_offset_type,
+        num_cells * constants::cell_var_offset_size,
+        constants::cell_var_offset_size,
+        0);
+  }
+
+  rt.init_coord_tile(dim_name, dim_idx);
+  auto tile_tuple = rt.tile_tuple(dim_name);
+  Tile* const t = &std::get<0>(*tile_tuple);
+  Tile* const t_var = &std::get<1>(*tile_tuple);
+
+  // Initialize offsets, use 1 character strings.
+  t->init_unfiltered(
+      constants::format_version,
+      constants::cell_var_offset_type,
+      num_cells * constants::cell_var_offset_size,
+      constants::cell_var_offset_size,
+      dim_idx);
+  uint64_t* offsets = (uint64_t*)t->data();
+  for (uint64_t i = 0; i < num_cells; i++) {
+    offsets[i] = i;
+  }
+
+  // Initialize data, use incrementing single string values starting with 'a'.
+  t_var->init_unfiltered(
+      constants::format_version, Datatype::STRING_ASCII, num_cells, 1, 0);
+  char* var = (char*)t_var->data();
+  for (uint64_t i = 0; i < num_cells; i++) {
+    var[i] = 'a' + i;
+  }
+
+  // Initialize ranges.
+  NDRange ranges;
+  char temp[2];
+  std::vector<uint64_t> exp_result_count;
+  SECTION("- First and last cell included multiple times") {
+    ranges.resize(5);
+    temp[0] = temp[1] = 'a';
+    ranges[0] = Range(temp, 2, 1);
+    ranges[1] = Range(temp, 2, 1);
+    ranges[2] = Range(temp, 2, 1);
+
+    temp[0] = temp[1] = 'h';
+    ranges[3] = Range(temp, 2, 1);
+    ranges[4] = Range(temp, 2, 1);
+
+    exp_result_count = {3, 0, 0, 0, 0, 0, 0, 2};
+  }
+
+  SECTION("- Middle cells included multiple times") {
+    ranges.resize(2);
+    temp[0] = 'b';
+    temp[1] = 'g';
+    ranges[0] = Range(temp, 2, 1);
+
+    temp[0] = 'c';
+    temp[1] = 'f';
+    ranges[1] = Range(temp, 2, 1);
+
+    exp_result_count = {0, 1, 2, 2, 2, 2, 1, 0};
+  }
+
+  SECTION("- Complex ranges") {
+    ranges.resize(6);
+    temp[0] = 'b';
+    temp[1] = 'd';
+    ranges[0] = Range(temp, 2, 1);
+
+    temp[0] = temp[1] = 'c';
+    ranges[1] = Range(temp, 2, 1);
+
+    temp[0] = 'f';
+    temp[1] = 'h';
+    ranges[2] = Range(temp, 2, 1);
+
+    temp[0] = temp[1] = 'g';
+    ranges[3] = Range(temp, 2, 1);
+    ranges[4] = Range(temp, 2, 1);
+
+    temp[0] = temp[1] = 'h';
+    ranges[5] = Range(temp, 2, 1);
+
+    exp_result_count = {0, 1, 2, 1, 0, 1, 3, 2};
+  }
+
+  std::vector<uint64_t> range_indexes(ranges.size());
+  std::iota(range_indexes.begin(), range_indexes.end(), 0);
+
+  std::vector<uint64_t> result_count(num_cells, 1);
+  ResultTile::compute_results_count_sparse_string(
+      &rt,
+      dim_idx,
+      ranges,
+      range_indexes,
+      result_count,
+      Layout::ROW_MAJOR,
+      0,
+      num_cells);
+
+  CHECK(memcmp(result_count.data(), exp_result_count.data(), num_cells) == 0);
 }

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -275,6 +275,29 @@ class ResultTile {
    * Applicable only to sparse arrays.
    *
    * Computes a result count for the input string dimension for the coordinates
+   * that fall in the input ranges and multiply with the previous count. The
+   * caller has already determined that the input start-end range needs to be
+   * processed fully.
+   *
+   * When called over multiple ranges, this follows the formula:
+   * total_count = d1_count * d2_count ... dN_count.
+   */
+  template <class BitmapType>
+  static void compute_results_count_sparse_string_range(
+      const NDRange& ranges,
+      const std::vector<uint64_t>& range_indexes,
+      const char* buff_str,
+      const uint64_t* buff_off,
+      const uint64_t cell_num,
+      const uint64_t buff_str_size,
+      const uint64_t start,
+      const uint64_t end,
+      std::vector<BitmapType>& result_count);
+
+  /**
+   * Applicable only to sparse arrays.
+   *
+   * Computes a result count for the input string dimension for the coordinates
    * that fall in the input ranges and multiply with the previous count.
    *
    * This only processes cells from min_cell to max_cell as we might

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -284,9 +284,8 @@ class ResultTile {
    */
   template <class BitmapType>
   static void compute_results_count_sparse_string_range(
-      const std::vector<std::string_view> range_starts,
-      const std::vector<std::string_view> range_ends,
-      const std::vector<uint64_t>& range_indexes,
+      const std::vector<std::pair<std::string_view, std::string_view>>
+          cached_ranges,
       const char* buff_str,
       const uint64_t* buff_off,
       const uint64_t cell_num,

--- a/tiledb/sm/query/result_tile.h
+++ b/tiledb/sm/query/result_tile.h
@@ -284,7 +284,8 @@ class ResultTile {
    */
   template <class BitmapType>
   static void compute_results_count_sparse_string_range(
-      const NDRange& ranges,
+      const std::vector<std::string_view> range_starts,
+      const std::vector<std::string_view> range_ends,
       const std::vector<uint64_t>& range_indexes,
       const char* buff_str,
       const uint64_t* buff_off,


### PR DESCRIPTION
This implements binary search across ranges for
compute_results_count_sparse_string the same way we implement it for
compute_results_count_sparse. It also caches the start/end stringviews for
the ranges for faster processing.

---
TYPE: IMPROVEMENT
DESC: Optimize compute_results_count_sparse_string.
