### PR TITLE
WIP: Enable Wswitch-enum on GCC and Clang to catch unhandled cases

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -405,6 +405,11 @@ endif()
 # Compile options/definitions
 ############################################################
 
+if (NOT MSVC)
+# Enable exhaustive enum check even with default case
+  target_compile_options(TILEDB_CORE_OBJECTS PRIVATE -Wswitch-enum)
+endif()
+
 if (SANITIZER)
   if (NOT CMAKE_BUILD_TYPE MATCHES "Debug")
     message(FATAL_ERROR "Sanitizers only enabled for Debug build")

--- a/tiledb/common/logger.cc
+++ b/tiledb/common/logger.cc
@@ -228,6 +228,7 @@ void Logger::set_format(Logger::Format fmt) {
       logger_->set_pattern(json_pattern);
       break;
     }
+    case Logger::Format::DEFAULT:
     default: {
       /*
        * Set up the default logging format
@@ -265,9 +266,11 @@ std::string Logger::add_tag(const std::string& tag, uint64_t id) {
                              fmt::format("{},\"{}\":\"{}\"", name_, tag, id);
       break;
     }
-    default:
+    case Logger::Format::DEFAULT:
+    default: {
       tags = name_.empty() ? fmt::format("{}: {}", tag, id) :
                              fmt::format("{}] [{}: {}", name_, tag, id);
+    }
   }
   return tags;
 }

--- a/tiledb/common/macros.h
+++ b/tiledb/common/macros.h
@@ -59,16 +59,28 @@
 /** Disables warning for specific compiler
  */
 #if defined(_MSC_VER)
-#define TILEDB_DISABLE_WARNING_PUSH __pragma(warning(push))
-#define TILEDB_DISABLE_WARNING_POP __pragma(warning(pop))
-#define TILEDB_DISABLE_WARNING(warningNumber) \
+
+#define TILEDB_MSVC_DISABLE_WARNING_PUSH __pragma(warning(push))
+#define TILEDB_MSVC_DISABLE_WARNING_POP __pragma(warning(pop))
+#define TILEDB_MSVC_DISABLE_WARNING(warningNumber) \
   __pragma(warning(disable : warningNumber))
+
+#define TILEDB_GCC_DISABLE_WARNING_PUSH
+#define TILEDB_GCC_DISABLE_WARNING_POP
+#define TILEDB_GCC_DISABLE_WARNING
+
 #elif defined(__GNUC__) || defined(__clang__)
+
 #define TILEDB_DO_PRAGMA(X) _Pragma(#X)
-#define TILEDB_DISABLE_WARNING_PUSH TILEDB_DO_PRAGMA(GCC diagnostic push)
-#define TILEDB_DISABLE_WARNING_POP TILEDB_DO_PRAGMA(GCC diagnostic pop)
-#define TILEDB_DISABLE_WARNING(warningName) \
+#define TILEDB_GCC_DISABLE_WARNING_PUSH TILEDB_DO_PRAGMA(GCC diagnostic push)
+#define TILEDB_GCC_DISABLE_WARNING_POP TILEDB_DO_PRAGMA(GCC diagnostic pop)
+#define TILEDB_GCC_DISABLE_WARNING(warningName) \
   TILEDB_DO_PRAGMA(GCC diagnostic ignored #warningName)
+
+#define TILEDB_MSVC_DISABLE_WARNING_PUSH
+#define TILEDB_MSVC_DISABLE_WARNING_POP
+#define TILEDB_MSVC_DISABLE_WARNING
+
 #endif
 
 #endif  // TILEDB_MACROS_H

--- a/tiledb/common/macros.h
+++ b/tiledb/common/macros.h
@@ -56,4 +56,19 @@
   DISABLE_MOVE(C);                      \
   DISABLE_MOVE_ASSIGN(C)
 
+/** Disables warning for specific compiler
+ */
+#if defined(_MSC_VER)
+#define TILEDB_DISABLE_WARNING_PUSH __pragma(warning(push))
+#define TILEDB_DISABLE_WARNING_POP __pragma(warning(pop))
+#define TILEDB_DISABLE_WARNING(warningNumber) \
+  __pragma(warning(disable : warningNumber))
+#elif defined(__GNUC__) || defined(__clang__)
+#define TILEDB_DO_PRAGMA(X) _Pragma(#X)
+#define TILEDB_DISABLE_WARNING_PUSH TILEDB_DO_PRAGMA(GCC diagnostic push)
+#define TILEDB_DISABLE_WARNING_POP TILEDB_DO_PRAGMA(GCC diagnostic pop)
+#define TILEDB_DISABLE_WARNING(warningName) \
+  TILEDB_DO_PRAGMA(GCC diagnostic ignored #warningName)
+#endif
+
 #endif  // TILEDB_MACROS_H

--- a/tiledb/common/types/dynamic_typed_datum.cc
+++ b/tiledb/common/types/dynamic_typed_datum.cc
@@ -49,6 +49,12 @@ std::ostream& operator<<(
     case Datatype::CHAR:
       os << *static_cast<const char*>(x.datum_.content());
       break;
+    case Datatype::BLOB:
+      os << *static_cast<const uint8_t*>(x.datum_.content());
+      break;
+    case Datatype::BOOL:
+      os << *static_cast<const bool*>(x.datum_.content());
+      break;
     case Datatype::INT8:
       os << *static_cast<const int8_t*>(x.datum_.content());
       break;

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -73,6 +73,8 @@ inline const std::string& filter_type_str(FilterType filter_type) {
       return constants::bzip2_str;
     case FilterType::FILTER_DOUBLE_DELTA:
       return constants::double_delta_str;
+    case FilterType::INTERNAL_FILTER_AES_256_GCM:
+      return constants::aes_256_gcm_str;
     case FilterType::FILTER_BIT_WIDTH_REDUCTION:
       return constants::filter_bit_width_reduction_str;
     case FilterType::FILTER_BITSHUFFLE:

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -46,6 +46,8 @@
 #include "tiledb/sm/stats/stats.h"
 #include "uri.h"
 
+TILEDB_DISABLE_WARNING_PUSH
+TILEDB_DISABLE_WARNING("-Wswitch-enum")
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/client/ClientConfiguration.h>
@@ -73,6 +75,8 @@
 #include <aws/s3/model/ListObjectsRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
+TILEDB_DISABLE_WARNING_POP
+
 #include <sys/types.h>
 #include <mutex>
 #include <string>

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -46,8 +46,10 @@
 #include "tiledb/sm/stats/stats.h"
 #include "uri.h"
 
-TILEDB_DISABLE_WARNING_PUSH
-TILEDB_DISABLE_WARNING("-Wswitch-enum")
+TILEDB_GCC_DISABLE_WARNING_PUSH
+// clang-format off
+TILEDB_GCC_DISABLE_WARNING(-Wswitch-enum)
+// clang-format on
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/client/ClientConfiguration.h>
@@ -75,7 +77,7 @@ TILEDB_DISABLE_WARNING("-Wswitch-enum")
 #include <aws/s3/model/ListObjectsRequest.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
-TILEDB_DISABLE_WARNING_POP
+TILEDB_GCC_DISABLE_WARNING_POP
 
 #include <sys/types.h>
 #include <mutex>

--- a/tiledb/sm/fragment/single_fragment_info.h
+++ b/tiledb/sm/fragment/single_fragment_info.h
@@ -253,9 +253,24 @@ class SingleFragmentInfo {
              << ((int64_t*)non_empty_domain_[d].data())[1] << "]";
           break;
         case Datatype::STRING_ASCII:
+        case Datatype::STRING_UTF8:
           ss << "[" << std::string(non_empty_domain_[d].start_str()) << ", "
              << std::string(non_empty_domain_[d].end_str()) << "]";
           break;
+        // Not supported for nonempty_domain
+        case Datatype::BLOB:
+        case Datatype::CHAR:
+        case Datatype::BOOL:
+        case Datatype::STRING_UTF16:
+        case Datatype::STRING_UTF32:
+        case Datatype::STRING_UCS2:
+        case Datatype::STRING_UCS4:
+        case Datatype::ANY:
+          ss << "["
+             << "unsupported"
+             << ", "
+             << "unsupported"
+             << "]";
         default:
           assert(false);
           break;


### PR DESCRIPTION
This PR adds `-Wswitch-enum` to the compile options for TileDB core objects. With this option the compiler will warn on unhandled enum cases in a switch statement _even when a default case is present_`. This highlighted a few small issues which are fixed in this PR.

---
TYPE: IMPROVEMENT
DESC: Enable switch-enum on GCC and Clang to catch unhandled cases
