### PR TITLE
Fix S3 build with GCC 11

### DIFF
--- a/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
+++ b/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
@@ -31,14 +31,8 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-        include:
-          - os: ubuntu-22.04
-            cxx: g++-11
-            cc: gcc-11
-    env:
-      CXX: ${{ matrix.cxx }}
-      CC: ${{ matrix.cc }}
+        os:
+          - ubuntu-20.04
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
     timeout-minutes: 120
     name: Build - ${{matrix.os}} - SERIALIZATION ${{ matrix.cxx }}

--- a/.github/workflows/build-ubuntu22.04-S3.yml
+++ b/.github/workflows/build-ubuntu22.04-S3.yml
@@ -25,7 +25,8 @@ env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_STATIC: OFF
   TILEDB_TOOLS: ON
-  CXX: g++
+  CXX: g++-11
+  CC: gcc-11
 
 jobs:
   build:
@@ -33,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
     timeout-minutes: 90
     name: Build - ${{matrix.os}} - S3

--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -102,6 +102,9 @@ if (NOT AWSSDK_FOUND)
       set(CONDITIONAL_PATCH patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch &&
                             patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsconfig_cmake_3.22.patch)
     endif()
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      set(CONDITIONAL_CXX_FLAGS "-DCMAKE_CXX_FLAGS=-Wno-nonnull -Wno-error=deprecated-declarations")
+    endif()
 
     ExternalProject_Add(ep_awssdk
       PREFIX "externals"
@@ -119,6 +122,7 @@ if (NOT AWSSDK_FOUND)
         -DCMAKE_INSTALL_BINDIR=lib
         -DENABLE_UNITY_BUILD=ON
         -DCUSTOM_MEMORY_MANAGEMENT=0
+        ${CONDITIONAL_CXX_FLAGS}
         -DCMAKE_PREFIX_PATH=${TILEDB_EP_INSTALL_PREFIX}
         -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -105,6 +105,21 @@ capi_status_t tiledb_status(capi_return_t x);
 /*               MACROS              */
 /* ********************************* */
 
+/**
+  * TILEDB_NOEXCEPT usage:
+  *
+  * 1. Header files that may appear in C programs (such as tiledb.h) must use
+  the macro because we require API entry points not to throw. We enforce that
+  with noexcept in C++ declarations but must omit that keyword in a C
+  declaration.
+    2. Definitions of C API entry point functions (which may not appear in C
+  headers) are compiled as C++ and should be declared noexcept. These functions
+  are wrapped versions of API implementation functions.
+    3. Implementation functions should not be declared noexcept. They have no
+  way of providing uniform error handling and should defer to the wrapper for
+  that.
+*/
+
 #ifdef __cplusplus
 #define TILEDB_NOEXCEPT noexcept
 #else


### PR DESCRIPTION
Silence a new GCC 11 warning for pre-existing issue in the AWS SDK. Opened SC-18651 to update SDK for proper upstream fix.

TYPE: NO_HISTORY
DESC: Silence GCC 11 compiler warning in AWS SDK