### PR TITLE
Support async preloading of Array Metadata and Nonempty Domain

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -2094,8 +2094,8 @@ TEST_CASE_METHOD(
   // Close array and clean up
   rc = tiledb_array_close(ctx_, array);
   CHECK(rc == TILEDB_OK);
-  tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_array_free(&array);
 
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &new_array);
   REQUIRE(rc == TILEDB_OK);

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -234,6 +234,8 @@ void check_save_to_file() {
   ss << "rest.retry_initial_delay_ms 500\n";
   ss << "rest.server_address https://api.tiledb.com\n";
   ss << "rest.server_serialization_format CAPNP\n";
+  ss << "sm.array.metadata.preload read\n";
+  ss << "sm.array.nonempty_domain.preload read\n";
   ss << "sm.check_coord_dups true\n";
   ss << "sm.check_coord_oob true\n";
   ss << "sm.check_global_order true\n";
@@ -560,6 +562,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["rest.retry_initial_delay_ms"] = "500";
   all_param_values["rest.retry_http_codes"] = "503";
   all_param_values["rest.curl.verbose"] = "false";
+  all_param_values["sm.array.metadata.preload"] = "read";
+  all_param_values["sm.array.nonempty_domain.preload"] = "read";
   all_param_values["sm.encryption_key"] = "";
   all_param_values["sm.encryption_type"] = "NO_ENCRYPTION";
   all_param_values["sm.dedup_coords"] = "false";

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -71,7 +71,7 @@ class Array {
   Array(const URI& array_uri, StorageManager* storage_manager);
 
   /** Destructor. */
-  ~Array() = default;
+  ~Array();
 
   DISABLE_COPY_AND_COPY_ASSIGN(Array);
   DISABLE_MOVE_AND_MOVE_ASSIGN(Array);
@@ -468,6 +468,19 @@ class Array {
   /** Memory tracker for the array. */
   MemoryTracker memory_tracker_;
 
+  /** Future used to block destructor if we are preloading the metadata. */
+  std::future<Status> preload_metadata_future_;
+
+  /** Future used to block destructor if we are preloading the non empty domain.
+   */
+  std::future<Status> preload_non_empty_domain_future_;
+
+  /** Mutex to protect loading metadata. */
+  std::mutex load_metadata_mtx_;
+
+  /** Mutex to protect loading non empty domain. */
+  std::mutex load_non_empty_domain_mtx_;
+
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
@@ -517,6 +530,12 @@ class Array {
 
   /** Checks if consolidation with timestamps is enabled in config. */
   bool consolidation_with_timestamps_config_enabled() const;
+
+  /** Should metadata be preloaded on open? */
+  bool preload_metadata() const;
+
+  /** Should non empty domain be preloaded on open? */
+  bool preload_non_empty_domain() const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1023,6 +1023,24 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *
  * **Parameters**
  *
+ * - `sm.array.metadata.preload` <br>
+ *    Controls if array metadata will be preloaded on array open in a background
+ *    thread <br>
+ *    Acceptable values are `reads`, `writes`, `always`, `never` <br>
+ *    `reads`: preload only when an array is opened for reads <br>
+ *    `writes`: preload only when an array is opened for writes <br>
+ *    `always`: always preload on array open <br>
+ *    `never`: do not preload on array open <br>
+ *    **Default**: reads
+ * - `sm.array.nonempty_domain.preload` <br>
+ *    Controls if the array nonempty domain will be preloaded on array open in a
+ *    background thread <br>
+ *    Acceptable values are `reads`, `writes`, `always`, `never` <br>
+ *    `reads`: preload only when an array is opened for reads <br>
+ *    `writes`: preload only when an array is opened for writes <br>
+ *    `always`: always preload on array open <br>
+ *    `never`: do not preload on array open <br>
+ *    **Default**: reads
  * - `sm.dedup_coords` <br>
  *    If `true`, cells with duplicate coordinates will be removed during sparse
  *    fragment writes. Note that ties during deduplication are broken

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -65,6 +65,8 @@ const std::string Config::REST_RETRY_COUNT = "25";
 const std::string Config::REST_RETRY_INITIAL_DELAY_MS = "500";
 const std::string Config::REST_RETRY_DELAY_FACTOR = "1.25";
 const std::string Config::REST_CURL_VERBOSE = "false";
+const std::string Config::SM_ARRAY_METADATA_PRELOAD = "read";
+const std::string Config::SM_ARRAY_NONEMPTY_DOMAIN_PRELOAD = "read";
 const std::string Config::SM_ENCRYPTION_KEY = "";
 const std::string Config::SM_ENCRYPTION_TYPE = "NO_ENCRYPTION";
 const std::string Config::SM_DEDUP_COORDS = "false";
@@ -226,6 +228,9 @@ Config::Config() {
   param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
   param_values_["config.logging_level"] = CONFIG_LOGGING_LEVEL;
   param_values_["config.logging_format"] = CONFIG_LOGGING_DEFAULT_FORMAT;
+  param_values_["sm.array.metadata.preload"] = SM_ARRAY_METADATA_PRELOAD;
+  param_values_["sm.array.nonempty_domain.preload"] =
+      SM_ARRAY_NONEMPTY_DOMAIN_PRELOAD;
   param_values_["sm.encryption_key"] = SM_ENCRYPTION_KEY;
   param_values_["sm.encryption_type"] = SM_ENCRYPTION_TYPE;
   param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
@@ -525,6 +530,11 @@ Status Config::unset(const std::string& param) {
     param_values_["config.logging_level"] = CONFIG_LOGGING_LEVEL;
   } else if (param == "config.logging_format") {
     param_values_["config.logging_foramt"] = CONFIG_LOGGING_DEFAULT_FORMAT;
+  } else if (param == "sm.array.metadata.preload") {
+    param_values_["sm.array.metadata.preload"] = SM_ARRAY_METADATA_PRELOAD;
+  } else if (param == "sm.array.nonempty_domain.preload") {
+    param_values_["sm.array.nonempty_domain.preload"] =
+        SM_ARRAY_NONEMPTY_DOMAIN_PRELOAD;
   } else if (param == "sm.encryption_key") {
     param_values_["sm.encryption_key"] = SM_ENCRYPTION_KEY;
   } else if (param == "sm.encryption_type") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -93,6 +93,12 @@ class Config {
   /** The default format for logging. */
   static const std::string CONFIG_LOGGING_DEFAULT_FORMAT;
 
+  /* Should Array Metadata be Preloaded on Array Open */
+  static const std::string SM_ARRAY_METADATA_PRELOAD;
+
+  /* Should Array Nonempty Domain be Preloaded on Array Open */
+  static const std::string SM_ARRAY_NONEMPTY_DOMAIN_PRELOAD;
+
   /**
    * The key for encrypted arrays.
    *  */

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -265,6 +265,22 @@ class Config {
    *
    * **Parameters**
    *
+   * - `sm.array.metadata.preload` <br>
+   *    Controls if array metadata will be preloaded on array open in a
+   * background thread <br> Acceptable values are `reads`, `writes`, `always`,
+   * `never` <br> `reads`: preload only when an array is opened for reads <br>
+   *    `writes`: preload only when an array is opened for writes <br>
+   *    `always`: always preload on array open <br>
+   *    `never`: do not preload on array open <br>
+   *    **Default**: reads
+   * - `sm.array.nonempty_domain.preload` <br>
+   *    Controls if the array nonempty domain will be preloaded on array open in
+   * a background thread <br> Acceptable values are `reads`, `writes`, `always`,
+   * `never` <br> `reads`: preload only when an array is opened for reads <br>
+   *    `writes`: preload only when an array is opened for writes <br>
+   *    `always`: always preload on array open <br>
+   *    `never`: do not preload on array open <br>
+   *    **Default**: reads
    * - `sm.dedup_coords` <br>
    *    If `true`, cells with duplicate coordinates will be removed during
    *    sparse fragment writes. Note that ties during deduplication are broken


### PR DESCRIPTION
This helps to reduce total latency for common use cases of using the Array Metadata and the Nonempty Domain for read queries.

Two new configuration options are presented:
`sm.array.metadata.preload`
`sm.array.nonempty_domain.preload`

Acceptable values are:
- "read"
- "write"
- "always"
- "never"

If "read" then any array opened in TILEDB_READ mode will preload
metadata. If "write" then TILEDB_WRITE mode triggers preloading. If
"always" then on any open metadata/nonempty domain is preloaded. If
"never", preloading does not occur.

---
TYPE: IMPROVEMENT
DESC: Support async preloading of Array Metadata and Nonempty Domain
