### PR TITLE
Dense tiler uses WriterTile.

### DIFF
--- a/test/src/unit-DenseTiler.cc
+++ b/test/src/unit-DenseTiler.cc
@@ -83,7 +83,7 @@ struct DenseTilerFx {
       uint64_t range_size,
       tiledb::sm::Subarray* subarray);
   template <class T>
-  bool check_tile(Tile* tile, const std::vector<T>& data);
+  bool check_tile(Tile& tile, const std::vector<T>& data);
 };
 
 DenseTilerFx::DenseTilerFx() {
@@ -171,10 +171,10 @@ void DenseTilerFx::close_array() {
 }
 
 template <class T>
-bool DenseTilerFx::check_tile(Tile* tile, const std::vector<T>& data) {
+bool DenseTilerFx::check_tile(Tile& tile, const std::vector<T>& data) {
   std::vector<T> tile_data(data.size());
-  CHECK(tile->size() == data.size() * sizeof(T));
-  CHECK(tile->read(&tile_data[0], 0, data.size() * sizeof(T)).ok());
+  CHECK(tile.size() == data.size() * sizeof(T));
+  CHECK(tile.read(&tile_data[0], 0, data.size() * sizeof(T)).ok());
   CHECK(tile_data == data);
   return tile_data == data;
 }
@@ -390,19 +390,31 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
-  CHECK(!tiler1.get_tile(0, "foo", &tile1_0).ok());
-  CHECK(!tiler1.get_tile(10, "a", &tile1_0).ok());
-  CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(!tiler1.get_tile(0, "foo", tile1_0).ok());
+  CHECK(!tiler1.get_tile(10, "a", tile1_0).ok());
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<int32_t> c_data1_0 = {fill_value, fill_value, 1, 2, 3};
-  CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
+  CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
-  CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<int32_t> c_data1_1 = {
       4, fill_value, fill_value, fill_value, fill_value};
-  CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
+  CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Create new subarray
   close_array();
@@ -419,10 +431,16 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2;
-  CHECK(tiler2.get_tile(0, "a", &tile2).ok());
+  WriterTile tile2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler2.get_tile(0, "a", tile2).ok());
   std::vector<int32_t> c_data2 = {fill_value, 1, 2, 3, 4};
-  CHECK(check_tile<int32_t>(&tile2, c_data2));
+  CHECK(check_tile<int32_t>(tile2.fixed_tile(), c_data2));
 
   // Create new subarray (col-major)
   close_array();
@@ -439,10 +457,16 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3;
-  CHECK(tiler3.get_tile(0, "a", &tile3).ok());
+  WriterTile tile3(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(0, "a", tile3).ok());
   std::vector<int32_t> c_data3 = {fill_value, 1, 2, 3, 4};
-  CHECK(check_tile<int32_t>(&tile3, c_data3));
+  CHECK(check_tile<int32_t>(tile3.fixed_tile(), c_data3));
 
   // Clean up
   close_array();
@@ -484,19 +508,31 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
-  CHECK(!tiler1.get_tile(0, "foo", &tile1_0).ok());
-  CHECK(!tiler1.get_tile(10, "a", &tile1_0).ok());
-  CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(!tiler1.get_tile(0, "foo", tile1_0).ok());
+  CHECK(!tiler1.get_tile(10, "a", tile1_0).ok());
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<int32_t> c_data1_0 = {fill_value, fill_value, 1, 2, 3};
-  CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
+  CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
-  CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<int32_t> c_data1_1 = {
       4, fill_value, fill_value, fill_value, fill_value};
-  CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
+  CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Clean up
   close_array();
@@ -538,19 +574,31 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
-  CHECK(!tiler1.get_tile(0, "foo", &tile1_0).ok());
-  CHECK(!tiler1.get_tile(10, "a", &tile1_0).ok());
-  CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(!tiler1.get_tile(0, "foo", tile1_0).ok());
+  CHECK(!tiler1.get_tile(10, "a", tile1_0).ok());
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<int32_t> c_data1_0 = {fill_value, fill_value, 1, 2, 3};
-  CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
+  CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
-  CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<int32_t> c_data1_1 = {
       4, fill_value, fill_value, fill_value, fill_value};
-  CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
+  CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Clean up
   close_array();
@@ -1365,8 +1413,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
-  CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<int32_t> c_data1_0(50);
   for (int i = 0; i <= 36; ++i)
     c_data1_0[i] = fill_value;
@@ -1376,11 +1430,17 @@ TEST_CASE_METHOD(
     c_data1_0[i] = fill_value;
   for (int i = 47; i <= 49; ++i)
     c_data1_0[i] = i - 41;
-  CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
+  CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
-  CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<int32_t> c_data1_1(50);
   for (int i = 0; i <= 29; ++i)
     c_data1_1[i] = fill_value;
@@ -1392,11 +1452,17 @@ TEST_CASE_METHOD(
     c_data1_1[i] = i - 31;
   for (int i = 42; i <= 49; ++i)
     c_data1_1[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
+  CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Test get tile 2
-  Tile tile1_2;
-  CHECK(tiler1.get_tile(2, "a", &tile1_2).ok());
+  WriterTile tile1_2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(2, "a", tile1_2).ok());
   std::vector<int32_t> c_data1_2(50);
   for (int i = 0; i <= 6; ++i)
     c_data1_2[i] = fill_value;
@@ -1404,17 +1470,23 @@ TEST_CASE_METHOD(
     c_data1_2[i] = i + 4;
   for (int i = 10; i <= 49; ++i)
     c_data1_2[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile1_2, c_data1_2));
+  CHECK(check_tile<int32_t>(tile1_2.fixed_tile(), c_data1_2));
 
   // Test get tile 3
-  Tile tile1_3;
-  CHECK(tiler1.get_tile(3, "a", &tile1_3).ok());
+  WriterTile tile1_3(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(3, "a", tile1_3).ok());
   std::vector<int32_t> c_data1_3(50);
   for (int i = 0; i <= 1; ++i)
     c_data1_3[i] = i + 14;
   for (int i = 2; i <= 49; ++i)
     c_data1_3[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile1_3, c_data1_3));
+  CHECK(check_tile<int32_t>(tile1_3.fixed_tile(), c_data1_3));
 
   // Create subarray (single tile)
   close_array();
@@ -1435,8 +1507,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0;
-  CHECK(tiler2.get_tile(0, "a", &tile2_0).ok());
+  WriterTile tile2_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler2.get_tile(0, "a", tile2_0).ok());
   std::vector<int32_t> c_data2_0(50);
   for (int i = 0; i <= 21; ++i)
     c_data2_0[i] = fill_value;
@@ -1452,7 +1530,7 @@ TEST_CASE_METHOD(
     c_data2_0[i] = i - 29;
   for (int i = 48; i <= 49; ++i)
     c_data2_0[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile2_0, c_data2_0));
+  CHECK(check_tile<int32_t>(tile2_0.fixed_tile(), c_data2_0));
 
   // Create subarray (multiple tiles, col-major)
   close_array();
@@ -1473,8 +1551,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3_0;
-  CHECK(tiler3.get_tile(0, "a", &tile3_0).ok());
+  WriterTile tile3_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(0, "a", tile3_0).ok());
   std::vector<int32_t> c_data3_0(50);
   for (int i = 0; i <= 36; ++i)
     c_data3_0[i] = fill_value;
@@ -1484,11 +1568,17 @@ TEST_CASE_METHOD(
     c_data3_0[i] = fill_value;
   for (int i = 47; i <= 49; ++i)
     c_data3_0[i] = i - 41;
-  CHECK(check_tile<int32_t>(&tile3_0, c_data3_0));
+  CHECK(check_tile<int32_t>(tile3_0.fixed_tile(), c_data3_0));
 
   // Test get tile 1
-  Tile tile3_1;
-  CHECK(tiler3.get_tile(1, "a", &tile3_1).ok());
+  WriterTile tile3_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(1, "a", tile3_1).ok());
   std::vector<int32_t> c_data3_1(50);
   for (int i = 0; i <= 29; ++i)
     c_data3_1[i] = fill_value;
@@ -1500,11 +1590,17 @@ TEST_CASE_METHOD(
     c_data3_1[i] = i - 31;
   for (int i = 42; i <= 49; ++i)
     c_data3_1[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile3_1, c_data3_1));
+  CHECK(check_tile<int32_t>(tile3_1.fixed_tile(), c_data3_1));
 
   // Test get tile 2
-  Tile tile3_2;
-  CHECK(tiler3.get_tile(2, "a", &tile3_2).ok());
+  WriterTile tile3_2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(2, "a", tile3_2).ok());
   std::vector<int32_t> c_data3_2(50);
   for (int i = 0; i <= 6; ++i)
     c_data3_2[i] = fill_value;
@@ -1512,17 +1608,23 @@ TEST_CASE_METHOD(
     c_data3_2[i] = i + 4;
   for (int i = 10; i <= 49; ++i)
     c_data3_2[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile3_2, c_data3_2));
+  CHECK(check_tile<int32_t>(tile3_2.fixed_tile(), c_data3_2));
 
   // Test get tile 3
-  Tile tile3_3;
-  CHECK(tiler3.get_tile(3, "a", &tile3_3).ok());
+  WriterTile tile3_3(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(3, "a", tile3_3).ok());
   std::vector<int32_t> c_data3_3(50);
   for (int i = 0; i <= 1; ++i)
     c_data3_3[i] = i + 14;
   for (int i = 2; i <= 49; ++i)
     c_data3_3[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile3_3, c_data3_3));
+  CHECK(check_tile<int32_t>(tile3_3.fixed_tile(), c_data3_3));
 
   // Create subarray (single tile, col-major)
   close_array();
@@ -1543,8 +1645,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile4_0;
-  CHECK(tiler4.get_tile(0, "a", &tile4_0).ok());
+  WriterTile tile4_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler4.get_tile(0, "a", tile4_0).ok());
   std::vector<int32_t> c_data4_0(50);
   for (int i = 0; i <= 21; ++i)
     c_data4_0[i] = fill_value;
@@ -1560,7 +1668,7 @@ TEST_CASE_METHOD(
     c_data4_0[i] = i - 29;
   for (int i = 48; i <= 49; ++i)
     c_data4_0[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile4_0, c_data4_0));
+  CHECK(check_tile<int32_t>(tile4_0.fixed_tile(), c_data4_0));
 
   // Clean up
   close_array();
@@ -1607,8 +1715,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
-  CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<int32_t> c_data1_0(50);
   for (int i = 0; i <= 37; ++i)
     c_data1_0[i] = fill_value;
@@ -1622,11 +1736,17 @@ TEST_CASE_METHOD(
     c_data1_0[i] = fill_value;
   c_data1_0[48] = 3;
   c_data1_0[49] = 8;
-  CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
+  CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
-  CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<int32_t> c_data1_1(50);
   for (int i = 0; i <= 34; ++i)
     c_data1_1[i] = fill_value;
@@ -1639,11 +1759,17 @@ TEST_CASE_METHOD(
   c_data1_1[45] = 13;
   for (int i = 46; i <= 49; ++i)
     c_data1_1[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
+  CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Test get tile 2
-  Tile tile1_2;
-  CHECK(tiler1.get_tile(2, "a", &tile1_2).ok());
+  WriterTile tile1_2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(2, "a", tile1_2).ok());
   std::vector<int32_t> c_data1_2(50);
   for (int i = 0; i <= 2; ++i)
     c_data1_2[i] = fill_value;
@@ -1655,11 +1781,17 @@ TEST_CASE_METHOD(
   c_data1_2[9] = 10;
   for (int i = 10; i <= 49; ++i)
     c_data1_2[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile1_2, c_data1_2));
+  CHECK(check_tile<int32_t>(tile1_2.fixed_tile(), c_data1_2));
 
   // Test get tile 3
-  Tile tile1_3;
-  CHECK(tiler1.get_tile(3, "a", &tile1_3).ok());
+  WriterTile tile1_3(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(3, "a", tile1_3).ok());
   std::vector<int32_t> c_data1_3(50);
   c_data1_3[0] = 14;
   for (int i = 1; i <= 4; ++i)
@@ -1667,7 +1799,7 @@ TEST_CASE_METHOD(
   c_data1_3[5] = 15;
   for (int i = 6; i <= 49; ++i)
     c_data1_3[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile1_3, c_data1_3));
+  CHECK(check_tile<int32_t>(tile1_3.fixed_tile(), c_data1_3));
 
   // Create subarray (single tile)
   close_array();
@@ -1688,8 +1820,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0;
-  CHECK(tiler2.get_tile(0, "a", &tile2_0).ok());
+  WriterTile tile2_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler2.get_tile(0, "a", tile2_0).ok());
   std::vector<int32_t> c_data2_0(50);
   for (int i = 0; i <= 11; ++i)
     c_data2_0[i] = fill_value;
@@ -1723,7 +1861,7 @@ TEST_CASE_METHOD(
   c_data2_0[39] = 18;
   for (int i = 40; i <= 49; ++i)
     c_data2_0[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile2_0, c_data2_0));
+  CHECK(check_tile<int32_t>(tile2_0.fixed_tile(), c_data2_0));
 
   // Create subarray (multiple tiles, col-major)
   close_array();
@@ -1744,8 +1882,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3_0;
-  CHECK(tiler3.get_tile(0, "a", &tile3_0).ok());
+  WriterTile tile3_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(0, "a", tile3_0).ok());
   std::vector<int32_t> c_data3_0(50);
   for (int i = 0; i <= 37; ++i)
     c_data3_0[i] = fill_value;
@@ -1759,11 +1903,17 @@ TEST_CASE_METHOD(
     c_data3_0[i] = fill_value;
   c_data3_0[48] = 3;
   c_data3_0[49] = 8;
-  CHECK(check_tile<int32_t>(&tile3_0, c_data3_0));
+  CHECK(check_tile<int32_t>(tile3_0.fixed_tile(), c_data3_0));
 
   // Test get tile 1
-  Tile tile3_1;
-  CHECK(tiler3.get_tile(1, "a", &tile3_1).ok());
+  WriterTile tile3_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(1, "a", tile3_1).ok());
   std::vector<int32_t> c_data3_1(50);
   for (int i = 0; i <= 34; ++i)
     c_data3_1[i] = fill_value;
@@ -1776,11 +1926,17 @@ TEST_CASE_METHOD(
   c_data3_1[45] = 13;
   for (int i = 46; i <= 49; ++i)
     c_data3_1[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile3_1, c_data3_1));
+  CHECK(check_tile<int32_t>(tile3_1.fixed_tile(), c_data3_1));
 
   // Test get tile 2
-  Tile tile3_2;
-  CHECK(tiler3.get_tile(2, "a", &tile3_2).ok());
+  WriterTile tile3_2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(2, "a", tile3_2).ok());
   std::vector<int32_t> c_data3_2(50);
   for (int i = 0; i <= 2; ++i)
     c_data3_2[i] = fill_value;
@@ -1792,11 +1948,17 @@ TEST_CASE_METHOD(
   c_data3_2[9] = 10;
   for (int i = 10; i <= 49; ++i)
     c_data3_2[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile3_2, c_data3_2));
+  CHECK(check_tile<int32_t>(tile3_2.fixed_tile(), c_data3_2));
 
   // Test get tile 3
-  Tile tile3_3;
-  CHECK(tiler3.get_tile(3, "a", &tile3_3).ok());
+  WriterTile tile3_3(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(3, "a", tile3_3).ok());
   std::vector<int32_t> c_data3_3(50);
   c_data3_3[0] = 14;
   for (int i = 1; i <= 4; ++i)
@@ -1804,7 +1966,7 @@ TEST_CASE_METHOD(
   c_data3_3[5] = 15;
   for (int i = 6; i <= 49; ++i)
     c_data3_3[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile3_3, c_data3_3));
+  CHECK(check_tile<int32_t>(tile3_3.fixed_tile(), c_data3_3));
 
   // Create subarray (single tile, col-major)
   close_array();
@@ -1825,8 +1987,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile4_0;
-  CHECK(tiler4.get_tile(0, "a", &tile4_0).ok());
+  WriterTile tile4_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler4.get_tile(0, "a", tile4_0).ok());
   std::vector<int32_t> c_data4_0(50);
   for (int i = 0; i <= 11; ++i)
     c_data4_0[i] = fill_value;
@@ -1860,7 +2028,7 @@ TEST_CASE_METHOD(
   c_data4_0[39] = 18;
   for (int i = 40; i <= 49; ++i)
     c_data4_0[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile4_0, c_data4_0));
+  CHECK(check_tile<int32_t>(tile4_0.fixed_tile(), c_data4_0));
 
   // Clean up
   close_array();
@@ -1910,24 +2078,36 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
-  CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<int32_t> c_data1_0(50);
   for (int i = 0; i <= 29; ++i)
     c_data1_0[i] = fill_value;
   for (int i = 30; i <= 49; ++i)
     c_data1_0[i] = i - 29;
-  CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
+  CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
-  CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<int32_t> c_data1_1(50);
   for (int i = 0; i <= 39; ++i)
     c_data1_1[i] = i + 21;
   for (int i = 40; i <= 49; ++i)
     c_data1_1[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
+  CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Clean up
   close_array();
@@ -1975,24 +2155,36 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
-  CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<int32_t> c_data1_0(50);
   for (int i = 0; i <= 34; ++i)
     c_data1_0[i] = fill_value;
   for (int i = 35; i <= 49; ++i)
     c_data1_0[i] = i - 34;
-  CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
+  CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
-  CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<int32_t> c_data1_1(50);
   for (int i = 0; i <= 9; ++i)
     c_data1_1[i] = i + 16;
   for (int i = 10; i <= 49; ++i)
     c_data1_1[i] = fill_value;
-  CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
+  CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Clean up
   close_array();
@@ -2034,15 +2226,27 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
-  CHECK(tiler1.get_tile(0, "a", &tile1_0).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      2 * sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<int32_t> c_data1_0 = {
       fill_value, fill_value, fill_value, fill_value, 1, 11, 2, 22, 3, 33};
-  CHECK(check_tile<int32_t>(&tile1_0, c_data1_0));
+  CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
-  CHECK(tiler1.get_tile(1, "a", &tile1_1).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      2 * sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<int32_t> c_data1_1 = {4,
                                     44,
                                     fill_value,
@@ -2053,7 +2257,7 @@ TEST_CASE_METHOD(
                                     fill_value,
                                     fill_value,
                                     fill_value};
-  CHECK(check_tile<int32_t>(&tile1_1, c_data1_1));
+  CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Create new subarray
   close_array();
@@ -2070,11 +2274,17 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2;
-  CHECK(tiler2.get_tile(0, "a", &tile2).ok());
+  WriterTile tile2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      2 * sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler2.get_tile(0, "a", tile2).ok());
   std::vector<int32_t> c_data2 = {
       fill_value, fill_value, 1, 11, 2, 22, 3, 33, 4, 44};
-  CHECK(check_tile<int32_t>(&tile2, c_data2));
+  CHECK(check_tile<int32_t>(tile2.fixed_tile(), c_data2));
 
   // Create new subarray (col-major)
   close_array();
@@ -2091,11 +2301,17 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3;
-  CHECK(tiler3.get_tile(0, "a", &tile3).ok());
+  WriterTile tile3(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      2 * sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(0, "a", tile3).ok());
   std::vector<int32_t> c_data3 = {
       fill_value, fill_value, 1, 11, 2, 22, 3, 33, 4, 44};
-  CHECK(check_tile<int32_t>(&tile3, c_data3));
+  CHECK(check_tile<int32_t>(tile3.fixed_tile(), c_data3));
 
   // Clean up
   close_array();
@@ -2140,30 +2356,54 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0_a1;
-  CHECK(tiler1.get_tile(0, "a1", &tile1_0_a1).ok());
+  WriterTile tile1_0_a1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a1", tile1_0_a1).ok());
   std::vector<int32_t> c_data1_0_a1 = {fill_value, fill_value, 1, 2, 3};
-  CHECK(check_tile<int32_t>(&tile1_0_a1, c_data1_0_a1));
-  Tile tile1_0_a2;
-  CHECK(tiler1.get_tile(0, "a2", &tile1_0_a2).ok());
+  CHECK(check_tile<int32_t>(tile1_0_a1.fixed_tile(), c_data1_0_a1));
+  WriterTile tile1_0_a2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(double),
+      Datatype::FLOAT64);
+  CHECK(tiler1.get_tile(0, "a2", tile1_0_a2).ok());
   std::vector<double> c_data1_0_a2 = {
       double(fill_value), double(fill_value), 1.1, 2.2, 3.3};
-  CHECK(check_tile<double>(&tile1_0_a2, c_data1_0_a2));
+  CHECK(check_tile<double>(tile1_0_a2.fixed_tile(), c_data1_0_a2));
 
   // Test get tile 1
-  Tile tile1_1_a1;
-  CHECK(tiler1.get_tile(1, "a1", &tile1_1_a1).ok());
+  WriterTile tile1_1_a1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a1", tile1_1_a1).ok());
   std::vector<int32_t> c_data1_1_a1 = {
       4, fill_value, fill_value, fill_value, fill_value};
-  CHECK(check_tile<int32_t>(&tile1_1_a1, c_data1_1_a1));
-  Tile tile1_1_a2;
-  CHECK(tiler1.get_tile(1, "a2", &tile1_1_a2).ok());
+  CHECK(check_tile<int32_t>(tile1_1_a1.fixed_tile(), c_data1_1_a1));
+  WriterTile tile1_1_a2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(double),
+      Datatype::FLOAT64);
+  CHECK(tiler1.get_tile(1, "a2", tile1_1_a2).ok());
   std::vector<double> c_data1_1_a2 = {4.4,
                                       double(fill_value),
                                       double(fill_value),
                                       double(fill_value),
                                       double(fill_value)};
-  CHECK(check_tile<double>(&tile1_1_a2, c_data1_1_a2));
+  CHECK(check_tile<double>(tile1_1_a2.fixed_tile(), c_data1_1_a2));
 
   // Create new subarray
   close_array();
@@ -2180,14 +2420,26 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_a1;
-  CHECK(tiler2.get_tile(0, "a1", &tile2_a1).ok());
+  WriterTile tile2_a1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler2.get_tile(0, "a1", tile2_a1).ok());
   std::vector<int32_t> c_data2_a1 = {fill_value, 1, 2, 3, 4};
-  CHECK(check_tile<int32_t>(&tile2_a1, c_data2_a1));
-  Tile tile2_a2;
-  CHECK(tiler2.get_tile(0, "a2", &tile2_a2).ok());
+  CHECK(check_tile<int32_t>(tile2_a1.fixed_tile(), c_data2_a1));
+  WriterTile tile2_a2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(double),
+      Datatype::FLOAT64);
+  CHECK(tiler2.get_tile(0, "a2", tile2_a2).ok());
   std::vector<double> c_data2_a2 = {double(fill_value), 1.1, 2.2, 3.3, 4.4};
-  CHECK(check_tile<double>(&tile2_a2, c_data2_a2));
+  CHECK(check_tile<double>(tile2_a2.fixed_tile(), c_data2_a2));
 
   // Create new subarray (col-major)
   close_array();
@@ -2204,14 +2456,26 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3_a1;
-  CHECK(tiler3.get_tile(0, "a1", &tile3_a1).ok());
+  WriterTile tile3_a1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(0, "a1", tile3_a1).ok());
   std::vector<int32_t> c_data3_a1 = {fill_value, 1, 2, 3, 4};
-  CHECK(check_tile<int32_t>(&tile3_a1, c_data3_a1));
-  Tile tile3_a2;
-  CHECK(tiler3.get_tile(0, "a2", &tile3_a2).ok());
+  CHECK(check_tile<int32_t>(tile3_a1.fixed_tile(), c_data3_a1));
+  WriterTile tile3_a2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      false,
+      sizeof(double),
+      Datatype::FLOAT64);
+  CHECK(tiler3.get_tile(0, "a2", tile3_a2).ok());
   std::vector<double> c_data3_a2 = {double(fill_value), 1.1, 2.2, 3.3, 4.4};
-  CHECK(check_tile<double>(&tile3_a2, c_data3_a2));
+  CHECK(check_tile<double>(tile3_a2.fixed_tile(), c_data3_a2));
 
   // Clean up
   close_array();
@@ -2265,8 +2529,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0;
-  CHECK(tiler1.get_tile_null(0, "a", &tile1_0).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<uint8_t> c_data1_0(50);
   for (int i = 0; i <= 36; ++i)
     c_data1_0[i] = fill_value;
@@ -2278,11 +2548,17 @@ TEST_CASE_METHOD(
   c_data1_0[47] = 0;
   c_data1_0[48] = 1;
   c_data1_0[49] = 0;
-  CHECK(check_tile<uint8_t>(&tile1_0, c_data1_0));
+  CHECK(check_tile<uint8_t>(tile1_0.validity_tile(), c_data1_0));
 
   // Test get tile 1
-  Tile tile1_1;
-  CHECK(tiler1.get_tile_null(1, "a", &tile1_1).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<uint8_t> c_data1_1(50);
   for (int i = 0; i <= 29; ++i)
     c_data1_1[i] = fill_value;
@@ -2294,11 +2570,17 @@ TEST_CASE_METHOD(
   c_data1_1[41] = 1;
   for (int i = 42; i <= 49; ++i)
     c_data1_1[i] = fill_value;
-  CHECK(check_tile<uint8_t>(&tile1_1, c_data1_1));
+  CHECK(check_tile<uint8_t>(tile1_1.validity_tile(), c_data1_1));
 
   // Test get tile 2
-  Tile tile1_2;
-  CHECK(tiler1.get_tile_null(2, "a", &tile1_2).ok());
+  WriterTile tile1_2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(2, "a", tile1_2).ok());
   std::vector<uint8_t> c_data1_2(50);
   for (int i = 0; i <= 6; ++i)
     c_data1_2[i] = fill_value;
@@ -2307,17 +2589,23 @@ TEST_CASE_METHOD(
   c_data1_2[9] = 0;
   for (int i = 10; i <= 49; ++i)
     c_data1_2[i] = fill_value;
-  CHECK(check_tile<uint8_t>(&tile1_2, c_data1_2));
+  CHECK(check_tile<uint8_t>(tile1_2.validity_tile(), c_data1_2));
 
   // Test get tile 3
-  Tile tile1_3;
-  CHECK(tiler1.get_tile_null(3, "a", &tile1_3).ok());
+  WriterTile tile1_3(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(3, "a", tile1_3).ok());
   std::vector<uint8_t> c_data1_3(50);
   c_data1_3[0] = 0;
   c_data1_3[1] = 1;
   for (int i = 2; i <= 49; ++i)
     c_data1_3[i] = fill_value;
-  CHECK(check_tile<uint8_t>(&tile1_3, c_data1_3));
+  CHECK(check_tile<uint8_t>(tile1_3.validity_tile(), c_data1_3));
 
   // Create subarray (single tile)
   close_array();
@@ -2345,8 +2633,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0;
-  CHECK(tiler2.get_tile_null(0, "a", &tile2_0).ok());
+  WriterTile tile2_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler2.get_tile(0, "a", tile2_0).ok());
   std::vector<uint8_t> c_data2_0(50);
   for (int i = 0; i <= 21; ++i)
     c_data2_0[i] = fill_value;
@@ -2374,7 +2668,7 @@ TEST_CASE_METHOD(
   c_data2_0[47] = 0;
   for (int i = 48; i <= 49; ++i)
     c_data2_0[i] = fill_value;
-  CHECK(check_tile<uint8_t>(&tile2_0, c_data2_0));
+  CHECK(check_tile<uint8_t>(tile2_0.validity_tile(), c_data2_0));
 
   // Create subarray (multiple tiles, col-major)
   close_array();
@@ -2402,8 +2696,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile3_0;
-  CHECK(tiler3.get_tile_null(0, "a", &tile3_0).ok());
+  WriterTile tile3_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(0, "a", tile3_0).ok());
   std::vector<uint8_t> c_data3_0(50);
   for (int i = 0; i <= 36; ++i)
     c_data3_0[i] = fill_value;
@@ -2415,11 +2715,17 @@ TEST_CASE_METHOD(
   c_data3_0[47] = 1;
   c_data3_0[48] = 0;
   c_data3_0[49] = 0;
-  CHECK(check_tile<uint8_t>(&tile3_0, c_data3_0));
+  CHECK(check_tile<uint8_t>(tile3_0.validity_tile(), c_data3_0));
 
   // Test get tile 1
-  Tile tile3_1;
-  CHECK(tiler3.get_tile_null(1, "a", &tile3_1).ok());
+  WriterTile tile3_1(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(1, "a", tile3_1).ok());
   std::vector<uint8_t> c_data3_1(50);
   for (int i = 0; i <= 29; ++i)
     c_data3_1[i] = fill_value;
@@ -2431,11 +2737,17 @@ TEST_CASE_METHOD(
   c_data3_1[41] = 0;
   for (int i = 42; i <= 49; ++i)
     c_data3_1[i] = fill_value;
-  CHECK(check_tile<uint8_t>(&tile3_1, c_data3_1));
+  CHECK(check_tile<uint8_t>(tile3_1.validity_tile(), c_data3_1));
 
   // Test get tile 2
-  Tile tile3_2;
-  CHECK(tiler3.get_tile_null(2, "a", &tile3_2).ok());
+  WriterTile tile3_2(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(2, "a", tile3_2).ok());
   std::vector<uint8_t> c_data3_2(50);
   for (int i = 0; i <= 6; ++i)
     c_data3_2[i] = fill_value;
@@ -2444,17 +2756,23 @@ TEST_CASE_METHOD(
   c_data3_2[9] = 1;
   for (int i = 10; i <= 49; ++i)
     c_data3_2[i] = fill_value;
-  CHECK(check_tile<uint8_t>(&tile3_2, c_data3_2));
+  CHECK(check_tile<uint8_t>(tile3_2.validity_tile(), c_data3_2));
 
   // Test get tile 3
-  Tile tile3_3;
-  CHECK(tiler3.get_tile_null(3, "a", &tile3_3).ok());
+  WriterTile tile3_3(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler3.get_tile(3, "a", tile3_3).ok());
   std::vector<uint8_t> c_data3_3(50);
   c_data3_3[0] = 1;
   c_data3_3[1] = 1;
   for (int i = 2; i <= 49; ++i)
     c_data3_3[i] = fill_value;
-  CHECK(check_tile<uint8_t>(&tile3_3, c_data3_3));
+  CHECK(check_tile<uint8_t>(tile3_3.validity_tile(), c_data3_3));
 
   // Create subarray (single tile, col-major)
   close_array();
@@ -2482,8 +2800,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile4_0;
-  CHECK(tiler4.get_tile_null(0, "a", &tile4_0).ok());
+  WriterTile tile4_0(
+      array_->array_->array_schema_latest(),
+      false,
+      false,
+      true,
+      sizeof(int32_t),
+      Datatype::INT32);
+  CHECK(tiler4.get_tile(0, "a", tile4_0).ok());
   std::vector<uint8_t> c_data4_0(50);
   for (int i = 0; i <= 21; ++i)
     c_data4_0[i] = fill_value;
@@ -2511,7 +2835,7 @@ TEST_CASE_METHOD(
   c_data4_0[47] = 0;
   for (int i = 48; i <= 49; ++i)
     c_data4_0[i] = fill_value;
-  CHECK(check_tile<uint8_t>(&tile4_0, c_data4_0));
+  CHECK(check_tile<uint8_t>(tile4_0.validity_tile(), c_data4_0));
 
   // Clean up
   close_array();
@@ -2564,8 +2888,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
-  CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::STRING_ASCII);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
     c_data1_0_off[i] = i;
@@ -2577,7 +2907,7 @@ TEST_CASE_METHOD(
   c_data1_0_off[47] = c_data1_0_off[46] + 1;
   c_data1_0_off[48] = c_data1_0_off[47] + std::string("f").size();
   c_data1_0_off[49] = c_data1_0_off[48] + std::string("gg").size();
-  CHECK(check_tile<uint64_t>(&tile1_0_off, c_data1_0_off));
+  CHECK(check_tile<uint64_t>(tile1_0.offset_tile(), c_data1_0_off));
   std::vector<uint8_t> c_data1_0_val(56);
   for (int i = 0; i <= 36; ++i)
     c_data1_0_val[i] = 0;
@@ -2595,11 +2925,17 @@ TEST_CASE_METHOD(
   c_data1_0_val[53] = 'h';
   c_data1_0_val[54] = 'h';
   c_data1_0_val[55] = 'h';
-  CHECK(check_tile<uint8_t>(&tile1_0_val, c_data1_0_val));
+  CHECK(check_tile<uint8_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
-  CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::STRING_ASCII);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
     c_data1_1_off[i] = i;
@@ -2611,7 +2947,7 @@ TEST_CASE_METHOD(
   c_data1_1_off[42] = c_data1_1_off[41] + std::string("ooooo").size();
   for (int i = 43; i <= 49; ++i)
     c_data1_1_off[i] = c_data1_1_off[i - 1] + 1;
-  CHECK(check_tile<uint64_t>(&tile1_1_off, c_data1_1_off));
+  CHECK(check_tile<uint64_t>(tile1_1.offset_tile(), c_data1_1_off));
   std::vector<uint8_t> c_data1_1_val(64);
   for (int i = 0; i <= 29; ++i)
     c_data1_1_val[i] = 0;
@@ -2637,11 +2973,17 @@ TEST_CASE_METHOD(
   c_data1_1_val[55] = 'j';
   for (int i = 56; i <= 63; ++i)
     c_data1_1_val[i] = 0;
-  CHECK(check_tile<uint8_t>(&tile1_1_val, c_data1_1_val));
+  CHECK(check_tile<uint8_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
-  CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
+  WriterTile tile1_2(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::STRING_ASCII);
+  CHECK(tiler1.get_tile(2, "a", tile1_2).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
     c_data1_2_off[i] = i;
@@ -2650,7 +2992,7 @@ TEST_CASE_METHOD(
   c_data1_2_off[10] = c_data1_2_off[9] + std::string("mmm").size();
   for (int i = 11; i <= 49; ++i)
     c_data1_2_off[i] = c_data1_2_off[i - 1] + 1;
-  CHECK(check_tile<uint64_t>(&tile1_2_off, c_data1_2_off));
+  CHECK(check_tile<uint64_t>(tile1_2.offset_tile(), c_data1_2_off));
   std::vector<uint8_t> c_data1_2_val(53);
   for (int i = 0; i <= 6; ++i)
     c_data1_2_val[i] = 0;
@@ -2662,18 +3004,24 @@ TEST_CASE_METHOD(
   c_data1_2_val[12] = 'm';
   for (int i = 13; i <= 52; ++i)
     c_data1_2_val[i] = 0;
-  CHECK(check_tile<uint8_t>(&tile1_2_val, c_data1_2_val));
+  CHECK(check_tile<uint8_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
-  CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
+  WriterTile tile1_3(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::STRING_ASCII);
+  CHECK(tiler1.get_tile(3, "a", tile1_3).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
   c_data1_3_off[1] = 4;
   c_data1_3_off[2] = 9;
   for (int i = 3; i <= 49; ++i)
     c_data1_3_off[i] = c_data1_3_off[i - 1] + 1;
-  CHECK(check_tile<uint64_t>(&tile1_3_off, c_data1_3_off));
+  CHECK(check_tile<uint64_t>(tile1_3.offset_tile(), c_data1_3_off));
   std::vector<uint8_t> c_data1_3_val(57);
   c_data1_3_val[0] = 'n';
   c_data1_3_val[1] = 'n';
@@ -2686,7 +3034,7 @@ TEST_CASE_METHOD(
   c_data1_3_val[8] = 'o';
   for (int i = 9; i < 57; ++i)
     c_data1_3_val[i] = 0;
-  CHECK(check_tile<uint8_t>(&tile1_3_val, c_data1_3_val));
+  CHECK(check_tile<uint8_t>(tile1_3.var_tile(), c_data1_3_val));
 
   // Create subarray (single tile)
   close_array();
@@ -2712,8 +3060,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
-  CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
+  WriterTile tile2_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::STRING_ASCII);
+  CHECK(tiler2.get_tile(0, "a", tile2_0).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)
     c_data2_0_off[i] = i;
@@ -2740,7 +3094,7 @@ TEST_CASE_METHOD(
   c_data2_0_off[47] = c_data2_0_off[46] + std::string("qq").size();
   c_data2_0_off[48] = c_data2_0_off[47] + std::string("r").size();
   c_data2_0_off[49] = c_data2_0_off[48] + 1;
-  CHECK(check_tile<uint64_t>(&tile2_0_off, c_data2_0_off));
+  CHECK(check_tile<uint64_t>(tile2_0.offset_tile(), c_data2_0_off));
   std::vector<uint8_t> c_data2_0_val(81);
   for (int i = 0; i <= 21; ++i)
     c_data2_0_val[i] = 0;
@@ -2799,7 +3153,7 @@ TEST_CASE_METHOD(
   c_data2_0_val[78] = 'r';
   for (int i = 79; i <= 80; ++i)
     c_data2_0_val[i] = 0;
-  CHECK(check_tile<uint8_t>(&tile2_0_val, c_data2_0_val));
+  CHECK(check_tile<uint8_t>(tile2_0.var_tile(), c_data2_0_val));
 
   // Clean up
   close_array();
@@ -2868,8 +3222,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
-  CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
     c_data1_0_off[i] = i * sizeof(int32_t);
@@ -2881,7 +3241,7 @@ TEST_CASE_METHOD(
   c_data1_0_off[47] = c_data1_0_off[46] + sizeof(int32_t);
   c_data1_0_off[48] = c_data1_0_off[47] + sizeof(int32_t);
   c_data1_0_off[49] = c_data1_0_off[48] + 2 * sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_0_off, c_data1_0_off));
+  CHECK(check_tile<uint64_t>(tile1_0.offset_tile(), c_data1_0_off));
   std::vector<int32_t> c_data1_0_val(56);
   for (int i = 0; i <= 36; ++i)
     c_data1_0_val[i] = 0;
@@ -2899,11 +3259,17 @@ TEST_CASE_METHOD(
   c_data1_0_val[53] = 8;
   c_data1_0_val[54] = 8;
   c_data1_0_val[55] = 8;
-  CHECK(check_tile<int32_t>(&tile1_0_val, c_data1_0_val));
+  CHECK(check_tile<int32_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
-  CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
     c_data1_1_off[i] = i * sizeof(int32_t);
@@ -2915,7 +3281,7 @@ TEST_CASE_METHOD(
   c_data1_1_off[42] = c_data1_1_off[41] + 5 * sizeof(int32_t);
   for (int i = 43; i <= 49; ++i)
     c_data1_1_off[i] = c_data1_1_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_1_off, c_data1_1_off));
+  CHECK(check_tile<uint64_t>(tile1_1.offset_tile(), c_data1_1_off));
   std::vector<int32_t> c_data1_1_val(64);
   for (int i = 0; i <= 29; ++i)
     c_data1_1_val[i] = 0;
@@ -2941,11 +3307,17 @@ TEST_CASE_METHOD(
   c_data1_1_val[55] = 10;
   for (int i = 56; i <= 63; ++i)
     c_data1_1_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_1_val, c_data1_1_val));
+  CHECK(check_tile<int32_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
-  CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
+  WriterTile tile1_2(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(2, "a", tile1_2).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
     c_data1_2_off[i] = i * sizeof(int32_t);
@@ -2954,7 +3326,7 @@ TEST_CASE_METHOD(
   c_data1_2_off[10] = c_data1_2_off[9] + 3 * sizeof(int32_t);
   for (int i = 11; i <= 49; ++i)
     c_data1_2_off[i] = c_data1_2_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_2_off, c_data1_2_off));
+  CHECK(check_tile<uint64_t>(tile1_2.offset_tile(), c_data1_2_off));
   std::vector<int32_t> c_data1_2_val(53);
   for (int i = 0; i <= 6; ++i)
     c_data1_2_val[i] = 0;
@@ -2966,18 +3338,24 @@ TEST_CASE_METHOD(
   c_data1_2_val[12] = 13;
   for (int i = 13; i <= 52; ++i)
     c_data1_2_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_2_val, c_data1_2_val));
+  CHECK(check_tile<int32_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
-  CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
+  WriterTile tile1_3(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(3, "a", tile1_3).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
   c_data1_3_off[1] = 4 * sizeof(int32_t);
   c_data1_3_off[2] = 9 * sizeof(int32_t);
   for (int i = 3; i <= 49; ++i)
     c_data1_3_off[i] = c_data1_3_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_3_off, c_data1_3_off));
+  CHECK(check_tile<uint64_t>(tile1_3.offset_tile(), c_data1_3_off));
   std::vector<int32_t> c_data1_3_val(57);
   c_data1_3_val[0] = 14;
   c_data1_3_val[1] = 14;
@@ -2990,7 +3368,7 @@ TEST_CASE_METHOD(
   c_data1_3_val[8] = 15;
   for (int i = 9; i < 57; ++i)
     c_data1_3_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_3_val, c_data1_3_val));
+  CHECK(check_tile<int32_t>(tile1_3.var_tile(), c_data1_3_val));
 
   // Create subarray (single tile)
   close_array();
@@ -3035,8 +3413,14 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
-  CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
+  WriterTile tile2_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::STRING_ASCII);
+  CHECK(tiler2.get_tile(0, "a", tile2_0).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)
     c_data2_0_off[i] = i * sizeof(int32_t);
@@ -3063,7 +3447,7 @@ TEST_CASE_METHOD(
   c_data2_0_off[47] = c_data2_0_off[46] + 2 * sizeof(int32_t);
   c_data2_0_off[48] = c_data2_0_off[47] + sizeof(int32_t);
   c_data2_0_off[49] = c_data2_0_off[48] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile2_0_off, c_data2_0_off));
+  CHECK(check_tile<uint64_t>(tile2_0.offset_tile(), c_data2_0_off));
   std::vector<int32_t> c_data2_0_val(81);
   for (int i = 0; i <= 21; ++i)
     c_data2_0_val[i] = 0;
@@ -3122,7 +3506,7 @@ TEST_CASE_METHOD(
   c_data2_0_val[78] = 18;
   for (int i = 79; i <= 80; ++i)
     c_data2_0_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile2_0_val, c_data2_0_val));
+  CHECK(check_tile<int32_t>(tile2_0.var_tile(), c_data2_0_val));
 
   // Clean up
   close_array();
@@ -3193,8 +3577,14 @@ TEST_CASE_METHOD(
       &buffers, &subarray1, &test::g_helper_stats, "bytes", 64, true);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
-  CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
     c_data1_0_off[i] = i * sizeof(int32_t);
@@ -3206,7 +3596,7 @@ TEST_CASE_METHOD(
   c_data1_0_off[47] = c_data1_0_off[46] + sizeof(int32_t);
   c_data1_0_off[48] = c_data1_0_off[47] + sizeof(int32_t);
   c_data1_0_off[49] = c_data1_0_off[48] + 2 * sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_0_off, c_data1_0_off));
+  CHECK(check_tile<uint64_t>(tile1_0.offset_tile(), c_data1_0_off));
   std::vector<int32_t> c_data1_0_val(56);
   for (int i = 0; i <= 36; ++i)
     c_data1_0_val[i] = 0;
@@ -3224,11 +3614,17 @@ TEST_CASE_METHOD(
   c_data1_0_val[53] = 8;
   c_data1_0_val[54] = 8;
   c_data1_0_val[55] = 8;
-  CHECK(check_tile<int32_t>(&tile1_0_val, c_data1_0_val));
+  CHECK(check_tile<int32_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
-  CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
     c_data1_1_off[i] = i * sizeof(int32_t);
@@ -3240,7 +3636,7 @@ TEST_CASE_METHOD(
   c_data1_1_off[42] = c_data1_1_off[41] + 5 * sizeof(int32_t);
   for (int i = 43; i <= 49; ++i)
     c_data1_1_off[i] = c_data1_1_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_1_off, c_data1_1_off));
+  CHECK(check_tile<uint64_t>(tile1_1.offset_tile(), c_data1_1_off));
   std::vector<int32_t> c_data1_1_val(64);
   for (int i = 0; i <= 29; ++i)
     c_data1_1_val[i] = 0;
@@ -3266,11 +3662,17 @@ TEST_CASE_METHOD(
   c_data1_1_val[55] = 10;
   for (int i = 56; i <= 63; ++i)
     c_data1_1_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_1_val, c_data1_1_val));
+  CHECK(check_tile<int32_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
-  CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
+  WriterTile tile1_2(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(2, "a", tile1_2).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
     c_data1_2_off[i] = i * sizeof(int32_t);
@@ -3279,7 +3681,7 @@ TEST_CASE_METHOD(
   c_data1_2_off[10] = c_data1_2_off[9] + 3 * sizeof(int32_t);
   for (int i = 11; i <= 49; ++i)
     c_data1_2_off[i] = c_data1_2_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_2_off, c_data1_2_off));
+  CHECK(check_tile<uint64_t>(tile1_2.offset_tile(), c_data1_2_off));
   std::vector<int32_t> c_data1_2_val(53);
   for (int i = 0; i <= 6; ++i)
     c_data1_2_val[i] = 0;
@@ -3291,18 +3693,24 @@ TEST_CASE_METHOD(
   c_data1_2_val[12] = 13;
   for (int i = 13; i <= 52; ++i)
     c_data1_2_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_2_val, c_data1_2_val));
+  CHECK(check_tile<int32_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
-  CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
+  WriterTile tile1_3(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(3, "a", tile1_3).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
   c_data1_3_off[1] = 4 * sizeof(int32_t);
   c_data1_3_off[2] = 9 * sizeof(int32_t);
   for (int i = 3; i <= 49; ++i)
     c_data1_3_off[i] = c_data1_3_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_3_off, c_data1_3_off));
+  CHECK(check_tile<uint64_t>(tile1_3.offset_tile(), c_data1_3_off));
   std::vector<int32_t> c_data1_3_val(57);
   c_data1_3_val[0] = 14;
   c_data1_3_val[1] = 14;
@@ -3315,7 +3723,7 @@ TEST_CASE_METHOD(
   c_data1_3_val[8] = 15;
   for (int i = 9; i < 57; ++i)
     c_data1_3_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_3_val, c_data1_3_val));
+  CHECK(check_tile<int32_t>(tile1_3.var_tile(), c_data1_3_val));
 
   // Create subarray (single tile)
   close_array();
@@ -3362,8 +3770,14 @@ TEST_CASE_METHOD(
       &buffers, &subarray2, &test::g_helper_stats, "bytes", 64, true);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
-  CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
+  WriterTile tile2_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler2.get_tile(0, "a", tile2_0).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)
     c_data2_0_off[i] = i * sizeof(int32_t);
@@ -3390,7 +3804,7 @@ TEST_CASE_METHOD(
   c_data2_0_off[47] = c_data2_0_off[46] + 2 * sizeof(int32_t);
   c_data2_0_off[48] = c_data2_0_off[47] + sizeof(int32_t);
   c_data2_0_off[49] = c_data2_0_off[48] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile2_0_off, c_data2_0_off));
+  CHECK(check_tile<uint64_t>(tile2_0.offset_tile(), c_data2_0_off));
   std::vector<int32_t> c_data2_0_val(81);
   for (int i = 0; i <= 21; ++i)
     c_data2_0_val[i] = 0;
@@ -3449,7 +3863,7 @@ TEST_CASE_METHOD(
   c_data2_0_val[78] = 18;
   for (int i = 79; i <= 80; ++i)
     c_data2_0_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile2_0_val, c_data2_0_val));
+  CHECK(check_tile<int32_t>(tile2_0.var_tile(), c_data2_0_val));
 
   // Clean up
   close_array();
@@ -3506,8 +3920,14 @@ TEST_CASE_METHOD(
       &buffers, &subarray1, &test::g_helper_stats, "elements", 64, false);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
-  CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
     c_data1_0_off[i] = i * sizeof(int32_t);
@@ -3519,7 +3939,7 @@ TEST_CASE_METHOD(
   c_data1_0_off[47] = c_data1_0_off[46] + sizeof(int32_t);
   c_data1_0_off[48] = c_data1_0_off[47] + sizeof(int32_t);
   c_data1_0_off[49] = c_data1_0_off[48] + 2 * sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_0_off, c_data1_0_off));
+  CHECK(check_tile<uint64_t>(tile1_0.offset_tile(), c_data1_0_off));
   std::vector<int32_t> c_data1_0_val(56);
   for (int i = 0; i <= 36; ++i)
     c_data1_0_val[i] = 0;
@@ -3537,11 +3957,17 @@ TEST_CASE_METHOD(
   c_data1_0_val[53] = 8;
   c_data1_0_val[54] = 8;
   c_data1_0_val[55] = 8;
-  CHECK(check_tile<int32_t>(&tile1_0_val, c_data1_0_val));
+  CHECK(check_tile<int32_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
-  CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
     c_data1_1_off[i] = i * sizeof(int32_t);
@@ -3553,7 +3979,7 @@ TEST_CASE_METHOD(
   c_data1_1_off[42] = c_data1_1_off[41] + 5 * sizeof(int32_t);
   for (int i = 43; i <= 49; ++i)
     c_data1_1_off[i] = c_data1_1_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_1_off, c_data1_1_off));
+  CHECK(check_tile<uint64_t>(tile1_1.offset_tile(), c_data1_1_off));
   std::vector<int32_t> c_data1_1_val(64);
   for (int i = 0; i <= 29; ++i)
     c_data1_1_val[i] = 0;
@@ -3579,11 +4005,17 @@ TEST_CASE_METHOD(
   c_data1_1_val[55] = 10;
   for (int i = 56; i <= 63; ++i)
     c_data1_1_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_1_val, c_data1_1_val));
+  CHECK(check_tile<int32_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
-  CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
+  WriterTile tile1_2(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(2, "a", tile1_2).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
     c_data1_2_off[i] = i * sizeof(int32_t);
@@ -3592,7 +4024,7 @@ TEST_CASE_METHOD(
   c_data1_2_off[10] = c_data1_2_off[9] + 3 * sizeof(int32_t);
   for (int i = 11; i <= 49; ++i)
     c_data1_2_off[i] = c_data1_2_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_2_off, c_data1_2_off));
+  CHECK(check_tile<uint64_t>(tile1_2.offset_tile(), c_data1_2_off));
   std::vector<int32_t> c_data1_2_val(53);
   for (int i = 0; i <= 6; ++i)
     c_data1_2_val[i] = 0;
@@ -3604,18 +4036,24 @@ TEST_CASE_METHOD(
   c_data1_2_val[12] = 13;
   for (int i = 13; i <= 52; ++i)
     c_data1_2_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_2_val, c_data1_2_val));
+  CHECK(check_tile<int32_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
-  CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
+  WriterTile tile1_3(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(3, "a", tile1_3).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
   c_data1_3_off[1] = 4 * sizeof(int32_t);
   c_data1_3_off[2] = 9 * sizeof(int32_t);
   for (int i = 3; i <= 49; ++i)
     c_data1_3_off[i] = c_data1_3_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_3_off, c_data1_3_off));
+  CHECK(check_tile<uint64_t>(tile1_3.offset_tile(), c_data1_3_off));
   std::vector<int32_t> c_data1_3_val(57);
   c_data1_3_val[0] = 14;
   c_data1_3_val[1] = 14;
@@ -3628,7 +4066,7 @@ TEST_CASE_METHOD(
   c_data1_3_val[8] = 15;
   for (int i = 9; i < 57; ++i)
     c_data1_3_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_3_val, c_data1_3_val));
+  CHECK(check_tile<int32_t>(tile1_3.var_tile(), c_data1_3_val));
 
   // Create subarray (single tile)
   close_array();
@@ -3658,8 +4096,14 @@ TEST_CASE_METHOD(
       &buffers, &subarray2, &test::g_helper_stats, "elements", 64, false);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
-  CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
+  WriterTile tile2_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler2.get_tile(0, "a", tile2_0).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)
     c_data2_0_off[i] = i * sizeof(int32_t);
@@ -3686,7 +4130,7 @@ TEST_CASE_METHOD(
   c_data2_0_off[47] = c_data2_0_off[46] + 2 * sizeof(int32_t);
   c_data2_0_off[48] = c_data2_0_off[47] + sizeof(int32_t);
   c_data2_0_off[49] = c_data2_0_off[48] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile2_0_off, c_data2_0_off));
+  CHECK(check_tile<uint64_t>(tile2_0.offset_tile(), c_data2_0_off));
   std::vector<int32_t> c_data2_0_val(81);
   for (int i = 0; i <= 21; ++i)
     c_data2_0_val[i] = 0;
@@ -3745,7 +4189,7 @@ TEST_CASE_METHOD(
   c_data2_0_val[78] = 18;
   for (int i = 79; i <= 80; ++i)
     c_data2_0_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile2_0_val, c_data2_0_val));
+  CHECK(check_tile<int32_t>(tile2_0.var_tile(), c_data2_0_val));
 
   // Clean up
   close_array();
@@ -3802,8 +4246,14 @@ TEST_CASE_METHOD(
       &buffers, &subarray1, &test::g_helper_stats, "elements", 32, false);
 
   // Test get tile 0
-  Tile tile1_0_off, tile1_0_val;
-  CHECK(tiler1.get_tile_var(0, "a", &tile1_0_off, &tile1_0_val).ok());
+  WriterTile tile1_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(0, "a", tile1_0).ok());
   std::vector<uint64_t> c_data1_0_off(50);
   for (int i = 0; i <= 37; ++i)
     c_data1_0_off[i] = i * sizeof(int32_t);
@@ -3815,7 +4265,7 @@ TEST_CASE_METHOD(
   c_data1_0_off[47] = c_data1_0_off[46] + sizeof(int32_t);
   c_data1_0_off[48] = c_data1_0_off[47] + sizeof(int32_t);
   c_data1_0_off[49] = c_data1_0_off[48] + 2 * sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_0_off, c_data1_0_off));
+  CHECK(check_tile<uint64_t>(tile1_0.offset_tile(), c_data1_0_off));
   std::vector<int32_t> c_data1_0_val(56);
   for (int i = 0; i <= 36; ++i)
     c_data1_0_val[i] = 0;
@@ -3833,11 +4283,17 @@ TEST_CASE_METHOD(
   c_data1_0_val[53] = 8;
   c_data1_0_val[54] = 8;
   c_data1_0_val[55] = 8;
-  CHECK(check_tile<int32_t>(&tile1_0_val, c_data1_0_val));
+  CHECK(check_tile<int32_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  Tile tile1_1_off, tile1_1_val;
-  CHECK(tiler1.get_tile_var(1, "a", &tile1_1_off, &tile1_1_val).ok());
+  WriterTile tile1_1(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(1, "a", tile1_1).ok());
   std::vector<uint64_t> c_data1_1_off(50);
   for (int i = 0; i <= 30; ++i)
     c_data1_1_off[i] = i * sizeof(int32_t);
@@ -3849,7 +4305,7 @@ TEST_CASE_METHOD(
   c_data1_1_off[42] = c_data1_1_off[41] + 5 * sizeof(int32_t);
   for (int i = 43; i <= 49; ++i)
     c_data1_1_off[i] = c_data1_1_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_1_off, c_data1_1_off));
+  CHECK(check_tile<uint64_t>(tile1_1.offset_tile(), c_data1_1_off));
   std::vector<int32_t> c_data1_1_val(64);
   for (int i = 0; i <= 29; ++i)
     c_data1_1_val[i] = 0;
@@ -3875,11 +4331,17 @@ TEST_CASE_METHOD(
   c_data1_1_val[55] = 10;
   for (int i = 56; i <= 63; ++i)
     c_data1_1_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_1_val, c_data1_1_val));
+  CHECK(check_tile<int32_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  Tile tile1_2_off, tile1_2_val;
-  CHECK(tiler1.get_tile_var(2, "a", &tile1_2_off, &tile1_2_val).ok());
+  WriterTile tile1_2(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(2, "a", tile1_2).ok());
   std::vector<uint64_t> c_data1_2_off(50);
   for (int i = 0; i <= 7; ++i)
     c_data1_2_off[i] = i * sizeof(int32_t);
@@ -3888,7 +4350,7 @@ TEST_CASE_METHOD(
   c_data1_2_off[10] = c_data1_2_off[9] + 3 * sizeof(int32_t);
   for (int i = 11; i <= 49; ++i)
     c_data1_2_off[i] = c_data1_2_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_2_off, c_data1_2_off));
+  CHECK(check_tile<uint64_t>(tile1_2.offset_tile(), c_data1_2_off));
   std::vector<int32_t> c_data1_2_val(53);
   for (int i = 0; i <= 6; ++i)
     c_data1_2_val[i] = 0;
@@ -3900,18 +4362,24 @@ TEST_CASE_METHOD(
   c_data1_2_val[12] = 13;
   for (int i = 13; i <= 52; ++i)
     c_data1_2_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_2_val, c_data1_2_val));
+  CHECK(check_tile<int32_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  Tile tile1_3_off, tile1_3_val;
-  CHECK(tiler1.get_tile_var(3, "a", &tile1_3_off, &tile1_3_val).ok());
+  WriterTile tile1_3(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler1.get_tile(3, "a", tile1_3).ok());
   std::vector<uint64_t> c_data1_3_off(50);
   c_data1_3_off[0] = 0;
   c_data1_3_off[1] = 4 * sizeof(int32_t);
   c_data1_3_off[2] = 9 * sizeof(int32_t);
   for (int i = 3; i <= 49; ++i)
     c_data1_3_off[i] = c_data1_3_off[i - 1] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile1_3_off, c_data1_3_off));
+  CHECK(check_tile<uint64_t>(tile1_3.offset_tile(), c_data1_3_off));
   std::vector<int32_t> c_data1_3_val(57);
   c_data1_3_val[0] = 14;
   c_data1_3_val[1] = 14;
@@ -3924,7 +4392,7 @@ TEST_CASE_METHOD(
   c_data1_3_val[8] = 15;
   for (int i = 9; i < 57; ++i)
     c_data1_3_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile1_3_val, c_data1_3_val));
+  CHECK(check_tile<int32_t>(tile1_3.var_tile(), c_data1_3_val));
 
   // Create subarray (single tile)
   close_array();
@@ -3954,8 +4422,14 @@ TEST_CASE_METHOD(
       &buffers, &subarray2, &test::g_helper_stats, "elements", 32, false);
 
   // Test get tile 0
-  Tile tile2_0_off, tile2_0_val;
-  CHECK(tiler2.get_tile_var(0, "a", &tile2_0_off, &tile2_0_val).ok());
+  WriterTile tile2_0(
+      array_->array_->array_schema_latest(),
+      false,
+      true,
+      false,
+      1,
+      Datatype::INT32);
+  CHECK(tiler2.get_tile(0, "a", tile2_0).ok());
   std::vector<uint64_t> c_data2_0_off(50);
   for (int i = 0; i <= 22; ++i)
     c_data2_0_off[i] = i * sizeof(int32_t);
@@ -3982,7 +4456,7 @@ TEST_CASE_METHOD(
   c_data2_0_off[47] = c_data2_0_off[46] + 2 * sizeof(int32_t);
   c_data2_0_off[48] = c_data2_0_off[47] + sizeof(int32_t);
   c_data2_0_off[49] = c_data2_0_off[48] + sizeof(int32_t);
-  CHECK(check_tile<uint64_t>(&tile2_0_off, c_data2_0_off));
+  CHECK(check_tile<uint64_t>(tile2_0.offset_tile(), c_data2_0_off));
   std::vector<int32_t> c_data2_0_val(81);
   for (int i = 0; i <= 21; ++i)
     c_data2_0_val[i] = 0;
@@ -4041,11 +4515,9 @@ TEST_CASE_METHOD(
   c_data2_0_val[78] = 18;
   for (int i = 79; i <= 80; ++i)
     c_data2_0_val[i] = 0;
-  CHECK(check_tile<int32_t>(&tile2_0_val, c_data2_0_val));
+  CHECK(check_tile<int32_t>(tile2_0.var_tile(), c_data2_0_val));
 
   // Clean up
   close_array();
   remove_array(array_name);
 }
-
-// TODO: add stats

--- a/tiledb/sm/query/dense_tiler.cc
+++ b/tiledb/sm/query/dense_tiler.cc
@@ -190,7 +190,7 @@ const typename DenseTiler<T>::CopyPlan DenseTiler<T>::copy_plan(
 
 template <class T>
 Status DenseTiler<T>::get_tile(
-    uint64_t id, const std::string& name, Tile* tile) {
+    uint64_t id, const std::string& name, WriterTile& tile) {
   auto timer_se = stats_->start_timer("get_tile");
 
   // Checks
@@ -200,165 +200,106 @@ Status DenseTiler<T>::get_tile(
   if (!array_schema_.is_attr(name))
     return LOG_STATUS(Status_DenseTilerError(
         std::string("Cannot get tile; '") + name + "' is not an attribute"));
-  if (array_schema_.var_size(name))
-    return LOG_STATUS(Status_DenseTilerError(
-        std::string("Cannot get tile; '") + name +
-        "' is not a fixed-sized attribute"));
 
-  // For easy reference
   auto& domain{array_schema_.domain()};
-  auto type = array_schema_.type(name);
-  auto cell_num_per_tile = domain.cell_num_per_tile();
-  auto cell_size = array_schema_.cell_size(name);
-  auto tile_size = cell_num_per_tile * cell_size;
-  auto buff = (uint8_t*)buffers_->find(name)->second.buffer_;
-  assert(buff != nullptr);
-
-  // Initialize tile
-  RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version, type, tile_size, cell_size, 0, true));
-
-  // Copy tile from buffer
-  RETURN_NOT_OK(copy_tile(id, cell_size, buff, tile));
-
-  return Status::Ok();
-}
-
-template <class T>
-Status DenseTiler<T>::get_tile_null(
-    uint64_t id, const std::string& name, Tile* tile) const {
-  // Checks
-  if (id >= tile_num_)
-    return LOG_STATUS(
-        Status_DenseTilerError("Cannot get tile; Invalid tile id"));
-  if (!array_schema_.is_attr(name))
-    return LOG_STATUS(Status_DenseTilerError(
-        std::string("Cannot get tile; '") + name + "' is not an attribute"));
-  if (!array_schema_.is_nullable(name))
-    return LOG_STATUS(Status_DenseTilerError(
-        std::string("Cannot get tile; '") + name +
-        "' is not a nullable attribute"));
-
-  // For easy reference
-  auto& domain{array_schema_.domain()};
-  auto type = array_schema_.type(name);
-  auto cell_num_per_tile = domain.cell_num_per_tile();
-  auto cell_size = constants::cell_validity_size;
-  auto tile_size = cell_num_per_tile * cell_size;
-  auto buff = (uint8_t*)buffers_->find(name)->second.validity_vector_.buffer();
-  assert(buff != nullptr);
-
-  // Initialize tile
-  RETURN_NOT_OK(tile->init_unfiltered(
-      constants::format_version, type, tile_size, cell_size, 0, true));
-
-  // Copy tile from buffer
-  return copy_tile(id, cell_size, buff, tile);
-}
-
-template <class T>
-Status DenseTiler<T>::get_tile_var(
-    uint64_t id,
-    const std::string& name,
-    Tile* tile_off,
-    Tile* tile_val) const {
-  // Checks
-  if (id >= tile_num_)
-    return LOG_STATUS(
-        Status_DenseTilerError("Cannot get tile; Invalid tile id"));
-  if (!array_schema_.is_attr(name))
-    return LOG_STATUS(Status_DenseTilerError(
-        std::string("Cannot get tile; '") + name + "' is not an attribute"));
-  if (!array_schema_.var_size(name))
-    return LOG_STATUS(Status_DenseTilerError(
-        std::string("Cannot get tile; '") + name +
-        "' is not a var-sized attribute"));
-
-  // For easy reference
-  auto& domain{array_schema_.domain()};
-  auto type = array_schema_.type(name);
   auto cell_num_in_tile = domain.cell_num_per_tile();
-  auto tile_off_size = constants::cell_var_offset_size * cell_num_in_tile;
-  auto buff_it = buffers_->find(name);
-  assert(buff_it != buffers_->end());
-  auto buff_var = (uint8_t*)buff_it->second.buffer_var_;
-  auto div = (offsets_bytesize_ == 8) ? 1 : 2;
-  uint64_t buff_off_size = *(buff_it->second.buffer_size_) / div;
-  uint64_t buff_var_size = *(buff_it->second.buffer_var_size_);
-  auto cell_size = datatype_size(type);
-  std::vector<uint8_t> fill_var(sizeof(uint64_t), 0);
 
-  // Initialize position tile
-  Tile tile_pos;
-  RETURN_NOT_OK(tile_pos.init_unfiltered(
-      constants::format_version,
-      constants::cell_var_offset_type,
-      tile_off_size,
-      constants::cell_var_offset_size,
-      0));
+  // For easy reference
+  if (tile.var_size()) {
+    auto type = array_schema_.type(name);
+    auto tile_off_size = constants::cell_var_offset_size * cell_num_in_tile;
+    auto buff_it = buffers_->find(name);
+    assert(buff_it != buffers_->end());
+    auto buff_var = (uint8_t*)buff_it->second.buffer_var_;
+    auto div = (offsets_bytesize_ == 8) ? 1 : 2;
+    uint64_t buff_off_size = *(buff_it->second.buffer_size_) / div;
+    uint64_t buff_var_size = *(buff_it->second.buffer_var_size_);
+    auto cell_size = datatype_size(type);
+    std::vector<uint8_t> fill_var(sizeof(uint64_t), 0);
 
-  // Fill entire tile with MAX_UINT64
-  std::vector<uint64_t> to_write(
-      cell_num_in_tile, std::numeric_limits<uint64_t>::max());
-  RETURN_NOT_OK(tile_pos.write(to_write.data(), 0, tile_off_size));
-  to_write.clear();
-  to_write.shrink_to_fit();
+    // Initialize position tile
+    Tile tile_pos;
+    RETURN_NOT_OK(tile_pos.init_unfiltered(
+        constants::format_version,
+        constants::cell_var_offset_type,
+        tile_off_size,
+        constants::cell_var_offset_size,
+        0));
 
-  // Get position tile
-  auto cell_num_in_buff =  // TODO: fix
-      (buff_off_size - (offsets_extra_element_ * offsets_bytesize_)) /
-      offsets_bytesize_;
-  std::vector<uint64_t> cell_pos(cell_num_in_buff);
-  for (uint64_t i = 0; i < cell_num_in_buff; ++i)
-    cell_pos[i] = i;
-  RETURN_NOT_OK(copy_tile(
-      id, constants::cell_var_offset_size, (uint8_t*)&cell_pos[0], &tile_pos));
+    // Fill entire tile with MAX_UINT64
+    std::vector<uint64_t> to_write(
+        cell_num_in_tile, std::numeric_limits<uint64_t>::max());
+    RETURN_NOT_OK(tile_pos.write(to_write.data(), 0, tile_off_size));
+    to_write.clear();
+    to_write.shrink_to_fit();
 
-  // Initialize offset and value tiles
-  RETURN_NOT_OK(tile_off->init_unfiltered(
-      constants::format_version,
-      constants::cell_var_offset_type,
-      tile_off_size,
-      constants::cell_var_offset_size,
-      0));
-  RETURN_NOT_OK(tile_val->init_unfiltered(
-      constants::format_version,
-      type,
-      buff_var_size,  // This is only the initial allocation
-      cell_size,
-      0));
+    // Get position tile
+    auto cell_num_in_buff =  // TODO: fix
+        (buff_off_size - (offsets_extra_element_ * offsets_bytesize_)) /
+        offsets_bytesize_;
+    std::vector<uint64_t> cell_pos(cell_num_in_buff);
+    for (uint64_t i = 0; i < cell_num_in_buff; ++i)
+      cell_pos[i] = i;
+    RETURN_NOT_OK(copy_tile(
+        id, constants::cell_var_offset_size, (uint8_t*)&cell_pos[0], tile_pos));
 
-  // Copy real offsets and values to the corresponding tiles
-  void* tile_pos_buff_tmp = tile_pos.data();
-  auto tile_pos_buff = (uint64_t*)tile_pos_buff_tmp;
-  uint64_t tile_off_offset = 0, offset = 0, val_offset, val_size, pos;
-  auto mul = (offsets_format_mode_ == "bytes") ? 1 : cell_size;
-  for (uint64_t i = 0; i < cell_num_in_tile; ++i) {
-    pos = tile_pos_buff[i];
-    RETURN_NOT_OK(tile_off->write(&offset, tile_off_offset, sizeof(offset)));
-    tile_off_offset += sizeof(offset);
-    if (pos == std::numeric_limits<uint64_t>::max()) {  // Empty
-      RETURN_NOT_OK(tile_val->write_var(&fill_var[0], offset, cell_size));
-      offset += cell_size;
-    } else {  // Non-empty
-      val_offset = ((offsets_bytesize_ == 8) ?
-                        ((uint64_t*)buff_it->second.buffer_)[pos] :
-                        ((uint32_t*)buff_it->second.buffer_)[pos]) *
-                   mul;
-      val_size = (pos < cell_num_in_buff - 1) ?
-                     (((offsets_bytesize_ == 8) ?
-                           ((uint64_t*)buff_it->second.buffer_)[pos + 1] :
-                           ((uint32_t*)buff_it->second.buffer_)[pos + 1]) *
-                          mul -
-                      val_offset) :
-                     buff_var_size - val_offset;
-      RETURN_NOT_OK(
-          tile_val->write_var(&buff_var[val_offset], offset, val_size));
-      offset += val_size;
+    // Copy real offsets and values to the corresponding tiles
+    void* tile_pos_buff_tmp = tile_pos.data();
+    auto tile_pos_buff = (uint64_t*)tile_pos_buff_tmp;
+    uint64_t tile_off_offset = 0, offset = 0, val_offset, val_size, pos;
+    auto mul = (offsets_format_mode_ == "bytes") ? 1 : cell_size;
+    auto& tile_off = tile.offset_tile();
+    auto& tile_val = tile.var_tile();
+    for (uint64_t i = 0; i < cell_num_in_tile; ++i) {
+      pos = tile_pos_buff[i];
+      RETURN_NOT_OK(tile_off.write(&offset, tile_off_offset, sizeof(offset)));
+      tile_off_offset += sizeof(offset);
+      if (pos == std::numeric_limits<uint64_t>::max()) {  // Empty
+        RETURN_NOT_OK(tile_val.write_var(&fill_var[0], offset, cell_size));
+        offset += cell_size;
+      } else {  // Non-empty
+        val_offset = ((offsets_bytesize_ == 8) ?
+                          ((uint64_t*)buff_it->second.buffer_)[pos] :
+                          ((uint32_t*)buff_it->second.buffer_)[pos]) *
+                     mul;
+        val_size = (pos < cell_num_in_buff - 1) ?
+                       (((offsets_bytesize_ == 8) ?
+                             ((uint64_t*)buff_it->second.buffer_)[pos + 1] :
+                             ((uint32_t*)buff_it->second.buffer_)[pos + 1]) *
+                            mul -
+                        val_offset) :
+                       buff_var_size - val_offset;
+        RETURN_NOT_OK(
+            tile_val.write_var(&buff_var[val_offset], offset, val_size));
+        offset += val_size;
+      }
     }
+
+    tile_val.set_size(offset);
+  } else {
+    auto cell_size = array_schema_.cell_size(name);
+    auto tile_size = cell_size * cell_num_in_tile;
+    auto buff = (uint8_t*)buffers_->find(name)->second.buffer_;
+    assert(buff != nullptr);
+
+    memset(tile.fixed_tile().data(), 0, tile_size);
+
+    // Copy tile from buffer
+    RETURN_NOT_OK(copy_tile(id, cell_size, buff, tile.fixed_tile()));
   }
 
-  tile_val->set_size(offset);
+  if (tile.nullable()) {
+    auto cell_size = constants::cell_validity_size;
+    auto tile_size = cell_size * cell_num_in_tile;
+    auto buff =
+        (uint8_t*)buffers_->find(name)->second.validity_vector_.buffer();
+    assert(buff != nullptr);
+
+    memset(tile.validity_tile().data(), 0, tile_size);
+
+    // Copy tile from buffer
+    return copy_tile(id, cell_size, buff, tile.validity_tile());
+  }
 
   return Status::Ok();
 }
@@ -559,7 +500,7 @@ std::vector<std::array<T, 2>> DenseTiler<T>::tile_subarray(uint64_t id) const {
 
 template <class T>
 Status DenseTiler<T>::copy_tile(
-    uint64_t id, uint64_t cell_size, uint8_t* buff, Tile* tile) const {
+    uint64_t id, uint64_t cell_size, uint8_t* buff, Tile& tile) const {
   // Calculate copy plan
   const CopyPlan copy_plan = this->copy_plan(id);
 
@@ -594,7 +535,7 @@ Status DenseTiler<T>::copy_tile(
   while (true) {
     // Copy a slab
     RETURN_NOT_OK(
-        tile->write(&buff[sub_offsets[d]], tile_offsets[d], copy_nbytes));
+        tile.write(&buff[sub_offsets[d]], tile_offsets[d], copy_nbytes));
 
     // Advance cell coordinates, tile and buffer offsets
     auto last_dim_changed = d;

--- a/tiledb/sm/query/dense_tiler.h
+++ b/tiledb/sm/query/dense_tiler.h
@@ -164,8 +164,7 @@ class DenseTiler {
   const CopyPlan copy_plan(uint64_t id) const;
 
   /**
-   * Retrieves the fixed-sized tile with the input id and for the input
-   * attribute.
+   * Retrieves the tile with the input id and for the input attribute.
    *
    * @param id The id of the tile within the subarray to be retrieved.
    *     The id is serialied in the tile order of the array domain.
@@ -174,39 +173,7 @@ class DenseTiler {
    *     be preallocated and initialized before passed to the function.
    * @return Status
    */
-  Status get_tile(uint64_t id, const std::string& name, Tile* tile);
-
-  /**
-   * Retrieves the validity tile with the input id and for the input
-   * attribute.
-   *
-   * @param id The id of the tile within the subarray to be retrieved.
-   *     The id is serialied in the tile order of the array domain.
-   * @param name The name of the attribute.
-   * @param tile The tile to be retrieved. This needs to
-   *     be preallocated and initialized before passed to the function.
-   * @return Status
-   */
-  Status get_tile_null(uint64_t id, const std::string& name, Tile* tile) const;
-
-  /**
-   * Retrieves the var-sized tile with the input id and for the input
-   * attribute.
-   *
-   * @param id The id of the tile to be retrieved. The id is serialied in the
-   *     tile order of the array domain.
-   * @param name The name of the attribute.
-   * @param tile_off The tile with the offsets to be retrieved. This needs to
-   *     be preallocated and initialized before passed to the function.
-   * @param tile_val The tile with the values to be retrieves. This needs to
-   *     be preallocated and initialized before passed to the function.
-   * @return Status
-   */
-  Status get_tile_var(
-      uint64_t id,
-      const std::string& name,
-      Tile* tile_off,
-      Tile* tile_var) const;
+  Status get_tile(uint64_t id, const std::string& name, WriterTile& tile);
 
   /**
    * Returns the number of tiles to be created. This is equal
@@ -351,7 +318,7 @@ class DenseTiler {
    * @return Status
    */
   Status copy_tile(
-      uint64_t id, uint64_t cell_size, uint8_t* buff, Tile* tile) const;
+      uint64_t id, uint64_t cell_size, uint8_t* buff, Tile& tile) const;
 };
 
 }  // namespace sm


### PR DESCRIPTION
As a follow up to the WriterTileVector PR, this updates the dense tiler
code to use WriterTile instead of having a separate function for all
combinations of fixed/var/nullable.

---
TYPE: IMPROVEMENT
DESC: Dense tiler uses WriterTile.
