### PR TITLE
Fix ByteshuffleFilter in filter_constructor

### DIFF
--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -173,7 +173,7 @@ static tuple<Status, optional<shared_ptr<Filter>>> filter_constructor(
     }
     case FilterType::FILTER_BYTESHUFFLE: {
       return {Status::Ok(),
-              tiledb::common::make_shared<BitshuffleFilter>(HERE())};
+              tiledb::common::make_shared<ByteshuffleFilter>(HERE())};
     }
     case FilterType::FILTER_CHECKSUM_MD5: {
       return {Status::Ok(),


### PR DESCRIPTION
This fixes a typo in the byteshuffle constructor for capnp serialization.

Credit to @eric-hughes-tiledb for a fresh set of eyes and seeing the problem quickly.

---
TYPE: BUG
DESC: Fix a typo in the byteshuffle constructor for capnp serialization
