### PR TITLE
Fix undefined behavior in filestore whilst detecting compression

### DIFF
--- a/scripts/install-hadoop.sh
+++ b/scripts/install-hadoop.sh
@@ -27,7 +27,7 @@
 # Installs and configures HDFS.
 set -x
 
-HADOOP_VERSION="3.3.1"
+HADOOP_VERSION="3.3.3"
 
 die() {
   echo "$@" 1>&2 ; popd 2>/dev/null; exit 1

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -659,6 +659,11 @@ bool libmagic_file_is_compressed(void* data, uint64_t size) {
     magic_close(magic);
     return true;
   }
+  auto rv = magic_buffer(magic, data, size);
+  if (!rv) {
+    return true;
+  }
+
   std::string mime(magic_buffer(magic, data, size));
 
   return compressed_mime_types.find(mime) != compressed_mime_types.end();


### PR DESCRIPTION
As exemplified in https://app.shortcut.com/tiledb-inc/story/18476/sigabrt-in-filestore-on-gcc-7-3, if in some cases libmagic `magic_buffer` returns nullptr, we should avoid constructing a string from its result as it's undefined behavior.

---
TYPE: BUG
DESC: Fix undefined behavior in filestore whilst detecting compression
