### PR TITLE
fix timestamp_no_ms() for 32bit

### DIFF
--- a/scripts/install-hadoop.sh
+++ b/scripts/install-hadoop.sh
@@ -50,7 +50,7 @@ function install_hadoop {
   pushd /usr/local/hadoop
   # download from closest mirror
   curl -G -L -d "action=download" \
-    "https://dlcdn.apache.org/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz" \
+    "https://www.apache.org/dyn/closer.cgi/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz" \
     -o hadoop-${HADOOP_VERSION}.tar.gz
   if [ $? -ne 0 ]; then
     die "error downloading hadoop from apache mirror"

--- a/scripts/install-hadoop.sh
+++ b/scripts/install-hadoop.sh
@@ -50,7 +50,7 @@ function install_hadoop {
   pushd /usr/local/hadoop
   # download from closest mirror
   curl -G -L -d "action=download" \
-    "https://dlcdn.apache.org/dyn/closer.cgi/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz" \
+    "https://dlcdn.apache.org/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz" \
     -o hadoop-${HADOOP_VERSION}.tar.gz
   if [ $? -ne 0 ]; then
     die "error downloading hadoop from apache mirror"

--- a/scripts/install-hadoop.sh
+++ b/scripts/install-hadoop.sh
@@ -50,7 +50,7 @@ function install_hadoop {
   pushd /usr/local/hadoop
   # download from closest mirror
   curl -G -L -d "action=download" \
-    "https://www.apache.org/dyn/closer.cgi/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz" \
+    "https://dlcdn.apache.org/dyn/closer.cgi/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz" \
     -o hadoop-${HADOOP_VERSION}.tar.gz
   if [ $? -ne 0 ]; then
     die "error downloading hadoop from apache mirror"

--- a/tiledb/sm/misc/tdb_time.cc
+++ b/tiledb/sm/misc/tdb_time.cc
@@ -45,7 +45,7 @@ namespace tiledb::sm::utils::time {
 uint64_t timestamp_now_ms() {
 #ifdef _WIN32
   struct __timeb64 tb;
-  memset(&tb, 0, sizeof(struct _timeb));
+  memset(&tb, 0, sizeof(tb));
   _ftime64_s(&tb);
   return static_cast<uint64_t>(tb.time * 1000L + tb.millitm);
 #else

--- a/tiledb/sm/misc/tdb_time.cc
+++ b/tiledb/sm/misc/tdb_time.cc
@@ -44,9 +44,9 @@ namespace tiledb::sm::utils::time {
 
 uint64_t timestamp_now_ms() {
 #ifdef _WIN32
-  struct _timeb tb;
+  struct __timeb64 tb;
   memset(&tb, 0, sizeof(struct _timeb));
-  _ftime_s(&tb);
+  _ftime64_s(&tb);
   return static_cast<uint64_t>(tb.time * 1000L + tb.millitm);
 #else
   struct timeval tp;


### PR DESCRIPTION
change for 32/64 bit consistency (corrects return of incorrect 32bit values)
(affects rtools40 32bit build)

---
TYPE: BUG
DESC: fix timestamp_no_ms() for 32bit
