### PR TITLE
Remove unnecessary static storage duration on GCS internal variables

### DIFF
--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -437,7 +437,11 @@ tuple<Status, optional<std::vector<directory_entry>>> GCS::ls_with_sizes(
     }
 
     auto& results = object_metadata.value();
-    const static std::string gcs_prefix = uri_dir.is_gcs() ? "gcs://" : "gs://";
+    // returned above if (!uri_dir.is_gcs()), i.e. one of following prefixes
+    // need to propogate orig prefix as other parse_gcs_uri() and other routines may
+    // have already set an internal 'static' gcs_prefix path to that original prefix.
+    const static std::string gcs_prefix =
+      (uri_dir.to_string().rfind("gcs://", 0) == 0) ? "gcs://" : "gs://";
 
     if (absl::holds_alternative<google::cloud::storage::ObjectMetadata>(
             results)) {

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -437,12 +437,7 @@ tuple<Status, optional<std::vector<directory_entry>>> GCS::ls_with_sizes(
     }
 
     auto& results = object_metadata.value();
-    // returned above if (!uri_dir.is_gcs()), i.e. one of following prefixes
-    // need to propogate orig prefix as other parse_gcs_uri() and other routines
-    // may have already set an internal 'static' gcs_prefix path to that
-    // original prefix.
-    const static std::string gcs_prefix =
-        (uri_dir.to_string().rfind("gcs://", 0) == 0) ? "gcs://" : "gs://";
+    const std::string gcs_prefix = uri_dir.is_gcs() ? "gcs://" : "gs://";
 
     if (absl::holds_alternative<google::cloud::storage::ObjectMetadata>(
             results)) {
@@ -1165,7 +1160,7 @@ Status GCS::parse_gcs_uri(
   assert(uri.is_gcs());
   const std::string uri_str = uri.to_string();
 
-  const static std::string gcs_prefix =
+  const std::string gcs_prefix =
       (uri_str.rfind("gcs://", 0) == 0) ? "gcs://" : "gs://";
   assert(uri_str.rfind(gcs_prefix, 0) == 0);
 

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -438,10 +438,11 @@ tuple<Status, optional<std::vector<directory_entry>>> GCS::ls_with_sizes(
 
     auto& results = object_metadata.value();
     // returned above if (!uri_dir.is_gcs()), i.e. one of following prefixes
-    // need to propogate orig prefix as other parse_gcs_uri() and other routines may
-    // have already set an internal 'static' gcs_prefix path to that original prefix.
+    // need to propogate orig prefix as other parse_gcs_uri() and other routines
+    // may have already set an internal 'static' gcs_prefix path to that
+    // original prefix.
     const static std::string gcs_prefix =
-      (uri_dir.to_string().rfind("gcs://", 0) == 0) ? "gcs://" : "gs://";
+        (uri_dir.to_string().rfind("gcs://", 0) == 0) ? "gcs://" : "gs://";
 
     if (absl::holds_alternative<google::cloud::storage::ObjectMetadata>(
             results)) {


### PR DESCRIPTION
Remove unnecessary static storage duration on GCS internal variables, which causes bugs in GCS read path.

---
TYPE: BUG
DESC: Remove unnecessary static storage duration on GCS internal variables
