### PR TITLE
fix example compilation errors, augment CI running them

### DIFF
--- a/.github/workflows/build-macOS11-GCS.yml
+++ b/.github/workflows/build-macOS11-GCS.yml
@@ -89,8 +89,10 @@ jobs:
           bootstrap_args="${bootstrap_args} --enable-release-symbols";
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
 
-          # GCS unit tests are temporarily unsupported on CI for MacOS. Fake success with
-          # this echo.
+          source $GITHUB_WORKSPACE/scripts/run-nix-examples.sh
+
+          # GCS unit tests (tiledb_unit) are temporarily unsupported on CI for MacOS GCS build.
+          # Fake success with this echo since actual tiledb_unit that does this not being run
           echo ::set-output name=TILEDB_CI_SUCCESS::1
 
           source $GITHUB_WORKSPACE/scripts/ci/build_benchmarks.sh

--- a/.github/workflows/build-macOS11-S3.yml
+++ b/.github/workflows/build-macOS11-S3.yml
@@ -96,11 +96,13 @@ jobs:
           bootstrap_args="${bootstrap_args} --enable-s3";
           bootstrap_args="${bootstrap_args} --enable-tools";
           bootstrap_args="${bootstrap_args} --enable-release-symbols";
-          
+
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
 
           ./tiledb/test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/test/regression/tiledb_regression -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
+
+          source $GITHUB_WORKSPACE/scripts/run-nix-examples.sh
 
           # Kill the running Minio server, OSX only because Linux runs it within
           # docker.

--- a/.github/workflows/build-ubuntu16.04-HDFS.yml
+++ b/.github/workflows/build-ubuntu16.04-HDFS.yml
@@ -116,6 +116,8 @@ jobs:
           ./tiledb/test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/test/regression/tiledb_regression -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
 
+          source $GITHUB_WORKSPACE/scripts/run-nix-examples.sh
+
           pushd $GITHUB_WORKSPACE/examples/cmake_project
           mkdir build && cd build
           cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dist .. && make

--- a/.github/workflows/build-ubuntu20.04-AZURE.yml
+++ b/.github/workflows/build-ubuntu20.04-AZURE.yml
@@ -117,11 +117,13 @@ jobs:
           bootstrap_args="${bootstrap_args} --enable-azure";
           bootstrap_args="${bootstrap_args} --enable-release-symbols";
           source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
-          
+
           # Bypass Catch2 Framework stdout interception with awk on test output
           # make check | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/test/regression/tiledb_regression -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
+
+          source $GITHUB_WORKSPACE/scripts/run-nix-examples.sh
 
           # Kill the running Azurite server
           kill -n 9 $AZURITE_PID

--- a/.github/workflows/build-ubuntu20.04-GCS.yml
+++ b/.github/workflows/build-ubuntu20.04-GCS.yml
@@ -110,6 +110,8 @@ jobs:
           ./tiledb/test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/test/regression/tiledb_regression -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
 
+          source $GITHUB_WORKSPACE/scripts/run-nix-examples.sh
+
           # Kill the running GCS emulator server Linux only because OSX does not
           # run the emulator
           kill -9 $GCS_PID

--- a/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
+++ b/.github/workflows/build-ubuntu20.04-SERIALIZATION.yml
@@ -103,6 +103,8 @@ jobs:
           ./tiledb/test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/test/regression/tiledb_regression -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
 
+          source $GITHUB_WORKSPACE/scripts/run-nix-examples.sh
+
           # - bash: |
           pushd $GITHUB_WORKSPACE/examples/cmake_project
           mkdir build && cd build

--- a/.github/workflows/build-ubuntu22.04-S3.yml
+++ b/.github/workflows/build-ubuntu22.04-S3.yml
@@ -113,6 +113,8 @@ jobs:
           ./tiledb/test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/test/regression/tiledb_regression -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
 
+          source $GITHUB_WORKSPACE/scripts/run-nix-examples.sh
+
           pushd $GITHUB_WORKSPACE/examples/cmake_project
           mkdir build && cd build
           cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dist .. && make

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -64,6 +64,7 @@ jobs:
       TILEDB_SERIALIZATION: ${{ matrix.TILEDB_SERIALIZATION }} #serialization }}
       TILEDB_ARROW_TESTS: ${{ matrix.TILEDB_ARROW_TESTS }}
       TILEDB_WEBP: ${{ matrix.TILEDB_WEBP }}
+      TILEDB_CMAKE_BUILD_TYPE: 'RelWithDebInfo'
     steps:
       - name: 'tiledb env prep'
         run: |
@@ -116,10 +117,10 @@ jobs:
       - name: Prepare git
         run: git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - name: core tiledb windows build 
+      - name: core tiledb windows build
         run: |
-          $ErrorView = "NormalView" 
-          
+          $ErrorView = "NormalView"
+
           #directory $env:BUILD_BUILDDIRECTORY was created in step 'tiledb env prep'
           cd $env:BUILD_BUILDDIRECTORY
 
@@ -134,7 +135,7 @@ jobs:
             Write-Host "Unknown image name: '$($env:TILEDB_GA_IMAGE_NAME)'"
             exit $LastExitCode
           }
-          
+
           # allow double-checking path
           cmd /c "echo $PATH"
 
@@ -162,8 +163,15 @@ jobs:
           if ($env:TILEDB_TOOLS -eq "ON") {
             $bootstrapOptions = $bootstrapOptions + " -EnableTools"
           }
+          $CMakeBuildType = $env:TILEDB_CMAKE_BUILD_TYPE
           if ($env:TILEDB_DEBUG -eq "ON") {
             $bootstrapOptions = $bootstrapOptions + " -EnableDebug"
+            $CMakeBuildType = "Debug"
+            # Change in environment for next steps!
+            write-host "TILEDB_CMAKE_BUILD_TYPE=$CMakeBuildType" *>> $env:GITHUB_ENV
+
+          } elseif ($CMakeBuildType -eq "RelWithDebInfo") {
+            $bootstrapOptions = $bootstrapOptions + " -EnableReleaseSymbols"
           }
           # if ($env:TILEDB_CI_ASAN -eq "ON") {
           #  $bootstrapOptions = $bootstrapOptions + " -EnableSanitizer address -EnableDebug"
@@ -181,7 +189,7 @@ jobs:
           if ($env:TILEDB_WEBP -eq "ON") {
             $bootstrapOptions = $bootstrapOptions + " -EnableWebP"
           }
-          
+
           $bootstrapExpression = "& $env:BUILD_SOURCESDIRECTORY\bootstrap.ps1 " + $bootstrapOptions
           Write-Host "bootstrapExpression: $bootstrapExpression"
           Invoke-Expression $bootstrapExpression
@@ -191,14 +199,14 @@ jobs:
             exit $LastExitCode
           }
 
-          cmake --build $env:BUILD_BUILDDIRECTORY --config Release -j $env:NUMBER_OF_PROCESSORS 2>&1
+          cmake --build $env:BUILD_BUILDDIRECTORY --config $CMakeBuildType -j $env:NUMBER_OF_PROCESSORS 2>&1
 
           if ($LastExitCode -ne 0) {
             Write-Host "Build failed. CMake exit status: " $LastExitCocde
             exit $LastExitCode
           }
 
-          cmake --build $env:BUILD_BUILDDIRECTORY --target install-tiledb --config Release 2>&1
+          cmake --build $env:BUILD_BUILDDIRECTORY --target install-tiledb --config $CMakeBuildType 2>&1
 
           if ($LastExitCode -ne 0) {
             Write-Host "Installation failed."
@@ -211,6 +219,8 @@ jobs:
         shell: powershell
         run: |
           write-host "begin run: 'Test'"
+
+          $CMakeBuildType = $env:TILEDB_CMAKE_BUILD_TYPE
 
           # Clone backwards compatibility test arrays
           if ($env:BACKWARDS_COMPATIBILITY_ARRAYS -eq "ON") {
@@ -231,8 +241,8 @@ jobs:
           }
 
           # CMake exits with non-0 status if there are any warnings during the build, so
-          cmake --build $env:BUILD_BUILDDIRECTORY\tiledb -j $env:NUMBER_OF_PROCESSORS --target tiledb_unit --config Release -- /verbosity:minimal
-          cmake --build $env:BUILD_BUILDDIRECTORY\tiledb -j $env:NUMBER_OF_PROCESSORS --target tiledb_regression --config Release -- /verbosity:minimal
+          cmake --build $env:BUILD_BUILDDIRECTORY\tiledb -j $env:NUMBER_OF_PROCESSORS --target tiledb_unit --config $CMakeBuildType -- /verbosity:minimal
+          cmake --build $env:BUILD_BUILDDIRECTORY\tiledb -j $env:NUMBER_OF_PROCESSORS --target tiledb_regression --config $CMakeBuildType -- /verbosity:minimal
 
           if ($env:TILEDB_AZURE -eq "ON") {
             if($env.TILEDB_USE_CUSTOM_NODE_JS) {
@@ -258,11 +268,11 @@ jobs:
           }
 
           # Actually run tests
-          #~ $cmds = "cmake --build $env:BUILD_BUILDDIRECTORY\tiledb --target check --config Release -- /verbosity:minimal"
+          #~ $cmds = "cmake --build $env:BUILD_BUILDDIRECTORY\tiledb --target check --config $CMakeBuildType -- /verbosity:minimal"
           #~ Write-Host "cmds: '$cmds'"
           #~ Invoke-Expression $cmds
-          #$cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\Release\tiledb_unit.exe -d=yes | c:\msys64\usr\bin\awk '/1: ::set-output/{sub(/.*1: /, `"`"); print; next} 1'"
-          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\Release\tiledb_unit.exe -d=yes"
+          #$cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\$CMakeBuildType\tiledb_unit.exe -d=yes | c:\msys64\usr\bin\awk '/1: ::set-output/{sub(/.*1: /, `"`"); print; next} 1'"
+          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\$CMakeBuildType\tiledb_unit.exe -d=yes"
           Write-Host "cmds: '$cmds'"
           Invoke-Expression $cmds
 
@@ -272,7 +282,7 @@ jobs:
           }
 
           if ($env:TILEDB_WEBP -eq "ON") {
-            $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\tiledb\sm\compressors\Release\unit_link_webp.exe"
+            $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\tiledb\sm\compressors\$CMakeBuildType\unit_link_webp.exe"
             Write-Host "cmds: '$cmds'"
             Invoke-Expression $cmds
 
@@ -282,7 +292,7 @@ jobs:
             }
           }
           # Build the examples
-          cmake --build $env:BUILD_BUILDDIRECTORY --target examples --config Release -- /verbosity:minimal
+          cmake --build $env:BUILD_BUILDDIRECTORY --target examples --config $CMakeBuildType -- /verbosity:minimal
 
           if ($LastExitCode -ne 0) {
             Write-Host "Examples failed to build."
@@ -291,27 +301,71 @@ jobs:
 
           $env:Path += ";$env:BUILD_SOURCESDIRECTORY\dist\bin;$env:BUILD_BUILDDIRECTORY\externals\install\bin"
 
-          try {
-            $exepath = Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\c_api\Release\quickstart_dense_c.exe"
-            & $exepath
-          } catch {
-            Write-Host "C API example failed. Error:"
-            Write-Host $_
-            $host.SetShouldExit(1)
-          }
+          $TestAppDir = (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\c_api")
+          $TestAppDataDir = (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\c_api\test_app_data")
+          Get-ChildItem (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\c_api\$CMakeBuildType") -Filter *.exe |
+          Foreach-Object {
+            try {
+              Set-Location -path $TestAppDir
+              Remove-Item -Path $TestAppDataDir -recurse -force -ErrorAction SilentlyContinue
+              New-Item -ItemType Directory -Path $TestAppDataDir > $nul
+              Set-Location -path $TestAppDataDir
+              $exepath = $_.FullName
+              write-host "Executing $exepath"
+              & $exepath
+              $status = $?
+              if (-not $status) {
+                Write-Host "FAILED: Error $status running $exepath"
+                Write-Host "::set-output name=TILEDB_CI_SUCCESS::0"
+                $host.SetShouldExit(1)
+              }  elseif ($LastExitCode -ne 0) {
+                Write-Host "FAILED: C++ API example failed $LastExitCode,  $exepath."
+                Write-Host "::set-output name=TILEDB_CI_SUCCESS::0"
+                $host.SetShouldExit($LastExitCode)
+              }
 
-          try {
-            $exepath = Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\cpp_api\Release\quickstart_dense_cpp.exe"
-            & $exepath
-          } catch {
-            Write-Host "C++ API example failed."
-            $host.SetShouldExit(1)
+            } catch {
+              $status = $_
+              Write-Host "FAILED: exception C API example failed, $status, $exepath."
+              Write-Host "::set-output name=TILEDB_CI_SUCCESS::0"
+              $host.SetShouldExit(1)
+            }
           }
+          Set-Location -path $TestAppDir
+          Remove-Item -Path $TestAppDataDir -recurse -force -ErrorAction SilentlyContinue
 
-          if ($LastExitCode -ne 0) {
-            Write-Host "C++ API example failed."
-            $host.SetShouldExit($LastExitCode)
+          $TestAppDir = (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\cpp_api")
+          $TestAppDataDir = (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\cpp_api\test_app_data")
+          Get-ChildItem (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\cpp_api\$CMakeBuildType") -Filter *.exe |
+          Foreach-Object {
+            try {
+              Set-Location -path $TestAppDir
+              Remove-Item -Path $TestAppDataDir -recurse -force -ErrorAction SilentlyContinue
+              New-Item -ItemType Directory -Path $TestAppDataDir > $nul
+              Set-Location -path $TestAppDataDir
+              $exepath = $_.FullName
+              write-host "Executing $exepath"
+              & $exepath
+              $status = $?
+              if (-not $status) {
+                Write-Host "FAILED: Error $status running $exepath"
+                Write-Host "::set-output name=TILEDB_CI_SUCCESS::0"
+                $host.SetShouldExit(1)
+              } elseif ($LastExitCode -ne 0) {
+                Write-Host "FAILED: C++ API example failed $LastExitCode,  $exepath."
+                Write-Host "::set-output name=TILEDB_CI_SUCCESS::0"
+                $host.SetShouldExit($LastExitCode)
+              }
+            } catch {
+              $status = $_
+              Write-Host "FAILED: exception, C++ API example failed, $status, $exepath."
+              Write-Host "::set-output name=TILEDB_CI_SUCCESS::0"
+              $host.SetShouldExit(1)
+            }
+
           }
+          Set-Location -path $TestAppDir
+          Remove-Item -Path $TestAppDataDir -recurse -force -ErrorAction SilentlyContinue
 
           # Build examples
           cd $env:BUILD_SOURCESDIRECTORY\examples\cmake_project
@@ -323,11 +377,17 @@ jobs:
           # Build zip artifact
           cmake -A X64 -DCMAKE_PREFIX_PATH="$env:BUILD_SOURCESDIRECTORY\dist" ..
 
-          cmake --build . --config Release -- /verbosity:minimal
+          cmake --build . --config $CMakeBuildType -- /verbosity:minimal
 
-          .\Release\ExampleExe.exe
+          #.\$CMakeBuildType\ExampleExe.exe
+          $cmd = ".\$CMakeBuildType\ExampleExe.exe"
+          Write-Host "cmd: '$cmd'"
+          Invoke-Expression $cmd
 
-          .\Release\ExampleExe_static.exe
+          #.\$CMakeBuildType\ExampleExe_static.exe
+          $cmd = ".\$CMakeBuildType\ExampleExe_static.exe"
+          Write-Host "cmd: '$cmd'"
+          Invoke-Expression $cmd
 
           # Packaging test
           cd $env:BUILD_SOURCESDIRECTORY\test\packaging
@@ -355,7 +415,7 @@ jobs:
         with:
           retention-days: 10
           name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{matrix.environ}}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"
-          if-no-files-found: warn # 'ignore/', 'warn' or 'error' are available, defaults to `warn` 
+          if-no-files-found: warn # 'ignore/', 'warn' or 'error' are available, defaults to `warn`
           # fails, empty env context... ${{ env.LOCALAPPDATA }}/CrashDumps/*.dmp
           path: |
             ${{ env.TDBLOCALAPPDATA }}/CrashDumps/*.dmp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -98,6 +98,9 @@ endif()
 
 # Add custom target 'examples' that builds all examples.
 add_custom_target(examples DEPENDS tiledb-header-dir examples_c)
+if (TILEDB_STATIC)
+  add_dependencies(examples static_examples_c)
+endif()
 
 if (TILEDB_CPP_API)
   add_dependencies(examples examples_cpp)

--- a/examples/c_api/CMakeLists.txt
+++ b/examples/c_api/CMakeLists.txt
@@ -33,6 +33,10 @@ set(CMAKE_C_EXTENSIONS OFF) # Don't use GNU extensions
 # Add custom target 'examples_c'
 add_custom_target(examples_c DEPENDS tiledb_shared)
 
+if (TILEDB_STATIC)
+  add_custom_target(static_examples_c DEPENDS tiledb_static)
+endif()
+
 # Function that builds an executable per example
 function(build_TileDB_example_capi TARGET)
   add_executable(${TARGET}_c EXCLUDE_FROM_ALL ${TARGET}.c)
@@ -46,6 +50,20 @@ function(build_TileDB_example_capi TARGET)
     target_link_libraries(${TARGET}_c pthread dl)
   endif()
   add_dependencies(examples_c ${TARGET}_c)
+endfunction()
+
+function(build_TileDB_static_example_capi TARGET)
+  add_executable(static_${TARGET}_c EXCLUDE_FROM_ALL ${TARGET}.c)
+  target_include_directories(static_${TARGET}_c PUBLIC
+    "${CMAKE_CURRENT_BINARY_DIR}/../"
+  )
+  target_link_libraries(static_${TARGET}_c tiledb_static)
+  if (NOT WIN32)
+    # On Linux, must explicitly link -lpthread -ldl in order for static linking
+    # to libzstd or libcurl to work.
+    target_link_libraries(static_${TARGET}_c pthread dl)
+  endif()
+  add_dependencies(static_examples_c static_${TARGET}_c)
 endfunction()
 
 # Get the example sources
@@ -65,4 +83,7 @@ foreach(EXAMPLE_SOURCE ${TILEDB_EXAMPLE_SOURCES_CAPI})
 
   # Build example executable
   build_TileDB_example_capi(${EXAMPLE_BIN})
+  if (TILEDB_STATIC)
+    build_TileDB_static_example_capi(${EXAMPLE_BIN})
+  endif()
 endforeach()

--- a/scripts/run-nix-examples.sh
+++ b/scripts/run-nix-examples.sh
@@ -1,0 +1,40 @@
+BaseDir="$(pwd)"
+TestAppDir="$(pwd)/tiledb/examples/c_api"
+TestAppDataDir="$(pwd)/tiledb/examples/c_api/test_app_data"
+for exampleexe in $(ls ${TestAppDir}/*_c) ;
+do
+  cd ${TestAppDir}
+  rm -rf ${TestAppDataDir}
+  mkdir ${TestAppDataDir}
+  cd ${TestAppDataDir}
+  echo $exampleexe
+  $exampleexe;
+  status=$?
+  if (($status != 0)); then
+    echo "FAILED: $exampleexe exited with $status"
+    echo "::set-output name=TILEDB_CI_SUCCESS::0"
+  fi
+done
+cd ${TestAppDir}
+rm -rf ${TestAppDataDir}
+
+cd ${BaseDir}
+TestAppDir="$(pwd)/tiledb/examples/cpp_api"
+TestAppDataDir="$(pwd)/tiledb/examples/cpp_api/test_app_data"
+for exampleexe in $(ls ${TestAppDir}/*_cpp) ;
+do
+  cd ${TestAppDir}
+  rm -rf ${TestAppDataDir}
+  mkdir ${TestAppDataDir}
+  cd ${TestAppDataDir}
+  echo $exampleexe
+  $exampleexe;
+  status=$?
+  if (($status != 0)); then
+    echo "FAILED: $exampleexe exited with $status"
+    echo "::set-output name=TILEDB_CI_SUCCESS::0"
+  fi
+done
+cd ${TestAppDir}
+rm -rf ${TestAppDataDir}
+cd ${BaseDir}


### PR DESCRIPTION
Correct any compilation errors currently in building of examples.

Augment CI by running through the examples that are built.

Recognize errors/failures in building/running and fault the CI run when encountered.

Add build of static _c executables for static builds.

TYPE: NO_HISTORY
DESC: address CI issues with building/running examples
