### PR TITLE
Query condition: enable dimensions for sparse arrays.

### DIFF
--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -111,6 +111,8 @@ void create_array(
   if (array_type == TILEDB_DENSE) {
     attr_a.set_fill_value(&a_fill_value, sizeof(int));
     attr_b.set_fill_value(&b_fill_value, sizeof(float));
+  } else {
+    schema.set_capacity(16);
   }
   schema.add_attribute(attr_a);
   schema.add_attribute(attr_b);
@@ -234,15 +236,20 @@ static void perform_query(
 
 struct TestParams {
   TestParams(
-      tiledb_array_type_t array_type, tiledb_layout_t layout, bool set_dups)
+      tiledb_array_type_t array_type,
+      tiledb_layout_t layout,
+      bool set_dups,
+      bool legacy)
       : array_type_(array_type)
       , layout_(layout)
-      , set_dups_(set_dups) {
+      , set_dups_(set_dups)
+      , legacy_(legacy) {
   }
 
   tiledb_array_type_t array_type_;
   tiledb_layout_t layout_;
   bool set_dups_;
+  bool legacy_;
 };
 
 TEST_CASE(
@@ -253,8 +260,9 @@ TEST_CASE(
   Context ctx;
   VFS vfs(ctx);
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 
   // Define query condition (b < 4.0).
   QueryCondition qc(ctx);
@@ -272,9 +280,9 @@ TEST_CASE(
 
   // Generate test parameters.
   TestParams params = GENERATE(
-      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false),
-      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true),
-      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false));
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false),
+      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false, false));
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
@@ -282,8 +290,14 @@ TEST_CASE(
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array);
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
 
   // Set a subarray for dense.
   if (params.array_type_ == TILEDB_DENSE) {
@@ -327,7 +341,7 @@ TEST_CASE(
     }
   } else {
     // Check the query for accuracy. The query results should contain 400
-    // elements. Elements that meet the query conditioe should have the cell
+    // elements. Elements that meet the query condition should have the cell
     // value 1 on attribute a and should match the original value in the array
     // on attribute b. Elements that do not should have the fill value for both
     // attributes.
@@ -371,8 +385,9 @@ TEST_CASE(
   Context ctx;
   VFS vfs(ctx);
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 
   // Define query condition (b < 4.0).
   QueryCondition qc(ctx);
@@ -390,9 +405,9 @@ TEST_CASE(
 
   // Generate test parameters.
   TestParams params = GENERATE(
-      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false),
-      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true),
-      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false));
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false),
+      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false, false));
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
@@ -400,8 +415,14 @@ TEST_CASE(
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array);
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
 
   // Define range.
   int range[] = {2, 3};
@@ -474,8 +495,9 @@ TEST_CASE(
   query.finalize();
   array.close();
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 }
 
 TEST_CASE(
@@ -487,8 +509,9 @@ TEST_CASE(
   Context ctx;
   VFS vfs(ctx);
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 
   // Define query condition (b < 4.0).
   QueryCondition qc(ctx);
@@ -506,9 +529,9 @@ TEST_CASE(
 
   // Generate test parameters.
   TestParams params = GENERATE(
-      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false),
-      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true),
-      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false));
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false),
+      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false, false));
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
@@ -516,8 +539,14 @@ TEST_CASE(
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array);
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
 
   // Define range.
   int range[] = {2, 3};
@@ -600,8 +629,9 @@ TEST_CASE(
   query.finalize();
   array.close();
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 }
 
 TEST_CASE(
@@ -613,8 +643,9 @@ TEST_CASE(
   Context ctx;
   VFS vfs(ctx);
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 
   // Define query condition (b < 4.0).
   QueryCondition qc(ctx);
@@ -632,9 +663,9 @@ TEST_CASE(
 
   // Generate test parameters.
   TestParams params = GENERATE(
-      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false),
-      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true),
-      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false));
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false),
+      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false, false));
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
@@ -642,8 +673,14 @@ TEST_CASE(
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array);
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
 
   // Define range.
   int range[] = {2, 3};
@@ -712,8 +749,9 @@ TEST_CASE(
   query.finalize();
   array.close();
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 }
 
 TEST_CASE(
@@ -725,8 +763,9 @@ TEST_CASE(
   Context ctx;
   VFS vfs(ctx);
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 
   // Define query condition (b < 4.0).
   QueryCondition qc(ctx);
@@ -744,9 +783,9 @@ TEST_CASE(
 
   // Generate test parameters.
   TestParams params = GENERATE(
-      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false),
-      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true),
-      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false));
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false),
+      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false, false));
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
@@ -754,8 +793,14 @@ TEST_CASE(
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array);
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
 
   // Define range.
   int range[] = {7, 14};
@@ -844,8 +889,9 @@ TEST_CASE(
   query.finalize();
   array.close();
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 }
 
 TEST_CASE(
@@ -857,8 +903,9 @@ TEST_CASE(
   Context ctx;
   VFS vfs(ctx);
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 
   // Define query condition (b < 4.0f AND b <= 3.7f AND b >= 3.3f AND b
   // != 3.4f);
@@ -893,9 +940,9 @@ TEST_CASE(
 
   // Generate test parameters.
   TestParams params = GENERATE(
-      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false),
-      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true),
-      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false));
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false),
+      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false, false));
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
@@ -903,8 +950,14 @@ TEST_CASE(
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array);
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
 
   // Define range.
   int range[] = {7, 14};
@@ -994,8 +1047,9 @@ TEST_CASE(
   query.finalize();
   array.close();
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 }
 
 TEST_CASE(
@@ -1004,8 +1058,9 @@ TEST_CASE(
   Context ctx;
   VFS vfs(ctx);
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
 
   // Create a simple 1D vector with domain 1-10 and one attribute.
   Domain domain(ctx);
@@ -1062,6 +1117,656 @@ TEST_CASE(
 
   array_r.close();
 
-  if (vfs.is_dir(array_name))
+  if (vfs.is_dir(array_name)) {
     vfs.remove_dir(array_name);
+  }
+}
+
+TEST_CASE(
+    "Testing read query with basic QC, condition on dimension, with range "
+    "within a tile.",
+    "[query][query-condition][dimension]") {
+  // Initial setup.
+  std::srand(static_cast<uint32_t>(time(0)));
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+
+  // Define query condition (b < 4.0).
+  QueryCondition qc(ctx);
+  float val = 4.0f;
+  qc.init("b", &val, sizeof(float), TILEDB_LT);
+
+  // Define ranges through query condition.
+  int range[] = {2, 3};
+  QueryCondition qc_range_rows_1(ctx);
+  qc_range_rows_1.init("rows", &range[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_rows_1, TILEDB_AND);
+
+  QueryCondition qc_range_rows_2(ctx);
+  qc_range_rows_2.init("rows", &range[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_rows_2, TILEDB_AND);
+
+  QueryCondition qc_range_cols_1(ctx);
+  qc_range_cols_1.init("cols", &range[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_cols_1, TILEDB_AND);
+
+  QueryCondition qc_range_cols_2(ctx);
+  qc_range_cols_2.init("cols", &range[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_cols_2, TILEDB_AND);
+
+  // Create buffers with size of the results of the two queries.
+  std::vector<int> a_data_read(num_rows * num_rows);
+  std::vector<float> b_data_read(num_rows * num_rows);
+
+  // These buffers store the results of the second query made with the query
+  // condition specified above.
+  std::vector<int> a_data_read_2(num_rows * num_rows);
+  std::vector<float> b_data_read_2(num_rows * num_rows);
+
+  // Generate test parameters.
+  TestParams params = GENERATE(
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, false),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false));
+
+  // Setup by creating buffers to store all elements of the original array.
+  create_array(
+      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+
+  // Create the query, which reads over the entire array with query condition
+  // (b < 4.0).
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
+
+  // Perform query and validate.
+  perform_query(a_data_read_2, b_data_read_2, qc, params.layout_, query);
+
+  // Check the query for accuracy. The query results should contain 2
+  // elements.
+  auto table = query.result_buffer_elements();
+  REQUIRE(table.size() == 2);
+  REQUIRE(table["a"].first == 0);
+  REQUIRE(table["a"].second == 2);
+  REQUIRE(table["b"].first == 0);
+  REQUIRE(table["b"].second == 2);
+
+  // Testing (2,3), which should be in the result buffer.
+  int ind_0 = index_from_row_col(2, 3);
+  REQUIRE(a_data_read_2[0] == a_data_read[ind_0]);
+  REQUIRE(
+      fabs(b_data_read_2[0] - b_data_read[ind_0]) <
+      std::numeric_limits<float>::epsilon());
+
+  // Testing (3,3), which should be in the result buffer.
+  int ind_1 = index_from_row_col(3, 3);
+  REQUIRE(a_data_read_2[1] == a_data_read[ind_1]);
+  REQUIRE(
+      fabs(b_data_read_2[1] - b_data_read[ind_1]) <
+      std::numeric_limits<float>::epsilon());
+
+  query.finalize();
+  array.close();
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+}
+
+TEST_CASE(
+    "Testing read query with basic QC, condition on dimension, with range "
+    "across tile for rows dimension, within tile for cols dimension.",
+    "[query][query-condition][dimension]") {
+  // Initial setup.
+  std::srand(static_cast<uint32_t>(time(0)));
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+
+  // Define query condition (b < 4.0).
+  QueryCondition qc(ctx);
+  float val = 4.0f;
+  qc.init("b", &val, sizeof(float), TILEDB_LT);
+
+  // Define ranges through query condition.
+  int range[] = {2, 3};
+  int range1[] = {7, 10};
+  QueryCondition qc_range_rows_1(ctx);
+  qc_range_rows_1.init("rows", &range1[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_rows_1, TILEDB_AND);
+
+  QueryCondition qc_range_rows_2(ctx);
+  qc_range_rows_2.init("rows", &range1[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_rows_2, TILEDB_AND);
+
+  QueryCondition qc_range_cols_1(ctx);
+  qc_range_cols_1.init("cols", &range[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_cols_1, TILEDB_AND);
+
+  QueryCondition qc_range_cols_2(ctx);
+  qc_range_cols_2.init("cols", &range[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_cols_2, TILEDB_AND);
+
+  // Create buffers with size of the results of the two queries.
+  std::vector<int> a_data_read(num_rows * num_rows);
+  std::vector<float> b_data_read(num_rows * num_rows);
+
+  // These buffers store the results of the second query made with the query
+  // condition specified above.
+  std::vector<int> a_data_read_2(num_rows * num_rows);
+  std::vector<float> b_data_read_2(num_rows * num_rows);
+
+  // Generate test parameters.
+  TestParams params = GENERATE(
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, false),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false));
+
+  // Setup by creating buffers to store all elements of the original array.
+  create_array(
+      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+
+  // Create the query, which reads over the entire array with query condition
+  // (b < 4.0).
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
+
+  // Perform query and validate.
+  perform_query(a_data_read_2, b_data_read_2, qc, params.layout_, query);
+
+  // Check the query for accuracy. The query results should contain 2
+  // elements.
+  auto table = query.result_buffer_elements();
+  REQUIRE(table.size() == 2);
+  REQUIRE(table["a"].first == 0);
+  REQUIRE(table["a"].second == 4);
+  REQUIRE(table["b"].first == 0);
+  REQUIRE(table["b"].second == 4);
+
+  // Testing (7,3), which should be in the result buffer.
+  int ind_0 = index_from_row_col(7, 3);
+  REQUIRE(a_data_read_2[0] == a_data_read[ind_0]);
+  REQUIRE(
+      fabs(b_data_read_2[0] - b_data_read[ind_0]) <
+      std::numeric_limits<float>::epsilon());
+
+  // Testing (8,3), which should be in the result buffer.
+  int ind_1 = index_from_row_col(8, 3);
+  REQUIRE(a_data_read_2[1] == a_data_read[ind_1]);
+  REQUIRE(
+      fabs(b_data_read_2[1] - b_data_read[ind_1]) <
+      std::numeric_limits<float>::epsilon());
+
+  // Testing (9,3), which should be in the result buffer.
+  int ind_2 = index_from_row_col(9, 3);
+  REQUIRE(a_data_read_2[2] == a_data_read[ind_2]);
+  REQUIRE(
+      fabs(b_data_read_2[2] - b_data_read[ind_2]) <
+      std::numeric_limits<float>::epsilon());
+
+  // Testing (10,3), which should be in the result buffer.
+  int ind_3 = index_from_row_col(10, 3);
+  REQUIRE(a_data_read_2[3] == a_data_read[ind_3]);
+  REQUIRE(
+      fabs(b_data_read_2[3] - b_data_read[ind_3]) <
+      std::numeric_limits<float>::epsilon());
+
+  query.finalize();
+  array.close();
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+}
+
+TEST_CASE(
+    "Testing read query with basic QC, condition on dimension, with range "
+    "within tile for rows dimension, across tile for cols dimension.",
+    "[query][query-condition][dimension]") {
+  // Initial setup.
+  std::srand(static_cast<uint32_t>(time(0)));
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+
+  // Define query condition (b < 4.0).
+  QueryCondition qc(ctx);
+  float val = 4.0f;
+  qc.init("b", &val, sizeof(float), TILEDB_LT);
+
+  // Define ranges through query condition.
+  int range[] = {2, 3};
+  int range1[] = {7, 10};
+  QueryCondition qc_range_rows_1(ctx);
+  qc_range_rows_1.init("rows", &range[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_rows_1, TILEDB_AND);
+
+  QueryCondition qc_range_rows_2(ctx);
+  qc_range_rows_2.init("rows", &range[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_rows_2, TILEDB_AND);
+
+  QueryCondition qc_range_cols_1(ctx);
+  qc_range_cols_1.init("cols", &range1[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_cols_1, TILEDB_AND);
+
+  QueryCondition qc_range_cols_2(ctx);
+  qc_range_cols_2.init("cols", &range1[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_cols_2, TILEDB_AND);
+
+  // Create buffers with size of the results of the two queries.
+  std::vector<int> a_data_read(num_rows * num_rows);
+  std::vector<float> b_data_read(num_rows * num_rows);
+
+  // These buffers store the results of the second query made with the query
+  // condition specified above.
+  std::vector<int> a_data_read_2(num_rows * num_rows);
+  std::vector<float> b_data_read_2(num_rows * num_rows);
+
+  // Generate test parameters.
+  TestParams params = GENERATE(
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, false),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false));
+
+  // Setup by creating buffers to store all elements of the original array.
+  create_array(
+      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+
+  // Create the query, which reads over the entire array with query condition
+  // (b < 4.0).
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
+
+  // Perform query and validate.
+  perform_query(a_data_read_2, b_data_read_2, qc, params.layout_, query);
+
+  // Check the query for accuracy. The query results should contain 4
+  // elements.
+  auto table = query.result_buffer_elements();
+  REQUIRE(table.size() == 2);
+  REQUIRE(table["a"].first == 0);
+  REQUIRE(table["a"].second == 4);
+  REQUIRE(table["b"].first == 0);
+  REQUIRE(table["b"].second == 4);
+
+  // Ensure that the same data is in each array (global order).
+  int i = 0;
+  for (int c = range1[0]; c <= range1[1]; c += 2) {
+    for (int r = range[0]; r <= range[1]; ++r) {
+      int original_arr_i = index_from_row_col(r, c);
+      REQUIRE(a_data_read_2[i] == a_data_read[original_arr_i]);
+      REQUIRE(
+          fabs(b_data_read_2[i] - b_data_read[original_arr_i]) <
+          std::numeric_limits<float>::epsilon());
+      i += 1;
+    }
+  }
+
+  query.finalize();
+  array.close();
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+}
+
+TEST_CASE(
+    "Testing read query with basic QC, condition on dimension, with ranges "
+    "across tiles on both dimensions.",
+    "[query][query-condition][dimension]") {
+  // Initial setup.
+  std::srand(static_cast<uint32_t>(time(0)));
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+
+  // Define query condition (b < 4.0).
+  QueryCondition qc(ctx);
+  float val = 4.0f;
+  qc.init("b", &val, sizeof(float), TILEDB_LT);
+
+  // Define ranges through query condition.
+  int range[] = {7, 14};
+  QueryCondition qc_range_rows_1(ctx);
+  qc_range_rows_1.init("rows", &range[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_rows_1, TILEDB_AND);
+
+  QueryCondition qc_range_rows_2(ctx);
+  qc_range_rows_2.init("rows", &range[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_rows_2, TILEDB_AND);
+
+  QueryCondition qc_range_cols_1(ctx);
+  qc_range_cols_1.init("cols", &range[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_cols_1, TILEDB_AND);
+
+  QueryCondition qc_range_cols_2(ctx);
+  qc_range_cols_2.init("cols", &range[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_cols_2, TILEDB_AND);
+
+  // Create buffers with size of the results of the two queries.
+  std::vector<int> a_data_read(num_rows * num_rows);
+  std::vector<float> b_data_read(num_rows * num_rows);
+
+  // These buffers store the results of the second query made with the query
+  // condition specified above.
+  std::vector<int> a_data_read_2(num_rows * num_rows);
+  std::vector<float> b_data_read_2(num_rows * num_rows);
+
+  // Generate test parameters.
+  TestParams params = GENERATE(
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, false),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false));
+
+  // Setup by creating buffers to store all elements of the original array.
+  create_array(
+      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+
+  // Create the query, which reads over the entire array with query condition
+  // (b < 4.0).
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
+
+  // Perform query and validate.
+  perform_query(a_data_read_2, b_data_read_2, qc, params.layout_, query);
+
+  // Check the query for accuracy. The query results should contain 32
+  // elements.
+  auto table = query.result_buffer_elements();
+  REQUIRE(table.size() == 2);
+  REQUIRE(table["a"].first == 0);
+  REQUIRE(table["a"].second == 32);
+  REQUIRE(table["b"].first == 0);
+  REQUIRE(table["b"].second == 32);
+
+  int i = 0;
+  std::vector<std::pair<int, int>> ranges_vec;
+  ranges_vec.push_back(std::make_pair(7, 8));
+  ranges_vec.push_back(std::make_pair(9, 12));
+  ranges_vec.push_back(std::make_pair(13, 14));
+
+  for (size_t a = 0; a < 3; ++a) {    // Iterating over rows.
+    for (size_t b = 0; b < 3; ++b) {  // Iterating over cols.
+      int row_lo = ranges_vec[a].first;
+      int row_hi = ranges_vec[a].second;
+      int col_lo = ranges_vec[b].first;
+      int col_hi = ranges_vec[b].second;
+
+      for (int r = row_lo; r <= row_hi; ++r) {
+        for (int c = col_lo; c <= col_hi; ++c) {
+          int original_arr_i = index_from_row_col(r, c);
+          // The buffer should have kept elements that were originally
+          // constructed to have values less than 4.0; this means that any
+          // element whose original index is even should be in the result
+          // buffer.
+          if (original_arr_i % 2 == 0) {
+            REQUIRE(a_data_read_2[i] == 1);
+            REQUIRE(a_data_read_2[i] == a_data_read[original_arr_i]);
+            REQUIRE(
+                fabs(b_data_read_2[i] - b_data_read[original_arr_i]) <
+                std::numeric_limits<float>::epsilon());
+            i += 1;
+          }
+        }
+      }
+    }
+  }
+
+  query.finalize();
+  array.close();
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+}
+
+TEST_CASE(
+    "Testing read query with complex QC, condition on dimensions, with ranges "
+    "across tiles on both dimensions.",
+    "[query][query-condition][dimension]") {
+  // Initial setup.
+  std::srand(static_cast<uint32_t>(time(0)));
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+
+  // Define query condition (b < 4.0f AND b <= 3.7f AND b >= 3.3f AND b
+  // != 3.4f);
+  QueryCondition qc1(ctx);
+  float val1 = 4.0f;
+  qc1.init("b", &val1, sizeof(float), TILEDB_LT);
+
+  QueryCondition qc2(ctx);
+  float val2 = 3.7f;
+  qc2.init("b", &val2, sizeof(float), TILEDB_LE);
+
+  QueryCondition qc3(ctx);
+  float val3 = 3.3f;
+  qc3.init("b", &val3, sizeof(float), TILEDB_GE);
+
+  QueryCondition qc4(ctx);
+  float val4 = 3.4f;
+  qc4.init("b", &val4, sizeof(float), TILEDB_NE);
+
+  QueryCondition qc5 = qc1.combine(qc2, TILEDB_AND);
+  QueryCondition qc6 = qc5.combine(qc3, TILEDB_AND);
+  QueryCondition qc = qc6.combine(qc4, TILEDB_AND);
+
+  // Define ranges through query condition.
+  int range[] = {7, 14};
+  QueryCondition qc_range_rows_1(ctx);
+  qc_range_rows_1.init("rows", &range[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_rows_1, TILEDB_AND);
+
+  QueryCondition qc_range_rows_2(ctx);
+  qc_range_rows_2.init("rows", &range[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_rows_2, TILEDB_AND);
+
+  QueryCondition qc_range_cols_1(ctx);
+  qc_range_cols_1.init("cols", &range[0], sizeof(int), TILEDB_GE);
+  qc = qc.combine(qc_range_cols_1, TILEDB_AND);
+
+  QueryCondition qc_range_cols_2(ctx);
+  qc_range_cols_2.init("cols", &range[1], sizeof(int), TILEDB_LE);
+  qc = qc.combine(qc_range_cols_2, TILEDB_AND);
+
+  // Create buffers with size of the results of the two queries.
+  std::vector<int> a_data_read(num_rows * num_rows);
+  std::vector<float> b_data_read(num_rows * num_rows);
+
+  // These buffers store the results of the second query made with the query
+  // condition specified above.
+  std::vector<int> a_data_read_2(num_rows * num_rows);
+  std::vector<float> b_data_read_2(num_rows * num_rows);
+
+  // Generate test parameters.
+  TestParams params = GENERATE(
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, false),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false));
+
+  // Setup by creating buffers to store all elements of the original array.
+  create_array(
+      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+
+  // Create the query, which reads over the entire array with query condition
+  // (b < 4.0).
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
+
+  // Perform query and validate.
+  perform_query(a_data_read_2, b_data_read_2, qc, params.layout_, query);
+
+  // Check the query for accuracy. The query results should contain 8
+  // elements.
+  auto table = query.result_buffer_elements();
+  REQUIRE(table.size() == 2);
+  REQUIRE(table["a"].first == 0);
+  REQUIRE(table["a"].second == 8);
+  REQUIRE(table["b"].first == 0);
+  REQUIRE(table["b"].second == 8);
+
+  int i = 0;
+  std::vector<std::pair<int, int>> ranges_vec;
+  ranges_vec.push_back(std::make_pair(7, 8));
+  ranges_vec.push_back(std::make_pair(9, 12));
+  ranges_vec.push_back(std::make_pair(13, 14));
+
+  for (size_t a = 0; a < 3; ++a) {    // Iterating over rows.
+    for (size_t b = 0; b < 3; ++b) {  // Iterating over cols.
+      int row_lo = ranges_vec[a].first;
+      int row_hi = ranges_vec[a].second;
+      int col_lo = ranges_vec[b].first;
+      int col_hi = ranges_vec[b].second;
+
+      for (int r = row_lo; r <= row_hi; ++r) {
+        for (int c = col_lo; c <= col_hi; ++c) {
+          int original_arr_i = index_from_row_col(r, c);
+          // The buffer should have kept elements that were originally
+          // constructed to have values that satisfy the range [3.3, 3.7] but
+          // are not equal to 3.4. This means that any element whose original
+          // index is 4 mod 8 should be in the result buffer.
+          if (original_arr_i % 8 == 4) {
+            REQUIRE(a_data_read_2[i] == 1);
+            REQUIRE(a_data_read_2[i] == a_data_read[original_arr_i]);
+            REQUIRE(
+                fabs(b_data_read_2[i] - b_data_read[original_arr_i]) <
+                std::numeric_limits<float>::epsilon());
+            i += 1;
+          }
+        }
+      }
+    }
+  }
+
+  query.finalize();
+  array.close();
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+}
+
+TEST_CASE(
+    "Testing read query with simple QC, condition on dimensions, string dim",
+    "[query][query-condition][dimension]") {
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{1, 4}}, 4))
+      .add_dimension(Dimension::create(
+          ctx, "cols", TILEDB_STRING_ASCII, nullptr, nullptr));
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  Attribute attr_a = Attribute::create<int>(ctx, "a");
+  schema.set_capacity(16);
+  schema.add_attribute(attr_a);
+  Array::create(array_name, schema);
+
+  // Write some initial data and close the array.
+  std::vector<int> rows_dims = {1, 2};
+  std::string cols_dims = "ab";
+  std::vector<uint64_t> cols_dim_offs = {0, 1};
+  std::vector<int> a_data = {3, 4};
+
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w);
+  query_w.set_layout(TILEDB_UNORDERED)
+      .set_data_buffer("rows", rows_dims)
+      .set_data_buffer("cols", cols_dims)
+      .set_offsets_buffer("cols", cols_dim_offs)
+      .set_data_buffer("a", a_data);
+
+  query_w.submit();
+  query_w.finalize();
+  array_w.close();
+
+  // Read the data with query condition on the string dimension.
+  Array array(ctx, array_name, TILEDB_READ);
+  Query query(ctx, array);
+
+  QueryCondition qc(ctx);
+  std::string val = "b";
+  qc.init("cols", val.data(), 1, TILEDB_EQ);
+
+  std::vector<int> rows_read(1);
+  std::string cols_read;
+  cols_read.resize(1);
+  std::vector<uint64_t> cols_offs_read(1);
+  std::vector<int> a_read(1);
+
+  query.set_layout(TILEDB_GLOBAL_ORDER)
+      .set_data_buffer("rows", rows_read)
+      .set_data_buffer("cols", cols_read)
+      .set_offsets_buffer("cols", cols_offs_read)
+      .set_data_buffer("a", a_read)
+      .set_condition(qc);
+  query.submit();
+  CHECK(query.query_status() == Query::Status::COMPLETE);
+
+  // Check the query for accuracy. The query results should contain 1 element.
+  auto table = query.result_buffer_elements();
+  CHECK(table.size() == 3);
+  CHECK(table["a"].first == 0);
+  CHECK(table["a"].second == 1);
+
+  CHECK(rows_read[0] == 2);
+  CHECK(cols_read == "b");
+  CHECK(cols_offs_read[0] == 0);
+  CHECK(a_read[0] == 4);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
 }

--- a/tiledb/sm/query/ast/query_ast.cc
+++ b/tiledb/sm/query/ast/query_ast.cc
@@ -61,32 +61,12 @@ bool ASTNodeVal::is_backwards_compatible() const {
 
 Status ASTNodeVal::check_node_validity(const ArraySchema& array_schema) const {
   const uint64_t condition_value_size = condition_value_data_.size();
-  const bool is_dim = array_schema.is_dim(field_name_);
 
-  bool nullable = false;
-  bool var_size = false;
-  auto type = Datatype::ANY;
-  unsigned cell_val_num = 0;
-  size_t cell_size = 0;
-  if (is_dim) {
-    if (array_schema.dense()) {
-      return Status_QueryConditionError(
-          "Value node field name is not an attribute " + field_name_);
-    }
-
-    const auto dim_ptr = array_schema.dimension_ptr(field_name_);
-    var_size = dim_ptr->var_size();
-    type = dim_ptr->type();
-    cell_val_num = dim_ptr->cell_val_num();
-    cell_size = dim_ptr->coord_size();
-  } else {
-    const auto attribute = array_schema.attribute(field_name_);
-    nullable = attribute->nullable();
-    var_size = attribute->var_size();
-    type = attribute->type();
-    cell_val_num = attribute->cell_val_num();
-    cell_size = attribute->cell_size();
-  }
+  const auto nullable = array_schema.is_nullable(field_name_);
+  const auto var_size = array_schema.var_size(field_name_);
+  const auto type = array_schema.type(field_name_);
+  const auto cell_size = array_schema.cell_size(field_name_);
+  const auto cell_val_num = array_schema.cell_val_num(field_name_);
 
   // Ensure that null value can only be used with equality operators.
   if (condition_value_view_.content() == nullptr) {

--- a/tiledb/sm/query/ast/query_ast.h
+++ b/tiledb/sm/query/ast/query_ast.h
@@ -44,6 +44,7 @@
 #include "tiledb/common/types/untyped_datum.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/enums/query_condition_combination_op.h"
 #include "tiledb/sm/enums/query_condition_op.h"
 

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1672,31 +1672,14 @@ void QueryCondition::apply_ast_node_sparse(
     ResultTile& result_tile,
     CombinationOp combination_op,
     std::vector<BitmapType>& result_bitmap) const {
-  bool var_size = false, nullable = false;
-
-  // Initialize to timestamps type.
-  Datatype type = Datatype::UINT64;
   std::string node_field_name = node->get_field_name();
-  if (node_field_name != constants::timestamps) {
-    if (array_schema.is_dim(node_field_name)) {
-      const auto dim_ptr = array_schema.dimension_ptr(node_field_name);
-      var_size = dim_ptr->var_size();
-      type = dim_ptr->type();
-    } else {
-      const auto attribute = array_schema.attribute(node_field_name);
-      if (!attribute) {
-        throw std::runtime_error("Unknown attribute " + node_field_name);
-      }
-
-      var_size = attribute->var_size();
-      nullable = attribute->nullable();
-      type = attribute->type();
-    }
-  }
+  const auto nullable = array_schema.is_nullable(node_field_name);
+  const auto var_size = array_schema.var_size(node_field_name);
+  const auto type = array_schema.type(node_field_name);
 
   // Process the validity buffer now.
   if (nullable) {
-    const auto tile_tuple = result_tile.tile_tuple(node->get_field_name());
+    const auto tile_tuple = result_tile.tile_tuple(node_field_name);
     const auto& tile_validity = std::get<2>(*tile_tuple);
     const auto buffer_validity = static_cast<uint8_t*>(tile_validity.data());
 

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -536,26 +536,19 @@ void QueryCondition::apply_ast_node(
     const std::vector<ResultCellSlab>& result_cell_slabs,
     CombinationOp combination_op,
     std::vector<uint8_t>& result_cell_bitmap) const {
-  bool var_size = false, nullable = false;
-
-  // Initialize to timestamps type.
-  Datatype type = Datatype::UINT64;
   std::string node_field_name = node->get_field_name();
+
+  const auto nullable = array_schema.is_nullable(node_field_name);
+  const auto var_size = array_schema.var_size(node_field_name);
+  const auto type = array_schema.type(node_field_name);
+
   ByteVecValue fill_value;
   if (node_field_name != constants::timestamps) {
-    if (array_schema.is_dim(node_field_name)) {
-      const auto dim_ptr = array_schema.dimension_ptr(node_field_name);
-      var_size = dim_ptr->var_size();
-      type = dim_ptr->type();
-    } else {
+    if (!array_schema.is_dim(node_field_name)) {
       const auto attribute = array_schema.attribute(node_field_name);
       if (!attribute) {
         throw std::runtime_error("Unknown attribute " + node_field_name);
       }
-
-      var_size = attribute->var_size();
-      nullable = attribute->nullable();
-      type = attribute->type();
       fill_value = attribute->fill_value();
     }
   }

--- a/tiledb/sm/query/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/sparse_global_order_reader.cc
@@ -170,7 +170,7 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
   }
 
   // Load initial data, if not loaded already.
-  RETURN_NOT_OK(load_initial_data());
+  RETURN_NOT_OK(load_initial_data(true));
 
   // Attributes names to process.
   std::vector<std::string> names;

--- a/tiledb/sm/query/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/sparse_index_reader_base.cc
@@ -181,8 +181,9 @@ SparseIndexReaderBase::get_coord_tiles_size(
   tiles_size += sizeof(ResultTileWithBitmap<BitmapType>);
 
   // Add the tile bitmap size if there is a subarray.
-  if (subarray_.is_set())
+  if (subarray_.is_set()) {
     tiles_size += fragment_metadata_[f]->cell_num(t) * sizeof(BitmapType);
+  }
 
   if (include_timestamps(f)) {
     tiles_size +=
@@ -203,7 +204,7 @@ SparseIndexReaderBase::get_coord_tiles_size(
   return {Status::Ok(), std::make_pair(tiles_size, tiles_size_qc)};
 }
 
-Status SparseIndexReaderBase::load_initial_data() {
+Status SparseIndexReaderBase::load_initial_data(bool include_coords) {
   if (initial_data_loaded_)
     return Status::Ok();
 
@@ -214,7 +215,9 @@ Status SparseIndexReaderBase::load_initial_data() {
   if (!initial_data_loaded_) {
     if (!condition_.empty()) {
       for (auto& name : condition_.field_names()) {
-        qc_loaded_names_.emplace_back(name);
+        if (!array_schema_.is_dim(name) || !include_coords) {
+          qc_loaded_names_.emplace_back(name);
+        }
       }
     }
   }

--- a/tiledb/sm/query/sparse_index_reader_base.h
+++ b/tiledb/sm/query/sparse_index_reader_base.h
@@ -333,9 +333,10 @@ class SparseIndexReaderBase : public ReaderBase {
   /**
    * Load tile offsets and result tile ranges.
    *
+   * @param include_coords Are coords included.
    * @return Status.
    */
-  Status load_initial_data();
+  Status load_initial_data(bool include_coords);
 
   /**
    * Read and unfilter coord tiles.

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -169,7 +169,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
   }
 
   // Load initial data, if not loaded already.
-  RETURN_NOT_OK(load_initial_data());
+  RETURN_NOT_OK(load_initial_data(subarray_.is_set()));
 
   // Attributes names to process.
   std::vector<std::string> names;

--- a/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/sparse_unordered_with_dups_reader.cc
@@ -168,7 +168,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
     return Status::Ok();
   }
 
-  // Load initial data, if not loaded already.
+  // Load initial data, if not loaded already. Coords are only included if the
+  // subarray is set.
   RETURN_NOT_OK(load_initial_data(subarray_.is_set()));
 
   // Attributes names to process.


### PR DESCRIPTION
This change enables query condition on dimensions for sparse arrays. For
now, it uses the regular query condition evaluation. Later, we can
implement a more performant way through ranges.

---
TYPE: IMPROVEMENT
DESC: Query condition: enable dimensions for sparse arrays.
