### PR TITLE
Add backward compatibility arrays to CI matrix for 2.8 and 2.9

### DIFF
--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -27,7 +27,8 @@ jobs:
         os:
           - ubuntu-20.04
         # Note: v2_1_0 arrays were never created so its currently skipped
-        tiledb_version: ["v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v2_0_0", "v2_2_0", "v2_2_3", "v2_3_0", "v2_4_0", "v2_5_0", "v2_6_0", "v2_7_0"]
+        # Note: This matrix is used to set the value of TILEDB_COMPATIBILITY_VERSION
+        tiledb_version: ["v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v2_0_0", "v2_2_0", "v2_2_3", "v2_3_0", "v2_4_0", "v2_5_0", "v2_6_0", "v2_7_0", "v2_8_3", "v2_9_1"]
     timeout-minutes: 120
     name: Ubuntu-20.04-back-comp
     steps:
@@ -92,7 +93,9 @@ jobs:
           ulimit -c unlimited
           ulimit -c
 
-          git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch 2.7.1 test/inputs/arrays/read_compatibility_test
+          # we clone the latest version, because we are specifying the
+          # test target version in the TILEDB_COMPATIBILITY_VERSION variable
+          git clone https://github.com/TileDB-Inc/TileDB-Unit-Test-Arrays.git --branch main test/inputs/arrays/read_compatibility_test
 
           # Remove all arrays besides the current matrix version
           ls test/inputs/arrays/read_compatibility_test/ | grep -v ${TILEDB_COMPATIBILITY_VERSION} | grep -v "__tiledb_group.tdb" | xargs -I{} echo "rm -r test/inputs/arrays/read_compatibility_test/{}"


### PR DESCRIPTION

---
TYPE: NO_HISTORY
