### PR TITLE
Comment out Go annotation import in tiledb-rest.capnp

### DIFF
--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -3,9 +3,11 @@
 using Json = import "/capnp/compat/json.capnp";
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("tiledb::sm::serialization::capnp");
-using Go = import "/go.capnp";
-$Go.package("capnp_models");
-$Go.import("capnp_models");
+
+# ** un-comment below for Go generator use **
+#using Go = import "/go.capnp";
+#$Go.package("capnp_models");
+#$Go.import("capnp_models");
 
 struct DomainArray {
   int8 @0 :List(Int8);


### PR DESCRIPTION
This import imposes a hard dependency on Go capnproto2 available
and installed locally.

At this time capnp does not support conditional imports or any other
mechanisms to avoid commenting out the code.

  see `https://github.com/capnproto/capnproto/issues/323`

---
TYPE: NO_HISTORY
