### PR TITLE
compute_results_count_sparse_string: using cached ranges properly.

### DIFF
--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -916,13 +916,13 @@ void ResultTile::compute_results_count_sparse_string(
       if (first_c_size == last_c_size &&
           strncmp(first_c_coord, second_coord, first_c_size) == 0) {
         uint64_t count = 0;
-        for (auto i : range_indexes) {
+        for (auto& cached_range : cached_ranges) {
           count += str_coord_intersects(
               first_c_offset,
               first_c_size,
               buff_str,
-              cached_ranges[i].first,
-              cached_ranges[i].second);
+              cached_range.first,
+              cached_range.second);
         }
 
         for (uint64_t pos = first_c_pos; pos < first_c_pos + c_partition_size;


### PR DESCRIPTION
In #3263, compute_results_count_sparse_string now caches ranges to do
it's computations, so cached_ranges should be used instead of
range_indexes. This change fixes one place that still used range_indexes.

---
TYPE: IMPROVEMENT
DESC: compute_results_count_sparse_string: using cached ranges properly.
