### PR TITLE
Close magic resources

### DIFF
--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -610,9 +610,8 @@ std::pair<Status, optional<std::string>> libmagic_get_mime(
   if (tiledb::sm::magic_dict::magic_mgc_embedded_load(magic)) {
     auto err_no = std::to_string(magic_errno(magic));
     magic_close(magic);
-    return {
-        Status_Error(std::string("Cannot load magic database - ") + err_no),
-        nullopt};
+    return {Status_Error(std::string("Cannot load magic database - ") + err_no),
+            nullopt};
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {
@@ -631,9 +630,8 @@ std::pair<Status, optional<std::string>> libmagic_get_mime_encoding(
   if (tiledb::sm::magic_dict::magic_mgc_embedded_load(magic)) {
     auto err_no = std::to_string(magic_errno(magic));
     magic_close(magic);
-    return {
-        Status_Error(std::string("Cannot load magic database - ") + err_no),
-        nullopt};
+    return {Status_Error(std::string("Cannot load magic database - ") + err_no),
+            nullopt};
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -608,17 +608,17 @@ std::pair<Status, optional<std::string>> libmagic_get_mime(
     void* data, uint64_t size) {
   magic_t magic = magic_open(MAGIC_MIME_TYPE);
   if (tiledb::sm::magic_dict::magic_mgc_embedded_load(magic)) {
-    auto err_msg = std::string(magic_error(magic));
+    auto err_no = std::to_string(magic_errno(magic));
     magic_close(magic);
     return {
-        Status_Error(std::string("Cannot load magic database - ") + err_msg),
+        Status_Error(std::string("Cannot load magic database - ") + err_no),
         nullopt};
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {
-    auto err_msg = std::string(magic_error(magic));
+    auto err_no = std::to_string(magic_errno(magic));
     magic_close(magic);
-    return {Status_Error(std::string("Cannot get the mime type - ") + err_msg),
+    return {Status_Error(std::string("Cannot get the mime type - ") + err_no),
             nullopt};
   }
   magic_close(magic);
@@ -629,18 +629,18 @@ std::pair<Status, optional<std::string>> libmagic_get_mime_encoding(
     void* data, uint64_t size) {
   magic_t magic = magic_open(MAGIC_MIME_ENCODING);
   if (tiledb::sm::magic_dict::magic_mgc_embedded_load(magic)) {
-    auto err_msg = std::string(magic_error(magic));
+    auto err_no = std::to_string(magic_errno(magic));
     magic_close(magic);
     return {
-        Status_Error(std::string("Cannot load magic database - ") + err_msg),
+        Status_Error(std::string("Cannot load magic database - ") + err_no),
         nullopt};
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {
-    auto err_msg = std::string(magic_error(magic));
+    auto err_no = std::to_string(magic_errno(magic));
     magic_close(magic);
     return {
-        Status_Error(std::string("Cannot get the mime encoding - ") + err_msg),
+        Status_Error(std::string("Cannot get the mime encoding - ") + err_no),
         nullopt};
   }
   magic_close(magic);

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -608,41 +608,43 @@ std::pair<Status, optional<std::string>> libmagic_get_mime(
     void* data, uint64_t size) {
   magic_t magic = magic_open(MAGIC_MIME_TYPE);
   if (tiledb::sm::magic_dict::magic_mgc_embedded_load(magic)) {
-    auto err_no = std::to_string(magic_errno(magic));
+    std::string errmsg(magic_error(magic));
     magic_close(magic);
-    return {Status_Error(std::string("Cannot load magic database - ") + err_no),
+    return {Status_Error(std::string("Cannot load magic database - ") + errmsg),
             nullopt};
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {
-    auto err_no = std::to_string(magic_errno(magic));
+    std::string errmsg(magic_error(magic));
     magic_close(magic);
-    return {Status_Error(std::string("Cannot get the mime type - ") + err_no),
+    return {Status_Error(std::string("Cannot get the mime type - ") + errmsg),
             nullopt};
   }
+  std::string mime(rv);
   magic_close(magic);
-  return {Status::Ok(), rv};
+  return {Status::Ok(), mime};
 }
 
 std::pair<Status, optional<std::string>> libmagic_get_mime_encoding(
     void* data, uint64_t size) {
   magic_t magic = magic_open(MAGIC_MIME_ENCODING);
   if (tiledb::sm::magic_dict::magic_mgc_embedded_load(magic)) {
-    auto err_no = std::to_string(magic_errno(magic));
+    std::string errmsg(magic_error(magic));
     magic_close(magic);
-    return {Status_Error(std::string("Cannot load magic database - ") + err_no),
+    return {Status_Error(std::string("Cannot load magic database - ") + errmsg),
             nullopt};
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {
-    auto err_no = std::to_string(magic_errno(magic));
+    std::string errmsg(magic_error(magic));
     magic_close(magic);
     return {
-        Status_Error(std::string("Cannot get the mime encoding - ") + err_no),
+        Status_Error(std::string("Cannot get the mime encoding - ") + errmsg),
         nullopt};
   }
+  std::string mime(rv);
   magic_close(magic);
-  return {Status::Ok(), rv};
+  return {Status::Ok(), mime};
 }
 
 bool libmagic_file_is_compressed(void* data, uint64_t size) {
@@ -661,12 +663,12 @@ bool libmagic_file_is_compressed(void* data, uint64_t size) {
     return true;
   }
   auto rv = magic_buffer(magic, data, size);
-  magic_close(magic);
   if (!rv) {
+    magic_close(magic);
     return true;
   }
-
   std::string mime(rv);
+  magic_close(magic);
 
   return compressed_mime_types.find(mime) != compressed_mime_types.end();
 }

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -611,18 +611,15 @@ std::pair<Status, optional<std::string>> libmagic_get_mime(
     auto err_msg = std::string(magic_error(magic));
     magic_close(magic);
     return {
-        Status_Error(
-            std::string("Cannot load magic database - ") + err_msg),
+        Status_Error(std::string("Cannot load magic database - ") + err_msg),
         nullopt};
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {
     auto err_msg = std::string(magic_error(magic));
     magic_close(magic);
-    return {
-        Status_Error(
-            std::string("Cannot get the mime type - ") + err_msg),
-        nullopt};
+    return {Status_Error(std::string("Cannot get the mime type - ") + err_msg),
+            nullopt};
   }
   magic_close(magic);
   return {Status::Ok(), rv};
@@ -635,18 +632,16 @@ std::pair<Status, optional<std::string>> libmagic_get_mime_encoding(
     auto err_msg = std::string(magic_error(magic));
     magic_close(magic);
     return {
-        Status_Error(
-            std::string("Cannot load magic database - ") + err_msg),
+        Status_Error(std::string("Cannot load magic database - ") + err_msg),
         nullopt};
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {
     auto err_msg = std::string(magic_error(magic));
     magic_close(magic);
-    return {Status_Error(
-                std::string("Cannot get the mime encoding - ") +
-                err_msg),
-            nullopt};
+    return {
+        Status_Error(std::string("Cannot get the mime encoding - ") + err_msg),
+        nullopt};
   }
   magic_close(magic);
   return {Status::Ok(), rv};


### PR DESCRIPTION
The `valgrind` checker (from the the R package) noticed that some the `magic_open()` calls did not have 
corresponding `magic_close()` calls.  This PR correct this, and passes subsequent `valgrind` checks.

It also makes one minor efficiency gain as `rv = magic_buffer(magic, data, size)` was being called twice in 
`libmagic_file_is_compressed`. The result from the first call can be reused in the non-error case which is 
what we do now.

---
TYPE: BUG
DESC: Close magic resources
