### PR TITLE
Add configuration variables for new array open

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -228,12 +228,15 @@ void check_save_to_file() {
   ss << "filestore.buffer_size 104857600\n";
   ss << "rest.curl.verbose false\n";
   ss << "rest.http_compressor any\n";
+  ss << "rest.load_metadata_on_array_open true\n";
+  ss << "rest.load_non_empty_domain_on_array_open true\n";
   ss << "rest.retry_count 25\n";
   ss << "rest.retry_delay_factor 1.25\n";
   ss << "rest.retry_http_codes 503\n";
   ss << "rest.retry_initial_delay_ms 500\n";
   ss << "rest.server_address https://api.tiledb.com\n";
   ss << "rest.server_serialization_format CAPNP\n";
+  ss << "rest.use_refactored_array_open false\n";
   ss << "sm.check_coord_dups true\n";
   ss << "sm.check_coord_oob true\n";
   ss << "sm.check_global_order true\n";
@@ -544,6 +547,18 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   rc = tiledb_config_set(config, "sm.var_offsets.bitsize", "32", &error);
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
+  rc = tiledb_config_set(
+      config, "rest.load_metadata_on_array_open", "false", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  rc = tiledb_config_set(
+      config, "rest.load_non_empty_domain_on_array_open", "false", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  rc = tiledb_config_set(
+      config, "rest.use_refactored_array_open", "true", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
 
   // Prepare maps
   std::map<std::string, std::string> all_param_values;
@@ -559,6 +574,9 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["rest.retry_initial_delay_ms"] = "500";
   all_param_values["rest.retry_http_codes"] = "503";
   all_param_values["rest.curl.verbose"] = "false";
+  all_param_values["rest.load_metadata_on_array_open"] = "false";
+  all_param_values["rest.load_non_empty_domain_on_array_open"] = "false";
+  all_param_values["rest.use_refactored_array_open"] = "true";
   all_param_values["sm.encryption_key"] = "";
   all_param_values["sm.encryption_type"] = "NO_ENCRYPTION";
   all_param_values["sm.dedup_coords"] = "false";

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1470,8 +1470,20 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    REST request <br>
  *    **Default**: 1.25
  * - `rest.curl.verbose` <br>
- * Set curl to run in verbose mode for REST requests <br>
- * curl will print to stdout with this option
+ *    Set curl to run in verbose mode for REST requests <br>
+ *    curl will print to stdout with this option
+ *    **Default**: false
+ * - `rest.load_metadata_on_array_open` <br>
+ *    If true, array metadata will be loaded and sent to server together with
+ *    the open array <br>
+ *    **Default**: true
+ * - `rest.load_non_empty_domain_on_array_open` <br>
+ *    If true, array non empty domain will be loaded and sent to server together
+ *    with the open array <br>
+ *    **Default**: true
+ * - `rest.use_refactored_array_open` <br>
+ *    If true, the new, experimental REST routes and APIs for opening an array
+ *    will be used <br>
  *    **Default**: false
  * - `filestore.buffer_size` <br>
  *    Specifies the size in bytes of the internal buffers used in the filestore

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -65,6 +65,9 @@ const std::string Config::REST_RETRY_COUNT = "25";
 const std::string Config::REST_RETRY_INITIAL_DELAY_MS = "500";
 const std::string Config::REST_RETRY_DELAY_FACTOR = "1.25";
 const std::string Config::REST_CURL_VERBOSE = "false";
+const std::string Config::REST_LOAD_METADATA_ON_ARRAY_OPEN = "true";
+const std::string Config::REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN = "true";
+const std::string Config::REST_USE_REFACTORED_ARRAY_OPEN = "false";
 const std::string Config::SM_ENCRYPTION_KEY = "";
 const std::string Config::SM_ENCRYPTION_TYPE = "NO_ENCRYPTION";
 const std::string Config::SM_DEDUP_COORDS = "false";
@@ -222,6 +225,12 @@ Config::Config() {
   param_values_["rest.retry_initial_delay_ms"] = REST_RETRY_INITIAL_DELAY_MS;
   param_values_["rest.retry_delay_factor"] = REST_RETRY_DELAY_FACTOR;
   param_values_["rest.curl.verbose"] = REST_CURL_VERBOSE;
+  param_values_["rest.load_metadata_on_array_open"] =
+      REST_LOAD_METADATA_ON_ARRAY_OPEN;
+  param_values_["rest.load_non_empty_domain_on_array_open"] =
+      REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN;
+  param_values_["rest.use_refactored_array_open"] =
+      REST_USE_REFACTORED_ARRAY_OPEN;
   param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
   param_values_["config.logging_level"] = CONFIG_LOGGING_LEVEL;
   param_values_["config.logging_format"] = CONFIG_LOGGING_DEFAULT_FORMAT;
@@ -516,6 +525,15 @@ Status Config::unset(const std::string& param) {
     param_values_["rest.retry_delay_factor"] = REST_RETRY_DELAY_FACTOR;
   } else if (param == "rest.curl.verbose") {
     param_values_["rest.curl.verbose"] = REST_CURL_VERBOSE;
+  } else if (param == "rest.load_metadata_on_array_open") {
+    param_values_["rest.load_metadata_on_array_open"] =
+        REST_LOAD_METADATA_ON_ARRAY_OPEN;
+  } else if (param == "rest.load_non_empty_domain_on_array_open") {
+    param_values_["rest.load_non_empty_domain_on_array_open"] =
+        REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN;
+  } else if (param == "rest.use_refactored_array_open") {
+    param_values_["rest.use_refactored_array_open"] =
+        REST_USE_REFACTORED_ARRAY_OPEN;
   } else if (param == "config.env_var_prefix") {
     param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
   } else if (param == "config.logging_level") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -80,6 +80,15 @@ class Config {
   /** The default for Curl's verbose mode used by REST. */
   static const std::string REST_CURL_VERBOSE;
 
+  /** If the array metadata should be loaded on array open */
+  static const std::string REST_LOAD_METADATA_ON_ARRAY_OPEN;
+
+  /** If the array non empty domain should be loaded on array open */
+  static const std::string REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN;
+
+  /** Refactored array open is disabled by default */
+  static const std::string REST_USE_REFACTORED_ARRAY_OPEN;
+
   /** The prefix to use for checking for parameter environmental variables. */
   static const std::string CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
 
@@ -277,12 +286,12 @@ class Config {
 
   /**
    * An array will vacuum between timestamp_start and this value.
-   *  */
+   */
   static const std::string SM_VACUUM_TIMESTAMP_END;
 
   /**
    * The size of offsets in bits to be used for offset buffers of var-sized
-   * attributes<br>
+   * attributes
    */
   static const std::string SM_OFFSETS_BITSIZE;
 
@@ -312,7 +321,7 @@ class Config {
 
   /**
    * An group will open between timestamp_start and this value.
-   *  */
+   */
   static const std::string SM_GROUP_TIMESTAMP_END;
 
   /** The default minimum number of bytes in a parallel VFS operation. */

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -704,13 +704,25 @@ class Config {
    *    failed REST request <br>
    *    **Default**: 1.25
    * - `rest.curl.verbose` <br>
-   * Set curl to run in verbose mode for REST requests <br>
-   * curl will print to stdout with this option
+   *    Set curl to run in verbose mode for REST requests <br>
+   *    curl will print to stdout with this option
+   *    **Default**: false
+   * - `rest.load_metadata_on_array_open` <br>
+   *    If true, array metadata will be loaded and sent to server together with
+   *    the open array <br>
+   *    **Default**: true
+   * - `rest.load_non_empty_domain_on_array_open` <br>
+   *    If true, array non empty domain will be loaded and sent to server
+   *    together with the open array <br>
+   *    **Default**: true
+   * - `rest.use_refactored_array_open` <br>
+   *    If true, the new, experimental REST routes and APIs for opening an array
+   *    will be used <br>
    *    **Default**: false
    * - `filestore.buffer_size` <br>
    *    Specifies the size in bytes of the internal buffers used in the
-   * filestore API. The size should be bigger than the minimum tile size
-   * filestore currently supports, that is currently 1024bytes. <br>
+   *    filestore API. The size should be bigger than the minimum tile size
+   *    filestore currently supports, that is currently 1024bytes. <br>
    *    **Default**: 100MB
    */
   Config& set(const std::string& param, const std::string& value) {


### PR DESCRIPTION
We are introducing 3 configuration variables related to the new array open work:
-   `rest.use_refactored_array_open`, by default `false` to toggle temporarily the new path on and off until implementation is completed
- `rest.load_metadata_on_array_open`, by default `true`, to request to load array metadata when opening an array from server
- `rest.load_non_empty_domain_on_array_open` , by default `true`, to request to load array non empty domain when opening an array from server

For now the configuration variables are not used, but just defined.

---
TYPE: IMPROVEMENT
DESC: Add configuration variables for new array open
