### PR TITLE
Deletes: adding delete tiles location to array directory.

### DIFF
--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -272,6 +272,11 @@ const std::vector<URI>& ArrayDirectory::fragment_meta_uris() const {
   return fragment_meta_uris_;
 }
 
+const std::vector<ArrayDirectory::DeleteTileLocation>&
+ArrayDirectory::delete_tiles_location() const {
+  return delete_tiles_location_;
+}
+
 URI ArrayDirectory::get_fragments_dir(uint32_t write_version) const {
   if (write_version < 12) {
     return uri_;
@@ -398,7 +403,7 @@ ArrayDirectory::load_commits_dir_uris_v12_or_higher(
     const std::vector<URI>& commits_dir_uris,
     const std::vector<URI>& consolidated_uris) {
   std::vector<URI> fragment_uris;
-  // Find the commited fragments
+  // Find the commited fragments from consolidated commits URIs
   for (size_t i = 0; i < consolidated_uris.size(); ++i) {
     if (stdx::string::ends_with(
             consolidated_uris[i].to_string(), constants::write_file_suffix)) {
@@ -424,6 +429,13 @@ ArrayDirectory::load_commits_dir_uris_v12_or_higher(
       }
     } else if (is_vacuum_file(commits_dir_uris[i])) {
       fragment_uris.emplace_back(commits_dir_uris[i]);
+    } else if (stdx::string::ends_with(
+                   commits_dir_uris[i].to_string(),
+                   constants::delete_file_suffix)) {
+      if (consolidated_commit_uris_set_.count(commits_dir_uris[i].c_str()) ==
+          0) {
+        delete_tiles_location_.emplace_back(commits_dir_uris[i], 0);
+      }
     }
   }
 

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -150,6 +150,49 @@ class ArrayDirectory {
     std::vector<TimestampedURI> fragment_uris_;
   };
 
+  /**
+   * Class to return a location of a delete tile, which is file URI/offset.
+   */
+  class DeleteTileLocation {
+   public:
+    /* ********************************* */
+    /*     CONSTRUCTORS & DESTRUCTORS    */
+    /* ********************************* */
+
+    /**
+     * Constructor.
+     */
+    DeleteTileLocation(const URI& uri, const storage_size_t offset)
+        : uri_(uri)
+        , offset_(offset) {
+    }
+
+    /** Destructor. */
+    ~DeleteTileLocation() = default;
+
+    /* ********************************* */
+    /*                API                */
+    /* ********************************* */
+    inline URI& Uri() {
+      return uri_;
+    }
+
+    inline uint64_t Offset() {
+      return offset_;
+    }
+
+   private:
+    /* ********************************* */
+    /*         PRIVATE ATTRIBUTES        */
+    /* ********************************* */
+
+    /** The URIs of the file. */
+    URI uri_;
+
+    /** The offset within the file. */
+    uint64_t offset_;
+  };
+
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -218,6 +261,9 @@ class ArrayDirectory {
 
   /** Returns the URIs of the consolidated fragment metadata files. */
   const std::vector<URI>& fragment_meta_uris() const;
+
+  /** Returns the location of delete tiles. */
+  const std::vector<DeleteTileLocation>& delete_tiles_location() const;
 
   /** Returns the URI to store fragments. */
   URI get_fragments_dir(uint32_t write_version) const;
@@ -297,6 +343,9 @@ class ArrayDirectory {
 
   /** The URIs of the consolidated fragment metadata files. */
   std::vector<URI> fragment_meta_uris_;
+
+  /** The location of delete tiles. */
+  std::vector<DeleteTileLocation> delete_tiles_location_;
 
   /**
    * Only array fragments, metadata, etc. that

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -212,6 +212,9 @@ const std::string ok_file_suffix = ".ok";
 /** Suffix for the special write files used in TileDB. */
 const std::string write_file_suffix = ".wrt";
 
+/** Suffix for the special delete files used in TileDB. */
+const std::string delete_file_suffix = ".del";
+
 /** Suffix for the special metadata files used in TileDB. */
 const std::string meta_file_suffix = ".meta";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -197,6 +197,9 @@ extern const std::string ok_file_suffix;
 /** Suffix for the special write files used in TileDB. */
 extern const std::string write_file_suffix;
 
+/** Suffix for the special delete files used in TileDB. */
+extern const std::string delete_file_suffix;
+
 /** Suffix for the special metadata files used in TileDB. */
 extern const std::string meta_file_suffix;
 


### PR DESCRIPTION
This adds delete tiles location to the array directory, a delete tile
location is a URI and offset. For now, offsets are always 0, as we only
read delete files, which have one delete per file, but in the future,
we will also read tiles from the consolidated commits file, which will
have tiles at different offsets.

---
TYPE: IMPROVEMENT
DESC: Deletes: adding delete tiles location to array directory.
