### PR TITLE
Only update pkg-config private requirements if on Windows

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -1097,8 +1097,10 @@ set(ver_patch ${CMAKE_MATCH_1})
 
 set(VERSION "${ver_major}.${ver_minor}.${ver_patch}")
 
-set(PKGCONF_REQ_PRIV "libmagic pcre2-8 pcre2-posix")
-string(CONCAT PKGCONF_REQ_PRIV ${PKGCONF_REQ_PRIV} " webp imagedec imageenc imageioutil webpdecoder webpdmux webpmux")
+if (WIN32)
+  set(PKGCONF_REQ_PRIV "libmagic pcre2-8 pcre2-posix")
+  string(CONCAT PKGCONF_REQ_PRIV ${PKGCONF_REQ_PRIV} " webp imagedec imageenc imageioutil webpdecoder webpdmux webpmux")
+endif()
 
 # PKG Config file
 configure_file(


### PR DESCRIPTION
The `tiledb.pc` for for `pkg-config` currently gets an unconditional private requirements part which breaks its use under Linux.  This PR changes this only add the section if on Windows.

---
TYPE: BUG
DESC: Update pkg-config private requirements on Windows only
