### PR TITLE
Result tile with bitmaps: make attributes private.

### DIFF
--- a/test/src/unit-result-coords.cc
+++ b/test/src/unit-result-coords.cc
@@ -54,6 +54,7 @@ struct CResultCoordsFx {
   std::string array_name_;
   const char* ARRAY_NAME = "test_result_coords";
   tiledb_array_t* array_;
+  std::unique_ptr<FragmentMetadata> frag_md;
 
   CResultCoordsFx();
   ~CResultCoordsFx();
@@ -104,6 +105,14 @@ CResultCoordsFx::CResultCoordsFx() {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array_, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
+
+  frag_md.reset(new FragmentMetadata(
+      nullptr,
+      nullptr,
+      array_->array_->array_schema_latest_ptr(),
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true));
 }
 
 CResultCoordsFx::~CResultCoordsFx() {
@@ -118,8 +127,7 @@ CResultCoordsFx::~CResultCoordsFx() {
 
 GlobalOrderResultTile<uint8_t> CResultCoordsFx::make_tile_with_num_cells(
     uint64_t num_cells) {
-  GlobalOrderResultTile<uint8_t> result_tile(
-      0, 0, array_->array_->array_schema_latest());
+  GlobalOrderResultTile<uint8_t> result_tile(0, 0, false, *frag_md);
   auto tile_tuple = result_tile.tile_tuple(constants::coords);
   Tile* const tile = &std::get<0>(*tile_tuple);
   auto cell_size = sizeof(int64_t);
@@ -166,18 +174,18 @@ TEST_CASE_METHOD(
   REQUIRE(rc1.max_slab_length() == 4);
 
   // Test max_slab_length with bitmap 1.
-  tile.bitmap_ = {0, 1, 1, 1, 1};
-  tile.bitmap_result_num_ = 4;
+  tile.bitmap() = {0, 1, 1, 1, 1};
+  tile.count_cells();
   REQUIRE(rc1.max_slab_length() == 4);
 
   // Test max_slab_length with bitmap 2.
-  tile.bitmap_ = {0, 1, 1, 1, 0};
-  tile.bitmap_result_num_ = 3;
+  tile.bitmap() = {0, 1, 1, 1, 0};
+  tile.count_cells();
   REQUIRE(rc1.max_slab_length() == 3);
 
   // Test max_slab_length with bitmap 3.
-  tile.bitmap_ = {0, 1, 1, 1, 0};
-  tile.bitmap_result_num_ = 3;
+  tile.bitmap() = {0, 1, 1, 1, 0};
+  tile.count_cells();
   rc1.pos_ = 0;
   REQUIRE(rc1.max_slab_length() == 0);
 }
@@ -194,20 +202,20 @@ TEST_CASE_METHOD(
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 2);
 
   // Test max_slab_length with bitmap and comparator 1.
-  tile.bitmap_ = {0, 1, 1, 1, 1};
-  tile.bitmap_result_num_ = 4;
+  tile.bitmap() = {0, 1, 1, 1, 1};
+  tile.count_cells();
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 10), cmp) == 4);
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 2);
 
   // Test max_slab_length with bitmap and comparator 2.
-  tile.bitmap_ = {0, 1, 1, 1, 0};
-  tile.bitmap_result_num_ = 3;
+  tile.bitmap() = {0, 1, 1, 1, 0};
+  tile.count_cells();
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 10), cmp) == 3);
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 2);
 
   // Test max_slab_length with bitmap and comparator 3.
-  tile.bitmap_ = {0, 1, 1, 1, 0};
-  tile.bitmap_result_num_ = 3;
+  tile.bitmap() = {0, 1, 1, 1, 0};
+  tile.count_cells();
   rc1.pos_ = 0;
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 0);
 }
@@ -220,8 +228,8 @@ TEST_CASE_METHOD(
   Cmp cmp;
 
   GlobalOrderResultCoords rc1(&tile, 0);
-  tile.bitmap_ = {0, 1, 1, 0, 1};
-  tile.bitmap_result_num_ = 3;
+  tile.bitmap() = {0, 1, 1, 0, 1};
+  tile.count_cells();
   REQUIRE(rc1.advance_to_next_cell() == true);
   REQUIRE(rc1.pos_ == 1);
   REQUIRE(rc1.advance_to_next_cell() == true);
@@ -232,8 +240,8 @@ TEST_CASE_METHOD(
 
   // Recreate to test that we don't move pos_ on the first call.
   GlobalOrderResultCoords rc2(&tile, 0);
-  tile.bitmap_ = {1, 1, 1, 0, 0};
-  tile.bitmap_result_num_ = 3;
+  tile.bitmap() = {1, 1, 1, 0, 0};
+  tile.count_cells();
   REQUIRE(rc2.advance_to_next_cell() == true);
   REQUIRE(rc2.pos_ == 0);
   REQUIRE(rc2.advance_to_next_cell() == true);

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -59,6 +59,7 @@ struct CResultTileFx {
   std::string array_name_;
   const char* ARRAY_NAME = "test_result_coords";
   tiledb_array_t* array_;
+  std::unique_ptr<FragmentMetadata> frag_md_;
 
   CResultTileFx();
   ~CResultTileFx();
@@ -98,13 +99,21 @@ CResultTileFx::CResultTileFx() {
       {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
       TILEDB_ROW_MAJOR,
       TILEDB_ROW_MAJOR,
-      100000);
+      100);
 
   // Open array for reading.
   auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array_);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array_, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
+
+  frag_md_.reset(new FragmentMetadata(
+      nullptr,
+      nullptr,
+      array_->array_->array_schema_latest_ptr(),
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      false));
 }
 
 CResultTileFx::~CResultTileFx() {
@@ -117,7 +126,8 @@ CResultTileFx::~CResultTileFx() {
   tiledb_vfs_free(&vfs_);
 }
 
-TEST_CASE(
+TEST_CASE_METHOD(
+    CResultTileFx,
     "ResultTileWithBitmap: result_num_between_pos and "
     "pos_with_given_result_sum test",
     "[resulttilewithbitmap][pos_with_given_result_sum][pos_with_given_result_"
@@ -149,25 +159,21 @@ TEST_CASE(
   REQUIRE(rc == TILEDB_OK);
   tiledb_domain_free(&domain);
 
-  UnorderedWithDupsResultTile<uint8_t> tile(
-      0, 0, *(array_schema->array_schema_.get()));
-  tile.bitmap_result_num_ = 100;
+  UnorderedWithDupsResultTile<uint8_t> tile(0, 0, *frag_md_);
 
   // Check the function with an empty bitmap.
   CHECK(tile.result_num_between_pos(2, 10) == 8);
   CHECK(tile.pos_with_given_result_sum(2, 8) == 9);
 
   // Check the functions with a bitmap.
-  tile.bitmap_.resize(100, 1);
+  tile.alloc_bitmap();
   CHECK(tile.result_num_between_pos(2, 10) == 8);
   CHECK(tile.pos_with_given_result_sum(2, 8) == 9);
 
-  tile.bitmap_result_num_ = 99;
-  tile.bitmap_[6] = 0;
+  tile.bitmap()[6] = 0;
+  tile.count_cells();
   CHECK(tile.result_num_between_pos(2, 10) == 7);
   CHECK(tile.pos_with_given_result_sum(2, 8) == 10);
-
-  tiledb_ctx_free(&ctx);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1303,8 +1303,7 @@ TEST_CASE_METHOD(
   auto&& [array, fragments] = open_default_array_1d_with_fragments();
 
   // Make a vector of tiles.
-  UnorderedWithDupsResultTile<uint64_t> result_tile(
-      0, 0, array->array_->array_schema_latest());
+  UnorderedWithDupsResultTile<uint64_t> result_tile(0, 0, *fragments[0]);
   std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
   rt.push_back(std::move(result_tile));
 
@@ -1312,7 +1311,7 @@ TEST_CASE_METHOD(
   }
 
   SECTION("- With bitmap") {
-    rt[0].bitmap_.resize(5, 1);
+    rt[0].alloc_bitmap();
   }
 
   // Create the result_tiles pointer vector.
@@ -1371,12 +1370,10 @@ TEST_CASE_METHOD(
   auto&& [array, fragments] = open_default_array_1d_with_fragments();
 
   // Make a vector of tiles.
-  UnorderedWithDupsResultTile<uint64_t> result_tile(
-      0, 0, array->array_->array_schema_latest());
+  UnorderedWithDupsResultTile<uint64_t> result_tile(0, 0, *fragments[0]);
   std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
   rt.push_back(std::move(result_tile));
-  rt[0].bitmap_.resize(5);
-  rt[0].bitmap_ = {0, 1, 2, 0, 2};
+  rt[0].bitmap() = {0, 1, 2, 0, 2};
 
   // Create the result_tiles pointer vector.
   std::vector<ResultTile*> result_tiles(rt.size());
@@ -1433,8 +1430,7 @@ TEST_CASE_METHOD(
   auto&& [array, fragments] = open_default_array_1d_with_fragments();
 
   // Make a vector of tiles.
-  UnorderedWithDupsResultTile<uint64_t> result_tile(
-      0, 0, array->array_->array_schema_latest());
+  UnorderedWithDupsResultTile<uint64_t> result_tile(0, 0, *fragments[0]);
   std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
   rt.push_back(std::move(result_tile));
 
@@ -1442,7 +1438,7 @@ TEST_CASE_METHOD(
   }
 
   SECTION("- With bitmap") {
-    rt[0].bitmap_.resize(5, 1);
+    rt[0].alloc_bitmap();
   }
 
   // Create the result_tiles pointer vector.

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -397,7 +397,7 @@ Status Reader::compute_range_result_coords(
         array_->timestamp_start(), array_->timestamp_end_opened_at());
     if (frag_meta->has_timestamps() && partial_overlap) {
       RETURN_NOT_OK(partial_overlap_condition_.apply_sparse<uint8_t>(
-          *(frag_meta->array_schema().get()), *tile, result_bitmap, nullptr));
+          *(frag_meta->array_schema().get()), *tile, result_bitmap));
     }
 
     // Gather results
@@ -1748,7 +1748,7 @@ Status Reader::get_all_result_coords(
       partial_overlap) {
     std::vector<uint8_t> result_bitmap(coords_num, 1);
     RETURN_NOT_OK(partial_overlap_condition_.apply_sparse<uint8_t>(
-        *(frag_meta->array_schema().get()), *tile, result_bitmap, nullptr));
+        *(frag_meta->array_schema().get()), *tile, result_bitmap));
 
     for (uint64_t i = 0; i < coords_num; ++i) {
       if (result_bitmap[i]) {

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1877,18 +1877,13 @@ template <typename BitmapType>
 Status QueryCondition::apply_sparse(
     const ArraySchema& array_schema,
     ResultTile& result_tile,
-    std::vector<BitmapType>& result_bitmap,
-    uint64_t* cell_count) {
+    std::vector<BitmapType>& result_bitmap) {
   apply_tree_sparse<BitmapType>(
       tree_,
       array_schema,
       result_tile,
       std::multiplies<BitmapType>(),
       result_bitmap);
-  if (cell_count != nullptr) {
-    *cell_count =
-        std::accumulate(result_bitmap.begin(), result_bitmap.end(), 0);
-  }
 
   return Status::Ok();
 }
@@ -1907,14 +1902,8 @@ void QueryCondition::set_ast(tdb_unique_ptr<ASTNode>&& ast) {
 
 // Explicit template instantiations.
 template Status QueryCondition::apply_sparse<uint8_t>(
-    const ArraySchema& array_schema,
-    ResultTile&,
-    std::vector<uint8_t>&,
-    uint64_t*);
+    const ArraySchema& array_schema, ResultTile&, std::vector<uint8_t>&);
 template Status QueryCondition::apply_sparse<uint64_t>(
-    const ArraySchema& array_schema,
-    ResultTile&,
-    std::vector<uint64_t>&,
-    uint64_t*);
+    const ArraySchema& array_schema, ResultTile&, std::vector<uint64_t>&);
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -180,15 +180,13 @@ class QueryCondition {
    * @param array_schema The array schema.
    * @param result_tile The result tile to get the cells from.
    * @param result_bitmap The bitmap to use for results.
-   * @param cell_count The cell count after condition is applied.
    * @return Status
    */
   template <typename BitmapType>
   Status apply_sparse(
       const ArraySchema& array_schema,
       ResultTile& result_tile,
-      std::vector<BitmapType>& result_bitmap,
-      uint64_t* cell_count);
+      std::vector<BitmapType>& result_bitmap);
 
   /**
    * Reverse the query condition using De Morgan's law.

--- a/tiledb/sm/query/readers/result_coords.h
+++ b/tiledb/sm/query/readers/result_coords.h
@@ -162,7 +162,7 @@ struct GlobalOrderResultCoords
     if (base::pos_ != cell_num) {
       if (base::tile_->has_bmp()) {
         while (base::pos_ < cell_num) {
-          if (base::tile_->bitmap_[base::pos_]) {
+          if (base::tile_->bitmap()[base::pos_]) {
             return true;
           }
           base::pos_++;
@@ -248,7 +248,8 @@ struct GlobalOrderResultCoords
       // from the current position, with coordinares smaller than the next one
       // in the queue.
       base::pos_++;
-      while (base::pos_ < cell_num && bitmap[base::pos_] && !cmp(*this, next)) {
+      while (base::pos_ < cell_num && bitmap[base::pos_] &&
+             !cmp(*this, next)) {
         base::pos_++;
         ret++;
       }

--- a/tiledb/sm/query/readers/result_coords.h
+++ b/tiledb/sm/query/readers/result_coords.h
@@ -248,8 +248,7 @@ struct GlobalOrderResultCoords
       // from the current position, with coordinares smaller than the next one
       // in the queue.
       base::pos_++;
-      while (base::pos_ < cell_num && bitmap[base::pos_] &&
-             !cmp(*this, next)) {
+      while (base::pos_ < cell_num && bitmap[base::pos_] && !cmp(*this, next)) {
         base::pos_++;
         ret++;
       }

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -573,6 +573,7 @@ class ResultTileWithBitmap : public ResultTile {
    * @param cell_idx Cell index to clear.
    */
   void clear_cell(uint64_t cell_idx) {
+    assert(cell_idx < bitmap_.size());
     result_num_ -= bitmap_[cell_idx];
     bitmap_[cell_idx] = 0;
   }
@@ -594,7 +595,7 @@ class ResultTileWithBitmap : public ResultTile {
   }
 
   /**
-   * Resize the bitmap.
+   * Allocate the bitmap.
    */
   void alloc_bitmap() {
     assert(bitmap_.size() == 0);
@@ -673,6 +674,7 @@ class ResultTileWithBitmap : public ResultTile {
   void swap(ResultTileWithBitmap<BitmapType>& tile) {
     ResultTile::swap(tile);
     std::swap(bitmap_, tile.bitmap_);
+    std::swap(cell_num_, tile.cell_num_);
     std::swap(result_num_, tile.result_num_);
     std::swap(coords_loaded_, tile.coords_loaded_);
   }
@@ -702,7 +704,10 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
   GlobalOrderResultTile(
-      unsigned frag_idx, uint64_t tile_idx, bool dups, const FragmentMetadata& frag_md)
+      unsigned frag_idx,
+      uint64_t tile_idx,
+      bool dups,
+      const FragmentMetadata& frag_md)
       : ResultTileWithBitmap<BitmapType>(frag_idx, tile_idx, frag_md)
       , dups_(dups)
       , used_(false) {
@@ -771,7 +776,8 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
       }
     } else {
       if (ResultTileWithBitmap<BitmapType>::bitmap_.size() == 0) {
-        ResultTileWithBitmap<BitmapType>::bitmap_.resize(ResultTileWithBitmap<BitmapType>::cell_num_, 1);
+        ResultTileWithBitmap<BitmapType>::bitmap_.resize(
+            ResultTileWithBitmap<BitmapType>::cell_num_, 1);
       }
     }
   }
@@ -893,7 +899,8 @@ class UnorderedWithDupsResultTile : public ResultTileWithBitmap<BitmapType> {
    */
   void ensure_bitmap_for_query_condition() {
     if (ResultTileWithBitmap<BitmapType>::bitmap_.size() == 0) {
-      ResultTileWithBitmap<BitmapType>::bitmap_.resize(ResultTileWithBitmap<BitmapType>::cell_num_, 1);
+      ResultTileWithBitmap<BitmapType>::bitmap_.resize(
+          ResultTileWithBitmap<BitmapType>::cell_num_, 1);
     }
   }
 

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -49,8 +49,6 @@
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/subarray/subarray.h"
 
-#include <numeric>
-
 using namespace tiledb;
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;
@@ -201,8 +199,8 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
       std::vector<ResultTile*> tmp_result_tiles;
       for (auto& rt_list : result_tiles_) {
         for (auto& result_tile : rt_list) {
-          if (!result_tile.coords_loaded_) {
-            result_tile.coords_loaded_ = true;
+          if (!result_tile.coords_loaded()) {
+            result_tile.set_coords_loaded();
             tmp_result_tiles.emplace_back(&result_tile);
           }
         }
@@ -229,7 +227,7 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
           storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
             auto it = result_tiles_[f].begin();
             while (it != result_tiles_[f].end()) {
-              if (it->bitmap_result_num_ == 0) {
+              if (it->result_num() == 0) {
                 {
                   std::unique_lock<std::mutex> lck(ignored_tiles_mutex);
                   ignored_tiles_.emplace(f, it->tile_idx());
@@ -322,7 +320,7 @@ SparseGlobalOrderReader<BitmapType>::add_result_tile(
     const uint64_t memory_budget_qc_tiles,
     const unsigned f,
     const uint64_t t,
-    const ArraySchema& array_schema) {
+    const FragmentMetadata& frag_md) {
   if (ignored_tiles_.count(IgnoredTile(f, t))) {
     return {Status::Ok(), false};
   }
@@ -356,7 +354,7 @@ SparseGlobalOrderReader<BitmapType>::add_result_tile(
   memory_used_for_qc_tiles_[f] += tiles_size_qc;
 
   // Add the tile.
-  result_tiles_[f].emplace_back(f, t, array_schema);
+  result_tiles_[f].emplace_back(f, t, array_schema_.allows_dups(), frag_md);
 
   return {Status::Ok(), false};
 }
@@ -397,7 +395,7 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
                   per_fragment_qc_memory_,
                   f,
                   t,
-                  *(fragment_metadata_[f]->array_schema()).get());
+                  *fragment_metadata_[f]);
               RETURN_NOT_OK(st);
               tiles_found = true;
 
@@ -445,7 +443,7 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
                 per_fragment_qc_memory_,
                 f,
                 t,
-                *(fragment_metadata_[f]->array_schema()).get());
+                *fragment_metadata_[f]);
             RETURN_NOT_OK(st);
             tiles_found = true;
 
@@ -510,15 +508,14 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_tiles_with_timestamps(
 
           // Make a bitmap if necessary.
           if (!rt->has_bmp()) {
-            rt->bitmap_.resize(cell_num, 1);
-            rt->bitmap_result_num_ = cell_num;
+            rt->alloc_bitmap();
           }
 
           // Process all cells.
           uint64_t c = 0;
           while (c < cell_num - 1) {
             // If the cell is in the bitmap.
-            if (rt->bitmap_[c]) {
+            if (rt->bitmap()[c]) {
               // Save the current cell timestamp as max and move to the next.
               uint64_t max_timestamp = rt->timestamp(c);
               uint64_t max = c;
@@ -528,18 +525,18 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_tiles_with_timestamps(
               // one with the biggest timestamp in the bitmap.
               while (c < cell_num && rt->same_coords(max, c)) {
                 // If the cell is in the bitmap.
-                if (rt->bitmap_[c]) {
+                if (rt->bitmap()[c]) {
                   uint64_t current_timestamp = rt->timestamp(c);
 
                   // If the current cell has a bigger timestamp, clear the old
                   // max in the bitmap and save the new max.
                   if (current_timestamp > max_timestamp) {
-                    rt->bitmap_[max] = 0;
+                    rt->bitmap()[max] = 0;
                     max_timestamp = current_timestamp;
                     max = c;
                   } else {
                     // Clear this cell from the bitmap.
-                    rt->bitmap_[c] = 0;
+                    rt->bitmap()[c] = 0;
                   }
                 }
 
@@ -553,8 +550,7 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_tiles_with_timestamps(
           }
 
           // Count new number of cells in the bitmap.
-          rt->bitmap_result_num_ =
-              std::accumulate(rt->bitmap_.begin(), rt->bitmap_.end(), 0);
+          rt->count_cells();
         }
 
         return Status::Ok();
@@ -605,7 +601,7 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps() {
                 // Same coords, compare timestamps.
                 if (it->timestamp(last) > next_tile->timestamp(first)) {
                   // Remove the cell in the next tile.
-                  if (next_tile->bitmap_result_num_ == 1) {
+                  if (next_tile->result_num() == 1) {
                     // Only one cell in the bitmap, delete next tile.
                     // Stay on this tile as we will compare to the new next.
                     {
@@ -615,13 +611,12 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps() {
                     remove_result_tile(f, next_tile);
                   } else {
                     // Remove the cell in the bitmap and move to the next tile.
-                    next_tile->bitmap_[first] = 0;
-                    next_tile->bitmap_result_num_--;
+                    next_tile->clear_cell(first);
                     it++;
                   }
                 } else {
                   // Remove the cell in the current tile.
-                  if (next_tile->bitmap_result_num_ == 1) {
+                  if (next_tile->result_num() == 1) {
                     // Only one cell in the bitmap, delete current tile.
                     auto to_delete = it;
                     it++;
@@ -632,8 +627,7 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps() {
                     remove_result_tile(f, to_delete);
                   } else {
                     // Remove the cell in the bitmap and move to the next tile.
-                    it->bitmap_[last] = 0;
-                    it->bitmap_result_num_--;
+                    it->clear_cell(last);
                     it++;
                   }
                 }
@@ -798,7 +792,7 @@ Status SparseGlobalOrderReader<BitmapType>::compute_hilbert_values(
         tile->allocate_hilbert_vector();
         for (rc.pos_ = 0; rc.pos_ < cell_num; rc.pos_++) {
           // Process only values in bitmap.
-          if (!tile->has_bmp() || tile->bitmap_[rc.pos_]) {
+          if (!tile->has_bmp() || tile->bitmap()[rc.pos_]) {
             // Compute Hilbert number for all dimensions first.
             for (uint32_t d = 0; d < dim_num; ++d) {
               auto dim{array_schema_.dimension_ptr(d)};
@@ -903,7 +897,7 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
           num_cells--;
         } else {
           // For overlapping ranges, create as many slabs as there are counts.
-          auto num = to_process_dup.tile_->bitmap_[to_process_dup.pos_];
+          auto num = to_process_dup.tile_->bitmap()[to_process_dup.pos_];
           if (num_cells < num) {
             num_cells = 0;
             break;
@@ -974,7 +968,7 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
         read_state_.frag_idx_[frag_idx] = FragIdx(tile_idx, start + length);
         num_cells -= length;
       } else {
-        auto num = to_process.tile_->bitmap_[to_process.pos_];
+        auto num = to_process.tile_->bitmap()[to_process.pos_];
         if (num > num_cells) {
           num_cells = 0;
           break;
@@ -1387,12 +1381,7 @@ SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
             // Account for the pointers to the var data that is created in
             // copy_tiles for var sized attributes.
             if (var_sized) {
-              auto cell_num = rt->bitmap_result_num_ !=
-                                      std::numeric_limits<uint64_t>::max() ?
-                                  rt->bitmap_result_num_ :
-                                  fragment_metadata_[rt->frag_idx()]->cell_num(
-                                      rt->tile_idx());
-              *tile_size += sizeof(void*) * cell_num;
+              *tile_size += sizeof(void*) * rt->result_num();
             }
 
             // Stop when we reach the budget.

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -206,7 +206,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param memory_budget_qc_tiles Memory budget for query condition tiles.
    * @param f Fragment index.
    * @param t Tile index.
-   * @param array_schema Array schema.
+   * @param frag_md Fragment metadata.
    *
    * @return buffers_full, new_var_buffer_size, new_result_tiles_size.
    */
@@ -216,7 +216,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       const uint64_t memory_budget_qc_tiles,
       const unsigned f,
       const uint64_t t,
-      const ArraySchema& array_schema);
+      const FragmentMetadata& frag_md);
 
   /**
    * Create the result tiles.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -557,9 +557,7 @@ Status SparseIndexReaderBase::apply_query_condition(
           if (!condition_.empty()) {
             rt->ensure_bitmap_for_query_condition();
             RETURN_NOT_OK(condition_.apply_sparse<BitmapType>(
-                *(frag_meta->array_schema().get()),
-                *rt,
-                rt->bitmap_with_qc()));
+                *(frag_meta->array_schema().get()), *rt, rt->bitmap_with_qc()));
             if (array_schema_.allows_dups()) {
               rt->count_cells();
             }

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -366,20 +366,6 @@ Status SparseIndexReaderBase::read_and_unfilter_coords(
 }
 
 template <class BitmapType>
-Status SparseIndexReaderBase::allocate_tile_bitmap(
-    ResultTileWithBitmap<BitmapType>* rt) {
-  // Bitmap was already computed for this tile.
-  if (rt->bitmap_result_num_ != std::numeric_limits<uint64_t>::max()) {
-    return Status::Ok();
-  }
-
-  auto cell_num = fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
-  rt->bitmap_.resize(cell_num, 1);
-
-  return Status::Ok();
-}
-
-template <class BitmapType>
 Status SparseIndexReaderBase::compute_tile_bitmaps(
     std::vector<ResultTile*>& result_tiles) {
   auto timer_se = stats_->start_timer("compute_tile_bitmaps");
@@ -412,8 +398,9 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
         0,
         result_tiles.size(),
         [&](uint64_t t) {
-          return allocate_tile_bitmap(
-              (ResultTileWithBitmap<BitmapType>*)result_tiles[t]);
+          static_cast<ResultTileWithBitmap<BitmapType>*>(result_tiles[t])
+              ->alloc_bitmap();
+          return Status::Ok();
         });
     RETURN_NOT_OK_ELSE(status, logger_->status(status));
   }
@@ -431,13 +418,9 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
         auto cell_num =
             fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
-        // Bitmap was already computed for this tile.
-        if (rt->bitmap_result_num_ != std::numeric_limits<uint64_t>::max())
-          return Status::Ok();
-
         // Allocate the bitmap if not preallocated.
         if (num_range_threads == 1) {
-          RETURN_NOT_OK(allocate_tile_bitmap(rt));
+          rt->alloc_bitmap();
         }
 
         // Prevent processing past the end of the cells in case there are more
@@ -500,7 +483,7 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
                 dim_idx,
                 ranges_for_dim,
                 relevant_ranges,
-                rt->bitmap_,
+                rt->bitmap(),
                 cell_order,
                 min,
                 max));
@@ -510,7 +493,7 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
         // Only compute bitmap cells here if we are processing a single cell
         // range. If not, it will be done below.
         if (num_range_threads == 1) {
-          RETURN_NOT_OK(count_tile_bitmap_cells(rt));
+          rt->count_cells();
         }
 
         return Status::Ok();
@@ -526,41 +509,14 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
         0,
         result_tiles.size(),
         [&](uint64_t t) {
-          return count_tile_bitmap_cells(
-              (ResultTileWithBitmap<BitmapType>*)result_tiles[t]);
+          static_cast<ResultTileWithBitmap<BitmapType>*>(result_tiles[t])
+              ->count_cells();
+          return Status::Ok();
         });
     RETURN_NOT_OK_ELSE(status, logger_->status(status));
   }
 
   logger_->debug("Done computing tile bitmaps");
-  return Status::Ok();
-}
-
-/** Count the number of cells in a bitmap. */
-template <class BitmapType>
-Status SparseIndexReaderBase::count_tile_bitmap_cells(
-    ResultTileWithBitmap<BitmapType>* rt) {
-  // Bitmap was already computed for this tile.
-  if (rt->bitmap_result_num_ != std::numeric_limits<uint64_t>::max()) {
-    return Status::Ok();
-  }
-
-  // Compute number of cells in this tile.
-  auto cell_num = fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
-  rt->bitmap_result_num_ = 0;
-  for (uint64_t c = 0; c < cell_num; ++c) {
-    rt->bitmap_result_num_ += rt->bitmap_[c];
-  }
-
-  const bool non_overlapping = std::is_same<BitmapType, uint8_t>::value;
-  if (non_overlapping) {
-    // Clear the bitmap, which will also signal the copy operation to copy the
-    // whole tile.
-    if (rt->bitmap_result_num_ == cell_num) {
-      rt->bitmap_.resize(0);
-    }
-  }
-
   return Status::Ok();
 }
 
@@ -580,8 +536,6 @@ Status SparseIndexReaderBase::apply_query_condition(
           auto rt = static_cast<ResultTileType*>(result_tiles[t]);
           const auto frag_meta = fragment_metadata_[rt->frag_idx()];
 
-          auto cell_num = frag_meta->cell_num(rt->tile_idx());
-
           // If timestamps are present and fragment is partially included,
           // filter out tiles based on time by applying the query condition
           if (frag_meta->has_timestamps() &&
@@ -590,26 +544,25 @@ Status SparseIndexReaderBase::apply_query_condition(
                   array_->timestamp_end_opened_at())) {
             // Full overlap in bitmap calculation, make a bitmap.
             if (!rt->has_bmp()) {
-              rt->bitmap_.resize(cell_num, 1);
-              rt->bitmap_result_num_ = cell_num;
+              rt->alloc_bitmap();
             }
 
             // Remove cells with partial overlap from the bitmap.
             RETURN_NOT_OK(partial_overlap_condition_.apply_sparse<BitmapType>(
-                *(frag_meta->array_schema().get()),
-                *rt,
-                rt->bitmap_,
-                &rt->bitmap_result_num_));
+                *(frag_meta->array_schema().get()), *rt, rt->bitmap()));
+            rt->count_cells();
           }
 
           // Compute the result of the query condition for this tile.
           if (!condition_.empty()) {
-            rt->ensure_bitmap_for_query_condition(cell_num);
+            rt->ensure_bitmap_for_query_condition();
             RETURN_NOT_OK(condition_.apply_sparse<BitmapType>(
                 *(frag_meta->array_schema().get()),
                 *rt,
-                rt->bitmap_with_qc(),
-                rt->qc_result_num_ptr()));
+                rt->bitmap_with_qc()));
+            if (array_schema_.allows_dups()) {
+              rt->count_cells();
+            }
           }
 
           return Status::Ok();

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -350,16 +350,6 @@ class SparseIndexReaderBase : public ReaderBase {
       bool include_coords, const std::vector<ResultTile*>& result_tiles);
 
   /**
-   * Allocate a tile bitmap if required for this tile.
-   *
-   * @param rt Result tile currently in process.
-   *
-   * @return Status.
-   */
-  template <class BitmapType>
-  Status allocate_tile_bitmap(ResultTileWithBitmap<BitmapType>* rt);
-
-  /**
    * Compute tile bitmaps.
    *
    * @param result_tiles Result tiles to process.
@@ -368,16 +358,6 @@ class SparseIndexReaderBase : public ReaderBase {
    * */
   template <class BitmapType>
   Status compute_tile_bitmaps(std::vector<ResultTile*>& result_tiles);
-
-  /**
-   * Count the number of cells in a bitmap.
-   *
-   * @param rt Result tile currently in process.
-   *
-   * @return Status.
-   */
-  template <class BitmapType>
-  Status count_tile_bitmap_cells(ResultTileWithBitmap<BitmapType>* rt);
 
   /**
    * Apply query condition.

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -204,8 +204,9 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
     std::vector<ResultTile*> result_tiles_created;
     std::vector<ResultTile*> result_tiles_loaded;
     for (auto& result_tile : result_tiles_) {
-      if (!result_tile.coords_loaded_) {
-        result_tile.coords_loaded_ = true;
+      if (!result_tile.coords_loaded()) {
+        result_tile.set_coords_loaded();
+        ;
         result_tiles_created.emplace_back(&result_tile);
       } else {
         result_tiles_loaded.emplace_back(&result_tile);
@@ -229,8 +230,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
       // Clear result tiles that are not necessary anymore.
       uint64_t current = 0;
       for (uint64_t i = 0; i < result_tiles_created.size(); i++) {
-        if (((UnorderedWithDupsResultTile<uint64_t>*)result_tiles_created[i])
-                ->bitmap_result_num_ != 0) {
+        if (((ResultTileWithBitmap<uint64_t>*)result_tiles_created[i])
+                ->result_num() != 0) {
           result_tiles_created[current++] = result_tiles_created[i];
         }
       }
@@ -240,7 +241,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
       auto it = result_tiles_.begin();
       while (it != result_tiles_.end()) {
         auto f = it->frag_idx();
-        if (it->bitmap_result_num_ == 0) {
+        if (it->result_num() == 0) {
           RETURN_NOT_OK(remove_result_tile(f, it++));
         } else {
           it++;
@@ -313,7 +314,7 @@ SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
     const unsigned f,
     const uint64_t t,
     const uint64_t last_t,
-    const ArraySchema& array_schema) {
+    const FragmentMetadata& frag_md) {
   // Calculate memory consumption for this tile.
   auto&& [st, tiles_sizes] = get_coord_tiles_size(dim_num, f, t);
   RETURN_NOT_OK_TUPLE(st, nullopt);
@@ -331,7 +332,7 @@ SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
   memory_used_qc_tiles_total_ += tiles_size_qc;
 
   // Add the result tile.
-  result_tiles_.emplace_back(f, t, array_schema);
+  result_tiles_.emplace_back(f, t, frag_md);
 
   // Are all tiles loaded for this fragment.
   if (t == last_t)
@@ -374,7 +375,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
                 f,
                 t,
                 last_t,
-                *(fragment_metadata_[f]->array_schema()).get());
+                *fragment_metadata_[f]);
             RETURN_NOT_OK(st);
 
             // Make sure we can add at least one tile.
@@ -425,7 +426,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
               f,
               t,
               tile_num - 1,
-              *(fragment_metadata_[f]->array_schema()).get());
+              *fragment_metadata_[f]);
           (void)st;
           // Make sure we can add at least one tile.
           if (*exceeded) {
@@ -523,7 +524,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
   // Process all cells. Last cell might be taken out for vectorization.
   uint64_t end = (src_max_pos == cell_num) ? src_max_pos - 1 : src_max_pos;
   for (uint64_t c = src_min_pos; c < end; c++) {
-    for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+    for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
       *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / offset_div;
       buffer++;
       *var_data = src_var_buff + src_buff[c];
@@ -533,7 +534,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
 
   // Do last cell.
   if (src_max_pos == cell_num) {
-    for (uint64_t i = 0; i < rt->bitmap_[src_max_pos - 1]; i++) {
+    for (uint64_t i = 0; i < rt->bitmap()[src_max_pos - 1]; i++) {
       *buffer =
           (OffType)(t_var->size() - src_buff[src_max_pos - 1]) / offset_div;
       buffer++;
@@ -546,7 +547,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
   if (nullable) {
     const auto src_val_buff = t_val->data_as<uint8_t>();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+      for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
         *val_buffer = src_val_buff[c];
         val_buffer++;
       }
@@ -579,12 +580,11 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
-  // 0 sized bitmap means full tile, full tile copy done below.
-  if (rt->has_bmp()) {
+  if (!rt->copy_full_tile()) {
     // Process all cells. Last cell might be taken out for vectorization.
     uint64_t end = (src_max_pos == cell_num) ? src_max_pos - 1 : src_max_pos;
     for (uint64_t c = src_min_pos; c < end; c++) {
-      if (rt->bitmap_[c]) {
+      if (rt->bitmap()[c]) {
         *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / offset_div;
         buffer++;
         *var_data = src_var_buff + src_buff[c];
@@ -593,7 +593,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     }
 
     // Do last cell.
-    if (src_max_pos == cell_num && rt->bitmap_[src_max_pos - 1]) {
+    if (src_max_pos == cell_num && rt->bitmap()[src_max_pos - 1]) {
       *buffer =
           (OffType)(t_var->size() - src_buff[src_max_pos - 1]) / offset_div;
       *var_data = src_var_buff + src_buff[src_max_pos - 1];
@@ -603,7 +603,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     if (nullable) {
       const auto src_val_buff = t_val->data_as<uint8_t>();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-        if (rt->bitmap_[c]) {
+        if (rt->bitmap()[c]) {
           *val_buffer = src_val_buff[c];
           val_buffer++;
         }
@@ -679,15 +679,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
         // Adjust max cell if this is the last tile.
         if (i == result_tiles.size() - 1) {
           auto to_copy = cell_offsets[i + 1] - cell_offsets[i];
-
-          // No bitmap, just use the cell offsets. Otherwise, we need to check
-          // the bitmap to determine the max.
-          if (rt->bitmap_result_num_ == std::numeric_limits<uint64_t>::max()) {
-            max_pos_tile = min_pos_tile + to_copy;
-          } else {
-            max_pos_tile =
-                rt->pos_with_given_result_sum(min_pos_tile, to_copy) + 1;
-          }
+          max_pos_tile =
+              rt->pos_with_given_result_sum(min_pos_tile, to_copy) + 1;
         }
 
         auto&& [skip_copy, src_min_pos, src_max_pos, dest_cell_offset] =
@@ -840,7 +833,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
   // Copy values.
   if (!stores_zipped_coords) {
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+      for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
         memcpy(buffer, src_buff + c * cell_size, cell_size);
         buffer += cell_size;
       }
@@ -848,7 +841,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
   } else {  // Copy for zipped coords.
     const auto dim_num = rt->domain()->dim_num();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+      for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
         auto pos = c * dim_num + dim_idx;
         memcpy(buffer, src_buff + pos * cell_size, cell_size);
         buffer += cell_size;
@@ -861,7 +854,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
     const auto t_val = &std::get<2>(*tile_tuple);
     const auto src_val_buff = t_val->data_as<uint8_t>();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+      for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
         *val_buffer = src_val_buff[c];
         val_buffer++;
       }
@@ -893,8 +886,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
   const auto src_buff = t->data_as<uint8_t>();
   const auto t_val = &std::get<2>(*tile_tuple);
 
-  // Partial tile copy, full tile copy done below.
-  if (rt->has_bmp()) {
+  if (!rt->copy_full_tile()) {
     // Copy values.
     if (!stores_zipped_coords) {
       // Go through bitmap, when there is a hole in cell contiguity, do a
@@ -902,7 +894,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
       uint64_t length = 0;
       uint64_t start = src_min_pos;
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-        if (rt->bitmap_[c]) {
+        if (rt->bitmap()[c]) {
           length++;
         } else {
           if (length != 0) {
@@ -923,7 +915,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
     } else {  // Copy for zipped coords.
       const auto dim_num = rt->domain()->dim_num();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-        if (rt->bitmap_[c]) {
+        if (rt->bitmap()[c]) {
           auto pos = c * dim_num + dim_idx;
           memcpy(buffer, src_buff + pos * cell_size, cell_size);
           buffer += cell_size;
@@ -939,7 +931,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
       uint64_t start = src_min_pos;
       const auto src_val_buff = t_val->data_as<uint8_t>();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-        if (rt->bitmap_[c]) {
+        if (rt->bitmap()[c]) {
           length++;
         } else {
           if (length != 0) {
@@ -988,7 +980,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
   if (fragment_metadata_[rt->frag_idx()]->has_timestamps()) {
     // Copy values.
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+      for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
         memcpy(buffer, src_buff + c * cell_size, cell_size);
         buffer += cell_size;
       }
@@ -997,7 +989,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
     // Copy fragment timestamp.
     auto timestamp = fragment_timestamp(rt);
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+      for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
         memcpy(buffer, &timestamp, cell_size);
         buffer += cell_size;
       }
@@ -1020,15 +1012,14 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_timestamp_data_tile(
   const uint64_t cell_size = constants::timestamp_size;
   auto frag_timestamp = fragment_timestamp(rt);
 
-  // Partial tile copy, full tile copy done below.
-  if (rt->has_bmp()) {
+  if (!rt->copy_full_tile()) {
     // Copy values.
     // Go through bitmap, when there is a hole in cell contiguity, do a
     // memcpy.
     uint64_t length = 0;
     uint64_t start = src_min_pos;
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      if (rt->bitmap_[c]) {
+      if (rt->bitmap()[c]) {
         length++;
       } else {
         if (length != 0) {
@@ -1112,15 +1103,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
         // Adjust max cell if this is the last tile.
         if (i == result_tiles.size() - 1) {
           auto to_copy = cell_offsets[i + 1] - cell_offsets[i];
-
-          // No bitmap, just use the cell offsets. Otherwise, we need to check
-          // the bitmap to determine the max.
-          if (rt->bitmap_result_num_ == std::numeric_limits<uint64_t>::max()) {
-            max_pos_tile = min_pos_tile + to_copy;
-          } else {
-            max_pos_tile =
-                rt->pos_with_given_result_sum(min_pos_tile, to_copy) + 1;
-          }
+          max_pos_tile =
+              rt->pos_with_given_result_sum(min_pos_tile, to_copy) + 1;
         }
 
         auto&& [skip_copy, src_min_pos, src_max_pos, dest_cell_offset] =
@@ -1206,24 +1190,15 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_fixed_results_to_copy(
   // in the fragment metadata to do so.
   uint64_t cell_offset = cells_copied(names);
   for (uint64_t i = 0; i < result_tiles.size(); i++) {
-    auto rt = (UnorderedWithDupsResultTile<BitmapType>*)result_tiles[i];
-    auto cell_num =
-        rt->bitmap_result_num_ != std::numeric_limits<uint64_t>::max() ?
-            rt->bitmap_result_num_ :
-            fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
+    auto rt = (ResultTileWithBitmap<BitmapType>*)result_tiles[i];
+    auto cell_num = rt->result_num();
 
     // First tile might have been partially copied. Adjust cell_num to account
     // for it.
     if (i == 0) {
       if (read_state_.frag_idx_[rt->frag_idx()].tile_idx_ == rt->tile_idx()) {
-        if (rt->bitmap_result_num_ != std::numeric_limits<uint64_t>::max()) {
-          if (rt->bitmap_result_num_ != 0) {
-            auto pos = read_state_.frag_idx_[rt->frag_idx()].cell_idx_;
-            cell_num -= rt->result_num_between_pos(0, pos);
-          }
-        } else {
-          cell_num -= read_state_.frag_idx_[rt->frag_idx()].cell_idx_;
-        }
+        auto pos = read_state_.frag_idx_[rt->frag_idx()].cell_idx_;
+        cell_num -= rt->result_num_between_pos(0, pos);
       }
     }
 
@@ -1291,12 +1266,7 @@ SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
           // Account for the pointers to the var data that is created in
           // copy_tiles for var sized attributes.
           if (var_sized) {
-            auto cell_num =
-                rt->bitmap_result_num_ != std::numeric_limits<uint64_t>::max() ?
-                    rt->bitmap_result_num_ :
-                    fragment_metadata_[rt->frag_idx()]->cell_num(
-                        rt->tile_idx());
-            *tile_size += sizeof(void*) * cell_num;
+            *tile_size += sizeof(void*) * rt->result_num();
           }
 
           // Stop when we reach the budget.
@@ -1380,10 +1350,9 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
           new_result_tiles_size > 0 ? cell_offsets[new_result_tiles_size - 1] :
                                       0;
 
-      const bool has_bmp = last_tile->has_bmp();
       const auto min_pos = new_result_tiles_size == 1 ? first_tile_min_pos : 0;
       for (uint64_t c = min_pos; c < last_tile_num_cells - 1; c++) {
-        auto cell_count = has_bmp ? last_tile->bitmap_[c] : 1;
+        auto cell_count = last_tile->has_bmp() ? last_tile->bitmap()[c] : 1;
         auto new_size =
             ((OffType*)query_buffer
                  .buffer_)[cell_offsets[new_result_tiles_size] + cell_count];
@@ -1567,12 +1536,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
   auto last_tile_cells_copied =
       cell_offsets[result_tiles.size()] - cell_offsets[result_tiles.size() - 1];
   if (frag_tile_idx.tile_idx_ == last_tile->tile_idx()) {
-    if (last_tile->bitmap_result_num_ != std::numeric_limits<uint64_t>::max()) {
-      last_tile_cells_copied +=
-          last_tile->result_num_between_pos(0, frag_tile_idx.cell_idx_);
-    } else {
-      last_tile_cells_copied += frag_tile_idx.cell_idx_;
-    }
+    last_tile_cells_copied +=
+        last_tile->result_num_between_pos(0, frag_tile_idx.cell_idx_);
   }
 
   // Adjust tile index.
@@ -1581,18 +1546,10 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
   }
 
   // If the last tile is not fully copied, save the cell index.
-  auto last_tile_num_cells =
-      fragment_metadata_[last_tile->frag_idx()]->cell_num(
-          last_tile->tile_idx());
-  if (last_tile->bitmap_result_num_ != std::numeric_limits<uint64_t>::max()) {
-    if (last_tile->bitmap_result_num_ != last_tile_cells_copied) {
-      frag_tile_idx.tile_idx_ = last_tile->tile_idx();
-      frag_tile_idx.cell_idx_ =
-          last_tile->pos_with_given_result_sum(0, last_tile_cells_copied) + 1;
-    }
-  } else if (last_tile_num_cells != last_tile_cells_copied) {
+  if (last_tile->result_num() != last_tile_cells_copied) {
     frag_tile_idx.tile_idx_ = last_tile->tile_idx();
-    frag_tile_idx.cell_idx_ = last_tile_cells_copied;
+    frag_tile_idx.cell_idx_ =
+        last_tile->pos_with_given_result_sum(0, last_tile_cells_copied) + 1;
   }
 
   logger_->debug("Done copying tiles");

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -195,7 +195,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param f Fragment index.
    * @param t Tile index.
    * @param last_t Last tile index.
-   * @param array_schema Array schema.
+   * @param frag_md Fragment metadata.
    *
    * @return buffers_full, new_var_buffer_size, new_result_tiles_size.
    */
@@ -206,7 +206,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const unsigned f,
       const uint64_t t,
       const uint64_t last_t,
-      const ArraySchema& array_schema);
+      const FragmentMetadata& frag_md);
 
   /**
    * Create the result tiles.


### PR DESCRIPTION
This changes the ResultTileWithBitmap class attributes to be private
instead of public and proper accessors are created.

Also cleaning up the usage to get rid of magic numbers and usage of
fields for things they are not meant to be used for.

---
TYPE: IMPROVEMENT
DESC: Result tile with bitmaps: make attributes private.
