### PR TITLE
Correct typo in argument string

### DIFF
--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -539,7 +539,7 @@ Status Config::unset(const std::string& param) {
   } else if (param == "config.logging_level") {
     param_values_["config.logging_level"] = CONFIG_LOGGING_LEVEL;
   } else if (param == "config.logging_format") {
-    param_values_["config.logging_foramt"] = CONFIG_LOGGING_DEFAULT_FORMAT;
+    param_values_["config.logging_format"] = CONFIG_LOGGING_DEFAULT_FORMAT;
   } else if (param == "sm.encryption_key") {
     param_values_["sm.encryption_key"] = SM_ENCRYPTION_KEY;
   } else if (param == "sm.encryption_type") {


### PR DESCRIPTION
The `unset` function branches on its argument to reset a given configuration parameter.  One case has a simple typo in the assignment meaning that value will be missed.  This PR corrects this.

---
TYPE: BUG
DESC: Correct simple typo in assignment
