### PR TITLE
Store and parse compression filter version as a uint32

### DIFF
--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -148,7 +148,7 @@ class CompressionFilter : public Filter {
   int level_;
 
   /** The format version. */
-  int version_;
+  uint32_t version_;
 
   /** The default filter compression level. */
   static constexpr int default_level_ = -30000;

--- a/tiledb/storage_format/uri/parse_uri.cc
+++ b/tiledb/storage_format/uri/parse_uri.cc
@@ -87,7 +87,8 @@ Status get_fragment_name_version(const std::string& name, uint32_t* version) {
     // version is greater than or equal to 10, we have a footer version of 5.
     // version is greater than or equal to 7, we have a footer version of 4.
     // Otherwise, it is version 3.
-    const int frag_version = std::stoi(name.substr(name.find_last_of('_') + 1));
+    const uint32_t frag_version =
+        std::stol(name.substr(name.find_last_of('_') + 1));
     if (frag_version >= 10)
       *version = 5;
     else if (frag_version >= 7)


### PR DESCRIPTION
Format version needs to be universally treated as a `uint32_t`

---
TYPE: IMPROVEMENT
DESC: Store compression filter's version as uint32
