### PR TITLE
Sparse without dups unordered uses indexreader

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1279,6 +1279,7 @@ Status query_to_capnp(
       }
     } else if (
         query.use_refactored_sparse_global_order_reader() && !schema.dense() &&
+        (query.condition() == nullptr || query.condition()->empty()) &&
         (layout == Layout::GLOBAL_ORDER || layout == Layout::UNORDERED)) {
       auto builder = query_builder->initReaderIndex();
 
@@ -1830,7 +1831,7 @@ Status query_from_capnp(
   // heterogeneous coordinate changes
   if (type == QueryType::READ) {
     if (query_reader.hasReaderIndex() && !schema.dense() &&
-        layout == Layout::GLOBAL_ORDER) {
+        (layout == Layout::GLOBAL_ORDER || layout == Layout::UNORDERED)) {
       // Strategy needs to be cleared here to create the correct reader.
       query->clear_strategy();
       RETURN_NOT_OK(query->set_layout_unsafe(layout));


### PR DESCRIPTION
This fixes a mismatch between the serialization path and the query strategy decision code that resulted in the serialization path
incorrectly trying to load the base reader state instead of the indexed reader state.

This was causing a `Error: Invalid Layout ` error in de-serializing.

A followup story has been opened about centralizing the logic for handling query strategies.

---
TYPE: BUG
DESC: Fix issue with sparse unordered without duplicates query deserialization to use Indexed Reader
