### PR TITLE
 [Backport release-2.10]  Sparse without dups unordered uses indexreader

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1271,8 +1271,9 @@ Status query_to_capnp(
       }
     } else if (
         query.use_refactored_sparse_global_order_reader() && !schema.dense() &&
-        (layout == Layout::GLOBAL_ORDER ||
-         (layout == Layout::UNORDERED && query.subarray()->range_num() <= 1))) {
+        (query.condition() == nullptr || query.condition()->empty()) &&
+        (layout == Layout::GLOBAL_ORDER || layout == Layout::UNORDERED) &&
+        query.subarray()->range_num() <= 1) {
       auto builder = query_builder->initReaderIndex();
       auto reader = (SparseGlobalOrderReader*)query.strategy();
 
@@ -1801,7 +1802,7 @@ Status query_from_capnp(
   // heterogeneous coordinate changes
   if (type == QueryType::READ) {
     if (query_reader.hasReaderIndex() && !schema.dense() &&
-        layout == Layout::GLOBAL_ORDER) {
+        (layout == Layout::GLOBAL_ORDER || layout == Layout::UNORDERED)) {
       // Strategy needs to be cleared here to create the correct reader.
       query->clear_strategy();
       RETURN_NOT_OK(query->set_layout_unsafe(layout));


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/5e02006cc8beec669a1c6ccf9f1a06ea3fd231b2 from https://github.com/TileDB-Inc/TileDB/pull/3347

---
TYPE: BUG
DESC: Fix issue with sparse unordered without duplicates query deserialization to use Indexed Reader
